### PR TITLE
scheduler: ensure pods are requeued when nomination is cleared

### DIFF
--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -104,6 +104,9 @@ type SchedulingQueue interface {
 	// But, if a pod isn't found in unschedulablePods or backoffQ and it's not in-flight (i.e., completely unknown pod),
 	// Activate would ignore the pod.
 	Activate(logger klog.Logger, pods map[string]*v1.Pod)
+	// Requeue moves the given pods from unschedulablePods to either activeQ or backoffQ
+	// depending on their backoff status.
+	Requeue(logger klog.Logger, pods []*v1.Pod)
 	// AddUnschedulableIfNotPresent adds an unschedulable pod back to scheduling queue.
 	// The podSchedulingCycle represents the current scheduling cycle number which can be
 	// returned by calling SchedulingCycle().
@@ -761,6 +764,43 @@ func (p *PriorityQueue) Activate(logger klog.Logger, pods map[string]*v1.Pod) {
 	if activated {
 		p.activeQ.broadcast()
 	}
+}
+
+// Requeue moves the given pods from unschedulablePods to either activeQ or backoffQ
+// depending on their backoff status. If any pod was successfully moved, it broadcasts
+// to activeQ to wake up waiting goroutines.
+func (p *PriorityQueue) Requeue(logger klog.Logger, pods []*v1.Pod) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	activated := false
+	for _, pod := range pods {
+		if p.requeue(logger, pod) {
+			activated = true
+		}
+	}
+
+	if activated {
+		p.activeQ.broadcast()
+	}
+}
+
+// requeue attempts to move a pod from unschedulablePods to either backoffQ or activeQ
+// depending on its backoff status. It returns true if the pod was successfully moved
+// to activeQ, and false otherwise.
+func (p *PriorityQueue) requeue(logger klog.Logger, pod *v1.Pod) bool {
+	pInfo := p.unschedulablePods.get(pod)
+	if pInfo == nil {
+		return false
+	}
+
+	// If the pod is backing off, move it to backoffQ.
+	if p.backoffQ.isPodBackingoff(pInfo) {
+		addedToBackoffQ := p.moveToBackoffQ(logger, pInfo, framework.ForceRequeue)
+		return addedToBackoffQ && p.isPopFromBackoffQEnabled
+	}
+
+	return p.moveToActiveQ(logger, pInfo, framework.ForceRequeue, false)
 }
 
 func (p *PriorityQueue) activate(logger klog.Logger, pod *v1.Pod) bool {

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -5136,3 +5136,147 @@ func TestPriorityQueue_MultipleProfiles(t *testing.T) {
 		t.Errorf("Pod3: expected nil signature (no signer), got '%s'", string(pInfo3.PodSignature))
 	}
 }
