### PR TITLE
Configure strategies to auto-wire declarative validation

### DIFF
--- a/pkg/api/testing/validation.go
+++ b/pkg/api/testing/validation.go
@@ -291,11 +291,7 @@ func VerifyValidationEquivalence(t *testing.T, ctx context.Context, obj runtime.
 	verifyValidationEquivalence(t, expectedErrs, func(c context.Context) field.ErrorList {
 		errs := strategy.Validate(c, obj)
 		if dv, ok := strategy.(rest.DeclarativeValidationStrategy); ok {
-			var config rest.DeclarativeValidationConfig
-			if vc, ok := strategy.(rest.DeclarativeValidationConfigurer); ok {
-				config = vc.DeclarativeValidationConfig(c, obj, nil)
-			}
-			errs = dv.ValidateDeclaratively(c, obj, nil, errs, operation.Create, config)
+			errs = dv.ValidateDeclaratively(c, obj, nil, errs, operation.Create, dv.DeclarativeValidationConfig(c, obj, nil))
 		}
 		return errs
 	}, ctx, opts)
@@ -330,11 +326,7 @@ func VerifyUpdateValidationEquivalence(t *testing.T, ctx context.Context, obj, o
 	verifyValidationEquivalence(t, expectedErrs, func(c context.Context) field.ErrorList {
 		errs := strategy.ValidateUpdate(c, obj, old)
 		if dv, ok := strategy.(rest.DeclarativeValidationStrategy); ok {
-			var config rest.DeclarativeValidationConfig
-			if vc, ok := strategy.(rest.DeclarativeValidationConfigurer); ok {
-				config = vc.DeclarativeValidationConfig(c, obj, old)
-			}
-			errs = dv.ValidateDeclaratively(c, obj, old, errs, operation.Update, config)
+			errs = dv.ValidateDeclaratively(c, obj, old, errs, operation.Update, dv.DeclarativeValidationConfig(c, obj, old))
 		}
 		return errs
 	}, ctx, opts)

--- a/pkg/api/testing/validation.go
+++ b/pkg/api/testing/validation.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	runtimetest "k8s.io/apimachinery/pkg/runtime/testing"
@@ -38,12 +39,6 @@ import (
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"sigs.k8s.io/randfill"
 )
-
-// ValidateFunc is a function that runs validation.
-type ValidateFunc func(ctx context.Context, obj runtime.Object) field.ErrorList
-
-// ValidateUpdateFunc is a function that runs update validation.
-type ValidateUpdateFunc func(ctx context.Context, obj, old runtime.Object) field.ErrorList
 
 // VerifyVersionedValidationEquivalence tests that all versions of an API return equivalent validation errors.
 // It accepts optional configuration to handle path normalization across API versions where structures differ.
@@ -286,7 +281,7 @@ func WithMinEmulationVersion(v *version.Version) ValidationTestConfig {
 // guaranteeing a safe migration. It also checks the errors against an expected set.
 // It compares errors by field, origin and type; all three should match to be called equivalent.
 // It also make sure all versions of the given API returns equivalent errors.
-func VerifyValidationEquivalence(t *testing.T, ctx context.Context, obj runtime.Object, validateFn ValidateFunc, expectedErrs field.ErrorList, testConfigs ...ValidationTestConfig) {
+func VerifyValidationEquivalence(t *testing.T, ctx context.Context, obj runtime.Object, strategy rest.RESTCreateStrategy, expectedErrs field.ErrorList, testConfigs ...ValidationTestConfig) {
 	t.Helper()
 	opts := &validationOption{}
 	for _, testcfg := range testConfigs {
@@ -294,7 +289,15 @@ func VerifyValidationEquivalence(t *testing.T, ctx context.Context, obj runtime.
 	}
 
 	verifyValidationEquivalence(t, expectedErrs, func(c context.Context) field.ErrorList {
-		return validateFn(c, obj)
+		errs := strategy.Validate(c, obj)
+		if dv, ok := strategy.(rest.DeclarativeValidationStrategy); ok {
+			var config rest.DeclarativeValidationConfig
+			if vc, ok := strategy.(rest.DeclarativeValidationConfigurer); ok {
+				config = vc.DeclarativeValidationConfig(c, obj, nil)
+			}
+			errs = dv.ValidateDeclaratively(c, obj, nil, errs, operation.Create, config)
+		}
+		return errs
 	}, ctx, opts)
 	VerifyVersionedValidationEquivalence(t, obj, nil, testConfigs...)
 }
@@ -317,7 +320,7 @@ func VerifyValidationEquivalence(t *testing.T, ctx context.Context, obj runtime.
 // guaranteeing a safe migration. It also checks the errors against an expected set.
 // It compares errors by field, origin and type; all three should match to be called equivalent.
 // It also make sure all versions of the given API returns equivalent errors.
-func VerifyUpdateValidationEquivalence(t *testing.T, ctx context.Context, obj, old runtime.Object, validateUpdateFn ValidateUpdateFunc, expectedErrs field.ErrorList, testConfigs ...ValidationTestConfig) {
+func VerifyUpdateValidationEquivalence(t *testing.T, ctx context.Context, obj, old runtime.Object, strategy rest.RESTUpdateStrategy, expectedErrs field.ErrorList, testConfigs ...ValidationTestConfig) {
 	t.Helper()
 	opts := &validationOption{}
 	for _, testcfg := range testConfigs {
@@ -325,7 +328,15 @@ func VerifyUpdateValidationEquivalence(t *testing.T, ctx context.Context, obj, o
 	}
 
 	verifyValidationEquivalence(t, expectedErrs, func(c context.Context) field.ErrorList {
-		return validateUpdateFn(c, obj, old)
+		errs := strategy.ValidateUpdate(c, obj, old)
+		if dv, ok := strategy.(rest.DeclarativeValidationStrategy); ok {
+			var config rest.DeclarativeValidationConfig
+			if vc, ok := strategy.(rest.DeclarativeValidationConfigurer); ok {
+				config = vc.DeclarativeValidationConfig(c, obj, old)
+			}
+			errs = dv.ValidateDeclaratively(c, obj, old, errs, operation.Update, config)
+		}
+		return errs
 	}, ctx, opts)
 	VerifyVersionedValidationEquivalence(t, obj, old, testConfigs...)
 }

--- a/pkg/apis/autoscaling/v1/zz_generated.validations.go
+++ b/pkg/apis/autoscaling/v1/zz_generated.validations.go
@@ -42,7 +42,7 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 	// type HorizontalPodAutoscaler
 	scheme.AddValidationFunc((*autoscalingv1.HorizontalPodAutoscaler)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
-		case "/":
+		case "/", "/status":
 			return Validate_HorizontalPodAutoscaler(ctx, op, nil /* fldPath */, obj.(*autoscalingv1.HorizontalPodAutoscaler), safe.Cast[*autoscalingv1.HorizontalPodAutoscaler](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}

--- a/pkg/apis/autoscaling/v2/zz_generated.validations.go
+++ b/pkg/apis/autoscaling/v2/zz_generated.validations.go
@@ -42,7 +42,7 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 	// type HorizontalPodAutoscaler
 	scheme.AddValidationFunc((*autoscalingv2.HorizontalPodAutoscaler)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
-		case "/":
+		case "/", "/status":
 			return Validate_HorizontalPodAutoscaler(ctx, op, nil /* fldPath */, obj.(*autoscalingv2.HorizontalPodAutoscaler), safe.Cast[*autoscalingv2.HorizontalPodAutoscaler](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}

--- a/pkg/apis/batch/v1/zz_generated.validations.go
+++ b/pkg/apis/batch/v1/zz_generated.validations.go
@@ -42,7 +42,7 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 	// type CronJob
 	scheme.AddValidationFunc((*batchv1.CronJob)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
-		case "/":
+		case "/", "/status":
 			return Validate_CronJob(ctx, op, nil /* fldPath */, obj.(*batchv1.CronJob), safe.Cast[*batchv1.CronJob](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}

--- a/pkg/apis/batch/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/batch/v1beta1/zz_generated.validations.go
@@ -42,7 +42,7 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 	// type CronJob
 	scheme.AddValidationFunc((*batchv1beta1.CronJob)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
-		case "/":
+		case "/", "/status":
 			return Validate_CronJob(ctx, op, nil /* fldPath */, obj.(*batchv1beta1.CronJob), safe.Cast[*batchv1beta1.CronJob](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}

--- a/pkg/apis/core/v1/zz_generated.validations.go
+++ b/pkg/apis/core/v1/zz_generated.validations.go
@@ -43,7 +43,7 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 	// type ReplicationController
 	scheme.AddValidationFunc((*corev1.ReplicationController)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
-		case "/", "/scale":
+		case "/", "/scale", "/status":
 			return Validate_ReplicationController(ctx, op, nil /* fldPath */, obj.(*corev1.ReplicationController), safe.Cast[*corev1.ReplicationController](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}

--- a/pkg/apis/flowcontrol/v1/zz_generated.validations.go
+++ b/pkg/apis/flowcontrol/v1/zz_generated.validations.go
@@ -42,7 +42,7 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 	// type PriorityLevelConfiguration
 	scheme.AddValidationFunc((*flowcontrolv1.PriorityLevelConfiguration)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
-		case "/":
+		case "/", "/status":
 			return Validate_PriorityLevelConfiguration(ctx, op, nil /* fldPath */, obj.(*flowcontrolv1.PriorityLevelConfiguration), safe.Cast[*flowcontrolv1.PriorityLevelConfiguration](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}

--- a/pkg/apis/flowcontrol/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/flowcontrol/v1beta1/zz_generated.validations.go
@@ -42,7 +42,7 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 	// type PriorityLevelConfiguration
 	scheme.AddValidationFunc((*flowcontrolv1beta1.PriorityLevelConfiguration)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
-		case "/":
+		case "/", "/status":
 			return Validate_PriorityLevelConfiguration(ctx, op, nil /* fldPath */, obj.(*flowcontrolv1beta1.PriorityLevelConfiguration), safe.Cast[*flowcontrolv1beta1.PriorityLevelConfiguration](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}

--- a/pkg/apis/flowcontrol/v1beta2/zz_generated.validations.go
+++ b/pkg/apis/flowcontrol/v1beta2/zz_generated.validations.go
@@ -42,7 +42,7 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 	// type PriorityLevelConfiguration
 	scheme.AddValidationFunc((*flowcontrolv1beta2.PriorityLevelConfiguration)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
-		case "/":
+		case "/", "/status":
 			return Validate_PriorityLevelConfiguration(ctx, op, nil /* fldPath */, obj.(*flowcontrolv1beta2.PriorityLevelConfiguration), safe.Cast[*flowcontrolv1beta2.PriorityLevelConfiguration](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}

--- a/pkg/apis/flowcontrol/v1beta3/zz_generated.validations.go
+++ b/pkg/apis/flowcontrol/v1beta3/zz_generated.validations.go
@@ -42,7 +42,7 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 	// type PriorityLevelConfiguration
 	scheme.AddValidationFunc((*flowcontrolv1beta3.PriorityLevelConfiguration)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
-		case "/":
+		case "/", "/status":
 			return Validate_PriorityLevelConfiguration(ctx, op, nil /* fldPath */, obj.(*flowcontrolv1beta3.PriorityLevelConfiguration), safe.Cast[*flowcontrolv1beta3.PriorityLevelConfiguration](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}

--- a/pkg/apis/resource/v1alpha3/zz_generated.validations.go
+++ b/pkg/apis/resource/v1alpha3/zz_generated.validations.go
@@ -44,7 +44,7 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 	// type DeviceTaintRule
 	scheme.AddValidationFunc((*resourcev1alpha3.DeviceTaintRule)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
-		case "/":
+		case "/", "/status":
 			return Validate_DeviceTaintRule(ctx, op, nil /* fldPath */, obj.(*resourcev1alpha3.DeviceTaintRule), safe.Cast[*resourcev1alpha3.DeviceTaintRule](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}

--- a/pkg/apis/resource/v1beta2/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta2/zz_generated.validations.go
@@ -53,7 +53,7 @@ func RegisterValidations(scheme *runtime.Scheme) error {
 	// type DeviceTaintRule
 	scheme.AddValidationFunc((*resourcev1beta2.DeviceTaintRule)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		switch op.Request.SubresourcePath() {
-		case "/":
+		case "/", "/status":
 			return Validate_DeviceTaintRule(ctx, op, nil /* fldPath */, obj.(*resourcev1beta2.DeviceTaintRule), safe.Cast[*resourcev1beta2.DeviceTaintRule](oldObj))
 		}
 		return field.ErrorList{field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath()))}

--- a/pkg/controlplane/instance_test.go
+++ b/pkg/controlplane/instance_test.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
 	openapinamer "k8s.io/apiserver/pkg/endpoints/openapi"
+	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/options"
@@ -644,6 +645,59 @@ func TestGetResetFieldsHasAllVersions(t *testing.T) {
 							t.Errorf("%s: GetResetFieldsFilter() is missing version %q, has %v; all served versions: %v",
 								gvr(groupName, v, resource), sv, resetFieldsFilter, servedVersions)
 						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestDeclarativeValidationEnablementInStrategies verifies that every CreateStrategy and
+// UpdateStrategy installed supports declarative validation.
+func TestDeclarativeValidationEnablementInStrategies(t *testing.T) {
+	_, config, _ := setUp(t)
+
+	client, err := kubernetes.NewForConfig(config.ControlPlane.Generic.LoopbackClientConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	providers, err := config.Complete().StorageProviders(client)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Enable all versions (including alpha and beta) so the check covers
+	// every resource that kube-apiserver can serve.
+	allVersionsConfig := DefaultAPIResourceConfigSource()
+	allVersionsConfig.EnableVersions(betaAPIGroupVersionsDisabledByDefault...)
+	allVersionsConfig.EnableVersions(alphaAPIGroupVersionsDisabledByDefault...)
+
+	for _, provider := range providers {
+		groupName := provider.GroupName()
+		apiGroupInfo, err := provider.NewRESTStorage(allVersionsConfig, config.ControlPlane.Generic.RESTOptionsGetter)
+		if err != nil {
+			t.Errorf("error creating REST storage for %s: %v", groupName, err)
+			continue
+		}
+
+		for v, resourcesInVersion := range apiGroupInfo.VersionedResourcesStorageMap {
+			for resource, storage := range resourcesInVersion {
+				gs, ok := storage.(registry.GenericStore)
+				if !ok {
+					// Non-generic storage (e.g. proxy/exec subresources)
+					// has no strategy to check.
+					continue
+				}
+				name := gvr(groupName, v, resource)
+				if cs := gs.GetCreateStrategy(); cs != nil {
+					if _, ok := cs.(rest.DeclarativeValidationStrategy); !ok {
+						t.Errorf("%s: CreateStrategy %T does not implement rest.DeclarativeValidationStrategy; embed rest.DeclarativeValidation to enable automatic declarative validation", name, cs)
+					}
+				}
+				if us := gs.GetUpdateStrategy(); us != nil {
+					if _, ok := us.(rest.DeclarativeValidationStrategy); !ok {
+						t.Errorf("%s: UpdateStrategy %T does not implement rest.DeclarativeValidationStrategy; embed rest.DeclarativeValidation to enable automatic declarative validation", name, us)
 					}
 				}
 			}

--- a/pkg/registry/admissionregistration/mutatingadmissionpolicy/strategy.go
+++ b/pkg/registry/admissionregistration/mutatingadmissionpolicy/strategy.go
@@ -44,10 +44,10 @@ type mutatingAdmissionPolicyStrategy struct {
 // NewStrategy is the default logic that applies when creating and updating MutatingAdmissionPolicy objects.
 func NewStrategy(authorizer authorizer.Authorizer, resourceResolver resolver.ResourceResolver) *mutatingAdmissionPolicyStrategy {
 	return &mutatingAdmissionPolicyStrategy{
-		DeclarativeValidation:   rest.DeclarativeValidation{Scheme: legacyscheme.Scheme},
-		NameGenerator:    names.SimpleNameGenerator,
-		authorizer:       authorizer,
-		resourceResolver: resourceResolver,
+		DeclarativeValidation: rest.DeclarativeValidation{Scheme: legacyscheme.Scheme},
+		NameGenerator:         names.SimpleNameGenerator,
+		authorizer:            authorizer,
+		resourceResolver:      resourceResolver,
 	}
 }
 

--- a/pkg/registry/admissionregistration/mutatingadmissionpolicy/strategy.go
+++ b/pkg/registry/admissionregistration/mutatingadmissionpolicy/strategy.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/features"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -34,7 +35,7 @@ import (
 
 // mutatingAdmissionPolicyStrategy implements verification logic for MutatingAdmissionPolicy.
 type mutatingAdmissionPolicyStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 	authorizer       authorizer.Authorizer
 	resourceResolver resolver.ResourceResolver
@@ -43,7 +44,7 @@ type mutatingAdmissionPolicyStrategy struct {
 // NewStrategy is the default logic that applies when creating and updating MutatingAdmissionPolicy objects.
 func NewStrategy(authorizer authorizer.Authorizer, resourceResolver resolver.ResourceResolver) *mutatingAdmissionPolicyStrategy {
 	return &mutatingAdmissionPolicyStrategy{
-		ObjectTyper:      legacyscheme.Scheme,
+		DeclarativeValidation:   rest.DeclarativeValidation{Scheme: legacyscheme.Scheme},
 		NameGenerator:    names.SimpleNameGenerator,
 		authorizer:       authorizer,
 		resourceResolver: resourceResolver,

--- a/pkg/registry/admissionregistration/mutatingadmissionpolicybinding/strategy.go
+++ b/pkg/registry/admissionregistration/mutatingadmissionpolicybinding/strategy.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/features"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -34,7 +35,7 @@ import (
 
 // MutatingAdmissionPolicyBindingStrategy implements verification logic for MutatingAdmissionPolicyBinding.
 type mutatingAdmissionPolicyBindingStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 	authorizer       authorizer.Authorizer
 	policyGetter     PolicyGetter
@@ -50,7 +51,7 @@ type PolicyGetter interface {
 // NewStrategy is the default logic that applies when creating and updating MutatingAdmissionPolicyBinding objects.
 func NewStrategy(authorizer authorizer.Authorizer, policyGetter PolicyGetter, resourceResolver resolver.ResourceResolver) *mutatingAdmissionPolicyBindingStrategy {
 	return &mutatingAdmissionPolicyBindingStrategy{
-		ObjectTyper:      legacyscheme.Scheme,
+		DeclarativeValidation:   rest.DeclarativeValidation{Scheme: legacyscheme.Scheme},
 		NameGenerator:    names.SimpleNameGenerator,
 		authorizer:       authorizer,
 		policyGetter:     policyGetter,

--- a/pkg/registry/admissionregistration/mutatingadmissionpolicybinding/strategy.go
+++ b/pkg/registry/admissionregistration/mutatingadmissionpolicybinding/strategy.go
@@ -51,11 +51,11 @@ type PolicyGetter interface {
 // NewStrategy is the default logic that applies when creating and updating MutatingAdmissionPolicyBinding objects.
 func NewStrategy(authorizer authorizer.Authorizer, policyGetter PolicyGetter, resourceResolver resolver.ResourceResolver) *mutatingAdmissionPolicyBindingStrategy {
 	return &mutatingAdmissionPolicyBindingStrategy{
-		DeclarativeValidation:   rest.DeclarativeValidation{Scheme: legacyscheme.Scheme},
-		NameGenerator:    names.SimpleNameGenerator,
-		authorizer:       authorizer,
-		policyGetter:     policyGetter,
-		resourceResolver: resourceResolver,
+		DeclarativeValidation: rest.DeclarativeValidation{Scheme: legacyscheme.Scheme},
+		NameGenerator:         names.SimpleNameGenerator,
+		authorizer:            authorizer,
+		policyGetter:          policyGetter,
+		resourceResolver:      resourceResolver,
 	}
 }
 

--- a/pkg/registry/admissionregistration/mutatingwebhookconfiguration/strategy.go
+++ b/pkg/registry/admissionregistration/mutatingwebhookconfiguration/strategy.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/features"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -32,12 +33,12 @@ import (
 
 // mutatingWebhookConfigurationStrategy implements verification logic for mutatingWebhookConfiguration.
 type mutatingWebhookConfigurationStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating mutatingWebhookConfiguration objects.
-var Strategy = mutatingWebhookConfigurationStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = mutatingWebhookConfigurationStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // NamespaceScoped returns false because MutatingWebhookConfiguration is cluster-scoped resource.
 func (mutatingWebhookConfigurationStrategy) NamespaceScoped() bool {

--- a/pkg/registry/admissionregistration/validatingadmissionpolicy/strategy.go
+++ b/pkg/registry/admissionregistration/validatingadmissionpolicy/strategy.go
@@ -47,10 +47,10 @@ type validatingAdmissionPolicyStrategy struct {
 // NewStrategy is the default logic that applies when creating and updating validatingAdmissionPolicy objects.
 func NewStrategy(authorizer authorizer.Authorizer, resourceResolver resolver.ResourceResolver) *validatingAdmissionPolicyStrategy {
 	return &validatingAdmissionPolicyStrategy{
-		DeclarativeValidation:   rest.DeclarativeValidation{Scheme: legacyscheme.Scheme},
-		NameGenerator:    names.SimpleNameGenerator,
-		authorizer:       authorizer,
-		resourceResolver: resourceResolver,
+		DeclarativeValidation: rest.DeclarativeValidation{Scheme: legacyscheme.Scheme},
+		NameGenerator:         names.SimpleNameGenerator,
+		authorizer:            authorizer,
+		resourceResolver:      resourceResolver,
 	}
 }
 

--- a/pkg/registry/admissionregistration/validatingadmissionpolicy/strategy.go
+++ b/pkg/registry/admissionregistration/validatingadmissionpolicy/strategy.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/features"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -37,7 +38,7 @@ import (
 
 // validatingAdmissionPolicyStrategy implements verification logic for ValidatingAdmissionPolicy.
 type validatingAdmissionPolicyStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 	authorizer       authorizer.Authorizer
 	resourceResolver resolver.ResourceResolver
@@ -46,7 +47,7 @@ type validatingAdmissionPolicyStrategy struct {
 // NewStrategy is the default logic that applies when creating and updating validatingAdmissionPolicy objects.
 func NewStrategy(authorizer authorizer.Authorizer, resourceResolver resolver.ResourceResolver) *validatingAdmissionPolicyStrategy {
 	return &validatingAdmissionPolicyStrategy{
-		ObjectTyper:      legacyscheme.Scheme,
+		DeclarativeValidation:   rest.DeclarativeValidation{Scheme: legacyscheme.Scheme},
 		NameGenerator:    names.SimpleNameGenerator,
 		authorizer:       authorizer,
 		resourceResolver: resourceResolver,

--- a/pkg/registry/admissionregistration/validatingadmissionpolicybinding/declarative_validation_test.go
+++ b/pkg/registry/admissionregistration/validatingadmissionpolicybinding/declarative_validation_test.go
@@ -67,7 +67,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 	}
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
-			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs)
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, &Strategy, tc.expectedErrs)
 		})
 	}
 }
@@ -117,7 +117,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				IsResourceRequest: true,
 				Verb:              "update",
 			})
-			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, Strategy.ValidateUpdate, tc.expectedErrs)
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, &Strategy, tc.expectedErrs)
 		})
 	}
 }

--- a/pkg/registry/admissionregistration/validatingadmissionpolicybinding/strategy.go
+++ b/pkg/registry/admissionregistration/validatingadmissionpolicybinding/strategy.go
@@ -53,11 +53,11 @@ type PolicyGetter interface {
 // NewStrategy is the default logic that applies when creating and updating ValidatingAdmissionPolicyBinding objects.
 func NewStrategy(authorizer authorizer.Authorizer, policyGetter PolicyGetter, resourceResolver resolver.ResourceResolver) *validatingAdmissionPolicyBindingStrategy {
 	return &validatingAdmissionPolicyBindingStrategy{
-		DeclarativeValidation:   rest.DeclarativeValidation{Scheme: legacyscheme.Scheme},
-		NameGenerator:    names.SimpleNameGenerator,
-		authorizer:       authorizer,
-		policyGetter:     policyGetter,
-		resourceResolver: resourceResolver,
+		DeclarativeValidation: rest.DeclarativeValidation{Scheme: legacyscheme.Scheme},
+		NameGenerator:         names.SimpleNameGenerator,
+		authorizer:            authorizer,
+		policyGetter:          policyGetter,
+		resourceResolver:      resourceResolver,
 	}
 }
 

--- a/pkg/registry/admissionregistration/validatingadmissionpolicybinding/strategy.go
+++ b/pkg/registry/admissionregistration/validatingadmissionpolicybinding/strategy.go
@@ -42,7 +42,9 @@ type validatingAdmissionPolicyBindingStrategy struct {
 	resourceResolver resolver.ResourceResolver
 }
 
-var Strategy = validatingAdmissionPolicyBindingStrategy{}
+var Strategy = validatingAdmissionPolicyBindingStrategy{
+	DeclarativeValidation: rest.DeclarativeValidation{Scheme: legacyscheme.Scheme},
+}
 
 type PolicyGetter interface {
 	// GetValidatingAdmissionPolicy returns a GetValidatingAdmissionPolicy

--- a/pkg/registry/admissionregistration/validatingadmissionpolicybinding/strategy.go
+++ b/pkg/registry/admissionregistration/validatingadmissionpolicybinding/strategy.go
@@ -18,7 +18,6 @@ package validatingadmissionpolicybinding
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -36,7 +35,7 @@ import (
 
 // validatingAdmissionPolicyBindingStrategy implements verification logic for ValidatingAdmissionPolicyBinding.
 type validatingAdmissionPolicyBindingStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 	authorizer       authorizer.Authorizer
 	policyGetter     PolicyGetter
@@ -54,7 +53,7 @@ type PolicyGetter interface {
 // NewStrategy is the default logic that applies when creating and updating ValidatingAdmissionPolicyBinding objects.
 func NewStrategy(authorizer authorizer.Authorizer, policyGetter PolicyGetter, resourceResolver resolver.ResourceResolver) *validatingAdmissionPolicyBindingStrategy {
 	return &validatingAdmissionPolicyBindingStrategy{
-		ObjectTyper:      legacyscheme.Scheme,
+		DeclarativeValidation:   rest.DeclarativeValidation{Scheme: legacyscheme.Scheme},
 		NameGenerator:    names.SimpleNameGenerator,
 		authorizer:       authorizer,
 		policyGetter:     policyGetter,
@@ -99,7 +98,7 @@ func (v *validatingAdmissionPolicyBindingStrategy) Validate(ctx context.Context,
 			errs = append(errs, field.Forbidden(field.NewPath("spec", "paramRef"), err.Error()))
 		}
 	}
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, obj, nil, errs, operation.Create)
+	return errs
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -131,7 +130,7 @@ func (v *validatingAdmissionPolicyBindingStrategy) ValidateUpdate(ctx context.Co
 			errs = append(errs, field.Forbidden(field.NewPath("spec", "paramRef"), err.Error()))
 		}
 	}
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, obj, old, errs, operation.Update)
+	return errs
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/pkg/registry/admissionregistration/validatingwebhookconfiguration/strategy.go
+++ b/pkg/registry/admissionregistration/validatingwebhookconfiguration/strategy.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/features"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -32,12 +33,12 @@ import (
 
 // validatingWebhookConfigurationStrategy implements verification logic for validatingWebhookConfiguration.
 type validatingWebhookConfigurationStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating validatingWebhookConfiguration objects.
-var Strategy = validatingWebhookConfigurationStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = validatingWebhookConfigurationStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // NamespaceScoped returns false because ValidatingWebhookConfiguration is cluster-scoped resource.
 func (validatingWebhookConfigurationStrategy) NamespaceScoped() bool {

--- a/pkg/registry/apiserverinternal/storageversion/strategy.go
+++ b/pkg/registry/apiserverinternal/storageversion/strategy.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/apiserverinternal"
@@ -31,12 +32,12 @@ import (
 
 // storageVersionStrategy implements verification logic for StorageVersion.
 type storageVersionStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating StorageVersion objects.
-var Strategy = storageVersionStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = storageVersionStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // NamespaceScoped returns false because all StorageVersion's need to be cluster scoped
 func (storageVersionStrategy) NamespaceScoped() bool {

--- a/pkg/registry/apps/controllerrevision/strategy.go
+++ b/pkg/registry/apps/controllerrevision/strategy.go
@@ -30,13 +30,13 @@ import (
 
 // strategy implements behavior for ConfigMap objects
 type strategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating ControllerRevision
 // objects via the REST API.
-var Strategy = strategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = strategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // Strategy should implement rest.RESTCreateStrategy
 var _ rest.RESTCreateStrategy = Strategy

--- a/pkg/registry/apps/daemonset/strategy.go
+++ b/pkg/registry/apps/daemonset/strategy.go
@@ -34,12 +34,12 @@ import (
 
 // daemonSetStrategy implements verification logic for daemon sets.
 type daemonSetStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating DaemonSet objects.
-var Strategy = daemonSetStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = daemonSetStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // Make sure we correctly implement the interface.
 var _ = rest.GarbageCollectionDeleteStrategy(Strategy)

--- a/pkg/registry/apps/deployment/strategy.go
+++ b/pkg/registry/apps/deployment/strategy.go
@@ -37,13 +37,13 @@ import (
 
 // deploymentStrategy implements behavior for Deployments.
 type deploymentStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating Deployment
 // objects via the REST API.
-var Strategy = deploymentStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = deploymentStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // Make sure we correctly implement the interface.
 var _ = rest.GarbageCollectionDeleteStrategy(Strategy)

--- a/pkg/registry/apps/replicaset/strategy.go
+++ b/pkg/registry/apps/replicaset/strategy.go
@@ -44,12 +44,12 @@ import (
 
 // rsStrategy implements verification logic for ReplicaSets.
 type rsStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating ReplicaSet objects.
-var Strategy = rsStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = rsStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // Make sure we correctly implement the interface.
 var _ = rest.GarbageCollectionDeleteStrategy(Strategy)

--- a/pkg/registry/apps/statefulset/strategy.go
+++ b/pkg/registry/apps/statefulset/strategy.go
@@ -36,12 +36,12 @@ import (
 
 // statefulSetStrategy implements verification logic for Replication StatefulSets.
 type statefulSetStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating Replication StatefulSet objects.
-var Strategy = statefulSetStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = statefulSetStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // Make sure we correctly implement the interface.
 var _ = rest.GarbageCollectionDeleteStrategy(Strategy)

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/declarative_validation_test.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/declarative_validation_test.go
@@ -82,7 +82,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.HPAScaleToZero, tc.enableScaleToZero)
-			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs)
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy, tc.expectedErrs)
 		})
 	}
 }
@@ -153,7 +153,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				IsResourceRequest: true,
 				Verb:              "update",
 			})
-			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, Strategy.ValidateUpdate, tc.expectedErrs)
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, Strategy, tc.expectedErrs)
 		})
 	}
 }

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/strategy.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/strategy.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -35,13 +34,13 @@ import (
 
 // autoscalerStrategy implements behavior for HorizontalPodAutoscalers
 type autoscalerStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating HorizontalPodAutoscaler
 // objects via the REST API.
-var Strategy = autoscalerStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = autoscalerStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // NamespaceScoped is true for autoscaler.
 func (autoscalerStrategy) NamespaceScoped() bool {
@@ -82,12 +81,27 @@ func (autoscalerStrategy) PrepareForCreate(ctx context.Context, obj runtime.Obje
 func (autoscalerStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	autoscaler := obj.(*autoscaling.HorizontalPodAutoscaler)
 	opts := validationOptionsForHorizontalPodAutoscaler(autoscaler, nil)
-	allErrs := validation.ValidateHorizontalPodAutoscaler(autoscaler, opts)
+	return validation.ValidateHorizontalPodAutoscaler(autoscaler, opts)
+}
+
+// DeclarativeValidationConfig implements rest.DeclarativeValidationConfigurer to supply declarative
+// validation options.
+func (autoscalerStrategy) DeclarativeValidationConfig(ctx context.Context, obj, oldObj runtime.Object) rest.DeclarativeValidationConfig {
 	var options []string
-	if utilfeature.DefaultFeatureGate.Enabled(features.HPAScaleToZero) {
+	// Pass HPAScaleToZero when the gate is enabled, OR (on update) when the
+	// existing object already has MinReplicas == 0.
+	enableScaleToZero := utilfeature.DefaultFeatureGate.Enabled(features.HPAScaleToZero)
+	if !enableScaleToZero && oldObj != nil {
+		if oldHPA, ok := oldObj.(*autoscaling.HorizontalPodAutoscaler); ok {
+			if oldHPA.Spec.MinReplicas != nil && *oldHPA.Spec.MinReplicas == 0 {
+				enableScaleToZero = true
+			}
+		}
+	}
+	if enableScaleToZero {
 		options = append(options, "HPAScaleToZero")
 	}
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, autoscaler, nil, allErrs, operation.Create, rest.WithOptions(options))
+	return rest.DeclarativeValidationConfig{Options: options}
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -125,13 +139,7 @@ func (autoscalerStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.O
 	newHPA := obj.(*autoscaling.HorizontalPodAutoscaler)
 	oldHPA := old.(*autoscaling.HorizontalPodAutoscaler)
 	opts := validationOptionsForHorizontalPodAutoscaler(newHPA, oldHPA)
-	errs := validation.ValidateHorizontalPodAutoscalerUpdate(newHPA, oldHPA, opts)
-	var options []string
-	oldHasZeroMinReplicas := oldHPA.Spec.MinReplicas != nil && *oldHPA.Spec.MinReplicas == 0
-	if utilfeature.DefaultFeatureGate.Enabled(features.HPAScaleToZero) || oldHasZeroMinReplicas {
-		options = append(options, "HPAScaleToZero")
-	}
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newHPA, oldHPA, errs, operation.Update, rest.WithOptions(options))
+	return validation.ValidateHorizontalPodAutoscalerUpdate(newHPA, oldHPA, opts)
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/pkg/registry/batch/cronjob/declarative_validation_test.go
+++ b/pkg/registry/batch/cronjob/declarative_validation_test.go
@@ -55,7 +55,7 @@ func testDeclarativeValidateForDeclarative(t *testing.T, apiVersion string) {
 	}
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
-			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs)
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy, tc.expectedErrs)
 		})
 	}
 }
@@ -93,7 +93,7 @@ func testValidateUpdateForDeclarative(t *testing.T, apiVersion string) {
 		t.Run(k, func(t *testing.T) {
 			tc.old.ResourceVersion = "1"
 			tc.update.ResourceVersion = "2"
-			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy.ValidateUpdate, tc.expectedErrs)
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy, tc.expectedErrs)
 		})
 	}
 }

--- a/pkg/registry/batch/cronjob/strategy.go
+++ b/pkg/registry/batch/cronjob/strategy.go
@@ -23,7 +23,6 @@ import (
 
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
@@ -41,12 +40,12 @@ import (
 
 // cronJobStrategy implements verification logic for Replication Controllers.
 type cronJobStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating CronJob objects.
-var Strategy = cronJobStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = cronJobStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // DefaultGarbageCollectionPolicy returns OrphanDependents for batch/v1beta1 for backwards compatibility,
 // and DeleteDependents for all other versions.
@@ -113,8 +112,7 @@ func (cronJobStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Ob
 func (cronJobStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	cronJob := obj.(*batch.CronJob)
 	opts := pod.GetValidationOptionsFromPodTemplate(&cronJob.Spec.JobTemplate.Spec.Template, nil)
-	allErrs := batchvalidation.ValidateCronJobCreate(cronJob, opts)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, obj, nil, allErrs, operation.Create)
+	return batchvalidation.ValidateCronJobCreate(cronJob, opts)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -147,8 +145,7 @@ func (cronJobStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Obje
 	oldCronJob := old.(*batch.CronJob)
 
 	opts := pod.GetValidationOptionsFromPodTemplate(&newCronJob.Spec.JobTemplate.Spec.Template, &oldCronJob.Spec.JobTemplate.Spec.Template)
-	allErrs := batchvalidation.ValidateCronJobUpdate(newCronJob, oldCronJob, opts)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newCronJob, oldCronJob, allErrs, operation.Update)
+	return batchvalidation.ValidateCronJobUpdate(newCronJob, oldCronJob, opts)
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/pkg/registry/batch/job/strategy.go
+++ b/pkg/registry/batch/job/strategy.go
@@ -50,12 +50,12 @@ import (
 
 // jobStrategy implements verification logic for Replication Controllers.
 type jobStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating Replication Controller objects.
-var Strategy = jobStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = jobStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // DefaultGarbageCollectionPolicy returns OrphanDependents for batch/v1 for backwards compatibility,
 // and DeleteDependents for all other versions.

--- a/pkg/registry/certificates/certificates/declarative_validation_test.go
+++ b/pkg/registry/certificates/certificates/declarative_validation_test.go
@@ -26,9 +26,9 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	api "k8s.io/kubernetes/pkg/apis/certificates"
 	"k8s.io/kubernetes/pkg/apis/core"
@@ -36,11 +36,6 @@ import (
 )
 
 var apiVersions = []string{"v1", "v1beta1"}
-
-type validationStrategy interface {
-	Validate(ctx context.Context, obj runtime.Object) field.ErrorList
-	ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList
-}
 
 func TestDeclarativeValidateForDeclarative(t *testing.T) {
 	for _, apiVersion := range apiVersions {
@@ -90,7 +85,7 @@ func testDeclarativeValidateForDeclarative(t *testing.T, apiVersion string) {
 	}
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
-			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs)
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy, tc.expectedErrs)
 		})
 	}
 }
@@ -188,7 +183,7 @@ func testValidateUpdateForDeclarative(t *testing.T, apiVersion string) {
 		for _, subresource := range tc.subresources {
 			t.Run(k+" subresource="+subresource, func(t *testing.T) {
 				ctx := createContextForSubresource(apiVersion, subresource)
-				var strategy validationStrategy
+				var strategy rest.RESTUpdateStrategy
 				switch subresource {
 				case "/":
 					strategy = Strategy
@@ -200,7 +195,7 @@ func testValidateUpdateForDeclarative(t *testing.T, apiVersion string) {
 
 				tc.old.ResourceVersion = "1"
 				tc.update.ResourceVersion = "1"
-				apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, strategy.ValidateUpdate, tc.expectedErrs)
+				apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, strategy, tc.expectedErrs)
 			})
 		}
 	}

--- a/pkg/registry/certificates/certificates/strategy.go
+++ b/pkg/registry/certificates/certificates/strategy.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/api/operation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -38,13 +37,13 @@ import (
 
 // csrStrategy implements behavior for CSRs
 type csrStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // csrStrategy is the default logic that applies when creating and updating
 // CSR objects.
-var Strategy = csrStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = csrStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // NamespaceScoped is false for CSRs.
 func (csrStrategy) NamespaceScoped() bool {
@@ -114,8 +113,7 @@ func (csrStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object
 // Validate validates a new CSR. Validation must check for a correct signature.
 func (csrStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	csr := obj.(*certificates.CertificateSigningRequest)
-	allErrs := validation.ValidateCertificateSigningRequestCreate(csr)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, csr, nil, allErrs, operation.Create)
+	return validation.ValidateCertificateSigningRequestCreate(csr)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -128,8 +126,7 @@ func (csrStrategy) Canonicalize(obj runtime.Object) {}
 func (csrStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	oldCSR := old.(*certificates.CertificateSigningRequest)
 	newCSR := obj.(*certificates.CertificateSigningRequest)
-	errs := validation.ValidateCertificateSigningRequestUpdate(newCSR, oldCSR)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newCSR, oldCSR, errs, operation.Update)
+	return validation.ValidateCertificateSigningRequestUpdate(newCSR, oldCSR)
 }
 
 // WarningsOnUpdate returns warnings for the given update.
@@ -244,8 +241,7 @@ func populateConditionTimestamps(newCSR, oldCSR *certificates.CertificateSigning
 func (csrStatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	newCSR := obj.(*certificates.CertificateSigningRequest)
 	oldCSR := old.(*certificates.CertificateSigningRequest)
-	errs := validation.ValidateCertificateSigningRequestStatusUpdate(newCSR, oldCSR)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newCSR, oldCSR, errs, operation.Update)
+	return validation.ValidateCertificateSigningRequestStatusUpdate(newCSR, oldCSR)
 }
 
 // WarningsOnUpdate returns warnings for the given update.
@@ -299,8 +295,7 @@ func (csrApprovalStrategy) PrepareForUpdate(ctx context.Context, obj, old runtim
 func (csrApprovalStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	newCSR := obj.(*certificates.CertificateSigningRequest)
 	oldCSR := old.(*certificates.CertificateSigningRequest)
-	errs := validation.ValidateCertificateSigningRequestApprovalUpdate(newCSR, oldCSR)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newCSR, oldCSR, errs, operation.Update)
+	return validation.ValidateCertificateSigningRequestApprovalUpdate(newCSR, oldCSR)
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/pkg/registry/certificates/clustertrustbundle/strategy.go
+++ b/pkg/registry/certificates/clustertrustbundle/strategy.go
@@ -32,12 +32,12 @@ import (
 
 // strategy implements behavior for ClusterTrustBundles.
 type strategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the create, update, and delete strategy for ClusterTrustBundles.
-var Strategy = strategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = strategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 var _ rest.RESTCreateStrategy = Strategy
 var _ rest.RESTUpdateStrategy = Strategy

--- a/pkg/registry/certificates/podcertificaterequest/strategy.go
+++ b/pkg/registry/certificates/podcertificaterequest/strategy.go
@@ -41,7 +41,7 @@ import (
 
 // strategy implements behavior for PodCertificateRequests.
 type Strategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
@@ -51,8 +51,8 @@ var _ rest.RESTDeleteStrategy = (*Strategy)(nil)
 
 func NewStrategy() *Strategy {
 	return &Strategy{
-		ObjectTyper:   legacyscheme.Scheme,
-		NameGenerator: names.SimpleNameGenerator,
+		DeclarativeValidation: rest.DeclarativeValidation{Scheme: legacyscheme.Scheme},
+		NameGenerator:  names.SimpleNameGenerator,
 	}
 }
 

--- a/pkg/registry/certificates/podcertificaterequest/strategy.go
+++ b/pkg/registry/certificates/podcertificaterequest/strategy.go
@@ -52,7 +52,7 @@ var _ rest.RESTDeleteStrategy = (*Strategy)(nil)
 func NewStrategy() *Strategy {
 	return &Strategy{
 		DeclarativeValidation: rest.DeclarativeValidation{Scheme: legacyscheme.Scheme},
-		NameGenerator:  names.SimpleNameGenerator,
+		NameGenerator:         names.SimpleNameGenerator,
 	}
 }
 

--- a/pkg/registry/coordination/lease/strategy.go
+++ b/pkg/registry/coordination/lease/strategy.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -31,12 +32,12 @@ import (
 
 // leaseStrategy implements verification logic for Leases.
 type leaseStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating Lease objects.
-var Strategy = leaseStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = leaseStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // NamespaceScoped returns true because all Lease' need to be within a namespace.
 func (leaseStrategy) NamespaceScoped() bool {

--- a/pkg/registry/coordination/leasecandidate/strategy.go
+++ b/pkg/registry/coordination/leasecandidate/strategy.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -34,12 +35,12 @@ import (
 
 // LeaseCandidateStrategy implements verification logic for leasecandidates.
 type LeaseCandidateStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating leasecandidate objects.
-var Strategy = LeaseCandidateStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = LeaseCandidateStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // NamespaceScoped returns true because all leasecandidate' need to be within a namespace.
 func (LeaseCandidateStrategy) NamespaceScoped() bool {

--- a/pkg/registry/core/configmap/strategy.go
+++ b/pkg/registry/core/configmap/strategy.go
@@ -35,13 +35,13 @@ import (
 
 // strategy implements behavior for ConfigMap objects
 type strategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating ConfigMap
 // objects via the REST API.
-var Strategy = strategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = strategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // Strategy should implement rest.RESTCreateStrategy
 var _ rest.RESTCreateStrategy = Strategy

--- a/pkg/registry/core/endpoint/strategy.go
+++ b/pkg/registry/core/endpoint/strategy.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -31,13 +32,13 @@ import (
 
 // endpointsStrategy implements behavior for Endpoints
 type endpointsStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating Endpoint
 // objects via the REST API.
-var Strategy = endpointsStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = endpointsStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // NamespaceScoped is true for endpoints.
 func (endpointsStrategy) NamespaceScoped() bool {

--- a/pkg/registry/core/event/strategy.go
+++ b/pkg/registry/core/event/strategy.go
@@ -36,13 +36,13 @@ import (
 )
 
 type eventStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating
 // Event objects via the REST API.
-var Strategy = eventStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = eventStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 func (eventStrategy) DefaultGarbageCollectionPolicy(ctx context.Context) rest.GarbageCollectionPolicy {
 	return rest.Unsupported

--- a/pkg/registry/core/limitrange/strategy.go
+++ b/pkg/registry/core/limitrange/strategy.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -29,13 +30,13 @@ import (
 )
 
 type limitrangeStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating
 // LimitRange objects via the REST API.
-var Strategy = limitrangeStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = limitrangeStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 func (limitrangeStrategy) NamespaceScoped() bool {
 	return true

--- a/pkg/registry/core/namespace/strategy.go
+++ b/pkg/registry/core/namespace/strategy.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/registry/rest"
 	apistorage "k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -36,13 +37,13 @@ import (
 
 // namespaceStrategy implements behavior for Namespaces
 type namespaceStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating Namespace
 // objects via the REST API.
-var Strategy = namespaceStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = namespaceStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // NamespaceScoped is false for namespaces.
 func (namespaceStrategy) NamespaceScoped() bool {

--- a/pkg/registry/core/node/strategy.go
+++ b/pkg/registry/core/node/strategy.go
@@ -33,6 +33,7 @@ import (
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/registry/rest"
 	pkgstorage "k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -46,13 +47,13 @@ import (
 
 // nodeStrategy implements behavior for nodes
 type nodeStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Nodes is the default logic that applies when creating and updating Node
 // objects.
-var Strategy = nodeStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = nodeStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // NamespaceScoped is false for nodes.
 func (nodeStrategy) NamespaceScoped() bool {

--- a/pkg/registry/core/persistentvolume/strategy.go
+++ b/pkg/registry/core/persistentvolume/strategy.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -38,13 +39,13 @@ import (
 
 // persistentvolumeStrategy implements behavior for PersistentVolume objects
 type persistentvolumeStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating PersistentVolume
 // objects via the REST API.
-var Strategy = persistentvolumeStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = persistentvolumeStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 func (persistentvolumeStrategy) NamespaceScoped() bool {
 	return false

--- a/pkg/registry/core/persistentvolumeclaim/strategy.go
+++ b/pkg/registry/core/persistentvolumeclaim/strategy.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
 	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
@@ -37,13 +38,13 @@ import (
 
 // persistentvolumeclaimStrategy implements behavior for PersistentVolumeClaim objects
 type persistentvolumeclaimStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating PersistentVolumeClaim
 // objects via the REST API.
-var Strategy = persistentvolumeclaimStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = persistentvolumeclaimStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 func (persistentvolumeclaimStrategy) NamespaceScoped() bool {
 	return true

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	apiserverfeatures "k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -58,13 +59,13 @@ import (
 
 // podStrategy implements behavior for Pods
 type podStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating Pod
 // objects via the REST API.
-var Strategy = podStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = podStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // NamespaceScoped is true for pods.
 func (podStrategy) NamespaceScoped() bool {

--- a/pkg/registry/core/podtemplate/strategy.go
+++ b/pkg/registry/core/podtemplate/strategy.go
@@ -22,6 +22,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/api/pod"
@@ -31,13 +32,13 @@ import (
 
 // podTemplateStrategy implements behavior for PodTemplates
 type podTemplateStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating PodTemplate
 // objects via the REST API.
-var Strategy = podTemplateStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = podTemplateStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // NamespaceScoped is true for pod templates.
 func (podTemplateStrategy) NamespaceScoped() bool {

--- a/pkg/registry/core/replicationcontroller/declarative_validation_test.go
+++ b/pkg/registry/core/replicationcontroller/declarative_validation_test.go
@@ -189,7 +189,7 @@ func TestDeclarativeValidateForDeclarative(t *testing.T) {
 	}
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
-			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs)
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy, tc.expectedErrs)
 		})
 	}
 }
@@ -274,7 +274,7 @@ func TestValidateUpdateForDeclarative(t *testing.T) {
 		t.Run(k, func(t *testing.T) {
 			tc.old.ObjectMeta.ResourceVersion = "1"
 			tc.update.ObjectMeta.ResourceVersion = "1"
-			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy.ValidateUpdate, tc.expectedErrs)
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy, tc.expectedErrs)
 		})
 	}
 }

--- a/pkg/registry/core/replicationcontroller/storage/storage.go
+++ b/pkg/registry/core/replicationcontroller/storage/storage.go
@@ -314,7 +314,8 @@ func (i *scaleUpdatedObjectInfo) UpdatedObject(ctx context.Context, oldObj runti
 	}
 
 	errs := validation.ValidateScale(scale)
-	errs = rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, scale, oldScale, errs, operation.Update, rest.WithSubresourceMapper(i.scaleGVKMapper))
+	dv := rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}
+	errs = dv.ValidateDeclaratively(ctx, scale, oldScale, errs, operation.Update, rest.DeclarativeValidationConfig{SubresourceGVKMapper: i.scaleGVKMapper})
 
 	if len(errs) > 0 {
 		return nil, errors.NewInvalid(autoscaling.Kind("Scale"), replicationcontroller.Name, errs)

--- a/pkg/registry/core/replicationcontroller/strategy.go
+++ b/pkg/registry/core/replicationcontroller/strategy.go
@@ -28,7 +28,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -49,12 +48,12 @@ import (
 
 // rcStrategy implements verification logic for Replication Controllers.
 type rcStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating Replication Controller objects.
-var Strategy = rcStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = rcStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // DefaultGarbageCollectionPolicy returns OrphanDependents for v1 for backwards compatibility,
 // and DeleteDependents for all other versions.
@@ -127,8 +126,7 @@ func (rcStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorL
 	opts := pod.GetValidationOptionsFromPodTemplate(controller.Spec.Template, nil)
 
 	// Run imperative validation
-	allErrs := corevalidation.ValidateReplicationController(controller, opts)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, controller, nil, allErrs, operation.Create)
+	return corevalidation.ValidateReplicationController(controller, opts)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -177,7 +175,7 @@ func (rcStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) f
 		}
 	}
 
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newRc, oldRc, errs, operation.Update)
+	return errs
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/pkg/registry/core/resourcequota/strategy.go
+++ b/pkg/registry/core/resourcequota/strategy.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -31,13 +32,13 @@ import (
 
 // resourcequotaStrategy implements behavior for ResourceQuota objects
 type resourcequotaStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating ResourceQuota
 // objects via the REST API.
-var Strategy = resourcequotaStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = resourcequotaStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // NamespaceScoped is true for resourcequotas.
 func (resourcequotaStrategy) NamespaceScoped() bool {

--- a/pkg/registry/core/secret/strategy.go
+++ b/pkg/registry/core/secret/strategy.go
@@ -36,13 +36,13 @@ import (
 
 // strategy implements behavior for Secret objects
 type strategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating Secret
 // objects via the REST API.
-var Strategy = strategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = strategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 var _ = rest.RESTCreateStrategy(Strategy)
 

--- a/pkg/registry/core/service/strategy.go
+++ b/pkg/registry/core/service/strategy.go
@@ -28,6 +28,7 @@ import (
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/registry/rest"
 	pkgstorage "k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -40,13 +41,13 @@ import (
 
 // svcStrategy implements behavior for Services
 type svcStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating Services
 // objects via the REST API.
-var Strategy = svcStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = svcStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // NamespaceScoped is true for services.
 func (svcStrategy) NamespaceScoped() bool {

--- a/pkg/registry/core/serviceaccount/strategy.go
+++ b/pkg/registry/core/serviceaccount/strategy.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -31,13 +32,13 @@ import (
 
 // strategy implements behavior for ServiceAccount objects
 type strategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating ServiceAccount
 // objects via the REST API.
-var Strategy = strategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = strategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 func (strategy) NamespaceScoped() bool {
 	return true

--- a/pkg/registry/discovery/endpointslice/declarative_validation_test.go
+++ b/pkg/registry/discovery/endpointslice/declarative_validation_test.go
@@ -85,7 +85,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs)
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy, tc.expectedErrs)
 		})
 	}
 }
@@ -149,7 +149,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			})
 			tc.oldObj.ResourceVersion = "1"
 			tc.updateObj.ResourceVersion = "2"
-			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, Strategy.ValidateUpdate, tc.expectedErrs)
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, Strategy, tc.expectedErrs)
 		})
 	}
 }

--- a/pkg/registry/discovery/endpointslice/strategy.go
+++ b/pkg/registry/discovery/endpointslice/strategy.go
@@ -24,7 +24,6 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	discoveryv1beta1 "k8s.io/api/discovery/v1beta1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/operation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -46,12 +45,12 @@ import (
 
 // endpointSliceStrategy implements verification logic for Replication.
 type endpointSliceStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating Replication EndpointSlice objects.
-var Strategy = endpointSliceStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = endpointSliceStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // NamespaceScoped returns true because all EndpointSlices need to be within a namespace.
 func (endpointSliceStrategy) NamespaceScoped() bool {
@@ -93,8 +92,7 @@ func (endpointSliceStrategy) PrepareForUpdate(ctx context.Context, obj, old runt
 // Validate validates a new EndpointSlice.
 func (endpointSliceStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	endpointSlice := obj.(*discovery.EndpointSlice)
-	allErrs := validation.ValidateEndpointSliceCreate(endpointSlice)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, endpointSlice, nil, allErrs, operation.Create)
+	return validation.ValidateEndpointSliceCreate(endpointSlice)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -122,8 +120,7 @@ func (endpointSliceStrategy) AllowCreateOnUpdate() bool {
 func (endpointSliceStrategy) ValidateUpdate(ctx context.Context, new, old runtime.Object) field.ErrorList {
 	newEPS := new.(*discovery.EndpointSlice)
 	oldEPS := old.(*discovery.EndpointSlice)
-	allErrs := validation.ValidateEndpointSliceUpdate(newEPS, oldEPS)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newEPS, oldEPS, allErrs, operation.Update)
+	return validation.ValidateEndpointSliceUpdate(newEPS, oldEPS)
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/pkg/registry/flowcontrol/flowschema/strategy.go
+++ b/pkg/registry/flowcontrol/flowschema/strategy.go
@@ -22,6 +22,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/flowcontrol"
@@ -31,12 +32,12 @@ import (
 
 // flowSchemaStrategy implements verification logic for FlowSchema.
 type flowSchemaStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating flow schema objects.
-var Strategy = flowSchemaStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = flowSchemaStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // NamespaceScoped returns false because all PriorityClasses are global.
 func (flowSchemaStrategy) NamespaceScoped() bool {

--- a/pkg/registry/flowcontrol/prioritylevelconfiguration/declarative_validation_test.go
+++ b/pkg/registry/flowcontrol/prioritylevelconfiguration/declarative_validation_test.go
@@ -107,7 +107,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs)
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy, tc.expectedErrs)
 		})
 	}
 }
@@ -183,7 +183,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				IsResourceRequest: true,
 				Verb:              "update",
 			})
-			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy.ValidateUpdate, tc.expectedErrs)
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy, tc.expectedErrs)
 		})
 	}
 }

--- a/pkg/registry/flowcontrol/prioritylevelconfiguration/strategy.go
+++ b/pkg/registry/flowcontrol/prioritylevelconfiguration/strategy.go
@@ -121,7 +121,6 @@ func (priorityLevelConfigurationStrategy) AllowCreateOnUpdate() bool {
 // ValidateUpdate is the default update validation for an end user.
 func (priorityLevelConfigurationStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	newPL := obj.(*flowcontrol.PriorityLevelConfiguration)
-	_ = old.(*flowcontrol.PriorityLevelConfiguration)
 
 	// 1.28 server is not aware of the roundtrip annotation, and will
 	// default any 0 value persisted (for the NominalConcurrencyShares

--- a/pkg/registry/flowcontrol/prioritylevelconfiguration/strategy.go
+++ b/pkg/registry/flowcontrol/prioritylevelconfiguration/strategy.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -35,12 +34,12 @@ import (
 
 // priorityLevelConfigurationStrategy implements verification logic for priority level configurations.
 type priorityLevelConfigurationStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating priority level configuration objects.
-var Strategy = priorityLevelConfigurationStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = priorityLevelConfigurationStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // NamespaceScoped returns false because all PriorityClasses are global.
 func (priorityLevelConfigurationStrategy) NamespaceScoped() bool {
@@ -98,8 +97,7 @@ func (priorityLevelConfigurationStrategy) Validate(ctx context.Context, obj runt
 	// all servers are at 1.29+ and will honor the zero value correctly.
 	plc := obj.(*flowcontrol.PriorityLevelConfiguration)
 	opts := validation.PriorityLevelValidationOptions{}
-	allErrs := validation.ValidatePriorityLevelConfiguration(plc, getRequestGroupVersion(ctx), opts)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, plc, nil, allErrs, operation.Create)
+	return validation.ValidatePriorityLevelConfiguration(plc, getRequestGroupVersion(ctx), opts)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -123,7 +121,7 @@ func (priorityLevelConfigurationStrategy) AllowCreateOnUpdate() bool {
 // ValidateUpdate is the default update validation for an end user.
 func (priorityLevelConfigurationStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	newPL := obj.(*flowcontrol.PriorityLevelConfiguration)
-	oldPL := old.(*flowcontrol.PriorityLevelConfiguration)
+	_ = old.(*flowcontrol.PriorityLevelConfiguration)
 
 	// 1.28 server is not aware of the roundtrip annotation, and will
 	// default any 0 value persisted (for the NominalConcurrencyShares
@@ -133,8 +131,7 @@ func (priorityLevelConfigurationStrategy) ValidateUpdate(ctx context.Context, ob
 	// via v1 or v1beta3(with the roundtrip annotation) until we know
 	// all servers are at 1.29+ and will honor the zero value correctly.
 	opts := validation.PriorityLevelValidationOptions{}
-	allErrs := validation.ValidatePriorityLevelConfiguration(newPL, getRequestGroupVersion(ctx), opts)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newPL, oldPL, allErrs, operation.Update)
+	return validation.ValidatePriorityLevelConfiguration(newPL, getRequestGroupVersion(ctx), opts)
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/pkg/registry/networking/ingress/strategy.go
+++ b/pkg/registry/networking/ingress/strategy.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/networking"
@@ -37,12 +38,12 @@ const (
 
 // ingressStrategy implements verification logic for Replication Ingress.
 type ingressStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating Replication Ingress objects.
-var Strategy = ingressStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = ingressStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // NamespaceScoped returns true because all Ingress' need to be within a namespace.
 func (ingressStrategy) NamespaceScoped() bool {

--- a/pkg/registry/networking/ingressclass/declarative_validation_test.go
+++ b/pkg/registry/networking/ingressclass/declarative_validation_test.go
@@ -76,7 +76,7 @@ func TestDeclarativeValidateParameter(t *testing.T) {
 						t,
 						ctx,
 						&tc.input,
-						Strategy.Validate,
+						Strategy,
 						tc.expectedErrs,
 					)
 				})
@@ -155,7 +155,7 @@ func TestDeclarativeValidateUpdateParameters(t *testing.T) {
 						ctx,
 						&tc.updateObj,
 						&tc.oldObj,
-						Strategy.ValidateUpdate,
+						Strategy,
 						tc.expectedErrs,
 					)
 				})

--- a/pkg/registry/networking/ingressclass/strategy.go
+++ b/pkg/registry/networking/ingressclass/strategy.go
@@ -18,7 +18,7 @@ package ingressclass
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/api/operation"
+
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -33,13 +33,13 @@ import (
 // ingressClassStrategy implements verification logic for IngressClass
 // resources.
 type ingressClassStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating
 // IngressClass objects.
-var Strategy = ingressClassStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = ingressClassStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // NamespaceScoped returns false because IngressClass is a non-namespaced
 // resource.
@@ -69,8 +69,7 @@ func (ingressClassStrategy) PrepareForUpdate(ctx context.Context, obj, old runti
 // Validate validates a new IngressClass.
 func (ingressClassStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	ingressClass := obj.(*networking.IngressClass)
-	allErrs := validation.ValidateIngressClass(ingressClass)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, ingressClass, nil, allErrs, operation.Create)
+	return validation.ValidateIngressClass(ingressClass)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -93,8 +92,7 @@ func (ingressClassStrategy) ValidateUpdate(ctx context.Context, obj, old runtime
 	newIngressClass := obj.(*networking.IngressClass)
 	oldIngressClass := old.(*networking.IngressClass)
 
-	allErrs := validation.ValidateIngressClassUpdate(newIngressClass, oldIngressClass)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newIngressClass, oldIngressClass, allErrs, operation.Update)
+	return validation.ValidateIngressClassUpdate(newIngressClass, oldIngressClass)
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/pkg/registry/networking/ipaddress/declarative_validation_test.go
+++ b/pkg/registry/networking/ipaddress/declarative_validation_test.go
@@ -74,7 +74,7 @@ func TestDeclarativeValidateIPAddress(t *testing.T) {
 						t,
 						ctx,
 						&tc.input,
-						Strategy.Validate,
+						Strategy,
 						tc.expectedErrs,
 					)
 				})
@@ -168,7 +168,7 @@ func TestDeclarativeValidateIPAddressUpdate(t *testing.T) {
 						ctx,
 						&tc.updateObj,
 						&tc.oldObj,
-						Strategy.ValidateUpdate,
+						Strategy,
 						tc.expectedErrs,
 					)
 				})

--- a/pkg/registry/networking/ipaddress/strategy.go
+++ b/pkg/registry/networking/ipaddress/strategy.go
@@ -19,7 +19,6 @@ package ipaddress
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -31,7 +30,7 @@ import (
 
 // ipAddressStrategy implements verification logic for Replication.
 type ipAddressStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
@@ -43,7 +42,7 @@ func (noopNameGenerator) GenerateName(base string) string {
 }
 
 // Strategy is the default logic that applies when creating and updating Replication IPAddress objects.
-var Strategy = ipAddressStrategy{legacyscheme.Scheme, noopNameGenerator{}}
+var Strategy = ipAddressStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, noopNameGenerator{}}
 
 // Strategy should implement rest.RESTCreateStrategy
 var _ rest.RESTCreateStrategy = Strategy
@@ -73,8 +72,7 @@ func (ipAddressStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.
 // Validate validates a new IPAddress.
 func (ipAddressStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	ipAddress := obj.(*networking.IPAddress)
-	err := validation.ValidateIPAddress(ipAddress)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, ipAddress, nil, err, operation.Create)
+	return validation.ValidateIPAddress(ipAddress)
 }
 
 // Canonicalize normalizes the object after validation.
@@ -92,7 +90,7 @@ func (ipAddressStrategy) ValidateUpdate(ctx context.Context, new, old runtime.Ob
 	oldIPAddress := old.(*networking.IPAddress)
 	errList := validation.ValidateIPAddress(newIPAddress)
 	errList = append(errList, validation.ValidateIPAddressUpdate(newIPAddress, oldIPAddress)...)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newIPAddress, oldIPAddress, errList, operation.Update)
+	return errList
 }
 
 // AllowUnconditionalUpdate is the default update policy for IPAddress objects.

--- a/pkg/registry/networking/networkpolicy/declarative_validation_test.go
+++ b/pkg/registry/networking/networkpolicy/declarative_validation_test.go
@@ -79,7 +79,7 @@ func TestDeclarativeValidateIPBlockCIDR(t *testing.T) {
 						t,
 						ctx,
 						&tc.input,
-						Strategy.Validate,
+						Strategy,
 						tc.expectedErrs,
 					)
 				})
@@ -147,7 +147,7 @@ func TestDeclarativeValidateIPBlockCIDRUpdate(t *testing.T) {
 						ctx,
 						&tc.updateObj,
 						&tc.oldObj,
-						Strategy.ValidateUpdate,
+						Strategy,
 						tc.expectedErrs,
 					)
 				})

--- a/pkg/registry/networking/networkpolicy/strategy.go
+++ b/pkg/registry/networking/networkpolicy/strategy.go
@@ -18,7 +18,6 @@ package networkpolicy
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"reflect"
 
@@ -33,12 +32,12 @@ import (
 
 // networkPolicyStrategy implements verification logic for NetworkPolicies
 type networkPolicyStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating NetworkPolicy objects.
-var Strategy = networkPolicyStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = networkPolicyStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // NamespaceScoped returns true because all NetworkPolicies need to be within a namespace.
 func (networkPolicyStrategy) NamespaceScoped() bool {
@@ -68,9 +67,7 @@ func (networkPolicyStrategy) PrepareForUpdate(ctx context.Context, obj, old runt
 func (networkPolicyStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	networkPolicy := obj.(*networking.NetworkPolicy)
 	ops := validation.ValidationOptionsForNetworking(networkPolicy, nil)
-	allErrs := validation.ValidateNetworkPolicy(networkPolicy, ops)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, networkPolicy, nil, allErrs, operation.Create)
-
+	return validation.ValidateNetworkPolicy(networkPolicy, ops)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -89,8 +86,7 @@ func (networkPolicyStrategy) AllowCreateOnUpdate() bool {
 // ValidateUpdate is the default update validation for an end user.
 func (networkPolicyStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	opts := validation.ValidationOptionsForNetworking(obj.(*networking.NetworkPolicy), old.(*networking.NetworkPolicy))
-	allErrs := validation.ValidateNetworkPolicyUpdate(obj.(*networking.NetworkPolicy), old.(*networking.NetworkPolicy), opts)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, obj, old, allErrs, operation.Update)
+	return validation.ValidateNetworkPolicyUpdate(obj.(*networking.NetworkPolicy), old.(*networking.NetworkPolicy), opts)
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/pkg/registry/networking/servicecidr/strategy.go
+++ b/pkg/registry/networking/servicecidr/strategy.go
@@ -35,12 +35,12 @@ import (
 
 // serviceCIDRStrategy implements verification logic for ServiceCIDR allocators.
 type serviceCIDRStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating Replication ServiceCIDR objects.
-var Strategy = serviceCIDRStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = serviceCIDRStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // Strategy should implement rest.RESTCreateStrategy
 var _ rest.RESTCreateStrategy = Strategy

--- a/pkg/registry/node/runtimeclass/declarative_validation_test.go
+++ b/pkg/registry/node/runtimeclass/declarative_validation_test.go
@@ -102,7 +102,7 @@ func TestRuntimeClass_DeclarativeValidate_Create(t *testing.T) {
 
 			for name, tc := range tests {
 				t.Run(name, func(t *testing.T) {
-					apitesting.VerifyValidationEquivalence(t, ctx, &tc.obj, Strategy.Validate, tc.expectedErrs,
+					apitesting.VerifyValidationEquivalence(t, ctx, &tc.obj, Strategy, tc.expectedErrs,
 						apitesting.WithNormalizationRules(validation.NodeNormalizationRules...))
 				})
 			}
@@ -148,7 +148,7 @@ func TestRuntimeClass_DeclarativeValidate_Update(t *testing.T) {
 				t.Run(name, func(t *testing.T) {
 					tc.oldObj.ObjectMeta.ResourceVersion = "1"
 					tc.newObj.ObjectMeta.ResourceVersion = "1"
-					apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.newObj, &tc.oldObj, Strategy.ValidateUpdate, tc.expectedErrs, apitesting.WithNormalizationRules(validation.NodeNormalizationRules...))
+					apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.newObj, &tc.oldObj, Strategy, tc.expectedErrs, apitesting.WithNormalizationRules(validation.NodeNormalizationRules...))
 				})
 			}
 		})

--- a/pkg/registry/node/runtimeclass/strategy.go
+++ b/pkg/registry/node/runtimeclass/strategy.go
@@ -18,7 +18,6 @@ package runtimeclass
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/api/operation"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -32,12 +31,12 @@ import (
 
 // strategy implements verification logic for RuntimeClass.
 type strategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating RuntimeClass objects.
-var Strategy = strategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = strategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // Strategy should implement rest.RESTCreateStrategy
 var _ rest.RESTCreateStrategy = Strategy
@@ -71,9 +70,13 @@ func (strategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
 // Validate validates a new RuntimeClass. Validation must check for a correct signature.
 func (strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	runtimeClass := obj.(*node.RuntimeClass)
-	allErrs := validation.ValidateRuntimeClass(runtimeClass)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, runtimeClass, nil, allErrs, operation.Create, rest.WithNormalizationRules(validation.NodeNormalizationRules))
+	return validation.ValidateRuntimeClass(runtimeClass)
+}
 
+// DeclarativeValidationConfig implements rest.DeclarativeValidationConfigurer to supply declarative
+// validation options to the generic BeforeCreate/BeforeUpdate code path.
+func (strategy) DeclarativeValidationConfig(ctx context.Context, obj, oldObj runtime.Object) rest.DeclarativeValidationConfig {
+	return rest.DeclarativeValidationConfig{NormalizationRules: validation.NodeNormalizationRules}
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -91,8 +94,7 @@ func (strategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) fie
 	newObj := obj.(*node.RuntimeClass)
 	errorList := validation.ValidateRuntimeClass(newObj)
 	errorList = append(errorList, validation.ValidateRuntimeClassUpdate(newObj, old.(*node.RuntimeClass))...)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newObj, old, errorList, operation.Update, rest.WithNormalizationRules(validation.NodeNormalizationRules))
-
+	return errorList
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/pkg/registry/policy/poddisruptionbudget/strategy.go
+++ b/pkg/registry/policy/poddisruptionbudget/strategy.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/policy"
@@ -34,12 +35,12 @@ import (
 
 // podDisruptionBudgetStrategy implements verification logic for PodDisruptionBudgets.
 type podDisruptionBudgetStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating PodDisruptionBudget objects.
-var Strategy = podDisruptionBudgetStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = podDisruptionBudgetStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // NamespaceScoped returns true because all PodDisruptionBudget' need to be within a namespace.
 func (podDisruptionBudgetStrategy) NamespaceScoped() bool {

--- a/pkg/registry/rbac/clusterrole/declarative_validation_test.go
+++ b/pkg/registry/rbac/clusterrole/declarative_validation_test.go
@@ -62,7 +62,7 @@ func testDeclarativeValidateForDeclarative(t *testing.T, apiVersion string) {
 	}
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
-			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs)
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy, tc.expectedErrs)
 		})
 	}
 }
@@ -100,7 +100,7 @@ func testValidateUpdateForDeclarative(t *testing.T, apiVersion string) {
 		t.Run(k, func(t *testing.T) {
 			tc.old.ResourceVersion = "1"
 			tc.update.ResourceVersion = "2"
-			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy.ValidateUpdate, tc.expectedErrs)
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy, tc.expectedErrs)
 		})
 	}
 }

--- a/pkg/registry/rbac/clusterrole/strategy.go
+++ b/pkg/registry/rbac/clusterrole/strategy.go
@@ -19,7 +19,6 @@ package clusterrole
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/api/operation"
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -32,13 +31,13 @@ import (
 
 // strategy implements behavior for ClusterRoles
 type strategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating
 // ClusterRole objects.
-var Strategy = strategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = strategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // Strategy should implement rest.RESTCreateStrategy
 var _ rest.RESTCreateStrategy = Strategy
@@ -76,9 +75,7 @@ func (strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorLis
 	opts := validation.ClusterRoleValidationOptions{
 		AllowInvalidLabelValueInSelector: false,
 	}
-	allErrs := validation.ValidateClusterRole(clusterRole, opts)
-
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, clusterRole, nil, allErrs, operation.Create)
+	return validation.ValidateClusterRole(clusterRole, opts)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -96,9 +93,7 @@ func (strategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) fie
 	opts := validation.ClusterRoleValidationOptions{
 		AllowInvalidLabelValueInSelector: hasInvalidLabelValueInLabelSelector(oldObj),
 	}
-	errs := validation.ValidateClusterRoleUpdate(newObj, oldObj, opts)
-
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newObj, oldObj, errs, operation.Update)
+	return validation.ValidateClusterRoleUpdate(newObj, oldObj, opts)
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/pkg/registry/rbac/clusterrolebinding/strategy.go
+++ b/pkg/registry/rbac/clusterrolebinding/strategy.go
@@ -30,13 +30,13 @@ import (
 
 // strategy implements behavior for ClusterRoleBindings
 type strategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // strategy is the default logic that applies when creating and updating
 // ClusterRoleBinding objects.
-var Strategy = strategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = strategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // Strategy should implement rest.RESTCreateStrategy
 var _ rest.RESTCreateStrategy = Strategy

--- a/pkg/registry/rbac/role/declarative_validation_test.go
+++ b/pkg/registry/rbac/role/declarative_validation_test.go
@@ -69,7 +69,7 @@ func testDeclarativeValidateForDeclarative(t *testing.T, apiVersion string) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs)
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy, tc.expectedErrs)
 		})
 	}
 }
@@ -113,7 +113,7 @@ func testValidateUpdateForDeclarative(t *testing.T, apiVersion string) {
 		t.Run(name, func(t *testing.T) {
 			tc.old.ResourceVersion = "1"
 			tc.update.ResourceVersion = "2"
-			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy.ValidateUpdate, tc.expectedErrs)
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy, tc.expectedErrs)
 		})
 	}
 }

--- a/pkg/registry/rbac/role/strategy.go
+++ b/pkg/registry/rbac/role/strategy.go
@@ -19,7 +19,6 @@ package role
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -31,13 +30,13 @@ import (
 
 // strategy implements behavior for Roles
 type strategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating
 // Role objects.
-var Strategy = strategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = strategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // Strategy should implement rest.RESTCreateStrategy
 var _ rest.RESTCreateStrategy = Strategy
@@ -72,8 +71,7 @@ func (strategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
 // Validate validates a new Role. Validation must check for a correct signature.
 func (strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	role := obj.(*rbac.Role)
-	allErrs := validation.ValidateRole(role)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, role, nil, allErrs, operation.Create)
+	return validation.ValidateRole(role)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -88,8 +86,7 @@ func (strategy) Canonicalize(obj runtime.Object) {
 func (strategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	newObj := obj.(*rbac.Role)
 	oldObj := old.(*rbac.Role)
-	errs := validation.ValidateRoleUpdate(newObj, oldObj)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newObj, oldObj, errs, operation.Update)
+	return validation.ValidateRoleUpdate(newObj, oldObj)
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/pkg/registry/rbac/rolebinding/declarative_validation_test.go
+++ b/pkg/registry/rbac/rolebinding/declarative_validation_test.go
@@ -99,7 +99,7 @@ func testDeclarativeValidateForDeclarative(t *testing.T, apiVersion string) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs)
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy, tc.expectedErrs)
 		})
 	}
 }

