### PR TITLE
Fix: Backward incompatibility of OpenAPI changes

### DIFF
--- a/vendor/k8s.io/kube-openapi/pkg/generators/openapi.go
+++ b/vendor/k8s.io/kube-openapi/pkg/generators/openapi.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/gengo/v2/namer"
 	"k8s.io/gengo/v2/types"
 	openapi "k8s.io/kube-openapi/pkg/common"
+	openapiutil "k8s.io/kube-openapi/pkg/util"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 
 	"k8s.io/klog/v2"
@@ -382,8 +383,11 @@ func (g openAPITypeWriter) generateCall(t *types.Type) error {
 		if g.shouldUseOpenAPIModelName(t) {
 			g.Do("$.|raw${}.OpenAPIModelName(): ", t)
 		} else {
-			// Legacy case: use the "canonical type name"
-			g.Do("\"$.$\": ", t.Name)
+			// Legacy case: use a REST-friendly OpenAPI model name derived from the Go canonical
+			// name (package path + "." + type). Using the raw path would leave '/' in the name;
+			// those become "~1" in JSON pointer fragments and break aggregated OpenAPI v2.
+			legacyKey := openapiutil.ToRESTFriendlyName(t.Name.Package + "." + t.Name.Name)
+			g.Do(fmt.Sprintf("%q: ", legacyKey), nil)
 		}
 
 		hasV2Definition := hasOpenAPIDefinitionMethod(t)

--- a/vendor/k8s.io/kube-openapi/pkg/generators/openapi.go
+++ b/vendor/k8s.io/kube-openapi/pkg/generators/openapi.go
@@ -330,6 +330,13 @@ func (g openAPITypeWriter) shouldUseOpenAPIModelName(t *types.Type) bool {
 	return value != ""
 }
 
+// legacyOpenAPIMapKey is the OpenAPI definitions map key for types that do not use OpenAPIModelName() or
+// +k8s:openapi-model-package. Raw Go type ids contain '/'; in OpenAPI v2 those become '~1' in JSON pointers.
+// ToRESTFriendlyName matches historical behavior and k8s.io/apimachinery runtime.Scheme.toOpenAPIDefinitionName.
+func legacyOpenAPIMapKey(t *types.Type) string {
+	return openapiutil.ToRESTFriendlyName(t.Name.String())
+}
+
 // typeShortName returns short package name (e.g. the name x appears in package x definition) dot type name.
 func typeShortName(t *types.Type) string {
 	// `path` vs. `filepath` because packages use '/'
@@ -383,11 +390,7 @@ func (g openAPITypeWriter) generateCall(t *types.Type) error {
 		if g.shouldUseOpenAPIModelName(t) {
 			g.Do("$.|raw${}.OpenAPIModelName(): ", t)
 		} else {
-			// Legacy case: use a REST-friendly OpenAPI model name derived from the Go canonical
-			// name (package path + "." + type). Using the raw path would leave '/' in the name;
-			// those become "~1" in JSON pointer fragments and break aggregated OpenAPI v2.
-			legacyKey := openapiutil.ToRESTFriendlyName(t.Name.Package + "." + t.Name.Name)
-			g.Do(fmt.Sprintf("%q: ", legacyKey), nil)
+			g.Do("\"$.$\": ", legacyOpenAPIMapKey(t))
 		}
 
 		hasV2Definition := hasOpenAPIDefinitionMethod(t)
@@ -722,7 +725,7 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 				if g.shouldUseOpenAPIModelName(t) {
 					g.Do("$.|raw${}.OpenAPIModelName(),", t)
 				} else {
-					g.Do("\"$.$\",", k)
+					g.Do("\"$.$\",", legacyOpenAPIMapKey(t))
 				}
 			}
 			g.Do("},\n", nil)
@@ -1088,7 +1091,7 @@ func (g openAPITypeWriter) generateReferenceProperty(t *types.Type) {
 	if g.shouldUseOpenAPIModelName(t) {
 		g.Do("Ref: ref($.|raw${}.OpenAPIModelName()),\n", t)
 	} else {
-		g.Do("Ref: ref(\"$.$\"),\n", t.Name.String())
+		g.Do("Ref: ref(\"$.$\"),\n", legacyOpenAPIMapKey(t))
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

For types that do **not** use `OpenAPIModelName()` or `+k8s:openapi-model-package`, `openapi-gen` already used `ToRESTFriendlyName` for definition **map keys**, but **Dependencies** and **`$ref`** still used the raw Go canonical name (`t.Name.String()`), which contains `/`. Those slashes become `~1` in JSON Pointer fragments when OpenAPI v2 is aggregated, corrupting the spec and breaking clients that validate against `/openapi/v2`.

This change adds `legacyOpenAPIMapKey` and uses `ToRESTFriendlyName(t.Name.String())` consistently for the legacy path (map keys, dependency entries, and `Ref` targets), matching historical behavior and `k8s.io/apimachinery/pkg/runtime.Scheme`’s `toOpenAPIDefinitionName` / `kube-openapi/pkg/util.ToRESTFriendlyName`.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Related-to https://github.com/kubernetes/kubernetes/issues/138247

(This issue also mentions validating extension OpenAPI before `APIService` creation; this PR only fixes the `openapi-gen` naming regression.)

#### Special notes for your reviewer:

- No behavior change for types that already use `OpenAPIModelName()` or `+k8s:openapi-model-package`.
- After this merges in **kube-openapi**, **kubernetes/kubernetes** needs a `k8s.io/kube-openapi` bump and `hack/update-vendor.sh`.

#### Does this PR introduce a user-facing change?
```release-note
openapi-gen: for APIs without OpenAPI model name annotations, generated OpenAPI v2 definition keys, dependency lists, and $ref values now consistently use REST-friendly names (dots instead of slashes in package paths), avoiding invalid `~1` escapes in aggregated OpenAPI v2 documents.
```


####  Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
``` NONE

```


