### PR TITLE
kubectl: Remove unused CreateSubcommandOptions from create.go

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
@@ -17,29 +17,20 @@ limitations under the License.
 package create
 
 import (
-	"context"
 	"fmt"
-	"io"
 	"net/url"
 	"runtime"
 	"strings"
 
 	"github.com/spf13/cobra"
-	"k8s.io/klog/v2"
 
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
-	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
-	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/cmd/util/editor"
-	"k8s.io/kubectl/pkg/generate"
 	"k8s.io/kubectl/pkg/rawhttp"
 	"k8s.io/kubectl/pkg/scheme"
 	"k8s.io/kubectl/pkg/util"
@@ -334,137 +325,4 @@ func NameFromCommandArgs(cmd *cobra.Command, args []string) (string, error) {
 		return "", cmdutil.UsageErrorf(cmd, "exactly one NAME is required, got %d", argsLen)
 	}
 	return args[0], nil
-}
-
-// CreateSubcommandOptions is an options struct to support create subcommands
-type CreateSubcommandOptions struct {
-	// PrintFlags holds options necessary for obtaining a printer
-	PrintFlags *genericclioptions.PrintFlags
-	// Name of resource being created
-	Name string
-	// StructuredGenerator is the resource generator for the object being created
-	StructuredGenerator generate.StructuredGenerator
-	DryRunStrategy      cmdutil.DryRunStrategy
-	CreateAnnotation    bool
-	FieldManager        string
-	ValidationDirective string
-
-	Namespace        string
-	EnforceNamespace bool
-
-	Mapper        meta.RESTMapper
-	DynamicClient dynamic.Interface
-
-	PrintObj printers.ResourcePrinterFunc
-
-	genericiooptions.IOStreams
-}
-
-// NewCreateSubcommandOptions returns initialized CreateSubcommandOptions
-func NewCreateSubcommandOptions(ioStreams genericiooptions.IOStreams) *CreateSubcommandOptions {
-	return &CreateSubcommandOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
-		IOStreams:  ioStreams,
-	}
-}
-
-// Complete completes all the required options
-func (o *CreateSubcommandOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string, generator generate.StructuredGenerator) error {
-	name, err := NameFromCommandArgs(cmd, args)
-	if err != nil {
-		return err
-	}
-
-	o.Name = name
-	o.StructuredGenerator = generator
-	o.DryRunStrategy, err = cmdutil.GetDryRunStrategy(cmd)
-	if err != nil {
-		return err
-	}
-	o.CreateAnnotation = cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag)
-
-	cmdutil.PrintFlagsWithDryRunStrategy(o.PrintFlags, o.DryRunStrategy)
-	printer, err := o.PrintFlags.ToPrinter()
-	if err != nil {
-		return err
-	}
-
-	o.ValidationDirective, err = cmdutil.GetValidationDirective(cmd)
-	if err != nil {
-		return err
-	}
-
-	o.PrintObj = func(obj kruntime.Object, out io.Writer) error {
-		return printer.PrintObj(obj, out)
-	}
-
-	o.Namespace, o.EnforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
-	if err != nil {
-		return err
-	}
-
-	o.DynamicClient, err = f.DynamicClient()
-	if err != nil {
-		return err
-	}
-
-	o.Mapper, err = f.ToRESTMapper()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// Run executes a create subcommand using the specified options
-func (o *CreateSubcommandOptions) Run() error {
-	obj, err := o.StructuredGenerator.StructuredGenerate()
-	if err != nil {
-		return err
-	}
-	if err := util.CreateOrUpdateAnnotation(o.CreateAnnotation, obj, scheme.DefaultJSONEncoder()); err != nil {
-		return err
-	}
-	if o.DryRunStrategy != cmdutil.DryRunClient {
-		// create subcommands have compiled knowledge of things they create, so type them directly
-		gvks, _, err := scheme.Scheme.ObjectKinds(obj)
-		if err != nil {
-			return err
-		}
-		gvk := gvks[0]
-		mapping, err := o.Mapper.RESTMapping(schema.GroupKind{Group: gvk.Group, Kind: gvk.Kind}, gvk.Version)
-		if err != nil {
-			return err
-		}
-
-		asUnstructured := &unstructured.Unstructured{}
-		if err := scheme.Scheme.Convert(obj, asUnstructured, nil); err != nil {
-			return err
-		}
-		if mapping.Scope.Name() == meta.RESTScopeNameRoot {
-			o.Namespace = ""
-		}
-		createOptions := metav1.CreateOptions{}
-		if o.FieldManager != "" {
-			createOptions.FieldManager = o.FieldManager
-		}
-		createOptions.FieldValidation = o.ValidationDirective
-
-		if o.DryRunStrategy == cmdutil.DryRunServer {
-			createOptions.DryRun = []string{metav1.DryRunAll}
-		}
-		actualObject, err := o.DynamicClient.Resource(mapping.Resource).Namespace(o.Namespace).Create(context.TODO(), asUnstructured, createOptions)
-		if err != nil {
-			return err
-		}
-
-		// ensure we pass a versioned object to the printer
-		obj = actualObject
-	} else {
-		if meta, err := meta.Accessor(obj); err == nil && o.EnforceNamespace {
-			meta.SetNamespace(o.Namespace)
-		}
-	}
-
-	return o.PrintObj(obj, o.Out)
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go
@@ -152,7 +152,7 @@ func (o *ClusterRoleBindingOptions) Complete(f cmdutil.Factory, cmd *cobra.Comma
 	return nil
 }
 
-// Run calls the CreateSubcommandOptions.Run in ClusterRoleBindingOptions instance
+// Run performs the execution of the 'create clusterrolebinding' sub command
 func (o *ClusterRoleBindingOptions) Run() error {
 	clusterRoleBinding, err := o.createClusterRoleBinding()
 	if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_namespace.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_namespace.go
@@ -136,7 +136,7 @@ func (o *NamespaceOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 	return err
 }
 
-// Run calls the CreateSubcommandOptions.Run in NamespaceOpts instance
+// Run performs the execution of the 'create namespace' sub command
 func (o *NamespaceOptions) Run() error {
 	namespace := o.createNamespace()
 	if err := util.CreateOrUpdateAnnotation(o.CreateAnnotation, namespace, scheme.DefaultJSONEncoder()); err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb.go
@@ -196,7 +196,7 @@ func (o *PodDisruptionBudgetOpts) Validate() error {
 	return nil
 }
 
-// Run calls the CreateSubcommandOptions.Run in PodDisruptionBudgetOpts instance
+// Run performs the execution of the 'create poddisruptionbudget' sub command
 func (o *PodDisruptionBudgetOpts) Run() error {
 	podDisruptionBudget, err := o.createPodDisruptionBudgets()
 	if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go
@@ -152,7 +152,7 @@ func (o *PriorityClassOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, a
 	return nil
 }
 
-// Run calls the CreateSubcommandOptions.Run in the PriorityClassOptions instance
+// Run performs the execution of the 'create priorityclass' sub command
 func (o *PriorityClassOptions) Run() error {
 	priorityClass, err := o.createPriorityClass()
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
* Removes unused `CreateSubcommandOptions` from create.go
* Fixes subcommand Run() comments which mistakenly mentioned CreateSubcommandOptions

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
