### PR TITLE
fix: accumulate subpath cleanup actions in makeMounts to prevent handle leak

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -30,6 +30,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -279,7 +280,15 @@ func makeMounts(logger klog.Logger, pod *v1.Pod, podDir string, container *v1.Co
 	mountEtcHostsFile := shouldMountHostsFile(pod, podIPs)
 	logger.V(3).Info("Creating hosts mount for container", "pod", klog.KObj(pod), "containerName", container.Name, "podIPs", podIPs, "path", mountEtcHostsFile)
 	mounts := []kubecontainer.Mount{}
-	var cleanupAction func()
+	var cleanupActions []func()
+	cleanupAction := func() {
+		// We reverse the order to do the cleanup in the opposite order the mounts were done in - in case there are dependencies
+		// between the cleanup actions. Note that there is no hierarchy or any other order here in the first place,
+		// it is just clean up actions are performed in opposite order.
+		for _, fn := range slices.Backward(cleanupActions) {
+			fn()
+		}
+	}
 	for i, mount := range container.VolumeMounts {
 		// do not mount /etc/hosts if container is already mounting on the path
 		mountEtcHostsFile = mountEtcHostsFile && (mount.MountPath != etcHostsPath)
@@ -358,7 +367,8 @@ func makeMounts(logger klog.Logger, pod *v1.Pod, podDir string, container *v1.Co
 						return nil, cleanupAction, fmt.Errorf("failed to create subPath directory for volumeMount %q of container %q", mount.Name, container.Name)
 					}
 				}
-				hostPath, cleanupAction, err = subpather.PrepareSafeSubpath(subpath.Subpath{
+				var subpathCleanup func()
+				hostPath, subpathCleanup, err = subpather.PrepareSafeSubpath(subpath.Subpath{
 					VolumeMountIndex: i,
 					Path:             hostPath,
 					VolumeName:       vol.InnerVolumeSpecName,
@@ -366,6 +376,11 @@ func makeMounts(logger klog.Logger, pod *v1.Pod, podDir string, container *v1.Co
 					PodDir:           podDir,
 					ContainerName:    container.Name,
 				})
+				if subpathCleanup != nil {
+					// Append to the cleanup slice so all subpath cleanup actions are
+					// invoked when the composite cleanupAction is called.
+					cleanupActions = append(cleanupActions, subpathCleanup)
+				}
 				if err != nil {
 					// Don't pass detailed error back to the user because it could give information about host filesystem
 					logger.Error(nil, "Failed to prepare subPath for volumeMount of the container", "containerName", container.Name, "volumeMountName", mount.Name)

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -61,6 +61,8 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/secret"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/volume"
+	"k8s.io/kubernetes/pkg/volume/util/hostutil"
+	"k8s.io/kubernetes/pkg/volume/util/subpath"
 	"k8s.io/kubernetes/test/utils/ktesting"
 	netutils "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
@@ -9172,6 +9174,147 @@ func TestGeneratePodHostNameAndDomain(t *testing.T) {
 			if domain != tc.expectedDomain {
 				t.Errorf("expected domain %q, but got %q", tc.expectedDomain, domain)
 			}
+		})
+	}
+}
+
+// trackingSubpath is a mock subpath.Interface that returns non-nil cleanup
+// functions from PrepareSafeSubpath and tracks which subpaths had cleanup
+// called. This is used to verify that makeMounts accumulates all
+// cleanup actions rather than overwriting them.
+type trackingSubpath struct {
+	cleanedSubPaths []string
+	errorOnSubPath  string // SubPath name to fail on; empty means no error
+	safeMakeDirErr  error
+}
+
+func (ts *trackingSubpath) PrepareSafeSubpath(sub subpath.Subpath) (string, func(), error) {
+	subPathName := filepath.Base(sub.Path)
+	if ts.errorOnSubPath != "" && subPathName == ts.errorOnSubPath {
+		return "", nil, fmt.Errorf("mock PrepareSafeSubpath error on subpath %s", subPathName)
+	}
+	cleanup := func() {
+		ts.cleanedSubPaths = append(ts.cleanedSubPaths, subPathName)
+	}
+	return sub.Path, cleanup, nil
+}
+
+func (ts *trackingSubpath) CleanSubPaths(podDir string, volumeName string) error {
+	return nil
+}
+
+func (ts *trackingSubpath) SafeMakeDir(pathname string, base string, perm os.FileMode) error {
+	return ts.safeMakeDirErr
+}
+
+func TestMakemountsSubpathCleanupAccumulation(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
+	podDir := t.TempDir()
+	volPath := filepath.Join(podDir, "volumes", "disk")
+	require.NoError(t, os.MkdirAll(volPath, 0755))
+
+	// Create the subpath directories on disk so PathExists returns true
+	sub1 := filepath.Join(volPath, "sub1")
+	sub2 := filepath.Join(volPath, "sub2")
+	sub3 := filepath.Join(volPath, "sub3")
+	require.NoError(t, os.MkdirAll(sub1, 0755))
+	require.NoError(t, os.MkdirAll(sub2, 0755))
+	require.NoError(t, os.MkdirAll(sub3, 0755))
+
+	tests := []struct {
+		name                    string
+		volumeMounts            []v1.VolumeMount
+		expectedCleanedSubPaths []string
+		expectError             bool
+		errorOnSubPath          string
+	}{
+		{
+			name: "multiple subpath mounts all get cleanup called",
+			volumeMounts: []v1.VolumeMount{
+				{MountPath: "/mnt/a", Name: "disk", SubPath: "sub1"},
+				{MountPath: "/mnt/b", Name: "disk", SubPath: "sub2"},
+				{MountPath: "/mnt/c", Name: "disk", SubPath: "sub3"},
+			},
+			expectedCleanedSubPaths: []string{"sub1", "sub2", "sub3"},
+		},
+		{
+			name: "single subpath mount cleanup called once",
+			volumeMounts: []v1.VolumeMount{
+				{MountPath: "/mnt/a", Name: "disk", SubPath: "sub1"},
+			},
+			expectedCleanedSubPaths: []string{"sub1"},
+		},
+		{
+			name: "no subpath mounts no cleanup needed",
+			volumeMounts: []v1.VolumeMount{
+				{MountPath: "/mnt/a", Name: "disk"},
+			},
+		},
+		{
+			name: "error on third mount still cleans up first two",
+			volumeMounts: []v1.VolumeMount{
+				{MountPath: "/mnt/a", Name: "disk", SubPath: "sub1"},
+				{MountPath: "/mnt/b", Name: "disk", SubPath: "sub2"},
+				{MountPath: "/mnt/c", Name: "disk", SubPath: "sub3"},
+			},
+			expectedCleanedSubPaths: []string{"sub1", "sub2"},
+			expectError:             true,
+			errorOnSubPath:          "sub3",
+		},
+		{
+			name: "error on first mount returns zero cleanups",
+			volumeMounts: []v1.VolumeMount{
+				{MountPath: "/mnt/a", Name: "disk", SubPath: "sub1"},
+				{MountPath: "/mnt/b", Name: "disk", SubPath: "sub2"},
+			},
+			expectError:    true,
+			errorOnSubPath: "sub1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tracker := &trackingSubpath{
+				errorOnSubPath: tc.errorOnSubPath,
+			}
+
+			container := v1.Container{
+				VolumeMounts: tc.volumeMounts,
+			}
+
+			// FakeHostUtil with the subpath directories registered so PathExists returns true
+			fhu := hostutil.NewFakeHostUtil(map[string]hostutil.FileType{
+				sub1: hostutil.FileTypeDirectory,
+				sub2: hostutil.FileTypeDirectory,
+				sub3: hostutil.FileTypeDirectory,
+			})
+
+			podVolumes := kubecontainer.VolumeMap{
+				"disk": kubecontainer.VolumeInfo{Mounter: &stubVolume{path: volPath}},
+			}
+
+			pod := v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: "test-pod-uid",
+				},
+				Spec: v1.PodSpec{},
+			}
+
+			_, cleanupAction, err := makeMounts(logger, &pod, podDir, &container, "fakepod", "", []string{""}, podVolumes, fhu, tracker, nil, false, nil)
+
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// Call the cleanup action returned by makeMounts
+			require.NotNil(t, cleanupAction, "cleanupAction should never be nil")
+			cleanupAction()
+
+			require.ElementsMatch(t, tc.expectedCleanedSubPaths, tracker.cleanedSubPaths,
+				"expected cleaned subpaths %v but got %v", tc.expectedCleanedSubPaths, tracker.cleanedSubPaths)
 		})
 	}
 }

