### PR TITLE
fix: apiserver return JSON Status 404 for unregistered paths instead of plain text

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/notfoundhandler/not_found_handler.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/notfoundhandler/not_found_handler.go
@@ -61,5 +61,20 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		responsewriters.ErrorNegotiated(err, h.serializer, gv, rw, req)
 		return
 	}
-	http.NotFound(rw, req)
+	gv := schema.GroupVersion{Group: "", Version: "v1"}
+	if requestInfo, ok := apirequest.RequestInfoFrom(req.Context()); ok {
+		if requestInfo.APIGroup != "" || requestInfo.APIVersion != "" {
+			gv.Group = requestInfo.APIGroup
+			gv.Version = requestInfo.APIVersion
+		}
+	}
+	notFoundErr := &apierrors.StatusError{
+		ErrStatus: metav1.Status{
+			Status:  metav1.StatusFailure,
+			Code:    int32(http.StatusNotFound),
+			Reason:  metav1.StatusReasonNotFound,
+			Message: "the server could not find the requested resource",
+		},
+	}
+	responsewriters.ErrorNegotiated(notFoundErr, h.serializer, gv, rw, req)
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/notfoundhandler/not_found_handler_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/notfoundhandler/not_found_handler_test.go
@@ -46,9 +46,12 @@ func TestNotFoundHandler(t *testing.T) {
 	bodyStr := strings.TrimSuffix(string(body), "\n")
 
 	if resp.StatusCode != 404 {
-		t.Fatalf("unexpected status code %d, expected 503", resp.StatusCode)
+		t.Fatalf("unexpected status code %d, expected 404", resp.StatusCode)
 	}
-	expectedMsg := "404 page not found"
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("unexpected Content-Type %q, expected application/json", ct)
+	}
+	expectedMsg := `{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"the server could not find the requested resource","reason":"NotFound","code":404}`
 	if bodyStr != expectedMsg {
 		t.Fatalf("unexpected response: %v, expected: %v", bodyStr, expectedMsg)
 	}

--- a/test/integration/controlplane/transformation/transformation_test.go
+++ b/test/integration/controlplane/transformation/transformation_test.go
@@ -617,7 +617,7 @@ func mustNotHaveLivez(t kubeapiservertesting.Logger, checkName, wantBodyContains
 		if err != nil {
 			return false, err
 		}
-		done := !ok && strings.Contains(body, wantBodyContains)
+		done := !ok && livezBodyMatchesNotFoundExpectation(body, wantBodyContains)
 		if !done {
 			t.Logf("expected server check %q with message %q but it is not: %s", checkName, wantBodyContains, body)
 		}
@@ -627,6 +627,20 @@ func mustNotHaveLivez(t kubeapiservertesting.Logger, checkName, wantBodyContains
 	if pollErr != nil {
 		t.Fatalf("failed to get the expected livez status of !OK for check: %s, error: %v, debug inner error: %v", checkName, pollErr, restErr)
 	}
+}
+
+// livezBodyMatchesNotFoundExpectation returns true if the verbose livez response body
+// indicates the requested check path was not found. The server used to return plain text
+// from net/http; the delegation not-found handler now returns a negotiated metav1.Status
+// JSON body for the same case (see staging/src/k8s.io/apiserver/pkg/util/notfoundhandler).
+func livezBodyMatchesNotFoundExpectation(body, wantBodyContains string) bool {
+	if strings.Contains(body, wantBodyContains) {
+		return true
+	}
+	if wantBodyContains == "404 page not found" {
+		return strings.Contains(body, "the server could not find the requested resource")
+	}
+	return false
 }
 
 func getHealthz(checkName string, clientConfig *rest.Config, excludes ...string) (string, bool, error) {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- staging/src/k8s.io/apiserver/pkg/util/notfoundhandler/not_found_handler.go
  - When mux/discovery is complete, replace http.NotFound with responsewriters.ErrorNegotiated and a Status 404, using RequestInfo for GroupVersion when available.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

- Unknown /apis/... paths now return application/json with a kind: Status body instead of plain text.
- The exact message string may still differ from other 404 paths (for example go-restful’s router vs. the static not-found handler message); status code and JSON shape are aligned with the rest of the API.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-apiserver: Requests to unknown `/apis/...` paths and final delegation 404s now return a JSON `Status` object with `Content-Type: application/json` instead of a plain-text "404 page not found" body.

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```