### PR TITLE
Propagate context through CRD test fixture create/delete functions

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/apiapproval_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/apiapproval_test.go
@@ -35,7 +35,7 @@ func TestAPIApproval(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +68,7 @@ func TestAPIApproval(t *testing.T) {
 	}
 	// the unit tests cover all variations. We just need to be sure that we see the code being called
 	approvedKubeAPI := newSigKubeAPIFn("approved", "https://github.com/kubernetes/kubernetes/pull/79724")
-	approvedKubeAPI, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), approvedKubeAPI, apiExtensionClient, dynamicClient)
+	approvedKubeAPI, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), approvedKubeAPI, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/apiapproval_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/apiapproval_test.go
@@ -35,7 +35,7 @@ func TestAPIApproval(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +68,7 @@ func TestAPIApproval(t *testing.T) {
 	}
 	// the unit tests cover all variations. We just need to be sure that we see the code being called
 	approvedKubeAPI := newSigKubeAPIFn("approved", "https://github.com/kubernetes/kubernetes/pull/79724")
-	approvedKubeAPI, err = fixtures.CreateNewV1CustomResourceDefinition(approvedKubeAPI, apiExtensionClient, dynamicClient)
+	approvedKubeAPI, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), approvedKubeAPI, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/apply_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/apply_test.go
@@ -46,7 +46,7 @@ func TestApplyBasic(t *testing.T) {
 	}
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/apply_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/apply_test.go
@@ -46,7 +46,7 @@ func TestApplyBasic(t *testing.T) {
 	}
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
@@ -54,7 +54,7 @@ func TestNamespaceScopedCRUD(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestClusterScopedCRUD(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -327,7 +327,7 @@ func TestInvalidCRUD(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -534,7 +534,7 @@ func TestDiscovery(t *testing.T) {
 
 	scope := apiextensionsv1.NamespaceScoped
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(scope)
-	if _, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient); err != nil {
+	if _, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient); err != nil {
 		t.Fatal(err)
 	}
 
@@ -580,7 +580,7 @@ func TestNoNamespaceReject(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -619,7 +619,7 @@ func TestSameNameDiffNamespace(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -639,7 +639,7 @@ func TestPreserveInt(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -681,7 +681,7 @@ func TestPatch(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -759,7 +759,7 @@ func TestCrossNamespaceListWatch(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -901,7 +901,7 @@ func TestNameConflict(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -930,7 +930,7 @@ func TestNameConflict(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient)
+	err = fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -962,7 +962,7 @@ func TestStatusGetAndPatch(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
@@ -54,7 +54,7 @@ func TestNamespaceScopedCRUD(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestClusterScopedCRUD(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -327,7 +327,7 @@ func TestInvalidCRUD(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -534,7 +534,7 @@ func TestDiscovery(t *testing.T) {
 
 	scope := apiextensionsv1.NamespaceScoped
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(scope)
-	if _, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient); err != nil {
+	if _, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient); err != nil {
 		t.Fatal(err)
 	}
 
@@ -580,7 +580,7 @@ func TestNoNamespaceReject(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -619,7 +619,7 @@ func TestSameNameDiffNamespace(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -639,7 +639,7 @@ func TestPreserveInt(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -681,7 +681,7 @@ func TestPatch(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -759,7 +759,7 @@ func TestCrossNamespaceListWatch(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -901,7 +901,7 @@ func TestNameConflict(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -930,7 +930,7 @@ func TestNameConflict(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient)
+	err = fixtures.DeleteV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -962,7 +962,7 @@ func TestStatusGetAndPatch(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/cbor_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/cbor_test.go
@@ -76,7 +76,7 @@ func TestCBORStorageEnablement(t *testing.T) {
 		}
 		defer tearDown()
 
-		if _, err := fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionsClientset, dynamicClient); err != nil {
+		if _, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionsClientset, dynamicClient); err != nil {
 			t.Fatal(err)
 		}
 
@@ -228,7 +228,7 @@ func TestCBORServingEnablement(t *testing.T) {
 					Scope: apiextensionsv1.ClusterScoped,
 				},
 			}
-			if _, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionsClientset, dynamicClient); err != nil {
+			if _, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionsClientset, dynamicClient); err != nil {
 				t.Fatal(err)
 			}
 			cr, err := dynamicClient.Resource(schema.GroupVersionResource{Group: "mygroup.example.com", Version: "v1beta1", Resource: "foos"}).Create(

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/cbor_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/cbor_test.go
@@ -76,7 +76,7 @@ func TestCBORStorageEnablement(t *testing.T) {
 		}
 		defer tearDown()
 
-		if _, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionsClientset, dynamicClient); err != nil {
+		if _, err := fixtures.CreateNewV1CustomResourceDefinition(t.Context(), crd, apiExtensionsClientset, dynamicClient); err != nil {
 			t.Fatal(err)
 		}
 
@@ -228,7 +228,7 @@ func TestCBORServingEnablement(t *testing.T) {
 					Scope: apiextensionsv1.ClusterScoped,
 				},
 			}
-			if _, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionsClientset, dynamicClient); err != nil {
+			if _, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), crd, apiExtensionsClientset, dynamicClient); err != nil {
 				t.Fatal(err)
 			}
 			cr, err := dynamicClient.Resource(schema.GroupVersionResource{Group: "mygroup.example.com", Version: "v1beta1", Resource: "foos"}).Create(

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/change_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/change_test.go
@@ -51,7 +51,7 @@ func TestChangeCRD(t *testing.T) {
 	}
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionsClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionsClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/change_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/change_test.go
@@ -51,7 +51,7 @@ func TestChangeCRD(t *testing.T) {
 	}
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionsClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionsClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
@@ -1061,7 +1061,7 @@ func getUnexpectedVersionCheckConverter(t *testing.T, version string) ObjectConv
 }
 
 func newConversionTestContext(t *testing.T, apiExtensionsClient clientset.Interface, dynamicClient dynamic.Interface, etcdObjectReader *storage.EtcdObjectReader, v1CRD *apiextensionsv1.CustomResourceDefinition) (func(), *conversionTestContext) {
-	v1CRD, err := fixtures.CreateNewV1CustomResourceDefinition(v1CRD, apiExtensionsClient, dynamicClient)
+	v1CRD, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), v1CRD, apiExtensionsClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1071,7 +1071,7 @@ func newConversionTestContext(t *testing.T, apiExtensionsClient clientset.Interf
 	}
 
 	tearDown := func() {
-		if err := fixtures.DeleteV1CustomResourceDefinition(crd, apiExtensionsClient); err != nil {
+		if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), crd, apiExtensionsClient); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
@@ -1061,7 +1061,7 @@ func getUnexpectedVersionCheckConverter(t *testing.T, version string) ObjectConv
 }
 
 func newConversionTestContext(t *testing.T, apiExtensionsClient clientset.Interface, dynamicClient dynamic.Interface, etcdObjectReader *storage.EtcdObjectReader, v1CRD *apiextensionsv1.CustomResourceDefinition) (func(), *conversionTestContext) {
-	v1CRD, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), v1CRD, apiExtensionsClient, dynamicClient)
+	v1CRD, err := fixtures.CreateNewV1CustomResourceDefinition(t.Context(), v1CRD, apiExtensionsClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1071,7 +1071,7 @@ func newConversionTestContext(t *testing.T, apiExtensionsClient clientset.Interf
 	}
 
 	tearDown := func() {
-		if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), crd, apiExtensionsClient); err != nil {
+		if err := fixtures.DeleteV1CustomResourceDefinition(t.Context(), crd, apiExtensionsClient); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/defaulting_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/defaulting_test.go
@@ -209,7 +209,7 @@ func testDefaulting(t *testing.T, watchCache bool) {
 		t.Fatal(err)
 	}
 
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -631,7 +631,7 @@ func TestCustomResourceDefaultingOfMetaFields(t *testing.T) {
 	if err := yaml.Unmarshal([]byte(metaDefaultingFooV1beta1Schema), &crd.Spec.Versions[0].Schema.OpenAPIV3Schema); err != nil {
 		t.Fatal(err)
 	}
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/defaulting_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/defaulting_test.go
@@ -209,7 +209,7 @@ func testDefaulting(t *testing.T, watchCache bool) {
 		t.Fatal(err)
 	}
 
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -631,7 +631,7 @@ func TestCustomResourceDefaultingOfMetaFields(t *testing.T) {
 	if err := yaml.Unmarshal([]byte(metaDefaultingFooV1beta1Schema), &crd.Spec.Versions[0].Schema.OpenAPIV3Schema); err != nil {
 		t.Fatal(err)
 	}
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/deprecation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/deprecation_test.go
@@ -95,7 +95,7 @@ func TestCustomResourceDeprecation(t *testing.T) {
 	}
 
 	crd := deprecationFixture.DeepCopy()
-	if _, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionsClient, dynamicClient); err != nil {
+	if _, err := fixtures.CreateNewV1CustomResourceDefinition(t.Context(), crd, apiExtensionsClient, dynamicClient); err != nil {
 		t.Fatal(err)
 	}
 

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/deprecation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/deprecation_test.go
@@ -95,7 +95,7 @@ func TestCustomResourceDeprecation(t *testing.T) {
 	}
 
 	crd := deprecationFixture.DeepCopy()
-	if _, err := fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionsClient, dynamicClient); err != nil {
+	if _, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionsClient, dynamicClient); err != nil {
 		t.Fatal(err)
 	}
 

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/fieldselector_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/fieldselector_test.go
@@ -228,7 +228,7 @@ func TestSelectableFields(t *testing.T) {
 	}
 
 	// create the CRD
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -512,7 +512,7 @@ func TestFieldSelectorOpenAPI(t *testing.T) {
 	}
 
 	crd := selectableFieldFixture.DeepCopy()
-	crd, err = fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(crd, apiExtensionsClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(context.TODO(), crd, apiExtensionsClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -698,7 +698,7 @@ func TestFieldSelectorDisablement(t *testing.T) {
 	// Write a field that uses the feature while the feature gate is enabled
 	t.Run("CustomResourceFieldSelectors", func(t *testing.T) {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, apiextensionsfeatures.CustomResourceFieldSelectors, true)
-		crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+		crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/fieldselector_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/fieldselector_test.go
@@ -228,7 +228,7 @@ func TestSelectableFields(t *testing.T) {
 	}
 
 	// create the CRD
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -512,7 +512,7 @@ func TestFieldSelectorOpenAPI(t *testing.T) {
 	}
 
 	crd := selectableFieldFixture.DeepCopy()
-	crd, err = fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(context.TODO(), crd, apiExtensionsClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(t.Context(), crd, apiExtensionsClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -698,7 +698,7 @@ func TestFieldSelectorDisablement(t *testing.T) {
 	// Write a field that uses the feature while the feature gate is enabled
 	t.Run("CustomResourceFieldSelectors", func(t *testing.T) {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, apiextensionsfeatures.CustomResourceFieldSelectors, true)
-		crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
+		crd, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), crd, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go
@@ -42,7 +42,7 @@ func TestFinalization(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	require.NoError(t, err)
 
 	ns := testNamespace
@@ -106,7 +106,7 @@ func TestFinalizationAndDeletion(t *testing.T) {
 
 	// Create a CRD.
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	require.NoError(t, err)
 
 	// Create a CR with a finalizer.
@@ -134,7 +134,7 @@ func TestFinalizationAndDeletion(t *testing.T) {
 	require.NotNil(t, gottenNoxuInstance.GetDeletionTimestamp())
 
 	// Delete the CRD.
-	fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient)
+	fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient)
 
 	// Check is CR still there after the CRD deletion.
 	gottenNoxuInstance, err = noxuResourceClient.Get(context.TODO(), name, metav1.GetOptions{})
@@ -178,7 +178,7 @@ func TestApplyCRDuringCRDFinalization(t *testing.T) {
 	// Create a CRD with a finalizer which will stall deletion
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
 	noxuDefinition.SetFinalizers([]string{testFinalizer})
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	require.NoError(t, err)
 
 	// Delete the CRD. Since it has a finalizer it will be stuck in terminating state

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go
@@ -42,7 +42,7 @@ func TestFinalization(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	require.NoError(t, err)
 
 	ns := testNamespace
@@ -106,7 +106,7 @@ func TestFinalizationAndDeletion(t *testing.T) {
 
 	// Create a CRD.
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	require.NoError(t, err)
 
 	// Create a CR with a finalizer.
@@ -134,7 +134,7 @@ func TestFinalizationAndDeletion(t *testing.T) {
 	require.NotNil(t, gottenNoxuInstance.GetDeletionTimestamp())
 
 	// Delete the CRD.
-	fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient)
+	fixtures.DeleteV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient)
 
 	// Check is CR still there after the CRD deletion.
 	gottenNoxuInstance, err = noxuResourceClient.Get(context.TODO(), name, metav1.GetOptions{})
@@ -178,7 +178,7 @@ func TestApplyCRDuringCRDFinalization(t *testing.T) {
 	// Create a CRD with a finalizer which will stall deletion
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
 	noxuDefinition.SetFinalizers([]string{testFinalizer})
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	require.NoError(t, err)
 
 	// Delete the CRD. Since it has a finalizer it will be stuck in terminating state

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/etcd.go
@@ -34,7 +34,7 @@ import (
 // with removed data.  Do not use this just because you don't want to update your test to use v1.  Only use this
 // when it actually matters.
 func CreateCRDUsingRemovedAPI(ctx context.Context, etcdClient *clientv3.Client, etcdStoragePrefix string, betaCRD *apiextensionsv1beta1.CustomResourceDefinition, apiExtensionsClient clientset.Interface, dynamicClientSet dynamic.Interface) (*apiextensionsv1.CustomResourceDefinition, error) {
-	crd, err := CreateCRDUsingRemovedAPIWatchUnsafe(etcdClient, etcdStoragePrefix, betaCRD, apiExtensionsClient)
+	crd, err := CreateCRDUsingRemovedAPIWatchUnsafe(ctx, etcdClient, etcdStoragePrefix, betaCRD, apiExtensionsClient)
 	if err != nil {
 		return nil, err
 	}
@@ -44,18 +44,18 @@ func CreateCRDUsingRemovedAPI(ctx context.Context, etcdClient *clientv3.Client, 
 // CreateCRDUsingRemovedAPIWatchUnsafe creates a CRD directly using etcd.  This is must *ONLY* be used for checks of compatibility
 // with removed data.  Do not use this just because you don't want to update your test to use v1.  Only use this
 // when it actually matters.
-func CreateCRDUsingRemovedAPIWatchUnsafe(etcdClient *clientv3.Client, etcdStoragePrefix string, betaCRD *apiextensionsv1beta1.CustomResourceDefinition, apiExtensionsClient clientset.Interface) (*apiextensionsv1.CustomResourceDefinition, error) {
+func CreateCRDUsingRemovedAPIWatchUnsafe(ctx context.Context, etcdClient *clientv3.Client, etcdStoragePrefix string, betaCRD *apiextensionsv1beta1.CustomResourceDefinition, apiExtensionsClient clientset.Interface) (*apiextensionsv1.CustomResourceDefinition, error) {
 	// attempt defaulting, best effort
 	apiextensionsv1beta1.SetDefaults_CustomResourceDefinition(betaCRD)
 	betaCRD.Kind = "CustomResourceDefinition"
 	betaCRD.APIVersion = apiextensionsv1beta1.SchemeGroupVersion.Group + "/" + apiextensionsv1beta1.SchemeGroupVersion.Version
 
-	ctx := genericapirequest.WithNamespace(genericapirequest.NewContext(), metav1.NamespaceNone)
+	reqCtx := genericapirequest.WithNamespace(genericapirequest.NewContext(), metav1.NamespaceNone)
 	key := path.Join("/", etcdStoragePrefix, "apiextensions.k8s.io", "customresourcedefinitions", betaCRD.Name)
 	val, _ := json.Marshal(betaCRD)
-	if _, err := etcdClient.Put(ctx, key, string(val)); err != nil {
+	if _, err := etcdClient.Put(reqCtx, key, string(val)); err != nil {
 		return nil, err
 	}
 
-	return apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), betaCRD.Name, metav1.GetOptions{})
+	return apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, betaCRD.Name, metav1.GetOptions{})
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/etcd.go
@@ -33,12 +33,12 @@ import (
 // CreateCRDUsingRemovedAPI creates a CRD directly using etcd.  This is must *ONLY* be used for checks of compatibility
 // with removed data.  Do not use this just because you don't want to update your test to use v1.  Only use this
 // when it actually matters.
-func CreateCRDUsingRemovedAPI(etcdClient *clientv3.Client, etcdStoragePrefix string, betaCRD *apiextensionsv1beta1.CustomResourceDefinition, apiExtensionsClient clientset.Interface, dynamicClientSet dynamic.Interface) (*apiextensionsv1.CustomResourceDefinition, error) {
+func CreateCRDUsingRemovedAPI(ctx context.Context, etcdClient *clientv3.Client, etcdStoragePrefix string, betaCRD *apiextensionsv1beta1.CustomResourceDefinition, apiExtensionsClient clientset.Interface, dynamicClientSet dynamic.Interface) (*apiextensionsv1.CustomResourceDefinition, error) {
 	crd, err := CreateCRDUsingRemovedAPIWatchUnsafe(etcdClient, etcdStoragePrefix, betaCRD, apiExtensionsClient)
 	if err != nil {
 		return nil, err
 	}
-	return waitForCRDReady(crd, apiExtensionsClient, dynamicClientSet)
+	return waitForCRDReady(ctx, crd, apiExtensionsClient, dynamicClientSet)
 }
 
 // CreateCRDUsingRemovedAPIWatchUnsafe creates a CRD directly using etcd.  This is must *ONLY* be used for checks of compatibility

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/resources.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/resources.go
@@ -343,10 +343,10 @@ func existsInDiscoveryV1(crd *apiextensionsv1.CustomResourceDefinition, apiExten
 // the apiextension apiserver has installed the CRD. But it's not safe to watch
 // the created CR. Please call CreateCRDUsingRemovedAPI if you need to
 // watch the CR.
-func waitForCRDReadyWatchUnsafe(crd *apiextensionsv1.CustomResourceDefinition, apiExtensionsClient clientset.Interface) (*apiextensionsv1.CustomResourceDefinition, error) {
+func waitForCRDReadyWatchUnsafe(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition, apiExtensionsClient clientset.Interface) (*apiextensionsv1.CustomResourceDefinition, error) {
 	// wait until all resources appears in discovery
 	for _, version := range servedV1Versions(crd) {
-		err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		err := wait.PollUntilContextCancel(ctx, 500*time.Millisecond, true, func(ctx context.Context) (bool, error) {
 			return existsInDiscoveryV1(crd, apiExtensionsClient, version)
 		})
 		if err != nil {
@@ -358,8 +358,8 @@ func waitForCRDReadyWatchUnsafe(crd *apiextensionsv1.CustomResourceDefinition, a
 }
 
 // waitForCRDReady creates the given CRD and makes sure its watch cache is primed on the server.
-func waitForCRDReady(crd *apiextensionsv1.CustomResourceDefinition, apiExtensionsClient clientset.Interface, dynamicClientSet dynamic.Interface) (*apiextensionsv1.CustomResourceDefinition, error) {
-	v1CRD, err := waitForCRDReadyWatchUnsafe(crd, apiExtensionsClient)
+func waitForCRDReady(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition, apiExtensionsClient clientset.Interface, dynamicClientSet dynamic.Interface) (*apiextensionsv1.CustomResourceDefinition, error) {
+	v1CRD, err := waitForCRDReadyWatchUnsafe(ctx, crd, apiExtensionsClient)
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +374,7 @@ func waitForCRDReady(crd *apiextensionsv1.CustomResourceDefinition, apiExtension
 	// For this test, we'll actually cycle, "list/watch/create/delete" until we get an RV from list that observes the create and not an error.
 	// This way all the tests that are checking for watches don't have to worry about RV too old problems because crazy things *could* happen
 	// before like the created RV could be too old to watch.
-	err = wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(ctx, 500*time.Millisecond, true, func(ctx context.Context) (bool, error) {
 		return isWatchCachePrimed(v1CRD, dynamicClientSet)
 	})
 	if err != nil {
@@ -387,15 +387,15 @@ func waitForCRDReady(crd *apiextensionsv1.CustomResourceDefinition, apiExtension
 // the apiextension apiserver has installed the CRD. But it's not safe to watch
 // the created CR. Please call CreateNewV1CustomResourceDefinition if you need to
 // watch the CR.
-func CreateNewV1CustomResourceDefinitionWatchUnsafe(v1CRD *apiextensionsv1.CustomResourceDefinition, apiExtensionsClient clientset.Interface) (*apiextensionsv1.CustomResourceDefinition, error) {
-	v1CRD, err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Create(context.TODO(), v1CRD, metav1.CreateOptions{})
+func CreateNewV1CustomResourceDefinitionWatchUnsafe(ctx context.Context, v1CRD *apiextensionsv1.CustomResourceDefinition, apiExtensionsClient clientset.Interface) (*apiextensionsv1.CustomResourceDefinition, error) {
+	v1CRD, err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Create(ctx, v1CRD, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}
 
 	// wait until all resources appears in discovery
 	for _, version := range servedV1Versions(v1CRD) {
-		err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		err := wait.PollUntilContextCancel(ctx, 500*time.Millisecond, true, func(ctx context.Context) (bool, error) {
 			return existsInDiscoveryV1(v1CRD, apiExtensionsClient, version)
 		})
 		if err != nil {
@@ -407,8 +407,8 @@ func CreateNewV1CustomResourceDefinitionWatchUnsafe(v1CRD *apiextensionsv1.Custo
 }
 
 // CreateNewV1CustomResourceDefinition creates the given CRD and makes sure its watch cache is primed on the server.
-func CreateNewV1CustomResourceDefinition(v1CRD *apiextensionsv1.CustomResourceDefinition, apiExtensionsClient clientset.Interface, dynamicClientSet dynamic.Interface) (*apiextensionsv1.CustomResourceDefinition, error) {
-	v1CRD, err := CreateNewV1CustomResourceDefinitionWatchUnsafe(v1CRD, apiExtensionsClient)
+func CreateNewV1CustomResourceDefinition(ctx context.Context, v1CRD *apiextensionsv1.CustomResourceDefinition, apiExtensionsClient clientset.Interface, dynamicClientSet dynamic.Interface) (*apiextensionsv1.CustomResourceDefinition, error) {
+	v1CRD, err := CreateNewV1CustomResourceDefinitionWatchUnsafe(ctx, v1CRD, apiExtensionsClient)
 	if err != nil {
 		return nil, err
 	}
@@ -423,7 +423,7 @@ func CreateNewV1CustomResourceDefinition(v1CRD *apiextensionsv1.CustomResourceDe
 	// For this test, we'll actually cycle, "list/watch/create/delete" until we get an RV from list that observes the create and not an error.
 	// This way all the tests that are checking for watches don't have to worry about RV too old problems because crazy things *could* happen
 	// before like the created RV could be too old to watch.
-	err = wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(ctx, 500*time.Millisecond, true, func(ctx context.Context) (bool, error) {
 		return isWatchCachePrimed(v1CRD, dynamicClientSet)
 	})
 	if err != nil {
@@ -512,12 +512,12 @@ func isWatchCachePrimed(crd *apiextensionsv1.CustomResourceDefinition, dynamicCl
 }
 
 // DeleteV1CustomResourceDefinition deletes a CRD and waits until it disappears from discovery.
-func DeleteV1CustomResourceDefinition(crd *apiextensionsv1.CustomResourceDefinition, apiExtensionsClient clientset.Interface) error {
-	if err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Delete(context.TODO(), crd.Name, metav1.DeleteOptions{}); err != nil {
+func DeleteV1CustomResourceDefinition(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition, apiExtensionsClient clientset.Interface) error {
+	if err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Delete(ctx, crd.Name, metav1.DeleteOptions{}); err != nil {
 		return err
 	}
 	for _, version := range servedV1Versions(crd) {
-		err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		err := wait.PollUntilContextCancel(ctx, 500*time.Millisecond, true, func(ctx context.Context) (bool, error) {
 			exists, err := existsInDiscoveryV1(crd, apiExtensionsClient, version)
 			return !exists, err
 		})
@@ -529,17 +529,17 @@ func DeleteV1CustomResourceDefinition(crd *apiextensionsv1.CustomResourceDefinit
 }
 
 // DeleteV1CustomResourceDefinitions deletes all CRD matching the provided deleteListOpts and waits until all the CRDs disappear from discovery.
-func DeleteV1CustomResourceDefinitions(deleteListOpts metav1.ListOptions, apiExtensionsClient clientset.Interface) error {
-	list, err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().List(context.TODO(), deleteListOpts)
+func DeleteV1CustomResourceDefinitions(ctx context.Context, deleteListOpts metav1.ListOptions, apiExtensionsClient clientset.Interface) error {
+	list, err := apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().List(ctx, deleteListOpts)
 	if err != nil {
 		return err
 	}
-	if err = apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().DeleteCollection(context.TODO(), metav1.DeleteOptions{}, deleteListOpts); err != nil {
+	if err = apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().DeleteCollection(ctx, metav1.DeleteOptions{}, deleteListOpts); err != nil {
 		return err
 	}
 	for _, crd := range list.Items {
 		for _, version := range servedV1Versions(&crd) {
-			err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+			err := wait.PollUntilContextCancel(ctx, 500*time.Millisecond, true, func(ctx context.Context) (bool, error) {
 				exists, err := existsInDiscoveryV1(&crd, apiExtensionsClient, version)
 				return !exists, err
 			})

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/limit_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/limit_test.go
@@ -47,7 +47,7 @@ func TestLimits(t *testing.T) {
 	}
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/limit_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/limit_test.go
@@ -47,7 +47,7 @@ func TestLimits(t *testing.T) {
 	}
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/listtype_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/listtype_test.go
@@ -131,7 +131,7 @@ func TestListTypes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/listtype_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/listtype_test.go
@@ -131,7 +131,7 @@ func TestListTypes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/objectmeta_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/objectmeta_test.go
@@ -53,7 +53,7 @@ func TestPostInvalidObjectMeta(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +127,7 @@ func TestInvalidObjectMetaInStorage(t *testing.T) {
 			},
 		},
 	}
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -441,7 +441,7 @@ func TestEmbeddedResources(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/objectmeta_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/objectmeta_test.go
@@ -53,7 +53,7 @@ func TestPostInvalidObjectMeta(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +127,7 @@ func TestInvalidObjectMetaInStorage(t *testing.T) {
 			},
 		},
 	}
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -441,7 +441,7 @@ func TestEmbeddedResources(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/pruning_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/pruning_test.go
@@ -205,7 +205,7 @@ func TestPruningCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -257,7 +257,7 @@ func TestPruningStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -321,7 +321,7 @@ func TestPruningFromStorage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -410,7 +410,7 @@ func TestPruningPatch(t *testing.T) {
 	if err := yaml.Unmarshal([]byte(fooSchema), &crd.Spec.Versions[0].Schema.OpenAPIV3Schema); err != nil {
 		t.Fatal(err)
 	}
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -462,7 +462,7 @@ func TestPruningCreatePreservingUnknownFields(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -547,7 +547,7 @@ func TestPruningEmbeddedResources(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/pruning_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/pruning_test.go
@@ -205,7 +205,7 @@ func TestPruningCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -257,7 +257,7 @@ func TestPruningStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -321,7 +321,7 @@ func TestPruningFromStorage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -410,7 +410,7 @@ func TestPruningPatch(t *testing.T) {
 	if err := yaml.Unmarshal([]byte(fooSchema), &crd.Spec.Versions[0].Schema.OpenAPIV3Schema); err != nil {
 		t.Fatal(err)
 	}
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -462,7 +462,7 @@ func TestPruningCreatePreservingUnknownFields(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -547,7 +547,7 @@ func TestPruningEmbeddedResources(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/ratcheting_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/ratcheting_test.go
@@ -426,7 +426,7 @@ func runTests(t *testing.T, cases []ratchetingTestCase) {
 		},
 	}
 
-	_, err = fixtures.CreateNewV1CustomResourceDefinition(myCRD, apiExtensionClient, dynamicClient)
+	_, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), myCRD, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/ratcheting_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/ratcheting_test.go
@@ -426,7 +426,7 @@ func runTests(t *testing.T, cases []ratchetingTestCase) {
 		},
 	}
 
-	_, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), myCRD, apiExtensionClient, dynamicClient)
+	_, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), myCRD, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/registration_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/registration_test.go
@@ -48,7 +48,7 @@ func TestMultipleResourceInstances(t *testing.T) {
 
 	ns := "not-the-default"
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +173,7 @@ func TestMultipleRegistration(t *testing.T) {
 	ns := "not-the-default"
 	sameInstanceName := "foo"
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +192,7 @@ func TestMultipleRegistration(t *testing.T) {
 	}
 
 	curletDefinition := fixtures.NewCurletV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	curletDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(curletDefinition, apiExtensionClient, dynamicClient)
+	curletDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), curletDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,7 +229,7 @@ func TestDeRegistrationAndReRegistration(t *testing.T) {
 	ns := "not-the-default"
 	sameInstanceName := "foo"
 	func() {
-		noxuDefinition, err := fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -237,7 +237,7 @@ func TestDeRegistrationAndReRegistration(t *testing.T) {
 		if _, err := instantiateCustomResource(t, fixtures.NewNoxuInstance(ns, sameInstanceName), noxuNamespacedResourceClient, noxuDefinition); err != nil {
 			t.Fatal(err)
 		}
-		if err := fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
+		if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
 		}
 		if _, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), noxuDefinition.Name, metav1.GetOptions{}); err == nil || !errors.IsNotFound(err) {
@@ -255,7 +255,7 @@ func TestDeRegistrationAndReRegistration(t *testing.T) {
 		if _, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), noxuDefinition.Name, metav1.GetOptions{}); err == nil || !errors.IsNotFound(err) {
 			t.Fatalf("expected a NotFound error, got:%v", err)
 		}
-		noxuDefinition, err := fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -328,7 +328,7 @@ func TestEtcdStorage(t *testing.T) {
 
 	ns1 := "another-default-is-possible"
 	curletDefinition := fixtures.NewCurletV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
-	curletDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(curletDefinition, apiExtensionClient, dynamicClient)
+	curletDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), curletDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -339,7 +339,7 @@ func TestEtcdStorage(t *testing.T) {
 
 	ns2 := "the-cruel-default"
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/registration_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/registration_test.go
@@ -48,7 +48,7 @@ func TestMultipleResourceInstances(t *testing.T) {
 
 	ns := "not-the-default"
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +173,7 @@ func TestMultipleRegistration(t *testing.T) {
 	ns := "not-the-default"
 	sameInstanceName := "foo"
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +192,7 @@ func TestMultipleRegistration(t *testing.T) {
 	}
 
 	curletDefinition := fixtures.NewCurletV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	curletDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), curletDefinition, apiExtensionClient, dynamicClient)
+	curletDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), curletDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,7 +229,7 @@ func TestDeRegistrationAndReRegistration(t *testing.T) {
 	ns := "not-the-default"
 	sameInstanceName := "foo"
 	func() {
-		noxuDefinition, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err := fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -237,7 +237,7 @@ func TestDeRegistrationAndReRegistration(t *testing.T) {
 		if _, err := instantiateCustomResource(t, fixtures.NewNoxuInstance(ns, sameInstanceName), noxuNamespacedResourceClient, noxuDefinition); err != nil {
 			t.Fatal(err)
 		}
-		if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
+		if err := fixtures.DeleteV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
 		}
 		if _, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), noxuDefinition.Name, metav1.GetOptions{}); err == nil || !errors.IsNotFound(err) {
@@ -255,7 +255,7 @@ func TestDeRegistrationAndReRegistration(t *testing.T) {
 		if _, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), noxuDefinition.Name, metav1.GetOptions{}); err == nil || !errors.IsNotFound(err) {
 			t.Fatalf("expected a NotFound error, got:%v", err)
 		}
-		noxuDefinition, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err := fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -328,7 +328,7 @@ func TestEtcdStorage(t *testing.T) {
 
 	ns1 := "another-default-is-possible"
 	curletDefinition := fixtures.NewCurletV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
-	curletDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), curletDefinition, apiExtensionClient, dynamicClient)
+	curletDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), curletDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -339,7 +339,7 @@ func TestEtcdStorage(t *testing.T) {
 
 	ns2 := "the-cruel-default"
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/scope_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/scope_test.go
@@ -74,7 +74,7 @@ func TestHandlerScope(t *testing.T) {
 					Scope: scope,
 				},
 			}
-			crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
+			crd, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), crd, apiExtensionClient, dynamicClient)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/scope_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/scope_test.go
@@ -74,7 +74,7 @@ func TestHandlerScope(t *testing.T) {
 					Scope: scope,
 				},
 			}
-			crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+			crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
@@ -142,7 +142,7 @@ func TestStatusSubresource(t *testing.T) {
 
 	noxuDefinitions := NewNoxuSubresourcesCRDs(apiextensionsv1.NamespaceScoped)
 	for _, noxuDefinition := range noxuDefinitions {
-		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -239,7 +239,7 @@ func TestStatusSubresource(t *testing.T) {
 			}
 			noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{})
 		}
-		if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
+		if err := fixtures.DeleteV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -278,13 +278,13 @@ func TestScaleSubresource(t *testing.T) {
 			}
 			// set invalid json path for specReplicasPath
 			subresources.Scale.SpecReplicasPath = "foo,bar"
-			_, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+			_, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 			if err == nil {
 				t.Fatalf("unexpected non-error: specReplicasPath should be a valid json path under .spec")
 			}
 
 			subresources.Scale.SpecReplicasPath = ".spec.replicas"
-			noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+			noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -377,7 +377,7 @@ func TestScaleSubresource(t *testing.T) {
 				t.Fatalf("unexpected non-error: .spec.replicas should be less than 2147483647")
 			}
 			noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{})
-			if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
+			if err := fixtures.DeleteV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -406,7 +406,7 @@ func TestApplyScaleSubresource(t *testing.T) {
 		t.Fatal(err)
 	}
 	subresources.Scale.SpecReplicasPath = ".spec.replicas[0]"
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -500,7 +500,7 @@ func TestValidationSchemaWithStatus(t *testing.T) {
 	}
 	noxuDefinition.Spec.Versions[1].Schema.OpenAPIV3Schema = noxuDefinition.Spec.Versions[0].Schema.OpenAPIV3Schema
 
-	_, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	_, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatalf("unable to created crd %v: %v", noxuDefinition.Name, err)
 	}
@@ -553,7 +553,7 @@ func TestValidateOnlyStatus(t *testing.T) {
 			OpenAPIV3Schema: schema.DeepCopy(),
 		}
 
-		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -602,7 +602,7 @@ func TestValidateOnlyStatus(t *testing.T) {
 			}
 			noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{})
 		}
-		if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
+		if err := fixtures.DeleteV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -626,7 +626,7 @@ func TestSubresourcesDiscovery(t *testing.T) {
 
 	noxuDefinitions := NewNoxuSubresourcesCRDs(apiextensionsv1.NamespaceScoped)
 	for _, noxuDefinition := range noxuDefinitions {
-		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -693,7 +693,7 @@ func TestSubresourcesDiscovery(t *testing.T) {
 				t.Fatalf("incorrect scale via discovery: expected: %v, got: %v", expectedVerbs, scale.Verbs)
 			}
 		}
-		if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
+		if err := fixtures.DeleteV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -708,7 +708,7 @@ func TestGeneration(t *testing.T) {
 
 	noxuDefinitions := NewNoxuSubresourcesCRDs(apiextensionsv1.NamespaceScoped)
 	for _, noxuDefinition := range noxuDefinitions {
-		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -766,7 +766,7 @@ func TestGeneration(t *testing.T) {
 			}
 			noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{})
 		}
-		if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
+		if err := fixtures.DeleteV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -795,7 +795,7 @@ func TestSubresourcePatch(t *testing.T) {
 
 	noxuDefinitions := NewNoxuSubresourcesCRDs(apiextensionsv1.NamespaceScoped)
 	for _, noxuDefinition := range noxuDefinitions {
-		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -916,7 +916,7 @@ func TestSubresourcePatch(t *testing.T) {
 			}
 			noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{})
 		}
-		if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
+		if err := fixtures.DeleteV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
@@ -142,7 +142,7 @@ func TestStatusSubresource(t *testing.T) {
 
 	noxuDefinitions := NewNoxuSubresourcesCRDs(apiextensionsv1.NamespaceScoped)
 	for _, noxuDefinition := range noxuDefinitions {
-		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -239,7 +239,7 @@ func TestStatusSubresource(t *testing.T) {
 			}
 			noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{})
 		}
-		if err := fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
+		if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -278,13 +278,13 @@ func TestScaleSubresource(t *testing.T) {
 			}
 			// set invalid json path for specReplicasPath
 			subresources.Scale.SpecReplicasPath = "foo,bar"
-			_, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+			_, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 			if err == nil {
 				t.Fatalf("unexpected non-error: specReplicasPath should be a valid json path under .spec")
 			}
 
 			subresources.Scale.SpecReplicasPath = ".spec.replicas"
-			noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+			noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -377,7 +377,7 @@ func TestScaleSubresource(t *testing.T) {
 				t.Fatalf("unexpected non-error: .spec.replicas should be less than 2147483647")
 			}
 			noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{})
-			if err := fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
+			if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -406,7 +406,7 @@ func TestApplyScaleSubresource(t *testing.T) {
 		t.Fatal(err)
 	}
 	subresources.Scale.SpecReplicasPath = ".spec.replicas[0]"
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -500,7 +500,7 @@ func TestValidationSchemaWithStatus(t *testing.T) {
 	}
 	noxuDefinition.Spec.Versions[1].Schema.OpenAPIV3Schema = noxuDefinition.Spec.Versions[0].Schema.OpenAPIV3Schema
 
-	_, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	_, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatalf("unable to created crd %v: %v", noxuDefinition.Name, err)
 	}
@@ -553,7 +553,7 @@ func TestValidateOnlyStatus(t *testing.T) {
 			OpenAPIV3Schema: schema.DeepCopy(),
 		}
 
-		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -602,7 +602,7 @@ func TestValidateOnlyStatus(t *testing.T) {
 			}
 			noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{})
 		}
-		if err := fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
+		if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -626,7 +626,7 @@ func TestSubresourcesDiscovery(t *testing.T) {
 
 	noxuDefinitions := NewNoxuSubresourcesCRDs(apiextensionsv1.NamespaceScoped)
 	for _, noxuDefinition := range noxuDefinitions {
-		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -693,7 +693,7 @@ func TestSubresourcesDiscovery(t *testing.T) {
 				t.Fatalf("incorrect scale via discovery: expected: %v, got: %v", expectedVerbs, scale.Verbs)
 			}
 		}
-		if err := fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
+		if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -708,7 +708,7 @@ func TestGeneration(t *testing.T) {
 
 	noxuDefinitions := NewNoxuSubresourcesCRDs(apiextensionsv1.NamespaceScoped)
 	for _, noxuDefinition := range noxuDefinitions {
-		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -766,7 +766,7 @@ func TestGeneration(t *testing.T) {
 			}
 			noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{})
 		}
-		if err := fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
+		if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -795,7 +795,7 @@ func TestSubresourcePatch(t *testing.T) {
 
 	noxuDefinitions := NewNoxuSubresourcesCRDs(apiextensionsv1.NamespaceScoped)
 	for _, noxuDefinition := range noxuDefinitions {
-		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -916,7 +916,7 @@ func TestSubresourcePatch(t *testing.T) {
 			}
 			noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{})
 		}
-		if err := fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
+		if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/table_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/table_test.go
@@ -120,7 +120,7 @@ func TestTableGet(t *testing.T) {
 	}
 
 	crd := newTableCRD()
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -379,7 +379,7 @@ func TestColumnsPatch(t *testing.T) {
 
 	// CRD with no top-level and per-version columns should be created successfully
 	crd := NewNoxuSubresourcesCRDs(apiextensionsv1.NamespaceScoped)[0]
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -461,7 +461,7 @@ func TestPatchCleanTopLevelColumns(t *testing.T) {
 	crd.Spec.Versions[0].AdditionalPrinterColumns = []apiextensionsv1.CustomResourceColumnDefinition{
 		{Name: "Age", Type: "date", Description: swaggerMetadataDescriptions["creationTimestamp"], JSONPath: ".metadata.creationTimestamp"},
 	}
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/table_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/table_test.go
@@ -120,7 +120,7 @@ func TestTableGet(t *testing.T) {
 	}
 
 	crd := newTableCRD()
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -379,7 +379,7 @@ func TestColumnsPatch(t *testing.T) {
 
 	// CRD with no top-level and per-version columns should be created successfully
 	crd := NewNoxuSubresourcesCRDs(apiextensionsv1.NamespaceScoped)[0]
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -461,7 +461,7 @@ func TestPatchCleanTopLevelColumns(t *testing.T) {
 	crd.Spec.Versions[0].AdditionalPrinterColumns = []apiextensionsv1.CustomResourceColumnDefinition{
 		{Name: "Age", Type: "date", Description: swaggerMetadataDescriptions["creationTimestamp"], JSONPath: ".metadata.creationTimestamp"},
 	}
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -47,7 +47,7 @@ func TestForProperValidationErrors(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -221,7 +221,7 @@ func TestCustomResourceValidation(t *testing.T) {
 
 	noxuDefinitions := newNoxuValidationCRDs()
 	for _, noxuDefinition := range noxuDefinitions {
-		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -237,7 +237,7 @@ func TestCustomResourceValidation(t *testing.T) {
 			}
 			noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{})
 		}
-		if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
+		if err := fixtures.DeleteV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -259,7 +259,7 @@ func TestCustomResourceItemsValidation(t *testing.T) {
 
 	// create CRDs
 	t.Logf("Creating CRD %s", crd.Name)
-	if _, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, client); err != nil {
+	if _, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), crd, apiExtensionClient, client); err != nil {
 		t.Fatalf("unexpected create error: %v", err)
 	}
 
@@ -426,7 +426,7 @@ func TestCustomResourceUpdateValidation(t *testing.T) {
 
 	noxuDefinitions := newNoxuValidationCRDs()
 	for _, noxuDefinition := range noxuDefinitions {
-		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -464,7 +464,7 @@ func TestCustomResourceUpdateValidation(t *testing.T) {
 			}
 			noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{})
 		}
-		if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
+		if err := fixtures.DeleteV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -574,7 +574,7 @@ spec:
 		t.Fatalf("failed decoding of: %v\n\n%s", err, crdManifest)
 	}
 	crd := crdObj.(*apiextensionsv1.CustomResourceDefinition)
-	_, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
+	_, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -647,7 +647,7 @@ func TestCustomResourceValidationErrors(t *testing.T) {
 
 	noxuDefinitions := newNoxuValidationCRDs()
 	for _, noxuDefinition := range noxuDefinitions {
-		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -724,7 +724,7 @@ func TestCustomResourceValidationErrors(t *testing.T) {
 				}
 			}
 		}
-		if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
+		if err := fixtures.DeleteV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -750,7 +750,7 @@ func TestCRValidationOnCRDUpdate(t *testing.T) {
 			// set stricter schema
 			validationSchema.OpenAPIV3Schema.Required = []string{"alpha", "beta", "gamma"}
 
-			noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+			noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -796,7 +796,7 @@ func TestCRValidationOnCRDUpdate(t *testing.T) {
 				t.Fatal(err)
 			}
 			noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{})
-			if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
+			if err := fixtures.DeleteV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -822,7 +822,7 @@ func TestForbiddenFieldsInSchema(t *testing.T) {
 			existingProperties := validationSchema.OpenAPIV3Schema.Properties
 			validationSchema.OpenAPIV3Schema.Properties = nil
 			validationSchema.OpenAPIV3Schema.AdditionalProperties = &apiextensionsv1.JSONSchemaPropsOrBool{Allows: false}
-			_, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+			_, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 			if err == nil {
 				t.Fatalf("unexpected non-error: additionalProperties cannot be set to false")
 			}
@@ -837,7 +837,7 @@ func TestForbiddenFieldsInSchema(t *testing.T) {
 					Allows: true,
 				},
 			}
-			_, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+			_, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 			if err == nil {
 				t.Fatalf("unexpected non-error: uniqueItems cannot be set to true")
 			}
@@ -851,18 +851,18 @@ func TestForbiddenFieldsInSchema(t *testing.T) {
 				},
 			}
 
-			_, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+			_, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 			if err == nil {
 				t.Fatal("unexpected non-error: $ref cannot be non-empty string")
 			}
 
 			validationSchema.OpenAPIV3Schema.Ref = nil
 
-			noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+			noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
+			if err := fixtures.DeleteV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -921,7 +921,7 @@ spec:
 
 	// create CRDs.  We cannot create these in v1, but they can exist in upgraded clusters
 	t.Logf("Creating CRD %s", betaCRD.Name)
-	if _, err := fixtures.CreateCRDUsingRemovedAPI(context.TODO(), etcdclient, etcdStoragePrefix, betaCRD, apiExtensionClient, dynamicClient); err != nil {
+	if _, err := fixtures.CreateCRDUsingRemovedAPI(t.Context(), etcdclient, etcdStoragePrefix, betaCRD, apiExtensionClient, dynamicClient); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1525,7 +1525,7 @@ properties:
 
 			// create CRDs.  We cannot create these in v1, but they can exist in upgraded clusters
 			t.Logf("Creating CRD %s", betaCRD.Name)
-			if _, err := fixtures.CreateCRDUsingRemovedAPIWatchUnsafe(etcdClient, etcdPrefix, betaCRD, apiExtensionClient); err != nil {
+			if _, err := fixtures.CreateCRDUsingRemovedAPIWatchUnsafe(t.Context(), etcdClient, etcdPrefix, betaCRD, apiExtensionClient); err != nil {
 				t.Fatal(err)
 			}
 

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -47,7 +47,7 @@ func TestForProperValidationErrors(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -221,7 +221,7 @@ func TestCustomResourceValidation(t *testing.T) {
 
 	noxuDefinitions := newNoxuValidationCRDs()
 	for _, noxuDefinition := range noxuDefinitions {
-		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -237,7 +237,7 @@ func TestCustomResourceValidation(t *testing.T) {
 			}
 			noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{})
 		}
-		if err := fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
+		if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -259,7 +259,7 @@ func TestCustomResourceItemsValidation(t *testing.T) {
 
 	// create CRDs
 	t.Logf("Creating CRD %s", crd.Name)
-	if _, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, client); err != nil {
+	if _, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, client); err != nil {
 		t.Fatalf("unexpected create error: %v", err)
 	}
 
@@ -426,7 +426,7 @@ func TestCustomResourceUpdateValidation(t *testing.T) {
 
 	noxuDefinitions := newNoxuValidationCRDs()
 	for _, noxuDefinition := range noxuDefinitions {
-		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -464,7 +464,7 @@ func TestCustomResourceUpdateValidation(t *testing.T) {
 			}
 			noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{})
 		}
-		if err := fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
+		if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -574,7 +574,7 @@ spec:
 		t.Fatalf("failed decoding of: %v\n\n%s", err, crdManifest)
 	}
 	crd := crdObj.(*apiextensionsv1.CustomResourceDefinition)
-	_, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	_, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -647,7 +647,7 @@ func TestCustomResourceValidationErrors(t *testing.T) {
 
 	noxuDefinitions := newNoxuValidationCRDs()
 	for _, noxuDefinition := range noxuDefinitions {
-		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -724,7 +724,7 @@ func TestCustomResourceValidationErrors(t *testing.T) {
 				}
 			}
 		}
-		if err := fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
+		if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -750,7 +750,7 @@ func TestCRValidationOnCRDUpdate(t *testing.T) {
 			// set stricter schema
 			validationSchema.OpenAPIV3Schema.Required = []string{"alpha", "beta", "gamma"}
 
-			noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+			noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -796,7 +796,7 @@ func TestCRValidationOnCRDUpdate(t *testing.T) {
 				t.Fatal(err)
 			}
 			noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{})
-			if err := fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
+			if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -822,7 +822,7 @@ func TestForbiddenFieldsInSchema(t *testing.T) {
 			existingProperties := validationSchema.OpenAPIV3Schema.Properties
 			validationSchema.OpenAPIV3Schema.Properties = nil
 			validationSchema.OpenAPIV3Schema.AdditionalProperties = &apiextensionsv1.JSONSchemaPropsOrBool{Allows: false}
-			_, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+			_, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 			if err == nil {
 				t.Fatalf("unexpected non-error: additionalProperties cannot be set to false")
 			}
@@ -837,7 +837,7 @@ func TestForbiddenFieldsInSchema(t *testing.T) {
 					Allows: true,
 				},
 			}
-			_, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+			_, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 			if err == nil {
 				t.Fatalf("unexpected non-error: uniqueItems cannot be set to true")
 			}
@@ -851,18 +851,18 @@ func TestForbiddenFieldsInSchema(t *testing.T) {
 				},
 			}
 
-			_, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+			_, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 			if err == nil {
 				t.Fatal("unexpected non-error: $ref cannot be non-empty string")
 			}
 
 			validationSchema.OpenAPIV3Schema.Ref = nil
 
-			noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+			noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if err := fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
+			if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -921,7 +921,7 @@ spec:
 
 	// create CRDs.  We cannot create these in v1, but they can exist in upgraded clusters
 	t.Logf("Creating CRD %s", betaCRD.Name)
-	if _, err := fixtures.CreateCRDUsingRemovedAPI(etcdclient, etcdStoragePrefix, betaCRD, apiExtensionClient, dynamicClient); err != nil {
+	if _, err := fixtures.CreateCRDUsingRemovedAPI(context.TODO(), etcdclient, etcdStoragePrefix, betaCRD, apiExtensionClient, dynamicClient); err != nil {
 		t.Fatal(err)
 	}
 

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
@@ -48,7 +48,7 @@ func TestInternalVersionIsHandlerVersion(t *testing.T) {
 	assert.Equal(t, "v1beta2", noxuDefinition.Spec.Versions[1].Name)
 	assert.True(t, noxuDefinition.Spec.Versions[1].Storage)
 
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,7 +143,7 @@ func TestVersionedNamespacedScopedCRD(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewMultipleVersionNoxuCRD(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +160,7 @@ func TestVersionedClusterScopedCRD(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewMultipleVersionNoxuCRD(apiextensionsv1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -217,7 +217,7 @@ func testStoragedVersionInCRDStatus(t *testing.T, ns string, noxuDefinition *api
 	defer tearDown()
 
 	noxuDefinition.Spec.Versions = versionsV1Beta1Storage
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -245,7 +245,7 @@ func testStoragedVersionInCRDStatus(t *testing.T, ns string, noxuDefinition *api
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
-	err = fixtures.DeleteV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient)
+	err = fixtures.DeleteV1CustomResourceDefinition(t.Context(), crd, apiExtensionClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
@@ -48,7 +48,7 @@ func TestInternalVersionIsHandlerVersion(t *testing.T) {
 	assert.Equal(t, "v1beta2", noxuDefinition.Spec.Versions[1].Name)
 	assert.True(t, noxuDefinition.Spec.Versions[1].Storage)
 
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,7 +143,7 @@ func TestVersionedNamespacedScopedCRD(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewMultipleVersionNoxuCRD(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +160,7 @@ func TestVersionedClusterScopedCRD(t *testing.T) {
 	defer tearDown()
 
 	noxuDefinition := fixtures.NewMultipleVersionNoxuCRD(apiextensionsv1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -217,7 +217,7 @@ func testStoragedVersionInCRDStatus(t *testing.T, ns string, noxuDefinition *api
 	defer tearDown()
 
 	noxuDefinition.Spec.Versions = versionsV1Beta1Storage
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -245,7 +245,7 @@ func testStoragedVersionInCRDStatus(t *testing.T, ns string, noxuDefinition *api
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
-	err = fixtures.DeleteV1CustomResourceDefinition(crd, apiExtensionClient)
+	err = fixtures.DeleteV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/yaml_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/yaml_test.go
@@ -52,7 +52,7 @@ func TestYAML(t *testing.T) {
 	}
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -371,7 +371,7 @@ func TestYAMLSubresource(t *testing.T) {
 	}
 
 	noxuDefinition := NewNoxuSubresourcesCRDs(apiextensionsv1.ClusterScoped)[0]
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/yaml_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/yaml_test.go
@@ -52,7 +52,7 @@ func TestYAML(t *testing.T) {
 	}
 
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -371,7 +371,7 @@ func TestYAMLSubresource(t *testing.T) {
 	}
 
 	noxuDefinition := NewNoxuSubresourcesCRDs(apiextensionsv1.ClusterScoped)[0]
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/apimachinery/aggregated_discovery.go
+++ b/test/e2e/apimachinery/aggregated_discovery.go
@@ -223,10 +223,10 @@ var _ = SIGDescribe("AggregatedDiscovery", func() {
 			},
 		}
 		gvr := schema.GroupVersionResource{Group: crd.Spec.Group, Version: crd.Spec.Versions[0].Name, Resource: resourceName + "s"}
-		_, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+		_, err = fixtures.CreateNewV1CustomResourceDefinition(ctx, crd, apiExtensionClient, dynamicClient)
 		framework.ExpectNoError(err)
 		defer func() {
-			_ = fixtures.DeleteV1CustomResourceDefinition(crd, apiExtensionClient)
+			_ = fixtures.DeleteV1CustomResourceDefinition(ctx, crd, apiExtensionClient)
 		}()
 
 		err = wait.PollUntilContextTimeout(context.Background(), time.Second*1, wait.ForeverTestTimeout, true, func(context.Context) (bool, error) {
@@ -332,10 +332,10 @@ var _ = SIGDescribe("AggregatedDiscovery", func() {
 			},
 		}
 		gvr := schema.GroupVersionResource{Group: crd.Spec.Group, Version: crd.Spec.Versions[0].Name, Resource: resourceName + "s"}
-		_, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+		_, err = fixtures.CreateNewV1CustomResourceDefinition(ctx, crd, apiExtensionClient, dynamicClient)
 		framework.ExpectNoError(err)
 		defer func() {
-			_ = fixtures.DeleteV1CustomResourceDefinition(crd, apiExtensionClient)
+			_ = fixtures.DeleteV1CustomResourceDefinition(ctx, crd, apiExtensionClient)
 		}()
 
 		d := f.ClientSet.Discovery()

--- a/test/e2e/apimachinery/apply.go
+++ b/test/e2e/apimachinery/apply.go
@@ -641,13 +641,13 @@ var _ = SIGDescribe("ServerSideApply", func() {
 			noxuDefinition.Spec.Versions[i].Schema = &c
 		}
 
-		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(ctx, noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			framework.Failf("cannot create crd %s", err)
 		}
 
 		defer func() {
-			err = fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient)
+			err = fixtures.DeleteV1CustomResourceDefinition(ctx, noxuDefinition, apiExtensionClient)
 			framework.ExpectNoError(err, "deleting CustomResourceDefinition")
 		}()
 
@@ -903,13 +903,13 @@ spec:
 			crd.Spec.Versions[i].Schema = &c
 		}
 
-		crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+		crd, err = fixtures.CreateNewV1CustomResourceDefinition(ctx, crd, apiExtensionClient, dynamicClient)
 		if err != nil {
 			framework.Failf("cannot create crd %s", err)
 		}
 
 		defer func() {
-			err = fixtures.DeleteV1CustomResourceDefinition(crd, apiExtensionClient)
+			err = fixtures.DeleteV1CustomResourceDefinition(ctx, crd, apiExtensionClient)
 			framework.ExpectNoError(err, "deleting CustomResourceDefinition")
 		}()
 

--- a/test/e2e/apimachinery/crd_validation_rules.go
+++ b/test/e2e/apimachinery/crd_validation_rules.go
@@ -99,10 +99,10 @@ var _ = SIGDescribe("CustomResourceValidationRules [Privileged:ClusterAdmin]", f
 	ginkgo.It("MUST NOT fail validation for create of a custom resource that satisfies the x-kubernetes-validations rules", func(ctx context.Context) {
 		ginkgo.By("Creating a custom resource definition with validation rules")
 		crd := fixtures.NewRandomNameV1CustomResourceDefinitionWithSchema(v1.NamespaceScoped, schemaWithValidationExpression, false)
-		crd, err := fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(crd, apiExtensionClient)
+		crd, err := fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(ctx, crd, apiExtensionClient)
 		framework.ExpectNoError(err, "creating CustomResourceDefinition")
 		defer func() {
-			err = fixtures.DeleteV1CustomResourceDefinition(crd, apiExtensionClient)
+			err = fixtures.DeleteV1CustomResourceDefinition(ctx, crd, apiExtensionClient)
 			framework.ExpectNoError(err, "deleting CustomResourceDefinition")
 		}()
 
@@ -129,10 +129,10 @@ var _ = SIGDescribe("CustomResourceValidationRules [Privileged:ClusterAdmin]", f
 	ginkgo.It("MUST fail validation for create of a custom resource that does not satisfy the x-kubernetes-validations rules", func(ctx context.Context) {
 		ginkgo.By("Creating a custom resource definition with validation rules")
 		crd := fixtures.NewRandomNameV1CustomResourceDefinitionWithSchema(v1.NamespaceScoped, schemaWithValidationExpression, false)
-		crd, err := fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(crd, apiExtensionClient)
+		crd, err := fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(ctx, crd, apiExtensionClient)
 		framework.ExpectNoError(err, "creating CustomResourceDefinition")
 		defer func() {
-			err = fixtures.DeleteV1CustomResourceDefinition(crd, apiExtensionClient)
+			err = fixtures.DeleteV1CustomResourceDefinition(ctx, crd, apiExtensionClient)
 			framework.ExpectNoError(err, "deleting CustomResourceDefinition")
 		}()
 
@@ -175,7 +175,7 @@ var _ = SIGDescribe("CustomResourceValidationRules [Privileged:ClusterAdmin]", f
 		   }
 		}`))
 		crd := fixtures.NewRandomNameV1CustomResourceDefinitionWithSchema(v1.NamespaceScoped, schemaWithInvalidValidationRule, false)
-		_, err := fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(crd, apiExtensionClient)
+		_, err := fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(ctx, crd, apiExtensionClient)
 		gomega.Expect(err).To(gomega.HaveOccurred(), "creating CustomResourceDefinition with a validation rule that refers to a property that do not exist")
 		expectedErrMsg := "undefined field 'z'"
 		if !strings.Contains(err.Error(), expectedErrMsg) {
@@ -197,7 +197,7 @@ var _ = SIGDescribe("CustomResourceValidationRules [Privileged:ClusterAdmin]", f
 			}
 		}`))
 		crd := fixtures.NewRandomNameV1CustomResourceDefinitionWithSchema(v1.NamespaceScoped, schemaWithSyntaxErrorRule, false)
-		_, err := fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(crd, apiExtensionClient)
+		_, err := fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(ctx, crd, apiExtensionClient)
 		gomega.Expect(err).To(gomega.HaveOccurred(), "creating a CustomResourceDefinition with a validation rule that contains a syntax error")
 		expectedErrMsg := "Syntax error"
 		if !strings.Contains(err.Error(), expectedErrMsg) {
@@ -230,7 +230,7 @@ var _ = SIGDescribe("CustomResourceValidationRules [Privileged:ClusterAdmin]", f
 		    }
 		}`))
 		crd := fixtures.NewRandomNameV1CustomResourceDefinitionWithSchema(v1.NamespaceScoped, schemaWithExpensiveRule, false)
-		_, err := fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(crd, apiExtensionClient)
+		_, err := fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(ctx, crd, apiExtensionClient)
 		gomega.Expect(err).To(gomega.HaveOccurred(), "creating a CustomResourceDefinition with a validation rule that exceeds the cost limit")
 		expectedErrMsg := "exceeds budget"
 		if !strings.Contains(err.Error(), expectedErrMsg) {
@@ -241,10 +241,10 @@ var _ = SIGDescribe("CustomResourceValidationRules [Privileged:ClusterAdmin]", f
 	ginkgo.It("MUST fail create of a custom resource that exceeds the runtime cost limit for x-kubernetes-validations rule execution", func(ctx context.Context) {
 		ginkgo.By("Defining a custom resource definition including an expensive rule on a large amount of data")
 		crd := fixtures.NewRandomNameV1CustomResourceDefinitionWithSchema(v1.NamespaceScoped, schemaWithValidationExpression, false)
-		_, err := fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(crd, apiExtensionClient)
+		_, err := fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(ctx, crd, apiExtensionClient)
 		framework.ExpectNoError(err, "creating CustomResourceDefinition including an expensive rule on a large amount of data")
 		defer func() {
-			err = fixtures.DeleteV1CustomResourceDefinition(crd, apiExtensionClient)
+			err = fixtures.DeleteV1CustomResourceDefinition(ctx, crd, apiExtensionClient)
 			framework.ExpectNoError(err, "deleting CustomResourceDefinition")
 		}()
 		ginkgo.By("Attempting to create a custom resource that will exceed the runtime cost limit")
@@ -287,10 +287,10 @@ var _ = SIGDescribe("CustomResourceValidationRules [Privileged:ClusterAdmin]", f
 			  }
 		}`))
 		crd := fixtures.NewRandomNameV1CustomResourceDefinitionWithSchema(v1.NamespaceScoped, schemaWithTransitionRule, false)
-		_, err := fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(crd, apiExtensionClient)
+		_, err := fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(ctx, crd, apiExtensionClient)
 		framework.ExpectNoError(err, "creating CustomResourceDefinition including an x-kubernetes-validations transition rule")
 		defer func() {
-			err = fixtures.DeleteV1CustomResourceDefinition(crd, apiExtensionClient)
+			err = fixtures.DeleteV1CustomResourceDefinition(ctx, crd, apiExtensionClient)
 			framework.ExpectNoError(err, "deleting CustomResourceDefinition")
 		}()
 		ginkgo.By("Attempting to create a custom resource")

--- a/test/e2e/apimachinery/crd_watch.go
+++ b/test/e2e/apimachinery/crd_watch.go
@@ -67,13 +67,13 @@ var _ = SIGDescribe("CustomResourceDefinition Watch [Privileged:ClusterAdmin]", 
 			}
 
 			noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
-			noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, f.DynamicClient)
+			noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(ctx, noxuDefinition, apiExtensionClient, f.DynamicClient)
 			if err != nil {
 				framework.Failf("failed to create CustomResourceDefinition: %v", err)
 			}
 
 			defer func() {
-				err = fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient)
+				err = fixtures.DeleteV1CustomResourceDefinition(ctx, noxuDefinition, apiExtensionClient)
 				if err != nil {
 					framework.Failf("failed to delete CustomResourceDefinition: %v", err)
 				}

--- a/test/e2e/apimachinery/custom_resource_definition.go
+++ b/test/e2e/apimachinery/custom_resource_definition.go
@@ -68,11 +68,11 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 			randomDefinition := fixtures.NewRandomNameV1CustomResourceDefinition(v1.ClusterScoped)
 
 			// Create CRD and waits for the resource to be recognized and available.
-			randomDefinition, err = fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(randomDefinition, apiExtensionClient)
+			randomDefinition, err = fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(ctx, randomDefinition, apiExtensionClient)
 			framework.ExpectNoError(err, "creating CustomResourceDefinition")
 
 			defer func() {
-				err = fixtures.DeleteV1CustomResourceDefinition(randomDefinition, apiExtensionClient)
+				err = fixtures.DeleteV1CustomResourceDefinition(ctx, randomDefinition, apiExtensionClient)
 				framework.ExpectNoError(err, "deleting CustomResourceDefinition")
 			}()
 		})
@@ -100,17 +100,17 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 			for i := range testListSize {
 				crd := fixtures.NewRandomNameV1CustomResourceDefinition(v1.ClusterScoped)
 				crd.Labels = map[string]string{"e2e-list-test-uuid": testUUID}
-				crd, err = fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(crd, apiExtensionClient)
+				crd, err = fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(ctx, crd, apiExtensionClient)
 				framework.ExpectNoError(err, "creating CustomResourceDefinition")
 				crds[i] = crd
 			}
 
 			// Create a crd w/o the label to ensure the label selector matching works correctly
 			crd := fixtures.NewRandomNameV1CustomResourceDefinition(v1.ClusterScoped)
-			crd, err = fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(crd, apiExtensionClient)
+			crd, err = fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(ctx, crd, apiExtensionClient)
 			framework.ExpectNoError(err, "creating CustomResourceDefinition")
 			defer func() {
-				err = fixtures.DeleteV1CustomResourceDefinition(crd, apiExtensionClient)
+				err = fixtures.DeleteV1CustomResourceDefinition(ctx, crd, apiExtensionClient)
 				framework.ExpectNoError(err, "deleting CustomResourceDefinition")
 			}()
 
@@ -133,7 +133,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 			}
 
 			// Use delete collection to remove the CRDs
-			err = fixtures.DeleteV1CustomResourceDefinitions(selectorListOpts, apiExtensionClient)
+			err = fixtures.DeleteV1CustomResourceDefinitions(ctx, selectorListOpts, apiExtensionClient)
 			framework.ExpectNoError(err, "deleting CustomResourceDefinitions")
 			_, err = apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crd.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err, "getting remaining CustomResourceDefinition")
@@ -157,10 +157,10 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 
 			// Create CRD and waits for the resource to be recognized and available.
 			crd := fixtures.NewRandomNameV1CustomResourceDefinition(v1.ClusterScoped)
-			crd, err = fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(crd, apiExtensionClient)
+			crd, err = fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(ctx, crd, apiExtensionClient)
 			framework.ExpectNoError(err, "creating CustomResourceDefinition")
 			defer func() {
-				err = fixtures.DeleteV1CustomResourceDefinition(crd, apiExtensionClient)
+				err = fixtures.DeleteV1CustomResourceDefinition(ctx, crd, apiExtensionClient)
 				framework.ExpectNoError(err, "deleting CustomResourceDefinition")
 			}()
 
@@ -284,10 +284,10 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 		}
 		crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["a"] = v1.JSONSchemaProps{Type: "string"}
 		crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["b"] = v1.JSONSchemaProps{Type: "string"}
-		crd, err = fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(crd, apiExtensionClient)
+		crd, err = fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(ctx, crd, apiExtensionClient)
 		framework.ExpectNoError(err, "creating CustomResourceDefinition")
 		defer func() {
-			err = fixtures.DeleteV1CustomResourceDefinition(crd, apiExtensionClient)
+			err = fixtures.DeleteV1CustomResourceDefinition(ctx, crd, apiExtensionClient)
 			framework.ExpectNoError(err, "deleting CustomResourceDefinition")
 		}()
 

--- a/test/e2e/apimachinery/field_validation.go
+++ b/test/e2e/apimachinery/field_validation.go
@@ -240,13 +240,13 @@ var _ = SIGDescribe("FieldValidation", func() {
 			noxuDefinition.Spec.Versions[i].Schema = &c
 		}
 
-		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(ctx, noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			framework.Failf("cannot create crd %s", err)
 		}
 
 		defer func() {
-			err = fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient)
+			err = fixtures.DeleteV1CustomResourceDefinition(ctx, noxuDefinition, apiExtensionClient)
 			framework.ExpectNoError(err, "deleting CustomResourceDefinition")
 		}()
 
@@ -300,13 +300,13 @@ spec:
 
 		noxuDefinition := fixtures.NewRandomNameMultipleVersionCustomResourceDefinition(apiextensionsv1.ClusterScoped)
 
-		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(ctx, noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			framework.Failf("cannot create crd %s", err)
 		}
 
 		defer func() {
-			err = fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient)
+			err = fixtures.DeleteV1CustomResourceDefinition(ctx, noxuDefinition, apiExtensionClient)
 			framework.ExpectNoError(err, "deleting CustomResourceDefinition")
 		}()
 
@@ -423,13 +423,13 @@ spec:
 			noxuDefinition.Spec.Versions[i].Schema = &c
 		}
 
-		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(ctx, noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			framework.Failf("cannot create crd %s", err)
 		}
 
 		defer func() {
-			err = fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient)
+			err = fixtures.DeleteV1CustomResourceDefinition(ctx, noxuDefinition, apiExtensionClient)
 			framework.ExpectNoError(err, "deleting CustomResourceDefinition")
 		}()
 
@@ -565,13 +565,13 @@ spec:
 			noxuDefinition.Spec.Versions[i].Schema = &c
 		}
 
-		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(ctx, noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			framework.Failf("cannot create crd %s", err)
 		}
 
 		defer func() {
-			err = fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient)
+			err = fixtures.DeleteV1CustomResourceDefinition(ctx, noxuDefinition, apiExtensionClient)
 			framework.ExpectNoError(err, "deleting CustomResourceDefinition")
 		}()
 
@@ -695,13 +695,13 @@ spec:
 			noxuDefinition.Spec.Versions[i].Schema = &c
 		}
 
-		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+		noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(ctx, noxuDefinition, apiExtensionClient, dynamicClient)
 		if err != nil {
 			framework.Failf("cannot create crd %s", err)
 		}
 
 		defer func() {
-			err = fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient)
+			err = fixtures.DeleteV1CustomResourceDefinition(ctx, noxuDefinition, apiExtensionClient)
 			framework.ExpectNoError(err, "deleting CustomResourceDefinition")
 		}()
 

--- a/test/e2e/apimachinery/garbage_collector.go
+++ b/test/e2e/apimachinery/garbage_collector.go
@@ -894,12 +894,12 @@ var _ = SIGDescribe("Garbage collector", func() {
 		// use.
 		definition := apiextensionstestserver.NewRandomNameV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
 		defer func() {
-			err = apiextensionstestserver.DeleteV1CustomResourceDefinition(definition, apiExtensionClient)
+			err = apiextensionstestserver.DeleteV1CustomResourceDefinition(ctx, definition, apiExtensionClient)
 			if err != nil && !apierrors.IsNotFound(err) {
 				framework.Failf("failed to delete CustomResourceDefinition: %v", err)
 			}
 		}()
-		definition, err = apiextensionstestserver.CreateNewV1CustomResourceDefinition(definition, apiExtensionClient, f.DynamicClient)
+		definition, err = apiextensionstestserver.CreateNewV1CustomResourceDefinition(ctx, definition, apiExtensionClient, f.DynamicClient)
 		if err != nil {
 			framework.Failf("failed to create CustomResourceDefinition: %v", err)
 		}
@@ -1029,12 +1029,12 @@ var _ = SIGDescribe("Garbage collector", func() {
 		// use.
 		definition := apiextensionstestserver.NewRandomNameV1CustomResourceDefinition(apiextensionsv1.ClusterScoped)
 		defer func() {
-			err = apiextensionstestserver.DeleteV1CustomResourceDefinition(definition, apiExtensionClient)
+			err = apiextensionstestserver.DeleteV1CustomResourceDefinition(ctx, definition, apiExtensionClient)
 			if err != nil && !apierrors.IsNotFound(err) {
 				framework.Failf("failed to delete CustomResourceDefinition: %v", err)
 			}
 		}()
-		definition, err = apiextensionstestserver.CreateNewV1CustomResourceDefinition(definition, apiExtensionClient, f.DynamicClient)
+		definition, err = apiextensionstestserver.CreateNewV1CustomResourceDefinition(ctx, definition, apiExtensionClient, f.DynamicClient)
 		if err != nil {
 			framework.Failf("failed to create CustomResourceDefinition: %v", err)
 		}

--- a/test/e2e/apimachinery/openapiv3.go
+++ b/test/e2e/apimachinery/openapiv3.go
@@ -122,9 +122,9 @@ var _ = SIGDescribe("OpenAPIV3", func() {
 			},
 		}
 		gv := schema.GroupVersion{Group: crd.Spec.Group, Version: crd.Spec.Versions[0].Name}
-		_, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+		_, err = fixtures.CreateNewV1CustomResourceDefinition(ctx, crd, apiExtensionClient, dynamicClient)
 		defer func() {
-			_ = fixtures.DeleteV1CustomResourceDefinition(crd, apiExtensionClient)
+			_ = fixtures.DeleteV1CustomResourceDefinition(ctx, crd, apiExtensionClient)
 		}()
 
 		framework.ExpectNoError(err)
@@ -150,7 +150,7 @@ var _ = SIGDescribe("OpenAPIV3", func() {
 			framework.Failf("%s", diff)
 		}
 
-		err = fixtures.DeleteV1CustomResourceDefinition(crd, apiExtensionClient)
+		err = fixtures.DeleteV1CustomResourceDefinition(ctx, crd, apiExtensionClient)
 		framework.ExpectNoError(err, "deleting CustomResourceDefinition")
 		// Poll for the OpenAPI to be updated with the deleted CRD
 		err = wait.PollUntilContextTimeout(ctx, time.Second*1, wait.ForeverTestTimeout, true, func(_ context.Context) (bool, error) {

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -973,7 +973,7 @@ func TestMetadataClient(t *testing.T) {
 			},
 		},
 	}
-	fooCRD, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), fooCRD, apiExtensionClient, dynamicClient)
+	fooCRD, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), fooCRD, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1305,7 +1305,7 @@ func TestAPICRDProtobuf(t *testing.T) {
 			},
 		},
 	}
-	fooCRD, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), fooCRD, apiExtensionClient, dynamicClient)
+	fooCRD, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), fooCRD, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1551,7 +1551,7 @@ func TestGetSubresourcesAsTables(t *testing.T) {
 		},
 	}
 
-	fooWithSubresourceCRD, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), fooWithSubresourceCRD, apiExtensionClient, dynamicClient)
+	fooWithSubresourceCRD, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), fooWithSubresourceCRD, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1944,7 +1944,7 @@ func TestTransform(t *testing.T) {
 			},
 		},
 	}
-	fooCRD, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), fooCRD, apiExtensionClient, dynamicClient)
+	fooCRD, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), fooCRD, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -973,7 +973,7 @@ func TestMetadataClient(t *testing.T) {
 			},
 		},
 	}
-	fooCRD, err = fixtures.CreateNewV1CustomResourceDefinition(fooCRD, apiExtensionClient, dynamicClient)
+	fooCRD, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), fooCRD, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1305,7 +1305,7 @@ func TestAPICRDProtobuf(t *testing.T) {
 			},
 		},
 	}
-	fooCRD, err = fixtures.CreateNewV1CustomResourceDefinition(fooCRD, apiExtensionClient, dynamicClient)
+	fooCRD, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), fooCRD, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1551,7 +1551,7 @@ func TestGetSubresourcesAsTables(t *testing.T) {
 		},
 	}
 
-	fooWithSubresourceCRD, err = fixtures.CreateNewV1CustomResourceDefinition(fooWithSubresourceCRD, apiExtensionClient, dynamicClient)
+	fooWithSubresourceCRD, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), fooWithSubresourceCRD, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1944,7 +1944,7 @@ func TestTransform(t *testing.T) {
 			},
 		},
 	}
-	fooCRD, err = fixtures.CreateNewV1CustomResourceDefinition(fooCRD, apiExtensionClient, dynamicClient)
+	fooCRD, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), fooCRD, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/apply/apply_crd_beta_test.go
+++ b/test/integration/apiserver/apply/apply_crd_beta_test.go
@@ -55,7 +55,7 @@ func TestApplyCRDNoSchema(t *testing.T) {
 
 	noxuBetaDefinition := nearlyRemovedBetaMultipleVersionNoxuCRD(apiextensionsv1beta1.ClusterScoped)
 
-	noxuDefinition, err := fixtures.CreateCRDUsingRemovedAPI(server.EtcdClient, server.EtcdStoragePrefix, noxuBetaDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err := fixtures.CreateCRDUsingRemovedAPI(context.TODO(), server.EtcdClient, server.EtcdStoragePrefix, noxuBetaDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/apply/apply_crd_beta_test.go
+++ b/test/integration/apiserver/apply/apply_crd_beta_test.go
@@ -55,7 +55,7 @@ func TestApplyCRDNoSchema(t *testing.T) {
 
 	noxuBetaDefinition := nearlyRemovedBetaMultipleVersionNoxuCRD(apiextensionsv1beta1.ClusterScoped)
 
-	noxuDefinition, err := fixtures.CreateCRDUsingRemovedAPI(context.TODO(), server.EtcdClient, server.EtcdStoragePrefix, noxuBetaDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err := fixtures.CreateCRDUsingRemovedAPI(t.Context(), server.EtcdClient, server.EtcdStoragePrefix, noxuBetaDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/apply/apply_crd_test.go
+++ b/test/integration/apiserver/apply/apply_crd_test.go
@@ -124,7 +124,7 @@ func TestApplyCRDStructuralSchema(t *testing.T) {
 		noxuDefinition.Spec.Versions[i].Schema = &c
 	}
 
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -649,7 +649,7 @@ func TestDefaultMissingKeyCRD(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -757,7 +757,7 @@ func TestNoOpApplyWithDefaultsSameResourceVersionCRD(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/apply/apply_crd_test.go
+++ b/test/integration/apiserver/apply/apply_crd_test.go
@@ -124,7 +124,7 @@ func TestApplyCRDStructuralSchema(t *testing.T) {
 		noxuDefinition.Spec.Versions[i].Schema = &c
 	}
 
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -649,7 +649,7 @@ func TestDefaultMissingKeyCRD(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -757,7 +757,7 @@ func TestNoOpApplyWithDefaultsSameResourceVersionCRD(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/apply/reset_fields_test.go
+++ b/test/integration/apiserver/apply/reset_fields_test.go
@@ -662,7 +662,7 @@ func TestUpdateStatusWithOldVersion(t *testing.T) {
 
 	noxuBetaDefinition := nearlyRemovedBetaMultipleVersionNoxuCRDWithStatus(apiextensionsv1beta1.NamespaceScoped)
 
-	noxuDefinition, err := fixtures.CreateCRDUsingRemovedAPI(context.TODO(), server.EtcdClient, server.EtcdStoragePrefix, noxuBetaDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err := fixtures.CreateCRDUsingRemovedAPI(t.Context(), server.EtcdClient, server.EtcdStoragePrefix, noxuBetaDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/apply/reset_fields_test.go
+++ b/test/integration/apiserver/apply/reset_fields_test.go
@@ -662,7 +662,7 @@ func TestUpdateStatusWithOldVersion(t *testing.T) {
 
 	noxuBetaDefinition := nearlyRemovedBetaMultipleVersionNoxuCRDWithStatus(apiextensionsv1beta1.NamespaceScoped)
 
-	noxuDefinition, err := fixtures.CreateCRDUsingRemovedAPI(server.EtcdClient, server.EtcdStoragePrefix, noxuBetaDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err := fixtures.CreateCRDUsingRemovedAPI(context.TODO(), server.EtcdClient, server.EtcdStoragePrefix, noxuBetaDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/crd_validation_expressions_test.go
+++ b/test/integration/apiserver/crd_validation_expressions_test.go
@@ -57,7 +57,7 @@ func TestCustomResourceValidators(t *testing.T) {
 
 	t.Run("Structural schema", func(t *testing.T) {
 		structuralWithValidators := crdWithSchema(t, "Structural", structuralSchemaWithValidators)
-		crd, err := fixtures.CreateNewV1CustomResourceDefinition(structuralWithValidators, apiExtensionClient, dynamicClient)
+		crd, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), structuralWithValidators, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -215,7 +215,7 @@ func TestCustomResourceValidators(t *testing.T) {
 	})
 	t.Run("CRD writes MUST fail for a non-structural schema containing x-kubernetes-validations", func(t *testing.T) {
 		// The only way for a non-structural schema to exist is for it to already be persisted in etcd as a non-structural CRD.
-		nonStructuralCRD, err := fixtures.CreateCRDUsingRemovedAPI(server.EtcdClient, server.EtcdStoragePrefix, nonStructuralCrdWithValidations(), apiExtensionClient, dynamicClient)
+		nonStructuralCRD, err := fixtures.CreateCRDUsingRemovedAPI(context.TODO(), server.EtcdClient, server.EtcdStoragePrefix, nonStructuralCrdWithValidations(), apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatalf("Unexpected error non-structural CRD by writing directly to etcd: %v", err)
 		}
@@ -247,7 +247,7 @@ func TestCustomResourceValidators(t *testing.T) {
 	})
 	t.Run("CRD creation MUST fail if a x-kubernetes-validations rule accesses a metadata field other than name", func(t *testing.T) {
 		structuralWithValidators := crdWithSchema(t, "InvalidStructuralMetadata", structuralSchemaWithInvalidMetadataValidators)
-		_, err := fixtures.CreateNewV1CustomResourceDefinition(structuralWithValidators, apiExtensionClient, dynamicClient)
+		_, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), structuralWithValidators, apiExtensionClient, dynamicClient)
 		if err == nil {
 			t.Error("Expected error creating custom resource but got none")
 		} else if !strings.Contains(err.Error(), "undefined field 'labels'") {
@@ -256,21 +256,21 @@ func TestCustomResourceValidators(t *testing.T) {
 	})
 	t.Run("CRD creation MUST pass if a x-kubernetes-validations rule accesses metadata.name", func(t *testing.T) {
 		structuralWithValidators := crdWithSchema(t, "ValidStructuralMetadata", structuralSchemaWithValidMetadataValidators)
-		_, err := fixtures.CreateNewV1CustomResourceDefinition(structuralWithValidators, apiExtensionClient, dynamicClient)
+		_, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), structuralWithValidators, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Error("Unexpected error creating custom resource but metadata validation rule")
 		}
 	})
 	t.Run("CRD creation MUST pass for an CRD with empty field", func(t *testing.T) {
 		structuralWithValidators := crdWithSchema(t, "WithEmptyObject", structuralSchemaWithEmptyObject)
-		_, err := fixtures.CreateNewV1CustomResourceDefinition(structuralWithValidators, apiExtensionClient, dynamicClient)
+		_, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), structuralWithValidators, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Errorf("unexpected error creating CRD with empty field: %v", err)
 		}
 	})
 	t.Run("CR creation MUST fail if a x-kubernetes-validations rule exceeds the runtime cost limit", func(t *testing.T) {
 		structuralWithValidators := crdWithSchema(t, "RuntimeCostLimit", structuralSchemaWithCostLimit)
-		crd, err := fixtures.CreateNewV1CustomResourceDefinition(structuralWithValidators, apiExtensionClient, dynamicClient)
+		crd, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), structuralWithValidators, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Errorf("Unexpected error creating custom resource definition: %v", err)
 		}
@@ -300,7 +300,7 @@ func TestCustomResourceValidators(t *testing.T) {
 	})
 	t.Run("Schema with valid transition rule", func(t *testing.T) {
 		structuralWithValidators := crdWithSchema(t, "ValidTransitionRule", structuralSchemaWithValidTransitionRule)
-		crd, err := fixtures.CreateNewV1CustomResourceDefinition(structuralWithValidators, apiExtensionClient, dynamicClient)
+		crd, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), structuralWithValidators, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -363,7 +363,7 @@ func TestCustomResourceValidators(t *testing.T) {
 
 	t.Run("CRD creation MUST fail if a x-kubernetes-validations rule contains invalid transition rule", func(t *testing.T) {
 		structuralWithValidators := crdWithSchema(t, "InvalidTransitionRule", structuralSchemaWithInvalidTransitionRule)
-		_, err := fixtures.CreateNewV1CustomResourceDefinition(structuralWithValidators, apiExtensionClient, dynamicClient)
+		_, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), structuralWithValidators, apiExtensionClient, dynamicClient)
 		if err == nil {
 			t.Error("Expected error creating custom resource but got none")
 		} else if !strings.Contains(err.Error(), "oldSelf cannot be used on the uncorrelatable portion of the schema") {
@@ -372,7 +372,7 @@ func TestCustomResourceValidators(t *testing.T) {
 	})
 	t.Run("Schema with default map key transition rule", func(t *testing.T) {
 		structuralWithValidators := crdWithSchema(t, "DefaultMapKeyTransitionRule", structuralSchemaWithDefaultMapKeyTransitionRule)
-		crd, err := fixtures.CreateNewV1CustomResourceDefinition(structuralWithValidators, apiExtensionClient, dynamicClient)
+		crd, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), structuralWithValidators, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -438,7 +438,7 @@ func TestCustomResourceValidatorsWithBlockingErrors(t *testing.T) {
 
 	t.Run("Structural schema", func(t *testing.T) {
 		structuralWithValidators := crdWithSchema(t, "Structural", structuralSchemaWithBlockingErr)
-		crd, err := fixtures.CreateNewV1CustomResourceDefinition(structuralWithValidators, apiExtensionClient, dynamicClient)
+		crd, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), structuralWithValidators, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -670,7 +670,7 @@ func TestCustomResourceValidatorsWithSchemaConversion(t *testing.T) {
 
 	// Create CRD with normal items+array schema
 	structuralWithValidators := crdWithSchema(t, "Structural", structuralSchemaWithItemsUnderArray)
-	crd, err := fixtures.CreateNewV1CustomResourceDefinition(structuralWithValidators, apiExtensionClient, dynamicClient)
+	crd, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), structuralWithValidators, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -741,7 +741,7 @@ func TestCustomResourceValidatorsWithSchemaConversion(t *testing.T) {
 		t.Fatalf("expect error to contain \"Invalid value: \"array\": spec.backend in body must be of type object: \"array\"\" but get: %v", err)
 	}
 	// Delete the CRD
-	err = fixtures.DeleteV1CustomResourceDefinition(structuralWithValidators, apiExtensionClient)
+	err = fixtures.DeleteV1CustomResourceDefinition(context.TODO(), structuralWithValidators, apiExtensionClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/crd_validation_expressions_test.go
+++ b/test/integration/apiserver/crd_validation_expressions_test.go
@@ -57,7 +57,7 @@ func TestCustomResourceValidators(t *testing.T) {
 
 	t.Run("Structural schema", func(t *testing.T) {
 		structuralWithValidators := crdWithSchema(t, "Structural", structuralSchemaWithValidators)
-		crd, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), structuralWithValidators, apiExtensionClient, dynamicClient)
+		crd, err := fixtures.CreateNewV1CustomResourceDefinition(t.Context(), structuralWithValidators, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -215,7 +215,7 @@ func TestCustomResourceValidators(t *testing.T) {
 	})
 	t.Run("CRD writes MUST fail for a non-structural schema containing x-kubernetes-validations", func(t *testing.T) {
 		// The only way for a non-structural schema to exist is for it to already be persisted in etcd as a non-structural CRD.
-		nonStructuralCRD, err := fixtures.CreateCRDUsingRemovedAPI(context.TODO(), server.EtcdClient, server.EtcdStoragePrefix, nonStructuralCrdWithValidations(), apiExtensionClient, dynamicClient)
+		nonStructuralCRD, err := fixtures.CreateCRDUsingRemovedAPI(t.Context(), server.EtcdClient, server.EtcdStoragePrefix, nonStructuralCrdWithValidations(), apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatalf("Unexpected error non-structural CRD by writing directly to etcd: %v", err)
 		}
@@ -247,7 +247,7 @@ func TestCustomResourceValidators(t *testing.T) {
 	})
 	t.Run("CRD creation MUST fail if a x-kubernetes-validations rule accesses a metadata field other than name", func(t *testing.T) {
 		structuralWithValidators := crdWithSchema(t, "InvalidStructuralMetadata", structuralSchemaWithInvalidMetadataValidators)
-		_, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), structuralWithValidators, apiExtensionClient, dynamicClient)
+		_, err := fixtures.CreateNewV1CustomResourceDefinition(t.Context(), structuralWithValidators, apiExtensionClient, dynamicClient)
 		if err == nil {
 			t.Error("Expected error creating custom resource but got none")
 		} else if !strings.Contains(err.Error(), "undefined field 'labels'") {
@@ -256,21 +256,21 @@ func TestCustomResourceValidators(t *testing.T) {
 	})
 	t.Run("CRD creation MUST pass if a x-kubernetes-validations rule accesses metadata.name", func(t *testing.T) {
 		structuralWithValidators := crdWithSchema(t, "ValidStructuralMetadata", structuralSchemaWithValidMetadataValidators)
-		_, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), structuralWithValidators, apiExtensionClient, dynamicClient)
+		_, err := fixtures.CreateNewV1CustomResourceDefinition(t.Context(), structuralWithValidators, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Error("Unexpected error creating custom resource but metadata validation rule")
 		}
 	})
 	t.Run("CRD creation MUST pass for an CRD with empty field", func(t *testing.T) {
 		structuralWithValidators := crdWithSchema(t, "WithEmptyObject", structuralSchemaWithEmptyObject)
-		_, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), structuralWithValidators, apiExtensionClient, dynamicClient)
+		_, err := fixtures.CreateNewV1CustomResourceDefinition(t.Context(), structuralWithValidators, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Errorf("unexpected error creating CRD with empty field: %v", err)
 		}
 	})
 	t.Run("CR creation MUST fail if a x-kubernetes-validations rule exceeds the runtime cost limit", func(t *testing.T) {
 		structuralWithValidators := crdWithSchema(t, "RuntimeCostLimit", structuralSchemaWithCostLimit)
-		crd, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), structuralWithValidators, apiExtensionClient, dynamicClient)
+		crd, err := fixtures.CreateNewV1CustomResourceDefinition(t.Context(), structuralWithValidators, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Errorf("Unexpected error creating custom resource definition: %v", err)
 		}
@@ -300,7 +300,7 @@ func TestCustomResourceValidators(t *testing.T) {
 	})
 	t.Run("Schema with valid transition rule", func(t *testing.T) {
 		structuralWithValidators := crdWithSchema(t, "ValidTransitionRule", structuralSchemaWithValidTransitionRule)
-		crd, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), structuralWithValidators, apiExtensionClient, dynamicClient)
+		crd, err := fixtures.CreateNewV1CustomResourceDefinition(t.Context(), structuralWithValidators, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -363,7 +363,7 @@ func TestCustomResourceValidators(t *testing.T) {
 
 	t.Run("CRD creation MUST fail if a x-kubernetes-validations rule contains invalid transition rule", func(t *testing.T) {
 		structuralWithValidators := crdWithSchema(t, "InvalidTransitionRule", structuralSchemaWithInvalidTransitionRule)
-		_, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), structuralWithValidators, apiExtensionClient, dynamicClient)
+		_, err := fixtures.CreateNewV1CustomResourceDefinition(t.Context(), structuralWithValidators, apiExtensionClient, dynamicClient)
 		if err == nil {
 			t.Error("Expected error creating custom resource but got none")
 		} else if !strings.Contains(err.Error(), "oldSelf cannot be used on the uncorrelatable portion of the schema") {
@@ -372,7 +372,7 @@ func TestCustomResourceValidators(t *testing.T) {
 	})
 	t.Run("Schema with default map key transition rule", func(t *testing.T) {
 		structuralWithValidators := crdWithSchema(t, "DefaultMapKeyTransitionRule", structuralSchemaWithDefaultMapKeyTransitionRule)
-		crd, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), structuralWithValidators, apiExtensionClient, dynamicClient)
+		crd, err := fixtures.CreateNewV1CustomResourceDefinition(t.Context(), structuralWithValidators, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -438,7 +438,7 @@ func TestCustomResourceValidatorsWithBlockingErrors(t *testing.T) {
 
 	t.Run("Structural schema", func(t *testing.T) {
 		structuralWithValidators := crdWithSchema(t, "Structural", structuralSchemaWithBlockingErr)
-		crd, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), structuralWithValidators, apiExtensionClient, dynamicClient)
+		crd, err := fixtures.CreateNewV1CustomResourceDefinition(t.Context(), structuralWithValidators, apiExtensionClient, dynamicClient)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -670,7 +670,7 @@ func TestCustomResourceValidatorsWithSchemaConversion(t *testing.T) {
 
 	// Create CRD with normal items+array schema
 	structuralWithValidators := crdWithSchema(t, "Structural", structuralSchemaWithItemsUnderArray)
-	crd, err := fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), structuralWithValidators, apiExtensionClient, dynamicClient)
+	crd, err := fixtures.CreateNewV1CustomResourceDefinition(t.Context(), structuralWithValidators, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -741,7 +741,7 @@ func TestCustomResourceValidatorsWithSchemaConversion(t *testing.T) {
 		t.Fatalf("expect error to contain \"Invalid value: \"array\": spec.backend in body must be of type object: \"array\"\" but get: %v", err)
 	}
 	// Delete the CRD
-	err = fixtures.DeleteV1CustomResourceDefinition(context.TODO(), structuralWithValidators, apiExtensionClient)
+	err = fixtures.DeleteV1CustomResourceDefinition(t.Context(), structuralWithValidators, apiExtensionClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/field_validation_test.go
+++ b/test/integration/apiserver/field_validation_test.go
@@ -3062,7 +3062,7 @@ func setupCRD(t testing.TB, config *rest.Config, apiGroup string, schemaless boo
 		crd.Spec.Versions[i].Schema = &c
 	}
 	// install the CRD
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/field_validation_test.go
+++ b/test/integration/apiserver/field_validation_test.go
@@ -3062,7 +3062,7 @@ func setupCRD(t testing.TB, config *rest.Config, apiGroup string, schemaless boo
 		crd.Spec.Versions[i].Schema = &c
 	}
 	// install the CRD
-	crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	crd, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/openapi/openapi_crd_test.go
+++ b/test/integration/apiserver/openapi/openapi_crd_test.go
@@ -58,7 +58,7 @@ func TestOpenAPICRDGenerationNumber(t *testing.T) {
 
 	// Create a new CRD with group mygroup.example.com
 	crd := fixtures.NewRandomNameV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	_, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
+	_, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/openapi/openapi_crd_test.go
+++ b/test/integration/apiserver/openapi/openapi_crd_test.go
@@ -58,7 +58,7 @@ func TestOpenAPICRDGenerationNumber(t *testing.T) {
 
 	// Create a new CRD with group mygroup.example.com
 	crd := fixtures.NewRandomNameV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	_, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), crd, apiExtensionClient, dynamicClient)
+	_, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), crd, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/openapi/openapi_merge_test.go
+++ b/test/integration/apiserver/openapi/openapi_merge_test.go
@@ -161,12 +161,12 @@ func TestOpenAPIV3MultipleCRDsSameGV(t *testing.T) {
 		},
 	}
 
-	_, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), fooWithSubresourceCRD, apiExtensionClient, dynamicClient)
+	_, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), fooWithSubresourceCRD, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), bazWithSubresourceCRD, apiExtensionClient, dynamicClient)
+	_, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), bazWithSubresourceCRD, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/openapi/openapi_merge_test.go
+++ b/test/integration/apiserver/openapi/openapi_merge_test.go
@@ -161,12 +161,12 @@ func TestOpenAPIV3MultipleCRDsSameGV(t *testing.T) {
 		},
 	}
 
-	_, err = fixtures.CreateNewV1CustomResourceDefinition(fooWithSubresourceCRD, apiExtensionClient, dynamicClient)
+	_, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), fooWithSubresourceCRD, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = fixtures.CreateNewV1CustomResourceDefinition(bazWithSubresourceCRD, apiExtensionClient, dynamicClient)
+	_, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), bazWithSubresourceCRD, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/openapi/openapi_v2_merge_test.go
+++ b/test/integration/apiserver/openapi/openapi_v2_merge_test.go
@@ -158,12 +158,12 @@ func TestOpenAPIV2CRDMergeNoDuplicateTypes(t *testing.T) {
 		},
 	}
 
-	_, err = fixtures.CreateNewV1CustomResourceDefinition(foo, apiExtensionClient, dynamicClient)
+	_, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), foo, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = fixtures.CreateNewV1CustomResourceDefinition(baz, apiExtensionClient, dynamicClient)
+	_, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), baz, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/openapi/openapi_v2_merge_test.go
+++ b/test/integration/apiserver/openapi/openapi_v2_merge_test.go
@@ -158,12 +158,12 @@ func TestOpenAPIV2CRDMergeNoDuplicateTypes(t *testing.T) {
 		},
 	}
 
-	_, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), foo, apiExtensionClient, dynamicClient)
+	_, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), foo, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), baz, apiExtensionClient, dynamicClient)
+	_, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), baz, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/openapi/openapiv3_test.go
+++ b/test/integration/apiserver/openapi/openapiv3_test.go
@@ -119,7 +119,7 @@ func TestAddRemoveGroupVersion(t *testing.T) {
 
 	// Create a new CRD with group mygroup.example.com
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,7 +159,7 @@ func TestAddRemoveGroupVersion(t *testing.T) {
 	}
 
 	// Delete the CRD and ensure that the group/version is also deleted in discovery
-	if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
+	if err := fixtures.DeleteV1CustomResourceDefinition(t.Context(), noxuDefinition, apiExtensionClient); err != nil {
 		t.Fatal(err)
 	}
 	time.Sleep(4 * time.Second)

--- a/test/integration/apiserver/openapi/openapiv3_test.go
+++ b/test/integration/apiserver/openapi/openapiv3_test.go
@@ -119,7 +119,7 @@ func TestAddRemoveGroupVersion(t *testing.T) {
 
 	// Create a new CRD with group mygroup.example.com
 	noxuDefinition := fixtures.NewNoxuV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
-	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
+	noxuDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,7 +159,7 @@ func TestAddRemoveGroupVersion(t *testing.T) {
 	}
 
 	// Delete the CRD and ensure that the group/version is also deleted in discovery
-	if err := fixtures.DeleteV1CustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
+	if err := fixtures.DeleteV1CustomResourceDefinition(context.TODO(), noxuDefinition, apiExtensionClient); err != nil {
 		t.Fatal(err)
 	}
 	time.Sleep(4 * time.Second)

--- a/test/integration/controlplane/crd_test.go
+++ b/test/integration/controlplane/crd_test.go
@@ -234,7 +234,7 @@ func TestCRDOpenAPI(t *testing.T) {
 			},
 		},
 	}
-	nonStructuralCRD, err := fixtures.CreateCRDUsingRemovedAPI(result.EtcdClient, result.EtcdStoragePrefix, nonStructuralBetaCRD, apiextensionsclient, dynamicClient)
+	nonStructuralCRD, err := fixtures.CreateCRDUsingRemovedAPI(context.TODO(), result.EtcdClient, result.EtcdStoragePrefix, nonStructuralBetaCRD, apiextensionsclient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/controlplane/crd_test.go
+++ b/test/integration/controlplane/crd_test.go
@@ -234,7 +234,7 @@ func TestCRDOpenAPI(t *testing.T) {
 			},
 		},
 	}
-	nonStructuralCRD, err := fixtures.CreateCRDUsingRemovedAPI(context.TODO(), result.EtcdClient, result.EtcdStoragePrefix, nonStructuralBetaCRD, apiextensionsclient, dynamicClient)
+	nonStructuralCRD, err := fixtures.CreateCRDUsingRemovedAPI(t.Context(), result.EtcdClient, result.EtcdStoragePrefix, nonStructuralBetaCRD, apiextensionsclient, dynamicClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/garbagecollector/garbage_collector_test.go
+++ b/test/integration/garbagecollector/garbage_collector_test.go
@@ -210,7 +210,7 @@ func createRandomCustomResourceDefinition(
 	// use.
 	definition := apiextensionstestserver.NewRandomNameV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
 
-	definition, err := apiextensionstestserver.CreateNewV1CustomResourceDefinition(context.TODO(), definition, apiExtensionClient, dynamicClient)
+	definition, err := apiextensionstestserver.CreateNewV1CustomResourceDefinition(t.Context(), definition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatalf("failed to create CustomResourceDefinition: %v", err)
 	}
@@ -1258,7 +1258,7 @@ func TestCRDDeletionCascading(t *testing.T) {
 	t.Logf("Second pass CRD cascading deletion")
 	accessor := meta.NewAccessor()
 	accessor.SetResourceVersion(definition, "")
-	_, err := apiextensionstestserver.CreateNewV1CustomResourceDefinition(context.TODO(), definition, apiExtensionClient, dynamicClient)
+	_, err := apiextensionstestserver.CreateNewV1CustomResourceDefinition(t.Context(), definition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatalf("failed to create CustomResourceDefinition: %v", err)
 	}

--- a/test/integration/garbagecollector/garbage_collector_test.go
+++ b/test/integration/garbagecollector/garbage_collector_test.go
@@ -210,7 +210,7 @@ func createRandomCustomResourceDefinition(
 	// use.
 	definition := apiextensionstestserver.NewRandomNameV1CustomResourceDefinition(apiextensionsv1.NamespaceScoped)
 
-	definition, err := apiextensionstestserver.CreateNewV1CustomResourceDefinition(definition, apiExtensionClient, dynamicClient)
+	definition, err := apiextensionstestserver.CreateNewV1CustomResourceDefinition(context.TODO(), definition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatalf("failed to create CustomResourceDefinition: %v", err)
 	}
@@ -1258,7 +1258,7 @@ func TestCRDDeletionCascading(t *testing.T) {
 	t.Logf("Second pass CRD cascading deletion")
 	accessor := meta.NewAccessor()
 	accessor.SetResourceVersion(definition, "")
-	_, err := apiextensionstestserver.CreateNewV1CustomResourceDefinition(definition, apiExtensionClient, dynamicClient)
+	_, err := apiextensionstestserver.CreateNewV1CustomResourceDefinition(context.TODO(), definition, apiExtensionClient, dynamicClient)
 	if err != nil {
 		t.Fatalf("failed to create CustomResourceDefinition: %v", err)
 	}
@@ -1289,7 +1289,7 @@ func testCRDDeletion(t *testing.T, ctx *testContext, ns *v1.Namespace, definitio
 	time.Sleep(ctx.syncPeriod + 5*time.Second)
 
 	// Delete the definition, which should cascade to the owner and ultimately its dependents.
-	if err := apiextensionstestserver.DeleteV1CustomResourceDefinition(definition, apiExtensionClient); err != nil {
+	if err := apiextensionstestserver.DeleteV1CustomResourceDefinition(context.TODO(), definition, apiExtensionClient); err != nil {
 		t.Fatalf("failed to delete %q: %v", definition.Name, err)
 	}
 

--- a/test/utils/crd/crd_util.go
+++ b/test/utils/crd/crd_util.go
@@ -74,7 +74,7 @@ func CreateMultiVersionTestCRD(f *framework.Framework, group string, opts ...Opt
 	var got *apiextensionsv1.CustomResourceDefinition
 	if err := wait.PollUntilContextTimeout(context.TODO(), f.Timeouts.Poll, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 		// Create CRD and waits for the resource to be recognized and available.
-		got, err = fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(crd, apiExtensionClient)
+		got, err = fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(ctx, crd, apiExtensionClient)
 		if err != nil {
 			if apierrors.IsAlreadyExists(err) {
 				// regenerate on conflict
@@ -102,7 +102,7 @@ func CreateMultiVersionTestCRD(f *framework.Framework, group string, opts ...Opt
 	testcrd.Crd = got
 	testcrd.DynamicClients = resourceClients
 	testcrd.CleanUp = func(ctx context.Context) error {
-		err := fixtures.DeleteV1CustomResourceDefinition(got, apiExtensionClient)
+		err := fixtures.DeleteV1CustomResourceDefinition(ctx, got, apiExtensionClient)
 		if err != nil {
 			framework.Failf("failed to delete CustomResourceDefinition(%s): %v", got.Name, err)
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
Emulated the pattern in validatingadmissionpolicy.go and mutatingadmissionpolicy.go instead of the existing hardcoded timeout. This will resort to using Go's standard 10 minute timeout instead, which could potentially cause longer test runs but ultimately better coverage.

#### Which issue(s) this PR is related to:
Issue #138085

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
