### PR TITLE
proxy: warn when NodePort or HealthCheckNodePort overlaps with epheme…

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -645,6 +645,8 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		return
 	}
 
+	proxy.WarnIfNodePortsOverlapEphemeralRange(proxier.logger, proxier.svcPortMap)
+
 	// Keep track of how long syncs take.
 	start := time.Now()
 

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -681,6 +681,8 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		return
 	}
 
+	proxy.WarnIfNodePortsOverlapEphemeralRange(proxier.logger, proxier.svcPortMap)
+
 	// its safe to set initialSync to false as it acts as a flag for startup actions
 	// and the mutex is held.
 	defer func() {

--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -1069,6 +1069,8 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		return
 	}
 
+	proxy.WarnIfNodePortsOverlapEphemeralRange(proxier.logger, proxier.svcPortMap)
+
 	// Keep track of how long syncs take.
 	start := time.Now()
 

--- a/pkg/proxy/nodeportcheck.go
+++ b/pkg/proxy/nodeportcheck.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"k8s.io/klog/v2"
+)
+
+const ephemeralPortRangeFile = "/proc/sys/net/ipv4/ip_local_port_range"
+
+// WarnIfNodePortsOverlapEphemeralRange reads the node's ephemeral port range from
+// /proc/sys/net/ipv4/ip_local_port_range and logs a warning for any NodePort or
+// HealthCheckNodePort in svcPortMap that falls within that range. Such overlap can
+// cause connection failures when the kernel assigns the same port for outbound traffic.
+func WarnIfNodePortsOverlapEphemeralRange(logger klog.Logger, svcPortMap ServicePortMap) {
+	low, high, err := readEphemeralPortRange()
+	if err != nil {
+		logger.Error(err, "Failed to read ephemeral port range, skipping overlap check")
+		return
+	}
+	warnNodePortOverlaps(logger, svcPortMap, low, high)
+}
+
+func warnNodePortOverlaps(logger klog.Logger, svcPortMap ServicePortMap, low, high int) {
+	for svcName, svc := range svcPortMap {
+		if np := svc.NodePort(); np != 0 && np >= low && np <= high {
+			logger.V(0).Info("NodePort overlaps with ephemeral port range and may conflict with outbound connections",
+				"service", svcName, "nodePort", np, "ephemeralRange", fmt.Sprintf("%d-%d", low, high))
+		}
+		if hcnp := svc.HealthCheckNodePort(); hcnp != 0 && hcnp >= low && hcnp <= high {
+			logger.V(0).Info("HealthCheckNodePort overlaps with ephemeral port range and may conflict with outbound connections",
+				"service", svcName, "healthCheckNodePort", hcnp, "ephemeralRange", fmt.Sprintf("%d-%d", low, high))
+		}
+	}
+}
+
+func readEphemeralPortRange() (int, int, error) {
+	data, err := os.ReadFile(ephemeralPortRangeFile)
+	if err != nil {
+		return 0, 0, err
+	}
+	return parseEphemeralPortRange(string(data))
+}
+
+func parseEphemeralPortRange(data string) (int, int, error) {
+	fields := strings.Fields(strings.TrimSpace(data))
+	if len(fields) != 2 {
+		return 0, 0, fmt.Errorf("unexpected format in %s: %q", ephemeralPortRangeFile, data)
+	}
+	low, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to parse low value in %s: %w", ephemeralPortRangeFile, err)
+	}
+	high, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to parse high value in %s: %w", ephemeralPortRangeFile, err)
+	}
+	return low, high, nil
+}

