### PR TITLE
scheduler: bypass opportunistic OpportunisticBatching for nominated pods

### DIFF
--- a/pkg/scheduler/framework/runtime/batch.go
+++ b/pkg/scheduler/framework/runtime/batch.go
@@ -178,6 +178,12 @@ func (b *OpportunisticBatch) batchStateCompatible(ctx context.Context, pod *v1.P
 		return false
 	}
 
+	// Pods with a nominated node should bypass opportunistic batching.
+	if pod.Status.NominatedNodeName != "" {
+		b.logUnusableState(logger, cycleCount, metrics.BatchFlushPodNominated)
+		return false
+	}
+
 	// If the new pod is incompatible with the current state, throw the state away.
 	if signature == nil || !bytes.Equal(signature, b.state.signature) {
 		b.logUnusableState(logger, cycleCount, metrics.BatchFlushPodIncompatible)

--- a/pkg/scheduler/framework/runtime/batch_test.go
+++ b/pkg/scheduler/framework/runtime/batch_test.go
@@ -196,13 +196,14 @@ func TestBatchBasic(t *testing.T) {
 		// firstOtherNodes is supposed to set only if firstPodScheduledSuccessfully is true.
 		firstOtherNodes framework.SortedScoredNodes
 		// if it's true, the test case behaves as if there is another pod handled by another profile between the first and second pod.
-		skipPod          bool
-		secondPodID      string
-		secondSig        string
-		secondChosenNode string
-		secondOtherNodes framework.SortedScoredNodes
-		expectedHint     string
-		expectedState    *batchState
+		skipPod                    bool
+		secondPodID                string
+		secondPodNominatedNodeName string
+		secondSig                  string
+		secondChosenNode           string
+		secondOtherNodes           framework.SortedScoredNodes
+		expectedHint               string
+		expectedState              *batchState
 	}{
 		{
 			name:                          "a second pod with the same signature gets a hint",
@@ -305,6 +306,19 @@ func TestBatchBasic(t *testing.T) {
 				sortedNodes: newTestNodes([]string{"n2"}),
 			},
 		},
+		{
+			name:                          "a second pod with a nominated node does not get a hint",
+			firstPodID:                    blockingPodID("1"),
+			firstSig:                      "sig",
+			firstChosenNode:               "n3",
+			firstOtherNodes:               newTestNodes([]string{"n1"}),
+			firstPodScheduledSuccessfully: true,
+			secondPodID:                   blockingPodID("2"),
+			secondPodNominatedNodeName:    "n1",
+			secondSig:                     "sig",
+			secondChosenNode:              "n1",
+			expectedHint:                  "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -347,6 +361,9 @@ func TestBatchBasic(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pod2",
 					UID:  types.UID(tt.secondPodID),
+				},
+				Status: v1.PodStatus{
+					NominatedNodeName: tt.secondPodNominatedNodeName,
 				},
 			}
 

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -109,6 +109,7 @@ const (
 const (
 	BatchFlushPodFailed       = "pod_failed"
 	BatchFlushPodSkipped      = "pod_skipped"
+	BatchFlushPodNominated    = "pod_nominated"
 	BatchFlushNodeMissing     = "node_missing"
 	BatchFlushNodeNotFull     = "node_not_full"
 	BatchFlushEmptyList       = "empty_list"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

If Pods have NNN, it should respect NNN without using batch scheduling. The current implementation already behaves this way due to subsequent processing, so there will be no change in behavior for users.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fix: https://github.com/kubernetes/kubernetes/issues/138084

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
 None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
