### PR TITLE
Reject ambiguous device lookups in mount-utils

### DIFF
--- a/staging/src/k8s.io/mount-utils/mount.go
+++ b/staging/src/k8s.io/mount-utils/mount.go
@@ -22,9 +22,11 @@ package mount
 import (
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	utilexec "k8s.io/utils/exec"
 )
 
@@ -264,8 +266,7 @@ func GetDeviceNameFromMount(mounter Interface, mountPath string) (string, int, e
 	}
 
 	// Find the device name.
-	// FIXME if multiple devices mounted on the same mount path, only the first one is returned.
-	device := ""
+	devices := sets.New[string]()
 	// If mountPath is symlink, need get its target path.
 	slTarget, err := filepath.EvalSymlinks(mountPath)
 	if err != nil {
@@ -273,9 +274,17 @@ func GetDeviceNameFromMount(mounter Interface, mountPath string) (string, int, e
 	}
 	for i := range mps {
 		if mps[i].Path == slTarget {
-			device = mps[i].Device
-			break
+			devices.Insert(mps[i].Device)
 		}
+	}
+	if len(devices) > 1 {
+		deviceList := sets.List(devices)
+		sort.Strings(deviceList)
+		return "", 0, fmt.Errorf("multiple devices mounted on %q: %s", slTarget, strings.Join(deviceList, ", "))
+	}
+	device := ""
+	if len(devices) == 1 {
+		device = sets.List(devices)[0]
 	}
 
 	// Find all references to the device.

--- a/staging/src/k8s.io/mount-utils/mount_linux_test.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux_test.go
@@ -148,34 +148,62 @@ func setEquivalent(set1, set2 []string) bool {
 }
 
 func TestGetDeviceNameFromMount(t *testing.T) {
-	fm := NewFakeMounter(
-		[]MountPoint{
-			{
-				Device: "/dev/disk/by-path/prefix-lun-1",
-				Path:   "/mnt/111",
-			},
-			{
-				Device: "/dev/disk/by-path/prefix-lun-1",
-				Path:   "/mnt/222",
-			},
-		})
-
 	tests := []struct {
+		name           string
+		mounter        *FakeMounter
 		mountPath      string
 		expectedDevice string
 		expectedRefs   int
+		expectedErr    string
 	}{
 		{
-			"/mnt/222",
-			"/dev/disk/by-path/prefix-lun-1",
-			2,
+			name: "single device",
+			mounter: NewFakeMounter(
+				[]MountPoint{
+					{
+						Device: "/dev/disk/by-path/prefix-lun-1",
+						Path:   "/mnt/111",
+					},
+					{
+						Device: "/dev/disk/by-path/prefix-lun-1",
+						Path:   "/mnt/222",
+					},
+				}),
+			mountPath:      "/mnt/222",
+			expectedDevice: "/dev/disk/by-path/prefix-lun-1",
+			expectedRefs:   2,
+		},
+		{
+			name: "multiple devices on same mount path",
+			mounter: NewFakeMounter(
+				[]MountPoint{
+					{
+						Device: "/dev/disk/by-path/prefix-lun-1",
+						Path:   "/mnt/shared",
+					},
+					{
+						Device: "/dev/disk/by-path/prefix-lun-2",
+						Path:   "/mnt/shared",
+					},
+				}),
+			mountPath:   "/mnt/shared",
+			expectedErr: "multiple devices mounted on",
 		},
 	}
 
-	for i, test := range tests {
-		if device, refs, err := GetDeviceNameFromMount(fm, test.mountPath); err != nil || test.expectedRefs != refs || test.expectedDevice != device {
-			t.Errorf("%d. GetDeviceNameFromMount(%s) = (%s, %d), %v; expected (%s,%d), nil", i, test.mountPath, device, refs, err, test.expectedDevice, test.expectedRefs)
-		}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			device, refs, err := GetDeviceNameFromMount(test.mounter, test.mountPath)
+			if test.expectedErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.expectedErr) {
+					t.Fatalf("GetDeviceNameFromMount(%s) error = %v, want error containing %q", test.mountPath, err, test.expectedErr)
+				}
+				return
+			}
+			if err != nil || test.expectedRefs != refs || test.expectedDevice != device {
+				t.Fatalf("GetDeviceNameFromMount(%s) = (%s, %d), %v; expected (%s, %d), nil", test.mountPath, device, refs, err, test.expectedDevice, test.expectedRefs)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
/kind bug

## Summary

`GetDeviceNameFromMount()` stopped at the first mount entry that matched the path.

That is fine when there is only one backing device, but if multiple devices share the same mount path it can return the wrong device and the wrong refcount. In that case it is better to fail than to guess.

This keeps the current behavior for the normal single-device case and returns an error for the ambiguous multi-device case.

## Testing

- `go test ./staging/src/k8s.io/mount-utils`
- `GOOS=linux GOARCH=amd64 go test -c -o /tmp/mount-utils-linux.test ./staging/src/k8s.io/mount-utils`
