### PR TITLE
Recreate deployment: resync when only terminal pods remain

### DIFF
--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -392,7 +392,7 @@ func (dc *DeploymentController) deletePod(logger klog.Logger, obj interface{}) {
 	}
 	logger.V(4).Info("Pod deleted", "pod", klog.KObj(pod))
 	if d.Spec.Strategy.Type == apps.RecreateDeploymentStrategyType {
-		// Sync if this Deployment now has no more Pods.
+		// Sync if this Deployment now has no more active Pods.
 		rsList, err := util.ListReplicaSets(d, util.RsListFromClient(dc.client.AppsV1()))
 		if err != nil {
 			return
@@ -401,11 +401,15 @@ func (dc *DeploymentController) deletePod(logger klog.Logger, obj interface{}) {
 		if err != nil {
 			return
 		}
-		numPods := 0
+		numActivePods := 0
 		for _, podList := range podMap {
-			numPods += len(podList)
+			for _, pod := range podList {
+				if !isPodTerminalForRecreate(pod) {
+					numActivePods++
+				}
+			}
 		}
-		if numPods == 0 {
+		if numActivePods == 0 {
 			dc.enqueueDeployment(d)
 		}
 	}

--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -528,6 +528,45 @@ func TestPodDeletionPartialReplicaSetOwnershipDoesntEnqueueRecreateDeployment(t 
 	}
 }
 
+// TestPodDeletionEnqueuesRecreateDeploymentWithTerminalPods ensures that the
+// deletion of a pod will requeue a Recreate deployment when the only remaining
+// pods are in a terminal phase (Failed or Succeeded).
+func TestPodDeletionEnqueuesRecreateDeploymentWithTerminalPods(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+
+	f := newFixture(t)
+
+	foo := newDeployment("foo", 1, nil, nil, nil, map[string]string{"foo": "bar"})
+	foo.Spec.Strategy.Type = apps.RecreateDeploymentStrategyType
+	rs := newReplicaSet(foo, "foo-1", 1)
+	pod := generatePodFromRS(rs)
+
+	terminatedPod := generatePodFromRS(rs)
+	terminatedPod.Name = "terminated"
+	terminatedPod.Status.Phase = v1.PodSucceeded
+
+	f.dLister = append(f.dLister, foo)
+	f.rsLister = append(f.rsLister, rs)
+	f.podLister = append(f.podLister, terminatedPod)
+
+	c, _, err := f.newController(ctx)
+	if err != nil {
+		t.Fatalf("error creating Deployment controller: %v", err)
+	}
+	enqueued := false
+	c.enqueueDeployment = func(d *apps.Deployment) {
+		if d.Name == "foo" {
+			enqueued = true
+		}
+	}
+
+	c.deletePod(logger, pod)
+
+	if !enqueued {
+		t.Errorf("expected deployment %q to be queued after pod deletion when only terminal pods remain", foo.Name)
+	}
+}
+
 func TestGetReplicaSetsForDeployment(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
 

--- a/pkg/controller/deployment/recreate.go
+++ b/pkg/controller/deployment/recreate.go
@@ -95,6 +95,22 @@ func (dc *DeploymentController) scaleDownOldReplicaSetsForRecreate(ctx context.C
 	return scaled, nil
 }
 
+// isPodTerminalForRecreate returns true if the pod is in a terminal phase (Failed or Succeeded).
+func isPodTerminalForRecreate(pod *v1.Pod) bool {
+	switch pod.Status.Phase {
+	case v1.PodFailed, v1.PodSucceeded:
+		return true
+	case v1.PodUnknown:
+		// v1.PodUnknown is a deprecated status.
+		// This logic is kept for backward compatibility.
+		// This used to happen in situation like when the node is temporarily disconnected from the cluster.
+		// If we can't be sure that the pod is not running, we have to count it.
+		return false
+	default:
+		return false
+	}
+}
+
 // oldPodsRunning returns whether there are old pods running or any of the old ReplicaSets thinks that it runs pods.
 func oldPodsRunning(newRS *apps.ReplicaSet, oldRSs []*apps.ReplicaSet, podMap map[types.UID][]*v1.Pod) bool {
 	if oldPods := util.GetActualReplicaCountForReplicaSets(oldRSs); oldPods > 0 {
@@ -106,18 +122,7 @@ func oldPodsRunning(newRS *apps.ReplicaSet, oldRSs []*apps.ReplicaSet, podMap ma
 			continue
 		}
 		for _, pod := range podList {
-			switch pod.Status.Phase {
-			case v1.PodFailed, v1.PodSucceeded:
-				// Don't count pods in terminal state.
-				continue
-			case v1.PodUnknown:
-				// v1.PodUnknown is a deprecated status.
-				// This logic is kept for backward compatibility.
-				// This used to happen in situation like when the node is temporarily disconnected from the cluster.
-				// If we can't be sure that the pod is not running, we have to count it.
-				return true
-			default:
-				// Pod is not in terminal phase.
+			if !isPodTerminalForRecreate(pod) {
 				return true
 			}
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

- Fix Recreate deployment strategy to resync in `deletePod` when only terminal pods (Succeeded/Failed) remain, instead of waiting for zero pods total
- Extract `isPodTerminalForRecreate` helper to share pod phase logic between `deletePod` and `oldPodsRunning`
- Add unit test covering the terminal-pods-only scenario

Previously, the `deletePod` handler for Recreate deployments counted all pods and only enqueued a resync when `numPods == 0`. This meant that if old pods were in a terminal phase (Succeeded/Failed) but hadn't been garbage collected yet, the rollout would stall waiting for them to disappear after deleting the old replicaset.

Now `deletePod` uses the same terminal-pod logic as `oldPodsRunning` in `recreate.go`, skipping pods in Failed/Succeeded phase. Pods in PodUnknown are conservatively treated as active since we can't confirm they've stopped, keeping existing behavior.

**Which issue(s) this PR fixes:**

Fixes https://github.com/kubernetes/kubernetes/issues/106410

#### Special notes for your reviewer:

Per the comment here:
https://github.com/kubernetes/kubernetes/issues/54525#issuecomment-367845264

Looks like the original design was to wait for the replicaset controller to delete the evicted pods, but not sure if this is clear given it is also helpful to keep them around for debugging/viewing logs, etc. Given the current implementation of the deployment controller for Recreate deployments, my sense is this PR would be a worthwhile add that could be removed if the behavior of rs controller ever changes.

#### Does this PR introduce a user-facing change?

```release-note
deployment-controller: Fixed bug where Recreate deployments would stall if evicted or non-terminal pods existed.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
