### PR TITLE
kubeletplugin: Use CDI v0.5.0 for metadata specs

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/metadata.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/metadata.go
@@ -101,7 +101,10 @@ const (
 	// DefaultCDIDir is the default directory for CDI spec files.
 	DefaultCDIDir = "/var/run/cdi"
 
-	cdiVersionStr     = "0.3.0"
+	// v0.5.0 is required when CDI device names may start with a non-letter.
+	// Metadata device names are derived from claim UID + request name, and
+	// claim UIDs can start with digits.
+	cdiVersionStr     = "0.5.0"
 	metadataFilePerms = os.FileMode(0644)
 	metadataDirPerms  = os.FileMode(0755)
 )

--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/metadata_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/metadata_test.go
@@ -359,6 +359,53 @@ func TestProcessPreparedClaim(t *testing.T) {
 	}
 }
 
+func TestProcessPreparedClaimDigitLeadingUIDUsesCDIV050(t *testing.T) {
+	w, _, cdiDir := newTestWriter(t)
+	claim := testClaim()
+	claim.UID = types.UID("3314d6f8-b86c-46b7-a56a-cd42072e1b32")
+
+	devices := []Device{{
+		Requests:   []string{"vf"},
+		PoolName:   "node-1",
+		DeviceName: "vf-0",
+	}}
+
+	cdiIDs, err := w.processPreparedClaim(claim, devices)
+	if err != nil {
+		t.Fatalf("processPreparedClaim: %v", err)
+	}
+
+	cdiPath := filepath.Join(cdiDir, testDriverName+"_metadata_"+string(claim.UID)+"_vf.json")
+	cdiData, err := os.ReadFile(cdiPath)
+	if err != nil {
+		t.Fatalf("read CDI spec %s: %v", cdiPath, err)
+	}
+
+	var gotCDISpec cdiSpec
+	if err := json.Unmarshal(cdiData, &gotCDISpec); err != nil {
+		t.Fatalf("unmarshal CDI spec: %v", err)
+	}
+
+	if gotCDISpec.Version != cdiVersionStr {
+		t.Fatalf("unexpected CDI version %q, want %q", gotCDISpec.Version, cdiVersionStr)
+	}
+	if len(gotCDISpec.Devices) != 1 {
+		t.Fatalf("expected 1 CDI device, got %d", len(gotCDISpec.Devices))
+	}
+	if len(cdiIDs) != 1 {
+		t.Fatalf("expected 1 CDI ID, got %d", len(cdiIDs))
+	}
+
+	expectedName := string(claim.UID) + "_vf"
+	if gotCDISpec.Devices[0].Name != expectedName {
+		t.Fatalf("unexpected CDI device name %q, want %q", gotCDISpec.Devices[0].Name, expectedName)
+	}
+	expectedID := testDriverName + "/metadata=" + expectedName
+	if gotID := cdiIDs["vf"]; gotID != expectedID {
+		t.Fatalf("unexpected CDI ID %q, want %q", gotID, expectedID)
+	}
+}
+
 func TestCleanupClaim(t *testing.T) {
 	strVal := "0000:03:00.0"
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Metadata CDI device IDs are generated as `<claimUID>_<request>`. Claim UIDs can
start with digits. With CDI validation in runtime CDI `v0.8.0`, non-letter-
leading names require spec `v0.5.0`, so metadata specs emitted as
`cdiVersion: "0.3.0"` can fail with:
`CDI device injection failed: unresolvable CDI devices .../metadata=...`.

This PR updates metadata CDI generation to emit `cdiVersion: "0.5.0"` and adds
a regression test for a digit-leading claim UID.

Alternative considered: prefix metadata device names with a letter and keep
`0.3.0`. Not chosen because it changes naming semantics; this keeps current IDs
and emits the required spec version.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
- Unit tests:
  - `go test ./staging/src/k8s.io/dynamic-resource-allocation/... -count=1`
  - Added: `TestProcessPreparedClaimDigitLeadingUIDUsesCDIV050`

- Manual verification (local env):
  - kind cluster built from latest Kubernetes source
  - SR-IOV DRA driver with metadata enabled:
    - kubeletplugin option: `EnableDeviceMetadata`
    - env var: `ENABLE_DEVICE_METADATA=true`
  - observed metadata device name example:
    `3314d6f8-b86c-46b7-a56a-cd42072e1b32_vf`
  - verified failure with metadata CDI `0.3.0`, success with `0.5.0`

- Runtime reference: `containerd v2.0.2` uses CDI `v0.8.0`
  - [containerd `go.mod` (v2.0.2)](https://github.com/containerd/containerd/blob/v2.0.2/go.mod)
  - [CDI `requiresV050` rule](https://github.com/cncf-tags/container-device-interface/blob/v0.8.0/pkg/cdi/version.go#L181)
  - [CDI minimum-version enforcement](https://github.com/cncf-tags/container-device-interface/blob/v0.8.0/pkg/cdi/spec.go#L209-L215)

- AI assistance: AI tools were used for drafting and code iteration; changes were
  reviewed and validated by the PR author.

#### Does this PR introduce a user-facing change?
Yes. Users who enable DRA device metadata can hit pod startup failures with
metadata CDI `0.3.0` when claim UIDs are digit-leading. This change fixes that
behavior by emitting `0.5.0`. An alternative (prefix metadata device names
with a letter) was considered, but not chosen because it changes metadata
device naming.

```release-note
Fixed DRA metadata CDI spec generation to use `cdiVersion: "0.5.0"` instead of
`"0.3.0"`. This prevents CDI validation failures for metadata device IDs
derived from `<claimUID>_<request>` when claim UIDs start with digits on
runtimes using CDI v0.8+.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
N/A
```
