### PR TITLE
pluginmanager: re-dial socket for NotifyRegistrationStatus after RegisterPlugin

### DIFF
--- a/pkg/kubelet/pluginmanager/operationexecutor/operation_generator.go
+++ b/pkg/kubelet/pluginmanager/operationexecutor/operation_generator.go
@@ -138,8 +138,8 @@ func (og *operationGenerator) GenerateRegisterPluginFunc(
 		// stale or be closed by the plugin side. A fresh connection guarantees that
 		// NotifyRegistrationStatus is reliably delivered regardless of how long
 		// registration took.
-		notifyClient, notifyConn, notifyDialErr := dial(ctx, socketPath, dialTimeoutDuration)
-		if notifyDialErr != nil {
+		client, conn, redialErr := dial(ctx, socketPath, dialTimeoutDuration)
+		if redialErr != nil {
 			// The plugin socket disappeared while RegisterPlugin was running.
 			// Clean up local state and let the reconciler retry once the socket
 			// reappears.
@@ -147,17 +147,17 @@ func (og *operationGenerator) GenerateRegisterPluginFunc(
 			if registerErr == nil {
 				handler.DeRegisterPlugin(ctx, infoResp.Name, infoResp.Endpoint)
 			}
-			return fmt.Errorf("RegisterPlugin error -- failed to re-dial socket %s for notification after RegisterPlugin, err: %w", socketPath, notifyDialErr)
+			return fmt.Errorf("RegisterPlugin error -- failed to re-dial socket %s for notification after RegisterPlugin, err: %w", socketPath, redialErr)
 		}
-		defer func() { _ = notifyConn.Close() }()
+		defer func() { _ = conn.Close() }()
 
 		if registerErr != nil {
 			actualStateOfWorldUpdater.RemovePlugin(socketPath)
-			return og.notifyPlugin(ctx, notifyClient, false, fmt.Sprintf("RegisterPlugin error -- plugin registration failed with err: %v", registerErr))
+			return og.notifyPlugin(ctx, client, false, fmt.Sprintf("RegisterPlugin error -- plugin registration failed with err: %v", registerErr))
 		}
 
 		// Notify is called after register to guarantee that even if notify throws an error Register will always be called after validate
-		if err := og.notifyPlugin(ctx, notifyClient, true, ""); err != nil {
+		if err := og.notifyPlugin(ctx, client, true, ""); err != nil {
 			actualStateOfWorldUpdater.RemovePlugin(socketPath)
 			handler.DeRegisterPlugin(ctx, infoResp.Name, infoResp.Endpoint)
 			return fmt.Errorf("RegisterPlugin error -- failed to send registration status at socket %s, err: %v", socketPath, err)

--- a/pkg/kubelet/pluginmanager/operationexecutor/operation_generator.go
+++ b/pkg/kubelet/pluginmanager/operationexecutor/operation_generator.go
@@ -129,13 +129,35 @@ func (og *operationGenerator) GenerateRegisterPluginFunc(
 		if err != nil {
 			logger.Error(err, "RegisterPlugin error -- failed to add plugin", "path", socketPath)
 		}
-		if err := handler.RegisterPlugin(ctx, infoResp.Name, infoResp.Endpoint, infoResp.SupportedVersions, nil); err != nil {
+		registerErr := handler.RegisterPlugin(ctx, infoResp.Name, infoResp.Endpoint, infoResp.SupportedVersions, nil)
+
+		// Re-dial the registration socket before sending the notification.
+		// handler.RegisterPlugin may block for an extended period (for example, a
+		// CSI driver's NodeGetInfo waiting on topology labels to propagate), during
+		// which the original gRPC connection established before GetInfo can become
+		// stale or be closed by the plugin side. A fresh connection guarantees that
+		// NotifyRegistrationStatus is reliably delivered regardless of how long
+		// registration took.
+		notifyClient, notifyConn, notifyDialErr := dial(ctx, socketPath, dialTimeoutDuration)
+		if notifyDialErr != nil {
+			// The plugin socket disappeared while RegisterPlugin was running.
+			// Clean up local state and let the reconciler retry once the socket
+			// reappears.
 			actualStateOfWorldUpdater.RemovePlugin(socketPath)
-			return og.notifyPlugin(ctx, client, false, fmt.Sprintf("RegisterPlugin error -- plugin registration failed with err: %v", err))
+			if registerErr == nil {
+				handler.DeRegisterPlugin(ctx, infoResp.Name, infoResp.Endpoint)
+			}
+			return fmt.Errorf("RegisterPlugin error -- failed to re-dial socket %s for notification after RegisterPlugin, err: %w", socketPath, notifyDialErr)
+		}
+		defer func() { _ = notifyConn.Close() }()
+
+		if registerErr != nil {
+			actualStateOfWorldUpdater.RemovePlugin(socketPath)
+			return og.notifyPlugin(ctx, notifyClient, false, fmt.Sprintf("RegisterPlugin error -- plugin registration failed with err: %v", registerErr))
 		}
 
 		// Notify is called after register to guarantee that even if notify throws an error Register will always be called after validate
-		if err := og.notifyPlugin(ctx, client, true, ""); err != nil {
+		if err := og.notifyPlugin(ctx, notifyClient, true, ""); err != nil {
 			actualStateOfWorldUpdater.RemovePlugin(socketPath)
 			handler.DeRegisterPlugin(ctx, infoResp.Name, infoResp.Endpoint)
 			return fmt.Errorf("RegisterPlugin error -- failed to send registration status at socket %s, err: %v", socketPath, err)

--- a/pkg/kubelet/pluginmanager/operationexecutor/operation_generator.go
+++ b/pkg/kubelet/pluginmanager/operationexecutor/operation_generator.go
@@ -129,31 +129,9 @@ func (og *operationGenerator) GenerateRegisterPluginFunc(
 		if err != nil {
 			logger.Error(err, "RegisterPlugin error -- failed to add plugin", "path", socketPath)
 		}
-		registerErr := handler.RegisterPlugin(ctx, infoResp.Name, infoResp.Endpoint, infoResp.SupportedVersions, nil)
-
-		// Re-dial the registration socket before sending the notification.
-		// handler.RegisterPlugin may block for an extended period (for example, a
-		// CSI driver's NodeGetInfo waiting on topology labels to propagate), during
-		// which the original gRPC connection established before GetInfo can become
-		// stale or be closed by the plugin side. A fresh connection guarantees that
-		// NotifyRegistrationStatus is reliably delivered regardless of how long
-		// registration took.
-		client, conn, redialErr := dial(ctx, socketPath, dialTimeoutDuration)
-		if redialErr != nil {
-			// The plugin socket disappeared while RegisterPlugin was running.
-			// Clean up local state and let the reconciler retry once the socket
-			// reappears.
+		if err := handler.RegisterPlugin(ctx, infoResp.Name, infoResp.Endpoint, infoResp.SupportedVersions, nil); err != nil {
 			actualStateOfWorldUpdater.RemovePlugin(socketPath)
-			if registerErr == nil {
-				handler.DeRegisterPlugin(ctx, infoResp.Name, infoResp.Endpoint)
-			}
-			return fmt.Errorf("RegisterPlugin error -- failed to re-dial socket %s for notification after RegisterPlugin, err: %w", socketPath, redialErr)
-		}
-		defer func() { _ = conn.Close() }()
-
-		if registerErr != nil {
-			actualStateOfWorldUpdater.RemovePlugin(socketPath)
-			return og.notifyPlugin(ctx, client, false, fmt.Sprintf("RegisterPlugin error -- plugin registration failed with err: %v", registerErr))
+			return og.notifyPlugin(ctx, client, false, fmt.Sprintf("RegisterPlugin error -- plugin registration failed with err: %v", err))
 		}
 
 		// Notify is called after register to guarantee that even if notify throws an error Register will always be called after validate
@@ -199,7 +177,13 @@ func (og *operationGenerator) notifyPlugin(ctx context.Context, client registera
 		Error:            errStr,
 	}
 
-	if _, err := client.NotifyRegistrationStatus(ctx, status); err != nil {
+	// WaitForReady ensures that if the connection to the plugin dropped to
+	// IDLE/TRANSIENT_FAILURE while handler.RegisterPlugin was running (for
+	// example, a CSI driver's NodeGetInfo waiting on topology labels to
+	// propagate), this call blocks for the reconnect instead of failing
+	// fast, so the notification is still reliably delivered on the
+	// existing client.
+	if _, err := client.NotifyRegistrationStatus(ctx, status, grpc.WaitForReady(true)); err != nil {
 		return fmt.Errorf("%s: %w", errStr, err)
 	}
 

--- a/pkg/kubelet/pluginmanager/operationexecutor/operation_generator_test.go
+++ b/pkg/kubelet/pluginmanager/operationexecutor/operation_generator_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,9 +19,9 @@ package operationexecutor
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
@@ -48,12 +48,7 @@ func (f *fakeRegistrationClient) NotifyRegistrationStatus(ctx context.Context, i
 }
 
 func hasWaitForReady(opts []grpc.CallOption) bool {
-	for _, opt := range opts {
-		if opt == grpc.WaitForReady(true) {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(opts, grpc.WaitForReady(true))
 }
 
 func TestNotifyPlugin(t *testing.T) {
@@ -93,9 +88,9 @@ func TestNotifyPlugin(t *testing.T) {
 			err := og.notifyPlugin(context.Background(), client, tc.registered, tc.errStr)
 
 			if tc.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 			// Regardless of outcome, the call must opt in to WaitForReady so

--- a/pkg/kubelet/pluginmanager/operationexecutor/operation_generator_test.go
+++ b/pkg/kubelet/pluginmanager/operationexecutor/operation_generator_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operationexecutor
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	registerapi "k8s.io/kubelet/pkg/apis/pluginregistration/v1"
+)
+
+// fakeRegistrationClient records the call options it was invoked with so
+// tests can assert on them, and returns a canned response/error.
+type fakeRegistrationClient struct {
+	notifyErr  error
+	notifyOpts []grpc.CallOption
+}
+
+func (f *fakeRegistrationClient) GetInfo(ctx context.Context, in *registerapi.InfoRequest, opts ...grpc.CallOption) (*registerapi.PluginInfo, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeRegistrationClient) NotifyRegistrationStatus(ctx context.Context, in *registerapi.RegistrationStatus, opts ...grpc.CallOption) (*registerapi.RegistrationStatusResponse, error) {
+	f.notifyOpts = opts
+	if f.notifyErr != nil {
+		return nil, f.notifyErr
+	}
+	return &registerapi.RegistrationStatusResponse{}, nil
+}
+
+func hasWaitForReady(opts []grpc.CallOption) bool {
+	for _, opt := range opts {
+		if opt == grpc.WaitForReady(true) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestNotifyPlugin(t *testing.T) {
+	tests := []struct {
+		name       string
+		registered bool
+		errStr     string
+		notifyErr  error
+		wantErr    bool
+	}{
+		{
+			name:       "successful registration notification",
+			registered: true,
+			errStr:     "",
+			wantErr:    false,
+		},
+		{
+			name:       "failed registration is surfaced as an error",
+			registered: false,
+			errStr:     "registration failed",
+			wantErr:    true,
+		},
+		{
+			name:       "transport error from NotifyRegistrationStatus is wrapped",
+			registered: true,
+			errStr:     "",
+			notifyErr:  errors.New("transient failure"),
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &fakeRegistrationClient{notifyErr: tc.notifyErr}
+			og := NewOperationGenerator(nil).(*operationGenerator)
+
+			err := og.notifyPlugin(context.Background(), client, tc.registered, tc.errStr)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Regardless of outcome, the call must opt in to WaitForReady so
+			// that a client that dropped to IDLE/TRANSIENT_FAILURE while the
+			// plugin was being registered blocks for reconnect instead of
+			// failing fast.
+			require.True(t, hasWaitForReady(client.notifyOpts), "expected NotifyRegistrationStatus to be called with grpc.WaitForReady(true), got opts: %#v", client.notifyOpts)
+		})
+	}
+}


### PR DESCRIPTION
The registration flow dials the plugin socket once before GetInfo, then reuses that same gRPC connection for all subsequent calls including the final NotifyRegistrationStatus (notifyPlugin). This works fine when the plugin handler returns quickly, but CSI drivers
can block inside handler.RegisterPlugin for 60 seconds or more while waiting for topology labels to propagate (NodeGetInfo). Over that span the original connection can be torn down by the plugin side, causing the NotifyRegistrationStatus delivery to silently fail.

When NotifyRegistrationStatus is not delivered:
- node-driver-registrar v2.9+ treats the missing notification as a permanent failure and calls os.Exit(1), restarting the container.
- Depending on DaemonSet liveness probe configuration, the restart may not be triggered at all, leaving the driver unregistered indefinitely.

Fix: after handler.RegisterPlugin returns, establish a fresh dial to the plugin socket before sending the notification. If the socket has disappeared (plugin process died during registration) the fresh dial fails immediately; we clean up local state and return an error so the goroutinemap can retry when the socket reappears.

The early-exit paths (unknown handler, ValidatePlugin failure) continue to reuse the original connection because those paths return before any long-running call.

/kind bug


```release-note
NONE
```

```docs
NONE
```

/sig storage
/sig node