--- a/pkg/registry/rbac/rolebinding/strategy.go
+++ b/pkg/registry/rbac/rolebinding/strategy.go
@@ -19,7 +19,6 @@ package rolebinding
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -31,13 +30,13 @@ import (
 
 // strategy implements behavior for RoleBindings
 type strategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // strategy is the default logic that applies when creating and updating
 // RoleBinding objects.
-var Strategy = strategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = strategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // Strategy should implement rest.RESTCreateStrategy
 var _ rest.RESTCreateStrategy = Strategy
@@ -72,8 +71,7 @@ func (strategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
 // Validate validates a new RoleBinding. Validation must check for a correct signature.
 func (strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	roleBinding := obj.(*rbac.RoleBinding)
-	allErrs := validation.ValidateRoleBinding(roleBinding)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, roleBinding, nil, allErrs, operation.Create)
+	return validation.ValidateRoleBinding(roleBinding)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -90,9 +88,7 @@ func (strategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) fie
 	newRoleBinding := obj.(*rbac.RoleBinding)
 	oldRoleBinding := old.(*rbac.RoleBinding)
 
-	allErrs := validation.ValidateRoleBindingUpdate(newRoleBinding, oldRoleBinding)
-
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newRoleBinding, oldRoleBinding, allErrs, operation.Update)
+	return validation.ValidateRoleBindingUpdate(newRoleBinding, oldRoleBinding)
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/pkg/registry/resource/deviceclass/declarative_validation_test.go
+++ b/pkg/registry/resource/deviceclass/declarative_validation_test.go
@@ -142,7 +142,7 @@ func TestDeclarativeValidate(t *testing.T) {
 
 			for k, tc := range testCases {
 				t.Run(k, func(t *testing.T) {
-					apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, strategy.Validate, tc.expectedErrs)
+					apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, strategy, tc.expectedErrs)
 				})
 			}
 		})
