### PR TITLE
Migrate FlowSchema PriorityLevelConfiguration.Name to declarative validation

### DIFF
--- a/pkg/api/testing/validation_test.go
+++ b/pkg/api/testing/validation_test.go
@@ -64,6 +64,10 @@ func TestVersionedValidationByFuzzing(t *testing.T) {
 		{Group: "admissionregistration.k8s.io", Version: "v1"},
 		{Group: "admissionregistration.k8s.io", Version: "v1beta1"},
 		{Group: "admissionregistration.k8s.io", Version: "v1alpha1"},
+		{Group: "flowcontrol.apiserver.k8s.io", Version: "v1"},
+		{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta1"},
+		{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta2"},
+		{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta3"},
 	}
 
 	// subresourceOnly specifies the subresource path for types that can only be validated

--- a/pkg/apis/flowcontrol/v1/zz_generated.validations.go
+++ b/pkg/apis/flowcontrol/v1/zz_generated.validations.go
@@ -39,6 +39,14 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
+	// type FlowSchema
+	scheme.AddValidationFunc((*flowcontrolv1.FlowSchema)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_FlowSchema(ctx, op, nil /* fldPath */, obj.(*flowcontrolv1.FlowSchema), safe.Cast[*flowcontrolv1.FlowSchema](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	// type PriorityLevelConfiguration
 	scheme.AddValidationFunc((*flowcontrolv1.PriorityLevelConfiguration)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
@@ -48,6 +56,51 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
 	return nil
+}
+
+// Validate_FlowSchema validates an instance of FlowSchema according
+// to declarative validation rules in the API schema.
+func Validate_FlowSchema(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1.FlowSchema) (errs field.ErrorList) {
+	// field flowcontrolv1.FlowSchema.TypeMeta has no validation
+	// field flowcontrolv1.FlowSchema.ObjectMeta has no validation
+
+	// field flowcontrolv1.FlowSchema.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *flowcontrolv1.FlowSchemaSpec, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_FlowSchemaSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *flowcontrolv1.FlowSchema) *flowcontrolv1.FlowSchemaSpec { return &oldObj.Spec }), oldObj != nil)...)
+
+	// field flowcontrolv1.FlowSchema.Status has no validation
+	return errs
+}
+
+// Validate_FlowSchemaSpec validates an instance of FlowSchemaSpec according
+// to declarative validation rules in the API schema.
+func Validate_FlowSchemaSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1.FlowSchemaSpec) (errs field.ErrorList) {
+	// field flowcontrolv1.FlowSchemaSpec.PriorityLevelConfiguration
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *flowcontrolv1.PriorityLevelConfigurationReference, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_PriorityLevelConfigurationReference(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("priorityLevelConfiguration"), &obj.PriorityLevelConfiguration, safe.Field(oldObj, func(oldObj *flowcontrolv1.FlowSchemaSpec) *flowcontrolv1.PriorityLevelConfigurationReference {
+			return &oldObj.PriorityLevelConfiguration
+		}), oldObj != nil)...)
+
+	// field flowcontrolv1.FlowSchemaSpec.MatchingPrecedence has no validation
+	// field flowcontrolv1.FlowSchemaSpec.DistinguisherMethod has no validation
+	// field flowcontrolv1.FlowSchemaSpec.Rules has no validation
+	return errs
 }
 
 // Validate_LimitResponse validates an instance of LimitResponse according
@@ -174,6 +227,31 @@ func Validate_PriorityLevelConfiguration(ctx context.Context, op operation.Opera
 		}), oldObj != nil)...)
 
 	// field flowcontrolv1.PriorityLevelConfiguration.Status has no validation
+	return errs
+}
+
+// Validate_PriorityLevelConfigurationReference validates an instance of PriorityLevelConfigurationReference according
+// to declarative validation rules in the API schema.
+func Validate_PriorityLevelConfigurationReference(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1.PriorityLevelConfigurationReference) (errs field.ErrorList) {
+	// field flowcontrolv1.PriorityLevelConfigurationReference.Name
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("name"), &obj.Name, safe.Field(oldObj, func(oldObj *flowcontrolv1.PriorityLevelConfigurationReference) *string { return &oldObj.Name }), oldObj != nil)...)
+
 	return errs
 }
 