--- a/pkg/proxy/nodeportcheck_test.go
+++ b/pkg/proxy/nodeportcheck_test.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"strings"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	klogtesting "k8s.io/klog/v2/ktesting"
+)
+
+func TestParseEphemeralPortRange(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantLow int
+		wantHi  int
+		wantErr string
+	}{
+		{
+			name:    "normal range",
+			input:   "32768 60999\n",
+			wantLow: 32768,
+			wantHi:  60999,
+		},
+		{
+			name:    "range without trailing newline",
+			input:   "1024 65535",
+			wantLow: 1024,
+			wantHi:  65535,
+		},
+		{
+			name:    "extra whitespace",
+			input:   "  32768   60999  \n",
+			wantLow: 32768,
+			wantHi:  60999,
+		},
+		{
+			name:    "empty input",
+			input:   "",
+			wantErr: "unexpected format",
+		},
+		{
+			name:    "only one value",
+			input:   "32768",
+			wantErr: "unexpected format",
+		},
+		{
+			name:    "non-numeric low",
+			input:   "abc 60999",
+			wantErr: "failed to parse low value",
+		},
+		{
+			name:    "non-numeric high",
+			input:   "32768 xyz",
+			wantErr: "failed to parse high value",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			low, high, err := parseEphemeralPortRange(tc.input)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if low != tc.wantLow || high != tc.wantHi {
+				t.Errorf("got (%d, %d), want (%d, %d)", low, high, tc.wantLow, tc.wantHi)
+			}
+		})
+	}
+}
+
+func makeSvcPortName(namespace, name, port string) ServicePortName {
+	return ServicePortName{
+		NamespacedName: types.NamespacedName{Namespace: namespace, Name: name},
+		Port:           port,
+		Protocol:       v1.ProtocolTCP,
+	}
+}
+
+func withNodePort(np int) func(*BaseServicePortInfo) {
+	return func(b *BaseServicePortInfo) { b.nodePort = np }
+}
+
+func TestWarnIfNodePortsOverlapEphemeralRange(t *testing.T) {
+	// ephemeral range: 32768-60999
+	const low, high = 32768, 60999
+
+	tests := []struct {
+		name         string
+		svcPortMap   ServicePortMap
+		wantWarnings []string // substrings that must appear in the captured log output
+	}{
+		{
+			name:         "empty map",
+			svcPortMap:   ServicePortMap{},
+			wantWarnings: nil,
+		},
+		{
+			name: "no overlap - port below range",
+			svcPortMap: ServicePortMap{
+				makeSvcPortName("default", "svc1", "http"): makeTestServiceInfo("10.0.0.1", 80, "TCP", 0, withNodePort(30000)),
+			},
+			wantWarnings: nil,
+		},
+		{
+			name: "no overlap - port above range",
+			svcPortMap: ServicePortMap{
+				makeSvcPortName("default", "svc1", "http"): makeTestServiceInfo("10.0.0.1", 80, "TCP", 0, withNodePort(61000)),
+			},
+			wantWarnings: nil,
+		},
+		{
+			name: "NodePort at bottom of range",
+			svcPortMap: ServicePortMap{
+				makeSvcPortName("default", "svc1", "http"): makeTestServiceInfo("10.0.0.1", 80, "TCP", 0, withNodePort(32768)),
+			},
+			wantWarnings: []string{"NodePort overlaps with ephemeral port range"},
+		},
+		{
+			name: "NodePort at top of range",
+			svcPortMap: ServicePortMap{
+				makeSvcPortName("default", "svc1", "http"): makeTestServiceInfo("10.0.0.1", 80, "TCP", 0, withNodePort(60999)),
+			},
+			wantWarnings: []string{"NodePort overlaps with ephemeral port range"},
+		},
+		{
+			name: "HealthCheckNodePort overlaps",
+			svcPortMap: ServicePortMap{
+				makeSvcPortName("default", "svc1", "http"): makeTestServiceInfo("10.0.0.1", 80, "TCP", 40000),
+			},
+			wantWarnings: []string{"HealthCheckNodePort overlaps with ephemeral port range"},
+		},
+		{
+			name: "both NodePort and HCNP overlap",
+			svcPortMap: ServicePortMap{
+				makeSvcPortName("default", "svc1", "http"): makeTestServiceInfo("10.0.0.1", 80, "TCP", 50001, withNodePort(50000)),
+			},
+			wantWarnings: []string{
+				"NodePort overlaps with ephemeral port range",
+				"HealthCheckNodePort overlaps with ephemeral port range",
+			},
+		},
+		{
+			name: "multiple services, only one overlaps",
+			svcPortMap: ServicePortMap{
+				makeSvcPortName("default", "svc1", "http"): makeTestServiceInfo("10.0.0.1", 80, "TCP", 0, withNodePort(30000)),
+				makeSvcPortName("default", "svc2", "http"): makeTestServiceInfo("10.0.0.2", 80, "TCP", 0, withNodePort(45000)),
+			},
+			wantWarnings: []string{"NodePort overlaps with ephemeral port range"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := &klogtesting.BufferTL{}
+			logger := klogtesting.NewLogger(buf, klogtesting.NewConfig())
+
+			warnNodePortOverlaps(logger, tc.svcPortMap, low, high)
+
+			output := buf.String()
+			if len(tc.wantWarnings) == 0 && output != "" {
+				t.Errorf("expected no log output, got: %s", output)
+			}
+			for _, want := range tc.wantWarnings {
+				if !strings.Contains(output, want) {
+					t.Errorf("expected log output containing %q, got: %s", want, output)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds a warning log in kube-proxy when NodePorts or HealthCheckNodePorts
overlap with the node's ephemeral port range (/proc/sys/net/ipv4/ip_local_port_range).
Such overlap can cause outbound connection failures that are difficult to debug.
#### Which issue(s) this PR is related to:
Fixes #111823

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
Started with log-only per the discussion in the issue. No Events yet to
avoid the etcd flooding concern raised by @aojea. The check is a shared
utility called from each backend's sync loop.
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Does this PR introduce a user-facing change?
kube-proxy now logs a warning when a NodePort or HealthCheckNodePort
overlaps with the node's ephemeral port range.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