@@ -247,7 +247,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 				t.Run(k, func(t *testing.T) {
 					tc.old.ResourceVersion = "1"
 					tc.update.ResourceVersion = "1"
-					apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, strategy.ValidateUpdate, tc.expectedErrs)
+					apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, strategy, tc.expectedErrs)
 				})
 			}
 		})

--- a/pkg/registry/resource/deviceclass/strategy.go
+++ b/pkg/registry/resource/deviceclass/strategy.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -34,11 +33,11 @@ import (
 
 // deviceClassStrategy implements behavior for DeviceClass objects
 type deviceClassStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
-var Strategy = deviceClassStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = deviceClassStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 func (deviceClassStrategy) NamespaceScoped() bool {
 	return false
@@ -52,9 +51,7 @@ func (deviceClassStrategy) PrepareForCreate(ctx context.Context, obj runtime.Obj
 
 func (deviceClassStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	deviceClass := obj.(*resource.DeviceClass)
-	errorList := validation.ValidateDeviceClass(deviceClass)
-
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, deviceClass, nil, errorList, operation.Create)
+	return validation.ValidateDeviceClass(deviceClass)
 }
 
 func (deviceClassStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
@@ -83,8 +80,7 @@ func (deviceClassStrategy) PrepareForUpdate(ctx context.Context, obj, old runtim
 func (deviceClassStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	newClass := obj.(*resource.DeviceClass)
 	oldClass := old.(*resource.DeviceClass)
-	errorList := validation.ValidateDeviceClassUpdate(newClass, oldClass)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newClass, oldClass, errorList, operation.Update)
+	return validation.ValidateDeviceClassUpdate(newClass, oldClass)
 }
 
 func (deviceClassStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {

--- a/pkg/registry/resource/devicetaintrule/strategy.go
+++ b/pkg/registry/resource/devicetaintrule/strategy.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/resource"
@@ -33,12 +34,12 @@ import (
 
 // deviceTaintRuleStrategy implements behavior for DeviceTaintRule objects
 type deviceTaintRuleStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 var (
-	Strategy       = &deviceTaintRuleStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+	Strategy       = &deviceTaintRuleStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 	StatusStrategy = &deviceTaintRuleStatusStrategy{deviceTaintRuleStrategy: Strategy}
 )
 

--- a/pkg/registry/resource/resourceclaim/declarative_validation_test.go
+++ b/pkg/registry/resource/resourceclaim/declarative_validation_test.go
@@ -502,7 +502,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 	}
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
-			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs, apitesting.WithNormalizationRules(validation.ResourceNormalizationRules...))
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy, tc.expectedErrs, apitesting.WithNormalizationRules(validation.ResourceNormalizationRules...))
 		})
 	}
 }