--- a/pkg/apis/flowcontrol/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/flowcontrol/v1beta1/zz_generated.validations.go
@@ -39,6 +39,14 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
+	// type FlowSchema
+	scheme.AddValidationFunc((*flowcontrolv1beta1.FlowSchema)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_FlowSchema(ctx, op, nil /* fldPath */, obj.(*flowcontrolv1beta1.FlowSchema), safe.Cast[*flowcontrolv1beta1.FlowSchema](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	// type PriorityLevelConfiguration
 	scheme.AddValidationFunc((*flowcontrolv1beta1.PriorityLevelConfiguration)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
@@ -48,6 +56,51 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
 	return nil
+}
+
+// Validate_FlowSchema validates an instance of FlowSchema according
+// to declarative validation rules in the API schema.
+func Validate_FlowSchema(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta1.FlowSchema) (errs field.ErrorList) {
+	// field flowcontrolv1beta1.FlowSchema.TypeMeta has no validation
+	// field flowcontrolv1beta1.FlowSchema.ObjectMeta has no validation
+
+	// field flowcontrolv1beta1.FlowSchema.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *flowcontrolv1beta1.FlowSchemaSpec, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_FlowSchemaSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *flowcontrolv1beta1.FlowSchema) *flowcontrolv1beta1.FlowSchemaSpec { return &oldObj.Spec }), oldObj != nil)...)
+
+	// field flowcontrolv1beta1.FlowSchema.Status has no validation
+	return errs
+}
+
+// Validate_FlowSchemaSpec validates an instance of FlowSchemaSpec according
+// to declarative validation rules in the API schema.
+func Validate_FlowSchemaSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta1.FlowSchemaSpec) (errs field.ErrorList) {
+	// field flowcontrolv1beta1.FlowSchemaSpec.PriorityLevelConfiguration
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *flowcontrolv1beta1.PriorityLevelConfigurationReference, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_PriorityLevelConfigurationReference(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("priorityLevelConfiguration"), &obj.PriorityLevelConfiguration, safe.Field(oldObj, func(oldObj *flowcontrolv1beta1.FlowSchemaSpec) *flowcontrolv1beta1.PriorityLevelConfigurationReference {
+			return &oldObj.PriorityLevelConfiguration
+		}), oldObj != nil)...)
+
+	// field flowcontrolv1beta1.FlowSchemaSpec.MatchingPrecedence has no validation
+	// field flowcontrolv1beta1.FlowSchemaSpec.DistinguisherMethod has no validation
+	// field flowcontrolv1beta1.FlowSchemaSpec.Rules has no validation
+	return errs
 }
 
 // Validate_LimitResponse validates an instance of LimitResponse according
@@ -180,6 +233,31 @@ func Validate_PriorityLevelConfiguration(ctx context.Context, op operation.Opera
 		}), oldObj != nil)...)
 
 	// field flowcontrolv1beta1.PriorityLevelConfiguration.Status has no validation
+	return errs
+}
+
+// Validate_PriorityLevelConfigurationReference validates an instance of PriorityLevelConfigurationReference according
+// to declarative validation rules in the API schema.
+func Validate_PriorityLevelConfigurationReference(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta1.PriorityLevelConfigurationReference) (errs field.ErrorList) {
+	// field flowcontrolv1beta1.PriorityLevelConfigurationReference.Name
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("name"), &obj.Name, safe.Field(oldObj, func(oldObj *flowcontrolv1beta1.PriorityLevelConfigurationReference) *string { return &oldObj.Name }), oldObj != nil)...)
+
 	return errs
 }
 

