### PR TITLE
Add --load-restrictor flag for kubectl commands supporting -k

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/filename_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/filename_flags.go
@@ -32,9 +32,10 @@ import (
 type FileNameFlags struct {
 	Usage string
 
-	Filenames *[]string
-	Kustomize *string
-	Recursive *bool
+	Filenames        *[]string
+	Kustomize        *string
+	Recursive        *bool
+	LoadRestrictions *string
 }
 
 // ToOptions creates a new FileNameOptions struct and sets FilenameOptions based on FileNameflags
@@ -53,6 +54,9 @@ func (o *FileNameFlags) ToOptions() resource.FilenameOptions {
 	}
 	if o.Kustomize != nil {
 		options.Kustomize = *o.Kustomize
+	}
+	if o.LoadRestrictions != nil {
+		options.LoadRestrictions = *o.LoadRestrictions
 	}
 
 	return options
@@ -78,5 +82,23 @@ func (o *FileNameFlags) AddFlags(flags *pflag.FlagSet) {
 	if o.Kustomize != nil {
 		flags.StringVarP(o.Kustomize, "kustomize", "k", *o.Kustomize,
 			"Process a kustomization directory. This flag can't be used together with -f or -R.")
+	}
+	if o.LoadRestrictions != nil {
+		flags.StringVar(o.LoadRestrictions, "load-restrictor", *o.LoadRestrictions,
+			"if set to 'LoadRestrictionsNone', local kustomizations may load files from outside their root. "+
+				"This does, however, break the relocatability of the kustomization.")
+	}
+}
+
+// AddFlagCompletions registers shell completions for the flags. Must be called
+// after AddFlags and requires access to the cobra.Command.
+func (o *FileNameFlags) AddFlagCompletions(cmd *cobra.Command) {
+	if o == nil {
+		return
+	}
+	if o.LoadRestrictions != nil {
+		cmd.RegisterFlagCompletionFunc("load-restrictor", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return []string{"LoadRestrictionsNone", "LoadRestrictionsRootOnly"}, cobra.ShellCompDirectiveNoFileComp
+		})
 	}
 }

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -142,9 +142,10 @@ func IsUsageError(err error) bool {
 }
 
 type FilenameOptions struct {
-	Filenames []string
-	Kustomize string
-	Recursive bool
+	Filenames        []string
+	Kustomize        string
+	Recursive        bool
+	LoadRestrictions string
 }
 
 func (o *FilenameOptions) validate() []error {
@@ -286,10 +287,11 @@ func (b *Builder) FilenameParam(enforceNamespace bool, filenameOptions *Filename
 		b.paths = append(
 			b.paths,
 			&KustomizeVisitor{
-				mapper:  b.mapper,
-				dirPath: filenameOptions.Kustomize,
-				schema:  b.schema,
-				fSys:    filesys.MakeFsOnDisk(),
+				mapper:           b.mapper,
+				dirPath:          filenameOptions.Kustomize,
+				schema:           b.schema,
+				fSys:             filesys.MakeFsOnDisk(),
+				loadRestrictions: filenameOptions.LoadRestrictions,
 			})
 	}
 

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/kustomizevisitor.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/kustomizevisitor.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 
 	"sigs.k8s.io/kustomize/api/krusty"
+	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
@@ -31,6 +32,8 @@ type KustomizeVisitor struct {
 	dirPath string
 	// File system containing dirPath.
 	fSys filesys.FileSystem
+	// loadRestrictions holds the raw --load-restrictor flag value.
+	loadRestrictions string
 	// Holds result of kustomize build, retained for tests.
 	yml []byte
 }
@@ -39,6 +42,10 @@ type KustomizeVisitor struct {
 func (v *KustomizeVisitor) Visit(fn VisitorFunc) error {
 	kOpts := krusty.MakeDefaultOptions()
 	kOpts.Reorder = krusty.ReorderOptionLegacy
+	switch v.loadRestrictions {
+	case types.LoadRestrictionsNone.String(), "none":
+		kOpts.LoadRestrictions = types.LoadRestrictionsNone
+	}
 	k := krusty.MakeKustomizer(kOpts)
 	m, err := k.Run(v.fSys, v.dirPath)
 	if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_flags.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_flags.go
@@ -116,6 +116,7 @@ func (f *DeleteFlags) ToOptions(dynamicClient dynamic.Interface, streams generic
 
 func (f *DeleteFlags) AddFlags(cmd *cobra.Command) {
 	f.FileNameFlags.AddFlags(cmd.Flags())
+	f.FileNameFlags.AddFlagCompletions(cmd)
 	if f.LabelSelector != nil {
 		cmdutil.AddLabelSelectorFlagVar(cmd, f.LabelSelector)
 	}
@@ -187,10 +188,11 @@ func NewDeleteCommandFlags(usage string) *DeleteFlags {
 	filenames := []string{}
 	recursive := false
 	kustomize := ""
+	loadRestrictions := "LoadRestrictionsRootOnly"
 
 	return &DeleteFlags{
 		// Not using helpers.go since it provides function to add '-k' for FileNameOptions, but not FileNameFlags
-		FileNameFlags: &genericclioptions.FileNameFlags{Usage: usage, Filenames: &filenames, Kustomize: &kustomize, Recursive: &recursive},
+		FileNameFlags: &genericclioptions.FileNameFlags{Usage: usage, Filenames: &filenames, Kustomize: &kustomize, Recursive: &recursive, LoadRestrictions: &loadRestrictions},
 		LabelSelector: &labelSelector,
 		FieldSelector: &fieldSelector,
 
@@ -222,9 +224,10 @@ func NewDeleteFlags(usage string) *DeleteFlags {
 	filenames := []string{}
 	kustomize := ""
 	recursive := false
+	loadRestrictions := "LoadRestrictionsRootOnly"
 
 	return &DeleteFlags{
-		FileNameFlags: &genericclioptions.FileNameFlags{Usage: usage, Filenames: &filenames, Kustomize: &kustomize, Recursive: &recursive},
+		FileNameFlags: &genericclioptions.FileNameFlags{Usage: usage, Filenames: &filenames, Kustomize: &kustomize, Recursive: &recursive, LoadRestrictions: &loadRestrictions},
 
 		CascadingStrategy: &cascadingStrategy,
 		GracePeriod:       &gracePeriod,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -477,7 +477,7 @@ func AddValidateFlags(cmd *cobra.Command) {
 
 func AddFilenameOptionFlags(cmd *cobra.Command, options *resource.FilenameOptions, usage string) {
 	AddJsonFilenameFlag(cmd.Flags(), &options.Filenames, "Filename, directory, or URL to files "+usage)
-	AddKustomizeFlag(cmd.Flags(), &options.Kustomize)
+	AddKustomizeFlags(cmd, &options.Kustomize, &options.LoadRestrictions)
 	cmd.Flags().BoolVarP(&options.Recursive, "recursive", "R", options.Recursive, "Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.")
 }
 
@@ -490,9 +490,19 @@ func AddJsonFilenameFlag(flags *pflag.FlagSet, value *[]string, usage string) {
 	flags.SetAnnotation("filename", cobra.BashCompFilenameExt, annotations)
 }
 
-// AddKustomizeFlag adds kustomize flag to a command
-func AddKustomizeFlag(flags *pflag.FlagSet, value *string) {
-	flags.StringVarP(value, "kustomize", "k", *value, "Process the kustomization directory. This flag can't be used together with -f or -R.")
+// AddKustomizeFlags adds kustomize flag to a command
+func AddKustomizeFlags(cmd *cobra.Command, value *string, loadRestrictions *string) {
+	cmd.Flags().StringVarP(value, "kustomize", "k", *value, "Process the kustomization directory. This flag can't be used together with -f or -R.")
+	cmd.Flags().StringVar(
+		loadRestrictions,
+		"load-restrictor",
+		"LoadRestrictionsRootOnly",
+		"if set to 'LoadRestrictionsNone', local kustomizations may load files from outside their root. "+
+			"This does, however, break the relocatability of the kustomization.",
+	)
+	cmd.RegisterFlagCompletionFunc("load-restrictor", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"LoadRestrictionsNone", "LoadRestrictionsRootOnly"}, cobra.ShellCompDirectiveNoFileComp
+	})
 }
 
 // AddDryRunFlag adds dry-run flag to a command. Usually used by mutations.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The --load-restrictor flag was registered on all kubectl subcommands that support -k, but its value was bound to an unexported global in the kustomize build package and never read back by KustomizeVisitor. This meant kustomizations referencing files outside their root always failed with a security error, even when --load-restrictor=LoadRestrictionsNone was explicitly passed.

Thread the flag value through FilenameOptions and FileNameFlags into KustomizeVisitor, which now applies it to krusty.Options before running the build. Both flag registration paths (AddFilenameOptionFlags for most commands, DeleteFlags/FileNameFlags for apply/delete) are covered, including shell completion for the flag values.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add --load-restrictor flag to kubectl commands supporting -k flag
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
