### PR TITLE
Fix goroutine leak in storageversionmigrator migrationrunner test

### DIFF
--- a/pkg/controller/storageversionmigrator/migrationrunner_test.go
+++ b/pkg/controller/storageversionmigrator/migrationrunner_test.go
@@ -348,7 +348,8 @@ func TestCustomResourceController_Sync(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			var initialSVMs []runtime.Object
 			for _, svm := range tc.svms {
 				initialSVMs = append(initialSVMs, svm)
@@ -384,6 +385,7 @@ func TestCustomResourceController_Sync(t *testing.T) {
 				svmInformer,
 				crdClientSet.ApiextensionsV1().CustomResourceDefinitions(),
 			)
+			defer controller.queue.ShutDown()
 
 			resource := metav1.GroupResource{Group: "example.com", Resource: "widgets"}
 			if len(tc.svms) > 0 {

--- a/pkg/controller/storageversionmigrator/migrationrunner_test.go
+++ b/pkg/controller/storageversionmigrator/migrationrunner_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package storageversionmigrator
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -34,6 +33,7 @@ import (
 	svminformers "k8s.io/client-go/informers"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 func init() {
@@ -348,8 +348,7 @@ func TestCustomResourceController_Sync(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			_, ctx := ktesting.NewTestContext(t)
 			var initialSVMs []runtime.Object
 			for _, svm := range tc.svms {
 				initialSVMs = append(initialSVMs, svm)


### PR DESCRIPTION
## Summary

Follow-up to #137970 for issue #134565.

`TestCustomResourceController_Sync` in `pkg/controller/storageversionmigrator/migrationrunner_test.go` calls `NewCustomResourceController`, which creates a workqueue (via `workqueue.NewTypedRateLimitingQueueWithConfig`). The test never shuts it down, leaking the workqueue's `waitingLoop` goroutines.

This PR:
- Replaces `context.Background()` with `context.WithCancel()` and defers `cancel()`
- Adds `defer controller.queue.ShutDown()` to clean up the workqueue

Verified locally with a temporary `goleak.VerifyTestMain`. The other two test files in the same package (`storageversionmigrator_test.go` and `resourceversion_test.go`) construct controller structs directly without a queue, so they do not leak goroutines and are not modified.

/sig api-machinery
/kind bug

## Test plan

- [x] `go test ./pkg/controller/storageversionmigrator/ -count=1` passes
- [x] Goroutine leak is confirmed fixed under goleak verification

```release-note
NONE
```