--- a/pkg/apis/flowcontrol/v1beta2/zz_generated.validations.go
+++ b/pkg/apis/flowcontrol/v1beta2/zz_generated.validations.go
@@ -39,6 +39,14 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
+	// type FlowSchema
+	scheme.AddValidationFunc((*flowcontrolv1beta2.FlowSchema)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_FlowSchema(ctx, op, nil /* fldPath */, obj.(*flowcontrolv1beta2.FlowSchema), safe.Cast[*flowcontrolv1beta2.FlowSchema](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	// type PriorityLevelConfiguration
 	scheme.AddValidationFunc((*flowcontrolv1beta2.PriorityLevelConfiguration)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
@@ -48,6 +56,51 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
 	return nil
+}
+
+// Validate_FlowSchema validates an instance of FlowSchema according
+// to declarative validation rules in the API schema.
+func Validate_FlowSchema(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta2.FlowSchema) (errs field.ErrorList) {
+	// field flowcontrolv1beta2.FlowSchema.TypeMeta has no validation
+	// field flowcontrolv1beta2.FlowSchema.ObjectMeta has no validation
+
+	// field flowcontrolv1beta2.FlowSchema.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *flowcontrolv1beta2.FlowSchemaSpec, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_FlowSchemaSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *flowcontrolv1beta2.FlowSchema) *flowcontrolv1beta2.FlowSchemaSpec { return &oldObj.Spec }), oldObj != nil)...)
+
+	// field flowcontrolv1beta2.FlowSchema.Status has no validation
+	return errs
+}
+
+// Validate_FlowSchemaSpec validates an instance of FlowSchemaSpec according
+// to declarative validation rules in the API schema.
+func Validate_FlowSchemaSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta2.FlowSchemaSpec) (errs field.ErrorList) {
+	// field flowcontrolv1beta2.FlowSchemaSpec.PriorityLevelConfiguration
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *flowcontrolv1beta2.PriorityLevelConfigurationReference, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_PriorityLevelConfigurationReference(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("priorityLevelConfiguration"), &obj.PriorityLevelConfiguration, safe.Field(oldObj, func(oldObj *flowcontrolv1beta2.FlowSchemaSpec) *flowcontrolv1beta2.PriorityLevelConfigurationReference {
+			return &oldObj.PriorityLevelConfiguration
+		}), oldObj != nil)...)
+
+	// field flowcontrolv1beta2.FlowSchemaSpec.MatchingPrecedence has no validation
+	// field flowcontrolv1beta2.FlowSchemaSpec.DistinguisherMethod has no validation
+	// field flowcontrolv1beta2.FlowSchemaSpec.Rules has no validation
+	return errs
 }
 
 // Validate_LimitResponse validates an instance of LimitResponse according
@@ -180,6 +233,31 @@ func Validate_PriorityLevelConfiguration(ctx context.Context, op operation.Opera
 		}), oldObj != nil)...)
 
 	// field flowcontrolv1beta2.PriorityLevelConfiguration.Status has no validation
+	return errs
+}
+
+// Validate_PriorityLevelConfigurationReference validates an instance of PriorityLevelConfigurationReference according
+// to declarative validation rules in the API schema.
+func Validate_PriorityLevelConfigurationReference(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta2.PriorityLevelConfigurationReference) (errs field.ErrorList) {
+	// field flowcontrolv1beta2.PriorityLevelConfigurationReference.Name
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("name"), &obj.Name, safe.Field(oldObj, func(oldObj *flowcontrolv1beta2.PriorityLevelConfigurationReference) *string { return &oldObj.Name }), oldObj != nil)...)
+
 	return errs
 }
 

--- a/pkg/apis/flowcontrol/v1beta3/zz_generated.validations.go
+++ b/pkg/apis/flowcontrol/v1beta3/zz_generated.validations.go
@@ -39,6 +39,14 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *runtime.Scheme) error {
+	// type FlowSchema
+	scheme.AddValidationFunc((*flowcontrolv1beta3.FlowSchema)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		switch op.Request.SubresourcePath() {
+		case "/":
+			return Validate_FlowSchema(ctx, op, nil /* fldPath */, obj.(*flowcontrolv1beta3.FlowSchema), safe.Cast[*flowcontrolv1beta3.FlowSchema](oldObj))
+		}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
+	})
 	// type PriorityLevelConfiguration
 	scheme.AddValidationFunc((*flowcontrolv1beta3.PriorityLevelConfiguration)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
@@ -48,6 +56,51 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}
 	})
 	return nil
+}
+
+// Validate_FlowSchema validates an instance of FlowSchema according
+// to declarative validation rules in the API schema.
+func Validate_FlowSchema(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta3.FlowSchema) (errs field.ErrorList) {
+	// field flowcontrolv1beta3.FlowSchema.TypeMeta has no validation
+	// field flowcontrolv1beta3.FlowSchema.ObjectMeta has no validation
+
+	// field flowcontrolv1beta3.FlowSchema.Spec
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *flowcontrolv1beta3.FlowSchemaSpec, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_FlowSchemaSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("spec"), &obj.Spec, safe.Field(oldObj, func(oldObj *flowcontrolv1beta3.FlowSchema) *flowcontrolv1beta3.FlowSchemaSpec { return &oldObj.Spec }), oldObj != nil)...)
+
+	// field flowcontrolv1beta3.FlowSchema.Status has no validation
+	return errs
+}
+
+// Validate_FlowSchemaSpec validates an instance of FlowSchemaSpec according
+// to declarative validation rules in the API schema.
+func Validate_FlowSchemaSpec(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta3.FlowSchemaSpec) (errs field.ErrorList) {
+	// field flowcontrolv1beta3.FlowSchemaSpec.PriorityLevelConfiguration
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *flowcontrolv1beta3.PriorityLevelConfigurationReference, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_PriorityLevelConfigurationReference(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("priorityLevelConfiguration"), &obj.PriorityLevelConfiguration, safe.Field(oldObj, func(oldObj *flowcontrolv1beta3.FlowSchemaSpec) *flowcontrolv1beta3.PriorityLevelConfigurationReference {
+			return &oldObj.PriorityLevelConfiguration
+		}), oldObj != nil)...)
+
+	// field flowcontrolv1beta3.FlowSchemaSpec.MatchingPrecedence has no validation
+	// field flowcontrolv1beta3.FlowSchemaSpec.DistinguisherMethod has no validation
+	// field flowcontrolv1beta3.FlowSchemaSpec.Rules has no validation
+	return errs
 }
 
 // Validate_LimitResponse validates an instance of LimitResponse according
