### PR TITLE
kubelet: fix shared digest poisoning under NeverVerifyPreloadedImages

### DIFF
--- a/pkg/kubelet/images/pullmanager/image_pull_manager.go
+++ b/pkg/kubelet/images/pullmanager/image_pull_manager.go
@@ -240,6 +240,18 @@ func (f *PullManager) MustAttemptImagePull(ctx context.Context, image, imageRef 
 		return true, nil
 	}
 
+	// if the credential mapping has entries for other repos but not this one,
+	// kubelet never pulled this specific image treat it as preloaded.
+	if imagePulledByKubelet && pulledRecord != nil && len(pulledRecord.CredentialMapping) > 0 {
+		sanitizedImage, err := trimImageTagDigest(image)
+		if err == nil {
+
+			if _, found := pulledRecord.CredentialMapping[sanitizedImage]; !found {
+				imagePulledByKubelet = false
+			}
+		}
+	}
+
 	if !f.imagePolicyEnforcer.RequireCredentialVerificationForImage(image, imagePulledByKubelet) {
 		resultForMetrics = checkResultCredentialPolicyAllowed
 		return false, nil

--- a/pkg/kubelet/images/pullmanager/image_pull_manager_test.go
+++ b/pkg/kubelet/images/pullmanager/image_pull_manager_test.go
@@ -552,7 +552,7 @@ func TestFileBasedImagePullManager_MustAttemptImagePull(t *testing.T) {
 			image:                 "docker.io/testing/different:latest",
 			imageRef:              "testimageref",
 			pulledFiles:           []string{"sha256-b3c0cc4278800b03a308ceb2611161430df571ca733122f0a40ac8b9792a9064"},
-			want:                  true,
+			want:                  false,
 			wantPodCredsRequested: false,
 		},
 		{
@@ -714,7 +714,7 @@ func TestFileBasedImagePullManager_MustAttemptImagePull(t *testing.T) {
 			image:                 "docker.io/testing/different:latest",
 			imageRef:              "testimageref-sa",
 			pulledFiles:           []string{"sha256-917e8b3439bf8a7a6f37ffd2d2ddfdfafac8a251bf214a0be39675742b420b1a"},
-			want:                  true,
+			want:                  false,
 			wantPodCredsRequested: false,
 		},
 		{
@@ -810,6 +810,71 @@ func TestFileBasedImagePullManager_MustAttemptImagePull(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestPreloadedImageNotPoisonedByPullFromDifferentRepo(t *testing.T) {
+	encoder, decoder, err := createKubeletConfigSchemeEncoderDecoder()
+	require.NoError(t, err)
+	_, tCtx := ktesting.NewTestContext(t)
+
+	testDir := t.TempDir()
+	pullingDir := filepath.Join(testDir, "pulling")
+	pulledDir := filepath.Join(testDir, "pulled")
+	require.NoError(t, os.MkdirAll(pullingDir, fs.ModePerm))
+	require.NoError(t, os.MkdirAll(pulledDir, fs.ModePerm))
+
+	fsRecordAccessor := &fsPullRecordsAccessor{
+		pullingDir: pullingDir,
+		pulledDir:  pulledDir,
+		encoder:    encoder,
+		decoder:    decoder,
+	}
+
+	f := &PullManager{
+		recordsAccessor:     fsRecordAccessor,
+		imagePolicyEnforcer: NeverVerifyPreloadedPullPolicy(),
+		intentAccessors:     NewStripedLockSet(10),
+		intentCounters:      &sync.Map{},
+		pulledAccessors:     NewStripedLockSet(10),
+	}
+
+	sharedImageRef := "sha256:6446253dd96b1a1ec4a6d69fe9859961929c3a6c79a17f119f4f5021693d998b"
+	publicImage := "quay.io/mowsiany/qa-multi-arch:foo"
+	privateImage := "quay.io/mowsiany/qa-multi-arch-priv:foo"
+
+	noPodCreds := func() ([]kubeletconfiginternal.ImagePullSecret, *kubeletconfiginternal.ImagePullServiceAccount, error) {
+		return nil, nil, nil
+	}
+
+	mustPull, err := f.MustAttemptImagePull(tCtx, publicImage, sharedImageRef, noPodCreds)
+	require.NoError(t, err)
+	if mustPull {
+		t.Fatal("Step 1: preloaded image from repo X should NOT require a pull, but MustAttemptImagePull returned true")
+	}
+
+	f.RecordImagePulled(tCtx, privateImage, sharedImageRef, &kubeletconfiginternal.ImagePullCredentials{
+		KubernetesSecrets: []kubeletconfiginternal.ImagePullSecret{
+			{
+				UID:            "3d2a7cfc-3554-49b5-9fdb-7da367b705e3",
+				Namespace:      "t",
+				Name:           "mowsiany-robot1-pull-secret",
+				CredentialHash: "8d80430d4f9c305461e11e35e4faa310611ca4d577265b2d18859ce5679eb9c0",
+			},
+		},
+	})
+
+	record, exists, err := fsRecordAccessor.GetImagePulledRecord(sharedImageRef)
+	require.NoError(t, err)
+	require.True(t, exists, "pulled record should exist after RecordImagePulled")
+	require.Contains(t, record.CredentialMapping, "quay.io/mowsiany/qa-multi-arch-priv",
+		"pulled record should have credential mapping for repo Y")
+
+	mustPull, err = f.MustAttemptImagePull(tCtx, publicImage, sharedImageRef, noPodCreds)
+	require.NoError(t, err)
+	if mustPull {
+		t.Fatal("Step 3 (issue #138175): preloaded image from repo X should NOT require a pull after " +
+			"a different repo Y with the same digest was pulled with secrets, but MustAttemptImagePull returned true")
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

There is a flaw in the `MustAttemptImagePull` logic that causes properly preloaded images to be incorrectly rejected with `ErrImageNeverPull` if a strictly different image (e.g., from a private repo) sharing the exact same content digest is pulled by the Kubelet. 

`ImagePulledRecord`s are keyed by content digest `imageRef`. When an image sharing the same digest is pulled, Kubelet creates a pulled record. Later, when a Pod requests the *preloaded* image under its public name with `imagePullPolicy: Never`, Kubelet matches the digest to the pulled record and strictly sets `imagePulledByKubelet = true`.

The `NeverVerifyPreloadedImages` policy sees `imagePulledByKubelet` as true and enforces credential verification. Kubelet checks the `CredentialMapping` but fails to find the preloaded image name (since it only knows about the private pulled name). It concludes a pull is required, resulting in the pod crashing with `ErrImageNeverPull`.

**Fix:**
This PR updates `MustAttemptImagePull` so that if Kubelet finds a `pulledRecord` via a shared digest, it explicitly checks the `CredentialMapping`. If the mapping contains entries for other image names but is missing the currently requested name, it correctly evaluates that Kubelet never pulled *this specific* image name. 

In this scenario, Kubelet enforces `imagePulledByKubelet = false`, thus properly treating the specific image as preloaded under the policy. An empty mapping safely defaults to requiring auth.

Two existing tests that incorrectly expected cross-repo digest poisoning to enforce pulls were updated to assert the fixed behavior, and a new test was added for this specific edge case.

#### Which issue(s) this PR is related to:

Fixes #138175

#### Special notes for your reviewer:

You can verify the bug and fix locally using a Kind cluster and a dummy image pushed to both a public and private repo:

<details>
<summary><b>Reproduction Script</b></summary>

```bash
#!/usr/bin/env bash
set -e

USER="your-dockerhub-user"
PUB="${USER}/repro-138175-pub:test"
PRIV="${USER}/repro-138175-priv:test"
CLUSTER="repro"

# 1. Build & push identical image
echo "FROM busybox" | docker build -q -t "$PUB" -
docker tag "$PUB" "$PRIV"
docker push -q "$PUB"
docker push -q "$PRIV"

kind create cluster --name "${CLUSTER}"
kind load docker-image "$PUB" --name "${CLUSTER}"

kubectl create ns "${CLUSTER}"
until kubectl get serviceaccount default -n "${CLUSTER}" &>/dev/null; do sleep 1; done

kubectl create secret docker-registry pull-secret -n "${CLUSTER}" \
    --docker-server=https://index.docker.io/v1/ \
    --docker-username="$USER" --docker-password="your-password"

deploy_pod() {
    cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: Pod
metadata: { name: $1, namespace: ${CLUSTER} }
spec:
  nodeName: ${CLUSTER}-control-plane
  restartPolicy: Never
  $( [ "$4" == "pull-secret" ] && echo "imagePullSecrets: [{ name: pull-secret }]" )
  containers:
  - name: test
    image: $2
    imagePullPolicy: $3
    command: ["/bin/sh", "-c", "sleep 3600"]
EOF
}

# Step 1: Preloaded Image
deploy_pod pod-a "$PUB" Never ""
kubectl wait --for=condition=Ready pod/pod-a -n "${CLUSTER}" --timeout=30s
kubectl delete pod pod-a -n "${CLUSTER}" --wait=true

# Step 2: Private Repo Pull (Triggers the poison)
deploy_pod pod-b "$PRIV" IfNotPresent "pull-secret"
kubectl wait --for=condition=Ready pod/pod-b -n "${CLUSTER}" --timeout=60s
kubectl delete pod pod-b -n "${CLUSTER}" --wait=true

# Step 3: Verify Poison
deploy_pod pod-a2 "$PUB" Never ""
sleep 5
echo "=============================="
kubectl get events -n "${CLUSTER}" --field-selector involvedObject.name=pod-a2
# BUG: ErrImageNeverPull
# AFTER FIX: "already present on machine"
echo "=============================="
```
</details>

#### Does this PR introduce a user-facing change?
```release-note
Fixed a bug where a preloaded image was incorrectly rejected with `ErrImageNeverPull` after a different image sharing the same repository content digest was pulled using private credentials under the `NeverVerifyPreloadedImages` pull policy.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
