### PR TITLE
fix incorrect strings in statefulset controller and sa token cleaner

### DIFF
--- a/pkg/controller/serviceaccount/legacy_serviceaccount_token_cleaner.go
+++ b/pkg/controller/serviceaccount/legacy_serviceaccount_token_cleaner.go
@@ -116,7 +116,7 @@ func (tc *LegacySATokenCleaner) evaluateSATokens(ctx context.Context) {
 	now := tc.clock.Now().UTC()
 	trackedSince, err := tc.latestPossibleTrackedSinceTime(ctx)
 	if err != nil {
-		logger.Error(err, "Getting lastest possible tracked_since time")
+		logger.Error(err, "Getting latest possible tracked_since time")
 		return
 	}
 

--- a/pkg/controller/statefulset/stateful_pod_control.go
+++ b/pkg/controller/statefulset/stateful_pod_control.go
@@ -287,7 +287,7 @@ func (spc *StatefulPodControl) UpdatePodClaimForRetentionPolicy(ctx context.Cont
 		default:
 			if hasUnexpectedController(claim, set, pod) {
 				// Add an event so the user knows they're in a strange configuration. The claim will be cleaned up below.
-				msg := fmt.Sprintf("PersistentVolumeClaim %s has a conflicting OwnerReference that acts as a manging controller, the retention policy is ignored for this claim", claimName)
+				msg := fmt.Sprintf("PersistentVolumeClaim %s has a conflicting OwnerReference that acts as a managing controller, the retention policy is ignored for this claim", claimName)
 				spc.recorder.Event(set, v1.EventTypeWarning, "ConflictingController", msg)
 			}
 			if !isClaimOwnerUpToDate(logger, claim, set, pod) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

found a couple of incorrect strings while reading through the controller code

- "manging controller" -> "managing controller" in the ConflictingController warning event
- "lastest" -> "latest" in error log message

these show up in `kubectl describe` output and kubelet logs so operators could see misleading text.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A
