### PR TITLE
kubectl: strict check for exec command

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
@@ -208,7 +208,9 @@ func (p *ExecOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, argsIn []s
 	if len(argsIn) > 0 && argsLenAtDash != 0 {
 		p.ResourceName = argsIn[0]
 	}
-	if argsLenAtDash > -1 {
+	// we expect exactly one arg (the pod/resource name) before the dash separator.
+	// pflag guarantees `argsLenAtDash <= len(args)`.
+	if argsLenAtDash == 0 || argsLenAtDash == 1 {
 		p.Command = argsIn[argsLenAtDash:]
 	} else if len(argsIn) > 1 || (len(argsIn) > 0 && len(p.FilenameOptions.Filenames) != 0) {
 		return cmdutil.UsageErrorf(cmd, "exec [POD] [COMMAND] is not supported anymore. Use exec [POD] -- [COMMAND] instead")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec_test.go
@@ -127,6 +127,22 @@ func TestPodAndContainer(t *testing.T) {
 			name:          "cmd, container in flag",
 			obj:           execPod(),
 		},
+		{
+			p:             &ExecOptions{},
+			args:          []string{"foo", "cmd", "bar"},
+			argsLenAtDash: 2,
+			expectError:   true,
+			name:          "cmd with double dashes and extra args between pod and cmd",
+			obj:           execPod(),
+		},
+		{
+			p:             &ExecOptions{},
+			args:          []string{"foo", "--any-flag", "any-value"},
+			argsLenAtDash: -1,
+			expectError:   true,
+			name:          "cmd without dash separator with flag-like args",
+			obj:           execPod(),
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/test/cmd/exec.sh
+++ b/test/cmd/exec.sh
@@ -67,7 +67,27 @@ __EOF__
   output_message=$(! kubectl exec test-pod -c nonexistent -- date 2>&1)
   kube::test::if_has_string "${output_message}" 'container nonexistent is not valid for pod test-pod out of: kubernetes-pause'
 
+  kubectl create -f - << __EOF__
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-test
+spec:
+  containers:
+  - name: container-a
+    image: registry.k8s.io/pause:3.10.1
+  - name: container-b
+    image: registry.k8s.io/pause:3.10.1
+__EOF__
+
+  ### Test execute with pod and container before dash separator
+  output_message=$(! kubectl exec -it pod-test -c container-a -- echo "test" 2>&1)
+  kube::test::if_has_not_string "${output_message}" 'exec [POD] [COMMAND] is not supported anymore'
+  kube::test::if_has_not_string "${output_message}" 'container container-a is not valid for pod pod-test'
+  kube::test::if_has_not_string "${output_message}" 'pods "pod-test" not found'
+
   # Clean up
+  kubectl delete pods pod-test
   kubectl delete pods test-pod
 
   set +o nounset

--- a/test/cmd/exec.sh
+++ b/test/cmd/exec.sh
@@ -82,7 +82,7 @@ __EOF__
 
   ### Test execute with pod and container before dash separator
   output_message=$(! kubectl exec -it pod-test -c container-a -- echo "test" 2>&1)
-  kube::test::if_has_not_string "${output_message}" 'exec [POD] [COMMAND] is not supported anymore'
+  kube::test::if_has_not_string "${output_message}" 'exec \[POD\] \[COMMAND\] is not supported anymore'
   kube::test::if_has_not_string "${output_message}" 'container container-a is not valid for pod pod-test'
   kube::test::if_has_not_string "${output_message}" 'pods "pod-test" not found'
 


### PR DESCRIPTION
kubectl: strict check for exec command

Re-open of #131353 which was closed due to inactivity.

Fix https://github.com/kubernetes/kubectl/issues/1745

The current implementation doesn't properly check for arguments between the resource name and the dash separator. This can lead to unexpected behavior when using commands like 'kubectl exec -it pod-0 bash -- run.sh', which should raise an error but doesn't.

This fix adds a check to ensure that when a dash separator (--) is used, there are no extra arguments between the resource name and the dash. If there are extra arguments, it will raise an error.

Changes:
- Only allow argsLenAtDash == 0 or == 1 (exactly one arg before --)
- Add test for extra args between pod and --
- Add test for flag-like args without dash separator

/kind bug

#### Does this PR introduce a user-facing change?
```release-note
Improve error reporting when invoking kubectl exec
```
