### PR TITLE
Fix pull-kubernetes-node-kubelet-serial-containerd flaky tests

### DIFF
--- a/test/e2e_node/device_manager_test.go
+++ b/test/e2e_node/device_manager_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -30,7 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
-	"k8s.io/klog/v2"
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	"k8s.io/kubernetes/test/e2e/feature"
@@ -111,30 +111,57 @@ var _ = SIGDescribe("Device Manager", framework.WithSerial(), feature.DeviceMana
 				WithTimeout(time.Minute).
 				Should(gomega.BeEquivalentTo(1))
 
-			ginkgo.By("Setting up the directory and file for controlling registration")
-			triggerPathDir = filepath.Join(devicePluginDir, "sample")
-			if _, err := os.Stat(triggerPathDir); errors.Is(err, os.ErrNotExist) {
-				err := os.Mkdir(triggerPathDir, os.ModePerm)
+			// Before we run the device plugin test, we need to ensure
+			// that the cluster is in a clean state and there are no
+			// pods running on this node.
+			// This is done in a gomega.Eventually with retries since a prior test in a different test suite could've run and the deletion of it's resources may still be in progress.
+			// xref: https://issue.k8s.io/115381
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				v1PodResources, err := getV1NodeDevices(ctx)
 				if err != nil {
-					klog.Errorf("Directory creation %s failed: %v ", triggerPathDir, err)
-					panic(err)
+					return fmt.Errorf("failed to get node local podresources by accessing the (v1) podresources API endpoint: %w", err)
 				}
-				klog.InfoS("Directory created successfully")
 
-				triggerPathFile = filepath.Join(triggerPathDir, "registration")
-				if _, err := os.Stat(triggerPathFile); errors.Is(err, os.ErrNotExist) {
-					_, err = os.Create(triggerPathFile)
-					if err != nil {
-						klog.Errorf("File creation %s failed: %v ", triggerPathFile, err)
-						panic(err)
-					}
+				if len(v1PodResources.PodResources) > 0 {
+					return fmt.Errorf("expected v1 pod resources to be empty, but got non-empty resources: %+v", v1PodResources.PodResources)
 				}
+				return nil
+			}, f.Timeouts.SystemDaemonsetStartup, f.Timeouts.Poll).Should(gomega.Succeed())
+
+			ginkgo.By("Setting up the directory for controlling registration")
+			triggerPathDir = filepath.Join(devicePluginDir, "sample")
+			if _, err := os.Stat(triggerPathDir); err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					if err := os.Mkdir(triggerPathDir, os.ModePerm); err != nil {
+						framework.Fail(fmt.Sprintf("registration control directory %q creation failed: %v ", triggerPathDir, err))
+					}
+					framework.Logf("registration control directory created successfully")
+				} else {
+					framework.Fail(fmt.Sprintf("unexpected error checking %q: %v", triggerPathDir, err))
+				}
+			} else {
+				framework.Logf("registration control directory %q already present", triggerPathDir)
+			}
+
+			ginkgo.By("Setting up the file trigger for controlling registration")
+			triggerPathFile = filepath.Join(triggerPathDir, "registration")
+			if _, err := os.Stat(triggerPathFile); err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					if _, err = os.Create(triggerPathFile); err != nil {
+						framework.Fail(fmt.Sprintf("registration control file %q creation failed: %v", triggerPathFile, err))
+					}
+					framework.Logf("registration control file created successfully")
+				} else {
+					framework.Fail(fmt.Sprintf("unexpected error creating %q: %v", triggerPathFile, err))
+				}
+			} else {
+				framework.Logf("registration control file %q already present", triggerPathFile)
 			}
 
 			ginkgo.By("Scheduling a sample device plugin pod")
 			data, err := e2etestfiles.Read(e2enode.SampleDevicePluginControlRegistrationDSYAML)
 			if err != nil {
-				framework.Fail(err.Error())
+				framework.Fail(fmt.Sprintf("error reading test data %q: %v", e2enode.SampleDevicePluginControlRegistrationDSYAML, err))
 			}
 			ds := readDaemonSetV1OrDie(data)
 
@@ -146,6 +173,30 @@ var _ = SIGDescribe("Device Manager", framework.WithSerial(), feature.DeviceMana
 			}
 
 			devicePluginPod = e2epod.NewPodClient(f).CreateSync(ctx, dp)
