### PR TITLE
Add e2e test to ensure that the NotReady pod status does not change after kubelet restart

### DIFF
--- a/test/e2e_node/container_lifecycle_test.go
+++ b/test/e2e_node/container_lifecycle_test.go
@@ -81,6 +81,61 @@ func expectPodTerminationContainerStatuses(statuses []v1.ContainerStatus, to map
 	}
 }
 
+func watchPodStatusDuringKubeletRestart(
+	ctx context.Context,
+	f *framework.Framework,
+	pod *v1.Pod,
+	stopCh <-chan struct{},
+	validateStatus func(*v1.Pod) error,
+) <-chan error {
+	ginkgo.GinkgoHelper()
+
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(errCh)
+
+		watcher, err := f.ClientSet.CoreV1().Pods(pod.Namespace).Watch(ctx, metav1.ListOptions{
+			FieldSelector: "metadata.name=" + pod.Name,
+		})
+		if err != nil {
+			errCh <- fmt.Errorf("failed to watch pod: %w", err)
+			return
+		}
+		defer watcher.Stop()
+
+		for {
+			select {
+			case event, ok := <-watcher.ResultChan():
+				if !ok {
+					return
+				}
+				if event.Type != watch.Modified {
+					continue
+				}
+				currentPod, ok := event.Object.(*v1.Pod)
+				if !ok {
+					continue
+				}
+
+				if currentPod.Status.Phase != v1.PodRunning {
+					errCh <- fmt.Errorf("pod phase is %v, expected %v", currentPod.Status.Phase, v1.PodRunning)
+					return
+				}
+
+				err := validateStatus(currentPod)
+				if err != nil {
+					errCh <- err
+					return
+				}
+			case <-stopCh:
+				return
+			}
+		}
+	}()
+
+	return errCh
+}
+
 var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", func() {
 	f := framework.NewDefaultFramework("containers-lifecycle-test")
 	addAfterEachForCleaningUpPods(f)
