### PR TITLE
test/e2e_node: fix CRI proxy event forwarding

### DIFF
--- a/test/e2e_node/criproxy/proxy_runtime_service.go
+++ b/test/e2e_node/criproxy/proxy_runtime_service.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"time"
 
 	"google.golang.org/grpc"
@@ -485,20 +486,28 @@ func (p *RemoteRuntime) GetContainerEvents(req *runtimeapi.GetEventsRequest, ces
 		return err
 	}
 
+	ctx, cancel := context.WithCancel(ces.Context())
+	defer cancel()
+
 	// Capacity of the channel for receiving pod lifecycle events. This number
 	// is a bit arbitrary and may be adjusted in the future.
 	plegChannelCapacity := 1000
 	containerEventsResponseCh := make(chan *runtimeapi.ContainerEventResponse, plegChannelCapacity)
-	defer close(containerEventsResponseCh)
-
-	if err := p.runtimeService.GetContainerEvents(context.Background(), containerEventsResponseCh, nil); err != nil {
-		return err
-	}
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(containerEventsResponseCh)
+		errCh <- p.runtimeService.GetContainerEvents(ctx, containerEventsResponseCh, nil)
+	}()
 
 	for event := range containerEventsResponseCh {
 		if err := ces.Send(event); err != nil {
+			cancel()
 			return status.Errorf(codes.Unknown, "Failed to send event: %v", err)
 		}
+	}
+
+	if err := <-errCh; err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, io.EOF) {
+		return err
 	}
 
 	return nil

--- a/test/e2e_node/criproxy_test.go
+++ b/test/e2e_node/criproxy_test.go
@@ -219,7 +219,7 @@ var _ = SIGDescribe(feature.CriProxy, framework.WithSerial(), func() {
 
 			ginkgo.By("Expecting an error when imageSpec.Image is empty")
 			gomega.Eventually(func() error {
-				return verifyErrorInKubeletLogs("Failed to inspect image")
+				return verifyErrorInKubeletLogs("image was not found")
 			}).WithPolling(5*time.Second).WithTimeout(20*time.Second).ToNot(gomega.HaveOccurred(), "Could not verify error in kubelet logs")
 		})
 	})


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test
/kind cleanup

#### What this PR does / why we need it:

The CRI proxy called `GetContainerEvents` synchronously, which blocked in the upstream receive loop and prevented kubelet from receiving container lifecycle events. With `AllAlpha=true`, that broke the EventedPLEG path and left the CRI proxy node tests dependent on delayed fallback relists.

This PR runs the upstream event stream in a goroutine, ties it to the downstream stream context, propagates non-cancellation errors after forwarding completes, and restores the image-volume test to expect the kubelet log line that is actually emitted when `Image.Image` is empty.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Representative failing signal:
- TestGrid lane: https://testgrid.k8s.io/sig-node-kubelet#node-kubelet-cri-proxy-all-alpha
- Prow job history: https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-kubernetes-node-e2e-cri-proxy-all-alpha-serial
- Representative failing build: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-node-e2e-cri-proxy-all-alpha-serial/2038950645955825664

Representative failing tests from that job:
- `Container Restart [Feature:CriProxy]` in `test/e2e_node/container_restart_test.go`: https://github.com/kubernetes/kubernetes/blob/c2f018046389c61a496cc4b71d16366d03353182/test/e2e_node/container_restart_test.go
- `Pull Image [Feature:CriProxy] Image pull retry backs off on error.` in `test/e2e_node/image_pull_test.go`: https://github.com/kubernetes/kubernetes/blob/c2f018046389c61a496cc4b71d16366d03353182/test/e2e_node/image_pull_test.go
- `Image volume digest error handling` in `test/e2e_node/criproxy_test.go`: https://github.com/kubernetes/kubernetes/blob/c2f018046389c61a496cc4b71d16366d03353182/test/e2e_node/criproxy_test.go

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
