### PR TITLE
Fix sourceFile goroutine leak by adding ctx to NewSourceFile()

### DIFF
--- a/pkg/kubelet/config/file.go
+++ b/pkg/kubelet/config/file.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -59,22 +60,27 @@ type sourceFile struct {
 }
 
 // NewSourceFile watches a config file for changes.
-func NewSourceFile(logger klog.Logger, path string, nodeName types.NodeName, period time.Duration, updates chan<- sourceUpdate) {
+// The watcher stops and releases resources when ctx is canceled.
+func NewSourceFile(ctx context.Context, path string, nodeName types.NodeName, period time.Duration, updates chan<- sourceUpdate) {
 	// "github.com/sigma/go-inotify" requires a path without trailing "/"
 	path = strings.TrimRight(path, string(os.PathSeparator))
 
-	config := newSourceFile(path, nodeName, period, updates)
+	logger := klog.FromContext(ctx)
+	config := newSourceFile(ctx, path, nodeName, period, updates)
 	logger.V(1).Info("Watching path", "path", path)
-	config.run(logger)
+	config.run(ctx)
 }
 
-func newSourceFile(path string, nodeName types.NodeName, period time.Duration, updates chan<- sourceUpdate) *sourceFile {
+func newSourceFile(ctx context.Context, path string, nodeName types.NodeName, period time.Duration, updates chan<- sourceUpdate) *sourceFile {
 	send := func(objs []interface{}) {
 		var pods []*v1.Pod
 		for _, o := range objs {
 			pods = append(pods, o.(*v1.Pod))
 		}
-		updates <- sourceUpdate{Pods: pods}
+		select {
+		case updates <- sourceUpdate{Pods: pods}:
+		case <-ctx.Done():
+		}
 	}
 	store := cache.NewUndeltaStore(send, cache.MetaNamespaceKeyFunc)
 	return &sourceFile{
@@ -88,16 +94,20 @@ func newSourceFile(path string, nodeName types.NodeName, period time.Duration, u
 	}
 }
 
-func (s *sourceFile) run(logger klog.Logger) {
+func (s *sourceFile) run(ctx context.Context) {
+	logger := klog.FromContext(ctx)
 	listTicker := time.NewTicker(s.period)
 
 	go func() {
+		defer listTicker.Stop()
 		// Read path immediately to speed up startup.
 		if err := s.listConfig(logger); err != nil {
 			logger.Error(err, "Unable to read config path", "path", s.path)
 		}
 		for {
 			select {
+			case <-ctx.Done():
+				return
 			case <-listTicker.C:
 				if err := s.listConfig(logger); err != nil {
 					logger.Error(err, "Unable to read config path", "path", s.path)
@@ -110,7 +120,7 @@ func (s *sourceFile) run(logger klog.Logger) {
 		}
 	}()
 
-	s.startWatch(logger)
+	s.startWatch(ctx)
 }
 
 func (s *sourceFile) applyDefaults(logger klog.Logger, pod *api.Pod, source string) error {

--- a/pkg/kubelet/config/file_linux.go
+++ b/pkg/kubelet/config/file_linux.go
@@ -19,6 +19,7 @@ limitations under the License.
 package config
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -46,16 +47,17 @@ func (e *retryableError) Error() string {
 	return e.message
 }
 
-func (s *sourceFile) startWatch(logger klog.Logger) {
+func (s *sourceFile) startWatch(ctx context.Context) {
+	logger := klog.FromContext(ctx)
 	backOff := flowcontrol.NewBackOff(retryPeriod, maxRetryPeriod)
 	backOffID := "watch"
 
-	go wait.Forever(func() {
+	go wait.UntilWithContext(ctx, func(ctx context.Context) {
 		if backOff.IsInBackOffSinceUpdate(backOffID, time.Now()) {
 			return
 		}
 
-		if err := s.doWatch(logger); err != nil {
+		if err := s.doWatch(ctx); err != nil {
 			logger.Error(err, "Unable to read config path", "path", s.path)
 			if _, retryable := err.(*retryableError); !retryable {
 				backOff.Next(backOffID, time.Now())
@@ -64,7 +66,8 @@ func (s *sourceFile) startWatch(logger klog.Logger) {
 	}, retryPeriod)
 }
 
-func (s *sourceFile) doWatch(logger klog.Logger) error {
+func (s *sourceFile) doWatch(ctx context.Context) error {
+	logger := klog.FromContext(ctx)
 	_, err := os.Stat(s.path)
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -88,6 +91,8 @@ func (s *sourceFile) doWatch(logger klog.Logger) error {
 
 	for {
 		select {
+		case <-ctx.Done():
+			return nil
 		case event := <-w.Events:
 			if err = s.produceWatchEvent(logger, &event); err != nil {
 				return fmt.Errorf("error while processing inotify event (%+v): %v", event, err)

--- a/pkg/kubelet/config/file_linux_test.go
+++ b/pkg/kubelet/config/file_linux_test.go
@@ -43,19 +43,19 @@ import (
 )
 
 func TestExtractFromNonExistentFile(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	_, ctx := ktesting.NewTestContext(t)
 	ch := make(chan sourceUpdate, 1)
-	lw := newSourceFile("/some/fake/file", "localhost", time.Millisecond, ch)
-	err := lw.doWatch(logger)
+	lw := newSourceFile(ctx, "/some/fake/file", "localhost", time.Millisecond, ch)
+	err := lw.doWatch(ctx)
 	if err == nil {
 		t.Errorf("Expected error")
 	}
 }
 
 func TestUpdateOnNonExistentFile(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	_, ctx := ktesting.NewTestContext(t)
 	ch := make(chan sourceUpdate)
-	NewSourceFile(logger, "random_non_existent_path", "localhost", time.Millisecond, ch)
+	NewSourceFile(ctx, "random_non_existent_path", "localhost", time.Millisecond, ch)
 	select {
 	case update := <-ch:
 		expected := createSourceUpdate() // Expect empty update.
@@ -69,7 +69,7 @@ func TestUpdateOnNonExistentFile(t *testing.T) {
 }
 
 func TestReadPodsFromFileExistAlready(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	_, ctx := ktesting.NewTestContext(t)
 	hostname := types.NodeName("random-test-hostname")
 	var testCases = getTestCases(hostname)
 
@@ -83,7 +83,7 @@ func TestReadPodsFromFileExistAlready(t *testing.T) {
 			file := testCase.writeToFile(dirName, "test_pod_manifest", t)
 
 			ch := make(chan sourceUpdate)
-			NewSourceFile(logger, file, hostname, time.Millisecond, ch)
+			NewSourceFile(ctx, file, hostname, time.Millisecond, ch)
 			select {
 			case update := <-ch:
 				for _, pod := range update.Pods {
@@ -229,7 +229,7 @@ func createSymbolicLink(link, target, name string, t *testing.T) string {
 }
 
 func watchFileAdded(watchDir bool, symlink bool, t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	_, ctx := ktesting.NewTestContext(t)
 	hostname := types.NodeName("random-test-hostname")
 	var testCases = getTestCases(hostname)
 
@@ -255,9 +255,9 @@ func watchFileAdded(watchDir bool, symlink bool, t *testing.T) {
 
 			ch := make(chan sourceUpdate)
 			if watchDir {
-				NewSourceFile(logger, dirName, hostname, 100*time.Millisecond, ch)
+				NewSourceFile(ctx, dirName, hostname, 100*time.Millisecond, ch)
 			} else {
-				NewSourceFile(logger, filepath.Join(dirName, fileName), hostname, 100*time.Millisecond, ch)
+				NewSourceFile(ctx, filepath.Join(dirName, fileName), hostname, 100*time.Millisecond, ch)
 			}
 			expectEmptyUpdate(t, ch)
 
@@ -283,7 +283,7 @@ func watchFileAdded(watchDir bool, symlink bool, t *testing.T) {
 }
 
 func watchFileChanged(watchDir bool, symlink bool, period time.Duration, t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	_, ctx := ktesting.NewTestContext(t)
 	hostname := types.NodeName("random-test-hostname")
 	var testCases = getTestCases(hostname)
 
@@ -322,9 +322,9 @@ func watchFileChanged(watchDir bool, symlink bool, period time.Duration, t *test
 			}()
 
 			if watchDir {
-				NewSourceFile(logger, dirName, hostname, period, ch)
+				NewSourceFile(ctx, dirName, hostname, period, ch)
 			} else {
-				NewSourceFile(logger, file, hostname, period, ch)
+				NewSourceFile(ctx, file, hostname, period, ch)
 			}
 
 			// await fsnotify to be ready

--- a/pkg/kubelet/config/file_test.go
+++ b/pkg/kubelet/config/file_test.go
@@ -33,7 +33,7 @@ func TestExtractFromBadDataFile(t *testing.T) {
 	}
 	defer removeAll(dirName, t)
 
-	logger, _ := ktesting.NewTestContext(t)
+	logger, ctx := ktesting.NewTestContext(t)
 	fileName := filepath.Join(dirName, "test_pod_config")
 	err = os.WriteFile(fileName, []byte{1, 2, 3}, 0555)
 	if err != nil {
@@ -41,7 +41,7 @@ func TestExtractFromBadDataFile(t *testing.T) {
 	}
 
 	ch := make(chan sourceUpdate, 1)
-	lw := newSourceFile(fileName, "localhost", time.Millisecond, ch)
+	lw := newSourceFile(ctx, fileName, "localhost", time.Millisecond, ch)
 	err = lw.listConfig(logger)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
@@ -56,9 +56,9 @@ func TestExtractFromEmptyDir(t *testing.T) {
 	}
 	defer removeAll(dirName, t)
 
-	logger, _ := ktesting.NewTestContext(t)
+	logger, ctx := ktesting.NewTestContext(t)
 	ch := make(chan sourceUpdate, 1)
-	lw := newSourceFile(dirName, "localhost", time.Millisecond, ch)
+	lw := newSourceFile(ctx, dirName, "localhost", time.Millisecond, ch)
 	err = lw.listConfig(logger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/pkg/kubelet/config/file_unsupported.go
+++ b/pkg/kubelet/config/file_unsupported.go
@@ -19,12 +19,14 @@ limitations under the License.
 package config
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/klog/v2"
 )
 
-func (s *sourceFile) startWatch(logger klog.Logger) {
+func (s *sourceFile) startWatch(ctx context.Context) {
+	logger := klog.FromContext(ctx)
 	logger.Error(nil, "Watching source file is unsupported in this build")
 }
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -384,7 +384,7 @@ func makePodSourceConfig(ctx context.Context, kubeCfg *kubeletconfiginternal.Kub
 	// define file config source
 	if kubeCfg.StaticPodPath != "" {
 		logger.Info("Adding static pod path", "path", kubeCfg.StaticPodPath)
-		config.NewSourceFile(logger, kubeCfg.StaticPodPath, nodeName, kubeCfg.FileCheckFrequency.Duration, cfg.Channel(ctx, kubetypes.FileSource))
+		config.NewSourceFile(ctx, kubeCfg.StaticPodPath, nodeName, kubeCfg.FileCheckFrequency.Duration, cfg.Channel(ctx, kubetypes.FileSource))
 	}
 
 	// define url config source


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
Fixes #138134 

#### Special notes for your reviewer:
NewSourceFile() spawned goroutines with no exit mechanism, causing a goroutine leak. Add a ctx context.Context parameter to NewSourceFile() so goroutines can exit cleanly when the context is canceled.

- Replace wait.Forever with wait.UntilWithContext in startWatch
- Add ctx.Done() cases in run() and doWatch() select loops
- Make the UndeltaStore send callback context-aware to unblock channel sends on cancellation
- Defer-close the fsnotify watcher on context cancellation

For kubelet, the existing ctx from makePodSourceConfig() is passed directly. Tests use the context from ktesting.NewTestContext(t), which is canceled when the test ends.

#### Does this PR introduce a user-facing change?
NONE

```release-notes
Fixed a goroutine leak in the kubelet static pod file watcher
```
