### PR TITLE
Automated cherry pick of #138131: Deflake TestPodSubresourceAuth by waiting for effective permissions before testing

### DIFF
--- a/test/integration/apiserver/subresource_auth_test.go
+++ b/test/integration/apiserver/subresource_auth_test.go
@@ -25,9 +25,12 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
+	"k8s.io/kubernetes/test/integration/authutil"
 	"k8s.io/kubernetes/test/integration/framework"
 	"k8s.io/kubernetes/test/utils/ktesting"
 )
@@ -139,6 +142,11 @@ func TestPodSubresourceAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Wait for the permissions to become effective by ensuring a create request is allowed
+	waitContext, cancel := context.WithTimeout(context.TODO(), wait.ForeverTestTimeout)
+	defer cancel()
+	authutil.WaitForNamedAuthorizationUpdate(t, waitContext, adminClientset.AuthorizationV1(), podCreatorUsername, ns, "create", "", schema.GroupResource{Group: "", Resource: "pods/exec"}, true)
 
 	subresources := []string{"exec", "attach", "portforward"}
 	for _, subresource := range subresources {

--- a/test/integration/authutil/authutil.go
+++ b/test/integration/authutil/authutil.go
@@ -62,6 +62,7 @@ func WaitForNamedAuthorizationUpdate(t *testing.T, ctx context.Context, c author
 		}
 		return true, nil
 	}); err != nil {
+		t.Logf("did not see expected allowed response %v for user=%s,namespace=%s,verb=%s,resourceName=%s,resource=%v", allowed, user, namespace, verb, resourceName, resource)
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Cherry pick of #138131 on release-1.35.

#138131: Deflake TestPodSubresourceAuth by waiting for effective permissions before testing

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind flake


```release-note
NONE
```