### PR TITLE
[WIP] apiserver: use indexed lookup for watch cache initial events

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
@@ -299,7 +299,7 @@ func TestResourceVersionAfterInitEvents(t *testing.T) {
 		store.Add(elem)
 	}
 
-	wci, err := newCacheIntervalFromStore(numObjects, store, "", false)
+	wci, err := newCacheIntervalFromStore(numObjects, store, "", false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -627,7 +627,7 @@ func (c *Cacher) Watch(ctx context.Context, key string, opts storage.ListOptions
 	defer c.watchCache.RUnlock()
 
 	var cacheInterval *watchCacheInterval
-	cacheInterval, err = c.watchCache.getAllEventsSinceLocked(requiredResourceVersion, key, opts)
+	cacheInterval, err = c.watchCache.getAllEventsSinceLocked(ctx, requiredResourceVersion, key, opts)
 	if err != nil {
 		// To match the uncached watch implementation, once we have passed authn/authz/admission,
 		// and successfully parsed a resource version, other errors must fail with a watch event of type ERROR,

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -638,24 +638,37 @@ func (w *watchCache) waitAndListLatestRV(ctx context.Context, resourceVersion ui
 }
 
 func (w *watchCache) listLatestRV(key, continueKey string, matchValues []storage.MatchValue) (resp listResp, index string, err error) {
-	// This isn't the place where we do "final filtering" - only some "prefiltering" is happening here. So the only
-	// requirement here is to NOT miss anything that should be returned. We can return as many non-matching items as we
-	// want - they will be filtered out later. The fact that we return less things is only further performance improvement.
-	// TODO: if multiple indexes match, return the one with the fewest items, so as to do as much filtering as possible.
+	items, index, matched, err := readPrefilteredByIndex(w.store, key, matchValues)
+	if err != nil {
+		return listResp{}, "", err
+	}
+	if !matched {
+		items = w.store.OrderedListPrefix(key, continueKey)
+	}
+	return listResp{
+		Items:           items,
+		ResourceVersion: w.resourceVersion,
+	}, index, nil
+}
+
+// readPrefilteredByIndex serves a prefiltered set of store elements through the first
+// matchValue that maps to an index, and reports whether an index matched. Callers fall
+// back to their own full read when no index matched. It is shared by the list path
+// (listLatestRV) and the watch initialization path (newCacheIntervalFromStore) so that
+// improvements to the indexed read benefit both.
+//
+// This isn't the place where we do "final filtering" - only some "prefiltering" is happening here. So the only
+// requirement here is to NOT miss anything that should be returned. We can return as many non-matching items as we
+// want - they will be filtered out later. The fact that we return less things is only further performance improvement.
+// TODO: if multiple indexes match, return the one with the fewest items, so as to do as much filtering as possible.
+func readPrefilteredByIndex(s store.Indexer, key string, matchValues []storage.MatchValue) (items []interface{}, indexName string, matched bool, err error) {
 	for _, matchValue := range matchValues {
-		if result, err := w.store.ByIndex(matchValue.IndexName, matchValue.Value); err == nil {
+		if result, err := s.ByIndex(matchValue.IndexName, matchValue.Value); err == nil {
 			result, err = filterPrefixAndOrder(key, result)
-			return listResp{
-				Items:           result,
-				ResourceVersion: w.resourceVersion,
-			}, matchValue.IndexName, err
+			return result, matchValue.IndexName, true, err
 		}
 	}
-	result := w.store.OrderedListPrefix(key, continueKey)
-	return listResp{
-		Items:           result,
-		ResourceVersion: w.resourceVersion,
-	}, "", nil
+	return nil, "", false, nil
 }
 
 func filterPrefixAndOrder(prefix string, items []interface{}) ([]interface{}, error) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -876,11 +876,11 @@ func (w *watchCache) isIndexValidLocked(index int) bool {
 // getAllEventsSinceLocked returns a watchCacheInterval that can be used to
 // retrieve events since a certain resourceVersion. This function assumes to
 // be called under the watchCache lock.
-func (w *watchCache) getAllEventsSinceLocked(resourceVersion uint64, key string, opts storage.ListOptions) (*watchCacheInterval, error) {
+func (w *watchCache) getAllEventsSinceLocked(ctx context.Context, resourceVersion uint64, key string, opts storage.ListOptions) (*watchCacheInterval, error) {
 	_, matchesSingle := opts.Predicate.MatchesSingle()
 	matchesSingle = matchesSingle && !opts.Recursive
 	if opts.SendInitialEvents != nil && *opts.SendInitialEvents {
-		return w.getIntervalFromStoreLocked(key, matchesSingle)
+		return w.getIntervalFromStoreLocked(key, matchesSingle, opts.Predicate.MatcherIndex(ctx))
 	}
 
 	size := w.endIndex - w.startIndex
@@ -909,7 +909,7 @@ func (w *watchCache) getAllEventsSinceLocked(resourceVersion uint64, key string,
 			// current state and only then start watching from that point.
 			//
 			// TODO: In v2 api, we should stop returning the current state - #13969.
-			return w.getIntervalFromStoreLocked(key, matchesSingle)
+			return w.getIntervalFromStoreLocked(key, matchesSingle, opts.Predicate.MatcherIndex(ctx))
 		}
 		// SendInitialEvents = false and resourceVersion = 0
 		// means that the request would like to start watching
@@ -935,8 +935,8 @@ func (w *watchCache) getAllEventsSinceLocked(resourceVersion uint64, key string,
 // getIntervalFromStoreLocked returns a watchCacheInterval
 // that covers the entire storage state.
 // This function assumes to be called under the watchCache lock.
-func (w *watchCache) getIntervalFromStoreLocked(key string, matchesSingle bool) (*watchCacheInterval, error) {
-	ci, err := newCacheIntervalFromStore(w.resourceVersion, w.store, key, matchesSingle)
+func (w *watchCache) getIntervalFromStoreLocked(key string, matchesSingle bool, matchValues []storage.MatchValue) (*watchCacheInterval, error) {
+	ci, err := newCacheIntervalFromStore(w.resourceVersion, w.store, key, matchesSingle, matchValues)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/cacher/store"
 )
 
@@ -121,8 +122,10 @@ func newCacheInterval(startIndex, endIndex int, indexer indexerFunc, indexValida
 // newCacheIntervalFromStore is meant to handle the case of rv=0, such that the events
 // returned by Next() need to be events from a List() done on the underlying store of
 // the watch cache.
-// The items returned in the interval will be sorted by Key.
-func newCacheIntervalFromStore(resourceVersion uint64, indexer store.Indexer, key string, matchesSingle bool) (*watchCacheInterval, error) {
+// When matchValues map to an index, the matching items are served through that index
+// (readPrefilteredByIndex, shared with the list path); otherwise the full store is
+// listed. Items are ordered by Key.
+func newCacheIntervalFromStore(resourceVersion uint64, indexer store.Indexer, key string, matchesSingle bool, matchValues []storage.MatchValue) (*watchCacheInterval, error) {
 	buffer := &watchCacheIntervalBuffer{}
 	var allItems []interface{}
 	if matchesSingle {
@@ -135,7 +138,15 @@ func newCacheIntervalFromStore(resourceVersion uint64, indexer store.Indexer, ke
 			allItems = append(allItems, item)
 		}
 	} else {
-		allItems = indexer.List()
+		items, _, matched, err := readPrefilteredByIndex(indexer, key, matchValues)
+		if err != nil {
+			return nil, err
+		}
+		if matched {
+			allItems = items
+		} else {
+			allItems = indexer.List()
+		}
 	}
 	buffer.buffer = make([]*watchCacheEvent, len(allItems))
 	for i, item := range allItems {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval_test.go
@@ -29,9 +29,9 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/tools/cache"
-
+	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/cacher/store"
+	"k8s.io/client-go/tools/cache"
 )
 
 func intervalFromEvents(events []*watchCacheEvent) *watchCacheInterval {
@@ -395,7 +395,7 @@ func TestCacheIntervalNextFromStore(t *testing.T) {
 		store.Add(elem)
 	}
 
-	wci, err := newCacheIntervalFromStore(rv, store, "", false)
+	wci, err := newCacheIntervalFromStore(rv, store, "", false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -453,7 +453,7 @@ func TestCacheIntervalFromStoreSorted(t *testing.T) {
 				}
 			}
 
-			wci, err := newCacheIntervalFromStore(n, tc.indexer, "", false)
+			wci, err := newCacheIntervalFromStore(n, tc.indexer, "", false, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -470,5 +470,55 @@ func TestCacheIntervalFromStoreSorted(t *testing.T) {
 				t.Errorf("events not sorted by key: %v", got)
 			}
 		})
+	}
+}
+
+func TestNewCacheIntervalFromStoreWithMatchValues(t *testing.T) {
+	// Create a store with an index on spec.nodeName via the "f:spec.nodeName" index.
+	nodeNameIndexFunc := func(obj interface{}) ([]string, error) {
+		elem, ok := obj.(*store.Element)
+		if !ok {
+			return nil, fmt.Errorf("not a store element")
+		}
+		return []string{elem.Fields.Get("spec.nodeName")}, nil
+	}
+	storeIndexer := cache.NewIndexer(store.ElementKey, cache.Indexers{"f:spec.nodeName": nodeNameIndexFunc})
+
+	// Add 100 pods: 10 on target-node, 90 on other-node.
+	for i := 0; i < 100; i++ {
+		node := "other-node"
+		if i < 10 {
+			node = "target-node"
+		}
+		pod := makeTestPodDetails(fmt.Sprintf("pod%03d", i), uint64(i), node, nil)
+		storeIndexer.Add(makeTestStoreElement(pod))
+	}
+
+	var rv uint64 = 5
+	matchValues := []storage.MatchValue{{IndexName: "f:spec.nodeName", Value: "target-node"}}
+	wci, err := newCacheIntervalFromStore(rv, storeIndexer, "", false, matchValues)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	count := 0
+	for {
+		event, err := wci.Next()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if event == nil {
+			break
+		}
+		count++
+		if event.Type != watch.Added {
+			t.Errorf("expected Added event, got %v", event.Type)
+		}
+		if event.ResourceVersion != rv {
+			t.Errorf("expected rv %d, got %d", rv, event.ResourceVersion)
+		}
+	}
+	if count != 10 {
+		t.Fatalf("expected 10 events for target-node, got %d", count)
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
@@ -110,7 +110,7 @@ func (w *testWatchCache) getCacheIntervalForEvents(resourceVersion uint64, opts 
 	w.RLock()
 	defer w.RUnlock()
 
-	return w.getAllEventsSinceLocked(resourceVersion, "", opts)
+	return w.getAllEventsSinceLocked(context.Background(), resourceVersion, "", opts)
 }
 
 // newTestWatchCache just adds a fake clock.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When a filtered watch starts with `SendInitialEvents=true` or `rv=0`, `newCacheIntervalFromStore()` listed the whole store and ignored the predicate (a kubelet watching `spec.nodeName=mynode` allocated every pod, then dropped most while filtering). It now serves the initial events through the matching index when the field selector maps to one, via a `readPrefilteredByIndex` helper shared by the list and watch paths. The non-indexed path is unchanged.

`BenchmarkStoreWriteThroughput`, `Background=WatchList`, 150k pods / 5k nodes, `benchtime=2s`, n=20:

```
benchstat -filter ".unit:(list-calls/s OR list-objs/s)" master.txt pr.txt

                                    │   master    │            this PR            │
                                    │ list-calls/s│  list-calls/s     vs base     │
Background=WatchList/UseIndex=true     9.841        118.60     +1105% (p=0.000 n=20)
Background=WatchList/UseIndex=false    4.080        3.936      ~      (p=0.862 n=20)

                                    │ list-objs/s │  list-objs/s      vs base     │
Background=WatchList/UseIndex=true     246.0        4268.5     +1635% (p=0.000 n=20)
Background=WatchList/UseIndex=false    260.6k       318.3k     ~      (p=0.142 n=20)
```

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
