### PR TITLE
scheduler: graduate plugin_execution_duration_seconds and scheduling_algorithm_duration_seconds metrics to BETA

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -6336,7 +6336,7 @@
   subsystem: scheduler
   help: Duration for running a plugin at a specific extension point.
   type: Histogram
-  stabilityLevel: ALPHA
+  stabilityLevel: BETA
   labels:
   - extension_point
   - plugin
@@ -6517,7 +6517,7 @@
   subsystem: scheduler
   help: Scheduling algorithm latency in seconds
   type: Histogram
-  stabilityLevel: ALPHA
+  stabilityLevel: BETA
   buckets:
   - 0.001
   - 0.002

--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -6332,39 +6332,6 @@
   componentEndpoints:
   - component: kube-scheduler
     endpoint: /metrics
-- name: plugin_execution_duration_seconds
-  subsystem: scheduler
-  help: Duration for running a plugin at a specific extension point.
-  type: Histogram
-  stabilityLevel: BETA
-  labels:
-  - extension_point
-  - plugin
-  - status
-  buckets:
-  - 1e-05
-  - 1.5000000000000002e-05
-  - 2.2500000000000005e-05
-  - 3.375000000000001e-05
-  - 5.062500000000001e-05
-  - 7.593750000000002e-05
-  - 0.00011390625000000003
-  - 0.00017085937500000006
-  - 0.0002562890625000001
-  - 0.00038443359375000017
-  - 0.0005766503906250003
-  - 0.0008649755859375004
-  - 0.0012974633789062506
-  - 0.0019461950683593758
-  - 0.0029192926025390638
-  - 0.004378938903808595
-  - 0.006568408355712893
-  - 0.009852612533569338
-  - 0.014778918800354007
-  - 0.02216837820053101
-  componentEndpoints:
-  - component: kube-scheduler
-    endpoint: /metrics
 - name: pod_scheduled_after_flush_total
   subsystem: scheduler
   help: Number of pods that were successfully scheduled after being flushed from unschedulableEntities
@@ -6510,30 +6477,6 @@
   - 0.009852612533569338
   - 0.014778918800354007
   - 0.02216837820053101
-  componentEndpoints:
-  - component: kube-scheduler
-    endpoint: /metrics
-- name: scheduling_algorithm_duration_seconds
-  subsystem: scheduler
-  help: Scheduling algorithm latency in seconds
-  type: Histogram
-  stabilityLevel: BETA
-  buckets:
-  - 0.001
-  - 0.002
-  - 0.004
-  - 0.008
-  - 0.016
-  - 0.032
-  - 0.064
-  - 0.128
-  - 0.256
-  - 0.512
-  - 1.024
-  - 2.048
-  - 4.096
-  - 8.192
-  - 16.384
   componentEndpoints:
   - component: kube-scheduler
     endpoint: /metrics
@@ -7703,6 +7646,39 @@
   componentEndpoints:
   - component: kube-scheduler
     endpoint: /metrics
+- name: plugin_execution_duration_seconds
+  subsystem: scheduler
+  help: Duration for running a plugin at a specific extension point.
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - extension_point
+  - plugin
+  - status
+  buckets:
+  - 1e-05
+  - 1.5000000000000002e-05
+  - 2.2500000000000005e-05
+  - 3.375000000000001e-05
+  - 5.062500000000001e-05
+  - 7.593750000000002e-05
+  - 0.00011390625000000003
+  - 0.00017085937500000006
+  - 0.0002562890625000001
+  - 0.00038443359375000017
+  - 0.0005766503906250003
+  - 0.0008649755859375004
+  - 0.0012974633789062506
+  - 0.0019461950683593758
+  - 0.0029192926025390638
+  - 0.004378938903808595
+  - 0.006568408355712893
+  - 0.009852612533569338
+  - 0.014778918800354007
+  - 0.02216837820053101
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: pod_scheduling_sli_duration_seconds
   subsystem: scheduler
   help: E2e latency for a pod being scheduled, from the time the pod enters the scheduling
@@ -7732,6 +7708,30 @@
   - 1310.72
   - 2621.44
   - 5242.88
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
+- name: scheduling_algorithm_duration_seconds
+  subsystem: scheduler
+  help: Scheduling algorithm latency in seconds
+  type: Histogram
+  stabilityLevel: BETA
+  buckets:
+  - 0.001
+  - 0.002
+  - 0.004
+  - 0.008
+  - 0.016
+  - 0.032
+  - 0.064
+  - 0.128
+  - 0.256
+  - 0.512
+  - 1.024
+  - 2.048
+  - 4.096
+  - 8.192
+  - 16.384
   componentEndpoints:
   - component: kube-scheduler
     endpoint: /metrics

--- a/hack/tools/instrumentation/testdata/stable-metrics-list.yaml
+++ b/hack/tools/instrumentation/testdata/stable-metrics-list.yaml
@@ -537,6 +537,36 @@
   - extension_point
   - plugin
   - profile