@@ -820,7 +820,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 		t.Run(k, func(t *testing.T) {
 			tc.old.ResourceVersion = "1"
 			tc.update.ResourceVersion = "2"
-			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy.ValidateUpdate, tc.expectedErrs, apitesting.WithNormalizationRules(validation.ResourceNormalizationRules...))
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy, tc.expectedErrs, apitesting.WithNormalizationRules(validation.ResourceNormalizationRules...))
 		})
 	}
 }
@@ -1437,7 +1437,7 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 		t.Run(k, func(t *testing.T) {
 			tc.old.ObjectMeta.ResourceVersion = "1"
 			tc.update.ObjectMeta.ResourceVersion = "1"
-			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, strategy.ValidateUpdate, tc.expectedErrs, apitesting.WithSubResources("status"))
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, strategy, tc.expectedErrs, apitesting.WithSubResources("status"))
 		})
 	}
 }

--- a/pkg/registry/resource/resourceclaim/strategy.go
+++ b/pkg/registry/resource/resourceclaim/strategy.go
@@ -22,7 +22,6 @@ import (
 
 	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
 
-	"k8s.io/apimachinery/pkg/api/operation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -49,7 +48,7 @@ import (
 
 // resourceclaimStrategy implements behavior for ResourceClaim objects
 type resourceclaimStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 	nsClient   v1.NamespaceInterface
 	authorizer authorizer.Authorizer
@@ -58,7 +57,7 @@ type resourceclaimStrategy struct {
 // NewStrategy is the default logic that applies when creating and updating ResourceClaim objects.
 func NewStrategy(nsClient v1.NamespaceInterface, authorizer authorizer.Authorizer) *resourceclaimStrategy {
 	return &resourceclaimStrategy{
-		legacyscheme.Scheme,
+		rest.DeclarativeValidation{Scheme: legacyscheme.Scheme},
 		names.SimpleNameGenerator,
 		nsClient,
 		authorizer,
@@ -104,7 +103,23 @@ func (s *resourceclaimStrategy) Validate(ctx context.Context, obj runtime.Object
 
 	allErrs := resourceutils.AuthorizedForAdmin(ctx, claim.Spec.Devices.Requests, claim.Namespace, s.nsClient)
 	allErrs = append(allErrs, validation.ValidateResourceClaim(claim)...)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, claim, nil, allErrs, operation.Create, rest.WithNormalizationRules(validation.ResourceNormalizationRules))
+	return allErrs
+}
+
+// DeclarativeValidationConfig implements rest.DeclarativeValidationConfigurer to supply declarative
+// validation options to the generic BeforeCreate/BeforeUpdate code path.
+//
+// TODO: Behavior drift introduced when wiring declarative validation
+// universally: the status substrategy embeds *resourceclaimStrategy and now
+// inherits this method, so status updates pick up
+// WithNormalizationRules(ResourceNormalizationRules). Previously the
+// pre-migration inline declarative-validation call on the status subresource
+// did NOT pass normalization rules. The change is additive (mismatch
+// comparisons are stricter on status updates) but should be reviewed; if the
+// status subresource should not use these rules, override
+// ValidationConfig on resourceclaimStatusStrategy.
+func (*resourceclaimStrategy) DeclarativeValidationConfig(ctx context.Context, obj, oldObj runtime.Object) rest.DeclarativeValidationConfig {
+	return rest.DeclarativeValidationConfig{NormalizationRules: validation.ResourceNormalizationRules}
 }
 
 func (*resourceclaimStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
@@ -130,8 +145,7 @@ func (s *resourceclaimStrategy) ValidateUpdate(ctx context.Context, obj, old run
 	newClaim := obj.(*resource.ResourceClaim)
 	oldClaim := old.(*resource.ResourceClaim)
 	// AuthorizedForAdmin isn't needed here because the spec is immutable.
-	errorList := validation.ValidateResourceClaimUpdate(newClaim, oldClaim)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newClaim, oldClaim, errorList, operation.Update, rest.WithNormalizationRules(validation.ResourceNormalizationRules))
+	return validation.ValidateResourceClaimUpdate(newClaim, oldClaim)
 }
 
 func (*resourceclaimStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
@@ -209,7 +223,7 @@ func (r *resourceclaimStatusStrategy) ValidateUpdate(ctx context.Context, obj, o
 		}
 	}
 	errs = append(errs, validation.ValidateResourceClaimStatusUpdate(newClaim, oldClaim)...)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newClaim, oldClaim, errs, operation.Update)
+	return errs
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/pkg/registry/resource/resourceclaimtemplate/strategy.go
+++ b/pkg/registry/resource/resourceclaimtemplate/strategy.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -36,7 +37,7 @@ import (
 
 // resourceClaimTemplateStrategy implements behavior for ResourceClaimTemplate objects
 type resourceClaimTemplateStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 	nsClient v1.NamespaceInterface
 }
@@ -44,7 +45,7 @@ type resourceClaimTemplateStrategy struct {
 // NewStrategy is the default logic that applies when creating and updating ResourceClaimTemplate objects.
 func NewStrategy(nsClient v1.NamespaceInterface) *resourceClaimTemplateStrategy {
 	return &resourceClaimTemplateStrategy{
-		legacyscheme.Scheme,
+		rest.DeclarativeValidation{Scheme: legacyscheme.Scheme},
 		names.SimpleNameGenerator,
 		nsClient,
 	}

--- a/pkg/registry/resource/resourcepoolstatusrequest/declarative_validation_test.go
+++ b/pkg/registry/resource/resourcepoolstatusrequest/declarative_validation_test.go
@@ -92,7 +92,7 @@ func TestDeclarativeValidate(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs)
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy, tc.expectedErrs)
 		})
 	}
 }
@@ -129,7 +129,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, Strategy.ValidateUpdate, tc.expectedErrs)
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, Strategy, tc.expectedErrs)
 		})
 	}
 }
@@ -341,7 +341,7 @@ func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, StatusStrategy.ValidateUpdate, tc.expectedErrs)
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, StatusStrategy, tc.expectedErrs)
 		})
 	}
 }

--- a/pkg/registry/resource/resourcepoolstatusrequest/strategy.go
+++ b/pkg/registry/resource/resourcepoolstatusrequest/strategy.go
@@ -19,7 +19,6 @@ package resourcepoolstatusrequest
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/api/operation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -33,12 +32,12 @@ import (
 
 // resourcePoolStatusRequestStrategy implements behavior for ResourcePoolStatusRequest objects
 type resourcePoolStatusRequestStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 var (
-	Strategy       = &resourcePoolStatusRequestStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+	Strategy       = &resourcePoolStatusRequestStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 	StatusStrategy = &resourcePoolStatusRequestStatusStrategy{resourcePoolStatusRequestStrategy: Strategy}
 )
 
@@ -67,8 +66,13 @@ func (*resourcePoolStatusRequestStrategy) PrepareForCreate(ctx context.Context, 
 
 func (*resourcePoolStatusRequestStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	request := obj.(*resource.ResourcePoolStatusRequest)
-	allErrs := validation.ValidateResourcePoolStatusRequest(request)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, obj, nil, allErrs, operation.Create, rest.WithDeclarativeEnforcement())
+	return validation.ValidateResourcePoolStatusRequest(request)
+}
+
+// DeclarativeValidationConfig implements rest.DeclarativeValidationConfigurer to supply declarative
+// validation options to the generic BeforeCreate/BeforeUpdate code path.
+func (*resourcePoolStatusRequestStrategy) DeclarativeValidationConfig(ctx context.Context, obj, oldObj runtime.Object) rest.DeclarativeValidationConfig {
+	return rest.DeclarativeValidationConfig{DeclarativeEnforcement: true}
 }
 
 func (*resourcePoolStatusRequestStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
@@ -90,8 +94,7 @@ func (*resourcePoolStatusRequestStrategy) PrepareForUpdate(ctx context.Context, 
 }
 
 func (*resourcePoolStatusRequestStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
-	allErrs := validation.ValidateResourcePoolStatusRequestUpdate(obj.(*resource.ResourcePoolStatusRequest), old.(*resource.ResourcePoolStatusRequest))
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, obj, old, allErrs, operation.Update, rest.WithDeclarativeEnforcement())
+	return validation.ValidateResourcePoolStatusRequestUpdate(obj.(*resource.ResourcePoolStatusRequest), old.(*resource.ResourcePoolStatusRequest))
 }
 
 func (*resourcePoolStatusRequestStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
@@ -129,8 +132,7 @@ func (*resourcePoolStatusRequestStatusStrategy) PrepareForUpdate(ctx context.Con
 func (r *resourcePoolStatusRequestStatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	newRequest := obj.(*resource.ResourcePoolStatusRequest)
 	oldRequest := old.(*resource.ResourcePoolStatusRequest)
-	allErrs := validation.ValidateResourcePoolStatusRequestStatusUpdate(newRequest, oldRequest)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, obj, old, allErrs, operation.Update, rest.WithDeclarativeEnforcement())
+	return validation.ValidateResourcePoolStatusRequestStatusUpdate(newRequest, oldRequest)
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/pkg/registry/resource/resourceslice/declarative_validation_test.go
+++ b/pkg/registry/resource/resourceslice/declarative_validation_test.go
@@ -240,7 +240,7 @@ func TestDeclarativeValidate(t *testing.T) {
 			for k, tc := range testCases {
 				t.Run(k, func(t *testing.T) {
 					apitesting.VerifyValidationEquivalence(
-						t, ctx, &tc.input, strategy.Validate, tc.expectedErrs,
+						t, ctx, &tc.input, strategy, tc.expectedErrs,
 						apitesting.WithNormalizationRules(validation.ResourceNormalizationRules...),
 						apitesting.WithIgnoreObjectConversionErrors(),
 					)
@@ -459,7 +459,7 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 				t.Run(k, func(t *testing.T) {
 					tc.old.ResourceVersion = "1"
 					tc.update.ResourceVersion = "1"
-					apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, strategy.ValidateUpdate, tc.expectedErrs, apitesting.WithNormalizationRules(validation.ResourceNormalizationRules...))
+					apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, strategy, tc.expectedErrs, apitesting.WithNormalizationRules(validation.ResourceNormalizationRules...))
 				})
 			}
 		})

--- a/pkg/registry/resource/resourceslice/strategy.go
+++ b/pkg/registry/resource/resourceslice/strategy.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -41,11 +40,11 @@ import (
 
 // resourceSliceStrategy implements behavior for ResourceSlice objects
 type resourceSliceStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
-var Strategy = resourceSliceStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = resourceSliceStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 func (resourceSliceStrategy) NamespaceScoped() bool {
 	return false
@@ -60,9 +59,13 @@ func (resourceSliceStrategy) PrepareForCreate(ctx context.Context, obj runtime.O
 
 func (resourceSliceStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	slice := obj.(*resource.ResourceSlice)
-	errorList := validation.ValidateResourceSlice(slice)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, slice, nil, errorList, operation.Create, rest.WithNormalizationRules(validation.ResourceNormalizationRules))
+	return validation.ValidateResourceSlice(slice)
+}
 
+// DeclarativeValidationConfig implements rest.DeclarativeValidationConfigurer to supply declarative
+// validation options to the generic BeforeCreate/BeforeUpdate code path.
+func (resourceSliceStrategy) DeclarativeValidationConfig(ctx context.Context, obj, oldObj runtime.Object) rest.DeclarativeValidationConfig {
+	return rest.DeclarativeValidationConfig{NormalizationRules: validation.ResourceNormalizationRules}
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -98,8 +101,7 @@ func (resourceSliceStrategy) PrepareForUpdate(ctx context.Context, obj, old runt
 }
 
 func (resourceSliceStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
-	errorList := validation.ValidateResourceSliceUpdate(obj.(*resource.ResourceSlice), old.(*resource.ResourceSlice))
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, obj, old, errorList, operation.Update, rest.WithNormalizationRules(validation.ResourceNormalizationRules))
+	return validation.ValidateResourceSliceUpdate(obj.(*resource.ResourceSlice), old.(*resource.ResourceSlice))
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/pkg/registry/scheduling/podgroup/declarative_validation_test.go
+++ b/pkg/registry/scheduling/podgroup/declarative_validation_test.go
@@ -341,7 +341,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				features.GangScheduling:                  tc.enableWorkloadAwarePreemption,
 				features.WorkloadAwarePreemption:         tc.enableWorkloadAwarePreemption,
 			})
-			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, strategy.Validate, tc.expectedErrs, apitesting.WithMinEmulationVersion(version.MustParse("1.36")))
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, strategy, tc.expectedErrs, apitesting.WithMinEmulationVersion(version.MustParse("1.36")))
 		})
 	}
 }
@@ -566,7 +566,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				features.WorkloadAwarePreemption:         tc.enableWorkloadAwarePreemption,
 			})
 			strategy := NewStrategy()
-			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, strategy.ValidateUpdate, tc.expectedErrs, apitesting.WithMinEmulationVersion(version.MustParse("1.36")))
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, strategy, tc.expectedErrs, apitesting.WithMinEmulationVersion(version.MustParse("1.36")))
 		})
 	}
 }
@@ -689,7 +689,7 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
 			strategy := NewStatusStrategy(NewStrategy())
-			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, strategy.ValidateUpdate, tc.expectedErrs)
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, strategy, tc.expectedErrs)
 		})
 	}
 }

