### PR TITLE
kubelet: parallelize container kills in SyncPod Step 3

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1641,14 +1641,14 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 		}
 		wg.Wait()
 		close(containerResults)
-		var killErr error
+		killFailed := false
 		for containerResult := range containerResults {
 			result.AddSyncResult(containerResult)
-			if containerResult.Error != nil && killErr == nil {
-				killErr = containerResult.Error
+			if containerResult.Error != nil {
+				killFailed = true
 			}
 		}
-		if killErr != nil {
+		if killFailed {
 			return
 		}
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	cadvisorapi "github.com/google/cadvisor/lib/model"
@@ -1617,15 +1618,38 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 		}
 	} else {
 		// Step 3: kill any running containers in this pod which are not to keep.
+		// Kill containers in parallel so that a container whose kill completes
+		// quickly is not blocked from restarting by slow-to-terminate siblings.
+		// All kills run to completion before this step returns so every
+		// container's SyncResult is recorded, matching the pattern used by
+		// killContainersWithSyncResult for the whole-pod teardown path.
+		containerResults := make(chan *kubecontainer.SyncResult, len(podContainerChanges.ContainersToKill))
+		wg := sync.WaitGroup{}
+		wg.Add(len(podContainerChanges.ContainersToKill))
 		for containerID, containerInfo := range podContainerChanges.ContainersToKill {
-			logger.V(3).Info("Killing unwanted container for pod", "containerName", containerInfo.name, "containerID", containerID, "pod", klog.KObj(pod))
-			killContainerResult := kubecontainer.NewSyncResult(kubecontainer.KillContainer, containerInfo.name)
-			result.AddSyncResult(killContainerResult)
-			if err := m.killContainer(ctx, pod, containerID, containerInfo.name, containerInfo.message, containerInfo.reason, nil, nil); err != nil {
-				killContainerResult.Fail(kubecontainer.ErrKillContainer, err.Error())
-				logger.Error(err, "killContainer for pod failed", "containerName", containerInfo.name, "containerID", containerID, "pod", klog.KObj(pod))
-				return
+			go func(containerID kubecontainer.ContainerID, containerInfo containerToKillInfo) {
+				defer utilruntime.HandleCrashWithContext(ctx)
+				defer wg.Done()
+				logger.V(3).Info("Killing unwanted container for pod", "containerName", containerInfo.name, "containerID", containerID, "pod", klog.KObj(pod))
+				killContainerResult := kubecontainer.NewSyncResult(kubecontainer.KillContainer, containerInfo.name)
+				if err := m.killContainer(ctx, pod, containerID, containerInfo.name, containerInfo.message, containerInfo.reason, nil, nil); err != nil {
+					killContainerResult.Fail(kubecontainer.ErrKillContainer, err.Error())
+					logger.Error(err, "killContainer for pod failed", "containerName", containerInfo.name, "containerID", containerID, "pod", klog.KObj(pod))
+				}
+				containerResults <- killContainerResult
+			}(containerID, containerInfo)
+		}
+		wg.Wait()
+		close(containerResults)
+		var killErr error
+		for containerResult := range containerResults {
+			result.AddSyncResult(containerResult)
+			if containerResult.Error != nil && killErr == nil {
+				killErr = containerResult.Error
 			}
+		}
+		if killErr != nil {
+			return
 		}
 
 		// Removes the containers if they are marked for removal (for in-place restart)

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -25,6 +25,7 @@ import (
 	goruntime "runtime"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -6788,4 +6789,350 @@ func TestSysctlFiltering(t *testing.T) {
 			}
 		})
 	}
