### PR TITLE
fix incorrect godoc on exported API types and server options

### DIFF
--- a/pkg/apis/admissionregistration/types.go
+++ b/pkg/apis/admissionregistration/types.go
@@ -334,7 +334,7 @@ type Validation struct {
 	// If unset, the message is "failed rule: {Rule}".
 	// e.g. "must be a URL with the host matching spec.host"
 	// If ExpressMessage is specified, Message will be ignored
-	// If the Expression contains line breaks. Eith Message or ExpressMessage is required.
+	// If the Expression contains line breaks. Either Message or ExpressMessage is required.
 	// The message must not contain line breaks.
 	// If unset, the message is "failed Expression: {Expression}".
 	// +optional
@@ -413,7 +413,7 @@ type AuditAnnotation struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// ValidatingAdmissionPolicyBinding binds the ValidatingAdmissionPolicy with paramerized resources.
+// ValidatingAdmissionPolicyBinding binds the ValidatingAdmissionPolicy with parameterized resources.
 // ValidatingAdmissionPolicyBinding and parameter CRDs together define how cluster administrators configure policies for clusters.
 //
 // For a given admission request, each binding will cause its policy to be

--- a/pkg/apis/certificates/types.go
+++ b/pkg/apis/certificates/types.go
@@ -279,7 +279,7 @@ type ClusterTrustBundleList struct {
 	Items []ClusterTrustBundle
 }
 
-// MaxTrustBundleSize is the maximimum size of a single trust bundle field.
+// MaxTrustBundleSize is the maximum size of a single trust bundle field.
 const MaxTrustBundleSize = 1 * 1024 * 1024
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -453,7 +453,7 @@ type PersistentVolumeStatus struct {
 	// +optional
 	Reason string
 	// LastPhaseTransitionTime is the time the phase transitioned from one to another
-	// and automatically resets to current time everytime a volume phase transitions.
+	// and automatically resets to current time every time a volume phase transitions.
 	// +optional
 	LastPhaseTransitionTime *metav1.Time
 }

--- a/pkg/apis/resource/types.go
+++ b/pkg/apis/resource/types.go
@@ -1807,7 +1807,7 @@ type DeviceClassSpec struct {
 	Selectors []DeviceSelector
 
 	// Config defines configuration parameters that apply to each device that is claimed via this class.
-	// Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor
+	// Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor
 	// configuration applies to exactly one driver.
 	//
 	// They are passed to the driver, but are not considered while allocating the claim.

--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -82,7 +82,7 @@ const (
 // Exported as a variable so that it can be overridden in integration tests.
 var UpdateAuthenticationConfigTimeout = time.Minute
 
-// BuiltInAuthenticationOptions contains all build-in authentication options for API Server
+// BuiltInAuthenticationOptions contains all built-in authentication options for API Server
 type BuiltInAuthenticationOptions struct {
 	APIAudiences    []string
 	Anonymous       *AnonymousAuthenticationOptions
@@ -170,7 +170,7 @@ func NewBuiltInAuthenticationOptions() *BuiltInAuthenticationOptions {
 	}
 }
 
-// WithAll set default value for every build-in authentication option
+// WithAll set default value for every built-in authentication option
 func (o *BuiltInAuthenticationOptions) WithAll() *BuiltInAuthenticationOptions {
 	return o.
 		WithAnonymous().

--- a/pkg/kubeapiserver/options/authorization.go
+++ b/pkg/kubeapiserver/options/authorization.go
@@ -46,7 +46,7 @@ const (
 	authorizationConfigFlag                 = "authorization-config"
 )
 
-// BuiltInAuthorizationOptions contains all build-in authorization options for API Server
+// BuiltInAuthorizationOptions contains all built-in authorization options for API Server
 type BuiltInAuthorizationOptions struct {
 	Modes                       []string
 	PolicyFile                  string

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -595,7 +595,7 @@ type KubeletWebhookAuthorization struct {
 	CacheUnauthorizedTTL metav1.Duration
 }
 
-// KubeletAuthentication holds the Kubetlet Authentication setttings.
+// KubeletAuthentication holds the Kubelet Authentication settings.
 type KubeletAuthentication struct {
 	// x509 contains settings related to x509 client certificate authentication
 	X509 KubeletX509Authentication
@@ -857,7 +857,7 @@ const (
 	// a list of images that were pulled outside the kubelet process
 	NeverVerifyAllowlistedImages ImagePullCredentialsVerificationPolicy = "NeverVerifyAllowlistedImages"
 	// AlwaysVerify requires credential verification for accessing any image on the
-	// node irregardless how it was pulled
+	// node regardless of how it was pulled
 	AlwaysVerify ImagePullCredentialsVerificationPolicy = "AlwaysVerify"
 )
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

fixes incorrect godoc comments on exported types in `pkg/apis/` and `pkg/kubeapiserver/options/`. these show up on pkg.go.dev and feed into generated API docs so they should be accurate.

some examples:
- "paramerized resources" -> "parameterized resources"
- "maximimum size" -> "maximum size"
- "build-in authentication" -> "built-in authentication"
- "Kubetlet Authentication setttings" -> "Kubelet Authentication settings"

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A
