### PR TITLE
opti: make ParseMountInfo pre-allocate space when parsing mountinfo

### DIFF
--- a/staging/src/k8s.io/mount-utils/mount_helper_unix.go
+++ b/staging/src/k8s.io/mount-utils/mount_helper_unix.go
@@ -103,10 +103,10 @@ func ParseMountInfo(filename string) ([]MountInfo, error) {
 	if err != nil {
 		return []MountInfo{}, err
 	}
-	contentStr := string(content)
-	infos := []MountInfo{}
+	lines := strings.Split(string(content), "\n")
+	infos := make([]MountInfo, 0, len(lines))
 
-	for _, line := range strings.Split(contentStr, "\n") {
+	for _, line := range lines {
 		if line == "" {
 			// the last split() item is empty string following the last \n
 			continue


### PR DESCRIPTION
#### What type of PR is this?

/kind dependency

#### What this PR does / why we need it:

We use the mount-utils lib to parse mountinfo in internal system. On the servers where it runs, there are 300~1500 lines in the file content of mountinfo. Because `ParseMountInfo()` doesn't do pre-allocation with the returned result set, it brings significant GC load to applications when there is traffic peaks. This PR improves this. As it doesn't change API nor behaviour, the unit tests stay unchanged.