### PR TITLE
topologymanager: add CPU-attached NUMA filter option

### DIFF
--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -957,12 +957,14 @@ func (p *staticPolicy) GetPodTopologyHints(logger logr.Logger, s state.State, po
 // bits set as the narrowest matching NUMANodeAffinity with 'Preferred: true', and
 // marking all others with 'Preferred: false'.
 func (p *staticPolicy) generateCPUTopologyHints(availableCPUs cpuset.CPUSet, reusableCPUs cpuset.CPUSet, request int) []topologymanager.TopologyHint {
+	numaNodes := p.getNUMANodesForTopologyHints()
+
 	// Initialize minAffinitySize to include all NUMA Nodes.
-	minAffinitySize := p.topology.CPUDetails.NUMANodes().Size()
+	minAffinitySize := len(numaNodes)
 
 	// Iterate through all combinations of numa nodes bitmask and build hints from them.
 	hints := []topologymanager.TopologyHint{}
-	bitmask.IterateBitMasks(p.topology.CPUDetails.NUMANodes().List(), func(mask bitmask.BitMask) {
+	bitmask.IterateBitMasks(numaNodes, func(mask bitmask.BitMask) {
 		// First, update minAffinitySize for the current request size.
 		cpusInMask := p.topology.CPUDetails.CPUsInNUMANodes(mask.GetBits()...).Size()
 		if cpusInMask >= request && mask.Count() < minAffinitySize {
@@ -1017,6 +1019,20 @@ func (p *staticPolicy) generateCPUTopologyHints(availableCPUs cpuset.CPUSet, reu
 	}
 
 	return hints
+}
+
+func (p *staticPolicy) getNUMANodesForTopologyHints() []int {
+	topologyNUMANodes := p.topology.CPUDetails.NUMANodes()
+	if p.affinity == nil {
+		return topologyNUMANodes.List()
+	}
+
+	hintNUMANodes := p.affinity.GetNUMANodeIDs()
+	if hintNUMANodes == nil {
+		return topologyNUMANodes.List()
+	}
+
+	return topologyNUMANodes.Intersection(cpuset.New(hintNUMANodes...)).List()
 }
 
 // isHintSocketAligned function return true if numa nodes in hint are socket aligned.

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	goerrors "errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -94,6 +95,8 @@ type ManagerImpl struct {
 
 	// List of NUMA Nodes available on the underlying machine
 	numaNodes []int
+	// Distances between all NUMA nodes reported by cadvisor, keyed by NUMA node ID.
+	numaDistances map[int][]uint64
 
 	// Store of Topology Affinities that the Device Manager can query.
 	topologyAffinityStore topologymanager.Store
@@ -144,8 +147,18 @@ func newManagerImpl(logger klog.Logger, socketPath string, topology []cadvisorap
 	logger.V(2).Info("Creating Device Plugin manager", "path", socketPath)
 
 	var numaNodes []int
+	if topologyAffinityStore != nil {
+		numaNodes = append(numaNodes, topologyAffinityStore.GetNUMANodeIDs()...)
+	}
+	if len(numaNodes) == 0 {
+		for _, node := range topology {
+			numaNodes = append(numaNodes, node.Id)
+		}
+	}
+
+	numaDistances := make(map[int][]uint64, len(topology))
 	for _, node := range topology {
-		numaNodes = append(numaNodes, node.Id)
+		numaDistances[node.Id] = node.Distances
 	}
 
 	manager := &ManagerImpl{
@@ -157,6 +170,7 @@ func newManagerImpl(logger klog.Logger, socketPath string, topology []cadvisorap
 		allocatedDevices:      make(map[string]sets.Set[string]),
 		podDevices:            newPodDevices(),
 		numaNodes:             numaNodes,
+		numaDistances:         numaDistances,
 		topologyAffinityStore: topologyAffinityStore,
 		devicesToReuse:        make(PodReusableDevices),
 		update:                make(chan resourceupdates.Update, 100),
@@ -185,6 +199,54 @@ func newManagerImpl(logger klog.Logger, socketPath string, topology []cadvisorap
 
 func (m *ManagerImpl) Updates() <-chan resourceupdates.Update {
 	return m.update
+}
+
+func (m *ManagerImpl) projectToEffectiveNUMANodes(rawNUMANodes []int) []int {
+	if len(rawNUMANodes) == 0 {
+		return nil
+	}
+	if len(m.numaNodes) == 0 {
+		return rawNUMANodes
+	}
+
+	effectiveNUMANodes := sets.New[int](m.numaNodes...)
+	projected := sets.New[int]()
+	for _, nodeID := range rawNUMANodes {
+		if effectiveNUMANodes.Has(nodeID) {
+			projected.Insert(nodeID)
+			continue
+		}
+
+		distances, ok := m.numaDistances[nodeID]
+		if !ok || len(distances) == 0 {
+			projected.Insert(m.numaNodes...)
+			continue
+		}
+
+		minDistance := uint64(math.MaxUint64)
+		closestNodes := make([]int, 0, len(m.numaNodes))
+		for _, effectiveNodeID := range m.numaNodes {
+			if effectiveNodeID < 0 || effectiveNodeID >= len(distances) {
+				continue
+			}
+			distance := distances[effectiveNodeID]
+			if distance < minDistance {
+				minDistance = distance
+				closestNodes = []int{effectiveNodeID}
+				continue
+			}
+			if distance == minDistance {
+				closestNodes = append(closestNodes, effectiveNodeID)
+			}
+		}
+		if len(closestNodes) == 0 {
+			projected.Insert(m.numaNodes...)
+			continue
+		}
+		projected.Insert(closestNodes...)
+	}
+
+	return sets.List(projected)
 }
 
 // CleanupPluginDirectory is to remove all existing unix sockets

--- a/pkg/kubelet/cm/devicemanager/topology_hints.go
+++ b/pkg/kubelet/cm/devicemanager/topology_hints.go
@@ -222,11 +222,11 @@ func (m *ManagerImpl) getNUMANodeIds(topology *pluginapi.TopologyInfo) []int {
 	if topology == nil {
 		return nil
 	}
-	var ids []int
+	rawIDs := make([]int, 0, len(topology.Nodes))
 	for _, n := range topology.Nodes {
-		ids = append(ids, int(n.ID))
+		rawIDs = append(rawIDs, int(n.ID))
 	}
-	return ids
+	return m.projectToEffectiveNUMANodes(rawIDs)
 }
 
 func (m *ManagerImpl) getPodDeviceRequest(pod *v1.Pod) map[string]int {

--- a/pkg/kubelet/cm/devicemanager/topology_hints_test.go
+++ b/pkg/kubelet/cm/devicemanager/topology_hints_test.go
@@ -34,6 +34,7 @@ import (
 
 type mockAffinityStore struct {
 	hint topologymanager.TopologyHint
+	ids  []int
 }
 
 func (m *mockAffinityStore) GetAffinity(podUID string, containerName string) topologymanager.TopologyHint {
@@ -48,10 +49,25 @@ func (m *mockAffinityStore) Name() string {
 	return "container"
 }
 
+func (m *mockAffinityStore) GetNUMANodeIDs() []int {
+	return append([]int{}, m.ids...)
+}
+
 func makeNUMADevice(id string, numa int) *pluginapi.Device {
 	return &pluginapi.Device{
 		ID:       id,
 		Topology: &pluginapi.TopologyInfo{Nodes: []*pluginapi.NUMANode{{ID: int64(numa)}}},
+	}
+}
+
+func makeMultiNUMADevice(id string, numas ...int) *pluginapi.Device {
+	nodes := make([]*pluginapi.NUMANode, 0, len(numas))
+	for _, numa := range numas {
+		nodes = append(nodes, &pluginapi.NUMANode{ID: int64(numa)})
+	}
+	return &pluginapi.Device{
+		ID:       id,
+		Topology: &pluginapi.TopologyInfo{Nodes: nodes},
 	}
 }
 
@@ -110,6 +126,62 @@ func TestGetTopologyHints(t *testing.T) {
 				t.Errorf("%v: Expected result to be %#v, got %#v", tc.description, tc.expectedHints[r], hints[r])
 			}
 		}
+	}
+}
+
+func TestGetTopologyHintsProjectedToEffectiveNUMANodes(t *testing.T) {
+	m := ManagerImpl{
+		allDevices:       NewResourceDeviceInstances(),
+		healthyDevices:   make(map[string]sets.Set[string]),
+		allocatedDevices: make(map[string]sets.Set[string]),
+		podDevices:       newPodDevices(),
+		sourcesReady:     &sourcesReadyStub{},
+		activePods:       func() []*v1.Pod { return []*v1.Pod{} },
+		numaNodes:        []int{0, 1},
+		numaDistances: map[int][]uint64{
+			0: {10, 20, 11, 30},
+			1: {20, 10, 30, 11},
+			2: {11, 30, 10, 40},
+			3: {30, 11, 40, 10},
+		},
+	}
+
+	resourceName := "example.com/gpu"
+	m.allDevices[resourceName] = DeviceInstances{
+		"dev0": makeMultiNUMADevice("dev0", 2),
+		"dev1": makeMultiNUMADevice("dev1", 3),
+	}
+	m.healthyDevices[resourceName] = sets.New("dev0", "dev1")
+
+	pod := &v1.Pod{
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "c0",
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceName(resourceName): resource.MustParse("1"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	hints := m.GetTopologyHints(pod, &pod.Spec.Containers[0])
+	expected := []topologymanager.TopologyHint{
+		{NUMANodeAffinity: makeSocketMask(0), Preferred: true},
+		{NUMANodeAffinity: makeSocketMask(1), Preferred: true},
+		{NUMANodeAffinity: makeSocketMask(0, 1), Preferred: false},
+	}
+	sort.SliceStable(hints[resourceName], func(i, j int) bool {
+		return hints[resourceName][i].LessThan(hints[resourceName][j])
+	})
+	sort.SliceStable(expected, func(i, j int) bool {
+		return expected[i].LessThan(expected[j])
+	})
+	if !reflect.DeepEqual(hints[resourceName], expected) {
+		t.Fatalf("expected projected hints %#v, got %#v", expected, hints[resourceName])
 	}
 }
 
@@ -426,7 +498,7 @@ func TestTopologyAlignedAllocation(t *testing.T) {
 			podDevices:            newPodDevices(),
 			sourcesReady:          &sourcesReadyStub{},
 			activePods:            func() []*v1.Pod { return []*v1.Pod{} },
-			topologyAffinityStore: &mockAffinityStore{tc.hint},
+			topologyAffinityStore: &mockAffinityStore{hint: tc.hint},
 		}
 
 		m.allDevices[tc.resource] = make(DeviceInstances)
@@ -616,7 +688,7 @@ func TestGetPreferredAllocationParameters(t *testing.T) {
 			podDevices:            newPodDevices(),
 			sourcesReady:          &sourcesReadyStub{},
 			activePods:            func() []*v1.Pod { return []*v1.Pod{} },
-			topologyAffinityStore: &mockAffinityStore{tc.hint},
+			topologyAffinityStore: &mockAffinityStore{hint: tc.hint},
 		}
 
 		m.allDevices[tc.resource] = make(DeviceInstances)

--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -885,11 +885,10 @@ func getContainerRequestedResources(logger logr.Logger, pod *v1.Pod, container *
 }
 
 func (p *staticPolicy) calculateHints(machineState state.NUMANodeMap, pod *v1.Pod, requestedResources map[v1.ResourceName]uint64) map[string][]topologymanager.TopologyHint {
-	var numaNodes []int
-	for n := range machineState {
-		numaNodes = append(numaNodes, n)
+	numaNodes := p.getNUMANodesForTopologyHints(machineState)
+	if len(numaNodes) == 0 {
+		return nil
 	}
-	sort.Ints(numaNodes)
 
 	// Initialize minAffinitySize to include all NUMA Cells.
 	minAffinitySize := len(numaNodes)
@@ -977,6 +976,37 @@ func (p *staticPolicy) calculateHints(machineState state.NUMANodeMap, pod *v1.Po
 	}
 
 	return hints
+}
+
+func (p *staticPolicy) getNUMANodesForTopologyHints(machineState state.NUMANodeMap) []int {
+	var topologyNUMANodes []int
+	for nodeID := range machineState {
+		topologyNUMANodes = append(topologyNUMANodes, nodeID)
+	}
+	sort.Ints(topologyNUMANodes)
+
+	if p.affinity == nil {
+		return topologyNUMANodes
+	}
+
+	hintNUMANodes := p.affinity.GetNUMANodeIDs()
+	if hintNUMANodes == nil {
+		return topologyNUMANodes
+	}
+
+	hintNodeSet := map[int]struct{}{}
+	for _, nodeID := range hintNUMANodes {
+		hintNodeSet[nodeID] = struct{}{}
+	}
+
+	var filteredNUMANodes []int
+	for _, nodeID := range topologyNUMANodes {
+		if _, ok := hintNodeSet[nodeID]; ok {
+			filteredNUMANodes = append(filteredNUMANodes, nodeID)
+		}
+	}
+
+	return filteredNUMANodes
 }
 
 func (p *staticPolicy) isHintPreferred(maskBits []int, minAffinitySize int) bool {

--- a/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
@@ -88,6 +88,10 @@ func (m *fakeManager) Name() string {
 	return m.scope
 }
 
+func (m *fakeManager) GetNUMANodeIDs() []int {
+	return nil
+}
+
 func (m *fakeManager) AddHintProvider(logger klog.Logger, h HintProvider) {
 	logger.Info("AddHintProvider", "hintProvider", h)
 }

--- a/pkg/kubelet/cm/topologymanager/policy_options.go
+++ b/pkg/kubelet/cm/topologymanager/policy_options.go
@@ -29,10 +29,13 @@ import (
 const (
 	PreferClosestNUMANodes string = "prefer-closest-numa-nodes"
 	MaxAllowableNUMANodes  string = "max-allowable-numa-nodes"
+	RestrictToCPUNUMANodes string = "restrict-to-cpu-numa-nodes"
 )
 
 var (
-	alphaOptions  = sets.New[string]()
+	alphaOptions = sets.New[string](
+		RestrictToCPUNUMANodes,
+	)
 	betaOptions   = sets.New[string]()
 	stableOptions = sets.New[string](
 		PreferClosestNUMANodes,
@@ -57,8 +60,9 @@ func CheckPolicyOptionAvailable(option string) error {
 }
 
 type PolicyOptions struct {
-	PreferClosestNUMA     bool
-	MaxAllowableNUMANodes int
+	PreferClosestNUMA      bool
+	MaxAllowableNUMANodes  int
+	RestrictToCPUNUMANodes bool
 }
 
 func NewPolicyOptions(logger klog.Logger, policyOptions map[string]string) (PolicyOptions, error) {
@@ -94,6 +98,12 @@ func NewPolicyOptions(logger klog.Logger, policyOptions map[string]string) (Poli
 				logger.Info("WARNING: the value of max-allowable-numa-nodes is more than the default recommended value", "max-allowable-numa-nodes", optValue, "defaultMaxAllowableNUMANodes", defaultMaxAllowableNUMANodes)
 			}
 			opts.MaxAllowableNUMANodes = optValue
+		case RestrictToCPUNUMANodes:
+			optValue, err := strconv.ParseBool(value)
+			if err != nil {
+				return opts, fmt.Errorf("bad value for option %q: %w", name, err)
+			}
+			opts.RestrictToCPUNUMANodes = optValue
 		default:
 			// this should never be reached, we already detect unknown options,
 			// but we keep it as further safety.

--- a/pkg/kubelet/cm/topologymanager/policy_options_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_options_test.go
@@ -75,6 +75,18 @@ func TestNewTopologyManagerOptions(t *testing.T) {
 			},
 		},
 		{
+			description:       "return TopologyManagerOptions with RestrictToCPUNUMANodes set to true",
+			featureGate:       pkgfeatures.TopologyManagerPolicyAlphaOptions,
+			featureGateEnable: true,
+			expectedOptions: PolicyOptions{
+				MaxAllowableNUMANodes:  8,
+				RestrictToCPUNUMANodes: true,
+			},
+			policyOptions: map[string]string{
+				RestrictToCPUNUMANodes: "true",
+			},
+		},
+		{
 			description:       "fail to parse options with error PreferClosestNUMANodes",
 			featureGateEnable: true,
 			policyOptions: map[string]string{
@@ -179,6 +191,10 @@ func TestPolicyDefaultsAvailable(t *testing.T) {
 			option:            MaxAllowableNUMANodes,
 			expectedAvailable: true,
 		},
+		{
+			option:            RestrictToCPUNUMANodes,
+			expectedAvailable: false,
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.option, func(t *testing.T) {
@@ -234,6 +250,18 @@ func TestPolicyOptionsAvailable(t *testing.T) {
 			featureGate:       pkgfeatures.TopologyManagerPolicyAlphaOptions,
 			featureGateEnable: true,
 			expectedAvailable: true,
+		},
+		{
+			option:            RestrictToCPUNUMANodes,
+			featureGate:       pkgfeatures.TopologyManagerPolicyAlphaOptions,
+			featureGateEnable: true,
+			expectedAvailable: true,
+		},
+		{
+			option:            RestrictToCPUNUMANodes,
+			featureGate:       pkgfeatures.TopologyManagerPolicyAlphaOptions,
+			featureGateEnable: false,
+			expectedAvailable: false,
 		},
 		{
 			option:            fancyAlphaOption,

--- a/pkg/kubelet/cm/topologymanager/scope.go
+++ b/pkg/kubelet/cm/topologymanager/scope.go
@@ -96,6 +96,10 @@ func (s *scope) GetPolicy() Policy {
 	return s.policy
 }
 
+func (s *scope) GetNUMANodeIDs() []int {
+	return nil
+}
+
 func (s *scope) AddHintProvider(h HintProvider) {
 	s.hintProviders = append(s.hintProviders, h)
 }

--- a/pkg/kubelet/cm/topologymanager/topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager.go
@@ -19,6 +19,7 @@ package topologymanager
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
@@ -98,6 +99,8 @@ type Manager interface {
 type manager struct {
 	//Topology Manager Scope
 	scope Scope
+	// NUMA nodes available to topology-aware hint providers.
+	numaNodes []int
 }
 
 // HintProvider is an interface for components that want to collaborate to
@@ -128,6 +131,7 @@ type Store interface {
 	GetAffinity(podUID string, containerName string) TopologyHint
 	GetPolicy() Policy
 	Name() string
+	GetNUMANodeIDs() []int
 }
 
 // TopologyHint is a struct containing the NUMANodeAffinity for a Container
@@ -180,7 +184,12 @@ func NewManager(topology []cadvisorapi.Node, topologyPolicyName string, topology
 
 	logger.Info("Creating topology manager with policy per scope", "topologyPolicyName", topologyPolicyName, "topologyScopeName", topologyScopeName, "topologyPolicyOptions", opts)
 
-	numaInfo, err := NewNUMAInfo(topology, opts)
+	effectiveTopology := topology
+	if opts.RestrictToCPUNUMANodes {
+		effectiveTopology = filterTopologyToCPUNUMANodes(topology)
+	}
+
+	numaInfo, err := NewNUMAInfo(effectiveTopology, opts)
 	if err != nil {
 		return nil, fmt.Errorf("cannot discover NUMA topology: %w", err)
 	}
@@ -219,12 +228,36 @@ func NewManager(topology []cadvisorapi.Node, topologyPolicyName string, topology
 	}
 
 	manager := &manager{
-		scope: scope,
+		scope:     scope,
+		numaNodes: extractNUMANodes(effectiveTopology),
 	}
 
 	manager.initializeMetrics()
 
 	return manager, nil
+}
+
+func filterTopologyToCPUNUMANodes(topology []cadvisorapi.Node) []cadvisorapi.Node {
+	filtered := make([]cadvisorapi.Node, 0, len(topology))
+	for _, node := range topology {
+		if len(node.Cores) == 0 {
+			continue
+		}
+		filtered = append(filtered, node)
+	}
+	if len(filtered) == 0 {
+		return topology
+	}
+	return filtered
+}
+
+func extractNUMANodes(topology []cadvisorapi.Node) []int {
+	numaNodes := make([]int, 0, len(topology))
+	for _, node := range topology {
+		numaNodes = append(numaNodes, node.Id)
+	}
+	sort.Ints(numaNodes)
+	return numaNodes
 }
 
 func (m *manager) initializeMetrics() {
@@ -245,6 +278,10 @@ func (m *manager) GetPolicy() Policy {
 
 func (m *manager) Name() string {
 	return m.scope.Name()
+}
+
+func (m *manager) GetNUMANodeIDs() []int {
+	return append([]int{}, m.numaNodes...)
 }
 
 func (m *manager) AddHintProvider(_ klog.Logger, h HintProvider) {

--- a/pkg/kubelet/cm/topologymanager/topology_manager_test.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager_test.go
@@ -18,11 +18,15 @@ package topologymanager
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
 	"k8s.io/api/core/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2"
+	pkgfeatures "k8s.io/kubernetes/pkg/features"
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 
@@ -200,6 +204,35 @@ func TestManagerScope(t *testing.T) {
 				t.Errorf("Unexpected scope name. Have: %q wants %q", rawMgr.scope, tc.expectedScope)
 			}
 		}
+	}
+}
+
+func TestNewManagerRestrictToCPUNUMANodes(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.TopologyManagerPolicyAlphaOptions, true)
+
+	topology := []cadvisorapi.Node{
+		{Id: 0, Cores: []cadvisorapi.Core{{}}},
+		{Id: 1, Cores: []cadvisorapi.Core{{}}},
+		{Id: 2},
+		{Id: 3},
+		{Id: 4},
+		{Id: 5},
+		{Id: 6},
+		{Id: 7},
+		{Id: 8},
+	}
+
+	mgr, err := NewManager(topology, PolicyBestEffort, ContainerTopologyScope, map[string]string{
+		RestrictToCPUNUMANodes: "true",
+	})
+	if err != nil {
+		t.Fatalf("NewManager() returned unexpected error: %v", err)
+	}
+
+	got := mgr.GetNUMANodeIDs()
+	expected := []int{0, 1}
+	if !reflect.DeepEqual(got, expected) {
+		t.Fatalf("expected NUMA node IDs %v, got %v", expected, got)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
Bug Fix

/kind bug

#### What this PR does / why we need it:
This PR adds an opt-in TopologyManager mode for large NUMA systems with many CPU-less NUMA nodes.
On systems such as NVIDIA Grace/Vera-class platforms (typically GB200), firmware can expose a large NUMA ID space even though only a small subset of NUMA nodes actually have CPUs. When kubelet is configured to allow that large NUMA count, topology hint generation can still scale poorly in the device-manager / topology-manager path and block admission before device plugin `Allocate()` is reached.

This PR adds a new TopologyManager policy option:
- `restrict-to-cpu-numa-nodes`

When enabled, TopologyManager computes an effective NUMA-node set containing only NUMA nodes with CPUs attached and propagates that same view to all topology-aware hint providers.

Specifically:
- TopologyManager uses the filtered NUMA set for policy creation and NUMA accounting.
- CPUManager generates hints only across that filtered set.
- MemoryManager generates hints only across that filtered set.
- DeviceManager projects device topology onto that same filtered set using NUMA distance information so hint generation and aligned allocation stay consistent.

This is intended to address the large-NUMA root cause in #135541.
This PR is separate from the reserved-memory consistency fix. That is a different bug and should be reviewed independently.

#### Which issue(s) this PR is related to:
Fixes #135541
KEP: [KEP-5726](https://github.com/kubernetes/enhancements/pull/5992)

#### Special notes for your reviewer:
1. This reworks the earlier approach from #135581 around a TopologyManager option instead of provider-local heuristics.

Behavior is unchanged unless `restrict-to-cpu-numa-nodes` is explicitly enabled.

Example kubelet config for affected systems:

```yaml
topologyManagerPolicy: best-effort
topologyManagerScope: pod
topologyManagerPolicyOptions:
  prefer-closest-numa-nodes: "true"
  max-allowable-numa-nodes: "34"
  restrict-to-cpu-numa-nodes: "true"
cpuManagerPolicy: static
```

2. This PR reuses some of the same plumbing which was carried by a separate PR `reserved-memory consistency bug fix`  https://github.com/kubernetes/kubernetes/pull/137280 
e.g.,
- topologymanager.Store.GetNUMANodeIDs()
- storing/exporting filtered NUMA IDs from TopologyManager
- CPU/Memory hint paths consuming that filtered NUMA set
- DeviceManager reading the filtered NUMA set from TopologyManager

What is happening now is this PR duplicates some common infrastructure that the reserved-memory PR also introduced. That is expected from an implementation standpoint. 
If `reserved-memory PR` is likely to merge first, then rebase this PR on top of that and drop the duplicated plumbing.

Need to flag out for reviwewer that the overlap is only shared plumbing and that the reserved-memory semantics are intentionally not part of this PR.

#### Does this PR introduce a user-facing change?
Added an alpha TopologyManager policy option, `restrict-to-cpu-numa-nodes`, to limit topology hint generation to NUMA nodes with CPUs attached. This helps kubelet handle large CPU-less NUMA topologies such as NVIDIA Grace/Vera-class systems.

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

[KEP-5726]:  https://github.com/kubernetes/enhancements/pull/5992 

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: https://github.com/kubernetes/enhancements/issues/5726
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
