### PR TITLE
fix inconsistent naming in logparse regex groups

### DIFF
--- a/cmd/prune-junit-xml/logparse/logparse.go
+++ b/cmd/prune-junit-xml/logparse/logparse.go
@@ -39,7 +39,7 @@ limitations under the License.
 //	  PASS
 //	  ok  	k8s.io/klog/v2/ktesting/example	(cached)
 //
-// Arbitrary indention with space or tab is supported. All lines of
+// Arbitrary indentation with space or tab is supported. All lines of
 // a klog log entry must be indented the same way.
 package logparse
 
@@ -174,14 +174,14 @@ const (
 )
 
 var (
-	klogPrefix = regexp.MustCompile(`^(?<indention>[[:blank:]]*)` +
+	klogPrefix = regexp.MustCompile(`^(?<indentation>[[:blank:]]*)` +
 		`(?:` + source + `: )?` + // `go test` source code
 		severity +
 		datetime +
 		`(?: +` + pid + ` ` + source + `)?` + // klog pid + source code
 		`\] `)
 
-	indentionIndex = lookupSubmatch("indention")
+	indentationIndex = lookupSubmatch("indentation")
 	severityIndex  = lookupSubmatch("severity")
 )
 
@@ -215,13 +215,13 @@ func parseLine(reader *bufio.Reader, line string, yield func(Entry) bool) (strin
 	if !strings.HasSuffix(line, "=<\n") {
 		return "", yield(e), nil
 	}
-	indention := line[match[2*indentionIndex]:match[2*indentionIndex+1]]
+	indentation := line[match[2*indentationIndex]:match[2*indentationIndex+1]]
 	for {
 		var err error
 		line, err = reader.ReadString('\n')
-		if !strings.HasPrefix(line, indention) ||
-			!strings.HasPrefix(line[len(indention):], "\t") && !strings.HasPrefix(line[len(indention):], " >") {
-			// Some other line (wrong indention or wrong continuation).
+		if !strings.HasPrefix(line, indentation) ||
+			!strings.HasPrefix(line[len(indentation):], "\t") && !strings.HasPrefix(line[len(indentation):], " >") {
+			// Some other line (wrong indentation or wrong continuation).
 			// Yield what we have so far and the go back to processing that new line.
 			cont := yield(e)
 			return line, cont, err


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

renames `indention` to `indentation` across `cmd/prune-junit-xml/logparse/logparse.go`. the word is used in the regex group name, `lookupSubmatch()` call, and variable names - all 8 spots need to match or it panics at init time:

```go
func lookupSubmatch(name string) int {
    ...
    panic(fmt.Errorf("named submatch %q not found in %q", name, klogPrefix.String()))
}
```

so this fixes all of them together to avoid that.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A