+
+			ginkgo.By("making sure all the pods are ready")
+
+			err = e2epod.WaitForPodCondition(ctx, f.ClientSet, devicePluginPod.Namespace, devicePluginPod.Name, "Ready", 120*time.Second, testutils.PodRunningReady)
+			framework.ExpectNoError(err, "pod %s/%s did not go running", devicePluginPod.Namespace, devicePluginPod.Name)
+			framework.Logf("pod %s/%s running", devicePluginPod.Namespace, devicePluginPod.Name)
+
+			ginkgo.By("Verifying the devicePluginPod handleRegistrationProcess entered twice in the loop before we delete the registration file to trigger manual registration")
+			gomega.Eventually(ctx, func() bool {
+				logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, devicePluginPod.Namespace, devicePluginPod.Name, devicePluginPod.Spec.Containers[0].Name)
+				if err != nil {
+					framework.Logf("error getting logs for pod %q: %v", devicePluginPod.Name, err)
+					return false // Returning false to continue trying
+				}
+				framework.Logf("got pod logs: %v", logs)
+				regex := regexp.MustCompile("Starting watching routine(.?)")
+				matches := regex.Find([]byte(logs))
+				if matches == nil {
+					framework.Logf("handleRegistrationProcess not started for pod %q", devicePluginPod.Name)
+					return false // Returning false to continue trying
+				}
+				framework.Logf("handleRegistrationProcess started: %s", matches)
+				return true
+			}, 60*time.Second, framework.Poll).Should(gomega.BeTrueBecause("expected watching routine"))
 
 			go func() {
 				// Since autoregistration is disabled for the device plugin (as REGISTER_CONTROL_FILE
@@ -259,11 +310,21 @@ var _ = SIGDescribe("Device Manager", framework.WithSerial(), feature.DeviceMana
 		})
 
 		ginkgo.AfterEach(func(ctx context.Context) {
+
+			ginkgo.By("Get and print devicePluginPod logs")
+			// Printing the logs form the pod, help to troubleshoot cases when devicePluginPod fails to register device with manual registration
+			logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, devicePluginPod.Namespace, devicePluginPod.Name, devicePluginPod.Spec.Containers[0].Name)
+			if err != nil {
+				framework.Logf("failed to get pod logs %v", err)
+			} else {
+				framework.Logf("logs of %s/%s/%s (error: %v): %s", devicePluginPod.Namespace, devicePluginPod.Name, devicePluginPod.Spec.Containers[0].Name, err, logs)
+			}
+
 			ginkgo.By("Deleting the device plugin pod")
 			e2epod.NewPodClient(f).DeleteSync(ctx, devicePluginPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
 
 			ginkgo.By("Deleting the directory and file setup for controlling registration")
-			err := os.RemoveAll(triggerPathDir)
+			err = os.RemoveAll(triggerPathDir)
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Deleting any Pods created by the test")
@@ -283,6 +344,8 @@ var _ = SIGDescribe("Device Manager", framework.WithSerial(), feature.DeviceMana
 				WithArguments(f).
 				WithTimeout(5 * time.Minute).
 				Should(BeReady())
+
+			ginkgo.By("devices now unavailable on the local node")
 		})
 
 	})

--- a/test/e2e_node/device_plugin_failures_test.go
+++ b/test/e2e_node/device_plugin_failures_test.go
@@ -112,6 +112,9 @@ var _ = SIGDescribe("Device Plugin Failures:", framework.WithNodeConformance(), 
 			return nil
 		})
 
+		ginkgo.By("Wait enough for unix socket to be open")
+		time.Sleep(time.Second)
+
 		err := plugin.RegisterDevicePlugin(ctx, f.UniqueName, resourceName, []*kubeletdevicepluginv1beta1.Device{{ID: "testdevice", Health: kubeletdevicepluginv1beta1.Healthy}})
 		defer plugin.Stop() // should stop even if registration failed
 		gomega.Expect(err).To(gomega.MatchError(gomega.ContainSubstring("failed to get device plugin options")))
