### PR TITLE
Address DRA controller feedback from DRAWorkloadResourceClaims implementation

### DIFF
--- a/cmd/kube-controller-manager/app/resource.go
+++ b/cmd/kube-controller-manager/app/resource.go
@@ -47,7 +47,7 @@ func newDeviceTaintEvictionController(ctx context.Context, controllerContext Con
 		return nil, err
 	}
 
-	deviceTaintEvictionController := devicetainteviction.New(
+	controller := devicetainteviction.New(
 		client,
 		controllerContext.InformerFactory.Core().V1().Pods(),
 		controllerContext.InformerFactory.Resource().V1().ResourceClaims(),
@@ -57,7 +57,7 @@ func newDeviceTaintEvictionController(ctx context.Context, controllerContext Con
 		controllerName,
 	)
 	return newControllerLoop(func(ctx context.Context) {
-		if err := deviceTaintEvictionController.Run(ctx, int(controllerContext.ComponentConfig.DeviceTaintEvictionController.ConcurrentSyncs)); err != nil {
+		if err := controller.Run(ctx, int(controllerContext.ComponentConfig.DeviceTaintEvictionController.ConcurrentSyncs)); err != nil {
 			klog.FromContext(ctx).Error(err, "Device taint processing leading to Pod eviction failed and is now paused")
 		}
 		<-ctx.Done()
@@ -81,7 +81,7 @@ func newResourceClaimController(ctx context.Context, controllerContext Controlle
 		return nil, err
 	}
 
-	ephemeralController, err := resourceclaim.NewController(
+	controller, err := resourceclaim.NewController(
 		klog.FromContext(ctx),
 		client,
 		controllerContext.InformerFactory.Core().V1().Pods(),
@@ -93,7 +93,7 @@ func newResourceClaimController(ctx context.Context, controllerContext Controlle
 	}
 
 	return newControllerLoop(func(ctx context.Context) {
-		ephemeralController.Run(ctx, int(controllerContext.ComponentConfig.ResourceClaimController.ConcurrentSyncs))
+		controller.Run(ctx, int(controllerContext.ComponentConfig.ResourceClaimController.ConcurrentSyncs))
 	}, controllerName), nil
 }
 

--- a/cmd/kube-controller-manager/app/resource.go
+++ b/cmd/kube-controller-manager/app/resource.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/featuregate"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
@@ -56,7 +55,6 @@ func newDeviceTaintEvictionController(ctx context.Context, controllerContext Con
 		controllerContext.InformerFactory.Resource().V1().DeviceTaintRules(),
 		controllerContext.InformerFactory.Resource().V1().DeviceClasses(),
 		controllerName,
-		utilfeature.DefaultFeatureGate.Enabled(features.DRAWorkloadResourceClaims),
 	)
 	return newControllerLoop(func(ctx context.Context) {
 		if err := deviceTaintEvictionController.Run(ctx, int(controllerContext.ComponentConfig.DeviceTaintEvictionController.ConcurrentSyncs)); err != nil {
@@ -85,11 +83,6 @@ func newResourceClaimController(ctx context.Context, controllerContext Controlle
 
 	ephemeralController, err := resourceclaim.NewController(
 		klog.FromContext(ctx),
-		resourceclaim.Features{
-			AdminAccess:            utilfeature.DefaultFeatureGate.Enabled(features.DRAAdminAccess),
-			PrioritizedList:        utilfeature.DefaultFeatureGate.Enabled(features.DRAPrioritizedList),
-			WorkloadResourceClaims: utilfeature.DefaultFeatureGate.Enabled(features.DRAWorkloadResourceClaims),
-		},
 		client,
 		controllerContext.InformerFactory.Core().V1().Pods(),
 		controllerContext.InformerFactory.Scheduling().V1alpha3().PodGroups(),

--- a/pkg/controller/devicetainteviction/device_taint_eviction.go
+++ b/pkg/controller/devicetainteviction/device_taint_eviction.go
@@ -1236,10 +1236,7 @@ func (tc *Controller) claimEvictionTime(claim *resourceapi.ResourceClaim) *evict
 						// Tolerate forever -> ignore taint.
 						continue nextTaint
 					}
-					newTolerationSeconds := *toleration.TolerationSeconds
-					if newTolerationSeconds < 0 {
-						newTolerationSeconds = 0
-					}
+					newTolerationSeconds := max(*toleration.TolerationSeconds, 0)
 					if newTolerationSeconds < tolerationSeconds {
 						tolerationSeconds = newTolerationSeconds
 					}

--- a/pkg/controller/devicetainteviction/device_taint_eviction.go
+++ b/pkg/controller/devicetainteviction/device_taint_eviction.go
@@ -731,7 +731,11 @@ func (tc *Controller) countTaintedDevices(rule *resourceapi.DeviceTaintRule) (nu
 
 // New creates a new Controller that will use passed clientset to communicate with the API server.
 // Spawns no goroutines. That happens in Run.
-func New(c clientset.Interface, podInformer coreinformers.PodInformer, claimInformer resourceinformers.ResourceClaimInformer, sliceInformer resourceinformers.ResourceSliceInformer, ruleInformer resourceinformers.DeviceTaintRuleInformer, classInformer resourceinformers.DeviceClassInformer, controllerName string, workloadResourceClaimsEnabled bool) *Controller {
+func New(c clientset.Interface, podInformer coreinformers.PodInformer, claimInformer resourceinformers.ResourceClaimInformer, sliceInformer resourceinformers.ResourceSliceInformer, ruleInformer resourceinformers.DeviceTaintRuleInformer, classInformer resourceinformers.DeviceClassInformer, controllerName string) *Controller {
+	return newWithFeatures(c, podInformer, claimInformer, sliceInformer, ruleInformer, classInformer, controllerName, utilfeature.DefaultFeatureGate.Enabled(features.DRAWorkloadResourceClaims))
+}
+
+func newWithFeatures(c clientset.Interface, podInformer coreinformers.PodInformer, claimInformer resourceinformers.ResourceClaimInformer, sliceInformer resourceinformers.ResourceSliceInformer, ruleInformer resourceinformers.DeviceTaintRuleInformer, classInformer resourceinformers.DeviceClassInformer, controllerName string, workloadResourceClaimsEnabled bool) *Controller {
 	metrics.Register() // It would be nicer to pass the controller name here, but that probably would break generating https://kubernetes.io/docs/reference/instrumentation/metrics.
 
 	tc := &Controller{

--- a/pkg/controller/devicetainteviction/device_taint_eviction_test.go
+++ b/pkg/controller/devicetainteviction/device_taint_eviction_test.go
@@ -58,7 +58,6 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	"k8s.io/kubernetes/test/utils/client-go/ktesting"
-	"k8s.io/utils/ptr"
 )
 
 func init() {
@@ -389,7 +388,7 @@ var (
 
 		Spec: resourceapi.DeviceTaintRuleSpec{
 			DeviceSelector: &resourceapi.DeviceTaintSelector{
-				Driver: ptr.To(driver),
+				Driver: new(driver),
 			},
 			Taint: resourceapi.DeviceTaint{
 				Key:       taint.Key,
@@ -407,8 +406,8 @@ var (
 
 		Spec: resourceapi.DeviceTaintRuleSpec{
 			DeviceSelector: &resourceapi.DeviceTaintSelector{
-				Driver: ptr.To(driver),
-				Device: ptr.To("instance"),
+				Driver: new(driver),
+				Device: new("instance"),
 			},
 			Taint: resourceapi.DeviceTaint{
 				Key:       taint.Key,
@@ -427,8 +426,8 @@ var (
 
 		Spec: resourceapi.DeviceTaintRuleSpec{
 			DeviceSelector: &resourceapi.DeviceTaintSelector{
-				Driver: ptr.To(driver),
-				Device: ptr.To("instance-no-execute"),
+				Driver: new(driver),
+				Device: new("instance-no-execute"),
 			},
 			Taint: resourceapi.DeviceTaint{
 				Key:       taint.Key,
@@ -446,7 +445,7 @@ var (
 
 		Spec: resourceapi.DeviceTaintRuleSpec{
 			DeviceSelector: &resourceapi.DeviceTaintSelector{
-				Driver: ptr.To(driver),
+				Driver: new(driver),
 			},
 			Taint: resourceapi.DeviceTaint{
 				Key:       taint.Key,
@@ -464,7 +463,7 @@ var (
 
 		Spec: resourceapi.DeviceTaintRuleSpec{
 			DeviceSelector: &resourceapi.DeviceTaintSelector{
-				Device: ptr.To("instance"),
+				Device: new("instance"),
 			},
 			Taint: resourceapi.DeviceTaint{
 				Key:       taint.Key,
@@ -544,7 +543,7 @@ var (
 			Operator:          resourceapi.DeviceTolerationOpEqual,
 			Value:             taintValue,
 			Effect:            resourceapi.DeviceTaintEffectNoExecute,
-			TolerationSeconds: ptr.To(int64(tolerationDuration.Seconds())),
+			TolerationSeconds: new(int64(tolerationDuration.Seconds())),
 		}}
 		return claim
 	}()
@@ -1358,17 +1357,17 @@ func testController(tCtx ktesting.TContext) {
 							Operator:          resourceapi.DeviceTolerationOpEqual,
 							Value:             taintValue,
 							Effect:            resourceapi.DeviceTaintEffectNoExecute,
-							TolerationSeconds: ptr.To(int64(20)),
+							TolerationSeconds: new(int64(20)),
 						},
 						{
 							Operator:          resourceapi.DeviceTolerationOpExists,
 							Effect:            resourceapi.DeviceTaintEffectNoExecute,
-							TolerationSeconds: ptr.To(int64(60)),
+							TolerationSeconds: new(int64(60)),
 						},
 						{
 							Operator:          resourceapi.DeviceTolerationOpExists,
 							Effect:            resourceapi.DeviceTaintEffectNoExecute,
-							TolerationSeconds: ptr.To(int64(30)),
+							TolerationSeconds: new(int64(30)),
 						},
 					}
 					return claim
@@ -1385,17 +1384,17 @@ func testController(tCtx ktesting.TContext) {
 							Operator:          resourceapi.DeviceTolerationOpEqual,
 							Value:             taintValue,
 							Effect:            resourceapi.DeviceTaintEffectNoExecute,
-							TolerationSeconds: ptr.To(int64(20)),
+							TolerationSeconds: new(int64(20)),
 						},
 						{
 							Operator:          resourceapi.DeviceTolerationOpExists,
 							Effect:            resourceapi.DeviceTaintEffectNoExecute,
-							TolerationSeconds: ptr.To(int64(60)),
+							TolerationSeconds: new(int64(60)),
 						},
 						{
 							Operator:          resourceapi.DeviceTolerationOpExists,
 							Effect:            resourceapi.DeviceTaintEffectNoExecute,
-							TolerationSeconds: ptr.To(int64(30)),
+							TolerationSeconds: new(int64(30)),
 						},
 					}
 					return claim
@@ -1427,7 +1426,7 @@ func testController(tCtx ktesting.TContext) {
 						Operator:          resourceapi.DeviceTolerationOpEqual,
 						Value:             taintValue,
 						Effect:            resourceapi.DeviceTaintEffectNoExecute,
-						TolerationSeconds: ptr.To(int64(60)),
+						TolerationSeconds: new(int64(60)),
 					}}
 					return claim
 				}()),
@@ -1442,7 +1441,7 @@ func testController(tCtx ktesting.TContext) {
 						Operator:          resourceapi.DeviceTolerationOpEqual,
 						Value:             taintValue,
 						Effect:            resourceapi.DeviceTaintEffectNoExecute,
-						TolerationSeconds: ptr.To(int64(60)),
+						TolerationSeconds: new(int64(60)),
 					}}
 					return claim
 				}(), newEvictionTime(taintTime, sliceTainted, sliceTainted.Spec.Devices[0].Name, 0))),
@@ -1488,7 +1487,7 @@ func testController(tCtx ktesting.TContext) {
 						{
 							Operator:          resourceapi.DeviceTolerationOpExists,
 							Effect:            resourceapi.DeviceTaintEffectNoExecute,
-							TolerationSeconds: ptr.To(int64(60)),
+							TolerationSeconds: new(int64(60)),
 						},
 						{
 							Operator: resourceapi.DeviceTolerationOpExists,
@@ -1507,7 +1506,7 @@ func testController(tCtx ktesting.TContext) {
 						{
 							Operator:          resourceapi.DeviceTolerationOpExists,
 							Effect:            resourceapi.DeviceTaintEffectNoExecute,
-							TolerationSeconds: ptr.To(int64(60)),
+							TolerationSeconds: new(int64(60)),
 						},
 						{
 							Operator: resourceapi.DeviceTolerationOpExists,
@@ -1563,13 +1562,13 @@ func testController(tCtx ktesting.TContext) {
 							Operator:          resourceapi.DeviceTolerationOpExists,
 							Key:               taint1.Key,
 							Effect:            resourceapi.DeviceTaintEffectNoExecute,
-							TolerationSeconds: ptr.To(int64(60)),
+							TolerationSeconds: new(int64(60)),
 						},
 						{
 							Operator:          resourceapi.DeviceTolerationOpExists,
 							Key:               taint2.Key,
 							Effect:            resourceapi.DeviceTaintEffectNoExecute,
-							TolerationSeconds: ptr.To(int64(30)),
+							TolerationSeconds: new(int64(30)),
 						},
 					}
 					return claim
@@ -1585,13 +1584,13 @@ func testController(tCtx ktesting.TContext) {
 							Operator:          resourceapi.DeviceTolerationOpExists,
 							Key:               taint1.Key,
 							Effect:            resourceapi.DeviceTaintEffectNoExecute,
-							TolerationSeconds: ptr.To(int64(60)),
+							TolerationSeconds: new(int64(60)),
 						},
 						{
 							Operator:          resourceapi.DeviceTolerationOpExists,
 							Key:               taint2.Key,
 							Effect:            resourceapi.DeviceTaintEffectNoExecute,
-							TolerationSeconds: ptr.To(int64(30)),
+							TolerationSeconds: new(int64(30)),
 						},
 					}
 					return claim
@@ -1858,7 +1857,7 @@ func testController(tCtx ktesting.TContext) {
 					claim.Status.Allocation.Devices.Results[0].Tolerations = []resourceapi.DeviceToleration{{
 						Operator:          resourceapi.DeviceTolerationOpExists,
 						Effect:            resourceapi.DeviceTaintEffectNoExecute,
-						TolerationSeconds: ptr.To(int64(60)),
+						TolerationSeconds: new(int64(60)),
 					}}
 					return claim
 				}(), newEvictionTime(metav1Time(taintTime.Add(60*time.Second))))),
@@ -1874,7 +1873,7 @@ func testController(tCtx ktesting.TContext) {
 					claim.Status.Allocation.Devices.Results[0].Tolerations = []resourceapi.DeviceToleration{{
 						Operator:          resourceapi.DeviceTolerationOpExists,
 						Effect:            resourceapi.DeviceTaintEffectNoExecute,
-						TolerationSeconds: ptr.To(int64(60)),
+						TolerationSeconds: new(int64(60)),
 					}}
 					return claim
 				}(), newEvictionTime(metav1Time(taintTime.Add(60*time.Second))))),

--- a/pkg/controller/devicetainteviction/device_taint_eviction_test.go
+++ b/pkg/controller/devicetainteviction/device_taint_eviction_test.go
@@ -113,7 +113,7 @@ func l[T any](items ...T) []T {
 func setup(tCtx ktesting.TContext, workloadResourceClaimsEnabled bool) *testContext {
 	fakeClientset := fake.NewClientset()
 	informerFactory := informers.NewSharedInformerFactory(fakeClientset, 0)
-	controller := New(fakeClientset,
+	controller := newWithFeatures(fakeClientset,
 		informerFactory.Core().V1().Pods(),
 		informerFactory.Resource().V1().ResourceClaims(),
 		informerFactory.Resource().V1().ResourceSlices(),
@@ -2201,7 +2201,6 @@ func newTestController(tCtx ktesting.TContext) *Controller {
 		informerFactory.Resource().V1().DeviceTaintRules(),
 		informerFactory.Resource().V1().DeviceClasses(),
 		"device-taint-eviction",
-		utilfeature.DefaultFeatureGate.Enabled(features.DRAWorkloadResourceClaims),
 	)
 	controller.metrics = metrics.New()
 	// Always log, not matter what the -v value is.

--- a/pkg/controller/devicetainteviction/device_taint_eviction_test.go
+++ b/pkg/controller/devicetainteviction/device_taint_eviction_test.go
@@ -1969,7 +1969,7 @@ func testController(tCtx ktesting.TContext) {
 				if depth >= numEvents {
 					// Define a sub-test which runs the current permutation of events.
 					events := make([]any, numEvents)
-					for i := 0; i < numEvents; i++ {
+					for i := range numEvents {
 						events[i] = tc.events[permutation[i]]
 					}
 					tc := tc
@@ -1984,7 +1984,7 @@ func testController(tCtx ktesting.TContext) {
 					})
 					return
 				}
-				for i := 0; i < numEvents; i++ {
+				for i := range numEvents {
 					if slices.Index(permutation[0:depth], i) != -1 {
 						// Already taken.
 						continue

--- a/pkg/controller/devicetainteviction/device_taint_eviction_test.go
+++ b/pkg/controller/devicetainteviction/device_taint_eviction_test.go
@@ -2391,11 +2391,9 @@ func testEviction(tCtx ktesting.TContext) {
 				tCtx.Cancel("time to stop")
 				wg.Wait()
 			}()
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				tCtx.AssertNoError(controller.Run(tCtx, 10 /* workers */), "eviction controller failed")
-			}()
+			})
 
 			// Eventually the controller should have synced it's informers.
 			tCtx.Wait()
@@ -2695,11 +2693,9 @@ func doCancelEviction(tCtx ktesting.TContext, deletePod bool) {
 		tCtx.Cancel("time to stop")
 		wg.Wait()
 	}()
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		tCtx.AssertNoError(controller.Run(tCtx, 10 /* workers */), "eviction controller failed")
-	}()
+	})
 
 	// Eventually the pod gets scheduled for eviction.
 	tCtx.Wait()
@@ -2794,11 +2790,9 @@ func synctestParallelPodDeletion(tCtx ktesting.TContext) {
 		tCtx.Cancel("time to stop")
 		wg.Wait()
 	}()
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		tCtx.AssertNoError(controller.Run(tCtx, 10 /* workers */), "eviction controller failed")
-	}()
+	})
 
 	// We don't want any events.
 	tCtx.Wait()
@@ -2863,11 +2857,9 @@ func synctestRetry(tCtx ktesting.TContext) {
 		tCtx.Cancel("time to stop")
 		wg.Wait()
 	}()
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		tCtx.AssertNoError(controller.Run(tCtx, 10 /* workers */), "eviction controller failed")
-	}()
+	})
 
 	expectLatencies := []time.Duration{5 * time.Millisecond /* default exponential retry */}
 

--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	corev1apply "k8s.io/client-go/applyconfigurations/core/v1"
 	schedulingapply "k8s.io/client-go/applyconfigurations/scheduling/v1alpha3"
 	v1informers "k8s.io/client-go/informers/core/v1"
@@ -56,6 +57,7 @@ import (
 	"k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	controllermetrics "k8s.io/kubernetes/pkg/controller/resourceclaim/metrics"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/utils/ptr"
 )
 
@@ -97,7 +99,7 @@ const (
 // Controller creates ResourceClaims for ResourceClaimTemplates in a pod spec.
 type Controller struct {
 	// features defines the feature gates that are enabled.
-	features Features
+	features controllerFeatures
 
 	// kubeClient is the kube API client used to communicate with the API
 	// server.
@@ -154,8 +156,8 @@ const (
 	podGroupKeyPrefix = "podgroup:"
 )
 
-// Features defines which features should be enabled in the controller.
-type Features struct {
+// controllerFeatures defines which features should be enabled in the controller.
+type controllerFeatures struct {
 	AdminAccess            bool
 	PrioritizedList        bool
 	WorkloadResourceClaims bool
@@ -164,12 +166,34 @@ type Features struct {
 // NewController creates a ResourceClaim controller.
 func NewController(
 	logger klog.Logger,
-	features Features,
 	kubeClient clientset.Interface,
 	podInformer v1informers.PodInformer,
 	podGroupInformer schedulinginformers.PodGroupInformer,
 	claimInformer resourceinformers.ResourceClaimInformer,
 	templateInformer resourceinformers.ResourceClaimTemplateInformer) (*Controller, error) {
+	return newControllerWithFeatures(
+		logger,
+		kubeClient,
+		podInformer,
+		podGroupInformer,
+		claimInformer,
+		templateInformer,
+		controllerFeatures{
+			AdminAccess:            utilfeature.DefaultFeatureGate.Enabled(features.DRAAdminAccess),
+			PrioritizedList:        utilfeature.DefaultFeatureGate.Enabled(features.DRAPrioritizedList),
+			WorkloadResourceClaims: utilfeature.DefaultFeatureGate.Enabled(features.DRAWorkloadResourceClaims),
+		},
+	)
+}
+
+func newControllerWithFeatures(
+	logger klog.Logger,
+	kubeClient clientset.Interface,
+	podInformer v1informers.PodInformer,
+	podGroupInformer schedulinginformers.PodGroupInformer,
+	claimInformer resourceinformers.ResourceClaimInformer,
+	templateInformer resourceinformers.ResourceClaimTemplateInformer,
+	features controllerFeatures) (*Controller, error) {
 
 	ec := &Controller{
 		features:        features,

--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -163,6 +163,21 @@ type controllerFeatures struct {
 	WorkloadResourceClaims bool
 }
 
+func (f controllerFeatures) String() string {
+	enabled := func(b bool) string {
+		if b {
+			return "enabled"
+		}
+		return "disabled"
+	}
+	return fmt.Sprintf(
+		"AdminAccess %s, PrioritizedList %s, WorkloadResourceClaims %s",
+		enabled(f.AdminAccess),
+		enabled(f.PrioritizedList),
+		enabled(f.WorkloadResourceClaims),
+	)
+}
+
 // NewController creates a ResourceClaim controller.
 func NewController(
 	logger klog.Logger,

--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -613,7 +613,7 @@ func (ec *Controller) enqueuePodGroup(logger klog.Logger, obj any, deleted bool)
 			runtime.HandleErrorWithLogger(logger, nil, "unexpected object in Pod indexer", "type", fmt.Sprintf("%T", object))
 			return
 		}
-		logger.V(4).Info(
+		logger.V(6).Info(
 			"Enqueuing Pod due to PodGroup change",
 			"podgroup", klog.KObj(podGroup),
 			"pod", klog.KObj(pod),

--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -167,6 +167,7 @@ type controllerFeatures struct {
 	WorkloadResourceClaims bool
 }
 
+// String describes the features suitably for unit test names.
 func (f controllerFeatures) String() string {
 	enabled := func(b bool) string {
 		if b {
@@ -175,7 +176,7 @@ func (f controllerFeatures) String() string {
 		return "disabled"
 	}
 	return fmt.Sprintf(
-		"AdminAccess %s, GenericWorkload %s, PrioritizedList %s, WorkloadResourceClaims %s",
+		"adminaccess-%s-genericworkload-%s-prioritizedlist-%s-workloadresourceclaims-%s",
 		enabled(f.AdminAccess),
 		enabled(f.GenericWorkload),
 		enabled(f.PrioritizedList),

--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -192,28 +192,28 @@ func NewController(
 	controllermetrics.RegisterMetrics(newCustomCollector(ec.claimLister, getAdminAccessMetricLabel, logger))
 
 	if _, err := podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			ec.enqueuePod(logger, obj, false)
 		},
-		UpdateFunc: func(old, updated interface{}) {
+		UpdateFunc: func(old, updated any) {
 			ec.enqueuePod(logger, updated, false)
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			ec.enqueuePod(logger, obj, true)
 		},
 	}, cache.HandlerOptions{Logger: &logger}); err != nil {
 		return nil, err
 	}
 	if _, err := claimInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			logger.V(6).Info("New claim", "claimDump", obj)
 			ec.enqueueResourceClaim(logger, nil, obj)
 		},
-		UpdateFunc: func(old, updated interface{}) {
+		UpdateFunc: func(old, updated any) {
 			logger.V(6).Info("Updated claim", "claimDump", updated)
 			ec.enqueueResourceClaim(logger, old, updated)
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			logger.V(6).Info("Deleted claim", "claimDump", obj)
 			ec.enqueueResourceClaim(logger, obj, nil)
 		},
@@ -221,15 +221,15 @@ func NewController(
 		return nil, err
 	}
 	if _, err := templateInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			logger.V(6).Info("New claim template", "claimTemplateDump", obj)
 			ec.enqueueResourceClaimTemplate(logger, obj)
 		},
-		UpdateFunc: func(old, updated interface{}) {
+		UpdateFunc: func(old, updated any) {
 			logger.V(6).Info("Updated claim template", "claimTemplateDump", updated)
 			ec.enqueueResourceClaimTemplate(logger, updated)
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			logger.V(6).Info("Deleted claim template", "claimTemplateDump", obj)
 		},
 	}, cache.HandlerOptions{Logger: &logger}); err != nil {
@@ -250,15 +250,15 @@ func NewController(
 		ec.podGroupIndexer = podGroupInformer.Informer().GetIndexer()
 
 		if _, err := podGroupInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
+			AddFunc: func(obj any) {
 				logger.V(6).Info("New PodGroup", "podGroupDump", obj)
 				ec.enqueuePodGroup(logger, obj, false)
 			},
-			UpdateFunc: func(old, updated interface{}) {
+			UpdateFunc: func(old, updated any) {
 				logger.V(6).Info("Updated PodGroup", "podGroupDump", updated)
 				ec.enqueuePodGroup(logger, updated, false)
 			},
-			DeleteFunc: func(obj interface{}) {
+			DeleteFunc: func(obj any) {
 				logger.V(6).Info("Deleted PodGroup", "podGroupDump", obj)
 				ec.enqueuePodGroup(logger, obj, true)
 			},
@@ -307,7 +307,7 @@ func NewController(
 	return ec, nil
 }
 
-func (ec *Controller) enqueueResourceClaimTemplate(logger klog.Logger, obj interface{}) {
+func (ec *Controller) enqueueResourceClaimTemplate(logger klog.Logger, obj any) {
 	if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 		obj = d.Obj
 	}
@@ -372,7 +372,7 @@ func (ec *Controller) enqueueResourceClaimTemplate(logger klog.Logger, obj inter
 	}
 }
 
-func (ec *Controller) enqueuePod(logger klog.Logger, obj interface{}, deleted bool) {
+func (ec *Controller) enqueuePod(logger klog.Logger, obj any, deleted bool) {
 	if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 		obj = d.Obj
 	}
@@ -537,7 +537,7 @@ func (ec *Controller) podNeedsWork(pod *v1.Pod) (bool, string) {
 	return false, "nothing to do for any claim: " + strings.Join(doNothingReasons, ", ")
 }
 
-func (ec *Controller) enqueuePodGroup(logger klog.Logger, obj interface{}, deleted bool) {
+func (ec *Controller) enqueuePodGroup(logger klog.Logger, obj any, deleted bool) {
 	if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 		obj = d.Obj
 	}
@@ -678,7 +678,7 @@ func (ec *Controller) podGroupNeedsWork(podGroup *schedulingapi.PodGroup) (bool,
 	return false, "nothing to do for any claim: " + strings.Join(doNothingReasons, ", ")
 }
 
-func (ec *Controller) enqueueResourceClaim(logger klog.Logger, oldObj, newObj interface{}) {
+func (ec *Controller) enqueueResourceClaim(logger klog.Logger, oldObj, newObj any) {
 	deleted := newObj == nil
 	if d, ok := oldObj.(cache.DeletedFinalStateUnknown); ok {
 		oldObj = d.Obj
@@ -1613,7 +1613,7 @@ func owningPod(claim *resourceapi.ResourceClaim) (string, types.UID) {
 	return "", ""
 }
 
-func podResourceClaimTemplateIndexFunc(obj interface{}) ([]string, error) {
+func podResourceClaimTemplateIndexFunc(obj any) ([]string, error) {
 	pod, ok := obj.(*v1.Pod)
 	if !ok {
 		return nil, nil
@@ -1633,7 +1633,7 @@ func podResourceClaimTemplateIndexFunc(obj interface{}) ([]string, error) {
 
 // podResourceClaimIndexFunc is an index function that returns ResourceClaim keys (=
 // namespace/name) for ResourceClaim or ResourceClaimTemplates in a given pod.
-func podResourceClaimIndexFunc(obj interface{}) ([]string, error) {
+func podResourceClaimIndexFunc(obj any) ([]string, error) {
 	pod, ok := obj.(*v1.Pod)
 	if !ok {
 		return nil, nil
@@ -1654,7 +1654,7 @@ func podResourceClaimIndexFunc(obj interface{}) ([]string, error) {
 
 // podGroupMemberIndexFunc is an index function that returns PodGroup keys (=
 // namespace/name) for Pods in a given group.
-func podGroupMemberIndexFunc(obj interface{}) ([]string, error) {
+func podGroupMemberIndexFunc(obj any) ([]string, error) {
 	pod, ok := obj.(*v1.Pod)
 	if !ok {
 		return nil, nil
@@ -1668,7 +1668,7 @@ func podGroupMemberIndexFunc(obj interface{}) ([]string, error) {
 
 // podGroupResourceClaimTemplateIndexFunc is an index function that returns
 // ResourceClaimTemplate keys (= namespace/name) for a given PodGroup.
-func podGroupResourceClaimTemplateIndexFunc(obj interface{}) ([]string, error) {
+func podGroupResourceClaimTemplateIndexFunc(obj any) ([]string, error) {
 	podGroup, ok := obj.(*schedulingapi.PodGroup)
 	if !ok {
 		return nil, nil
@@ -1689,7 +1689,7 @@ func podGroupResourceClaimTemplateIndexFunc(obj interface{}) ([]string, error) {
 // podGroupResourceClaimIndexFunc is an index function that returns
 // ResourceClaim keys (= namespace/name) for ResourceClaim or
 // ResourceClaimTemplates in a given PodGroup.
-func podGroupResourceClaimIndexFunc(obj interface{}) ([]string, error) {
+func podGroupResourceClaimIndexFunc(obj any) ([]string, error) {
 	podGroup, ok := obj.(*schedulingapi.PodGroup)
 	if !ok {
 		return nil, nil
@@ -1717,7 +1717,7 @@ func isPodDone(pod *v1.Pod) bool {
 
 // claimPodOwnerIndexFunc is an index function that returns the pod UIDs of
 // all pods which own the resource claim. Should only be one, though.
-func claimPodOwnerIndexFunc(obj interface{}) ([]string, error) {
+func claimPodOwnerIndexFunc(obj any) ([]string, error) {
 	claim, ok := obj.(*resourceapi.ResourceClaim)
 	if !ok {
 		return nil, nil
@@ -1736,7 +1736,7 @@ func claimPodOwnerIndexFunc(obj interface{}) ([]string, error) {
 
 // claimPodGroupOwnerIndexFunc is an index function that returns the PodGroup UIDs of
 // all PodGroups which own the resource claim. Should only be one, though.
-func claimPodGroupOwnerIndexFunc(obj interface{}) ([]string, error) {
+func claimPodGroupOwnerIndexFunc(obj any) ([]string, error) {
 	claim, ok := obj.(*resourceapi.ResourceClaim)
 	if !ok {
 		return nil, nil

--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -75,7 +75,7 @@ const (
 	podGroupResourceClaimTemplateIndex = "podGroupResourceClaimTemplate"
 
 	// claimPodOwnerIndex is used to find ResourceClaims which have
-	// a specific pod as owner. Values for this index are the pod UID.
+	// a specific pod as owner. Values for this index are the pod "namespace/UID".
 	claimPodOwnerIndex = "claimPodOwner"
 
 	// claimPodGroupOwnerIndex is used to find ResourceClaims which have a
@@ -1111,7 +1111,7 @@ func hasPrioritizedList(claimTemplate *resourceapi.ResourceClaimTemplate) bool {
 // the pod).
 func (ec *Controller) findPodResourceClaim(pod *v1.Pod, podClaim v1.PodResourceClaim) (*resourceapi.ResourceClaim, error) {
 	// Only claims owned by the pod will get returned here.
-	claims, err := ec.claimCache.ByIndex(claimPodOwnerIndex, string(pod.UID))
+	claims, err := ec.claimCache.ByIndex(claimPodOwnerIndex, pod.Namespace+"/"+string(pod.UID))
 	if err != nil {
 		return nil, err
 	}
@@ -1728,7 +1728,7 @@ func claimPodOwnerIndexFunc(obj any) ([]string, error) {
 			*owner.Controller &&
 			owner.APIVersion == "v1" &&
 			owner.Kind == "Pod" {
-			keys = append(keys, string(owner.UID))
+			keys = append(keys, claim.Namespace+"/"+string(owner.UID))
 		}
 	}
 	return keys, nil

--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -142,7 +142,10 @@ type Controller struct {
 	// recorder is used to record events in the API server
 	recorder record.EventRecorder
 
-	queue workqueue.TypedRateLimitingInterface[string]
+	// syncHandlerFunc runs for each item in the workqueue. It is replaced in
+	// some tests that exercise the workqueue.
+	syncHandlerFunc func(context.Context, string) error
+	queue           workqueue.TypedRateLimitingInterface[string]
 
 	// The deletedObjects cache keeps track of Pods for which we know that
 	// they have existed and have been removed. For those we can be sure
@@ -178,6 +181,11 @@ func (f controllerFeatures) String() string {
 		enabled(f.PrioritizedList),
 		enabled(f.WorkloadResourceClaims),
 	)
+}
+
+// nonRetryableError is an error for a key in the workqueue that will not be requeued.
+type nonRetryableError struct {
+	error
 }
 
 // NewController creates a ResourceClaim controller.
@@ -229,6 +237,7 @@ func newControllerWithFeatures(
 		),
 		deletedObjects: newUIDCache(maxUIDCacheEntries),
 	}
+	ec.syncHandlerFunc = ec.syncHandler
 
 	resourceclaimmetrics.RegisterMetrics()
 	controllermetrics.RegisterMetrics(newCustomCollector(ec.claimLister, getAdminAccessMetricLabel, logger))
@@ -839,8 +848,12 @@ func (ec *Controller) processNextWorkItem(ctx context.Context) bool {
 	}
 	defer ec.queue.Done(key)
 
-	err := ec.syncHandler(ctx, key)
-	if err == nil {
+	err := ec.syncHandlerFunc(ctx, key)
+	_, nonRetryable := errors.AsType[nonRetryableError](err)
+	if nonRetryable {
+		runtime.HandleErrorWithContext(ctx, err, "Work item failed, will not retry", "item", key)
+	}
+	if err == nil || nonRetryable {
 		ec.queue.Forget(key)
 		return true
 	}
@@ -1051,7 +1064,7 @@ func (ec *Controller) handleClaim(ctx context.Context, pod *v1.Pod, podGroup *sc
 	var claim *resourceapi.ResourceClaim
 	if isPodGroupClaim(bindTo) {
 		if !ec.features.WorkloadResourceClaims {
-			return fmt.Errorf("claim %s is a PodGroup claim but the %s feature is disabled", podClaim.Name, features.DRAWorkloadResourceClaims)
+			return nonRetryableError{fmt.Errorf("claim %s is a PodGroup claim but the %s feature is disabled", podClaim.Name, features.DRAWorkloadResourceClaims)}
 		}
 		claim, err = ec.findPodGroupResourceClaim(podGroup, schedulingapi.PodGroupResourceClaim{
 			Name: podClaim.Name,
@@ -1655,7 +1668,7 @@ func (ec *Controller) getPodGroup(pod *v1.Pod) (*schedulingapi.PodGroup, error) 
 		return nil, nil
 	}
 	if !ec.features.GenericWorkload {
-		return nil, fmt.Errorf("Pod is a member of PodGroup %s but %s feature is disabled", *pod.Spec.SchedulingGroup.PodGroupName, features.GenericWorkload)
+		return nil, nonRetryableError{fmt.Errorf("Pod is a member of PodGroup %s but %s feature is disabled", *pod.Spec.SchedulingGroup.PodGroupName, features.GenericWorkload)}
 	}
 	return ec.podGroupLister.PodGroups(pod.Namespace).Get(*pod.Spec.SchedulingGroup.PodGroupName)
 }

--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -775,7 +775,7 @@ func (ec *Controller) Run(ctx context.Context, workers int) {
 		return
 	}
 
-	for i := 0; i < workers; i++ {
+	for range workers {
 		wg.Go(func() {
 			wait.UntilWithContext(ctx, ec.runWorker, time.Second)
 		})

--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -159,6 +159,7 @@ const (
 // controllerFeatures defines which features should be enabled in the controller.
 type controllerFeatures struct {
 	AdminAccess            bool
+	GenericWorkload        bool
 	PrioritizedList        bool
 	WorkloadResourceClaims bool
 }
@@ -171,8 +172,9 @@ func (f controllerFeatures) String() string {
 		return "disabled"
 	}
 	return fmt.Sprintf(
-		"AdminAccess %s, PrioritizedList %s, WorkloadResourceClaims %s",
+		"AdminAccess %s, GenericWorkload %s, PrioritizedList %s, WorkloadResourceClaims %s",
 		enabled(f.AdminAccess),
+		enabled(f.GenericWorkload),
 		enabled(f.PrioritizedList),
 		enabled(f.WorkloadResourceClaims),
 	)
@@ -195,6 +197,7 @@ func NewController(
 		templateInformer,
 		controllerFeatures{
 			AdminAccess:            utilfeature.DefaultFeatureGate.Enabled(features.DRAAdminAccess),
+			GenericWorkload:        utilfeature.DefaultFeatureGate.Enabled(features.GenericWorkload),
 			PrioritizedList:        utilfeature.DefaultFeatureGate.Enabled(features.DRAPrioritizedList),
 			WorkloadResourceClaims: utilfeature.DefaultFeatureGate.Enabled(features.DRAWorkloadResourceClaims),
 		},
@@ -282,9 +285,11 @@ func newControllerWithFeatures(
 		return nil, fmt.Errorf("could not initialize ResourceClaim controller: %w", err)
 	}
 
+	if features.GenericWorkload {
+		ec.podGroupLister = podGroupInformer.Lister()
+	}
 	ec.podGroupSynced = func() bool { return true }
 	if features.WorkloadResourceClaims {
-		ec.podGroupLister = podGroupInformer.Lister()
 		ec.podGroupSynced = podGroupInformer.Informer().HasSynced
 		ec.podGroupIndexer = podGroupInformer.Informer().GetIndexer()
 
@@ -972,6 +977,15 @@ func (ec *Controller) syncPod(ctx context.Context, namespace, name string) error
 			if err != nil {
 				return err
 			}
+			if isPodGroupClaim(bindTo) && !ec.features.WorkloadResourceClaims {
+				// It's not expected for ResourceClaims to remain allocated but
+				// unreserved for too long. This message is logged at a lower
+				// verbosity threshold so cluster admins can more easily
+				// identify when that happens because of this feature gate in
+				// normal production clusters.
+				logger.V(3).Info("Not reserving PodGroup ResourceClaim because feature is disabled", "feature", features.DRAWorkloadResourceClaims, "resourceClaim", klog.KObj(claim))
+				continue
+			}
 			logger.V(5).Info("Reserve claim", "resourceClaim", klog.KObj(claim), "reservedForResource", bindTo.Resource)
 			if err := ec.reserveFor(ctx, bindTo, claim); err != nil {
 				return err
@@ -1034,9 +1048,11 @@ func (ec *Controller) handleClaim(ctx context.Context, pod *v1.Pod, podGroup *sc
 	if err != nil {
 		return err
 	}
-	isPodGroupClaim := bindTo.APIGroup == schedulingapi.GroupName && bindTo.Resource == "podgroups"
 	var claim *resourceapi.ResourceClaim
-	if isPodGroupClaim {
+	if isPodGroupClaim(bindTo) {
+		if !ec.features.WorkloadResourceClaims {
+			return fmt.Errorf("claim %s is a PodGroup claim but the %s feature is disabled", podClaim.Name, features.DRAWorkloadResourceClaims)
+		}
 		claim, err = ec.findPodGroupResourceClaim(podGroup, schedulingapi.PodGroupResourceClaim{
 			Name: podClaim.Name,
 		})
@@ -1633,10 +1649,13 @@ func (ec *Controller) syncClaim(ctx context.Context, namespace, name string) err
 }
 
 func (ec *Controller) getPodGroup(pod *v1.Pod) (*schedulingapi.PodGroup, error) {
-	if !ec.features.WorkloadResourceClaims ||
-		pod.Spec.SchedulingGroup == nil ||
+	if pod.Spec.SchedulingGroup == nil ||
 		pod.Spec.SchedulingGroup.PodGroupName == nil {
+		// Pod is not a member of a PodGroup.
 		return nil, nil
+	}
+	if !ec.features.GenericWorkload {
+		return nil, fmt.Errorf("Pod is a member of PodGroup %s but %s feature is disabled", *pod.Spec.SchedulingGroup.PodGroupName, features.GenericWorkload)
 	}
 	return ec.podGroupLister.PodGroups(pod.Namespace).Get(*pod.Spec.SchedulingGroup.PodGroupName)
 }
@@ -1798,6 +1817,10 @@ func getAdminAccessMetricLabel(claim *resourceapi.ResourceClaim) string {
 		}
 	}
 	return "false"
+}
+
+func isPodGroupClaim(bindTo resourceapi.ResourceClaimConsumerReference) bool {
+	return bindTo.APIGroup == schedulingapi.GroupName && bindTo.Resource == "podgroups"
 }
 
 func newCustomCollector(rcLister resourcelisters.ResourceClaimLister, adminAccessFunc func(*resourceapi.ResourceClaim) string, logger klog.Logger) metrics.StableCollector {

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -64,6 +64,7 @@ var (
 
 	otherTestPod = makePod(testPodName+"-II", testNamespace, testPodUID+"-II")
 
+	testPodGroup                     = makePodGroup(testPodGroupName, testNamespace, testPodGroupUID)
 	testPodGroupWithResource         = makePodGroup(testPodGroupName, testNamespace, testPodGroupUID, *makePodGroupResourceClaim(podResourceClaimName, templateName))
 	testPodGroupWithResourceInStatus = func() *schedulingapi.PodGroup {
 		podGroup := testPodGroupWithResource.DeepCopy()
@@ -114,39 +115,74 @@ var (
 	testPodWithPodGroupAndNodeName = podInPodGroup(testPodWithNodeName, testPodName, testPodGroupName)
 	adminAccessFeatureOffError     = "admin access is requested, but the feature is disabled"
 
+	// WorkloadResourceClaims depends on GenericWorkload
 	allPossibleFeatures = []controllerFeatures{
-		{AdminAccess: false, PrioritizedList: false, WorkloadResourceClaims: false},
-		{AdminAccess: false, PrioritizedList: false, WorkloadResourceClaims: true},
-		{AdminAccess: false, PrioritizedList: true, WorkloadResourceClaims: false},
-		{AdminAccess: false, PrioritizedList: true, WorkloadResourceClaims: true},
-		{AdminAccess: true, PrioritizedList: false, WorkloadResourceClaims: false},
-		{AdminAccess: true, PrioritizedList: false, WorkloadResourceClaims: true},
-		{AdminAccess: true, PrioritizedList: true, WorkloadResourceClaims: false},
-		{AdminAccess: true, PrioritizedList: true, WorkloadResourceClaims: true},
+		{AdminAccess: false, GenericWorkload: false, PrioritizedList: false, WorkloadResourceClaims: false},
+		{AdminAccess: false, GenericWorkload: false, PrioritizedList: true, WorkloadResourceClaims: false},
+		{AdminAccess: false, GenericWorkload: true, PrioritizedList: false, WorkloadResourceClaims: false},
+		{AdminAccess: false, GenericWorkload: true, PrioritizedList: false, WorkloadResourceClaims: true},
+		{AdminAccess: false, GenericWorkload: true, PrioritizedList: true, WorkloadResourceClaims: false},
+		{AdminAccess: false, GenericWorkload: true, PrioritizedList: true, WorkloadResourceClaims: true},
+		{AdminAccess: true, GenericWorkload: false, PrioritizedList: false, WorkloadResourceClaims: false},
+		{AdminAccess: true, GenericWorkload: false, PrioritizedList: true, WorkloadResourceClaims: false},
+		{AdminAccess: true, GenericWorkload: true, PrioritizedList: false, WorkloadResourceClaims: false},
+		{AdminAccess: true, GenericWorkload: true, PrioritizedList: false, WorkloadResourceClaims: true},
+		{AdminAccess: true, GenericWorkload: true, PrioritizedList: true, WorkloadResourceClaims: false},
+		{AdminAccess: true, GenericWorkload: true, PrioritizedList: true, WorkloadResourceClaims: true},
 	}
 	adminAccessDisabled = []controllerFeatures{
-		{AdminAccess: false, PrioritizedList: false, WorkloadResourceClaims: false},
-		{AdminAccess: false, PrioritizedList: false, WorkloadResourceClaims: true},
-		{AdminAccess: false, PrioritizedList: true, WorkloadResourceClaims: false},
-		{AdminAccess: false, PrioritizedList: true, WorkloadResourceClaims: true},
+		{AdminAccess: false, GenericWorkload: false, PrioritizedList: false, WorkloadResourceClaims: false},
+		{AdminAccess: false, GenericWorkload: false, PrioritizedList: true, WorkloadResourceClaims: false},
+		{AdminAccess: false, GenericWorkload: true, PrioritizedList: false, WorkloadResourceClaims: false},
+		{AdminAccess: false, GenericWorkload: true, PrioritizedList: false, WorkloadResourceClaims: true},
+		{AdminAccess: false, GenericWorkload: true, PrioritizedList: true, WorkloadResourceClaims: false},
+		{AdminAccess: false, GenericWorkload: true, PrioritizedList: true, WorkloadResourceClaims: true},
 	}
 	adminAccessEnabled = []controllerFeatures{
-		{AdminAccess: true, PrioritizedList: false, WorkloadResourceClaims: false},
-		{AdminAccess: true, PrioritizedList: false, WorkloadResourceClaims: true},
-		{AdminAccess: true, PrioritizedList: true, WorkloadResourceClaims: false},
-		{AdminAccess: true, PrioritizedList: true, WorkloadResourceClaims: true},
+		{AdminAccess: true, GenericWorkload: false, PrioritizedList: false, WorkloadResourceClaims: false},
+		{AdminAccess: true, GenericWorkload: false, PrioritizedList: true, WorkloadResourceClaims: false},
+		{AdminAccess: true, GenericWorkload: true, PrioritizedList: false, WorkloadResourceClaims: false},
+		{AdminAccess: true, GenericWorkload: true, PrioritizedList: false, WorkloadResourceClaims: true},
+		{AdminAccess: true, GenericWorkload: true, PrioritizedList: true, WorkloadResourceClaims: false},
+		{AdminAccess: true, GenericWorkload: true, PrioritizedList: true, WorkloadResourceClaims: true},
+	}
+	genericWorkloadDisabled = []controllerFeatures{
+		{AdminAccess: false, GenericWorkload: false, PrioritizedList: false, WorkloadResourceClaims: false},
+		{AdminAccess: false, GenericWorkload: false, PrioritizedList: true, WorkloadResourceClaims: false},
+		{AdminAccess: true, GenericWorkload: false, PrioritizedList: false, WorkloadResourceClaims: false},
+		{AdminAccess: true, GenericWorkload: false, PrioritizedList: true, WorkloadResourceClaims: false},
+	}
+	genericWorkloadEnabled = []controllerFeatures{
+		{AdminAccess: false, GenericWorkload: true, PrioritizedList: false, WorkloadResourceClaims: false},
+		{AdminAccess: false, GenericWorkload: true, PrioritizedList: false, WorkloadResourceClaims: true},
+		{AdminAccess: false, GenericWorkload: true, PrioritizedList: true, WorkloadResourceClaims: false},
+		{AdminAccess: false, GenericWorkload: true, PrioritizedList: true, WorkloadResourceClaims: true},
+		{AdminAccess: true, GenericWorkload: true, PrioritizedList: false, WorkloadResourceClaims: false},
+		{AdminAccess: true, GenericWorkload: true, PrioritizedList: false, WorkloadResourceClaims: true},
+		{AdminAccess: true, GenericWorkload: true, PrioritizedList: true, WorkloadResourceClaims: false},
+		{AdminAccess: true, GenericWorkload: true, PrioritizedList: true, WorkloadResourceClaims: true},
 	}
 	workloadResourceClaimsDisabled = []controllerFeatures{
-		{AdminAccess: false, PrioritizedList: false, WorkloadResourceClaims: false},
-		{AdminAccess: false, PrioritizedList: true, WorkloadResourceClaims: false},
-		{AdminAccess: true, PrioritizedList: false, WorkloadResourceClaims: false},
-		{AdminAccess: true, PrioritizedList: true, WorkloadResourceClaims: false},
+		{AdminAccess: false, GenericWorkload: false, PrioritizedList: false, WorkloadResourceClaims: false},
+		{AdminAccess: false, GenericWorkload: false, PrioritizedList: true, WorkloadResourceClaims: false},
+		{AdminAccess: false, GenericWorkload: true, PrioritizedList: false, WorkloadResourceClaims: false},
+		{AdminAccess: false, GenericWorkload: true, PrioritizedList: true, WorkloadResourceClaims: false},
+		{AdminAccess: true, GenericWorkload: false, PrioritizedList: false, WorkloadResourceClaims: false},
+		{AdminAccess: true, GenericWorkload: false, PrioritizedList: true, WorkloadResourceClaims: false},
+		{AdminAccess: true, GenericWorkload: true, PrioritizedList: false, WorkloadResourceClaims: false},
+		{AdminAccess: true, GenericWorkload: true, PrioritizedList: true, WorkloadResourceClaims: false},
 	}
 	workloadResourceClaimsEnabled = []controllerFeatures{
-		{AdminAccess: false, PrioritizedList: false, WorkloadResourceClaims: true},
-		{AdminAccess: false, PrioritizedList: true, WorkloadResourceClaims: true},
-		{AdminAccess: true, PrioritizedList: false, WorkloadResourceClaims: true},
-		{AdminAccess: true, PrioritizedList: true, WorkloadResourceClaims: true},
+		{AdminAccess: false, GenericWorkload: true, PrioritizedList: false, WorkloadResourceClaims: true},
+		{AdminAccess: false, GenericWorkload: true, PrioritizedList: true, WorkloadResourceClaims: true},
+		{AdminAccess: true, GenericWorkload: true, PrioritizedList: false, WorkloadResourceClaims: true},
+		{AdminAccess: true, GenericWorkload: true, PrioritizedList: true, WorkloadResourceClaims: true},
+	}
+	workloadResourceClaimsDisabledGenericWorkloadEnabled = []controllerFeatures{
+		{AdminAccess: false, GenericWorkload: true, PrioritizedList: false, WorkloadResourceClaims: false},
+		{AdminAccess: false, GenericWorkload: true, PrioritizedList: true, WorkloadResourceClaims: false},
+		{AdminAccess: true, GenericWorkload: true, PrioritizedList: false, WorkloadResourceClaims: false},
+		{AdminAccess: true, GenericWorkload: true, PrioritizedList: true, WorkloadResourceClaims: false},
 	}
 )
 
@@ -204,6 +240,29 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: expectedMetrics{0, 1, 0, 0},
 		},
 		{
+			name:                "create for Pod in PodGroup",
+			featureCombinations: workloadResourceClaimsEnabled,
+			pods:                []*v1.Pod{podInPodGroup(testPodWithResource, testPodName, testPodGroupName)},
+			podGroups:           []*schedulingapi.PodGroup{testPodGroup},
+			templates:           []*resourceapi.ResourceClaimTemplate{template},
+			key:                 podKey(testPodWithResource),
+			expectedClaims:      []resourceapi.ResourceClaim{*templatedTestClaim},
+			expectedStatuses: map[string][]v1.PodResourceClaimStatus{
+				testPodWithResource.Name: {
+					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestClaim.Name},
+				},
+			},
+			expectedMetrics: expectedMetrics{1, 0, 0, 0},
+		},
+		{
+			name:                "skip-create-for-pod-podgroup-does-not-exist",
+			featureCombinations: genericWorkloadEnabled,
+			pods:                []*v1.Pod{podInPodGroup(testPodWithResource, testPodName, testPodGroupName)},
+			templates:           []*resourceapi.ResourceClaimTemplate{template},
+			key:                 podKey(testPodWithResource),
+			expectedError:       `podgroup.scheduling.k8s.io "test-podgroup" not found`,
+		},
+		{
 			name:                "create for PodGroup",
 			featureCombinations: workloadResourceClaimsEnabled,
 			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
@@ -254,17 +313,34 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: expectedMetrics{0, 0, 0, 0},
 		},
 		{
-			name:                "create ResourceClaim for Pod with PodGroup claim when feature is disabled",
-			featureCombinations: workloadResourceClaimsDisabled,
+			name:                "skip create ResourceClaim for Pod with PodGroup claim when GenericWorkload feature is disabled",
+			featureCombinations: genericWorkloadDisabled,
 			pods:                []*v1.Pod{testPodWithPodGroupResource},
 			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
-			claims:              []*resourceapi.ResourceClaim{templatedTestPodGroupClaim},
 			templates:           []*resourceapi.ResourceClaimTemplate{template},
 			key:                 podKey(testPodWithPodGroupResource),
-			expectedClaims:      []resourceapi.ResourceClaim{*templatedTestPodGroupClaim, *templatedTestClaim},
+			expectedError:       "GenericWorkload feature is disabled",
+		},
+		{
+			name:                "skip create ResourceClaim for Pod with PodGroup claim when DRAWorkloadResourceClaims feature is disabled",
+			featureCombinations: workloadResourceClaimsDisabledGenericWorkloadEnabled,
+			pods:                []*v1.Pod{testPodWithPodGroupResource},
+			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
+			templates:           []*resourceapi.ResourceClaimTemplate{template},
+			key:                 podKey(testPodWithPodGroupResource),
+			expectedError:       "DRAWorkloadResourceClaims feature is disabled",
+		},
+		{
+			name:                "create ResourceClaim for grouped Pod with claim when DRAWorkloadResourceClaims feature is disabled",
+			featureCombinations: workloadResourceClaimsDisabledGenericWorkloadEnabled,
+			pods:                []*v1.Pod{podInPodGroup(testPodWithResource, testPodName, testPodGroupName)},
+			podGroups:           []*schedulingapi.PodGroup{testPodGroup},
+			templates:           []*resourceapi.ResourceClaimTemplate{template},
+			key:                 podKey(testPodWithResource),
+			expectedClaims:      []resourceapi.ResourceClaim{*templatedTestClaim},
 			expectedStatuses: map[string][]v1.PodResourceClaimStatus{
-				testPodWithPodGroupResource.Name: {
-					{Name: testPodWithPodGroupResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestClaim.Name},
+				testPodName: {
+					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestClaim.Name},
 				},
 			},
 			expectedMetrics: expectedMetrics{1, 0, 0, 0},
@@ -502,7 +578,7 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			pods:            []*v1.Pod{testPodWithResource},
 			templates:       []*resourceapi.ResourceClaimTemplate{template},
 			key:             podKey(testPodWithResource),
-			expectedMetrics: expectedMetrics{1, 0, 1, 0},
+			expectedMetrics: expectedMetrics{0, 0, 1, 0},
 			expectedError:   "create ResourceClaim : Operation cannot be fulfilled on resourceclaims.resource.k8s.io \"fake name\": fake conflict",
 		},
 		{
@@ -511,7 +587,7 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
 			templates:           []*resourceapi.ResourceClaimTemplate{template},
 			key:                 podGroupKey(testPodGroupWithResource),
-			expectedMetrics:     expectedMetrics{1, 0, 1, 0},
+			expectedMetrics:     expectedMetrics{0, 0, 1, 0},
 			expectedError:       "create ResourceClaim : Operation cannot be fulfilled on resourceclaims.resource.k8s.io \"fake name\": fake conflict",
 		},
 		{
@@ -685,14 +761,31 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: expectedMetrics{0, 0, 0, 0},
 		},
 		{
-			name:                "add-reserved-podgroup-feature-disabled",
-			featureCombinations: workloadResourceClaimsDisabled,
+			name:                "skip-add-reserved-podgroup-genericworkload-disabled",
+			featureCombinations: genericWorkloadDisabled,
 			pods:                []*v1.Pod{testPodWithPodGroupAndNodeName},
 			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
 			key:                 podKey(testPodWithPodGroupAndNodeName),
 			templates:           []*resourceapi.ResourceClaimTemplate{template},
 			claims:              []*resourceapi.ResourceClaim{templatedTestClaimAllocated},
-			expectedClaims:      []resourceapi.ResourceClaim{*templatedTestClaimReserved},
+			expectedError:       "GenericWorkload feature is disabled",
+			expectedClaims:      []resourceapi.ResourceClaim{*templatedTestClaimAllocated},
+			expectedStatuses: map[string][]v1.PodResourceClaimStatus{
+				testPodWithPodGroupAndNodeName.Name: {
+					{Name: testPodWithPodGroupAndNodeName.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestClaim.Name},
+				},
+			},
+			expectedMetrics: expectedMetrics{0, 0, 0, 0},
+		},
+		{
+			name:                "skip-add-reserved-podgroup-workloadresourceclaims-disabled",
+			featureCombinations: workloadResourceClaimsDisabledGenericWorkloadEnabled,
+			pods:                []*v1.Pod{testPodWithPodGroupAndNodeName},
+			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
+			key:                 podKey(testPodWithPodGroupAndNodeName),
+			templates:           []*resourceapi.ResourceClaimTemplate{template},
+			claims:              []*resourceapi.ResourceClaim{templatedTestClaimAllocated},
+			expectedClaims:      []resourceapi.ResourceClaim{*templatedTestClaimAllocated},
 			expectedStatuses: map[string][]v1.PodResourceClaimStatus{
 				testPodWithPodGroupAndNodeName.Name: {
 					{Name: testPodWithPodGroupAndNodeName.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestClaim.Name},
@@ -831,13 +924,12 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			}
 
 			err = ec.syncHandler(tCtx, tc.key)
-			if err != nil {
-				assert.ErrorContains(tCtx, err, tc.expectedError, "the error message should have contained the expected error message")
-				return
-			}
 			if tc.expectedError != "" {
-				tCtx.Fatalf("expected error, got none")
+				assert.ErrorContains(tCtx, err, tc.expectedError, "the error message should have contained the expected error message")
+			} else if err != nil {
+				tCtx.Errorf("unexpected sync handler error: %v", err)
 			}
+			// keep going to check other side effects
 
 			if tc.name == "flapping-resourceclaim-statuses" {
 				assert.Len(tCtx, appliedPatches, 1, "should have applied status once")

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -63,7 +63,6 @@ var (
 	otherNamespace       = "not-my-namespace"
 	podResourceClaimName = "acme-resource"
 	templateName         = "my-template"
-	className            = "my-resource-class"
 	nodeName             = "worker"
 
 	testPod                     = makePod(testPodName, testNamespace, testPodUID)
@@ -81,8 +80,8 @@ var (
 		return podGroup
 	}()
 
-	testClaim              = makeClaim(testPodName+"-"+podResourceClaimName, testNamespace, className, makeOwnerReference(testPodWithResource, true))
-	testPodGroupClaim      = makeClaim(testPodName+"-"+podResourceClaimName, testNamespace, className, makeOwnerReference(testPodGroupWithResource, true))
+	testClaim              = makeClaim(testPodName+"-"+podResourceClaimName, testNamespace, makeOwnerReference(testPodWithResource, true))
+	testPodGroupClaim      = makeClaim(testPodName+"-"+podResourceClaimName, testNamespace, makeOwnerReference(testPodGroupWithResource, true))
 	testClaimAllocated     = allocateClaim(testClaim)
 	testClaimReserved      = reserveClaim(testClaimAllocated, testPodWithResource)
 	testClaimReservedTwice = reserveClaim(testClaimReserved, otherTestPod)
@@ -92,23 +91,23 @@ var (
 
 	testClaimReservedForPodGroup = reserveClaim(testClaimAllocated, testPodGroupWithResource)
 
-	templatedTestClaim                    = makeTemplatedClaim(podResourceClaimName, testPodName+"-"+podResourceClaimName+"-", testNamespace, className, 1, makeOwnerReference(testPodWithResource, true), nil)
+	templatedTestClaim                    = makeTemplatedClaim(podResourceClaimName, testPodName+"-"+podResourceClaimName+"-", testNamespace, 1, makeOwnerReference(testPodWithResource, true), nil)
 	templatedTestClaimAllocated           = allocateClaim(templatedTestClaim)
 	templatedTestClaimReserved            = reserveClaim(templatedTestClaimAllocated, testPodWithResource)
 	templatedTestClaimReservedForPodGroup = reserveClaim(templatedTestClaimAllocated, testPodGroupWithResource)
-	templatedTestPodGroupClaim            = makeTemplatedClaim(podResourceClaimName, testPodGroupName+"-"+podResourceClaimName+"-", testNamespace, className, 1, makeOwnerReference(testPodGroupWithResource, true), nil)
+	templatedTestPodGroupClaim            = makeTemplatedClaim(podResourceClaimName, testPodGroupName+"-"+podResourceClaimName+"-", testNamespace, 1, makeOwnerReference(testPodGroupWithResource, true), nil)
 
-	templatedTestClaimWithAdmin          = makeTemplatedClaim(podResourceClaimName, testPodName+"-"+podResourceClaimName+"-", testNamespace, className, 1, makeOwnerReference(testPodWithResource, true), new(true))
+	templatedTestClaimWithAdmin          = makeTemplatedClaim(podResourceClaimName, testPodName+"-"+podResourceClaimName+"-", testNamespace, 1, makeOwnerReference(testPodWithResource, true), new(true))
 	templatedTestClaimWithAdminAllocated = allocateClaim(templatedTestClaimWithAdmin)
 
 	extendedTestClaim          = makeExtendedResourceClaim(testPodName, testNamespace, 1, makeOwnerReference(testPodWithResource, true))
 	extendedTestClaimAllocated = allocateClaim(extendedTestClaim)
 
-	conflictingClaim         = makeClaim(testPodName+"-"+podResourceClaimName, testNamespace, className, nil)
-	conflictingPodGroupClaim = makeClaim(testPodGroupName+"-"+podResourceClaimName, testNamespace, className, nil)
-	otherNamespaceClaim      = makeClaim(testPodName+"-"+podResourceClaimName, otherNamespace, className, nil)
-	template                 = makeTemplate(templateName, testNamespace, className, nil)
-	templateWithAdminAccess  = makeTemplate(templateName, testNamespace, className, new(true))
+	conflictingClaim         = makeClaim(testPodName+"-"+podResourceClaimName, testNamespace, nil)
+	conflictingPodGroupClaim = makeClaim(testPodGroupName+"-"+podResourceClaimName, testNamespace, nil)
+	otherNamespaceClaim      = makeClaim(testPodName+"-"+podResourceClaimName, otherNamespace, nil)
+	template                 = makeTemplate(templateName, testNamespace, nil)
+	templateWithAdminAccess  = makeTemplate(templateName, testNamespace, new(true))
 
 	testPodWithNodeName = func() *v1.Pod {
 		pod := testPodWithResource.DeepCopy()
@@ -720,7 +719,7 @@ func TestSyncHandler(t *testing.T) {
 			}(),
 			templates: []*resourceapi.ResourceClaimTemplate{template},
 			claims: []*resourceapi.ResourceClaim{
-				makeClaim("claimA-object", testNamespace, className, makeOwnerReference(testPod, true)),
+				makeClaim("claimA-object", testNamespace, makeOwnerReference(testPod, true)),
 			},
 			key: podKeyPrefix + testNamespace + "/" + testPodName,
 			expectedStatuses: map[string][]v1.PodResourceClaimStatus{
@@ -730,8 +729,8 @@ func TestSyncHandler(t *testing.T) {
 				},
 			},
 			expectedClaims: []resourceapi.ResourceClaim{
-				*makeClaim("claimA-object", testNamespace, className, makeOwnerReference(testPod, true)),
-				*makeTemplatedClaim("claimB", testPodName+"-claimB-", testNamespace, className, 1, makeOwnerReference(testPod, true), nil),
+				*makeClaim("claimA-object", testNamespace, makeOwnerReference(testPod, true)),
+				*makeTemplatedClaim("claimB", testPodName+"-claimB-", testNamespace, 1, makeOwnerReference(testPod, true), nil),
 			},
 			expectedMetrics: expectedMetrics{1, 0, 0, 0},
 		},
@@ -1062,7 +1061,7 @@ func TestResourceClaimTemplateEventHandler(t *testing.T) {
 	})
 
 	// After create tmp namespace claim template,queue should have fake pod key
-	TmpNamespaceTemplate := makeTemplate(templateName, "tmp", className, nil)
+	TmpNamespaceTemplate := makeTemplate(templateName, "tmp", nil)
 	_, err = claimTemplateTmpClient.Create(tCtx, TmpNamespaceTemplate, metav1.CreateOptions{})
 	tCtx.Step("create  claim template in tmp namespace after  pod backoff in test namespace", func(tCtx ktesting.TContext) {
 		tCtx.ExpectNoError(err)
@@ -1579,7 +1578,7 @@ func TestGetAdminAccessMetricLabel(t *testing.T) {
 	}
 }
 
-func makeClaim(name, namespace, classname string, owner *metav1.OwnerReference) *resourceapi.ResourceClaim {
+func makeClaim(name, namespace string, owner *metav1.OwnerReference) *resourceapi.ResourceClaim {
 	claim := &resourceapi.ResourceClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 	}
@@ -1590,7 +1589,7 @@ func makeClaim(name, namespace, classname string, owner *metav1.OwnerReference) 
 	return claim
 }
 
-func makeTemplatedClaim(podClaimName, generateName, namespace, classname string, createCounter int, owner *metav1.OwnerReference, adminAccess *bool) *resourceapi.ResourceClaim {
+func makeTemplatedClaim(podClaimName, generateName, namespace string, createCounter int, owner *metav1.OwnerReference, adminAccess *bool) *resourceapi.ResourceClaim {
 	claim := &resourceapi.ResourceClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:         fmt.Sprintf("%s-%d", generateName, createCounter),
@@ -1720,7 +1719,7 @@ func podInPodGroup(pod *v1.Pod, podName, podGroupName string) *v1.Pod {
 	return pod
 }
 
-func makeTemplate(name, namespace, classname string, adminAccess *bool) *resourceapi.ResourceClaimTemplate {
+func makeTemplate(name, namespace string, adminAccess *bool) *resourceapi.ResourceClaimTemplate {
 	template := &resourceapi.ResourceClaimTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 	}

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -52,7 +52,6 @@ import (
 	controllermetrics "k8s.io/kubernetes/pkg/controller/resourceclaim/metrics"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/utils/ktesting"
-	"k8s.io/utils/ptr"
 )
 
 var (
@@ -715,7 +714,7 @@ func TestSyncHandler(t *testing.T) {
 				)
 				// Initially only claimA is in status
 				pod.Status.ResourceClaimStatuses = []v1.PodResourceClaimStatus{
-					{Name: "claimA", ResourceClaimName: ptr.To("claimA-object")},
+					{Name: "claimA", ResourceClaimName: new("claimA-object")},
 				}
 				return []*v1.Pod{pod}
 			}(),
@@ -726,8 +725,8 @@ func TestSyncHandler(t *testing.T) {
 			key: podKeyPrefix + testNamespace + "/" + testPodName,
 			expectedStatuses: map[string][]v1.PodResourceClaimStatus{
 				testPodName: {
-					{Name: "claimA", ResourceClaimName: ptr.To("claimA-object")},
-					{Name: "claimB", ResourceClaimName: ptr.To("test-pod-claimB--1")},
+					{Name: "claimA", ResourceClaimName: new("claimA-object")},
+					{Name: "claimB", ResourceClaimName: new("test-pod-claimB--1")},
 				},
 			},
 			expectedClaims: []resourceapi.ResourceClaim{
@@ -1483,7 +1482,7 @@ func TestGetAdminAccessMetricLabel(t *testing.T) {
 						Requests: []resourceapi.DeviceRequest{
 							{
 								Exactly: &resourceapi.ExactDeviceRequest{
-									AdminAccess: ptr.To(false),
+									AdminAccess: new(false),
 								},
 							},
 						},
@@ -1500,7 +1499,7 @@ func TestGetAdminAccessMetricLabel(t *testing.T) {
 						Requests: []resourceapi.DeviceRequest{
 							{
 								Exactly: &resourceapi.ExactDeviceRequest{
-									AdminAccess: ptr.To(true),
+									AdminAccess: new(true),
 								},
 							},
 						},
@@ -1532,12 +1531,12 @@ func TestGetAdminAccessMetricLabel(t *testing.T) {
 						Requests: []resourceapi.DeviceRequest{
 							{
 								Exactly: &resourceapi.ExactDeviceRequest{
-									AdminAccess: ptr.To(false),
+									AdminAccess: new(false),
 								},
 							},
 							{
 								Exactly: &resourceapi.ExactDeviceRequest{
-									AdminAccess: ptr.To(true),
+									AdminAccess: new(true),
 								},
 							},
 						},
@@ -1559,7 +1558,7 @@ func TestGetAdminAccessMetricLabel(t *testing.T) {
 							},
 							{
 								Exactly: &resourceapi.ExactDeviceRequest{
-									AdminAccess: ptr.To(false),
+									AdminAccess: new(false),
 								},
 							},
 						},

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -115,7 +115,8 @@ var (
 	adminAccessFeatureOffError     = "admin access is requested, but the feature is disabled"
 )
 
-func TestSyncHandler(t *testing.T) {
+func TestSyncHandler(t *testing.T) { testSyncHandler(ktesting.Init(t)) }
+func testSyncHandler(tCtx ktesting.TContext) {
 	tests := []struct {
 		name                          string
 		key                           string
@@ -731,9 +732,7 @@ func TestSyncHandler(t *testing.T) {
 
 	for _, tc := range tests {
 		// Run sequentially because of global logging and global metrics.
-		t.Run(tc.name, func(t *testing.T) {
-			tCtx := ktesting.Init(t)
-
+		tCtx.Run(tc.name, func(tCtx ktesting.TContext) {
 			var objects []runtime.Object
 			for _, pod := range tc.pods {
 				objects = append(objects, pod)
@@ -776,7 +775,7 @@ func TestSyncHandler(t *testing.T) {
 			}
 			ec, err := NewController(tCtx.Logger(), features, fakeKubeClient, podInformer, podGroupInformer, claimInformer, templateInformer)
 			if err != nil {
-				t.Fatalf("error creating ephemeral controller : %v", err)
+				tCtx.Fatalf("error creating ephemeral controller : %v", err)
 			}
 
 			// Ensure informers are up-to-date.
@@ -798,34 +797,34 @@ func TestSyncHandler(t *testing.T) {
 			for _, pod := range tc.podsLater {
 				_, err := fakeKubeClient.CoreV1().Pods(pod.Namespace).Create(tCtx, pod, metav1.CreateOptions{})
 				if err != nil {
-					t.Fatalf("unexpected error while creating pod: %v", err)
+					tCtx.Fatalf("unexpected error while creating pod: %v", err)
 				}
 			}
 
 			err = ec.syncHandler(tCtx, tc.key)
 			if err != nil {
-				assert.ErrorContains(t, err, tc.expectedError, "the error message should have contained the expected error message")
+				assert.ErrorContains(tCtx, err, tc.expectedError, "the error message should have contained the expected error message")
 				return
 			}
 			if tc.expectedError != "" {
-				t.Fatalf("expected error, got none")
+				tCtx.Fatalf("expected error, got none")
 			}
 
 			if tc.name == "flapping-resourceclaim-statuses" {
-				assert.Len(t, appliedPatches, 1, "should have applied status once")
-				assert.Contains(t, appliedPatches[0], `"name":"claimA"`, "patch should contain claimA")
-				assert.Contains(t, appliedPatches[0], `"name":"claimB"`, "patch should contain claimB")
+				assert.Len(tCtx, appliedPatches, 1, "should have applied status once")
+				assert.Contains(tCtx, appliedPatches[0], `"name":"claimA"`, "patch should contain claimA")
+				assert.Contains(tCtx, appliedPatches[0], `"name":"claimB"`, "patch should contain claimB")
 			}
 
 			claims, err := fakeKubeClient.ResourceV1().ResourceClaims("").List(tCtx, metav1.ListOptions{})
 			if err != nil {
-				t.Fatalf("unexpected error while listing claims: %v", err)
+				tCtx.Fatalf("unexpected error while listing claims: %v", err)
 			}
-			assert.Equal(t, normalizeClaims(tc.expectedClaims), normalizeClaims(claims.Items))
+			assert.Equal(tCtx, normalizeClaims(tc.expectedClaims), normalizeClaims(claims.Items))
 
 			pods, err := fakeKubeClient.CoreV1().Pods("").List(tCtx, metav1.ListOptions{})
 			if err != nil {
-				t.Fatalf("unexpected error while listing pods: %v", err)
+				tCtx.Fatalf("unexpected error while listing pods: %v", err)
 			}
 			var actualStatuses map[string][]v1.PodResourceClaimStatus
 			for _, pod := range pods.Items {
@@ -837,11 +836,11 @@ func TestSyncHandler(t *testing.T) {
 				}
 				actualStatuses[pod.Name] = pod.Status.ResourceClaimStatuses
 			}
-			assert.Equal(t, tc.expectedStatuses, actualStatuses, "pod resource claim statuses")
+			assert.Equal(tCtx, tc.expectedStatuses, actualStatuses, "pod resource claim statuses")
 
 			podGroups, err := fakeKubeClient.SchedulingV1alpha3().PodGroups("").List(tCtx, metav1.ListOptions{})
 			if err != nil {
-				t.Fatalf("unexpected error while listing podgroups: %v", err)
+				tCtx.Fatalf("unexpected error while listing podgroups: %v", err)
 			}
 			var actualPodGroupStatuses map[string][]schedulingapi.PodGroupResourceClaimStatus
 			for _, podGroup := range podGroups.Items {
@@ -853,9 +852,9 @@ func TestSyncHandler(t *testing.T) {
 				}
 				actualPodGroupStatuses[podGroup.Name] = podGroup.Status.ResourceClaimStatuses
 			}
-			assert.Equal(t, tc.expectedPodGroupStatuses, actualPodGroupStatuses, "podgroup resource claim statuses")
+			assert.Equal(tCtx, tc.expectedPodGroupStatuses, actualPodGroupStatuses, "podgroup resource claim statuses")
 
-			expectMetrics(t, tc.expectedMetrics)
+			expectMetrics(tCtx, tc.expectedMetrics)
 		})
 	}
 }
@@ -1758,40 +1757,40 @@ type expectedMetrics struct {
 	numFailureWithAdmin int
 }
 
-func expectMetrics(t *testing.T, em expectedMetrics) {
-	t.Helper()
+func expectMetrics(tCtx ktesting.TContext, em expectedMetrics) {
+	tCtx.Helper()
 
 	// Check created claims
 	actualCreated, err := testutil.GetCounterMetricValue(resourceclaimmetrics.ResourceClaimCreate.WithLabelValues("success", "false"))
-	handleErr(t, err, "ResourceClaimCreateSuccesses")
+	handleErr(tCtx, err, "ResourceClaimCreateSuccesses")
 	if actualCreated != float64(em.numCreated) {
-		t.Errorf("Expected claims to be created %d, got %v", em.numCreated, actualCreated)
+		tCtx.Errorf("Expected claims to be created %d, got %v", em.numCreated, actualCreated)
 	}
 
 	// Check created claims with admin access
 	actualCreatedWithAdmin, err := testutil.GetCounterMetricValue(resourceclaimmetrics.ResourceClaimCreate.WithLabelValues("success", "true"))
-	handleErr(t, err, "ResourceClaimCreateSuccessesWithAdminAccess")
+	handleErr(tCtx, err, "ResourceClaimCreateSuccessesWithAdminAccess")
 	if actualCreatedWithAdmin != float64(em.numCreatedWithAdmin) {
-		t.Errorf("Expected claims with admin access to be created %d, got %v", em.numCreatedWithAdmin, actualCreatedWithAdmin)
+		tCtx.Errorf("Expected claims with admin access to be created %d, got %v", em.numCreatedWithAdmin, actualCreatedWithAdmin)
 	}
 
 	// Check failed claims
 	actualFailed, err := testutil.GetCounterMetricValue(resourceclaimmetrics.ResourceClaimCreate.WithLabelValues("failure", "false"))
-	handleErr(t, err, "ResourceClaimCreateFailures")
+	handleErr(tCtx, err, "ResourceClaimCreateFailures")
 	if actualFailed != float64(em.numFailures) {
-		t.Errorf("Expected claims to have failed %d, got %v", em.numFailures, actualFailed)
+		tCtx.Errorf("Expected claims to have failed %d, got %v", em.numFailures, actualFailed)
 	}
 
 	// Check failed claims with admin access
 	actualFailedWithAdmin, err := testutil.GetCounterMetricValue(resourceclaimmetrics.ResourceClaimCreate.WithLabelValues("failure", "true"))
-	handleErr(t, err, "ResourceClaimCreateFailuresWithAdminAccess")
+	handleErr(tCtx, err, "ResourceClaimCreateFailuresWithAdminAccess")
 	if actualFailedWithAdmin != float64(em.numFailureWithAdmin) {
-		t.Errorf("Expected claims with admin access to have failed %d, got %v", em.numFailureWithAdmin, actualFailedWithAdmin)
+		tCtx.Errorf("Expected claims with admin access to have failed %d, got %v", em.numFailureWithAdmin, actualFailedWithAdmin)
 	}
 }
-func handleErr(t *testing.T, err error, metricName string) {
+func handleErr(tCtx ktesting.TContext, err error, metricName string) {
 	if err != nil {
-		t.Errorf("Failed to get %s value, err: %v", metricName, err)
+		tCtx.Errorf("Failed to get %s value, err: %v", metricName, err)
 	}
 }
 func setupMetrics() {

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -113,27 +113,60 @@ var (
 	}()
 	testPodWithPodGroupAndNodeName = podInPodGroup(testPodWithNodeName, testPodName, testPodGroupName)
 	adminAccessFeatureOffError     = "admin access is requested, but the feature is disabled"
+
+	allPossibleFeatures = []controllerFeatures{
+		{AdminAccess: false, PrioritizedList: false, WorkloadResourceClaims: false},
+		{AdminAccess: false, PrioritizedList: false, WorkloadResourceClaims: true},
+		{AdminAccess: false, PrioritizedList: true, WorkloadResourceClaims: false},
+		{AdminAccess: false, PrioritizedList: true, WorkloadResourceClaims: true},
+		{AdminAccess: true, PrioritizedList: false, WorkloadResourceClaims: false},
+		{AdminAccess: true, PrioritizedList: false, WorkloadResourceClaims: true},
+		{AdminAccess: true, PrioritizedList: true, WorkloadResourceClaims: false},
+		{AdminAccess: true, PrioritizedList: true, WorkloadResourceClaims: true},
+	}
+	adminAccessDisabled = []controllerFeatures{
+		{AdminAccess: false, PrioritizedList: false, WorkloadResourceClaims: false},
+		{AdminAccess: false, PrioritizedList: false, WorkloadResourceClaims: true},
+		{AdminAccess: false, PrioritizedList: true, WorkloadResourceClaims: false},
+		{AdminAccess: false, PrioritizedList: true, WorkloadResourceClaims: true},
+	}
+	adminAccessEnabled = []controllerFeatures{
+		{AdminAccess: true, PrioritizedList: false, WorkloadResourceClaims: false},
+		{AdminAccess: true, PrioritizedList: false, WorkloadResourceClaims: true},
+		{AdminAccess: true, PrioritizedList: true, WorkloadResourceClaims: false},
+		{AdminAccess: true, PrioritizedList: true, WorkloadResourceClaims: true},
+	}
+	workloadResourceClaimsDisabled = []controllerFeatures{
+		{AdminAccess: false, PrioritizedList: false, WorkloadResourceClaims: false},
+		{AdminAccess: false, PrioritizedList: true, WorkloadResourceClaims: false},
+		{AdminAccess: true, PrioritizedList: false, WorkloadResourceClaims: false},
+		{AdminAccess: true, PrioritizedList: true, WorkloadResourceClaims: false},
+	}
+	workloadResourceClaimsEnabled = []controllerFeatures{
+		{AdminAccess: false, PrioritizedList: false, WorkloadResourceClaims: true},
+		{AdminAccess: false, PrioritizedList: true, WorkloadResourceClaims: true},
+		{AdminAccess: true, PrioritizedList: false, WorkloadResourceClaims: true},
+		{AdminAccess: true, PrioritizedList: true, WorkloadResourceClaims: true},
+	}
 )
 
 func TestSyncHandler(t *testing.T) { testSyncHandler(ktesting.Init(t)) }
 func testSyncHandler(tCtx ktesting.TContext) {
 	tests := []struct {
-		name                          string
-		key                           string
-		adminAccessEnabled            bool
-		prioritizedListEnabled        bool
-		workloadResourceClaimsEnabled bool
-		claims                        []*resourceapi.ResourceClaim
-		claimsInCache                 []*resourceapi.ResourceClaim
-		pods                          []*v1.Pod
-		podsLater                     []*v1.Pod
-		podGroups                     []*schedulingapi.PodGroup
-		templates                     []*resourceapi.ResourceClaimTemplate
-		expectedClaims                []resourceapi.ResourceClaim
-		expectedStatuses              map[string][]v1.PodResourceClaimStatus
-		expectedPodGroupStatuses      map[string][]schedulingapi.PodGroupResourceClaimStatus
-		expectedError                 string
-		expectedMetrics               expectedMetrics
+		name                     string
+		key                      string
+		featureCombinations      []controllerFeatures
+		claims                   []*resourceapi.ResourceClaim
+		claimsInCache            []*resourceapi.ResourceClaim
+		pods                     []*v1.Pod
+		podsLater                []*v1.Pod
+		podGroups                []*schedulingapi.PodGroup
+		templates                []*resourceapi.ResourceClaimTemplate
+		expectedClaims           []resourceapi.ResourceClaim
+		expectedStatuses         map[string][]v1.PodResourceClaimStatus
+		expectedPodGroupStatuses map[string][]schedulingapi.PodGroupResourceClaimStatus
+		expectedError            string
+		expectedMetrics          expectedMetrics
 	}{
 		{
 			name:           "create",
@@ -149,33 +182,34 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: expectedMetrics{1, 0, 0, 0},
 		},
 		{
-			name:          "create with admin and feature gate off",
-			pods:          []*v1.Pod{testPodWithResource},
-			templates:     []*resourceapi.ResourceClaimTemplate{templateWithAdminAccess},
-			key:           podKey(testPodWithResource),
-			expectedError: adminAccessFeatureOffError,
+			name:                "create with admin and feature gate off",
+			featureCombinations: adminAccessDisabled,
+			pods:                []*v1.Pod{testPodWithResource},
+			templates:           []*resourceapi.ResourceClaimTemplate{templateWithAdminAccess},
+			key:                 podKey(testPodWithResource),
+			expectedError:       adminAccessFeatureOffError,
 		},
 		{
-			name:           "create with admin and feature gate on",
-			pods:           []*v1.Pod{testPodWithResource},
-			templates:      []*resourceapi.ResourceClaimTemplate{templateWithAdminAccess},
-			key:            podKey(testPodWithResource),
-			expectedClaims: []resourceapi.ResourceClaim{*templatedTestClaimWithAdmin},
+			name:                "create with admin and feature gate on",
+			featureCombinations: adminAccessEnabled,
+			pods:                []*v1.Pod{testPodWithResource},
+			templates:           []*resourceapi.ResourceClaimTemplate{templateWithAdminAccess},
+			key:                 podKey(testPodWithResource),
+			expectedClaims:      []resourceapi.ResourceClaim{*templatedTestClaimWithAdmin},
 			expectedStatuses: map[string][]v1.PodResourceClaimStatus{
 				testPodWithResource.Name: {
 					{Name: testPodWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestClaimWithAdmin.Name},
 				},
 			},
-			adminAccessEnabled: true,
-			expectedMetrics:    expectedMetrics{0, 1, 0, 0},
+			expectedMetrics: expectedMetrics{0, 1, 0, 0},
 		},
 		{
-			workloadResourceClaimsEnabled: true,
-			name:                          "create for PodGroup",
-			podGroups:                     []*schedulingapi.PodGroup{testPodGroupWithResource},
-			templates:                     []*resourceapi.ResourceClaimTemplate{template},
-			key:                           podGroupKey(testPodGroupWithResource),
-			expectedClaims:                []resourceapi.ResourceClaim{*templatedTestPodGroupClaim},
+			name:                "create for PodGroup",
+			featureCombinations: workloadResourceClaimsEnabled,
+			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
+			templates:           []*resourceapi.ResourceClaimTemplate{template},
+			key:                 podGroupKey(testPodGroupWithResource),
+			expectedClaims:      []resourceapi.ResourceClaim{*templatedTestPodGroupClaim},
 			expectedPodGroupStatuses: map[string][]schedulingapi.PodGroupResourceClaimStatus{
 				testPodGroupWithResource.Name: {
 					{Name: testPodGroupWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestPodGroupClaim.Name},
@@ -184,34 +218,34 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: expectedMetrics{1, 0, 0, 0},
 		},
 		{
-			workloadResourceClaimsEnabled: true,
-			name:                          "skip create for Pod with PodGroup before template exists",
-			pods:                          []*v1.Pod{testPodWithPodGroupResource},
-			podGroups:                     []*schedulingapi.PodGroup{testPodGroupWithResource},
-			templates:                     []*resourceapi.ResourceClaimTemplate{},
-			key:                           podKey(testPodWithPodGroupResource),
-			expectedClaims:                nil,
-			expectedMetrics:               expectedMetrics{0, 0, 0, 0},
+			name:                "skip create for Pod with PodGroup before template exists",
+			featureCombinations: workloadResourceClaimsEnabled,
+			pods:                []*v1.Pod{testPodWithPodGroupResource},
+			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
+			templates:           []*resourceapi.ResourceClaimTemplate{},
+			key:                 podKey(testPodWithPodGroupResource),
+			expectedClaims:      nil,
+			expectedMetrics:     expectedMetrics{0, 0, 0, 0},
 		},
 		{
-			workloadResourceClaimsEnabled: true,
-			name:                          "skip create for Pod with PodGroup after template exists",
-			pods:                          []*v1.Pod{testPodWithPodGroupResource},
-			podGroups:                     []*schedulingapi.PodGroup{testPodGroupWithResource},
-			templates:                     []*resourceapi.ResourceClaimTemplate{template},
-			key:                           podKey(testPodWithPodGroupResource),
-			expectedClaims:                nil,
-			expectedMetrics:               expectedMetrics{0, 0, 0, 0},
+			name:                "skip create for Pod with PodGroup after template exists",
+			featureCombinations: workloadResourceClaimsEnabled,
+			pods:                []*v1.Pod{testPodWithPodGroupResource},
+			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
+			templates:           []*resourceapi.ResourceClaimTemplate{template},
+			key:                 podKey(testPodWithPodGroupResource),
+			expectedClaims:      nil,
+			expectedMetrics:     expectedMetrics{0, 0, 0, 0},
 		},
 		{
-			workloadResourceClaimsEnabled: true,
-			name:                          "update Pod status with PodGroup claim",
-			pods:                          []*v1.Pod{testPodWithPodGroupResource},
-			podGroups:                     []*schedulingapi.PodGroup{testPodGroupWithResource},
-			claims:                        []*resourceapi.ResourceClaim{templatedTestPodGroupClaim},
-			templates:                     []*resourceapi.ResourceClaimTemplate{template},
-			key:                           podKey(testPodWithPodGroupResource),
-			expectedClaims:                []resourceapi.ResourceClaim{*templatedTestPodGroupClaim},
+			name:                "update Pod status with PodGroup claim",
+			featureCombinations: workloadResourceClaimsEnabled,
+			pods:                []*v1.Pod{testPodWithPodGroupResource},
+			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
+			claims:              []*resourceapi.ResourceClaim{templatedTestPodGroupClaim},
+			templates:           []*resourceapi.ResourceClaimTemplate{template},
+			key:                 podKey(testPodWithPodGroupResource),
+			expectedClaims:      []resourceapi.ResourceClaim{*templatedTestPodGroupClaim},
 			expectedStatuses: map[string][]v1.PodResourceClaimStatus{
 				testPodWithPodGroupResource.Name: {
 					{Name: testPodWithPodGroupResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestPodGroupClaim.Name},
@@ -220,14 +254,14 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: expectedMetrics{0, 0, 0, 0},
 		},
 		{
-			workloadResourceClaimsEnabled: false,
-			name:                          "create ResourceClaim for Pod with PodGroup claim when feature is disabled",
-			pods:                          []*v1.Pod{testPodWithPodGroupResource},
-			podGroups:                     []*schedulingapi.PodGroup{testPodGroupWithResource},
-			claims:                        []*resourceapi.ResourceClaim{templatedTestPodGroupClaim},
-			templates:                     []*resourceapi.ResourceClaimTemplate{template},
-			key:                           podKey(testPodWithPodGroupResource),
-			expectedClaims:                []resourceapi.ResourceClaim{*templatedTestPodGroupClaim, *templatedTestClaim},
+			name:                "create ResourceClaim for Pod with PodGroup claim when feature is disabled",
+			featureCombinations: workloadResourceClaimsDisabled,
+			pods:                []*v1.Pod{testPodWithPodGroupResource},
+			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
+			claims:              []*resourceapi.ResourceClaim{templatedTestPodGroupClaim},
+			templates:           []*resourceapi.ResourceClaimTemplate{template},
+			key:                 podKey(testPodWithPodGroupResource),
+			expectedClaims:      []resourceapi.ResourceClaim{*templatedTestPodGroupClaim, *templatedTestClaim},
 			expectedStatuses: map[string][]v1.PodResourceClaimStatus{
 				testPodWithPodGroupResource.Name: {
 					{Name: testPodWithPodGroupResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestClaim.Name},
@@ -256,8 +290,8 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: expectedMetrics{0, 0, 0, 0},
 		},
 		{
-			workloadResourceClaimsEnabled: true,
-			name:                          "nop for PodGroup",
+			name:                "nop for PodGroup",
+			featureCombinations: workloadResourceClaimsEnabled,
 			podGroups: []*schedulingapi.PodGroup{func() *schedulingapi.PodGroup {
 				podGroup := testPodGroupWithResource.DeepCopy()
 				podGroup.Status.ResourceClaimStatuses = []schedulingapi.PodGroupResourceClaimStatus{
@@ -296,8 +330,8 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: expectedMetrics{1, 0, 0, 0},
 		},
 		{
-			workloadResourceClaimsEnabled: true,
-			name:                          "recreate for PodGroup",
+			name:                "recreate for PodGroup",
+			featureCombinations: workloadResourceClaimsEnabled,
 			podGroups: []*schedulingapi.PodGroup{func() *schedulingapi.PodGroup {
 				pod := testPodGroupWithResource.DeepCopy()
 				pod.Status.ResourceClaimStatuses = []schedulingapi.PodGroupResourceClaimStatus{
@@ -323,12 +357,12 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedError: "resource claim template \"my-template\": resourceclaimtemplate.resource.k8s.io \"my-template\" not found",
 		},
 		{
-			workloadResourceClaimsEnabled: true,
-			name:                          "missing-template-podgroup",
-			podGroups:                     []*schedulingapi.PodGroup{testPodGroupWithResource},
-			templates:                     nil,
-			key:                           podGroupKey(testPodGroupWithResource),
-			expectedError:                 "resource claim template \"my-template\": resourceclaimtemplate.resource.k8s.io \"my-template\" not found",
+			name:                "missing-template-podgroup",
+			featureCombinations: workloadResourceClaimsEnabled,
+			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
+			templates:           nil,
+			key:                 podGroupKey(testPodGroupWithResource),
+			expectedError:       "resource claim template \"my-template\": resourceclaimtemplate.resource.k8s.io \"my-template\" not found",
 		},
 		{
 			name:           "find-existing-claim-by-label",
@@ -344,12 +378,12 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: expectedMetrics{0, 0, 0, 0},
 		},
 		{
-			workloadResourceClaimsEnabled: true,
-			name:                          "find-existing-claim-by-label-podgroup",
-			podGroups:                     []*schedulingapi.PodGroup{testPodGroupWithResource},
-			key:                           podGroupKey(testPodGroupWithResource),
-			claims:                        []*resourceapi.ResourceClaim{templatedTestPodGroupClaim},
-			expectedClaims:                []resourceapi.ResourceClaim{*templatedTestPodGroupClaim},
+			name:                "find-existing-claim-by-label-podgroup",
+			featureCombinations: workloadResourceClaimsEnabled,
+			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
+			key:                 podGroupKey(testPodGroupWithResource),
+			claims:              []*resourceapi.ResourceClaim{templatedTestPodGroupClaim},
+			expectedClaims:      []resourceapi.ResourceClaim{*templatedTestPodGroupClaim},
 			expectedPodGroupStatuses: map[string][]schedulingapi.PodGroupResourceClaimStatus{
 				testPodGroupWithResource.Name: {
 					{Name: testPodGroupWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestPodGroupClaim.Name},
@@ -370,11 +404,11 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: expectedMetrics{0, 0, 0, 0},
 		},
 		{
-			workloadResourceClaimsEnabled: true,
-			name:                          "find-created-claim-in-cache-podgroup",
-			podGroups:                     []*schedulingapi.PodGroup{testPodGroupWithResource},
-			key:                           podGroupKey(testPodGroupWithResource),
-			claimsInCache:                 []*resourceapi.ResourceClaim{templatedTestPodGroupClaim},
+			name:                "find-created-claim-in-cache-podgroup",
+			featureCombinations: workloadResourceClaimsEnabled,
+			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
+			key:                 podGroupKey(testPodGroupWithResource),
+			claimsInCache:       []*resourceapi.ResourceClaim{templatedTestPodGroupClaim},
 			expectedPodGroupStatuses: map[string][]schedulingapi.PodGroupResourceClaimStatus{
 				testPodGroupWithResource.Name: {
 					{Name: testPodGroupWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestPodGroupClaim.Name},
@@ -387,9 +421,9 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			key:  podKey(testPodWithResource),
 		},
 		{
-			workloadResourceClaimsEnabled: true,
-			name:                          "no-such-podgroup",
-			key:                           podGroupKey(testPodGroupWithResource),
+			name:                "no-such-podgroup",
+			featureCombinations: workloadResourceClaimsEnabled,
+			key:                 podGroupKey(testPodGroupWithResource),
 		},
 		{
 			name: "pod-deleted",
@@ -402,8 +436,8 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			key: podKey(testPodWithResource),
 		},
 		{
-			workloadResourceClaimsEnabled: true,
-			name:                          "podgroup-deleted",
+			name:                "podgroup-deleted",
+			featureCombinations: workloadResourceClaimsEnabled,
 			podGroups: func() []*schedulingapi.PodGroup {
 				deleted := metav1.Now()
 				podGroups := []*schedulingapi.PodGroup{testPodGroupWithResource.DeepCopy()}
@@ -432,13 +466,13 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: expectedMetrics{1, 0, 0, 0},
 		},
 		{
-			workloadResourceClaimsEnabled: true,
-			name:                          "create-with-other-claim-podgroup",
-			podGroups:                     []*schedulingapi.PodGroup{testPodGroupWithResource},
-			templates:                     []*resourceapi.ResourceClaimTemplate{template},
-			key:                           podGroupKey(testPodGroupWithResource),
-			claims:                        []*resourceapi.ResourceClaim{otherNamespaceClaim},
-			expectedClaims:                []resourceapi.ResourceClaim{*otherNamespaceClaim, *templatedTestPodGroupClaim},
+			name:                "create-with-other-claim-podgroup",
+			featureCombinations: workloadResourceClaimsEnabled,
+			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
+			templates:           []*resourceapi.ResourceClaimTemplate{template},
+			key:                 podGroupKey(testPodGroupWithResource),
+			claims:              []*resourceapi.ResourceClaim{otherNamespaceClaim},
+			expectedClaims:      []resourceapi.ResourceClaim{*otherNamespaceClaim, *templatedTestPodGroupClaim},
 			expectedPodGroupStatuses: map[string][]schedulingapi.PodGroupResourceClaimStatus{
 				testPodGroupWithResource.Name: {
 					{Name: testPodGroupWithResource.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestPodGroupClaim.Name},
@@ -455,13 +489,13 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedError:  "resource claim template \"my-template\": resourceclaimtemplate.resource.k8s.io \"my-template\" not found",
 		},
 		{
-			workloadResourceClaimsEnabled: true,
-			name:                          "wrong-claim-owner-podgroup",
-			podGroups:                     []*schedulingapi.PodGroup{testPodGroupWithResource},
-			key:                           podGroupKey(testPodGroupWithResource),
-			claims:                        []*resourceapi.ResourceClaim{conflictingPodGroupClaim},
-			expectedClaims:                []resourceapi.ResourceClaim{*conflictingPodGroupClaim},
-			expectedError:                 "resource claim template \"my-template\": resourceclaimtemplate.resource.k8s.io \"my-template\" not found",
+			name:                "wrong-claim-owner-podgroup",
+			featureCombinations: workloadResourceClaimsEnabled,
+			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
+			key:                 podGroupKey(testPodGroupWithResource),
+			claims:              []*resourceapi.ResourceClaim{conflictingPodGroupClaim},
+			expectedClaims:      []resourceapi.ResourceClaim{*conflictingPodGroupClaim},
+			expectedError:       "resource claim template \"my-template\": resourceclaimtemplate.resource.k8s.io \"my-template\" not found",
 		},
 		{
 			name:            "create-conflict",
@@ -472,13 +506,13 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedError:   "create ResourceClaim : Operation cannot be fulfilled on resourceclaims.resource.k8s.io \"fake name\": fake conflict",
 		},
 		{
-			workloadResourceClaimsEnabled: true,
-			name:                          "create-conflict-podgroup",
-			podGroups:                     []*schedulingapi.PodGroup{testPodGroupWithResource},
-			templates:                     []*resourceapi.ResourceClaimTemplate{template},
-			key:                           podGroupKey(testPodGroupWithResource),
-			expectedMetrics:               expectedMetrics{1, 0, 1, 0},
-			expectedError:                 "create ResourceClaim : Operation cannot be fulfilled on resourceclaims.resource.k8s.io \"fake name\": fake conflict",
+			name:                "create-conflict-podgroup",
+			featureCombinations: workloadResourceClaimsEnabled,
+			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
+			templates:           []*resourceapi.ResourceClaimTemplate{template},
+			key:                 podGroupKey(testPodGroupWithResource),
+			expectedMetrics:     expectedMetrics{1, 0, 1, 0},
+			expectedError:       "create ResourceClaim : Operation cannot be fulfilled on resourceclaims.resource.k8s.io \"fake name\": fake conflict",
 		},
 		{
 			name:            "stay-reserved-seen",
@@ -510,11 +544,11 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: expectedMetrics{0, 0, 0, 0},
 		},
 		{
-			workloadResourceClaimsEnabled: true,
-			name:                          "clear-reserved-podgroup",
-			podGroups:                     []*schedulingapi.PodGroup{},
-			key:                           claimKey(testClaimReservedForPodGroup),
-			claims:                        []*resourceapi.ResourceClaim{structuredParameters(testClaimReservedForPodGroup)},
+			name:                "clear-reserved-podgroup",
+			featureCombinations: workloadResourceClaimsEnabled,
+			podGroups:           []*schedulingapi.PodGroup{},
+			key:                 claimKey(testClaimReservedForPodGroup),
+			claims:              []*resourceapi.ResourceClaim{structuredParameters(testClaimReservedForPodGroup)},
 			expectedClaims: func() []resourceapi.ResourceClaim {
 				claim := testClaimAllocated.DeepCopy()
 				claim.Finalizers = []string{}
@@ -524,13 +558,13 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: expectedMetrics{0, 0, 0, 0},
 		},
 		{
-			workloadResourceClaimsEnabled: false,
-			name:                          "dont-clear-reserved-podgroup-feature-disabled",
-			podGroups:                     []*schedulingapi.PodGroup{},
-			key:                           claimKey(testClaimReservedForPodGroup),
-			claims:                        []*resourceapi.ResourceClaim{structuredParameters(testClaimReservedForPodGroup)},
-			expectedClaims:                []resourceapi.ResourceClaim{*structuredParameters(testClaimReservedForPodGroup)},
-			expectedMetrics:               expectedMetrics{0, 0, 0, 0},
+			name:                "dont-clear-reserved-podgroup-feature-disabled",
+			featureCombinations: workloadResourceClaimsDisabled,
+			podGroups:           []*schedulingapi.PodGroup{},
+			key:                 claimKey(testClaimReservedForPodGroup),
+			claims:              []*resourceapi.ResourceClaim{structuredParameters(testClaimReservedForPodGroup)},
+			expectedClaims:      []resourceapi.ResourceClaim{*structuredParameters(testClaimReservedForPodGroup)},
+			expectedMetrics:     expectedMetrics{0, 0, 0, 0},
 		},
 		{
 			name: "dont-clear-reserved-structured",
@@ -635,14 +669,14 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: expectedMetrics{0, 0, 0, 0},
 		},
 		{
-			workloadResourceClaimsEnabled: true,
-			name:                          "add-reserved-podgroup",
-			pods:                          []*v1.Pod{testPodWithPodGroupAndNodeName},
-			podGroups:                     []*schedulingapi.PodGroup{testPodGroupWithResource},
-			key:                           podKey(testPodWithPodGroupAndNodeName),
-			templates:                     []*resourceapi.ResourceClaimTemplate{template},
-			claims:                        []*resourceapi.ResourceClaim{templatedTestClaimAllocated},
-			expectedClaims:                []resourceapi.ResourceClaim{*templatedTestClaimReservedForPodGroup},
+			name:                "add-reserved-podgroup",
+			featureCombinations: workloadResourceClaimsEnabled,
+			pods:                []*v1.Pod{testPodWithPodGroupAndNodeName},
+			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
+			key:                 podKey(testPodWithPodGroupAndNodeName),
+			templates:           []*resourceapi.ResourceClaimTemplate{template},
+			claims:              []*resourceapi.ResourceClaim{templatedTestClaimAllocated},
+			expectedClaims:      []resourceapi.ResourceClaim{*templatedTestClaimReservedForPodGroup},
 			expectedStatuses: map[string][]v1.PodResourceClaimStatus{
 				testPodWithPodGroupAndNodeName.Name: {
 					{Name: testPodWithPodGroupAndNodeName.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestClaim.Name},
@@ -651,14 +685,14 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: expectedMetrics{0, 0, 0, 0},
 		},
 		{
-			workloadResourceClaimsEnabled: false,
-			name:                          "add-reserved-podgroup-feature-disabled",
-			pods:                          []*v1.Pod{testPodWithPodGroupAndNodeName},
-			podGroups:                     []*schedulingapi.PodGroup{testPodGroupWithResource},
-			key:                           podKey(testPodWithPodGroupAndNodeName),
-			templates:                     []*resourceapi.ResourceClaimTemplate{template},
-			claims:                        []*resourceapi.ResourceClaim{templatedTestClaimAllocated},
-			expectedClaims:                []resourceapi.ResourceClaim{*templatedTestClaimReserved},
+			name:                "add-reserved-podgroup-feature-disabled",
+			featureCombinations: workloadResourceClaimsDisabled,
+			pods:                []*v1.Pod{testPodWithPodGroupAndNodeName},
+			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
+			key:                 podKey(testPodWithPodGroupAndNodeName),
+			templates:           []*resourceapi.ResourceClaimTemplate{template},
+			claims:              []*resourceapi.ResourceClaim{templatedTestClaimAllocated},
+			expectedClaims:      []resourceapi.ResourceClaim{*templatedTestClaimReserved},
 			expectedStatuses: map[string][]v1.PodResourceClaimStatus{
 				testPodWithPodGroupAndNodeName.Name: {
 					{Name: testPodWithPodGroupAndNodeName.Spec.ResourceClaims[0].Name, ResourceClaimName: &templatedTestClaim.Name},
@@ -732,7 +766,7 @@ func testSyncHandler(tCtx ktesting.TContext) {
 
 	for _, tc := range tests {
 		// Run sequentially because of global logging and global metrics.
-		tCtx.Run(tc.name, func(tCtx ktesting.TContext) {
+		run := func(tCtx ktesting.TContext, features controllerFeatures) {
 			var objects []runtime.Object
 			for _, pod := range tc.pods {
 				objects = append(objects, pod)
@@ -768,11 +802,6 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			templateInformer := informerFactory.Resource().V1().ResourceClaimTemplates()
 			setupMetrics()
 
-			features := controllerFeatures{
-				AdminAccess:            tc.adminAccessEnabled,
-				PrioritizedList:        tc.prioritizedListEnabled,
-				WorkloadResourceClaims: tc.workloadResourceClaimsEnabled,
-			}
 			ec, err := newControllerWithFeatures(tCtx.Logger(), fakeKubeClient, podInformer, podGroupInformer, claimInformer, templateInformer, features)
 			if err != nil {
 				tCtx.Fatalf("error creating ephemeral controller : %v", err)
@@ -855,6 +884,16 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			assert.Equal(tCtx, tc.expectedPodGroupStatuses, actualPodGroupStatuses, "podgroup resource claim statuses")
 
 			expectMetrics(tCtx, tc.expectedMetrics)
+		}
+		tCtx.Run(tc.name, func(tCtx ktesting.TContext) {
+			if len(tc.featureCombinations) == 0 {
+				tc.featureCombinations = allPossibleFeatures
+			}
+			for _, features := range tc.featureCombinations {
+				tCtx.Run(features.String(), func(tCtx ktesting.TContext) {
+					run(tCtx, features)
+				})
+			}
 		})
 	}
 }
@@ -983,11 +1022,11 @@ func testEventHandlers(tCtx ktesting.TContext) {
 	extendedResourceClaimKey := claimKeyPrefix + testNamespace + "/" + extendedResourceClaimName
 
 	tests := map[string]struct {
-		features       controllerFeatures
-		initialObjects []runtime.Object
-		createObjects  []object
-		updateObjects  []object
-		deleteObjects  []object
+		featureCombinations []controllerFeatures
+		initialObjects      []runtime.Object
+		createObjects       []object
+		updateObjects       []object
+		deleteObjects       []object
 
 		expectedKeys    []string
 		expectedMetrics map[controllermetrics.NumResourceClaimLabels]float64
@@ -1184,41 +1223,41 @@ func testEventHandlers(tCtx ktesting.TContext) {
 			expectedKeys:  []string{extendedResourceClaimKey, testPodKey},
 		},
 		"new-podgroup-feature-disabled": {
-			features:      controllerFeatures{WorkloadResourceClaims: false},
-			createObjects: []object{testPodGroupWithResourceInStatus},
-			expectedKeys:  []string{},
+			featureCombinations: workloadResourceClaimsDisabled,
+			createObjects:       []object{testPodGroupWithResourceInStatus},
+			expectedKeys:        []string{},
 		},
 		"new-podgroup": {
-			features:      controllerFeatures{WorkloadResourceClaims: true},
-			createObjects: []object{testPodGroupWithResourceInStatus},
-			expectedKeys:  []string{testPodGroupKey},
+			featureCombinations: workloadResourceClaimsEnabled,
+			createObjects:       []object{testPodGroupWithResourceInStatus},
+			expectedKeys:        []string{testPodGroupKey},
 		},
 		"new-podgroup-templated-claim-already-exists": {
-			features:       controllerFeatures{WorkloadResourceClaims: true},
-			initialObjects: []runtime.Object{testPodGroupClaim},
-			createObjects:  []object{testPodGroupWithResourceInStatus},
-			expectedKeys:   []string{},
+			featureCombinations: workloadResourceClaimsEnabled,
+			initialObjects:      []runtime.Object{testPodGroupClaim},
+			createObjects:       []object{testPodGroupWithResourceInStatus},
+			expectedKeys:        []string{},
 			expectedMetrics: map[controllermetrics.NumResourceClaimLabels]float64{
 				{Allocated: "false", AdminAccess: "false"}: 1,
 			},
 		},
 		"new-templated-claim-for-podgroup": {
-			features:       controllerFeatures{WorkloadResourceClaims: true},
-			initialObjects: []runtime.Object{testPodGroupWithResourceInStatus},
-			createObjects:  []object{testPodGroupClaim},
-			expectedKeys:   []string{testClaimKey},
+			featureCombinations: workloadResourceClaimsEnabled,
+			initialObjects:      []runtime.Object{testPodGroupWithResourceInStatus},
+			createObjects:       []object{testPodGroupClaim},
+			expectedKeys:        []string{testClaimKey},
 			expectedMetrics: map[controllermetrics.NumResourceClaimLabels]float64{
 				{Allocated: "false", AdminAccess: "false"}: 1,
 			},
 		},
 		"new-template-for-podgroup": {
-			features:       controllerFeatures{WorkloadResourceClaims: true},
-			initialObjects: []runtime.Object{testPodGroupWithResource},
-			createObjects:  []object{template},
-			expectedKeys:   []string{testPodGroupKey},
+			featureCombinations: workloadResourceClaimsEnabled,
+			initialObjects:      []runtime.Object{testPodGroupWithResource},
+			createObjects:       []object{template},
+			expectedKeys:        []string{testPodGroupKey},
 		},
 		"podgroup-claim-status-update": {
-			features: controllerFeatures{WorkloadResourceClaims: true},
+			featureCombinations: workloadResourceClaimsEnabled,
 			initialObjects: []runtime.Object{
 				testPodGroupWithResource,
 				podInPodGroup(testPodWithPodGroupResource, testPodName+"-1", testPodGroupName),
@@ -1235,7 +1274,7 @@ func testEventHandlers(tCtx ktesting.TContext) {
 			expectedIndexedPodsByResourceClaimTemplate: []string{testNamespace + "/" + templateName},
 		},
 		"podgroup-claim-status-update-feature-disabled": {
-			features: controllerFeatures{WorkloadResourceClaims: false},
+			featureCombinations: workloadResourceClaimsDisabled,
 			initialObjects: []runtime.Object{
 				testPodGroupWithResource,
 				podInPodGroup(testPodWithPodGroupResource, testPodName+"-1", testPodGroupName),
@@ -1249,7 +1288,7 @@ func testEventHandlers(tCtx ktesting.TContext) {
 		},
 	}
 	for name, test := range tests {
-		tCtx.SyncTest(name, func(tCtx ktesting.TContext) {
+		run := func(tCtx ktesting.TContext, features controllerFeatures) {
 			fakeKubeClient := createTestClient(test.initialObjects...)
 			informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
 			podInformer := informerFactory.Core().V1().Pods()
@@ -1258,7 +1297,7 @@ func testEventHandlers(tCtx ktesting.TContext) {
 			templateInformer := informerFactory.Resource().V1().ResourceClaimTemplates()
 			setupMetrics()
 
-			ec, err := newControllerWithFeatures(tCtx.Logger(), fakeKubeClient, podInformer, podGroupInformer, claimInformer, templateInformer, test.features)
+			ec, err := newControllerWithFeatures(tCtx.Logger(), fakeKubeClient, podInformer, podGroupInformer, claimInformer, templateInformer, features)
 			tCtx.ExpectNoError(err, "creating ephemeral controller")
 			tCtx.Cleanup(ec.queue.ShutDown)
 
@@ -1324,6 +1363,16 @@ func testEventHandlers(tCtx ktesting.TContext) {
 
 			actualIndexedPodsByResourceClaimTemplate := ec.podIndexer.ListIndexFuncValues(podResourceClaimTemplateIndex)
 			tCtx.Expect(actualIndexedPodsByResourceClaimTemplate).To(gomega.ConsistOf(test.expectedIndexedPodsByResourceClaimTemplate), "expected Pods were not indexed by ResourceClaimTemplate")
+		}
+		if len(test.featureCombinations) == 0 {
+			test.featureCombinations = allPossibleFeatures
+		}
+		tCtx.Run(name, func(tCtx ktesting.TContext) {
+			for _, features := range test.featureCombinations {
+				tCtx.SyncTest(features.String(), func(tCtx ktesting.TContext) {
+					run(tCtx, features)
+				})
+			}
 		})
 	}
 }

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -768,12 +768,12 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			templateInformer := informerFactory.Resource().V1().ResourceClaimTemplates()
 			setupMetrics()
 
-			features := Features{
+			features := controllerFeatures{
 				AdminAccess:            tc.adminAccessEnabled,
 				PrioritizedList:        tc.prioritizedListEnabled,
 				WorkloadResourceClaims: tc.workloadResourceClaimsEnabled,
 			}
-			ec, err := NewController(tCtx.Logger(), features, fakeKubeClient, podInformer, podGroupInformer, claimInformer, templateInformer)
+			ec, err := newControllerWithFeatures(tCtx.Logger(), fakeKubeClient, podInformer, podGroupInformer, claimInformer, templateInformer, features)
 			if err != nil {
 				tCtx.Fatalf("error creating ephemeral controller : %v", err)
 			}
@@ -878,7 +878,7 @@ func testControllerCreateDeleteRecreate(tCtx ktesting.TContext) {
 	claimInformer := informerFactory.Resource().V1().ResourceClaims()
 	templateInformer := informerFactory.Resource().V1().ResourceClaimTemplates()
 
-	ec, err := NewController(tCtx.Logger(), Features{}, fakeKubeClient, podInformer, podGroupInformer, claimInformer, templateInformer)
+	ec, err := newControllerWithFeatures(tCtx.Logger(), fakeKubeClient, podInformer, podGroupInformer, claimInformer, templateInformer, controllerFeatures{})
 	tCtx.ExpectNoError(err, "creating controller")
 	tCtx.Cleanup(ec.queue.ShutDown)
 
@@ -983,11 +983,12 @@ func testEventHandlers(tCtx ktesting.TContext) {
 	extendedResourceClaimKey := claimKeyPrefix + testNamespace + "/" + extendedResourceClaimName
 
 	tests := map[string]struct {
-		features        Features
-		initialObjects  []runtime.Object
-		createObjects   []object
-		updateObjects   []object
-		deleteObjects   []object
+		features       controllerFeatures
+		initialObjects []runtime.Object
+		createObjects  []object
+		updateObjects  []object
+		deleteObjects  []object
+
 		expectedKeys    []string
 		expectedMetrics map[controllermetrics.NumResourceClaimLabels]float64
 
@@ -1183,17 +1184,17 @@ func testEventHandlers(tCtx ktesting.TContext) {
 			expectedKeys:  []string{extendedResourceClaimKey, testPodKey},
 		},
 		"new-podgroup-feature-disabled": {
-			features:      Features{WorkloadResourceClaims: false},
+			features:      controllerFeatures{WorkloadResourceClaims: false},
 			createObjects: []object{testPodGroupWithResourceInStatus},
 			expectedKeys:  []string{},
 		},
 		"new-podgroup": {
-			features:      Features{WorkloadResourceClaims: true},
+			features:      controllerFeatures{WorkloadResourceClaims: true},
 			createObjects: []object{testPodGroupWithResourceInStatus},
 			expectedKeys:  []string{testPodGroupKey},
 		},
 		"new-podgroup-templated-claim-already-exists": {
-			features:       Features{WorkloadResourceClaims: true},
+			features:       controllerFeatures{WorkloadResourceClaims: true},
 			initialObjects: []runtime.Object{testPodGroupClaim},
 			createObjects:  []object{testPodGroupWithResourceInStatus},
 			expectedKeys:   []string{},
@@ -1202,7 +1203,7 @@ func testEventHandlers(tCtx ktesting.TContext) {
 			},
 		},
 		"new-templated-claim-for-podgroup": {
-			features:       Features{WorkloadResourceClaims: true},
+			features:       controllerFeatures{WorkloadResourceClaims: true},
 			initialObjects: []runtime.Object{testPodGroupWithResourceInStatus},
 			createObjects:  []object{testPodGroupClaim},
 			expectedKeys:   []string{testClaimKey},
@@ -1211,13 +1212,13 @@ func testEventHandlers(tCtx ktesting.TContext) {
 			},
 		},
 		"new-template-for-podgroup": {
-			features:       Features{WorkloadResourceClaims: true},
+			features:       controllerFeatures{WorkloadResourceClaims: true},
 			initialObjects: []runtime.Object{testPodGroupWithResource},
 			createObjects:  []object{template},
 			expectedKeys:   []string{testPodGroupKey},
 		},
 		"podgroup-claim-status-update": {
-			features: Features{WorkloadResourceClaims: true},
+			features: controllerFeatures{WorkloadResourceClaims: true},
 			initialObjects: []runtime.Object{
 				testPodGroupWithResource,
 				podInPodGroup(testPodWithPodGroupResource, testPodName+"-1", testPodGroupName),
@@ -1234,7 +1235,7 @@ func testEventHandlers(tCtx ktesting.TContext) {
 			expectedIndexedPodsByResourceClaimTemplate: []string{testNamespace + "/" + templateName},
 		},
 		"podgroup-claim-status-update-feature-disabled": {
-			features: Features{WorkloadResourceClaims: false},
+			features: controllerFeatures{WorkloadResourceClaims: false},
 			initialObjects: []runtime.Object{
 				testPodGroupWithResource,
 				podInPodGroup(testPodWithPodGroupResource, testPodName+"-1", testPodGroupName),
@@ -1257,7 +1258,7 @@ func testEventHandlers(tCtx ktesting.TContext) {
 			templateInformer := informerFactory.Resource().V1().ResourceClaimTemplates()
 			setupMetrics()
 
-			ec, err := NewController(tCtx.Logger(), test.features, fakeKubeClient, podInformer, podGroupInformer, claimInformer, templateInformer)
+			ec, err := newControllerWithFeatures(tCtx.Logger(), fakeKubeClient, podInformer, podGroupInformer, claimInformer, templateInformer, test.features)
 			tCtx.ExpectNoError(err, "creating ephemeral controller")
 			tCtx.Cleanup(ec.queue.ShutDown)
 

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package resourceclaim
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
@@ -34,10 +36,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	resourcelisters "k8s.io/client-go/listers/resource/v1"
 	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/testutil"
 	resourceclaimmetrics "k8s.io/dynamic-resource-allocation/resourceclaim/metrics"
@@ -1469,6 +1473,102 @@ func testEventHandlers(tCtx ktesting.TContext) {
 	}
 }
 
+func TestWorkqueue(t *testing.T) { testWorkqueue(ktesting.Init(t)) }
+func testWorkqueue(tCtx ktesting.TContext) {
+	tests := map[string]struct {
+		shutdown       bool
+		syncHandlerErr error
+		expectStopLoop bool
+		expectSynced   bool
+		expectRequeue  bool
+	}{
+		"no-error": {
+			syncHandlerErr: nil,
+			expectSynced:   true,
+		},
+		"retryable-error": {
+			syncHandlerErr: fmt.Errorf("will retry"),
+			expectSynced:   true,
+			expectRequeue:  true,
+		},
+		"nonretryable-error": {
+			syncHandlerErr: nonRetryableError{fmt.Errorf("will not retry")},
+			expectSynced:   true,
+			expectRequeue:  false,
+		},
+		"wrapped-nonretryable-error": {
+			syncHandlerErr: fmt.Errorf("%w", nonRetryableError{fmt.Errorf("will not retry")}),
+			expectSynced:   true,
+			expectRequeue:  false,
+		},
+		"shutdown": {
+			shutdown:       true,
+			expectSynced:   false,
+			expectStopLoop: true,
+		},
+	}
+	for name, test := range tests {
+		tCtx.SyncTest(name, func(tCtx ktesting.TContext) {
+			// The default [utilruntime.ErrorHandlers] use [time] but are
+			// initialized before the synctest bubble is established. As a
+			// result, when the error handler is invoked the default rate
+			// limiting begins a sleep for the duration between *fake* now and
+			// *actual* now. The workqueue in turn spins through its internal
+			// periodic accounting for more than 26 years(!) which eventually
+			// resolves, but wastes actual CPU time.
+			oldErrorHandlers := utilruntime.ErrorHandlers
+			tCtx.Cleanup(func() {
+				utilruntime.ErrorHandlers = oldErrorHandlers
+			})
+			utilruntime.ErrorHandlers = []utilruntime.ErrorHandler{
+				func(ctx context.Context, err error, msg string, keysAndValues ...any) {
+					klog.FromContext(ctx).Error(err, msg, keysAndValues...)
+				},
+			}
+
+			rateLimitDelay := 1 * time.Second
+			ec := &Controller{
+				queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+					&staticRateLimiter[string]{delay: rateLimitDelay, requeues: map[string]int{}},
+					workqueue.TypedRateLimitingQueueConfig[string]{Name: "resource_claim"},
+				),
+			}
+			tCtx.Cleanup(ec.queue.ShutDown)
+
+			synced := false
+			ec.syncHandlerFunc = func(ctx context.Context, s string) error {
+				synced = true
+				return test.syncHandlerErr
+			}
+
+			if test.shutdown {
+				ec.queue.ShutDown()
+			}
+
+			var key string
+			ec.queue.Add(key)
+
+			actual := ec.processNextWorkItem(tCtx)
+			tCtx.Expect(actual).To(gomega.Equal(!test.expectStopLoop))
+
+			if test.expectSynced {
+				tCtx.Expect(synced).To(gomega.BeTrueBecause("sync handler should have run but did not"))
+			} else {
+				tCtx.Expect(synced).To(gomega.BeFalseBecause("sync handler should not have run but did"))
+			}
+			time.Sleep(rateLimitDelay)
+			// The delayed Add races with checking the length of the queue. Wait
+			// for the Add to finish before checking the length.
+			tCtx.Wait()
+			if test.expectRequeue {
+				tCtx.Expect(ec.queue.Len()).To(gomega.Equal(1), "key should have been queued")
+			} else {
+				tCtx.Expect(ec.queue.Len()).To(gomega.Equal(0), "no key should have been queued")
+			}
+		})
+	}
+}
+
 func TestGetAdminAccessMetricLabel(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -1968,4 +2068,36 @@ func (em numMetrics) withUpdates(rcLabels controllermetrics.NumResourceClaimLabe
 		metrics: em.metrics,
 		lister:  em.lister,
 	}
+}
+
+// staticRateLimiter delays any item by a fixed amount of time. It allows a test
+// to know exactly how long to wait before rate-limited items are added to the
+// queue.
+type staticRateLimiter[T comparable] struct {
+	delay time.Duration
+
+	requeuesLock sync.Mutex
+	requeues     map[T]int
+}
+
+// Forget implements [workqueue.TypedRateLimiter].
+func (s *staticRateLimiter[T]) Forget(item T) {
+	s.requeuesLock.Lock()
+	defer s.requeuesLock.Unlock()
+	delete(s.requeues, item)
+}
+
+// NumRequeues implements [workqueue.TypedRateLimiter].
+func (s *staticRateLimiter[T]) NumRequeues(item T) int {
+	s.requeuesLock.Lock()
+	defer s.requeuesLock.Unlock()
+	return s.requeues[item]
+}
+
+// When implements [workqueue.TypedRateLimiter].
+func (s *staticRateLimiter[T]) When(item T) time.Duration {
+	s.requeuesLock.Lock()
+	defer s.requeuesLock.Unlock()
+	s.requeues[item]++
+	return s.delay
 }

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -19,11 +19,9 @@ package resourceclaim
 import (
 	"errors"
 	"fmt"
-	"slices"
 	"sort"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
@@ -36,21 +34,16 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/diff"
-	"k8s.io/apimachinery/pkg/util/version"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	resourcelisters "k8s.io/client-go/listers/resource/v1"
 	k8stesting "k8s.io/client-go/testing"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/testutil"
 	resourceclaimmetrics "k8s.io/dynamic-resource-allocation/resourceclaim/metrics"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller"
 	controllermetrics "k8s.io/kubernetes/pkg/controller/resourceclaim/metrics"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
@@ -937,369 +930,58 @@ func testControllerCreateDeleteRecreate(tCtx ktesting.TContext) {
 	}
 }
 
-func TestResourceClaimTemplateEventHandler(t *testing.T) {
-	tCtx := ktesting.Init(t)
-
-	fakeKubeClient := createTestClient()
-	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
-	podInformer := informerFactory.Core().V1().Pods()
-	podGroupInformer := informerFactory.Scheduling().V1alpha3().PodGroups()
-	claimInformer := informerFactory.Resource().V1().ResourceClaims()
-	templateInformer := informerFactory.Resource().V1().ResourceClaimTemplates()
-	claimTemplateClient := fakeKubeClient.ResourceV1().ResourceClaimTemplates(testNamespace)
-	claimTemplateTmpClient := fakeKubeClient.ResourceV1().ResourceClaimTemplates("tmp")
-	podClient := fakeKubeClient.CoreV1().Pods(testNamespace)
-	podTmpClient := fakeKubeClient.CoreV1().Pods("tmp")
-
-	ec, err := NewController(tCtx.Logger(), Features{}, fakeKubeClient, podInformer, podGroupInformer, claimInformer, templateInformer)
-	tCtx.ExpectNoError(err, "creating ephemeral controller")
-
-	informerFactory.Start(tCtx.Done())
-	stopInformers := func() {
-		tCtx.Cancel("stopping informers")
-		informerFactory.Shutdown()
-	}
-	defer stopInformers()
-
-	expectQueue := func(tCtx ktesting.TContext, expectedKeys []string, expectedIndexerKeys []string) {
-		g := gomega.NewWithT(tCtx)
-		tCtx.Helper()
-
-		lenDiffMessage := func() string {
-			actualKeys := []string{}
-			for ec.queue.Len() > 0 {
-				actual, _ := ec.queue.Get()
-				actualKeys = append(actualKeys, actual)
-				ec.queue.Forget(actual)
-				ec.queue.Done(actual)
-			}
-			return "Workqueue does not contain expected number of elements\n" +
-				"Diff of elements (- expected, + actual):\n" +
-				diff.Diff(expectedKeys, actualKeys)
-		}
-
-		g.Eventually(ec.queue.Len).
-			WithTimeout(5*time.Second).
-			Should(gomega.Equal(len(expectedKeys)), lenDiffMessage)
-		g.Consistently(ec.queue.Len).
-			WithTimeout(1*time.Second).
-			Should(gomega.Equal(len(expectedKeys)), lenDiffMessage)
-
-		g.Eventually(func() int { return len(ec.podIndexer.ListIndexFuncValues(podResourceClaimTemplateIndex)) }).
-			WithTimeout(5 * time.Second).
-			Should(gomega.Equal(len(expectedIndexerKeys)))
-		g.Consistently(func() int { return len(ec.podIndexer.ListIndexFuncValues(podResourceClaimTemplateIndex)) }).
-			WithTimeout(1 * time.Second).
-			Should(gomega.Equal(len(expectedIndexerKeys)))
-
-		for _, expected := range expectedKeys {
-			actual, shuttingDown := ec.queue.Get()
-			g.Expect(shuttingDown).To(gomega.BeFalseBecause("workqueue is unexpectedly shutting down"))
-			g.Expect(actual).To(gomega.Equal(expected))
-			ec.queue.Forget(actual)
-			ec.queue.Done(actual)
-		}
-
-		for _, src := range expectedIndexerKeys {
-			objects, err := ec.podIndexer.ByIndex(podResourceClaimTemplateIndex, src)
-			g.Expect(err).NotTo(gomega.HaveOccurred(), "should not error when getting objects by index for key %s", src)
-			g.Expect(objects).NotTo(gomega.BeEmpty(), "should have at least one object indexed for key %s", src)
-
-			// Verify that the indexed objects are the expected pods
-			found := false
-			for _, obj := range objects {
-				pod, ok := obj.(*v1.Pod)
-				if !ok {
-					continue
-				}
-				// Check if this pod matches the expected template reference
-				for _, claim := range pod.Spec.ResourceClaims {
-					if claim.ResourceClaimTemplateName != nil {
-						// Build the expected index key for this pod
-						expectedKey := pod.Namespace + "/" + *claim.ResourceClaimTemplateName
-						if expectedKey == src {
-							found = true
-							break
-						}
-					}
-				}
-			}
-			g.Expect(found).To(gomega.BeTrueBecause("should find a pod with template %s in index for key %s", templateName, src))
-		}
-	}
-
-	tmpNamespace := "tmp"
-
-	expectQueue(tCtx, []string{}, []string{})
-
-	// Create two pods:
-	// - testPodWithResource in the my-namespace namespace
-	// - fake-1 in the tmp namespace
-	_, err = podClient.Create(tCtx, testPodWithResource, metav1.CreateOptions{})
-	_, err1 := podTmpClient.Create(tCtx, makePod("fake-1", tmpNamespace, "uidpod2", *makePodResourceClaim(podResourceClaimName, templateName)), metav1.CreateOptions{})
-	tCtx.Step("create pod", func(tCtx ktesting.TContext) {
-		tCtx.ExpectNoError(err)
-		tCtx.ExpectNoError(err1)
-		expectQueue(tCtx, []string{testPodKey, podKeyPrefix + tmpNamespace + "/" + "fake-1"}, []string{testNamespace + "/" + templateName, tmpNamespace + "/" + templateName})
-	})
-
-	// The item  has been forgotten and marked as done in the workqueue,so queue is nil
-	tCtx.Step("expect queue is nil", func(tCtx ktesting.TContext) {
-		expectQueue(tCtx, []string{}, []string{testNamespace + "/" + templateName, tmpNamespace + "/" + templateName})
-	})
-
-	// After create claim template,queue should have test pod key
-	_, err = claimTemplateClient.Create(tCtx, template, metav1.CreateOptions{})
-	tCtx.Step("create claim template after pod backoff", func(tCtx ktesting.TContext) {
-		tCtx.ExpectNoError(err)
-		expectQueue(tCtx, []string{testPodKey}, []string{testNamespace + "/" + templateName, tmpNamespace + "/" + templateName})
-	})
-
-	// The item  has been forgotten and marked as done in the workqueue,so queue is nil
-	tCtx.Step("expect queue is nil", func(tCtx ktesting.TContext) {
-		expectQueue(tCtx, []string{}, []string{testNamespace + "/" + templateName, tmpNamespace + "/" + templateName})
-	})
-
-	// After create tmp namespace claim template,queue should have fake pod key
-	TmpNamespaceTemplate := makeTemplate(templateName, "tmp", nil)
-	_, err = claimTemplateTmpClient.Create(tCtx, TmpNamespaceTemplate, metav1.CreateOptions{})
-	tCtx.Step("create  claim template in tmp namespace after  pod backoff in test namespace", func(tCtx ktesting.TContext) {
-		tCtx.ExpectNoError(err)
-		expectQueue(tCtx, []string{podKeyPrefix + tmpNamespace + "/" + "fake-1"}, []string{testNamespace + "/" + templateName, tmpNamespace + "/" + templateName})
-	})
-
-}
-
-func TestResourceClaimEventHandler(t *testing.T) {
-	tCtx := ktesting.Init(t)
-
-	fakeKubeClient := createTestClient()
-	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
-	podInformer := informerFactory.Core().V1().Pods()
-	podGroupInformer := informerFactory.Scheduling().V1alpha3().PodGroups()
-	claimInformer := informerFactory.Resource().V1().ResourceClaims()
-	templateInformer := informerFactory.Resource().V1().ResourceClaimTemplates()
-	setupMetrics()
-	claimClient := fakeKubeClient.ResourceV1().ResourceClaims(testNamespace)
-
-	ec, err := NewController(tCtx.Logger(), Features{}, fakeKubeClient, podInformer, podGroupInformer, claimInformer, templateInformer)
-	tCtx.ExpectNoError(err, "creating ephemeral controller")
-
-	informerFactory.Start(tCtx.Done())
-	stopInformers := func() {
-		tCtx.Cancel("stopping informers")
-		informerFactory.Shutdown()
-	}
-	defer stopInformers()
-
-	em := newNumMetrics(claimInformer.Lister())
-
-	expectQueue := func(tCtx ktesting.TContext, expectedKeys []string) {
-		g := gomega.NewWithT(tCtx)
-		tCtx.Helper()
-
-		lenDiffMessage := func() string {
-			actualKeys := []string{}
-			for ec.queue.Len() > 0 {
-				actual, _ := ec.queue.Get()
-				actualKeys = append(actualKeys, actual)
-				ec.queue.Forget(actual)
-				ec.queue.Done(actual)
-			}
-			return "Workqueue does not contain expected number of elements\n" +
-				"Diff of elements (- expected, + actual):\n" +
-				diff.Diff(expectedKeys, actualKeys)
-		}
-
-		g.Eventually(ec.queue.Len).
-			WithTimeout(5*time.Second).
-			Should(gomega.Equal(len(expectedKeys)), lenDiffMessage)
-		g.Consistently(ec.queue.Len).
-			WithTimeout(1*time.Second).
-			Should(gomega.Equal(len(expectedKeys)), lenDiffMessage)
-
-		for _, expected := range expectedKeys {
-			actual, shuttingDown := ec.queue.Get()
-			g.Expect(shuttingDown).To(gomega.BeFalseBecause("workqueue is unexpectedly shutting down"))
-			g.Expect(actual).To(gomega.Equal(expected))
-			ec.queue.Forget(actual)
-			ec.queue.Done(actual)
-		}
-	}
-
-	expectQueue(tCtx, []string{})
-
-	_, err = claimClient.Create(tCtx, testClaim, metav1.CreateOptions{})
-	em = em.withUpdates(controllermetrics.NumResourceClaimLabels{Allocated: "false", AdminAccess: "false", Source: ""}, 1)
-	tCtx.Step("create claim", func(tCtx ktesting.TContext) {
-		tCtx.ExpectNoError(err)
-		em.Eventually(tCtx)
-		expectQueue(tCtx, []string{testClaimKey})
-	})
-
-	modifiedClaim := testClaim.DeepCopy()
-	modifiedClaim.Labels = map[string]string{"foo": "bar"}
-	_, err = claimClient.Update(tCtx, modifiedClaim, metav1.UpdateOptions{})
-	tCtx.Step("modify claim", func(tCtx ktesting.TContext) {
-		tCtx.ExpectNoError(err)
-		em.Consistently(tCtx)
-		expectQueue(tCtx, []string{testClaimKey})
-	})
-
-	_, err = claimClient.Update(tCtx, testClaimAllocated, metav1.UpdateOptions{})
-	em = em.withUpdates(controllermetrics.NumResourceClaimLabels{Allocated: "false", AdminAccess: "false", Source: ""}, -1)
-	em = em.withUpdates(controllermetrics.NumResourceClaimLabels{Allocated: "true", AdminAccess: "false", Source: ""}, 1)
-	tCtx.Step("allocate claim", func(tCtx ktesting.TContext) {
-		tCtx.ExpectNoError(err)
-		em.Eventually(tCtx)
-		expectQueue(tCtx, []string{testClaimKey})
-	})
-
-	modifiedClaim = testClaimAllocated.DeepCopy()
-	modifiedClaim.Labels = map[string]string{"foo": "bar2"}
-	_, err = claimClient.Update(tCtx, modifiedClaim, metav1.UpdateOptions{})
-	tCtx.Step("modify claim", func(tCtx ktesting.TContext) {
-		tCtx.ExpectNoError(err)
-		em.Consistently(tCtx)
-		expectQueue(tCtx, []string{testClaimKey})
-	})
-
-	otherClaimAllocated := testClaimAllocated.DeepCopy()
-	otherClaimAllocated.Name += "2"
-	_, err = claimClient.Create(tCtx, otherClaimAllocated, metav1.CreateOptions{})
-	em = em.withUpdates(controllermetrics.NumResourceClaimLabels{Allocated: "true", AdminAccess: "false", Source: ""}, 1)
-	tCtx.Step("create allocated claim", func(tCtx ktesting.TContext) {
-		tCtx.ExpectNoError(err)
-		em.Eventually(tCtx)
-		expectQueue(tCtx, []string{testClaimKey + "2"})
-	})
-
-	_, err = claimClient.Update(tCtx, testClaim, metav1.UpdateOptions{})
-	em = em.withUpdates(controllermetrics.NumResourceClaimLabels{Allocated: "false", AdminAccess: "false", Source: ""}, 1)
-	em = em.withUpdates(controllermetrics.NumResourceClaimLabels{Allocated: "true", AdminAccess: "false", Source: ""}, -1)
-	tCtx.Step("deallocate claim", func(tCtx ktesting.TContext) {
-		tCtx.ExpectNoError(err)
-		em.Eventually(tCtx)
-		expectQueue(tCtx, []string{testClaimKey})
-	})
-
-	err = claimClient.Delete(tCtx, testClaim.Name, metav1.DeleteOptions{})
-	em = em.withUpdates(controllermetrics.NumResourceClaimLabels{Allocated: "false", AdminAccess: "false", Source: ""}, -1)
-	tCtx.Step("delete deallocated claim", func(tCtx ktesting.TContext) {
-		tCtx.ExpectNoError(err)
-		em.Eventually(tCtx)
-		expectQueue(tCtx, []string{})
-	})
-
-	err = claimClient.Delete(tCtx, otherClaimAllocated.Name, metav1.DeleteOptions{})
-	em = em.withUpdates(controllermetrics.NumResourceClaimLabels{Allocated: "true", AdminAccess: "false", Source: ""}, -1)
-	tCtx.Step("delete allocated claim", func(tCtx ktesting.TContext) {
-		tCtx.ExpectNoError(err)
-		em.Eventually(tCtx)
-		expectQueue(tCtx, []string{})
-	})
-
-	_, err = claimClient.Create(tCtx, templatedTestClaimWithAdmin, metav1.CreateOptions{})
-	em = em.withUpdates(controllermetrics.NumResourceClaimLabels{Allocated: "false", AdminAccess: "true", Source: "resource_claim_template"}, 1)
-	tCtx.Step("create claim with admin access", func(tCtx ktesting.TContext) {
-		tCtx.ExpectNoError(err)
-		em.Eventually(tCtx)
-	})
-
-	modifiedClaim = templatedTestClaimWithAdmin.DeepCopy()
-	modifiedClaim.Labels = map[string]string{"foo": "bar"}
-	_, err = claimClient.Update(tCtx, modifiedClaim, metav1.UpdateOptions{})
-	tCtx.Step("modify claim", func(tCtx ktesting.TContext) {
-		tCtx.ExpectNoError(err)
-		em.Consistently(tCtx)
-	})
-
-	_, err = claimClient.Update(tCtx, templatedTestClaimWithAdminAllocated, metav1.UpdateOptions{})
-	em = em.withUpdates(controllermetrics.NumResourceClaimLabels{Allocated: "false", AdminAccess: "true", Source: "resource_claim_template"}, -1)
-	em = em.withUpdates(controllermetrics.NumResourceClaimLabels{Allocated: "true", AdminAccess: "true", Source: "resource_claim_template"}, 1)
-	tCtx.Step("allocate claim with admin access", func(tCtx ktesting.TContext) {
-		tCtx.ExpectNoError(err)
-		em.Eventually(tCtx)
-	})
-
-	modifiedClaim = templatedTestClaimWithAdminAllocated.DeepCopy()
-	modifiedClaim.Labels = map[string]string{"foo": "bar2"}
-	_, err = claimClient.Update(tCtx, modifiedClaim, metav1.UpdateOptions{})
-	tCtx.Step("modify claim", func(tCtx ktesting.TContext) {
-		tCtx.ExpectNoError(err)
-		em.Consistently(tCtx)
-	})
-
-	otherClaimAllocated = templatedTestClaimWithAdminAllocated.DeepCopy()
-	otherClaimAllocated.Name += "2"
-	_, err = claimClient.Create(tCtx, otherClaimAllocated, metav1.CreateOptions{})
-	em = em.withUpdates(controllermetrics.NumResourceClaimLabels{Allocated: "true", AdminAccess: "true", Source: "resource_claim_template"}, 1)
-	tCtx.Step("create allocated claim with admin access", func(tCtx ktesting.TContext) {
-		tCtx.ExpectNoError(err)
-		em.Eventually(tCtx)
-	})
-
-	_, err = claimClient.Update(tCtx, templatedTestClaimWithAdmin, metav1.UpdateOptions{})
-	em = em.withUpdates(controllermetrics.NumResourceClaimLabels{Allocated: "false", AdminAccess: "true", Source: "resource_claim_template"}, 1)
-	em = em.withUpdates(controllermetrics.NumResourceClaimLabels{Allocated: "true", AdminAccess: "true", Source: "resource_claim_template"}, -1)
-	tCtx.Step("deallocate claim with admin access", func(tCtx ktesting.TContext) {
-		tCtx.ExpectNoError(err)
-		em.Eventually(tCtx)
-	})
-
-	err = claimClient.Delete(tCtx, templatedTestClaimWithAdmin.Name, metav1.DeleteOptions{})
-	em = em.withUpdates(controllermetrics.NumResourceClaimLabels{Allocated: "false", AdminAccess: "true", Source: "resource_claim_template"}, -1)
-	tCtx.Step("delete deallocated claim with admin access", func(tCtx ktesting.TContext) {
-		tCtx.ExpectNoError(err)
-		em.Eventually(tCtx)
-	})
-
-	err = claimClient.Delete(tCtx, otherClaimAllocated.Name, metav1.DeleteOptions{})
-	em = em.withUpdates(controllermetrics.NumResourceClaimLabels{Allocated: "true", AdminAccess: "true", Source: "resource_claim_template"}, -1)
-	tCtx.Step("delete allocated claim with admin access", func(tCtx ktesting.TContext) {
-		tCtx.ExpectNoError(err)
-		em.Eventually(tCtx)
-	})
-
-	_, err = claimClient.Create(tCtx, extendedTestClaim, metav1.CreateOptions{})
-	em = em.withUpdates(controllermetrics.NumResourceClaimLabels{Allocated: "false", AdminAccess: "false", Source: "extended_resource"}, 1)
-	tCtx.Step("create extended resource claim", func(tCtx ktesting.TContext) {
-		tCtx.ExpectNoError(err)
-		em.Eventually(tCtx)
-	})
-
-	_, err = claimClient.Update(tCtx, extendedTestClaimAllocated, metav1.UpdateOptions{})
-	em = em.withUpdates(controllermetrics.NumResourceClaimLabels{Allocated: "false", AdminAccess: "false", Source: "extended_resource"}, -1)
-	em = em.withUpdates(controllermetrics.NumResourceClaimLabels{Allocated: "true", AdminAccess: "false", Source: "extended_resource"}, 1)
-	tCtx.Step("allocate extended resource claim", func(tCtx ktesting.TContext) {
-		tCtx.ExpectNoError(err)
-		em.Eventually(tCtx)
-	})
-
-	_, err = claimClient.Update(tCtx, extendedTestClaim, metav1.UpdateOptions{})
-	em = em.withUpdates(controllermetrics.NumResourceClaimLabels{Allocated: "false", AdminAccess: "false", Source: "extended_resource"}, 1)
-	em = em.withUpdates(controllermetrics.NumResourceClaimLabels{Allocated: "true", AdminAccess: "false", Source: "extended_resource"}, -1)
-	tCtx.Step("deallocate extended resource claim", func(tCtx ktesting.TContext) {
-		tCtx.ExpectNoError(err)
-		em.Eventually(tCtx)
-	})
-
-	err = claimClient.Delete(tCtx, extendedTestClaim.Name, metav1.DeleteOptions{})
-	em = em.withUpdates(controllermetrics.NumResourceClaimLabels{Allocated: "false", AdminAccess: "false", Source: "extended_resource"}, -1)
-	tCtx.Step("delete extended resource claim", func(tCtx ktesting.TContext) {
-		tCtx.ExpectNoError(err)
-		em.Eventually(tCtx)
-	})
-
-	em.Consistently(tCtx)
-}
-
 func TestEventHandlers(t *testing.T) { testEventHandlers(ktesting.Init(t)) }
 func testEventHandlers(tCtx ktesting.TContext) {
 	type object interface {
 		runtime.Object
 		metav1.Object
 	}
+
+	modifiedClaim := testClaim.DeepCopy()
+	modifiedClaim.Labels = map[string]string{"foo": "bar"}
+
+	modifiedClaimAdminAccess := templatedTestClaimWithAdmin.DeepCopy()
+	modifiedClaim.Labels = map[string]string{"foo": "bar"}
+
+	otherClaimAllocated := testClaimAllocated.DeepCopy()
+	otherClaimAllocated.Name += "2"
+	otherClaimKey := testClaimKey + "2"
+
+	otherClaimAllocatedAdminAccess := templatedTestClaimWithAdminAllocated.DeepCopy()
+	otherClaimAllocatedAdminAccess.Name += "2"
+
+	templatedTestClaimKey := testClaimKey + "--1"
+	templatedOtherClaimKey := templatedTestClaimKey + "2"
+	extendedResourceTemplatedClaimKey := claimKeyPrefix + testNamespace + "/" + testPodName + "-extended-resources--1"
+
+	otherNSTemplate := makeTemplate(templateName, otherNamespace, nil)
+
+	otherNSPod := makePod("fake-1", otherNamespace, "uidpod2", *makePodResourceClaim(podResourceClaimName, templateName))
+	otherNSPodKey := podKeyPrefix + otherNamespace + "/" + otherNSPod.Name
+
+	extendedResourceClaimName := "test-extended-claim"
+	podWithExtendedResourceClaim := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: testPodName, Namespace: testNamespace},
+		Spec:       v1.PodSpec{},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+			ExtendedResourceClaimStatus: &v1.PodExtendedResourceClaimStatus{
+				ResourceClaimName: extendedResourceClaimName,
+			},
+		},
+	}
+
+	completedPodWithExtendedResourceClaim := podWithExtendedResourceClaim.DeepCopy()
+	completedPodWithExtendedResourceClaim.Status.Phase = v1.PodSucceeded
+
+	completedPodWithRegularAndExtendedResourceClaim := podWithExtendedResourceClaim.DeepCopy()
+	completedPodWithRegularAndExtendedResourceClaim.Spec.ResourceClaims = []v1.PodResourceClaim{{Name: "regular-claim"}}
+	completedPodWithRegularAndExtendedResourceClaim.Status.Phase = v1.PodSucceeded
+
+	failedPodWithExtendedResourceClaim := podWithExtendedResourceClaim.DeepCopy()
+	failedPodWithExtendedResourceClaim.Status.Phase = v1.PodFailed
+
+	extendedResourceClaimKey := claimKeyPrefix + testNamespace + "/" + extendedResourceClaimName
 
 	tests := map[string]struct {
 		features        Features
@@ -1309,8 +991,198 @@ func testEventHandlers(tCtx ktesting.TContext) {
 		deleteObjects   []object
 		expectedKeys    []string
 		expectedMetrics map[controllermetrics.NumResourceClaimLabels]float64
+
+		expectedIndexedPodsByResourceClaimTemplate []string
 	}{
 		"nothing": {},
+		"new-claim": {
+			createObjects: []object{testClaim},
+			expectedKeys:  []string{testClaimKey},
+			expectedMetrics: map[controllermetrics.NumResourceClaimLabels]float64{
+				{Allocated: "false", AdminAccess: "false"}: 1,
+			},
+		},
+		"update-claim": {
+			initialObjects: []runtime.Object{testClaim},
+			updateObjects:  []object{modifiedClaim},
+			expectedKeys:   []string{testClaimKey},
+			expectedMetrics: map[controllermetrics.NumResourceClaimLabels]float64{
+				{Allocated: "false", AdminAccess: "false"}: 1,
+			},
+		},
+		"allocate-claim": {
+			initialObjects: []runtime.Object{testClaim},
+			updateObjects:  []object{testClaimAllocated},
+			expectedKeys:   []string{testClaimKey},
+			expectedMetrics: map[controllermetrics.NumResourceClaimLabels]float64{
+				{Allocated: "true", AdminAccess: "false"}: 1,
+			},
+		},
+		"allocate-another-claim": {
+			initialObjects: []runtime.Object{testClaimAllocated},
+			createObjects:  []object{otherClaimAllocated},
+			expectedKeys:   []string{otherClaimKey},
+			expectedMetrics: map[controllermetrics.NumResourceClaimLabels]float64{
+				{Allocated: "true", AdminAccess: "false"}: 2,
+			},
+		},
+		"deallocate-claim": {
+			initialObjects: []runtime.Object{testClaimAllocated, otherClaimAllocated},
+			updateObjects:  []object{testClaim},
+			expectedKeys:   []string{testClaimKey},
+			expectedMetrics: map[controllermetrics.NumResourceClaimLabels]float64{
+				{Allocated: "true", AdminAccess: "false"}:  1,
+				{Allocated: "false", AdminAccess: "false"}: 1,
+			},
+		},
+		"delete-deallocated-claim": {
+			initialObjects: []runtime.Object{testClaim, otherClaimAllocated},
+			deleteObjects:  []object{testClaim},
+			expectedKeys:   []string{},
+			expectedMetrics: map[controllermetrics.NumResourceClaimLabels]float64{
+				{Allocated: "true", AdminAccess: "false"}: 1,
+			},
+		},
+		"delete-allocated-claim": {
+			initialObjects:  []runtime.Object{otherClaimAllocated},
+			deleteObjects:   []object{otherClaimAllocated},
+			expectedKeys:    []string{},
+			expectedMetrics: map[controllermetrics.NumResourceClaimLabels]float64{},
+		},
+		"new-claim-admin-access": {
+			createObjects: []object{templatedTestClaimWithAdmin},
+			expectedKeys:  []string{templatedTestClaimKey},
+			expectedMetrics: map[controllermetrics.NumResourceClaimLabels]float64{
+				{Allocated: "false", AdminAccess: "true", Source: "resource_claim_template"}: 1,
+			},
+		},
+		"update-claim-admin-access": {
+			initialObjects: []runtime.Object{templatedTestClaimWithAdmin},
+			updateObjects:  []object{modifiedClaimAdminAccess},
+			expectedKeys:   []string{templatedTestClaimKey},
+			expectedMetrics: map[controllermetrics.NumResourceClaimLabels]float64{
+				{Allocated: "false", AdminAccess: "true", Source: "resource_claim_template"}: 1,
+			},
+		},
+		"allocate-claim-admin-access": {
+			initialObjects: []runtime.Object{modifiedClaimAdminAccess},
+			updateObjects:  []object{templatedTestClaimWithAdminAllocated},
+			expectedKeys:   []string{templatedTestClaimKey},
+			expectedMetrics: map[controllermetrics.NumResourceClaimLabels]float64{
+				{Allocated: "true", AdminAccess: "true", Source: "resource_claim_template"}: 1,
+			},
+		},
+		"allocate-another-claim-admin-access": {
+			initialObjects: []runtime.Object{templatedTestClaimWithAdminAllocated},
+			createObjects:  []object{otherClaimAllocatedAdminAccess},
+			expectedKeys:   []string{templatedOtherClaimKey},
+			expectedMetrics: map[controllermetrics.NumResourceClaimLabels]float64{
+				{Allocated: "true", AdminAccess: "true", Source: "resource_claim_template"}: 2,
+			},
+		},
+		"deallocate-claim-admin-access": {
+			initialObjects: []runtime.Object{templatedTestClaimWithAdminAllocated, otherClaimAllocatedAdminAccess},
+			updateObjects:  []object{templatedTestClaimWithAdmin},
+			expectedKeys:   []string{templatedTestClaimKey},
+			expectedMetrics: map[controllermetrics.NumResourceClaimLabels]float64{
+				{Allocated: "true", AdminAccess: "true", Source: "resource_claim_template"}:  1,
+				{Allocated: "false", AdminAccess: "true", Source: "resource_claim_template"}: 1,
+			},
+		},
+		"delete-deallocated-claim-admin-access": {
+			initialObjects: []runtime.Object{templatedTestClaimWithAdmin, otherClaimAllocatedAdminAccess},
+			deleteObjects:  []object{templatedTestClaimWithAdmin},
+			expectedKeys:   []string{},
+			expectedMetrics: map[controllermetrics.NumResourceClaimLabels]float64{
+				{Allocated: "true", AdminAccess: "true", Source: "resource_claim_template"}: 1,
+			},
+		},
+		"delete-allocated-claim-admin-access": {
+			initialObjects:  []runtime.Object{otherClaimAllocatedAdminAccess},
+			deleteObjects:   []object{otherClaimAllocatedAdminAccess},
+			expectedKeys:    []string{},
+			expectedMetrics: map[controllermetrics.NumResourceClaimLabels]float64{},
+		},
+		"new-claim-extended-resources": {
+			createObjects: []object{extendedTestClaim},
+			expectedKeys:  []string{extendedResourceTemplatedClaimKey},
+			expectedMetrics: map[controllermetrics.NumResourceClaimLabels]float64{
+				{Allocated: "false", AdminAccess: "false", Source: "extended_resource"}: 1,
+			},
+		},
+		"allocate-claim-extended-resources": {
+			initialObjects: []runtime.Object{extendedTestClaim},
+			updateObjects:  []object{extendedTestClaimAllocated},
+			expectedKeys:   []string{extendedResourceTemplatedClaimKey},
+			expectedMetrics: map[controllermetrics.NumResourceClaimLabels]float64{
+				{Allocated: "true", AdminAccess: "false", Source: "extended_resource"}: 1,
+			},
+		},
+		"deallocate-claim-extended-resources": {
+			initialObjects: []runtime.Object{extendedTestClaimAllocated},
+			updateObjects:  []object{extendedTestClaim},
+			expectedKeys:   []string{extendedResourceTemplatedClaimKey},
+			expectedMetrics: map[controllermetrics.NumResourceClaimLabels]float64{
+				{Allocated: "false", AdminAccess: "false", Source: "extended_resource"}: 1,
+			},
+		},
+		"delete-claim-extended-resources": {
+			initialObjects:  []runtime.Object{extendedTestClaimAllocated},
+			deleteObjects:   []object{extendedTestClaimAllocated},
+			expectedKeys:    []string{},
+			expectedMetrics: map[controllermetrics.NumResourceClaimLabels]float64{},
+		},
+		"new-pods": {
+			createObjects: []object{testPodWithResource, otherNSPod},
+			expectedKeys:  []string{testPodKey, otherNSPodKey},
+			expectedIndexedPodsByResourceClaimTemplate: []string{
+				testNamespace + "/" + templateName,
+				otherNamespace + "/" + templateName,
+			},
+		},
+		"new-template-for-pod": {
+			initialObjects: []runtime.Object{testPodWithResource, otherNSPod},
+			createObjects:  []object{template},
+			expectedKeys:   []string{testPodKey},
+			expectedIndexedPodsByResourceClaimTemplate: []string{
+				testNamespace + "/" + templateName,
+				otherNamespace + "/" + templateName,
+			},
+		},
+		"new-template-for-pod-other-namespace": {
+			initialObjects: []runtime.Object{testPodWithResource, otherNSPod, template},
+			createObjects:  []object{otherNSTemplate},
+			expectedKeys:   []string{otherNSPodKey},
+			expectedIndexedPodsByResourceClaimTemplate: []string{
+				testNamespace + "/" + templateName,
+				otherNamespace + "/" + templateName,
+			},
+		},
+		"pod-without-resource-claims": {
+			createObjects: []object{testPod},
+			expectedKeys:  []string{},
+		},
+		"running-pod-with-extended-resource-claim": {
+			createObjects: []object{podWithExtendedResourceClaim},
+			expectedKeys:  []string{},
+		},
+		"completed-pod-with-extended-resource-claim": {
+			createObjects: []object{completedPodWithExtendedResourceClaim},
+			expectedKeys:  []string{extendedResourceClaimKey},
+		},
+		"faled-pod-with-extended-resource-claim": {
+			createObjects: []object{failedPodWithExtendedResourceClaim},
+			expectedKeys:  []string{extendedResourceClaimKey},
+		},
+		"delete-pod-with-extended-resource-claim": {
+			initialObjects: []runtime.Object{podWithExtendedResourceClaim},
+			deleteObjects:  []object{podWithExtendedResourceClaim},
+			expectedKeys:   []string{extendedResourceClaimKey},
+		},
+		"completed-pod-with-regular-and-extended-resource-claim": {
+			createObjects: []object{completedPodWithRegularAndExtendedResourceClaim},
+			expectedKeys:  []string{extendedResourceClaimKey, testPodKey},
+		},
 		"new-podgroup-feature-disabled": {
 			features:      Features{WorkloadResourceClaims: false},
 			createObjects: []object{testPodGroupWithResourceInStatus},
@@ -1360,6 +1232,7 @@ func testEventHandlers(tCtx ktesting.TContext) {
 				testPodKey + "-1",
 				testPodKey + "-2",
 			},
+			expectedIndexedPodsByResourceClaimTemplate: []string{testNamespace + "/" + templateName},
 		},
 		"podgroup-claim-status-update-feature-disabled": {
 			features: Features{WorkloadResourceClaims: false},
@@ -1372,6 +1245,7 @@ func testEventHandlers(tCtx ktesting.TContext) {
 			},
 			updateObjects: []object{testPodGroupWithResourceInStatus},
 			expectedKeys:  []string{},
+			expectedIndexedPodsByResourceClaimTemplate: []string{testNamespace + "/" + templateName},
 		},
 	}
 	for name, test := range tests {
@@ -1435,7 +1309,7 @@ func testEventHandlers(tCtx ktesting.TContext) {
 				tCtx.ExpectNoError(err)
 			}
 			for _, object := range test.deleteObjects {
-				err := fakeKubeClient.Tracker().Delete(gvr(object), object.GetName(), object.GetNamespace(), metav1.DeleteOptions{})
+				err := fakeKubeClient.Tracker().Delete(gvr(object), object.GetNamespace(), object.GetName(), metav1.DeleteOptions{})
 				tCtx.ExpectNoError(err)
 			}
 
@@ -1447,6 +1321,9 @@ func testEventHandlers(tCtx ktesting.TContext) {
 				em = em.withUpdates(labels, val)
 			}
 			em.verify(tCtx)
+
+			actualIndexedPodsByResourceClaimTemplate := ec.podIndexer.ListIndexFuncValues(podResourceClaimTemplateIndex)
+			tCtx.Expect(actualIndexedPodsByResourceClaimTemplate).To(gomega.ConsistOf(test.expectedIndexedPodsByResourceClaimTemplate), "expected Pods were not indexed by ResourceClaimTemplate")
 		})
 	}
 }
@@ -1874,28 +1751,6 @@ func (em numMetrics) verify(tCtx ktesting.TContext) {
 	tCtx.Expect(result.metrics).To(gomega.Equal(em.metrics))
 }
 
-func (em numMetrics) Eventually(tCtx ktesting.TContext) {
-	g := gomega.NewWithT(tCtx)
-	tCtx.Helper()
-
-	g.Eventually(func() (numMetrics, error) {
-		result, err := getNumMetric(em.lister, tCtx.Logger())
-		result.lister = em.lister
-		return result, err
-	}).WithTimeout(5 * time.Second).Should(gomega.Equal(em))
-}
-
-func (em numMetrics) Consistently(tCtx ktesting.TContext) {
-	g := gomega.NewWithT(tCtx)
-	tCtx.Helper()
-
-	g.Consistently(func() (numMetrics, error) {
-		result, err := getNumMetric(em.lister, tCtx.Logger())
-		result.lister = em.lister
-		return result, err
-	}).WithTimeout(time.Second).Should(gomega.Equal(em))
-}
-
 type expectedMetrics struct {
 	numCreated          int
 	numCreatedWithAdmin int
@@ -1971,194 +1826,5 @@ func (em numMetrics) withUpdates(rcLabels controllermetrics.NumResourceClaimLabe
 	return numMetrics{
 		metrics: em.metrics,
 		lister:  em.lister,
-	}
-}
-
-func TestEnqueuePodExtendedResourceClaims(t *testing.T) {
-	tests := []struct {
-		name                        string
-		pod                         *v1.Pod
-		featureGateEnabled          bool
-		deleted                     bool
-		expectEarlyReturn           bool
-		expectExtendedClaimEnqueued bool
-	}{
-		{
-			name: "pod with no resource claims",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
-				Spec:       v1.PodSpec{},
-				Status:     v1.PodStatus{},
-			},
-			featureGateEnabled:          true,
-			expectEarlyReturn:           true,
-			expectExtendedClaimEnqueued: false,
-		},
-		{
-			name: "pod with regular resource claims only",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
-				Spec: v1.PodSpec{
-					ResourceClaims: []v1.PodResourceClaim{{Name: "regular-claim"}},
-				},
-				Status: v1.PodStatus{Phase: v1.PodRunning},
-			},
-			featureGateEnabled:          true,
-			expectEarlyReturn:           false,
-			expectExtendedClaimEnqueued: false,
-		},
-		{
-			name: "pod with extended resource claim, feature enabled, running pod",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
-				Spec:       v1.PodSpec{},
-				Status: v1.PodStatus{
-					Phase: v1.PodRunning,
-					ExtendedResourceClaimStatus: &v1.PodExtendedResourceClaimStatus{
-						ResourceClaimName: "test-extended-claim",
-					},
-				},
-			},
-			featureGateEnabled:          true,
-			expectEarlyReturn:           false,
-			expectExtendedClaimEnqueued: false,
-		},
-		{
-			name: "pod with extended resource claim, feature enabled, completed pod",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
-				Spec:       v1.PodSpec{},
-				Status: v1.PodStatus{
-					Phase: v1.PodSucceeded,
-					ExtendedResourceClaimStatus: &v1.PodExtendedResourceClaimStatus{
-						ResourceClaimName: "test-extended-claim",
-					},
-				},
-			},
-			featureGateEnabled:          true,
-			expectEarlyReturn:           false,
-			expectExtendedClaimEnqueued: true,
-		},
-		{
-			name: "pod with extended resource claim, feature enabled, failed pod",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
-				Spec:       v1.PodSpec{},
-				Status: v1.PodStatus{
-					Phase: v1.PodFailed, // Failed pod
-					ExtendedResourceClaimStatus: &v1.PodExtendedResourceClaimStatus{
-						ResourceClaimName: "test-extended-claim",
-					},
-				},
-			},
-			featureGateEnabled:          true,
-			expectEarlyReturn:           false,
-			expectExtendedClaimEnqueued: true,
-		},
-		{
-			name: "pod with extended resource claim, feature disabled",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
-				Spec:       v1.PodSpec{},
-				Status: v1.PodStatus{
-					Phase: v1.PodSucceeded,
-					ExtendedResourceClaimStatus: &v1.PodExtendedResourceClaimStatus{
-						ResourceClaimName: "test-extended-claim",
-					},
-				},
-			},
-			featureGateEnabled:          false,
-			expectEarlyReturn:           false,
-			expectExtendedClaimEnqueued: true,
-		},
-		{
-			name: "deleted pod with extended resource claim",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
-				Spec:       v1.PodSpec{},
-				Status: v1.PodStatus{
-					Phase: v1.PodSucceeded,
-					ExtendedResourceClaimStatus: &v1.PodExtendedResourceClaimStatus{
-						ResourceClaimName: "test-extended-claim",
-					},
-				},
-			},
-			featureGateEnabled:          true,
-			deleted:                     true,
-			expectEarlyReturn:           false,
-			expectExtendedClaimEnqueued: true,
-		},
-		{
-			name: "pod with both regular and extended resource claims, completed",
-			pod: &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
-				Spec: v1.PodSpec{
-					ResourceClaims: []v1.PodResourceClaim{{Name: "regular-claim"}},
-				},
-				Status: v1.PodStatus{
-					Phase: v1.PodSucceeded,
-					ExtendedResourceClaimStatus: &v1.PodExtendedResourceClaimStatus{
-						ResourceClaimName: "test-extended-claim",
-					},
-				},
-			},
-			featureGateEnabled:          true,
-			expectEarlyReturn:           false,
-			expectExtendedClaimEnqueued: true,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			if !test.featureGateEnabled {
-				featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.36"))
-			}
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DRAExtendedResource, test.featureGateEnabled)
-
-			tCtx := ktesting.Init(t)
-
-			fakeKubeClient := createTestClient()
-			informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
-			podInformer := informerFactory.Core().V1().Pods()
-			podGroupInformer := informerFactory.Scheduling().V1alpha3().PodGroups()
-			claimInformer := informerFactory.Resource().V1().ResourceClaims()
-			templateInformer := informerFactory.Resource().V1().ResourceClaimTemplates()
-
-			setupMetrics()
-
-			ec, err := NewController(tCtx.Logger(), Features{}, fakeKubeClient, podInformer, podGroupInformer, claimInformer, templateInformer)
-			if err != nil {
-				t.Fatalf("error creating controller: %v", err)
-			}
-
-			ec.enqueuePod(tCtx.Logger(), test.pod, test.deleted)
-
-			var keys []string
-			for ec.queue.Len() > 0 {
-				k, _ := ec.queue.Get()
-				keys = append(keys, k)
-				ec.queue.Forget(k)
-				ec.queue.Done(k)
-			}
-
-			if test.expectEarlyReturn {
-				if len(keys) != 0 {
-					t.Errorf("expected no keys enqueued on early return, got: %v", keys)
-				}
-				return
-			}
-
-			var expectedClaimKey string
-			if test.pod.Status.ExtendedResourceClaimStatus != nil {
-				expectedClaimKey = claimKeyPrefix + test.pod.Namespace + "/" + test.pod.Status.ExtendedResourceClaimStatus.ResourceClaimName
-			}
-			found := slices.Contains(keys, expectedClaimKey)
-			if test.expectExtendedClaimEnqueued && !found {
-				t.Errorf("expected extended claim key %q to be enqueued, got keys: %v", expectedClaimKey, keys)
-			}
-			if !test.expectExtendedClaimEnqueued && found {
-				t.Errorf("did not expect extended claim key %q to be enqueued, got keys: %v", expectedClaimKey, keys)
-			}
-		})
 	}
 }

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -222,7 +222,7 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: expectedMetrics{1, 0, 0, 0},
 		},
 		{
-			name:                "create with admin and feature gate off",
+			name:                "create-adminaccess-feature-disabled",
 			featureCombinations: adminAccessDisabled,
 			pods:                []*v1.Pod{testPodWithResource},
 			templates:           []*resourceapi.ResourceClaimTemplate{templateWithAdminAccess},
@@ -230,7 +230,7 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedError:       adminAccessFeatureOffError,
 		},
 		{
-			name:                "create with admin and feature gate on",
+			name:                "create-adminaccess-feature-enabled",
 			featureCombinations: adminAccessEnabled,
 			pods:                []*v1.Pod{testPodWithResource},
 			templates:           []*resourceapi.ResourceClaimTemplate{templateWithAdminAccess},
@@ -244,7 +244,7 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: expectedMetrics{0, 1, 0, 0},
 		},
 		{
-			name:                "create for Pod in PodGroup",
+			name:                "create-for-grouped-pod",
 			featureCombinations: workloadResourceClaimsEnabled,
 			pods:                []*v1.Pod{podInPodGroup(testPodWithResource, testPodName, testPodGroupName)},
 			podGroups:           []*schedulingapi.PodGroup{testPodGroup},
@@ -267,7 +267,7 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedError:       `podgroup.scheduling.k8s.io "test-podgroup" not found`,
 		},
 		{
-			name:                "create for PodGroup",
+			name:                "create-for-podgroup",
 			featureCombinations: workloadResourceClaimsEnabled,
 			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
 			templates:           []*resourceapi.ResourceClaimTemplate{template},
@@ -281,17 +281,7 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: expectedMetrics{1, 0, 0, 0},
 		},
 		{
-			name:                "skip create for Pod with PodGroup before template exists",
-			featureCombinations: workloadResourceClaimsEnabled,
-			pods:                []*v1.Pod{testPodWithPodGroupResource},
-			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
-			templates:           []*resourceapi.ResourceClaimTemplate{},
-			key:                 podKey(testPodWithPodGroupResource),
-			expectedClaims:      nil,
-			expectedMetrics:     expectedMetrics{0, 0, 0, 0},
-		},
-		{
-			name:                "skip create for Pod with PodGroup after template exists",
+			name:                "skip-create-podgroup-claim-for-pod",
 			featureCombinations: workloadResourceClaimsEnabled,
 			pods:                []*v1.Pod{testPodWithPodGroupResource},
 			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
@@ -301,7 +291,7 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics:     expectedMetrics{0, 0, 0, 0},
 		},
 		{
-			name:                "update Pod status with PodGroup claim",
+			name:                "update-pod-status-with-podgroup-claim",
 			featureCombinations: workloadResourceClaimsEnabled,
 			pods:                []*v1.Pod{testPodWithPodGroupResource},
 			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
@@ -317,7 +307,7 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: expectedMetrics{0, 0, 0, 0},
 		},
 		{
-			name:                "skip create ResourceClaim for Pod with PodGroup claim when GenericWorkload feature is disabled",
+			name:                "skip-create-for-pod-with-podgroup-claim-genericworkload-disabled",
 			featureCombinations: genericWorkloadDisabled,
 			pods:                []*v1.Pod{testPodWithPodGroupResource},
 			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
@@ -326,7 +316,7 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedError:       "GenericWorkload feature is disabled",
 		},
 		{
-			name:                "skip create ResourceClaim for Pod with PodGroup claim when DRAWorkloadResourceClaims feature is disabled",
+			name:                "skip-create-for-pod-with-podgroup-claim-workloadresourceclaims-disabled",
 			featureCombinations: workloadResourceClaimsDisabledGenericWorkloadEnabled,
 			pods:                []*v1.Pod{testPodWithPodGroupResource},
 			podGroups:           []*schedulingapi.PodGroup{testPodGroupWithResource},
@@ -335,7 +325,7 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedError:       "DRAWorkloadResourceClaims feature is disabled",
 		},
 		{
-			name:                "create ResourceClaim for grouped Pod with claim when DRAWorkloadResourceClaims feature is disabled",
+			name:                "create-for-grouped-pod-with-claim-workloadresourceclaims-disabled",
 			featureCombinations: workloadResourceClaimsDisabledGenericWorkloadEnabled,
 			pods:                []*v1.Pod{podInPodGroup(testPodWithResource, testPodName, testPodGroupName)},
 			podGroups:           []*schedulingapi.PodGroup{testPodGroup},
@@ -370,7 +360,7 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: expectedMetrics{0, 0, 0, 0},
 		},
 		{
-			name:                "nop for PodGroup",
+			name:                "nop-podgroup",
 			featureCombinations: workloadResourceClaimsEnabled,
 			podGroups: []*schedulingapi.PodGroup{func() *schedulingapi.PodGroup {
 				podGroup := testPodGroupWithResource.DeepCopy()
@@ -410,7 +400,7 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: expectedMetrics{1, 0, 0, 0},
 		},
 		{
-			name:                "recreate for PodGroup",
+			name:                "recreate-for-podgroup",
 			featureCombinations: workloadResourceClaimsEnabled,
 			podGroups: []*schedulingapi.PodGroup{func() *schedulingapi.PodGroup {
 				pod := testPodGroupWithResource.DeepCopy()
@@ -798,7 +788,7 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: expectedMetrics{0, 0, 0, 0},
 		},
 		{
-			name: "clean up pod reservation with non-pod reservation present",
+			name: "remove-pod-reservation-with-non-pod-reservation-present",
 			pods: func() []*v1.Pod {
 				pod := testPodWithResource.DeepCopy()
 				pod.Status.Phase = v1.PodSucceeded
@@ -1576,12 +1566,12 @@ func TestGetAdminAccessMetricLabel(t *testing.T) {
 		want  string
 	}{
 		{
-			name:  "nil claim",
+			name:  "nil-claim",
 			claim: nil,
 			want:  "false",
 		},
 		{
-			name: "no requests",
+			name: "no-requests",
 			claim: &resourceapi.ResourceClaim{
 				Spec: resourceapi.ResourceClaimSpec{
 					Devices: resourceapi.DeviceClaim{
@@ -1592,7 +1582,7 @@ func TestGetAdminAccessMetricLabel(t *testing.T) {
 			want: "false",
 		},
 		{
-			name: "admin access false",
+			name: "admin-access-false",
 			claim: &resourceapi.ResourceClaim{
 				Spec: resourceapi.ResourceClaimSpec{
 					Devices: resourceapi.DeviceClaim{
@@ -1609,7 +1599,7 @@ func TestGetAdminAccessMetricLabel(t *testing.T) {
 			want: "false",
 		},
 		{
-			name: "admin access true",
+			name: "admin-access-true",
 			claim: &resourceapi.ResourceClaim{
 				Spec: resourceapi.ResourceClaimSpec{
 					Devices: resourceapi.DeviceClaim{
@@ -1626,7 +1616,7 @@ func TestGetAdminAccessMetricLabel(t *testing.T) {
 			want: "true",
 		},
 		{
-			name: "prioritized list",
+			name: "prioritized-list",
 			claim: &resourceapi.ResourceClaim{
 				Spec: resourceapi.ResourceClaimSpec{
 					Devices: resourceapi.DeviceClaim{
@@ -1641,7 +1631,7 @@ func TestGetAdminAccessMetricLabel(t *testing.T) {
 			want: "false",
 		},
 		{
-			name: "multiple requests, one with admin access true",
+			name: "one-of-multiple-requests-with-admin-access-true",
 			claim: &resourceapi.ResourceClaim{
 				Spec: resourceapi.ResourceClaimSpec{
 					Devices: resourceapi.DeviceClaim{
@@ -1663,7 +1653,7 @@ func TestGetAdminAccessMetricLabel(t *testing.T) {
 			want: "true",
 		},
 		{
-			name: "multiple requests, all admin access false or nil",
+			name: "multiple-requests-admin-access-false-or-nil",
 			claim: &resourceapi.ResourceClaim{
 				Spec: resourceapi.ResourceClaimSpec{
 					Devices: resourceapi.DeviceClaim{

--- a/test/e2e_dra/featuregatecycle_test.go
+++ b/test/e2e_dra/featuregatecycle_test.go
@@ -61,17 +61,20 @@ func testFeatureGateCycle(tCtx ktesting.TContext) {
 	subTests := map[string]struct {
 		test                gateOnFunc
 		driverResourcesFunc getResources
-		// gates lists the feature gates to start ON in phase 0, toggle OFF in phase 1, and re-enable in phase 2.
-		gates []string
+		// enabledGates lists the feature gates that are enabled throughout the test.
+		enabledGates []string
+		// toggledGates lists the feature gates to start ON in phase 0, toggle OFF in phase 1, and re-enable in phase 2.
+		toggledGates []string
 		// emulatedVersion, if non-empty, is passed as EMULATED_VERSION to local-up-cluster.sh.
 		// Set this to the last version where the gates were still toggleable so the test
 		// keeps working once those gates become locked in a future release.
-		emulatedVersion string
+		emulatedVersion    string
+		extraRuntimeConfig string
 	}{
 		"extended-resource": {
 			test:                extendedResourceGateCycle,
 			driverResourcesFunc: extendedResourcesDriverResources,
-			gates:               []string{"DRAExtendedResource"},
+			toggledGates:        []string{"DRAExtendedResource"},
 			// Emulate 1.36 so that gates which are locked in the current binary
 			// remain toggleable. DRAExtendedResource is toggleable in 1.36.
 			emulatedVersion: "1.36",
@@ -88,11 +91,14 @@ func testFeatureGateCycle(tCtx ktesting.TContext) {
 			localUpClusterEnv := map[string]string{
 				"RUNTIME_CONFIG": localUpClusterRuntimeConfig,
 			}
+			if def.extraRuntimeConfig != "" {
+				localUpClusterEnv["RUNTIME_CONFIG"] += "," + def.extraRuntimeConfig
+			}
 			if def.emulatedVersion != "" {
 				localUpClusterEnv["EMULATED_VERSION"] = def.emulatedVersion
 			}
 			phase := "phase-0-gate-on"
-			cluster.Start(tCtx, phase, dir, localUpClusterEnv, turnFgOn(def.gates))
+			cluster.Start(tCtx, phase, dir, localUpClusterEnv, turnFgOn(def.enabledGates)+","+turnFgOn(def.toggledGates))
 
 			restConfig := cluster.LoadConfig(tCtx)
 			restConfig.UserAgent = restclient.DefaultKubernetesUserAgent() + " -- dra"
@@ -119,7 +125,7 @@ func testFeatureGateCycle(tCtx ktesting.TContext) {
 
 			// ---- Phase 1: gate(s) OFF ----
 			phase = "phase-1-gate-off"
-			cluster.ToggleFeatureGates(tCtx, phase, turnFgOff(def.gates))
+			cluster.ToggleFeatureGates(tCtx, phase, turnFgOn(def.enabledGates)+","+turnFgOff(def.toggledGates))
 			waitForSlices(tCtx, name, builder, def.driverResourcesFunc(nodes))
 
 			var gateOnAgainFn gateOnAgainFunc
@@ -129,7 +135,7 @@ func testFeatureGateCycle(tCtx ktesting.TContext) {
 
 			// ---- Phase 2: gate(s) ON again ----
 			phase = "phase-2-gate-on-again"
-			cluster.ToggleFeatureGates(tCtx, phase, turnFgOn(def.gates))
+			cluster.ToggleFeatureGates(tCtx, phase, turnFgOn(def.enabledGates)+","+turnFgOn(def.toggledGates))
 			waitForSlices(tCtx, name, builder, def.driverResourcesFunc(nodes))
 
 			tCtx.Run(phase, func(tCtx ktesting.TContext) {

--- a/test/e2e_dra/featuregatecycle_test.go
+++ b/test/e2e_dra/featuregatecycle_test.go
@@ -79,6 +79,13 @@ func testFeatureGateCycle(tCtx ktesting.TContext) {
 			// remain toggleable. DRAExtendedResource is toggleable in 1.36.
 			emulatedVersion: "1.36",
 		},
+		"workload-resourceclaims": {
+			test:                workloadResourceClaimsGateCycle,
+			driverResourcesFunc: workloadResourceClaimsDriverResources,
+			enabledGates:        []string{"GenericWorkload"},
+			toggledGates:        []string{"DRAWorkloadResourceClaims"},
+			extraRuntimeConfig:  "scheduling.k8s.io/v1alpha3",
+		},
 	}
 
 	for name, def := range subTests {

--- a/test/e2e_dra/workloadresourceclaims_test.go
+++ b/test/e2e_dra/workloadresourceclaims_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2edra
+
+import (
+	"time"
+
+	"github.com/onsi/gomega"
+	resourceapi "k8s.io/api/resource/v1"
+	schedulingapi "k8s.io/api/scheduling/v1alpha3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/dynamic-resource-allocation/resourceslice"
+	drautils "k8s.io/kubernetes/test/e2e/dra/utils"
+	"k8s.io/kubernetes/test/utils/client-go/ktesting"
+)
+
+func workloadResourceClaimsDriverResources(nodes *drautils.Nodes) map[string]resourceslice.DriverResources {
+	return drautils.DriverResourcesNow(nodes, 1)
+}
+
+// workloadResourceClaimsGateCycle implements the DRAWorkloadResourceClaims feature gate ON→OFF→ON cycle test:
+//
+//   - Phase 0 (gate ON): create a PodGroup with 2 member Pods sharing a
+//     ResourceClaim reserved for the PodGroup.
+//   - Phase 1 (gate OFF): The ResourceClaim remains reserved for
+//     the PodGroup and no new ResourceClaims are created. Pods using claims
+//     reserved for a PodGroup can still be deleted.
+//   - Phase 2 (gate ON again): A new Pod added to the group can share the
+//     ResourceClaim initially allocated in phase 0.
+func workloadResourceClaimsGateCycle(tCtx ktesting.TContext, b *drautils.Builder) gateOffFunc {
+	namespace := tCtx.Namespace()
+	workload, template := b.WorkloadInline()
+	podGroup := b.PodGroup(workload, workload.Spec.PodGroupTemplates[0])
+	pod := b.GroupedPodWithClaims(podGroup)
+	podToDelete := b.GroupedPodWithClaims(podGroup)
+	b.Create(tCtx, workload, podGroup, template, pod, podToDelete)
+	b.TestPod(tCtx, pod)
+	b.TestPod(tCtx, podToDelete)
+
+	podGroup, err := tCtx.Client().SchedulingV1alpha3().PodGroups(namespace).Get(tCtx, podGroup.Name, metav1.GetOptions{})
+	tCtx.ExpectNoError(err, "get PodGroup")
+	tCtx.Expect(podGroup.Status.ResourceClaimStatuses).To(gomega.HaveExactElements(
+		gomega.SatisfyAll(
+			gomega.HaveField("Name", podGroup.Spec.ResourceClaims[0].Name),
+			gomega.HaveField("ResourceClaimName", gomega.HaveValue(gomega.Not(gomega.BeEmpty()))),
+		),
+	), "PodGroup status is missing generated ResourceClaim name")
+
+	claimName := *podGroup.Status.ResourceClaimStatuses[0].ResourceClaimName
+	claim, err := tCtx.Client().ResourceV1().ResourceClaims(namespace).Get(tCtx, claimName, metav1.GetOptions{})
+	tCtx.ExpectNoError(err, "get generated ResourceClaim")
+	reservedFor := claim.Status.ReservedFor
+	tCtx.Expect(reservedFor).To(gomega.HaveExactElements(
+		resourceapi.ResourceClaimConsumerReference{
+			APIGroup: schedulingapi.GroupName,
+			Resource: "podgroups",
+			Name:     podGroup.Name,
+			UID:      podGroup.UID,
+		},
+	))
+
+	checkClaimsStable := func(tCtx ktesting.TContext) {
+		tCtx.Helper()
+		tCtx.Consistently(func(tCtx ktesting.TContext) (*resourceapi.ResourceClaimList, error) {
+			return tCtx.Client().ResourceV1().ResourceClaims(namespace).List(tCtx, metav1.ListOptions{})
+		}).
+			WithPolling(100 * time.Millisecond).
+			WithTimeout(15 * time.Second).
+			Should(gomega.HaveField("Items", gomega.HaveExactElements(
+				gomega.SatisfyAll(
+					gomega.HaveField("ObjectMeta.UID", claim.UID),
+					gomega.HaveField("Status.ReservedFor", reservedFor),
+				),
+			)))
+	}
+
+	return func(tCtx ktesting.TContext) gateOnAgainFunc {
+		// A new Pod in the PodGroup making the same claim as the other Pods
+		// will not be able to schedule because the ResourceClaim controller
+		// will not associate the PodGroup claim with the Pod when the feature
+		// is disabled. Kubernetes 1.36 would have created a new ResourceClaim
+		// for the Pod, which we want to verify does *not* happen.
+		stuckPod := b.GroupedPodWithClaims(podGroup)
+		b.Create(tCtx, stuckPod)
+		checkClaimsStable(tCtx)
+
+		// Pods created before or after the feature was disabled should still
+		// be able to be deleted.
+		b.DeletePodAndWaitForNotFound(tCtx, stuckPod)
+		b.DeletePodAndWaitForNotFound(tCtx, podToDelete)
+
+		return func(tCtx ktesting.TContext) {
+			newPod := b.GroupedPodWithClaims(podGroup)
+			b.Create(tCtx, newPod)
+			b.TestPod(tCtx, newPod)
+			checkClaimsStable(tCtx)
+		}
+	}
+}

--- a/test/integration/dra/core.go
+++ b/test/integration/dra/core.go
@@ -45,7 +45,6 @@ import (
 	resourceclaimmetrics "k8s.io/dynamic-resource-allocation/resourceclaim/metrics"
 	"k8s.io/dynamic-resource-allocation/resourceslice"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/pkg/controller/resourceclaim"
 	"k8s.io/kubernetes/pkg/features"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -605,11 +604,7 @@ func testControllerManagerMetrics(tCtx ktesting.TContext) {
 	class, _ := createTestClass(tCtx, namespace)
 
 	informerFactory := informers.NewSharedInformerFactory(tCtx.Client(), 0)
-	features := resourceclaim.Features{
-		AdminAccess:     true,
-		PrioritizedList: true,
-	}
-	runResourceClaimController := util.CreateResourceClaimController(tCtx, tCtx, tCtx.Client(), informerFactory, features)
+	runResourceClaimController := util.CreateResourceClaimController(tCtx, tCtx, tCtx.Client(), informerFactory)
 	informerFactory.Start(tCtx.Done())
 	cache.WaitForCacheSync(tCtx.Done(),
 		informerFactory.Core().V1().Pods().Informer().HasSynced,

--- a/test/integration/dra/device_taints.go
+++ b/test/integration/dra/device_taints.go
@@ -153,7 +153,6 @@ func testEvictCluster(tCtx ktesting.TContext, useRule useRuleMode) {
 		ruleInformer,
 		informerFactory.Resource().V1().DeviceClasses(),
 		"device-taint-eviction",
-		utilfeature.DefaultFeatureGate.Enabled(features.DRAWorkloadResourceClaims),
 	)
 
 	var numExistingPods atomic.Int64

--- a/test/integration/dra/dra.go
+++ b/test/integration/dra/dra.go
@@ -635,11 +635,6 @@ func (claimController *claimControllerSingleton) start(tCtx ktesting.TContext) {
 	claimController.informerFactory = informers.NewSharedInformerFactory(client, 0 /* resync period */)
 	controller, err := resourceclaim.NewController(
 		klog.FromContext(claimControllerCtx),
-		resourceclaim.Features{
-			AdminAccess:            utilfeature.DefaultFeatureGate.Enabled(features.DRAAdminAccess),
-			PrioritizedList:        utilfeature.DefaultFeatureGate.Enabled(features.DRAPrioritizedList),
-			WorkloadResourceClaims: utilfeature.DefaultFeatureGate.Enabled(features.DRAWorkloadResourceClaims),
-		},
 		claimControllerCtx.Client(),
 		claimController.informerFactory.Core().V1().Pods(),
 		claimController.informerFactory.Scheduling().V1alpha3().PodGroups(),

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -51,7 +51,6 @@ import (
 	"k8s.io/klog/v2"
 	kubeschedulerconfigv1 "k8s.io/kube-scheduler/config/v1"
 	apiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
-	"k8s.io/kubernetes/pkg/controller/resourceclaim"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
@@ -151,12 +150,7 @@ func mustSetupCluster(tCtx ktesting.TContext, config *config.KubeSchedulerConfig
 	if enabledFeatures[features.DynamicResourceAllocation] {
 		// Testing of DRA with inline resource claims depends on this
 		// controller for creating and removing ResourceClaims.
-		features := resourceclaim.Features{
-			AdminAccess:            true,
-			PrioritizedList:        true,
-			WorkloadResourceClaims: enabledFeatures[features.DRAWorkloadResourceClaims],
-		}
-		runResourceClaimController = util.CreateResourceClaimController(tCtx, tCtx, tCtx.Client(), informerFactory, features)
+		runResourceClaimController = util.CreateResourceClaimController(tCtx, tCtx, tCtx.Client(), informerFactory)
 	}
 
 	informerFactory.Start(tCtx.Done())

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -141,12 +141,12 @@ func StartSchedulerWithDone(tCtx ktesting.TContext, cfg *kubeschedulerconfig.Kub
 
 // CreateResourceClaimController creates a ResourceClaim controller and returns a blocking run function.
 // The caller is responsible for the management of the goroutine where that method is invoked.
-func CreateResourceClaimController(ctx context.Context, tb ktesting.TB, clientSet clientset.Interface, informerFactory informers.SharedInformerFactory, features resourceclaim.Features) func() {
+func CreateResourceClaimController(ctx context.Context, tb ktesting.TB, clientSet clientset.Interface, informerFactory informers.SharedInformerFactory) func() {
 	podInformer := informerFactory.Core().V1().Pods()
 	podGroupInformer := informerFactory.Scheduling().V1alpha3().PodGroups()
 	claimInformer := informerFactory.Resource().V1().ResourceClaims()
 	claimTemplateInformer := informerFactory.Resource().V1().ResourceClaimTemplates()
-	claimController, err := resourceclaim.NewController(klog.FromContext(ctx), features, clientSet, podInformer, podGroupInformer, claimInformer, claimTemplateInformer)
+	claimController, err := resourceclaim.NewController(klog.FromContext(ctx), clientSet, podInformer, podGroupInformer, claimInformer, claimTemplateInformer)
 	if err != nil {
 		tb.Fatalf("Error creating claim controller: %v", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR addresses follow-up feedback from #136989 on the resourceclaim and devicetainteviction controllers:

- https://github.com/kubernetes/kubernetes/pull/136989#discussion_r2949662912 by @liggitt
- https://github.com/kubernetes/kubernetes/pull/136989#discussion_r2966617282 and https://github.com/kubernetes/kubernetes/pull/136989#discussion_r2966673016 by @pohly
- https://github.com/kubernetes/kubernetes/pull/136989#pullrequestreview-3989912954 by @soltysh

I also did some `go fix` cleanup here too.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

KEP: https://github.com/kubernetes/enhancements/issues/5729


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
Most of the changes here are tests/cleanup. This is the main user-visible change:
```release-note
DRA: when a Pod is a member of a PodGroup, the ResourceClaim controller will no longer create ResourceClaims from ResourceClaimTemplates referenced by the Pod unless the DRAWorkloadResourceClaims feature gate is enabled. This prevents the controller from generating a ResourceClaim for the individual Pod in case it was intended to be generated for the PodGroup.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```
