### PR TITLE
kubectl debug: make sysadmin profile OS-aware for Windows node debugging

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
@@ -2120,6 +2120,65 @@ func TestGenerateNodeDebugPodCustomProfile(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "sysadmin profile with custom RunAsUserName on windows node",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-XXX",
+					Labels: map[string]string{
+						corev1.LabelOSStable: string(corev1.Windows),
+					},
+				},
+			},
+			opts: &DebugOptions{
+				Image:      "busybox",
+				PullPolicy: corev1.PullIfNotPresent,
+				Profile:    ProfileSysadmin,
+				CustomProfile: &corev1.Container{
+					SecurityContext: &corev1.SecurityContext{
+						WindowsOptions: &corev1.WindowsSecurityContextOptions{
+							RunAsUserName: ptr.To("NT AUTHORITY\\NetworkService"),
+						},
+					},
+				},
+			},
+			expected: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app.kubernetes.io/managed-by": "kubectl-debug",
+					},
+				},
+				Spec: corev1.PodSpec{
+					OS:          &corev1.PodOS{Name: corev1.Windows},
+					HostNetwork: true,
+					SecurityContext: &corev1.PodSecurityContext{
+						WindowsOptions: &corev1.WindowsSecurityContextOptions{
+							HostProcess: ptr.To(true),
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:                     "debugger",
+							Image:                    "busybox",
+							ImagePullPolicy:          corev1.PullIfNotPresent,
+							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+							SecurityContext: &corev1.SecurityContext{
+								WindowsOptions: &corev1.WindowsSecurityContextOptions{
+									RunAsUserName: ptr.To("NT AUTHORITY\\NetworkService"),
+								},
+							},
+						},
+					},
+					NodeName:      "node-XXX",
+					RestartPolicy: corev1.RestartPolicyNever,
+					Tolerations: []corev1.Toleration{
+						{
+							Operator: corev1.TolerationOpExists,
+						},
+					},
+				},
+			},
+		},
 	} {
 
 		t.Run(tc.name, func(t *testing.T) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/profiles.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/profiles.go
@@ -300,14 +300,23 @@ func (p *sysadminProfile) Apply(pod *corev1.Pod, containerName string, target ru
 		return fmt.Errorf("sysadmin profile: %w", err)
 	}
 
-	setPrivileged(pod, containerName)
-
 	switch style {
 	case node:
-		useHostNamespaces(pod)
-		mountRootPartition(pod, containerName)
+		n := target.(*corev1.Node)
+		if isWindowsNode(n) {
+			pod.Spec.OS = &corev1.PodOS{Name: corev1.Windows}
+			clearSecurityContext(pod, containerName)
+			setWindowsHostProcess(pod)
+			setWindowsRunAsUserName(pod, containerName)
+			pod.Spec.HostNetwork = true
+		} else {
+			setPrivileged(pod, containerName)
+			useHostNamespaces(pod)
+			mountRootPartition(pod, containerName)
+		}
 
 	case podCopy:
+		setPrivileged(pod, containerName)
 		// to mimic general, default and baseline
 		p.RemoveLabels(pod)
 		p.RemoveAnnotations(pod)
@@ -316,7 +325,7 @@ func (p *sysadminProfile) Apply(pod *corev1.Pod, containerName string, target ru
 		shareProcessNamespace(pod)
 
 	case ephemeral:
-		// no additional modifications needed
+		setPrivileged(pod, containerName)
 	}
 
 	return nil
@@ -473,6 +482,42 @@ func setSeccompProfile(p *corev1.Pod, containerName string) {
 			c.SecurityContext = &corev1.SecurityContext{}
 		}
 		c.SecurityContext.SeccompProfile = &corev1.SeccompProfile{Type: "RuntimeDefault"}
+		return false
+	})
+}
+
+// isWindowsNode returns true if the node has the well-known OS label set to "windows".
+func isWindowsNode(n *corev1.Node) bool {
+	return n.Labels[corev1.LabelOSStable] == string(corev1.Windows)
+}
+
+// setWindowsHostProcess configures the pod for Windows Host Process Container (HPC) execution.
+// HostProcess is set at the pod level because all containers in an HPC pod must agree.
+func setWindowsHostProcess(p *corev1.Pod) {
+	if p.Spec.SecurityContext == nil {
+		p.Spec.SecurityContext = &corev1.PodSecurityContext{}
+	}
+	if p.Spec.SecurityContext.WindowsOptions == nil {
+		p.Spec.SecurityContext.WindowsOptions = &corev1.WindowsSecurityContextOptions{}
+	}
+	p.Spec.SecurityContext.WindowsOptions.HostProcess = ptr.To(true)
+}
+
+// setWindowsRunAsUserName sets the RunAsUserName at the container level.
+// This is set at container level rather than pod level so that it can be
+// overridden via the --custom flag.
+func setWindowsRunAsUserName(p *corev1.Pod, containerName string) {
+	podutils.VisitContainers(&p.Spec, podutils.AllContainers, func(c *corev1.Container, _ podutils.ContainerType) bool {
+		if c.Name != containerName {
+			return true
+		}
+		if c.SecurityContext == nil {
+			c.SecurityContext = &corev1.SecurityContext{}
+		}
+		if c.SecurityContext.WindowsOptions == nil {
+			c.SecurityContext.WindowsOptions = &corev1.WindowsSecurityContextOptions{}
+		}
+		c.SecurityContext.WindowsOptions.RunAsUserName = ptr.To("NT AUTHORITY\\SYSTEM")
 		return false
 	})
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/profiles_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/profiles_test.go
@@ -34,6 +34,15 @@ var testNode = &corev1.Node{
 	},
 }
 
