### PR TITLE
Improve error messages for invalid restart policy and image pull policy

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -579,7 +579,7 @@ func getRestartPolicy(restart string, interactive bool) (corev1.RestartPolicy, e
 	case corev1.RestartPolicyAlways, corev1.RestartPolicyNever, corev1.RestartPolicyOnFailure:
 		return restartPolicy, nil
 	default:
-		return "", fmt.Errorf("invalid restart policy: %s", restart)
+		return "", fmt.Errorf("invalid restart policy: %s, valid values are: %s, %s, %s", restart, corev1.RestartPolicyAlways, corev1.RestartPolicyOnFailure, corev1.RestartPolicyNever)
 	}
 }
 
@@ -591,7 +591,7 @@ func getImagePullPolicy(pullPolicy string) (corev1.PullPolicy, error) {
 	case "":
 		return "", nil
 	default:
-		return "", fmt.Errorf("invalid image pull policy: %s", pullPolicy)
+		return "", fmt.Errorf("invalid image pull policy: %s, valid values are: %s, %s, %s", pullPolicy, corev1.PullAlways, corev1.PullIfNotPresent, corev1.PullNever)
 	}
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run_test.go
@@ -81,6 +81,32 @@ func TestGetRestartPolicy(t *testing.T) {
 	}
 }
 
+func TestGetRestartPolicyErrorListsValidValues(t *testing.T) {
+	_, err := getRestartPolicy("never", false)
+	if err == nil {
+		t.Fatal("expected error for lowercase 'never'")
+	}
+	errMsg := err.Error()
+	for _, policy := range []corev1.RestartPolicy{corev1.RestartPolicyAlways, corev1.RestartPolicyOnFailure, corev1.RestartPolicyNever} {
+		if !strings.Contains(errMsg, string(policy)) {
+			t.Errorf("error message %q does not contain valid value %q", errMsg, policy)
+		}
+	}
+}
+
+func TestGetImagePullPolicyErrorListsValidValues(t *testing.T) {
+	_, err := getImagePullPolicy("always")
+	if err == nil {
+		t.Fatal("expected error for lowercase 'always'")
+	}
+	errMsg := err.Error()
+	for _, policy := range []corev1.PullPolicy{corev1.PullAlways, corev1.PullIfNotPresent, corev1.PullNever} {
+		if !strings.Contains(errMsg, string(policy)) {
+			t.Errorf("error message %q does not contain valid value %q", errMsg, policy)
+		}
+	}
+}
+
 func TestRunArgsFollowDashRules(t *testing.T) {
 	tests := []struct {
 		args          []string


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When users pass an invalid value to `--restart` or `--image-pull-policy` (e.g. `--restart=never` instead of `--restart=Never`), the error message only says "invalid restart policy: never" without telling them what the valid values are.

This change updates both error messages to list the accepted values, so users can correct their input without having to look up the docs.

Before:
```
error: invalid restart policy: never
```

After:
```
error: invalid restart policy: never, valid values are: Always, OnFailure, Never
```

The same improvement is applied to `--image-pull-policy` for consistency.

#### Which issue(s) this PR is related to:

Fixes kubernetes/kubectl#1504

Prior PR #121570 addressed this but was closed due to inactivity. This picks up where it left off and also fixes the same issue in `verifyImagePullPolicy`.

#### Special notes for your reviewer:

The fix uses the `corev1` constants (`RestartPolicyAlways`, etc.) rather than string literals, so the error messages stay in sync if the API values ever change.

I also added two new test functions that verify the error messages contain all valid values for both `--restart` and `--image-pull-policy`.

#### Does this PR introduce a user-facing change?

```release-note
kubectl run: error messages for invalid --restart and --image-pull-policy values now list the accepted values
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

/sig cli
/area kubectl