### PR TITLE
kubectl top pod: add NODE column with -o wide flag

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
@@ -48,12 +48,14 @@ type TopPodOptions struct {
 	LabelSelector      string
 	FieldSelector      string
 	SortBy             string
+	OutputFormat       string
 	AllNamespaces      bool
 	PrintContainers    bool
 	NoHeaders          bool
 	UseProtocolBuffers bool
 	Sum                bool
 	ShowSwap           bool
+	ShowNodeName       bool
 
 	PodClient       corev1client.PodsGetter
 	Printer         *metricsutil.TopCmdPrinter
@@ -85,7 +87,10 @@ var (
 		kubectl top pod POD_NAME --containers
 
 		# Show metrics for the pods defined by label name=myLabel
-		kubectl top pod -l name=myLabel`))
+		kubectl top pod -l name=myLabel
+
+		# Show metrics for the pods with node information
+		kubectl top pod -o wide`))
 )
 
 func NewCmdTopPod(f cmdutil.Factory, o *TopPodOptions, streams genericiooptions.IOStreams) *cobra.Command {
@@ -119,6 +124,7 @@ func NewCmdTopPod(f cmdutil.Factory, o *TopPodOptions, streams genericiooptions.
 	cmd.Flags().BoolVar(&o.UseProtocolBuffers, "use-protocol-buffers", o.UseProtocolBuffers, "Enables using protocol-buffers to access Metrics API.")
 	cmd.Flags().BoolVar(&o.Sum, "sum", o.Sum, "Print the sum of the resource usage")
 	cmd.Flags().BoolVar(&o.ShowSwap, "show-swap", o.ShowSwap, "Print pod resources related to swap memory.")
+	cmd.Flags().StringVarP(&o.OutputFormat, "output", "o", o.OutputFormat, "Output format. One of: wide.")
 	return cmd
 }
 
@@ -154,6 +160,7 @@ func (o *TopPodOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []s
 
 	o.PodClient = clientset.CoreV1()
 
+	o.ShowNodeName = o.OutputFormat == "wide"
 	o.Printer = metricsutil.NewTopCmdPrinter(o.Out, o.ShowSwap)
 	return nil
 }
@@ -166,6 +173,9 @@ func (o *TopPodOptions) Validate() error {
 	}
 	if len(o.ResourceName) > 0 && (len(o.LabelSelector) > 0 || len(o.FieldSelector) > 0) {
 		return errors.New("only one of NAME or selector can be provided")
+	}
+	if len(o.OutputFormat) > 0 && o.OutputFormat != "wide" {
+		return errors.New("--output accepts only wide")
 	}
 	return nil
 }
@@ -219,7 +229,42 @@ func (o TopPodOptions) RunTopPod() error {
 		}
 	}
 
