### PR TITLE
pause: fix version drift and enforce full SemVer validation

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -195,50 +195,50 @@ dependencies:
       match: TAG\s*\?=
 
   - name: "registry.k8s.io/pause: dependents"
-    version: 3.10
+    version: 3.10.2
     refPaths:
     - path: cluster/gce/config-common.sh
-      match: registry.k8s.io\/pause:\d+\.\d+
+      match: registry.k8s.io\/pause:\d+\.\d+\.\d+
     - path: cluster/gce/gci/configure-helper.sh
-      match: registry.k8s.io\/pause:\d+\.\d+
+      match: registry.k8s.io\/pause:\d+\.\d+\.\d+
     - path: cluster/gce/windows/smoke-test.sh
-      match: registry.k8s.io\/pause:\d+\.\d+
+      match: registry.k8s.io\/pause:\d+\.\d+\.\d+
     - path: cmd/kubeadm/app/constants/constants.go
       match: PauseVersion\s+=
     - path: hack/testdata/pod-with-precision.json
-      match: registry.k8s.io\/pause:\d+\.\d+
+      match: registry.k8s.io\/pause:\d+\.\d+\.\d+
     - path: staging/src/k8s.io/kubectl/testdata/set/multi-resource-yaml.yaml
-      match: registry.k8s.io\/pause:\d+\.\d+
+      match: registry.k8s.io\/pause:\d+\.\d+\.\d+
     - path: staging/src/k8s.io/kubectl/testdata/set/namespaced-resource.yaml
-      match: registry.k8s.io\/pause:\d+\.\d+
+      match: registry.k8s.io\/pause:\d+\.\d+\.\d+
     - path: test/cmd/core.sh
-      match: registry.k8s.io\/pause:\d+\.\d+
+      match: registry.k8s.io\/pause:\d+\.\d+\.\d+
     - path: test/fixtures/pkg/kubectl/cmd/set/multi-resource-yaml.yaml
-      match: registry.k8s.io\/pause:\d+\.\d+
+      match: registry.k8s.io\/pause:\d+\.\d+\.\d+
     - path: test/fixtures/pkg/kubectl/cmd/set/namespaced-resource.yaml
-      match: registry.k8s.io\/pause:\d+\.\d+
+      match: registry.k8s.io\/pause:\d+\.\d+\.\d+
     - path: test/integration/benchmark-controller.json
-      match: registry.k8s.io\/pause:\d+\.\d+
+      match: registry.k8s.io\/pause:\d+\.\d+\.\d+
     - path: test/integration/scheduler_perf/templates/pod-default.yaml
-      match: registry.k8s.io\/pause:\d+\.\d+
+      match: registry.k8s.io\/pause:\d+\.\d+\.\d+
     - path: test/integration/scheduler_perf/templates/pod-with-node-affinity.yaml
-      match: registry.k8s.io\/pause:\d+\.\d+
+      match: registry.k8s.io\/pause:\d+\.\d+\.\d+
     - path: test/integration/scheduler_perf/templates/pod-with-pod-affinity.yaml
-      match: registry.k8s.io\/pause:\d+\.\d+
+      match: registry.k8s.io\/pause:\d+\.\d+\.\d+
     - path: test/integration/scheduler_perf/templates/pod-with-pod-anti-affinity.yaml
-      match: registry.k8s.io\/pause:\d+\.\d+
+      match: registry.k8s.io\/pause:\d+\.\d+\.\d+
     - path: test/integration/scheduler_perf/templates/pod-with-preferred-pod-affinity.yaml
-      match: registry.k8s.io\/pause:\d+\.\d+
+      match: registry.k8s.io\/pause:\d+\.\d+\.\d+
     - path: test/integration/scheduler_perf/templates/pod-with-preferred-pod-anti-affinity.yaml
-      match: registry.k8s.io\/pause:\d+\.\d+
+      match: registry.k8s.io\/pause:\d+\.\d+\.\d+
     - path: test/integration/scheduler_perf/templates/pod-with-preferred-topology-spreading.yaml
-      match: registry.k8s.io\/pause:\d+\.\d+
+      match: registry.k8s.io\/pause:\d+\.\d+\.\d+
     - path: test/integration/scheduler_perf/templates/pod-with-secret-volume.yaml
