### PR TITLE
metrics-server: update to v0.8.1 and fix stale RBAC resourceName

### DIFF
--- a/cluster/addons/metrics-server/README.md
+++ b/cluster/addons/metrics-server/README.md
@@ -1,6 +1,6 @@
 # Metrics Server
 
-[Metrics Server](https://github.com/kubernetes-incubator/metrics-server) exposes
+[Metrics Server](https://github.com/kubernetes-sigs/metrics-server) exposes
 core Kubernetes metrics via metrics API.
 
 More details can be found in [Core metrics pipeline documentation](https://kubernetes.io/docs/tasks/debug-application-cluster/resource-metrics-pipeline/).

--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -23,23 +23,23 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: metrics-server-v0.8.0
+  name: metrics-server-v0.8.1
   namespace: kube-system
   labels:
     k8s-app: metrics-server
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v0.8.0
+    version: v0.8.1
 spec:
   selector:
     matchLabels:
       k8s-app: metrics-server
-      version: v0.8.0
+      version: v0.8.1
   template:
     metadata:
       name: metrics-server
       labels:
         k8s-app: metrics-server
-        version: v0.8.0
+        version: v0.8.1
     spec:
       securityContext:
         seccompProfile:
@@ -50,7 +50,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: metrics-server
-        image: registry.k8s.io/metrics-server/metrics-server:v0.8.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.8.1
         command:
         - /metrics-server
         - --metric-resolution=15s
@@ -109,7 +109,7 @@ spec:
           - --memory={{ base_metrics_server_memory }}
           - --extra-memory={{ metrics_server_memory_per_node }}Mi
           - --threshold=5
-          - --deployment=metrics-server-v0.8.0
+          - --deployment=metrics-server-v0.8.1
           - --container=metrics-server
           - --poll-period=30000
           - --estimator=exponential

--- a/cluster/addons/metrics-server/resource-reader.yaml
+++ b/cluster/addons/metrics-server/resource-reader.yaml
@@ -23,7 +23,7 @@ rules:
     resources:
       - deployments
     resourceNames:
-      - metrics-server-v0.7.1
+      - metrics-server-v0.8.1
     verbs:
       - get
       - patch

--- a/pkg/volume/emptydir/empty_dir.go
+++ b/pkg/volume/emptydir/empty_dir.go
@@ -503,7 +503,7 @@ func (ed *emptyDir) TearDownAt(dir string) error {
 	if pathExists, pathErr := mount.PathExists(dir); pathErr != nil {
 		return fmt.Errorf("error checking if path exists: %w", pathErr)
 	} else if !pathExists {
-		klog.Warningf("Warning: Unmount skipped because path does not exist: %v", dir)
+		klog.Warningf("Unmount skipped because path does not exist: %v", dir)
 		return nil
 	}
 
@@ -534,7 +534,7 @@ func (ed *emptyDir) teardownDefault(dir string) error {
 		}
 		err := fsquota.ClearQuota(ed.mounter, dir, userNamespacesEnabled)
 		if err != nil {
-			klog.Warningf("Warning: Failed to clear quota on %s: %v", dir, err)
+			klog.Warningf("Failed to clear quota on %s: %v", dir, err)
 		}
 	}
 	// Renaming the directory is not required anymore because the operation executor

--- a/pkg/volume/fc/fc_util.go
+++ b/pkg/volume/fc/fc_util.go
@@ -412,7 +412,7 @@ func checkPathExists(path string) (bool, error) {
 	if pathExists, pathErr := mount.PathExists(path); pathErr != nil {
 		return pathExists, fmt.Errorf("error checking if path exists: %w", pathErr)
 	} else if !pathExists {
-		klog.Warningf("Warning: Unmap skipped because path does not exist: %v", path)
+		klog.Warningf("Unmap skipped because path does not exist: %v", path)
 		return pathExists, nil
 	}
 	return true, nil

--- a/pkg/volume/flexvolume/detacher.go
+++ b/pkg/volume/flexvolume/detacher.go
@@ -54,7 +54,7 @@ func (d *flexVolumeDetacher) UnmountDevice(deviceMountPath string) error {
 
 	pathExists, pathErr := mount.PathExists(deviceMountPath)
 	if !pathExists {
-		klog.Warningf("Warning: Unmount skipped because path does not exist: %v", deviceMountPath)
+		klog.Warningf("Unmount skipped because path does not exist: %v", deviceMountPath)
 		return nil
 	}
 	if pathErr != nil && !mount.IsCorruptedMnt(pathErr) {
@@ -71,7 +71,7 @@ func (d *flexVolumeDetacher) UnmountDevice(deviceMountPath string) error {
 	}
 
 	if notmnt {
-		klog.Warningf("Warning: Path: %v already unmounted", deviceMountPath)
+		klog.Warningf("Path %v already unmounted", deviceMountPath)
 	} else {
 		call := d.plugin.NewDriverCall(unmountDeviceCmd)
 		call.Append(deviceMountPath)

--- a/pkg/volume/flexvolume/unmounter.go
+++ b/pkg/volume/flexvolume/unmounter.go
@@ -49,7 +49,7 @@ func (f *flexVolumeUnmounter) TearDownAt(dir string) error {
 		klog.Warningf("Error checking path: %v", pathErr)
 	} else {
 		if !pathExists {
-			klog.Warningf("Warning: Unmount skipped because path does not exist: %v", dir)
+			klog.Warningf("Unmount skipped because path does not exist: %v", dir)
 			return nil
 		}
 	}

--- a/pkg/volume/iscsi/iscsi_util.go
+++ b/pkg/volume/iscsi/iscsi_util.go
@@ -373,7 +373,7 @@ func (util *ISCSIUtil) AttachDisk(b iscsiDiskMounter) (string, error) {
 				_, err = execWithLog(b, "iscsiadm", "-m", "node", "-p", tp, "-T", b.Iqn, "-o", "update", "-n", "node.startup", "-v", "manual")
 				if err != nil {
 					// don't fail if we can't set startup mode, but log warning so there is a clue
-					klog.Warningf("Warning: Failed to set iSCSI login mode to manual. Error: %v", err)
+					klog.Warningf("Failed to set iSCSI login mode to manual: %v", err)
 				}
 
 				// Rebuild the host map after logging in
@@ -564,7 +564,7 @@ func deleteDevices(c iscsiDiskUnmounter) error {
 	for mpathDevice := range mpathDevices {
 		_, err = c.exec.Command("multipath", "-f", mpathDevice).CombinedOutput()
 		if err != nil {
-			klog.Warningf("Warning: Failed to flush multipath device map: %s\nError: %v", mpathDevice, err)
+			klog.Warningf("Failed to flush multipath device map: %s: %v", mpathDevice, err)
 			// Fall through -- keep deleting the block devices
 		}
 		klog.V(4).Infof("Flushed multipath device: %s", mpathDevice)
@@ -572,7 +572,7 @@ func deleteDevices(c iscsiDiskUnmounter) error {
 	for _, deviceName := range deviceNames {
 		err = deleteDevice(deviceName)
 		if err != nil {
-			klog.Warningf("Warning: Failed to delete block device: %s\nError: %v", deviceName, err)
+			klog.Warningf("Failed to delete block device: %s: %v", deviceName, err)
 			// Fall through -- keep deleting other block devices
 		}
 	}
@@ -584,7 +584,7 @@ func (util *ISCSIUtil) DetachDisk(c iscsiDiskUnmounter, mntPath string) error {
 	if pathExists, pathErr := mount.PathExists(mntPath); pathErr != nil {
 		return fmt.Errorf("error checking if path exists: %w", pathErr)
 	} else if !pathExists {
-		klog.Warningf("Warning: Unmount skipped because path does not exist: %v", mntPath)
+		klog.Warningf("Unmount skipped because path does not exist: %v", mntPath)
 		return nil
 	}
 
@@ -660,7 +660,7 @@ func (util *ISCSIUtil) DetachBlockISCSIDisk(c iscsiDiskUnmapper, mapPath string)
 	if pathExists, pathErr := mount.PathExists(mapPath); pathErr != nil {
 		return fmt.Errorf("error checking if path exists: %w", pathErr)
 	} else if !pathExists {
-		klog.Warningf("Warning: Unmap skipped because path does not exist: %v", mapPath)
+		klog.Warningf("Unmap skipped because path does not exist: %v", mapPath)
 		return nil
 	}
 	// If we arrive here, device is no longer used, see if need to logout the target

--- a/pkg/volume/util/atomic_writer.go
+++ b/pkg/volume/util/atomic_writer.go
@@ -190,7 +190,7 @@ func (w *AtomicWriter) Write(payload map[string]FileProjection, setPerms func(su
 		// (5)
 		tsDir, err := w.newTimestampDir()
 		if err != nil {
-			klog.V(4).Infof("%s: error creating new ts data directory: %v", w.logContext, err)
+			klog.Errorf("%s: error creating new ts data directory: %v", w.logContext, err)
 			return err
 		}
 		tsDirName := filepath.Base(tsDir)

--- a/pkg/volume/util/fsquota/common/quota_common_linux_impl.go
+++ b/pkg/volume/util/fsquota/common/quota_common_linux_impl.go
@@ -193,7 +193,7 @@ func isFilesystemOfType(mountpoint string, backingDev string, typeMagic int64) b
 	var buf syscall.Statfs_t
 	err := syscall.Statfs(mountpoint, &buf)
 	if err != nil {
-		klog.Warningf("Warning: Unable to statfs %s: %v", mountpoint, err)
+		klog.Warningf("Unable to statfs %s: %v", mountpoint, err)
 		return false
 	}
 	if int64(buf.Type) != typeMagic {

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -1566,7 +1566,7 @@ func (og *operationGenerator) GenerateExpandVolumeFunc(
 			klog.V(4).Infof("Controller resizing done for PVC %s", util.GetPersistentVolumeClaimQualifiedName(pvc))
 			_, err := util.MarkResizeFinished(pvc, newSize, og.kubeClient)
 			if err != nil {
-				detailedErr := fmt.Errorf("error marking pvc %s as resized : %v", util.GetPersistentVolumeClaimQualifiedName(pvc), err)
+				detailedErr := fmt.Errorf("error marking pvc %s as resized: %w", util.GetPersistentVolumeClaimQualifiedName(pvc), err)
 				return volumetypes.NewOperationContext(detailedErr, detailedErr, migrated)
 			}
 			successMsg := fmt.Sprintf("ExpandVolume succeeded for volume %s", util.GetPersistentVolumeClaimQualifiedName(pvc))
@@ -1574,7 +1574,7 @@ func (og *operationGenerator) GenerateExpandVolumeFunc(
 		} else {
 			_, err := util.MarkForFSResize(pvc, og.kubeClient)
 			if err != nil {
-				detailedErr := fmt.Errorf("error updating pvc %s condition for fs resize : %v", util.GetPersistentVolumeClaimQualifiedName(pvc), err)
+				detailedErr := fmt.Errorf("error updating pvc %s condition for fs resize: %w", util.GetPersistentVolumeClaimQualifiedName(pvc), err)
 				klog.Warning(detailedErr)
 				return volumetypes.NewOperationContext(nil, nil, migrated)
 			}

--- a/pkg/volume/util/volumepathhandler/volume_path_handler.go
+++ b/pkg/volume/util/volumepathhandler/volume_path_handler.go
@@ -130,11 +130,11 @@ func mapBindMountDevice(devicePath string, mapPath string, linkName string) erro
 		// Check if device file
 		// TODO: Need to check if this device file is actually the expected bind mount
 		if file.Mode()&os.ModeDevice == os.ModeDevice {
-			klog.Warningf("Warning: Map skipped because bind mount already exists on the path: %v", linkPath)
+			klog.Warningf("Map skipped because bind mount already exists on the path: %v", linkPath)
 			return nil
 		}
 
-		klog.Warningf("Warning: file %s already exists but is not mounted, skip creating file", linkPath)
+		klog.Warningf("File %s already exists but is not mounted, skip creating file", linkPath)
 	}
 
 	// Bind mount file
@@ -177,7 +177,7 @@ func unmapBindMountDevice(v VolumePathHandler, mapPath string, linkName string) 
 	if isMountExist, checkErr := v.IsDeviceBindMountExist(linkPath); checkErr != nil {
 		return checkErr
 	} else if !isMountExist {
-		klog.Warningf("Warning: Unmap skipped because bind mount does not exist on the path: %v", linkPath)
+		klog.Warningf("Unmap skipped because bind mount does not exist on the path: %v", linkPath)
 
 		// Check if linkPath still exists
 		if _, err := os.Stat(linkPath); err != nil {
@@ -214,7 +214,7 @@ func unmapSymlinkDevice(v VolumePathHandler, mapPath string, linkName string) er
 	if islinkExist, checkErr := v.IsSymlinkExist(linkPath); checkErr != nil {
 		return checkErr
 	} else if !islinkExist {
-		klog.Warningf("Warning: Unmap skipped because symlink does not exist on the path: %v", linkPath)
+		klog.Warningf("Unmap skipped because symlink does not exist on the path: %v", linkPath)
 		return nil
 	}
 	return os.Remove(linkPath)

--- a/staging/src/k8s.io/mount-utils/mount_helper_common.go
+++ b/staging/src/k8s.io/mount-utils/mount_helper_common.go
@@ -31,7 +31,7 @@ import (
 func CleanupMountPoint(mountPath string, mounter Interface, extensiveMountPointCheck bool) error {
 	pathExists, pathErr := PathExists(mountPath)
 	if !pathExists && pathErr == nil {
-		klog.Warningf("Warning: mount cleanup skipped because path does not exist: %v", mountPath)
+		klog.Warningf("Mount cleanup skipped because path does not exist: %v", mountPath)
 		return nil
 	}
 	corruptedMnt := IsCorruptedMnt(pathErr)
@@ -44,7 +44,7 @@ func CleanupMountPoint(mountPath string, mounter Interface, extensiveMountPointC
 func CleanupMountWithForce(mountPath string, mounter MounterForceUnmounter, extensiveMountPointCheck bool, umountTimeout time.Duration) error {
 	pathExists, pathErr := PathExists(mountPath)
 	if !pathExists && pathErr == nil {
-		klog.Warningf("Warning: mount cleanup skipped because path does not exist: %v", mountPath)
+		klog.Warningf("Mount cleanup skipped because path does not exist: %v", mountPath)
 		return nil
 	}
 	corruptedMnt := IsCorruptedMnt(pathErr)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Updates the metrics-server addon from v0.8.0 to v0.8.1 and fixes
two additional issues in the addon manifests:

1. **metrics-server image bump**: v0.8.0 -> v0.8.1
   ([changelog](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.1))

2. **Fix stale RBAC resourceName** (functional bug): The ClusterRole
   `system:metrics-server` in `resource-reader.yaml` still referenced
   the deployment name `metrics-server-v0.7.1` from a previous version.
   The actual deployment is `metrics-server-v0.8.0` (now v0.8.1). This
   means the addon-resizer nanny could not `get` or `patch` the
   deployment, so auto-scaling of the metrics-server pod resources
   based on cluster size was silently broken.

3. **Fix dead README link**: The link pointed to the archived
   `kubernetes-incubator/metrics-server` repo. Updated to the current
   `kubernetes-sigs/metrics-server`.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The RBAC resourceName mismatch has been present since the v0.7.1 -> v0.8.0
bump and would cause addon-resizer nanny RBAC failures on clusters using
kube-up with the metrics-server addon enabled.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

/sig instrumentation
/sig cluster-lifecycle
/priority important-longterm