--- a/test/e2e/windows/subpath_cleanup.go
+++ b/test/e2e/windows/subpath_cleanup.go
@@ -1,0 +1,306 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package windows
+
+import (
+	"context"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/kubernetes/test/e2e/feature"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	"github.com/onsi/ginkgo/v2"
+)
+
+// This test verifies that pods with multiple subPath volume mounts on Windows
+// nodes terminate cleanly. It validates the fix for
+// https://github.com/kubernetes/kubernetes/issues/112630 where leaked file
+// handles from subPath preparation caused emptyDir volumes to fail cleanup,
+// leaving pods stuck in Terminating state.
+var _ = sigDescribe(feature.Windows, "Windows subpath cleanup", skipUnlessWindows(func() {
+	f := framework.NewDefaultFramework("windows-subpath-cleanup")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	ginkgo.It("pod with multiple subPath mounts should terminate cleanly", func(ctx context.Context) {
+		podName := "subpath-cleanup-" + string(uuid.NewUUID())
+		configMapName := "subpath-cm-" + string(uuid.NewUUID())
+
+		ginkgo.By("creating a ConfigMap with multiple keys")
+		configMap := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapName,
+				Namespace: f.Namespace.Name,
+			},
+			Data: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			},
+		}
+		_, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configMap, metav1.CreateOptions{})
+		framework.ExpectNoError(err, "creating ConfigMap")
+
+		ginkgo.By("creating a Secret with multiple keys")
+		secretName := "subpath-secret-" + string(uuid.NewUUID())
+		secret := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: f.Namespace.Name,
+			},
+			StringData: map[string]string{
+				"secret1": "secretvalue1",
+				"secret2": "secretvalue2",
+			},
+		}
+		_, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, secret, metav1.CreateOptions{})
+		framework.ExpectNoError(err, "creating Secret")
+
+		ginkgo.By("creating a pod with multiple volume types and subPath mounts")
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: podName,
+			},
+			Spec: v1.PodSpec{
+				NodeSelector: map[string]string{
+					"kubernetes.io/os": "windows",
+				},
+				Containers: []v1.Container{
+					{
+						Name:  "test-container",
+						Image: imageutils.GetE2EImage(imageutils.Pause),
+						VolumeMounts: []v1.VolumeMount{
+							{
+								Name:      "config-volume",
+								MountPath: `C:\etc\config\key1`,
+								SubPath:   "key1",
+							},
+							{
+								Name:      "config-volume",
+								MountPath: `C:\etc\config\key2`,
+								SubPath:   "key2",
+							},
+							{
+								Name:      "config-volume",
+								MountPath: `C:\etc\config\key3`,
+								SubPath:   "key3",
+							},
+							// Nested HostPath mounts: each is inside the previous,
+							// testing cleanup with overlapping mount points. Note that these are intentionally not
+							// in the right order to test a mount that is containing an existing mount.
+							{
+								Name:      "hostpath-outer",
+								MountPath: `C:\data`,
+							},
+							{
+								Name:      "hostpath-inner",
+								MountPath: `C:\data\nested\deep`,
+							},
+							{
+								Name:      "hostpath-middle",
+								MountPath: `C:\data\nested`,
+							},
+							// EmptyDir mounts
+							{
+								Name:      "emptydir-1",
+								MountPath: `C:\scratch\dir1`,
+							},
+							{
+								Name:      "emptydir-2",
+								MountPath: `C:\scratch\dir2`,
+							},
+							// EmptyDir memory-backed mounts
+							{
+								Name:      "emptydir-memory-1",
+								MountPath: `C:\scratch\mem1`,
+							},
+							{
+								Name:      "emptydir-memory-2",
+								MountPath: `C:\scratch\mem2`,
+							},
+							// Secret mounts with subPath
+							{
+								Name:      "secret-volume",
+								MountPath: `C:\etc\secret\secret1`,
+								SubPath:   "secret1",
+							},
+							{
+								Name:      "secret-volume",
+								MountPath: `C:\etc\secret\secret2`,
+								SubPath:   "secret2",
+							},
+							// Projected volume mounts with subPath
+							{
+								Name:      "projected-volume",
+								MountPath: `C:\etc\projected\key1`,
+								SubPath:   "key1",
+							},
+							{
+								Name:      "projected-volume",
+								MountPath: `C:\etc\projected\secret1`,
+								SubPath:   "secret1",
+							},
+							// DownwardAPI mounts with subPath
+							{
+								Name:      "downwardapi-volume",
+								MountPath: `C:\etc\podinfo\labels`,
+								SubPath:   "labels",
+							},
+							{
+								Name:      "downwardapi-volume",
+								MountPath: `C:\etc\podinfo\name`,
+								SubPath:   "name",
+							},
+						},
+					},
+				},
+				RestartPolicy: v1.RestartPolicyNever,
+				Volumes: []v1.Volume{
+					{
+						Name: "config-volume",
+						VolumeSource: v1.VolumeSource{
+							ConfigMap: &v1.ConfigMapVolumeSource{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: configMapName,
+								},
+							},
+						},
+					},
+					{
+						Name: "hostpath-outer",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{
+								Path: `C:\var\hostpath\outer`,
+							},
+						},
+					},
+					{
+						Name: "hostpath-middle",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{
+								Path: `C:\var\hostpath\middle`,
+							},
+						},
+					},
+					{
+						Name: "hostpath-inner",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{
+								Path: `C:\var\hostpath\inner`,
+							},
+						},
+					},
+					{
+						Name: "emptydir-1",
+						VolumeSource: v1.VolumeSource{
+							EmptyDir: &v1.EmptyDirVolumeSource{},
+						},
+					},
+					{
+						Name: "emptydir-2",
+						VolumeSource: v1.VolumeSource{
+							EmptyDir: &v1.EmptyDirVolumeSource{},
+						},
+					},
+					{
+						Name: "emptydir-memory-1",
+						VolumeSource: v1.VolumeSource{
+							EmptyDir: &v1.EmptyDirVolumeSource{
+								Medium: v1.StorageMediumMemory,
+							},
+						},
+					},
+					{
+						Name: "emptydir-memory-2",
+						VolumeSource: v1.VolumeSource{
+							EmptyDir: &v1.EmptyDirVolumeSource{
+								Medium: v1.StorageMediumMemory,
+							},
+						},
+					},
+					{
+						Name: "secret-volume",
+						VolumeSource: v1.VolumeSource{
+							Secret: &v1.SecretVolumeSource{
+								SecretName: secretName,
+							},
+						},
+					},
+					{
+						Name: "projected-volume",
+						VolumeSource: v1.VolumeSource{
+							Projected: &v1.ProjectedVolumeSource{
+								Sources: []v1.VolumeProjection{
+									{
+										ConfigMap: &v1.ConfigMapProjection{
+											LocalObjectReference: v1.LocalObjectReference{
+												Name: configMapName,
+											},
+										},
+									},
+									{
+										Secret: &v1.SecretProjection{
+											LocalObjectReference: v1.LocalObjectReference{
+												Name: secretName,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Name: "downwardapi-volume",
+						VolumeSource: v1.VolumeSource{
+							DownwardAPI: &v1.DownwardAPIVolumeSource{
+								Items: []v1.DownwardAPIVolumeFile{
+									{
+										Path: "labels",
+										FieldRef: &v1.ObjectFieldSelector{
+											FieldPath: "metadata.labels",
+										},
+									},
+									{
+										Path: "name",
+										FieldRef: &v1.ObjectFieldSelector{
+											FieldPath: "metadata.name",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+
+		ginkgo.By("deleting the pod and verifying it terminates within a reasonable time")
+		err = e2epod.DeletePodWithGracePeriod(ctx, f.ClientSet, pod, 30)
+		framework.ExpectNoError(err, "deleting pod")
+
+		// Prior to addressing https://github.com/kubernetes/kubernetes/issues/112630, this would time out
+		err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, podName, f.Namespace.Name, 5*time.Minute)
+		framework.ExpectNoError(err, "waiting for pod to be fully deleted")
+	})
+}))


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it
Fixes a file handle leak in `makeMounts()` that causes emptyDir volumes to fail cleanup on Windows, leaving pods stuck in Terminating state after deletion.

In `makeMounts()`, a single `cleanupAction` variable was overwritten each time `PrepareSafeSubpath()` was called in the volume mount loop. On Windows, `PrepareSafeSubpath` acquires file handles via `syscall.CreateFile` (in `lockAndCheckSubPath` → `lockPath`) to prevent symlink race attacks. Because only the last mount's cleanup function was returned to the caller (`kuberuntime_container.go:255: defer cleanupAction()`), all prior handles leaked permanently. This prevented `os.RemoveAll` from deleting the emptyDir volume directory during pod teardown.

Linux is unaffected because its `PrepareSafeSubpath` uses bind mounts and always returns `cleanupAction = nil`.

## How does this fix it?
Replaces the single `cleanupAction` variable with a `[]func{}` slice accumulator. Each call to `PrepareSafeSubpath` appends its cleanup to the slice, and the composite `cleanupAction` closure invokes all of them when called.

## Which issue(s) this PR fixes
Fixes https://github.com/kubernetes/kubernetes/issues/112630

## Does this PR introduce a user-facing change?
```release-note
Fixed a bug where pods with multiple subPath volume mounts on Windows would get stuck in Terminating state because file handles from subPath preparation were leaked, preventing volume cleanup.
```

## Testing
- **Unit test**: `TestMakemountsSubpathCleanupAccumulation` with 5 table-driven cases covering multi-mount cleanup accumulation, single mount, no subpaths, and error paths (verifying earlier cleanups still fire when a later mount fails)
- **E2e test**: Windows-specific test that creates a pod with 3 subPath mounts from a ConfigMap and verifies it terminates cleanly after deletion

/sig node
/sig windows
/area kubelet