+
+func TestPriorityQueue_Requeue(t *testing.T) {
+	mustNewPodInfo := func(pod *v1.Pod) *framework.PodInfo {
+		pi, _ := framework.NewPodInfo(pod)
+		return pi
+	}
+	metrics.Register()
+	tests := []struct {
+		name                       string
+		podInfoInUnschedulablePods []*framework.QueuedPodInfo
+		podInfoInBackoffQ          []*framework.QueuedPodInfo
+		podInActiveQ               []*v1.Pod
+		podsToRequeue              []*v1.Pod
+		wantActive                 int
+		wantBackoff                int
+		wantUnschedulable          int
+	}{
+		{
+			name: "pod in unschedulablePods, not backing off",
+			podInfoInUnschedulablePods: []*framework.QueuedPodInfo{
+				{
+					PodInfo:            mustNewPodInfo(st.MakePod().Name("p1").UID("p1").Obj()),
+					Timestamp:          time.Now().Add(-10 * time.Second),
+					UnschedulableCount: 1, // 1s backoff, so it should be expired
+				},
+			},
+			podsToRequeue:     []*v1.Pod{st.MakePod().Name("p1").UID("p1").Obj()},
+			wantActive:        1,
+			wantBackoff:       0,
+			wantUnschedulable: 0,
+		},
+		{
+			name: "pod in unschedulablePods, backing off",
+			podInfoInUnschedulablePods: []*framework.QueuedPodInfo{
+				{
+					PodInfo:            mustNewPodInfo(st.MakePod().Name("p1").UID("p1").Obj()),
+					Timestamp:          time.Now(),
+					UnschedulableCount: 1, // 1s backoff, not expired
+				},
+			},
+			podsToRequeue:     []*v1.Pod{st.MakePod().Name("p1").UID("p1").Obj()},
+			wantActive:        0,
+			wantBackoff:       1,
+			wantUnschedulable: 0,
+		},
+		{
+			name: "pod in backoffQ, not backing off",
+			podInfoInBackoffQ: []*framework.QueuedPodInfo{
+				{
+					PodInfo:            mustNewPodInfo(st.MakePod().Name("p1").UID("p1").Obj()),
+					Timestamp:          time.Now().Add(-10 * time.Second),
+					UnschedulableCount: 1,
+				},
+			},
+			podsToRequeue:     []*v1.Pod{st.MakePod().Name("p1").UID("p1").Obj()},
+			wantActive:        0,
+			wantBackoff:       1, // Should stay in backoffQ
+			wantUnschedulable: 0,
+		},
+		{
+			name: "pod in backoffQ, backing off",
+			podInfoInBackoffQ: []*framework.QueuedPodInfo{
+				{
+					PodInfo:            mustNewPodInfo(st.MakePod().Name("p1").UID("p1").Obj()),
+					Timestamp:          time.Now(),
+					UnschedulableCount: 1,
+				},
+			},
+			podsToRequeue:     []*v1.Pod{st.MakePod().Name("p1").UID("p1").Obj()},
+			wantActive:        0,
+			wantBackoff:       1,
+			wantUnschedulable: 0,
+		},
+		{
+			name:              "pod not in any queue",
+			podsToRequeue:     []*v1.Pod{st.MakePod().Name("p1").UID("p1").Obj()},
+			wantActive:        0,
+			wantBackoff:       0,
+			wantUnschedulable: 0,
+		},
+		{
+			name:              "pod already in activeQ",
+			podInActiveQ:      []*v1.Pod{st.MakePod().Name("p1").UID("p1").Obj()},
+			podsToRequeue:     []*v1.Pod{st.MakePod().Name("p1").UID("p1").Obj()},
+			wantActive:        1,
+			wantBackoff:       0,
+			wantUnschedulable: 0,
+		},
+		{
+			name: "multiple pods mixed",
+			podInfoInUnschedulablePods: []*framework.QueuedPodInfo{
+				{
+					PodInfo:            mustNewPodInfo(st.MakePod().Name("p1").UID("p1").Obj()),
+					Timestamp:          time.Now().Add(-10 * time.Second),
+					UnschedulableCount: 1, // should be active
+				},
+			},
+			podInfoInBackoffQ: []*framework.QueuedPodInfo{
+				{
+					PodInfo:            mustNewPodInfo(st.MakePod().Name("p2").UID("p2").Obj()),
+					Timestamp:          time.Now(),
+					UnschedulableCount: 1, // should stay in backoff
+				},
+			},
+			podInActiveQ: []*v1.Pod{st.MakePod().Name("p3").UID("p3").Obj()},
+			podsToRequeue: []*v1.Pod{
+				st.MakePod().Name("p1").UID("p1").Obj(),
+				st.MakePod().Name("p2").UID("p2").Obj(),
+			},
+			wantActive:        2, // p1 (requeued) + p3 (existing)
+			wantBackoff:       1, // p2 (stayed)
+			wantUnschedulable: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			q := NewTestQueue(ctx, newDefaultQueueSort())
+
+			for _, pInfo := range tt.podInfoInUnschedulablePods {
+				q.unschedulablePods.addOrUpdate(pInfo, false, "event")
+			}
+			for _, pInfo := range tt.podInfoInBackoffQ {
+				q.backoffQ.add(logger, pInfo, "event")
+			}
+			for _, pod := range tt.podInActiveQ {
+				q.Add(ctx, pod)
+			}
+
+			q.Requeue(logger, tt.podsToRequeue)
+
+			if q.activeQ.len() != tt.wantActive {
+				t.Errorf("activeQ length: want %v, got %v", tt.wantActive, q.activeQ.len())
+			}
+			if q.backoffQ.len() != tt.wantBackoff {
+				t.Errorf("backoffQ length: want %v, got %v", tt.wantBackoff, q.backoffQ.len())
+			}
+			if len(q.unschedulablePods.podInfoMap) != tt.wantUnschedulable {
+				t.Errorf("unschedulablePods length: want %v, got %v", tt.wantUnschedulable, len(q.unschedulablePods.podInfoMap))
+			}
+		})
+	}
+}