--- a/pkg/registry/scheduling/podgroup/strategy.go
+++ b/pkg/registry/scheduling/podgroup/strategy.go
@@ -86,7 +86,7 @@ func (*podGroupStrategy) DeclarativeValidationConfig(ctx context.Context, obj, o
 	if utilfeature.DefaultFeatureGate.Enabled(features.WorkloadAwarePreemption) {
 		opts = append(opts, string(features.WorkloadAwarePreemption))
 	}
-	return rest.DeclarativeValidationConfig{Options: opts}
+	return rest.DeclarativeValidationConfig{Options: opts, DeclarativeEnforcement: true}
 }
 
 func (*podGroupStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {

--- a/pkg/registry/scheduling/podgroup/strategy.go
+++ b/pkg/registry/scheduling/podgroup/strategy.go
@@ -21,7 +21,6 @@ import (
 
 	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
 
-	"k8s.io/apimachinery/pkg/api/operation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -36,14 +35,14 @@ import (
 
 // podGroupStrategy implements behavior for PodGroup objects.
 type podGroupStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // NewStrategy is the default logic that applies when creating and updating PodGroup objects.
 func NewStrategy() *podGroupStrategy {
 	return &podGroupStrategy{
-		legacyscheme.Scheme,
+		rest.DeclarativeValidation{Scheme: legacyscheme.Scheme},
 		names.SimpleNameGenerator,
 	}
 }
@@ -73,7 +72,21 @@ func (*podGroupStrategy) PrepareForCreate(ctx context.Context, obj runtime.Objec
 
 func (*podGroupStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	podGroup := obj.(*scheduling.PodGroup)
-	allErrs := validation.ValidatePodGroup(podGroup)
+	return validation.ValidatePodGroup(podGroup)
+}
+
+// DeclarativeValidationConfig implements rest.DeclarativeValidationConfigurer to supply declarative
+// validation options to the generic BeforeCreate/BeforeUpdate code path.
+//
+// TODO: Behavior drift introduced when wiring declarative validation
+// universally: the status substrategy embeds *podGroupStrategy and now
+// inherits this method, so status updates pick up the full feature-gated
+// options list and rest.WithDeclarativeEnforcement(). Previously the
+// pre-migration inline call on the status subresource only passed
+// WithDeclarativeEnforcement() (no options list). The change is additive but
+// should be reviewed; if the status subresource should not see these
+// options, override ValidationConfig on podGroupStatusStrategy.
+func (*podGroupStrategy) DeclarativeValidationConfig(ctx context.Context, obj, oldObj runtime.Object) rest.DeclarativeValidationConfig {
 	opts := []string{}
 	if utilfeature.DefaultFeatureGate.Enabled(features.TopologyAwareWorkloadScheduling) {
 		opts = append(opts, string(features.TopologyAwareWorkloadScheduling))
@@ -84,7 +97,7 @@ func (*podGroupStrategy) Validate(ctx context.Context, obj runtime.Object) field
 	if utilfeature.DefaultFeatureGate.Enabled(features.WorkloadAwarePreemption) {
 		opts = append(opts, string(features.WorkloadAwarePreemption))
 	}
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, obj, nil, allErrs, operation.Create, rest.WithDeclarativeEnforcement(), rest.WithOptions(opts))
+	return rest.DeclarativeValidationConfig{DeclarativeEnforcement: true, Options: opts}
 }
 
 func (*podGroupStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
@@ -107,22 +120,7 @@ func (*podGroupStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.
 func (*podGroupStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	newPodGroup := obj.(*scheduling.PodGroup)
 	oldPodGroup := old.(*scheduling.PodGroup)
-	allErrs := validation.ValidatePodGroupUpdate(newPodGroup, oldPodGroup)
-	opts := []string{}
-	// Declarative validation will always allow fields to remain unchanged, so if any
-	// of the fields which are covered by these gates are set, we will not re-validate them
-	// (even if the gates are disabled) as long as they do not change values. If a gate
-	// is disabled, they will not be allowed to change values.
-	if utilfeature.DefaultFeatureGate.Enabled(features.TopologyAwareWorkloadScheduling) {
-		opts = append(opts, string(features.TopologyAwareWorkloadScheduling))
-	}
-	if utilfeature.DefaultFeatureGate.Enabled(features.DRAWorkloadResourceClaims) {
-		opts = append(opts, string(features.DRAWorkloadResourceClaims))
-	}
-	if utilfeature.DefaultFeatureGate.Enabled(features.WorkloadAwarePreemption) {
-		opts = append(opts, string(features.WorkloadAwarePreemption))
-	}
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newPodGroup, oldPodGroup, allErrs, operation.Update, rest.WithDeclarativeEnforcement(), rest.WithOptions(opts))
+	return validation.ValidatePodGroupUpdate(newPodGroup, oldPodGroup)
 }
 
 func (*podGroupStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
@@ -166,8 +164,7 @@ func (*podGroupStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old ru
 func (r *podGroupStatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	newPodGroup := obj.(*scheduling.PodGroup)
 	oldPodGroup := old.(*scheduling.PodGroup)
-	errs := validation.ValidatePodGroupStatusUpdate(newPodGroup, oldPodGroup)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, newPodGroup, oldPodGroup, errs, operation.Update, rest.WithDeclarativeEnforcement())
+	return validation.ValidatePodGroupStatusUpdate(newPodGroup, oldPodGroup)
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/pkg/registry/scheduling/podgroup/strategy.go
+++ b/pkg/registry/scheduling/podgroup/strategy.go
@@ -75,17 +75,6 @@ func (*podGroupStrategy) Validate(ctx context.Context, obj runtime.Object) field
 	return validation.ValidatePodGroup(podGroup)
 }
 
-// DeclarativeValidationConfig implements rest.DeclarativeValidationConfigurer to supply declarative
-// validation options to the generic BeforeCreate/BeforeUpdate code path.
-//
-// TODO: Behavior drift introduced when wiring declarative validation
-// universally: the status substrategy embeds *podGroupStrategy and now
-// inherits this method, so status updates pick up the full feature-gated
-// options list and rest.WithDeclarativeEnforcement(). Previously the
-// pre-migration inline call on the status subresource only passed
-// WithDeclarativeEnforcement() (no options list). The change is additive but
-// should be reviewed; if the status subresource should not see these
-// options, override ValidationConfig on podGroupStatusStrategy.
 func (*podGroupStrategy) DeclarativeValidationConfig(ctx context.Context, obj, oldObj runtime.Object) rest.DeclarativeValidationConfig {
 	opts := []string{}
 	if utilfeature.DefaultFeatureGate.Enabled(features.TopologyAwareWorkloadScheduling) {
@@ -97,7 +86,7 @@ func (*podGroupStrategy) DeclarativeValidationConfig(ctx context.Context, obj, o
 	if utilfeature.DefaultFeatureGate.Enabled(features.WorkloadAwarePreemption) {
 		opts = append(opts, string(features.WorkloadAwarePreemption))
 	}
-	return rest.DeclarativeValidationConfig{DeclarativeEnforcement: true, Options: opts}
+	return rest.DeclarativeValidationConfig{Options: opts}
 }
 
 func (*podGroupStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {

--- a/pkg/registry/scheduling/podgroup/strategy_test.go
+++ b/pkg/registry/scheduling/podgroup/strategy_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/api/operation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -268,7 +269,9 @@ func TestStrategyCreate(t *testing.T) {
 
 			strategy := NewStrategy()
 			strategy.PrepareForCreate(ctx, podGroup)
-			if errs := strategy.Validate(ctx, podGroup); len(errs) != 0 {
+			errs := strategy.Validate(ctx, podGroup)
+			errs = strategy.ValidateDeclaratively(ctx, podGroup, nil, errs, operation.Create, strategy.DeclarativeValidationConfig(ctx, podGroup, nil))
+			if len(errs) != 0 {
 				if tc.expectValidationError == "" {
 					t.Fatalf("unexpected error(s): %v", errs)
 				}
@@ -458,7 +461,9 @@ func TestStrategyUpdate(t *testing.T) {
 
 			strategy := NewStrategy()
 			strategy.PrepareForUpdate(ctx, newPodGroup, podGroup)
-			if errs := strategy.ValidateUpdate(ctx, newPodGroup, podGroup); len(errs) != 0 {
+			errs := strategy.ValidateUpdate(ctx, newPodGroup, podGroup)
+			errs = strategy.ValidateDeclaratively(ctx, newPodGroup, podGroup, errs, operation.Update, strategy.DeclarativeValidationConfig(ctx, newPodGroup, podGroup))
+			if len(errs) != 0 {
 				if tc.expectValidationError == "" {
 					t.Fatalf("unexpected error(s): %v", errs)
 				}

--- a/pkg/registry/scheduling/priorityclass/strategy.go
+++ b/pkg/registry/scheduling/priorityclass/strategy.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
@@ -29,12 +30,12 @@ import (
 
 // priorityClassStrategy implements verification logic for PriorityClass.
 type priorityClassStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating PriorityClass objects.
-var Strategy = priorityClassStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = priorityClassStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 // NamespaceScoped returns false because all PriorityClasses are global.
 func (priorityClassStrategy) NamespaceScoped() bool {

--- a/pkg/registry/scheduling/workload/declarative_validation_test.go
+++ b/pkg/registry/scheduling/workload/declarative_validation_test.go
@@ -359,7 +359,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				features.GangScheduling:                  tc.enableWorkloadAwarePreemption,
 				features.WorkloadAwarePreemption:         tc.enableWorkloadAwarePreemption,
 			})
-			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs, apitesting.WithMinEmulationVersion(version.MustParse("1.36")))
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy, tc.expectedErrs, apitesting.WithMinEmulationVersion(version.MustParse("1.36")))
 		})
 	}
 }
@@ -605,7 +605,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				IsResourceRequest: true,
 				Verb:              "update",
 			})
-			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, Strategy.ValidateUpdate, tc.expectedErrs, apitesting.WithMinEmulationVersion(version.MustParse("1.36")))
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, Strategy, tc.expectedErrs, apitesting.WithMinEmulationVersion(version.MustParse("1.36")))
 		})
 	}
 }

--- a/pkg/registry/scheduling/workload/strategy.go
+++ b/pkg/registry/scheduling/workload/strategy.go
@@ -19,7 +19,6 @@ package workload
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -33,12 +32,12 @@ import (
 
 // workloadStrategy implements behavior for Workload objects.
 type workloadStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating Workload objects.
-var Strategy = workloadStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = workloadStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 func (workloadStrategy) NamespaceScoped() bool {
 	return true
@@ -50,7 +49,12 @@ func (workloadStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object
 
 func (workloadStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	workloadScheduling := obj.(*scheduling.Workload)
-	allErrs := validation.ValidateWorkload(workloadScheduling)
+	return validation.ValidateWorkload(workloadScheduling)
+}
+
+// DeclarativeValidationConfig implements rest.DeclarativeValidationConfigurer to supply declarative
+// validation options to the generic BeforeCreate/BeforeUpdate code path.
+func (workloadStrategy) DeclarativeValidationConfig(ctx context.Context, obj, oldObj runtime.Object) rest.DeclarativeValidationConfig {
 	opts := []string{}
 	if utilfeature.DefaultFeatureGate.Enabled(features.TopologyAwareWorkloadScheduling) {
 		opts = append(opts, string(features.TopologyAwareWorkloadScheduling))
@@ -61,7 +65,7 @@ func (workloadStrategy) Validate(ctx context.Context, obj runtime.Object) field.
 	if utilfeature.DefaultFeatureGate.Enabled(features.WorkloadAwarePreemption) {
 		opts = append(opts, string(features.WorkloadAwarePreemption))
 	}
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, obj, nil, allErrs, operation.Create, rest.WithDeclarativeEnforcement(), rest.WithOptions(opts))
+	return rest.DeclarativeValidationConfig{DeclarativeEnforcement: true, Options: opts}
 }
 
 func (workloadStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
@@ -79,22 +83,7 @@ func (workloadStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.O
 }
 
 func (workloadStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
-	allErrs := validation.ValidateWorkloadUpdate(obj.(*scheduling.Workload), old.(*scheduling.Workload))
-	opts := []string{}
-	// Declarative validation will always allow fields to remain unchanged, so if any
-	// of the fields which are covered by these gates are set, we will not re-validate them
-	// (even if the gates are disabled) as long as they do not change values. If a gate
-	// is disabled, they will not be allowed to change values.
-	if utilfeature.DefaultFeatureGate.Enabled(features.TopologyAwareWorkloadScheduling) {
-		opts = append(opts, string(features.TopologyAwareWorkloadScheduling))
-	}
-	if utilfeature.DefaultFeatureGate.Enabled(features.DRAWorkloadResourceClaims) {
-		opts = append(opts, string(features.DRAWorkloadResourceClaims))
-	}
-	if utilfeature.DefaultFeatureGate.Enabled(features.WorkloadAwarePreemption) {
-		opts = append(opts, string(features.WorkloadAwarePreemption))
-	}
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, obj, old, allErrs, operation.Update, rest.WithDeclarativeEnforcement(), rest.WithOptions(opts))
+	return validation.ValidateWorkloadUpdate(obj.(*scheduling.Workload), old.(*scheduling.Workload))
 }
 
 func (workloadStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {

--- a/pkg/registry/scheduling/workload/strategy_test.go
+++ b/pkg/registry/scheduling/workload/strategy_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/api/operation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -243,7 +244,9 @@ func TestStrategyCreate(t *testing.T) {
 			})
 
 			Strategy.PrepareForCreate(ctx, workload)
-			if errs := Strategy.Validate(ctx, workload); len(errs) != 0 {
+			errs := Strategy.Validate(ctx, workload)
+			errs = Strategy.ValidateDeclaratively(ctx, workload, nil, errs, operation.Create, Strategy.DeclarativeValidationConfig(ctx, workload, nil))
+			if len(errs) != 0 {
 				if tc.expectValidationError == "" {
 					t.Fatalf("unexpected error(s): %v", errs)
 				}
@@ -539,7 +542,9 @@ func TestStrategyUpdate(t *testing.T) {
 			newWorkload.ResourceVersion = "4"
 
 			Strategy.PrepareForUpdate(ctx, newWorkload, oldWorkload)
-			if errs := Strategy.ValidateUpdate(ctx, newWorkload, oldWorkload); len(errs) != 0 {
+			errs := Strategy.ValidateUpdate(ctx, newWorkload, oldWorkload)
+			errs = Strategy.ValidateDeclaratively(ctx, newWorkload, oldWorkload, errs, operation.Update, Strategy.DeclarativeValidationConfig(ctx, newWorkload, oldWorkload))
+			if len(errs) != 0 {
 				if tc.expectValidationError == "" {
 					t.Fatalf("unexpected error(s): %v", errs)
 				}

--- a/pkg/registry/storage/csidriver/strategy.go
+++ b/pkg/registry/storage/csidriver/strategy.go
@@ -22,6 +22,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -36,13 +37,13 @@ const (
 
 // csiDriverStrategy implements behavior for CSIDriver objects
 type csiDriverStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating
 // CSIDriver objects via the REST API.
-var Strategy = csiDriverStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = csiDriverStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 func (csiDriverStrategy) NamespaceScoped() bool {
 	return false

--- a/pkg/registry/storage/csinode/strategy.go
+++ b/pkg/registry/storage/csinode/strategy.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/storage"
@@ -29,13 +30,13 @@ import (
 
 // csiNodeStrategy implements behavior for CSINode objects
 type csiNodeStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating
 // CSINode objects via the REST API.
-var Strategy = csiNodeStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = csiNodeStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 func (csiNodeStrategy) NamespaceScoped() bool {
 	return false

--- a/pkg/registry/storage/csistoragecapacity/strategy.go
+++ b/pkg/registry/storage/csistoragecapacity/strategy.go
@@ -22,6 +22,7 @@ import (
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	storageutil "k8s.io/kubernetes/pkg/api/storage"
@@ -31,13 +32,13 @@ import (
 
 // csiStorageCapacityStrategy implements behavior for CSIStorageCapacity objects
 type csiStorageCapacityStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating
 // CSIStorageCapacity objects via the REST API.
-var Strategy = csiStorageCapacityStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = csiStorageCapacityStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 func (csiStorageCapacityStrategy) NamespaceScoped() bool {
 	return true

--- a/pkg/registry/storage/storageclass/declarative_validation_test.go
+++ b/pkg/registry/storage/storageclass/declarative_validation_test.go
@@ -65,7 +65,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 	}
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
-			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs)
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy, tc.expectedErrs)
 		})
 	}
 }
@@ -188,7 +188,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				IsResourceRequest: true,
 				Verb:              "update",
 			})
-			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, Strategy.ValidateUpdate, tc.expectedErrs)
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, Strategy, tc.expectedErrs)
 		})
 	}
 }

--- a/pkg/registry/storage/storageclass/strategy.go
+++ b/pkg/registry/storage/storageclass/strategy.go
@@ -18,7 +18,7 @@ package storageclass
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/api/operation"
+
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,13 +32,13 @@ import (
 
 // storageClassStrategy implements behavior for StorageClass objects
 type storageClassStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating
 // StorageClass objects via the REST API.
-var Strategy = storageClassStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = storageClassStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 func (storageClassStrategy) NamespaceScoped() bool {
 	return false
@@ -50,8 +50,7 @@ func (storageClassStrategy) PrepareForCreate(ctx context.Context, obj runtime.Ob
 
 func (storageClassStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	storageClass := obj.(*storage.StorageClass)
-	allErrs := validation.ValidateStorageClass(storageClass)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, obj, nil, allErrs, operation.Create)
+	return validation.ValidateStorageClass(storageClass)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -74,7 +73,7 @@ func (storageClassStrategy) PrepareForUpdate(ctx context.Context, obj, old runti
 func (storageClassStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	allErrs := validation.ValidateStorageClass(obj.(*storage.StorageClass))
 	allErrs = append(allErrs, validation.ValidateStorageClassUpdate(obj.(*storage.StorageClass), old.(*storage.StorageClass))...)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, obj, old, allErrs, operation.Update)
+	return allErrs
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/pkg/registry/storage/volumeattachment/declarative_validation_test.go
+++ b/pkg/registry/storage/volumeattachment/declarative_validation_test.go
@@ -89,7 +89,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy.Validate, tc.expectedErrs)
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy, tc.expectedErrs)
 		})
 	}
 }
@@ -123,7 +123,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.newInput, &tc.oldInput, Strategy.ValidateUpdate, tc.expectedErrs)
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.newInput, &tc.oldInput, Strategy, tc.expectedErrs)
 		})
 	}
 }

