### PR TITLE
bugfix:correct the usage of ephemeral storage volumes in the eviction…

### DIFF
--- a/pkg/kubelet/eviction/helpers.go
+++ b/pkg/kubelet/eviction/helpers.go
@@ -581,6 +581,20 @@ func podLocalVolumeUsage(volumeNames []string, podStats statsapi.PodStats) v1.Re
 	}
 }
 
+// diskUsagePerPodLocalVolume returns the disk usage for each local volume in the pod.
+func diskUsagePerPodLocalVolume(volumeNames []string, podStats statsapi.PodStats) map[string]resource.Quantity {
+	usage := make(map[string]resource.Quantity)
+	for _, volumeName := range volumeNames {
+		for _, volumeStats := range podStats.VolumeStats {
+			if volumeStats.Name == volumeName {
+				usage[volumeName] = *diskUsage(&volumeStats.FsStats)
+				break
+			}
+		}
+	}
+	return usage
+}
+
 // podDiskUsage aggregates pod disk usage and inode consumption for the specified stats to measure.
 func podDiskUsage(podStats statsapi.PodStats, pod *v1.Pod, statsToMeasure []fsStatsType) (v1.ResourceList, error) {
 	disk := resource.Quantity{Format: resource.BinarySI}
@@ -1270,6 +1284,7 @@ func evictionMessage(resourceToReclaim v1.ResourceName, pod *v1.Pod, stats stats
 	if len(pod.Spec.InitContainers) != 0 {
 		containers = append(containers, pod.Spec.InitContainers...)
 	}
+	podLocalVolumeDiskUsages := diskUsagePerPodLocalVolume(localVolumeNames(pod), podStats)
 	for _, containerStats := range podStats.Containers {
 		for _, container := range containers {
 			if container.Name == containerStats.Name {
@@ -1279,6 +1294,14 @@ func evictionMessage(resourceToReclaim v1.ResourceName, pod *v1.Pod, stats stats
 				case v1.ResourceEphemeralStorage:
 					if containerStats.Rootfs != nil && containerStats.Rootfs.UsedBytes != nil && containerStats.Logs != nil && containerStats.Logs.UsedBytes != nil {
 						usage = resource.NewQuantity(int64(*containerStats.Rootfs.UsedBytes+*containerStats.Logs.UsedBytes), resource.BinarySI)
+					}
+					for _, volumeMount := range container.VolumeMounts {
+						if localVolumeUsage, found := podLocalVolumeDiskUsages[volumeMount.Name]; found && !localVolumeUsage.IsZero() {
+							if usage == nil {
+								usage = resource.NewQuantity(0, resource.BinarySI)
+							}
+							usage.Add(localVolumeUsage)
+						}
 					}
 				case v1.ResourceMemory:
 					if containerStats.Memory != nil && containerStats.Memory.WorkingSetBytes != nil {

--- a/pkg/kubelet/eviction/helpers_test.go
+++ b/pkg/kubelet/eviction/helpers_test.go
@@ -3721,3 +3721,50 @@ func TestEvictionMessage(t *testing.T) {
 		})
 	}
 }
+
+func TestEvictionMessageIncludesLocalVolumeUsageForEphemeralStorage(t *testing.T) {
+	const (
+		podName       = "pod-ephemeral-eviction-message"
+		containerName = "regular1"
+	)
+
+	container := newContainer(containerName, newResourceList("", "", "100Mi"), newResourceList("", "", ""))
+	container.VolumeMounts = []v1.VolumeMount{{Name: "local-volume"}}
+	pod := newPod(podName, defaultPriority, []v1.Container{container}, []v1.Volume{
+		newVolume("local-volume", v1.VolumeSource{
+			EmptyDir: &v1.EmptyDirVolumeSource{},
+		}),
+	})
+
+	podStats := newPodDiskStats(
+		pod,
+		resource.MustParse("20Mi"),
+		resource.MustParse("10Mi"),
+		resource.MustParse("150Mi"),
+	)
+	statsFn := func(pod *v1.Pod) (statsapi.PodStats, bool) {
+		return podStats, true
+	}
+
+	msg, annotations := evictionMessage(v1.ResourceEphemeralStorage, pod, statsFn, nil, signalObservations{})
+
+	expectedUsage := resource.MustParse("180Mi")
+	expectedMessage := fmt.Sprintf(nodeLowMessageFmt, v1.ResourceEphemeralStorage) +
+		fmt.Sprintf(containerMessageFmt, containerName, expectedUsage.String(), "100Mi", v1.ResourceEphemeralStorage)
+
+	if msg != expectedMessage {
+		t.Fatalf("unexpected ephemeral storage eviction message, got: %s, want: %s", msg, expectedMessage)
+	}
+	if got := annotations[OffendingContainersKey]; got != containerName {
+		t.Fatalf("unexpected %s annotation, got: %s, want: %s", OffendingContainersKey, got, containerName)
+	}
+	if got := annotations[OffendingContainersUsageKey]; got != expectedUsage.String() {
+		t.Fatalf("unexpected %s annotation, got: %s, want: %s", OffendingContainersUsageKey, got, expectedUsage.String())
+	}
+	if _, found := annotations[OffendingPodKey]; found {
+		t.Fatalf("unexpected %s annotation found: %s", OffendingPodKey, annotations[OffendingPodKey])
+	}
+	if _, found := annotations[OffendingPodUsageKey]; found {
+		t.Fatalf("unexpected %s annotation found: %s", OffendingPodUsageKey, annotations[OffendingPodUsageKey])
+	}
+}

--- a/test/e2e_node/eviction_test.go
+++ b/test/e2e_node/eviction_test.go
@@ -293,13 +293,40 @@ var _ = SIGDescribe("LocalStorageEviction", framework.WithSlow(), framework.With
 			initialConfig.EvictionHard = map[string]string{string(evictionapi.SignalNodeFsAvailable): evictionThreshold}
 			initialConfig.EvictionMinimumReclaim = map[string]string{}
 		})
+		emptyDirDiskHog := diskConsumingPod("container-disk-hog", lotsOfDisk, &v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}, v1.ResourceRequirements{})
+		expectedContainerUsage := resource.MustParse("1Gi")
+		emptyDirDiskHogContainerName := emptyDirDiskHog.Spec.Containers[0].Name
 
 		runEvictionTest(f, pressureTimeout, expectedNodeCondition, expectedStarvedResource, logDiskMetrics, []podEvictSpec{
 			{
 				evictionPriority: 1,
 				// TODO(#127864): Container runtime may not immediate free up the resources after the pod eviction,
 				// causing the test to fail. We provision an emptyDir volume to avoid relying on the runtime behavior.
-				pod: diskConsumingPod("container-disk-hog", lotsOfDisk, &v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}, v1.ResourceRequirements{}),
+				pod: emptyDirDiskHog,
+				verifyEvictionEvent: func(event *v1.Event) {
+					offendingContainers, found := event.Annotations[eviction.OffendingContainersKey]
+					if !found {
+						framework.Failf("Expected eviction event for pod %s to include annotation %s", emptyDirDiskHog.Name, eviction.OffendingContainersKey)
+					}
+					gomega.Expect(strings.Split(offendingContainers, ",")).To(gomega.ContainElement(emptyDirDiskHogContainerName),
+						"Expected %s annotation for pod %s to include container %s", eviction.OffendingContainersKey, emptyDirDiskHog.Name, emptyDirDiskHogContainerName)
+
+					usageString, found := event.Annotations[eviction.OffendingContainersUsageKey]
+					if !found {
+						framework.Failf("Expected eviction event for pod %s to include annotation %s", emptyDirDiskHog.Name, eviction.OffendingContainersUsageKey)
+					}
+					usageQuantities := strings.Split(usageString, ",")
+					gomega.Expect(usageQuantities).ToNot(gomega.BeEmpty(), "Expected %s annotation for pod %s to contain at least one quantity",
+						eviction.OffendingContainersUsageKey, emptyDirDiskHog.Name)
+					usageQuantity, err := resource.ParseQuantity(usageQuantities[0])
+					framework.ExpectNoError(err, "parsing pod %s's %s annotation as a quantity", emptyDirDiskHog.Name, eviction.OffendingContainersUsageKey)
+					gomega.Expect(usageQuantity.Cmp(expectedContainerUsage)).To(gomega.BeNumerically(">=", 0),
+						"Expected container ephemeral storage usage recorded in the eviction event for pod %s to be at least %s, but got %s instead",
+						emptyDirDiskHog.Name, expectedContainerUsage.String(), usageQuantity.String())
+					gomega.Expect(event.Message).To(gomega.ContainSubstring(
+						fmt.Sprintf("Container %s was using %s, request is 0, has larger consumption of %s.", emptyDirDiskHogContainerName, usageQuantity.String(), v1.ResourceEphemeralStorage),
+					), "Expected eviction message for pod %s to include the container-level ephemeral storage usage from the emptyDir volume", emptyDirDiskHog.Name)
+				},
 			},
 			{
 				evictionPriority: 0,
@@ -745,6 +772,7 @@ type podEvictSpec struct {
 
 	// Can be used in order to alter pod using runtime data
 	prePodCreationModificationFunc func(ctx context.Context, pod *v1.Pod)
+	verifyEvictionEvent            func(event *v1.Event)
 }
 
 // runEvictionTest sets up a testing environment given the provided pods, and checks a few things:
@@ -1074,6 +1102,9 @@ func verifyEvictionEvents(ctx context.Context, f *framework.Framework, testSpecs
 					gomega.Expect(usageQuantity.Cmp(request)).To(gomega.Equal(1), "Expected usage of offending container: %s in pod %s to exceed its request %s",
 						usageQuantity.String(), pod.Name, request.String())
 				}
+			}
+			if spec.verifyEvictionEvent != nil {
+				spec.verifyEvictionEvent(&event)
 			}
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #130439

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
 the usage of ephemeral storage volumes will be added in the eviction message
```