@@ -130,6 +133,9 @@ var _ = SIGDescribe("Device Plugin Failures:", framework.WithNodeConformance(), 
 		resourceName := fmt.Sprintf("test.device/%s", f.UniqueName)
 		devices := []*kubeletdevicepluginv1beta1.Device{{ID: "testdevice", Health: kubeletdevicepluginv1beta1.Healthy}}
 		plugin := testdeviceplugin.NewDevicePlugin(nil)
+
+		ginkgo.By("Wait enough for unix socket to be open")
+		time.Sleep(time.Second)
 
 		err := plugin.RegisterDevicePlugin(ctx, f.UniqueName, resourceName, devices)
 		defer plugin.Stop() // should stop even if registration failed
@@ -156,6 +162,9 @@ var _ = SIGDescribe("Device Plugin Failures:", framework.WithNodeConformance(), 
 		resourceName := fmt.Sprintf("test.device/%s", f.UniqueName)
 		devices := []*kubeletdevicepluginv1beta1.Device{{ID: "testdevice", Health: kubeletdevicepluginv1beta1.Healthy}}
 		plugin := testdeviceplugin.NewDevicePlugin(nil)
+
+		ginkgo.By("Wait enough for unix socket to be open")
+		time.Sleep(time.Second)
 
 		err := plugin.RegisterDevicePlugin(ctx, f.UniqueName, resourceName, devices)
 		defer plugin.Stop() // should stop even if registration failed
@@ -215,6 +224,9 @@ var _ = SIGDescribe("Device Plugin Failures:", framework.WithNodeConformance(), 
 		}
 		plugin := testdeviceplugin.NewDevicePlugin(nil)
 
+		ginkgo.By("Wait enough for unix socket to be open")
+		time.Sleep(time.Second)
+
 		err := plugin.RegisterDevicePlugin(ctx, f.UniqueName, resourceName, devices)
 		defer plugin.Stop() // should stop even if registration failed
 		gomega.Expect(err).To(gomega.Succeed())
@@ -269,6 +281,9 @@ var _ = SIGDescribe("Device Plugin Failures:", framework.WithNodeConformance(), 
 			return nil
 		})
 
+		ginkgo.By("Wait enough for unix socket to be open")
+		time.Sleep(time.Second)
+
 		err := plugin.RegisterDevicePlugin(ctx, f.UniqueName, resourceName, devices)
 		defer plugin.Stop() // should stop even if registration failed
 		gomega.Expect(err).To(gomega.Succeed())
@@ -300,6 +315,9 @@ var _ = SIGDescribe("Device Plugin Failures:", framework.WithNodeConformance(), 
 			}
 			return nil
 		})
+
+		ginkgo.By("Wait enough for unix socket to be open")
+		time.Sleep(time.Second)
 
 		err := plugin.RegisterDevicePlugin(ctx, f.UniqueName, resourceName, devices)
 		defer plugin.Stop() // should stop even if registration failed
