### PR TITLE
DRA: use full image name in test manifests

### DIFF
--- a/test/e2e/testing-manifests/dra/dra-test-driver-proxy.yaml
+++ b/test/e2e/testing-manifests/dra/dra-test-driver-proxy.yaml
@@ -47,7 +47,7 @@ spec:
 
       containers:
         - name: pause
-          image: registry.k8s.io/sig-storage/hostpathplugin # Version and actual registry get patched in during deployment.
+          image: registry.k8s.io/sig-storage/hostpathplugin:to-be-replaced # Version and actual registry get patched in during deployment.
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
In air-gaped environment, the image must have `name:tag` to be parsed and updated with a private registry.

#### Which issue(s) this PR is related to:
Fixes:  #138317

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed running of DRA e2e tests in air-gaped clusters or with test images in private registries.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
