### PR TITLE
docs: add kubernetes source deep dive guides

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,35 @@
+# Kubernetes Repository Deep Dive Docs
+
+This folder adds a code-oriented learning layer for `kubernetes/kubernetes`. It is intentionally different from the end-user documentation on `kubernetes.io`: the goal here is to explain how the repository is wired internally.
+
+## Available language editions
+
+- English: [`docs/en/README.md`](en/README.md)
+
+## What this series explains
+
+- how the repository is laid out
+- how `kube-apiserver`, `kube-scheduler`, `kube-controller-manager`, and `kubelet` fit together
+- how a Pod request becomes a running workload
+- how scheduler formulas turn raw resources into placement decisions
+- how controller queues, retries, and kubelet pod workers actually work
+
+## Source-first, not marketing-first
+
+The documents in this folder are anchored in the repository itself, especially these paths:
+
+- `cmd/`
+- `pkg/`
+- `staging/src/k8s.io/apiserver/`
+- `staging/src/k8s.io/client-go/`
+- `pkg/scheduler/`
+- `pkg/controller/`
+- `pkg/kubelet/`
+
+## Reading order
+
+1. [`docs/en/quick-start.md`](en/quick-start.md)
+2. [`docs/en/architecture.md`](en/architecture.md)
+3. [`docs/en/control-plane.md`](en/control-plane.md)
+4. [`docs/en/math-theory.md`](en/math-theory.md)
+5. [`docs/en/controller-kubelet.md`](en/controller-kubelet.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ This folder adds a code-oriented learning layer for `kubernetes/kubernetes`. It 
 ## Available language editions
 
 - English: [`docs/en/README.md`](en/README.md)
+- Chinese: [`docs/zh/README.md`](zh/README.md)
 
 ## What this series explains
 
@@ -33,3 +34,11 @@ The documents in this folder are anchored in the repository itself, especially t
 3. [`docs/en/control-plane.md`](en/control-plane.md)
 4. [`docs/en/math-theory.md`](en/math-theory.md)
 5. [`docs/en/controller-kubelet.md`](en/controller-kubelet.md)
+
+## 中文阅读顺序
+
+1. [`docs/zh/quick-start.md`](zh/quick-start.md)
+2. [`docs/zh/architecture.md`](zh/architecture.md)
+3. [`docs/zh/control-plane.md`](zh/control-plane.md)
+4. [`docs/zh/math-theory.md`](zh/math-theory.md)
+5. [`docs/zh/controller-kubelet.md`](zh/controller-kubelet.md)

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -1,0 +1,60 @@
+# Kubernetes Source Code Deep Dive
+
+This series is for readers who want to understand the **real structure** of `kubernetes/kubernetes`, not just how to use Kubernetes from the outside.
+
+If the repository feels overwhelming, that feeling is normal. Kubernetes ships an API server, a scheduler, a controller host, a node agent, a reusable API machinery stack, generated clients, tests, and a huge amount of compatibility code. The trick is to learn the system in layers.
+
+## What you will get from this series
+
+- a stable mental model of the repository layout
+- a source-level map of the control plane
+- a step-by-step trace from `kubectl apply` to running containers
+- a plain-English explanation of the scheduler's core formulas
+- a controller and kubelet guide that explains the reconciliation loops at node and cluster level
+
+## Reading map
+
+| File | Main question it answers | Best read after |
+| --- | --- | --- |
+| [`quick-start.md`](quick-start.md) | Where do I start in this giant repository? | none |
+| [`architecture.md`](architecture.md) | What is the macro architecture of Kubernetes? | quick start |
+| [`control-plane.md`](control-plane.md) | What exactly happens inside the API server and scheduler? | architecture |
+| [`math-theory.md`](math-theory.md) | How do scheduler formulas really work? | control plane |
+| [`controller-kubelet.md`](controller-kubelet.md) | How do controllers and kubelet continuously reconcile state? | architecture |
+
+## Recommended path
+
+```mermaid
+flowchart LR
+    A[quick-start.md<br/>repo map] --> B[architecture.md<br/>macro mental model]
+    B --> C[control-plane.md<br/>api server and scheduler]
+    C --> D[math-theory.md<br/>scoring and backoff formulas]
+    B --> E[controller-kubelet.md<br/>reconciliation on cluster and node]
+```
+
+## The five ideas to keep in your head
+
+1. **The API server is the shared source of truth.** Almost every major component either writes to it, watches it, or both.
+2. **Kubernetes is built around level-triggered reconciliation.** Components do not "perform one action and finish". They keep comparing desired state with current state.
+3. **The control plane mostly decides; nodes mostly execute.** Scheduling and reconciliation decisions happen centrally, but containers are created on nodes by kubelet.
+4. **Watches are the bloodstream of the system.** Informers, caches, workqueues, and the watch cache are how change propagates efficiently.
+5. **Most smart behavior is surprisingly numeric.** Fit checks, balancing, priority sorting, and backoff all reduce to small formulas.
+
+## Primary source anchors
+
+These are the best entry files for the topics covered here:
+
+- `cmd/kube-apiserver/app/server.go`
+- `staging/src/k8s.io/apiserver/pkg/server/config.go`
+- `pkg/scheduler/schedule_one.go`
+- `pkg/scheduler/framework/plugins/noderesources/*.go`
+- `pkg/controller/deployment/deployment_controller.go`
+- `pkg/controller/deployment/sync.go`
+- `pkg/kubelet/kubelet.go`
+- `pkg/kubelet/pod_workers.go`
+
+## One-sentence summary
+
+If you remember only one thing, remember this:
+
+> Kubernetes is a giant distributed state machine whose components keep reading from the API server, reasoning over cached state, and writing back corrections until reality matches intent.

--- a/docs/en/architecture.md
+++ b/docs/en/architecture.md
@@ -1,0 +1,155 @@
+# Kubernetes Architecture: The Big Picture Before the Details
+
+## Start with the real pain
+
+Running distributed applications is hard for three reasons:
+
+1. machines fail
+2. desired state changes constantly
+3. the cluster never stops moving while you are making decisions
+
+Kubernetes solves this by turning the cluster into a **continuously reconciled system** rather than a one-shot deployment engine.
+
+## The macro skeleton
+
+```mermaid
+flowchart LR
+    subgraph Clients
+        U[kubectl / operators / controllers / apps]
+    end
+
+    subgraph ControlPlane
+        A[kube-apiserver]
+        ETCD[(etcd)]
+        S[kube-scheduler]
+        CM[kube-controller-manager]
+    end
+
+    subgraph Nodes
+        K1[kubelet on node A]
+        K2[kubelet on node B]
+        CRI[container runtime]
+    end
+
+    U --> A
+    A <--> ETCD
+    S --> A
+    CM --> A
+    K1 --> A
+    K2 --> A
+    K1 --> CRI
+    K2 --> CRI
+```
+
+## The most important architectural truth
+
+The API server is not just a request router. It is the **shared coordination surface** for the whole system.
+
+- clients write intent to it
+- controllers watch it
+- scheduler watches it
+- kubelets watch it
+- status flows back through it
+
+This is why Kubernetes often feels API-first: the API server is the meeting point where decentralized components coordinate.
+
+## One Pod from YAML to containers
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant A as kube-apiserver
+    participant E as etcd
+    participant S as kube-scheduler
+    participant K as kubelet
+    participant R as container runtime
+
+    C->>A: POST Pod
+    A->>A: authn -> authz -> admission
+    A->>E: store Pod object
+    S->>A: watch Pod without nodeName
+    S->>S: filter and score candidate nodes
+    S->>A: bind Pod to node
+    K->>A: watch Pod assigned to this node
+    K->>K: SyncPod
+    K->>R: create sandbox and containers
+    K->>A: update PodStatus and Events
+```
+
+## The three loops that define Kubernetes
+
+### 1. Request loop
+
+A client sends intent to the API server.
+
+### 2. Reconciliation loop
+
+Controllers and scheduler watch for objects whose current state is not good enough yet.
+
+### 3. Execution loop
+
+Kubelet continuously turns assigned PodSpecs into actual running containers.
+
+If you compress Kubernetes to one sentence, it is this:
+
+> request creates intent, watches spread change, reconcilers react, kubelet executes.
+
+## Why watches matter so much
+
+Polling every object repeatedly would be too expensive. Instead, Kubernetes leans on:
+
+- etcd-backed storage
+- watch streams from the API server
+- local caches and informers
+- workqueues that only process changed keys
+
+```mermaid
+flowchart LR
+    E[(etcd)] --> WC[watch cache]
+    WC --> W[watch stream]
+    W --> I[shared informer cache]
+    I --> Q[workqueue]
+    Q --> R[reconcile function]
+    R --> A[kube-apiserver writes]
+```
+
+This is the hidden bloodstream of the project.
+
+## Why `CreateServerChain` matters
+
+The API server path is not a single monolith. In `cmd/kube-apiserver/app/server.go`, `CreateServerChain()` wires a delegation chain that conceptually looks like this:
+
+```mermaid
+flowchart LR
+    REQ[Incoming request] --> AGG[API Aggregator]
+    AGG --> CORE[Kubernetes core APIs]
+    CORE --> CRD[CRD API server]
+    CRD --> NF[NotFound handler]
+```
+
+That is why a request can pass through multiple layers even though users experience it as one endpoint.
+
+## The four source anchors behind the big picture
+
+| Area | Best file to open | Why |
+| --- | --- | --- |
+| API server bootstrap | `cmd/kube-apiserver/app/server.go` | builds the server chain |
+| Handler chain | `staging/src/k8s.io/apiserver/pkg/server/config.go` | shows authn/authz/audit/filter wrapping |
+| Scheduler cycle | `pkg/scheduler/schedule_one.go` | shows the end-to-end node selection path |
+| Kubelet execution | `pkg/kubelet/kubelet.go` | shows the node-side sync loop |
+
+## A plain-language model for beginners
+
+Imagine a supermarket warehouse:
+
+- the API server is the central order board
+- controllers check whether shelves match the orders
+- the scheduler picks which loading dock should receive a shipment
+- kubelet is the dock worker that actually unloads and places boxes
+- etcd is the secure filing cabinet holding the official record
+
+Nothing magical happens. The system just keeps comparing the board with reality and fixing the gap.
+
+## Next step
+
+Now that the macro skeleton is clear, move to [`control-plane.md`](control-plane.md) for the micro-level request path inside the API server and the actual scheduler cycle.

--- a/docs/en/control-plane.md
+++ b/docs/en/control-plane.md
@@ -1,0 +1,142 @@
+# Control Plane Deep Dive: API Server, Scheduler, and the Shared State Machine
+
+## Why the control plane exists
+
+The control plane answers one question over and over:
+
+> Given the latest desired state and the latest observed state, what should happen next?
+
+Different components answer different slices of that question, but they coordinate through the same API surface.
+
+## 1. The API server handler chain
+
+In `staging/src/k8s.io/apiserver/pkg/server/config.go`, `DefaultBuildHandlerChain()` wraps the core API handler with filters. The code is written inside-out, so the request path is easiest to understand as a pipeline.
+
+```mermaid
+flowchart TD
+    R[HTTP request] --> AI[audit init and request metadata]
+    AI --> REC[panic recovery, timeout, warning recorder, CORS]
+    REC --> AUTHN[authentication]
+    AUTHN --> AUDIT[audit]
+    AUDIT --> IMP[impersonation]
+    IMP --> FC[priority and fairness / max in flight]
+    FC --> AUTHZ[authorization]
+    AUTHZ --> H[resource handler]
+    H --> STORE[generic registry store]
+    STORE --> CACHE[watch cache / cacher]
+    CACHE --> ETCD[(etcd3 storage)]
+```
+
+### What each stage means in plain English
+
+- **authentication**: who are you?
+- **authorization**: are you allowed to do this?
+- **admission**: even if you are allowed, should the object be mutated or rejected based on policy?
+- **storage**: how is the object persisted and later watched efficiently?
+
+## 2. From HTTP route to storage
+
+The important source anchors are:
+
+- `cmd/kube-apiserver/app/server.go` for server bootstrap and `CreateServerChain()`
+- `staging/src/k8s.io/apiserver/pkg/server/handler.go` for API handler routing
+- `staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go` for create requests
+- `staging/src/k8s.io/apiserver/pkg/endpoints/handlers/update.go` for updates
+- `staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go` for streaming watch responses
+- `staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go` for generic persistence logic
+- `staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go` for the watch cache layer
+- `staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go` for etcd-backed storage
+
+## 3. Why the watch cache changes everything
+
+Without a cache, each watcher would force the API server to hit storage too often. With the cacher layer:
+
+- recent object history is buffered
+- list and watch can often be served from cache
+- watchers get streamed updates efficiently
+
+This is one of the biggest reasons Kubernetes can keep so many controllers and kubelets synchronized.
+
+## 4. The scheduler is a two-phase machine
+
+`pkg/scheduler/schedule_one.go` is the best file for understanding the scheduler. The key pattern is:
+
+1. **scheduling cycle**: decide *where* the Pod should go
+2. **binding cycle**: make that decision real
+
+```mermaid
+flowchart LR
+    Q[SchedulingQueue] --> N[NextPod]
+    N --> PF[PreFilter]
+    PF --> F[Filter candidate nodes]
+    F --> PS[PreScore]
+    PS --> SC[Score plugins + extenders]
+    SC --> PICK[select best node]
+    PICK --> ASSUME[assume in scheduler cache]
+    ASSUME --> RESERVE[reserve plugins]
+    RESERVE --> PERMIT[permit plugins]
+    PERMIT --> PREBIND[pre-bind plugins]
+    PREBIND --> BIND[bind plugin / default binder]
+    BIND --> API[write Binding via API server]
+```
+
+### Why `assume` exists
+
+The scheduler does not always wait for the real bind to finish before continuing. It **assumes** the Pod is on the chosen node in its own cache so it can keep scheduling other Pods.
+
+This is an optimistic concurrency trick: it improves throughput without changing the API server's final authority.
+
+## 5. What the default binder really does
+
+The default binder is intentionally small. In `pkg/scheduler/framework/plugins/defaultbinder/default_binder.go`, it creates a `v1.Binding` and sends it through the API server.
+
+That means the scheduler does not directly launch containers. It only records placement.
+
+## 6. Where controllers fit into the control plane
+
+The scheduler solves **placement**.
+
+Controllers solve **state drift**.
+
+- Deployment controller: desired ReplicaSets and Pods vs actual ones
+- Service controller: desired endpoints vs actual backing Pods
+- Namespace controller: cleanup and lifecycle transitions
+- many more under `pkg/controller/`
+
+```mermaid
+flowchart LR
+    A[kube-apiserver] --> INF[informer cache]
+    INF --> Q[workqueue]
+    Q --> SYNC[controller sync handler]
+    SYNC --> A
+```
+
+The repeating pattern is always the same: watch, enqueue, reconcile, write back.
+
+## 7. One request, many asynchronous consequences
+
+A single Pod creation request can trigger all of these downstream effects:
+
+1. object stored in etcd
+2. scheduler notices a pending Pod
+3. scheduler writes binding
+4. kubelet notices an assigned Pod
+5. kubelet starts containers
+6. kubelet updates status
+7. other controllers react to status or label changes
+
+This is why Kubernetes feels event-driven even though each individual component is mostly a loop over caches and queues.
+
+## 8. The most useful functions to open next
+
+| Topic | Function / file |
+| --- | --- |
+| API server chain | `CreateServerChain()` in `cmd/kube-apiserver/app/server.go` |
+| handler wrapping | `DefaultBuildHandlerChain()` in `staging/src/k8s.io/apiserver/pkg/server/config.go` |
+| scheduler core loop | `ScheduleOne()` and `schedulingCycle()` in `pkg/scheduler/schedule_one.go` |
+| score plugin execution | `RunScorePlugins()` in `pkg/scheduler/framework/runtime/framework.go` |
+| default bind | `Bind()` in `pkg/scheduler/framework/plugins/defaultbinder/default_binder.go` |
+
+## Next step
+
+Continue with [`math-theory.md`](math-theory.md) to see how the scheduler turns resource pressure, balance, and retries into actual numbers.

--- a/docs/en/controller-kubelet.md
+++ b/docs/en/controller-kubelet.md
@@ -1,0 +1,222 @@
+# Controllers and Kubelet: The Two Reconcilers That Keep Kubernetes Alive
+
+## Why group these together?
+
+Controllers and kubelet live at different layers, but they share the same philosophy:
+
+- observe current state
+- compare with desired state
+- make one step toward convergence
+- retry until the gap disappears
+
+The difference is scope:
+
+- controllers reconcile **cluster-level intent**
+- kubelet reconciles **node-level execution**
+
+## Part I. Deployment controller as the canonical cluster reconciler
+
+Best source anchors:
+
+- `pkg/controller/deployment/deployment_controller.go`
+- `pkg/controller/deployment/sync.go`
+
+### The standard controller pattern
+
+```mermaid
+flowchart LR
+    W[watch / informer event] --> Q[workqueue key]
+    Q --> WK[worker goroutine]
+    WK --> S[syncDeployment]
+    S --> RS[create or update ReplicaSet]
+    S --> P[create or delete Pods]
+    S --> ST[update Deployment status]
+    ST --> W
+```
+
+### What `NewDeploymentController()` sets up
+
+The controller wires informer event handlers for:
+
+- Deployments
+- ReplicaSets
+- Pods
+
+Every interesting change eventually enqueues the owning Deployment key.
+
+### What the worker does
+
+`processNextWorkItem()` in `deployment_controller.go` is beautifully simple:
+
+1. get one key from the workqueue
+2. call `syncHandler`
+3. forget on success
+4. `AddRateLimited()` on failure
+
+That small shape is one of the most important patterns in Kubernetes.
+
+### What `sync.go` actually reconciles
+
+In `sync.go`, the controller:
+
+- identifies the new and old ReplicaSets
+- computes the next revision
+- scales the right ReplicaSets
+- cleans up paused or outdated state when needed
+- updates Deployment status
+
+This is not a one-shot rollout script. It is a convergence loop.
+
+## A grandmother-friendly analogy
+
+Imagine a restaurant manager.
+
+- the menu says 10 bowls of noodle soup should be available
+- the kitchen currently has only 7 ready
+- the manager does not shout "done" once and leave
+- the manager keeps counting and asking for more bowls until the front counter really has 10
+
+That is exactly how a controller thinks.
+
+## Controller retry math
+
+`deployment_controller.go` documents a retry pattern that looks like:
+
+$$
+5ms \times 2^{n-1}
+$$
+
+with `maxRetries = 15`.
+
+So the waits grow roughly like:
+
+- `5ms`
+- `10ms`
+- `20ms`
+- `40ms`
+- ...
+- up to tens of seconds
+
+This prevents a broken object from causing a hot loop.
+
+## Part II. Kubelet as the node-side reconciler
+
+Best source anchors:
+
+- `pkg/kubelet/kubelet.go`
+- `pkg/kubelet/pod_workers.go`
+
+### The kubelet sync loop
+
+`syncLoop()` and `syncLoopIteration()` in `kubelet.go` listen to multiple event sources:
+
+- API server updates
+- file and HTTP pod sources
+- PLEG runtime events
+- periodic sync ticks
+- housekeeping ticks
+- health and probe related updates
+
+```mermaid
+flowchart TD
+    APIServer[API server pod updates] --> LOOP[syncLoopIteration]
+    File[file source] --> LOOP
+    HTTP[http source] --> LOOP
+    PLEG[PLEG runtime events] --> LOOP
+    Tick[periodic sync tick] --> LOOP
+    LOOP --> ADD[HandlePodAdditions]
+    LOOP --> UPD[HandlePodUpdates]
+    LOOP --> REM[HandlePodRemoves]
+    ADD --> PW[podWorkers.UpdatePod]
+    UPD --> PW
+    REM --> PW
+    PW --> PL[podWorkerLoop]
+    PL --> SP[Kubelet.SyncPod]
+    SP --> CRI[containerRuntime.SyncPod]
+```
+
+### Why `podWorkers` matter
+
+Kubelet does not let random goroutines mutate the same Pod at the same time. `podWorkers` serialize work per Pod.
+
+That gives kubelet something like a **per-Pod state machine**.
+
+```mermaid
+stateDiagram-v2
+    [*] --> WaitingToStart
+    WaitingToStart --> SyncPod
+    SyncPod --> SyncPod: update / periodic resync
+    SyncPod --> Terminating: deletion or stop request
+    Terminating --> Terminated
+    Terminated --> [*]
+```
+
+### What `HandlePodAdditions()` really does
+
+When kubelet gets a new Pod, it:
+
+1. adds it to the pod manager
+2. tracks certificates and mirror pod relationships if needed
+3. runs admission / allocation checks
+4. sends an `UpdatePod()` request into the pod worker system
+
+So the addition handler is not "start container now". It is "update the local desired-state machinery so that the worker can reconcile safely".
+
+### What `SyncPod()` really does
+
+The kubelet's `SyncPod()` path is where node execution becomes real. It handles things like:
+
+- Pod status generation
+- mirror pod reconciliation
+- cgroup setup
+- volume attachment and mount waiting
+- image pull secret lookup
+- probe registration
+- delegation to `containerRuntime.SyncPod(...)`
+
+In other words, kubelet is the final translator from Kubernetes objects to runtime actions.
+
+## Kubelet backoff in the main loop
+
+The kubelet sync loop also uses exponential backoff when runtime errors occur.
+
+In `kubelet.go`, the parameters are:
+
+- base = `100ms`
+- factor = `2`
+- max = `5s`
+
+That gives a sequence like:
+
+- `100ms`
+- `200ms`
+- `400ms`
+- `800ms`
+- `1.6s`
+- `3.2s`
+- `5s` cap
+
+This is the same design philosophy we saw in the scheduler and controllers: retry, but do not thrash.
+
+## Cluster-level vs node-level reconciliation
+
+| Dimension | Controllers | Kubelet |
+| --- | --- | --- |
+| Scope | whole cluster resources | one node's assigned Pods |
+| Trigger | informer events + resync | API/file/http/PLEG/ticks |
+| Unit of work | usually object key in workqueue | Pod update in pod worker |
+| Main action | create/update/delete API objects | create/update/stop containers and sandboxes |
+| Goal | make cluster objects converge | make node runtime converge |
+
+## The big unifying insight
+
+Controllers and kubelet are the same idea at different zoom levels.
+
+- Deployment controller asks: "Do ReplicaSets and Pods match Deployment intent?"
+- kubelet asks: "Do containers on this node match Pod intent?"
+
+Kubernetes works because both layers keep answering that question forever.
+
+## Where to go next
+
+After this file, revisit [`architecture.md`](architecture.md) and [`control-plane.md`](control-plane.md). The system usually clicks hardest when you see that every component is just another reconciler standing at a different place in the pipeline.

--- a/docs/en/math-theory.md
+++ b/docs/en/math-theory.md
@@ -1,0 +1,316 @@
+# Math Theory Made Friendly: Scheduler Scoring, Queue Order, and Backoff
+
+## Why this file matters
+
+Kubernetes scheduling looks mysterious until you notice that many key decisions are powered by very small formulas.
+
+This file explains the formulas behind:
+
+- resource fit
+- least / most allocated scoring
+- configurable utilization curves
+- balanced allocation via standard deviation
+- queue priority ordering
+- exponential backoff
+
+## 1. Fit check: can the Pod even fit?
+
+Source anchor: `pkg/scheduler/framework/plugins/noderesources/fit.go`, especially `fitsRequest()`.
+
+### Core idea
+
+For each resource:
+
+$$
+\text{pod request} \le \text{node allocatable} - \text{already requested}
+$$
+
+### What the variables mean in real life
+
+- `pod request`: what the incoming Pod asks for
+- `node allocatable`: what the node can safely offer to Pods
+- `already requested`: what other Pods already reserved on that node
+
+### Grocery-bag example
+
+Imagine a basket that can safely carry 10 kg.
+
+- 6 kg is already inside
+- you want to add 3 kg of fruit
+- remaining room is `10 - 6 = 4`
+- because `3 <= 4`, it fits
+
+If you tried to add 5 kg instead, it would fail.
+
+### Numeric scheduler example
+
+- node allocatable CPU: `4000m`
+- already requested CPU: `2500m`
+- incoming Pod CPU request: `1800m`
+- remaining CPU: `1500m`
+
+Because `1800m > 1500m`, the plugin returns **Insufficient cpu**.
+
+## 2. LeastAllocated: prefer emptier nodes
+
+Source anchor: `pkg/scheduler/framework/plugins/noderesources/least_allocated.go`.
+
+The code computes a score per resource and then takes a weighted average.
+
+$$
+\text{score}_r = \frac{\text{capacity}_r - \text{requested}_r}{\text{capacity}_r} \times 100
+$$
+
+Then:
+
+$$
+\text{node score} = \frac{\sum_r \text{weight}_r \times \text{score}_r}{\sum_r \text{weight}_r}
+$$
+
+### Intuition
+
+More free space means a higher score.
+
+### Example
+
+Suppose the Pod would make a node look like this:
+
+- CPU requested: `3/8` cores
+- Memory requested: `10/16` GiB
+
+Then:
+
+- CPU score = `(8 - 3) / 8 * 100 = 62.5`
+- Memory score = `(16 - 10) / 16 * 100 = 37.5`
+- equal weights => node score ≈ `50`
+
+That node is moderately empty, not extremely empty.
+
+## 3. MostAllocated: prefer fuller nodes
+
+Source anchor: `pkg/scheduler/framework/plugins/noderesources/most_allocated.go`.
+
+This is the mirror image of LeastAllocated.
+
+$$
+\text{score}_r = \frac{\text{requested}_r}{\text{capacity}_r} \times 100
+$$
+
+### Intuition
+
+Now a fuller node scores higher. This is useful when you want tighter packing and more untouched nodes left over.
+
+### Example
+
+- CPU used after placement: `6/8 = 75%`
+- Memory used after placement: `12/16 = 75%`
+- final score = `75`
+
+This node is attractive when your policy prefers packing instead of spreading.
+
+## 4. RequestedToCapacityRatio: policy as a curve
+
+Source anchors:
+
+- `pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio.go`
+- `pkg/scheduler/framework/plugins/helper/shape_score.go`
+
+The helper `BuildBrokenLinearFunction()` turns a list of points into a piecewise linear scoring function.
+
+### Core idea
+
+1. compute utilization percentage
+2. map that percentage onto a configured line made of segments
+
+$$
+\text{utilization} = \frac{\text{requested}}{\text{capacity}} \times 100
+$$
+
+Then use linear interpolation between nearby shape points.
+
+```mermaid
+flowchart LR
+    P0[0% -> 0] --> P1[50% -> 50]
+    P1 --> P2[80% -> 90]
+    P2 --> P3[100% -> 100]
+```
+
+### Vegetable-market example
+
+Suppose your rule is:
+
+- empty stall: low value
+- half-full stall: medium value
+- almost-full stall: very high value
+
+If the utilization lands at `60%`, it sits between `50% -> 50` and `80% -> 90`, so the score is interpolated between 50 and 90.
+
+### Numeric example
+
+Shape points:
+
+- `(0, 0)`
+- `(50, 50)`
+- `(100, 100)`
+
+If utilization is `60%`, the score becomes `60`.
+
+This is powerful because cluster operators can express policy as a curve instead of hardcoding one formula.
+
+## 5. BalancedAllocation: prefer balanced resource pressure
+
+Source anchor: `pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go`.
+
+This plugin looks at how similar the usage fractions are across resources.
+
+First compute fractions:
+
+$$
+f_i = \frac{\text{requested}_i}{\text{allocatable}_i}
+$$
+
+Then compute standard deviation:
+
+$$
+\sigma = \sqrt{\frac{1}{n} \sum_i (f_i - \bar f)^2}
+$$
+
+Then score approximately as:
+
+$$
+\text{score} = (1 - \sigma) \times 100
+$$
+
+### Intuition without the scary symbol
+
+If CPU and memory are used at similar rates, the node is "balanced".
+
+If one resource is almost full while the other is mostly empty, the node is "crooked".
+
+### Simplified two-resource trick
+
+When only CPU and memory matter, the code comments note that the standard deviation simplifies nicely.
+
+If CPU fraction is `0.8` and memory fraction is `0.2`, then:
+
+$$
+\sigma = \frac{|0.8 - 0.2|}{2} = 0.3
+$$
+
+So:
+
+$$
+\text{score} = (1 - 0.3) \times 100 = 70
+$$
+
+If CPU and memory are both `0.5`, then `\sigma = 0` and the score becomes `100`.
+
+That is the heart of the plugin: balanced usage is rewarded.
+
+```mermaid
+flowchart TD
+    A[CPU 50%<br/>Memory 50%] --> H[stddev = 0<br/>score = 100]
+    B[CPU 80%<br/>Memory 20%] --> L[stddev = 0.3<br/>score = 70]
+```
+
+## 6. Queue sort: priority first, time second
+
+Source anchor: `pkg/scheduler/framework/plugins/queuesort/priority_sort.go`.
+
+The queue ordering rule is tiny but crucial:
+
+- higher Pod priority wins
+- if priorities tie, earlier timestamp wins
+
+In formula-like form:
+
+$$
+A \text{ comes first if } priority(A) > priority(B)
+$$
+
+or, if equal:
+
+$$
+A \text{ comes first if } timestamp(A) < timestamp(B)
+$$
+
+### Example
+
+- Pod X priority = `1000`, queued at `10:00`
+- Pod Y priority = `5000`, queued at `10:05`
+
+Pod Y still wins because priority dominates time.
+
+## 7. Scheduler backoff: retry, but do not thrash
+
+Source anchors:
+
+- `pkg/scheduler/backend/queue/backoff_queue.go`
+- `pkg/scheduler/backend/queue/scheduling_queue.go`
+
+The queue uses exponential backoff with caps.
+
+$$
+\text{backoff}(n) = \min(\text{initial} \times 2^{n-1}, \text{max})
+$$
+
+Typical defaults in the scheduler queue are conceptually:
+
+- initial backoff: `1s`
+- max backoff: `10s`
+
+### Example
+
+Attempt counts produce:
+
+- attempt 1 -> `1s`
+- attempt 2 -> `2s`
+- attempt 3 -> `4s`
+- attempt 4 -> `8s`
+- attempt 5 -> `10s` (cap reached)
+
+```mermaid
+flowchart LR
+    A1[1st failure<br/>1s] --> A2[2nd failure<br/>2s]
+    A2 --> A3[3rd failure<br/>4s]
+    A3 --> A4[4th failure<br/>8s]
+    A4 --> A5[5th failure<br/>10s cap]
+```
+
+### Why this is elegant
+
+If the cluster is temporarily congested, the scheduler avoids hammering the same impossible decision over and over.
+
+## 8. Bonus: the same mathematical style appears elsewhere
+
+### Deployment controller retries
+
+`pkg/controller/deployment/deployment_controller.go` documents retries based on approximately:
+
+$$
+5ms \times 2^{n-1}
+$$
+
+with `maxRetries = 15`.
+
+### Kubelet runtime-error backoff
+
+In `pkg/kubelet/kubelet.go`, the main sync loop uses:
+
+- base = `100ms`
+- factor = `2`
+- max = `5s`
+
+Same pattern, different subsystem: if the system is unhealthy, retry progressively instead of spinning wildly.
+
+## Final takeaway
+
+The scheduler is not magic. It is mostly a careful composition of:
+
+- inequality checks
+- weighted averages
+- interpolation on simple curves
+- standard deviation for balance
+- exponential backoff for fairness and stability
+
+Once you see that, the code becomes much less intimidating.

--- a/docs/en/quick-start.md
+++ b/docs/en/quick-start.md
@@ -1,0 +1,127 @@
+# Quick Start: How to Read the Kubernetes Repository Without Drowning
+
+## Why the repository feels huge
+
+The repository is not "just an orchestrator". It contains:
+
+- the control plane entrypoints
+- the reusable API machinery stack
+- the scheduler framework
+- the controller implementations
+- the kubelet node agent
+- generated APIs and clients
+- build, release, and compatibility machinery
+
+That is why the repo feels like a small operating system instead of a normal service.
+
+## The 30-second mental model
+
+Think of Kubernetes as a city:
+
+- `kube-apiserver` is the **city hall ledger**
+- etcd is the **vault that stores the ledger**
+- controllers are **clerks** that keep rechecking whether reality matches the forms
+- the scheduler is the **placement officer** that picks a node for each unscheduled Pod
+- kubelet is the **local foreman** on every node that actually starts and monitors containers
+
+## Repository map
+
+```mermaid
+flowchart TB
+    R[kubernetes/] --> CMD[cmd/<br/>main binaries and CLIs]
+    R --> PKG[pkg/<br/>core in-repo implementations]
+    R --> STAGING[staging/src/k8s.io/<br/>authoritative component libraries]
+    R --> API[api/<br/>versioned external API types]
+    R --> TEST[test/<br/>integration e2e perf]
+    R --> HACK[hack/<br/>build verify generation scripts]
+    R --> DOCS[docs/<br/>repo-local learning docs]
+```
+
+## Which top-level directories matter most
+
+| Path | Why it matters |
+| --- | --- |
+| `cmd/` | Process entrypoints: `kube-apiserver`, `kube-scheduler`, `kube-controller-manager`, `kubelet`, `kubectl`, `kubeadm` |
+| `pkg/` | Core implementations that are specific to this repository |
+| `staging/src/k8s.io/` | The published libraries and API machinery source of truth |
+| `api/` | External versioned API types |
+| `test/` | Integration and e2e truth serum |
+| `hack/` | How the project verifies and generates things |
+
+## The four binaries to learn first
+
+| Binary | Entry path | What it really does |
+| --- | --- | --- |
+| `kube-apiserver` | `cmd/kube-apiserver/app/server.go` | accepts API requests, validates them, runs admission, persists them, and exposes watches |
+| `kube-scheduler` | `cmd/kube-scheduler/app/server.go` | chooses nodes for unscheduled Pods |
+| `kube-controller-manager` | `cmd/kube-controller-manager/app/controllermanager.go` | hosts many cluster-level control loops |
+| `kubelet` | `cmd/kubelet/app/server.go` | runs on each node and makes PodSpecs real |
+
+## The best first end-to-end story
+
+Do not start by reading every subsystem independently. Start with one life cycle:
+
+1. a client submits a Pod
+2. the API server persists it
+3. the scheduler assigns a node
+4. kubelet sees the assigned Pod and starts containers
+5. controllers and kubelet keep updating status
+
+```mermaid
+sequenceDiagram
+    participant U as User / kubectl
+    participant A as kube-apiserver
+    participant E as etcd
+    participant S as kube-scheduler
+    participant K as kubelet
+
+    U->>A: create Pod
+    A->>E: persist desired state
+    S->>A: watch unscheduled Pods
+    S->>A: bind Pod to node
+    K->>A: watch assigned Pods
+    K->>K: SyncPod and call runtime
+    K->>A: report status and events
+```
+
+## The first files worth opening
+
+If you only have one hour, open these files in roughly this order:
+
+1. `cmd/kube-apiserver/app/server.go`
+2. `staging/src/k8s.io/apiserver/pkg/server/config.go`
+3. `pkg/scheduler/schedule_one.go`
+4. `pkg/scheduler/framework/plugins/noderesources/fit.go`
+5. `pkg/scheduler/framework/plugins/noderesources/least_allocated.go`
+6. `pkg/controller/deployment/deployment_controller.go`
+7. `pkg/controller/deployment/sync.go`
+8. `pkg/kubelet/kubelet.go`
+9. `pkg/kubelet/pod_workers.go`
+10. `staging/src/k8s.io/client-go/tools/cache/shared_informer.go`
+
+## A practical reading strategy
+
+### Pass 1: build the skeleton
+
+Only answer these questions:
+
+- Where does each main process start?
+- What shared state do they read?
+- What shared state do they write?
+- Which part is event-driven, and which part is periodic?
+
+### Pass 2: follow one Pod
+
+Trace a Pod from API creation to kubelet execution.
+
+### Pass 3: study the numbers
+
+Only after you understand the flow should you read scheduler scoring, backoff, and balancing formulas.
+
+## A small warning that saves a lot of time
+
+Much of the reusable machinery is in `staging/src/k8s.io/`, not just in `pkg/`. If something feels "missing" in `pkg/`, check the staged libraries before assuming the logic is elsewhere.
+
+## Next step
+
+Continue with [`architecture.md`](architecture.md) to build the macro picture before diving into the API handler chain and scheduler cycle.

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -1,0 +1,68 @@
+# Kubernetes 源码深潜教程
+
+这套文档不是教你“怎么用 Kubernetes”，而是带你看懂 `kubernetes/kubernetes` 这个仓库本身是如何组织、如何运转、以及为什么会这样设计。
+
+如果你第一次打开这个仓库就感到压迫感，这很正常。Kubernetes 不是一个普通服务，它同时承载了：
+
+- API server
+- scheduler
+- controller host
+- node agent
+- API machinery 通用框架
+- 客户端生成代码
+- 测试、构建、兼容层
+
+真正高效的学习方式，不是把文件全扫一遍，而是先建立正确的“骨架感”。
+
+## 这套文档会帮你拿到什么
+
+- 一个稳定的仓库结构脑图
+- 一张从源码视角出发的控制面地图
+- 一条从 `kubectl apply` 到容器落地运行的完整链路
+- 一份把 scheduler 数学公式讲成直觉的解释
+- 一份把 controller 与 kubelet 的对账循环讲透的教程
+
+## 阅读地图
+
+| 文件 | 主要回答什么问题 | 推荐顺序 |
+| --- | --- | --- |
+| [`quick-start.md`](quick-start.md) | 这么大的仓库，我到底从哪里开始？ | 第一篇 |
+| [`architecture.md`](architecture.md) | Kubernetes 的宏观架构骨架是什么？ | 第二篇 |
+| [`control-plane.md`](control-plane.md) | API server 和 scheduler 内部到底在干什么？ | 第三篇 |
+| [`math-theory.md`](math-theory.md) | scheduler 的打分、排队、退避公式到底怎么理解？ | 第四篇 |
+| [`controller-kubelet.md`](controller-kubelet.md) | controller 和 kubelet 是怎么持续对账的？ | 第五篇 |
+
+## 推荐阅读路径
+
+```mermaid
+flowchart LR
+    A[quick-start.md<br/>仓库地图] --> B[architecture.md<br/>宏观骨架]
+    B --> C[control-plane.md<br/>控制面细节]
+    C --> D[math-theory.md<br/>调度公式与退避]
+    B --> E[controller-kubelet.md<br/>控制器与节点执行]
+```
+
+## 先把这五句话记住
+
+1. **API server 是全系统共享事实源。** 几乎所有关键组件都在读它、写它、或者持续 watch 它。
+2. **Kubernetes 的核心不是“一次性执行”，而是“持续对账”。** 它不断比较“想要什么”和“现在是什么”。
+3. **控制面更像决策层，节点更像执行层。** 调度和大部分协调动作发生在中心，容器真正启动发生在 kubelet 所在节点。
+4. **watch 是整个系统的血液循环。** informer、cache、workqueue、watch cache 共同承担变化传播。
+5. **很多所谓的“智能”，本质上都是小公式。** fit check、加权平均、标准差、指数退避，都是非常朴素的数学。
+
+## 关键源码锚点
+
+- `cmd/kube-apiserver/app/server.go`
+- `staging/src/k8s.io/apiserver/pkg/server/config.go`
+- `pkg/scheduler/schedule_one.go`
+- `pkg/scheduler/framework/plugins/noderesources/*.go`
+- `pkg/controller/deployment/deployment_controller.go`
+- `pkg/controller/deployment/sync.go`
+- `pkg/kubelet/kubelet.go`
+- `pkg/kubelet/pod_workers.go`
+
+## 一句话总纲
+
+如果你只记住一句话，那就记住这个：
+
+> Kubernetes 本质上是一个巨大的分布式状态机，不同组件不断从 API server 读状态、基于缓存做判断、再把修正写回去，直到现实逼近期望。

--- a/docs/zh/architecture.md
+++ b/docs/zh/architecture.md
@@ -1,0 +1,155 @@
+# Kubernetes 架构总览：先看大骨架，再下钻细节
+
+## 先看它到底在解决什么痛点
+
+分布式系统难，难在三件事：
+
+1. 机器会坏
+2. 期望状态一直在变
+3. 你做决策的时候，系统本身也还在动
+
+Kubernetes 的核心解法不是“一次部署成功”，而是把整个集群变成一个**持续对账系统**。
+
+## 宏观骨架
+
+```mermaid
+flowchart LR
+    subgraph Clients
+        U[kubectl / operators / controllers / apps]
+    end
+
+    subgraph ControlPlane
+        A[kube-apiserver]
+        ETCD[(etcd)]
+        S[kube-scheduler]
+        CM[kube-controller-manager]
+    end
+
+    subgraph Nodes
+        K1[node A 上的 kubelet]
+        K2[node B 上的 kubelet]
+        CRI[container runtime]
+    end
+
+    U --> A
+    A <--> ETCD
+    S --> A
+    CM --> A
+    K1 --> A
+    K2 --> A
+    K1 --> CRI
+    K2 --> CRI
+```
+
+## 架构里最关键的一条真相
+
+API server 不只是一个 HTTP 路由器，它是整个系统的**共享协调平面**。
+
+- 客户端把期望写进去
+- controller 持续 watch 它
+- scheduler 持续 watch 它
+- kubelet 持续 watch 它
+- 状态更新最终也回写到它
+
+所以 Kubernetes 的很多设计天然带有一种“API first”的气质，因为所有组件都通过它汇合。
+
+## 一颗 Pod 从 YAML 到容器的旅程
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant A as kube-apiserver
+    participant E as etcd
+    participant S as kube-scheduler
+    participant K as kubelet
+    participant R as container runtime
+
+    C->>A: POST Pod
+    A->>A: 鉴权 -> 授权 -> 准入
+    A->>E: 存储 Pod 对象
+    S->>A: watch 没有 nodeName 的 Pod
+    S->>S: 过滤并打分节点
+    S->>A: 绑定 Pod 到节点
+    K->>A: watch 分配给本节点的 Pod
+    K->>K: SyncPod
+    K->>R: 创建 sandbox 和 containers
+    K->>A: 更新 PodStatus 和 Events
+```
+
+## 定义 Kubernetes 的三种循环
+
+### 1. 请求循环
+
+客户端把“想要什么”送进 API server。
+
+### 2. 对账循环
+
+controller 和 scheduler 持续观察哪些对象“还没达成目标”。
+
+### 3. 执行循环
+
+kubelet 把分配到本节点的 PodSpec 一次次逼近成真实运行状态。
+
+把 Kubernetes 压成一句话就是：
+
+> 请求产生期望，watch 传播变化，reconciler 响应偏差，kubelet 执行落地。
+
+## 为什么 watch 如此重要
+
+如果所有组件都不停轮询，那代价太高了。Kubernetes 更偏爱这套组合：
+
+- etcd 持久化
+- API server 提供 watch 流
+- 各组件使用 informer + 本地 cache
+- workqueue 只处理真正变更过的 key
+
+```mermaid
+flowchart LR
+    E[(etcd)] --> WC[watch cache]
+    WC --> W[watch stream]
+    W --> I[shared informer cache]
+    I --> Q[workqueue]
+    Q --> R[reconcile 函数]
+    R --> A[kube-apiserver 回写]
+```
+
+这就是整个项目真正的“血液循环系统”。
+
+## 为什么 `CreateServerChain()` 值得你专门记住
+
+API server 不是一个单层大块头。在 `cmd/kube-apiserver/app/server.go` 里，`CreateServerChain()` 把多个 server 串成委托链，大致可以理解成：
+
+```mermaid
+flowchart LR
+    REQ[请求进入] --> AGG[API Aggregator]
+    AGG --> CORE[Kubernetes 核心 API]
+    CORE --> CRD[CRD API server]
+    CRD --> NF[NotFound handler]
+```
+
+所以用户看起来像在访问“一个 API server”，但内部其实经过了多层委派结构。
+
+## 最值得记住的四个源码入口
+
+| 领域 | 最佳入口文件 | 原因 |
+| --- | --- | --- |
+| API server 启动 | `cmd/kube-apiserver/app/server.go` | 看 server 链如何拼起来 |
+| handler 链 | `staging/src/k8s.io/apiserver/pkg/server/config.go` | 看 authn/authz/audit/filter 如何包裹请求 |
+| scheduler 核心循环 | `pkg/scheduler/schedule_one.go` | 看节点选择全过程 |
+| kubelet 执行逻辑 | `pkg/kubelet/kubelet.go` | 看节点侧同步主循环 |
+
+## 用超生活化类比再压一遍
+
+把 Kubernetes 想成一个大型仓库：
+
+- API server 是总调度台白板
+- controller 是巡视仓库的管理员
+- scheduler 是安排货物去哪条传送带的人
+- kubelet 是现场装卸工
+- etcd 是上锁的总账档案柜
+
+它并不神秘，只是在反复对比“白板上写的”与“仓库里真实发生的”，然后不断修正差距。
+
+## 下一步
+
+接下来请看 [`control-plane.md`](control-plane.md)，我们开始拆 API server 的请求链和 scheduler 的调度链。

--- a/docs/zh/control-plane.md
+++ b/docs/zh/control-plane.md
@@ -1,0 +1,142 @@
+# 控制面深潜：API Server、Scheduler 与共享状态机
+
+## 控制面到底在干什么
+
+控制面其实一直在重复回答一个问题：
+
+> 给定最新的期望状态和最新的观察状态，下一步应该做什么？
+
+不同组件只负责这个问题的一部分，但它们都通过同一个 API 平面协作。
+
+## 1. API server 的 handler 链
+
+在 `staging/src/k8s.io/apiserver/pkg/server/config.go` 里，`DefaultBuildHandlerChain()` 会把核心 API handler 一层层包起来。代码写法是“从里往外包”，所以理解时最好把它翻译成请求流水线。
+
+```mermaid
+flowchart TD
+    R[HTTP 请求] --> AI[audit init 与请求元数据]
+    AI --> REC[panic recovery / timeout / warning recorder / CORS]
+    REC --> AUTHN[authentication]
+    AUTHN --> AUDIT[audit]
+    AUDIT --> IMP[impersonation]
+    IMP --> FC[priority and fairness / max in flight]
+    FC --> AUTHZ[authorization]
+    AUTHZ --> H[资源 handler]
+    H --> STORE[generic registry store]
+    STORE --> CACHE[watch cache / cacher]
+    CACHE --> ETCD[(etcd3 storage)]
+```
+
+### 每一层用大白话怎么理解
+
+- **authentication**：你是谁？
+- **authorization**：你有权这么干吗？
+- **admission**：就算你有权，这个对象是否还要被策略修改或拒绝？
+- **storage**：对象怎么高效持久化、又怎么高效被 watch？
+
+## 2. 请求如何从 HTTP 路由走到存储
+
+最关键的源码锚点：
+
+- `cmd/kube-apiserver/app/server.go`：看 server 启动与 `CreateServerChain()`
+- `staging/src/k8s.io/apiserver/pkg/server/handler.go`：看 API handler 如何分发
+- `staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go`：看 create 请求
+- `staging/src/k8s.io/apiserver/pkg/endpoints/handlers/update.go`：看 update 请求
+- `staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go`：看 watch 流式响应
+- `staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go`：看通用持久化逻辑
+- `staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go`：看 watch cache
+- `staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go`：看 etcd 后端
+
+## 3. 为什么 watch cache 这么关键
+
+如果没有 cacher 层，每个 watcher 都会把 API server 拖向更重的存储读取压力。有了它以后：
+
+- 最近对象历史可以缓存在内存中
+- list 与 watch 很多时候可以直接从缓存服务
+- watcher 可以更平滑地拿到事件流
+
+这就是为什么 Kubernetes 能同时维持大量 controller 与 kubelet 的同步，而不至于把底层存储打爆。
+
+## 4. Scheduler 是一个“两段式机器”
+
+理解 scheduler，最该看的文件就是 `pkg/scheduler/schedule_one.go`。它最重要的结构是：
+
+1. **scheduling cycle**：决定 Pod 应该去哪
+2. **binding cycle**：把这个决定正式写实
+
+```mermaid
+flowchart LR
+    Q[SchedulingQueue] --> N[NextPod]
+    N --> PF[PreFilter]
+    PF --> F[过滤候选节点]
+    F --> PS[PreScore]
+    PS --> SC[Score plugins + extenders]
+    SC --> PICK[挑出最佳节点]
+    PICK --> ASSUME[在 scheduler cache 中假定落位]
+    ASSUME --> RESERVE[reserve plugins]
+    RESERVE --> PERMIT[permit plugins]
+    PERMIT --> PREBIND[pre-bind plugins]
+    PREBIND --> BIND[bind plugin / default binder]
+    BIND --> API[经 API server 写入 Binding]
+```
+
+### 为什么要有 `assume`
+
+scheduler 不想每次都傻等真正 bind 完才继续调度，它会先在自己的缓存里**乐观假设**这颗 Pod 已经占用了目标节点资源，然后继续处理下一颗 Pod。
+
+这是一种非常典型的吞吐优化：最终权威仍然在 API server，但调度器先把自己脑内模型推进一步。
+
+## 5. default binder 真实干了什么
+
+default binder 非常克制。在 `pkg/scheduler/framework/plugins/defaultbinder/default_binder.go` 中，它只是构造一个 `v1.Binding`，再通过 API server 发送出去。
+
+也就是说，scheduler 不负责启动容器，它只负责**记录“该去哪”**。
+
+## 6. controller 在控制面里的位置
+
+scheduler 主要解决的是**放在哪**。
+
+controller 主要解决的是**差多少、怎么补**。
+
+- Deployment controller：期望的 ReplicaSet/Pod 数量和实际是否一致
+- Service controller：期望的 endpoints 与实际后端是否一致
+- Namespace controller：生命周期与清理
+- 更多实现都在 `pkg/controller/`
+
+```mermaid
+flowchart LR
+    A[kube-apiserver] --> INF[informer cache]
+    INF --> Q[workqueue]
+    Q --> SYNC[controller sync handler]
+    SYNC --> A
+```
+
+模式永远很像：watch -> enqueue -> reconcile -> write back。
+
+## 7. 一个请求会引发很多异步后果
+
+一次 Pod 创建请求，背后可能依次触发：
+
+1. 对象写入 etcd
+2. scheduler 发现有 pending Pod
+3. scheduler 写 binding
+4. kubelet 发现有分给自己的 Pod
+5. kubelet 启动容器
+6. kubelet 回写状态
+7. 其他 controller 因状态变化继续反应
+
+所以 Kubernetes 给人的感觉很“事件驱动”，但每个单独组件内部其实往往就是 cache + queue + loop 的组合。
+
+## 8. 最值得继续点开的函数
+
+| 主题 | 函数 / 文件 |
+| --- | --- |
+| API server 串链 | `cmd/kube-apiserver/app/server.go` 中的 `CreateServerChain()` |
+| handler 包裹顺序 | `staging/src/k8s.io/apiserver/pkg/server/config.go` 中的 `DefaultBuildHandlerChain()` |
+| scheduler 核心循环 | `pkg/scheduler/schedule_one.go` 中的 `ScheduleOne()`、`schedulingCycle()` |
+| score plugin 执行 | `pkg/scheduler/framework/runtime/framework.go` 中的 `RunScorePlugins()` |
+| 默认绑定 | `pkg/scheduler/framework/plugins/defaultbinder/default_binder.go` 中的 `Bind()` |
+
+## 下一步
+
+继续看 [`math-theory.md`](math-theory.md)，我们把 scheduler 的打分、排队和退避公式彻底讲通。

--- a/docs/zh/controller-kubelet.md
+++ b/docs/zh/controller-kubelet.md
@@ -1,0 +1,224 @@
+# Controllers 与 Kubelet：让 Kubernetes 活起来的两类对账器
+
+## 为什么把这两者放在一起讲
+
+controller 和 kubelet 所在层级不同，但它们共享同一种世界观：
+
+- 先观察当前状态
+- 再对比期望状态
+- 做一步朝收敛方向的修正
+- 如果还没收敛，就继续重试
+
+区别只在作用域：
+
+- controller 对账的是 **集群级意图**
+- kubelet 对账的是 **节点级执行**
+
+## 第一部分：Deployment controller 作为集群级 reconciler 的典型代表
+
+最佳源码锚点：
+
+- `pkg/controller/deployment/deployment_controller.go`
+- `pkg/controller/deployment/sync.go`
+
+### controller 的经典工作流
+
+```mermaid
+flowchart LR
+    W[watch / informer 事件] --> Q[workqueue key]
+    Q --> WK[worker goroutine]
+    WK --> S[syncDeployment]
+    S --> RS[创建或更新 ReplicaSet]
+    S --> P[创建或删除 Pods]
+    S --> ST[更新 Deployment status]
+    ST --> W
+```
+
+### `NewDeploymentController()` 做了什么
+
+它为这些对象注册了 informer handler：
+
+- Deployment
+- ReplicaSet
+- Pod
+
+任何重要变化，最后都会被归并成一个 Deployment key 入队。
+
+### worker 真正做的事情
+
+`deployment_controller.go` 里的 `processNextWorkItem()` 非常经典：
+
+1. 从 workqueue 里拿出一个 key
+2. 调用 `syncHandler`
+3. 成功就 `Forget`
+4. 失败就 `AddRateLimited()`
+
+这四步几乎就是 Kubernetes controller 模式的缩影。
+
+### `sync.go` 到底在对什么账
+
+在 `sync.go` 里，这个 controller 会：
+
+- 找出新的和旧的 ReplicaSet
+- 计算下一个 revision
+- 伸缩正确的 ReplicaSet
+- 在合适的时候清理旧状态
+- 更新 Deployment status
+
+它不是一次性 rollout 脚本，而是一个持续逼近目标的收敛循环。
+
+## 给菜市场大妈也能听懂的类比
+
+想象你经营一家面馆：
+
+- 菜单上要求前台始终有 10 碗招牌面可卖
+- 厨房现在只备好了 7 碗
+- 你不会喊一句“做面”然后永远不看了
+- 你会不断去看，直到前台真的有 10 碗
+
+controller 的脑回路就是这样：**盯着“应该有多少”和“现在有多少”的差值，直到差值归零。**
+
+## controller 的重试数学
+
+`deployment_controller.go` 注释里给出的退避节奏近似是：
+
+$$
+5ms \times 2^{n-1}
+$$
+
+并且 `maxRetries = 15`。
+
+所以等待时间大致是：
+
+- `5ms`
+- `10ms`
+- `20ms`
+- `40ms`
+- ...
+- 最后会上升到几十秒
+
+这样做的目的，是避免有问题的对象把 controller 拉进高频空转。
+
+## 第二部分：Kubelet 作为节点侧 reconciler
+
+最佳源码锚点：
+
+- `pkg/kubelet/kubelet.go`
+- `pkg/kubelet/pod_workers.go`
+
+### kubelet 的主同步循环
+
+`kubelet.go` 里的 `syncLoop()` 与 `syncLoopIteration()` 会同时监听多种事件源：
+
+- API server 下发的 Pod 更新
+- file / HTTP pod source
+- PLEG runtime 事件
+- 周期性同步 tick
+- housekeeping tick
+- 健康检查和探针相关更新
+
+```mermaid
+flowchart TD
+    APIServer[API server Pod updates] --> LOOP[syncLoopIteration]
+    File[file source] --> LOOP
+    HTTP[http source] --> LOOP
+    PLEG[PLEG runtime events] --> LOOP
+    Tick[周期同步 tick] --> LOOP
+    LOOP --> ADD[HandlePodAdditions]
+    LOOP --> UPD[HandlePodUpdates]
+    LOOP --> REM[HandlePodRemoves]
+    ADD --> PW[podWorkers.UpdatePod]
+    UPD --> PW
+    REM --> PW
+    PW --> PL[podWorkerLoop]
+    PL --> SP[Kubelet.SyncPod]
+    SP --> CRI[containerRuntime.SyncPod]
+```
+
+### 为什么 `podWorkers` 如此关键
+
+kubelet 不允许多个 goroutine 随便同时改同一颗 Pod。`podWorkers` 的职责就是为每颗 Pod 提供串行化处理。
+
+这让 kubelet 拥有了一个近似于**每 Pod 独立状态机**的执行模型。
+
+```mermaid
+stateDiagram-v2
+    [*] --> WaitingToStart
+    WaitingToStart --> SyncPod
+    SyncPod --> SyncPod: update / periodic resync
+    SyncPod --> Terminating: deletion or stop request
+    Terminating --> Terminated
+    Terminated --> [*]
+```
+
+### `HandlePodAdditions()` 真正干了什么
+
+当 kubelet 收到一颗新 Pod 时，它会：
+
+1. 把 Pod 加入 pod manager
+2. 处理证书与 mirror pod 关系
+3. 做 admission / allocation 检查
+4. 把一次 `UpdatePod()` 请求送入 pod worker 体系
+
+所以这里并不是“立刻起容器”，而是“把本地期望状态体系更新好，让后续 worker 安全地收敛”。
+
+### `SyncPod()` 真正做了什么
+
+`SyncPod()` 才是节点侧落地动作最密集的地方。它会处理：
+
+- Pod status 生成
+- mirror pod 对齐
+- cgroup 建立
+- volume attach / mount 等待
+- image pull secret 获取
+- probe 注册
+- 最后委托给 `containerRuntime.SyncPod(...)`
+
+也就是说，kubelet 是 Kubernetes 对象世界到容器 runtime 世界的最终翻译器。
+
+## kubelet 主循环里的错误退避
+
+kubelet 主循环遇到 runtime error 时，也会做指数退避。
+
+在 `kubelet.go` 里，参数是：
+
+- base = `100ms`
+- factor = `2`
+- max = `5s`
+
+所以序列会像这样：
+
+- `100ms`
+- `200ms`
+- `400ms`
+- `800ms`
+- `1.6s`
+- `3.2s`
+- `5s` 封顶
+
+这和 scheduler、controller 的风格完全一致：**允许重试，但拒绝失控。**
+
+## 集群级对账 vs 节点级对账
+
+| 维度 | Controllers | Kubelet |
+| --- | --- | --- |
+| 作用范围 | 整个集群资源 | 单节点上被分配到的 Pods |
+| 触发源 | informer 事件 + resync | API/file/http/PLEG/ticks |
+| 工作单元 | 通常是对象 key | Pod update |
+| 主要动作 | 创建/更新/删除 API 对象 | 创建/更新/停止容器与 sandbox |
+| 目标 | 让集群对象收敛 | 让节点运行态收敛 |
+
+## 最重要的统一洞察
+
+controller 和 kubelet，其实是同一个思想在不同放大倍数下的体现。
+
+- Deployment controller 问的是：“ReplicaSet 和 Pod 是否匹配 Deployment 的意图？”
+- kubelet 问的是：“这个节点上的容器是否匹配 Pod 的意图？”
+
+Kubernetes 能成立，就是因为这两层都在不停地问这个问题，并不停地把答案往正确方向推进。
+
+## 看完这一篇后建议怎么回看
+
+再回去看 [`architecture.md`](architecture.md) 和 [`control-plane.md`](control-plane.md)，你会更强烈地意识到：
+
+> 整个 Kubernetes 里，几乎每个组件都只是站在不同位置上的 reconciler。

--- a/docs/zh/math-theory.md
+++ b/docs/zh/math-theory.md
@@ -1,0 +1,322 @@
+# 数学理论降维打击：把 Scheduler 打分、排队与退避讲成人话
+
+## 为什么这一篇很重要
+
+Kubernetes scheduler 看起来神秘，往往只是因为大家先被术语吓到了。真把代码扒开，会发现很多关键决策就是几个非常朴素的小公式。
+
+这一篇会讲透：
+
+- 资源 fit 检查
+- LeastAllocated / MostAllocated 打分
+- 可配置利用率曲线
+- 用标准差表达平衡度
+- 队列优先级排序
+- 指数退避
+
+## 1. Fit check：这颗 Pod 到底塞不塞得下？
+
+源码锚点：`pkg/scheduler/framework/plugins/noderesources/fit.go`，重点看 `fitsRequest()`。
+
+### 核心公式
+
+对每种资源，都在检查：
+
+$$
+\text{Pod 请求量} \le \text{节点可分配量} - \text{已被请求量}
+$$
+
+### 公式里的字母在现实里是什么意思
+
+- `Pod 请求量`：这颗新 Pod 想要多少 CPU / 内存 / 存储
+- `节点可分配量`：节点真正能拿出来给 Pod 用的资源
+- `已被请求量`：节点上已有 Pod 已经占走的那部分请求量
+
+### 买菜篮子类比
+
+你有一个最多能装 10 公斤的篮子：
+
+- 里面已经有 6 公斤菜
+- 现在还想塞 3 公斤水果
+- 剩余空间是 `10 - 6 = 4`
+- 因为 `3 <= 4`，所以能塞下
+
+如果你现在想再塞 5 公斤，那就超了。
+
+### 调度器数字例子
+
+- 节点可分配 CPU：`4000m`
+- 已被请求 CPU：`2500m`
+- 新 Pod 请求 CPU：`1800m`
+- 剩余 CPU：`1500m`
+
+因为 `1800m > 1500m`，所以调度器会给出 **Insufficient cpu**。
+
+## 2. LeastAllocated：偏爱“更空”的节点
+
+源码锚点：`pkg/scheduler/framework/plugins/noderesources/least_allocated.go`
+
+它先对每种资源算分，再按权重求平均。
+
+$$
+\text{score}_r = \frac{\text{capacity}_r - \text{requested}_r}{\text{capacity}_r} \times 100
+$$
+
+最后：
+
+$$
+\text{node score} = \frac{\sum_r \text{weight}_r \times \text{score}_r}{\sum_r \text{weight}_r}
+$$
+
+### 直觉解释
+
+空余越多，得分越高。
+
+### 例子
+
+假设某节点在放下新 Pod 后会变成：
+
+- CPU 已请求：`3/8`
+- 内存已请求：`10/16`
+
+那么：
+
+- CPU 分数 = `(8 - 3) / 8 * 100 = 62.5`
+- 内存分数 = `(16 - 10) / 16 * 100 = 37.5`
+- 若权重相同，则综合分大约是 `50`
+
+这说明它不算特别空，但也不算特别满。
+
+## 3. MostAllocated：偏爱“更满”的节点
+
+源码锚点：`pkg/scheduler/framework/plugins/noderesources/most_allocated.go`
+
+它是 LeastAllocated 的镜像：
+
+$$
+\text{score}_r = \frac{\text{requested}_r}{\text{capacity}_r} \times 100
+$$
+
+### 直觉解释
+
+现在不是“越空越好”，而是“越满越好”。这适合想要更紧凑装箱、保留更多空节点的策略。
+
+### 例子
+
+- CPU 使用率：`6/8 = 75%`
+- 内存使用率：`12/16 = 75%`
+- 综合分就是 `75`
+
+也就是：这个节点很“满”，因此在打包型策略里反而更受欢迎。
+
+## 4. RequestedToCapacityRatio：把调度策略写成一条曲线
+
+源码锚点：
+
+- `pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio.go`
+- `pkg/scheduler/framework/plugins/helper/shape_score.go`
+
+辅助函数 `BuildBrokenLinearFunction()` 会把一组点拼成折线函数。
+
+### 核心思想
+
+第一步，先算利用率：
+
+$$
+\text{utilization} = \frac{\text{requested}}{\text{capacity}} \times 100
+$$
+
+第二步，把这个利用率投到一条管理员预先配置好的折线函数上。
+
+```mermaid
+flowchart LR
+    P0[0% -> 0] --> P1[50% -> 50]
+    P1 --> P2[80% -> 90]
+    P2 --> P3[100% -> 100]
+```
+
+### 菜市场摊位类比
+
+你可以想象一条规则：
+
+- 空摊位价值低
+- 半满摊位价值中等
+- 快满的摊位价值很高
+
+如果某节点利用率落在 `60%`，那它就位于 `50% -> 50` 和 `80% -> 90` 之间，因此分数也在这两点之间线性插值。
+
+### 数字例子
+
+如果折线点是：
+
+- `(0, 0)`
+- `(50, 50)`
+- `(100, 100)`
+
+那利用率是 `60%` 时，得分就是 `60`。
+
+这类策略的妙处在于：管理员不是写死一个公式，而是画一条“偏好曲线”。
+
+## 5. BalancedAllocation：用标准差衡量“是否均衡”
+
+源码锚点：`pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go`
+
+这个插件关注的是：CPU、内存等资源的使用比例是否接近。
+
+先算各资源分数：
+
+$$
+f_i = \frac{\text{requested}_i}{\text{allocatable}_i}
+$$
+
+再算标准差：
+
+$$
+\sigma = \sqrt{\frac{1}{n} \sum_i (f_i - \bar f)^2}
+$$
+
+最后近似得分：
+
+$$
+\text{score} = (1 - \sigma) \times 100
+$$
+
+### 把标准差讲成人话
+
+如果 CPU 和内存的使用比例很接近，那么节点就“平衡”。
+
+如果 CPU 快满了、内存却还很空，或者反过来，那节点就“不平衡”。
+
+### 两资源场景下的极简理解
+
+代码里特别指出：当只关心 CPU 和内存时，标准差可以被大幅简化。
+
+如果：
+
+- CPU 比例 = `0.8`
+- 内存比例 = `0.2`
+
+那么：
+
+$$
+\sigma = \frac{|0.8 - 0.2|}{2} = 0.3
+$$
+
+于是：
+
+$$
+\text{score} = (1 - 0.3) \times 100 = 70
+$$
+
+如果 CPU 和内存都恰好是 `0.5`，那 `\sigma = 0`，得分就是 `100`。
+
+这就是这个插件的灵魂：**越均衡，越高分。**
+
+```mermaid
+flowchart TD
+    A[CPU 50%<br/>内存 50%] --> H[标准差 = 0<br/>分数 = 100]
+    B[CPU 80%<br/>内存 20%] --> L[标准差 = 0.3<br/>分数 = 70]
+```
+
+## 6. 队列排序：优先级第一，时间第二
+
+源码锚点：`pkg/scheduler/framework/plugins/queuesort/priority_sort.go`
+
+这个排序规则非常短，但非常重要：
+
+- Pod 优先级高的先来
+- 如果优先级相同，先进入队列的先来
+
+写成“类公式”就是：
+
+$$
+A \text{ 排在前面，当且仅当 } priority(A) > priority(B)
+$$
+
+如果优先级相等，则看：
+
+$$
+A \text{ 排在前面，当且仅当 } timestamp(A) < timestamp(B)
+$$
+
+### 例子
+
+- Pod X：priority = `1000`，入队时间 `10:00`
+- Pod Y：priority = `5000`，入队时间 `10:05`
+
+尽管 Y 更晚进队，但它还是先被考虑，因为优先级压过时间。
+
+## 7. Scheduler backoff：失败了要重试，但不能发疯重试
+
+源码锚点：
+
+- `pkg/scheduler/backend/queue/backoff_queue.go`
+- `pkg/scheduler/backend/queue/scheduling_queue.go`
+
+队列使用的是带上限的指数退避：
+
+$$
+\text{backoff}(n) = \min(\text{initial} \times 2^{n-1}, \text{max})
+$$
+
+直觉上的默认值通常可以理解为：
+
+- 初始退避：`1s`
+- 最大退避：`10s`
+
+### 数字例子
+
+如果连续失败：
+
+- 第 1 次：`1s`
+- 第 2 次：`2s`
+- 第 3 次：`4s`
+- 第 4 次：`8s`
+- 第 5 次：`10s`（到顶）
+
+```mermaid
+flowchart LR
+    A1[第 1 次失败<br/>1s] --> A2[第 2 次失败<br/>2s]
+    A2 --> A3[第 3 次失败<br/>4s]
+    A3 --> A4[第 4 次失败<br/>8s]
+    A4 --> A5[第 5 次失败<br/>10s 封顶]
+```
+
+### 这背后的系统直觉
+
+如果集群一时拥塞，调度器不应该疯狂地对同一颗一时无法调度的 Pod 进行高频重试，否则只会制造更多噪音和负担。
+
+## 8. 同样的数学风格也出现在别处
+
+### Deployment controller 的重试
+
+在 `pkg/controller/deployment/deployment_controller.go` 中，注释给出的重试节奏大致是：
+
+$$
+5ms \times 2^{n-1}
+$$
+
+并且 `maxRetries = 15`。
+
+### kubelet 主循环的错误退避
+
+在 `pkg/kubelet/kubelet.go` 中，主同步循环碰到 runtime error 时，也使用：
+
+- base = `100ms`
+- factor = `2`
+- max = `5s`
+
+你会发现整个 Kubernetes 的很多地方都在重复一个成熟思想：
+
+> 出错了要重试，但不能把系统打进空转风暴。
+
+## 最后的总领悟
+
+Scheduler 一点都不神秘，它大量依赖的只是：
+
+- 不等式判断
+- 加权平均
+- 折线插值
+- 标准差衡量平衡
+- 指数退避保证稳定
+
+一旦你看穿这一层，很多“高深感”会瞬间蒸发，剩下的就是把代码与直觉一一对应。

--- a/docs/zh/quick-start.md
+++ b/docs/zh/quick-start.md
@@ -1,0 +1,127 @@
+# 快速上手：如何阅读 Kubernetes 仓库而不被淹没
+
+## 为什么这个仓库看起来像天书
+
+因为它真的不只是一个“容器编排器”项目。这个仓库里同时装着：
+
+- 控制面主二进制入口
+- API machinery 通用基础设施
+- scheduler framework
+- 大量 controller 实现
+- kubelet 节点代理
+- 生成出来的 API 与 client
+- 构建、发布、兼容性维护工具链
+
+所以它给人的感觉更像一个“小型分布式操作系统”，而不是普通后端服务。
+
+## 30 秒建立直觉
+
+你可以把 Kubernetes 想成一座城市：
+
+- `kube-apiserver` 是 **市政总账本**
+- etcd 是 **存放总账本的保险柜**
+- controllers 是 **反复核对账目的办事员**
+- scheduler 是 **负责分配工位/地块的调度员**
+- kubelet 是 **每个节点上的现场工头**
+
+## 仓库地图
+
+```mermaid
+flowchart TB
+    R[kubernetes/] --> CMD[cmd/<br/>主二进制和命令行入口]
+    R --> PKG[pkg/<br/>仓库内核心实现]
+    R --> STAGING[staging/src/k8s.io/<br/>权威组件库源码]
+    R --> API[api/<br/>对外版本化 API 类型]
+    R --> TEST[test/<br/>集成、端到端、性能测试]
+    R --> HACK[hack/<br/>校验、生成、构建脚本]
+    R --> DOCS[docs/<br/>仓库内学习文档]
+```
+
+## 最该优先理解的顶层目录
+
+| 路径 | 意义 |
+| --- | --- |
+| `cmd/` | 主进程入口：`kube-apiserver`、`kube-scheduler`、`kube-controller-manager`、`kubelet`、`kubectl`、`kubeadm` |
+| `pkg/` | 该仓库特有的核心实现 |
+| `staging/src/k8s.io/` | 被拆分发布出去的公共组件库源码真身 |
+| `api/` | 对外版本化 API 类型定义 |
+| `test/` | 真正用来揭穿理解偏差的测试区域 |
+| `hack/` | 项目如何生成、校验、维护自身 |
+
+## 先学哪四个二进制
+
+| 二进制 | 入口文件 | 本质职责 |
+| --- | --- | --- |
+| `kube-apiserver` | `cmd/kube-apiserver/app/server.go` | 接收 API 请求、鉴权、准入、持久化、提供 watch |
+| `kube-scheduler` | `cmd/kube-scheduler/app/server.go` | 给未调度 Pod 选节点 |
+| `kube-controller-manager` | `cmd/kube-controller-manager/app/controllermanager.go` | 托管大量集群级控制循环 |
+| `kubelet` | `cmd/kubelet/app/server.go` | 在节点上把 PodSpec 真正落成容器 |
+
+## 最值得先追的一条主线
+
+不要一开始就把所有子系统分开硬啃。先跟一条主线：
+
+1. 客户端提交 Pod
+2. API server 存下对象
+3. scheduler 选出节点
+4. kubelet 看到分配给自己的 Pod
+5. kubelet 启动容器并持续上报状态
+
+```mermaid
+sequenceDiagram
+    participant U as 用户 / kubectl
+    participant A as kube-apiserver
+    participant E as etcd
+    participant S as kube-scheduler
+    participant K as kubelet
+
+    U->>A: 创建 Pod
+    A->>E: 持久化期望状态
+    S->>A: watch 未调度 Pod
+    S->>A: 绑定 Pod 到节点
+    K->>A: watch 分配给本节点的 Pod
+    K->>K: SyncPod 调 runtime
+    K->>A: 回写状态和事件
+```
+
+## 最值得先打开的文件
+
+如果你现在只有一小时，建议按这个顺序打开：
+
+1. `cmd/kube-apiserver/app/server.go`
+2. `staging/src/k8s.io/apiserver/pkg/server/config.go`
+3. `pkg/scheduler/schedule_one.go`
+4. `pkg/scheduler/framework/plugins/noderesources/fit.go`
+5. `pkg/scheduler/framework/plugins/noderesources/least_allocated.go`
+6. `pkg/controller/deployment/deployment_controller.go`
+7. `pkg/controller/deployment/sync.go`
+8. `pkg/kubelet/kubelet.go`
+9. `pkg/kubelet/pod_workers.go`
+10. `staging/src/k8s.io/client-go/tools/cache/shared_informer.go`
+
+## 一套实战阅读法
+
+### 第一遍：只搭骨架
+
+只回答四个问题：
+
+- 每个主进程从哪里启动？
+- 它读什么共享状态？
+- 它写什么共享状态？
+- 它是事件驱动还是周期驱动？
+
+### 第二遍：只追一颗 Pod
+
+从创建到运行，把一颗 Pod 的生命线完整走通。
+
+### 第三遍：再看公式
+
+先理解流程，再看 scheduler 的打分、退避、平衡度，效率最高。
+
+## 一个极其重要的提醒
+
+很多通用逻辑并不在 `pkg/`，而是在 `staging/src/k8s.io/`。如果你感觉 `pkg/` 里“缺了点什么”，先去 staged 组件里找，不要急着怀疑自己没搜对。
+
+## 下一步
+
+继续看 [`architecture.md`](architecture.md)，先把宏观骨架打牢，再进控制面与调度细节。


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Add a source-oriented deep-dive documentation set under `docs/` for readers who want to understand the Kubernetes repository from the inside out.

This first phase introduces the English edition under `docs/en/` and a top-level `docs/README.md` landing page.

The new material covers:

- repository navigation and reading order
- macro architecture and component roles
- kube-apiserver request path and scheduler cycle
- scheduler scoring, queue order, and backoff math
- controller reconciliation and kubelet pod sync flow

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- This change is documentation-only.
- The content is code-anchored to current repository paths in `cmd/`, `pkg/`, and `staging/src/k8s.io/`.
- Mermaid diagrams are included to make control-plane and reconciliation flows easier to follow.
- A Chinese edition will be added as a follow-up commit on the same branch.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [Usage]: docs/README.md
- [Usage]: docs/en/README.md
- [Usage]: docs/en/quick-start.md
- [Usage]: docs/en/architecture.md
- [Usage]: docs/en/control-plane.md
- [Usage]: docs/en/math-theory.md
- [Usage]: docs/en/controller-kubelet.md
```