@@ -335,6 +353,9 @@ var _ = SIGDescribe("Device Plugin Failures:", framework.WithNodeConformance(), 
 		gomega.Eventually(getNodeResourceValues, nodeStatusUpdateTimeout, f.Timeouts.Poll).WithContext(ctx).WithArguments(resourceName).Should(gomega.Equal(ResourceValue{Allocatable: -1, Capacity: -1}))
 
 		plugin := testdeviceplugin.NewDevicePlugin(nil)
+
+		ginkgo.By("Wait enough for unix socket to be open")
+		time.Sleep(time.Second)
 
 		err := plugin.RegisterDevicePlugin(ctx, f.UniqueName, resourceName, devices)
 		defer plugin.Stop() // should stop even if registration failed

--- a/test/e2e_node/device_plugin_test.go
+++ b/test/e2e_node/device_plugin_test.go
@@ -191,6 +191,14 @@ func testDevicePlugin(f *framework.Framework, pluginSockDir string) {
 		})
 
 		ginkgo.AfterEach(func(ctx context.Context) {
+			// Printing devicePluginPod logs for troubleshooting
+			ginkgo.By("Get and print devicePluginPod logs")
+			logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, devicePluginPod.Namespace, devicePluginPod.Name, devicePluginPod.Spec.Containers[0].Name)
+			if err != nil {
+				framework.Logf("failed to get pod logs %v", err)
+			} else {
+				framework.Logf("logs of %s/%s (error: %v): %s", devicePluginPod.Name, devicePluginPod.Spec.Containers[0].Name, err, logs)
+			}
 			ginkgo.By("Deleting the device plugin pod")
 			e2epod.NewPodClient(f).DeleteSync(ctx, devicePluginPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
 
@@ -865,6 +873,29 @@ func testDevicePluginNodeReboot(f *framework.Framework, pluginSockDir string) {
 			}
 			framework.ExpectNoError(err, "WaitForPodCondition() failed err: %v", err)
 
+			ginkgo.By("making sure all the pods are ready")
+			err = e2epod.WaitForPodCondition(ctx, f.ClientSet, devicePluginPod.Namespace, devicePluginPod.Name, "Ready", 120*time.Second, testutils.PodRunningReady)
+			framework.ExpectNoError(err, "pod %s/%s did not go running", devicePluginPod.Namespace, devicePluginPod.Name)
+			framework.Logf("pod %s/%s running", devicePluginPod.Namespace, devicePluginPod.Name)
+
+			ginkgo.By("Verifying the devicePluginPod handleRegistrationProcess entered twice in the loop before we delete the registration file to trigger manual registration")
+			gomega.Eventually(ctx, func() bool {
+				logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, devicePluginPod.Namespace, devicePluginPod.Name, devicePluginPod.Spec.Containers[0].Name)
+				if err != nil {
+					framework.Logf("error getting logs for pod %q: %v", devicePluginPod.Name, err)
+					return false // Returning false to continue trying
+				}
+				framework.Logf("got pod logs: %v", logs)
+				regex := regexp.MustCompile("Starting watching routine(.?)")
+				matches := regex.Find([]byte(logs))
+				if matches == nil {
+					framework.Logf("handleRegistrationProcess not started for pod %q", devicePluginPod.Name)
+					return false // Returning false to continue trying
+				}
+				framework.Logf("handleRegistrationProcess started: %s", matches)
+				return true
+			}, 60*time.Second, framework.Poll).Should(gomega.BeTrueBecause("expected watching routine"))
+
 			go func() {
 				// Since autoregistration is disabled for the device plugin (as REGISTER_CONTROL_FILE
 				// environment variable is specified), device plugin registration needs to be triggerred
@@ -895,6 +926,15 @@ func testDevicePluginNodeReboot(f *framework.Framework, pluginSockDir string) {
 		})
 
 		ginkgo.AfterEach(func(ctx context.Context) {
+			ginkgo.By("Get and print devicePluginPod logs")
+			// Printing the logs form the pod, help to troubleshoot cases when devicePluginPod fails to register device with manual registration
+			logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, devicePluginPod.Namespace, devicePluginPod.Name, devicePluginPod.Spec.Containers[0].Name)
+			if err != nil {
+				framework.Logf("failed to get pod logs %v", err)
+			} else {
+				framework.Logf("logs of %s/%s (error: %v): %s", devicePluginPod.Name, devicePluginPod.Spec.Containers[0].Name, err, logs)
+			}
+
 			ginkgo.By("Deleting the device plugin pod")
 			e2epod.NewPodClient(f).DeleteSync(ctx, devicePluginPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
 
@@ -960,6 +1000,7 @@ func testDevicePluginNodeReboot(f *framework.Framework, pluginSockDir string) {
 
 				err := rs.RemovePodSandbox(ctx, sandbox.Id)
 				framework.ExpectNoError(err)
+				waitForAllContainerRemoval(ctx, sandbox.Metadata.Name, sandbox.Metadata.Namespace)
 			}
 
 			ginkgo.By("restarting the kubelet")
@@ -987,9 +1028,22 @@ func testDevicePluginNodeReboot(f *framework.Framework, pluginSockDir string) {
 			// Hence, we verify that our test pod is NOT present in the podresources response.
 
 			// We need to poll because there's a delay between the pod failing admission and being
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				v1PodResources, err = getV1NodeDevices(ctx)
+				if err != nil {
+					return fmt.Errorf("failed to get node local podresources by accessing the (v1) podresources API endpoint: %w", err)
+				} else {
+					framework.Logf("Local podresources by accessing the (v1) podresources API enpoint: %+v", v1PodResources.PodResources)
+				}
+				if len(v1PodResources.PodResources) != 1 {
+					return fmt.Errorf("expected v1 pod resources to be one, but got resources: %+v", v1PodResources.PodResources)
+				}
+				return nil
+			}, f.Timeouts.PodDelete, f.Timeouts.Poll).Should(gomega.Succeed())
+
 			// removed from the podresources list.
 			gomega.Eventually(ctx, func(ctx context.Context) bool {
-				v1PodResources, err := getV1NodeDevices(ctx)
+				v1PodResources, err = getV1NodeDevices(ctx)
 				if err != nil {
 					framework.Logf("Failed to get node devices: %v, will retry", err)
 					return true // Return true to continue polling on error

--- a/test/e2e_node/memory_qos_test.go
+++ b/test/e2e_node/memory_qos_test.go
@@ -176,6 +176,7 @@ func memqosMakePod(name, namespace string, requests, limits v1.ResourceList) *v1
 
 var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 	f := framework.NewDefaultFramework("memory-qos")
+	addAfterEachForCleaningUpPods(f)
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 	var (

--- a/test/e2e_node/podresources_test.go
+++ b/test/e2e_node/podresources_test.go
@@ -1103,6 +1103,7 @@ func podresourcesGetTests(ctx context.Context, f *framework.Framework, cli kubel
 // Serial because the test updates kubelet configuration.
 var _ = SIGDescribe("POD Resources API", framework.WithSerial(), feature.PodResourcesAPI, func() {
 	f := framework.NewDefaultFramework("podresources-test")
+	addBeforeEachForCleaningUpPods(f)
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 	var reservedSystemCPUs cpuset.CPUSet

--- a/test/e2e_node/probe_stress_test.go
+++ b/test/e2e_node/probe_stress_test.go
@@ -44,6 +44,7 @@ const (
 
 var _ = SIGDescribe("Probe Stress", framework.WithSerial(), func() {
 	f := framework.NewDefaultFramework("probe-stress")
+	addAfterEachForCleaningUpPods(f)
 	// LevelPrivileged is required because the stress tests create pods with many containers
 	// that may require elevated permissions for networking and resource allocation
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged

--- a/test/e2e_node/testdeviceplugin/device-plugin.go
+++ b/test/e2e_node/testdeviceplugin/device-plugin.go
@@ -18,8 +18,10 @@ package testdeviceplugin
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"sync"
 	"time"
@@ -28,7 +30,14 @@ import (
 	"github.com/onsi/gomega"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"k8s.io/klog/v2"
 	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+	"k8s.io/kubernetes/pkg/cluster/ports"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+var (
+	kubeletHealthCheckURL = fmt.Sprintf("http://127.0.0.1:%d/healthz", ports.KubeletHealthzPort)
 )
 
 type DevicePlugin struct {
@@ -148,6 +157,27 @@ func (dp *DevicePlugin) GetPreferredAllocation(ctx context.Context, request *kub
 	return nil, nil
 }
 
+func kubeletHealthCheck(url string) bool {
+	insecureTransport := http.DefaultTransport.(*http.Transport).Clone()
+	insecureTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	insecureHTTPClient := &http.Client{
+		Transport: insecureTransport,
+	}
+
+	req, err := http.NewRequest(http.MethodHead, url, nil)
+	if err != nil {
+		return false
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", framework.TestContext.BearerToken))
+	resp, err := insecureHTTPClient.Do(req)
+	if err != nil {
+		klog.Warningf("Health check on %q failed, error=%v", url, err)
+	} else if resp.StatusCode != http.StatusOK {
+		klog.Warningf("Health check on %q failed, status=%d", url, resp.StatusCode)
+	}
+	return err == nil && resp.StatusCode == http.StatusOK
+}
+
 func (dp *DevicePlugin) RegisterDevicePlugin(ctx context.Context, uniqueName, resourceName string, devices []*kubeletdevicepluginv1beta1.Device) error {
 	ginkgo.GinkgoHelper()
 
@@ -158,26 +188,41 @@ func (dp *DevicePlugin) RegisterDevicePlugin(ctx context.Context, uniqueName, re
 	devicePluginEndpoint := fmt.Sprintf("%s-%s.sock", "test-device-plugin", uniqueName)
 	dp.uniqueName = uniqueName
 
+	ginkgo.By("Ensuring kubelet is healthy")
+	gomega.Eventually(ctx, func() bool {
+		ok := kubeletHealthCheck(kubeletHealthCheckURL)
+		framework.Logf("kubelet health check at %q value=%v", kubeletHealthCheckURL, ok)
+		return ok
+	}, framework.PodStartTimeout, framework.Poll).Should(gomega.BeTrueBecause("expected kubelet health check to be successful"))
+
 	// Implement the logic to register the device plugin with the kubelet
-	// Create a new gRPC server
-	dp.server = grpc.NewServer()
-	// Register the device plugin with the server
-	kubeletdevicepluginv1beta1.RegisterDevicePluginServer(dp.server, dp)
-	// Create a listener on a specific port
+	ginkgo.By("Create a listener on a specific port")
 	lis, err := net.Listen("unix", kubeletdevicepluginv1beta1.DevicePluginPath+devicePluginEndpoint)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to listen on the unix socket, error: %w", err)
 	}
-	// Start the gRPC server
+
+	ginkgo.By("Wait enough for unix socket to be open")
+	time.Sleep(time.Second)
+
+	ginkgo.By("Create a new gRPC server")
+	dp.server = grpc.NewServer()
+	ginkgo.By("Register the device plugin with the server")
+	kubeletdevicepluginv1beta1.RegisterDevicePluginServer(dp.server, dp)
+
+	ginkgo.By("Start the gRPC server")
 	go func() {
 		err := dp.server.Serve(lis)
 		gomega.Expect(err).To(gomega.Succeed())
 	}()
 
-	// Create a connection to the kubelet
-	conn, err := grpc.NewClient("unix://"+kubeletdevicepluginv1beta1.KubeletSocket,
+	ginkgo.By("Create a connection to the kubelet")
+	options := []grpc.DialOption{
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
+		grpc.WithIdleTimeout(5 * time.Second),
+	}
+	ginkgo.By("gRPC server listening at socketPath")
+	conn, err := grpc.NewClient("unix://"+kubeletdevicepluginv1beta1.KubeletSocket, options...)
 	if err != nil {
 		return err
 	}
@@ -186,15 +231,20 @@ func (dp *DevicePlugin) RegisterDevicePlugin(ctx context.Context, uniqueName, re
 		gomega.Expect(err).To(gomega.Succeed())
 	}()
 
-	// Create a client for the kubelet
+	ginkgo.By("Wait enough for gRPC server unix scoket to be open")
+	time.Sleep(time.Second)
+
+	ginkgo.By("Create a client for the kubelet")
 	client := kubeletdevicepluginv1beta1.NewRegistrationClient(conn)
 
-	// Register the device plugin with the kubelet
-	_, err = client.Register(ctx, &kubeletdevicepluginv1beta1.RegisterRequest{
+	reqt := &kubeletdevicepluginv1beta1.RegisterRequest{
 		Version:      kubeletdevicepluginv1beta1.Version,
 		Endpoint:     devicePluginEndpoint,
 		ResourceName: resourceName,
-	})
+	}
+
+	ginkgo.By("Register the device plugin with the kubelet")
+	_, err = client.Register(ctx, reqt)
 	if err != nil {
 		return err
 	}
@@ -202,8 +252,12 @@ func (dp *DevicePlugin) RegisterDevicePlugin(ctx context.Context, uniqueName, re
 }
 
 func (dp *DevicePlugin) Stop() {
+	ginkgo.By("Waiting one second before stoping gRPC server")
+	time.Sleep(time.Second)
 	if dp.server != nil {
+		ginkgo.By("Stoping gRPC server stopped")
 		dp.server.Stop()
+		ginkgo.By("Fake gRPC server stopped")
 		dp.server = nil
 	}
 }

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -182,6 +182,18 @@ func addAfterEachForCleaningUpPods(f *framework.Framework) {
 	})
 }
 
+func addBeforeEachForCleaningUpPods(f *framework.Framework) {
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		ginkgo.By("Deleting any Pods created by previous test(s) in all namespaces")
+		l, err := e2epod.NewPodClient(f).List(ctx, metav1.ListOptions{})
+		framework.ExpectNoError(err)
+		for _, p := range l.Items {
+			framework.Logf("Deleting pod: %s in %s", p.Name, p.Namespace)
+			e2epod.NewPodClient(f).DeleteSync(ctx, p.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
+		}
+	})
+}
+
 func waitForKubeletToStart(ctx context.Context, f *framework.Framework) {
 	// wait until the kubelet health check will succeed
 	gomega.Eventually(ctx, func() bool {


### PR DESCRIPTION

#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Attempt to fix flaky device-plugin-failures  and resource-api-sriov tests in pull-kubernetes-node-kubelet-serial-containerd and pull-kubernetes-node-kubelet-serial-device-manager

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/131703
https://github.com/kubernetes/kubernetes/issues/137602
https://github.com/kubernetes/kubernetes/issues/138607
https://github.com/kubernetes/kubernetes/issues/138634

#### Special notes for your reviewer:

##### (a) device_plugin_failures_pod_status_test  and device_plugin_failures_test flaky tests [Solved]

Failed tests run, can be seen [here](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/138244/pull-kubernetes-node-kubelet-serial-device-manager/2042403955396317184) . 

Root cause: It fails because test code attempts to connect to kubelet socket, without checking first if the kubelet is healthy.  Also checking the kubelet logs issue occurs when there are containers from other tests ( leftovers?) which result to kubelet taking some time after restarts to start.

Proposed solution:  Please see PR modifications, in brief health checks to ensure kubelet is up, addition of 1 second timeout to wait for unix socket to be up, cleanup of garbage containers using cri beforeEach.  Some consistent repetitive successful test runs [here](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/138289/pull-kubernetes-node-kubelet-serial-device-manager/2044812393535508480), [here](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/138289/pull-kubernetes-node-kubelet-serial-device-manager/2044792755011457024) , [here](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/138289/pull-kubernetes-node-kubelet-serial-device-manager/2044763298540294144) 

Outcome: Looks promising reducing the flakiness. [Job history](https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-kubernetes-node-kubelet-serial-device-manager) / [testgrid-pull-kubernetes-node-kubelete-serial-device-manager](https://testgrid.k8s.io/sig-node-presubmits#pr-kubelet-serial-e2e-device-manager&width=20)

<img width="1919" height="817" alt="image" src="https://github.com/user-attachments/assets/b54f32b6-ea93-4a2f-9595-b4320a70669a" />

##### (b) device_manager_test.go failed test. [Solved]

Root cause: There was no check when 'handleRegistrationProcess' started inside sample-device-plugin pod, 'handleRegistrationProcess' handles the Manual registration process, deleting the path before this process is started resulted no registration.
 
Proposed Solution: Get pod logs and check from logs that sampledeviceplugin container has entered the registration loop.   please check  below and successful run [here](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/138289/pull-kubernetes-node-kubelet-containerd-flaky/2045495607853846528)

> STEP: making sure all the pods are ready @ 04/18/26 13:45:08.225
>   I0418 13:45:08.227012    1763 device_manager_test.go:181] pod devicemanager-test-2744/sample-device-plugin running
>   STEP: Verifying the devicePluginPod handleRegistrationProcess entered twice in the loop before we delete the registration file to trigger manual registration @ 04/18/26 13:45:08.227
>   I0418 13:45:08.236729    1763 device_manager_test.go:190] got pod logs: 
>   I0418 13:45:08.236832    1763 device_manager_test.go:194] handleRegistrationProcess not started for pod "sample-device-plugin"
>   I0418 13:45:10.242260    1763 device_manager_test.go:190] got pod logs: I0418 13:45:08.495392       1 sampledeviceplugin.go:105] pluginSocksDir: /var/lib/kubelet/device-plugins
>   I0418 13:45:08.495681       1 stub.go:135] "Starting device plugin server"
>   I0418 13:45:08.506735       1 stub.go:176] "Starting to serve on socket" socket="/var/lib/kubelet/device-plugins/dp.1776519908"
>   I0418 13:45:08.506772       1 sampledeviceplugin.go:120] CDI_ENABLED: 
>   I0418 13:45:08.506797       1 sampledeviceplugin.go:149] "Registration process will be managed explicitly" triggerPath="/var/lib/kubelet/device-plugins/sample" triggerEntry="/var/lib/kubelet/device-plugins/sample/registration"
>   I0418 13:45:08.506907       1 sampledeviceplugin.go:204] "Starting watching routine"
>   I0418 13:45:08.506917       1 sampledeviceplugin.go:206] "handleRegistrationProcess for loop"
> 
>   I0418 13:45:10.242351    1763 device_manager_test.go:197] handleRegistrationProcess started: Starting watching routine"
> 

Outcome: Successful run https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/138289/pull-kubernetes-node-kubelet-containerd-flaky/2045495607853846528  
https://testgrid.k8s.io/sig-node-presubmits#pr-node-kubelet-serial-containerd-flaky

<img width="1914" height="537" alt="image" src="https://github.com/user-attachments/assets/2bd85cd1-10e3-4a25-b7c0-f701a66dda28" />

##### (c) device-plugin-test

Root cause: Checking the kubelet.logs, the pod is rejected as expected by the test and allocatedResources is set to nil

> I0419 20:35:13.767419   13942 pod_workers.go:1251] "Processing pod event" pod="device-plugin-errors-9907/sample-device-plugin" podUID="b105b54e-3ad5-4d38-bbf7-514fc8135dbc" updateType="sync"                                                
I0419 20:35:13.767485   13942 kubelet.go:2028] "SyncPod enter" pod="device-plugin-errors-9907/sample-device-plugin" podUID="b105b54e-3ad5-4d38-bbf7-514fc8135dbc"                                                                             I0419 20:35:13.767535   13942 kubelet_pods.go:1890] "Generating pod status" podIsTerminal=false pod="device-plugin-errors-9907/sample-device-plugin"                                                                                          I0419 20:35:13.767592   13942 event.go:389] "Event occurred" object="device-plugin-errors-9907/device-plugin-test-9783589c-7192-49cd-bf68-da9a5b039e9f" fieldPath="" kind="Pod" apiVersion="v1" type="Warning" reason="UnexpectedAdmissionError" message="Allocate failed due to no healthy devices present; cannot allocate unhealthy devices example.com/resource, which is unexpected"                                                                                                   
I0419 20:35:13.767791   13942 kubelet_pods.go:1900] "Got phase for pod" pod="device-plugin-errors-9907/sample-device-plugin" oldPhase="Running" phase="Running"                                                                               I0419 20:35:13.767834   13942 util.go:34] "No sandbox for pod can be found. Need to start a new one" pod="device-plugin-errors-9907/sample-device-plugin"                                                                                     I0419 20:35:13.768065   13942 volume_manager.go:409] "Waiting for volumes to attach and mount for pod" pod="device-plugin-errors-9907/sample-device-plugin"                                                                                   I0419 20:35:13.775883   13942 config.go:226] "Setting pods for source" source="api"                                                                                                                                                           I0419 20:35:13.775954   13942 kubelet.go:2722] "SyncLoop RECONCILE" source="api" pods=["device-plugin-errors-9907/device-plugin-test-9783589c-7192-49cd-bf68-da9a5b039e9f"]                                                                   I0419 20:35:13.775990   13942 status_manager.go:1184] "Patch status for pod" pod="device-plugin-errors-9907/device-plugin-test-9783589c-7192-49cd-bf68-da9a5b039e9f" podUID="ec0ecc04-4697-4e8b-897c-9d700fed5215" patch="{\"metadata\":{\"uid\":\"ec0ecc04-4697-4e8b-897c-9d700fed5215\"},\"status\":{\"allocatedResources\":null,\"conditions\":null,\"containerStatuses\":null,\"hostIP\":null,\"hostIPs\":null,\"podIP\":null,\"podIPs\":null,\"resources\":null}}"                     I0419 20:35:13.776015   13942 status_manager.go:1193] "Status for pod updated successfully" pod="device-plugin-errors-9907/device-plugin-test-9783589c-7192-49cd-bf68-da9a5b039e9f" statusVersion=1 status={"observedGeneration":1,"phase":"Running","startTime":"2026-04-19T20:35:09Z","qosClass":"BestEffort"}                                                                                                                                                                            

