### PR TITLE
apiserver: cap etcd watch substream buffer; add metrics and logs

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -142,6 +142,25 @@ var (
 		},
 		[]string{},
 	)
+	// etcdWatchSubstreamBufferDepth records buffer depth at exponentially spaced reporting milestones
+	// in the etcd v3 client (go.etcd.io/etcd/client/v3). See https://github.com/kubernetes/kubernetes/issues/138217.
+	etcdWatchSubstreamBufferDepth = compbasemetrics.NewHistogram(
+		&compbasemetrics.HistogramOpts{
+			Subsystem:      "apiserver",
+			Name:           "etcd_watch_substream_buffer_depth_milestone",
+			Help:           "Histogram of etcd watch client substream buffer depth at reporting milestones when the consumer is slower than etcd.",
+			Buckets:        []float64{1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288},
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+	)
+	etcdWatchSubstreamBufferOverload = compbasemetrics.NewCounter(
+		&compbasemetrics.CounterOpts{
+			Subsystem:      "apiserver",
+			Name:           "etcd_watch_substream_buffer_overload_cancellations_total",
+			Help:           "Count of etcd watches canceled after the client substream buffer reached its configured limit.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+	)
 	listStorageCount = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
 			Name:           "apiserver_storage_list_total",
@@ -203,6 +222,8 @@ func Register() {
 		legacyregistry.MustRegister(etcdBookmarkCounts)
 		legacyregistry.MustRegister(etcdBookmarkTotal)
 		legacyregistry.MustRegister(etcdLeaseObjectCounts)
+		legacyregistry.MustRegister(etcdWatchSubstreamBufferDepth)
+		legacyregistry.MustRegister(etcdWatchSubstreamBufferOverload)
 		legacyregistry.MustRegister(listStorageCount)
 		legacyregistry.MustRegister(listStorageNumFetched)
 		legacyregistry.MustRegister(listStorageNumSelectorEvals)
@@ -295,6 +316,17 @@ func UpdateLeaseObjectCount(count int64) {
 	// Currently we only store one previous lease, since all the events have the same ttl.
 	// See pkg/storage/etcd3/lease_manager.go
 	etcdLeaseObjectCounts.WithLabelValues().Observe(float64(count))
+}
+
+// RecordEtcdWatchSubstreamBufferDepthMilestone records a milestone depth from the etcd client's
+// per-watch substream buffer (go.etcd.io/etcd/client/v3).
+func RecordEtcdWatchSubstreamBufferDepthMilestone(depth int) {
+	etcdWatchSubstreamBufferDepth.Observe(float64(depth))
+}
+
+// RecordEtcdWatchSubstreamBufferOverload records that a watch was canceled due to buffer limit.
+func RecordEtcdWatchSubstreamBufferOverload() {
+	etcdWatchSubstreamBufferOverload.Inc()
 }
 
 // RecordStorageListMetrics notes various metrics of the cost to serve a LIST request

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -95,6 +95,9 @@ func init() {
 		l = zap.NewNop()
 	}
 	etcd3ClientLogger = l.Named("etcd-client")
+
+	clientv3.SetSubstreamBufferDepthObserver(metrics.RecordEtcdWatchSubstreamBufferDepthMilestone)
+	clientv3.SetSubstreamBufferOverloadObserver(metrics.RecordEtcdWatchSubstreamBufferOverload)
 }
 
 // etcdClientDebugLevel translates ETCD_CLIENT_DEBUG into zap log level.

--- a/vendor/go.etcd.io/etcd/client/v3/watch.go
+++ b/vendor/go.etcd.io/etcd/client/v3/watch.go
@@ -44,6 +44,15 @@ const (
 
 	// InvalidWatchID represents an invalid watch ID and prevents duplication with an existing watch.
 	InvalidWatchID = -1
+
+	// maxWatcherStreamBuffer caps the number of decoded watch responses queued per substream.
+	// Beyond this, the watch is canceled so the client can reconnect (avoids unbounded memory
+	// growth when consumers cannot keep up). See kubernetes/kubernetes#138217.
+	maxWatcherStreamBuffer = 50000
+
+	// firstWatcherBufferDepthReport is the first buffer depth at which we log and invoke the
+	// optional depth observer (then we report at exponentially increasing thresholds).
+	firstWatcherBufferDepthReport = 1024
 )
 
 type Event mvccpb.Event
@@ -241,6 +250,50 @@ type watcherStream struct {
 
 	// buf holds all events received from etcd but not yet consumed by the client
 	buf []*WatchResponse
+
+	// nextBufferDepthReport is the next depth (len(buf)) at which to log/emit metrics; zero means unset.
+	nextBufferDepthReport int
+}
+
+var (
+	bufferDepthObsMu  sync.RWMutex
+	bufferDepthObs    func(depth int)
+	bufferOverloadObs func()
+)
+
+// SetSubstreamBufferDepthObserver registers a function called when a watch substream's internal
+// buffer crosses exponentially spaced depths starting at firstWatcherBufferDepthReport. Pass nil to
+// disable. Safe for use before any Watch calls; typically used for metrics.
+func SetSubstreamBufferDepthObserver(observe func(depth int)) {
+	bufferDepthObsMu.Lock()
+	bufferDepthObs = observe
+	bufferDepthObsMu.Unlock()
+}
+
+// SetSubstreamBufferOverloadObserver registers a function invoked once when a substream hits
+// maxWatcherStreamBuffer and the watch is canceled. Pass nil to disable.
+func SetSubstreamBufferOverloadObserver(onOverload func()) {
+	bufferDepthObsMu.Lock()
+	bufferOverloadObs = onOverload
+	bufferDepthObsMu.Unlock()
+}
+
+func callSubstreamBufferDepthObserver(depth int) {
+	bufferDepthObsMu.RLock()
+	f := bufferDepthObs
+	bufferDepthObsMu.RUnlock()
+	if f != nil {
+		f(depth)
+	}
+}
+
+func callSubstreamBufferOverloadObserver() {
+	bufferDepthObsMu.RLock()
+	f := bufferOverloadObs
+	bufferDepthObsMu.RUnlock()
+	if f != nil {
+		f()
+	}
 }
 
 func NewWatcher(c *Client) Watcher {
@@ -710,6 +763,60 @@ func (w *watchGRPCStream) nextResume() *watcherStream {
 	return nil
 }
 
+func (w *watchGRPCStream) noteWatcherSubstreamBufferDepth(ws *watcherStream, depth int) {
+	if depth < firstWatcherBufferDepthReport {
+		return
+	}
+	if ws.nextBufferDepthReport == 0 {
+		ws.nextBufferDepthReport = firstWatcherBufferDepthReport
+	}
+	for ws.nextBufferDepthReport <= depth {
+		callSubstreamBufferDepthObserver(ws.nextBufferDepthReport)
+		if w.lg != nil {
+			if ws.nextBufferDepthReport >= 4096 {
+				w.lg.Warn("etcd watch client substream buffer depth is high",
+					zap.Int("buffer-depth", ws.nextBufferDepthReport),
+					zap.Int64("watch-id", ws.id),
+				)
+			} else {
+				w.lg.Info("etcd watch client substream buffer depth is elevated",
+					zap.Int("buffer-depth", ws.nextBufferDepthReport),
+					zap.Int64("watch-id", ws.id),
+				)
+			}
+		}
+		if ws.nextBufferDepthReport < 1<<16 {
+			ws.nextBufferDepthReport <<= 1
+		} else {
+			ws.nextBufferDepthReport += 1 << 16
+		}
+	}
+}
+
+func (w *watchGRPCStream) cancelWatchForBufferOverload(ws *watcherStream, depth int) {
+	callSubstreamBufferOverloadObserver()
+	if w.lg != nil {
+		w.lg.Error("etcd watch client substream buffer exceeded limit; canceling watch",
+			zap.Int("buffer-depth", depth),
+			zap.Int64("watch-id", ws.id),
+		)
+	}
+	resp := WatchResponse{
+		Canceled:     true,
+		cancelReason: "etcdclient: watch substream buffer size exceeded",
+	}
+	// Send asynchronously so this goroutine can exit and close(ws.donec) in defer,
+	// unblocking run()'s unicast (which selects on donec). Do not close outc here;
+	// closeSubstream does that after serveSubstream returns.
+	go func() {
+		select {
+		case ws.outc <- resp:
+		case <-ws.initReq.ctx.Done():
+		case <-time.After(closeSendErrTimeout):
+		}
+	}()
+}
+
 // dispatchEvent sends a WatchResponse to the appropriate watcher stream
 func (w *watchGRPCStream) dispatchEvent(pbresp *pb.WatchResponse) bool {
 	events := make([]*Event, len(pbresp.Events))
@@ -863,8 +970,12 @@ func (w *watchGRPCStream) serveSubstream(ws *watcherStream, resumec chan struct{
 				continue
 			}
 
-			// TODO pause channel if buffer gets too large
+			if len(ws.buf) >= maxWatcherStreamBuffer {
+				w.cancelWatchForBufferOverload(ws, len(ws.buf))
+				return
+			}
 			ws.buf = append(ws.buf, wr)
+			w.noteWatcherSubstreamBufferDepth(ws, len(ws.buf))
 		case <-w.ctx.Done():
 			return
 		case <-ws.initReq.ctx.Done():


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Issue [#138217](https://github.com/kubernetes/kubernetes/issues/138217) describes unbounded growth of `watcherStream.buf` in the etcd v3 client when watch traffic outpaces the consumer (for example heavy pod revision churn plus many watches). That path lacked visibility and had no backstop on memory.

This change:

- Enforces a per-watch **substream buffer limit** (50,000 queued responses) in vendored `go.etcd.io/etcd/client/v3`. When the limit is hit, the watch is **canceled with an explicit client-side reason** so callers can reconnect instead of growing memory without bound.
- Adds **structured logging** at increasing depth milestones (starting at 1024) using the existing etcd client zap logger (`etcd-client`).
- Adds **apiserver metrics**: a histogram at reporting milestones and a counter when the buffer limit forces cancellation.
- Wires **optional observers** from `storagebackend/factory` into `k8s.io/apiserver/pkg/storage/etcd3/metrics`.
- Sends the overload cancel to the subscriber **asynchronously** so `serveSubstream` can finish and `close(ws.donec)` runs, avoiding a deadlock with `run()` blocked on `unicast` to an unbuffered `recvc`.

#### Which issue(s) this PR is related to:

Fixes #138217

#### Special notes for your reviewer:

- The behavioral change lives in **vendor** (`vendor/go.etcd.io/etcd/client/v3/watch.go`). Maintainers may prefer the same logic **upstream in etcd-io/etcd** followed by a vendor bump; this PR carries a targeted patch until then.
- Please sanity-check the **50,000** default cap and whether we should make it configurable (for example via environment variable) in a follow-up.
- Suggested labels: `sig/api-machinery`, area storage/etcd.
- Tests run locally: `go build ./cmd/kube-apiserver/`, `go test` for `k8s.io/apiserver/pkg/storage/etcd3/metrics` and `k8s.io/apiserver/pkg/storage/storagebackend/factory` (short).

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```

#### Does this PR introduce a user-facing change?

```release-note
The kube-apiserver now exposes Prometheus metrics `apiserver_etcd_watch_substream_buffer_depth_milestone` and `apiserver_etcd_watch_substream_buffer_overload_cancellations_total` for etcd watch client substream buffering. Under extreme load, if the per-watch client buffer reaches its limit, that watch may be canceled so it can reconnect instead of growing without bound; related messages appear in etcd client logs when `ETCD_CLIENT_DEBUG` enables the client logger.
