### PR TITLE
Add --show-generation flag to kubectl diff

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
@@ -108,6 +108,7 @@ type DiffOptions struct {
 	ForceConflicts    bool
 	ShowManagedFields bool
 	ShowSecrets       bool
+	ShowGeneration    bool
 
 	Concurrency      int
 	Selector         string
@@ -171,6 +172,7 @@ func NewCmdDiff(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Co
 	cmd.Flags().Bool("prune", false, "Include resources that would be deleted by pruning. Can be used with -l and default shows all resources would be pruned")
 	cmd.Flags().BoolVar(&options.ShowManagedFields, "show-managed-fields", options.ShowManagedFields, "If true, include managed fields in the diff.")
 	cmd.Flags().BoolVar(&options.ShowSecrets, "show-secrets", false, "If true, do not mask secret values in the diff.")
+	cmd.Flags().BoolVar(&options.ShowGeneration, "show-generation", true, "If true, include the generation field in the diff.")
 	cmd.Flags().IntVar(&options.Concurrency, "concurrency", 1, "Number of objects to process in parallel when diffing against the live version. Larger number = faster, but more memory, I/O and CPU over that shorter period of time.")
 	cmdutil.AddFilenameOptionFlags(cmd, &options.FilenameOptions, usage)
 	cmdutil.AddServerSideApplyFlags(cmd)
@@ -565,7 +567,7 @@ func NewDiffer(from, to string) (*Differ, error) {
 }
 
 // Diff diffs to versions of a specific object, and print both versions to directories.
-func (d *Differ) Diff(obj Object, printer Printer, showManagedFields, showSecrets bool) error {
+func (d *Differ) Diff(obj Object, printer Printer, showManagedFields, showSecrets, showGeneration bool) error {
 	from, err := d.From.getObject(obj)
 	if err != nil {
 		return err
@@ -578,6 +580,10 @@ func (d *Differ) Diff(obj Object, printer Printer, showManagedFields, showSecret
 	if !showManagedFields {
 		from = omitManagedFields(from)
 		to = omitManagedFields(to)
+	}
+	if !showGeneration {
+		from = omitGenerationField(from)
+		to = omitGenerationField(to)
 	}
 
 	// Mask secret values if object is V1Secret
@@ -605,6 +611,16 @@ func omitManagedFields(o runtime.Object) runtime.Object {
 		return o
 	}
 	a.SetManagedFields(nil)
+	return o
+}
+
+func omitGenerationField(o runtime.Object) runtime.Object {
+	a, err := meta.Accessor(o)
+	if err != nil {
+		// The object is not a `metav1.Object`, ignore it.
+		return o
+	}
+	a.SetGeneration(0)
 	return o
 }
 
@@ -743,7 +759,7 @@ func (o *DiffOptions) Run() error {
 				o.tracker.MarkVisited(info)
 			}
 
-			err = differ.Diff(obj, printer, o.ShowManagedFields, o.ShowSecrets)
+			err = differ.Diff(obj, printer, o.ShowManagedFields, o.ShowSecrets, o.ShowGeneration)
 			if !isConflict(err) {
 				break
 			}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff_test.go
@@ -197,7 +197,7 @@ func TestDiffer(t *testing.T) {
 		live:   map[string]interface{}{"live": true},
 		merged: map[string]interface{}{"merged": true},
 	}
-	err = diff.Diff(&obj, Printer{}, true, false)
+	err = diff.Diff(&obj, Printer{}, true, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -281,7 +281,86 @@ metadata:
 				},
 			}
 
-			err = diff.Diff(&obj, Printer{}, tc.showManagedFields, false)
+			err = diff.Diff(&obj, Printer{}, tc.showManagedFields, false, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			actualFromContent, _ := os.ReadFile(filepath.Join(diff.From.Dir.Name, obj.Name()))
+			if string(actualFromContent) != tc.expectedFromContent {
+				t.Fatalf("File has %q, expected %q", string(actualFromContent), tc.expectedFromContent)
+			}
+
+			actualToContent, _ := os.ReadFile(filepath.Join(diff.To.Dir.Name, obj.Name()))
+			if string(actualToContent) != tc.expectedToContent {
+				t.Fatalf("File has %q, expected %q", string(actualToContent), tc.expectedToContent)
+			}
+		})
+	}
+}
+
+func TestShowGeneration(t *testing.T) {
+	diff, err := NewDiffer("LIVE", "MERGED")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer diff.TearDown()
+
+	testCases := []struct {
+		name                string
+		showGeneration      bool
+		expectedFromContent string
+		expectedToContent   string
+	}{
+		{
+			name:           "with generation",
+			showGeneration: true,
+			expectedFromContent: `live: true
+metadata:
+  generation: 1
+  name: foo
+`,
+			expectedToContent: `merged: true
+metadata:
+  generation: 2
+  name: foo
+`,
+		},
+		{
+			name:           "without generation",
+			showGeneration: false,
+			expectedFromContent: `live: true
+metadata:
+  name: foo
+`,
+			expectedToContent: `merged: true
+metadata:
+  name: foo
+`,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := FakeObject{
+				name: fmt.Sprintf("TestShowGen%d", i),
+				live: map[string]interface{}{
+					"live": true,
+					"metadata": map[string]interface{}{
+						"generation": int64(1),
+						"name":       "foo",
+					},
+				},
+				merged: map[string]interface{}{
+					"merged": true,
+					"metadata": map[string]interface{}{
+						"generation": int64(2),
+						"name":       "foo",
+					},
+				},
+			}
+
+			err = diff.Diff(&obj, Printer{}, false, false, tc.showGeneration)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -703,7 +782,7 @@ metadata:
 				merged: secretArgs,
 			}
 
-			err = diff.Diff(&obj, Printer{}, false, tc.showSecrets)
+			err = diff.Diff(&obj, Printer{}, false, tc.showSecrets, true)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add a new --show-generation flag (default true) to kubectl diff that controls whether the generation field is included in the diff output. When set to false, the generation field is stripped from both live and merged objects before comparing. This is useful because generation is a server-managed counter that changes on every spec update, producing noise in diffs.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Add --show-generation flag to kubectl diff
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