--- a/pkg/scheduler/framework/events.go
+++ b/pkg/scheduler/framework/events.go
@@ -42,6 +42,8 @@ const (
 	// UnschedulableTimeout is the event when a pod is moved from unschedulablePods
 	// due to the timeout specified at pod-max-in-unschedulable-pods-duration.
 	UnschedulableTimeout = "UnschedulableTimeout"
+	// ForceRequeue is the event when a pod is explicitly requeued.
+	ForceRequeue = "ForceRequeue"
 )
 
 var (

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -2459,6 +2459,8 @@ type fakePodActivator struct {
 
 func (f *fakePodActivator) Activate(logger klog.Logger, pods map[string]*v1.Pod) {}
 
+func (f *fakePodActivator) Requeue(logger klog.Logger, pods []*v1.Pod) {}
+
 type mockProposedAssignment struct {
 	nodeName string
 	pod      *v1.Pod

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -167,6 +167,9 @@ func (pam *podActivatorMock) Activate(_ klog.Logger, pods map[string]*v1.Pod) {
 	}
 }
 
+func (pam *podActivatorMock) Requeue(_ klog.Logger, _ []*v1.Pod) {
+}
+
 func TestGangSchedulingFlow(t *testing.T) {
 	gangPodGroup1 := st.MakePodGroup().Namespace("ns1").Name("pg1").TemplateRef("t1", "gang-wl").MinCount(3).Obj()
 	gangPodGroup2 := st.MakePodGroup().Namespace("ns1").Name("pg2").TemplateRef("t2", "gang-wl").MinCount(4).Obj()

--- a/pkg/scheduler/framework/preemption/executor.go
+++ b/pkg/scheduler/framework/preemption/executor.go
@@ -67,6 +67,11 @@ type ExecutorPreemptor interface {
 	Type() string
 }
 
+type preemptionSession struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
 // Executor is responsible for actuating the preemption process based on the provided candidate.
 // It supports both synchronous as well as asynchronous preemption.
 type Executor struct {
@@ -80,9 +85,18 @@ type Executor struct {
 	// preempting is a set that records the pods/podgroups that are currently triggering preemption asynchronously,
 	// which is used to prevent the pods and pods from podgroups from entering the scheduling cycle meanwhile.
 	preempting sets.Set[types.UID]
+	// activePreemptionSessions maps a preemptor UID to its current active preemption session.
+	// This is used to ensure that only one asynchronous preemption goroutine is actively executing for a given preemptor,
+	// and to guarantee that the tracking state in lastVictimsPendingPreemption remains consistent and refers strictly
+	// to the current preemption session.
+	// This session cancellation tracking became necessary because a running preemption can be canceled or superseded
+	// when a higher-priority pod preempts on the node, causing the lower-priority preemptor to lose its nomination,
+	// be requeued, and potentially initiate a new concurrent preemption session.
+	activePreemptionSessions map[types.UID]preemptionSession
 	// lastVictimsPendingPreemption is a map that records the victim pods that are currently being preempted for a given preemptor pod/podgroup,
 	// with a condition that the preemptor is waiting for one last victim to be preempted. This is used together with `preempting`
 	// to prevent the pods/podgroups from entering the scheduling cycle while waiting for preemption to complete.
+	// TODO(mm4tt@): Move this to preemptionSession.
 	lastVictimsPendingPreemption map[types.UID]pendingVictim
 
 	// PreemptPod is a function that actually makes API calls to preempt a specific Pod.
@@ -96,6 +110,7 @@ func NewExecutor(fh fwk.Handle, fts feature.Features) *Executor {
 		fh:                           fh,
 		podLister:                    fh.SharedInformerFactory().Core().V1().Pods().Lister(),
 		preempting:                   sets.New[types.UID](),
+		activePreemptionSessions:     make(map[types.UID]preemptionSession),
 		lastVictimsPendingPreemption: make(map[types.UID]pendingVictim),
 		fts:                          fts,
 	}
@@ -232,6 +247,13 @@ func (e *Executor) prepareCandidateAsync(c Candidate, preemptor ExecutorPreempto
 
 	e.mu.Lock()
 	e.preempting.Insert(preemptor.UID())
+	if previousPreemption, ok := e.activePreemptionSessions[preemptor.UID()]; ok {
+		previousPreemption.cancel()
+	}
+	e.activePreemptionSessions[preemptor.UID()] = preemptionSession{
+		ctx:    ctx,
+		cancel: cancel,
+	}
 	e.mu.Unlock()
 
 	go func() {
@@ -241,6 +263,7 @@ func (e *Executor) prepareCandidateAsync(c Candidate, preemptor ExecutorPreempto
 		defer metrics.PreemptionGoroutinesDuration.WithLabelValues(result).Observe(metrics.SinceInSeconds(startTime))
 		defer metrics.PreemptionGoroutinesExecutionTotal.WithLabelValues(result).Inc()
 		defer func() {
+
 			if result == metrics.GoroutineResultError {
 				// When API call isn't successful, the preemptor's Pods may get stuck in the unschedulable pod pool in the worst case.
 				// So, we should move the preemptor's Pods to the activeQ.
@@ -252,13 +275,30 @@ func (e *Executor) prepareCandidateAsync(c Candidate, preemptor ExecutorPreempto
 
 		// Lower priority pods nominated to run on this node, may no longer fit on
 		// this node. So, we should remove their nomination. Removing their
-		// nomination updates these pods and moves them to the active queue. It
+		// nomination updates these pods and moves them to the active or backoff queue. It
 		// lets scheduler find another place for them sooner than after waiting for preemption completion.
 		nominatedPods := getLowerPriorityNominatedPods(e.fh, preemptor.Priority(), c.Name())
 		if err := clearNominatedNodeName(ctx, e.fh.ClientSet(), e.fh.APICacher(), nominatedPods...); err != nil {
 			utilruntime.HandleErrorWithContext(ctx, err, "Cannot clear 'NominatedNodeName' field from lower priority pods on the same target node", "node", c.Name())
 			result = metrics.GoroutineResultError
 			// We do not return as this error is not critical.
+		}
+		if len(nominatedPods) > 0 {
+			// Since these pods are losing their nomination to a higher priority pod,
+			// their current preemption attempt on this node is effectively canceled.
+			// We remove them from the 'preempting' set so that PreEnqueue does not block them.
+			e.mu.Lock()
+			for _, pod := range nominatedPods {
+				if preemption, ok := e.activePreemptionSessions[pod.UID]; ok {
+					preemption.cancel()
+					delete(e.activePreemptionSessions, pod.UID)
+				}
+				e.preempting.Delete(pod.UID)
+				delete(e.lastVictimsPendingPreemption, pod.UID)
+			}
+			e.mu.Unlock()
+
+			e.fh.Requeue(logger, nominatedPods)
 		}
 
 		preemptLastVictim := true
@@ -287,6 +327,12 @@ func (e *Executor) prepareCandidateAsync(c Candidate, preemptor ExecutorPreempto
 		if preemptLastVictim {
 			lastVictim := victimPods[len(victimPods)-1]
 			e.mu.Lock()
+			currentSession, ok := e.activePreemptionSessions[preemptor.UID()]
+			if !ok || currentSession.ctx != ctx {
+				e.mu.Unlock()
+				logger.V(2).Info("Preemptor context has been canceled or superseded, skipping last victim preemption", "preemptor", klog.KObj(preemptor), "victim", klog.KObj(lastVictim))
+				return
+			}
 			e.lastVictimsPendingPreemption[preemptor.UID()] = pendingVictim{namespace: lastVictim.Namespace, name: lastVictim.Name}
 			e.mu.Unlock()
 
@@ -296,8 +342,12 @@ func (e *Executor) prepareCandidateAsync(c Candidate, preemptor ExecutorPreempto
 			}
 		}
 		e.mu.Lock()
-		e.preempting.Delete(preemptor.UID())
-		delete(e.lastVictimsPendingPreemption, preemptor.UID())
+		currentSession, ok := e.activePreemptionSessions[preemptor.UID()]
+		if ok && currentSession.ctx == ctx {
+			e.preempting.Delete(preemptor.UID())
+			delete(e.activePreemptionSessions, preemptor.UID())
+			delete(e.lastVictimsPendingPreemption, preemptor.UID())
+		}
 		e.mu.Unlock()
 
 		logger.V(2).Info("Async Preemption finished completely", "preemptor", klog.KObj(preemptor), "node", c.Name(), "result", result)
@@ -335,12 +385,15 @@ func (e *Executor) prepareCandidate(ctx context.Context, c Candidate, preemptor 
 
 	// Lower priority pods nominated to run on this node, may no longer fit on
 	// this node. So, we should remove their nomination. Removing their
-	// nomination updates these pods and moves them to the active queue. It
+	// nomination updates these pods and moves them to the active or backoff queue. It
 	// lets scheduler find another place for them sooner than after waiting for preemption completion.
 	nominatedPods := getLowerPriorityNominatedPods(fh, preemptor.Priority(), c.Name())
 	if err := clearNominatedNodeName(ctx, cs, fh.APICacher(), nominatedPods...); err != nil {
 		utilruntime.HandleErrorWithContext(ctx, err, "Cannot clear 'NominatedNodeName' field")
 		// We do not return as this error is not critical.
+	}
+	if len(nominatedPods) > 0 {
+		fh.Requeue(logger, nominatedPods)
 	}
 
 	return nil

--- a/pkg/scheduler/framework/preemption/executor_test.go
+++ b/pkg/scheduler/framework/preemption/executor_test.go
@@ -199,6 +199,7 @@ func TestIsPodRunningPreemption(t *testing.T) {
 
 type fakePodActivator struct {
 	activatedPods map[string]*v1.Pod
+	requeuedPods  map[string]*v1.Pod
 	mu            *sync.RWMutex
 }
 
@@ -210,17 +211,34 @@ func (f *fakePodActivator) Activate(logger klog.Logger, pods map[string]*v1.Pod)
 	}
 }
 
+func (f *fakePodActivator) Requeue(logger klog.Logger, pods []*v1.Pod) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, pod := range pods {
+		f.requeuedPods[pod.Name] = pod
+	}
+}
+
 type fakePodNominator struct {
 	// embed it so that we can only override NominatedPodsForNode
 	internalqueue.SchedulingQueue
+	nominatedPods []fwk.PodInfo
 
 	// fakePodNominator doesn't respond to NominatedPodsForNode() until the channel is closed.
 	requestStopper chan struct{}
 }
 
 func (f *fakePodNominator) NominatedPodsForNode(nodeName string) []fwk.PodInfo {
-	<-f.requestStopper
-	return nil
+	if f.requestStopper != nil {
+		<-f.requestStopper
+	}
+	return f.nominatedPods
+}
+
+func (f *fakePodNominator) PatchPodStatus(pod *v1.Pod, condition *v1.PodCondition, nominatingInfo *fwk.NominatingInfo) (<-chan error, error) {
+	ch := make(chan error, 1)
+	ch <- nil
+	return ch, nil
 }
 
 func TestPrepareCandidate(t *testing.T) {
@@ -285,6 +303,11 @@ func TestPrepareCandidate(t *testing.T) {
 				Containers([]v1.Container{st.MakeContainer().Name("container1").Obj()}).
 				Obj()
 
+		nominatedPod = st.MakePod().Name("nominated").UID("nominated").
+				SchedulerName(defaultSchedulerName).Priority(midPriority).
+				Containers([]v1.Container{st.MakeContainer().Name("container1").Obj()}).
+				Obj()
+
 		podGroupPreemptor = &schedulingapi.PodGroup{ObjectMeta: metav1.ObjectMeta{Name: "pg1", Namespace: "default", UID: "pg1"}}
 
 		errDeletePodFailed   = errors.New("delete pod failed")
@@ -304,6 +327,7 @@ func TestPrepareCandidate(t *testing.T) {
 		preemptor         *v1.Pod
 		preemptorPodGroup *schedulingapi.PodGroup
 		testPods          []*v1.Pod
+		nominatedPods     []*v1.Pod
 		// expectedDeletedPod is the pod name that is expected to be deleted.
 		//
 		// You can set multiple pod name if there're multiple possibilities.
@@ -316,6 +340,7 @@ func TestPrepareCandidate(t *testing.T) {
 		// Only compared when async preemption is enabled.
 		expectedPreemptingMap sets.Set[types.UID]
 		expectedActivatedPods map[string]*v1.Pod
+		expectedRequeuedPods  map[string]*v1.Pod
 	}{
 		{
 			name: "no victims",
@@ -547,6 +572,25 @@ func TestPrepareCandidate(t *testing.T) {
 			expectedPreemptingMap: sets.New(types.UID("preemptor")),
 			expectedActivatedPods: map[string]*v1.Pod{preemptor.Name: preemptor},
 		},
+		{
+			name: "nominated pods on the same node should be requeued",
+			candidate: &candidate{
+				name: node1Name,
+				victims: &extenderv1.Victims{
+					Pods: []*v1.Pod{victim1},
+				},
+			},
+			preemptor:     preemptor,
+			testPods:      []*v1.Pod{victim1, nominatedPod},
+			nominatedPods: []*v1.Pod{nominatedPod},
+			nodeNames:     []string{node1Name},
+			expectedDeletedPod: []string{
+				"victim1",
+			},
+			expectedStatus:        nil,
+			expectedPreemptingMap: sets.New(types.UID("preemptor")),
+			expectedRequeuedPods:  map[string]*v1.Pod{nominatedPod.Name: nominatedPod},
+		},
 	}
 
 	for _, asyncPreemptionEnabled := range []bool{true, false} {
@@ -611,14 +655,24 @@ func TestPrepareCandidate(t *testing.T) {
 
 					informerFactory := informers.NewSharedInformerFactory(cs, 0)
 					eventBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: cs.EventsV1()})
-					fakeActivator := &fakePodActivator{activatedPods: make(map[string]*v1.Pod), mu: mu}
+					fakeActivator := &fakePodActivator{
+						activatedPods: make(map[string]*v1.Pod),
+						requeuedPods:  make(map[string]*v1.Pod),
+						mu:            mu,
+					}
 
 					// Note: NominatedPodsForNode is called at the beginning of the goroutine in any case.
 					// fakePodNominator can delay the response of NominatedPodsForNode until the channel is closed,
 					// which allows us to test the preempting map before the goroutine does nothing yet.
 					requestStopper := make(chan struct{})
+					var nominatedPodInfos []fwk.PodInfo
+					for _, pod := range tt.nominatedPods {
+						pInfo, _ := framework.NewPodInfo(pod)
+						nominatedPodInfos = append(nominatedPodInfos, pInfo)
+					}
 					nominator := &fakePodNominator{
 						SchedulingQueue: internalqueue.NewSchedulingQueue(nil, informerFactory),
+						nominatedPods:   nominatedPodInfos,
 						requestStopper:  requestStopper,
 					}
 					var apiDispatcher *apidispatcher.APIDispatcher
@@ -649,7 +703,7 @@ func TestPrepareCandidate(t *testing.T) {
 					informerFactory.WaitForCacheSync(ctx.Done())
 					if asyncAPICallsEnabled {
 						cache := internalcache.New(ctx, apiDispatcher, false)
-						framework.SetAPICacher(apicache.New(nil, cache))
+						framework.SetAPICacher(apicache.New(nominator, cache))
 					}
 
 					executor := NewExecutor(framework, feature.Features{EnableAsyncPreemption: asyncPreemptionEnabled})
@@ -725,6 +779,15 @@ func TestPrepareCandidate(t *testing.T) {
 								lastErrMsg = fmt.Sprintf("expected no activated pods, got %v", fakeActivator.activatedPods)
 								return false, nil
 							}
+						}
+
+						if diff := cmp.Diff(tt.expectedRequeuedPods, fakeActivator.requeuedPods); tt.expectedRequeuedPods != nil && diff != "" {
+							lastErrMsg = fmt.Sprintf("Unexpected requeued pods (-want,+got):\n%s", diff)
+							return false, nil
+						}
+						if tt.expectedRequeuedPods == nil && len(fakeActivator.requeuedPods) != 0 {
+							lastErrMsg = fmt.Sprintf("expected no requeued pods, got %v", fakeActivator.requeuedPods)
+							return false, nil
 						}
 
 						if deletedPods.Len() > 1 {

--- a/staging/src/k8s.io/kube-scheduler/framework/interface.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/interface.go
@@ -906,6 +906,9 @@ type PodActivator interface {
 	// But, if a pod isn't found in unschedulablePods or backoffQ and it's not in-flight (i.e., completely unknown pod),
 	// Activate would ignore the pod.
 	Activate(logger klog.Logger, pods map[string]*v1.Pod)
+	// Requeue moves the given pods from unschedulablePods to either activeQ or backoffQ
+	// depending on their backoff status.
+	Requeue(logger klog.Logger, pods []*v1.Pod)
 }
 
 // PodNominator abstracts operations to maintain nominated Pods.

--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -533,6 +533,12 @@ func TestAsyncPreemption(t *testing.T) {
 		// verifyPodInUnschedulable waits for some time and confirms that the given pod is in the unschedulable pool.
 		// The value is the name of the checked pod.
 		verifyPodInUnschedulable string
+		// verifyPodInActiveQ waits for some time and confirms that the given pod is in the active queue.
+		// The value is the name of the checked pod.
+		verifyPodInActiveQ string
+		// verifyPodNominated checks if the given Pod has NominatedNodeName set.
+		// The value is the name of the checked pod.
+		verifyPodNominated string
 	}
 
 	tests := []struct {
@@ -1208,6 +1214,61 @@ func TestAsyncPreemption(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "preemptor nomination cleared by another preemption triggers re-queue",
+			scenarios: []scenario{
+				{
+					name: "create victim Pod blocked in binding",
+					createPod: &createPod{
+						pod: st.MakePod().Name(podBlockedInBindingName).Req(map[v1.ResourceName]string{v1.ResourceCPU: "3"}).Container("image").ZeroTerminationGracePeriod().Priority(1).Obj(),
+					},
+				},
+				{
+					name: "schedule victim Pod",
+					schedulePod: &schedulePod{
+						podName: podBlockedInBindingName,
+					},
+				},
+				{
+					name: "create a mid-priority Pod A",
+					createPod: &createPod{
+						pod: st.MakePod().Name("pod-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "3"}).Container("image").Priority(50).Obj(),
+					},
+				},
+				{
+					name: "schedule Pod A (expect unschedulable and nominated to node)",
+					schedulePod: &schedulePod{
+						podName:             "pod-a",
+						expectUnschedulable: true,
+					},
+				},
+				{
+					name:            "check Pod A is in the queue and gated (nominated)",
+					podGatedInQueue: "pod-a",
+				},
+				{
+					name:               "verify Pod A has NominatedNodeName set",
+					verifyPodNominated: "pod-a",
+				},
+				{
+					name: "create a high-priority Pod B",
+					createPod: &createPod{
+						pod: st.MakePod().Name("pod-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "3"}).Container("image").Priority(100).Obj(),
+					},
+				},
+				{
+					name: "schedule Pod B (expect unschedulable, triggers preemption on node)",
+					schedulePod: &schedulePod{
+						podName:             "pod-b",
+						expectUnschedulable: true,
+					},
+				},
+				{
+					name:               "verify Pod A is in the active queue (re-queued by nomination clearance)",
+					verifyPodInActiveQ: "pod-a",
+				},
+			},
+		},
 	}
 
 	// All test cases have the same node.
@@ -1466,6 +1527,30 @@ func TestAsyncPreemption(t *testing.T) {
 							// If timeout was reached or context was cancelled without finding that vanished from unschedulable, it means the state is as expected.
 							// If a different error occurred, it means that the pod got unexpectedly activated, or something else went wrong.
 							t.Fatalf("Error in scenario verifyPodInUnschedulable: %v", err)
+						}
+					case scenario.verifyPodInActiveQ != "":
+						if err := wait.PollUntilContextTimeout(testCtx.Ctx, 50*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+							for _, pod := range testCtx.Scheduler.SchedulingQueue.PodsInActiveQ() {
+								if pod.Name == scenario.verifyPodInActiveQ {
+									return true, nil
+								}
+							}
+							return false, nil
+						}); err != nil {
+							t.Fatalf("Expected the pod %s to be in the active queue", scenario.verifyPodInActiveQ)
+						}
+					case scenario.verifyPodNominated != "":
+						if err := wait.PollUntilContextTimeout(testCtx.Ctx, 50*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+							pod, err := cs.CoreV1().Pods(testCtx.NS.Name).Get(ctx, scenario.verifyPodNominated, metav1.GetOptions{})
+							if err != nil {
+								return false, err
+							}
+							if pod.Status.NominatedNodeName == "" {
+								return false, nil
+							}
+							return true, nil
+						}); err != nil {
+							t.Fatalf("Expected the pod %s to have NominatedNodeName set", scenario.verifyPodNominated)
 						}
 					}
 				}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

Previously, when the preemption executor cleared the 'NominatedNodeName' for lower-priority pods (because they no longer fit on their nominated node after preemption), they were not explicitly requeued. This contradicted the
[documentation in executor.go](https://github.com/kubernetes/kubernetes/blob/ccaaf9d3a509f54b69c021002afb102b70824e22/pkg/scheduler/framework/preemption/executor.go#L336-L339) and delayed the re-scheduling of these pods until a periodic
flush or an unrelated cluster event occurred.

This PR introduces a fix by:
   1.  Adding a `Requeue` method to the `SchedulingQueue` interface, allowing pods to be moved from unschedulable/backoff queues back into the scheduling flow while honoring their backoff status.
   2.  Updating the preemption executor to explicitly call `Requeue` for all pods whose nominations were cleared.
   
This ensures these pods are retried as soon as possible, improving scheduling efficiency when node state changes due to preemption.

#### Which issue(s) this PR is related to:
Part of https://github.com/kubernetes/kubernetes/issues/129948

#### Special notes for your reviewer:
The fix explicitly handles requeueing in the preemption logic rather than relying on side-effects of pod updates, which is more direct and easier to reason about. Comprehensive unit tests have been added to both `scheduling_queue_test.go` and `executor_test.go` to verify:
  *   `Requeue` correctly handles pods in both unschedulable and backoff states.
  *   Preemption accurately triggers requeueing for affected nominated pods in both synchronous and asynchronous modes.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
