### PR TITLE
kubelet: perf/optimize kubelet http probe.

### DIFF
--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -165,7 +165,7 @@ func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe
 		if attr.HttpRequestCacheHolder == nil {
 			req, err = httpprobe.NewRequestForHTTPGetAction(p.HTTPGet, &container, status.PodIP, "probe")
 		} else {
-			req, err = attr.HttpRequestCacheHolder.getRequest(pod.Status.PodIP)
+			req, err = attr.HttpRequestCacheHolder.getRequest(ctx, pod.Status.PodIP)
 
 			if err != nil {
 				logger.V(4).Info("HTTP-Probe failed to get cached request", "error", err)

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -136,12 +136,12 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 
 // runProbeWithRetries tries to probe the container in a finite loop, it returns the last result
 // if it never succeeds.
-func (pb *prober) runProbeWithRetries(ctx context.Context, probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, req *probeAttributes, retries int) (probe.Result, string, error) {
+func (pb *prober) runProbeWithRetries(ctx context.Context, probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, attr *probeAttributes, retries int) (probe.Result, string, error) {
 	var err error
 	var result probe.Result
 	var output string
 	for i := 0; i < retries; i++ {
-		result, output, err = pb.runProbe(ctx, probeType, p, pod, status, container, containerID, req)
+		result, output, err = pb.runProbe(ctx, probeType, p, pod, status, container, containerID, attr)
 		if err == nil {
 			return result, output, nil
 		}

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -165,7 +165,7 @@ func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe
 		if attr.HttpRequestCacheHolder == nil {
 			req, err = httpprobe.NewRequestForHTTPGetAction(p.HTTPGet, &container, status.PodIP, "probe")
 		} else {
-			req, err = attr.HttpRequestCacheHolder.getRequest(ctx, pod.Status.PodIP)
+			req, err = attr.HttpRequestCacheHolder.getRequest(pod.Status.PodIP)
 
 			if err != nil {
 				logger.V(4).Info("HTTP-Probe failed to get cached request", "error", err)

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -80,7 +81,7 @@ func (pb *prober) recordContainerEvent(ctx context.Context, pod *v1.Pod, contain
 }
 
 // probe probes the container.
-func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (results.Result, error) {
+func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, req *http.Request) (results.Result, error) {
 	var probeSpec *v1.Probe
 	switch probeType {
 	case readiness:
@@ -99,7 +100,7 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 		return results.Success, nil
 	}
 
-	result, output, err := pb.runProbeWithRetries(ctx, probeType, probeSpec, pod, status, container, containerID, maxProbeRetries)
+	result, output, err := pb.runProbeWithRetries(ctx, probeType, probeSpec, pod, status, container, containerID, req, maxProbeRetries)
 
 	if err != nil {
 		// Handle probe error
@@ -135,12 +136,12 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 
 // runProbeWithRetries tries to probe the container in a finite loop, it returns the last result
 // if it never succeeds.
-func (pb *prober) runProbeWithRetries(ctx context.Context, probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, retries int) (probe.Result, string, error) {
+func (pb *prober) runProbeWithRetries(ctx context.Context, probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, req *http.Request, retries int) (probe.Result, string, error) {
 	var err error
 	var result probe.Result
 	var output string
 	for i := 0; i < retries; i++ {
-		result, output, err = pb.runProbe(ctx, probeType, p, pod, status, container, containerID)
+		result, output, err = pb.runProbe(ctx, probeType, p, pod, status, container, containerID, req)
 		if err == nil {
 			return result, output, nil
 		}
@@ -148,7 +149,7 @@ func (pb *prober) runProbeWithRetries(ctx context.Context, probeType probeType, 
 	return result, output, err
 }
 
-func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (probe.Result, string, error) {
+func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, req *http.Request) (probe.Result, string, error) {
 	logger := klog.FromContext(ctx)
 	timeout := time.Duration(p.TimeoutSeconds) * time.Second
 	switch {
@@ -158,7 +159,11 @@ func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe
 		return pb.exec.Probe(pb.newExecInContainer(ctx, pod, container, containerID, command, timeout))
 
 	case p.HTTPGet != nil:
-		req, err := httpprobe.NewRequestForHTTPGetAction(p.HTTPGet, &container, status.PodIP, "probe")
+		var err error
+
+		if req == nil {
+			req, err = httpprobe.NewRequestForHTTPGetAction(p.HTTPGet, &container, status.PodIP, "probe")
+		}
 		if err != nil {
 			// Log and record event for Unknown result
 			logger.V(4).Info("HTTP-Probe failed to create request", "error", err)

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -81,7 +81,7 @@ func (pb *prober) recordContainerEvent(ctx context.Context, pod *v1.Pod, contain
 }
 
 // probe probes the container.
-func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, req *http.Request) (results.Result, error) {
+func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, attr *probeAttributes) (results.Result, error) {
 	var probeSpec *v1.Probe
 	switch probeType {
 	case readiness:
@@ -100,7 +100,7 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 		return results.Success, nil
 	}
 
-	result, output, err := pb.runProbeWithRetries(ctx, probeType, probeSpec, pod, status, container, containerID, req, maxProbeRetries)
+	result, output, err := pb.runProbeWithRetries(ctx, probeType, probeSpec, pod, status, container, containerID, attr, maxProbeRetries)
 
 	if err != nil {
 		// Handle probe error
@@ -136,7 +136,7 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 
 // runProbeWithRetries tries to probe the container in a finite loop, it returns the last result
 // if it never succeeds.
-func (pb *prober) runProbeWithRetries(ctx context.Context, probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, req *http.Request, retries int) (probe.Result, string, error) {
+func (pb *prober) runProbeWithRetries(ctx context.Context, probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, req *probeAttributes, retries int) (probe.Result, string, error) {
 	var err error
 	var result probe.Result
 	var output string
@@ -149,7 +149,7 @@ func (pb *prober) runProbeWithRetries(ctx context.Context, probeType probeType, 
 	return result, output, err
 }
 
-func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, req *http.Request) (probe.Result, string, error) {
+func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, attr *probeAttributes) (probe.Result, string, error) {
 	logger := klog.FromContext(ctx)
 	timeout := time.Duration(p.TimeoutSeconds) * time.Second
 	switch {
@@ -160,9 +160,17 @@ func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe
 
 	case p.HTTPGet != nil:
 		var err error
+		var req *http.Request
 
-		if req == nil {
+		if attr.HttpRequestCacheHolder == nil {
 			req, err = httpprobe.NewRequestForHTTPGetAction(p.HTTPGet, &container, status.PodIP, "probe")
+		} else {
+			req, err = attr.HttpRequestCacheHolder.getRequest(pod.Status.PodIP)
+
+			if err != nil {
+				logger.V(4).Info("HTTP-Probe failed to get cached request", "error", err)
+				return probe.Unknown, "", err
+			}
 		}
 		if err != nil {
 			// Log and record event for Unknown result

--- a/pkg/kubelet/prober/prober_test.go
+++ b/pkg/kubelet/prober/prober_test.go
@@ -253,7 +253,7 @@ func TestProbe(t *testing.T) {
 				prober.exec = fakeExecProber{test.execResult, nil}
 			}
 
-			result, err := prober.probe(ctx, pType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
+			result, err := prober.probe(ctx, pType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID, nil)
 
 			if test.expectError {
 				require.Error(t, err, "[%s] Expected probe error but no error was returned.", testID)
@@ -266,7 +266,7 @@ func TestProbe(t *testing.T) {
 			if len(test.expectCommand) > 0 {
 				prober.exec = execprobe.New()
 				prober.runner = &containertest.FakeContainerCommandRunner{}
-				_, err := prober.probe(ctx, pType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
+				_, err := prober.probe(ctx, pType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID, nil)
 				require.NoError(t, err, "[%s] Didn't expect probe error ", testID)
 
 				if !reflect.DeepEqual(test.expectCommand, prober.runner.(*containertest.FakeContainerCommandRunner).Cmd) {

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"math/rand"
 	"net/http"
+	"net/url"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -93,17 +94,21 @@ type probeAttributes struct {
 	HttpRequestCacheHolder *httpProbeRequestHolder
 }
 
-func (p *probeAttributes) setHttpRequestHodler(httpHolder *httpProbeRequestHolder) {
+func (p *probeAttributes) setHttpRequestHolder(httpHolder *httpProbeRequestHolder) {
 	p.HttpRequestCacheHolder = httpHolder
 }
 
 // httpProbeRequestHolder caches the http.Request object to minimize allocations during repeated probes.
 // It invalidates the cache if the Pod's IP address changes.
 type httpProbeRequestHolder struct {
-	httpGet     *v1.HTTPGetAction
-	container   *v1.Container
-	podIP       string
-	requestRoot *http.Request
+	httpGet      *v1.HTTPGetAction
+	container    *v1.Container
+	podIP        string
+	cachedURL    *url.URL
+	cachedHeader http.Header
+	cachedMethod string
+	cachedProto  string
+	requestRoot  *http.Request
 }
 
 // isInitContainer checks if the worker's container is in the pod's init containers
@@ -125,9 +130,17 @@ func (w *worker) initHttpProbeHolder(container *v1.Container) {
 	}
 }
 
+// Set request cache holder values for reuse in future requests.
+func (h *httpProbeRequestHolder) setCacheRequestValues(req *http.Request) {
+	h.cachedHeader = req.Header
+	h.cachedMethod = req.Method
+	h.cachedProto = req.Proto
+	h.cachedURL = req.URL
+}
+
 // getRequest returns a cached http.Request or creates a new one if the Pod IP has changed
 // or if the request hasn't been initialized yet.
-func (h *httpProbeRequestHolder) getRequest(ctx context.Context, currentPodIP string) (*http.Request, error) {
+func (h *httpProbeRequestHolder) getRequest(currentPodIP string) (*http.Request, error) {
 
 	if h.podIP != currentPodIP {
 		h.podIP = currentPodIP
@@ -135,22 +148,41 @@ func (h *httpProbeRequestHolder) getRequest(ctx context.Context, currentPodIP st
 	}
 
 	if h.requestRoot == nil {
-		// New request data (immutable in future pipeline)
 		req, err := httprobe.NewRequestForHTTPGetAction(h.httpGet, h.container, h.podIP, "probe")
 		if err != nil {
 			return nil, err
 		}
 		h.requestRoot = req
+		h.setCacheRequestValues(req)
 	}
 
-	// Fork root request
-	// Guaranteed shallow-copy with new Context
-	return h.requestRoot.WithContext(ctx), nil
+	// Use values from cache holder, without making new values
+	return h.buildRequestFromCache(), nil
+}
+
+// Build request from cached values
+func (h *httpProbeRequestHolder) buildRequestFromCache() *http.Request {
+	clear(h.cachedHeader)
+	return &http.Request{
+		Method:     h.cachedMethod,
+		URL:        h.cachedURL,
+		Proto:      h.cachedProto,
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     h.cachedHeader,
+		Host:       h.cachedURL.Host,
+		Body:       nil,
+	}
+
 }
 
 // reset clears the cached request, forcing a re-initialization on the next probe cycle.
 func (h *httpProbeRequestHolder) reset() {
 	h.requestRoot = nil
+	h.cachedHeader = nil
+	h.cachedMethod = ""
+	h.cachedProto = ""
+	h.cachedURL = nil
 }
 
 // Creates and starts a new probe worker.
@@ -420,7 +452,7 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 	// Instantly create probe attributes object.
 	if w.probeAttributes == nil {
 		w.probeAttributes = &probeAttributes{}
-		w.probeAttributes.setHttpRequestHodler(w.httpProbeRequest)
+		w.probeAttributes.setHttpRequestHolder(w.httpProbeRequest)
 	}
 
 	// Note, exec probe does NOT have access to pod environment variables or downward API

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -100,10 +100,10 @@ func (p *probeAttributes) setHttpRequestHodler(httpHolder *httpProbeRequestHolde
 // httpProbeRequestHolder caches the http.Request object to minimize allocations during repeated probes.
 // It invalidates the cache if the Pod's IP address changes.
 type httpProbeRequestHolder struct {
-	httpGet   *v1.HTTPGetAction
-	container *v1.Container
-	podIP     string
-	request   *http.Request
+	httpGet     *v1.HTTPGetAction
+	container   *v1.Container
+	podIP       string
+	requestRoot *http.Request
 }
 
 // isInitContainer checks if the worker's container is in the pod's init containers
@@ -127,27 +127,30 @@ func (w *worker) initHttpProbeHolder(container *v1.Container) {
 
 // getRequest returns a cached http.Request or creates a new one if the Pod IP has changed
 // or if the request hasn't been initialized yet.
-func (h *httpProbeRequestHolder) getRequest(currentPodIP string) (*http.Request, error) {
+func (h *httpProbeRequestHolder) getRequest(ctx context.Context, currentPodIP string) (*http.Request, error) {
 
 	if h.podIP != currentPodIP {
 		h.podIP = currentPodIP
 		h.reset()
 	}
 
-	if h.request == nil {
+	if h.requestRoot == nil {
+		// New request data (immutable in future pipeline)
 		req, err := httprobe.NewRequestForHTTPGetAction(h.httpGet, h.container, h.podIP, "probe")
 		if err != nil {
 			return nil, err
 		}
-		h.request = req
+		h.requestRoot = req
 	}
 
-	return h.request, nil
+	// Fork root request
+	// Guaranteed shallow-copy with new Context
+	return h.requestRoot.WithContext(ctx), nil
 }
 
 // reset clears the cached request, forcing a re-initialization on the next probe cycle.
 func (h *httpProbeRequestHolder) reset() {
-	h.request = nil
+	h.requestRoot = nil
 }
 
 // Creates and starts a new probe worker.

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -19,6 +19,7 @@ package prober
 import (
 	"context"
 	"math/rand"
+	"net/http"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -30,6 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/prober/results"
+	httprobe "k8s.io/kubernetes/pkg/probe/http"
 )
 
 // worker handles the periodic probing of its assigned container. Each worker has a go-routine
@@ -69,6 +71,9 @@ type worker struct {
 	// How many times in a row the probe has returned the same result.
 	resultRun int
 
+	// Cached probe http request
+	httpProbeRequest *httpProbeRequestHolder
+
 	// If set, skip probing.
 	onHold bool
 
@@ -83,6 +88,15 @@ type worker struct {
 	proberDurationUnknownMetricLabels    metrics.Labels
 }
 
+// httpProbeRequestHolder caches the http.Request object to minimize allocations during repeated probes.
+// It invalidates the cache if the Pod's IP address changes.
+type httpProbeRequestHolder struct {
+	httpGet   *v1.HTTPGetAction
+	container *v1.Container
+	podIP     string
+	request   *http.Request
+}
+
 // isInitContainer checks if the worker's container is in the pod's init containers
 func (w *worker) isInitContainer() bool {
 	for _, initContainer := range w.pod.Spec.InitContainers {
@@ -91,6 +105,39 @@ func (w *worker) isInitContainer() bool {
 		}
 	}
 	return false
+}
+
+// Initialize new http probe request holder with remove old object
+func (w *worker) initHttpProbeHolder() {
+	w.httpProbeRequest = &httpProbeRequestHolder{
+		httpGet: w.spec.HTTPGet,
+		podIP:   "", // Empty Initially because we are not sure if the pod IP is available yet (better to dynamically set in worker loop)
+	}
+}
+
+// getRequest returns a cached http.Request or creates a new one if the Pod IP has changed
+// or if the request hasn't been initialized yet.
+func (h *httpProbeRequestHolder) getRequest(container *v1.Container, currentPodIP string) (*http.Request, error) {
+
+	if h.podIP != currentPodIP {
+		h.podIP = currentPodIP
+		h.reset()
+	}
+
+	if h.request == nil {
+		req, err := httprobe.NewRequestForHTTPGetAction(h.httpGet, container, h.podIP, "probe")
+		if err != nil {
+			return nil, err
+		}
+		h.request = req
+	}
+
+	return h.request, nil
+}
+
+// reset clears the cached request, forcing a re-initialization on the next probe cycle.
+func (h *httpProbeRequestHolder) reset() {
+	h.request = nil
 }
 
 // Creates and starts a new probe worker.
@@ -150,6 +197,10 @@ func newWorker(
 
 	w.proberDurationSuccessfulMetricLabels = deepCopyPrometheusLabels(proberDurationLabels)
 	w.proberDurationUnknownMetricLabels = deepCopyPrometheusLabels(proberDurationLabels)
+
+	if w.spec != nil && w.spec.HTTPGet != nil {
+		w.initHttpProbeHolder()
+	}
 
 	return w
 }
@@ -345,8 +396,26 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 		}
 	}
 
+	var err error
+	var req *http.Request
+
+	// Use the cached request holder to reduce GC pressure on the hot path.
+	// If it's not initialized yet (e.g., first run or spec just loaded), set it up.
+	if w.httpProbeRequest != nil {
+		req, err = w.httpProbeRequest.getRequest(&w.container, status.PodIP) // either returns cached request or creates a new one
+		if err != nil {
+			// Request creation/reuse failed, try again next time.
+			klog.V(4).InfoS("HTTP-Probe worker failed to create request", "error", err)
+			return true
+		}
+	} else {
+		if w.spec != nil && w.spec.HTTPGet != nil {
+			w.initHttpProbeHolder()
+		}
+	}
+
 	// Note, exec probe does NOT have access to pod environment variables or downward API
-	result, err := w.probeManager.prober.probe(ctx, w.probeType, w.pod, status, w.container, w.containerID)
+	result, err := w.probeManager.prober.probe(ctx, w.probeType, w.pod, status, w.container, w.containerID, req)
 	if err != nil {
 		// Prober error, throw away the result.
 		return true

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -73,6 +73,7 @@ type worker struct {
 
 	// Cached probe http request
 	httpProbeRequest *httpProbeRequestHolder
+	probeAttributes  *probeAttributes
 
 	// If set, skip probing.
 	onHold bool
@@ -86,6 +87,14 @@ type worker struct {
 	// for the ProberDuration metric by result.
 	proberDurationSuccessfulMetricLabels metrics.Labels
 	proberDurationUnknownMetricLabels    metrics.Labels
+}
+
+type probeAttributes struct {
+	HttpRequestCacheHolder *httpProbeRequestHolder
+}
+
+func (p *probeAttributes) setHttpRequestHodler(httpHolder *httpProbeRequestHolder) {
+	p.HttpRequestCacheHolder = httpHolder
 }
 
 // httpProbeRequestHolder caches the http.Request object to minimize allocations during repeated probes.
@@ -108,16 +117,17 @@ func (w *worker) isInitContainer() bool {
 }
 
 // Initialize new http probe request holder with remove old object
-func (w *worker) initHttpProbeHolder() {
+func (w *worker) initHttpProbeHolder(container *v1.Container) {
 	w.httpProbeRequest = &httpProbeRequestHolder{
-		httpGet: w.spec.HTTPGet,
-		podIP:   "", // Empty Initially because we are not sure if the pod IP is available yet (better to dynamically set in worker loop)
+		container: container,
+		httpGet:   w.spec.HTTPGet,
+		podIP:     "", // Empty Initially because we are not sure if the pod IP is available yet (better to dynamically set in worker loop)
 	}
 }
 
 // getRequest returns a cached http.Request or creates a new one if the Pod IP has changed
 // or if the request hasn't been initialized yet.
-func (h *httpProbeRequestHolder) getRequest(container *v1.Container, currentPodIP string) (*http.Request, error) {
+func (h *httpProbeRequestHolder) getRequest(currentPodIP string) (*http.Request, error) {
 
 	if h.podIP != currentPodIP {
 		h.podIP = currentPodIP
@@ -125,7 +135,7 @@ func (h *httpProbeRequestHolder) getRequest(container *v1.Container, currentPodI
 	}
 
 	if h.request == nil {
-		req, err := httprobe.NewRequestForHTTPGetAction(h.httpGet, container, h.podIP, "probe")
+		req, err := httprobe.NewRequestForHTTPGetAction(h.httpGet, h.container, h.podIP, "probe")
 		if err != nil {
 			return nil, err
 		}
@@ -199,7 +209,7 @@ func newWorker(
 	w.proberDurationUnknownMetricLabels = deepCopyPrometheusLabels(proberDurationLabels)
 
 	if w.spec != nil && w.spec.HTTPGet != nil {
-		w.initHttpProbeHolder()
+		w.initHttpProbeHolder(&container)
 	}
 
 	return w
@@ -397,25 +407,21 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 	}
 
 	var err error
-	var req *http.Request
 
 	// Use the cached request holder to reduce GC pressure on the hot path.
 	// If it's not initialized yet (e.g., first run or spec just loaded), set it up.
-	if w.httpProbeRequest != nil {
-		req, err = w.httpProbeRequest.getRequest(&w.container, status.PodIP) // either returns cached request or creates a new one
-		if err != nil {
-			// Request creation/reuse failed, try again next time.
-			klog.V(4).InfoS("HTTP-Probe worker failed to create request", "error", err)
-			return true
-		}
-	} else {
-		if w.spec != nil && w.spec.HTTPGet != nil {
-			w.initHttpProbeHolder()
-		}
+	if w.httpProbeRequest != nil && w.spec != nil && w.spec.HTTPGet != nil {
+		w.initHttpProbeHolder(&w.container)
+	}
+
+	// Instantly create probe attributes object.
+	if w.probeAttributes == nil {
+		w.probeAttributes = &probeAttributes{}
+		w.probeAttributes.setHttpRequestHodler(w.httpProbeRequest)
 	}
 
 	// Note, exec probe does NOT have access to pod environment variables or downward API
-	result, err := w.probeManager.prober.probe(ctx, w.probeType, w.pod, status, w.container, w.containerID, req)
+	result, err := w.probeManager.prober.probe(ctx, w.probeType, w.pod, status, w.container, w.containerID, w.probeAttributes)
 	if err != nil {
 		// Prober error, throw away the result.
 		return true

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -1237,7 +1237,7 @@ func TestGetRequest(t *testing.T) {
 		},
 		{
 			name:        "invalid pod ip",
-			podIp:       "http://123123", // Assuming httprobe fails on scheme in IP
+			podIp:       "scheme://invalid-pod-ip", // httprobe fails on scheme in IP
 			expectError: true,
 		},
 	}

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -18,6 +18,8 @@ package prober
 
 import (
 	"fmt"
+	"net/http"
+	"reflect"
 	"testing"
 	"time"
 
@@ -1154,22 +1156,41 @@ func TestGetRequestCaching(t *testing.T) {
 		worker := newWorker(manager, readiness, pod, container)
 
 		worker.initHttpProbeHolder(&worker.container)
-		_, err := worker.httpProbeRequest.getRequest(t.Context(), fakePodIp)
+		req, err := worker.httpProbeRequest.getRequest(fakePodIp)
 
 		if err != nil {
 			t.Errorf("Expect no error, got: %v.", err)
 		}
 
-		req2, err := worker.httpProbeRequest.getRequest(t.Context(), fakePodIp)
+		// Check set cache values and fields equality
+		checkCache(t, worker, req)
+		req2, err := worker.httpProbeRequest.getRequest(fakePodIp)
 
 		if err != nil {
 			t.Errorf("Expect no error, got: %v.", err)
+		}
+
+		// Check cached fields between two requests for equality
+		if req.Proto != req2.Proto {
+			t.Errorf("Expected Proto: %v, but got %v.", req.Proto, req2.Proto)
+		}
+
+		if req.URL != req2.URL {
+			t.Errorf("Expected Host: %v, but got %v.", req.URL, req2.URL)
+		}
+
+		if req.Method != req2.Method {
+			t.Errorf("Expected Method: %v, but got %v.", req.Method, req2.Method)
+		}
+
+		if !reflect.DeepEqual(req.Header, req2.Header) {
+			t.Errorf("Expected Header: %v, but got %v.", req.Header, req2.Header)
 		}
 
 		// Cache invalidation
 		worker.httpProbeRequest.reset()
 
-		req3, _ := worker.httpProbeRequest.getRequest(t.Context(), fakePodIp)
+		req3, _ := worker.httpProbeRequest.getRequest(fakePodIp)
 
 		// Test cache invalidation by httpProbeRequest.reset()
 		if req2 == req3 {
@@ -1177,13 +1198,36 @@ func TestGetRequestCaching(t *testing.T) {
 		}
 
 		// Test cache invalidation by change Pod-IP
-		req4, _ := worker.httpProbeRequest.getRequest(t.Context(), fakePodIp+"updated_podIp")
+		req4, _ := worker.httpProbeRequest.getRequest(fakePodIp + "updated_podIp")
 
 		if req4 == req3 {
 			t.Errorf("Expected result: %p != %p, but got %p == %p.", req4, req3, req4, req3)
 		}
 
 	})
+}
+
+func checkCache(t *testing.T, worker *worker, req *http.Request) {
+
+	cachedProto := worker.httpProbeRequest.cachedProto
+	if req.Proto != cachedProto {
+		t.Errorf("Expected Proto: %v, but got %v.", cachedProto, req.Proto)
+	}
+
+	cachedUrl := worker.httpProbeRequest.cachedURL
+	if req.URL != cachedUrl {
+		t.Errorf("Expected Host: %v, but got %v.", cachedUrl, req.URL)
+	}
+
+	cachedMethod := worker.httpProbeRequest.cachedMethod
+	if req.Method != cachedMethod {
+		t.Errorf("Expected Method: %v, but got %v.", cachedMethod, req.Method)
+	}
+
+	cachedHeader := worker.httpProbeRequest.cachedHeader
+	if !reflect.DeepEqual(req.Header, cachedHeader) {
+		t.Errorf("Expected Header: %v, but got %v.", cachedHeader, req.Header)
+	}
 }
 
 func TestGetRequest(t *testing.T) {
@@ -1246,7 +1290,7 @@ func TestGetRequest(t *testing.T) {
 			worker := newWorker(manager, readiness, pod, container)
 
 			worker.initHttpProbeHolder(&worker.container)
-			req, err := worker.httpProbeRequest.getRequest(t.Context(), c.podIp)
+			req, err := worker.httpProbeRequest.getRequest(c.podIp)
 
 			if err != nil && !c.error {
 				t.Errorf("Not expected error: %v", err)
@@ -1260,6 +1304,8 @@ func TestGetRequest(t *testing.T) {
 		})
 	}
 }
+
+var benchmarkHttpProbeSink bool
 
 func BenchmarkHTTPProbe(b *testing.B) {
 	logger, ctx := ktesting.NewTestContext(b)
@@ -1303,6 +1349,6 @@ func BenchmarkHTTPProbe(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		worker.doProbe(ctx)
+		benchmarkHttpProbeSink = worker.doProbe(ctx)
 	}
 }

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -1152,99 +1153,92 @@ func TestGetRequestCaching(t *testing.T) {
 		})
 
 		fakePodIp := "some-pod"
-
 		worker := newWorker(manager, readiness, pod, container)
-
 		worker.initHttpProbeHolder(&worker.container)
+
 		req, err := worker.httpProbeRequest.getRequest(fakePodIp)
-
 		if err != nil {
-			t.Errorf("Expect no error, got: %v.", err)
+			t.Fatalf("Unexpected error getting initial request: %v", err)
 		}
 
-		// Check set cache values and fields equality
-		checkCache(t, worker, req)
+		// Verify internal cache fields are correctly populated
+		assertRequestMatchesCache(t, worker, req)
+
 		req2, err := worker.httpProbeRequest.getRequest(fakePodIp)
-
 		if err != nil {
-			t.Errorf("Expect no error, got: %v.", err)
+			t.Fatalf("Unexpected error getting cached request: %v", err)
 		}
 
-		// Check cached fields between two requests for equality
+		// Verify fields between two subsequent requests are identical (hit cache)
 		if req.Proto != req2.Proto {
-			t.Errorf("Expected Proto: %v, but got %v.", req.Proto, req2.Proto)
+			t.Errorf("Proto mismatch: expected %q, got %q", req.Proto, req2.Proto)
 		}
-
-		if req.URL != req2.URL {
-			t.Errorf("Expected Host: %v, but got %v.", req.URL, req2.URL)
+		if req.URL.String() != req2.URL.String() {
+			t.Errorf("URL mismatch: expected %q, got %q", req.URL.String(), req2.URL.String())
 		}
-
 		if req.Method != req2.Method {
-			t.Errorf("Expected Method: %v, but got %v.", req.Method, req2.Method)
+			t.Errorf("Method mismatch: expected %q, got %q", req.Method, req2.Method)
 		}
-
 		if !reflect.DeepEqual(req.Header, req2.Header) {
-			t.Errorf("Expected Header: %v, but got %v.", req.Header, req2.Header)
+			t.Errorf("Header mismatch:\nexpected: %v\ngot: %v", req.Header, req2.Header)
 		}
 
-		// Cache invalidation
+		// Test cache invalidation via explicit reset()
 		worker.httpProbeRequest.reset()
+		worker.container.ReadinessProbe.HTTPGet.Path = "/new-path"
 
-		req3, _ := worker.httpProbeRequest.getRequest(fakePodIp)
-
-		// Test cache invalidation by httpProbeRequest.reset()
-		if req2 == req3 {
-			t.Errorf("Expected result: %p != %p, but got %p == %p.", req2, req3, req2, req3)
+		req3, err := worker.httpProbeRequest.getRequest(fakePodIp)
+		if err != nil {
+			t.Fatalf("Unexpected error getting request after reset: %v", err)
+		}
+		if req3.URL.Path != "/new-path" {
+			t.Errorf("Cache reset failed: expected updated path %q, got cached path %q", "/new-path", req3.URL.Path)
 		}
 
-		// Test cache invalidation by change Pod-IP
-		req4, _ := worker.httpProbeRequest.getRequest(fakePodIp + "updated_podIp")
-
-		if req4 == req3 {
-			t.Errorf("Expected result: %p != %p, but got %p == %p.", req4, req3, req4, req3)
+		// Test cache invalidation via Pod-IP change
+		updatedPodIp := "updated-pod-ip"
+		req4, err := worker.httpProbeRequest.getRequest(updatedPodIp)
+		if err != nil {
+			t.Fatalf("Unexpected error getting request after IP change: %v", err)
 		}
-
+		if !strings.Contains(req4.URL.Host, updatedPodIp) {
+			t.Errorf("Cache invalidation via IP change failed: expected host to contain %q, got %q", updatedPodIp, req4.URL.Host)
+		}
 	})
 }
 
-func checkCache(t *testing.T, worker *worker, req *http.Request) {
+func assertRequestMatchesCache(t *testing.T, worker *worker, req *http.Request) {
+	t.Helper()
 
-	cachedProto := worker.httpProbeRequest.cachedProto
-	if req.Proto != cachedProto {
-		t.Errorf("Expected Proto: %v, but got %v.", cachedProto, req.Proto)
+	if req.Proto != worker.httpProbeRequest.cachedProto {
+		t.Errorf("Cache Proto mismatch: expected %q, got %q", worker.httpProbeRequest.cachedProto, req.Proto)
 	}
-
-	cachedUrl := worker.httpProbeRequest.cachedURL
-	if req.URL != cachedUrl {
-		t.Errorf("Expected Host: %v, but got %v.", cachedUrl, req.URL)
+	if req.URL != worker.httpProbeRequest.cachedURL {
+		t.Errorf("Cache URL mismatch: expected %v, got %v", worker.httpProbeRequest.cachedURL, req.URL)
 	}
-
-	cachedMethod := worker.httpProbeRequest.cachedMethod
-	if req.Method != cachedMethod {
-		t.Errorf("Expected Method: %v, but got %v.", cachedMethod, req.Method)
+	if req.Method != worker.httpProbeRequest.cachedMethod {
+		t.Errorf("Cache Method mismatch: expected %q, got %q", worker.httpProbeRequest.cachedMethod, req.Method)
 	}
-
-	cachedHeader := worker.httpProbeRequest.cachedHeader
-	if !reflect.DeepEqual(req.Header, cachedHeader) {
-		t.Errorf("Expected Header: %v, but got %v.", cachedHeader, req.Header)
+	if !reflect.DeepEqual(req.Header, worker.httpProbeRequest.cachedHeader) {
+		t.Errorf("Cache Header mismatch:\nexpected: %v\ngot: %v", worker.httpProbeRequest.cachedHeader, req.Header)
 	}
 }
 
 func TestGetRequest(t *testing.T) {
 	cases := []struct {
-		name  string
-		error bool
-		podIp string
+		name        string
+		podIp       string
+		expectError bool
 	}{
 		{
-			name:  "valid pod ip",
-			error: false,
-			podIp: "podip.docker",
+			name:        "valid pod ip",
+			podIp:       "podip.docker",
+			expectError: false,
 		},
 		{
-			name:  "invalid pod ip",
-			error: true,
-			podIp: "http://123123",
+			name:        "invalid pod ip",
+			podIp:       "http://123123", // Assuming httprobe fails on scheme in IP
+			expectError: true,
 		},
 	}
 
@@ -1288,18 +1282,52 @@ func TestGetRequest(t *testing.T) {
 			})
 
 			worker := newWorker(manager, readiness, pod, container)
-
 			worker.initHttpProbeHolder(&worker.container)
+
 			req, err := worker.httpProbeRequest.getRequest(c.podIp)
 
-			if err != nil && !c.error {
-				t.Errorf("Not expected error: %v", err)
-			} else if err == nil && c.error {
-				t.Errorf("No expected error.")
+			// Invariant 1: Error presence matches expectations
+			if (err != nil) != c.expectError {
+				t.Fatalf("Unexpected error state: expectError=%t, got err=%v", c.expectError, err)
 			}
 
-			if req == nil && err == nil {
-				t.Errorf("Request does not returning without error.")
+			// Invariant 2: If error is expected, no request should be returned
+			if c.expectError {
+				if req != nil {
+					t.Errorf("Expected nil request on error, but got: %v", req)
+				}
+				return // Stop further checks for failure cases
+			}
+
+			// --- Success Path Invariants ---
+
+			// Invariant 3: Request must not be nil if err is nil
+			if req == nil {
+				t.Error("Returned request is nil, but no error was reported")
+			}
+
+			// Invariant 4: Internal podIP state must be updated to the current IP
+			if worker.httpProbeRequest.podIP != c.podIp {
+				t.Errorf("Internal podIP state mismatch: expected %q, got %q", c.podIp, worker.httpProbeRequest.podIP)
+			}
+
+			// Invariant 5: Lazy initialization verification (requestRoot must be set)
+			if worker.httpProbeRequest.requestRoot == nil {
+				t.Error("Internal requestRoot was not initialized after a successful call")
+			}
+
+			// Invariant 6: Returned request data must match cached fields
+			if req.Proto != worker.httpProbeRequest.cachedProto {
+				t.Errorf("Cache Proto mismatch: expected %q, got %q", worker.httpProbeRequest.cachedProto, req.Proto)
+			}
+			if req.URL != worker.httpProbeRequest.cachedURL {
+				t.Errorf("Cache URL mismatch: expected %v, got %v", worker.httpProbeRequest.cachedURL, req.URL)
+			}
+			if req.Method != worker.httpProbeRequest.cachedMethod {
+				t.Errorf("Cache Method mismatch: expected %q, got %q", worker.httpProbeRequest.cachedMethod, req.Method)
+			}
+			if !reflect.DeepEqual(req.Header, worker.httpProbeRequest.cachedHeader) {
+				t.Errorf("Cache Header mismatch:\nexpected: %v\ngot: %v", worker.httpProbeRequest.cachedHeader, req.Header)
 			}
 		})
 	}

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -1154,27 +1154,22 @@ func TestGetRequestCaching(t *testing.T) {
 		worker := newWorker(manager, readiness, pod, container)
 
 		worker.initHttpProbeHolder(&worker.container)
-		req, err := worker.httpProbeRequest.getRequest(fakePodIp)
+		_, err := worker.httpProbeRequest.getRequest(t.Context(), fakePodIp)
 
 		if err != nil {
 			t.Errorf("Expect no error, got: %v.", err)
 		}
 
-		req2, err := worker.httpProbeRequest.getRequest(fakePodIp)
+		req2, err := worker.httpProbeRequest.getRequest(t.Context(), fakePodIp)
 
 		if err != nil {
 			t.Errorf("Expect no error, got: %v.", err)
-		}
-
-		// Test caching
-		if req != req2 {
-			t.Errorf("Expected the same request pointer for subsequent calls, but got %p != %p.", req, req2)
 		}
 
 		// Cache invalidation
 		worker.httpProbeRequest.reset()
 
-		req3, _ := worker.httpProbeRequest.getRequest(fakePodIp)
+		req3, _ := worker.httpProbeRequest.getRequest(t.Context(), fakePodIp)
 
 		// Test cache invalidation by httpProbeRequest.reset()
 		if req2 == req3 {
@@ -1182,7 +1177,7 @@ func TestGetRequestCaching(t *testing.T) {
 		}
 
 		// Test cache invalidation by change Pod-IP
-		req4, _ := worker.httpProbeRequest.getRequest(fakePodIp + "updated_podIp")
+		req4, _ := worker.httpProbeRequest.getRequest(t.Context(), fakePodIp+"updated_podIp")
 
 		if req4 == req3 {
 			t.Errorf("Expected result: %p != %p, but got %p == %p.", req4, req3, req4, req3)
@@ -1251,7 +1246,7 @@ func TestGetRequest(t *testing.T) {
 			worker := newWorker(manager, readiness, pod, container)
 
 			worker.initHttpProbeHolder(&worker.container)
-			req, err := worker.httpProbeRequest.getRequest(c.podIp)
+			req, err := worker.httpProbeRequest.getRequest(t.Context(), c.podIp)
 
 			if err != nil && !c.error {
 				t.Errorf("Not expected error: %v", err)

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -1172,7 +1172,7 @@ func TestGetRequestCaching(t *testing.T) {
 
 		worker.httpProbeRequest.reset()
 
-		req3, err := worker.httpProbeRequest.getRequest(&worker.container, fakePodIp)
+		req3, _ := worker.httpProbeRequest.getRequest(&worker.container, fakePodIp)
 
 		if req2 == req3 {
 			t.Errorf("Cache not invalidated.")

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -23,6 +23,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes/fake"
@@ -1105,5 +1106,198 @@ func TestChangeContainerStatusOnKubeletRestart(t *testing.T) {
 				t.Errorf("Expected result %v, but got: %v", tc.expectedResult, result)
 			}
 		})
+	}
+}
+
+func TestGetRequestCaching(t *testing.T) {
+
+	t.Run("test get request caching", func(t *testing.T) {
+		logger, _ := ktesting.NewTestContext(t)
+		pod := getTestPod()
+		manager := newTestManager()
+		container := pod.Spec.Containers[0]
+		trueReference := true
+
+		container.ReadinessProbe = &v1.Probe{
+			InitialDelaySeconds: 0,
+			TimeoutSeconds:      1,
+			PeriodSeconds:       10,
+			SuccessThreshold:    1,
+			FailureThreshold:    3,
+			ProbeHandler: v1.ProbeHandler{
+				HTTPGet: &v1.HTTPGetAction{
+					Path: "/",
+					Port: intstr.FromInt(8080),
+				},
+			},
+		}
+
+		manager.statusManager.SetPodStatus(logger, pod, v1.PodStatus{
+			Phase: v1.PodRunning,
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:        container.Name,
+					ContainerID: "docker://fake-id",
+					State: v1.ContainerState{
+						Running: &v1.ContainerStateRunning{
+							StartedAt: metav1.Now(),
+						},
+					},
+					Ready:   true,
+					Started: &trueReference,
+				},
+			},
+		})
+
+		fakePodIp := "some-pod"
+
+		worker := newWorker(manager, readiness, pod, container)
+
+		worker.initHttpProbeHolder()
+		req, err := worker.httpProbeRequest.getRequest(&worker.container, fakePodIp)
+
+		if err != nil {
+			t.Errorf("Unexpected error: %v.", err)
+		}
+
+		req2, err := worker.httpProbeRequest.getRequest(&worker.container, fakePodIp)
+
+		if err != nil {
+			t.Errorf("Unexpected error: %v.", err)
+		}
+
+		if req != req2 {
+			t.Errorf("expected the same request pointer for subsequent calls, but got %p != %p", req, req2)
+		}
+
+		worker.httpProbeRequest.reset()
+
+		req3, err := worker.httpProbeRequest.getRequest(&worker.container, fakePodIp)
+
+		if req2 == req3 {
+			t.Errorf("Cache not invalidated.")
+		}
+
+	})
+}
+
+func TestGetRequest(t *testing.T) {
+	cases := []struct {
+		name  string
+		error bool
+		podIp string
+	}{
+		{
+			name:  "valid pod ip",
+			error: false,
+			podIp: "podip.docker",
+		},
+		{
+			name:  "invalid pod ip",
+			error: true,
+			podIp: "http://123123",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
+			pod := getTestPod()
+			manager := newTestManager()
+			container := pod.Spec.Containers[0]
+			trueReference := true
+
+			container.ReadinessProbe = &v1.Probe{
+				InitialDelaySeconds: 0,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       10,
+				SuccessThreshold:    1,
+				FailureThreshold:    3,
+				ProbeHandler: v1.ProbeHandler{
+					HTTPGet: &v1.HTTPGetAction{
+						Path: "/",
+						Port: intstr.FromInt(8080),
+					},
+				},
+			}
+
+			manager.statusManager.SetPodStatus(logger, pod, v1.PodStatus{
+				Phase: v1.PodRunning,
+				ContainerStatuses: []v1.ContainerStatus{
+					{
+						Name:        container.Name,
+						ContainerID: "docker://fake-id",
+						State: v1.ContainerState{
+							Running: &v1.ContainerStateRunning{
+								StartedAt: metav1.Now(),
+							},
+						},
+						Ready:   true,
+						Started: &trueReference,
+					},
+				},
+			})
+
+			worker := newWorker(manager, readiness, pod, container)
+
+			worker.initHttpProbeHolder()
+			req, err := worker.httpProbeRequest.getRequest(&worker.container, c.podIp)
+
+			if err != nil && !c.error {
+				t.Errorf("Not expected error: %v", err)
+			} else if err == nil && c.error {
+				t.Errorf("No expected error.")
+			}
+
+			if req == nil && err == nil {
+				t.Errorf("Request does not returning without error.")
+			}
+		})
+	}
+}
+
+func BenchmarkHTTPProbe(b *testing.B) {
+	logger, ctx := ktesting.NewTestContext(b)
+	pod := getTestPod()
+	manager := newTestManager()
+	t := true
+
+	container := pod.Spec.Containers[0]
+	container.ReadinessProbe = &v1.Probe{
+		InitialDelaySeconds: 0,
+		TimeoutSeconds:      1,
+		PeriodSeconds:       10,
+		SuccessThreshold:    1,
+		FailureThreshold:    3,
+		ProbeHandler: v1.ProbeHandler{
+			HTTPGet: &v1.HTTPGetAction{
+				Path: "/",
+				Port: intstr.FromInt(8080),
+			},
+		},
+	}
+
+	manager.statusManager.SetPodStatus(logger, pod, v1.PodStatus{
+		Phase: v1.PodRunning,
+		ContainerStatuses: []v1.ContainerStatus{
+			{
+				Name:        container.Name,
+				ContainerID: "docker://fake-id",
+				State: v1.ContainerState{
+					Running: &v1.ContainerStateRunning{
+						StartedAt: metav1.Now(),
+					},
+				},
+				Ready:   true,
+				Started: &t,
+			},
+		},
+	})
+
+	worker := newWorker(manager, readiness, pod, container)
+
+	b.ResetTimer()
+	for b.Loop() {
+		worker.doProbe(ctx)
 	}
 }

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -1167,7 +1167,7 @@ func TestGetRequestCaching(t *testing.T) {
 		}
 
 		if req != req2 {
-			t.Errorf("expected the same request pointer for subsequent calls, but got %p != %p", req, req2)
+			t.Errorf("Expected the same request pointer for subsequent calls, but got %p != %p.", req, req2)
 		}
 
 		worker.httpProbeRequest.reset()
@@ -1175,7 +1175,7 @@ func TestGetRequestCaching(t *testing.T) {
 		req3, _ := worker.httpProbeRequest.getRequest(&worker.container, fakePodIp)
 
 		if req2 == req3 {
-			t.Errorf("Cache not invalidated.")
+			t.Errorf("Expected result: %p != %p, but got %p == %p.", req2, req3, req2, req3)
 		}
 
 	})

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -1153,29 +1153,39 @@ func TestGetRequestCaching(t *testing.T) {
 
 		worker := newWorker(manager, readiness, pod, container)
 
-		worker.initHttpProbeHolder()
-		req, err := worker.httpProbeRequest.getRequest(&worker.container, fakePodIp)
+		worker.initHttpProbeHolder(&worker.container)
+		req, err := worker.httpProbeRequest.getRequest(fakePodIp)
 
 		if err != nil {
 			t.Errorf("Expect no error, got: %v.", err)
 		}
 
-		req2, err := worker.httpProbeRequest.getRequest(&worker.container, fakePodIp)
+		req2, err := worker.httpProbeRequest.getRequest(fakePodIp)
 
 		if err != nil {
 			t.Errorf("Expect no error, got: %v.", err)
 		}
 
+		// Test caching
 		if req != req2 {
 			t.Errorf("Expected the same request pointer for subsequent calls, but got %p != %p.", req, req2)
 		}
 
+		// Cache invalidation
 		worker.httpProbeRequest.reset()
 
-		req3, _ := worker.httpProbeRequest.getRequest(&worker.container, fakePodIp)
+		req3, _ := worker.httpProbeRequest.getRequest(fakePodIp)
 
+		// Test cache invalidation by httpProbeRequest.reset()
 		if req2 == req3 {
 			t.Errorf("Expected result: %p != %p, but got %p == %p.", req2, req3, req2, req3)
+		}
+
+		// Test cache invalidation by change Pod-IP
+		req4, _ := worker.httpProbeRequest.getRequest(fakePodIp + "updated_podIp")
+
+		if req4 == req3 {
+			t.Errorf("Expected result: %p != %p, but got %p == %p.", req4, req3, req4, req3)
 		}
 
 	})
@@ -1240,8 +1250,8 @@ func TestGetRequest(t *testing.T) {
 
 			worker := newWorker(manager, readiness, pod, container)
 
-			worker.initHttpProbeHolder()
-			req, err := worker.httpProbeRequest.getRequest(&worker.container, c.podIp)
+			worker.initHttpProbeHolder(&worker.container)
+			req, err := worker.httpProbeRequest.getRequest(c.podIp)
 
 			if err != nil && !c.error {
 				t.Errorf("Not expected error: %v", err)

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -1157,13 +1157,13 @@ func TestGetRequestCaching(t *testing.T) {
 		req, err := worker.httpProbeRequest.getRequest(&worker.container, fakePodIp)
 
 		if err != nil {
-			t.Errorf("Unexpected error: %v.", err)
+			t.Errorf("Expect no error, got: %v.", err)
 		}
 
 		req2, err := worker.httpProbeRequest.getRequest(&worker.container, fakePodIp)
 
 		if err != nil {
-			t.Errorf("Unexpected error: %v.", err)
+			t.Errorf("Expect no error, got: %v.", err)
 		}
 
 		if req != req2 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR optimizes the prober by reusing the request objects, which significantly reduces heap allocations and memory pressure during high-frequency probing.

Use caching request metadata instead of http.Request

Benchmark:

|Metric|Before (Master) | After| Profit |
|---------|-----------|---------|----------|
|Alloc/op|  103     | 90      | -14%|
|B/op | 6713 | 5726 | -16% |

<details>
<summary>Raw Benchmark Stats</summary>

Command:
```
go test -bench=BenchmarkHTTPProbe -benchmem ./pkg/kubelet/prober
```


before (master)
```
goos: linux
goarch: amd64
pkg: k8s.io/kubernetes/pkg/kubelet/prober
cpu: AMD Ryzen 5 7640HS w/ Radeon 760M Graphics     
BenchmarkHTTPProbe-12              27481             44178 ns/op            6712 B/op        103 allocs/op
PASS
ok      k8s.io/kubernetes/pkg/kubelet/prober    12.243s

```

after
```
goos: linux
goarch: amd64
pkg: k8s.io/kubernetes/pkg/kubelet/prober
cpu: AMD Ryzen 5 7640HS w/ Radeon 760M Graphics     
BenchmarkHTTPProbe-12              28716             41344 ns/op            5726 B/op         90 allocs/op
PASS
ok      k8s.io/kubernetes/pkg/kubelet/prober    12.220s

```
</details>

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #115939

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
