### PR TITLE
Restart kube-proxy on node IP changes and deletion

### DIFF
--- a/pkg/proxy/node.go
+++ b/pkg/proxy/node.go
@@ -196,18 +196,16 @@ func (n *NodeManager) OnNodeChange(node *v1.Node) {
 	if !reflect.DeepEqual(n.nodeIPs, nodeIPs) {
 		klog.InfoS("NodeIPs changed for the node",
 			"node", klog.KObj(node), "newNodeIPs", nodeIPs, "oldNodeIPs", n.nodeIPs)
-		// FIXME: exit
-		// klog.Flush()
-		// n.exitFunc(1)
+		klog.Flush()
+		n.exitFunc(1)
 	}
 }
 
 // OnNodeDelete is a handler for Node deletes.
 func (n *NodeManager) OnNodeDelete(node *v1.Node) {
 	klog.InfoS("Node is being deleted", "node", klog.KObj(node))
-	// FIXME: exit
-	// klog.Flush()
-	// n.exitFunc(1)
+	klog.Flush()
+	n.exitFunc(1)
 }
 
 // OnNodeSynced is called after the cache is synced and all pre-existing Nodes have been reported

--- a/pkg/proxy/node_test.go
+++ b/pkg/proxy/node_test.go
@@ -252,11 +252,10 @@ func TestNodeManagerOnNodeChange(t *testing.T) {
 			expectedExitCode: nil,
 		},
 		{
-			name:           "node updated with different NodeIPs",
-			initialNodeIPs: []string{"192.168.1.1", "fd00:1:2:3::1"},
-			updatedNodeIPs: []string{"10.0.1.1", "fd00:3:2:1::2"},
-			// FIXME
-			// expectedExitCode: ptr.To(1),
+			name:             "node updated with different NodeIPs",
+			initialNodeIPs:   []string{"192.168.1.1", "fd00:1:2:3::1"},
+			updatedNodeIPs:   []string{"10.0.1.1", "fd00:3:2:1::2"},
+			expectedExitCode: ptr.To(1),
 		},
 		{
 			name:             "watchPodCIDR and node updated with same PodCIDRs",
@@ -313,9 +312,7 @@ func TestNodeManagerOnNodeDelete(t *testing.T) {
 	require.NoError(t, err)
 
 	nodeManager.OnNodeDelete(makeNode())
-	// FIXME
-	// require.Equal(t, ptr.To(1), exitCode)
-	require.Equal(t, (*int)(nil), exitCode)
+	require.Equal(t, ptr.To(1), exitCode)
 }
 
 func TestNodeManagerNode(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`NodeManager` is intended to force kube-proxy to restart when the watched `Node` changes in a way that invalidates its current network state.

That was no longer happening for node IP changes or node deletion because the exit path had been commented out. As a result, kube-proxy could keep running with stale node information.

This restores the restart path for both cases and updates the existing tests to cover that behavior.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This brings the implementation back in line with the existing `NodeManager` behavior comment and test intent.

Tested with:
- `go test ./pkg/proxy -run 'TestNodeManager'`

#### Does this PR introduce a user-facing change?

```release-note
Kube-proxy now exits when the watched Node's IPs change or when the Node object is deleted, allowing it to restart with updated node networking state.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
