### PR TITLE
pluginmanager: log backoff/in-progress skips at V(4) in reconciler

### DIFF
--- a/pkg/kubelet/pluginmanager/reconciler/reconciler.go
+++ b/pkg/kubelet/pluginmanager/reconciler/reconciler.go
@@ -133,14 +133,21 @@ func (rc *reconciler) reconcile(ctx context.Context) {
 		if unregisterPlugin {
 			logger.V(5).Info("Starting operationExecutor.UnregisterPlugin", "plugin", registeredPlugin)
 			err := rc.operationExecutor.UnregisterPlugin(ctx, registeredPlugin, rc.actualStateOfWorld)
-			if err != nil &&
-				!goroutinemap.IsAlreadyExists(err) &&
-				!exponentialbackoff.IsExponentialBackoff(err) {
-				// Ignore goroutinemap.IsAlreadyExists and exponentialbackoff.IsExponentialBackoff errors, they are expected.
-				// Log all other errors.
-				logger.Error(err, "OperationExecutor.UnregisterPlugin failed", "plugin", registeredPlugin)
-			}
-			if err == nil {
+			if err != nil {
+				if goroutinemap.IsAlreadyExists(err) {
+					// IsAlreadyExists is expected when the previous reconciler iteration
+					// already dispatched this operation and it has not yet completed;
+					// this is normal and not an error, so log at V(4) only.
+					logger.V(4).Info("OperationExecutor.UnregisterPlugin skipped: operation already in progress", "plugin", registeredPlugin)
+				} else if exponentialbackoff.IsExponentialBackoff(err) {
+					// IsExponentialBackoff is expected after a failed attempt while
+					// exponential backoff is still active; this is normal operation,
+					// but worth logging at V(4) so operators can diagnose prolonged delays.
+					logger.V(4).Info("OperationExecutor.UnregisterPlugin skipped: exponential backoff in effect", "plugin", registeredPlugin, "err", err)
+				} else {
+					logger.Error(err, "OperationExecutor.UnregisterPlugin failed", "plugin", registeredPlugin)
+				}
+			} else {
 				logger.V(1).Info("OperationExecutor.UnregisterPlugin started", "plugin", registeredPlugin)
 			}
 		}
@@ -151,13 +158,21 @@ func (rc *reconciler) reconcile(ctx context.Context) {
 		if !rc.actualStateOfWorld.PluginExistsWithCorrectUUID(pluginToRegister) {
 			logger.V(5).Info("Starting operationExecutor.RegisterPlugin", "plugin", pluginToRegister)
 			err := rc.operationExecutor.RegisterPlugin(ctx, pluginToRegister.SocketPath, pluginToRegister.UUID, rc.getHandlers(), rc.actualStateOfWorld)
-			if err != nil &&
-				!goroutinemap.IsAlreadyExists(err) &&
-				!exponentialbackoff.IsExponentialBackoff(err) {
-				// Ignore goroutinemap.IsAlreadyExists and exponentialbackoff.IsExponentialBackoff errors, they are expected.
-				logger.Error(err, "OperationExecutor.RegisterPlugin failed", "plugin", pluginToRegister)
-			}
-			if err == nil {
+			if err != nil {
+				if goroutinemap.IsAlreadyExists(err) {
+					// IsAlreadyExists is expected when the previous reconciler iteration
+					// already dispatched this operation and it has not yet completed;
+					// this is normal and not an error, so log at V(4) only.
+					logger.V(4).Info("OperationExecutor.RegisterPlugin skipped: operation already in progress", "plugin", pluginToRegister)
+				} else if exponentialbackoff.IsExponentialBackoff(err) {
+					// IsExponentialBackoff is expected after a failed attempt while
+					// exponential backoff is still active; this is normal operation,
+					// but worth logging at V(4) so operators can diagnose prolonged delays.
+					logger.V(4).Info("OperationExecutor.RegisterPlugin skipped: exponential backoff in effect", "plugin", pluginToRegister, "err", err)
+				} else {
+					logger.Error(err, "OperationExecutor.RegisterPlugin failed", "plugin", pluginToRegister)
+				}
+			} else {
 				logger.V(1).Info("OperationExecutor.RegisterPlugin started", "plugin", pluginToRegister)
 			}
 		}


### PR DESCRIPTION
Previously, when the reconciler skipped a Register or Unregister operation because goroutinemap reported the operation was already running (IsAlreadyExists) or because exponential backoff was in effect (IsExponentialBackoff), both conditions were silently dropped. This made it very difficult to diagnose situations where a plugin socket appeared in the desired state of world but registration was being continuously deferred -- for example, when a CSI driver's NodeGetInfo RPC blocks for an extended period waiting on topology labels, causing the first attempt to time out and trigger backoff.

Replace the compound negative guard with an explicit if/else chain:
- IsAlreadyExists: log at V(4) operation already in progress
- IsExponentialBackoff: log at V(4) exponential backoff in effect (includes the backoff error string so remaining duration is visible)
- all other errors: continue to log at Error level as before

With --v=4 or higher operators can now observe that registration is being held back by backoff and roughly how long the delay is without any additional tooling.


/kind bug

```release-note
NONE
```

```docs
NONE
```
