### PR TITLE
workqueue: add metric for rate limiter delay

### DIFF
--- a/staging/src/k8s.io/client-go/util/workqueue/metrics.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics.go
@@ -185,6 +185,8 @@ func (m *defaultRateLimiterMetrics) addRateLimiterDelay(delay time.Duration) {
 }
 
 // MetricsProvider generates various metrics used by the queue.
+//
+// Deprecated: Implement RateLimiterMetricsProvider instead.
 type MetricsProvider interface {
 	NewDepthMetric(name string) GaugeMetric
 	NewAddsMetric(name string) CounterMetric
@@ -193,36 +195,41 @@ type MetricsProvider interface {
 	NewUnfinishedWorkSecondsMetric(name string) SettableGaugeMetric
 	NewLongestRunningProcessorSecondsMetric(name string) SettableGaugeMetric
 	NewRetriesMetric(name string) CounterMetric
+}
+
+// RateLimiterMetricsProvider extends MetricsProvider with rate limiter delay tracking.
+type RateLimiterMetricsProvider interface {
+	MetricsProvider
 	NewRateLimiterDelayMetric(name string) HistogramMetric
 }
 
 type noopMetricsProvider struct{}
 
-func (_ noopMetricsProvider) NewDepthMetric(name string) GaugeMetric {
+func (noopMetricsProvider) NewDepthMetric(name string) GaugeMetric {
 	return noopMetric{}
 }
 
-func (_ noopMetricsProvider) NewAddsMetric(name string) CounterMetric {
+func (noopMetricsProvider) NewAddsMetric(name string) CounterMetric {
 	return noopMetric{}
 }
 
-func (_ noopMetricsProvider) NewLatencyMetric(name string) HistogramMetric {
+func (noopMetricsProvider) NewLatencyMetric(name string) HistogramMetric {
 	return noopMetric{}
 }
 
-func (_ noopMetricsProvider) NewWorkDurationMetric(name string) HistogramMetric {
+func (noopMetricsProvider) NewWorkDurationMetric(name string) HistogramMetric {
 	return noopMetric{}
 }
 
-func (_ noopMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) SettableGaugeMetric {
+func (noopMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) SettableGaugeMetric {
 	return noopMetric{}
 }
 
-func (_ noopMetricsProvider) NewLongestRunningProcessorSecondsMetric(name string) SettableGaugeMetric {
+func (noopMetricsProvider) NewLongestRunningProcessorSecondsMetric(name string) SettableGaugeMetric {
 	return noopMetric{}
 }
 
-func (_ noopMetricsProvider) NewRetriesMetric(name string) CounterMetric {
+func (noopMetricsProvider) NewRetriesMetric(name string) CounterMetric {
 	return noopMetric{}
 }
 
@@ -276,8 +283,13 @@ func newRateLimiterMetrics(name string, provider MetricsProvider) rateLimiterMet
 		provider = globalMetricsProvider
 	}
 
+	var delay HistogramMetric = noopMetric{}
+	if rlp, ok := provider.(RateLimiterMetricsProvider); ok {
+		delay = rlp.NewRateLimiterDelayMetric(name)
+	}
+
 	return &defaultRateLimiterMetrics{
-		delay: provider.NewRateLimiterDelayMetric(name),
+		delay: delay,
 	}
 }
 

--- a/staging/src/k8s.io/client-go/util/workqueue/metrics.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics.go
@@ -295,6 +295,7 @@ func newRateLimiterMetrics(name string, provider MetricsProvider) rateLimiterMet
 
 // SetProvider sets the metrics provider for all subsequently created work
 // queues. Only the first call has an effect.
+// metricsProvider should ideally implement RateLimiterMetricsProvider.
 func SetProvider(metricsProvider MetricsProvider) {
 	setGlobalMetricsProviderOnce.Do(func() {
 		globalMetricsProvider = metricsProvider

--- a/staging/src/k8s.io/client-go/util/workqueue/metrics.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics.go
@@ -169,6 +169,21 @@ func (m *defaultRetryMetrics) retry() {
 	m.retries.Inc()
 }
 
+type rateLimiterMetrics interface {
+	addRateLimiterDelay(delay time.Duration)
+}
+
+type defaultRateLimiterMetrics struct {
+	delay HistogramMetric
+}
+
+func (m *defaultRateLimiterMetrics) addRateLimiterDelay(delay time.Duration) {
+	if m == nil {
+		return
+	}
+	m.delay.Observe(delay.Seconds())
+}
+
 // MetricsProvider generates various metrics used by the queue.
 type MetricsProvider interface {
 	NewDepthMetric(name string) GaugeMetric
@@ -178,6 +193,7 @@ type MetricsProvider interface {
 	NewUnfinishedWorkSecondsMetric(name string) SettableGaugeMetric
 	NewLongestRunningProcessorSecondsMetric(name string) SettableGaugeMetric
 	NewRetriesMetric(name string) CounterMetric
+	NewRateLimiterDelayMetric(name string) HistogramMetric
 }
 
 type noopMetricsProvider struct{}
@@ -207,6 +223,10 @@ func (_ noopMetricsProvider) NewLongestRunningProcessorSecondsMetric(name string
 }
 
 func (_ noopMetricsProvider) NewRetriesMetric(name string) CounterMetric {
+	return noopMetric{}
+}
+
+func (noopMetricsProvider) NewRateLimiterDelayMetric(name string) HistogramMetric {
 	return noopMetric{}
 }
 
@@ -243,6 +263,21 @@ func newRetryMetrics(name string, provider MetricsProvider) retryMetrics {
 
 	return &defaultRetryMetrics{
 		retries: provider.NewRetriesMetric(name),
+	}
+}
+
+func newRateLimiterMetrics(name string, provider MetricsProvider) rateLimiterMetrics {
+	var ret *defaultRateLimiterMetrics
+	if len(name) == 0 {
+		return ret
+	}
+
+	if provider == nil {
+		provider = globalMetricsProvider
+	}
+
+	return &defaultRateLimiterMetrics{
+		delay: provider.NewRateLimiterDelayMetric(name),
 	}
 }
 

--- a/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
@@ -24,6 +24,25 @@ import (
 	testingclock "k8s.io/utils/clock/testing"
 )
 
+func TestRateLimiterDelayMetric(t *testing.T) {
+	mp := testMetricsProvider{}
+	limiter := NewTypedItemExponentialFailureRateLimiter[any](1*time.Millisecond, 1*time.Second)
+	q := NewTypedRateLimitingQueueWithConfig(limiter, TypedRateLimitingQueueConfig[any]{
+		Name:            "test",
+		MetricsProvider: &mp,
+	})
+	defer q.ShutDown()
+
+	q.AddRateLimited("foo")
+
+	if e, a := 0.001, mp.rateLimiterDelay.observationValue(); e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+	if e, a := 1, mp.rateLimiterDelay.observationCount(); e != a {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}
+
 type testMetrics struct {
 	added, gotten, finished int64
 

--- a/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/metrics_test.go
@@ -130,13 +130,14 @@ func (m *testMetric) notify() {
 }
 
 type testMetricsProvider struct {
-	depth      testMetric
-	adds       testMetric
-	latency    testMetric
-	duration   testMetric
-	unfinished testMetric
-	longest    testMetric
-	retries    testMetric
+	depth            testMetric
+	adds             testMetric
+	latency          testMetric
+	duration         testMetric
+	unfinished       testMetric
+	longest          testMetric
+	retries          testMetric
+	rateLimiterDelay testMetric
 }
 
 func (m *testMetricsProvider) NewDepthMetric(name string) GaugeMetric {
@@ -165,6 +166,10 @@ func (m *testMetricsProvider) NewLongestRunningProcessorSecondsMetric(name strin
 
 func (m *testMetricsProvider) NewRetriesMetric(name string) CounterMetric {
 	return &m.retries
+}
+
+func (m *testMetricsProvider) NewRateLimiterDelayMetric(name string) HistogramMetric {
+	return &m.rateLimiterDelay
 }
 
 func TestMetrics(t *testing.T) {

--- a/staging/src/k8s.io/client-go/util/workqueue/rate_limiting_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/rate_limiting_queue.go
@@ -106,6 +106,7 @@ func NewTypedRateLimitingQueueWithConfig[T comparable](rateLimiter TypedRateLimi
 	return &rateLimitingType[T]{
 		TypedDelayingInterface: config.DelayingQueue,
 		rateLimiter:            rateLimiter,
+		metrics:                newRateLimiterMetrics(config.Name, config.MetricsProvider),
 	}
 }
 
@@ -131,11 +132,14 @@ type rateLimitingType[T comparable] struct {
 	TypedDelayingInterface[T]
 
 	rateLimiter TypedRateLimiter[T]
+	metrics     rateLimiterMetrics
 }
 
 // AddRateLimited AddAfter's the item based on the time when the rate limiter says it's ok
 func (q *rateLimitingType[T]) AddRateLimited(item T) {
-	q.TypedDelayingInterface.AddAfter(item, q.rateLimiter.When(item))
+	delay := q.rateLimiter.When(item)
+	q.metrics.addRateLimiterDelay(delay)
+	q.TypedDelayingInterface.AddAfter(item, delay)
 }
 
 func (q *rateLimitingType[T]) NumRequeues(item T) int {

--- a/staging/src/k8s.io/component-base/metrics/prometheus/workqueue/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/workqueue/metrics.go
@@ -98,7 +98,7 @@ var (
 		Subsystem:      WorkQueueSubsystem,
 		Name:           RateLimiterDelayKey,
 		StabilityLevel: k8smetrics.ALPHA,
-		Help:           "How long in seconds an item stays in the workqueue rate limiter before being added to the queue.",
+		Help:           "How long in seconds the rate limiter delays an item before it is added to the workqueue.",
 		Buckets:        []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600, 1000},
 	}, []string{"name"})
 

--- a/staging/src/k8s.io/component-base/metrics/prometheus/workqueue/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/workqueue/metrics.go
@@ -35,6 +35,7 @@ const (
 	UnfinishedWorkKey          = "unfinished_work_seconds"
 	LongestRunningProcessorKey = "longest_running_processor_seconds"
 	RetriesKey                 = "retries_total"
+	RateLimiterDelayKey        = "ratelimiter_delay_seconds"
 )
 
 var (
@@ -93,8 +94,16 @@ var (
 		Help:           "Total number of retries handled by workqueue",
 	}, []string{"name"})
 
+	rateLimiterDelay = k8smetrics.NewHistogramVec(&k8smetrics.HistogramOpts{
+		Subsystem:      WorkQueueSubsystem,
+		Name:           RateLimiterDelayKey,
+		StabilityLevel: k8smetrics.ALPHA,
+		Help:           "How long in seconds an item stays in the workqueue rate limiter before being added to the queue.",
+		Buckets:        []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600, 1000},
+	}, []string{"name"})
+
 	metrics = []k8smetrics.Registerable{
-		depth, adds, latency, workDuration, unfinished, longestRunningProcessor, retries,
+		depth, adds, latency, workDuration, unfinished, longestRunningProcessor, retries, rateLimiterDelay,
 	}
 )
 
@@ -134,4 +143,8 @@ func (prometheusMetricsProvider) NewLongestRunningProcessorSecondsMetric(name st
 
 func (prometheusMetricsProvider) NewRetriesMetric(name string) workqueue.CounterMetric {
 	return retries.WithLabelValues(name)
+}
+
+func (prometheusMetricsProvider) NewRateLimiterDelayMetric(name string) workqueue.HistogramMetric {
+	return rateLimiterDelay.WithLabelValues(name)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR adds a histogram `workqueue_rate_limiter_delay_seconds` to observe how long items spend waiting in the configured rate limiter before being enqueued. 

There are existing metrics (e.g. `workqueue_depth` and `workqueue_queue_duration_seconds`) but these metrics only relate to items already in the queue. There's a missing observability gap about how long items are delayed by the rate limiter before being enqueued again.

This metric is useful to quantify changes to rate limiter(s) and also exposes distribution of items that are stuck in a large backoff. This bit us a few times in production when a combination of poorly configured rate limiters and some not-so-great controllers caused items to be delayed for ~15 minutes. 

Below is a visualisation of this metric (instrumented on our end) in production that we used to identify how severely items were being backed off. This metric helped us tune the rate limiter more appropriately.

<img width="2543" height="864" alt="image" src="https://github.com/user-attachments/assets/8745b49c-586e-4f6a-b44f-b87fc816680e" />


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

https://github.com/kubernetes/kubernetes/issues/133545

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added `workqueue_ratelimiter_delay_seconds` histogram metric to the workqueue package, which records the delay returned by the rate limiter on each `AddRateLimited` call. This fills an observability gap where items waiting on rate limiter delays were invisible to existing metrics.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
