### PR TITLE
e2e_node: fix swap LimitedSwap stress flake from kubelet restart orde…

### DIFF
--- a/test/e2e_node/swap_test.go
+++ b/test/e2e_node/swap_test.go
@@ -184,6 +184,14 @@ var _ = SIGDescribe("Swap", "[LinuxOnly]", ginkgo.Ordered, feature.Swap, framewo
 			ginkgo.Context("LimitedSwap", func() {
 				tempSetCurrentKubeletConfig(f, enableLimitedSwap)
 
+				// tempSetCurrentKubeletConfig registers AfterEach on this context that restarts the kubelet.
+				// That AfterEach runs before the Describe-level addAfterEachForCleaningUpPods (deeper nesting runs first),
+				// so without an earlier hook we would restart kubelet while swap-stress pods still hold memory.
+				ginkgo.JustAfterEach(func(ctx context.Context) {
+					ginkgo.By("Deleting swap stress pods before kubelet config is restored")
+					deleteSyncPodsInTestNamespace(ctx, f)
+				})
+
 				getRequestBySwapLimit := func(swapPercentage int64) *resource.Quantity {
 					gomega.ExpectWithOffset(1, swapPercentage).To(gomega.And(
 						gomega.BeNumerically(">=", 1),
@@ -203,7 +211,7 @@ var _ = SIGDescribe("Swap", "[LinuxOnly]", ginkgo.Ordered, feature.Swap, framewo
 					return pod
 				}
 
-				ginkgo.It("should be able to use more than the node memory capacity", func() {
+				ginkgo.It("should be able to use more than the node memory capacity", func(ctx context.Context) {
 					stressSize := cloneQuantity(nodeTotalMemory)
 
 					stressPod := getStressPod(stressSize)
@@ -234,12 +242,12 @@ var _ = SIGDescribe("Swap", "[LinuxOnly]", ginkgo.Ordered, feature.Swap, framewo
 						return nil
 					}, 5*time.Minute, 1*time.Second).Should(gomega.Succeed(), "swap usage is above zero: %s", swapUsage.String())
 
-					// Better to delete the stress pod ASAP to avoid node failures
-					err := podClient.Delete(context.Background(), stressPod.Name, metav1.DeleteOptions{})
+					// Wait for removal so the node is not under extreme memory pressure when kubelet restores config.
+					err := podClient.DeleteSync(ctx, stressPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
 					framework.ExpectNoError(err)
 				})
 
-				ginkgo.It("should be able to use more memory than memory limits", func() {
+				ginkgo.It("should be able to use more memory than memory limits", func(ctx context.Context) {
 					stressSize := divideQuantity(nodeTotalMemory, 5)
 					ginkgo.By("Creating a stress pod with stress size: " + stressSize.String())
 					stressPod := getStressPod(stressSize)
@@ -284,8 +292,7 @@ var _ = SIGDescribe("Swap", "[LinuxOnly]", ginkgo.Ordered, feature.Swap, framewo
 						return nil
 					}, 5*time.Minute, 1*time.Second).Should(gomega.Succeed())
 
-					// Better to delete the stress pod ASAP to avoid node failures
-					err := podClient.Delete(context.Background(), stressPod.Name, metav1.DeleteOptions{})
+					err := podClient.DeleteSync(ctx, stressPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
 					framework.ExpectNoError(err)
 				})
 

--- a/test/e2e_node/swap_test.go
+++ b/test/e2e_node/swap_test.go
@@ -243,8 +243,7 @@ var _ = SIGDescribe("Swap", "[LinuxOnly]", ginkgo.Ordered, feature.Swap, framewo
 					}, 5*time.Minute, 1*time.Second).Should(gomega.Succeed(), "swap usage is above zero: %s", swapUsage.String())
 
 					// Wait for removal so the node is not under extreme memory pressure when kubelet restores config.
-					err := podClient.DeleteSync(ctx, stressPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
-					framework.ExpectNoError(err)
+					podClient.DeleteSync(ctx, stressPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
 				})
 
 				ginkgo.It("should be able to use more memory than memory limits", func(ctx context.Context) {
@@ -292,8 +291,7 @@ var _ = SIGDescribe("Swap", "[LinuxOnly]", ginkgo.Ordered, feature.Swap, framewo
 						return nil
 					}, 5*time.Minute, 1*time.Second).Should(gomega.Succeed())
 
-					err := podClient.DeleteSync(ctx, stressPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
-					framework.ExpectNoError(err)
+					podClient.DeleteSync(ctx, stressPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
 				})
 
 				ginkgo.It("ensure summary API properly reports swap", func() {

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -167,18 +167,23 @@ func getV1NodeDevices(ctx context.Context) (*kubeletpodresourcesv1.ListPodResour
 	return resp, nil
 }
 
+// deleteSyncPodsInTestNamespace deletes all pods in the framework test namespace and waits for removal.
+func deleteSyncPodsInTestNamespace(ctx context.Context, f *framework.Framework) {
+	l, err := e2epod.NewPodClient(f).List(ctx, metav1.ListOptions{})
+	framework.ExpectNoError(err)
+	for _, p := range l.Items {
+		if p.Namespace != f.Namespace.Name {
+			continue
+		}
+		framework.Logf("Deleting pod: %s", p.Name)
+		e2epod.NewPodClient(f).DeleteSync(ctx, p.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
+	}
+}
+
 func addAfterEachForCleaningUpPods(f *framework.Framework) {
 	ginkgo.AfterEach(func(ctx context.Context) {
 		ginkgo.By("Deleting any Pods created by the test in namespace: " + f.Namespace.Name)
-		l, err := e2epod.NewPodClient(f).List(ctx, metav1.ListOptions{})
-		framework.ExpectNoError(err)
-		for _, p := range l.Items {
-			if p.Namespace != f.Namespace.Name {
-				continue
-			}
-			framework.Logf("Deleting pod: %s", p.Name)
-			e2epod.NewPodClient(f).DeleteSync(ctx, p.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
-		}
+		deleteSyncPodsInTestNamespace(ctx, f)
 	})
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake

#### What this PR does / why we need it:

Node swap conformance serial tests were flaky because kubelet config restore (stop kubelet → write config → restart → `waitForKubeletToStart`) ran in an `AfterEach` on the **LimitedSwap** context, while pod cleanup ran in an outer `Describe`-level `AfterEach`. Ginkgo runs deeper `AfterEach` hooks first, so the kubelet could restart while swap-stress pods still held large amounts of memory, and the kubelet health check timed out (see issue).

This PR adds a **JustAfterEach** on **LimitedSwap** to sync-delete pods in the test namespace before `tempSetCurrentKubeletConfig` restores config; extracts **deleteSyncPodsInTestNamespace** for reuse with **addAfterEachForCleaningUpPods**; and uses **DeleteSync** in the two stress specs that previously used async **Delete**.

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

https://github.com/kubernetes/kubernetes/issues/138226

#### Special notes for your reviewer:

- **JustAfterEach** runs before **AfterEach**; combined with deeper **AfterEach** running before outer ones, this ordering is the core fix.
- No kubelet or API changes; **test/e2e_node** only.

#### Does this PR introduce a user-facing change?
```
NONE
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
NONE
```
