### PR TITLE
Allow in-place pod resize to clear pod limits

### DIFF
--- a/pkg/kubelet/kuberuntime/helpers.go
+++ b/pkg/kubelet/kuberuntime/helpers.go
@@ -425,13 +425,13 @@ func convertResourceConfigToLinuxContainerResources(rc *cm.ResourceConfig) *runt
 	if rc.CPUPeriod != nil {
 		lcr.CpuPeriod = int64(*rc.CPUPeriod)
 	}
-	if rc.CPUQuota != nil {
+	if rc.CPUQuota != nil && *rc.CPUQuota > 0 {
 		lcr.CpuQuota = *rc.CPUQuota
 	}
 	if rc.CPUShares != nil {
 		lcr.CpuShares = int64(*rc.CPUShares)
 	}
-	if rc.Memory != nil {
+	if rc.Memory != nil && *rc.Memory > 0 {
 		lcr.MemoryLimitInBytes = *rc.Memory
 	}
 	if rc.CPUSet.Size() > 0 {

--- a/pkg/kubelet/kuberuntime/helpers_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_test.go
@@ -585,22 +585,50 @@ func TestMergeResourceConfig(t *testing.T) {
 }
 
 func TestConvertResourceConfigToLinuxContainerResources(t *testing.T) {
-	resCfg := &cm.ResourceConfig{
-		Memory:        ptr.To[int64](2048),
-		CPUShares:     ptr.To[uint64](2),
-		CPUPeriod:     ptr.To[uint64](10000),
-		CPUQuota:      ptr.To[int64](5000),
-		HugePageLimit: map[int64]int64{4096: 2048},
-		Unified:       map[string]string{"key1": "value1"},
+	tests := []struct {
+		name     string
+		resCfg   *cm.ResourceConfig
+		expected *runtimeapi.LinuxContainerResources
+	}{
+		{
+			name: "finite limits",
+			resCfg: &cm.ResourceConfig{
+				Memory:        ptr.To[int64](2048),
+				CPUShares:     ptr.To[uint64](2),
+				CPUPeriod:     ptr.To[uint64](10000),
+				CPUQuota:      ptr.To[int64](5000),
+				HugePageLimit: map[int64]int64{4096: 2048},
+				Unified:       map[string]string{"key1": "value1"},
+			},
+			expected: &runtimeapi.LinuxContainerResources{
+				CpuPeriod:          10000,
+				CpuQuota:           5000,
+				CpuShares:          2,
+				MemoryLimitInBytes: 2048,
+				Unified:            map[string]string{"key1": "value1"},
+			},
+		},
+		{
+			name: "unlimited cgroup sentinels",
+			resCfg: &cm.ResourceConfig{
+				Memory:    ptr.To[int64](-1),
+				CPUShares: ptr.To[uint64](2),
+				CPUPeriod: ptr.To[uint64](10000),
+				CPUQuota:  ptr.To[int64](-1),
+			},
+			expected: &runtimeapi.LinuxContainerResources{
+				CpuPeriod: 10000,
+				CpuShares: 2,
+			},
+		},
 	}
 
-	lcr := convertResourceConfigToLinuxContainerResources(resCfg)
-
-	assert.Equal(t, int64(*resCfg.CPUPeriod), lcr.CpuPeriod)
-	assert.Equal(t, *resCfg.CPUQuota, lcr.CpuQuota)
-	assert.Equal(t, int64(*resCfg.CPUShares), lcr.CpuShares)
-	assert.Equal(t, *resCfg.Memory, lcr.MemoryLimitInBytes)
-	assert.Equal(t, resCfg.Unified, lcr.Unified)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lcr := convertResourceConfigToLinuxContainerResources(tt.resCfg)
+			assert.Equal(t, tt.expected, lcr)
+		})
+	}
 }
 
 func TestContainerByCreatedThenID(t *testing.T) {

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -708,6 +708,38 @@ func podResourcesFromRequirements(requirements *v1.ResourceRequirements) resourc
 	}
 }
 
