### PR TITLE
validation-gen: add +k8s:maxProperties declarative validation tag for map fields

### DIFF
--- a/CHANGELOG/CHANGELOG-1.36.md
+++ b/CHANGELOG/CHANGELOG-1.36.md
@@ -232,6 +232,7 @@ name | architectures
 ### Feature
 
 - A new gRPC service is added to the Kubelet that provides information about pods running on the node. ([#134627](https://github.com/kubernetes/kubernetes/pull/134627), [@briansonnenberg](https://github.com/briansonnenberg)) [SIG Node and Testing]
+- Add a new `+k8s:maxProperties=<N>` declarative validation tag that enforces a maximum number of entries in a map field, corresponding to the OpenAPI/JSON Schema `maxProperties` keyword. The tag is restricted to map types, uses short-circuit semantics (skips per-entry validation when the map is oversized), and a `MaxProperties` runtime validation function is added to `k8s.io/apimachinery/pkg/api/validate`. `StorageClass.Parameters` is annotated with `+k8s:maxProperties=512` as the first consumer. ([#138112](https://github.com/kubernetes/kubernetes/pull/138112), [@sAchin-680](https://github.com/sAchin-680)) [SIG API Machinery]
 - Add alpha metrics tracking the resource version the cache layer of an informer is at. ([#137419](https://github.com/kubernetes/kubernetes/pull/137419), [@michaelasp](https://github.com/michaelasp)) [SIG API Machinery, Architecture, Instrumentation and Testing]
 - Add the `timezone` field to the cronjob describe output. ([#136663](https://github.com/kubernetes/kubernetes/pull/136663), [@kfess](https://github.com/kfess)) [SIG CLI]
 - Add the ability for statefulset controller to read its own pod and pvc writes ([#137254](https://github.com/kubernetes/kubernetes/pull/137254), [@michaelasp](https://github.com/michaelasp)) [SIG Apps]

--- a/pkg/apis/storage/types.go
+++ b/pkg/apis/storage/types.go
@@ -46,6 +46,7 @@ type StorageClass struct {
 	// to the provisioner.  The only validation done on keys is that they are
 	// not empty.  The maximum number of parameters is
 	// 512, with a cumulative max size of 256K
+	// +k8s:maxProperties=512
 	// +optional
 	Parameters map[string]string
 

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/limits.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/limits.go
@@ -86,6 +86,14 @@ func MinItems[T any](_ context.Context, _ operation.Operation, fldPath *field.Pa
 	return nil
 }
 
+// MaxProperties verifies that the specified map has no more than max entries.
+func MaxProperties[K comparable, V any](_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ map[K]V, max int) field.ErrorList {
+	if len(value) > max {
+		return field.ErrorList{field.TooMany(fldPath, len(value), max).WithOrigin("maxProperties")}
+	}
+	return nil
+}
+
 // Minimum verifies that the specified value is greater than or equal to min.
 func Minimum[T constraints.Integer](_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ *T, min T) field.ErrorList {
 	if value == nil {

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/limits_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/limits_test.go
@@ -542,3 +542,53 @@ func TestMinLength(t *testing.T) {
 		})
 	}
 }
+
+func TestMaxProperties(t *testing.T) {
+	cases := []struct {
+		name     string
+		items    int
+		max      int
+		wantErrs field.ErrorList
+	}{{
+		name:  "0 items, max 0",
+		items: 0,
+		max:   0,
+	}, {
+		name:  "1 item, max 0",
+		items: 1,
+		max:   0,
+		wantErrs: field.ErrorList{
+			field.TooMany(field.NewPath("fldpath"), 1, 0).WithOrigin("maxProperties"),
+		},
+	}, {
+		name:  "1 item, max 1",
+		items: 1,
+		max:   1,
+	}, {
+		name:  "2 items, max 1",
+		items: 2,
+		max:   1,
+		wantErrs: field.ErrorList{
+			field.TooMany(field.NewPath("fldpath"), 2, 1).WithOrigin("maxProperties"),
+		},
+	}, {
+		name:  "0 items, max -1",
+		items: 0,
+		max:   -1,
+		wantErrs: field.ErrorList{
+			field.TooMany(field.NewPath("fldpath"), 0, -1).WithOrigin("maxProperties"),
+		},
+	}}
+
+	matcher := field.ErrorMatcher{}.ByOrigin().ByDetailSubstring().ByField().ByType()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			value := make(map[string]bool, tc.items)
+			for i := range tc.items {
+				value[fmt.Sprintf("key%d", i)] = true
+			}
+			gotErrs := MaxProperties(context.Background(), operation.Operation{}, field.NewPath("fldpath"), value, nil, tc.max)
+			matcher.Test(t, tc.wantErrs, gotErrs)
+		})
+	}
+}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
@@ -26,13 +26,14 @@ import (
 )
 
 const (
-	minItemsTagName  = "k8s:minItems"
-	maxItemsTagName  = "k8s:maxItems"
-	minimumTagName   = "k8s:minimum"
-	maximumTagName   = "k8s:maximum"
-	minLengthTagName = "k8s:minLength"
-	maxLengthTagName = "k8s:maxLength"
-	maxBytesTagName  = "k8s:maxBytes"
+	minItemsTagName      = "k8s:minItems"
+	maxItemsTagName      = "k8s:maxItems"
+	minimumTagName       = "k8s:minimum"
+	maximumTagName       = "k8s:maximum"
+	minLengthTagName     = "k8s:minLength"
+	maxLengthTagName     = "k8s:maxLength"
+	maxBytesTagName      = "k8s:maxBytes"
+	maxPropertiesTagName = "k8s:maxProperties"
 )
 
 func init() {
@@ -43,6 +44,7 @@ func init() {
 	RegisterTagValidator(minLengthTagValidator{})
 	RegisterTagValidator(maxLengthTagValidator{})
 	RegisterTagValidator(maxBytesTagValidator{})
+	RegisterTagValidator(maxPropertiesTagValidator{})
 }
 
 type maxLengthTagValidator struct{}
@@ -419,6 +421,63 @@ func (mltv minLengthTagValidator) Docs() TagDoc {
 		Payloads: []TagPayloadDoc{{
 			Description: "<integer>",
 			Docs:        "This field must be at least X characters long.",
+		}},
+		PayloadsType:     codetags.ValueTypeInt,
+		PayloadsRequired: true,
+	}
+}
+
+type maxPropertiesTagValidator struct{}
+
+func (maxPropertiesTagValidator) Init(_ Config) {}
+
+func (maxPropertiesTagValidator) TagName() string {
+	return maxPropertiesTagName
+}
+
+var maxPropertiesTagValidScopes = sets.New(
+	ScopeType,
+	ScopeField,
+	ScopeListVal,
+	ScopeMapVal,
+)
+
+func (maxPropertiesTagValidator) ValidScopes() sets.Set[Scope] {
+	return maxPropertiesTagValidScopes
+}
+
+var maxPropertiesValidator = types.Name{Package: libValidationPkg, Name: "MaxProperties"}
+
+func (maxPropertiesTagValidator) GetValidations(context Context, tag codetags.Tag) (Validations, error) {
+	var result Validations
+
+	// NOTE: pointers to maps are not supported, so we should never see a pointer here.
+	if t := util.NativeType(context.Type); t.Kind != types.Map {
+		return Validations{}, fmt.Errorf("can only be used on map types (%s)", rootTypeString(context.Type, t))
+	}
+
+	intVal, err := util.ParseInt(tag.Value)
+	if err != nil {
+		return result, fmt.Errorf("failed to parse tag payload as int: %w", err)
+	}
+	if intVal < 0 {
+		return result, fmt.Errorf("must be greater than or equal to zero")
+	}
+	// Note: maxProperties short-circuits other validations for safety, preventing
+	// DoS via validation of oversized maps.
+	result.AddFunction(Function(maxPropertiesTagName, ShortCircuit, maxPropertiesValidator, intVal))
+	return result, nil
+}
+
+func (mptv maxPropertiesTagValidator) Docs() TagDoc {
+	return TagDoc{
+		Tag:            mptv.TagName(),
+		StabilityLevel: TagStabilityLevelAlpha,
+		Scopes:         sets.List(mptv.ValidScopes()),
+		Description:    "Indicates that a map field has a limit on its number of entries.",
+		Payloads: []TagPayloadDoc{{
+			Description: "<non-negative integer>",
+			Docs:        "This map must have no more than X entries.",
 		}},
 		PayloadsType:     codetags.ValueTypeInt,
 		PayloadsRequired: true,


### PR DESCRIPTION
**Summary**: Add a new +k8s:maxProperties=<N> declarative validation tag that enforces a maximum number of entries in a map field. This corresponds to the OpenAPI/JSON Schema maxProperties keyword.

**Changes**:
- Add MaxProperties[K comparable, V any] runtime validation function to k8s.io/apimachinery/pkg/api/validate with 'maxProperties' origin.
- Add TestMaxProperties to limits_test.go covering 0/1/2-item maps and negative max boundary cases.
- Add maxPropertiesTagValidator to validation-gen validators/limits.go:
  - Restricted to map types only (mirrors +k8s:maxItems for slices)
  - Uses ShortCircuit flag to prevent DoS via oversized-map validation
  - Parses value via util.ParseInt, rejects negative values
  - Stability level: Alpha
- Annotate StorageClass.Parameters with +k8s:maxProperties=512 as the first consumer, replacing the hand-written len(params) > 512 guard.
- Add CHANGELOG entry.

Fixes: https://github.com/kubernetes/kubernetes/issues/138112

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind api-change


<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds a `+k8s:maxProperties=<N>` declarative validation tag for map fields — the Go equivalent of the OpenAPI `maxProperties` keyword. Right now, upper bounds on map size (like the 512-entry limit on `StorageClass.Parameters`) are enforced through hand-written [len(map) > N] checks scattered across validation files. This tag lets you declare that constraint directly on the type, just like `+k8s:maxItems` does for slices.

The validator short-circuits on oversized maps (same as `+k8s:maxItems`) so we don't waste time validating individual entries when the map is already too large. `StorageClass.Parameters` is the first field to use it, replacing the existing hand-written guard.

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #138112 
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
- The implementation mirrors `maxItemsTagValidator` closely — if that pattern looks wrong to you, happy to discuss.
- Stability is set to Alpha for now since this is a new tag.
- The [ShortCircuit] flag is intentional: an oversized map shouldn't trigger per-key/per-value validation (DoS concern).
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added `+k8s:maxProperties=<N>` declarative validation tag for map fields, corresponding to the OpenAPI `maxProperties` keyword. Map fields annotated with this tag will fail validation if the number of entries exceeds N. `StorageClass.Parameters` is the first field to use it (limit: 512).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NA
```
