### PR TITLE
Migrate: use source file permission when writing destination file

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
@@ -300,7 +300,8 @@ func (rules *ClientConfigLoadingRules) Migrate() error {
 			return err
 		}
 
-		if sourceInfo, err := os.Stat(source); err != nil {
+		sourceInfo, err := os.Stat(source)
+		if err != nil {
 			if os.IsNotExist(err) || os.IsPermission(err) {
 				// if the source file doesn't exist or we can't access it, there's no work to do.
 				continue
@@ -316,8 +317,8 @@ func (rules *ClientConfigLoadingRules) Migrate() error {
 		if err != nil {
 			return err
 		}
-		// destination is created with mode 0666 before umask
-		err = os.WriteFile(destination, data, 0666)
+		// destination is created with source perm (before umask)
+		err = os.WriteFile(destination, data, sourceInfo.Mode().Perm())
 		if err != nil {
 			return err
 		}

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
@@ -317,8 +317,8 @@ func (rules *ClientConfigLoadingRules) Migrate() error {
 		if err != nil {
 			return err
 		}
-		// destination is created with source perm (before umask)
-		err = os.WriteFile(destination, data, sourceInfo.Mode().Perm())
+		// destination created with source perm, but never executable, and subject to umask
+		err = os.WriteFile(destination, data, sourceInfo.Mode().Perm()&0666)
 		if err != nil {
 			return err
 		}

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
@@ -656,6 +656,19 @@ func TestMigratingFile(t *testing.T) {
 	if !reflect.DeepEqual(sourceContent, destinationContent) {
 		t.Errorf("source and destination do not match")
 	}
+
+	// destination file permissions should be the same as the source file permissions
+	sourceInfo, err := os.Stat(sourceFile.Name())
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	destinationInfo, err := os.Stat(destinationFile.Name())
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	if destinationInfo.Mode().Perm() != sourceInfo.Mode().Perm() {
+		t.Errorf("expected permissions %v, got %v", sourceInfo.Mode().Perm(), destinationInfo.Mode().Perm())
+	}
 }
 
 func TestMigratingFileLeaveExistingFileAlone(t *testing.T) {


### PR DESCRIPTION

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
If you have a `~/.kube/.kubeconfig` file and no `~/.kube/config` file, client-go will perform a migration, which reads the contents of `~/.kube/.kubeconfig` and writes it to `~/.kube/config`.

However, the newly created `~/.kube/config` file is always created with `0666` permissions (subject to umask), which can result in `~/.kube/config` permissions exceeding `~/.kube/.kubeconfig` permissions as shown in the following example after migration has occurred:

```
~/.kube % umask
022
~/.kube % ls -l .kubeconfig config
-rw-------@ 1 bpursley  staff  5602 Mar 31 10:29 .kubeconfig
-rw-r--r--@ 1 bpursley  staff  5602 Mar 31 10:29 config
```

This can be a problem because config files can contain credentials, and the migration *could in some cases* result in accidental credential exposure to other users on the same system.

This PR changes the migrate functionality to use the source file's permissions when writing the destination file.  It still remains subject to umask as it does currently, so the destination permission may not exactly match the source permission, but with this change, the destination file's permissions won't exceed the source file's permissions.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Config file migration changed to use source file's permissions when creating destination file.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
