### PR TITLE
daemonset: Forget queue rate limit on pod delete to fix stuck rollout…

### DIFF
--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -721,6 +721,12 @@ func (dsc *DaemonSetsController) deletePod(logger klog.Logger, obj interface{}) 
 	}
 	logger.V(4).Info("Pod deleted", "pod", klog.KObj(pod))
 	dsc.expectations.DeletionObserved(logger, dsKey)
+	// A delete observed from the informer is meaningful progress for the
+	// DaemonSet (e.g. rolling update removed an old pod). Clear rate-limiter
+	// state so earlier failed syncs (such as repeated admission webhook errors)
+	// do not keep the key on maximum backoff and delay reconciliation until the
+	// next delayed requeue. See https://issue.k8s.io/138280.
+	dsc.queue.Forget(dsKey)
 	dsc.enqueueDaemonSet(ds)
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The DaemonSet controller requeues failed syncs with `AddRateLimited`, which can drive the workqueue per-key backoff up to the maximum (1000s). When a managed pod is **observed deleted** from the informer (for example after a rolling update removes an old pod), we already call `DeletionObserved` and `enqueueDaemonSet` → `queue.Add`, but the rate limiter still remembered prior failures. That could leave reconciliation effectively delayed until the next rate-limited requeue even though deletion is meaningful progress.

Call `queue.Forget(dsKey)` before enqueueing the DaemonSet when handling pod deletion so backoff is reset when we see the delete we care about.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/138280

#### Special notes for your reviewer:

Change is localized to `deletePod` in `pkg/controller/daemon/daemon_controller.go`. `Forget` only clears rate-limiter state for the key; it does not replace `Done` on items currently being processed. Unit tests: `go test ./pkg/controller/daemon/... -short`.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a case where the DaemonSet controller could wait for the maximum workqueue backoff before reconciling again after pod deletions, following repeated sync failures (for example admission webhook errors during rollout).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```NONE
```