### PR TITLE
Pin MutatingAdmissionPolicy storage version to v1beta1

### DIFF
--- a/pkg/kubeapiserver/default_storage_factory_builder.go
+++ b/pkg/kubeapiserver/default_storage_factory_builder.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apiserver/pkg/util/compatibility"
 	basecompatibility "k8s.io/component-base/compatibility"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	"k8s.io/kubernetes/pkg/apis/admissionregistration"
 	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/apis/certificates"
 	"k8s.io/kubernetes/pkg/apis/coordination"
@@ -79,6 +80,8 @@ func NewStorageFactoryConfigEffectiveVersion(effectiveVersion basecompatibility.
 		//
 		// TODO (https://github.com/kubernetes/kubernetes/issues/108451): remove the override in 1.25.
 		// apisstorage.Resource("csistoragecapacities").WithVersion("v1beta1"),
+		admissionregistration.Resource("mutatingadmissionpolicies").WithVersion("v1beta1"),
+		admissionregistration.Resource("mutatingadmissionpolicybindings").WithVersion("v1beta1"),
 		coordination.Resource("leasecandidates").WithVersion("v1beta1"),
 		certificates.Resource("clustertrustbundles").WithVersion("v1beta1"),
 		certificates.Resource("podcertificaterequests").WithVersion("v1beta1"),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Adds MutatingAdmissionPolicy and MutatingAdmissionPolicyBinding to the storage version overrides, pinning them to v1beta1. When master moves to 1.37 after the 1.36 branch is cut, the auto-calculated storage version will change the default to v1 despite 1.36 not being released yet. MAP is the first resource where we didn't need a manual v1beta1 override since we started auto-calculating storage versions.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

TODO: Remove override in 1.37.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```