### PR TITLE
E2E_Node: Remove duplicate kubelet health checks

### DIFF
--- a/test/e2e_node/container_lifecycle_test.go
+++ b/test/e2e_node/container_lifecycle_test.go
@@ -1742,9 +1742,6 @@ var _ = SIGDescribe(framework.WithSerial(), "Containers Lifecycle", func() {
 
 			ginkgo.By("Restarting the kubelet")
 			restartKubelet(ctx)
-			gomega.Eventually(ctx, func() bool {
-				return kubeletHealthCheck(kubeletHealthCheckURL)
-			}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeTrueBecause("kubelet was expected to be healthy"))
 
 			ginkgo.By("Waiting for the pod to be re-initialized and run")
 			err = e2epod.WaitForPodCondition(ctx, f.ClientSet, pod.Namespace, pod.Name, "re-initialized", f.Timeouts.PodStart, func(pod *v1.Pod) (bool, error) {
@@ -1862,10 +1859,6 @@ var _ = SIGDescribe(framework.WithSerial(), "Containers Lifecycle", func() {
 
 				ginkgo.By("restarting the kubelet")
 				restartKubelet(ctx)
-				// wait until the kubelet health check will succeed
-				gomega.Eventually(ctx, func() bool {
-					return kubeletHealthCheck(kubeletHealthCheckURL)
-				}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeTrueBecause("kubelet should be started"))
 
 				ginkgo.By("ensuring that no completed init container is restarted")
 				gomega.Consistently(ctx, func() bool {
@@ -1927,10 +1920,6 @@ var _ = SIGDescribe(framework.WithSerial(), "Containers Lifecycle", func() {
 
 				ginkgo.By("restarting the kubelet")
 				restartKubelet(ctx)
-				// wait until the kubelet health check will succeed
-				gomega.Eventually(ctx, func() bool {
-					return kubeletHealthCheck(kubeletHealthCheckURL)
-				}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeTrueBecause("kubelet should be restarted"))
 
 				ginkgo.By("ensuring that no completed init container is restarted")
 				gomega.Consistently(ctx, func() bool {
@@ -6153,9 +6142,6 @@ var _ = SIGDescribe(framework.WithNodeConformance(), framework.WithSerial(), "Co
 
 			ginkgo.By("Restarting the kubelet")
 			restartKubelet(ctx)
-			gomega.Eventually(ctx, func() bool {
-				return kubeletHealthCheck(kubeletHealthCheckURL)
-			}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeTrueBecause("kubelet was expected to be healthy"))
 
 			ginkgo.By("Waiting for the pod to re-initialize")
 			err = e2epod.WaitForPodCondition(ctx, f.ClientSet, pod.Namespace, pod.Name, "re-initialized", f.Timeouts.PodStart, func(pod *v1.Pod) (bool, error) {
@@ -6301,9 +6287,6 @@ var _ = SIGDescribe(framework.WithNodeConformance(), framework.WithSerial(), "Co
 
 				ginkgo.By("Restarting the kubelet")
 				restartKubelet(ctx)
-				gomega.Eventually(ctx, func() bool {
-					return kubeletHealthCheck(kubeletHealthCheckURL)
-				}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeTrueBecause("kubelet was expected to be healthy"))
 
 				ginkgo.By("Sending an update")
 				client.Update(ctx, pod.Name, func(pod *v1.Pod) {

--- a/test/e2e_node/device_plugin_test.go
+++ b/test/e2e_node/device_plugin_test.go
@@ -662,13 +662,6 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 			framework.Logf("Starting the kubelet")
 			restartKubelet(ctx)
 
-			// wait until the kubelet health check will succeed
-			gomega.Eventually(ctx, func() bool {
-				ok := kubeletHealthCheck(kubeletHealthCheckURL)
-				framework.Logf("kubelet health check at %q value=%v", kubeletHealthCheckURL, ok)
-				return ok
-			}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeTrueBecause("expected kubelet to be in healthy state"))
-
 			framework.Logf("wait for the pod %v to disappear", pod.Name)
 			gomega.Eventually(ctx, func(ctx context.Context) error {
 				err := checkMirrorPodDisappear(ctx, f.ClientSet, pod.Name, pod.Namespace)

--- a/test/e2e_node/kubelet_config_dir_test.go
+++ b/test/e2e_node/kubelet_config_dir_test.go
@@ -126,10 +126,6 @@ featureGates:
 			framework.ExpectNoError(os.WriteFile(filepath.Join(configDir, "20-kubelet.conf"), contents, 0755))
 			ginkgo.By("Restarting the kubelet")
 			restartKubelet(ctx)
-			// wait until the kubelet health check will succeed
-			gomega.Eventually(ctx, func() bool {
-				return kubeletHealthCheck(kubeletHealthCheckURL)
-			}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeTrueBecause("expected kubelet to be in healthy state"))
 
 			mergedConfig, err := getCurrentKubeletConfig(ctx)
 			framework.ExpectNoError(err)

--- a/test/e2e_node/mirror_pod_test.go
+++ b/test/e2e_node/mirror_pod_test.go
@@ -922,11 +922,6 @@ var _ = SIGDescribe("MirrorPod", framework.WithSerial(), func() {
 			restartKubelet := mustStopKubelet(ctx, f)
 			restartKubelet(ctx)
 
-			ginkgo.By("ensuring kubelet is healthy")
-			gomega.Eventually(ctx, func() bool {
-				return kubeletHealthCheck(kubeletHealthCheckURL)
-			}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeTrueBecause("kubelet should be started"))
-
 			// Let the goroutine run for a few more seconds to catch any delayed changes
 			time.Sleep(5 * time.Second)
 			close(stopCh)

--- a/test/e2e_node/node_container_manager_test.go
+++ b/test/e2e_node/node_container_manager_test.go
@@ -251,11 +251,6 @@ func runTest(ctx context.Context, f *framework.Framework) error {
 
 			ginkgo.By("Restarting the kubelet")
 			restartKubelet(ctx)
-
-			// wait until the kubelet health check will succeed
-			gomega.Eventually(ctx, func(ctx context.Context) bool {
-				return kubeletHealthCheck(kubeletHealthCheckURL)
-			}, 2*time.Minute, 5*time.Second).Should(gomega.BeTrueBecause("expected kubelet to be in healthy state"))
 		}
 	})
 	if err := createTemporaryCgroupsForReservation(cgroupManager); err != nil {
@@ -286,11 +281,6 @@ func runTest(ctx context.Context, f *framework.Framework) error {
 
 	ginkgo.By("Starting the kubelet")
 	restartKubelet(ctx)
-
-	// wait until the kubelet health check will succeed
-	gomega.Eventually(ctx, func() bool {
-		return kubeletHealthCheck(kubeletHealthCheckURL)
-	}, 2*time.Minute, 5*time.Second).Should(gomega.BeTrueBecause("expected kubelet to be in healthy state"))
 
 	if err != nil {
 		return err

--- a/test/e2e_node/pod_status_test.go
+++ b/test/e2e_node/pod_status_test.go
@@ -106,9 +106,6 @@ var _ = SIGDescribe(framework.WithSerial(), "Pods status phase", func() {
 
 		ginkgo.By("Starting the kubelet")
 		startKubelet(ctx)
-		gomega.Eventually(ctx, func() bool {
-			return kubeletHealthCheck(kubeletHealthCheckURL)
-		}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeTrueBecause("kubelet should be started"))
 
 		ginkgo.By("Waiting for the regular init container to be started after the node reboot")
 		err = e2epod.WaitForPodInitContainerStarted(ctx, f.ClientSet, pod.Namespace, pod.Name, 0, f.Timeouts.PodStart)

--- a/test/e2e_node/static_pod_test.go
+++ b/test/e2e_node/static_pod_test.go
@@ -96,9 +96,6 @@ var _ = SIGDescribe("StaticPod", framework.WithSerial(), func() {
 			ginkgo.By("restart kubelet")
 			startKubelet := mustStopKubelet(ctx, f)
 			startKubelet(ctx)
-			gomega.Eventually(ctx, func() bool {
-				return kubeletHealthCheck(kubeletHealthCheckURL)
-			}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeTrueBecause("kubelet should be started"))
 
 			ginkgo.By("wait for the mirror pod to be updated")
 			gomega.Eventually(ctx, func(g gomega.Gomega) {
@@ -172,9 +169,6 @@ var _ = SIGDescribe("StaticPod", framework.WithSerial(), func() {
 
 			ginkgo.By("start kubelet")
 			startKubelet(ctx)
-			gomega.Eventually(ctx, func() bool {
-				return kubeletHealthCheck(kubeletHealthCheckURL)
-			}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeTrueBecause("kubelet should be started"))
 
 			ginkgo.By("wait for the mirror pod to be updated")
 			gomega.Eventually(ctx, func(g gomega.Gomega) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In e2e node tests, `restartKubelet` is typically a closure returned by the `mustStopKubelet` function.

The function returned by `mustStopKubelet` internally already calls `waitForKubeletToStart`.

`waitForKubeletToStart` not only automatically performs `kubeletHealthCheck` (the logic removed by the current PR), but also further waits for the Node to become Ready. The code manually written in the test case to check the kubelet's health status actually duplicates the work already done by `restartKubelet(ctx)`.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