+- name: plugin_execution_duration_seconds
+  subsystem: scheduler
+  help: Duration for running a plugin at a specific extension point.
+  type: Histogram
+  stabilityLevel: BETA
+  labels:
+  - extension_point
+  - plugin
+  - status
+  buckets:
+  - 1e-05
+  - 1.5000000000000002e-05
+  - 2.2500000000000005e-05
+  - 3.375000000000001e-05
+  - 5.062500000000001e-05
+  - 7.593750000000002e-05
+  - 0.00011390625000000003
+  - 0.00017085937500000006
+  - 0.0002562890625000001
+  - 0.00038443359375000017
+  - 0.0005766503906250003
+  - 0.0008649755859375004
+  - 0.0012974633789062506
+  - 0.0019461950683593758
+  - 0.0029192926025390638
+  - 0.004378938903808595
+  - 0.006568408355712893
+  - 0.009852612533569338
+  - 0.014778918800354007
+  - 0.02216837820053101
 - name: pod_scheduling_sli_duration_seconds
   subsystem: scheduler
   help: E2e latency for a pod being scheduled, from the time the pod enters the scheduling
@@ -566,6 +596,27 @@
   - 1310.72
   - 2621.44
   - 5242.88
+- name: scheduling_algorithm_duration_seconds
+  subsystem: scheduler
+  help: Scheduling algorithm latency in seconds
+  type: Histogram
+  stabilityLevel: BETA
+  buckets:
+  - 0.001
+  - 0.002
+  - 0.004
+  - 0.008
+  - 0.016
+  - 0.032
+  - 0.064
+  - 0.128
+  - 0.256
+  - 0.512
+  - 1.024
+  - 2.048
+  - 4.096
+  - 8.192
+  - 16.384
 - name: unschedulable_pods
   subsystem: scheduler
   help: The number of unschedulable pods broken down by plugin name. A pod will increment

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -4462,7 +4462,7 @@ scheduler_pending_pods{queue="unschedulable"} 20
 			metricsName:                "scheduler_plugin_execution_duration_seconds",
 			pluginMetricsSamplePercent: 0,
 			wants: `
-# HELP scheduler_plugin_execution_duration_seconds [ALPHA] Duration for running a plugin at a specific extension point.
+# HELP scheduler_plugin_execution_duration_seconds [BETA] Duration for running a plugin at a specific extension point.
 # TYPE scheduler_plugin_execution_duration_seconds histogram
 `, // the observed value will always be 0, because we don't proceed the fake clock.
 		},
@@ -4477,7 +4477,7 @@ scheduler_pending_pods{queue="unschedulable"} 20
 			metricsName:                "scheduler_plugin_execution_duration_seconds",
 			pluginMetricsSamplePercent: 100,
 			wants: `
-# HELP scheduler_plugin_execution_duration_seconds [ALPHA] Duration for running a plugin at a specific extension point.
+# HELP scheduler_plugin_execution_duration_seconds [BETA] Duration for running a plugin at a specific extension point.
 # TYPE scheduler_plugin_execution_duration_seconds histogram
 scheduler_plugin_execution_duration_seconds_bucket{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success",le="1e-05"} 1
 scheduler_plugin_execution_duration_seconds_bucket{extension_point="PreEnqueue",plugin="preEnqueuePlugin",status="Success",le="1.5000000000000002e-05"} 1

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -257,7 +257,7 @@ func InitMetrics() {
 			Name:           "scheduling_algorithm_duration_seconds",
 			Help:           "Scheduling algorithm latency in seconds",
 			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 	)
 	PreemptionVictims = metrics.NewHistogram(
@@ -359,7 +359,7 @@ func InitMetrics() {
 			// Start with 0.01ms with the last bucket being [~22ms, Inf). We use a small factor (1.5)
 			// so that we have better granularity since plugin latency is very sensitive.
 			Buckets:        metrics.ExponentialBuckets(0.00001, 1.5, 20),
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"plugin", "extension_point", "status"})
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it:**

Graduates two remaining scheduler metrics from ALPHA to BETA stability level, completing the work tracked in #136311 (part of the broader effort in #136107).

Both metrics have been present in Kubernetes for a long time and are in active use:
- `scheduler_plugin_execution_duration_seconds` — duration for running a plugin at a specific extension point
- `scheduler_scheduling_algorithm_duration_seconds` — scheduling algorithm latency

The other four scheduler metrics (`scheduler_goroutines`, `scheduler_permit_wait_duration_seconds`, `scheduler_plugin_evaluation_total`, `scheduler_unschedulable_pods`) were already graduated to BETA in #136155.

**Which issue(s) this PR fixes:**
Fixes #136311

**Special notes for your reviewer:**
- Changed `StabilityLevel` from `metrics.ALPHA` to `metrics.BETA` in `pkg/scheduler/metrics/metrics.go`
- Added corresponding entries to `test/instrumentation/testdata/stable-metrics-list.yaml`
- All instrumentation tests pass: `go test ./test/instrumentation/...`
- All scheduler metrics tests pass: `go test ./pkg/scheduler/metrics/...`

**Does this PR introduce a user-facing change?**

```release-note
Graduate scheduler metrics `scheduler_plugin_execution_duration_seconds` and `scheduler_scheduling_algorithm_duration_seconds` from ALPHA to BETA stability.
```