### PR TITLE
bugfix: fix namespace deletion status

### DIFF
--- a/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
+++ b/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
@@ -553,6 +553,7 @@ func (d *namespacedResourcesDeleter) deleteAllContent(ctx context.Context, ns *v
 		// Check if any pods remain before proceeding to delete other resources
 		if numRemainingTotals.gvrToNumRemaining[podsGVR] > 0 {
 			logger.V(5).Info("Namespace controller - pods still remain, delaying deletion of other resources", "namespace", namespace)
+			conditionUpdater.ProcessContentTotals(numRemainingTotals)
 			if hasChanged := conditionUpdater.Update(ns); hasChanged {
 				if _, err = d.nsClient.UpdateStatus(ctx, ns, metav1.UpdateOptions{}); err != nil {
 					utilruntime.HandleErrorWithContext(ctx, err, "Couldn't update status condition for namespace", "namespace", namespace)

--- a/test/e2e/apimachinery/namespace.go
+++ b/test/e2e/apimachinery/namespace.go
@@ -563,13 +563,29 @@ func ensurePodsAreRemovedFirstInOrderedNamespaceDeletion(ctx context.Context, f 
 				return false, nil
 			}
 			hasContextFailure := false
+			hasContentRemaining := false
+			hasFinalizersRemaining := false
 			for _, cond := range ns.Status.Conditions {
 				if cond.Type == v1.NamespaceDeletionContentFailure {
 					hasContextFailure = true
 				}
+				if cond.Type == v1.NamespaceContentRemaining && cond.Status == v1.ConditionTrue {
+					hasContentRemaining = true
+				}
+				if cond.Type == v1.NamespaceFinalizersRemaining && cond.Status == v1.ConditionTrue {
+					hasFinalizersRemaining = true
+				}
 			}
 			if !hasContextFailure {
 				framework.Logf("Namespace %q does not yet have a NamespaceDeletionContentFailure condition, retrying...", nsName)
+				return false, nil
+			}
+			if !hasContentRemaining {
+				framework.Logf("Namespace %q does not yet have a NamespaceContentRemaining condition with status True, retrying...", nsName)
+				return false, nil
+			}
+			if !hasFinalizersRemaining {
+				framework.Logf("Namespace %q does not yet have a NamespaceFinalizersRemaining condition with status True, retrying...", nsName)
 				return false, nil
 			}
 			return true, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

During ordered namespace deletion, when pods with finalizers remain, `NamespaceContentRemaining` and `NamespaceFinalizersRemaining` conditions incorrectly report "All content successfully removed". This fix corrects the status reporting in that path.
 
#### Which issue(s) this PR is related to:

Fixes #138208
KEP: https://github.com/kubernetes/enhancements/issues/5080

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed namespace status conditions incorrectly reporting "All content successfully removed" while pods with finalizers still remain during ordered namespace deletion.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/5080
```

