### PR TITLE
Deployment controller cleanups

### DIFF
--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -610,7 +610,6 @@ func (dc *DeploymentController) syncDeployment(ctx context.Context, key string) 
 	}
 
 	// Deep-copy otherwise we are mutating our cache.
-	// TODO: Deep-copy only when needed.
 	d := deployment.DeepCopy()
 
 	everything := metav1.LabelSelector{}

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -629,15 +629,6 @@ func (dc *DeploymentController) syncDeployment(ctx context.Context, key string) 
 	if err != nil {
 		return err
 	}
-	// List all Pods owned by this Deployment, grouped by their ReplicaSet.
-	// Current uses of the podMap are:
-	//
-	// * check if a Pod is labeled correctly with the pod-template-hash label.
-	// * check that no old Pods are running in the middle of Recreate Deployments.
-	podMap, err := dc.getPodMapForDeployment(d, rsList)
-	if err != nil {
-		return err
-	}
 
 	if d.DeletionTimestamp != nil {
 		return dc.syncStatusOnly(ctx, d, rsList)
@@ -671,6 +662,12 @@ func (dc *DeploymentController) syncDeployment(ctx context.Context, key string) 
 
 	switch d.Spec.Strategy.Type {
 	case apps.RecreateDeploymentStrategyType:
+		// List all Pods owned by this Deployment, grouped by their ReplicaSet, to
+		// check that no old Pods are running in the middle of a Recreate rollout.
+		podMap, err := dc.getPodMapForDeployment(d, rsList)
+		if err != nil {
+			return err
+		}
 		return dc.rolloutRecreate(ctx, d, rsList, podMap)
 	case apps.RollingUpdateDeploymentStrategyType:
 		return dc.rolloutRolling(ctx, d, rsList)

--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -24,7 +24,6 @@ import (
 
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -354,7 +353,7 @@ func TestReentrantRollback(t *testing.T) {
 
 	d := newDeployment("foo", 1, nil, nil, nil, map[string]string{"foo": "bar"})
 	d.Annotations = map[string]string{util.RevisionAnnotation: "2"}
-	setRollbackTo(d, &extensions.RollbackConfig{Revision: 0})
+	setRollbackTo(d, new(int64))
 	f.dLister = append(f.dLister, d)
 
 	rs1 := newReplicaSet(d, "deploymentrs-old", 0)

--- a/pkg/controller/deployment/rollback.go
+++ b/pkg/controller/deployment/rollback.go
@@ -23,7 +23,6 @@ import (
 
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
@@ -38,10 +37,10 @@ func (dc *DeploymentController) rollback(ctx context.Context, d *apps.Deployment
 	}
 
 	allRSs := append(allOldRSs, newRS)
-	rollbackTo := getRollbackTo(d)
+	rollbackRevision := *getRollbackTo(d)
 	// If rollback revision is 0, rollback to the last revision
-	if rollbackTo.Revision == 0 {
-		if rollbackTo.Revision = deploymentutil.LastRevision(logger, allRSs); rollbackTo.Revision == 0 {
+	if rollbackRevision == 0 {
+		if rollbackRevision = deploymentutil.LastRevision(logger, allRSs); rollbackRevision == 0 {
 			// If we still can't find the last revision, gives up rollback
 			dc.emitRollbackWarningEvent(d, deploymentutil.RollbackRevisionNotFound, "Unable to find last revision.")
 			// Gives up rollback
@@ -54,14 +53,14 @@ func (dc *DeploymentController) rollback(ctx context.Context, d *apps.Deployment
 			logger.V(4).Info("Unable to extract revision from deployment's replica set", "replicaSet", klog.KObj(rs), "err", err)
 			continue
 		}
-		if v == rollbackTo.Revision {
+		if v == rollbackRevision {
 			logger.V(4).Info("Found replica set with desired revision", "replicaSet", klog.KObj(rs), "revision", v)
 			// rollback by copying podTemplate.Spec from the replica set
 			// revision number will be incremented during the next getAllReplicaSetsAndSyncRevision call
 			// no-op if the spec matches current deployment's podTemplate.Spec
 			performedRollback, err := dc.rollbackToTemplate(ctx, d, rs)
 			if performedRollback && err == nil {
-				dc.emitRollbackNormalEvent(d, fmt.Sprintf("Rolled back deployment %q to revision %d", d.Name, rollbackTo.Revision))
+				dc.emitRollbackNormalEvent(d, fmt.Sprintf("Rolled back deployment %q to revision %d", d.Name, rollbackRevision))
 			}
 			return err
 		}
@@ -121,8 +120,8 @@ func (dc *DeploymentController) updateDeploymentAndClearRollbackTo(ctx context.C
 	return err
 }
 
-// TODO: Remove this when extensions/v1beta1 and apps/v1beta1 Deployment are dropped.
-func getRollbackTo(d *apps.Deployment) *extensions.RollbackConfig {
+// getRollbackTo returns the revision to roll back to from the deprecated rollback annotation, or nil if absent or invalid.
+func getRollbackTo(d *apps.Deployment) *int64 {
 	// Extract the annotation used for round-tripping the deprecated RollbackTo field.
 	revision := d.Annotations[apps.DeprecatedRollbackTo]
 	if revision == "" {
@@ -133,19 +132,17 @@ func getRollbackTo(d *apps.Deployment) *extensions.RollbackConfig {
 		// If it's invalid, ignore it.
 		return nil
 	}
-	return &extensions.RollbackConfig{
-		Revision: revision64,
-	}
+	return &revision64
 }
 
-// TODO: Remove this when extensions/v1beta1 and apps/v1beta1 Deployment are dropped.
-func setRollbackTo(d *apps.Deployment, rollbackTo *extensions.RollbackConfig) {
-	if rollbackTo == nil {
+// setRollbackTo sets the deprecated rollback annotation to the given revision, or clears it if revision is nil.
+func setRollbackTo(d *apps.Deployment, revision *int64) {
+	if revision == nil {
 		delete(d.Annotations, apps.DeprecatedRollbackTo)
 		return
 	}
 	if d.Annotations == nil {
 		d.Annotations = make(map[string]string)
 	}
-	d.Annotations[apps.DeprecatedRollbackTo] = strconv.FormatInt(rollbackTo.Revision, 10)
+	d.Annotations[apps.DeprecatedRollbackTo] = strconv.FormatInt(*revision, 10)
 }

--- a/pkg/controller/deployment/sync.go
+++ b/pkg/controller/deployment/sync.go
@@ -390,7 +390,6 @@ func (dc *DeploymentController) scale(ctx context.Context, deployment *apps.Depl
 				}
 			}
 
-			// TODO: Use transactions when we have them.
 			if _, _, err := dc.scaleReplicaSet(ctx, rs, nameToSize[rs.Name], deployment, true); err != nil {
 				// Return as soon as we fail, the deployment is requeued
 				return err

--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -302,7 +302,6 @@ var annotationsToSkip = map[string]bool{
 }
 
 // skipCopyAnnotation returns true if we should skip copying the annotation with the given annotation key
-// TODO: How to decide which annotations should / should not be copied?
 //
 // See https://github.com/kubernetes/kubernetes/pull/20035#issuecomment-179558615
 func skipCopyAnnotation(key string) bool {
@@ -541,8 +540,6 @@ func RsListFromClient(c appsclient.AppsV1Interface) RsListFunc {
 		return ret, err
 	}
 }
-
-// TODO: switch RsListFunc and podListFunc to full namespacers
 
 // RsListFunc returns the ReplicaSet from the ReplicaSet namespace and the List metav1.ListOptions.
 type RsListFunc func(string, metav1.ListOptions) ([]*apps.ReplicaSet, error)
@@ -865,7 +862,6 @@ func IsSaturated(deployment *apps.Deployment, rs *apps.ReplicaSet) bool {
 // WaitForObservedDeployment polls for deployment to be updated so that deployment.Status.ObservedGeneration >= desiredGeneration.
 // Returns error if polling timesout.
 func WaitForObservedDeployment(getDeploymentFunc func() (*apps.Deployment, error), desiredGeneration int64, interval, timeout time.Duration) error {
-	// TODO: This should take clientset.Interface when all code is updated to use clientset. Keeping it this way allows the function to be used by callers who have client.Interface.
 	return wait.PollImmediate(interval, timeout, func() (bool, error) {
 		deployment, err := getDeploymentFunc()
 		if err != nil {
@@ -928,7 +924,6 @@ func GetDeploymentsForReplicaSet(deploymentLister appslisters.DeploymentLister, 
 		return nil, fmt.Errorf("no deployments found for ReplicaSet %v because it has no labels", rs.Name)
 	}
 
-	// TODO: MODIFY THIS METHOD so that it checks for the podTemplateSpecHash label
 	dList, err := deploymentLister.Deployments(rs.Namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig apps

#### What this PR does / why we need it:
This PR introduced the following cleanups in the deployment controller:
1. Move `podMap` construction to where it's actually used in `syncDeployment`. This should save a few bytes on majority of syncs. Will make bigger sense at scale.
2. Drop long dead `extensions/v1beta1` usage from the deployment controller.
3. Drops a few `TODO` which doesn't make sense anymore or are never gonna be implemented. 

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
/assign @janetkuo 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
