### PR TITLE
Fix device-plugin-failures flaking test with connection refused error

### DIFF
--- a/test/e2e_node/device_plugin_failures_test.go
+++ b/test/e2e_node/device_plugin_failures_test.go
@@ -18,20 +18,24 @@ package e2enode
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"time"
-
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"os"
+	"path/filepath"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e_node/testdeviceplugin"
 )
@@ -98,6 +102,36 @@ var _ = SIGDescribe("Device Plugin Failures:", framework.WithNodeConformance(), 
 	nodeStatusUpdateTimeout := 1 * time.Minute
 	devicePluginUpdateTimeout := 1 * time.Minute
 	devicePluginGracefulTimeout := 5 * time.Minute // see endpointStopGracePeriod in pkg/kubelet/cm/devicemanager/types.go
+
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		var triggerPathFile, triggerPathDir string
+
+		ginkgo.By("Wait for node to be ready")
+		gomega.Eventually(ctx, e2enode.TotalReady).
+			WithArguments(f.ClientSet).
+			WithTimeout(time.Minute).
+			Should(gomega.BeEquivalentTo(1))
+
+		ginkgo.By("Setting up the directory and file for controlling registration")
+		triggerPathDir = filepath.Join(devicePluginDir, "sample")
+		if _, err := os.Stat(triggerPathDir); errors.Is(err, os.ErrNotExist) {
+			err := os.Mkdir(triggerPathDir, os.ModePerm)
+			if err != nil {
+				klog.Errorf("Directory creation %s failed: %v ", triggerPathDir, err)
+				panic(err)
+			}
+			klog.InfoS("Directory created successfully")
+
+			triggerPathFile = filepath.Join(triggerPathDir, "registration")
+			if _, err := os.Stat(triggerPathFile); errors.Is(err, os.ErrNotExist) {
+				_, err = os.Create(triggerPathFile)
+				if err != nil {
+					klog.Errorf("File creation %s failed: %v ", triggerPathFile, err)
+					panic(err)
+				}
+			}
+		}
+	})
 
 	ginkgo.It("when GetDevicePluginOptions fails, device plugin will not be used", func(ctx context.Context) {
 		// randomizing so tests can run in parallel


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

When kubelet is not ready, tests fail with connection refused error while dialing device-plugins/kubelet.sock. 

This commit tries to fix using approach used in device_manager_test.go before each test to wait for test node to be ready.


#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

A failed run demonstrating the problem can be found [here](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/129719/pull-kubernetes-node-kubelet-serial-device-manager/2042145729530564608
)

```
E2eNode Suite: [It] [sig-node] Device Plugin Failures: [NodeConformance] when ListAndWatch fails after provisioning devices, node allocatable will be set to zero and kubelet will not retry to list resources expand_less 	0s

{ failed [FAILED] Expected success, but got an error:
    <*status.Error | 0x1fdd463f1010>: 
    rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial unix /var/lib/kubelet/device-plugins/kubelet.sock: connect: connection refused"
    {
        s: {
            s: {
                state: {
                    NoUnkeyedLiterals: {},
                    DoNotCompare: [],
                    DoNotCopy: [],
                    atomicMessageInfo: nil,
                },
                sizeCache: 0,
                unknownFields: nil,
                Code: 14,
                Message: "connection error: desc = \"transport: Error while dialing: dial unix /var/lib/kubelet/device-plugins/kubelet.sock: connect: connection refused\"",
                Details: nil,
            },
        },
    }
In [It] at: k8s.io/kubernetes/test/e2e_node/device_plugin_failures_test.go:306 @ 04/09/26 08:12:33.957
}
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
