### PR TITLE
topo e2e: wait for available CPU before running or skip

### DIFF
--- a/test/e2e_node/topology_manager_test.go
+++ b/test/e2e_node/topology_manager_test.go
@@ -18,10 +18,12 @@ package e2enode
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -29,8 +31,11 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	resourcehelper "k8s.io/component-helpers/resource"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
@@ -448,6 +453,9 @@ func runTopologyManagerPolicySuiteTests(ctx context.Context, f *framework.Framew
 	ginkgo.By("running a non-Gu pod")
 	runNonGuPodTest(ctx, f, cpuCap, cpuset.New())
 
+	ginkgo.By("waiting for available CPU before running a Gu pod")
+	waitForAvailableNodeCPUOrSkip(ctx, f, int64(1000), 30*time.Second)
+
 	ginkgo.By("running a Gu pod")
 	runGuPodTest(ctx, f, 1, cpuset.New())
 
@@ -467,6 +475,111 @@ func runTopologyManagerPolicySuiteTests(ctx context.Context, f *framework.Framew
 
 	ginkgo.By("running multiple Gu pods")
 	runMultipleGuPods(ctx, f)
+}
+
+func waitForAvailableNodeCPUOrSkip(ctx context.Context, f *framework.Framework, requiredMilliCPU int64, timeout time.Duration) {
+	ginkgo.GinkgoHelper()
+
+	pollInterval := 2 * time.Second
+	timeoutCause := errors.New("timed out waiting for CPU headroom")
+	waitCtx, cancel := context.WithTimeoutCause(ctx, timeout, timeoutCause)
+	defer cancel()
+
+	var (
+		nodeName            string
+		allocatableMilliCPU int64
+		requestedMilliCPU   int64
+		availableMilliCPU   int64
+		requestingPods      []string
+	)
+
+	err := wait.PollUntilContextCancel(waitCtx, pollInterval, true, func(ctx context.Context) (bool, error) {
+		node := getLocalNode(ctx, f)
+		nodeName = node.Name
+		allocatableCPU := node.Status.Allocatable[v1.ResourceCPU]
+		allocatableMilliCPU = allocatableCPU.MilliValue()
+
+		var err error
+		requestedMilliCPU, requestingPods, err = getNodeRequestedMilliCPU(ctx, f, nodeName)
+		if err != nil {
+			return false, err
+		}
+
+		availableMilliCPU = allocatableMilliCPU - requestedMilliCPU
+		if availableMilliCPU >= requiredMilliCPU {
+			framework.Logf(
+				"node %q has enough available CPU: allocatable=%dm requested=%dm available=%dm required=%dm",
+				nodeName,
+				allocatableMilliCPU,
+				requestedMilliCPU,
+				availableMilliCPU,
+				requiredMilliCPU,
+			)
+			return true, nil
+		}
+
+		framework.Logf(
+			"waiting for CPU headroom on node %q: need %dm available CPU, got %dm (allocatable=%dm requested=%dm)",
+			nodeName,
+			requiredMilliCPU,
+			availableMilliCPU,
+			allocatableMilliCPU,
+			requestedMilliCPU,
+		)
+		return false, nil
+	})
+	if err == nil {
+		return
+	}
+
+	if errors.Is(context.Cause(waitCtx), timeoutCause) {
+		details := strings.Join(requestingPods, ", ")
+		if details == "" {
+			details = "none"
+		}
+		e2eskipper.Skipf(
+			"Skipping Gu pod test due to CPU pressure on node %q: need %dm available CPU, got %dm (allocatable=%dm requested=%dm). Active pod requests: %s",
+			nodeName,
+			requiredMilliCPU,
+			availableMilliCPU,
+			allocatableMilliCPU,
+			requestedMilliCPU,
+			details,
+		)
+	}
+
+	framework.ExpectNoError(err)
+}
+
+func getNodeRequestedMilliCPU(ctx context.Context, f *framework.Framework, nodeName string) (int64, []string, error) {
+	pods, err := f.ClientSet.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("spec.nodeName", nodeName).String(),
+	})
+	if err != nil {
+		return 0, nil, err
+	}
+
+	var requestedMilliCPU int64
+	requestingPods := []string{}
+	for idx := range pods.Items {
+		pod := &pods.Items[idx]
+		if pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed {
+			continue
+		}
+
+		requests := resourcehelper.PodRequests(pod, resourcehelper.PodResourcesOptions{})
+		cpuRequest := requests.Cpu()
+		if cpuRequest == nil || cpuRequest.IsZero() {
+			continue
+		}
+
+		milliCPU := cpuRequest.MilliValue()
+		requestedMilliCPU += milliCPU
+		requestingPods = append(requestingPods, fmt.Sprintf("%s/%s=%dm", pod.Namespace, pod.Name, milliCPU))
+	}
+	sort.Strings(requestingPods)
+
+	return requestedMilliCPU, requestingPods, nil
 }
 
 func runTopologyManagerPositiveTest(ctx context.Context, f *framework.Framework, numPods int, ctnAttrs, initCtnAttrs []tmCtnAttribute, envInfo *testEnvInfo) {


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/blob/093c91d2264ad9c4b965ad6dd27b3089681b0d73/test/e2e_node/cpu_manager_test.go#L4078-L4090

similar to the skip in cpu manager.

wait first and skip if needed.

#### Which issue(s) this PR is related to:
None

In https://testgrid.k8s.io/sig-node-kubelet#kubelet-gce-e2e-arm64-ubuntu-serial, the topo test flakes.

#### Special notes for your reviewer:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-node-arm64-ubuntu-serial/2041001257841201152
> I0406 05:43:20.568919    2350 dump.go:53] At 2026-04-06 05:43:13 +0000 UTC - event for gu-pod: {kubelet t2a-standard-2-ubuntu-gke-2404-1-34-arm64-v20260405-350174f9} OutOfcpu: Node didn't have enough resource: cpu, requested: 1000, used: 100, capacity: 1000



#### Does this PR introduce a user-facing change?
```release-note
None
```
