### PR TITLE
Fix/probe failure threshold event

### DIFF
--- a/pkg/kubelet/events/event.go
+++ b/pkg/kubelet/events/event.go
@@ -95,8 +95,9 @@ const (
 
 // Probe event reason list
 const (
-	ContainerUnhealthy    = "Unhealthy"
-	ContainerProbeWarning = "ProbeWarning"
+	ContainerUnhealthy           = "Unhealthy"
+	ContainerProbeWarning        = "ProbeWarning"
+	ContainerProbeFailureIgnored = "ProbeFailureIgnored"
 )
 
 // Pod worker event reason list

--- a/pkg/kubelet/prober/common_test.go
+++ b/pkg/kubelet/prober/common_test.go
@@ -165,7 +165,7 @@ func newTestManager() *manager {
 		&record.FakeRecorder{},
 	).(*manager)
 	// Don't actually execute probes.
-	m.prober.exec = fakeExecProber{probe.Success, nil}
+	m.prober.exec = fakeExecProber{probe.Success, "", nil}
 	return m
 }
 
@@ -177,11 +177,12 @@ func newTestWorker(m *manager, probeType probeType, probeSpec v1.Probe) *worker 
 
 type fakeExecProber struct {
 	result probe.Result
+	output string
 	err    error
 }
 
 func (p fakeExecProber) Probe(c exec.Cmd) (probe.Result, string, error) {
-	return p.result, "", p.err
+	return p.result, p.output, p.err
 }
 
 type syncExecProber struct {

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -80,7 +80,9 @@ func (pb *prober) recordContainerEvent(ctx context.Context, pod *v1.Pod, contain
 }
 
 // probe probes the container.
-func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (results.Result, error) {
+// Returns a results.Result, the output string from the probe, and an error.
+// The output is returned so callers (e.g., the worker) can include it in threshold-aware events.
+func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (results.Result, string, error) {
 	var probeSpec *v1.Probe
 	switch probeType {
 	case readiness:
@@ -90,13 +92,13 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 	case startup:
 		probeSpec = container.StartupProbe
 	default:
-		return results.Failure, fmt.Errorf("unknown probe type: %q", probeType)
+		return results.Failure, "", fmt.Errorf("unknown probe type: %q", probeType)
 	}
 
 	logger := klog.FromContext(ctx)
 	if probeSpec == nil {
 		logger.Info("Probe is nil", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name)
-		return results.Success, nil
+		return results.Success, "", nil
 	}
 
 	result, output, err := pb.runProbeWithRetries(ctx, probeType, probeSpec, pod, status, container, containerID, maxProbeRetries)
@@ -105,31 +107,31 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 		// Handle probe error
 		logger.V(1).Info("Probe errored", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result, "err", err)
 		pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe errored and resulted in %s state: %s", probeType, result, err)
-		return results.Failure, err
+		return results.Failure, output, err
 	}
 
 	switch result {
 	case probe.Success:
 		logger.V(3).Info("Probe succeeded", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name)
-		return results.Success, nil
+		return results.Success, output, nil
 
 	case probe.Warning:
 		pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerProbeWarning, "%s probe warning: %s", probeType, output)
 		logger.V(3).Info("Probe succeeded with a warning", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "output", output)
-		return results.Success, nil
+		return results.Success, output, nil
 
 	case probe.Failure:
-		logger.V(1).Info("Probe failed", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name)
-		pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s", output)
-		return results.Failure, nil
+		logger.V(1).Info("Probe failed", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "output", output)
+		// The Unhealthy event is emitted by the worker with threshold context.
+		return results.Failure, output, nil
 
 	case probe.Unknown:
 		logger.V(1).Info("Probe unknown without error", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result)
-		return results.Failure, nil
+		return results.Failure, output, nil
 
 	default:
 		logger.V(1).Info("Unsupported probe result", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result)
-		return results.Failure, nil
+		return results.Failure, output, nil
 	}
 }
 

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -119,8 +119,8 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 		return results.Success, nil
 
 	case probe.Failure:
-		logger.V(1).Info("Probe failed", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result, "output", output)
-		pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed: %s", probeType, output)
+		logger.V(1).Info("Probe failed", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name)
+		pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s", output)
 		return results.Failure, nil
 
 	case probe.Unknown:

--- a/pkg/kubelet/prober/prober_test.go
+++ b/pkg/kubelet/prober/prober_test.go
@@ -248,12 +248,12 @@ func TestProbe(t *testing.T) {
 				testContainer.StartupProbe = test.probe
 			}
 			if test.execError {
-				prober.exec = fakeExecProber{test.execResult, errors.New("exec error")}
+				prober.exec = fakeExecProber{test.execResult, "", errors.New("exec error")}
 			} else {
-				prober.exec = fakeExecProber{test.execResult, nil}
+				prober.exec = fakeExecProber{test.execResult, "", nil}
 			}
 
-			result, err := prober.probe(ctx, pType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
+			result, _, err := prober.probe(ctx, pType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
 
 			if test.expectError {
 				require.Error(t, err, "[%s] Expected probe error but no error was returned.", testID)
@@ -266,7 +266,7 @@ func TestProbe(t *testing.T) {
 			if len(test.expectCommand) > 0 {
 				prober.exec = execprobe.New()
 				prober.runner = &containertest.FakeContainerCommandRunner{}
-				_, err := prober.probe(ctx, pType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
+				_, _, err := prober.probe(ctx, pType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
 				require.NoError(t, err, "[%s] Didn't expect probe error ", testID)
 
 				if !reflect.DeepEqual(test.expectCommand, prober.runner.(*containertest.FakeContainerCommandRunner).Cmd) {

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -380,7 +380,7 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 			msg := fmt.Sprintf("probe failure %d/%d: failure ignored, FailureThreshold not yet reached",
 				w.resultRun, int(w.spec.FailureThreshold))
 			w.probeManager.prober.recordContainerEvent(ctx, w.pod, &w.container,
-				v1.EventTypeWarning, events.ContainerUnhealthy, "%s", msg)
+				v1.EventTypeWarning, events.ContainerProbeFailureIgnored, "%s", msg)
 		}
 		return true
 	}

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -18,7 +18,6 @@ package prober
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"time"
 
@@ -348,7 +347,7 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 	}
 
 	// Note, exec probe does NOT have access to pod environment variables or downward API
-	result, err := w.probeManager.prober.probe(ctx, w.probeType, w.pod, status, w.container, w.containerID)
+	result, probeOutput, err := w.probeManager.prober.probe(ctx, w.probeType, w.pod, status, w.container, w.containerID)
 	if err != nil {
 		// Prober error, throw away the result.
 		return true
@@ -376,13 +375,24 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 		(result == results.Success && w.resultRun < int(w.spec.SuccessThreshold)) {
 		// Success or failure is below threshold - leave the probe state unchanged.
 		if result == results.Failure {
-			// Emit an event indicating the failure was ignored because FailureThreshold has not been reached.
-			msg := fmt.Sprintf("probe failure %d/%d: failure ignored, FailureThreshold not yet reached",
-				w.resultRun, int(w.spec.FailureThreshold))
+			// Emit a dedicated event indicating this failure was ignored because
+			// FailureThreshold has not yet been reached, including the probe output
+			// so operators can see why the probe failed.
 			w.probeManager.prober.recordContainerEvent(ctx, w.pod, &w.container,
-				v1.EventTypeWarning, events.ContainerProbeFailureIgnored, "%s", msg)
+				v1.EventTypeWarning, events.ContainerProbeFailureIgnored,
+				"%s probe failed: %s (failure %d/%d, FailureThreshold not yet reached)",
+				w.probeType, probeOutput, w.resultRun, int(w.spec.FailureThreshold))
 		}
 		return true
+	}
+
+	// Emit the Unhealthy event when FailureThreshold is reached, including the
+	// probe output so operators know what caused the threshold to be crossed.
+	if result == results.Failure {
+		w.probeManager.prober.recordContainerEvent(ctx, w.pod, &w.container,
+			v1.EventTypeWarning, events.ContainerUnhealthy,
+			"%s probe failed: %s (failure threshold %d reached)",
+			w.probeType, probeOutput, w.spec.FailureThreshold)
 	}
 
 	w.resultsManager.Set(w.containerID, result, w.pod)

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -377,10 +377,10 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 		// Success or failure is below threshold - leave the probe state unchanged.
 		if result == results.Failure {
 			// Emit an event indicating the failure was ignored because FailureThreshold has not been reached.
+			msg := fmt.Sprintf("probe failure %d/%d: failure ignored, FailureThreshold not yet reached",
+				w.resultRun, int(w.spec.FailureThreshold))
 			w.probeManager.prober.recordContainerEvent(ctx, w.pod, &w.container,
-				v1.EventTypeWarning, events.ContainerUnhealthy,
-				fmt.Sprintf("probe failure %d/%d: failure ignored, FailureThreshold not yet reached",
-					w.resultRun, int(w.spec.FailureThreshold)))
+				v1.EventTypeWarning, events.ContainerUnhealthy, "%s", msg)
 		}
 		return true
 	}

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -18,6 +18,7 @@ package prober
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"time"
 
@@ -29,6 +30,7 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/prober/results"
 )
 
@@ -373,6 +375,13 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 	if (result == results.Failure && w.resultRun < int(w.spec.FailureThreshold)) ||
 		(result == results.Success && w.resultRun < int(w.spec.SuccessThreshold)) {
 		// Success or failure is below threshold - leave the probe state unchanged.
+		if result == results.Failure {
+			// Emit an event indicating the failure was ignored because FailureThreshold has not been reached.
+			w.probeManager.prober.recordContainerEvent(ctx, w.pod, &w.container,
+				v1.EventTypeWarning, events.ContainerUnhealthy,
+				fmt.Sprintf("probe failure %d/%d: failure ignored, FailureThreshold not yet reached",
+					w.resultRun, int(w.spec.FailureThreshold)))
+		}
 		return true
 	}
 

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -898,29 +898,29 @@ func TestStartupProbeDisabledByStarted(t *testing.T) {
 	expectResult(t, w, results.Success, msg)
 }
 
-// TestProbeFailureEventEmittedBeforeThreshold verifies that when a probe fails
-// but FailureThreshold has not been reached, the probe result remains unchanged
-// and resultRun is incremented correctly, confirming the ignored-failure path.
-func TestProbeFailureEventEmittedBeforeThreshold(t *testing.T) {
+// TestProbeFailureBelowThresholdKeepsResultUnchanged verifies that when a probe
+// fails but FailureThreshold has not been reached, the probe result remains
+// unchanged and resultRun is incremented correctly.
+func TestProbeFailureBelowThresholdKeepsResultUnchanged(t *testing.T) {
 	logger, ctx := ktesting.NewTestContext(t)
 	m := newTestManager()
 	w := newTestWorker(m, liveness, v1.Probe{SuccessThreshold: 1, FailureThreshold: 3})
 	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatus())
 
-	// First failure - below threshold, result should stay Success, event emitted with "1/3"
+	// First failure - below threshold, result should stay Success
 	m.prober.exec = fakeExecProber{probe.Failure, nil}
 	msg := "1st probe failure, below threshold"
 	expectContinue(t, w, w.doProbe(ctx), msg)
-	expectResult(t, w, results.Success, msg) // result unchanged
+	expectResult(t, w, results.Success, msg)
 	if w.resultRun != 1 {
 		t.Errorf("resultRun should be 1, got %d", w.resultRun)
 	}
 
-	// Second failure - still below threshold, result should stay Success, event emitted with "2/3"
+	// Second failure - still below threshold, result should stay Success
 	m.prober.exec = fakeExecProber{probe.Failure, nil}
 	msg = "2nd probe failure, below threshold"
 	expectContinue(t, w, w.doProbe(ctx), msg)
-	expectResult(t, w, results.Success, msg) // result still unchanged
+	expectResult(t, w, results.Success, msg)
 	if w.resultRun != 2 {
 		t.Errorf("resultRun should be 2, got %d", w.resultRun)
 	}
@@ -929,7 +929,7 @@ func TestProbeFailureEventEmittedBeforeThreshold(t *testing.T) {
 	m.prober.exec = fakeExecProber{probe.Failure, nil}
 	msg = "3rd probe failure, threshold reached"
 	expectContinue(t, w, w.doProbe(ctx), msg)
-	expectResult(t, w, results.Failure, msg) // result now changes
+	expectResult(t, w, results.Failure, msg)
 	if w.resultRun != 0 {
 		t.Errorf("resultRun should be reset to 0, got %d", w.resultRun)
 	}

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -898,6 +898,43 @@ func TestStartupProbeDisabledByStarted(t *testing.T) {
 	expectResult(t, w, results.Success, msg)
 }
 
+// TestProbeFailureEventEmittedBeforeThreshold verifies that when a probe fails
+// but FailureThreshold has not been reached, the probe result remains unchanged
+// and resultRun is incremented correctly, confirming the ignored-failure path.
+func TestProbeFailureEventEmittedBeforeThreshold(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	m := newTestManager()
+	w := newTestWorker(m, liveness, v1.Probe{SuccessThreshold: 1, FailureThreshold: 3})
+	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatus())
+
+	// First failure - below threshold, result should stay Success, event emitted with "1/3"
+	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	msg := "1st probe failure, below threshold"
+	expectContinue(t, w, w.doProbe(ctx), msg)
+	expectResult(t, w, results.Success, msg) // result unchanged
+	if w.resultRun != 1 {
+		t.Errorf("resultRun should be 1, got %d", w.resultRun)
+	}
+
+	// Second failure - still below threshold, result should stay Success, event emitted with "2/3"
+	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	msg = "2nd probe failure, below threshold"
+	expectContinue(t, w, w.doProbe(ctx), msg)
+	expectResult(t, w, results.Success, msg) // result still unchanged
+	if w.resultRun != 2 {
+		t.Errorf("resultRun should be 2, got %d", w.resultRun)
+	}
+
+	// Third failure - threshold reached, result should now change to Failure
+	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	msg = "3rd probe failure, threshold reached"
+	expectContinue(t, w, w.doProbe(ctx), msg)
+	expectResult(t, w, results.Failure, msg) // result now changes
+	if w.resultRun != 0 {
+		t.Errorf("resultRun should be reset to 0, got %d", w.resultRun)
+	}
+}
+
 func TestChangeContainerStatusOnKubeletRestart(t *testing.T) {
 	logger, ctx := ktesting.NewTestContext(t)
 

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -455,7 +456,7 @@ func TestFailureThreshold(t *testing.T) {
 
 	for i := 0; i < 2; i++ {
 		// First probe should succeed.
-		m.prober.exec = fakeExecProber{probe.Success, nil}
+		m.prober.exec = fakeExecProber{probe.Success, "", nil}
 
 		for j := 0; j < 3; j++ {
 			msg := fmt.Sprintf("%d success (%d)", j+1, i)
@@ -464,7 +465,7 @@ func TestFailureThreshold(t *testing.T) {
 		}
 
 		// Prober starts failing :(
-		m.prober.exec = fakeExecProber{probe.Failure, nil}
+		m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 
 		// Next 2 probes should still be "success".
 		for j := 0; j < 2; j++ {
@@ -507,13 +508,13 @@ func TestSuccessThreshold(t *testing.T) {
 		}
 
 		// Prober flakes :(
-		m.prober.exec = fakeExecProber{probe.Failure, nil}
+		m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 		msg := fmt.Sprintf("1 failure (%d)", i)
 		expectContinue(t, w, w.doProbe(ctx), msg)
 		expectResult(t, w, results.Failure, msg)
 
 		// Back to success.
-		m.prober.exec = fakeExecProber{probe.Success, nil}
+		m.prober.exec = fakeExecProber{probe.Success, "", nil}
 	}
 }
 
@@ -524,7 +525,7 @@ func TestStartupProbeSuccessThreshold(t *testing.T) {
 	failureThreshold := 3
 	w := newTestWorker(m, startup, v1.Probe{SuccessThreshold: int32(successThreshold), FailureThreshold: int32(failureThreshold)})
 	m.statusManager.SetPodStatus(logger, w.pod, getTestNotRunningStatus())
-	m.prober.exec = fakeExecProber{probe.Success, nil}
+	m.prober.exec = fakeExecProber{probe.Success, "", nil}
 
 	for i := 0; i < successThreshold+1; i++ {
 		if i < successThreshold {
@@ -557,7 +558,7 @@ func TestStartupProbeFailureThreshold(t *testing.T) {
 	failureThreshold := 3
 	w := newTestWorker(m, startup, v1.Probe{SuccessThreshold: int32(successThreshold), FailureThreshold: int32(failureThreshold)})
 	m.statusManager.SetPodStatus(logger, w.pod, getTestNotRunningStatus())
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 
 	for i := 0; i < failureThreshold+1; i++ {
 		if i < failureThreshold {
@@ -678,7 +679,7 @@ func TestOnHoldOnLivenessOrStartupCheckFailure(t *testing.T) {
 		m.statusManager.SetPodStatus(logger, w.pod, status)
 
 		// First probe should fail.
-		m.prober.exec = fakeExecProber{probe.Failure, nil}
+		m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 		msg := "first probe"
 		expectContinue(t, w, w.doProbe(ctx), msg)
 		expectResult(t, w, results.Failure, msg)
@@ -687,7 +688,7 @@ func TestOnHoldOnLivenessOrStartupCheckFailure(t *testing.T) {
 		}
 		// Set fakeExecProber to return success. However, the result will remain
 		// failure because the worker is on hold and won't probe.
-		m.prober.exec = fakeExecProber{probe.Success, nil}
+		m.prober.exec = fakeExecProber{probe.Success, "", nil}
 		msg = "while on hold"
 		expectContinue(t, w, w.doProbe(ctx), msg)
 		expectResult(t, w, results.Failure, msg)
@@ -715,7 +716,7 @@ func TestResultRunOnLivenessCheckFailure(t *testing.T) {
 	w := newTestWorker(m, liveness, v1.Probe{SuccessThreshold: 1, FailureThreshold: 3})
 	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatus())
 
-	m.prober.exec = fakeExecProber{probe.Success, nil}
+	m.prober.exec = fakeExecProber{probe.Success, "", nil}
 	msg := "initial probe success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
@@ -723,7 +724,7 @@ func TestResultRunOnLivenessCheckFailure(t *testing.T) {
 		t.Errorf("Prober resultRun should be 1")
 	}
 
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "probe failure, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
@@ -731,7 +732,7 @@ func TestResultRunOnLivenessCheckFailure(t *testing.T) {
 		t.Errorf("Prober resultRun should be 1")
 	}
 
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "2nd probe failure, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
@@ -742,7 +743,7 @@ func TestResultRunOnLivenessCheckFailure(t *testing.T) {
 	// Exceeding FailureThreshold should cause resultRun to
 	// reset to 0 so that the probe on the restarted pod
 	// also gets FailureThreshold attempts to succeed.
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "3rd probe failure, result failure"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Failure, msg)
@@ -760,7 +761,7 @@ func TestResultRunOnStartupCheckFailure(t *testing.T) {
 
 	// Below FailureThreshold leaves probe state unchanged
 	// which is failed for startup at first.
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg := "probe failure, result unknown"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Unknown, msg)
@@ -768,7 +769,7 @@ func TestResultRunOnStartupCheckFailure(t *testing.T) {
 		t.Errorf("Prober resultRun should be 1")
 	}
 
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "2nd probe failure, result unknown"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Unknown, msg)
@@ -779,7 +780,7 @@ func TestResultRunOnStartupCheckFailure(t *testing.T) {
 	// Exceeding FailureThreshold should cause resultRun to
 	// reset to 0 so that the probe on the restarted pod
 	// also gets FailureThreshold attempts to succeed.
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "3rd probe failure, result failure"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Failure, msg)
@@ -860,14 +861,14 @@ func TestLivenessProbeDisabledByStarted(t *testing.T) {
 	w := newTestWorker(m, liveness, v1.Probe{SuccessThreshold: 1, FailureThreshold: 1})
 	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatusWithStarted(false))
 	// livenessProbe fails, but is disabled
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg := "Not started, probe failure, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
 	// setting started state
 	m.statusManager.SetContainerStartup(logger, w.pod.UID, w.containerID, true)
 	// livenessProbe fails
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "Started, probe failure, result failure"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Failure, msg)
@@ -880,19 +881,19 @@ func TestStartupProbeDisabledByStarted(t *testing.T) {
 	w := newTestWorker(m, startup, v1.Probe{SuccessThreshold: 1, FailureThreshold: 2})
 	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatusWithStarted(false))
 	// startupProbe fails < FailureThreshold, stays unknown
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg := "Not started, probe failure, result unknown"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Unknown, msg)
 	// startupProbe succeeds
-	m.prober.exec = fakeExecProber{probe.Success, nil}
+	m.prober.exec = fakeExecProber{probe.Success, "", nil}
 	msg = "Started, probe success, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
 	// setting started state
 	m.statusManager.SetContainerStartup(logger, w.pod.UID, w.containerID, true)
 	// startupProbe fails, but is disabled
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "Started, probe failure, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
@@ -900,15 +901,22 @@ func TestStartupProbeDisabledByStarted(t *testing.T) {
 
 // TestProbeFailureBelowThresholdKeepsResultUnchanged verifies that when a probe
 // fails but FailureThreshold has not been reached, the probe result remains
-// unchanged and resultRun is incremented correctly.
+// unchanged, resultRun is incremented correctly, and the correct threshold-aware
+// events are emitted including the probe output.
 func TestProbeFailureBelowThresholdKeepsResultUnchanged(t *testing.T) {
 	logger, ctx := ktesting.NewTestContext(t)
 	m := newTestManager()
 	w := newTestWorker(m, liveness, v1.Probe{SuccessThreshold: 1, FailureThreshold: 3})
 	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatus())
 
+	// Use a fake recorder with enough buffer for all expected events
+	fakeRecorder := record.NewFakeRecorder(10)
+	m.prober.recorder = fakeRecorder
+
+	probeOutput := "http probe failed with statuscode: 500"
+
 	// First failure - below threshold, result should stay Success
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, probeOutput, nil}
 	msg := "1st probe failure, below threshold"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
@@ -917,7 +925,7 @@ func TestProbeFailureBelowThresholdKeepsResultUnchanged(t *testing.T) {
 	}
 
 	// Second failure - still below threshold, result should stay Success
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, probeOutput, nil}
 	msg = "2nd probe failure, below threshold"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
@@ -926,12 +934,35 @@ func TestProbeFailureBelowThresholdKeepsResultUnchanged(t *testing.T) {
 	}
 
 	// Third failure - threshold reached, result should now change to Failure
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, probeOutput, nil}
 	msg = "3rd probe failure, threshold reached"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Failure, msg)
 	if w.resultRun != 0 {
 		t.Errorf("resultRun should be reset to 0, got %d", w.resultRun)
+	}
+
+	// Verify the correct events were emitted with probe output and threshold context
+	close(fakeRecorder.Events)
+	var eventMessages []string
+	for e := range fakeRecorder.Events {
+		eventMessages = append(eventMessages, e)
+	}
+
+	expectedEvents := []string{
+		"Warning ProbeFailureIgnored Liveness probe failed: http probe failed with statuscode: 500 (failure 1/3, FailureThreshold not yet reached)",
+		"Warning ProbeFailureIgnored Liveness probe failed: http probe failed with statuscode: 500 (failure 2/3, FailureThreshold not yet reached)",
+		"Warning Unhealthy Liveness probe failed: http probe failed with statuscode: 500 (failure threshold 3 reached)",
+	}
+
+	if len(eventMessages) != len(expectedEvents) {
+		t.Errorf("Expected %d events, got %d: %v", len(expectedEvents), len(eventMessages), eventMessages)
+	} else {
+		for i, expected := range expectedEvents {
+			if eventMessages[i] != expected {
+				t.Errorf("Event %d mismatch:\n  expected: %s\n  got:      %s", i+1, expected, eventMessages[i])
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
When a probe fails in Kubernetes, a container event is emitted regardless
of whether the FailureThreshold has been reached. This means users consuming
probe failure events have no way of knowing whether the failure resulted in
any control plane action, or was silently ignored because the threshold has
not yet been reached.

This PR addresses this by:
1. Threading the probe output string through the `probe()` return signature in prober.go so the worker has full context to construct threshold-aware events.
2. Emitting a dedicated `ProbeFailureIgnored` event from worker.go when a failure is below FailureThreshold, including the probe output, current failure count, and threshold.
3. Emitting the existing `Unhealthy` event from worker.go when FailureThreshold is reached, also including the probe output.

#### Which issue(s) this PR is related to:
Fixes #115823

#### Special notes for your reviewer:
- Events are emitted from worker.go rather than prober.go because worker.go is where FailureThreshold and resultRun are known.
- A dedicated event reason `ContainerProbeFailureIgnored` is used for below-threshold failures, keeping `ContainerUnhealthy` only for actionable threshold-reached failures. This avoids breaking clients that filter or alert on `ContainerUnhealthy`.
- The probe output is now returned from `probe()` as a second return value so both events can include the actual failure message.

#### Does this PR introduce a user-facing change?
```release-note
Probe failure events now include the probe output and failure count context.
Below threshold: "Liveness probe failed: <output> (failure 1/3, FailureThreshold not yet reached)"
Threshold reached: "Liveness probe failed: <output> (failure threshold 3 reached)"
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
```