### PR TITLE
Fix pull-kubernetes-verify pipeline openapi-spec failing test

### DIFF
--- a/api/discovery/apis__admissionregistration.k8s.io__v1.json
+++ b/api/discovery/apis__admissionregistration.k8s.io__v1.json
@@ -11,7 +11,7 @@
       "name": "mutatingadmissionpolicies",
       "namespaced": false,
       "singularName": "mutatingadmissionpolicy",
-      "storageVersionHash": "LYmCf+UMVdg=",
+      "storageVersionHash": "mHCkTKpUTrE=",
       "verbs": [
         "create",
         "delete",
@@ -31,7 +31,7 @@
       "name": "mutatingadmissionpolicybindings",
       "namespaced": false,
       "singularName": "mutatingadmissionpolicybinding",
-      "storageVersionHash": "90V5FRZZ3Zg=",
+      "storageVersionHash": "ZKgZT1uTmZ0=",
       "verbs": [
         "create",
         "delete",

--- a/api/discovery/apis__admissionregistration.k8s.io__v1alpha1.json
+++ b/api/discovery/apis__admissionregistration.k8s.io__v1alpha1.json
@@ -11,7 +11,7 @@
       "name": "mutatingadmissionpolicies",
       "namespaced": false,
       "singularName": "mutatingadmissionpolicy",
-      "storageVersionHash": "LYmCf+UMVdg=",
+      "storageVersionHash": "mHCkTKpUTrE=",
       "verbs": [
         "create",
         "delete",
@@ -31,7 +31,7 @@
       "name": "mutatingadmissionpolicybindings",
       "namespaced": false,
       "singularName": "mutatingadmissionpolicybinding",
-      "storageVersionHash": "90V5FRZZ3Zg=",
+      "storageVersionHash": "ZKgZT1uTmZ0=",
       "verbs": [
         "create",
         "delete",

--- a/api/discovery/apis__admissionregistration.k8s.io__v1beta1.json
+++ b/api/discovery/apis__admissionregistration.k8s.io__v1beta1.json
@@ -11,7 +11,7 @@
       "name": "mutatingadmissionpolicies",
       "namespaced": false,
       "singularName": "mutatingadmissionpolicy",
-      "storageVersionHash": "LYmCf+UMVdg=",
+      "storageVersionHash": "mHCkTKpUTrE=",
       "verbs": [
         "create",
         "delete",
@@ -31,7 +31,7 @@
       "name": "mutatingadmissionpolicybindings",
       "namespaced": false,
       "singularName": "mutatingadmissionpolicybinding",
-      "storageVersionHash": "90V5FRZZ3Zg=",
+      "storageVersionHash": "ZKgZT1uTmZ0=",
       "verbs": [
         "create",
         "delete",


### PR DESCRIPTION
Used update-openapi-spec script to fix issue.

#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Fixes CI failure in pull-kubernetes-verify pipeline due to failure
during verification of openapi spec.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

Example run with the failure can be found [here](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/129719/pull-kubernetes-verify/2042204057161961472)


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
