### PR TITLE
Fix race condition in PodGroup admission plugin for terminating Workloads

### DIFF
--- a/plugin/pkg/admission/podgroup/admission.go
+++ b/plugin/pkg/admission/podgroup/admission.go
@@ -131,14 +131,13 @@ func (p *PodGroupWorkloadExists) Validate(ctx context.Context, a admission.Attri
 	}
 
 	workloadRef := podGroup.Spec.PodGroupTemplateRef.Workload
-	workload, err := p.workloadLister.Workloads(a.GetNamespace()).Get(workloadRef.WorkloadName)
+
+	// Always fetch from API server to avoid informer cache race with DeletionTimestamp
+	workload, err := p.client.SchedulingV1alpha2().Workloads(
+		a.GetNamespace()).Get(ctx, workloadRef.WorkloadName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		workload, err = p.client.SchedulingV1alpha2().Workloads(
-			a.GetNamespace()).Get(ctx, workloadRef.WorkloadName, metav1.GetOptions{})
-		if apierrors.IsNotFound(err) {
-			return admission.NewForbidden(a,
-				fmt.Errorf("PodGroup rejected: Workload %q not found", workloadRef.WorkloadName))
-		}
+		return admission.NewForbidden(a,
+			fmt.Errorf("PodGroup rejected: Workload %q not found", workloadRef.WorkloadName))
 	}
 	if err != nil {
 		return apierrors.NewInternalError(err)

--- a/plugin/pkg/admission/podgroup/admission_test.go
+++ b/plugin/pkg/admission/podgroup/admission_test.go
@@ -21,6 +21,7 @@ import (
 
 	schedulingv1alpha2 "k8s.io/api/scheduling/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authentication/user"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -181,13 +182,17 @@ func TestValidate(t *testing.T) {
 
 			informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
 			plugin.SetExternalKubeInformerFactory(informerFactory)
-			for _, w := range tc.workloads {
+
+			// Populate both informer store and fake client with workloads
+			objs := make([]runtime.Object, len(tc.workloads))
+			for i, w := range tc.workloads {
 				if err := informerFactory.Scheduling().V1alpha2().Workloads().Informer().GetStore().Add(w); err != nil {
 					t.Fatalf("failed to add Workload: %v", err)
 				}
+				objs[i] = w
 			}
 			plugin.SetReadyFunc(func() bool { return true })
-			plugin.SetExternalKubeClientSet(fake.NewSimpleClientset())
+			plugin.SetExternalKubeClientSet(fake.NewSimpleClientset(objs...))
 
 			err := plugin.Validate(ctx, tc.attrs, nil)
 			if tc.wantErr && err == nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Fixes a race condition in the PodGroupWorkloadExists admission plugin that caused flaky test failures. The plugin was using the informer cache to check if a referenced Workload is being deleted, but the cache may not be synced yet when a Workload is deleted, causing the DeletionTimestamp check to incorrectly pass

Also populated both informer store and fake client with workloads to fix a unit test failure which occurred after the above change.

#### Which issue(s) this PR is related to:
#138012

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

The fix changes the admission plugin to always fetch Workload data directly from the API server instead of relying on the informer cache. This ensures we always have the most up-to-date DeletionTimestamp value, eliminating the race condition.

Trade-off: This adds one additional API call per PodGroup creation, but ensures correctness and eliminates flaky behavior. The performance impact is minimal since PodGroup creation is not a high-frequency operation.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```