+func isUnlimitedPodResourceLimit(limit *int64) bool {
+	return limit == nil || *limit <= 0
+}
+
+func isPodResourceLimitIncrease(current, desired *int64) bool {
+	if isUnlimitedPodResourceLimit(desired) {
+		return !isUnlimitedPodResourceLimit(current)
+	}
+	if isUnlimitedPodResourceLimit(current) {
+		return false
+	}
+	return *desired > *current
+}
+
+func isPodResourceLimitDecrease(current, desired *int64) bool {
+	if isUnlimitedPodResourceLimit(desired) {
+		return false
+	}
+	if isUnlimitedPodResourceLimit(current) {
+		return true
+	}
+	return *desired < *current
+}
+
+func cgroupLimitValue(limit *int64) *int64 {
+	if !isUnlimitedPodResourceLimit(limit) {
+		return limit
+	}
+	noLimit := int64(-1)
+	return &noLimit
+}
+
 // computePodResizeAction determines the actions required (if any) to resize the given container.
 // Returns whether to keep (true) or restart (false) the container.
 // TODO(vibansal): Make this function to be agnostic to whether it is dealing with a restartable init container or not (i.e. remove the argument `isRestartableInitContainer`).
@@ -888,23 +920,15 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 
 		switch resourceName {
 		case v1.ResourceMemory:
-			if allocatedResources.Requests != nil {
-				actuatedPodResources.Requests = defaultResourceListIfNil(actuatedPodResources.Requests)
-				actuatedPodResources.Requests[v1.ResourceMemory] = allocatedResources.Requests[v1.ResourceMemory]
-			}
-			if allocatedResources.Limits != nil {
-				actuatedPodResources.Limits = defaultResourceListIfNil(actuatedPodResources.Limits)
-				actuatedPodResources.Limits[v1.ResourceMemory] = allocatedResources.Limits[v1.ResourceMemory]
-			}
+			actuatedPodResources.Requests = defaultResourceListIfNil(actuatedPodResources.Requests)
+			actuatedPodResources.Requests[v1.ResourceMemory] = allocatedResources.Requests[v1.ResourceMemory]
+			actuatedPodResources.Limits = defaultResourceListIfNil(actuatedPodResources.Limits)
+			actuatedPodResources.Limits[v1.ResourceMemory] = allocatedResources.Limits[v1.ResourceMemory]
 		case v1.ResourceCPU:
-			if allocatedResources.Requests != nil {
-				actuatedPodResources.Requests = defaultResourceListIfNil(actuatedPodResources.Requests)
-				actuatedPodResources.Requests[v1.ResourceCPU] = allocatedResources.Requests[v1.ResourceCPU]
-			}
-			if allocatedResources.Limits != nil {
-				actuatedPodResources.Limits = defaultResourceListIfNil(actuatedPodResources.Limits)
-				actuatedPodResources.Limits[v1.ResourceCPU] = allocatedResources.Limits[v1.ResourceCPU]
-			}
+			actuatedPodResources.Requests = defaultResourceListIfNil(actuatedPodResources.Requests)
+			actuatedPodResources.Requests[v1.ResourceCPU] = allocatedResources.Requests[v1.ResourceCPU]
+			actuatedPodResources.Limits = defaultResourceListIfNil(actuatedPodResources.Limits)
+			actuatedPodResources.Limits[v1.ResourceCPU] = allocatedResources.Limits[v1.ResourceCPU]
 
 		}
 		if err = m.actuatedState.SetPodLevelResources(pod.UID, actuatedPodResources); err != nil {
@@ -917,26 +941,42 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 
 	setPodCgroupConfig := func(logger klog.Logger, rName v1.ResourceName, setLimitValue bool) error {
 		var err error
-		resizedResources := &cm.ResourceConfig{}
+		mergedPodResources := *currentPodResources
 		switch rName {
 		case v1.ResourceCPU:
 			if setLimitValue {
-				resizedResources.CPUPeriod = podResources.CPUPeriod
-				resizedResources.CPUQuota = podResources.CPUQuota
+				if podResources.CPUPeriod != nil {
+					mergedPodResources.CPUPeriod = podResources.CPUPeriod
+				} else if mergedPodResources.CPUPeriod == nil {
+					mergedPodResources.CPUPeriod = currentPodCPUConfig.CPUPeriod
+				}
+				mergedPodResources.CPUQuota = podResources.CPUQuota
 			} else {
-				resizedResources.CPUShares = podResources.CPUShares
+				mergedPodResources.CPUShares = podResources.CPUShares
 			}
 		case v1.ResourceMemory:
 			if !setLimitValue {
 				// Memory requests aren't written to cgroups.
 				return nil
 			}
-			resizedResources.Memory = podResources.Memory
+			mergedPodResources.Memory = podResources.Memory
+		}
+
+		resizedResources := &cm.ResourceConfig{}
+		switch rName {
+		case v1.ResourceCPU:
+			if setLimitValue {
+				resizedResources.CPUPeriod = mergedPodResources.CPUPeriod
+				resizedResources.CPUQuota = cgroupLimitValue(mergedPodResources.CPUQuota)
+			} else {
+				resizedResources.CPUShares = mergedPodResources.CPUShares
+			}
+		case v1.ResourceMemory:
+			resizedResources.Memory = cgroupLimitValue(mergedPodResources.Memory)
 		}
 
 		// Notify the runtime first. If this fails, the runtime has rejected the resize.
-		mergedPodResources := mergeResourceConfig(currentPodResources, resizedResources)
-		if err = m.updatePodSandboxResources(ctx, podContainerChanges.SandboxID, pod, mergedPodResources); err != nil {
+		if err = m.updatePodSandboxResources(ctx, podContainerChanges.SandboxID, pod, &mergedPodResources); err != nil {
 			return fmt.Errorf("failed to notify runtime for UpdatePodSandboxResources (resource=%s); resize rejected: %w", rName, err)
 		}
 
@@ -952,7 +992,7 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 		}
 
 		// Update our tracking of the current state.
-		currentPodResources = mergedPodResources
+		currentPodResources = &mergedPodResources
 		return nil
 	}
 
@@ -960,10 +1000,10 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 	// If resize results in net pod resource increase, set pod cgroup config before resizing containers.
 	// If resize results in net pod resource decrease, set pod cgroup config after resizing containers.
 	// If an error occurs at any point, abort. Let future syncpod iterations retry the unfinished stuff.
-	resizeContainers := func(rName v1.ResourceName, currPodCgLimValue, newPodCgLimValue, currPodCgReqValue, newPodCgReqValue int64) error {
+	resizeContainers := func(rName v1.ResourceName, currPodCgLimit, newPodCgLimit *int64, currPodCgReqValue, newPodCgReqValue int64) error {
 		var err error
 		// At upsizing, limits should expand prior to requests in order to keep "requests <= limits".
-		if newPodCgLimValue > currPodCgLimValue {
+		if isPodResourceLimitIncrease(currPodCgLimit, newPodCgLimit) {
 			// TODO: Pass logger from context once contextual logging migration is complete
 			if err = setPodCgroupConfig(klog.TODO(), rName, true); err != nil {
 				return err
@@ -989,7 +1029,7 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 				return err
 			}
 		}
-		if newPodCgLimValue < currPodCgLimValue {
+		if isPodResourceLimitDecrease(currPodCgLimit, newPodCgLimit) {
 			// TODO(#127825): Pass logger from context once contextual logging migration is complete
 			if err = setPodCgroupConfig(klog.TODO(), rName, true); err != nil {
 				return err
@@ -1009,12 +1049,7 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 	defer m.runtimeHelper.RequestPodReinspect(pod.UID)
 
 	if len(podContainerChanges.ContainersToUpdate[v1.ResourceMemory]) > 0 || podContainerChanges.UpdatePodResources || podContainerChanges.UpdatePodLevelResources {
-		if podResources.Memory == nil {
-			// Default pod memory limit to the current memory limit if unset to prevent it from updating.
-			// TODO(#128675): This does not support removing limits.
-			podResources.Memory = currentPodMemoryConfig.Memory
-		}
-		if errResize := resizeContainers(v1.ResourceMemory, int64(*currentPodMemoryConfig.Memory), *podResources.Memory, 0, 0); errResize != nil {
+		if errResize := resizeContainers(v1.ResourceMemory, currentPodMemoryConfig.Memory, podResources.Memory, 0, 0); errResize != nil {
 			resizeResult.Fail(kubecontainer.ErrResizePodInPlace, errResize.Error())
 			return resizeResult
 		}
@@ -1027,13 +1062,7 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 			return resizeResult
 		}
 
-		// Default pod CPUQuota to the current CPUQuota if no limit is set to prevent the pod limit
-		// from updating.
-		// TODO(#128675): This does not support removing limits.
-		if podResources.CPUQuota == nil {
-			podResources.CPUQuota = currentPodCPUConfig.CPUQuota
-		}
-		if errResize := resizeContainers(v1.ResourceCPU, *currentPodCPUConfig.CPUQuota, *podResources.CPUQuota,
+		if errResize := resizeContainers(v1.ResourceCPU, currentPodCPUConfig.CPUQuota, podResources.CPUQuota,
 			int64(*currentPodCPUConfig.CPUShares), int64(*podResources.CPUShares)); errResize != nil {
 			resizeResult.Fail(kubecontainer.ErrResizePodInPlace, errResize.Error())
 			return resizeResult
@@ -1067,9 +1096,7 @@ func (m *kubeGenericRuntimeManager) validateMemoryResizeAction(
 	podContainerChanges podActions,
 ) error {
 	// Determine which memory limits are decreasing.
-	podLimitDecreasing := desiredPodResources.Memory != nil &&
-		(currentPodResources.Memory == nil || // Pod memory limit added
-			*desiredPodResources.Memory < *currentPodResources.Memory) // Pod memory limit decreasing
+	podLimitDecreasing := isPodResourceLimitDecrease(currentPodResources.Memory, desiredPodResources.Memory)
 
 	decreasingContainerLimits := map[string]int64{} // Map of container name to desired memory limit.
 	for _, cUpdate := range podContainerChanges.ContainersToUpdate[v1.ResourceMemory] {

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -4117,6 +4117,38 @@ func TestDoPodResizeAction(t *testing.T) {
 	metrics.Register()
 	metrics.PodResizeDurationMilliseconds.Reset()
 
+	type podCgroupUpdate struct {
+		hasMemory    bool
+		memory       int64
+		hasCPUShares bool
+		cpuShares    uint64
+		hasCPUQuota  bool
+		cpuQuota     int64
+		hasCPUPeriod bool
+		cpuPeriod    uint64
+	}
+
+	toPodCgroupUpdate := func(cfg *cm.ResourceConfig) podCgroupUpdate {
+		update := podCgroupUpdate{}
+		if cfg.Memory != nil {
+			update.hasMemory = true
+			update.memory = *cfg.Memory
+		}
+		if cfg.CPUShares != nil {
+			update.hasCPUShares = true
+			update.cpuShares = *cfg.CPUShares
+		}
+		if cfg.CPUQuota != nil {
+			update.hasCPUQuota = true
+			update.cpuQuota = *cfg.CPUQuota
+		}
+		if cfg.CPUPeriod != nil {
+			update.hasCPUPeriod = true
+			update.cpuPeriod = *cfg.CPUPeriod
+		}
+		return update
+	}
+
 	for i, tc := range []struct {
 		testName                    string
 		currentResources            resourceRequirements
@@ -4130,7 +4162,10 @@ func TestDoPodResizeAction(t *testing.T) {
 		injectPodUpdateCgroupsError error
 		currentPodLevelResources    *resourceRequirements
 		desiredPodLevelResources    *resourceRequirements
+		omitDesiredPodLevelCPULimit bool
+		omitDesiredPodLevelMemLimit bool
 		updatedPodLevelResources    bool
+		expectedPodCgroupConfigs    []podCgroupUpdate
 		enablePLR                   bool
 	}{
 		{
@@ -4357,6 +4392,30 @@ func TestDoPodResizeAction(t *testing.T) {
 			enablePLR:                true,
 		},
 		{
+			testName: "Remove pod-level memory limit (clears cgroups and actuated state)",
+			currentResources: resourceRequirements{
+				memoryLimit: 200,
+			},
+			desiredResources: resourceRequirements{
+				memoryLimit: 200,
+			},
+			currentPodLevelResources: &resourceRequirements{
+				memoryLimit: 200,
+			},
+			desiredPodLevelResources: &resourceRequirements{
+				memoryLimit: 0,
+			},
+			omitDesiredPodLevelMemLimit: true,
+			updatedPodLevelResources:    true,
+			updatedResources:            []v1.ResourceName{},
+			expectPodCgroupUpdates:      1,
+			expectedPodCgroupConfigs: []podCgroupUpdate{{
+				hasMemory: true,
+				memory:    -1,
+			}},
+			enablePLR: true,
+		},
+		{
 			testName: "Resize pod-level CPU request (updates cgroups and actuated)",
 			currentResources: resourceRequirements{
 				cpuRequest: 100, cpuLimit: 100,
@@ -4393,6 +4452,32 @@ func TestDoPodResizeAction(t *testing.T) {
 			updatedResources:         []v1.ResourceName{},
 			expectPodCgroupUpdates:   1,
 			enablePLR:                true,
+		},
+		{
+			testName: "Remove pod-level CPU limit (clears cgroups and actuated state)",
+			currentResources: resourceRequirements{
+				cpuRequest: 100, cpuLimit: 200,
+			},
+			desiredResources: resourceRequirements{
+				cpuRequest: 100, cpuLimit: 200,
+			},
+			currentPodLevelResources: &resourceRequirements{
+				cpuRequest: 100, cpuLimit: 200,
+			},
+			desiredPodLevelResources: &resourceRequirements{
+				cpuRequest: 100, cpuLimit: 0,
+			},
+			omitDesiredPodLevelCPULimit: true,
+			updatedPodLevelResources:    true,
+			updatedResources:            []v1.ResourceName{},
+			expectPodCgroupUpdates:      1,
+			expectedPodCgroupConfigs: []podCgroupUpdate{{
+				hasCPUQuota:  true,
+				cpuQuota:     -1,
+				hasCPUPeriod: true,
+				cpuPeriod:    cm.QuotaPeriod,
+			}},
+			enablePLR: true,
 		},
 		{
 			testName: "Resize pod-level CPU limit and container-level CPU limit (updates cgroups and actuated)",
@@ -4484,6 +4569,7 @@ func TestDoPodResizeAction(t *testing.T) {
 			m.containerManager = mockCM
 			mockPCM := cmtesting.NewMockPodContainerManager(t)
 			mockCM.EXPECT().NewPodContainerManager().Return(mockPCM)
+			var podCgroupConfigs []podCgroupUpdate
 
 			mockPCM.EXPECT().GetPodCgroupConfig(mock.Anything, v1.ResourceMemory).Return(&cm.ResourceConfig{
 				Memory: ptr.To(tc.currentResources.memoryLimit),
@@ -4499,10 +4585,13 @@ func TestDoPodResizeAction(t *testing.T) {
 			mockPCM.EXPECT().GetPodCgroupConfig(mock.Anything, v1.ResourceCPU).Return(&cm.ResourceConfig{
 				CPUShares: ptr.To(cm.MilliCPUToShares(podCPURequest)),
 				CPUQuota:  ptr.To(cm.MilliCPUToQuota(podCPULimit, cm.QuotaPeriod)),
+				CPUPeriod: ptr.To[uint64](cm.QuotaPeriod),
 			}, nil).Maybe()
 			if tc.expectPodCgroupUpdates > 0 {
 				// TODO: Update to use proper logger once contextual logging migration is complete
-				call := mockPCM.EXPECT().SetPodCgroupConfig(klog.TODO(), mock.Anything, mock.Anything)
+				call := mockPCM.EXPECT().SetPodCgroupConfig(klog.TODO(), mock.Anything, mock.Anything).Run(func(_ klog.Logger, _ *v1.Pod, resourceConfig *cm.ResourceConfig) {
+					podCgroupConfigs = append(podCgroupConfigs, toPodCgroupUpdate(resourceConfig))
+				})
 				if tc.injectPodUpdateCgroupsError != nil {
 					call.Return(tc.injectPodUpdateCgroupsError).Times(1)
 				} else {
@@ -4513,15 +4602,22 @@ func TestDoPodResizeAction(t *testing.T) {
 			pod, kps := makeBasePodAndStatus()
 			if tc.desiredPodLevelResources != nil {
 				// pod spec and allocated resources are already updated as desired when doPodResizeAction() is called.
+				podLevelLimits := v1.ResourceList{}
+				if !tc.omitDesiredPodLevelCPULimit {
+					podLevelLimits[v1.ResourceCPU] = *resource.NewMilliQuantity(tc.desiredPodLevelResources.cpuLimit, resource.DecimalSI)
+				}
+				if !tc.omitDesiredPodLevelMemLimit {
+					podLevelLimits[v1.ResourceMemory] = *resource.NewQuantity(tc.desiredPodLevelResources.memoryLimit, resource.BinarySI)
+				}
 				pod.Spec.Resources = &v1.ResourceRequirements{
 					Requests: v1.ResourceList{
 						v1.ResourceCPU:    *resource.NewMilliQuantity(tc.desiredPodLevelResources.cpuRequest, resource.DecimalSI),
 						v1.ResourceMemory: *resource.NewQuantity(tc.desiredPodLevelResources.memoryRequest, resource.BinarySI),
 					},
-					Limits: v1.ResourceList{
-						v1.ResourceCPU:    *resource.NewMilliQuantity(tc.desiredPodLevelResources.cpuLimit, resource.DecimalSI),
-						v1.ResourceMemory: *resource.NewQuantity(tc.desiredPodLevelResources.memoryLimit, resource.BinarySI),
-					},
+					Limits: podLevelLimits,
+				}
+				if len(podLevelLimits) == 0 {
+					pod.Spec.Resources.Limits = nil
 				}
 			}
 			if tc.currentPodLevelResources != nil {
@@ -4613,12 +4709,18 @@ func TestDoPodResizeAction(t *testing.T) {
 					if tc.enablePLR {
 						assert.Equal(t, tc.desiredPodLevelResources.memoryRequest, updatedActuated.Requests.Memory().Value(), tc.testName)
 						assert.Equal(t, tc.desiredPodLevelResources.cpuRequest, updatedActuated.Requests.Cpu().MilliValue(), tc.testName)
+						assert.Equal(t, tc.desiredPodLevelResources.memoryLimit, updatedActuated.Limits.Memory().Value(), tc.testName)
+						assert.Equal(t, tc.desiredPodLevelResources.cpuLimit, updatedActuated.Limits.Cpu().MilliValue(), tc.testName)
 					} else {
 						assert.Equal(t, tc.currentPodLevelResources.memoryRequest, updatedActuated.Requests.Memory().Value(), tc.testName)
 						assert.Equal(t, tc.currentPodLevelResources.cpuRequest, updatedActuated.Requests.Cpu().MilliValue(), tc.testName)
+						assert.Equal(t, tc.currentPodLevelResources.memoryLimit, updatedActuated.Limits.Memory().Value(), tc.testName)
+						assert.Equal(t, tc.currentPodLevelResources.cpuLimit, updatedActuated.Limits.Cpu().MilliValue(), tc.testName)
 					}
 				}
 			}
+
+			assert.Equal(t, tc.expectedPodCgroupConfigs, podCgroupConfigs, tc.testName)
 
 			mock.AssertExpectationsForObjects(t, mockPCM)
 
@@ -4753,6 +4855,20 @@ func TestValidatePodResizeAction(t *testing.T) {
 			desiredResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 100,
 			},
+			desiredPodMemLimit:   ptr.To[int64](100),
+			containerMemoryUsage: ptr.To[uint64](20),
+			podMemoryUsage:       ptr.To[uint64](200),
+			expectedError:        true,
+		},
+		{
+			testName: "Add pod limit from unlimited current limit, high usage",
+			currentResources: resourceRequirements{
+				memoryRequest: 100, memoryLimit: 100,
+			},
+			desiredResources: resourceRequirements{
+				memoryRequest: 100, memoryLimit: 100,
+			},
+			currentPodMemLimit:   ptr.To[int64](-1),
 			desiredPodMemLimit:   ptr.To[int64](100),
 			containerMemoryUsage: ptr.To[uint64](20),
 			podMemoryUsage:       ptr.To[uint64](200),


### PR DESCRIPTION
/kind bug

## Summary

In-place pod resize could add or change pod-level CPU and memory limits, but it could not remove them.

If the desired pod-level limit was unset, kubelet fell back to the current cgroup value, so the old limit stayed in place. The actuated pod-level resource state could also keep the old limit when the updated pod spec no longer had that key.

This keeps a real "clear the limit" path through pod resize, uses the expected no-limit form when talking to cgroups and CRI, and updates the actuated pod-level state when a limit is removed.

## Testing

- `go test ./pkg/kubelet/kuberuntime -run 'TestConvertResourceConfigToLinuxContainerResources|TestDoPodResizeAction|TestValidatePodResizeAction'`
- `GOOS=linux GOARCH=amd64 go test -c -o /tmp/kuberuntime-linux.test ./pkg/kubelet/kuberuntime`
