### PR TITLE
Remove *cobra.Command dependency from kubectl create's RunCreate

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
@@ -55,6 +55,7 @@ type CreateOptions struct {
 	DryRunStrategy cmdutil.DryRunStrategy
 
 	ValidationDirective string
+	CreateAnnotation    bool
 
 	fieldManager string
 
@@ -63,8 +64,9 @@ type CreateOptions struct {
 	EditBeforeCreate bool
 	Raw              string
 
-	Recorder genericclioptions.Recorder
-	PrintObj func(obj kruntime.Object) error
+	Recorder    genericclioptions.Recorder
+	PrintObj    func(obj kruntime.Object) error
+	editOptions *editor.EditOptions
 
 	genericiooptions.IOStreams
 }
@@ -111,7 +113,7 @@ func NewCmdCreate(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobr
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate())
-			cmdutil.CheckErr(o.RunCreate(f, cmd))
+			cmdutil.CheckErr(o.RunCreate(f))
 		},
 	}
 
@@ -209,6 +211,24 @@ func (o *CreateOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []s
 		return err
 	}
 
+	o.CreateAnnotation = cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag)
+
+	if o.EditBeforeCreate {
+		editOptions := editor.NewEditOptions(editor.EditBeforeCreateMode, o.IOStreams)
+		editOptions.FilenameOptions = o.FilenameOptions
+		editOptions.ValidateOptions = cmdutil.ValidateOptions{
+			ValidationDirective: o.ValidationDirective,
+		}
+		editOptions.PrintFlags = o.PrintFlags
+		editOptions.ApplyAnnotation = o.CreateAnnotation
+		editOptions.RecordFlags = o.RecordFlags
+		editOptions.FieldManager = "kubectl-create"
+		if err := editOptions.Complete(f, []string{}, cmd); err != nil {
+			return err
+		}
+		o.editOptions = editOptions
+	}
+
 	printer, err := o.PrintFlags.ToPrinter()
 	if err != nil {
 		return err
@@ -222,7 +242,14 @@ func (o *CreateOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []s
 }
 
 // RunCreate performs the creation
-func (o *CreateOptions) RunCreate(f cmdutil.Factory, cmd *cobra.Command) error {
+func (o *CreateOptions) RunCreate(f cmdutil.Factory) error {
+	if o.EditBeforeCreate {
+		if o.editOptions == nil {
+			return fmt.Errorf("EditBeforeCreate requires edit options to be initialized via Complete()")
+		}
+		return o.editOptions.Run()
+	}
+
 	// raw only makes sense for a single file resource multiple objects aren't likely to do what you want.
 	// the validator enforces this, so
 	if len(o.Raw) > 0 {
@@ -231,10 +258,6 @@ func (o *CreateOptions) RunCreate(f cmdutil.Factory, cmd *cobra.Command) error {
 			return err
 		}
 		return rawhttp.RawPost(restClient, o.IOStreams, o.Raw, o.FilenameOptions.Filenames[0])
-	}
-
-	if o.EditBeforeCreate {
-		return RunEditOnCreate(f, o.PrintFlags, o.RecordFlags, o.IOStreams, cmd, &o.FilenameOptions, o.fieldManager)
 	}
 
 	schema, err := f.Validator(o.ValidationDirective)
@@ -266,7 +289,7 @@ func (o *CreateOptions) RunCreate(f cmdutil.Factory, cmd *cobra.Command) error {
 		if err != nil {
 			return err
 		}
-		if err := util.CreateOrUpdateAnnotation(cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag), info.Object, scheme.DefaultJSONEncoder()); err != nil {
+		if err := util.CreateOrUpdateAnnotation(o.CreateAnnotation, info.Object, scheme.DefaultJSONEncoder()); err != nil {
 			return cmdutil.AddSourceToErr("creating", info.Source, err)
 		}
 
@@ -298,29 +321,6 @@ func (o *CreateOptions) RunCreate(f cmdutil.Factory, cmd *cobra.Command) error {
 		return fmt.Errorf("no objects passed to create")
 	}
 	return nil
-}
-
-// RunEditOnCreate performs edit on creation
-func RunEditOnCreate(f cmdutil.Factory, printFlags *genericclioptions.PrintFlags, recordFlags *genericclioptions.RecordFlags, ioStreams genericiooptions.IOStreams, cmd *cobra.Command, options *resource.FilenameOptions, fieldManager string) error {
-	editOptions := editor.NewEditOptions(editor.EditBeforeCreateMode, ioStreams)
-	editOptions.FilenameOptions = *options
-	validationDirective, err := cmdutil.GetValidationDirective(cmd)
-	if err != nil {
-		return err
-	}
-	editOptions.ValidateOptions = cmdutil.ValidateOptions{
-		ValidationDirective: string(validationDirective),
-	}
-	editOptions.PrintFlags = printFlags
-	editOptions.ApplyAnnotation = cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag)
-	editOptions.RecordFlags = recordFlags
-	editOptions.FieldManager = "kubectl-create"
-
-	err = editOptions.Complete(f, []string{}, cmd)
-	if err != nil {
-		return err
-	}
-	return editOptions.Run()
 }
 
 // NameFromCommandArgs is a utility function for commands that assume the first argument is a resource name

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_test.go
@@ -152,6 +152,50 @@ func TestCreateDirectory(t *testing.T) {
 	}
 }
 
+func TestEditOptionsInitializedByComplete(t *testing.T) {
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+
+	ioStreams, _, _, _ := genericiooptions.NewTestIOStreams()
+	cmd := NewCmdCreate(tf, ioStreams)
+	cmd.Flags().Set("filename", "../../../testdata/redis-master-controller.yaml")
+
+	t.Run("editOptions is nil when EditBeforeCreate is false", func(t *testing.T) {
+		o := NewCreateOptions(ioStreams)
+		o.FilenameOptions.Filenames = []string{"../../../testdata/redis-master-controller.yaml"}
+		if err := o.Complete(tf, cmd, []string{}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if o.editOptions != nil {
+			t.Error("expected editOptions to be nil when EditBeforeCreate is false")
+		}
+	})
+
+	t.Run("editOptions is initialized when EditBeforeCreate is true", func(t *testing.T) {
+		o := NewCreateOptions(ioStreams)
+		o.EditBeforeCreate = true
+		o.FilenameOptions.Filenames = []string{"../../../testdata/redis-master-controller.yaml"}
+		if err := o.Complete(tf, cmd, []string{}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if o.editOptions == nil {
+			t.Error("expected editOptions to be initialized when EditBeforeCreate is true")
+		}
+	})
+
+	t.Run("RunCreate returns error when EditBeforeCreate is true but Complete was not called", func(t *testing.T) {
+		o := NewCreateOptions(ioStreams)
+		o.EditBeforeCreate = true
+		err := o.RunCreate(tf)
+		if err == nil {
+			t.Fatal("expected error when editOptions is nil")
+		}
+		if err.Error() != "EditBeforeCreate requires edit options to be initialized via Complete()" {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+}
+
 func TestMissingFilenameError(t *testing.T) {
 	var errStr string
 	var exitCode int

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_test.go
@@ -158,7 +158,7 @@ func TestEditOptionsInitializedByComplete(t *testing.T) {
 
 	ioStreams, _, _, _ := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdCreate(tf, ioStreams)
-	cmd.Flags().Set("filename", "../../../testdata/redis-master-controller.yaml")
+	cmd.Flags().Set("filename", "../../../testdata/redis-master-controller.yaml") // nolint:errcheck
 
 	t.Run("editOptions is nil when EditBeforeCreate is false", func(t *testing.T) {
 		o := NewCreateOptions(ioStreams)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`RunCreate` currently takes `*cobra.Command` as a parameter, which prevents external libraries from calling it without constructing a full Cobra command tree. This PR removes that dependency so `RunCreate` can be used programmatically.

The only two places `RunCreate` used `cmd` were:
1. `cmdutil.GetFlagBool(cmd, ApplyAnnotationsFlag)` — moved to a `CreateAnnotation` field on `CreateOptions`, extracted in `Complete()`
2. The `--edit` branch calling `RunEditOnCreate(f, ..., cmd, ...)` — moved to the Cobra handler, since `RunEditOnCreate` legitimately needs `cmd` for editor option completion and is an interactive feature not suited for library use

**Before** (library consumer):
```go
// Cannot call RunCreate without a *cobra.Command
o.RunCreate(f, cmd) // where does cmd come from?
```

**After**:
```go
o.RunCreate(f) // no Cobra dependency
```

Cobra `Run` is kept as-is for consistency with other commands, per discussion in kubernetes/kubectl#1615.

#### Which issue(s) this PR is related to:

kubernetes/kubectl#1615

#### Special notes for your reviewer:

- Single file change, 10 insertions / 7 deletions
- Follows the same pattern as `apply.go` where `Run()` takes zero args and flag extraction happens in `Complete()`/`ToOptions()`
- `RunEditOnCreate` signature is unchanged — it's an interactive feature that needs `cmd` for `EditOptions.Complete(f, args, cmd)`
- `go vet` clean, all tests pass

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

/sig cli
/area kubectl