+var testWindowsNode = &corev1.Node{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "node-WIN",
+		Labels: map[string]string{
+			"kubernetes.io/os": "windows",
+		},
+	},
+}
+
 func TestLegacyProfile(t *testing.T) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "pod"},
@@ -1270,6 +1279,87 @@ func TestSysAdminProfile(t *testing.T) {
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{{Name: "host-root", MountPath: "/host"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "debug by windows node",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "dbg", Image: "dbgimage"},
+					},
+				},
+			},
+			containerName: "dbg",
+			target:        testWindowsNode,
+			expectPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Spec: corev1.PodSpec{
+					OS:          &corev1.PodOS{Name: corev1.Windows},
+					HostNetwork: true,
+					SecurityContext: &corev1.PodSecurityContext{
+						WindowsOptions: &corev1.WindowsSecurityContextOptions{
+							HostProcess: ptr.To(true),
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:  "dbg",
+							Image: "dbgimage",
+							SecurityContext: &corev1.SecurityContext{
+								WindowsOptions: &corev1.WindowsSecurityContextOptions{
+									RunAsUserName: ptr.To("NT AUTHORITY\\SYSTEM"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "debug by windows node clears linux security context",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "dbg",
+							Image: "dbgimage",
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: ptr.To(true),
+								Capabilities: &corev1.Capabilities{
+									Add: []corev1.Capability{"SYS_PTRACE"},
+								},
+							},
+						},
+					},
+				},
+			},
+			containerName: "dbg",
+			target:        testWindowsNode,
+			expectPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod"},
+				Spec: corev1.PodSpec{
+					OS:          &corev1.PodOS{Name: corev1.Windows},
+					HostNetwork: true,
+					SecurityContext: &corev1.PodSecurityContext{
+						WindowsOptions: &corev1.WindowsSecurityContextOptions{
+							HostProcess: ptr.To(true),
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:  "dbg",
+							Image: "dbgimage",
+							SecurityContext: &corev1.SecurityContext{
+								WindowsOptions: &corev1.WindowsSecurityContextOptions{
+									RunAsUserName: ptr.To("NT AUTHORITY\\SYSTEM"),
+								},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig cli
/sig windows

#### What this PR does / why we need it:

Extends the existing `sysadmin` profile in `kubectl debug` to auto-detect Windows nodes via the `kubernetes.io/os` label and apply Windows Host Process Container (HPC) settings instead of Linux-specific privileged mode.

When debugging a Windows node with `--profile sysadmin`:
- Sets pod-level `WindowsOptions.HostProcess=true`
- Sets container-level `RunAsUserName` to `NT AUTHORITY\SYSTEM` (overridable via `--custom` flag)
- Enables `HostNetwork`
- Clears any Linux security context
- Skips `HostPID`, `HostIPC`, and `/host` volume mount (not applicable on Windows)

Linux node behavior remains unchanged.

Example usage:
```
kubectl debug -it node/<windows-node> --image mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0 --profile sysadmin
```

To override RunAsUserName via `--custom`:
```
echo '{"securityContext":{"windowsOptions":{"runAsUserName":"NT AUTHORITY\\NetworkService"}}}' > custom.json
kubectl debug -it node/<windows-node> --image <hpc-image> --profile sysadmin --custom custom.json
```

#### Which issue(s) this PR fixes:

Continuation of #130807 with improvements based on review feedback:
- Reuses existing `sysadmin` profile (OS-aware) instead of adding a new profile name
- Sets `HostProcess` at pod level (not container level)
- `RunAsUserName` is configurable via `--custom` flag
- Better test coverage

#### Special notes for your reviewer:

This PR addresses all review feedback from #130807:
- **Profile naming** (soltysh, brianpursley, aravindhp): No new profile name needed — reuses `sysadmin` with OS auto-detection per jsturtevant's suggestion
- **HostProcess at pod level** (jsturtevant): Set at `pod.spec.securityContext.windowsOptions` level
- **Configurable RunAsUserName** (jsturtevant): Set at container level so `--custom` can override it
- **Node OS validation**: Checks `kubernetes.io/os` label

Manually tested on an AKS cluster with Windows Server 2025 nodes (CAPZ + Hyper-V).

#### Does this PR introduce a user-facing change?

```release-note
kubectl debug: The sysadmin profile now auto-detects Windows nodes and configures debug pods as Windows Host Process Containers with NT AUTHORITY\SYSTEM access.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```
