### PR TITLE
KEP-6007: Add Topology Manager option prefer-most-allocated-numa-node

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -356,6 +356,7 @@ func NewContainerManager(ctx context.Context, mountUtil mount.Interface, cadviso
 		return nil, err
 	}
 	cm.topologyManager.AddHintProvider(logger, cm.memoryManager)
+	cm.topologyManager.SetNUMAScorer(NewNUMAScorerAggregator(cm.cpuManager, cm.memoryManager))
 
 	// Create a single channel for all resource updates. This channel is consumed
 	// by the Kubelet's main sync loop.

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -183,6 +183,7 @@ func NewContainerManager(ctx context.Context, mountUtil mount.Interface, cadviso
 			return nil, err
 		}
 		cm.topologyManager.AddHintProvider(logger, cm.memoryManager)
+		cm.topologyManager.SetNUMAScorer(NewNUMAScorerAggregator(cm.cpuManager, cm.memoryManager))
 	}
 
 	logger.Info("Creating device plugin manager")

--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/topology"
 	cmqos "k8s.io/kubernetes/pkg/kubelet/cm/qos"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
+	tmbitmask "k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/status"
@@ -110,6 +111,10 @@ type Manager interface {
 
 	// GetResourceIsolationLevel returns the isolation level of the container.
 	GetResourceIsolationLevel(pod *v1.Pod, container *v1.Container) cmqos.ResourceIsolationLevel
+
+	// GetNUMAUtilizationScores returns per-NUMA exclusive-CPU utilization scores for the
+	// prefer-most-allocated-numa-node NUMA scorer. Returns (0, 0) for non-static policy.
+	GetNUMAUtilizationScores(current, candidate tmbitmask.BitMask) (currentScore, candidateScore int64)
 }
 
 type manager struct {
@@ -589,4 +594,39 @@ func (m *manager) GetResourceIsolationLevel(pod *v1.Pod, container *v1.Container
 	}
 
 	return cmqos.ResourceIsolationContainer
+}
+
+func (m *manager) GetNUMAUtilizationScores(current, candidate tmbitmask.BitMask) (currentScore, candidateScore int64) {
+	m.Lock()
+	defer m.Unlock()
+	sp, static := m.policy.(*staticPolicy)
+	if !static {
+		return 0, 0
+	}
+	curBits := current.GetBits()
+	candBits := candidate.GetBits()
+	if len(curBits) != 1 || len(candBits) != 1 {
+		return 0, 0
+	}
+	currentScore = getMostAllocatedNUMAScore(
+		int64(sp.getExclusiveAssignedCPUsOnNUMANode(m.state, curBits[0])),
+		int64(sp.getAllocatableExclusiveCPUsOnNUMANode(curBits[0])),
+	)
+	candidateScore = getMostAllocatedNUMAScore(
+		int64(sp.getExclusiveAssignedCPUsOnNUMANode(m.state, candBits[0])),
+		int64(sp.getAllocatableExclusiveCPUsOnNUMANode(candBits[0])),
+	)
+	return currentScore, candidateScore
+}
+
+// getMostAllocatedNUMAScore mirrors kube-scheduler's mostRequestedScore:
+// (requested * 100) / capacity.  Returns 0 when capacity is zero.
+func getMostAllocatedNUMAScore(requested, capacity int64) int64 {
+	if capacity == 0 {
+		return 0
+	}
+	if requested > capacity {
+		requested = capacity
+	}
+	return (requested * 100) / capacity
 }