--- a/pkg/registry/storage/volumeattachment/strategy.go
+++ b/pkg/registry/storage/volumeattachment/strategy.go
@@ -18,7 +18,7 @@ package volumeattachment
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/api/operation"
+
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,13 +35,13 @@ import (
 
 // volumeAttachmentStrategy implements behavior for VolumeAttachment objects
 type volumeAttachmentStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating
 // VolumeAttachment objects via the REST API.
-var Strategy = volumeAttachmentStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = volumeAttachmentStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 func (volumeAttachmentStrategy) NamespaceScoped() bool {
 	return false
@@ -67,8 +67,7 @@ func (volumeAttachmentStrategy) PrepareForCreate(ctx context.Context, obj runtim
 
 func (volumeAttachmentStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	volumeAttachment := obj.(*storage.VolumeAttachment)
-	errs := validation.ValidateVolumeAttachment(volumeAttachment)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, obj, nil, errs, operation.Create)
+	return validation.ValidateVolumeAttachment(volumeAttachment)
 }
 
 // WarningsOnCreate returns warnings for the creation of the given object.
@@ -97,8 +96,7 @@ func (volumeAttachmentStrategy) PrepareForUpdate(ctx context.Context, obj, old r
 func (volumeAttachmentStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	newVolumeAttachmentObj := obj.(*storage.VolumeAttachment)
 	oldVolumeAttachmentObj := old.(*storage.VolumeAttachment)
-	allErrs := validation.ValidateVolumeAttachmentUpdate(newVolumeAttachmentObj, oldVolumeAttachmentObj)
-	return rest.ValidateDeclarativelyWithMigrationChecks(ctx, legacyscheme.Scheme, obj, old, allErrs, operation.Update)
+	return validation.ValidateVolumeAttachmentUpdate(newVolumeAttachmentObj, oldVolumeAttachmentObj)
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/pkg/registry/storage/volumeattributesclass/strategy.go
+++ b/pkg/registry/storage/volumeattributesclass/strategy.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/storage"
@@ -29,13 +30,13 @@ import (
 
 // volumeAttributesClassStrategy implements behavior for VolumeAttributesClassStrategy objects
 type volumeAttributesClassStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the default logic that applies when creating and updating
 // VolumeAttributesClass objects via the REST API.
-var Strategy = volumeAttributesClassStrategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = volumeAttributesClassStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 func (volumeAttributesClassStrategy) NamespaceScoped() bool {
 	return false

--- a/pkg/registry/storagemigration/storagemigration/strategy.go
+++ b/pkg/registry/storagemigration/storagemigration/strategy.go
@@ -35,12 +35,12 @@ import (
 
 // strategy implements behavior for ClusterTrustBundles.
 type strategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 }
 
 // Strategy is the create, update, and delete strategy for ClusterTrustBundles.
-var Strategy = strategy{legacyscheme.Scheme, names.SimpleNameGenerator}
+var Strategy = strategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 
 var _ rest.RESTCreateStrategy = Strategy
 var _ rest.RESTUpdateStrategy = Strategy

--- a/pkg/registry/testapigroup/carp/strategy.go
+++ b/pkg/registry/testapigroup/carp/strategy.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -36,7 +37,7 @@ import (
 
 // carpStrategy implements behavior for Carp objects
 type carpStrategy struct {
-	runtime.ObjectTyper
+	rest.DeclarativeValidation
 	names.NameGenerator
 	nsClient v1.NamespaceInterface
 }
@@ -44,7 +45,7 @@ type carpStrategy struct {
 // NewStrategy is the default logic that applies when creating and updating Carp objects.
 func NewStrategy(nsClient v1.NamespaceInterface) *carpStrategy {
 	return &carpStrategy{
-		legacyscheme.Scheme,
+		rest.DeclarativeValidation{Scheme: legacyscheme.Scheme},
 		names.SimpleNameGenerator,
 		nsClient,
 	}

--- a/staging/src/k8s.io/api/admissionregistration/v1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1/generated.proto
@@ -872,6 +872,7 @@ message TypeChecking {
 }
 
 // ValidatingAdmissionPolicy describes the definition of an admission validation policy that accepts or rejects an object without changing it.
+// +k8s:supportsSubresource="/status"
 message ValidatingAdmissionPolicy {
   // metadata is the standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
   // +optional

--- a/staging/src/k8s.io/api/admissionregistration/v1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1/types.go
@@ -139,6 +139,7 @@ const (
 // +k8s:prerelease-lifecycle-gen:introduced=1.30
 
 // ValidatingAdmissionPolicy describes the definition of an admission validation policy that accepts or rejects an object without changing it.
+// +k8s:supportsSubresource="/status"
 type ValidatingAdmissionPolicy struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.

--- a/staging/src/k8s.io/api/admissionregistration/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1alpha1/generated.proto
@@ -594,6 +594,7 @@ message TypeChecking {
 }
 
 // ValidatingAdmissionPolicy describes the definition of an admission validation policy that accepts or rejects an object without changing it.
+// +k8s:supportsSubresource="/status"
 message ValidatingAdmissionPolicy {
   // metadata is the standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
   // +optional

--- a/staging/src/k8s.io/api/admissionregistration/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1alpha1/types.go
@@ -81,6 +81,7 @@ const (
 // +k8s:prerelease-lifecycle-gen:introduced=1.26
 
 // ValidatingAdmissionPolicy describes the definition of an admission validation policy that accepts or rejects an object without changing it.
+// +k8s:supportsSubresource="/status"
 type ValidatingAdmissionPolicy struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/generated.proto
@@ -820,6 +820,7 @@ message TypeChecking {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.28
 // ValidatingAdmissionPolicy describes the definition of an admission validation policy that accepts or rejects an object without changing it.
+// +k8s:supportsSubresource="/status"
 message ValidatingAdmissionPolicy {
   // metadata is the standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
   // +optional

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go
@@ -93,6 +93,7 @@ const (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.28
 // ValidatingAdmissionPolicy describes the definition of an admission validation policy that accepts or rejects an object without changing it.
+// +k8s:supportsSubresource="/status"
 type ValidatingAdmissionPolicy struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.

--- a/staging/src/k8s.io/api/apiserverinternal/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/apiserverinternal/v1alpha1/generated.proto
@@ -55,6 +55,7 @@ message ServerStorageVersion {
 }
 
 // Storage version of a specific resource.
+// +k8s:supportsSubresource="/status"
 message StorageVersion {
   // metadata is the standard object metadata.
   // The name is <group>.<resource>.

--- a/staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/apiserverinternal/v1alpha1/types.go
@@ -25,6 +25,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Storage version of a specific resource.
+// +k8s:supportsSubresource="/status"
 type StorageVersion struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard object metadata.

--- a/staging/src/k8s.io/api/apps/v1/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1/generated.proto
@@ -63,6 +63,7 @@ message ControllerRevisionList {
 }
 
 // DaemonSet represents the configuration of a daemon set.
+// +k8s:supportsSubresource="/status"
 message DaemonSet {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -221,6 +222,7 @@ message DaemonSetUpdateStrategy {
 }
 
 // Deployment enables declarative updates for Pods and ReplicaSets.
+// +k8s:supportsSubresource="/status"
 message Deployment {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -377,6 +379,7 @@ message DeploymentStrategy {
 }
 
 // ReplicaSet ensures that a specified number of pod replicas are running at any given time.
+// +k8s:supportsSubresource="/status"
 message ReplicaSet {
   // If the Labels of a ReplicaSet are empty, they are defaulted to
   // be the same as the Pod(s) that the ReplicaSet manages.
@@ -598,6 +601,7 @@ message RollingUpdateStatefulSetStrategy {
 //
 // The StatefulSet guarantees that a given network identity will always
 // map to the same storage identity.
+// +k8s:supportsSubresource="/status"
 message StatefulSet {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/staging/src/k8s.io/api/apps/v1/types.go
+++ b/staging/src/k8s.io/api/apps/v1/types.go
@@ -46,6 +46,7 @@ const (
 //
 // The StatefulSet guarantees that a given network identity will always
 // map to the same storage identity.
+// +k8s:supportsSubresource="/status"
 type StatefulSet struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -359,6 +360,7 @@ type StatefulSetList struct {
 // +k8s:prerelease-lifecycle-gen:introduced=1.9
 
 // Deployment enables declarative updates for Pods and ReplicaSets.
+// +k8s:supportsSubresource="/status"
 type Deployment struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -762,6 +764,7 @@ type DaemonSetCondition struct {
 // +k8s:prerelease-lifecycle-gen:introduced=1.9
 
 // DaemonSet represents the configuration of a daemon set.
+// +k8s:supportsSubresource="/status"
 type DaemonSet struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -813,6 +816,7 @@ type DaemonSetList struct {
 // +k8s:prerelease-lifecycle-gen:introduced=1.9
 
 // ReplicaSet ensures that a specified number of pod replicas are running at any given time.
+// +k8s:supportsSubresource="/status"
 type ReplicaSet struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/staging/src/k8s.io/api/apps/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta1/generated.proto
@@ -67,6 +67,7 @@ message ControllerRevisionList {
 // DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for
 // more information.
 // Deployment enables declarative updates for Pods and ReplicaSets.
+// +k8s:supportsSubresource="/status"
 message Deployment {
   // Standard object metadata.
   // +optional
@@ -352,6 +353,7 @@ message ScaleStatus {
 //
 // The StatefulSet guarantees that a given network identity will always
 // map to the same storage identity.
+// +k8s:supportsSubresource="/status"
 message StatefulSet {
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;

--- a/staging/src/k8s.io/api/apps/v1beta1/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/types.go
@@ -97,6 +97,7 @@ type Scale struct {
 //
 // The StatefulSet guarantees that a given network identity will always
 // map to the same storage identity.
+// +k8s:supportsSubresource="/status"
 type StatefulSet struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
@@ -403,6 +404,7 @@ type StatefulSetList struct {
 // DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for
 // more information.
 // Deployment enables declarative updates for Pods and ReplicaSets.
+// +k8s:supportsSubresource="/status"
 type Deployment struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata.

--- a/staging/src/k8s.io/api/apps/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta2/generated.proto
@@ -67,6 +67,7 @@ message ControllerRevisionList {
 // DEPRECATED - This group version of DaemonSet is deprecated by apps/v1/DaemonSet. See the release notes for
 // more information.
 // DaemonSet represents the configuration of a daemon set.
+// +k8s:supportsSubresource="/status"
 message DaemonSet {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -227,6 +228,7 @@ message DaemonSetUpdateStrategy {
 // DEPRECATED - This group version of Deployment is deprecated by apps/v1/Deployment. See the release notes for
 // more information.
 // Deployment enables declarative updates for Pods and ReplicaSets.
+// +k8s:supportsSubresource="/status"
 message Deployment {
   // Standard object metadata.
   // +optional
@@ -384,6 +386,7 @@ message DeploymentStrategy {
 // DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1/ReplicaSet. See the release notes for
 // more information.
 // ReplicaSet ensures that a specified number of pod replicas are running at any given time.
+// +k8s:supportsSubresource="/status"
 message ReplicaSet {
   // If the Labels of a ReplicaSet are empty, they are defaulted to
   // be the same as the Pod(s) that the ReplicaSet manages.
@@ -651,6 +654,7 @@ message ScaleStatus {
 //
 // The StatefulSet guarantees that a given network identity will always
 // map to the same storage identity.
+// +k8s:supportsSubresource="/status"
 message StatefulSet {
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;

--- a/staging/src/k8s.io/api/apps/v1beta2/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types.go
@@ -103,6 +103,7 @@ type Scale struct {
 //
 // The StatefulSet guarantees that a given network identity will always
 // map to the same storage identity.
+// +k8s:supportsSubresource="/status"
 type StatefulSet struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
@@ -413,6 +414,7 @@ type StatefulSetList struct {
 // DEPRECATED - This group version of Deployment is deprecated by apps/v1/Deployment. See the release notes for
 // more information.
 // Deployment enables declarative updates for Pods and ReplicaSets.
+// +k8s:supportsSubresource="/status"
 type Deployment struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata.
@@ -821,6 +823,7 @@ type DaemonSetCondition struct {
 // DEPRECATED - This group version of DaemonSet is deprecated by apps/v1/DaemonSet. See the release notes for
 // more information.
 // DaemonSet represents the configuration of a daemon set.
+// +k8s:supportsSubresource="/status"
 type DaemonSet struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -877,6 +880,7 @@ type DaemonSetList struct {
 // DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1/ReplicaSet. See the release notes for
 // more information.
 // ReplicaSet ensures that a specified number of pod replicas are running at any given time.
+// +k8s:supportsSubresource="/status"
 type ReplicaSet struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/staging/src/k8s.io/api/authentication/v1/generated.proto
+++ b/staging/src/k8s.io/api/authentication/v1/generated.proto
@@ -59,6 +59,7 @@ message ExtraValue {
 // SelfSubjectReview contains the user information that the kube-apiserver has about the user making this request.
 // When using impersonation, users will receive the user info of the user being impersonated.  If impersonation or
 // request header authentication is used, any extra keys will have their case ignored and returned as lowercase.
+// +k8s:supportsSubresource="/status"
 message SelfSubjectReview {
   // metadata is standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -134,6 +135,7 @@ message TokenRequestStatus {
 // TokenReview attempts to authenticate a token to a known user.
 // Note: TokenReview requests may be cached by the webhook token authenticator
 // plugin in the kube-apiserver.
+// +k8s:supportsSubresource="/status"
 message TokenReview {
   // metadata is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/staging/src/k8s.io/api/authentication/v1/types.go
+++ b/staging/src/k8s.io/api/authentication/v1/types.go
@@ -50,6 +50,7 @@ const (
 // TokenReview attempts to authenticate a token to a known user.
 // Note: TokenReview requests may be cached by the webhook token authenticator
 // plugin in the kube-apiserver.
+// +k8s:supportsSubresource="/status"
 type TokenReview struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard object's metadata.
@@ -218,6 +219,7 @@ type BoundObjectReference struct {
 // SelfSubjectReview contains the user information that the kube-apiserver has about the user making this request.
 // When using impersonation, users will receive the user info of the user being impersonated.  If impersonation or
 // request header authentication is used, any extra keys will have their case ignored and returned as lowercase.
+// +k8s:supportsSubresource="/status"
 type SelfSubjectReview struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is standard object's metadata.

--- a/staging/src/k8s.io/api/authentication/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/authentication/v1alpha1/generated.proto
@@ -32,6 +32,7 @@ option go_package = "k8s.io/api/authentication/v1alpha1";
 // SelfSubjectReview contains the user information that the kube-apiserver has about the user making this request.
 // When using impersonation, users will receive the user info of the user being impersonated.  If impersonation or
 // request header authentication is used, any extra keys will have their case ignored and returned as lowercase.
+// +k8s:supportsSubresource="/status"
 message SelfSubjectReview {
   // metadata is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/staging/src/k8s.io/api/authentication/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/authentication/v1alpha1/types.go
@@ -30,6 +30,7 @@ import (
 // SelfSubjectReview contains the user information that the kube-apiserver has about the user making this request.
 // When using impersonation, users will receive the user info of the user being impersonated.  If impersonation or
 // request header authentication is used, any extra keys will have their case ignored and returned as lowercase.
+// +k8s:supportsSubresource="/status"
 type SelfSubjectReview struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard object's metadata.

--- a/staging/src/k8s.io/api/authentication/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/authentication/v1beta1/generated.proto
@@ -41,6 +41,7 @@ message ExtraValue {
 // SelfSubjectReview contains the user information that the kube-apiserver has about the user making this request.
 // When using impersonation, users will receive the user info of the user being impersonated.  If impersonation or
 // request header authentication is used, any extra keys will have their case ignored and returned as lowercase.
+// +k8s:supportsSubresource="/status"
 message SelfSubjectReview {
   // metadata is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -62,6 +63,7 @@ message SelfSubjectReviewStatus {
 // TokenReview attempts to authenticate a token to a known user.
 // Note: TokenReview requests may be cached by the webhook token authenticator
 // plugin in the kube-apiserver.
+// +k8s:supportsSubresource="/status"
 message TokenReview {
   // metadata is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/staging/src/k8s.io/api/authentication/v1beta1/types.go
+++ b/staging/src/k8s.io/api/authentication/v1beta1/types.go
@@ -34,6 +34,7 @@ import (
 // TokenReview attempts to authenticate a token to a known user.
 // Note: TokenReview requests may be cached by the webhook token authenticator
 // plugin in the kube-apiserver.
+// +k8s:supportsSubresource="/status"
 type TokenReview struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard object's metadata.
@@ -128,6 +129,7 @@ func (t ExtraValue) String() string {
 // SelfSubjectReview contains the user information that the kube-apiserver has about the user making this request.
 // When using impersonation, users will receive the user info of the user being impersonated.  If impersonation or
 // request header authentication is used, any extra keys will have their case ignored and returned as lowercase.
+// +k8s:supportsSubresource="/status"
 type SelfSubjectReview struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard object's metadata.

--- a/staging/src/k8s.io/api/authorization/v1/generated.proto
+++ b/staging/src/k8s.io/api/authorization/v1/generated.proto
@@ -94,6 +94,7 @@ message LabelSelectorAttributes {
 // LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace.
 // Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions
 // checking.
+// +k8s:supportsSubresource="/status"
 message LocalSubjectAccessReview {
   // metadata is the standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -203,6 +204,7 @@ message ResourceRule {
 // SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a
 // spec.namespace means "in all namespaces".  Self is a special case, because users should always be able
 // to check whether they can perform an action
+// +k8s:supportsSubresource="/status"
 message SelfSubjectAccessReview {
   // metadata is the standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -235,6 +237,7 @@ message SelfSubjectAccessReviewSpec {
 // or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to
 // drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns.
 // SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.
+// +k8s:supportsSubresource="/status"
 message SelfSubjectRulesReview {
   // metadata is the standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -256,6 +259,7 @@ message SelfSubjectRulesReviewSpec {
 }
 
 // SubjectAccessReview checks whether or not a user or group can perform an action.
+// +k8s:supportsSubresource="/status"
 message SubjectAccessReview {
   // metadata is the standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/staging/src/k8s.io/api/authorization/v1/types.go
+++ b/staging/src/k8s.io/api/authorization/v1/types.go
@@ -29,6 +29,7 @@ import (
 // +k8s:prerelease-lifecycle-gen:introduced=1.6
 
 // SubjectAccessReview checks whether or not a user or group can perform an action.
+// +k8s:supportsSubresource="/status"
 type SubjectAccessReview struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard list metadata.
@@ -53,6 +54,7 @@ type SubjectAccessReview struct {
 // SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a
 // spec.namespace means "in all namespaces".  Self is a special case, because users should always be able
 // to check whether they can perform an action
+// +k8s:supportsSubresource="/status"
 type SelfSubjectAccessReview struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard list metadata.
@@ -76,6 +78,7 @@ type SelfSubjectAccessReview struct {
 // LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace.
 // Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions
 // checking.
+// +k8s:supportsSubresource="/status"
 type LocalSubjectAccessReview struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard list metadata.
@@ -269,6 +272,7 @@ type SubjectAccessReviewStatus struct {
 // or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to
 // drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns.
 // SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.
+// +k8s:supportsSubresource="/status"
 type SelfSubjectRulesReview struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard list metadata.

--- a/staging/src/k8s.io/api/authorization/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/authorization/v1beta1/generated.proto
@@ -41,6 +41,7 @@ message ExtraValue {
 // LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace.
 // Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions
 // checking.
+// +k8s:supportsSubresource="/status"
 message LocalSubjectAccessReview {
   // metadata is the standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -150,6 +151,7 @@ message ResourceRule {
 // SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a
 // spec.namespace means "in all namespaces".  Self is a special case, because users should always be able
 // to check whether they can perform an action
+// +k8s:supportsSubresource="/status"
 message SelfSubjectAccessReview {
   // metadata is the standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -182,6 +184,7 @@ message SelfSubjectAccessReviewSpec {
 // or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to
 // drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns.
 // SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.
+// +k8s:supportsSubresource="/status"
 message SelfSubjectRulesReview {
   // metadata is the standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -203,6 +206,7 @@ message SelfSubjectRulesReviewSpec {
 }
 
 // SubjectAccessReview checks whether or not a user or group can perform an action.
+// +k8s:supportsSubresource="/status"
 message SubjectAccessReview {
   // metadata is the standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/staging/src/k8s.io/api/authorization/v1beta1/types.go
+++ b/staging/src/k8s.io/api/authorization/v1beta1/types.go
@@ -32,6 +32,7 @@ import (
 // +k8s:prerelease-lifecycle-gen:replacement=authorization.k8s.io,v1,SubjectAccessReview
 
 // SubjectAccessReview checks whether or not a user or group can perform an action.
+// +k8s:supportsSubresource="/status"
 type SubjectAccessReview struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard list metadata.
@@ -58,6 +59,7 @@ type SubjectAccessReview struct {
 // SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a
 // spec.namespace means "in all namespaces".  Self is a special case, because users should always be able
 // to check whether they can perform an action
+// +k8s:supportsSubresource="/status"
 type SelfSubjectAccessReview struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard list metadata.
@@ -83,6 +85,7 @@ type SelfSubjectAccessReview struct {
 // LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace.
 // Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions
 // checking.
+// +k8s:supportsSubresource="/status"
 type LocalSubjectAccessReview struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard list metadata.
@@ -224,6 +227,7 @@ type SubjectAccessReviewStatus struct {
 // or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to
 // drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns.
 // SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.
+// +k8s:supportsSubresource="/status"
 type SelfSubjectRulesReview struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard list metadata.

--- a/staging/src/k8s.io/api/autoscaling/v1/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v1/generated.proto
@@ -142,6 +142,7 @@ message ExternalMetricStatus {
 }
 
 // configuration of a horizontal pod autoscaler.
+// +k8s:supportsSubresource="/status"
 message HorizontalPodAutoscaler {
   // Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional

--- a/staging/src/k8s.io/api/autoscaling/v1/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v1/types.go
@@ -92,6 +92,7 @@ type HorizontalPodAutoscalerStatus struct {
 // +k8s:prerelease-lifecycle-gen:introduced=1.2
 
 // configuration of a horizontal pod autoscaler.
+// +k8s:supportsSubresource="/status"
 type HorizontalPodAutoscaler struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/staging/src/k8s.io/api/autoscaling/v2/generated.proto
+++ b/staging/src/k8s.io/api/autoscaling/v2/generated.proto
@@ -167,6 +167,7 @@ message HPAScalingRules {
 // HorizontalPodAutoscaler is the configuration for a horizontal pod
 // autoscaler, which automatically manages the replica count of any resource
 // implementing the scale subresource based on the metrics specified.
+// +k8s:supportsSubresource="/status"
 message HorizontalPodAutoscaler {
   // metadata is the standard object metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/staging/src/k8s.io/api/autoscaling/v2/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v2/types.go
@@ -31,6 +31,7 @@ import (
 // HorizontalPodAutoscaler is the configuration for a horizontal pod
 // autoscaler, which automatically manages the replica count of any resource
 // implementing the scale subresource based on the metrics specified.
+// +k8s:supportsSubresource="/status"
 type HorizontalPodAutoscaler struct {
 	metav1.TypeMeta `json:",inline"`
 	// metadata is the standard object metadata.

--- a/staging/src/k8s.io/api/batch/v1/generated.proto
+++ b/staging/src/k8s.io/api/batch/v1/generated.proto
@@ -30,6 +30,7 @@ import "k8s.io/apimachinery/pkg/runtime/schema/generated.proto";
 option go_package = "k8s.io/api/batch/v1";
 
 // CronJob represents the configuration of a single cron job.
+// +k8s:supportsSubresource="/status"
 message CronJob {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -127,6 +128,7 @@ message CronJobStatus {
 }
 
 // Job represents the configuration of a single job.
+// +k8s:supportsSubresource="/status"
 message Job {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/staging/src/k8s.io/api/batch/v1/types.go
+++ b/staging/src/k8s.io/api/batch/v1/types.go
@@ -66,6 +66,7 @@ const (
 // +k8s:prerelease-lifecycle-gen:introduced=1.2
 
 // Job represents the configuration of a single job.
+// +k8s:supportsSubresource="/status"
 type Job struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -677,6 +678,7 @@ type JobTemplateSpec struct {
 // +k8s:prerelease-lifecycle-gen:introduced=1.21
 
 // CronJob represents the configuration of a single cron job.
+// +k8s:supportsSubresource="/status"
 type CronJob struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.

--- a/staging/src/k8s.io/api/batch/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/batch/v1beta1/generated.proto
@@ -31,6 +31,7 @@ import "k8s.io/apimachinery/pkg/runtime/schema/generated.proto";
 option go_package = "k8s.io/api/batch/v1beta1";
 
 // CronJob represents the configuration of a single cron job.
+// +k8s:supportsSubresource="/status"
 message CronJob {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/staging/src/k8s.io/api/batch/v1beta1/types.go
+++ b/staging/src/k8s.io/api/batch/v1beta1/types.go
@@ -43,6 +43,7 @@ type JobTemplateSpec struct {
 // +k8s:prerelease-lifecycle-gen:replacement=batch,v1,CronJob
 
 // CronJob represents the configuration of a single cron job.
+// +k8s:supportsSubresource="/status"
 type CronJob struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.

--- a/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
@@ -282,6 +282,7 @@ message ExtraValue {
 // signer.
 //
 // Kubelets use this API to implement podCertificate projected volumes
+// +k8s:supportsSubresource="/status"
 message PodCertificateRequest {
   // metadata contains the object metadata.
   //

--- a/staging/src/k8s.io/api/certificates/v1beta1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1beta1/types.go
@@ -365,6 +365,7 @@ type ClusterTrustBundleList struct {
 // signer.
 //
 // Kubelets use this API to implement podCertificate projected volumes
+// +k8s:supportsSubresource="/status"
 type PodCertificateRequest struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -2557,6 +2557,7 @@ message NFSVolumeSource {
 
 // Namespace provides a scope for Names.
 // Use of multiple namespaces is optional.
+// +k8s:supportsSubresource="/status"
 message Namespace {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -2634,6 +2635,8 @@ message NamespaceStatus {
 
 // Node is a worker node in Kubernetes.
 // Each node will have a unique identifier in the cache (i.e. in etcd).
+// +k8s:supportsSubresource="/status"
+// +k8s:supportsSubresource="/proxy"
 message Node {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -3135,6 +3138,7 @@ message ObjectReference {
 // PersistentVolume (PV) is a storage resource provisioned by an administrator.
 // It is analogous to a node.
 // More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
+// +k8s:supportsSubresource="/status"
 message PersistentVolume {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -3156,6 +3160,7 @@ message PersistentVolume {
 }
 
 // PersistentVolumeClaim is a user's request for and claim to a persistent volume
+// +k8s:supportsSubresource="/status"
 message PersistentVolumeClaim {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -3675,6 +3680,8 @@ message PhotonPersistentDiskVolumeSource {
 
 // Pod is a collection of containers that can run on a host. This resource is created
 // by clients and scheduled onto hosts.
+// +k8s:supportsSubresource="/status"
+// +k8s:supportsSubresource="/ephemeralcontainers"
 message Pod {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -5548,6 +5555,7 @@ message ResourceHealth {
 }
 
 // ResourceQuota sets aggregate quota restrictions enforced per namespace
+// +k8s:supportsSubresource="/status"
 message ResourceQuota {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -6075,6 +6083,8 @@ message SerializedReference {
 // Service is a named abstraction of software service (for example, mysql) consisting of local port
 // (for example 3306) that the proxy listens on, and the selector that determines which pods
 // will answer requests sent through the proxy.
+// +k8s:supportsSubresource="/status"
+// +k8s:supportsSubresource="/proxy"
 message Service {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -360,6 +360,7 @@ const (
 // PersistentVolume (PV) is a storage resource provisioned by an administrator.
 // It is analogous to a node.
 // More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
+// +k8s:supportsSubresource="/status"
 type PersistentVolume struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -510,6 +511,7 @@ type PersistentVolumeList struct {
 // +k8s:prerelease-lifecycle-gen:introduced=1.0
 
 // PersistentVolumeClaim is a user's request for and claim to a persistent volume
+// +k8s:supportsSubresource="/status"
 type PersistentVolumeClaim struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -5506,6 +5508,8 @@ type PodStatusResult struct {
 
 // Pod is a collection of containers that can run on a host. This resource is created
 // by clients and scheduled onto hosts.
+// +k8s:supportsSubresource="/status"
+// +k8s:supportsSubresource="/ephemeralcontainers"
 type Pod struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -5698,6 +5702,7 @@ type ReplicationControllerCondition struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.0
 // +k8s:supportsSubresource="/scale"
+// +k8s:supportsSubresource="/status"
 
 // ReplicationController represents the configuration of a replication controller.
 type ReplicationController struct {
@@ -6294,6 +6299,8 @@ type ServicePort struct {
 // Service is a named abstraction of software service (for example, mysql) consisting of local port
 // (for example 3306) that the proxy listens on, and the selector that determines which pods
 // will answer requests sent through the proxy.
+// +k8s:supportsSubresource="/status"
+// +k8s:supportsSubresource="/proxy"
 type Service struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -7029,6 +7036,8 @@ type ResourceList map[ResourceName]resource.Quantity
 
 // Node is a worker node in Kubernetes.
 // Each node will have a unique identifier in the cache (i.e. in etcd).
+// +k8s:supportsSubresource="/status"
+// +k8s:supportsSubresource="/proxy"
 type Node struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -7156,6 +7165,7 @@ type NamespaceCondition struct {
 
 // Namespace provides a scope for Names.
 // Use of multiple namespaces is optional.
+// +k8s:supportsSubresource="/status"
 type Namespace struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -7891,6 +7901,7 @@ type ResourceQuotaStatus struct {
 // +k8s:prerelease-lifecycle-gen:introduced=1.0
 
 // ResourceQuota sets aggregate quota restrictions enforced per namespace
+// +k8s:supportsSubresource="/status"
 type ResourceQuota struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.

--- a/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
@@ -33,6 +33,7 @@ option go_package = "k8s.io/api/extensions/v1beta1";
 // DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for
 // more information.
 // DaemonSet represents the configuration of a daemon set.
+// +k8s:supportsSubresource="/status"
 message DaemonSet {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -202,6 +203,7 @@ message DaemonSetUpdateStrategy {
 // DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for
 // more information.
 // Deployment enables declarative updates for Pods and ReplicaSets.
+// +k8s:supportsSubresource="/status"
 message Deployment {
   // Standard object metadata.
   // +optional
@@ -445,6 +447,7 @@ message IPBlock {
 // externally-reachable urls, load balance traffic, terminate SSL, offer name
 // based virtual hosting etc.
 // DEPRECATED - This group version of Ingress is deprecated by networking.k8s.io/v1beta1 Ingress. See the release notes for more information.
+// +k8s:supportsSubresource="/status"
 message Ingress {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -827,6 +830,7 @@ message NetworkPolicySpec {
 // DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1beta2/ReplicaSet. See the release notes for
 // more information.
 // ReplicaSet ensures that a specified number of pod replicas are running at any given time.
+// +k8s:supportsSubresource="/status"
 message ReplicaSet {
   // If the Labels of a ReplicaSet are empty, they are defaulted to
   // be the same as the Pod(s) that the ReplicaSet manages.

--- a/staging/src/k8s.io/api/extensions/v1beta1/types.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types.go
@@ -88,6 +88,7 @@ type Scale struct {
 // DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for
 // more information.
 // Deployment enables declarative updates for Pods and ReplicaSets.
+// +k8s:supportsSubresource="/status"
 type Deployment struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata.
@@ -539,6 +540,7 @@ type DaemonSetCondition struct {
 // DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for
 // more information.
 // DaemonSet represents the configuration of a daemon set.
+// +k8s:supportsSubresource="/status"
 type DaemonSet struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -603,6 +605,7 @@ type DaemonSetList struct {
 // externally-reachable urls, load balance traffic, terminate SSL, offer name
 // based virtual hosting etc.
 // DEPRECATED - This group version of Ingress is deprecated by networking.k8s.io/v1beta1 Ingress. See the release notes for more information.
+// +k8s:supportsSubresource="/status"
 type Ingress struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -914,6 +917,7 @@ type IngressBackend struct {
 // DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1beta2/ReplicaSet. See the release notes for
 // more information.
 // ReplicaSet ensures that a specified number of pod replicas are running at any given time.
+// +k8s:supportsSubresource="/status"
 type ReplicaSet struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/staging/src/k8s.io/api/flowcontrol/v1/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1/generated.proto
@@ -72,6 +72,7 @@ message FlowDistinguisherMethod {
 
 // FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with
 // similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
+// +k8s:supportsSubresource="/status"
 message FlowSchema {
   // `metadata` is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -302,6 +303,7 @@ message PolicyRulesWithSubjects {
 }
 
 // PriorityLevelConfiguration represents the configuration of a priority level.
+// +k8s:supportsSubresource="/status"
 message PriorityLevelConfiguration {
   // `metadata` is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/staging/src/k8s.io/api/flowcontrol/v1/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1/types.go
@@ -110,6 +110,7 @@ const (
 
 // FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with
 // similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
+// +k8s:supportsSubresource="/status"
 type FlowSchema struct {
 	metav1.TypeMeta `json:",inline"`
 	// `metadata` is the standard object's metadata.
@@ -386,6 +387,7 @@ type FlowSchemaConditionType string
 // +k8s:prerelease-lifecycle-gen:introduced=1.29
 
 // PriorityLevelConfiguration represents the configuration of a priority level.
+// +k8s:supportsSubresource="/status"
 type PriorityLevelConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 	// `metadata` is the standard object's metadata.

--- a/staging/src/k8s.io/api/flowcontrol/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta1/generated.proto
@@ -72,6 +72,7 @@ message FlowDistinguisherMethod {
 
 // FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with
 // similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
+// +k8s:supportsSubresource="/status"
 message FlowSchema {
   // `metadata` is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -295,6 +296,7 @@ message PolicyRulesWithSubjects {
 }
 
 // PriorityLevelConfiguration represents the configuration of a priority level.
+// +k8s:supportsSubresource="/status"
 message PriorityLevelConfiguration {
   // `metadata` is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/staging/src/k8s.io/api/flowcontrol/v1beta1/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta1/types.go
@@ -111,6 +111,7 @@ const (
 
 // FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with
 // similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
+// +k8s:supportsSubresource="/status"
 type FlowSchema struct {
 	metav1.TypeMeta `json:",inline"`
 	// `metadata` is the standard object's metadata.
@@ -387,6 +388,7 @@ type FlowSchemaConditionType string
 // +k8s:prerelease-lifecycle-gen:replacement=flowcontrol.apiserver.k8s.io,v1beta3,PriorityLevelConfiguration
 
 // PriorityLevelConfiguration represents the configuration of a priority level.
+// +k8s:supportsSubresource="/status"
 type PriorityLevelConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 	// `metadata` is the standard object's metadata.

--- a/staging/src/k8s.io/api/flowcontrol/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta2/generated.proto
@@ -72,6 +72,7 @@ message FlowDistinguisherMethod {
 
 // FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with
 // similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
+// +k8s:supportsSubresource="/status"
 message FlowSchema {
   // `metadata` is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -295,6 +296,7 @@ message PolicyRulesWithSubjects {
 }
 
 // PriorityLevelConfiguration represents the configuration of a priority level.
+// +k8s:supportsSubresource="/status"
 message PriorityLevelConfiguration {
   // `metadata` is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/staging/src/k8s.io/api/flowcontrol/v1beta2/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta2/types.go
@@ -111,6 +111,7 @@ const (
 
 // FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with
 // similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
+// +k8s:supportsSubresource="/status"
 type FlowSchema struct {
 	metav1.TypeMeta `json:",inline"`
 	// `metadata` is the standard object's metadata.
@@ -387,6 +388,7 @@ type FlowSchemaConditionType string
 // +k8s:prerelease-lifecycle-gen:replacement=flowcontrol.apiserver.k8s.io,v1beta3,PriorityLevelConfiguration
 
 // PriorityLevelConfiguration represents the configuration of a priority level.
+// +k8s:supportsSubresource="/status"
 type PriorityLevelConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 	// `metadata` is the standard object's metadata.

--- a/staging/src/k8s.io/api/flowcontrol/v1beta3/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta3/generated.proto
@@ -72,6 +72,7 @@ message FlowDistinguisherMethod {
 
 // FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with
 // similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
+// +k8s:supportsSubresource="/status"
 message FlowSchema {
   // `metadata` is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -297,6 +298,7 @@ message PolicyRulesWithSubjects {
 }
 
 // PriorityLevelConfiguration represents the configuration of a priority level.
+// +k8s:supportsSubresource="/status"
 message PriorityLevelConfiguration {
   // `metadata` is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/staging/src/k8s.io/api/flowcontrol/v1beta3/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1beta3/types.go
@@ -125,6 +125,7 @@ const (
 
 // FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with
 // similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
+// +k8s:supportsSubresource="/status"
 type FlowSchema struct {
 	metav1.TypeMeta `json:",inline"`
 	// `metadata` is the standard object's metadata.
@@ -403,6 +404,7 @@ type FlowSchemaConditionType string
 // +k8s:prerelease-lifecycle-gen:replacement=flowcontrol.apiserver.k8s.io,v1,PriorityLevelConfiguration
 
 // PriorityLevelConfiguration represents the configuration of a priority level.
+// +k8s:supportsSubresource="/status"
 type PriorityLevelConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 	// `metadata` is the standard object's metadata.

--- a/staging/src/k8s.io/api/imagepolicy/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/imagepolicy/v1alpha1/generated.proto
@@ -29,6 +29,7 @@ import "k8s.io/apimachinery/pkg/runtime/schema/generated.proto";
 option go_package = "k8s.io/api/imagepolicy/v1alpha1";
 
 // ImageReview checks if the set of images in a pod are allowed.
+// +k8s:supportsSubresource="/status"
 message ImageReview {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/staging/src/k8s.io/api/imagepolicy/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/imagepolicy/v1alpha1/types.go
@@ -26,6 +26,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ImageReview checks if the set of images in a pod are allowed.
+// +k8s:supportsSubresource="/status"
 type ImageReview struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.

--- a/staging/src/k8s.io/api/networking/v1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1/generated.proto
@@ -134,6 +134,7 @@ message IPBlock {
 // endpoints defined by a backend. An Ingress can be configured to give services
 // externally-reachable urls, load balance traffic, terminate SSL, offer name
 // based virtual hosting etc.
+// +k8s:supportsSubresource="/status"
 message Ingress {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -630,6 +631,7 @@ message ServiceBackendPort {
 
 // ServiceCIDR defines a range of IP addresses using CIDR format (e.g. 192.168.0.0/24 or 2001:db2::/64).
 // This range is used to allocate ClusterIPs to Service objects.
+// +k8s:supportsSubresource="/status"
 message ServiceCIDR {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -246,6 +246,7 @@ type NetworkPolicyList struct {
 // endpoints defined by a backend. An Ingress can be configured to give services
 // externally-reachable urls, load balance traffic, terminate SSL, offer name
 // based virtual hosting etc.
+// +k8s:supportsSubresource="/status"
 type Ingress struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -722,6 +723,7 @@ type IPAddressList struct {
 
 // ServiceCIDR defines a range of IP addresses using CIDR format (e.g. 192.168.0.0/24 or 2001:db2::/64).
 // This range is used to allocate ClusterIPs to Service objects.
+// +k8s:supportsSubresource="/status"
 type ServiceCIDR struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.

--- a/staging/src/k8s.io/api/networking/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1beta1/generated.proto
@@ -117,6 +117,7 @@ message IPAddressSpec {
 // endpoints defined by a backend. An Ingress can be configured to give services
 // externally-reachable urls, load balance traffic, terminate SSL, offer name
 // based virtual hosting etc.
+// +k8s:supportsSubresource="/status"
 message Ingress {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -419,6 +420,7 @@ message ParentReference {
 
 // ServiceCIDR defines a range of IP addresses using CIDR format (e.g. 192.168.0.0/24 or 2001:db2::/64).
 // This range is used to allocate ClusterIPs to Service objects.
+// +k8s:supportsSubresource="/status"
 message ServiceCIDR {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/staging/src/k8s.io/api/networking/v1beta1/types.go
+++ b/staging/src/k8s.io/api/networking/v1beta1/types.go
@@ -32,6 +32,7 @@ import (
 // endpoints defined by a backend. An Ingress can be configured to give services
 // externally-reachable urls, load balance traffic, terminate SSL, offer name
 // based virtual hosting etc.
+// +k8s:supportsSubresource="/status"
 type Ingress struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -500,6 +501,7 @@ type IPAddressList struct {
 
 // ServiceCIDR defines a range of IP addresses using CIDR format (e.g. 192.168.0.0/24 or 2001:db2::/64).
 // This range is used to allocate ClusterIPs to Service objects.
+// +k8s:supportsSubresource="/status"
 type ServiceCIDR struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.

--- a/staging/src/k8s.io/api/policy/v1/generated.proto
+++ b/staging/src/k8s.io/api/policy/v1/generated.proto
@@ -43,6 +43,7 @@ message Eviction {
 }
 
 // PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
+// +k8s:supportsSubresource="/status"
 message PodDisruptionBudget {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/staging/src/k8s.io/api/policy/v1/types.go
+++ b/staging/src/k8s.io/api/policy/v1/types.go
@@ -174,6 +174,7 @@ const (
 // +k8s:prerelease-lifecycle-gen:introduced=1.21
 
 // PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
+// +k8s:supportsSubresource="/status"
 type PodDisruptionBudget struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.

--- a/staging/src/k8s.io/api/policy/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/policy/v1beta1/generated.proto
@@ -43,6 +43,7 @@ message Eviction {
 }
 
 // PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
+// +k8s:supportsSubresource="/status"
 message PodDisruptionBudget {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/staging/src/k8s.io/api/policy/v1beta1/types.go
+++ b/staging/src/k8s.io/api/policy/v1beta1/types.go
@@ -174,6 +174,7 @@ const (
 // +k8s:prerelease-lifecycle-gen:replacement=policy,v1,PodDisruptionBudget
 
 // PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
+// +k8s:supportsSubresource="/status"
 type PodDisruptionBudget struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/staging/src/k8s.io/api/resource/v1alpha3/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1alpha3/generated.proto
@@ -142,6 +142,7 @@ message DeviceTaint {
 // DeviceTaintRule adds one taint to all devices which match the selector.
 // This has the same effect as if the taint was specified directly
 // in the ResourceSlice by the DRA driver.
+// +k8s:supportsSubresource="/status"
 message DeviceTaintRule {
   // Standard object metadata
   // +optional

--- a/staging/src/k8s.io/api/resource/v1alpha3/types.go
+++ b/staging/src/k8s.io/api/resource/v1alpha3/types.go
@@ -203,6 +203,7 @@ const (
 // DeviceTaintRule adds one taint to all devices which match the selector.
 // This has the same effect as if the taint was specified directly
 // in the ResourceSlice by the DRA driver.
+// +k8s:supportsSubresource="/status"
 type DeviceTaintRule struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata

--- a/staging/src/k8s.io/api/resource/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta2/generated.proto
@@ -1238,6 +1238,7 @@ message DeviceTaint {
 // DeviceTaintRule adds one taint to all devices which match the selector.
 // This has the same effect as if the taint was specified directly
 // in the ResourceSlice by the DRA driver.
+// +k8s:supportsSubresource="/status"
 message DeviceTaintRule {
   // Standard object metadata
   // +optional

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -852,6 +852,7 @@ const (
 // DeviceTaintRule adds one taint to all devices which match the selector.
 // This has the same effect as if the taint was specified directly
 // in the ResourceSlice by the DRA driver.
+// +k8s:supportsSubresource="/status"
 type DeviceTaintRule struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata

--- a/staging/src/k8s.io/api/storagemigration/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/storagemigration/v1beta1/generated.proto
@@ -30,6 +30,7 @@ option go_package = "k8s.io/api/storagemigration/v1beta1";
 
 // StorageVersionMigration represents a migration of stored data to the latest
 // storage version.
+// +k8s:supportsSubresource="/status"
 message StorageVersionMigration {
   // Standard object metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/staging/src/k8s.io/api/storagemigration/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storagemigration/v1beta1/types.go
@@ -27,6 +27,7 @@ import (
 
 // StorageVersionMigration represents a migration of stored data to the latest
 // storage version.
+// +k8s:supportsSubresource="/status"
 type StorageVersionMigration struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata.

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/create.go
@@ -129,7 +129,7 @@ func BeforeCreate(strategy RESTCreateStrategy, ctx context.Context, obj runtime.
 
 	errs := strategy.Validate(ctx, obj)
 	if dv, ok := strategy.(DeclarativeValidationStrategy); ok {
-		errs = dv.ValidateDeclaratively(ctx, obj, nil, errs, operation.Create, declarativeValidationOptions(ctx, strategy, obj))
+		errs = dv.ValidateDeclaratively(ctx, obj, nil, errs, operation.Create, dv.DeclarativeValidationConfig(ctx, obj, nil))
 	}
 	if len(errs) > 0 {
 		return errors.NewInvalid(kind.GroupKind(), objectMeta.GetName(), errs)
@@ -149,14 +149,6 @@ func BeforeCreate(strategy RESTCreateStrategy, ctx context.Context, obj runtime.
 	strategy.Canonicalize(obj)
 
 	return nil
-}
-
-func declarativeValidationOptions(ctx context.Context, strategy RESTCreateStrategy, obj runtime.Object) DeclarativeValidationConfig {
-	var config DeclarativeValidationConfig
-	if vc, ok := strategy.(DeclarativeValidationConfigurer); ok {
-		config = vc.DeclarativeValidationConfig(ctx, obj, nil)
-	}
-	return config
 }
 
 // CheckGeneratedNameError checks whether an error that occurred creating a resource is due

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/create.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/api/validate/content"
 	genericvalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -126,7 +127,11 @@ func BeforeCreate(strategy RESTCreateStrategy, ctx context.Context, obj runtime.
 
 	strategy.PrepareForCreate(ctx, obj)
 
-	if errs := strategy.Validate(ctx, obj); len(errs) > 0 {
+	errs := strategy.Validate(ctx, obj)
+	if dv, ok := strategy.(DeclarativeValidationStrategy); ok {
+		errs = dv.ValidateDeclaratively(ctx, obj, nil, errs, operation.Create, declarativeValidationOptions(ctx, strategy, obj))
+	}
+	if len(errs) > 0 {
 		return errors.NewInvalid(kind.GroupKind(), objectMeta.GetName(), errs)
 	}
 
@@ -144,6 +149,14 @@ func BeforeCreate(strategy RESTCreateStrategy, ctx context.Context, obj runtime.
 	strategy.Canonicalize(obj)
 
 	return nil
+}
+
+func declarativeValidationOptions(ctx context.Context, strategy RESTCreateStrategy, obj runtime.Object) DeclarativeValidationConfig {
+	var config DeclarativeValidationConfig
+	if vc, ok := strategy.(DeclarativeValidationConfigurer); ok {
+		config = vc.DeclarativeValidationConfig(ctx, obj, nil)
+	}
+	return config
 }
 
 // CheckGeneratedNameError checks whether an error that occurred creating a resource is due

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
@@ -153,7 +153,7 @@ func BeforeUpdate(strategy RESTUpdateStrategy, ctx context.Context, obj, old run
 
 	errs = append(errs, strategy.ValidateUpdate(ctx, obj, old)...)
 	if dv, ok := strategy.(DeclarativeValidationStrategy); ok {
-		errs = dv.ValidateDeclaratively(ctx, obj, old, errs, operation.Update, declarativeValidationUpdateOptions(ctx, strategy, obj, old))
+		errs = dv.ValidateDeclaratively(ctx, obj, old, errs, operation.Update, dv.DeclarativeValidationConfig(ctx, obj, old))
 	}
 	if len(errs) > 0 {
 		RecordDuplicateValidationErrors(ctx, kind.GroupKind(), errs)
@@ -167,14 +167,6 @@ func BeforeUpdate(strategy RESTUpdateStrategy, ctx context.Context, obj, old run
 	strategy.Canonicalize(obj)
 
 	return nil
-}
-
-func declarativeValidationUpdateOptions(ctx context.Context, strategy RESTUpdateStrategy, obj, old runtime.Object) DeclarativeValidationConfig {
-	var config DeclarativeValidationConfig
-	if vc, ok := strategy.(DeclarativeValidationConfigurer); ok {
-		config = vc.DeclarativeValidationConfig(ctx, obj, old)
-	}
-	return config
 }
 
 // TransformFunc is a function to transform and return newObj

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/operation"
 	genericvalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -151,6 +152,9 @@ func BeforeUpdate(strategy RESTUpdateStrategy, ctx context.Context, obj, old run
 	}
 
 	errs = append(errs, strategy.ValidateUpdate(ctx, obj, old)...)
+	if dv, ok := strategy.(DeclarativeValidationStrategy); ok {
+		errs = dv.ValidateDeclaratively(ctx, obj, old, errs, operation.Update, declarativeValidationUpdateOptions(ctx, strategy, obj, old))
+	}
 	if len(errs) > 0 {
 		RecordDuplicateValidationErrors(ctx, kind.GroupKind(), errs)
 		return errors.NewInvalid(kind.GroupKind(), objectMeta.GetName(), errs)
@@ -163,6 +167,14 @@ func BeforeUpdate(strategy RESTUpdateStrategy, ctx context.Context, obj, old run
 	strategy.Canonicalize(obj)
 
 	return nil
+}
+
+func declarativeValidationUpdateOptions(ctx context.Context, strategy RESTUpdateStrategy, obj, old runtime.Object) DeclarativeValidationConfig {
+	var config DeclarativeValidationConfig
+	if vc, ok := strategy.(DeclarativeValidationConfigurer); ok {
+		config = vc.DeclarativeValidationConfig(ctx, obj, old)
+	}
+	return config
 }
 
 // TransformFunc is a function to transform and return newObj

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
@@ -63,6 +63,7 @@ type DeclarativeValidation struct {
 
 func (d DeclarativeValidation) ValidateDeclaratively(ctx context.Context, obj, oldObj runtime.Object, validationErrs field.ErrorList, opType operation.Type, config DeclarativeValidationConfig) field.ErrorList {
 	if d.Scheme == nil {
+		validationErrs = append(validationErrs, field.InternalError(nil, fmt.Errorf("cannot validate declaratively without a scheme")))
 		return validationErrs
 	}
 	return ValidateDeclarativelyWithMigrationChecks(ctx, d.Scheme, obj, oldObj, validationErrs, opType, config)
@@ -337,11 +338,9 @@ func createDeclarativeValidationPanicHandler(ctx context.Context, errs *field.Er
 // if shouldFail=false, and adding a validation error if shouldFail=true.
 func panicSafeValidateFunc(
 	validateFunc func(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, o *ValidationConfigOption) field.ErrorList,
-	shouldFail bool, validationIdentifier string,
 ) func(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, o *ValidationConfigOption) field.ErrorList {
 	return func(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, o *ValidationConfigOption) (errs field.ErrorList) {
-		defer createDeclarativeValidationPanicHandler(ctx, &errs, shouldFail, validationIdentifier)()
-
+		defer createDeclarativeValidationPanicHandler(ctx, &errs, o.DeclarativeEnforcement, o.ValidationIdentifier)()
 		return validateFunc(ctx, scheme, obj, oldObj, o)
 	}
 }
@@ -422,7 +421,7 @@ func ValidateDeclarativelyWithMigrationChecks(ctx context.Context, scheme *runti
 
 	// Call the panic-safe wrapper with the real validation function.
 	// We should fail if validation is enforced.
-	declarativeErrs := panicSafeValidateFunc(validateDeclaratively, cfg.DeclarativeEnforcement, cfg.ValidationIdentifier)(ctx, scheme, obj, oldObj, cfg)
+	declarativeErrs := panicSafeValidateFunc(validateDeclaratively)(ctx, scheme, obj, oldObj, cfg)
 
 	if declarativeValidationEnabled {
 		// Log mismatches.

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
@@ -34,57 +34,63 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// ValidationConfig defines how a declarative validation request may be configured.
-type ValidationConfig func(*validationConfigOption)
-
-// WithOptions sets the validation options.
-// Options should contain any validation options that the declarative validation
-// tags expect. These often correspond to feature gates.
-func WithOptions(options []string) ValidationConfig {
-	return func(config *validationConfigOption) {
-		config.options = options
-	}
+// DeclarativeValidationStrategy defines how a strategy may opt-in to declarative validation.
+//
+// When strategies implements ValidateDeclaratively and handwritten validation (Validate / ValidateUpdate),
+// the errors of both are merged and migration checks are performed.
+type DeclarativeValidationStrategy interface {
+	// ValidateDeclaratively runs declarative validation, merges the declarative validation errors with any
+	// validationErrs returned from the strategy's Validate / ValidateUpdate functions (which implement hand-written validation)
+	// and performs migration checks.
+	ValidateDeclaratively(ctx context.Context, obj, oldObj runtime.Object, validationErrs field.ErrorList, opType operation.Type, config DeclarativeValidationConfig) field.ErrorList
 }
 
-// WithSubresourceMapper sets the subresource mapper for validation.
-// This should be used when registering validation for polymorphic subresources like /scale.
+// DeclarativeValidation is an implementation of DeclarativeValidationStrategy that
+// provides a convenient way for a strategy to opt-in to declarative validation.
 //
-// For example, the deployments/scale subresource mapper might map from:
+// For example:
 //
-//	group: apps, version: v1, subresource=scale
+//		type podStrategy struct {
+//		  rest.DeclarativeValidation
+//		  names.NameGenerator
+//		}
+//	    var Strategy = podStrategy{rest.DeclarativeValidation{Scheme: legacyscheme.Scheme}, names.SimpleNameGenerator}
 //
-// to a target of:
-//
-//	group: autoscaling, version: v1, kind=Scale
-//
-// When set, the group version in the requestInfo of the ctx provided to a declarative validation
-// request will be passed to the subresource mapper to find the group version kind of the subresource.
-// Declarative validation will then convert the object to the subresource group version kind and validate it.
-//
-// Note that the target of the mapping contains no subresource part since the mapper is expected to
-// map to the group version kind of the subresource.
-func WithSubresourceMapper(subresourceMapper GroupVersionKindProvider) ValidationConfig {
-	return func(config *validationConfigOption) {
-		config.subresourceGVKMapper = subresourceMapper
-	}
+// Once a strategy opts-in this way, any generated declarative validation code is run automatically.
+type DeclarativeValidation struct {
+	*runtime.Scheme
 }
 
-// WithNormalizationRules sets the normalization rules for validation.
-func WithNormalizationRules(rules []field.NormalizationRule) ValidationConfig {
-	return func(config *validationConfigOption) {
-		config.normalizationRules = rules
-	}
+func (d DeclarativeValidation) ValidateDeclaratively(ctx context.Context, obj, oldObj runtime.Object, validationErrs field.ErrorList, opType operation.Type, config DeclarativeValidationConfig) field.ErrorList {
+	return ValidateDeclarativelyWithMigrationChecks(ctx, d.Scheme, obj, oldObj, validationErrs, opType, config)
 }
 
-// WithDeclarativeEnforcement marks the validation configuration to indicate that it includes
-// declarative validations that should follow the fine-grained Validation Lifecycle.
-// When set, declarative validation is always executed regardless of feature gates.
-// Authority is determined by individual tag prefixes (+k8s:alpha, +k8s:beta) and the
-// DeclarativeValidationBeta safety switch.
-func WithDeclarativeEnforcement() ValidationConfig {
-	return func(config *validationConfigOption) {
-		config.declarativeEnforcement = true
-	}
+// DeclarativeValidationConfigurer defines how a strategy may opt-in to configuration of declarative validation.
+type DeclarativeValidationConfigurer interface {
+	// DeclarativeValidationConfig configures declarative validation for a single request.
+	DeclarativeValidationConfig(ctx context.Context, obj, oldObj runtime.Object) DeclarativeValidationConfig
+}
+
+// DeclarativeValidationConfig holds configuration for declarative validation.
+// Strategies that need to customize declarative validation behavior implement
+// DeclarativeValidationConfigurer and return this struct.
+type DeclarativeValidationConfig struct {
+	// Options contains validation options that declarative validation tags
+	// expect. These often correspond to feature gates.
+	Options []string
+
+	// DeclarativeEnforcement indicates that declarative validations should
+	// follow the fine-grained Validation Lifecycle. When set, declarative
+	// validation is always executed regardless of feature gates.
+	DeclarativeEnforcement bool
+
+	// NormalizationRules are applied to field paths when comparing
+	// handwritten and declarative validation errors.
+	NormalizationRules []field.NormalizationRule
+
+	// SubresourceGVKMapper maps a subresource request to the GVK of the
+	// subresource type for polymorphic subresources like /scale.
+	SubresourceGVKMapper GroupVersionKindProvider
 }
 
 type allDeclarativeEnforcedKeyType struct{}
@@ -100,13 +106,12 @@ func WithAllDeclarativeEnforcedForTest(ctx context.Context) context.Context {
 	return context.WithValue(ctx, allDeclarativeEnforcedKey, true)
 }
 
-type validationConfigOption struct {
-	opType                 operation.Type
-	options                []string
-	subresourceGVKMapper   GroupVersionKindProvider
-	validationIdentifier   string
-	normalizationRules     []field.NormalizationRule
-	declarativeEnforcement bool
+// ValidationConfigOption is the internal configuration used by
+// ValidateDeclarativelyWithMigrationChecks. It is exported for use in tests.
+type ValidationConfigOption struct {
+	OpType               operation.Type
+	ValidationIdentifier string
+	DeclarativeValidationConfig
 }
 
 // validateDeclaratively validates obj and oldObj against declarative
@@ -121,9 +126,9 @@ type validationConfigOption struct {
 // Returns a field.ErrorList containing any validation errors. An internal error
 // is included if requestInfo is missing from the context or if version
 // conversion fails.
-func validateDeclaratively(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, o *validationConfigOption) field.ErrorList {
+func validateDeclaratively(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, o *ValidationConfigOption) field.ErrorList {
 	// Find versionedGroupVersion, which identifies the API version to use for declarative validation.
-	versionedGroupVersion, subresources, err := requestInfo(ctx, o.subresourceGVKMapper)
+	versionedGroupVersion, subresources, err := requestInfo(ctx, o.SubresourceGVKMapper)
 	if err != nil {
 		return field.ErrorList{field.InternalError(nil, err)}
 	}
@@ -133,17 +138,17 @@ func validateDeclaratively(ctx context.Context, scheme *runtime.Scheme, obj, old
 	}
 	var versionedOldObj runtime.Object
 
-	switch o.opType {
+	switch o.OpType {
 	case operation.Create:
-		return scheme.Validate(ctx, o.options, versionedObj, subresources...)
+		return scheme.Validate(ctx, o.Options, versionedObj, subresources...)
 	case operation.Update:
 		versionedOldObj, err = scheme.ConvertToVersion(oldObj, versionedGroupVersion)
 		if err != nil {
 			return field.ErrorList{field.InternalError(nil, fmt.Errorf("unexpected error converting to versioned type: %w", err))}
 		}
-		return scheme.ValidateUpdate(ctx, o.options, versionedObj, versionedOldObj, subresources...)
+		return scheme.ValidateUpdate(ctx, o.Options, versionedObj, versionedOldObj, subresources...)
 	default:
-		return field.ErrorList{field.InternalError(nil, fmt.Errorf("unknown operation type: %v", o.opType))}
+		return field.ErrorList{field.InternalError(nil, fmt.Errorf("unknown operation type: %v", o.OpType))}
 	}
 }
 
@@ -328,10 +333,10 @@ func createDeclarativeValidationPanicHandler(ctx context.Context, errs *field.Er
 // incrementing the panic metric, and logging an error message
 // if shouldFail=false, and adding a validation error if shouldFail=true.
 func panicSafeValidateFunc(
-	validateFunc func(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, o *validationConfigOption) field.ErrorList,
+	validateFunc func(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, o *ValidationConfigOption) field.ErrorList,
 	shouldFail bool, validationIdentifier string,
-) func(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, o *validationConfigOption) field.ErrorList {
-	return func(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, o *validationConfigOption) (errs field.ErrorList) {
+) func(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, o *ValidationConfigOption) field.ErrorList {
+	return func(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, o *ValidationConfigOption) (errs field.ErrorList) {
 		defer createDeclarativeValidationPanicHandler(ctx, &errs, shouldFail, validationIdentifier)()
 
 		return validateFunc(ctx, scheme, obj, oldObj, o)
@@ -387,7 +392,7 @@ func metricIdentifier(ctx context.Context, scheme *runtime.Scheme, obj runtime.O
 //
 // For testing purposes, WithAllDeclarativeEnforcedForTest can be used to enforce all declarative validations
 // regardless of feature gates and filter all covered handwritten validations.
-func ValidateDeclarativelyWithMigrationChecks(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, errs field.ErrorList, opType operation.Type, configOpts ...ValidationConfig) field.ErrorList {
+func ValidateDeclarativelyWithMigrationChecks(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, errs field.ErrorList, opType operation.Type, config DeclarativeValidationConfig) field.ErrorList {
 	declarativeValidationEnabled := utilfeature.DefaultFeatureGate.Enabled(features.DeclarativeValidation)
 	betaEnabled := utilfeature.DefaultFeatureGate.Enabled(features.DeclarativeValidationBeta)
 	// allDeclarativeEnforced indicates that we should check all declarative errors for testing purposes.
@@ -401,22 +406,20 @@ func ValidateDeclarativelyWithMigrationChecks(ctx context.Context, scheme *runti
 	}
 
 	// Directly create the config and call the core validation logic.
-	cfg := &validationConfigOption{
-		opType:               opType,
-		validationIdentifier: validationIdentifier,
-	}
-	for _, opt := range configOpts {
-		opt(cfg)
+	cfg := &ValidationConfigOption{
+		OpType:                      opType,
+		ValidationIdentifier:        validationIdentifier,
+		DeclarativeValidationConfig: config,
 	}
 
 	// Short-circuit if neither DeclarativeValidation is enabled nor the object is explicitly configured for declarative enforcement.
-	if !declarativeValidationEnabled && !cfg.declarativeEnforcement && !allDeclarativeEnforced {
+	if !declarativeValidationEnabled && !cfg.DeclarativeEnforcement && !allDeclarativeEnforced {
 		return errs
 	}
 
 	// Call the panic-safe wrapper with the real validation function.
 	// We should fail if validation is enforced.
-	declarativeErrs := panicSafeValidateFunc(validateDeclaratively, cfg.declarativeEnforcement, cfg.validationIdentifier)(ctx, scheme, obj, oldObj, cfg)
+	declarativeErrs := panicSafeValidateFunc(validateDeclaratively, cfg.DeclarativeEnforcement, cfg.ValidationIdentifier)(ctx, scheme, obj, oldObj, cfg)
 
 	if declarativeValidationEnabled {
 		// Log mismatches.
@@ -424,7 +427,7 @@ func ValidateDeclarativelyWithMigrationChecks(ctx context.Context, scheme *runti
 		// and may not have handwritten counterparts (e.g., in new APIs).
 		// We only mismatch check Alpha and Beta errors in this mode.
 		mismatchCandidateErrs := declarativeErrs
-		if cfg.declarativeEnforcement {
+		if cfg.DeclarativeEnforcement {
 			mismatchCandidateErrs = nil
 			for _, err := range declarativeErrs {
 				if err.IsAlpha() || err.IsBeta() {
@@ -434,10 +437,10 @@ func ValidateDeclarativelyWithMigrationChecks(ctx context.Context, scheme *runti
 		}
 
 		// We pass betaEnabled (and enforcement) as the takeover flag to avoid changing logic elsewhere for now.
-		compareDeclarativeErrorsAndEmitMismatches(ctx, errs, mismatchCandidateErrs, cfg.declarativeEnforcement && betaEnabled, validationIdentifier, cfg.normalizationRules)
+		compareDeclarativeErrorsAndEmitMismatches(ctx, errs, mismatchCandidateErrs, cfg.DeclarativeEnforcement && betaEnabled, validationIdentifier, cfg.NormalizationRules)
 	}
 
-	if !cfg.declarativeEnforcement && !allDeclarativeEnforced {
+	if !cfg.DeclarativeEnforcement && !allDeclarativeEnforced {
 		// If enforcement is not enabled, we shadow declarative errors with hand-written ones, so we return early here.
 		return errs
 	}

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
@@ -43,6 +43,9 @@ type DeclarativeValidationStrategy interface {
 	// validationErrs returned from the strategy's Validate / ValidateUpdate functions (which implement hand-written validation)
 	// and performs migration checks.
 	ValidateDeclaratively(ctx context.Context, obj, oldObj runtime.Object, validationErrs field.ErrorList, opType operation.Type, config DeclarativeValidationConfig) field.ErrorList
+
+	// DeclarativeValidationConfig configures declarative validation for a single request.
+	DeclarativeValidationConfig(ctx context.Context, obj, oldObj runtime.Object) DeclarativeValidationConfig
 }
 
 // DeclarativeValidation is an implementation of DeclarativeValidationStrategy that
@@ -69,10 +72,9 @@ func (d DeclarativeValidation) ValidateDeclaratively(ctx context.Context, obj, o
 	return ValidateDeclarativelyWithMigrationChecks(ctx, d.Scheme, obj, oldObj, validationErrs, opType, config)
 }
 
-// DeclarativeValidationConfigurer defines how a strategy may opt-in to configuration of declarative validation.
-type DeclarativeValidationConfigurer interface {
-	// DeclarativeValidationConfig configures declarative validation for a single request.
-	DeclarativeValidationConfig(ctx context.Context, obj, oldObj runtime.Object) DeclarativeValidationConfig
+func (d DeclarativeValidation) DeclarativeValidationConfig(ctx context.Context, obj, oldObj runtime.Object) DeclarativeValidationConfig {
+	// The zero value of DeclarativeValidationConfig is the default.
+	return DeclarativeValidationConfig{}
 }
 
 // DeclarativeValidationConfig holds configuration for declarative validation.
@@ -335,7 +337,6 @@ func createDeclarativeValidationPanicHandler(ctx context.Context, errs *field.Er
 // panicSafeValidateFunc wraps an validation function with panic recovery logic.
 // The returned function will execute the wrapped function and handle any panics by
 // incrementing the panic metric, and logging an error message
-// if shouldFail=false, and adding a validation error if shouldFail=true.
 func panicSafeValidateFunc(
 	validateFunc func(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, o *ValidationConfigOption) field.ErrorList,
 ) func(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, o *ValidationConfigOption) field.ErrorList {

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
@@ -62,6 +62,9 @@ type DeclarativeValidation struct {
 }
 
 func (d DeclarativeValidation) ValidateDeclaratively(ctx context.Context, obj, oldObj runtime.Object, validationErrs field.ErrorList, opType operation.Type, config DeclarativeValidationConfig) field.ErrorList {
+	if d.Scheme == nil {
+		return validationErrs
+	}
 	return ValidateDeclarativelyWithMigrationChecks(ctx, d.Scheme, obj, oldObj, validationErrs, opType, config)
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
@@ -167,16 +167,16 @@ func TestValidateDeclaratively(t *testing.T) {
 		})
 		t.Run(tc.name, func(t *testing.T) {
 
-			cfg := &validationConfigOption{
-				options: tc.options,
+			cfg := &ValidationConfigOption{
+				DeclarativeValidationConfig: DeclarativeValidationConfig{Options: tc.options},
 			}
 			if tc.oldObject == nil {
-				cfg.opType = operation.Create
+				cfg.OpType = operation.Create
 			} else {
-				cfg.opType = operation.Update
+				cfg.OpType = operation.Update
 			}
 			// takeover is not used here, passing false for shouldFail
-			results := panicSafeValidateFunc(validateDeclaratively, false, cfg.validationIdentifier)(ctx, scheme, tc.object, tc.oldObject, cfg)
+			results := panicSafeValidateFunc(validateDeclaratively, false, cfg.ValidationIdentifier)(ctx, scheme, tc.object, tc.oldObject, cfg)
 			matcher := field.ErrorMatcher{}.ByType().ByField().ByOrigin()
 			matcher.Test(t, tc.expected, results)
 		})
@@ -445,14 +445,14 @@ func TestWithRecover(t *testing.T) {
 
 	testCases := []struct {
 		name               string
-		validateFn         func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *validationConfigOption) field.ErrorList
+		validateFn         func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList
 		enforcementEnabled bool
 		wantErrs           field.ErrorList
 		expectLogRegex     string
 	}{
 		{
 			name: "no panic",
-			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *validationConfigOption) field.ErrorList {
+			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList {
 				return field.ErrorList{
 					field.Invalid(field.NewPath("field"), "value", "reason"),
 				}
@@ -465,7 +465,7 @@ func TestWithRecover(t *testing.T) {
 		},
 		{
 			name: "panic with enforcement disabled",
-			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *validationConfigOption) field.ErrorList {
+			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList {
 				panic("test panic")
 			},
 			enforcementEnabled: false,
@@ -475,7 +475,7 @@ func TestWithRecover(t *testing.T) {
 		},
 		{
 			name: "panic with enforcement enabled",
-			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *validationConfigOption) field.ErrorList {
+			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList {
 				panic("test panic")
 			},
 			enforcementEnabled: true,
@@ -486,7 +486,7 @@ func TestWithRecover(t *testing.T) {
 		},
 		{
 			name: "nil return, no panic",
-			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *validationConfigOption) field.ErrorList {
+			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList {
 				return nil
 			},
 			enforcementEnabled: false,
@@ -504,7 +504,7 @@ func TestWithRecover(t *testing.T) {
 
 			// Pass the enforcement flag to panicSafeValidateFunc
 			wrapped := panicSafeValidateFunc(tc.validateFn, tc.enforcementEnabled, "test_validationIdentifier")
-			gotErrs := wrapped(ctx, scheme, obj, nil, &validationConfigOption{opType: operation.Create, options: options})
+			gotErrs := wrapped(ctx, scheme, obj, nil, &ValidationConfigOption{OpType: operation.Create, DeclarativeValidationConfig: DeclarativeValidationConfig{Options: options}})
 
 			klog.Flush()
 			logOutput := buf.String()
@@ -539,14 +539,14 @@ func TestWithRecoverUpdate(t *testing.T) {
 
 	testCases := []struct {
 		name               string
-		validateFn         func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *validationConfigOption) field.ErrorList
+		validateFn         func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList
 		enforcementEnabled bool
 		wantErrs           field.ErrorList
 		expectLogRegex     string
 	}{
 		{
 			name: "no panic",
-			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *validationConfigOption) field.ErrorList {
+			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList {
 				return field.ErrorList{
 					field.Invalid(field.NewPath("field"), "value", "reason"),
 				}
@@ -559,7 +559,7 @@ func TestWithRecoverUpdate(t *testing.T) {
 		},
 		{
 			name: "panic with enforcement disabled",
-			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *validationConfigOption) field.ErrorList {
+			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList {
 				panic("test update panic")
 			},
 			enforcementEnabled: false,
@@ -569,7 +569,7 @@ func TestWithRecoverUpdate(t *testing.T) {
 		},
 		{
 			name: "panic with enforcement enabled",
-			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *validationConfigOption) field.ErrorList {
+			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList {
 				panic("test update panic")
 			},
 			enforcementEnabled: true,
@@ -580,7 +580,7 @@ func TestWithRecoverUpdate(t *testing.T) {
 		},
 		{
 			name: "nil return, no panic",
-			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *validationConfigOption) field.ErrorList {
+			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList {
 				return nil
 			},
 			enforcementEnabled: false,
@@ -598,7 +598,7 @@ func TestWithRecoverUpdate(t *testing.T) {
 
 			// Pass the enforcement flag to panicSafeValidateUpdateFunc
 			wrapped := panicSafeValidateFunc(tc.validateFn, tc.enforcementEnabled, "test_validationIdentifier")
-			gotErrs := wrapped(ctx, scheme, obj, oldObj, &validationConfigOption{opType: operation.Update, options: options})
+			gotErrs := wrapped(ctx, scheme, obj, oldObj, &ValidationConfigOption{OpType: operation.Update, DeclarativeValidationConfig: DeclarativeValidationConfig{Options: options}})
 
 			klog.Flush()
 			logOutput := buf.String()
@@ -932,12 +932,11 @@ func TestValidateDeclarativelyWithMigrationChecks(t *testing.T) {
 			inputErrs := make(field.ErrorList, len(tc.imperativeErrors))
 			copy(inputErrs, tc.imperativeErrors)
 
-			opts := []ValidationConfig{}
-			if tc.declarativeEnforcement {
-				opts = append(opts, WithDeclarativeEnforcement())
+			config := DeclarativeValidationConfig{
+				DeclarativeEnforcement: tc.declarativeEnforcement,
 			}
 
-			gotErrs := ValidateDeclarativelyWithMigrationChecks(ctx, localScheme, obj, nil, inputErrs, operation.Create, opts...)
+			gotErrs := ValidateDeclarativelyWithMigrationChecks(ctx, localScheme, obj, nil, inputErrs, operation.Create, config)
 
 			if !equalErrorLists(gotErrs, tc.expectedErrors) {
 				t.Errorf("Expected errors: %v, got: %v", tc.expectedErrors, gotErrs)

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
@@ -175,7 +175,6 @@ func TestValidateDeclaratively(t *testing.T) {
 			} else {
 				cfg.OpType = operation.Update
 			}
-			// takeover is not used here, passing false for shouldFail
 			results := panicSafeValidateFunc(validateDeclaratively)(ctx, scheme, tc.object, tc.oldObject, cfg)
 			matcher := field.ErrorMatcher{}.ByType().ByField().ByOrigin()
 			matcher.Test(t, tc.expected, results)
@@ -502,7 +501,6 @@ func TestWithRecover(t *testing.T) {
 			klog.LogToStderr(false)
 			defer klog.LogToStderr(true)
 
-			// Pass the enforcement flag to panicSafeValidateFunc
 			wrapped := panicSafeValidateFunc(tc.validateFn)
 			gotErrs := wrapped(ctx, scheme, obj, nil, &ValidationConfigOption{ValidationIdentifier: "test_validationIdentifier", OpType: operation.Create, DeclarativeValidationConfig: DeclarativeValidationConfig{Options: options, DeclarativeEnforcement: tc.enforcementEnabled}})
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
@@ -176,7 +176,7 @@ func TestValidateDeclaratively(t *testing.T) {
 				cfg.OpType = operation.Update
 			}
 			// takeover is not used here, passing false for shouldFail
-			results := panicSafeValidateFunc(validateDeclaratively, false, cfg.ValidationIdentifier)(ctx, scheme, tc.object, tc.oldObject, cfg)
+			results := panicSafeValidateFunc(validateDeclaratively)(ctx, scheme, tc.object, tc.oldObject, cfg)
 			matcher := field.ErrorMatcher{}.ByType().ByField().ByOrigin()
 			matcher.Test(t, tc.expected, results)
 		})
@@ -503,8 +503,8 @@ func TestWithRecover(t *testing.T) {
 			defer klog.LogToStderr(true)
 
 			// Pass the enforcement flag to panicSafeValidateFunc
-			wrapped := panicSafeValidateFunc(tc.validateFn, tc.enforcementEnabled, "test_validationIdentifier")
-			gotErrs := wrapped(ctx, scheme, obj, nil, &ValidationConfigOption{OpType: operation.Create, DeclarativeValidationConfig: DeclarativeValidationConfig{Options: options}})
+			wrapped := panicSafeValidateFunc(tc.validateFn)
+			gotErrs := wrapped(ctx, scheme, obj, nil, &ValidationConfigOption{ValidationIdentifier: "test_validationIdentifier", OpType: operation.Create, DeclarativeValidationConfig: DeclarativeValidationConfig{Options: options, DeclarativeEnforcement: tc.enforcementEnabled}})
 
 			klog.Flush()
 			logOutput := buf.String()
@@ -597,8 +597,8 @@ func TestWithRecoverUpdate(t *testing.T) {
 			defer klog.LogToStderr(true)
 
 			// Pass the enforcement flag to panicSafeValidateUpdateFunc
-			wrapped := panicSafeValidateFunc(tc.validateFn, tc.enforcementEnabled, "test_validationIdentifier")
-			gotErrs := wrapped(ctx, scheme, obj, oldObj, &ValidationConfigOption{OpType: operation.Update, DeclarativeValidationConfig: DeclarativeValidationConfig{Options: options}})
+			wrapped := panicSafeValidateFunc(tc.validateFn)
+			gotErrs := wrapped(ctx, scheme, obj, oldObj, &ValidationConfigOption{ValidationIdentifier: "test_validationIdentifier", OpType: operation.Update, DeclarativeValidationConfig: DeclarativeValidationConfig{Options: options, DeclarativeEnforcement: tc.enforcementEnabled}})
 
 			klog.Flush()
 			logOutput := buf.String()


### PR DESCRIPTION
#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:

- Strategies can now opt-in to declarative validation, eliminating the need to write special code in `Validation` and `ValidationUpdate` functions to enable DV.
- Add a cross-cutting test to verify that all strategies in the kubernetes codebase opt-in to declarative validation.
- Migrate all strategies so that the cross-cutting test passes.

Other notes:

- This does not enable code generation for all APIs.  DV will effectively be a no-op for APIs without validation codegen.
- This is part of a larger set of changes to make it impossible to have DV tags in types.go files that are ignored by validation


#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

- This only covers the core apiserver, the apiextensions server will be handled in a separate PR

#### Does this PR introduce a user-facing change?

No. This change is a no-op from a user perspective.

```release-note
NONE
```