-	return o.Printer.PrintPodMetrics(metrics.Items, o.PrintContainers, o.AllNamespaces, o.NoHeaders, o.SortBy, o.Sum)
+	var podNodeMap map[string]string
+	if o.ShowNodeName {
+		podNodeMap, err = o.buildPodNodeMap(labelSelector, fieldSelector)
+		if err != nil {
+			return err
+		}
+	}
+
+	return o.Printer.PrintPodMetrics(metrics.Items, o.PrintContainers, o.AllNamespaces, o.NoHeaders, o.SortBy, o.Sum, podNodeMap)
+}
+
+func (o TopPodOptions) buildPodNodeMap(labelSelector labels.Selector, fieldSelector fields.Selector) (map[string]string, error) {
+	podNodeMap := make(map[string]string)
+	ns := o.Namespace
+	if o.AllNamespaces {
+		ns = metav1.NamespaceAll
+	}
+	if o.ResourceName != "" {
+		pod, err := o.PodClient.Pods(ns).Get(context.TODO(), o.ResourceName, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		podNodeMap[pod.Namespace+"/"+pod.Name] = pod.Spec.NodeName
+	} else {
+		pods, err := o.PodClient.Pods(ns).List(context.TODO(), metav1.ListOptions{
+			LabelSelector: labelSelector.String(),
+			FieldSelector: fieldSelector.String(),
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, pod := range pods.Items {
+			podNodeMap[pod.Namespace+"/"+pod.Name] = pod.Spec.NodeName
+		}
+	}
+	return podNodeMap, nil
 }
 
 func getMetricsFromMetricsAPI(metricsClient metricsclientset.Interface, namespace, resourceName string, allNamespaces bool, labelSelector labels.Selector, fieldSelector fields.Selector) (*metricsapi.PodMetricsList, error) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_test.go
@@ -385,6 +385,106 @@ func TestTopPodWithSwap(t *testing.T) {
 	})
 }
 
+func TestTopPodWithNodeInfo(t *testing.T) {
+	cmdtesting.InitTestErrorHandler(t)
+
+	const testName = "TestTopPodWithNodeInfo"
+	testNS := "testns"
+	t.Run(testName, func(t *testing.T) {
+		metricsList := testV1beta1PodMetricsData()
+		// Set the namespace on metrics to match the test namespace.
+		for i := range metricsList {
+			metricsList[i].Namespace = testNS
+		}
+		fakemetricsClientset := &metricsfake.Clientset{}
+
+		fakemetricsClientset.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+			res := &metricsv1beta1api.PodMetricsList{
+				Items: metricsList,
+			}
+			return true, res, nil
+		})
+
+		tf := cmdtesting.NewTestFactory().WithNamespace(testNS)
+		defer tf.Cleanup()
+
+		codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+		ns := scheme.Codecs.WithoutConversion()
+
+		podList := &v1.PodList{
+			Items: []v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: testNS},
+					Spec:       v1.PodSpec{NodeName: "node-a"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: testNS},
+					Spec:       v1.PodSpec{NodeName: "node-b"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod3", Namespace: testNS},
+					Spec:       v1.PodSpec{NodeName: "node-c"},
+				},
+			},
+		}
+
+		tf.Client = &fake.RESTClient{
+			NegotiatedSerializer: ns,
+			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+				switch req.URL.Path {
+				case "/api":
+					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apibody)))}, nil
+				case "/apis":
+					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apisbodyWithMetrics)))}, nil
+				case "/api/v1/namespaces/" + testNS + "/pods":
+					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, podList)}, nil
+				default:
+					t.Fatalf("%s: unexpected request: %#v\nGot URL: %#v",
+						testName, req, req.URL)
+					return nil, nil
+				}
+			}),
+		}
+		tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
+		streams, _, buf, _ := genericiooptions.NewTestIOStreams()
+
+		cmd := NewCmdTopPod(tf, nil, streams)
+		cmdOptions := &TopPodOptions{
+			ShowNodeName: true,
+		}
+		cmdOptions.IOStreams = streams
+
+		if err := cmdOptions.Complete(tf, cmd, nil); err != nil {
+			t.Fatal(err)
+		}
+		cmdOptions.MetricsClient = fakemetricsClientset
+		cmdOptions.ShowNodeName = true
+		if err := cmdOptions.Validate(); err != nil {
+			t.Fatal(err)
+		}
+		if err := cmdOptions.RunTopPod(); err != nil {
+			t.Fatal(err)
+		}
+
+		result := buf.String()
+
+		if !strings.Contains(result, "NODE") {
+			t.Errorf("missing NODE header: \n%s", result)
+		}
+
+		expectedNodeNames := map[string]string{
+			"pod1": "node-a",
+			"pod2": "node-b",
+			"pod3": "node-c",
+		}
+		for podName, nodeName := range expectedNodeNames {
+			if !strings.Contains(result, nodeName) {
+				t.Errorf("missing node %s for pod %s: \n%s", nodeName, podName, result)
+			}
+		}
+	})
+}
+
 func getResultColumnValues(result string, columnIndex int) []string {
 	resultLines := strings.Split(result, "\n")
 	values := make([]string, len(resultLines)-2) // don't process first (header) and last (empty) line

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
@@ -31,6 +31,7 @@ import (
 var (
 	NamespaceColumn = "NAMESPACE"
 	PodColumn       = "POD"
+	NodeColumn      = "NODE"
 )
 
 const ResourceSwap = "swap"
@@ -102,7 +103,7 @@ func (printer *TopCmdPrinter) PrintNodeMetrics(metrics []metricsapi.NodeMetrics,
 	return nil
 }
 
-func (printer *TopCmdPrinter) PrintPodMetrics(metrics []metricsapi.PodMetrics, printContainers bool, withNamespace bool, noHeaders bool, sortBy string, sum bool) error {
+func (printer *TopCmdPrinter) PrintPodMetrics(metrics []metricsapi.PodMetrics, printContainers bool, withNamespace bool, noHeaders bool, sortBy string, sum bool, podNodeMap map[string]string) error {
 	if len(metrics) == 0 {
 		return nil
 	}
@@ -110,6 +111,9 @@ func (printer *TopCmdPrinter) PrintPodMetrics(metrics []metricsapi.PodMetrics, p
 	defer w.Flush()
 
 	columnWidth := len(printer.podColumns)
+	if podNodeMap != nil {
+		columnWidth++
+	}
 	if !noHeaders {
 		if withNamespace {
 			printValue(w, NamespaceColumn)
@@ -119,7 +123,22 @@ func (printer *TopCmdPrinter) PrintPodMetrics(metrics []metricsapi.PodMetrics, p
 			printValue(w, PodColumn)
 			columnWidth++
 		}
-		printColumnNames(w, printer.podColumns)
+		// Print NAME first, then NODE (if requested), then remaining metric columns.
+		printValue(w, printer.podColumns[0])
+		if podNodeMap != nil {
+			printValue(w, NodeColumn)
+		}
+		for _, name := range printer.podColumns[1:] {
+			printValue(w, name)
+		}
+		fmt.Fprint(w, "\n")
+	} else {
+		if withNamespace {
+			columnWidth++
+		}
+		if printContainers {
+			columnWidth++
+		}
 	}
 
 	sort.Sort(NewPodMetricsSorter(metrics, withNamespace, sortBy, printer.measuredResources))
@@ -127,9 +146,9 @@ func (printer *TopCmdPrinter) PrintPodMetrics(metrics []metricsapi.PodMetrics, p
 	for _, m := range metrics {
 		if printContainers {
 			sort.Sort(NewContainerMetricsSorter(m.Containers, sortBy))
-			printer.printSinglePodContainerMetrics(w, &m, withNamespace, printer.measuredResources)
+			printer.printSinglePodContainerMetrics(w, &m, withNamespace, podNodeMap, printer.measuredResources)
 		} else {
-			printer.printSinglePodMetrics(w, &m, withNamespace, printer.measuredResources)
+			printer.printSinglePodMetrics(w, &m, withNamespace, podNodeMap, printer.measuredResources)
 		}
 
 	}
@@ -159,29 +178,37 @@ func printColumnNames(out io.Writer, names []string) {
 	fmt.Fprint(out, "\n")
 }
 
-func (printer *TopCmdPrinter) printSinglePodMetrics(out io.Writer, m *metricsapi.PodMetrics, withNamespace bool, measuredResources []v1.ResourceName) {
+func (printer *TopCmdPrinter) printSinglePodMetrics(out io.Writer, m *metricsapi.PodMetrics, withNamespace bool, podNodeMap map[string]string, measuredResources []v1.ResourceName) {
 	podMetrics := getPodMetrics(m, measuredResources)
 	if withNamespace {
 		printValue(out, m.Namespace)
 	}
-	printer.printMetricsLine(out, &ResourceMetricsInfo{
+	var nodeName string
+	if podNodeMap != nil {
+		nodeName = podNodeMap[m.Namespace+"/"+m.Name]
+	}
+	printer.printMetricsLineWithNode(out, &ResourceMetricsInfo{
 		Name:      m.Name,
 		Metrics:   podMetrics,
 		Available: v1.ResourceList{},
-	}, measuredResources)
+	}, podNodeMap != nil, nodeName, measuredResources)
 }
 
-func (printer *TopCmdPrinter) printSinglePodContainerMetrics(out io.Writer, m *metricsapi.PodMetrics, withNamespace bool, measuredResources []v1.ResourceName) {
+func (printer *TopCmdPrinter) printSinglePodContainerMetrics(out io.Writer, m *metricsapi.PodMetrics, withNamespace bool, podNodeMap map[string]string, measuredResources []v1.ResourceName) {
 	for _, c := range m.Containers {
 		if withNamespace {
 			printValue(out, m.Namespace)
 		}
 		printValue(out, m.Name)
-		printer.printMetricsLine(out, &ResourceMetricsInfo{
+		var nodeName string
+		if podNodeMap != nil {
+			nodeName = podNodeMap[m.Namespace+"/"+m.Name]
+		}
+		printer.printMetricsLineWithNode(out, &ResourceMetricsInfo{
 			Name:      c.Name,
 			Metrics:   c.Usage,
 			Available: v1.ResourceList{},
-		}, measuredResources)
+		}, podNodeMap != nil, nodeName, measuredResources)
 	}
 }
 
@@ -203,6 +230,15 @@ func getPodMetrics(m *metricsapi.PodMetrics, measuredResources []v1.ResourceName
 
 func (printer *TopCmdPrinter) printMetricsLine(out io.Writer, metrics *ResourceMetricsInfo, measuredResources []v1.ResourceName) {
 	printValue(out, metrics.Name)
+	printer.printAllResourceUsages(out, metrics, measuredResources)
+	fmt.Fprint(out, "\n")
+}
+
+func (printer *TopCmdPrinter) printMetricsLineWithNode(out io.Writer, metrics *ResourceMetricsInfo, showNode bool, nodeName string, measuredResources []v1.ResourceName) {
+	printValue(out, metrics.Name)
+	if showNode {
+		printValue(out, nodeName)
+	}
 	printer.printAllResourceUsages(out, metrics, measuredResources)
 	fmt.Fprint(out, "\n")
 }

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer_test.go
@@ -148,6 +148,7 @@ func TestPrintPodMetrics(t *testing.T) {
 		noHeader        bool
 		sortBy          string
 		sum             bool
+		podNodeMap      map[string]string
 		expectedErr     error
 		expectedOutput  string
 	}{
@@ -308,6 +309,30 @@ test     400m         2048Mi
 `,
 		},
 		{
+			name: "Single Pod with Node Info (-o wide)",
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+			podNodeMap: map[string]string{"default/test": "node1"},
+			expectedOutput: "NAME   NODE    CPU(cores)   MEMORY(bytes)   \ntest   node1   200m         1024Mi          \n",
+		},
+		{
 			name: "Multiple Pods with Multiple Containers - Calculate Total Resource Usage",
 			podMetric: []metricsapi.PodMetrics{
 				{
@@ -376,7 +401,7 @@ test-1   400m         5120Mi
 
 			top := NewTopCmdPrinter(out, false)
 			err := top.PrintPodMetrics(test.podMetric, test.printContainers,
-				test.withNamespace, test.noHeader, test.sortBy, test.sum)
+				test.withNamespace, test.noHeader, test.sortBy, test.sum, test.podNodeMap)
 			assert.Equal(t, test.expectedErr, err)
 			assert.Equal(t, test.expectedOutput, out.String())
 		})


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Currently, with the metrics server, you can only view `top nodes` or `top pods`. If you want to see which pods are overloading a node, you have to use a script or a pipe to make further requests via kubectl to determine which node is hosting a particular pod and get a correct output. 

```bash
 ./_output/kubectl top pods -o wide
NAME                                                NODE            CPU(cores)   MEMORY(bytes)
argocd-application-controller-0                     talos-4e6-sx1   8m           585Mi
argocd-applicationset-controller-7fc974c7bd-zbrjc   talos-4e6-sx1   3m           41Mi
argocd-dex-server-65c6c4564b-w4c6m                  talos-4e6-sx1   1m           31Mi
argocd-notifications-controller-5b46765c85-2mt6t    talos-4e6-sx1   1m           26Mi
argocd-redis-c6f86875c-2wwk7                        talos-4e6-sx1   3m           16Mi
argocd-repo-server-75f96fffdd-jbppp                 talos-4e6-sx1   36m          444Mi
argocd-server-85749fbf98-5nkp2                      talos-4e6-sx1   1m           45Mi
```

I already know that another PR were closed( https://github.com/kubernetes/kubernetes/pull/133578 ) but I still think that this feature would be handy, would love to discuss about it here (since the issue has already been approved in the triage).

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubectl/issues/1706
Fixes https://github.com/kubernetes/kubernetes/issues/131896
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

This is my first PR, so please feel free to give me your feedbacks :) 

#### Does this PR introduce a user-facing change?

```release-note
`kubectl top pod -o wide` now includes a NODE column showing which node each pod is running on, consistent with the behavior of `kubectl get pod -o wide`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

None