### PR TITLE
fix(apiserver): remove spurious json:",inline" tag from TypeMeta embeddings

### DIFF
--- a/plugin/pkg/admission/eventratelimit/apis/eventratelimit/types.go
+++ b/plugin/pkg/admission/eventratelimit/apis/eventratelimit/types.go
@@ -41,7 +41,7 @@ const (
 // Configuration provides configuration for the EventRateLimit admission
 // controller.
 type Configuration struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta
 
 	// limits are the limits to place on event queries received.
 	// Limits can be placed on events received server-wide, per namespace,

--- a/plugin/pkg/admission/eventratelimit/apis/eventratelimit/v1alpha1/types.go
+++ b/plugin/pkg/admission/eventratelimit/apis/eventratelimit/v1alpha1/types.go
@@ -41,7 +41,7 @@ const (
 // Configuration provides configuration for the EventRateLimit admission
 // controller.
 type Configuration struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta
 
 	// limits are the limits to place on event queries received.
 	// Limits can be placed on events received server-wide, per namespace,

--- a/plugin/pkg/admission/podtolerationrestriction/apis/podtolerationrestriction/v1alpha1/types.go
+++ b/plugin/pkg/admission/podtolerationrestriction/apis/podtolerationrestriction/v1alpha1/types.go
@@ -25,7 +25,7 @@ import (
 
 // Configuration provides configuration for the PodTolerationRestriction admission controller.
 type Configuration struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta
 
 	// cluster level default tolerations
 	Default []v1.Toleration `json:"default,omitempty"`

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/config/apis/policyconfig/v1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/config/apis/policyconfig/v1/types.go
@@ -22,7 +22,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // ValidatingAdmissionPolicyConfiguration provides configuration for the validating admission policy controller.
 type ValidatingAdmissionPolicyConfiguration struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta
 
 	// StaticManifestsDir is the path to a directory containing static
 	// ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding
@@ -39,7 +39,7 @@ type ValidatingAdmissionPolicyConfiguration struct {
 
 // MutatingAdmissionPolicyConfiguration provides configuration for the mutating admission policy controller.
 type MutatingAdmissionPolicyConfiguration struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta
 
 	// StaticManifestsDir is the path to a directory containing static
 	// MutatingAdmissionPolicy and MutatingAdmissionPolicyBinding

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/apis/resourcequota/v1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/apis/resourcequota/v1/types.go
@@ -25,7 +25,7 @@ import (
 
 // Configuration provides configuration for the ResourceQuota admission controller.
 type Configuration struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta
 
 	// LimitedResources whose consumption is limited by default.
 	// +optional

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/apis/resourcequota/v1alpha1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/apis/resourcequota/v1alpha1/types.go
@@ -25,7 +25,7 @@ import (
 
 // Configuration provides configuration for the ResourceQuota admission controller.
 type Configuration struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta
 
 	// LimitedResources whose consumption is limited by default.
 	// +optional

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/apis/resourcequota/v1beta1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/apis/resourcequota/v1beta1/types.go
@@ -25,7 +25,7 @@ import (
 
 // Configuration provides configuration for the ResourceQuota admission controller.
 type Configuration struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta
 
 	// LimitedResources whose consumption is limited by default.
 	// +optional

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1/types.go
@@ -26,7 +26,7 @@ import (
 
 // AdmissionConfiguration provides versioned configuration for admission controllers.
 type AdmissionConfiguration struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta
 
 	// Plugins allows specifying a configuration per admission control plugin.
 	// +optional
@@ -558,7 +558,7 @@ type WebhookMatchCondition struct {
 
 // TracingConfiguration provides versioned configuration for tracing clients.
 type TracingConfiguration struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta
 
 	// Embed the component config tracing configuration struct
 	tracingapi.TracingConfiguration `json:",inline"`

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
@@ -26,7 +26,7 @@ import (
 
 // AdmissionConfiguration provides versioned configuration for admission controllers.
 type AdmissionConfiguration struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta
 
 	// Plugins allows specifying a configuration per admission control plugin.
 	// +optional
@@ -54,7 +54,7 @@ type AdmissionPluginConfiguration struct {
 
 // EgressSelectorConfiguration provides versioned configuration for egress selector clients.
 type EgressSelectorConfiguration struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta
 
 	// connectionServices contains a list of egress selection client configurations
 	EgressSelections []EgressSelection `json:"egressSelections"`
@@ -157,7 +157,7 @@ type TLSConfig struct {
 
 // TracingConfiguration provides versioned configuration for tracing clients.
 type TracingConfiguration struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta
 
 	// Embed the component config tracing configuration struct
 	tracingapi.TracingConfiguration `json:",inline"`

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/types.go
@@ -25,7 +25,7 @@ import (
 
 // EgressSelectorConfiguration provides versioned configuration for egress selector clients.
 type EgressSelectorConfiguration struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta
 
 	// connectionServices contains a list of egress selection client configurations
 	EgressSelections []EgressSelection `json:"egressSelections"`
@@ -128,7 +128,7 @@ type TLSConfig struct {
 
 // TracingConfiguration provides versioned configuration for tracing clients.
 type TracingConfiguration struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta
 
 	// Embed the component config tracing configuration struct
 	tracingapi.TracingConfiguration `json:",inline"`


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Removes the spurious `json:",inline"` struct tag from `metav1.TypeMeta` embeddings in the apiserver versioned types. Go's `encoding/json` already inlines embedded structs by default ([playground](https://go.dev/play/p/eGnmUwpt9bt)), so the tag has no behavioral effect.

Several types in the same package had the tag while others did not, creating an inconsistency. Per [review feedback](https://github.com/kubernetes/kubernetes/pull/137112#issuecomment-4179367736) from @liggitt, this PR makes them consistently untagged rather than continuing to add the spurious declaration.

#### Which issue(s) this PR is related to:

Ref #138133
Ref #137112

#### Special notes for your reviewer:

This is the counterpart to #137112. Instead of adding `json:",inline"` to the types that were missing it, this removes it from the types that had it, per https://github.com/kubernetes/kubernetes/pull/137112#issuecomment-4179367736.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/triage accepted
/label api-review
/sig auth api-machinery
/assign liggitt