+}
+
+// seedFakeContainersForKill populates the fake runtime with one
+// CONTAINER_RUNNING entry per ContainerStatus in podStatus so StopContainer
+// can succeed against IDs the test crafted by hand.
+func seedFakeContainersForKill(fakeRuntime *apitest.FakeRuntimeService, podStatus *kubecontainer.PodStatus) {
+	var fakes []*apitest.FakeContainer
+	for _, cs := range podStatus.ContainerStatuses {
+		fakes = append(fakes, &apitest.FakeContainer{
+			ContainerStatus: runtimeapi.ContainerStatus{
+				Id:       cs.ID.ID,
+				Metadata: &runtimeapi.ContainerMetadata{Name: cs.Name},
+				State:    runtimeapi.ContainerState_CONTAINER_RUNNING,
+				Image:    &runtimeapi.ImageSpec{Image: "busybox"},
+				ImageRef: "busybox",
+			},
+		})
+	}
+	fakeRuntime.SetFakeContainers(fakes)
+}
+
+// slowStopRuntimeService wraps a FakeRuntimeService and lets a test block
+// StopContainer calls on a per-container barrier and inject per-container
+// errors. It records the wall-clock duration of every StopContainer call so
+// tests can assert that kills overlap in time rather than running serially.
+type slowStopRuntimeService struct {
+	*apitest.FakeRuntimeService
+
+	mu           sync.Mutex
+	blockers     map[string]chan struct{}
+	stopErrors   map[string]error
+	startedAt    map[string]time.Time
+	completedAt  map[string]time.Time
+	stopDelay    time.Duration
+	maxOverlap   int
+	curOverlap   int
+	startCounter int
+}
+
+func newSlowStopRuntimeService(fake *apitest.FakeRuntimeService) *slowStopRuntimeService {
+	return &slowStopRuntimeService{
+		FakeRuntimeService: fake,
+		blockers:           map[string]chan struct{}{},
+		stopErrors:         map[string]error{},
+		startedAt:          map[string]time.Time{},
+		completedAt:        map[string]time.Time{},
+	}
+}
+
+func (s *slowStopRuntimeService) blockOn(containerID string) chan struct{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ch := make(chan struct{})
+	s.blockers[containerID] = ch
+	return ch
+}
+
+func (s *slowStopRuntimeService) failOn(containerID string, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stopErrors[containerID] = err
+}
+
+func (s *slowStopRuntimeService) StopContainer(ctx context.Context, containerID string, timeout int64) error {
+	s.mu.Lock()
+	ch, blocked := s.blockers[containerID]
+	injectErr := s.stopErrors[containerID]
+	delay := s.stopDelay
+	s.startedAt[containerID] = time.Now()
+	s.startCounter++
+	s.curOverlap++
+	if s.curOverlap > s.maxOverlap {
+		s.maxOverlap = s.curOverlap
+	}
+	s.mu.Unlock()
+
+	if blocked {
+		<-ch
+	}
+	if delay > 0 {
+		time.Sleep(delay)
+	}
+
+	s.mu.Lock()
+	s.curOverlap--
+	s.completedAt[containerID] = time.Now()
+	s.mu.Unlock()
+
+	if injectErr != nil {
+		return injectErr
+	}
+	return s.FakeRuntimeService.StopContainer(ctx, containerID, timeout)
+}
+
+// TestSyncPodKillsContainersInParallel verifies the Step 3 kill loop in
+// SyncPod kills multiple containers concurrently rather than serially. The
+// previous sequential implementation made the first-killed container wait
+// for every subsequent kill (and its preStop hook) before its replacement
+// could start; see https://github.com/kubernetes/kubernetes/issues/138146.
+//
+// The test marks three liveness-failed running containers, then blocks the
+// runtime's StopContainer call for all three until every kill is in flight.
+// If kills ran serially the second StopContainer would never start, the
+// barrier would never release, and the test would deadlock and time out.
+func TestSyncPodKillsContainersInParallel(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	fakeRuntime, _, m, err := createTestRuntimeManager(tCtx)
+	require.NoError(t, err)
+
+	slow := newSlowStopRuntimeService(fakeRuntime)
+	m.runtimeService = slow
+
+	pod, podStatus := makeBasePodAndStatus()
+	pod.Spec.RestartPolicy = v1.RestartPolicyAlways
+	seedFakeContainersForKill(fakeRuntime, podStatus)
+
+	// Mark all three containers as having failed their liveness probe so
+	// computePodActions populates ContainersToKill with all of them.
+	for _, cs := range podStatus.ContainerStatuses {
+		m.livenessManager.Set(cs.ID, proberesults.Failure, pod)
+	}
+
+	// Block every StopContainer call until released.
+	const totalContainers = 3
+	releaseChans := make([]chan struct{}, totalContainers)
+	for i, cs := range podStatus.ContainerStatuses {
+		releaseChans[i] = slow.blockOn(cs.ID.ID)
+	}
+
+	// Run SyncPod on a goroutine so we can inspect in-flight state.
+	syncDone := make(chan kubecontainer.PodSyncResult, 1)
+	backOff := flowcontrol.NewBackOff(time.Second, time.Minute)
+	go func() {
+		syncDone <- m.SyncPod(tCtx, pod, podStatus, []v1.Secret{}, backOff, false)
+	}()
+
+	// Wait until all three StopContainer calls are in flight at once.
+	require.Eventuallyf(t, func() bool {
+		slow.mu.Lock()
+		defer slow.mu.Unlock()
+		return slow.curOverlap == totalContainers
+	}, 10*time.Second, 10*time.Millisecond,
+		"expected %d concurrent in-flight StopContainer calls; the kill loop is serializing them",
+		totalContainers)
+
+	// Release all three.
+	for _, ch := range releaseChans {
+		close(ch)
+	}
+
+	select {
+	case result := <-syncDone:
+		// The kills themselves should not have produced an error.
+		for _, sr := range result.SyncResults {
+			if sr.Action == kubecontainer.KillContainer {
+				require.NoError(t, sr.Error,
+					"unexpected kill failure for %v: %s", sr.Target, sr.Message)
+			}
+		}
+		// Every container should have a KillContainer SyncResult appended,
+		// regardless of which kill completed first. The previous sequential
+		// implementation returned after the first kill's AddSyncResult call;
+		// the parallel implementation must record all of them so callers
+		// see the full picture.
+		killed := map[string]bool{}
+		for _, sr := range result.SyncResults {
+			if sr.Action == kubecontainer.KillContainer {
+				name, _ := sr.Target.(string)
+				killed[name] = true
+			}
+		}
+		for _, c := range pod.Spec.Containers {
+			assert.Truef(t, killed[c.Name],
+				"missing KillContainer SyncResult for %q; result=%+v", c.Name, result.SyncResults)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("SyncPod did not return after the kill barrier was released")
+	}
+
+	slow.mu.Lock()
+	defer slow.mu.Unlock()
+	assert.Equalf(t, totalContainers, slow.maxOverlap,
+		"expected %d StopContainer calls to overlap; max observed overlap was %d",
+		totalContainers, slow.maxOverlap)
+}
+
+// TestSyncPodKillsRecordsAllResultsWhenOneFails verifies that when one of
+// the parallel Step 3 kills fails, SyncPod still records a SyncResult for
+// every container it attempted to kill. The sequential implementation would
+// return after the first AddSyncResult on the failed kill and drop the
+// remaining containers' results; the parallel implementation must wait for
+// every kill to complete and add all results before returning.
+func TestSyncPodKillsRecordsAllResultsWhenOneFails(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	fakeRuntime, _, m, err := createTestRuntimeManager(tCtx)
+	require.NoError(t, err)
+
+	slow := newSlowStopRuntimeService(fakeRuntime)
+	m.runtimeService = slow
+
+	pod, podStatus := makeBasePodAndStatus()
+	pod.Spec.RestartPolicy = v1.RestartPolicyAlways
+	seedFakeContainersForKill(fakeRuntime, podStatus)
+	for _, cs := range podStatus.ContainerStatuses {
+		m.livenessManager.Set(cs.ID, proberesults.Failure, pod)
+	}
+
+	// Fail the kill for the first container. The other two should still be
+	// stopped and have their KillContainer SyncResult recorded.
+	failingID := podStatus.ContainerStatuses[0].ID.ID
+	slow.failOn(failingID, errors.New("simulated runtime failure"))
+
+	backOff := flowcontrol.NewBackOff(time.Second, time.Minute)
+	result := m.SyncPod(tCtx, pod, podStatus, []v1.Secret{}, backOff, false)
+
+	killResults := map[string]*kubecontainer.SyncResult{}
+	for _, sr := range result.SyncResults {
+		if sr.Action == kubecontainer.KillContainer {
+			name, _ := sr.Target.(string)
+			killResults[name] = sr
+		}
+	}
+
+	// All three containers must have a recorded kill result, regardless of
+	// the order goroutines finished in.
+	for _, c := range pod.Spec.Containers {
+		require.Containsf(t, killResults, c.Name,
+			"missing KillContainer SyncResult for %q (only got %v); the parallel kill loop must record every result before returning",
+			c.Name, killResults)
+	}
+
+	// The failing container's result must carry the kill error.
+	failingResult := killResults[podStatus.ContainerStatuses[0].Name]
+	require.NotNil(t, failingResult)
+	require.ErrorIs(t, failingResult.Error, kubecontainer.ErrKillContainer)
+	assert.Contains(t, failingResult.Message, "simulated runtime failure")
+}
+
+// TestSyncPodKillScenarioFromIssue138146 reproduces the reporter's scenario
+// from https://github.com/kubernetes/kubernetes/issues/138146 in miniature.
+// Four containers fail liveness simultaneously and each kill takes a fixed
+// simulated grace period. With sequential kills the total time is N*delay;
+// with parallel kills it is ~delay. The test demands the wall-clock to be
+// well under the sequential bound so a regression to serial behavior would
+// fail loudly.
+func TestSyncPodKillScenarioFromIssue138146(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	fakeRuntime, _, m, err := createTestRuntimeManager(tCtx)
+	require.NoError(t, err)
+
+	const (
+		numContainers       = 4
+		perContainerKillDur = 100 * time.Millisecond
+	)
+
+	slow := newSlowStopRuntimeService(fakeRuntime)
+	slow.mu.Lock()
+	slow.stopDelay = perContainerKillDur
+	slow.mu.Unlock()
+	m.runtimeService = slow
+
+	pod, podStatus := make4ContainerLivenessFailedPod()
+	seedFakeContainersForKill(fakeRuntime, podStatus)
+	for _, cs := range podStatus.ContainerStatuses {
+		m.livenessManager.Set(cs.ID, proberesults.Failure, pod)
+	}
+
+	backOff := flowcontrol.NewBackOff(time.Second, time.Minute)
+	start := time.Now()
+	result := m.SyncPod(tCtx, pod, podStatus, []v1.Secret{}, backOff, false)
+	elapsed := time.Since(start)
+
+	// Every container's kill must have happened and recorded a result.
+	killCount := 0
+	for _, sr := range result.SyncResults {
+		if sr.Action == kubecontainer.KillContainer {
+			killCount++
+			require.NoError(t, sr.Error, "unexpected kill error for %v", sr.Target)
+		}
+	}
+	assert.Equal(t, numContainers, killCount,
+		"expected %d KillContainer results, got %d (results=%+v)",
+		numContainers, killCount, result.SyncResults)
+
+	slow.mu.Lock()
+	maxOverlap := slow.maxOverlap
+	startCalls := slow.startCounter
+	slow.mu.Unlock()
+	assert.Equal(t, numContainers, startCalls,
+		"all %d containers must reach StopContainer", numContainers)
+	assert.Equal(t, numContainers, maxOverlap,
+		"all %d kills must overlap in time", numContainers)
+
+	// Parallel must finish well under the sequential lower bound. The
+	// sequential implementation would take numContainers*perContainerKillDur;
+	// parallel should take roughly perContainerKillDur. Demand at least a
+	// 2x speedup so flaky scheduling under load doesn't false-fail while
+	// still catching a regression to fully-serial behavior.
+	sequentialBound := numContainers * perContainerKillDur
+	assert.Lessf(t, elapsed, sequentialBound/2,
+		"Step 3 kills took %s; sequential lower bound is %s. Behavior has regressed to serial.",
+		elapsed, sequentialBound)
+	t.Logf("issue #138146 scenario: %d containers, %s per kill -> elapsed %s (sequential bound %s)",
+		numContainers, perContainerKillDur, elapsed, sequentialBound)
+}
+
+// make4ContainerLivenessFailedPod returns a pod and matching PodStatus with
+// four running containers, mirroring the issue #138146 reproduction.
+func make4ContainerLivenessFailedPod() (*v1.Pod, *kubecontainer.PodStatus) {
+	names := []string{"app-a", "app-b", "app-c", "app-d"}
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "issue-138146",
+			Name:      "sequential-kill-repro",
+			Namespace: "default",
+		},
+		Spec: v1.PodSpec{
+			RestartPolicy: v1.RestartPolicyAlways,
+		},
+	}
+	statuses := make([]*kubecontainer.Status, 0, len(names))
+	for _, n := range names {
+		c := v1.Container{Name: n, Image: "busybox"}
+		pod.Spec.Containers = append(pod.Spec.Containers, c)
+		statuses = append(statuses, &kubecontainer.Status{
+			ID:    kubecontainer.ContainerID{ID: "id-" + n},
+			Name:  n,
+			State: kubecontainer.ContainerStateRunning,
+			Hash:  kubecontainer.HashContainer(&c),
+		})
+	}
+	podStatus := &kubecontainer.PodStatus{
+		ID:        pod.UID,
+		Name:      pod.Name,
+		Namespace: pod.Namespace,
+		SandboxStatuses: []*runtimeapi.PodSandboxStatus{
+			{
+				Id:       "sandbox-id",
+				State:    runtimeapi.PodSandboxState_SANDBOX_READY,
+				Metadata: &runtimeapi.PodSandboxMetadata{Name: pod.Name, Namespace: pod.Namespace, Uid: string(pod.UID), Attempt: 0},
+				Network:  &runtimeapi.PodSandboxNetworkStatus{Ip: "10.0.0.1"},
+			},
+		},
+		ContainerStatuses: statuses,
+	}
+	return pod, podStatus
 }

