### PR TITLE
apiserver: prevent oversized resource names from reaching metrics

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -106,6 +106,9 @@ const (
 
 	// APIGroupPrefix is where non-legacy API group will be located.
 	APIGroupPrefix = "/apis"
+
+	// DefaultMaxResourceNameLegth is maximum length for resource name.
+	DefaultMaxResourceNameLength = 2048
 )
 
 // Config is a structure used to configure a GenericAPIServer.
@@ -1110,6 +1113,7 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
 		handler = routine.WithRoutine(handler, c.LongRunningFunc)
 	}
 	handler = genericapifilters.WithRequestInfo(handler, c.RequestInfoResolver)
+	handler = genericfilters.WithResourceNameLengthLimit(handler, DefaultMaxResourceNameLength)
 	handler = genericapifilters.WithRequestReceivedTimestamp(handler)
 	handler = genericapifilters.WithMuxAndDiscoveryComplete(handler, c.lifecycleSignals.MuxAndDiscoveryComplete.Signaled())
 	handler = genericfilters.WithPanicRecovery(handler, c.RequestInfoResolver)

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/request_name_limit.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/request_name_limit.go
@@ -1,3 +1,19 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package filters
 
 import (

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/request_name_limit.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/request_name_limit.go
@@ -1,0 +1,27 @@
+package filters
+
+import (
+	"net/http"
+
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+)
+
+// This rejects resource requests whose resourec name exceeds maxLen.
+// // This prevents big user given names from reaching request
+// paths, like metrics/error handling.
+func WithResourceNameLengthLimit(handler http.Handler, maxLen int) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		info, ok := apirequest.RequestInfoFrom(req.Context())
+		if !ok || info == nil || !info.IsResourceRequest {
+			handler.ServeHTTP(w, req)
+			return
+		}
+
+		if len(info.Name) > maxLen {
+			http.Error(w, "resource name too long", http.StatusBadRequest)
+			return
+		}
+
+		handler.ServeHTTP(w, req)
+	})
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/request_name_limit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/request_name_limit_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package filters
 
 import (

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/request_name_limit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/request_name_limit_test.go
@@ -1,0 +1,75 @@
+package filters
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+)
+
+const maxResourceNameLength = 10
+
+func TestWithResourceNameLengthLimit(t *testing.T) {
+	tests := []struct {
+		name           string
+		requestInfo    *apirequest.RequestInfo
+		wantStatus     int
+		wantNextCalled bool
+	}{
+		{
+			name:           "allows request when request info is missing",
+			requestInfo:    nil,
+			wantStatus:     http.StatusOK,
+			wantNextCalled: true,
+		},
+		{
+			name: "allows named resource request within limit",
+			requestInfo: &apirequest.RequestInfo{
+				IsResourceRequest: true,
+				Resource:          "pods",
+				Name:              "nginx",
+			},
+			wantStatus:     http.StatusOK,
+			wantNextCalled: true,
+		},
+		{
+			name: "rejects request when name exceeds max length",
+			requestInfo: &apirequest.RequestInfo{
+				IsResourceRequest: true,
+				Resource:          "pods",
+				Name:              "fooooooooooooooo",
+			},
+			wantStatus:     http.StatusBadRequest,
+			wantNextCalled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nextCalled := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+
+			handler := WithResourceNameLengthLimit(next, maxResourceNameLength)
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			if tt.requestInfo != nil {
+				req = req.WithContext(apirequest.WithRequestInfo(req.Context(), tt.requestInfo))
+			}
+
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d", tt.wantStatus, rr.Code)
+			}
+
+			if nextCalled != tt.wantNextCalled {
+				t.Fatalf("expected nextCalled=%v, got %v", tt.wantNextCalled, nextCalled)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:

/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it: 
This PR introduces a filter in the apiserver handler chain to reject requests that contain excessively long resource names. currently, resource names can be large given by users. such values can propagate into metrics and  leading to high cardinality and increased memory usage. 
By validating then rejecting these requests early in the request path, we prevent oversized large resource names from reaching downstream handlers and metrics, improving stability and and protecting against potential misuse.


#### Which issue(s) this PR is related to:  Fixes: #138140 
Related issue: #138140 
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer: 
This is an initial push focused on a minimal and a targeted fix. The change is intentionally small and scoped only to request level validation. Feedback is welcome, especially regarding the chosen validation point in handler chain and the maximum allowed resource name length or size.

