### PR TITLE
apiserver(apf): cap list memory estimate only for streaming watches and streamed lists

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
@@ -100,6 +100,16 @@ type EncoderWithAllocator interface {
 	EncodeWithAllocator(obj Object, w io.Writer, memAlloc MemoryAllocator) error
 }
 
+// StreamingCollectionEncoder is implemented by encoders that can serialize a
+// list one item at a time, keeping the amount of memory held at once bounded
+// regardless of the collection size.
+type StreamingCollectionEncoder interface {
+	// SupportsStreamingCollectionEncoding returns true if, for the way this
+	// encoder is currently configured, encoding a collection streams its items
+	// individually instead of materializing the whole collection in memory.
+	SupportsStreamingCollectionEncoding() bool
+}
+
 // Decoder attempts to load an object from data.
 type Decoder interface {
 	// Decode attempts to deserialize the provided data using either the innate typing of the scheme or the

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
@@ -264,6 +264,13 @@ func (s *Serializer) IsStrict() bool {
 	return s.options.Strict
 }
 
+// SupportsStreamingCollectionEncoding implements runtime.StreamingCollectionEncoder.
+// Streaming collection encoding only kicks in for the non-pretty JSON path; both
+// the YAML and pretty paths buffer the whole object before writing (see doEncode).
+func (s *Serializer) SupportsStreamingCollectionEncoding() bool {
+	return s.options.StreamingCollectionsEncoding && !s.options.Yaml && !s.options.Pretty
+}
+
 func (s *Serializer) unmarshal(into runtime.Object, data, originalData []byte) (strictErrs []error, err error) {
 	// If the deserializer is non-strict, return here.
 	if !s.options.Strict {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go
@@ -288,6 +288,11 @@ func (s *Serializer) RecognizesData(data []byte) (bool, bool, error) {
 	return bytes.HasPrefix(data, s.prefix), false, nil
 }
 
+// SupportsStreamingCollectionEncoding implements runtime.StreamingCollectionEncoder.
+func (s *Serializer) SupportsStreamingCollectionEncoding() bool {
+	return s.options.StreamingCollectionsEncoding
+}
+
 // copyKindDefaults defaults dst to the value in src if dst does not have a value set.
 func copyKindDefaults(dst, src *schema.GroupVersionKind) {
 	if src == nil {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/streaming_collection.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/streaming_collection.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/endpoints/handlers/negotiation"
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+// WithStreamingCollectionEncoding records whether a list response can be
+// streamed, so APF can cap the memory estimate.
+//
+// This runs before routing, so it uses a server-wide serializer and makes a
+// conservative prediction.
+func WithStreamingCollectionEncoding(handler http.Handler, serializer runtime.NegotiatedSerializer) http.Handler {
+	if serializer == nil {
+		return handler
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
+		if requestInfo, ok := request.RequestInfoFrom(ctx); ok &&
+			requestInfo.IsResourceRequest && requestInfo.Verb == "list" &&
+			negotiatesStreamingCollectionEncoding(req, serializer) {
+			req = req.WithContext(request.WithStreamingCollectionEncoding(ctx, true))
+		}
+		handler.ServeHTTP(w, req)
+	})
+}
+
+// negotiatesStreamingCollectionEncoding reports whether the serializer selected
+// for this request streams collection items individually.
+func negotiatesStreamingCollectionEncoding(req *http.Request, serializer runtime.NegotiatedSerializer) bool {
+	_, info, err := negotiation.NegotiateOutputMediaType(req, serializer, negotiation.DefaultEndpointRestrictions)
+	if err != nil {
+		return false
+	}
+	encoder, ok := info.Serializer.(runtime.StreamingCollectionEncoder)
+	return ok && encoder.SupportsStreamingCollectionEncoding()
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/streaming_collection_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/streaming_collection_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"net/http"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+func BenchmarkNegotiatesStreamingCollectionEncoding(b *testing.B) {
+	ns := serializer.NewCodecFactory(runtime.NewScheme(),
+		serializer.WithStreamingCollectionEncodingToJSON(),
+		serializer.WithStreamingCollectionEncodingToProtobuf())
+
+	cases := []struct {
+		name   string
+		accept string
+	}{
+		{"protobuf", "application/vnd.kubernetes.protobuf"},
+		{"json", "application/json"},
+		{"protobuf-fallback", "application/vnd.kubernetes.protobuf,*/*"},
+		{"empty", ""},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			req, _ := http.NewRequest(http.MethodGet, "/api/v1/pods", nil)
+			if tc.accept != "" {
+				req.Header.Set("Accept", tc.accept)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = negotiatesStreamingCollectionEncoding(req, ns)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/context.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/context.go
@@ -32,6 +32,10 @@ const (
 
 	// userKey is the context key for the request user.
 	userKey
+
+	// streamingCollectionEncodingKey is the context key for whether the response
+	// to this request will be encoded with a streaming collection encoder.
+	streamingCollectionEncodingKey
 )
 
 // NewContext instantiates a base context object for request flows.
@@ -75,4 +79,16 @@ func WithUser(parent context.Context, user user.Info) context.Context {
 func UserFrom(ctx context.Context) (user.Info, bool) {
 	user, ok := ctx.Value(userKey).(user.Info)
 	return user, ok
+}
+
+// WithStreamingCollectionEncoding returns a copy of parent in which the
+// streaming collection encoding value is set
+func WithStreamingCollectionEncoding(parent context.Context, streaming bool) context.Context {
+	return WithValue(parent, streamingCollectionEncodingKey, streaming)
+}
+
+// StreamingCollectionEncodingFrom returns the value of the streaming collection encoding key on the ctx
+func StreamingCollectionEncodingFrom(ctx context.Context) bool {
+	streaming, _ := ctx.Value(streamingCollectionEncodingKey).(bool)
+	return streaming
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -1051,6 +1051,8 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
 		handler = genericfilters.WithMaxInFlightLimit(handler, c.MaxRequestsInFlight, c.MaxMutatingRequestsInFlight, c.LongRunningFunc)
 	}
 
+	handler = genericapifilters.WithStreamingCollectionEncoding(handler, streamingCollectionNegotiationSerializer())
+
 	handler = filterlatency.TrackCompleted(handler)
 	if c.FeatureGate.Enabled(genericfeatures.ConstrainedImpersonation) {
 		handler = impersonation.WithConstrainedImpersonation(handler, c.Authorization.Authorizer, c.Serializer)

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -1014,17 +1014,26 @@ func (s *GenericAPIServer) newAPIGroupVersion(apiGroupInfo *APIGroupInfo, groupV
 	}
 }
 
-// NewDefaultAPIGroupInfo returns an APIGroupInfo stubbed with "normal" values
-// exposed for easier composition from other packages
-func NewDefaultAPIGroupInfo(group string, scheme *runtime.Scheme, parameterCodec runtime.ParameterCodec, codecs serializer.CodecFactory) APIGroupInfo {
-	opts := []serializer.CodecFactoryOptionsMutator{
-		serializer.WithStreamingCollectionEncodingToJSON(),
-		serializer.WithStreamingCollectionEncodingToProtobuf(),
-	}
+func codecFactoryMutators() []serializer.CodecFactoryOptionsMutator {
+	opts := []serializer.CodecFactoryOptionsMutator{}
 	if utilfeature.DefaultFeatureGate.Enabled(features.CBORServingAndStorage) {
 		opts = append(opts, serializer.WithSerializer(cbor.NewSerializerInfo))
 	}
-	if len(opts) != 0 {
+
+	opts = append(opts, serializer.WithStreamingCollectionEncodingToJSON())
+	opts = append(opts, serializer.WithStreamingCollectionEncodingToProtobuf())
+
+	return opts
+}
+
+func streamingCollectionNegotiationSerializer() runtime.NegotiatedSerializer {
+	return serializer.NewCodecFactory(runtime.NewScheme(), codecFactoryMutators()...)
+}
+
+// NewDefaultAPIGroupInfo returns an APIGroupInfo stubbed with "normal" values
+// exposed for easier composition from other packages
+func NewDefaultAPIGroupInfo(group string, scheme *runtime.Scheme, parameterCodec runtime.ParameterCodec, codecs serializer.CodecFactory) APIGroupInfo {
+	if opts := codecFactoryMutators(); len(opts) != 0 {
 		codecs = serializer.NewCodecFactory(scheme, opts...)
 	}
 	return APIGroupInfo{

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator.go
@@ -87,11 +87,15 @@ func (e *listWorkEstimator) estimate(r *http.Request, flowSchemaName, priorityLe
 	}
 
 	// For watch requests we want to set the cost low if they aren't requesting for init events,
-	// either via the explicit SendInitialEvents param or via legacy watches that have RV=0 or unset.
+	// either via the explicit SendInitialEvents param or via legacy watches that have RV=0 or unset
+	// Watch requests that pass this filter (isWatchList) serialize objects incrementally
+	// with bounded memory via the watch protocol.
+	var isWatchList bool
 	if requestInfo.Verb == "watch" {
 		sendInitEvents := listOptions.SendInitialEvents != nil && *listOptions.SendInitialEvents
-		legacyWatch := listOptions.ResourceVersion == "" || listOptions.ResourceVersion == "0"
-		if !sendInitEvents && !legacyWatch {
+		legacyWatch := listOptions.SendInitialEvents == nil && (listOptions.ResourceVersion == "" || listOptions.ResourceVersion == "0")
+		isWatchList = sendInitEvents || legacyWatch
+		if !isWatchList {
 			return WorkEstimate{InitialSeats: e.config.MinimumSeats}
 		}
 	}
@@ -104,7 +108,10 @@ func (e *listWorkEstimator) estimate(r *http.Request, flowSchemaName, priorityLe
 	} else {
 		listFromStorage = result.ShouldDelegate
 	}
-	isListFromCache := requestInfo.Verb == "watch" || !listFromStorage
+	isListFromCache := !listFromStorage
+	usesListCacheCostEstimate := isWatchList || isListFromCache
+
+	isStreamed := isWatchList || (isListFromCache && apirequest.StreamingCollectionEncodingFrom(r.Context()))
 
 	stats, err := e.statsGetterFn(key(requestInfo))
 	switch {
@@ -137,9 +144,9 @@ func (e *listWorkEstimator) estimate(r *http.Request, flowSchemaName, priorityLe
 
 	var seats uint64
 	if utilfeature.DefaultFeatureGate.Enabled(features.SizeBasedListCostEstimate) {
-		seats = e.seatsBasedOnObjectSize(stats, listOptions, isListFromCache, matchesSingle)
+		seats = e.seatsBasedOnObjectSize(stats, listOptions, usesListCacheCostEstimate, isStreamed, matchesSingle)
 	} else {
-		seats = e.seatsBasedOnObjectCount(stats, listOptions, isListFromCache, matchesSingle)
+		seats = e.seatsBasedOnObjectCount(stats, listOptions, usesListCacheCostEstimate, matchesSingle)
 	}
 
 	// make sure we never return a seat of zero
@@ -152,7 +159,7 @@ func (e *listWorkEstimator) estimate(r *http.Request, flowSchemaName, priorityLe
 	return WorkEstimate{InitialSeats: seats}
 }
 
-func (e *listWorkEstimator) seatsBasedOnObjectCount(stats storage.Stats, listOptions metav1.ListOptions, isListFromCache bool, matchesSingle bool) uint64 {
+func (e *listWorkEstimator) seatsBasedOnObjectCount(stats storage.Stats, listOptions metav1.ListOptions, usesListCacheCostEstimate bool, matchesSingle bool) uint64 {
 	numStored := stats.ObjectCount
 	limit := numStored
 	if listOptions.Limit > 0 && listOptions.Limit < numStored {
@@ -164,7 +171,7 @@ func (e *listWorkEstimator) seatsBasedOnObjectCount(stats storage.Stats, listOpt
 	switch {
 	case matchesSingle:
 		estimatedObjectsToBeProcessed = 1
-	case isListFromCache:
+	case usesListCacheCostEstimate:
 		// TODO: For resources that implement indexes at the watchcache level,
 		//  we need to adjust the cost accordingly
 		estimatedObjectsToBeProcessed = numStored
@@ -181,7 +188,7 @@ func (e *listWorkEstimator) seatsBasedOnObjectCount(stats storage.Stats, listOpt
 	return uint64(math.Ceil(float64(estimatedObjectsToBeProcessed) / e.config.ObjectsPerSeat))
 }
 
-func (e *listWorkEstimator) seatsBasedOnObjectSize(stats storage.Stats, listOptions metav1.ListOptions, isListFromCache bool, matchesSingle bool) uint64 {
+func (e *listWorkEstimator) seatsBasedOnObjectSize(stats storage.Stats, listOptions metav1.ListOptions, usesListCacheCostEstimate bool, isStreamed bool, matchesSingle bool) uint64 {
 	if stats.EstimatedAverageObjectSizeBytes <= 0 && stats.ObjectCount != 0 {
 		stats.EstimatedAverageObjectSizeBytes = maxObjectSize
 	}
@@ -193,7 +200,7 @@ func (e *listWorkEstimator) seatsBasedOnObjectSize(stats storage.Stats, listOpti
 	switch {
 	case matchesSingle:
 		objectsLoadedInMemory = 1
-	case isListFromCache:
+	case usesListCacheCostEstimate:
 		objectsLoadedInMemory = limited
 	case listOptions.FieldSelector != "" || listOptions.LabelSelector != "":
 		objectsLoadedInMemory = max(limited, stats.ObjectCount/2)
@@ -202,8 +209,7 @@ func (e *listWorkEstimator) seatsBasedOnObjectSize(stats storage.Stats, listOpti
 	}
 
 	memoryUsedAtOnce := objectsLoadedInMemory * stats.EstimatedAverageObjectSizeBytes
-	if isListFromCache {
-		// TODO: Identify if the resource is streamed
+	if isStreamed {
 		memoryUsedAtOnce = min(memoryUsedAtOnce, cacheWithStreamingMaxMemoryUsage)
 	}
 	return uint64(math.Ceil(float64(memoryUsedAtOnce) / bytesPerSeat))

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/request/list_work_estimator_test.go
@@ -33,6 +33,7 @@ func TestListWorkEstimator(t *testing.T) {
 		objectCount               int64
 		request                   metav1.ListOptions
 		isListFromCache           bool
+		isStreamingResponse       bool
 		matchesSingle             bool
 		expectObjectCountEstimate uint64
 		expectObjectSizeEstimate  uint64
@@ -187,7 +188,7 @@ func TestListWorkEstimator(t *testing.T) {
 			objectCount:               1000,
 			isListFromCache:           true,
 			expectObjectCountEstimate: 10,
-			expectObjectSizeEstimate:  10,
+			expectObjectSizeEstimate:  100,
 		},
 		{
 			name:                      "10MB resource, 1000 objects, cache, limit 100",
@@ -239,7 +240,7 @@ func TestListWorkEstimator(t *testing.T) {
 			objectCount:               99,
 			isListFromCache:           true,
 			expectObjectCountEstimate: 1,
-			expectObjectSizeEstimate:  10,
+			expectObjectSizeEstimate:  100,
 		},
 		{
 			name:                      "10MB resource, 99 objects, cache, limit 10",
@@ -248,7 +249,7 @@ func TestListWorkEstimator(t *testing.T) {
 			isListFromCache:           true,
 			request:                   metav1.ListOptions{Limit: 10},
 			expectObjectCountEstimate: 1,
-			expectObjectSizeEstimate:  10,
+			expectObjectSizeEstimate:  11,
 		},
 		{
 			name:                      "10MB resource, 99 objects, cache, limit 10, selector",
@@ -257,7 +258,7 @@ func TestListWorkEstimator(t *testing.T) {
 			isListFromCache:           true,
 			request:                   metav1.ListOptions{Limit: 10, LabelSelector: "a"},
 			expectObjectCountEstimate: 1,
-			expectObjectSizeEstimate:  10,
+			expectObjectSizeEstimate:  11,
 		},
 		{
 			name:                      "1000MB resource, 1000 objects, store, matchesSingle",
@@ -276,6 +277,61 @@ func TestListWorkEstimator(t *testing.T) {
 			expectObjectCountEstimate: 1,
 			expectObjectSizeEstimate:  10,
 		},
+		{
+			name:                      "10MB resource, 1000 objects, streaming",
+			totalSize:                 10_000_000 - 1,
+			objectCount:               1000,
+			isListFromCache:           true,
+			isStreamingResponse:       true,
+			expectObjectCountEstimate: 10,
+			expectObjectSizeEstimate:  10,
+		},
+		{
+			name:                      "10MB resource, 99 objects, streaming",
+			totalSize:                 10_000_000 - 1,
+			objectCount:               99,
+			isListFromCache:           true,
+			isStreamingResponse:       true,
+			expectObjectCountEstimate: 1,
+			expectObjectSizeEstimate:  10,
+		},
+		{
+			name:                      "10MB resource, 99 objects, streaming, limit 10",
+			totalSize:                 10_000_000 - 1,
+			objectCount:               99,
+			isListFromCache:           true,
+			isStreamingResponse:       true,
+			request:                   metav1.ListOptions{Limit: 10},
+			expectObjectCountEstimate: 1,
+			expectObjectSizeEstimate:  10,
+		},
+		{
+			name:                      "10MB resource, 1000 objects, cache, streamed list (JSON/Proto)",
+			totalSize:                 10_000_000 - 1,
+			objectCount:               1000,
+			isListFromCache:           true,
+			isStreamingResponse:       true,
+			expectObjectCountEstimate: 10,
+			expectObjectSizeEstimate:  10,
+		},
+		{
+			name:                      "10MB resource, 99 objects, cache, streamed list (JSON/Proto)",
+			totalSize:                 10_000_000 - 1,
+			objectCount:               99,
+			isListFromCache:           true,
+			isStreamingResponse:       true,
+			expectObjectCountEstimate: 1,
+			expectObjectSizeEstimate:  10,
+		},
+		{
+			name:                      "10MB resource, 1000 objects, cache, non-streamed list (YAML)",
+			totalSize:                 10_000_000 - 1,
+			objectCount:               1000,
+			isListFromCache:           true,
+			isStreamingResponse:       false,
+			expectObjectCountEstimate: 10,
+			expectObjectSizeEstimate:  100,
+		},
 	}
 
 	for _, test := range tests {
@@ -285,7 +341,7 @@ func TestListWorkEstimator(t *testing.T) {
 			stats := storage.Stats{ObjectCount: test.objectCount, EstimatedAverageObjectSizeBytes: test.totalSize / test.objectCount}
 
 			objectCountEstimate := estimator.seatsBasedOnObjectCount(stats, test.request, test.isListFromCache, test.matchesSingle)
-			objectSizeEstimage := estimator.seatsBasedOnObjectSize(stats, test.request, test.isListFromCache, test.matchesSingle)
+			objectSizeEstimage := estimator.seatsBasedOnObjectSize(stats, test.request, test.isListFromCache, test.isStreamingResponse, test.matchesSingle)
 
 			if objectCountEstimate != test.expectObjectCountEstimate {
 				t.Errorf("Expected object count work estimate to match, expected: %d, but got: %d", test.expectObjectCountEstimate, objectCountEstimate)


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This PR fixes APF list cost estimation for cache-served list requests.

Previously, in `seatsBasedOnObjectSize`, the `cacheWithStreamingMaxMemoryUsage` (1MB) cap was applied to all cache-served lists whenever `isListFromCache=true`. However, `isListFromCache=true` only means the request is served from the watch cache. It does not mean the response is streamed.

Cache-served list requests can have two different memory profiles:

- `WatchList streaming requests`: objects are sent incrementally as watch init events, so memory remains bounded.
- `Streamed list responses`: streaming collection encoding serializes objects incrementally, so memory remains bounded.
- `Non-streaming cache lists`: `Cacher.GetList` still materializes the full result set in memory before serialization, so memory usage grows with the result size.

Because of this, APF could underestimate the seat cost of large non-streaming cache lists and admit too many expensive requests concurrently.

This change applies the 1MB cap only to truly streamed responses, including both `WatchList` streaming requests and `streamed list` responses, while keeping proportional cost estimation for non-streaming cache lists.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
