### PR TITLE
Log only the tombstone object, rather than the full object

### DIFF
--- a/pkg/controller/certificates/rootcacertpublisher/publisher.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher.go
@@ -244,7 +244,7 @@ func convertToCM(obj interface{}) (*v1.ConfigMap, error) {
 		}
 		cm, ok = tombstone.Obj.(*v1.ConfigMap)
 		if !ok {
-			return nil, fmt.Errorf("tombstone contained object that is not a ConfigMap %#v", obj)
+			return nil, fmt.Errorf("tombstone contained object that is not a ConfigMap %#v", tombstone.Obj)
 		}
 	}
 	return cm, nil

--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -344,7 +344,7 @@ func (jm *ControllerV2) deleteJob(obj interface{}) {
 		}
 		job, ok = tombstone.Obj.(*batchv1.Job)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Job %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Job %#v", tombstone.Obj))
 			return
 		}
 	}

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -327,7 +327,7 @@ func (dsc *DaemonSetsController) deleteDaemonset(logger klog.Logger, obj interfa
 		}
 		ds, ok = tombstone.Obj.(*apps.DaemonSet)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a DaemonSet %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a DaemonSet %#v", tombstone.Obj))
 			return
 		}
 	}
@@ -701,7 +701,7 @@ func (dsc *DaemonSetsController) deletePod(logger klog.Logger, obj interface{}) 
 		}
 		pod, ok = tombstone.Obj.(*v1.Pod)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a pod %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a pod %#v", tombstone.Obj))
 			return
 		}
 	}

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -221,7 +221,7 @@ func (dc *DeploymentController) deleteDeployment(logger klog.Logger, obj interfa
 		}
 		d, ok = tombstone.Obj.(*apps.Deployment)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Deployment %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Deployment %#v", tombstone.Obj))
 			return
 		}
 	}
@@ -348,7 +348,7 @@ func (dc *DeploymentController) deleteReplicaSet(logger klog.Logger, obj interfa
 		}
 		rs, ok = tombstone.Obj.(*apps.ReplicaSet)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a ReplicaSet %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a ReplicaSet %#v", tombstone.Obj))
 			return
 		}
 	}
@@ -382,7 +382,7 @@ func (dc *DeploymentController) deletePod(logger klog.Logger, obj interface{}) {
 		}
 		pod, ok = tombstone.Obj.(*v1.Pod)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a pod %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a pod %#v", tombstone.Obj))
 			return
 		}
 	}

--- a/pkg/controller/endpointslicemirroring/utils.go
+++ b/pkg/controller/endpointslicemirroring/utils.go
@@ -164,7 +164,7 @@ func getServiceFromDeleteAction(obj interface{}) *corev1.Service {
 	}
 	service, ok := tombstone.Obj.(*corev1.Service)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Service resource: %#v", obj))
+		utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Service resource: %#v", tombstone.Obj))
 		return nil
 	}
 	return service
@@ -185,7 +185,7 @@ func getEndpointsFromDeleteAction(obj interface{}) *corev1.Endpoints {
 	}
 	endpoints, ok := tombstone.Obj.(*corev1.Endpoints)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not an Endpoints resource: %#v", obj))
+		utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not an Endpoints resource: %#v", tombstone.Obj))
 		return nil
 	}
 	return endpoints
@@ -205,7 +205,7 @@ func getEndpointSliceFromDeleteAction(obj interface{}) *discovery.EndpointSlice 
 	}
 	endpointSlice, ok := tombstone.Obj.(*discovery.EndpointSlice)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not an EndpointSlice resource: %#v", obj))
+		utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not an EndpointSlice resource: %#v", tombstone.Obj))
 		return nil
 	}
 	return endpointSlice

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -530,12 +530,12 @@ func (jm *Controller) deletePod(logger klog.Logger, obj interface{}, final bool)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %+v", obj))
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
 			return
 		}
 		pod, ok = tombstone.Obj.(*v1.Pod)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a pod %+v", obj))
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a pod %#v", tombstone.Obj))
 			return
 		}
 	}
@@ -634,12 +634,12 @@ func (jm *Controller) deleteJob(logger klog.Logger, obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %+v", obj))
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
 			return
 		}
 		jobObj, ok = tombstone.Obj.(*batch.Job)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a job %+v", obj))
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a job %#v", tombstone.Obj))
 			return
 		}
 	}

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -436,7 +436,7 @@ func (rsc *ReplicaSetController) deleteRS(logger klog.Logger, obj interface{}) {
 		}
 		rs, ok = tombstone.Obj.(*apps.ReplicaSet)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a ReplicaSet %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a ReplicaSet %#v", tombstone.Obj))
 			return
 		}
 	}
@@ -593,7 +593,7 @@ func (rsc *ReplicaSetController) deletePod(logger klog.Logger, obj interface{}) 
 		}
 		pod, ok = tombstone.Obj.(*v1.Pod)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a pod %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a pod %#v", tombstone.Obj))
 			return
 		}
 	}

--- a/pkg/controller/replication/conversion.go
+++ b/pkg/controller/replication/conversion.go
@@ -159,7 +159,7 @@ func (h conversionEventHandler) OnDelete(obj interface{}) {
 		}
 		rc, ok = tombstone.Obj.(*v1.ReplicationController)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("dropping RC OnDelete event: tombstone contained object that is not a RC %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("dropping RC OnDelete event: tombstone contained object that is not a RC %#v", tombstone.Obj))
 			return
 		}
 		rs, err := convertRCtoRS(rc, nil)

--- a/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller.go
+++ b/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller.go
@@ -331,7 +331,7 @@ func getPod(obj interface{}) *v1.Pod {
 		}
 		pod, ok = tombstone.Obj.(*v1.Pod)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Pod %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Pod %#v", tombstone.Obj))
 			return nil
 		}
 	}

--- a/pkg/controller/storageversiongc/gc_controller.go
+++ b/pkg/controller/storageversiongc/gc_controller.go
@@ -272,7 +272,7 @@ func (c *Controller) onDeleteLease(logger klog.Logger, obj interface{}) {
 		}
 		castObj, ok = tombstone.Obj.(*coordinationv1.Lease)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Lease %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Lease %#v", tombstone.Obj))
 			return
 		}
 	}

--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
@@ -559,7 +559,7 @@ func (*Controller) parsePod(obj interface{}) *v1.Pod {
 		}
 		pod, ok = tombstone.Obj.(*v1.Pod)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Pod %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Pod %#v", tombstone.Obj))
 			return nil
 		}
 	}

--- a/staging/src/k8s.io/endpointslice/util/controller_utils.go
+++ b/staging/src/k8s.io/endpointslice/util/controller_utils.go
@@ -258,7 +258,7 @@ func getPodFromObject(obj interface{}) *v1.Pod {
 	}
 	pod, ok := tombstone.Obj.(*v1.Pod)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Pod: %#v", obj))
+		utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Pod: %#v", tombstone.Obj))
 		return nil
 	}
 	return pod


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig apps
/sig network

#### What this PR does / why we need it:
I've noticed this while working on something else, we were logging the entire object when the `tombstone.Obj` failed to cast to expected type. It should be a rare occurrence, but let's only log the `tombstone.Obj`, rather than entire object. 

#### Which issue(s) this PR is related to:
None

#### Special notes for your reviewer:
/assign @atiratree 
for the controller changes
/assign @aojea 
for the networking part of the changes

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

