### PR TITLE
kubelet: log FLAGS against effective KubeletConfiguration

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -249,7 +249,10 @@ is checked every 20 seconds (also configurable with a flag).`,
 			if err := logsapi.ValidateAndApplyAsField(&kubeletConfig.Logging, utilfeature.DefaultFeatureGate, field.NewPath("logging")); err != nil {
 				return fmt.Errorf("initialize logging: %v", err)
 			}
-			cliflag.PrintFlags(cleanFlagSet)
+			// Log flags against the effective KubeletConfiguration. cleanFlagSet still binds
+			// KubeletConfiguration fields to the pre-LoadConfig object when --config is used,
+			// so PrintFlags(cleanFlagSet) can print stale values (see kubernetes/kubernetes#122736).
+			cliflag.PrintFlags(newKubeletEffectivePrintFlagSet(kubeletFlags, kubeletConfig, cleanFlagSet))
 
 			// We always validate the local configuration (command line + config file).
 			// This is the default "last-known-good" config for dynamic config, and must always remain valid.
@@ -326,6 +329,21 @@ is checked every 20 seconds (also configurable with a flag).`,
 	})
 
 	return cmd
+}
+
+// newKubeletEffectivePrintFlagSet returns a FlagSet for logging kubelet flags against the effective
+// KubeletConfiguration. cleanFlagSet may still bind KubeletConfiguration fields to a struct that was
+// replaced after --config was loaded (kubernetes/kubernetes#122736).
+func newKubeletEffectivePrintFlagSet(kubeletFlags *options.KubeletFlags, kubeletConfig *kubeletconfiginternal.KubeletConfiguration, cleanFlagSet *pflag.FlagSet) *pflag.FlagSet {
+	printFlagSet := pflag.NewFlagSet("", pflag.ContinueOnError)
+	printFlagSet.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
+	kubeletFlags.AddFlags(printFlagSet)
+	options.AddKubeletConfigFlags(printFlagSet, kubeletConfig)
+	options.AddGlobalFlags(printFlagSet)
+	if helpFlag := cleanFlagSet.Lookup("help"); helpFlag != nil {
+		printFlagSet.AddFlag(helpFlag)
+	}
+	return printFlagSet
 }
 
 // mergeKubeletConfigurations merges the provided drop-in configurations with the base kubelet configuration.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/sig node
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Fixes misleading flag: This change builds a temporary flag set registered against the final kubeletConfig (after load, merge, and kubeletConfigFlagPrecedence), reuses the parsed help flag from cleanFlagSet, and calls PrintFlags on that set so startup logs reflect the configuration the kubelet actually uses.

#### Which issue(s) this PR is related to:
Fixes #122736
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
No change to flag parsing or precedence, logging only.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kubelet:  FLAG:  log lines now show effective values after --config / --config-dir instead of stale defaults.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```
