### PR TITLE
Honor kube-proxy context cancellation in the run loop

### DIFF
--- a/cmd/kube-proxy/app/options.go
+++ b/cmd/kube-proxy/app/options.go
@@ -363,7 +363,6 @@ func (o *Options) Validate() error {
 
 // Run runs the specified ProxyServer.
 func (o *Options) Run(ctx context.Context) error {
-	defer close(o.errCh)
 	if len(o.WriteConfigTo) > 0 {
 		return o.writeConfigFile()
 	}
@@ -394,15 +393,21 @@ func (o *Options) runLoop(ctx context.Context) error {
 		o.watcher.Run(ctx)
 	}
 
+	proxyErrCh := make(chan error, 1)
 	// run the proxy in goroutine
 	go func() {
-		err := o.proxyServer.Run(ctx)
-		o.errCh <- err
+		proxyErrCh <- o.proxyServer.Run(ctx)
 	}()
 
 	for {
-		err := <-o.errCh
-		if err != nil {
+		select {
+		case <-ctx.Done():
+			return nil
+		case err := <-o.errCh:
+			if err != nil {
+				return err
+			}
+		case err := <-proxyErrCh:
 			return err
 		}
 	}

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -531,8 +531,7 @@ func serveMetrics(ctx context.Context, bindAddress string, proxyMode kubeproxyco
 	go wait.UntilWithContext(ctx, fn, 5*time.Second)
 }
 
-// Run runs the specified ProxyServer.  This should never exit (unless CleanupAndExit is set).
-// TODO: At the moment, Run() cannot return a nil error, otherwise it's caller will never exit. Update callers of Run to handle nil errors.
+// Run runs the specified ProxyServer until the context is canceled or a fatal error occurs.
 func (s *ProxyServer) Run(ctx context.Context) error {
 	logger := klog.FromContext(ctx)
 	// To help debugging, immediately log version
@@ -613,13 +612,13 @@ func (s *ProxyServer) Run(ctx context.Context) error {
 	if utilfeature.DefaultFeatureGate.Enabled(features.MultiCIDRServiceAllocator) {
 		serviceCIDRConfig := config.NewServiceCIDRConfig(ctx, informerFactory.Networking().V1().ServiceCIDRs(), s.Config.ConfigSyncPeriod.Duration)
 		serviceCIDRConfig.RegisterEventHandler(s.Proxier)
-		go serviceCIDRConfig.Run(wait.NeverStop)
+		go serviceCIDRConfig.Run(ctx.Done())
 	}
 	// This has to start after the calls to NewServiceConfig because that
 	// function must configure its shared informer event handlers first.
-	informerFactory.Start(wait.NeverStop)
-	endpointSliceInformerFactory.Start(wait.NeverStop)
-	serviceInformerFactory.Start(wait.NeverStop)
+	informerFactory.Start(ctx.Done())
+	endpointSliceInformerFactory.Start(ctx.Done())
+	serviceInformerFactory.Start(ctx.Done())
 
 	// hollow-proxy doesn't need node config, and we don't create nodeManager for hollow-proxy.
 	if s.NodeManager != nil {
@@ -628,7 +627,7 @@ func (s *ProxyServer) Run(ctx context.Context) error {
 		nodeTopologyConfig := config.NewNodeTopologyConfig(ctx, s.NodeManager.NodeInformer(), s.Config.ConfigSyncPeriod.Duration)
 		nodeTopologyConfig.RegisterEventHandler(s.Proxier)
 
-		go nodeConfig.Run(wait.NeverStop)
+		go nodeConfig.Run(ctx.Done())
 	}
 
 	// Birth Cry after the birth is successful
@@ -637,6 +636,8 @@ func (s *ProxyServer) Run(ctx context.Context) error {
 	go s.Proxier.SyncLoop()
 
 	select {
+	case <-ctx.Done():
+		return nil
 	case err = <-healthzErrCh:
 		s.Recorder.Eventf(s.NodeRef, nil, api.EventTypeWarning, "FailedToStartProxierHealthcheck", "StartKubeProxy", err.Error())
 	case err = <-metricsErrCh:

--- a/cmd/kube-proxy/app/server_linux_test.go
+++ b/cmd/kube-proxy/app/server_linux_test.go
@@ -496,8 +496,14 @@ detectLocalMode: "BridgeInterface"`)
 		name        string
 		proxyServer proxyRun
 		append      bool
+		cancel      bool
 		expectedErr string
 	}{
+		{
+			name:        "cancel context",
+			proxyServer: new(fakeProxyServerLongRun),
+			cancel:      true,
+		},
 		{
 			name:        "update config file",
 			proxyServer: new(fakeProxyServerLongRun),
@@ -512,7 +518,9 @@ detectLocalMode: "BridgeInterface"`)
 	}
 
 	for _, tc := range testCases {
-		_, ctx := ktesting.NewTestContext(t)
+		_, baseCtx := ktesting.NewTestContext(t)
+		ctx, cancel := context.WithCancel(baseCtx)
+		defer cancel()
 		file, tempDir, err := setUp()
 		if err != nil {
 			t.Fatalf("unexpected error when setting up environment: %v", err)
@@ -533,6 +541,9 @@ detectLocalMode: "BridgeInterface"`)
 
 		if tc.append {
 			file.WriteString("append fake content")
+		}
+		if tc.cancel {
+			cancel()
 		}
 
 		select {

--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -52,9 +52,8 @@ type fakeProxyServerLongRun struct{}
 
 // Run runs the specified ProxyServer.
 func (s *fakeProxyServerLongRun) Run(ctx context.Context) error {
-	for {
-		time.Sleep(2 * time.Second)
-	}
+	<-ctx.Done()
+	return nil
 }
 
 // CleanupAndExit runs in the specified ProxyServer.


### PR DESCRIPTION
/kind bug

## Summary

`ProxyServer.Run(ctx)` did not actually shut down when its context was canceled.

When `bindAddressHardFail` was false, the healthz and metrics channels were nil, so the final `select` in `Run()` had no way to notice `ctx.Done()`. The outer `runLoop()` had the same issue and could keep waiting for an error even after the proxy had already stopped.

This wires the long-running kube-proxy pieces to `ctx.Done()`, lets `Run()` return cleanly on cancellation, and separates proxy shutdown from config watcher events in `runLoop()`.

## Testing

- `go test ./cmd/kube-proxy/app`