--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -163,6 +163,114 @@ var _ = SIGDescribe("Probing container", func() {
 	})
 
 	/*
+		Testname: Pod liveness probe, multiple containers, parallel kill and restart
+		Description: Create a Pod with multiple containers that each configure an
+		exec liveness probe which fails shortly after startup, together with a
+		preStop hook. When the containers' liveness probes fail at the same time,
+		the kubelet MUST kill every failed container - running each container's
+		preStop hook - and restart all of them, and the Pod MUST recover to Ready.
+		This exercises the parallel container-kill path in SyncPod: a single
+		slow-terminating container (its preStop hook holds the kill open) must not
+		block its siblings from being killed and restarted.
+	*/
+	f.It("should kill and restart every container of a multi-container pod when they simultaneously fail liveness probes", f.WithSlow(), func(ctx context.Context) {
+		const numContainers = 3
+		containerNames := make([]string, 0, numContainers)
+		containers := make([]v1.Container, 0, numContainers)
+		for i := range numContainers {
+			name := fmt.Sprintf("liveness-%d", i)
+			containerNames = append(containerNames, name)
+			// First instance: become healthy briefly, then delete the health
+			// file so the liveness probe fails and the container is killed. On
+			// restart the per-container marker in the shared volume (an emptyDir
+			// survives container restarts) is already present, so the container
+			// stays healthy and the Pod stabilizes and can be inspected. Each
+			// preStop hook records that it ran into the shared volume and sleeps
+			// briefly, so the kill takes real time and would serialize the
+			// sibling kills if Step 3 were not parallelized.
+			cmd := fmt.Sprintf(
+				"if [ -f /shared/started-%[1]s ]; then echo ok >/tmp/health; sleep 600; "+
+					"else touch /shared/started-%[1]s; echo ok >/tmp/health; sleep 8; rm -f /tmp/health; sleep 600; fi",
+				name)
+			preStop := fmt.Sprintf("echo %s >> /shared/prestop.log; sleep 2", name)
+			containers = append(containers, v1.Container{
+				Name:    name,
+				Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+				Command: []string{"/bin/sh", "-c", cmd},
+				LivenessProbe: &v1.Probe{
+					ProbeHandler:        execHandler([]string{"cat", "/tmp/health"}),
+					InitialDelaySeconds: 15,
+					TimeoutSeconds:      5, // default 1s can be pretty aggressive in CI environments with low resources
+					FailureThreshold:    1,
+				},
+				Lifecycle: &v1.Lifecycle{
+					PreStop: &v1.LifecycleHandler{
+						Exec: &v1.ExecAction{
+							Command: []string{"/bin/sh", "-c", preStop},
+						},
+					},
+				},
+				VolumeMounts: []v1.VolumeMount{{Name: "shared", MountPath: "/shared"}},
+			})
+		}
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "liveness-parallel-kill-" + string(uuid.NewUUID()),
+				Labels: map[string]string{"test": "liveness-parallel-kill"},
+			},
+			Spec: v1.PodSpec{
+				RestartPolicy: v1.RestartPolicyAlways,
+				Containers:    containers,
+				Volumes: []v1.Volume{{
+					Name:         "shared",
+					VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}},
+				}},
+			},
+		}
+
+		podClient := e2epod.NewPodClient(f)
+		ginkgo.DeferCleanup(func(ctx context.Context) error {
+			ginkgo.By("deleting the pod")
+			return podClient.Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0))
+		})
+
+		ginkgo.By("creating the multi-container pod")
+		podClient.Create(ctx, pod)
+
+		ginkgo.By("waiting for every container to be killed and restarted exactly once")
+		framework.ExpectNoError(e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "all containers restarted", defaultObservationTimeout, func(p *v1.Pod) (bool, error) {
+			restarted := 0
+			for _, name := range containerNames {
+				for _, cs := range p.Status.ContainerStatuses {
+					if cs.Name != name {
+						continue
+					}
+					// Require an actual prior termination, not just a bumped
+					// counter, so we know the kill path (including the preStop
+					// hook) ran for this container.
+					if cs.RestartCount >= 1 && cs.LastTerminationState.Terminated != nil {
+						restarted++
+					}
+				}
+			}
+			return restarted == numContainers, nil
+		}))
+
+		ginkgo.By("waiting for the pod to become ready again after all containers restarted")
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, defaultObservationTimeout))
+
+		ginkgo.By("verifying every container's preStop hook ran during the parallel kill")
+		gomega.Eventually(ctx, func() (string, error) {
+			stdout, _, err := e2epod.ExecCommandInContainerWithFullOutput(f, pod.Name, containerNames[0], "cat", "/shared/prestop.log")
+			return stdout, err
+		}, defaultObservationTimeout, 2*time.Second).Should(gomega.SatisfyAll(
+			gomega.ContainSubstring(containerNames[0]),
+			gomega.ContainSubstring(containerNames[1]),
+			gomega.ContainSubstring(containerNames[2]),
+		), "each killed container's preStop hook must have recorded that it ran")
+	})
+
+	/*
 		Release: v1.9
 		Testname: Pod liveness probe, using http endpoint, restart
 		Description: A Pod is created with liveness probe on http endpoint /healthz. The http handler on the /healthz will return a http error after 10 seconds since the Pod is started. This MUST result in liveness check failure. The Pod MUST now be killed and restarted incrementing restart count to 1.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

SyncPod Step 3 currently kills containers sequentially.  Each `killContainer` call blocks for up to `terminationGracePeriodSeconds` (which includes running preStop hooks), so a container whose kill completes quickly cannot restart until all sibling kills finish.

With N containers and a grace period of G seconds, the first-killed container must wait up to (N−1)×G seconds before it can be restarted in Step 9.  In a concrete example from the issue reporter: 4 containers, 30 s grace period, 25 s preStop hooks → the first-killed container was dead for 68 seconds before restarting. With 300 s grace periods this penalty reaches 15+ minutes.

This PR parallelizes the Step 3 kill loop using goroutines and `sync.WaitGroup`, matching the pattern already used by `killContainersWithSyncResult` (called from KillPod in Step 2).  Results are collected via a buffered channel and added to the `PodSyncResult` after all goroutines complete, preserving thread safety and the existing fail-fast return on error.

#### Which issue(s) this PR is related to:

Reference: https://github.com/kubernetes/kubernetes/issues/138146

#### Special notes for your reviewer:

- The parallel kill pattern already exists in `killContainersWithSyncResult` (`kuberuntime_container.go:928-964`), used by `killPodWithSyncResult` in Step 2.  This PR applies the same pattern to Step 3.
- `PodSyncResult.AddSyncResult` is not thread-safe (plain slice append), so results are collected through a buffered channel and added after `wg.Wait()`, not from inside the goroutines.
- Each goroutine uses `defer utilruntime.HandleCrashWithContext(ctx)` for crash safety, consistent with `killContainersWithSyncResult`.
- The fail-fast behavior is preserved: after all kills complete, the first error found causes an early return.

#### Does this PR introduce a user-facing change?

```release-note
kubelet: container kills in SyncPod Step 3 are now performed in parallel, reducing pod restart latency when multiple containers fail liveness probes simultaneously.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```