### PR TITLE
Replace deprecated wait.PollImmediate with context-based wait.PollUntilContextCancel

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/mutation_detector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_detector_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cache
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -61,7 +62,8 @@ func TestMutationDetector(t *testing.T) {
 
 	fakeWatch.Add(pod)
 
-	wait.PollImmediate(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+	ctx := t.Context()
+	_ = wait.PollUntilContextCancel(ctx, 100*time.Millisecond, true, func(ctx context.Context) (bool, error) {
 		detector.addedObjsLock.Lock()
 		defer detector.addedObjsLock.Unlock()
 		return len(detector.addedObjs) > 0, nil

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -414,16 +414,17 @@ func WaitForNamedCacheSyncWithContext(ctx context.Context, cacheSyncs ...Informe
 // if the controller should shutdown
 // callers should prefer WaitForNamedCacheSync()
 func WaitForCacheSync(stopCh <-chan struct{}, cacheSyncs ...InformerSynced) bool {
-	err := wait.PollImmediateUntil(syncedPollPeriod,
-		func() (bool, error) {
+	err := wait.PollUntilContextCancel(wait.ContextForChannel(stopCh),
+		syncedPollPeriod,
+		true,
+		func(ctx context.Context) (done bool, err error) {
 			for _, syncFunc := range cacheSyncs {
 				if !syncFunc() {
 					return false, nil
 				}
 			}
 			return true, nil
-		},
-		stopCh)
+		})
 	if err != nil {
 		return false
 	}

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
@@ -95,12 +95,14 @@ func (l *testListener) handle(obj interface{}) {
 
 func (l *testListener) ok() bool {
 	l.println("polling")
-	err := wait.PollImmediate(100*time.Millisecond, 2*time.Second, func() (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	err := wait.PollUntilContextCancel(ctx, 100*time.Millisecond, true, func(ctx context.Context) (bool, error) {
 		if l.satisfiedExpectations() {
 			return true, nil
 		}
 		return false, nil
 	})
+	cancel()
 	if err != nil {
 		return false
 	}
@@ -1012,7 +1014,8 @@ func TestAddOnStoppedSharedInformer(t *testing.T) {
 	defer wg.Wait()
 	close(stop)
 
-	err := wait.PollImmediate(100*time.Millisecond, 2*time.Second, func() (bool, error) {
+	ctx := t.Context()
+	err := wait.PollUntilContextCancel(ctx, 100*time.Millisecond, true, func(ctx context.Context) (bool, error) {
 		if informer.IsStopped() {
 			return true, nil
 		}

--- a/staging/src/k8s.io/client-go/tools/events/eventseries_test.go
+++ b/staging/src/k8s.io/client-go/tools/events/eventseries_test.go
@@ -206,7 +206,8 @@ func TestEventSeriesWithEventSinkImplRace(t *testing.T) {
 	recorder.Eventf(&v1.ObjectReference{}, nil, v1.EventTypeNormal, "reason", "action", "", "")
 	recorder.Eventf(&v1.ObjectReference{}, nil, v1.EventTypeNormal, "reason", "action", "", "")
 
-	err := wait.PollImmediate(100*time.Millisecond, 5*time.Second, func() (done bool, err error) {
+	ctx := t.Context()
+	err := wait.PollUntilContextCancel(ctx, 100*time.Millisecond, true, func(ctx context.Context) (done bool, err error) {
 		events, err := kubeClient.EventsV1().Events(metav1.NamespaceDefault).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return false, err

--- a/staging/src/k8s.io/client-go/tools/watch/retrywatcher_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/retrywatcher_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package watch
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -590,7 +591,7 @@ func TestRetryWatcher(t *testing.T) {
 			var counter uint32
 			// We always count with the last watch reestablishing which is imminent but still a race.
 			// We will wait for the last watch to reestablish to avoid it.
-			err = wait.PollImmediate(10*time.Millisecond, 10*time.Second, func() (done bool, err error) {
+			err = wait.PollUntilContextCancel(ctx, 10*time.Millisecond, true, func(ctx context.Context) (done bool, err error) {
 				counter = atomic.LoadUint32(atomicCounter)
 				return counter == tc.watchCount, nil
 			})

--- a/staging/src/k8s.io/client-go/transport/cert_rotation.go
+++ b/staging/src/k8s.io/client-go/transport/cert_rotation.go
@@ -18,6 +18,7 @@ package transport
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"reflect"
 	"sync"
@@ -143,10 +144,12 @@ func (c *dynamicClientCert) run(stopCh <-chan struct{}) {
 
 	go wait.Until(c.runWorker, time.Second, stopCh)
 
-	go wait.PollImmediateUntil(CertCallbackRefreshDuration, func() (bool, error) {
-		c.queue.Add(workItemKey)
-		return false, nil
-	}, stopCh)
+	go func() {
+		_ = wait.PollUntilContextCancel(wait.ContextForChannel(stopCh), CertCallbackRefreshDuration, true, func(ctx context.Context) (bool, error) {
+			c.queue.Add(workItemKey)
+			return false, nil
+		})
+	}()
 
 	<-stopCh
 }

--- a/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package workqueue_test
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 	"sync"
@@ -452,7 +453,8 @@ func mustGarbageCollect(t *testing.T, i interface{}) {
 		atomic.StoreInt32(&collected, 1)
 	})
 	t.Cleanup(func() {
-		if err := wait.PollImmediate(time.Millisecond*100, wait.ForeverTestTimeout, func() (done bool, err error) {
+		ctx := t.Context()
+		if err := wait.PollUntilContextCancel(ctx, time.Millisecond*100, true, func(ctx context.Context) (done bool, err error) {
 			// Trigger GC explicitly, otherwise we may need to wait a long time for it to run
 			runtime.GC()
 			return atomic.LoadInt32(&collected) == 1, nil


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The deprecated polling functions in the wait package have been superseded by context-aware alternatives that provide better control over timeouts and cancellation semantics. This change modernizes the codebase to use the recommended patterns.

#### Which issue(s) this PR is related to:

Closes #138353

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