--- a/pkg/kubelet/cm/cpumanager/cpu_scoring_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_scoring_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpumanager
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/topology"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
+	"k8s.io/kubernetes/test/utils/ktesting"
+	"k8s.io/utils/cpuset"
+)
+
+// returnMachineInfo topology (from topology_hints_test.go):
+//   NUMA 0: CPUs {0,1,2,6,7,8}   (6 CPUs)
+//   NUMA 1: CPUs {3,4,5,9,10,11} (6 CPUs)
+
+func TestGetNUMAUtilizationScores_CPUScoring(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	mi := returnMachineInfo()
+	topo, err := topology.Discover(logger, &mi)
+	if err != nil {
+		t.Fatal(err)
+	}
+	staticPol, err := NewStaticPolicy(logger, topo, 0, cpuset.New(), topologymanager.NewFakeManager(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m0, err := bitmask.NewBitMask(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m1, err := bitmask.NewBitMask(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("equal utilization returns equal scores", func(t *testing.T) {
+		// 1/6 on each NUMA → score 16 vs 16
+		st := &mockState{assignments: state.ContainerCPUAssignments{
+			"p1": {"c": mustParseCPUSet(t, "0")},
+			"p2": {"c": mustParseCPUSet(t, "3")},
+		}}
+		m := &manager{policy: staticPol, state: st}
+		s0, s1 := m.GetNUMAUtilizationScores(m0, m1)
+		if s0 != s1 {
+			t.Fatalf("got s0=%d s1=%d want equal scores", s0, s1)
+		}
+	})
+
+	t.Run("higher utilization on candidate returns higher candidate score", func(t *testing.T) {
+		// NUMA 0: 1/6 → score 16, NUMA 1: 3/6 → score 50
+		st := &mockState{assignments: state.ContainerCPUAssignments{
+			"p1": {"c": mustParseCPUSet(t, "0")},
+			"p2": {"c": mustParseCPUSet(t, "3")},
+			"p3": {"c": mustParseCPUSet(t, "4")},
+			"p4": {"c": mustParseCPUSet(t, "5")},
+		}}
+		m := &manager{policy: staticPol, state: st}
+		s0, s1 := m.GetNUMAUtilizationScores(m0, m1)
+		if s1 <= s0 {
+			t.Fatalf("got s0=%d s1=%d want s1 > s0", s0, s1)
+		}
+	})
+
+	t.Run("higher utilization on current returns higher current score", func(t *testing.T) {
+		// NUMA 0: 3/6 → score 50, NUMA 1: 1/6 → score 16
+		st := &mockState{assignments: state.ContainerCPUAssignments{
+			"p1": {"c": mustParseCPUSet(t, "0")},
+			"p2": {"c": mustParseCPUSet(t, "1")},
+			"p3": {"c": mustParseCPUSet(t, "2")},
+			"p4": {"c": mustParseCPUSet(t, "3")},
+		}}
+		m := &manager{policy: staticPol, state: st}
+		s0, s1 := m.GetNUMAUtilizationScores(m0, m1)
+		if s0 <= s1 {
+			t.Fatalf("got s0=%d s1=%d want s0 > s1", s0, s1)
+		}
+	})
+
+	t.Run("non-static policy returns zero scores", func(t *testing.T) {
+		st := &mockState{assignments: state.ContainerCPUAssignments{
+			"p1": {"c": mustParseCPUSet(t, "0")},
+		}}
+		m := &manager{policy: &mockPolicy{}, state: st}
+		s0, s1 := m.GetNUMAUtilizationScores(m0, m1)
+		if s0 != 0 || s1 != 0 {
+			t.Fatalf("got s0=%d s1=%d want both 0", s0, s1)
+		}
+	})
+
+	t.Run("asymmetric reservation changes scores", func(t *testing.T) {
+		// Reserve CPUs {0,6} on NUMA 0 → allocatable: NUMA 0 = 4, NUMA 1 = 6.
+		// Assign 2 exclusive CPUs on each: NUMA 0 score = (2*100)/4 = 50,
+		// NUMA 1 score = (2*100)/6 = 33.
+		asymPol, err := NewStaticPolicy(logger, topo, 2, cpuset.New(0, 6), topologymanager.NewFakeManager(), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		st := &mockState{assignments: state.ContainerCPUAssignments{
+			"p1": {"c": mustParseCPUSet(t, "1")},
+			"p2": {"c": mustParseCPUSet(t, "2")},
+			"p3": {"c": mustParseCPUSet(t, "3")},
+			"p4": {"c": mustParseCPUSet(t, "4")},
+		}}
+		m := &manager{policy: asymPol, state: st}
+		s0, s1 := m.GetNUMAUtilizationScores(m0, m1)
+		if s0 <= s1 {
+			t.Fatalf("got s0=%d s1=%d want s0 > s1 (NUMA 0 more utilized due to reservation)", s0, s1)
+		}
+	})
+}

--- a/pkg/kubelet/cm/cpumanager/fake_cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/fake_cpu_manager.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state"
 	cmqos "k8s.io/kubernetes/pkg/kubelet/cm/qos"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
+	tmbitmask "k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	"k8s.io/kubernetes/pkg/kubelet/status"
 	"k8s.io/utils/cpuset"
@@ -107,6 +108,10 @@ func (m *fakeManager) GetAllCPUs() cpuset.CPUSet {
 
 func (m *fakeManager) GetResourceIsolationLevel(pod *v1.Pod, container *v1.Container) cmqos.ResourceIsolationLevel {
 	return cmqos.ResourceIsolationContainer
+}
+
+func (m *fakeManager) GetNUMAUtilizationScores(tmbitmask.BitMask, tmbitmask.BitMask) (int64, int64) {
+	return 0, 0
 }
 
 // NewFakeManager creates empty/fake cpu manager

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -1091,7 +1091,31 @@ func getTotalAssignedExclusiveCPUs(s state.State) cpuset.CPUSet {
 			totalAssignedCPUs = totalAssignedCPUs.Union(cset)
 		}
 	}
+	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) {
+		for _, pe := range s.GetPodCPUAssignments() {
+			totalAssignedCPUs = totalAssignedCPUs.Union(pe.CPUSet)
+		}
+	}
 	return totalAssignedCPUs
+}
+
+func (p *staticPolicy) getAllocatableExclusiveCPUsOnNUMANode(numa int) int {
+	total := p.topology.CPUDetails.CPUsInNUMANodes(numa)
+	return total.Difference(p.reservedCPUs).Size()
+}
+
+func (p *staticPolicy) getExclusiveAssignedCPUsOnNUMANode(s state.State, numa int) int {
+	n := 0
+	for _, cpuID := range getTotalAssignedExclusiveCPUs(s).UnsortedList() {
+		nodeID, err := p.topology.CPUNUMANodeID(cpuID)
+		if err != nil {
+			continue
+		}
+		if nodeID == numa {
+			n++
+		}
+	}
+	return n
 }
 
 func updateAllocationPerNUMAMetric(logger logr.Logger, topo *topology.CPUTopology, allocatedCPUs cpuset.CPUSet) {

--- a/pkg/kubelet/cm/memorymanager/fake_memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/fake_memory_manager.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager/state"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
+	tmbitmask "k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	"k8s.io/kubernetes/pkg/kubelet/status"
 )
@@ -98,6 +99,10 @@ func (m *fakeManager) GetMemory(podUID, containerName string) []state.Block {
 	logger := klog.LoggerWithValues(klog.TODO(), "podUID", podUID, "containerName", containerName)
 	logger.Info("Get Memory")
 	return []state.Block{}
+}
+
+func (m *fakeManager) GetNUMAUtilizationScores(tmbitmask.BitMask, tmbitmask.BitMask) (int64, int64) {
+	return 0, 0
 }
 
 // NewFakeManager creates empty/fake memory manager

--- a/pkg/kubelet/cm/memorymanager/memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager/state"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
+	tmbitmask "k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	"k8s.io/kubernetes/pkg/kubelet/status"
 )
@@ -95,6 +96,11 @@ type Manager interface {
 
 	// GetMemory returns the memory allocated by a container from NUMA nodes
 	GetMemory(podUID, containerName string) []state.Block
+
+	// GetNUMAUtilizationScores returns per-NUMA regular-memory utilization scores for the
+	// prefer-most-allocated-numa-node NUMA scorer. Uses regular memory only (no huge pages).
+	// Returns (0, 0) for non-static policy.
+	GetNUMAUtilizationScores(current, candidate tmbitmask.BitMask) (currentScore, candidateScore int64)
 }
 
 type manager struct {
@@ -493,4 +499,52 @@ func (m *manager) GetAllocatableMemory() []state.Block {
 // GetMemory returns the memory allocated by a container from NUMA nodes
 func (m *manager) GetMemory(podUID, containerName string) []state.Block {
 	return m.state.GetMemoryBlocks(podUID, containerName)
+}
+
+func (m *manager) GetNUMAUtilizationScores(current, candidate tmbitmask.BitMask) (currentScore, candidateScore int64) {
+	m.Lock()
+	defer m.Unlock()
+	_, isStatic := m.policy.(*staticPolicy)
+	if !isStatic {
+		return 0, 0
+	}
+	curBits := current.GetBits()
+	candBits := candidate.GetBits()
+	if len(curBits) != 1 || len(candBits) != 1 {
+		return 0, 0
+	}
+	machineState := m.state.GetMachineState()
+	currentScore = getMostAllocatedNUMAScore(
+		getRegularMemoryAssignedBytesOnNUMANode(m.state, curBits[0]),
+		getAllocatableRegularMemoryOnNUMANode(machineState, curBits[0]),
+	)
+	candidateScore = getMostAllocatedNUMAScore(
+		getRegularMemoryAssignedBytesOnNUMANode(m.state, candBits[0]),
+		getAllocatableRegularMemoryOnNUMANode(machineState, candBits[0]),
+	)
+	return currentScore, candidateScore
+}
+
+func getAllocatableRegularMemoryOnNUMANode(machineState state.NUMANodeMap, numa int) uint64 {
+	ns, ok := machineState[numa]
+	if !ok {
+		return 0
+	}
+	mt, ok := ns.MemoryMap[v1.ResourceMemory]
+	if !ok {
+		return 0
+	}
+	return mt.Allocatable
+}
+
+// getMostAllocatedNUMAScore mirrors kube-scheduler's mostRequestedScore:
+// (requested * 100) / capacity.  Returns 0 when capacity is zero.
+func getMostAllocatedNUMAScore(requested, capacity uint64) int64 {
+	if capacity == 0 {
+		return 0
+	}
+	if requested > capacity {
+		requested = capacity
+	}
+	return int64((requested * 100) / capacity)
 }

--- a/pkg/kubelet/cm/memorymanager/memory_scoring_test.go
+++ b/pkg/kubelet/cm/memorymanager/memory_scoring_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memorymanager
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
+	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager/state"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
+	"k8s.io/kubernetes/test/utils/ktesting"
+)
+
+func memBlock(numa int, sz uint64) state.Block {
+	return state.Block{
+		NUMAAffinity: []int{numa},
+		Type:         v1.ResourceMemory,
+		Size:         sz,
+	}
+}
+
+func symmetricMachineState(allocatable uint64) state.NUMANodeMap {
+	return state.NUMANodeMap{
+		0: &state.NUMANodeState{
+			MemoryMap: map[v1.ResourceName]*state.MemoryTable{
+				v1.ResourceMemory: {Allocatable: allocatable},
+			},
+			Cells: []int{0},
+		},
+		1: &state.NUMANodeState{
+			MemoryMap: map[v1.ResourceName]*state.MemoryTable{
+				v1.ResourceMemory: {Allocatable: allocatable},
+			},
+			Cells: []int{1},
+		},
+	}
+}
+
+func TestGetNUMAUtilizationScores_MemoryScoring(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	mi := returnMachineInfo()
+	reserved := systemReservedMemory{
+		0: {v1.ResourceMemory: 1 * gb},
+		1: {v1.ResourceMemory: 1 * gb},
+	}
+	staticPol, err := NewPolicyStatic(logger, &mi, reserved, topologymanager.NewFakeManager())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m0, err := bitmask.NewBitMask(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m1, err := bitmask.NewBitMask(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("equal utilization returns equal scores", func(t *testing.T) {
+		// 2GB/10GB on each NUMA → score 20 vs 20
+		st := state.NewMemoryState(logger)
+		st.SetMachineState(symmetricMachineState(10 * gb))
+		st.SetMemoryAssignments(state.ContainerMemoryAssignments{
+			"p1": {"c": {memBlock(0, 2*gb)}},
+			"p2": {"c": {memBlock(1, 2*gb)}},
+		})
+		m := &manager{policy: staticPol, state: st, containerMap: containermap.NewContainerMap()}
+		s0, s1 := m.GetNUMAUtilizationScores(m0, m1)
+		if s0 != s1 {
+			t.Fatalf("got s0=%d s1=%d want equal scores", s0, s1)
+		}
+	})
+
+	t.Run("higher utilization on candidate returns higher candidate score", func(t *testing.T) {
+		// NUMA 0: 1GB/10GB → score 10, NUMA 1: 4GB/10GB → score 40
+		st := state.NewMemoryState(logger)
+		st.SetMachineState(symmetricMachineState(10 * gb))
+		st.SetMemoryAssignments(state.ContainerMemoryAssignments{
+			"p1": {"c": {memBlock(0, 1*gb)}},
+			"p2": {"c": {memBlock(1, 4*gb)}},
+		})
+		m := &manager{policy: staticPol, state: st, containerMap: containermap.NewContainerMap()}
+		s0, s1 := m.GetNUMAUtilizationScores(m0, m1)
+		if s1 <= s0 {
+			t.Fatalf("got s0=%d s1=%d want s1 > s0", s0, s1)
+		}
+	})
+
+	t.Run("higher utilization on current returns higher current score", func(t *testing.T) {
+		// NUMA 0: 5GB/10GB → score 50, NUMA 1: 1GB/10GB → score 10
+		st := state.NewMemoryState(logger)
+		st.SetMachineState(symmetricMachineState(10 * gb))
+		st.SetMemoryAssignments(state.ContainerMemoryAssignments{
+			"p1": {"c": {memBlock(0, 5*gb)}},
+			"p2": {"c": {memBlock(1, 1*gb)}},
+		})
+		m := &manager{policy: staticPol, state: st, containerMap: containermap.NewContainerMap()}
+		s0, s1 := m.GetNUMAUtilizationScores(m0, m1)
+		if s0 <= s1 {
+			t.Fatalf("got s0=%d s1=%d want s0 > s1", s0, s1)
+		}
+	})
+
+	t.Run("non-static policy returns zero scores", func(t *testing.T) {
+		st := state.NewMemoryState(logger)
+		st.SetMachineState(symmetricMachineState(10 * gb))
+		st.SetMemoryAssignments(state.ContainerMemoryAssignments{
+			"p1": {"c": {memBlock(0, 100)}},
+		})
+		m := &manager{policy: &mockPolicy{}, state: st, containerMap: containermap.NewContainerMap()}
+		s0, s1 := m.GetNUMAUtilizationScores(m0, m1)
+		if s0 != 0 || s1 != 0 {
+			t.Fatalf("got s0=%d s1=%d want both 0", s0, s1)
+		}
+	})
+
+	t.Run("asymmetric allocatable changes scores", func(t *testing.T) {
+		// NUMA 0 allocatable = 8 GB, NUMA 1 allocatable = 4 GB.
+		// Both have 2 GB assigned:
+		//   NUMA 0 score = (2*100)/8 = 25
+		//   NUMA 1 score = (2*100)/4 = 50
+		st := state.NewMemoryState(logger)
+		st.SetMachineState(state.NUMANodeMap{
+			0: &state.NUMANodeState{
+				MemoryMap: map[v1.ResourceName]*state.MemoryTable{
+					v1.ResourceMemory: {Allocatable: 8 * gb},
+				},
+				Cells: []int{0},
+			},
+			1: &state.NUMANodeState{
+				MemoryMap: map[v1.ResourceName]*state.MemoryTable{
+					v1.ResourceMemory: {Allocatable: 4 * gb},
+				},
+				Cells: []int{1},
+			},
+		})
+		st.SetMemoryAssignments(state.ContainerMemoryAssignments{
+			"p1": {"c": {memBlock(0, 2*gb)}},
+			"p2": {"c": {memBlock(1, 2*gb)}},
+		})
+		m := &manager{policy: staticPol, state: st, containerMap: containermap.NewContainerMap()}
+		s0, s1 := m.GetNUMAUtilizationScores(m0, m1)
+		if s1 <= s0 {
+			t.Fatalf("got s0=%d s1=%d want s1 > s0 (NUMA 1 more utilized)", s0, s1)
+		}
+	})
+}

--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -1492,3 +1492,29 @@ func isAffinityViolatingNUMAAllocations(machineState state.NUMANodeMap, mask bit
 	}
 	return false
 }
+
+func getRegularMemoryAssignedBytesOnNUMANode(s state.State, numa int) uint64 {
+	var total uint64
+	addBlocks := func(blocks []state.Block) {
+		for _, b := range blocks {
+			if b.Type != v1.ResourceMemory {
+				continue
+			}
+			if len(b.NUMAAffinity) != 1 || b.NUMAAffinity[0] != numa {
+				continue
+			}
+			total += b.Size
+		}
+	}
+	for _, byContainer := range s.GetMemoryAssignments() {
+		for _, blocks := range byContainer {
+			addBlocks(blocks)
+		}
+	}
+	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) {
+		for _, pe := range s.GetPodMemoryAssignments() {
+			addBlocks(pe.MemoryBlocks)
+		}
+	}
+	return total
+}

--- a/pkg/kubelet/cm/numa_scorer.go
+++ b/pkg/kubelet/cm/numa_scorer.go
@@ -1,0 +1,59 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cm
+
+import (
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
+	tmbitmask "k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
+)
+
+type numaUtilizationScorer interface {
+	GetNUMAUtilizationScores(current, candidate tmbitmask.BitMask) (currentScore, candidateScore int64)
+}
+
+type numaScorerAggregator struct {
+	cpu numaUtilizationScorer
+	mem numaUtilizationScorer
+}
+
+// NewNUMAScorerAggregator combines CPU and memory static-manager utilization
+// scores for prefer-most-allocated-numa-node, mirroring kube-scheduler's MostAllocated
+// weighted-average: aggregateScore = (cpuScore + memScore) / 2 per NUMA.
+// Only exclusive CPUs and pinned regular memory are scored; devices and DRA
+// resources are not included in the utilization calculation.
+func NewNUMAScorerAggregator(cpu cpumanager.Manager, mem memorymanager.Manager) topologymanager.NUMAScorer {
+	return &numaScorerAggregator{cpu: cpu, mem: mem}
+}
+
+func (a *numaScorerAggregator) Score(current, candidate tmbitmask.BitMask) topologymanager.NUMAScoringResult {
+	cpuCur, cpuCand := a.cpu.GetNUMAUtilizationScores(current, candidate)
+	memCur, memCand := a.mem.GetNUMAUtilizationScores(current, candidate)
+	aggCur := (cpuCur + memCur) / 2
+	aggCand := (cpuCand + memCand) / 2
+	return topologymanager.NUMAScoringResult{
+		PreferCandidate:         aggCand > aggCur,
+		Ok:                      aggCur != aggCand,
+		CPUScoreCurrent:         cpuCur,
+		CPUScoreCandidate:       cpuCand,
+		MemScoreCurrent:         memCur,
+		MemScoreCandidate:       memCand,
+		AggregateScoreCurrent:   aggCur,
+		AggregateScoreCandidate: aggCand,
+	}
+}

--- a/pkg/kubelet/cm/numa_scorer_test.go
+++ b/pkg/kubelet/cm/numa_scorer_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cm
+
+import (
+	"testing"
+
+	tmbitmask "k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
+)
+
+type stubNUMAScorer struct {
+	curScore, candScore int64
+}
+
+func (s stubNUMAScorer) GetNUMAUtilizationScores(tmbitmask.BitMask, tmbitmask.BitMask) (int64, int64) {
+	return s.curScore, s.candScore
+}
+
+func TestNUMAScorerAggregator(t *testing.T) {
+	m0, err := tmbitmask.NewBitMask(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m1, err := tmbitmask.NewBitMask(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name      string
+		cpu       stubNUMAScorer
+		mem       stubNUMAScorer
+		wantPick  bool
+		wantOK    bool
+		current   tmbitmask.BitMask
+		candidate tmbitmask.BitMask
+	}{
+		{
+			name:      "equal aggregates fallback",
+			cpu:       stubNUMAScorer{curScore: 50, candScore: 50},
+			mem:       stubNUMAScorer{curScore: 30, candScore: 30},
+			wantOK:    false,
+			current:   m0,
+			candidate: m1,
+		},
+		{
+			name:      "cpu dominated prefers candidate",
+			cpu:       stubNUMAScorer{curScore: 20, candScore: 80},
+			mem:       stubNUMAScorer{curScore: 0, candScore: 0},
+			wantPick:  true,
+			wantOK:    true,
+			current:   m0,
+			candidate: m1,
+		},
+		{
+			name:      "memory dominated prefers current",
+			cpu:       stubNUMAScorer{curScore: 0, candScore: 0},
+			mem:       stubNUMAScorer{curScore: 90, candScore: 10},
+			wantPick:  false,
+			wantOK:    true,
+			current:   m0,
+			candidate: m1,
+		},
+		{
+			name:      "both agree candidate wins",
+			cpu:       stubNUMAScorer{curScore: 30, candScore: 70},
+			mem:       stubNUMAScorer{curScore: 20, candScore: 60},
+			wantPick:  true,
+			wantOK:    true,
+			current:   m0,
+			candidate: m1,
+		},
+		{
+			name:      "mixed scores candidate wins on aggregate",
+			cpu:       stubNUMAScorer{curScore: 40, candScore: 80},
+			mem:       stubNUMAScorer{curScore: 80, candScore: 79},
+			wantPick:  true,
+			wantOK:    true,
+			current:   m0,
+			candidate: m1,
+		},
+		{
+			name:      "both zero fallback",
+			cpu:       stubNUMAScorer{curScore: 0, candScore: 0},
+			mem:       stubNUMAScorer{curScore: 0, candScore: 0},
+			wantOK:    false,
+			current:   m0,
+			candidate: m1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &numaScorerAggregator{cpu: tc.cpu, mem: tc.mem}
+			result := a.Score(tc.current, tc.candidate)
+			if result.Ok != tc.wantOK {
+				t.Fatalf("ok: got %v want %v", result.Ok, tc.wantOK)
+			}
+			if result.Ok && result.PreferCandidate != tc.wantPick {
+				t.Fatalf("pick: got %v want %v", result.PreferCandidate, tc.wantPick)
+			}
+		})
+	}
+}

--- a/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
@@ -92,6 +92,8 @@ func (m *fakeManager) AddHintProvider(logger klog.Logger, h HintProvider) {
 	logger.Info("AddHintProvider", "hintProvider", h)
 }
 
+func (m *fakeManager) SetNUMAScorer(NUMAScorer) {}
+
 func (m *fakeManager) AddContainer(pod *v1.Pod, container *v1.Container, containerID string) {
 	// Use context.TODO() because we currently do not have a proper context to pass in.
 	// Replace this with an appropriate context when refactoring this function to accept a context parameter.

--- a/pkg/kubelet/cm/topologymanager/numa_scorer.go
+++ b/pkg/kubelet/cm/topologymanager/numa_scorer.go
@@ -1,0 +1,38 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topologymanager
+
+import "k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
+
+// NUMAScoringResult carries the comparison outcome and the scoring breakdown
+// so callers can log why a particular NUMA node was selected.
+type NUMAScoringResult struct {
+	PreferCandidate         bool
+	Ok                      bool
+	CPUScoreCurrent         int64
+	CPUScoreCandidate       int64
+	MemScoreCurrent         int64
+	MemScoreCandidate       int64
+	AggregateScoreCurrent   int64
+	AggregateScoreCandidate int64
+}
+
+// NUMAScorer scores two single-NUMA candidates by utilization when
+// topologyManagerPolicy is single-numa-node and prefer-most-allocated-numa-node is enabled.
+type NUMAScorer interface {
+	Score(current, candidate bitmask.BitMask) NUMAScoringResult
+}

--- a/pkg/kubelet/cm/topologymanager/policy.go
+++ b/pkg/kubelet/cm/topologymanager/policy.go
@@ -137,6 +137,7 @@ func maxOfMinAffinityCounts(filteredHints [][]TopologyHint) int {
 type HintMerger struct {
 	NUMAInfo *NUMAInfo
 	Hints    [][]TopologyHint
+	Logger   klog.Logger
 	// Set bestNonPreferredAffinityCount to help decide which affinity mask is
 	// preferred amongst all non-preferred hints. We calculate this value as
 	// the maximum of the minimum affinity counts supplied for any given hint
@@ -145,9 +146,10 @@ type HintMerger struct {
 	// NUMA nodes to satisfy its allocation.
 	BestNonPreferredAffinityCount int
 	CompareNUMAAffinityMasks      func(candidate *TopologyHint, current *TopologyHint) (best *TopologyHint)
+	NUMAScorer                    NUMAScorer
 }
 
-func NewHintMerger(numaInfo *NUMAInfo, hints [][]TopologyHint, policyName string, opts PolicyOptions) HintMerger {
+func NewHintMerger(logger klog.Logger, numaInfo *NUMAInfo, hints [][]TopologyHint, policyName string, opts PolicyOptions) HintMerger {
 	compareNumaAffinityMasks := func(current, candidate *TopologyHint) *TopologyHint {
 		// If current and candidate bitmasks are the same, prefer current hint.
 		if candidate.NUMANodeAffinity.IsEqual(current.NUMANodeAffinity) {
@@ -170,6 +172,7 @@ func NewHintMerger(numaInfo *NUMAInfo, hints [][]TopologyHint, policyName string
 	merger := HintMerger{
 		NUMAInfo:                      numaInfo,
 		Hints:                         hints,
+		Logger:                        logger,
 		BestNonPreferredAffinityCount: maxOfMinAffinityCounts(hints),
 		CompareNUMAAffinityMasks:      compareNumaAffinityMasks,
 	}
@@ -304,6 +307,8 @@ func (m HintMerger) Merge() TopologyHint {
 	defaultAffinity := m.NUMAInfo.DefaultAffinityMask()
 
 	var bestHint *TopologyHint
+	var preferredSingleNUMA []TopologyHint
+
 	iterateAllProviderTopologyHints(m.Hints, func(permutation []TopologyHint) {
 		// Get the NUMANodeAffinity from each hint in the permutation and see if any
 		// of them encode unpreferred allocations.
@@ -312,10 +317,49 @@ func (m HintMerger) Merge() TopologyHint {
 		// Compare the current bestHint with the candidate mergedHint and
 		// update bestHint if appropriate.
 		bestHint = m.compare(bestHint, &mergedHint)
+
+		if m.NUMAScorer != nil && mergedHint.Preferred &&
+			mergedHint.NUMANodeAffinity != nil && mergedHint.NUMANodeAffinity.Count() == 1 {
+			unique := true
+			for _, h := range preferredSingleNUMA {
+				if h.NUMANodeAffinity.IsEqual(mergedHint.NUMANodeAffinity) {
+					unique = false
+					break
+				}
+			}
+			if unique {
+				preferredSingleNUMA = append(preferredSingleNUMA, mergedHint)
+			}
+		}
 	})
 
 	if bestHint == nil {
 		bestHint = &TopologyHint{defaultAffinity, false}
+	}
+
+	if m.NUMAScorer != nil && bestHint.Preferred && len(preferredSingleNUMA) > 1 {
+		current := preferredSingleNUMA[0]
+		var lastResult NUMAScoringResult
+		for _, candidate := range preferredSingleNUMA[1:] {
+			result := m.NUMAScorer.Score(current.NUMANodeAffinity, candidate.NUMANodeAffinity)
+			if result.Ok && result.PreferCandidate {
+				current = candidate
+				lastResult = result
+			}
+		}
+		if !current.NUMANodeAffinity.IsEqual(bestHint.NUMANodeAffinity) {
+			m.Logger.V(2).Info("Prefer-most-allocated scorer overrode default NUMA selection",
+				"selectedNUMA", current.NUMANodeAffinity,
+				"defaultNUMA", bestHint.NUMANodeAffinity,
+				"cpuScoreSelected", lastResult.CPUScoreCandidate,
+				"cpuScoreDefault", lastResult.CPUScoreCurrent,
+				"memScoreSelected", lastResult.MemScoreCandidate,
+				"memScoreDefault", lastResult.MemScoreCurrent,
+				"aggregateScoreSelected", lastResult.AggregateScoreCandidate,
+				"aggregateScoreDefault", lastResult.AggregateScoreCurrent,
+			)
+		}
+		bestHint = &current
 	}
 
 	return *bestHint

--- a/pkg/kubelet/cm/topologymanager/policy_best_effort.go
+++ b/pkg/kubelet/cm/topologymanager/policy_best_effort.go
@@ -44,7 +44,7 @@ func (p *bestEffortPolicy) canAdmitPodResult(hint *TopologyHint) bool {
 
 func (p *bestEffortPolicy) Merge(logger klog.Logger, providersHints []map[string][]TopologyHint) (TopologyHint, bool) {
 	filteredHints := filterProvidersHints(logger, providersHints)
-	merger := NewHintMerger(p.numaInfo, filteredHints, p.Name(), p.opts)
+	merger := NewHintMerger(logger, p.numaInfo, filteredHints, p.Name(), p.opts)
 	bestHint := merger.Merge()
 	admit := p.canAdmitPodResult(&bestHint)
 	return bestHint, admit

--- a/pkg/kubelet/cm/topologymanager/policy_options.go
+++ b/pkg/kubelet/cm/topologymanager/policy_options.go
@@ -27,12 +27,15 @@ import (
 )
 
 const (
-	PreferClosestNUMANodes string = "prefer-closest-numa-nodes"
-	MaxAllowableNUMANodes  string = "max-allowable-numa-nodes"
+	PreferClosestNUMANodes      string = "prefer-closest-numa-nodes"
+	MaxAllowableNUMANodes       string = "max-allowable-numa-nodes"
+	PreferMostAllocatedNUMANode string = "prefer-most-allocated-numa-node"
 )
 
 var (
-	alphaOptions  = sets.New[string]()
+	alphaOptions = sets.New[string](
+		PreferMostAllocatedNUMANode,
+	)
 	betaOptions   = sets.New[string]()
 	stableOptions = sets.New[string](
 		PreferClosestNUMANodes,
@@ -57,8 +60,9 @@ func CheckPolicyOptionAvailable(option string) error {
 }
 
 type PolicyOptions struct {
-	PreferClosestNUMA     bool
-	MaxAllowableNUMANodes int
+	PreferClosestNUMA           bool
+	PreferMostAllocatedNUMANode bool
+	MaxAllowableNUMANodes       int
 }
 
 func NewPolicyOptions(logger klog.Logger, policyOptions map[string]string) (PolicyOptions, error) {
@@ -94,6 +98,12 @@ func NewPolicyOptions(logger klog.Logger, policyOptions map[string]string) (Poli
 				logger.Info("WARNING: the value of max-allowable-numa-nodes is more than the default recommended value", "max-allowable-numa-nodes", optValue, "defaultMaxAllowableNUMANodes", defaultMaxAllowableNUMANodes)
 			}
 			opts.MaxAllowableNUMANodes = optValue
+		case PreferMostAllocatedNUMANode:
+			optValue, err := strconv.ParseBool(value)
+			if err != nil {
+				return opts, fmt.Errorf("bad value for option %q: %w", name, err)
+			}
+			opts.PreferMostAllocatedNUMANode = optValue
 		default:
 			// this should never be reached, we already detect unknown options,
 			// but we keep it as further safety.

--- a/pkg/kubelet/cm/topologymanager/policy_options_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_options_test.go
@@ -128,6 +128,25 @@ func TestNewTopologyManagerOptions(t *testing.T) {
 			},
 			expectedErr: fmt.Errorf("topology manager policy alpha-level options not enabled,"),
 		},
+		{
+			description:       "prefer-most-allocated-numa-node with alpha gate",
+			featureGate:       pkgfeatures.TopologyManagerPolicyAlphaOptions,
+			featureGateEnable: true,
+			policyOptions: map[string]string{
+				PreferMostAllocatedNUMANode: "true",
+			},
+			expectedOptions: PolicyOptions{
+				PreferMostAllocatedNUMANode: true,
+				MaxAllowableNUMANodes:       8,
+			},
+		},
+		{
+			description: "prefer-most-allocated-numa-node without alpha gate",
+			policyOptions: map[string]string{
+				PreferMostAllocatedNUMANode: "true",
+			},
+			expectedErr: fmt.Errorf("topology manager policy alpha-level options not enabled,"),
+		},
 	}
 
 	setTopologyManagerOptionsDuringTest(t, betaOptions, fancyBetaOption)
@@ -178,6 +197,10 @@ func TestPolicyDefaultsAvailable(t *testing.T) {
 		{
 			option:            MaxAllowableNUMANodes,
 			expectedAvailable: true,
+		},
+		{
+			option:            PreferMostAllocatedNUMANode,
+			expectedAvailable: false,
 		},
 	}
 	for _, testCase := range testCases {
@@ -250,6 +273,18 @@ func TestPolicyOptionsAvailable(t *testing.T) {
 		{
 			option:            fancyBetaOption,
 			featureGate:       pkgfeatures.TopologyManagerPolicyBetaOptions,
+			featureGateEnable: false,
+			expectedAvailable: false,
+		},
+		{
+			option:            PreferMostAllocatedNUMANode,
+			featureGate:       pkgfeatures.TopologyManagerPolicyAlphaOptions,
+			featureGateEnable: true,
+			expectedAvailable: true,
+		},
+		{
+			option:            PreferMostAllocatedNUMANode,
+			featureGate:       pkgfeatures.TopologyManagerPolicyAlphaOptions,
 			featureGateEnable: false,
 			expectedAvailable: false,
 		},

--- a/pkg/kubelet/cm/topologymanager/policy_prefer_most_allocated_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_prefer_most_allocated_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topologymanager
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
+	"k8s.io/kubernetes/test/utils/ktesting"
+)
+
+// fakeNUMAScorer always resolves a 0-vs-1 single-NUMA tie in favor of the configured NUMA id.
+type fakeNUMAScorer int
+
+func (p fakeNUMAScorer) Score(current, candidate bitmask.BitMask) NUMAScoringResult {
+	t := int(p)
+	cb := candidate.GetBits()
+	ob := current.GetBits()
+	if len(cb) != 1 || len(ob) != 1 {
+		return NUMAScoringResult{}
+	}
+	if cb[0] == t && ob[0] != t {
+		return NUMAScoringResult{PreferCandidate: true, Ok: true}
+	}
+	if ob[0] == t && cb[0] != t {
+		return NUMAScoringResult{PreferCandidate: false, Ok: true}
+	}
+	return NUMAScoringResult{}
+}
+
+func TestSingleNumaPolicyPreferMostAllocatedScoring(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	numaInfo := commonNUMAInfoTwoNodes()
+	p := &singleNumaNodePolicy{
+		numaInfo: numaInfo,
+		opts:     PolicyOptions{PreferMostAllocatedNUMANode: true},
+	}
+	p.setNUMAScorer(fakeNUMAScorer(1))
+
+	providersHints := []map[string][]TopologyHint{
+		{
+			"resource1": {
+				{NUMANodeAffinity: NewTestBitMask(0), Preferred: true},
+				{NUMANodeAffinity: NewTestBitMask(1), Preferred: true},
+				{NUMANodeAffinity: NewTestBitMask(0, 1), Preferred: false},
+			},
+		},
+		nil,
+	}
+	actual, admit := p.Merge(logger, providersHints)
+	if !admit {
+		t.Fatalf("expected admit true, got false for hint %#v", actual)
+	}
+	want := TopologyHint{NUMANodeAffinity: NewTestBitMask(1), Preferred: true}
+	if !reflect.DeepEqual(actual, want) {
+		t.Errorf("got %#v want %#v", actual, want)
+	}
+}
+
+func TestSingleNumaPolicyPreferMostAllocatedDefaultNarrowest(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	numaInfo := commonNUMAInfoTwoNodes()
+	p := &singleNumaNodePolicy{
+		numaInfo: numaInfo,
+		opts:     PolicyOptions{PreferMostAllocatedNUMANode: true},
+	}
+
+	providersHints := []map[string][]TopologyHint{
+		{
+			"resource1": {
+				{NUMANodeAffinity: NewTestBitMask(0), Preferred: true},
+				{NUMANodeAffinity: NewTestBitMask(1), Preferred: true},
+				{NUMANodeAffinity: NewTestBitMask(0, 1), Preferred: false},
+			},
+		},
+		nil,
+	}
+	actual, admit := p.Merge(logger, providersHints)
+	if !admit {
+		t.Fatalf("expected admit true, got false for hint %#v", actual)
+	}
+	want := TopologyHint{NUMANodeAffinity: NewTestBitMask(0), Preferred: true}
+	if !reflect.DeepEqual(actual, want) {
+		t.Errorf("got %#v want %#v", actual, want)
+	}
+}

--- a/pkg/kubelet/cm/topologymanager/policy_restricted.go
+++ b/pkg/kubelet/cm/topologymanager/policy_restricted.go
@@ -42,7 +42,7 @@ func (p *restrictedPolicy) canAdmitPodResult(hint *TopologyHint) bool {
 
 func (p *restrictedPolicy) Merge(logger klog.Logger, providersHints []map[string][]TopologyHint) (TopologyHint, bool) {
 	filteredHints := filterProvidersHints(logger, providersHints)
-	merger := NewHintMerger(p.numaInfo, filteredHints, p.Name(), p.opts)
+	merger := NewHintMerger(logger, p.numaInfo, filteredHints, p.Name(), p.opts)
 	bestHint := merger.Merge()
 	admit := p.canAdmitPodResult(&bestHint)
 	return bestHint, admit

--- a/pkg/kubelet/cm/topologymanager/policy_single_numa_node.go
+++ b/pkg/kubelet/cm/topologymanager/policy_single_numa_node.go
@@ -20,8 +20,9 @@ import "k8s.io/klog/v2"
 
 type singleNumaNodePolicy struct {
 	// numaInfo represents list of NUMA Nodes available on the underlying machine and distances between them
-	numaInfo *NUMAInfo
-	opts     PolicyOptions
+	numaInfo   *NUMAInfo
+	opts       PolicyOptions
+	numaScorer NUMAScorer
 }
 
 var _ Policy = &singleNumaNodePolicy{}
@@ -32,6 +33,10 @@ const PolicySingleNumaNode string = "single-numa-node"
 // NewSingleNumaNodePolicy returns single-numa-node policy.
 func NewSingleNumaNodePolicy(numaInfo *NUMAInfo, opts PolicyOptions) Policy {
 	return &singleNumaNodePolicy{numaInfo: numaInfo, opts: opts}
+}
+
+func (p *singleNumaNodePolicy) setNUMAScorer(s NUMAScorer) {
+	p.numaScorer = s
 }
 
 func (p *singleNumaNodePolicy) Name() string {
@@ -65,7 +70,8 @@ func (p *singleNumaNodePolicy) Merge(logger klog.Logger, providersHints []map[st
 	// Filter to only include don't cares and hints with a single NUMA node.
 	singleNumaHints := filterSingleNumaHints(filteredHints)
 
-	merger := NewHintMerger(p.numaInfo, singleNumaHints, p.Name(), p.opts)
+	merger := NewHintMerger(logger, p.numaInfo, singleNumaHints, p.Name(), p.opts)
+	merger.NUMAScorer = p.numaScorer
 	bestHint := merger.Merge()
 
 	if bestHint.NUMANodeAffinity.IsEqual(p.numaInfo.DefaultAffinityMask()) {

--- a/pkg/kubelet/cm/topologymanager/policy_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_test.go
@@ -1557,7 +1557,8 @@ func TestCompareHintsNarrowest(t *testing.T) {
 	for _, tc := range tcases {
 		t.Run(tc.description, func(t *testing.T) {
 			numaInfo := &NUMAInfo{}
-			merger := NewHintMerger(numaInfo, [][]TopologyHint{}, PolicyBestEffort, PolicyOptions{})
+			logger, _ := ktesting.NewTestContext(t)
+			merger := NewHintMerger(logger, numaInfo, [][]TopologyHint{}, PolicyBestEffort, PolicyOptions{})
 			merger.BestNonPreferredAffinityCount = tc.bestNonPreferredAffinityCount
 
 			result := merger.compare(tc.current, tc.candidate)

--- a/pkg/kubelet/cm/topologymanager/scope.go
+++ b/pkg/kubelet/cm/topologymanager/scope.go
@@ -46,6 +46,9 @@ type Scope interface {
 	// AddHintProvider adds a hint provider to manager to indicate the hint provider
 	// wants to be consoluted with when making topology hints
 	AddHintProvider(h HintProvider)
+	// SetNUMAScorer registers a NUMA scorer for single-numa-node policy
+	// when prefer-most-allocated-numa-node is enabled.
+	SetNUMAScorer(scorer NUMAScorer)
 	// AddContainer adds pod to Manager for tracking
 	AddContainer(pod *v1.Pod, container *v1.Container, containerID string)
 	// RemoveContainer removes pod from Manager tracking
@@ -98,6 +101,12 @@ func (s *scope) GetPolicy() Policy {
 
 func (s *scope) AddHintProvider(h HintProvider) {
 	s.hintProviders = append(s.hintProviders, h)
+}
+
+func (s *scope) SetNUMAScorer(scorer NUMAScorer) {
+	if snp, ok := s.policy.(*singleNumaNodePolicy); ok {
+		snp.setNUMAScorer(scorer)
+	}
 }
 
 // It would be better to implement this function in topologymanager instead of scope

--- a/pkg/kubelet/cm/topologymanager/topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager.go
@@ -87,6 +87,9 @@ type Manager interface {
 	// AddHintProvider adds a hint provider to manager to indicate the hint provider
 	// wants to be consulted with when making topology hints
 	AddHintProvider(logger klog.Logger, h HintProvider)
+	// SetNUMAScorer registers a NUMA scorer for single-numa-node policy
+	// when prefer-most-allocated-numa-node is enabled.
+	SetNUMAScorer(scorer NUMAScorer)
 	// AddContainer adds pod to Manager for tracking
 	AddContainer(pod *v1.Pod, container *v1.Container, containerID string)
 	// RemoveContainer removes pod from Manager tracking
@@ -249,6 +252,10 @@ func (m *manager) Name() string {
 
 func (m *manager) AddHintProvider(_ klog.Logger, h HintProvider) {
 	m.scope.AddHintProvider(h)
+}
+
+func (m *manager) SetNUMAScorer(scorer NUMAScorer) {
+	m.scope.SetNUMAScorer(scorer)
 }
 
 func (m *manager) AddContainer(pod *v1.Pod, container *v1.Container, containerID string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Avoid workload capacity degradation for single-numa-node by favoring most-allocated packing on NUMA node hence leaving a larger exclusive-CPU and memory on another NUMA node for the next workload.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
KEP: https://github.com/kubernetes/enhancements/issues/6007

#### Special notes for your reviewer:
KEP HTML: https://github.com/nokia/kubernetes-enhancements/tree/single-numa-node-capacity/keps/sig-node/6007-prefer-most-allocated-numa-node

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added a new Topology Manager option: prefer-most-allocated-numa-node.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/6008
```