-      match: registry.k8s.io\/pause:\d+\.\d+
+      match: registry.k8s.io\/pause:\d+\.\d+\.\d+
     - path: test/integration/scheduler_perf/templates/pod-with-topology-spreading.yaml
-      match: registry.k8s.io\/pause:\d+\.\d+
+      match: registry.k8s.io\/pause:\d+\.\d+\.\d+
     - path: test/utils/image/manifest.go
-      match: configs\[Pause\] = Config{list\.GcRegistry, "pause", "\d+\.\d+(.\d+)?"}
+      match: configs\[Pause\] = Config{list\.GcRegistry, "pause", "\d+\.\d+\.\d+"}
     - path: test/images/agnhost/fakeregistryserver/images.txt
       match: pause\s
 

--- a/cluster/gce/config-common.sh
+++ b/cluster/gce/config-common.sh
@@ -154,7 +154,7 @@ export WINDOWS_KUBEPROXY_KUBECONFIG_FILE="${WINDOWS_K8S_DIR}\kubeproxy.kubeconfi
 # Path for kube-proxy kubeconfig file on Windows nodes.
 export WINDOWS_NODEPROBLEMDETECTOR_KUBECONFIG_FILE="${WINDOWS_K8S_DIR}\node-problem-detector.kubeconfig"
 # Pause container image for Windows container.
-export WINDOWS_INFRA_CONTAINER="registry.k8s.io/pause:3.10"
+export WINDOWS_INFRA_CONTAINER="registry.k8s.io/pause:3.10.2"
 # Storage Path for csi-proxy. csi-proxy only needs to be installed for Windows.
 export CSI_PROXY_STORAGE_PATH="https://storage.googleapis.com/gke-release/csi-proxy"
 # Version for csi-proxy

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -3285,7 +3285,7 @@ oom_score = -999
 [plugins."io.containerd.grpc.v1.cri"]
   stream_server_address = "127.0.0.1"
   max_container_log_line_size = ${CONTAINERD_MAX_CONTAINER_LOG_LINE:-262144}
-  sandbox_image = "${CONTAINERD_INFRA_CONTAINER:-"registry.k8s.io/pause:3.10"}"
+  sandbox_image = "${CONTAINERD_INFRA_CONTAINER:-"registry.k8s.io/pause:3.10.2"}"
 [plugins."io.containerd.grpc.v1.cri".cni]
   bin_dir = "${KUBE_HOME}/bin"
   conf_dir = "/etc/cni/net.d"

--- a/cluster/gce/windows/smoke-test.sh
+++ b/cluster/gce/windows/smoke-test.sh
@@ -341,7 +341,7 @@ spec:
     spec:
       containers:
       - name: pause-win
