### PR TITLE
fix(apiserver): introduce apiserver_storage_get metrics and separate …

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -174,6 +174,38 @@ var (
 		},
 		[]string{"group", "resource"},
 	)
+	getStorageCount = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Name:           "apiserver_storage_get_total",
+			Help:           "Number of GET requests served from storage",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"group", "resource"},
+	)
+	getStorageNumFetched = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Name:           "apiserver_storage_get_fetched_objects_total",
+			Help:           "Number of objects read from storage in the course of serving a GET request",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"group", "resource"},
+	)
+	getStorageNumSelectorEvals = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Name:           "apiserver_storage_get_evaluated_objects_total",
+			Help:           "Number of objects tested in the course of serving a GET request from storage",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"group", "resource"},
+	)
+	getStorageNumReturned = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Name:           "apiserver_storage_get_returned_objects_total",
+			Help:           "Number of objects returned for a GET request from storage",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"group", "resource"},
+	)
 	decodeErrorCounts = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
 			Namespace:      "apiserver",
@@ -207,6 +239,10 @@ func Register() {
 		legacyregistry.MustRegister(listStorageNumFetched)
 		legacyregistry.MustRegister(listStorageNumSelectorEvals)
 		legacyregistry.MustRegister(listStorageNumReturned)
+		legacyregistry.MustRegister(getStorageCount)
+		legacyregistry.MustRegister(getStorageNumFetched)
+		legacyregistry.MustRegister(getStorageNumSelectorEvals)
+		legacyregistry.MustRegister(getStorageNumReturned)
 		legacyregistry.MustRegister(decodeErrorCounts)
 	})
 }
@@ -303,6 +339,14 @@ func RecordStorageListMetrics(groupResource schema.GroupResource, numFetched, nu
 	listStorageNumFetched.WithLabelValues(groupResource.Group, groupResource.Resource).Add(float64(numFetched))
 	listStorageNumSelectorEvals.WithLabelValues(groupResource.Group, groupResource.Resource).Add(float64(numEvald))
 	listStorageNumReturned.WithLabelValues(groupResource.Group, groupResource.Resource).Add(float64(numReturned))
+}
+
+// RecordStorageGetMetrics notes various metrics of the cost to serve a GET request
+func RecordStorageGetMetrics(groupResource schema.GroupResource, numFetched, numEvald, numReturned int) {
+	getStorageCount.WithLabelValues(groupResource.Group, groupResource.Resource).Inc()
+	getStorageNumFetched.WithLabelValues(groupResource.Group, groupResource.Resource).Add(float64(numFetched))
+	getStorageNumSelectorEvals.WithLabelValues(groupResource.Group, groupResource.Resource).Add(float64(numEvald))
+	getStorageNumReturned.WithLabelValues(groupResource.Group, groupResource.Resource).Add(float64(numReturned))
 }
 
 type Monitor interface {

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -243,6 +243,12 @@ func (s *store) Get(ctx context.Context, key string, opts storage.GetOptions, ou
 	startTime := time.Now()
 	getResp, err := s.client.Kubernetes.Get(ctx, preparedKey, kubernetes.GetOptions{})
 	metrics.RecordEtcdRequest("get", s.groupResource, err, startTime)
+
+	numFetched, numReturned := 0, 0
+	defer func() {
+		metrics.RecordStorageGetMetrics(s.groupResource, numFetched, 0, numReturned)
+	}()
+
 	if err != nil {
 		return err
 	}
@@ -257,6 +263,7 @@ func (s *store) Get(ctx context.Context, key string, opts storage.GetOptions, ou
 		return storage.NewKeyNotFoundError(preparedKey, 0)
 	}
 
+	numFetched = 1
 	data, _, err := s.transformer.TransformFromStorage(ctx, getResp.KV.Value, authenticatedDataString(preparedKey))
 	if err != nil {
 		return storage.NewInternalError(err)
@@ -267,6 +274,7 @@ func (s *store) Get(ctx context.Context, key string, opts storage.GetOptions, ou
 		recordDecodeError(s.groupResource, preparedKey)
 		return err
 	}
+	numReturned = 1
 	return nil
 }
 
@@ -771,11 +779,16 @@ func (s *store) GetList(ctx context.Context, key string, opts storage.ListOption
 	var getResp kubernetes.ListResponse
 	var numFetched int
 	var numEvald int
-	// Because these metrics are for understanding the costs of handling LIST requests,
+	// Because these metrics are for understanding the costs of handling requests,
 	// get them recorded even in error cases.
+	// Non-recursive lists are essentially GET point queries, so we record them as GET operations.
 	defer func() {
 		numReturn := v.Len()
-		metrics.RecordStorageListMetrics(s.groupResource, numFetched, numEvald, numReturn)
+		if opts.Recursive {
+			metrics.RecordStorageListMetrics(s.groupResource, numFetched, numEvald, numReturn)
+		} else {
+			metrics.RecordStorageGetMetrics(s.groupResource, numFetched, numEvald, numReturn)
+		}
 	}()
 
 	aggregator := s.listErrAggrFactory()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

**Context:**
As discussed in #138190, currently `metrics.RecordStorageListMetrics` records every call to `GetList`. This causes point queries (where `opts.Recursive == false`) to be mistakenly counted as full list requests. This pollutes the `apiserver_storage_list_*` metrics and makes it difficult to observe the true cost of genuine list operations.

**The Fix:**
this PR expands the metrics to provide better observability:

1. **Introduced GET metrics:** Added a new set of `apiserver_storage_get_*` metrics (`_total`, `_fetched_objects_total`, `_evaluated_objects_total`, `_returned_objects_total`).
2. **Separated LIST and GET metrics in `GetList`:** Now, genuine recursive lists are recorded using `RecordStorageListMetrics`, while non-recursive lists (which are essentially point queries) are recorded using the newly introduced `RecordStorageGetMetrics`.
3. **Introduced native `Get`:** Added `RecordStorageGetMetrics` to the native `store.Get` method so that all standard GET operations are also properly tracked.

This provides cluster administrators with a complete and unpolluted view of both `LIST` and `GET` storage costs.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A (split from #138190 based on reviewer feedback)

#### Special notes for your reviewer:
/sig api-machinery
/sig etcd

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Introduced a new set of `apiserver_storage_get_*` metrics (`_total`, `_fetched_objects_total`, `_evaluated_objects_total`, `_returned_objects_total`) to track the cost of GET requests served from storage. Non-recursive LIST requests are now correctly recorded as GET operations to prevent polluting the LIST metrics.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```