@@ -180,6 +233,31 @@ func Validate_PriorityLevelConfiguration(ctx context.Context, op operation.Opera
 		}), oldObj != nil)...)
 
 	// field flowcontrolv1beta3.PriorityLevelConfiguration.Status has no validation
+	return errs
+}
+
+// Validate_PriorityLevelConfigurationReference validates an instance of PriorityLevelConfigurationReference according
+// to declarative validation rules in the API schema.
+func Validate_PriorityLevelConfigurationReference(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *flowcontrolv1beta3.PriorityLevelConfigurationReference) (errs field.ErrorList) {
+	// field flowcontrolv1beta3.PriorityLevelConfigurationReference.Name
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}(fldPath.Child("name"), &obj.Name, safe.Field(oldObj, func(oldObj *flowcontrolv1beta3.PriorityLevelConfigurationReference) *string { return &oldObj.Name }), oldObj != nil)...)
+
 	return errs
 }
 

--- a/pkg/apis/flowcontrol/validation/declarative_validation_test.go
+++ b/pkg/apis/flowcontrol/validation/declarative_validation_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/apis/flowcontrol"
+)
+
+func TestFlowSchemaDeclarativeValidation(t *testing.T) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:   "flowcontrol.apiserver.k8s.io",
+		APIVersion: "v1",
+	})
+
+	testCases := map[string]struct {
+		input        flowcontrol.FlowSchema
+		expectedErrs field.ErrorList
+	}{
+		"valid: PriorityLevelConfiguration.Name is set": {
+			input: mkFlowSchema(),
+		},
+		"invalid: PriorityLevelConfiguration.Name is empty": {
+			input: mkFlowSchema(clearPLCName),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "priorityLevelConfiguration", "name"), ""),
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			errs := ValidateFlowSchema(&tc.input)
+			tester := field.ErrorMatcher{}.ByType().ByField()
+			tester.Test(t, tc.expectedErrs, errs)
+
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, func(_ context.Context, obj runtime.Object) field.ErrorList {
+				return ValidateFlowSchema(obj.(*flowcontrol.FlowSchema))
+			}, tc.expectedErrs)
+		})
+	}
+}
+
+func mkFlowSchema(tweaks ...func(*flowcontrol.FlowSchema)) flowcontrol.FlowSchema {
+	fs := flowcontrol.FlowSchema{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-flowschema",
+		},
+		Spec: flowcontrol.FlowSchemaSpec{
+			MatchingPrecedence: 100,
+			PriorityLevelConfiguration: flowcontrol.PriorityLevelConfigurationReference{
+				Name: "test-priority-level",
+			},
+			Rules: []flowcontrol.PolicyRulesWithSubjects{
+				{
+					Subjects: []flowcontrol.Subject{
+						{
+							Kind: flowcontrol.SubjectKindUser,
+							User: &flowcontrol.UserSubject{Name: "test-user"},
+						},
+					},
+					ResourceRules: []flowcontrol.ResourcePolicyRule{
+						{
+							Verbs:        []string{"get"},
+							APIGroups:    []string{""},
+							Resources:    []string{"pods"},
+							ClusterScope: true,
+							Namespaces:   []string{flowcontrol.NamespaceEvery},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tweak := range tweaks {
+		tweak(&fs)
+	}
+	return fs
+}
+
+func clearPLCName(fs *flowcontrol.FlowSchema) {
+	fs.Spec.PriorityLevelConfiguration.Name = ""
+}

--- a/pkg/apis/flowcontrol/validation/validation.go
+++ b/pkg/apis/flowcontrol/validation/validation.go
@@ -123,7 +123,7 @@ func ValidateFlowSchemaSpec(fsName string, spec *flowcontrol.FlowSchemaSpec, fld
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("priorityLevelConfiguration").Child("name"), spec.PriorityLevelConfiguration.Name, msg))
 		}
 	} else {
-		allErrs = append(allErrs, field.Required(fldPath.Child("priorityLevelConfiguration").Child("name"), "must reference a priority level"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("priorityLevelConfiguration").Child("name"), "must reference a priority level").MarkCoveredByDeclarative())
 	}
 	for i, rule := range spec.Rules {
 		allErrs = append(allErrs, ValidateFlowSchemaPolicyRulesWithSubjects(&rule, fldPath.Child("rules").Index(i))...)

--- a/pkg/registry/flowcontrol/flowschema/strategy.go
+++ b/pkg/registry/flowcontrol/flowschema/strategy.go
@@ -20,8 +20,10 @@ import (
 	"context"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/flowcontrol"
@@ -85,7 +87,8 @@ func (flowSchemaStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime
 
 // Validate validates a new flow-schema.
 func (flowSchemaStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
-	return validation.ValidateFlowSchema(obj.(*flowcontrol.FlowSchema))
+	errs := validation.ValidateFlowSchema(obj.(*flowcontrol.FlowSchema))
+	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, obj, nil, errs, operation.Create)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -108,7 +111,8 @@ func (flowSchemaStrategy) AllowCreateOnUpdate() bool {
 
 // ValidateUpdate is the default update validation for an end user.
 func (flowSchemaStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateFlowSchemaUpdate(old.(*flowcontrol.FlowSchema), obj.(*flowcontrol.FlowSchema))
+	errs := validation.ValidateFlowSchemaUpdate(old.(*flowcontrol.FlowSchema), obj.(*flowcontrol.FlowSchema))
+	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, obj, old, errs, operation.Update)
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/staging/src/k8s.io/api/flowcontrol/v1/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1/types.go
@@ -194,6 +194,8 @@ type FlowDistinguisherMethod struct {
 type PriorityLevelConfigurationReference struct {
 	// `name` is the name of the priority level configuration being referenced
 	// Required.
+	// +required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1beta1/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta1/types.go
@@ -196,6 +196,8 @@ type FlowDistinguisherMethod struct {
 type PriorityLevelConfigurationReference struct {
 	// `name` is the name of the priority level configuration being referenced
 	// Required.
+	// +required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1beta2/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta2/types.go
@@ -196,6 +196,8 @@ type FlowDistinguisherMethod struct {
 type PriorityLevelConfigurationReference struct {
 	// `name` is the name of the priority level configuration being referenced
 	// Required.
+	// +required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 }
 

--- a/staging/src/k8s.io/api/flowcontrol/v1beta3/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta3/types.go
@@ -210,6 +210,8 @@ type FlowDistinguisherMethod struct {
 type PriorityLevelConfigurationReference struct {
 	// `name` is the name of the priority level configuration being referenced
 	// Required.
+	// +required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 }
 


### PR DESCRIPTION
## Summary

Migrate `FlowSchema.Spec.PriorityLevelConfiguration.Name` to declarative validation (`+k8s:required`) as part of KEP-5073.

### What type of PR is this?
/kind feature
/kind api-change

### What this PR does / why we need it
- Wires up the FlowSchema resource strategy to use `rest.ValidateDeclarativelyWithMigrationChecks`
- Adds `+k8s:alpha(since: "1.36")=+k8s:required` to `PriorityLevelConfigurationReference.Name` across all flowcontrol API versions (v1, v1beta1, v1beta2, v1beta3)
- Regenerates validation code via `hack/update-codegen.sh validation`
- Marks the existing handwritten Required check with `.MarkCoveredByDeclarative()`
- Adds `declarative_validation_test.go` proving equivalence between handwritten and declarative validation
- Registers the flowcontrol API group versions for fuzz testing

### Which issue(s) this PR fixes
Fixes part of https://github.com/kubernetes/kubernetes/issues/135752

### Special notes for your reviewer
The field meets all "Good First Migration" criteria:
1. **Validation Logic:** Simple `len(name) == 0` → `field.Required` check
2. **Versioning:** Field exists at same path across all API versions (v1, v1beta1, v1beta2, v1beta3)
3. **Nesting:** `PriorityLevelConfigurationReference` is a struct (not pointer) in `FlowSchemaSpec`, so always validated
4. **Not Optional:** Field is not marked `+optional`
5. **Status:** Was not previously migrated

/sig api-machinery
/area api-validation

```release-note
NONE
```