### PR TITLE
DRA: Introduce "GetPCIeRootAttributeMapFromCPUId" helper method for aligning NICs and CPUs

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/machine.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/machine.go
@@ -21,17 +21,23 @@ import (
 	"os"
 )
 
+type SysFS interface {
+	fs.ReadLinkFS
+	fs.ReadFileFS
+	fs.ReadDirFS
+}
+
 // machine is the bare minimum machine/host abstraction we need.
 // we use a wrapping struct to enable the functional option pattern
 type machine struct {
-	sysfs fs.ReadLinkFS
+	sysfs SysFS
 }
 
 // MachineModifier is the type of functional options
 type MachineModifier func(*machine)
 
 // WithFS replaces the host sysfs with a custom FS
-func WithFS(sysfs fs.ReadLinkFS) MachineModifier {
+func WithFS(sysfs SysFS) MachineModifier {
 	return func(mc *machine) {
 		mc.sysfs = sysfs
 	}
@@ -42,6 +48,6 @@ func WithFS(sysfs fs.ReadLinkFS) MachineModifier {
 // and testability and for usage within containers, not for security.
 func WithFSFromRoot(root string) MachineModifier {
 	return func(mc *machine) {
-		mc.sysfs = os.DirFS(root).(fs.ReadLinkFS)
+		mc.sysfs = os.DirFS(root).(SysFS)
 	}
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/machine_linux.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/machine_linux.go
@@ -17,7 +17,6 @@ limitations under the License.
 package deviceattribute
 
 import (
-	"io/fs"
 	"os"
 )
 
@@ -26,5 +25,5 @@ const (
 )
 
 func initDefaultMachine(mc *machine) {
-	mc.sysfs = os.DirFS(SysfsRoot).(fs.ReadLinkFS)
+	mc.sysfs = os.DirFS(SysfsRoot).(SysFS)
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/pci_linux.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/pci_linux.go
@@ -19,11 +19,15 @@ package deviceattribute
 import (
 	"fmt"
 	"io/fs"
+	"iter"
 	"path/filepath"
 	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 
 	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // GetPCIeRootAttributeByPCIBusID retrieves the PCIe Root Complex for a given PCI Bus ID.
@@ -55,6 +59,234 @@ func GetPCIeRootAttributeByPCIBusID(pciBusID string, mods ...MachineModifier) (D
 	}
 
 	return attr, nil
+}
+
+// GetPCIeRootAttributeMapFromCPUId retrieves the PCIe Root Complex information
+// for each CPU ID in the system.
+//
+// It returns a map of CPU ID to DeviceAttribute, where each attribute encapsulates
+// the associated PCIe Root Complexes as a sorted string list.
+//
+// API Design Note:
+// A dedicated API for looking up PCIe Roots by a single CPU ID is intentionally not
+// provided. While Linux sysfs exposes a PCI-device -> local-CPU relationship via
+// /sys/bus/pci/devices/*/local_cpulist, there is no direct CPU -> PCI-device index.
+// Since a reverse lookup always requires a full scan of all PCI devices, this
+// function builds and returns the complete mapping in a single pass for efficiency.
+//
+// Feature Gate Requirement:
+// String list attributes are an alpha feature. Enabling the "DRAListTypeAttributes"
+// feature gate is required for this data to be processed correctly in the cluster.
+func GetPCIeRootAttributeMapFromCPUId(mods ...MachineModifier) (map[int]DeviceAttribute, error) {
+	var mc machine
+	initDefaultMachine(&mc)
+	for _, mod := range mods {
+		mod(&mc)
+	}
+
+	// First, getting the set of all CPU IDs in the system
+	// to validate the CPU IDs we find in "local_cpulist" files later.
+	cpuIds, err := getCPUIds(mc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get CPU IDs: %w", err)
+	}
+
+	// Next, focusing on the PCI Bus IDs of all PCIe Bridges in the system,
+	// because scanning only PCI Bridges would be enough to resolve the relationship
+	// between CPU and PCIe Roots.
+	pcieBridgeBusIDs, err := getPCIeBridgeBusIDs(mc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get PCIe bridges: %w", err)
+	}
+
+	cpuIDToPCIeRoots := map[int]sets.Set[string]{}
+	pciDevicesDir := filepath.Join("bus", "pci", "devices")
+	for _, pcieBridgeBusID := range pcieBridgeBusIDs {
+		pcieRoot, err := resolvePCIeRoot(mc, pcieBridgeBusID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve PCIe Root Complex for PCI Bus ID %s: %w", pcieBridgeBusID, err)
+		}
+
+		localCPUListPaths := filepath.Join(pciDevicesDir, pcieBridgeBusID, "local_cpulist")
+		content, err := fs.ReadFile(mc.sysfs, localCPUListPaths)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read local_cpulist at %s: %w", localCPUListPaths, err)
+		}
+
+		localCPUList, err := parseCPUList(string(content))
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse CPU list %s at %s: %w", string(content), localCPUListPaths, err)
+		}
+		for cpuID := range localCPUList.Iter() {
+			if !cpuIds.Has(cpuID) {
+				return nil, fmt.Errorf("CPU ID %d from local_cpulist at %s is not in the CPU ID set", cpuID, localCPUListPaths)
+			}
+			if _, ok := cpuIDToPCIeRoots[cpuID]; !ok {
+				cpuIDToPCIeRoots[cpuID] = sets.New[string]()
+			}
+			cpuIDToPCIeRoots[cpuID].Insert(pcieRoot)
+		}
+	}
+
+	results := map[int]DeviceAttribute{}
+	for cpuID, pcieRoots := range cpuIDToPCIeRoots {
+		if pcieRoots.Len() > 0 {
+			results[cpuID] = DeviceAttribute{
+				Name:  StandardDeviceAttributePCIeRoot,
+				Value: resourceapi.DeviceAttribute{StringValues: sort.StringSlice(sets.List(pcieRoots))},
+			}
+		}
+	}
+
+	return results, nil
+}
+
+// getCPUIds returns a set of all online/present CPU IDs by scanning the
+// /sys/devices/system/cpu/ directory. It filters entries matching
+// the 'cpu[0-9]+' pattern to identify individual processor cores.
+func getCPUIds(mc machine) (sets.Set[int], error) {
+	cpuDir := filepath.Join("devices", "system", "cpu")
+	entries, err := fs.ReadDir(mc.sysfs, cpuDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CPU directory: %w", err)
+	}
+	cpuIds := sets.New[int]()
+	cpuDirEntryRegexp := regexp.MustCompile(`^cpu([0-9]+)$`)
+	for _, entry := range entries {
+		name := entry.Name()
+		matches := cpuDirEntryRegexp.FindStringSubmatch(name)
+		if matches == nil {
+			continue
+		}
+		cpuIDStr := matches[1]
+		id, err := strconv.Atoi(cpuIDStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse CPU ID from path %q: %w", name, err)
+		}
+		cpuIds.Insert(id)
+	}
+	return cpuIds, nil
+}
+
+// getPCIeBridgeBusIDs retrieves the PCI Bus IDs (BDF format) for all devices
+// identified as PCI Bridges (Class Code 0x06).
+//
+// It scans /sys/bus/pci/devices/ to find bridges that define the PCIe hierarchy.
+// By targeting the entire 0x06 class, it captures not only common Host (0x0600)
+// and PCI-to-PCI (0x0604) bridges but also specialized interconnects like
+// Non-Transparent Bridges (0x0609) and InfiniBand-to-PCI bridges (0x060a).
+//
+// This comprehensive scanning is critical for accurate CPU-to-PCIe-root
+// mapping in non-standard hardware topologies.
+//
+// ref: https://wiki.osdev.org/PCI#Class_Codes
+func getPCIeBridgeBusIDs(mc machine) ([]string, error) {
+	pciDevicesDir := filepath.Join("bus", "pci", "devices")
+	pcieDevicePaths, err := fs.ReadDir(mc.sysfs, pciDevicesDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read PCI devices directory: %w", err)
+	}
+
+	bridges := []string{}
+	for _, pcieDevicePath := range pcieDevicePaths {
+		pciBusID := pcieDevicePath.Name()
+		if err := verifyPCIBDFFormat(pciBusID); err != nil {
+			continue
+		}
+
+		classData, err := fs.ReadFile(mc.sysfs, filepath.Join(pciDevicesDir, pciBusID, "class"))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read PCI class for PCI Bus ID %s: %w", pciBusID, err)
+		}
+		pciClassInfo := strings.TrimSpace(string(classData))
+		if len(pciClassInfo) != 8 { // format: "0xCCSSpp" (Class, Subclass, Programming Interface)
+			return nil, fmt.Errorf("invalid PCI Class data for PCI Bus ID %s: %q", pciBusID, pciClassInfo)
+		}
+
+		if strings.HasPrefix(pciClassInfo, "0x06") {
+			bridges = append(bridges, pciBusID)
+		}
+	}
+
+	return bridges, nil
+}
+
+// cpuList represents a collection of CPU IDs, supporting the fragmented
+// range format common in Linux sysfs (e.g., "0-3,5,7-31").
+type cpuList []cpuListPart
+
+func (cl cpuList) Iter() iter.Seq[int] {
+	return func(yield func(int) bool) {
+		for _, part := range cl {
+			for e := range part.Iter() {
+				if !yield(e) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// cpuListPart represents a continuous range of CPU IDs,
+// defined by a start and end ID (inclusive).
+type cpuListPart struct {
+	start int
+	end   int
+}
+
+func (p cpuListPart) Iter() iter.Seq[int] {
+	return func(yield func(int) bool) {
+		for i := p.start; i <= p.end; i++ {
+			if !yield(i) {
+				return
+			}
+		}
+	}
+}
+
+// parseCPUList converts a Linux CPU list string (e.g., from local_cpulist)
+// into a structured cpuList. It handles both individual IDs and
+// hyphenated ranges (inclusive).
+func parseCPUList(cpuListStr string) (cpuList, error) {
+	cpuListStr = strings.TrimSpace(cpuListStr)
+	if cpuListStr == "" {
+		return nil, fmt.Errorf("CPU list string is empty")
+	}
+
+	// The CPU list can be in the format of "0-3,5,7-9", so we need to parse it accordingly.
+	parts := strings.Split(cpuListStr, ",")
+	cpuList := make(cpuList, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil, fmt.Errorf("invalid CPU list format: empty part in %q", cpuListStr)
+		}
+		if strings.Contains(part, "-") {
+			bounds := strings.Split(part, "-")
+			if len(bounds) != 2 {
+				return nil, fmt.Errorf("invalid CPU list format: %s", cpuListStr)
+			}
+			start, err := strconv.Atoi(bounds[0])
+			if err != nil {
+				return nil, fmt.Errorf("invalid CPU ID in list: %s", bounds[0])
+			}
+			end, err := strconv.Atoi(bounds[1])
+			if err != nil {
+				return nil, fmt.Errorf("invalid CPU ID in list: %s", bounds[1])
+			}
+			if start > end {
+				return nil, fmt.Errorf("invalid CPU range: %d-%d", start, end)
+			}
+			cpuList = append(cpuList, cpuListPart{start: start, end: end})
+		} else {
+			cpuID, err := strconv.Atoi(part)
+			if err != nil {
+				return nil, fmt.Errorf("invalid CPU ID in list: %s", part)
+			}
+			cpuList = append(cpuList, cpuListPart{start: cpuID, end: cpuID})
+		}
+	}
+	return cpuList, nil
 }
 
 // resolvePCIeRoot resolves the PCIe Root for a given PCI Bus ID

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/pci_linux_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceattribute/pci_linux_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -195,6 +196,303 @@ func TestGetPCIBusIDAttribute(t *testing.T) {
 	}
 }
 
+func TestGetPCIeRootAttributeMapByCPUId(t *testing.T) {
+	// https://wiki.osdev.org/PCI#Class_Codes
+	PCIClassHostBridge := "0x060000"
+	PCIClassPCItoPCIBridge := "0x060400"
+	PCIClassInfiniBandtoPCIBridge := "0x060a00"
+	PCIClassNotBridge := "0x050000" // Memory Controller
+
+	createCPUDevice := func(t *testing.T, testRootPath string, cpuIDs ...int) {
+		t.Helper()
+		for _, cpuID := range cpuIDs {
+			mkDirAll(t, filepath.Join(testRootPath, "devices", "system", "cpu", fmt.Sprintf("cpu%d", cpuID)))
+		}
+	}
+
+	createPCIDevice := func(t *testing.T, testRootPath string, rootDirName, pciBusID string, pciClass, localCPUList *string) {
+		t.Helper()
+
+		relDevicePath := filepath.Join("devices", rootDirName, pciBusID)
+		mkDirAll(t, filepath.Join(testRootPath, relDevicePath))
+		if pciClass != nil {
+			writeFile(t, filepath.Join(testRootPath, relDevicePath, "class"), *pciClass)
+		}
+		if localCPUList != nil {
+			writeFile(t, filepath.Join(testRootPath, relDevicePath, "local_cpulist"), *localCPUList)
+		}
+		busDir := filepath.Join(testRootPath, "bus", "pci", "devices")
+		mkDirAll(t, busDir)
+		createSymlink(t,
+			filepath.Join("..", "..", "..", relDevicePath),
+			filepath.Join(busDir, pciBusID),
+		)
+	}
+
+	tests := map[string]struct {
+		testMachineSetup func(t *testing.T, testRootPath string)
+		expectedMap      map[int]DeviceAttribute
+		expectsError     bool
+		expectedErrMsg   string
+	}{
+		"valid: with no PCI devices": {
+			testMachineSetup: func(t *testing.T, testRootPath string) {
+				createCPUDevice(t, testRootPath, 0)
+			},
+			expectedMap: map[int]DeviceAttribute{},
+		},
+		"valid: with no bridges": {
+			testMachineSetup: func(t *testing.T, testRootPath string) {
+				createCPUDevice(t, testRootPath, 0)
+				createPCIDevice(t, testRootPath, "pci0000:00", "0000:00:00.0", new(PCIClassNotBridge), new("0"))
+			},
+			expectedMap: map[int]DeviceAttribute{},
+		},
+		"valid: ignores malformed PCIBusID format": {
+			testMachineSetup: func(t *testing.T, testRootPath string) {
+				createCPUDevice(t, testRootPath, 0)
+				createPCIDevice(t, testRootPath, "pci0000:00", "invalid-pci-bus-id", new(PCIClassHostBridge), new("0"))
+			},
+			expectedMap: map[int]DeviceAttribute{},
+		},
+		"valid: with sole host bridge": {
+			testMachineSetup: func(t *testing.T, testRootPath string) {
+				createCPUDevice(t, testRootPath, 0, 1)
+				createPCIDevice(t, testRootPath, "pci0000:00", "0000:00:00.0", new(PCIClassHostBridge), new("0-1"))
+				createPCIDevice(t, testRootPath, "pci0000:00", "0000:00:01.0", new(PCIClassNotBridge), new("0-1"))
+			},
+			expectedMap: map[int]DeviceAttribute{
+				0: {
+					Name:  StandardDeviceAttributePCIeRoot,
+					Value: resourceapi.DeviceAttribute{StringValues: sort.StringSlice([]string{"pci0000:00"})},
+				},
+				1: {
+					Name:  StandardDeviceAttributePCIeRoot,
+					Value: resourceapi.DeviceAttribute{StringValues: sort.StringSlice([]string{"pci0000:00"})},
+				},
+			},
+		},
+		"valid: with host and other bridges": {
+			testMachineSetup: func(t *testing.T, testRootPath string) {
+				createCPUDevice(t, testRootPath, 0, 1, 2, 3)
+				createPCIDevice(t, testRootPath, "pci0000:00", "0000:00:00.0", new(PCIClassHostBridge), new("0-1"))
+				createPCIDevice(t, testRootPath, "pci0001:00", "0001:00:00.0", new(PCIClassPCItoPCIBridge), new("0-1"))
+				createPCIDevice(t, testRootPath, "pci0000:00", "0001:00:01.0", new(PCIClassNotBridge), new("0-1"))
+				createPCIDevice(t, testRootPath, "pci0002:00", "0002:00:00.0", new(PCIClassInfiniBandtoPCIBridge), new("2-3"))
+				createPCIDevice(t, testRootPath, "pci0000:00", "0002:00:01.0", new(PCIClassNotBridge), new("2-3"))
+			},
+			expectedMap: map[int]DeviceAttribute{
+				0: {
+					Name:  StandardDeviceAttributePCIeRoot,
+					Value: resourceapi.DeviceAttribute{StringValues: sort.StringSlice([]string{"pci0000:00", "pci0001:00"})},
+				},
+				1: {
+					Name:  StandardDeviceAttributePCIeRoot,
+					Value: resourceapi.DeviceAttribute{StringValues: sort.StringSlice([]string{"pci0000:00", "pci0001:00"})},
+				},
+				2: {
+					Name:  StandardDeviceAttributePCIeRoot,
+					Value: resourceapi.DeviceAttribute{StringValues: sort.StringSlice([]string{"pci0002:00"})},
+				},
+				3: {
+					Name:  StandardDeviceAttributePCIeRoot,
+					Value: resourceapi.DeviceAttribute{StringValues: sort.StringSlice([]string{"pci0002:00"})},
+				},
+			},
+		},
+		"invalid: invalid PCI class(no class file)": {
+			testMachineSetup: func(t *testing.T, testRootPath string) {
+				createCPUDevice(t, testRootPath, 0)
+				createPCIDevice(t, testRootPath, "pci0000:00", "0000:00:00.0", nil, new("0"))
+			},
+			expectsError:   true,
+			expectedErrMsg: "failed to get PCIe bridges: failed to read PCI class for PCI Bus ID",
+		},
+		"invalid: invalid PCI class (empty)": {
+			testMachineSetup: func(t *testing.T, testRootPath string) {
+				createCPUDevice(t, testRootPath, 0)
+				createPCIDevice(t, testRootPath, "pci0000:00", "0000:00:00.0", new(""), new("0"))
+			},
+			expectsError:   true,
+			expectedErrMsg: "failed to get PCIe bridges: invalid PCI Class data for PCI Bus ID",
+		},
+		"invalid: invalid PCI class": {
+			testMachineSetup: func(t *testing.T, testRootPath string) {
+				createCPUDevice(t, testRootPath, 0)
+				createPCIDevice(t, testRootPath, "pci0000:00", "0000:00:00.0", new("invalid-pci-class"), new("0"))
+			},
+			expectsError:   true,
+			expectedErrMsg: "failed to get PCIe bridges: invalid PCI Class data for PCI Bus ID",
+		},
+		"invalid: CPU with invalid cpuId": {
+			testMachineSetup: func(t *testing.T, testRootPath string) {
+				// Setup a CPU path that matches glob but cannot be parsed as int (overflow)
+				mkDirAll(t, filepath.Join(testRootPath, "devices", "system", "cpu", "cpu999999999999999999999999999999999"))
+			},
+			expectsError:   true,
+			expectedErrMsg: "failed to get CPU IDs: failed to parse CPU ID from path",
+		},
+		"invalid: no local_cpulist": {
+			testMachineSetup: func(t *testing.T, testRootPath string) {
+				createCPUDevice(t, testRootPath, 0)
+				createPCIDevice(t, testRootPath, "pci0000:00", "0000:01:00.0", new(PCIClassHostBridge), nil)
+			},
+			expectsError:   true,
+			expectedErrMsg: "failed to read local_cpulist",
+		},
+		"invalid: malformed local_cpulist (empty)": {
+			testMachineSetup: func(t *testing.T, testRootPath string) {
+				createCPUDevice(t, testRootPath, 0)
+				createPCIDevice(t, testRootPath, "pci0000:00", "0000:01:00.0", new(PCIClassHostBridge), new(""))
+			},
+			expectsError:   true,
+			expectedErrMsg: "CPU list string is empty",
+		},
+		"invalid: malformed local_cpulist (non integer id)": {
+			testMachineSetup: func(t *testing.T, testRootPath string) {
+				createCPUDevice(t, testRootPath, 0)
+				createPCIDevice(t, testRootPath, "pci0000:00", "0000:01:00.0", new(PCIClassHostBridge), new("a"))
+			},
+			expectsError:   true,
+			expectedErrMsg: "invalid CPU ID in list",
+		},
+		"invalid: malformed local_cpulist (non integer range)": {
+			testMachineSetup: func(t *testing.T, testRootPath string) {
+				createCPUDevice(t, testRootPath, 0)
+				createPCIDevice(t, testRootPath, "pci0000:00", "0000:01:00.0", new(PCIClassHostBridge), new("a-b"))
+			},
+			expectsError:   true,
+			expectedErrMsg: "invalid CPU ID in list",
+		},
+		"invalid: malformed local_cpulist (invalid range)": {
+			testMachineSetup: func(t *testing.T, testRootPath string) {
+				createCPUDevice(t, testRootPath, 0)
+				createCPUDevice(t, testRootPath, 1)
+				createPCIDevice(t, testRootPath, "pci0000:00", "0000:00:00.0", new(PCIClassHostBridge), new("0-1-2"))
+			},
+			expectsError:   true,
+			expectedErrMsg: "invalid CPU list format",
+		},
+		"invalid: malformed local_cpulist(reverse range)": {
+			testMachineSetup: func(t *testing.T, testRootPath string) {
+				createCPUDevice(t, testRootPath, 0)
+				createPCIDevice(t, testRootPath, "pci0000:00", "0000:01:00.0", new(PCIClassHostBridge), new("3-2"))
+			},
+			expectsError:   true,
+			expectedErrMsg: "invalid CPU range",
+		},
+		"invalid: malformed local_cpulist (empty part)": {
+			testMachineSetup: func(t *testing.T, testRootPath string) {
+				createCPUDevice(t, testRootPath, 0)
+				createPCIDevice(t, testRootPath, "pci0000:00", "0000:00:00.0", new(PCIClassHostBridge), new("0,"))
+			},
+			expectsError:   true,
+			expectedErrMsg: "invalid CPU list format: empty part in",
+		},
+		"invalid: local_cpulist with non-existent CPU IDs": {
+			testMachineSetup: func(t *testing.T, testRootPath string) {
+				createCPUDevice(t, testRootPath, 0)
+				createPCIDevice(t, testRootPath, "pci0000:00", "0000:01:00.0", new(PCIClassHostBridge), new("0-1")) // CPU 1 does not exist
+			},
+			expectsError:   true,
+			expectedErrMsg: "is not in the CPU ID set",
+		},
+		"invalid: local_cpulist with non-existent CPU IDs (no CPU)": {
+			testMachineSetup: func(t *testing.T, testRootPath string) {
+				createPCIDevice(t, testRootPath, "pci0000:00", "0000:01:00.0", new(PCIClassHostBridge), new("0")) // CPU 0 does not exist
+			},
+			expectsError:   true,
+			expectedErrMsg: "is not in the CPU ID set",
+		},
+		"invalid: PCIeRoot resolution error": {
+			testMachineSetup: func(t *testing.T, testRootPath string) {
+				// resolvePCIeRoot requires targets to start with "devices/pci".
+				createCPUDevice(t, testRootPath, 0)
+				createPCIDevice(t, testRootPath, "not-a-pci-root", "0000:01:00.0", new(PCIClassHostBridge), new("0"))
+			},
+			expectsError:   true,
+			expectedErrMsg: "failed to resolve PCIe Root Complex for PCI Bus ID",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			testMachinePath := t.TempDir()
+			mkDirAll(t, filepath.Join(testMachinePath, "bus", "pci", "devices"))
+			mkDirAll(t, filepath.Join(testMachinePath, "devices", "system", "cpu"))
+			if test.testMachineSetup != nil {
+				test.testMachineSetup(t, testMachinePath)
+			}
+			got, err := GetPCIeRootAttributeMapFromCPUId(WithFSFromRoot(testMachinePath))
+			if test.expectsError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+					return
+				}
+				if !strings.Contains(err.Error(), test.expectedErrMsg) {
+					t.Errorf("Expected error message to contain %q, got %q", test.expectedErrMsg, err.Error())
+					return
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, test.expectedMap) {
+				t.Errorf("Expected map %v, got %v", test.expectedMap, got)
+			}
+			// Additionally verify that the PCIe Root Complex values are sorted in the expected order
+			for cpuID, attr := range got {
+				if !sort.StringsAreSorted(attr.Value.StringValues) {
+					t.Errorf("PCIe Root Complex values for CPU %d are not sorted: %v", cpuID, attr.Value.StringValues)
+				}
+			}
+		})
+	}
+}
+
+func TestParseCPUList(t *testing.T) {
+	tests := map[string]struct {
+		cpuListStr   string
+		expectedList cpuList
+		expectsError bool
+	}{
+		"valid single CPU": {
+			cpuListStr:   "0",
+			expectedList: cpuList{{start: 0, end: 0}},
+			expectsError: false,
+		},
+		"valid multiple CPUs": {
+			cpuListStr:   "0-3,5,7-9",
+			expectedList: cpuList{{start: 0, end: 3}, {start: 5, end: 5}, {start: 7, end: 9}},
+			expectsError: false,
+		},
+		"invalid format": {
+			cpuListStr:   "invalid-cpu-list",
+			expectedList: cpuList{},
+			expectsError: true,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := parseCPUList(test.cpuListStr)
+			if test.expectsError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+					return
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, test.expectedList) {
+				t.Errorf("Expected CPU list %v, got %v", test.expectedList, got)
+			}
+		})
+	}
+}
+
 func mkDirAll(t *testing.T, path string) {
 	t.Helper()
 	if err := os.MkdirAll(path, 0755); err != nil {
@@ -207,6 +505,14 @@ func touchFile(t *testing.T, path string) {
 	mkDirAll(t, filepath.Dir(path))
 	if _, err := os.Create(path); err != nil {
 		t.Fatalf("Failed to create file %s: %v", path, err)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	mkDirAll(t, filepath.Dir(path))
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write file %s: %v", path, err)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR introduces `GetPCIeRootAttributeMapFromCPUId` helper method, which returns a map of CPU ID to DeviceAttribute, where the DeviceAttribute contains multiple PCIe Root Complexes (if applicable) as a string list. This method resolves CPU<->PCIe Roots correspondence by scanning sysfs(`/sys/bus/pci/devices/*/local_cpulist`).

Please note that an API from from a single CPU ID to PCIe Roots is intentionally not provided. It is because Linux sysfs exposes a PCI-device -> local-CPU relationship via `/sys/bus/pci/devices/*/local_cpulist`, but there is no direct CPU -> PCI-device index. Reverse lookup still requires scanning all PCI devices.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes-sigs/dra-driver-cpu/issues/114
https://github.com/google/dranet/issues/92
https://github.com/kubernetes/enhancements/pull/5316#pullrequestreview-2850069692
https://github.com/kubernetes/kubernetes/pull/132296#discussion_r2154828223

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
DRA: Introduce "GetPCIeRootAttributeMapFromCPUId" helper method for aligning PCIe topology between CPUs and PCIe devices(GPUs, NICs, InfiniBand HCAs, etc.).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
