### PR TITLE
Make cleanup aware of uid differences

### DIFF
--- a/test/integration/apiserver/discovery/framework.go
+++ b/test/integration/apiserver/discovery/framework.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
@@ -141,6 +142,13 @@ func (a applyAPIService) Do(ctx context.Context, client testClient) error {
 
 func (a applyAPIService) Cleanup(ctx context.Context, client testClient) error {
 	name := a.Version + "." + a.Group
+
+	// Capture the UID of the existing object (if it exists)
+	var uid types.UID
+	if obj, err := client.ApiregistrationV1().APIServices().Get(ctx, name, metav1.GetOptions{}); err == nil {
+		uid = obj.UID
+	}
+
 	err := client.ApiregistrationV1().APIServices().Delete(ctx, name, metav1.DeleteOptions{})
 
 	if err != nil && !errors.IsNotFound(err) {
@@ -153,15 +161,21 @@ func (a applyAPIService) Cleanup(ctx context.Context, client testClient) error {
 		maxTimeout,
 		true,
 		func(ctx context.Context) (done bool, err error) {
-			_, err = client.ApiregistrationV1().APIServices().Get(ctx, name, metav1.GetOptions{})
-			if err == nil {
+			obj, err := client.ApiregistrationV1().APIServices().Get(ctx, name, metav1.GetOptions{})
+			switch {
+			case errors.IsNotFound(err):
+				// object is gone
+				return true, nil
+			case err == nil && obj.UID != uid:
+				// the instance we were waiting for is gone
+				return true, nil
+			case err != nil:
+				// some other error occurred
+				return false, err
+			default:
+				// the instance we were waiting for is still around
 				return false, nil
 			}
-
-			if !errors.IsNotFound(err) {
-				return false, err
-			}
-			return true, nil
 		},
 	)
 
@@ -210,6 +224,13 @@ func (a applyCRD) Do(ctx context.Context, client testClient) error {
 
 func (a applyCRD) Cleanup(ctx context.Context, client testClient) error {
 	name := a.Names.Plural + "." + a.Group
+
+	// Capture the UID of the existing object (if it exists)
+	var uid types.UID
+	if obj, err := client.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, name, metav1.GetOptions{}); err == nil {
+		uid = obj.UID
+	}
+
 	err := client.ApiextensionsV1().CustomResourceDefinitions().Delete(ctx, name, metav1.DeleteOptions{})
 
 	if err != nil && !errors.IsNotFound(err) {
@@ -222,15 +243,21 @@ func (a applyCRD) Cleanup(ctx context.Context, client testClient) error {
 		maxTimeout,
 		true,
 		func(ctx context.Context) (done bool, err error) {
-			_, err = client.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, name, metav1.GetOptions{})
-			if err == nil {
+			obj, err := client.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, name, metav1.GetOptions{})
+			switch {
+			case errors.IsNotFound(err):
+				// object is gone
+				return true, nil
+			case err == nil && obj.UID != uid:
+				// the instance we were waiting for is gone
+				return true, nil
+			case err != nil:
+				// some other error occurred
+				return false, err
+			default:
+				// the instance we were waiting for is still around
 				return false, nil
 			}
-
-			if !errors.IsNotFound(err) {
-				return false, err
-			}
-			return true, nil
 		},
 	)
 


### PR DESCRIPTION
Fixes flake introduced by https://github.com/kubernetes/kubernetes/pull/137850 where the APIService cleanup was not uid-aware, and polled forever when the APIService was recreated based on a still-present CRD

Alternative to https://github.com/kubernetes/kubernetes/pull/138128

Fixes https://github.com/kubernetes/kubernetes/issues/138114

/sig api-machinery
/kind flake

```release-note
NONE
```

/cc @Jefftree 