### PR TITLE
client-go/tools/watch: downgrade 410 Gone error to V(4) debug log in RetryWatcher

### DIFF
--- a/staging/src/k8s.io/client-go/tools/watch/retrywatcher.go
+++ b/staging/src/k8s.io/client-go/tools/watch/retrywatcher.go
@@ -166,6 +166,13 @@ func (rw *RetryWatcher) doReceive(ctx context.Context) (bool, time.Duration) {
 			return true, 0
 		}
 
+		// Resource expired or 410 Gone errors (e.g. resource version too old)
+		// are expected and recoverable, so log at a lower verbosity instead of ERROR.
+		if apierrors.IsResourceExpired(err) || apierrors.IsGone(err) {
+			klog.FromContext(ctx).V(4).Info(msg, "err", err)
+			return false, 0
+		}
+
 		klog.FromContext(ctx).Error(err, msg)
 		// Retry
 		return false, 0

--- a/staging/src/k8s.io/client-go/tools/watch/retrywatcher_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/retrywatcher_test.go
@@ -200,6 +200,29 @@ func TestRetryWatcher(t *testing.T) {
 			},
 		},
 		{
+			name:      "recovers from 410 Gone error on watch establishment",
+			initialRV: "1",
+			watchClient: &cache.ListWatch{
+				WatchFunc: func() func(options metav1.ListOptions) (watch.Interface, error) {
+					firstRun := true
+					return func(options metav1.ListOptions) (watch.Interface, error) {
+						if firstRun {
+							firstRun = false
+							return nil, apierrors.NewResourceExpired("")
+						}
+
+						return watch.NewProxyWatcher(arrayToChannel(fromRV(options.ResourceVersion, []watch.Event{
+							makeTestEvent(2),
+						}))), nil
+					}
+				}(),
+			},
+			watchCount: 2,
+			expected: []watch.Event{
+				makeTestEvent(2),
+			},
+		},
+		{
 			name:      "recovers if watchClient returns nil watcher",
 			initialRV: "1",
 			watchClient: &cache.ListWatch{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a `WatchWithContext` call returns a 410 Gone (resource expired) error, the
RetryWatcher logs it at ERROR level before retrying. Since this is an expected
and recoverable condition (e.g. resource version too old), it should not produce
ERROR-level log noise.

This PR adds an `apierrors.IsGone(err)` check before the catch-all `klog.Error`
call in the watch establishment error handling, downgrading the log to
`klog.V(4).Info` — consistent with how `IsProbableEOF` and `IsTimeout` are
already handled.

#### Which issue(s) this PR is related to:

Fixes kubernetes/kubernetes#122207
Ref kubernetes/client-go#1321

#### Special notes for your reviewer:

The existing `watch.Error` event path (line 246, `http.StatusGone`) already
handles 410 Gone from the watch *stream*. This fix covers the case where
the `WatchWithContext` *establishment* call itself returns a Gone error.

#### Does this PR introduce a user-facing change?

```release-note
client-go: RetryWatcher now logs 410 Gone (resource expired) errors at debug verbosity (V(4)) instead of ERROR level during watch establishment.

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE


