### PR TITLE
prevent tracing span leaks in WatchList request handling

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/get.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/get.go
@@ -265,6 +265,9 @@ func handleWatch(ctx context.Context, rw rest.Watcher, scope *RequestScope, req 
 	}
 
 	if rw == nil {
+		if span != nil {
+			span.End(500 * time.Millisecond)
+		}
 		return errors.NewMethodNotSupported(scope.Resource.GroupResource(), "watch")
 	}
 	// TODO: Currently we explicitly ignore ?timeout= and use only ?timeoutSeconds=.
@@ -281,10 +284,16 @@ func handleWatch(ctx context.Context, rw rest.Watcher, scope *RequestScope, req 
 	defer func() { cancel() }()
 	watcher, err := rw.Watch(ctx, &opts)
 	if err != nil {
+		if span != nil {
+			span.End(500 * time.Millisecond)
+		}
 		return err
 	}
 	handler, err := serveWatchHandler(watcher, scope, outputMediaType, req, w, timeout, metrics.CleanListScope(ctx, &opts), onWatchListComplete)
 	if err != nil {
+		if span != nil {
+			span.End(500 * time.Millisecond)
+		}
 		return err
 	}
 	// Invalidate cancel() to defer until serve() is complete.

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
@@ -240,14 +240,21 @@ func (c *watchEventMetricsRecorder) RecordEvent() {
 // or over a websocket connection.
 func (s *WatchServer) HandleHTTP(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
-	ctx, span := tracing.Start(ctx, "WatchServer.HandleHTTP",
-		attribute.String("audit-id", audit.GetAuditIDTruncated(ctx)),
-		attribute.String("method", req.Method),
-		attribute.String("url", req.URL.Path),
-		attribute.String("protocol", req.Proto),
-		attribute.String("mediaType", s.MediaType),
-		attribute.String("encoder", string(s.Encoder.Identifier())))
-	req = req.WithContext(ctx)
+	// Only trace the initial-list phase for WatchList requests, where the span has a
+	// defined endpoint (the "initial events done" bookmark). For regular watches there
+	// is no such endpoint, so creating a span would cause it to leak for the entire
+	// (potentially minutes-long) lifetime of the connection.
+	var span *tracing.Span
+	if s.watchListCompleteHook != nil {
+		ctx, span = tracing.Start(ctx, "WatchServer.HandleHTTP",
+			attribute.String("audit-id", audit.GetAuditIDTruncated(ctx)),
+			attribute.String("method", req.Method),
+			attribute.String("url", req.URL.Path),
+			attribute.String("protocol", req.Proto),
+			attribute.String("mediaType", s.MediaType),
+			attribute.String("encoder", string(s.Encoder.Identifier())))
+		req = req.WithContext(ctx)
+	}
 	defer func() {
 		if s.MemoryAllocator != nil {
 			runtime.AllocatorPool.Put(s.MemoryAllocator)
@@ -293,7 +300,9 @@ func (s *WatchServer) HandleHTTP(w http.ResponseWriter, req *http.Request) {
 	ch := s.Watching.ResultChan()
 	done := req.Context().Done()
 
-	span.AddEvent("About to start writing response")
+	if span != nil {
+		span.AddEvent("About to start writing response")
+	}
 	for {
 		select {
 		case <-s.ServerShuttingDownCh:
@@ -331,6 +340,7 @@ func (s *WatchServer) HandleHTTP(w http.ResponseWriter, req *http.Request) {
 				receivedTimestamp, ok := apirequest.ReceivedTimestampFrom(req.Context())
 				if !ok {
 					utilruntime.HandleErrorWithContext(req.Context(), nil, "Unable to measure watchlist latency, no received timestamp found in the context", "gvr", s.Scope.Resource)
+					span.End(5 * time.Second)
 				} else {
 					initLatency := time.Since(receivedTimestamp)
 					metrics.RecordWatchListLatency(req.Context(), s.Scope.Resource, s.metricsScope, initLatency)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

The `WatchServer.HandlerHTTP` span was unconditionally created (ref: https://github.com/kubernetes/kubernetes/pull/137202) for all watch requests but only ever ended for WatchList requests, leaking for the entire lifetime of regular watch connections. Fixing that by gating span creation on `watchListCompleteHook != nil`. Also calling `span.End` in early-return paths to ensure spans are ended.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Related: https://github.com/kubernetes/kubernetes/issues/136003

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
