### PR TITLE
fix: Should also order containerStatus by attempt or create time

### DIFF
--- a/pkg/kubelet/kuberuntime/helpers.go
+++ b/pkg/kubelet/kuberuntime/helpers.go
@@ -36,23 +36,36 @@ import (
 	"k8s.io/kubernetes/pkg/security/apparmor"
 )
 
-type containerByCreatedThenID []*runtimeapi.Container
+type containerSort []*runtimeapi.Container
 
-func (b containerByCreatedThenID) Len() int      { return len(b) }
-func (b containerByCreatedThenID) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
-func (b containerByCreatedThenID) Less(i, j int) bool {
-	if b[i].CreatedAt != b[j].CreatedAt {
-		return b[i].CreatedAt > (b[j].CreatedAt)
+func (b containerSort) Len() int      { return len(b) }
+func (b containerSort) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
+
+// Less defines the sorting order for containerSort:
+// 1. Primary sort: Descending order of Metadata.Attempt (higher attempts first)
+// 2. Secondary sort: Descending order of CreatedAt (newer containers first)
+// 3. Tertiary sort: Ascending order of ID (smaller IDs first)
+func (b containerSort) Less(i, j int) bool {
+	if b[i].Metadata == nil || b[j].Metadata == nil || (b[i].Metadata.Attempt == b[j].Metadata.Attempt) {
+		if b[i].CreatedAt != b[j].CreatedAt {
+			return b[i].CreatedAt > (b[j].CreatedAt)
+		}
+		return b[i].Id < b[j].Id
 	}
-	return b[i].Id < b[j].Id
+	return b[i].Metadata.Attempt > b[j].Metadata.Attempt
 }
 
 // Newest first.
-type podSandboxByCreatedThenID []*runtimeapi.PodSandbox
+type podSandboxSort []*runtimeapi.PodSandbox
 
-func (p podSandboxByCreatedThenID) Len() int      { return len(p) }
-func (p podSandboxByCreatedThenID) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
-func (p podSandboxByCreatedThenID) Less(i, j int) bool {
+func (p podSandboxSort) Len() int      { return len(p) }
+func (p podSandboxSort) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
+
+// Less defines the sorting order for podSandboxSort:
+// 1. Primary sort: Descending order of Metadata.Attempt (higher attempts first)
+// 2. Secondary sort: Descending order of CreatedAt (newer containers first)
+// 3. Tertiary sort: Ascending order of ID (smaller IDs first)
+func (p podSandboxSort) Less(i, j int) bool {
 	if p[i].Metadata == nil || p[j].Metadata == nil || (p[i].Metadata.Attempt == p[j].Metadata.Attempt) {
 		if p[i].CreatedAt != p[j].CreatedAt {
 			return p[i].CreatedAt > p[j].CreatedAt
@@ -62,11 +75,24 @@ func (p podSandboxByCreatedThenID) Less(i, j int) bool {
 	return p[i].Metadata.Attempt > p[j].Metadata.Attempt
 }
 
-type containerStatusByCreated []*kubecontainer.Status
+type containerStatusSort []*kubecontainer.Status
 
-func (c containerStatusByCreated) Len() int           { return len(c) }
-func (c containerStatusByCreated) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
-func (c containerStatusByCreated) Less(i, j int) bool { return c[i].CreatedAt.After(c[j].CreatedAt) }
+func (c containerStatusSort) Len() int      { return len(c) }
+func (c containerStatusSort) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+
+// Less defines the sorting order for containerStatusSort:
+// 1. Primary sort: Descending order of RestartCount (higher attempts first)
+// 2. Secondary sort: Descending order of CreatedAt (newer containers first)
+// 3. Tertiary sort: Ascending order of ID (smaller IDs first)
+func (c containerStatusSort) Less(i, j int) bool {
+	if c[i].RestartCount != c[j].RestartCount {
+		return c[i].RestartCount > c[j].RestartCount
+	}
+	if !c[i].CreatedAt.Equal(c[j].CreatedAt) {
+		return c[i].CreatedAt.After(c[j].CreatedAt)
+	}
+	return c[i].ID.ID < c[j].ID.ID
+}
 
 // toKubeContainerState converts runtimeapi.ContainerState to kubecontainer.State.
 func toKubeContainerState(state runtimeapi.ContainerState) kubecontainer.State {

--- a/pkg/kubelet/kuberuntime/helpers_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_test.go
@@ -603,7 +603,7 @@ func TestConvertResourceConfigToLinuxContainerResources(t *testing.T) {
 	assert.Equal(t, resCfg.Unified, lcr.Unified)
 }
 
-func TestContainerByCreatedThenID(t *testing.T) {
+func TestContainerSort(t *testing.T) {
 	now := time.Now()
 
 	tests := []struct {
@@ -611,6 +611,31 @@ func TestContainerByCreatedThenID(t *testing.T) {
 		input    []*runtimeapi.Container
 		expected []*runtimeapi.Container
 	}{
+		{
+			name: "different Attempt higher Attempt first",
+			input: []*runtimeapi.Container{
+				{
+					Id:        "c1",
+					CreatedAt: now.Add(-30 * time.Minute).Unix(),
+					Metadata:  &runtimeapi.ContainerMetadata{Attempt: 0},
+				},
+				{
+					Id:        "c2",
+					CreatedAt: now.Unix(),
+					Metadata:  &runtimeapi.ContainerMetadata{Attempt: 1},
+				},
+				{
+					Id:        "c3",
+					CreatedAt: now.Add(-10 * time.Minute).Unix(),
+					Metadata:  &runtimeapi.ContainerMetadata{Attempt: 2},
+				},
+			},
+			expected: []*runtimeapi.Container{
+				{Id: "c3"},
+				{Id: "c2"},
+				{Id: "c1"},
+			},
+		},
 		{
 			name: "different CreatedAt sort by time desc (newest first)",
 			input: []*runtimeapi.Container{
@@ -689,7 +714,7 @@ func TestContainerByCreatedThenID(t *testing.T) {
 			containers := make([]*runtimeapi.Container, len(tt.input))
 			copy(containers, tt.input)
 
-			sort.Sort(containerByCreatedThenID(containers))
+			sort.Sort(containerSort(containers))
 
 			assert.Len(t, containers, len(tt.expected), "length mismatch")
 
@@ -700,7 +725,7 @@ func TestContainerByCreatedThenID(t *testing.T) {
 	}
 }
 
-func TestPodSandboxByCreatedThenID(t *testing.T) {
+func TestPodSandboxSort(t *testing.T) {
 	now := time.Now()
 
 	tests := []struct {
@@ -804,7 +829,7 @@ func TestPodSandboxByCreatedThenID(t *testing.T) {
 			sandboxes := make([]*runtimeapi.PodSandbox, len(tt.input))
 			copy(sandboxes, tt.input)
 
-			sort.Sort(podSandboxByCreatedThenID(sandboxes))
+			sort.Sort(podSandboxSort(sandboxes))
 
 			assert.Len(t, sandboxes, len(tt.expected), "length mismatch")
 
@@ -814,6 +839,120 @@ func TestPodSandboxByCreatedThenID(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.expected, actualIDs, "sorting order mismatch")
+		})
+	}
+}
+
+func TestContainerStatusSort(t *testing.T) {
+	// Helper to create test ContainerStatus instances
+	now := time.Now()
+	makeStatus := func(restartCount int, createdAt time.Time, id string) *kubecontainer.Status {
+		return &kubecontainer.Status{
+			RestartCount: restartCount,
+			CreatedAt:    createdAt,
+			ID:           kubecontainer.ContainerID{ID: id},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		c        containerStatusSort
+		i, j     int
+		wantLess bool // true if c[i] should be considered "less than" c[j] (i.e., i comes before j)
+	}{
+		{
+			name: "higher RestartCount should come first",
+			c: containerStatusSort{
+				makeStatus(5, now, "id1"),
+				makeStatus(3, now, "id2"),
+			},
+			i:        0,
+			j:        1,
+			wantLess: true,
+		},
+		{
+			name: "lower RestartCount should not come first",
+			c: containerStatusSort{
+				makeStatus(2, now, "id1"),
+				makeStatus(4, now, "id2"),
+			},
+			i:        0,
+			j:        1,
+			wantLess: false,
+		},
+		{
+			name: "same RestartCount, newer CreatedAt should come first",
+			c: containerStatusSort{
+				makeStatus(10, now.Add(10*time.Minute), "id1"), // newer
+				makeStatus(10, now, "id2"),                     // older
+			},
+			i:        0,
+			j:        1,
+			wantLess: true,
+		},
+		{
+			name: "same RestartCount and CreatedAt, smaller ID should come first",
+			c: containerStatusSort{
+				makeStatus(5, now, "aaa"),
+				makeStatus(5, now, "bbb"),
+			},
+			i:        0,
+			j:        1,
+			wantLess: true, // "aaa" < "bbb"
+		},
+		{
+			name: "same RestartCount and CreatedAt, larger ID should not come first",
+			c: containerStatusSort{
+				makeStatus(5, now, "zzz"),
+				makeStatus(5, now, "xxx"),
+			},
+			i:        0,
+			j:        1,
+			wantLess: false, // "zzz" > "xxx"
+		},
+		{
+			name: "identical elements should return false",
+			c: containerStatusSort{
+				makeStatus(7, now, "same"),
+				makeStatus(7, now, "same"),
+			},
+			i:        0,
+			j:        1,
+			wantLess: false,
+		},
+		{
+			name: "RestartCount takes priority over CreatedAt",
+			c: containerStatusSort{
+				makeStatus(1, now.Add(1*time.Hour), "old-high-restart"),
+				makeStatus(10, now.Add(-1*time.Hour), "new-low-restart"),
+			},
+			i:        1, // higher RestartCount
+			j:        0,
+			wantLess: true,
+		},
+		{
+			name: "edge case: zero RestartCount with same timestamp",
+			c: containerStatusSort{
+				makeStatus(0, now, "id-a"),
+				makeStatus(0, now, "id-b"),
+			},
+			i:        0,
+			j:        1,
+			wantLess: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.c.Less(tt.i, tt.j)
+			if got != tt.wantLess {
+				t.Errorf("containerStatusSort.Less(%d, %d) = %v, want %v", tt.i, tt.j, got, tt.wantLess)
+			}
+
+			// Optional: verify antisymmetry (if i < j, then j should not be < i)
+			if got && tt.c.Less(tt.j, tt.i) {
+				t.Error("Less() should not return true in both directions for unequal elements")
+			}
 		})
 	}
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -677,8 +677,8 @@ func (m *kubeGenericRuntimeManager) getPodContainerStatuses(ctx context.Context,
 		}
 	}
 
-	sort.Sort(containerStatusByCreated(statuses))
-	sort.Sort(containerStatusByCreated(activeContainerStatuses))
+	sort.Sort(containerStatusSort(statuses))
+	sort.Sort(containerStatusSort(activeContainerStatuses))
 	return statuses, activeContainerStatuses, nil
 }
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -486,8 +486,8 @@ func (m *kubeGenericRuntimeManager) getPods(ctx context.Context, opts listOption
 	if err != nil {
 		return nil, err
 	}
-	// Sort sandboxes by creation time, newest first.
-	sort.Sort(podSandboxByCreatedThenID(sandboxes))
+	// Sort sandboxes by attempt then creation time then Id.
+	sort.Sort(podSandboxSort(sandboxes))
 	for i := range sandboxes {
 		s := sandboxes[i]
 		if s.Metadata == nil {
@@ -523,7 +523,7 @@ func (m *kubeGenericRuntimeManager) getPods(ctx context.Context, opts listOption
 	// To avoid unexpected behavior on container name based search (for example
 	// by calling *Kubelet.findContainer() without specifying a pod ID), we
 	// return the list of pods ordered by their creation time.
-	sort.Sort(containerByCreatedThenID(containers))
+	sort.Sort(containerSort(containers))
 	for i := range containers {
 		c := containers[i]
 		if c.Metadata == nil {
@@ -1981,7 +1981,7 @@ func (m *kubeGenericRuntimeManager) GeneratePodStatus(event *runtimeapi.Containe
 		kubeContainerStatuses = append(kubeContainerStatuses, m.convertToKubeContainerStatus(ctx, podUID, status))
 	}
 
-	sort.Sort(containerStatusByCreated(kubeContainerStatuses))
+	sort.Sort(containerStatusSort(kubeContainerStatuses))
 
 	return &kubecontainer.PodStatus{
 		ID:                kubetypes.UID(event.PodSandboxStatus.Metadata.Uid),

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
@@ -325,9 +325,9 @@ func (m *kubeGenericRuntimeManager) getSandboxIDByPodUID(ctx context.Context, po
 		return nil, nil
 	}
 
-	// Sort with newest first.
+	// Sort sandboxes by attempt then creation time then Id.
 	sandboxIDs := make([]string, len(sandboxes))
-	sort.Sort(podSandboxByCreatedThenID(sandboxes))
+	sort.Sort(podSandboxSort(sandboxes))
 	for i, s := range sandboxes {
 		sandboxIDs[i] = s.Id
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In PR #130551, the sorting logic for containerStatus was changed to prioritize the attempt field for sandbox.
This change should also be applied consistently to  containers (init containers and regular containers) to keep the behavior uniform.
This fixes the issue reported in #138174.
#### Which issue(s) this PR is related to:
Fixes #138174
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
the sorting logic for containerStatus was changed to prioritize the attempt field
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