Later status is updated

> I0419 20:35:22.781295   13942 status_manager.go:1294] "Pod status is inconsistent with cached status for pod, a reconciliation should be triggered" pod="device-plugin-errors-9907/device-plugin-test-9783589c-7192-49cd-bf68-da9a5b039e9f" statusDiff=<                                                                                                                                                                                                                                    
        @@ -1,6 +1,8 @@                                                                                                                                                                                                                       
         {                                                                                                                                                                                                                                              "observedGeneration": 1,                                                                                                                                                                                                            
        - "phase": "Running",                                                                                                                                                                                                                         + "phase": "Failed",                                                                                                                                                                                                                  
        + "message": "Pod was rejected: Allocate failed due to no healthy devices present; cannot allocate unhealthy devices example.com/resource, which is unexpected",                                                                              + "reason": "UnexpectedAdmissionError",                                                                                                                                                                                               
          "startTime": "2026-04-19T20:35:09Z",                                                                                                                                                                                                
          "qosClass": "BestEffort"                                                                                                                                                                                                            
         }                                                                                                                                                                                                                                    
 >

and later
                                                                                                                                                                                                                                        
> I0419 20:35:22.789388   13942 status_manager.go:1184] "Patch status for pod" pod="device-plugin-errors-9907/device-plugin-test-9783589c-7192-49cd-bf68-da9a5b039e9f" podUID="ec0ecc04-4697-4e8b-897c-9d700fed5215" patch="{\"metadata\":{\"uid\":\"ec0ecc04-4697-4e8b-897c-9d700fed5215\"},\"status\":{\"message\":\"Pod was rejected: Allocate failed due to no healthy devices present; cannot allocate unhealthy devices example.com/resource, which is unexpected\",\"phase\":\"Failed\",\"reason\":\"UnexpectedAdmissionError\"}}"

Based on above, seems test need an extra check first to check that device drivers are only one ( the one from sample-device-plugin ), and then to confirm that the busybox-test-pod is not included. Also ensure that containers  are stopped when killed by CRI before proceeding to next step.

Proposed solution: Adds an extra check , getting Node Devices and checking that are one registered, otherwise it will fail after a timeout. and also ensure that containers are stopped when killed by CRI before proceeding to next step.  [One successful run here](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/138289/pull-kubernetes-node-kubelet-serial-containerd/2048113340445626368)

##### (d) Resources API SRIOV flaky test

Initially this PR focused on device-plugin test fixes, but since in the pipeline there were two other flaky tests, we combined another attempt to fix those in this PR, to overcome the pipeline failures being the fixed splitted in two. 

Root causes:  Test assumes that there are no other pods running, this is not the case sometimes because of previous test pods not cleaned up. 

Proposed solution: 

- Attempt to fix Resources API SRIOV flaky test, by cleaning up pods Before Each test step.
- Clean up pod-stress and memory-qos test pods AfterEach test step.
- Create a util function addBeforeEachForCleaningUpPods to reuse in other tests as done with addAfterEachForCleaningUpPods method.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
