### PR TITLE
localupcluster: kill the whole process group on Stop

### DIFF
--- a/test/utils/localupcluster/cmd.go
+++ b/test/utils/localupcluster/cmd.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -94,6 +95,10 @@ func (c *Cmd) Start(tCtx ktesting.TContext) {
 	tCtx = tCtx.WithCancel()
 	c.cancel = tCtx.Cancel
 	c.cmd = exec.CommandContext(tCtx, c.CommandLine[0], c.CommandLine[1:]...)
+	// Put the process in its own process group so that Stop can kill the entire
+	// group. This matters when the command is wrapped by sudo: killing sudo alone
+	// orphans its children (e.g. kubelet), which keep running and holding ports.
+	setProcessGroup(c.cmd)
 	c.gathering = false
 
 	c.cmd.Env = os.Environ()
@@ -158,6 +163,10 @@ func (c *Cmd) Start(tCtx ktesting.TContext) {
 		defer c.wg.Done()
 		// tCtx.Logf("Starting to wait for termination of command %s", c.Name)
 		c.result = c.cmd.Wait()
+		// Mark the process as no longer running immediately after Wait() so that
+		// Stop()'s killProcessGroup guard (c.running.Load()) sees the correct
+		// state as soon as the PID is released by the kernel and could be recycled.
+		c.running.Store(false)
 		tCtx.Logf("Command %s terminated, result: %v", c.Name, c.result)
 		now := time.Now()
 		if reader != nil {
@@ -177,7 +186,6 @@ func (c *Cmd) Start(tCtx ktesting.TContext) {
 				}
 			}
 		}
-		c.running.Store(false)
 	}()
 }
 
@@ -199,6 +207,13 @@ func (c *Cmd) Stop(tCtx ktesting.TContext, reason string) string {
 			}()
 			_, _ = fmt.Fprintf(f, "%s: killing: %s\n", time.Now(), reason)
 		}
+	}
+	// Kill the entire process group so that children spawned by the command
+	// (e.g. kubelet launched by sudo) are also terminated. Guard with
+	// c.running to avoid signalling a recycled PID if the process already exited.
+	if c.cmd != nil && c.cmd.Process != nil && c.running.Load() {
+		useSudo := len(c.CommandLine) > 0 && filepath.Base(c.CommandLine[0]) == "sudo"
+		killProcessGroup(tCtx, c.cmd.Process.Pid, useSudo)
 	}
 	c.cancel(reason)
 	return c.wait(tCtx, true)

--- a/test/utils/localupcluster/cmd_unix.go
+++ b/test/utils/localupcluster/cmd_unix.go
@@ -1,0 +1,57 @@
+//go:build !windows
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package localupcluster
+
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+
+	"k8s.io/kubernetes/test/utils/client-go/ktesting"
+)
+
+// setProcessGroup places cmd in its own process group so that killProcessGroup
+// can terminate the entire group, including sudo-launched children.
+func setProcessGroup(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+// killProcessGroup sends SIGKILL to the process group whose leader has the
+// given PID. For sudo-wrapped processes it attempts "sudo -n kill -KILL -<pgid>"
+// so that root-owned children (e.g. kubelet launched by sudo) are also killed,
+// but falls back to a non-sudo kill if that fails.
+func killProcessGroup(tCtx ktesting.TContext, pid int, useSudo bool) {
+	if useSudo {
+		// Use sudo to kill root-owned processes (e.g. kubelet launched via sudo).
+		// -n avoids interactive password prompts; failure is non-fatal because
+		// the process may have already exited (ESRCH) or sudo may not be available.
+		err := exec.Command("sudo", "-n", "kill", "-KILL", fmt.Sprintf("-%d", pid)).Run()
+		if err == nil {
+			return
+		}
+		tCtx.Logf("sudo kill of process group -%d failed: %v; falling back to non-sudo kill", pid, err)
+	}
+	// ESRCH means the process group no longer exists — that's the desired outcome.
+	if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+		tCtx.Errorf("kill of process group -%d failed: %v", pid, err)
+	}
+}

--- a/test/utils/localupcluster/cmd_windows.go
+++ b/test/utils/localupcluster/cmd_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package localupcluster
+
+import (
+	"os/exec"
+
+	"k8s.io/kubernetes/test/utils/client-go/ktesting"
+)
+
+// setProcessGroup is a no-op on Windows; process groups work differently and
+// hack/local-up-cluster.sh does not run on Windows anyway.
+func setProcessGroup(*exec.Cmd) {}
+
+// killProcessGroup is a no-op on Windows.
+func killProcessGroup(ktesting.TContext, int, bool) {}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind flake

#### What this PR does / why we need it:

Some commands are wrapped by sudo (KUBELET_SUDO / PROXY_SUDO in local-up-cluster.sh).  Go's exec.CommandContext sends SIGKILL only to the top-level process (sudo) when its context is cancelled.  Sudo does not forward signals to its children, so the actual component process is orphaned: it keeps running and holds its ports even after cmd.Stop() returns.

Fix: set SysProcAttr.Setpgid = true in Start so every launched process is placed in its own process group.  In Stop, explicitly send SIGKILL to the negated PID (i.e. the entire process group) before cancelling the context.  This ensures sudo and all its children are terminated together.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
