### PR TITLE
Tests: Call removeNodeTaint variadically instead of in a loop

### DIFF
--- a/test/e2e/framework/node/resource.go
+++ b/test/e2e/framework/node/resource.go
@@ -617,8 +617,14 @@ func CreatePodsPerNodeForSimpleApp(ctx context.Context, c clientset.Interface, n
 // RemoveTaintsOffNode removes a list of taints from the given node
 // It is simply a helper wrapper for RemoveTaintOffNode
 func RemoveTaintsOffNode(ctx context.Context, c clientset.Interface, nodeName string, taints []v1.Taint) {
+	taintPtrs := make([]*v1.Taint, len(taints))
+	for i := range taints {
+		taintPtrs[i] = &taints[i]
+	}
+	err := removeNodeTaint(ctx, c, nodeName, nil, taintPtrs...)
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 	for _, taint := range taints {
-		RemoveTaintOffNode(ctx, c, nodeName, taint)
+		verifyThatTaintIsGone(ctx, c, nodeName, &taint)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

I believe there is a sneaky timing/caching issue lurking here. When `RemoveTaintsOffNode` removes taints one at a time in a loop, each iteration reads the node from the API server cache, removes one taint, and patches. If the cache is stale for any iteration (still reflecting the state before the previous patch's watch event propagated) the patch sends the full stale list minus only the current taint, effectively re-adding the taint that was just removed in the prior step. Since the loop has already moved past that taint, it's never cleaned up. `verifyThatTaintIsGone` (previously called once per loop) doesn't catch this because it only checks whether the current taint was removed, not whether previously removed taints were re-introduced. The fix is to remove all taints in a single cycle instead of looping, which `removeNodeTaint`'s variadic signature already supports.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
