### PR TITLE
fix(apiserver): avoid storage list metrics pollution by optimizing GetCurrentResourceVersion

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"path"
 	"reflect"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -38,8 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/conversion"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
@@ -702,34 +699,22 @@ func (s *store) ReadinessCheck() error {
 }
 
 func (s *store) GetCurrentResourceVersion(ctx context.Context) (uint64, error) {
-	emptyList := s.newListFunc()
-	pred := storage.SelectionPredicate{
-		Label: labels.Everything(),
-		Field: fields.Everything(),
-		Limit: 1, // just in case we actually hit something
-	}
-
-	err := s.GetList(ctx, s.resourcePrefix, storage.ListOptions{Predicate: pred}, emptyList)
-	if err != nil {
-		return 0, err
-	}
-	emptyListAccessor, err := meta.ListAccessor(emptyList)
-	if err != nil {
-		return 0, err
-	}
-	if emptyListAccessor == nil {
-		return 0, fmt.Errorf("unable to extract a list accessor from %T", emptyList)
-	}
-
-	currentResourceVersion, err := strconv.Atoi(emptyListAccessor.GetResourceVersion())
+	preparedKey, err := s.prepareKey(s.resourcePrefix, false)
 	if err != nil {
 		return 0, err
 	}
 
-	if currentResourceVersion == 0 {
+	startTime := time.Now()
+	getResp, err := s.client.Kubernetes.Get(ctx, preparedKey, kubernetes.GetOptions{})
+	metrics.RecordEtcdRequest("get", s.groupResource, err, startTime)
+	if err != nil {
+		return 0, err
+	}
+
+	if getResp.Revision == 0 {
 		return 0, fmt.Errorf("the current resource version must be greater than 0")
 	}
-	return uint64(currentResourceVersion), nil
+	return uint64(getResp.Revision), nil
 }
 
 // GetList implements storage.Interface.
@@ -772,10 +757,12 @@ func (s *store) GetList(ctx context.Context, key string, opts storage.ListOption
 	var numFetched int
 	var numEvald int
 	// Because these metrics are for understanding the costs of handling LIST requests,
-	// get them recorded even in error cases.
+	// get them recorded even in error cases, but only for recursive list operations.
 	defer func() {
-		numReturn := v.Len()
-		metrics.RecordStorageListMetrics(s.groupResource, numFetched, numEvald, numReturn)
+		if opts.Recursive {
+			numReturn := v.Len()
+			metrics.RecordStorageListMetrics(s.groupResource, numFetched, numEvald, numReturn)
+		}
 	}()
 
 	aggregator := s.listErrAggrFactory()

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -706,7 +706,7 @@ func (s *store) GetCurrentResourceVersion(ctx context.Context) (uint64, error) {
 
 	startTime := time.Now()
 	getResp, err := s.client.Kubernetes.Get(ctx, preparedKey, kubernetes.GetOptions{})
-	metrics.RecordEtcdRequest("get", s.groupResource, err, startTime)
+	metrics.RecordEtcdRequest("getCurrentResourceVersion", s.groupResource, err, startTime)
 	if err != nil {
 		return 0, err
 	}
@@ -757,12 +757,10 @@ func (s *store) GetList(ctx context.Context, key string, opts storage.ListOption
 	var numFetched int
 	var numEvald int
 	// Because these metrics are for understanding the costs of handling LIST requests,
-	// get them recorded even in error cases, but only for recursive list operations.
+	// get them recorded even in error cases.
 	defer func() {
-		if opts.Recursive {
-			numReturn := v.Len()
-			metrics.RecordStorageListMetrics(s.groupResource, numFetched, numEvald, numReturn)
-		}
+		numReturn := v.Len()
+		metrics.RecordStorageListMetrics(s.groupResource, numFetched, numEvald, numReturn)
 	}()
 
 	aggregator := s.listErrAggrFactory()


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
 /kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
**Current Issue:**
Currently, `metrics.RecordStorageListMetrics` records every call to `GetList`. This causes point queries (where `opts.Recursive == false`, such as the internal call from `GetCurrentResourceVersion` with `limit=1`) to be mistakenly counted as full list requests. This pollutes the `apiserver_storage_list_*` metrics, skewing latency data for real list operations.

**The Fix:**

**Performance Improvement:** Refactored `GetCurrentResourceVersion`. Previously, it called `GetList(limit=1)` to fetch the current etcd revision, dragging the execution through the heavy `GetList` abstraction. 

Now, `GetCurrentResourceVersion` directly issues a pure `Get` point query and extracts the revision from the etcd response header. 


Besides avoiding this metric pollution, this also removes unnecessary list-path work in a hot path, including list initialization and metadata handling.

The separate metrics API discussion is tracked in #138264.

**Performance:**
While the old approach ultimately fetched an empty point-query against the prefix key (fetching no actual payload), it still suffered from framework overhead. It unnecessarily initialized an empty list (`newListFunc()`), injected the revision via reflection (`versioner.UpdateList`), and extracted it again (`meta.ListAccessor`).

By bypassing this abstraction, local profiling shows the new approach saves `~1.2KB` of throw-away memory and 18 heap allocations per call. In high-frequency RV fetching scenarios (e.g., Cacher resyncs), this considerably reduces APIServer GC pressure.
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A
#### Special notes for your reviewer:
 /sig api-machinery

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