@@ -6392,69 +6447,31 @@ var _ = SIGDescribe(framework.WithSerial(), "Not Change Container Status", frame
 			time.Sleep(time.Second * 11)
 
 			stopCh := make(chan struct{})
-			errCh := make(chan error, 1)
-			go func() {
-				watcher, err := f.ClientSet.CoreV1().Pods(pod.Namespace).Watch(ctx, metav1.ListOptions{
-					FieldSelector: "metadata.name=" + pod.Name,
-				})
-				if err != nil {
-					errCh <- fmt.Errorf("failed to watch pod: %w", err)
-					return
+			errCh := watchPodStatusDuringKubeletRestart(ctx, f, pod, stopCh, func(p *v1.Pod) error {
+				if len(p.Status.ContainerStatuses) < len(pod.Spec.Containers) {
+					return nil
 				}
-				defer watcher.Stop()
-
-				for {
-					select {
-					case event, ok := <-watcher.ResultChan():
-						if !ok {
-							return
-						}
-						if event.Type != watch.Modified {
-							continue
-						}
-						p, ok := event.Object.(*v1.Pod)
-						if !ok {
-							continue
-						}
-
-						if p.Status.Phase != v1.PodRunning {
-							errCh <- fmt.Errorf("pod phase is %v, expected %v", p.Status.Phase, v1.PodRunning)
-							return
-						}
-						if len(p.Status.ContainerStatuses) < len(pod.Spec.Containers) {
-							continue
-						}
-						for _, containerStatus := range p.Status.ContainerStatuses {
-							if containerStatus.RestartCount > 0 {
-								errCh <- fmt.Errorf("container %q restarted %d times", containerStatus.Name, containerStatus.RestartCount)
-								return
-							}
-							if containerStatus.Started == nil || !*containerStatus.Started {
-								errCh <- fmt.Errorf("container %q started status is not true", containerStatus.Name)
-								return
-							}
-							if !containerStatus.Ready {
-								errCh <- fmt.Errorf("container %q ready status is not true", containerStatus.Name)
-								return
-							}
-						}
-					case <-stopCh:
-						close(errCh)
-						return
+				for _, containerStatus := range p.Status.ContainerStatuses {
+					if containerStatus.RestartCount > 0 {
+						return fmt.Errorf("container %q restarted %d times", containerStatus.Name, containerStatus.RestartCount)
+					}
+					if containerStatus.Started == nil || !*containerStatus.Started {
+						return fmt.Errorf("container %q started status is not true", containerStatus.Name)
+					}
+					if !containerStatus.Ready {
+						return fmt.Errorf("container %q ready status is not true", containerStatus.Name)
 					}
 				}
-			}()
+				return nil
+			})
 
 			ginkgo.By("restarting the kubelet")
 			restartKubelet := mustStopKubelet(ctx, f)
 			restartKubelet(ctx)
 
-			ginkgo.By("ensuring kubelet is healthy")
-			gomega.Eventually(ctx, func() bool {
-				return kubeletHealthCheck(kubeletHealthCheckURL)
-			}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeTrueBecause("kubelet should be started"))
-
-			// Let the goroutine run for a few more seconds to catch any delayed changes
+			// We need to wait for a period of time to allow the kubelet to take over management
+			// of this pod, and ensure that after the kubelet manages the pod,
+			// the pod's status has not changed unexpectedly.
 			time.Sleep(5 * time.Second)
 			close(stopCh)
 
@@ -6770,69 +6787,30 @@ var _ = SIGDescribe(framework.WithSerial(), "Not Change Container Status", frame
 			time.Sleep(time.Second * 11)
 
 			stopCh := make(chan struct{})
-			errCh := make(chan error, 1)
-			go func() {
-				watcher, err := f.ClientSet.CoreV1().Pods(pod.Namespace).Watch(ctx, metav1.ListOptions{
-					FieldSelector: "metadata.name=" + pod.Name,
-				})
-				if err != nil {
-					errCh <- fmt.Errorf("failed to watch pod: %w", err)
-					return
+			errCh := watchPodStatusDuringKubeletRestart(ctx, f, pod, stopCh, func(p *v1.Pod) error {
+				if len(p.Status.InitContainerStatuses) == 0 {
+					return fmt.Errorf("pod has no init container statuses")
 				}
-				defer watcher.Stop()
-
-				for {
-					select {
-					case event, ok := <-watcher.ResultChan():
-						if !ok {
-							return
-						}
-						if event.Type != watch.Modified {
-							continue
-						}
-						p, ok := event.Object.(*v1.Pod)
-						if !ok {
-							continue
-						}
-
-						if p.Status.Phase != v1.PodRunning {
-							errCh <- fmt.Errorf("pod phase is %v, expected %v", p.Status.Phase, v1.PodRunning)
-							return
-						}
-						if len(p.Status.InitContainerStatuses) == 0 {
-							errCh <- fmt.Errorf("pod has no init container statuses")
-							return
-						}
-						containerStatus := p.Status.InitContainerStatuses[0]
-						if containerStatus.RestartCount > 0 {
-							errCh <- fmt.Errorf("container restarted %d times", containerStatus.RestartCount)
-							return
-						}
-						if containerStatus.Started == nil || !*containerStatus.Started {
-							errCh <- fmt.Errorf("container started status is not true")
-							return
-						}
-						if !containerStatus.Ready {
-							errCh <- fmt.Errorf("container ready status is not true")
-							return
-						}
-					case <-stopCh:
-						close(errCh)
-						return
-					}
+				containerStatus := p.Status.InitContainerStatuses[0]
+				if containerStatus.RestartCount > 0 {
+					return fmt.Errorf("container restarted %d times", containerStatus.RestartCount)
 				}
-			}()
+				if containerStatus.Started == nil || !*containerStatus.Started {
+					return fmt.Errorf("container started status is not true")
+				}
+				if !containerStatus.Ready {
+					return fmt.Errorf("container ready status is not true")
+				}
+				return nil
+			})
 
 			ginkgo.By("restarting the kubelet")
 			restartKubelet := mustStopKubelet(ctx, f)
 			restartKubelet(ctx)
 
-			ginkgo.By("ensuring kubelet is healthy")
-			gomega.Eventually(ctx, func() bool {
-				return kubeletHealthCheck(kubeletHealthCheckURL)
-			}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeTrueBecause("kubelet should be started"))
-
-			// Let the goroutine run for a few more seconds to catch any delayed changes
+			// We need to wait for a period of time to allow the kubelet to take over management
+			// of this pod, and ensure that after the kubelet manages the pod,
+			// the pod's status has not changed unexpectedly.
 			time.Sleep(5 * time.Second)
 			close(stopCh)
 
@@ -6979,6 +6957,417 @@ var _ = SIGDescribe(framework.WithSerial(), "Not Change Container Status", frame
 		})
 	})
 
+	ginkgo.When("a Pod transitions from Ready to NotReady before kubelet restart", func() {
+		testKubeletRestartNotReady := func(ctx context.Context, pod *v1.Pod) {
+			client := e2epod.NewPodClient(f)
+			pod = client.Create(ctx, pod)
+
+			ginkgo.By("Waiting for the pod to be running and ready")
+			err := e2epod.WaitForPodCondition(ctx, f.ClientSet, pod.Namespace, pod.Name, "PodReady", f.Timeouts.PodStart,
+				func(p *v1.Pod) (bool, error) {
+					if p.Status.Phase != v1.PodRunning {
+						return false, nil
+					}
+					for _, cond := range p.Status.Conditions {
+						if cond.Type == v1.PodReady && cond.Status == v1.ConditionTrue {
+							return true, nil
+						}
+					}
+					return false, nil
+				})
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Removing the readiness marker file from all containers to make the pod NotReady")
+			for _, c := range pod.Spec.Containers {
+				_, _, err = e2epod.ExecCommandInContainerWithFullOutput(f, pod.Name, c.Name, "rm", "/tmp/ready")
+				framework.ExpectNoError(err, "failed to remove /tmp/ready from container %s", c.Name)
+			}
+
+			ginkgo.By("Waiting for the pod to become NotReady")
+			err = e2epod.WaitForPodCondition(ctx, f.ClientSet, pod.Namespace, pod.Name, "PodNotReady", f.Timeouts.PodStart,
+				func(p *v1.Pod) (bool, error) {
+					for _, cond := range p.Status.Conditions {
+						if cond.Type == v1.PodReady && cond.Status == v1.ConditionFalse {
+							return true, nil
+						}
+					}
+					return false, nil
+				})
+			framework.ExpectNoError(err)
+
+			// Double check the initial state before starting the concurrent check
+			p, err := client.Get(ctx, pod.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			gomega.Expect(p.Status.ContainerStatuses).ToNot(gomega.BeEmpty())
+			for _, status := range p.Status.ContainerStatuses {
+				gomega.Expect(status.RestartCount).To(gomega.BeZero())
+				gomega.Expect(status.Started).ToNot(gomega.BeNil())
+				gomega.Expect(*status.Started).To(gomega.BeTrueBecause("The Started field should be set to true when all containers are started."))
+				gomega.Expect(status.Ready).To(gomega.BeFalseBecause("The Ready field should be false because the readiness probe fails."))
+			}
+
+			// The grace period for kubelet startup is 10 seconds, so we wait here for 11 seconds.
+			time.Sleep(time.Second * 11)
+
+			stopCh := make(chan struct{})
+			errCh := watchPodStatusDuringKubeletRestart(ctx, f, pod, stopCh, func(p *v1.Pod) error {
+				if len(p.Status.ContainerStatuses) < len(pod.Spec.Containers) {
+					return nil
+				}
+				for _, containerStatus := range p.Status.ContainerStatuses {
+					if containerStatus.RestartCount > 0 {
+						return fmt.Errorf("container %q restarted %d times", containerStatus.Name, containerStatus.RestartCount)
+					}
+					if containerStatus.Started == nil || !*containerStatus.Started {
+						return fmt.Errorf("container %q started status is not true", containerStatus.Name)
+					}
+					if containerStatus.Ready {
+						return fmt.Errorf("container %q ready status should remain false", containerStatus.Name)
+					}
+				}
+				return nil
+			})
+
+			ginkgo.By("restarting the kubelet")
+			restartKubelet := mustStopKubelet(ctx, f)
+			restartKubelet(ctx)
+
+			// We need to wait for a period of time to allow the kubelet to take over management
+			// of this pod, and ensure that after the kubelet manages the pod,
+			// the pod's status has not changed unexpectedly.
+			time.Sleep(5 * time.Second)
+			close(stopCh)
+
+			// Check for errors from the goroutine
+			for err := range errCh {
+				framework.ExpectNoError(err, "pod status check failed during kubelet restart")
+			}
+		}
+
+		ginkgo.It("should not affect NotReady pod status when pod has readinessProbe", func(ctx context.Context) {
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-not-ready-with-readiness-probe",
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:    "container",
+							Image:   defaultImage,
+							Command: []string{"sh", "-c", "touch /tmp/ready && sleep 3600"},
+							ReadinessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									Exec: &v1.ExecAction{
+										Command: []string{"cat", "/tmp/ready"},
+									},
+								},
+								InitialDelaySeconds: 1,
+								PeriodSeconds:       1,
+							},
+						},
+					},
+				},
+			}
+			testKubeletRestartNotReady(ctx, pod)
+		})
+
+		ginkgo.It("should not affect NotReady pod status when pod has startupProbe and readinessProbe", func(ctx context.Context) {
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-not-ready-with-startup-and-readiness-probe",
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:    "container",
+							Image:   defaultImage,
+							Command: []string{"sh", "-c", "touch /tmp/ready && sleep 3600"},
+							StartupProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									Exec: &v1.ExecAction{
+										Command: []string{"/bin/true"},
+									},
+								},
+								InitialDelaySeconds: 1,
+								PeriodSeconds:       1,
+							},
+							ReadinessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									Exec: &v1.ExecAction{
+										Command: []string{"cat", "/tmp/ready"},
+									},
+								},
+								InitialDelaySeconds: 1,
+								PeriodSeconds:       1,
+							},
+						},
+					},
+				},
+			}
+			testKubeletRestartNotReady(ctx, pod)
+		})
+
+		ginkgo.It("should not affect NotReady pod status when pod has multiple containers with readinessProbes", func(ctx context.Context) {
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-not-ready-mc-with-readiness-probes",
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:    "container1",
+							Image:   defaultImage,
+							Command: []string{"sh", "-c", "touch /tmp/ready && sleep 3600"},
+							ReadinessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									Exec: &v1.ExecAction{
+										Command: []string{"cat", "/tmp/ready"},
+									},
+								},
+								InitialDelaySeconds: 1,
+								PeriodSeconds:       1,
+							},
+						},
+						{
+							Name:    "container2",
+							Image:   defaultImage,
+							Command: []string{"sh", "-c", "touch /tmp/ready && sleep 3600"},
+							ReadinessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									Exec: &v1.ExecAction{
+										Command: []string{"cat", "/tmp/ready"},
+									},
+								},
+								InitialDelaySeconds: 1,
+								PeriodSeconds:       1,
+							},
+						},
+					},
+				},
+			}
+			testKubeletRestartNotReady(ctx, pod)
+		})
+
+		ginkgo.It("should not affect NotReady pod status when pod has multiple containers with startup and readiness probes", func(ctx context.Context) {
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-not-ready-mc-with-startup-and-readiness-probes",
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:    "container1",
+							Image:   defaultImage,
+							Command: []string{"sh", "-c", "touch /tmp/ready && sleep 3600"},
+							StartupProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									Exec: &v1.ExecAction{
+										Command: []string{"/bin/true"},
+									},
+								},
+								InitialDelaySeconds: 1,
+								PeriodSeconds:       1,
+							},
+							ReadinessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									Exec: &v1.ExecAction{
+										Command: []string{"cat", "/tmp/ready"},
+									},
+								},
+								InitialDelaySeconds: 1,
+								PeriodSeconds:       1,
+							},
+						},
+						{
+							Name:    "container2",
+							Image:   defaultImage,
+							Command: []string{"sh", "-c", "touch /tmp/ready && sleep 3600"},
+							StartupProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									Exec: &v1.ExecAction{
+										Command: []string{"/bin/true"},
+									},
+								},
+								InitialDelaySeconds: 1,
+								PeriodSeconds:       1,
+							},
+							ReadinessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									Exec: &v1.ExecAction{
+										Command: []string{"cat", "/tmp/ready"},
+									},
+								},
+								InitialDelaySeconds: 1,
+								PeriodSeconds:       1,
+							},
+						},
+					},
+				},
+			}
+			testKubeletRestartNotReady(ctx, pod)
+		})
+	})
+
+	ginkgo.When("a Pod with a restartable init container transitions from Ready to NotReady before kubelet restart", func() {
+		testKubeletRestartForRestartableInitNotReady := func(ctx context.Context, pod *v1.Pod) {
+			client := e2epod.NewPodClient(f)
+			pod = client.Create(ctx, pod)
+
+			ginkgo.By("Waiting for the pod to be running and ready")
+			err := e2epod.WaitForPodCondition(ctx, f.ClientSet, pod.Namespace, pod.Name, "PodReady", f.Timeouts.PodStart,
+				func(p *v1.Pod) (bool, error) {
+					if p.Status.Phase != v1.PodRunning {
+						return false, nil
+					}
+					for _, cond := range p.Status.Conditions {
+						if cond.Type == v1.PodReady && cond.Status == v1.ConditionTrue {
+							return true, nil
+						}
+					}
+					return false, nil
+				})
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Removing the readiness marker file from the restartable init container to make the pod NotReady")
+			_, _, err = e2epod.ExecCommandInContainerWithFullOutput(f, pod.Name, pod.Spec.InitContainers[0].Name, "rm", "/tmp/ready")
+			framework.ExpectNoError(err, "failed to remove /tmp/ready from restartable init container")
+
+			ginkgo.By("Waiting for the pod to become NotReady")
+			err = e2epod.WaitForPodCondition(ctx, f.ClientSet, pod.Namespace, pod.Name, "PodNotReady", f.Timeouts.PodStart,
+				func(p *v1.Pod) (bool, error) {
+					for _, cond := range p.Status.Conditions {
+						if cond.Type == v1.PodReady && cond.Status == v1.ConditionFalse {
+							return true, nil
+						}
+					}
+					return false, nil
+				})
+			framework.ExpectNoError(err)
+
+			// Double check the initial state before starting the concurrent check
+			p, err := client.Get(ctx, pod.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			gomega.Expect(p.Status.InitContainerStatuses).ToNot(gomega.BeEmpty())
+			gomega.Expect(p.Status.InitContainerStatuses[0].RestartCount).To(gomega.BeZero())
+			gomega.Expect(p.Status.InitContainerStatuses[0].Started).ToNot(gomega.BeNil())
+			gomega.Expect(*p.Status.InitContainerStatuses[0].Started).To(gomega.BeTrueBecause("The Started field should be set to true when the init container is started."))
+			gomega.Expect(p.Status.InitContainerStatuses[0].Ready).To(gomega.BeFalseBecause("The Ready field should be false because the readiness probe fails."))
+
+			// The grace period for kubelet startup is 10 seconds, so we wait here for 11 seconds.
+			time.Sleep(time.Second * 11)
+
+			stopCh := make(chan struct{})
+			errCh := watchPodStatusDuringKubeletRestart(ctx, f, pod, stopCh, func(p *v1.Pod) error {
+				if len(p.Status.InitContainerStatuses) == 0 {
+					return fmt.Errorf("pod has no init container statuses")
+				}
+				containerStatus := p.Status.InitContainerStatuses[0]
+				if containerStatus.RestartCount > 0 {
+					return fmt.Errorf("container restarted %d times", containerStatus.RestartCount)
+				}
+				if containerStatus.Started == nil || !*containerStatus.Started {
+					return fmt.Errorf("container started status is not true")
+				}
+				if containerStatus.Ready {
+					return fmt.Errorf("container ready status should remain false")
+				}
+				return nil
+			})
+
+			ginkgo.By("restarting the kubelet")
+			restartKubelet := mustStopKubelet(ctx, f)
+			restartKubelet(ctx)
+
+			// We need to wait for a period of time to allow the kubelet to take over management
+			// of this pod, and ensure that after the kubelet manages the pod,
+			// the pod's status has not changed unexpectedly.
+			time.Sleep(5 * time.Second)
+			close(stopCh)
+
+			// Check for errors from the goroutine
+			for err := range errCh {
+				framework.ExpectNoError(err, "pod status check failed during kubelet restart")
+			}
+		}
+
+		ginkgo.It("should not affect NotReady pod status when restartable init container has readinessProbe", func(ctx context.Context) {
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-not-ready-restartable-init-with-readiness-probe",
+				},
+				Spec: v1.PodSpec{
+					InitContainers: []v1.Container{
+						{
+							Name:          "restartable-init",
+							Image:         defaultImage,
+							Command:       []string{"sh", "-c", "touch /tmp/ready && sleep 3600"},
+							RestartPolicy: &containerRestartPolicyAlways,
+							ReadinessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									Exec: &v1.ExecAction{
+										Command: []string{"cat", "/tmp/ready"},
+									},
+								},
+								InitialDelaySeconds: 1,
+								PeriodSeconds:       1,
+							},
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Name:  "container",
+							Image: imageutils.GetPauseImageName(),
+						},
+					},
+				},
+			}
+			testKubeletRestartForRestartableInitNotReady(ctx, pod)
+		})
+
+		ginkgo.It("should not affect NotReady pod status when restartable init container has startupProbe and readinessProbe", func(ctx context.Context) {
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-not-ready-restartable-init-with-startup-and-readiness-probe",
+				},
+				Spec: v1.PodSpec{
+					InitContainers: []v1.Container{
+						{
+							Name:          "restartable-init",
+							Image:         defaultImage,
+							Command:       []string{"sh", "-c", "touch /tmp/ready && sleep 3600"},
+							RestartPolicy: &containerRestartPolicyAlways,
+							StartupProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									Exec: &v1.ExecAction{
+										Command: []string{"/bin/true"},
+									},
+								},
+								InitialDelaySeconds: 1,
+								PeriodSeconds:       1,
+							},
+							ReadinessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									Exec: &v1.ExecAction{
+										Command: []string{"cat", "/tmp/ready"},
+									},
+								},
+								InitialDelaySeconds: 1,
+								PeriodSeconds:       1,
+							},
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Name:  "container",
+							Image: imageutils.GetPauseImageName(),
+						},
+					},
+				},
+			}
+			testKubeletRestartForRestartableInitNotReady(ctx, pod)
+		})
+	})
+
 	// Regression test for https://github.com/kubernetes/kubernetes/issues/136910
 	var _ = SIGDescribe(framework.WithSerial(), "Sidecar container restart after kubelet restart", framework.WithFeatureGate(features.ChangeContainerStatusOnKubeletRestart), func() {
 		f := framework.NewDefaultFramework("sidecar-container-restart-test-serial")
@@ -7044,11 +7433,6 @@ var _ = SIGDescribe(framework.WithSerial(), "Not Change Container Status", frame
 			ginkgo.By("restarting the kubelet")
 			restartKubelet := mustStopKubelet(ctx, f)
 			restartKubelet(ctx)
-
-			ginkgo.By("ensuring kubelet is healthy")
-			gomega.Eventually(ctx, func() bool {
-				return kubeletHealthCheck(kubeletHealthCheckURL)
-			}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeTrueBecause("kubelet should be started"))
 
 			ginkgo.By("Sending SIGTERM to PID 1 in the crasher container")
 			_, _, err = e2epod.ExecCommandInContainerWithFullOutput(f, pod.Name, "crasher", "kill", "1")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
This PR adds e2e test cases for a special case in the `ChangeContainerStatusOnKubeletRestart` feature: when a Pod's `Ready` status has been set to `false` **before** the kubelet restarts, the kubelet should ensure that the Pod remains in the `NotReady` state until the readiness probe explicitly marks it as Ready.

**The tests cover the following scenarios:**

**Regular containers NotReady:**
1. Pod with only `readinessProbe` — remains NotReady after kubelet restart
2. Pod with `startupProbe` and `readinessProbe` — remains NotReady after kubelet restart
3. Multi-container pod with only `readinessProbes` — remains NotReady after kubelet restart
4. Multi-container pod with `startupProbe` and `readinessProbes` — remains NotReady after kubelet restart

**Restartable init containers NotReady:**

1. Restartable init container with only `readinessProbe` — remains NotReady after kubelet restart
2. Restartable init container with `startupProbe` and `readinessProbe` — remains NotReady after kubelet restart

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