-        image: registry.k8s.io/pause:3.10
+        image: registry.k8s.io/pause:3.10.2
       nodeSelector:
         kubernetes.io/os: windows
       tolerations:

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -442,7 +442,7 @@ const (
 	ModeNode string = "Node"
 
 	// PauseVersion indicates the default pause image version for kubeadm
-	PauseVersion = "3.10.1"
+	PauseVersion = "3.10.2"
 
 	// CgroupDriverSystemd holds the systemd driver type
 	CgroupDriverSystemd = "systemd"

--- a/hack/testdata/pod-with-precision.json
+++ b/hack/testdata/pod-with-precision.json
@@ -9,7 +9,7 @@
     "containers": [
       {
         "name": "kubernetes-pause",
-        "image": "registry.k8s.io/pause:3.10.1"
+        "image": "registry.k8s.io/pause:3.10.2"
       }
     ],
     "restartPolicy": "Never",

--- a/staging/src/k8s.io/kubectl/testdata/set/multi-resource-yaml.yaml
+++ b/staging/src/k8s.io/kubectl/testdata/set/multi-resource-yaml.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: registry.k8s.io/pause:3.10
+        image: registry.k8s.io/pause:3.10.2
 ---
 apiVersion: v1
 kind: ReplicationController
@@ -30,4 +30,4 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: registry.k8s.io/pause:3.10
+        image: registry.k8s.io/pause:3.10.2

--- a/staging/src/k8s.io/kubectl/testdata/set/namespaced-resource.yaml
+++ b/staging/src/k8s.io/kubectl/testdata/set/namespaced-resource.yaml
@@ -14,4 +14,4 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: registry.k8s.io/pause:3.10
+        image: registry.k8s.io/pause:3.10.2

--- a/test/cmd/core.sh
+++ b/test/cmd/core.sh
@@ -537,9 +537,9 @@ run_pod_tests() {
   kube::test::get_object_assert pods "{{range.items}}{{$image_field}}:{{end}}" 'changed-with-yaml:'
   ## Patch pod from JSON can change image
   # Command
-  kubectl patch "${kube_flags[@]}" -f test/fixtures/doc-yaml/admin/limitrange/valid-pod.yaml -p='{"spec":{"containers":[{"name": "kubernetes-serve-hostname", "image": "registry.k8s.io/pause:3.10.1"}]}}'
+  kubectl patch "${kube_flags[@]}" -f test/fixtures/doc-yaml/admin/limitrange/valid-pod.yaml -p='{"spec":{"containers":[{"name": "kubernetes-serve-hostname", "image": "registry.k8s.io/pause:3.10.2"}]}}'
   # Post-condition: valid-pod POD has expected image
-  kube::test::get_object_assert pods "{{range.items}}{{$image_field}}:{{end}}" 'registry.k8s.io/pause:3.10.1:'
+  kube::test::get_object_assert pods "{{range.items}}{{$image_field}}:{{end}}" 'registry.k8s.io/pause:3.10.2:'
 
   # pod has field for kubectl patch field manager
   output_message=$(kubectl get pod valid-pod -o=jsonpath='{.metadata.managedFields[*].manager}' "${kube_flags[@]:?}" 2>&1)

--- a/test/fixtures/pkg/kubectl/cmd/set/multi-resource-yaml.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/set/multi-resource-yaml.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: registry.k8s.io/pause:3.10.1
+        image: registry.k8s.io/pause:3.10.2
 ---
 apiVersion: v1
 kind: ReplicationController
@@ -30,4 +30,4 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: registry.k8s.io/pause:3.10.1
+        image: registry.k8s.io/pause:3.10.2

--- a/test/fixtures/pkg/kubectl/cmd/set/namespaced-resource.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/set/namespaced-resource.yaml
@@ -14,4 +14,4 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: registry.k8s.io/pause:3.10.1
+        image: registry.k8s.io/pause:3.10.2

--- a/test/images/agnhost/fakeregistryserver/images.txt
+++ b/test/images/agnhost/fakeregistryserver/images.txt
@@ -1,1 +1,1 @@
-pause 3.10.1 testing
+pause 3.10.2 testing

--- a/test/integration/benchmark-controller.json
+++ b/test/integration/benchmark-controller.json
@@ -17,7 +17,7 @@
        "spec": {
            "containers": [{
              "name": "test-container",
-             "image": "registry.k8s.io/pause:3.10.1"
+             "image": "registry.k8s.io/pause:3.10.2"
            }]
        }
     }

--- a/test/integration/scheduler_perf/templates/pod-default.yaml
+++ b/test/integration/scheduler_perf/templates/pod-default.yaml
@@ -4,7 +4,7 @@ metadata:
   generateName: pod-
 spec:
   containers:
-  - image: registry.k8s.io/pause:3.10.1
+  - image: registry.k8s.io/pause:3.10.2
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/templates/pod-with-node-affinity.yaml
+++ b/test/integration/scheduler_perf/templates/pod-with-node-affinity.yaml
@@ -14,7 +14,7 @@ spec:
             - zone1
             - zone2
   containers:
-  - image: registry.k8s.io/pause:3.10.1
+  - image: registry.k8s.io/pause:3.10.2
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/templates/pod-with-pod-affinity.yaml
+++ b/test/integration/scheduler_perf/templates/pod-with-pod-affinity.yaml
@@ -14,7 +14,7 @@ spec:
         topologyKey: topology.kubernetes.io/zone
         namespaces: ["sched-1", "sched-0"]
   containers:
-  - image: registry.k8s.io/pause:3.10.1
+  - image: registry.k8s.io/pause:3.10.2
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/templates/pod-with-pod-anti-affinity.yaml
+++ b/test/integration/scheduler_perf/templates/pod-with-pod-anti-affinity.yaml
@@ -14,7 +14,7 @@ spec:
         topologyKey: kubernetes.io/hostname
         namespaces: ["sched-1", "sched-0"]
   containers:
-  - image: registry.k8s.io/pause:3.10.1
+  - image: registry.k8s.io/pause:3.10.2
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/templates/pod-with-preferred-pod-affinity.yaml
+++ b/test/integration/scheduler_perf/templates/pod-with-preferred-pod-affinity.yaml
@@ -16,7 +16,7 @@ spec:
             namespaces: ["sched-1", "sched-0"]
           weight: 1
   containers:
-    - image: registry.k8s.io/pause:3.10.1
+    - image: registry.k8s.io/pause:3.10.2
       name: pause
       ports:
         - containerPort: 80

--- a/test/integration/scheduler_perf/templates/pod-with-preferred-pod-anti-affinity.yaml
+++ b/test/integration/scheduler_perf/templates/pod-with-preferred-pod-anti-affinity.yaml
@@ -16,7 +16,7 @@ spec:
             namespaces: ["sched-1", "sched-0"]
           weight: 1
   containers:
-    - image: registry.k8s.io/pause:3.10.1
+    - image: registry.k8s.io/pause:3.10.2
       name: pause
       ports:
         - containerPort: 80

--- a/test/integration/scheduler_perf/templates/pod-with-preferred-topology-spreading.yaml
+++ b/test/integration/scheduler_perf/templates/pod-with-preferred-topology-spreading.yaml
@@ -13,7 +13,7 @@ spec:
         matchLabels:
           color: blue
   containers:
-  - image: registry.k8s.io/pause:3.10.1
+  - image: registry.k8s.io/pause:3.10.2
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/templates/pod-with-secret-volume.yaml
+++ b/test/integration/scheduler_perf/templates/pod-with-secret-volume.yaml
@@ -4,7 +4,7 @@ metadata:
   generateName: secret-volume-
 spec:
   containers:
-  - image: registry.k8s.io/pause:3.10.1
+  - image: registry.k8s.io/pause:3.10.2
     name: pause
     ports:
     - containerPort: 80

--- a/test/integration/scheduler_perf/templates/pod-with-topology-spreading.yaml
+++ b/test/integration/scheduler_perf/templates/pod-with-topology-spreading.yaml
@@ -13,7 +13,7 @@ spec:
         matchLabels:
           color: blue
   containers:
-  - image: registry.k8s.io/pause:3.10.1
+  - image: registry.k8s.io/pause:3.10.2
     name: pause
     ports:
     - containerPort: 80

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -230,7 +230,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[Nonewprivs] = Config{list.PromoterE2eRegistry, "nonewprivs", "1.4"}
 	configs[NonRoot] = Config{list.PromoterE2eRegistry, "nonroot", "1.5"}
 	// Pause - when these values are updated, also update cmd/kubelet/app/options/container_runtime.go
-	configs[Pause] = Config{list.GcRegistry, "pause", "3.10.1"}
+	configs[Pause] = Config{list.GcRegistry, "pause", "3.10.2"}
 	configs[Perl] = Config{list.PromoterE2eRegistry, "perl", "5.26"}
 	configs[RegressionIssue74839] = Config{list.PromoterE2eRegistry, "regression-issue-74839", "1.4"}
 	configs[ResourceConsumer] = Config{list.PromoterE2eRegistry, "resource-consumer", "1.14"}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

```
The latest pause version is 3.10.2 but due to the introduction
of the PATCH level version to the pause image (previously was
only MAJOR.MINOR), various files have remained on an older
version. Either 3.10 or 3.10.1. Our validation with
build/dependencies.yaml ./hack/verify-external-dependencies.sh
did not account for that.
```

```
As it can be seen in build/pause/CHANGELOG.md the PATCH
level version for pause was introduced due to requirements
from the pause image for Windows. This however invalidated
our build/depedencies.yaml validation as it only accounted for
the MAJOR.MINOR version of pause (e.g. 3.10, not 3.10.1).

Enforce full SemVer validation for the pause image dependents.
```


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Update the version of the pause image to 3.10.2. Track all pause image version dependencies under the 'registry.k8s.io/pause' item in build/dependencies.yaml.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
