### PR TITLE
apiserver: refactor cacher snapshot storage to use ring buffer

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -264,7 +264,11 @@ func TestShouldDelegateList(t *testing.T) {
 			}
 			defer cacher.Stop()
 			if snapshotAvailable {
+				// Reset and re-add snapshots in monotonically increasing RV order
+				// to satisfy the ring buffer's ordering invariant.
+				cacher.watchCache.snapshots.Reset()
 				cacher.watchCache.snapshots.Add(uint64(mustAtoi(oldRV)), fakeOrderedLister{})
+				cacher.watchCache.snapshots.Add(uint64(mustAtoi(cacheRV)), fakeOrderedLister{})
 			}
 			result, err := delegator.ShouldDelegateList(toStorageOpts(opt), cacher)
 			if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/ring_buffer.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/ring_buffer.go
@@ -1,0 +1,219 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+// ringBuffer stores entries in revision order using a circular buffer.
+// Its layout follows the etcd cache ring buffer:
+// https://github.com/etcd-io/etcd/blob/main/cache/ringbuffer.go
+// TODO: Consider moving this generic implementation to k8s.io/utils
+type ringBuffer[T any] struct {
+	buffer []entry[T]
+	// head is the index immediately after the last non-empty entry in the buffer (i.e., the next write position).
+	head, tail, size int
+	revisionOf       RevisionOf[T]
+}
+
+type entry[T any] struct {
+	revision int64
+	item     T
+}
+
+type (
+	KeyPredicate      = func([]byte) bool
+	RevisionOf[T any] func(T) int64
+	IterFunc[T any]   func(rev int64, item T) bool
+)
+
+func newRingBuffer[T any](capacity int, revisionOf RevisionOf[T]) *ringBuffer[T] {
+	// assume capacity > 0 – validated by Cache
+	return &ringBuffer[T]{
+		buffer:     make([]entry[T], capacity),
+		revisionOf: revisionOf,
+	}
+}
+
+func (r *ringBuffer[T]) Append(item T) {
+	entry := entry[T]{revision: r.revisionOf(item), item: item}
+	if r.full() {
+		r.tail = (r.tail + 1) % len(r.buffer)
+	} else {
+		r.size++
+	}
+	r.buffer[r.head] = entry
+	r.head = (r.head + 1) % len(r.buffer)
+}
+
+func (r *ringBuffer[T]) full() bool {
+	return r.size == len(r.buffer)
+}
+
+// AscendGreaterOrEqual iterates through entries in ascending order starting from the first entry with revision >= pivot.
+func (r *ringBuffer[T]) AscendGreaterOrEqual(pivot int64, iter IterFunc[T]) {
+	for i := r.findFirstIndexGreaterOrEqual(pivot); i < r.size; i++ {
+		entry := r.at(i)
+		if !iter(entry.revision, entry.item) {
+			return
+		}
+	}
+}
+
+// AscendLessThan iterates in ascending order over entries with revision < pivot.
+func (r *ringBuffer[T]) AscendLessThan(pivot int64, iter IterFunc[T]) {
+	for i := 0; i < r.findFirstIndexGreaterOrEqual(pivot); i++ {
+		entry := r.at(i)
+		if !iter(entry.revision, entry.item) {
+			return
+		}
+	}
+}
+
+// DescendGreaterThan iterates in descending order over entries with revision > pivot.
+func (r *ringBuffer[T]) DescendGreaterThan(pivot int64, iter IterFunc[T]) {
+	for i := r.size - 1; i > r.findLastIndexLessOrEqual(pivot); i-- {
+		entry := r.at(i)
+		if !iter(entry.revision, entry.item) {
+			return
+		}
+	}
+}
+
+// DescendLessOrEqual iterates in descending order over entries with revision <= pivot.
+func (r *ringBuffer[T]) DescendLessOrEqual(pivot int64, iter IterFunc[T]) {
+	for i := r.findLastIndexLessOrEqual(pivot); i >= 0; i-- {
+		entry := r.at(i)
+		if !iter(entry.revision, entry.item) {
+			return
+		}
+	}
+}
+
+// PeekLatest returns the most recently-appended revision (or 0 if empty).
+func (r *ringBuffer[T]) PeekLatest() int64 {
+	if r.size == 0 {
+		return 0
+	}
+	idx := (r.head - 1 + len(r.buffer)) % len(r.buffer)
+	return r.buffer[idx].revision
+}
+
+// PeekOldest returns the oldest revision currently stored (or 0 if empty).
+func (r *ringBuffer[T]) PeekOldest() int64 {
+	if r.size == 0 {
+		return 0
+	}
+	return r.buffer[r.tail].revision
+}
+
+func (r *ringBuffer[T]) RebaseHistory() {
+	r.head, r.tail, r.size = 0, 0, 0
+	for i := range r.buffer {
+		r.buffer[i] = entry[T]{}
+	}
+}
+
+func (r *ringBuffer[T]) moduloIndex(index int) int {
+	return (index + len(r.buffer)) % len(r.buffer)
+}
+
+func (r *ringBuffer[T]) at(logicalIndex int) entry[T] {
+	return r.buffer[r.moduloIndex(r.tail+logicalIndex)]
+}
+
+func (r *ringBuffer[T]) findFirstIndexGreaterOrEqual(pivot int64) int {
+	left, right := 0, r.size-1
+	for left <= right {
+		// Prevent overflow; see https://github.com/golang/go/blob/master/src/sort/search.go#L105.
+		mid := int(uint(left+right) >> 1)
+		if r.at(mid).revision >= pivot {
+			right = mid - 1
+		} else {
+			left = mid + 1
+		}
+	}
+	return left
+}
+
+func (r *ringBuffer[T]) findLastIndexLessOrEqual(pivot int64) int {
+	left, right := 0, r.size-1
+	for left <= right {
+		// Prevent overflow; see https://github.com/golang/go/blob/master/src/sort/search.go#L105.
+		mid := int(uint(left+right) >> 1)
+		if r.at(mid).revision <= pivot {
+			left = mid + 1
+		} else {
+			right = mid - 1
+		}
+	}
+	return right
+}
+
+// Len returns the number of entries currently stored in the buffer.
+func (r *ringBuffer[T]) Len() int {
+	return r.size
+}
+
+// ReplaceLatest overwrites the most recently appended entry with the given item.
+// Panics if the buffer is empty.
+func (r *ringBuffer[T]) ReplaceLatest(item T) {
+	if r.size == 0 {
+		panic("ringBuffer.ReplaceLatest called on empty buffer")
+	}
+	r.buffer[r.moduloIndex(r.head-1)] = entry[T]{revision: r.revisionOf(item), item: item}
+}
+
+// RemoveLess drops all entries whose revision is strictly less than rv.
+func (r *ringBuffer[T]) RemoveLess(rv int64) {
+	if r.size == 0 {
+		return
+	}
+	idx := r.findFirstIndexGreaterOrEqual(rv)
+	if idx <= 0 {
+		return
+	}
+	if idx == r.size {
+		r.RebaseHistory()
+		return
+	}
+	for i := range idx {
+		r.buffer[r.moduloIndex(r.tail+i)] = entry[T]{}
+	}
+	r.tail = r.moduloIndex(r.tail + idx)
+	r.size -= idx
+}
+
+// ensureCapacity grows the underlying slice (doubling) until it can hold at
+// least minCapacity entries. After expansion the logical entries are laid out
+// contiguously starting at index 0.
+func (r *ringBuffer[T]) ensureCapacity(minCapacity int) {
+	if len(r.buffer) >= minCapacity {
+		return
+	}
+	newCap := len(r.buffer)
+	if newCap == 0 {
+		newCap = 1
+	}
+	for newCap < minCapacity {
+		newCap *= 2
+	}
+	newBuffer := make([]entry[T], newCap)
+	for i := 0; i < r.size; i++ {
+		newBuffer[i] = r.at(i)
+	}
+	r.buffer = newBuffer
+	r.tail = 0
+	r.head = r.size
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/ring_buffer_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/ring_buffer_test.go
@@ -1,0 +1,768 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"go.etcd.io/etcd/api/v3/mvccpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+func TestPeekLatestAndOldest(t *testing.T) {
+	tests := []struct {
+		name          string
+		capacity      int
+		revs          []int64
+		wantLatestRev int64
+		wantOldestRev int64
+	}{
+		{
+			name:          "empty_buffer",
+			capacity:      4,
+			revs:          nil,
+			wantLatestRev: 0,
+			wantOldestRev: 0,
+		},
+		{
+			name:          "single_element",
+			capacity:      8,
+			revs:          []int64{1},
+			wantLatestRev: 1,
+			wantOldestRev: 1,
+		},
+		{
+			name:          "ascending_fill",
+			capacity:      4,
+			revs:          []int64{1, 2, 3, 4},
+			wantLatestRev: 4,
+			wantOldestRev: 1,
+		},
+		{
+			name:          "overwrite_when_full",
+			capacity:      3,
+			revs:          []int64{5, 6, 7, 8},
+			wantLatestRev: 8,
+			wantOldestRev: 6,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rb := newRingBuffer(tt.capacity, func(batch []*clientv3.Event) int64 { return batch[0].Kv.ModRevision })
+			for _, r := range tt.revs {
+				batch, err := makeEventBatch(r, "k", 1)
+				if err != nil {
+					t.Fatalf("makeEventBatch(%d, k, 1) failed: %v", r, err)
+				}
+				rb.Append(batch)
+			}
+
+			latestRev := rb.PeekLatest()
+			oldestRev := rb.PeekOldest()
+
+			gotLatestRev := latestRev
+			gotOldestRev := oldestRev
+
+			if tt.wantLatestRev != gotLatestRev {
+				t.Fatalf("PeekLatest()=%d, want=%d", gotLatestRev, tt.wantLatestRev)
+			}
+			if tt.wantOldestRev != gotOldestRev {
+				t.Fatalf("PeekOldest()=%d, want=%d", gotOldestRev, tt.wantOldestRev)
+			}
+		})
+	}
+}
+
+func TestIterationMethods(t *testing.T) {
+	type iterTestCase struct {
+		method            iterMethod
+		pivot             int64
+		wantIterRevisions []int64
+	}
+	tests := []struct {
+		name           string
+		capacity       int
+		setupRevisions []int64
+		cases          []iterTestCase
+	}{
+		{
+			name:           "empty_buffer",
+			capacity:       4,
+			setupRevisions: nil,
+			cases: []iterTestCase{
+				{ascendGTE, 0, []int64{}},
+				{ascendLT, 10, []int64{}},
+				{descendGT, 0, []int64{}},
+				{descendLTE, 10, []int64{}},
+			},
+		},
+		{
+			name:           "basic_filtering",
+			capacity:       5,
+			setupRevisions: []int64{1, 2, 3},
+			cases: []iterTestCase{
+				{ascendGTE, 0, []int64{1, 2, 3}},
+				{ascendGTE, 2, []int64{2, 3}},
+				{ascendGTE, 100, []int64{}},
+				{ascendLT, 3, []int64{1, 2}},
+				{ascendLT, 1, []int64{}},
+				{ascendLT, 100, []int64{1, 2, 3}},
+				{descendGT, 1, []int64{3, 2}},
+				{descendGT, 3, []int64{}},
+				{descendGT, 0, []int64{3, 2, 1}},
+				{descendLTE, 2, []int64{2, 1}},
+				{descendLTE, 3, []int64{3, 2, 1}},
+				{descendLTE, 0, []int64{}},
+			},
+		},
+		{
+			name:           "overflowed stores only entries within capacity",
+			capacity:       3,
+			setupRevisions: []int64{20, 21, 22, 23, 24}, // stored: 22, 23, 24
+			cases: []iterTestCase{
+				{ascendGTE, 23, []int64{23, 24}},
+				{ascendGTE, 0, []int64{22, 23, 24}},
+				{ascendLT, 23, []int64{22}},
+				{ascendLT, 25, []int64{22, 23, 24}},
+				{descendGT, 22, []int64{24, 23}},
+				{descendGT, 25, []int64{}},
+				{descendLTE, 23, []int64{23, 22}},
+				{descendLTE, 24, []int64{24, 23, 22}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rb := setupRingBuffer(t, tt.capacity, tt.setupRevisions)
+
+			for _, tc := range tt.cases {
+				t.Run(fmt.Sprintf("%s_pivot_%d", tc.method, tc.pivot), func(t *testing.T) {
+					got := collectRevisions(rb, tc.method, tc.pivot)
+					if diff := cmp.Diff(tc.wantIterRevisions, got); diff != "" {
+						t.Fatalf("%s(%d) mismatch (-want +got):\n%s", tc.method, tc.pivot, diff)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestIterationWithBatching(t *testing.T) {
+	rb := newRingBuffer(6, func(batch []*clientv3.Event) int64 { return batch[0].Kv.ModRevision })
+	batchA := []*clientv3.Event{
+		{Kv: &mvccpb.KeyValue{Key: []byte("key-a"), ModRevision: 5}},
+	}
+	batchB := []*clientv3.Event{
+		{Kv: &mvccpb.KeyValue{Key: []byte("key-b-1"), ModRevision: 10}},
+		{Kv: &mvccpb.KeyValue{Key: []byte("key-b-2"), ModRevision: 10}},
+		{Kv: &mvccpb.KeyValue{Key: []byte("key-b-3"), ModRevision: 10}},
+	}
+	batchC := []*clientv3.Event{
+		{Kv: &mvccpb.KeyValue{Key: []byte("key-c"), ModRevision: 12}},
+	}
+	rb.Append(batchA)
+	rb.Append(batchB)
+	rb.Append(batchC)
+
+	tests := []struct {
+		name   string
+		method iterMethod
+		pivot  int64
+		want   [][]*clientv3.Event
+	}{
+		{
+			name:   "ascending_gte_includes_batched_revision",
+			method: ascendGTE,
+			pivot:  10,
+			want: [][]*clientv3.Event{
+				{
+					{Kv: &mvccpb.KeyValue{Key: []byte("key-b-1"), ModRevision: 10}},
+					{Kv: &mvccpb.KeyValue{Key: []byte("key-b-2"), ModRevision: 10}},
+					{Kv: &mvccpb.KeyValue{Key: []byte("key-b-3"), ModRevision: 10}},
+				},
+				{
+					{Kv: &mvccpb.KeyValue{Key: []byte("key-c"), ModRevision: 12}},
+				},
+			},
+		},
+		{
+			name:   "ascending_lt_stops_before_batched_revision",
+			method: ascendLT,
+			pivot:  10,
+			want: [][]*clientv3.Event{
+				{
+					{Kv: &mvccpb.KeyValue{Key: []byte("key-a"), ModRevision: 5}},
+				},
+			},
+		},
+		{
+			name:   "all_revisions_with_proper_batch_sizes",
+			method: ascendGTE,
+			pivot:  0,
+			want: [][]*clientv3.Event{
+				{
+					{Kv: &mvccpb.KeyValue{Key: []byte("key-a"), ModRevision: 5}},
+				},
+				{
+					{Kv: &mvccpb.KeyValue{Key: []byte("key-b-1"), ModRevision: 10}},
+					{Kv: &mvccpb.KeyValue{Key: []byte("key-b-2"), ModRevision: 10}},
+					{Kv: &mvccpb.KeyValue{Key: []byte("key-b-3"), ModRevision: 10}},
+				},
+				{
+					{Kv: &mvccpb.KeyValue{Key: []byte("key-c"), ModRevision: 12}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got [][]*clientv3.Event
+
+			rb.iterate(tt.method, tt.pivot, func(rev int64, events []*clientv3.Event) bool {
+				got = append(got, events)
+				return true
+			})
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatalf("Events mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIterationEarlyStop(t *testing.T) {
+	rb := setupRingBuffer(t, 5, []int64{5, 10, 15, 20})
+	tests := []struct {
+		name      string
+		method    iterMethod
+		pivot     int64
+		stopAfter int
+		want      []int64
+	}{
+		{
+			name:      "find_first_match_ascending",
+			method:    ascendGTE,
+			pivot:     10,
+			stopAfter: 1,
+			want:      []int64{10},
+		},
+		{
+			name:      "find_first_two_ascending_lt",
+			method:    ascendLT,
+			pivot:     20,
+			stopAfter: 2,
+			want:      []int64{5, 10},
+		},
+		{
+			name:      "find_first_two_descending_gt",
+			method:    descendGT,
+			pivot:     5,
+			stopAfter: 2,
+			want:      []int64{20, 15},
+		},
+		{
+			name:      "find_first_match_descending_lte",
+			method:    descendLTE,
+			pivot:     15,
+			stopAfter: 1,
+			want:      []int64{15},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var collected []int64
+			callCount := 0
+
+			rb.iterate(tt.method, tt.pivot, func(rev int64, events []*clientv3.Event) bool {
+				collected = append(collected, rev)
+				callCount++
+
+				shouldContinue := callCount < tt.stopAfter
+
+				if !shouldContinue {
+					t.Logf("Stopping early after %d items (callback returned false)", callCount)
+				}
+
+				return shouldContinue
+			})
+
+			if diff := cmp.Diff(tt.want, collected); diff != "" {
+				t.Fatalf("Early stop failed.\nExpected: \nDiff (-want +got):\n%s", diff)
+			}
+
+			if callCount != tt.stopAfter {
+				t.Fatalf("Expected exactly %d callback calls, got %d", tt.stopAfter, callCount)
+			}
+
+			t.Logf("Successfully stopped early: collected %v after %d callbacks",
+				collected, callCount)
+		})
+	}
+}
+
+type iterMethod string
+
+const (
+	ascendGTE  iterMethod = "AscendGreaterOrEqual"
+	ascendLT   iterMethod = "AscendLessThan"
+	descendGT  iterMethod = "DescendGreaterThan"
+	descendLTE iterMethod = "DescendLessOrEqual"
+)
+
+func (r *ringBuffer[T]) iterate(method iterMethod, pivot int64, fn IterFunc[T]) {
+	switch method {
+	case ascendGTE:
+		r.AscendGreaterOrEqual(pivot, fn)
+	case ascendLT:
+		r.AscendLessThan(pivot, fn)
+	case descendGT:
+		r.DescendGreaterThan(pivot, fn)
+	case descendLTE:
+		r.DescendLessOrEqual(pivot, fn)
+	default:
+		panic(fmt.Sprintf("unknown iteration method: %s", method))
+	}
+}
+
+func TestAtomicOrdered(t *testing.T) {
+	tests := []struct {
+		name     string
+		capacity int
+		inputs   []struct {
+			rev  int64
+			key  string
+			size int
+		}
+		wantRev  []int64
+		wantSize []int
+	}{
+		{
+			name:     "unfiltered",
+			capacity: 5,
+			inputs: []struct {
+				rev  int64
+				key  string
+				size int
+			}{
+				{5, "a", 1},
+				{10, "b", 3},
+				{15, "c", 7},
+				{20, "d", 11},
+			},
+			wantRev:  []int64{5, 10, 15, 20},
+			wantSize: []int{1, 3, 7, 11},
+		},
+		{
+			name:     "across_wrap",
+			capacity: 3,
+			inputs: []struct {
+				rev  int64
+				key  string
+				size int
+			}{
+				{1, "a", 2},
+				{2, "b", 1},
+				{3, "c", 3},
+				{4, "d", 7},
+			},
+			wantRev:  []int64{2, 3, 4},
+			wantSize: []int{1, 3, 7},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rb := newRingBuffer(tt.capacity, func(batch []*clientv3.Event) int64 { return batch[0].Kv.ModRevision })
+			for _, in := range tt.inputs {
+				batch, err := makeEventBatch(in.rev, in.key, in.size)
+				if err != nil {
+					t.Fatalf("makeEventBatch(%d, k, 1) failed: %v", in.rev, err)
+				}
+				rb.Append(batch)
+			}
+
+			gotRevs := []int64{}
+			var gotSizes []int
+			rb.AscendGreaterOrEqual(0, func(rev int64, events []*clientv3.Event) bool {
+				gotRevs = append(gotRevs, rev)
+				gotSizes = append(gotSizes, len(events))
+				return true
+			})
+
+			if len(gotRevs) != len(tt.wantRev) {
+				t.Fatalf("len(got) = %d, want %d", len(gotRevs), len(tt.wantRev))
+			}
+			for i := range gotRevs {
+				if gotRevs[i] != tt.wantRev[i] {
+					t.Errorf("at idx %d: rev = %d, want %d", i, gotRevs[i], tt.wantRev[i])
+				}
+				if gotSizes[i] != tt.wantSize[i] {
+					t.Errorf("at rev %d: events.len = %d, want %d", gotRevs[i], gotSizes[i], tt.wantSize[i])
+				}
+			}
+		})
+	}
+}
+
+func TestRebaseHistory(t *testing.T) {
+	tests := []struct {
+		name string
+		revs []int64
+	}{
+		{
+			name: "rebase_empty_buffer",
+			revs: nil,
+		},
+		{
+			name: "rebase_after_data",
+			revs: []int64{7, 8, 9},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rb := newRingBuffer(4, func(batch []*clientv3.Event) int64 { return batch[0].Kv.ModRevision })
+			for _, r := range tt.revs {
+				batch, err := makeEventBatch(r, "k", 1)
+				if err != nil {
+					t.Fatalf("makeEventBatch(%d, k, 1) failed: %v", r, err)
+				}
+				rb.Append(batch)
+			}
+
+			rb.RebaseHistory()
+
+			oldestRev := rb.PeekOldest()
+			latestRev := rb.PeekLatest()
+
+			if oldestRev != 0 {
+				t.Fatalf("PeekOldest()=%d, want=%d", oldestRev, 0)
+			}
+			if latestRev != 0 {
+				t.Fatalf("PeekLatest()=%d, want=%d", latestRev, 0)
+			}
+
+			gotRevs := []int64{}
+			rb.AscendGreaterOrEqual(0, func(rev int64, events []*clientv3.Event) bool {
+				gotRevs = append(gotRevs, rev)
+				return true
+			})
+
+			if len(gotRevs) != 0 {
+				t.Fatalf("AscendGreaterOrEqual() len(events)=%d, want=%d", len(gotRevs), 0)
+			}
+		})
+	}
+}
+
+func TestFull(t *testing.T) {
+	tests := []struct {
+		name         string
+		capacity     int
+		numAppends   int
+		expectedFull bool
+	}{
+		{
+			name:         "empty_buffer",
+			capacity:     3,
+			numAppends:   0,
+			expectedFull: false,
+		},
+		{
+			name:         "partially_filled",
+			capacity:     5,
+			numAppends:   3,
+			expectedFull: false,
+		},
+		{
+			name:         "exactly_at_capacity",
+			capacity:     3,
+			numAppends:   3,
+			expectedFull: true,
+		},
+		{
+			name:         "beyond_capacity_wrapping",
+			capacity:     3,
+			numAppends:   5,
+			expectedFull: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rb := newRingBuffer(tt.capacity, func(batch []*clientv3.Event) int64 { return batch[0].Kv.ModRevision })
+
+			for i := 1; i <= tt.numAppends; i++ {
+				batch, err := makeEventBatch(int64(i), "k", 1)
+				if err != nil {
+					t.Fatalf("makeEventBatch(%d, k, 1) failed: %v", i, err)
+				}
+				rb.Append(batch)
+			}
+
+			if got := rb.full(); got != tt.expectedFull {
+				t.Fatalf("full()=%t, want=%t (capacity=%d, appends=%d)",
+					got, tt.expectedFull, tt.capacity, tt.numAppends)
+			}
+		})
+	}
+}
+
+func setupRingBuffer(t *testing.T, capacity int, revs []int64) *ringBuffer[[]*clientv3.Event] {
+	rb := newRingBuffer(capacity, func(batch []*clientv3.Event) int64 { return batch[0].Kv.ModRevision })
+	for _, r := range revs {
+		batch, err := makeEventBatch(r, "key", 1)
+		if err != nil {
+			t.Fatalf("makeEventBatch(%d, %s, %d) failed: %v", r, "key", 1, err)
+		}
+		rb.Append(batch)
+	}
+	return rb
+}
+
+func collectRevisions(rb *ringBuffer[[]*clientv3.Event], method iterMethod, pivot int64) []int64 {
+	revs := []int64{}
+	rb.iterate(method, pivot, func(rev int64, events []*clientv3.Event) bool {
+		revs = append(revs, rev)
+		return true
+	})
+	return revs
+}
+
+func makeEventBatch(rev int64, key string, batchSize int) ([]*clientv3.Event, error) {
+	if batchSize < 0 {
+		return nil, fmt.Errorf("invalid batchSize %d", batchSize)
+	}
+	events := make([]*clientv3.Event, batchSize)
+	for i := range events {
+		events[i] = &clientv3.Event{
+			Kv: &mvccpb.KeyValue{
+				Key:         fmt.Appendf(nil, "%s-%d", key, i),
+				ModRevision: rev,
+			},
+		}
+	}
+	return events, nil
+}
+
+func TestLen(t *testing.T) {
+	rb := setupRingBuffer(t, 3, []int64{1, 2, 3, 4}) // stored: 2, 3, 4
+
+	if got := rb.Len(); got != 3 {
+		t.Fatalf("Len()=%d, want=%d", got, 3)
+	}
+
+	rb.RemoveLess(4)
+	if got := rb.Len(); got != 1 {
+		t.Fatalf("Len() after RemoveLess=%d, want=%d", got, 1)
+	}
+
+	rb.RebaseHistory()
+	if got := rb.Len(); got != 0 {
+		t.Fatalf("Len() after RebaseHistory=%d, want=%d", got, 0)
+	}
+}
+
+func TestReplaceLatest(t *testing.T) {
+	t.Run("replace_latest_entry", func(t *testing.T) {
+		rb := newRingBuffer(4, func(batch []*clientv3.Event) int64 { return batch[0].Kv.ModRevision })
+		for _, rev := range []int64{5, 10} {
+			batch, err := makeEventBatch(rev, "key", 1)
+			if err != nil {
+				t.Fatalf("makeEventBatch(%d, key, 1) failed: %v", rev, err)
+			}
+			rb.Append(batch)
+		}
+
+		replacement, err := makeEventBatch(12, "replacement", 2)
+		if err != nil {
+			t.Fatalf("makeEventBatch(12, replacement, 2) failed: %v", err)
+		}
+		rb.ReplaceLatest(replacement)
+
+		if got := rb.Len(); got != 2 {
+			t.Fatalf("Len()=%d, want=%d", got, 2)
+		}
+		if got := rb.PeekLatest(); got != 12 {
+			t.Fatalf("PeekLatest()=%d, want=%d", got, 12)
+		}
+
+		gotRevs := collectRevisions(rb, ascendGTE, 0)
+		if diff := cmp.Diff([]int64{5, 12}, gotRevs); diff != "" {
+			t.Fatalf("revisions mismatch (-want +got):\n%s", diff)
+		}
+
+		var gotBatch [][]*clientv3.Event
+		rb.AscendGreaterOrEqual(0, func(rev int64, events []*clientv3.Event) bool {
+			gotBatch = append(gotBatch, events)
+			return true
+		})
+		if diff := cmp.Diff(2, len(gotBatch[1])); diff != "" {
+			t.Fatalf("replacement batch size mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("panic_on_empty_buffer", func(t *testing.T) {
+		rb := newRingBuffer(2, func(batch []*clientv3.Event) int64 { return batch[0].Kv.ModRevision })
+		replacement, err := makeEventBatch(1, "replacement", 1)
+		if err != nil {
+			t.Fatalf("makeEventBatch(1, replacement, 1) failed: %v", err)
+		}
+
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("ReplaceLatest() did not panic on empty buffer")
+			}
+		}()
+		rb.ReplaceLatest(replacement)
+	})
+}
+
+func TestRemoveLess(t *testing.T) {
+	tests := []struct {
+		name         string
+		capacity     int
+		setupRevs    []int64
+		removeBefore int64
+		wantRevs     []int64
+		wantLen      int
+		wantOldest   int64
+		wantLatest   int64
+	}{
+		{
+			name:         "empty_buffer",
+			capacity:     4,
+			removeBefore: 10,
+			wantRevs:     []int64{},
+			wantLen:      0,
+			wantOldest:   0,
+			wantLatest:   0,
+		},
+		{
+			name:         "no_entries_removed",
+			capacity:     4,
+			setupRevs:    []int64{5, 10, 15},
+			removeBefore: 5,
+			wantRevs:     []int64{5, 10, 15},
+			wantLen:      3,
+			wantOldest:   5,
+			wantLatest:   15,
+		},
+		{
+			name:         "remove_prefix",
+			capacity:     5,
+			setupRevs:    []int64{5, 10, 15, 20},
+			removeBefore: 15,
+			wantRevs:     []int64{15, 20},
+			wantLen:      2,
+			wantOldest:   15,
+			wantLatest:   20,
+		},
+		{
+			name:         "remove_all_entries",
+			capacity:     3,
+			setupRevs:    []int64{10, 11, 12},
+			removeBefore: 20,
+			wantRevs:     []int64{},
+			wantLen:      0,
+			wantOldest:   0,
+			wantLatest:   0,
+		},
+		{
+			name:         "wrapped_buffer",
+			capacity:     3,
+			setupRevs:    []int64{20, 21, 22, 23, 24}, // stored: 22, 23, 24
+			removeBefore: 24,
+			wantRevs:     []int64{24},
+			wantLen:      1,
+			wantOldest:   24,
+			wantLatest:   24,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rb := setupRingBuffer(t, tt.capacity, tt.setupRevs)
+
+			rb.RemoveLess(tt.removeBefore)
+
+			if got := rb.Len(); got != tt.wantLen {
+				t.Fatalf("Len()=%d, want=%d", got, tt.wantLen)
+			}
+			if got := rb.PeekOldest(); got != tt.wantOldest {
+				t.Fatalf("PeekOldest()=%d, want=%d", got, tt.wantOldest)
+			}
+			if got := rb.PeekLatest(); got != tt.wantLatest {
+				t.Fatalf("PeekLatest()=%d, want=%d", got, tt.wantLatest)
+			}
+
+			gotRevs := collectRevisions(rb, ascendGTE, 0)
+			if diff := cmp.Diff(tt.wantRevs, gotRevs); diff != "" {
+				t.Fatalf("remaining revisions mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestEnsureCapacity(t *testing.T) {
+	t.Run("grow_preserves_logical_order", func(t *testing.T) {
+		rb := setupRingBuffer(t, 3, []int64{1, 2, 3, 4}) // wrapped: stored 2, 3, 4
+
+		rb.ensureCapacity(5)
+
+		if got := len(rb.buffer); got != 6 {
+			t.Fatalf("len(buffer)=%d, want=%d", got, 6)
+		}
+		if rb.tail != 0 {
+			t.Fatalf("tail=%d, want=%d", rb.tail, 0)
+		}
+		if rb.head != rb.size {
+			t.Fatalf("head=%d, want size=%d", rb.head, rb.size)
+		}
+
+		gotRevs := collectRevisions(rb, ascendGTE, 0)
+		if diff := cmp.Diff([]int64{2, 3, 4}, gotRevs); diff != "" {
+			t.Fatalf("revisions mismatch after ensureCapacity (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("noop_when_capacity_is_sufficient", func(t *testing.T) {
+		rb := setupRingBuffer(t, 4, []int64{1, 2})
+		beforeCap := len(rb.buffer)
+		beforeHead, beforeTail, beforeSize := rb.head, rb.tail, rb.size
+
+		rb.ensureCapacity(4)
+
+		if got := len(rb.buffer); got != beforeCap {
+			t.Fatalf("len(buffer)=%d, want=%d", got, beforeCap)
+		}
+		if rb.head != beforeHead || rb.tail != beforeTail || rb.size != beforeSize {
+			t.Fatalf("ringBuffer metadata changed unexpectedly: got head=%d tail=%d size=%d, want head=%d tail=%d size=%d",
+				rb.head, rb.tail, rb.size, beforeHead, beforeTail, beforeSize)
+		}
+	})
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_btree.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_btree.go
@@ -426,10 +426,10 @@ func (i *indexer) delete(key, value string, index map[string]map[string]*Element
 // However, this solution is more complex and is deferred for future implementation.
 //
 // TODO: Rewrite to use a cyclic buffer
-func NewSnapshotter() Snapshotter {
+func NewSnapshotter(capacity int) Snapshotter {
 	s := &storeSnapshotter{
-		snapshots: btree.New(btreeDegree, func(a, b rvSnapshot) bool {
-			return a.resourceVersion < b.resourceVersion
+		snapshots: newRingBuffer(capacity, func(item snapshotItem) int64 {
+			return int64(item.resourceVersion)
 		}),
 	}
 	return s
@@ -445,56 +445,59 @@ type Snapshotter interface {
 	Len() int
 }
 
-type storeSnapshotter struct {
-	mux       sync.RWMutex
-	snapshots *btree.BTree[rvSnapshot]
-}
-
-type rvSnapshot struct {
+// snapshotItem pairs a snapshot with the resource version used to index it.
+type snapshotItem struct {
 	resourceVersion uint64
 	snapshot        OrderedLister
+}
+
+type storeSnapshotter struct {
+	mux       sync.RWMutex
+	snapshots *ringBuffer[snapshotItem]
 }
 
 func (s *storeSnapshotter) Reset() {
 	s.mux.Lock()
 	defer s.mux.Unlock()
-	s.snapshots.Clear(false)
+	s.snapshots.RebaseHistory()
 }
 
 func (s *storeSnapshotter) GetLessOrEqual(rv uint64) (OrderedLister, bool) {
 	s.mux.RLock()
 	defer s.mux.RUnlock()
-
-	var result *rvSnapshot
-	s.snapshots.DescendLessOrEqual(rvSnapshot{resourceVersion: rv}, func(rvs rvSnapshot) bool {
-		result = &rvs
+	var result OrderedLister
+	found := false
+	s.snapshots.DescendLessOrEqual(int64(rv), func(_ int64, item snapshotItem) bool {
+		result = item.snapshot
+		found = true
 		return false
 	})
-	if result == nil {
-		return nil, false
-	}
-	return result.snapshot, true
+	return result, found
 }
 
 func (s *storeSnapshotter) Add(rv uint64, indexer OrderedLister) {
 	s.mux.Lock()
 	defer s.mux.Unlock()
-	s.snapshots.ReplaceOrInsert(rvSnapshot{resourceVersion: rv, snapshot: indexer.Clone()})
+	item := snapshotItem{resourceVersion: rv, snapshot: indexer.Clone()}
+	rv64 := int64(rv)
+	if s.snapshots.Len() > 0 {
+		latestRV := s.snapshots.PeekLatest()
+		if rv64 < latestRV {
+			panic(fmt.Sprintf("snapshot with resourceVersion %d is older than the last snapshot with resourceVersion %d", rv64, latestRV))
+		}
+		if rv64 == latestRV {
+			s.snapshots.ReplaceLatest(item)
+			return
+		}
+	}
+	s.snapshots.ensureCapacity(s.snapshots.Len() + 1)
+	s.snapshots.Append(item)
 }
 
 func (s *storeSnapshotter) RemoveLess(rv uint64) {
 	s.mux.Lock()
 	defer s.mux.Unlock()
-	for s.snapshots.Len() > 0 {
-		oldest, ok := s.snapshots.Min()
-		if !ok {
-			break
-		}
-		if rv <= oldest.resourceVersion {
-			break
-		}
-		s.snapshots.DeleteMin()
-	}
+	s.snapshots.RemoveLess(int64(rv))
 }
 
 func (s *storeSnapshotter) Len() int {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_btree_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_btree_test.go
@@ -71,7 +71,7 @@ func TestStoreListPrefix(t *testing.T) {
 }
 
 func TestStoreSnapshotter(t *testing.T) {
-	cache := NewSnapshotter()
+	cache := NewSnapshotter(4)
 	cache.Add(10, fakeOrderedLister{rv: 10})
 	cache.Add(20, fakeOrderedLister{rv: 20})
 	cache.Add(30, fakeOrderedLister{rv: 30})

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -197,7 +197,7 @@ func newWatchCache(
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
 		wc.snapshottingEnabled.Store(true)
-		wc.snapshots = store.NewSnapshotter()
+		wc.snapshots = store.NewSnapshotter(wc.capacity)
 	}
 	metrics.WatchCacheCapacity.WithLabelValues(groupResource.Group, groupResource.Resource).Set(float64(wc.capacity))
 	wc.cond = sync.NewCond(wc.RLocker())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you: 
 
 1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution  and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide 
 2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here: 
 https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label 
 3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md 
 4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews 
 5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests 
 --> 

#### What type of PR is this?

/kind feature
/sig api-machinery

#### What this PR does / why we need it:

This PR implements a TODO in `storeSnapshotter` by replacing its internal btree-backed snapshot directory with a more efficient cyclic ring buffer implementation (`snapshotRing`).

**Why we need it:**
The snapshot history in the watch cache is naturally appended in monotonically increasing resource version (RV) order, and old snapshots are only pruned from the oldest side. This FIFO-like access pattern maps perfectly to a ring buffer. The previous B-tree implementation incurred unnecessary overhead (`O(log n)` for insertions and deletions) for this specific access pattern.

**Key Changes & Complexity Improvements:**
The public `Snapshotter` interface remains strictly unchanged. The internal complexity is improved as follows:
- `Add`: `O(log n)` -> `O(1)` amortized. (Replaces `btree.ReplaceOrInsert` with slice append/wrap-around).
- `RemoveLess`: `O(k log n)` -> `O(k + log n)`. (Replaces sequential `btree.DeleteMin` with binary search `searchGE` + logical head pointer advancement).
- `GetLessOrEqual`: Remains `O(log n)` via binary search on the ring.
- `Reset`: `O(1)` -> `O(n)` (zeroing the array to prevent memory leaks of the `OrderedLister` interface).

**Performance (Benchmarks):**
The new `snapshotRing` implementation significantly outperforms the B-tree across various window sizes and workloads. 


```text
// without clone
BenchmarkSnapshotterMixedWorkload/btree/window-128                                81.63 ns/op     6 B/op      0 allocs/op 
BenchmarkSnapshotterMixedWorkload/ring/window-128                                 24.91 ns/op     0 B/op      0 allocs/op   (~3.2x faster) 

BenchmarkSnapshotterMixedWorkload/btree/window-4096                              102.60 ns/op     3 B/op      0 allocs/op 
BenchmarkSnapshotterMixedWorkload/ring/window-4096                                29.45 ns/op     0 B/op      0 allocs/op   (~3.4x faster) 

BenchmarkSnapshotterMixedWorkload/btree/window-32768-bursty-trim                 113.80 ns/op     1 B/op      0 allocs/op 
BenchmarkSnapshotterMixedWorkload/ring/window-32768-bursty-trim                   13.23 ns/op     0 B/op      0 allocs/op   (~8.6x faster) 

// with clone
BenchmarkSnapshotterMixedWorkloadWithRealClone/btree/objects-1000/window-128     129.20 ns/op    78 B/op      4 allocs/op 
BenchmarkSnapshotterMixedWorkloadWithRealClone/ring/objects-1000/window-128       72.22 ns/op    72 B/op      4 allocs/op   (~1.8x faster)

BenchmarkSnapshotterMixedWorkloadWithRealClone/btree/objects-10000/window-4096   148.90 ns/op    75 B/op      4 allocs/op 
BenchmarkSnapshotterMixedWorkloadWithRealClone/ring/objects-10000/window-4096     76.50 ns/op    72 B/op      4 allocs/op   (~1.9x faster)

BenchmarkSnapshotterMixedWorkloadWithRealClone/btree/objects-100k/window-32k-trim 159.0 ns/op    73 B/op      4 allocs/op 
BenchmarkSnapshotterMixedWorkloadWithRealClone/ring/objects-100k/window-32k-trim   53.8 ns/op    72 B/op      4 allocs/op   (~2.9x faster)
```

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

**Test Adjustments:**
Because the new `snapshotRing` strictly enforces the invariant that snapshots must be added in monotonically increasing RV order (or replaced at the same RV), one existing test in `cacher_whitebox_test.go` (`TestShouldDelegateList`) was modified. Previously, it inserted a smaller RV *after* a larger RV. The test setup has been adjusted to call `Reset()` and add the RVs in correct chronological order.

**Comments**
Some of the comments in `store_btree.go` explaining the B-tree background have been left unchanged

**Handling of Same or Older Resource Versions:**
The old B-tree implementation used `ReplaceOrInsert`, which allowed inserting snapshots with an older RV out-of-order anywhere in the tree. The new `snapshotRing` is optimized for the physical reality of the watch cache: events arrive in monotonically increasing RV order. 
Currently, the `snapshotRing.add()` implementation enforces this invariant:
- **Same RV:** It replaces the last element
- **Older RV:** It `panic`, because an out-of-order snapshot indicates a severe logical bug upstream in the watch cache event stream. 
#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```