### PR TITLE
kubectl/printers: Job table STATUS defaulted to Running for any in-pr…

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -1288,7 +1288,13 @@ func printJob(obj *batch.Job, options printers.GenerateOptions) ([]metav1.TableR
 	} else if hasJobCondition(obj.Status.Conditions, batch.JobSuccessCriteriaMet) {
 		status = "SuccessCriteriaMet"
 	} else {
-		status = "Running"
+		// Active includes pending and running pods; Ready counts pods that satisfy readiness.
+		// Avoid implying containers are executing when no pod is ready yet (for example, all pods still Pending).
+		if obj.Status.Active > 0 && obj.Status.Ready != nil && *obj.Status.Ready == 0 {
+			status = "Pending"
+		} else {
+			status = "Running"
+		}
 	}
 
 	row.Cells = append(row.Cells, obj.Name, status, completions, jobDuration, translateTimestampSince(obj.CreationTimestamp))

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -3101,6 +3101,45 @@ func TestPrintJob(t *testing.T) {
 			// Columns: Name, Status, Completions, Duration, Age
 			expected: []metav1.TableRow{{Cells: []interface{}{"job10", "SuccessCriteriaMet", "0/1", "", "0s"}}},
 		},
+		// Active pods exist but none are ready yet (e.g. all pods Pending): do not report Running.
+		{
+			job: batch.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "job11",
+					CreationTimestamp: metav1.Time{Time: time.Now().Add(1.9e9)},
+				},
+				Spec: batch.JobSpec{
+					Completions: ptr.To(int32(4)),
+				},
+				Status: batch.JobStatus{
+					Succeeded: 0,
+					Active:    4,
+					Ready:     ptr.To(int32(0)),
+					StartTime: &metav1.Time{Time: now.Add(-30 * time.Minute)},
+				},
+			},
+			options:  printers.GenerateOptions{},
+			expected: []metav1.TableRow{{Cells: []interface{}{"job11", "Pending", "0/4", "30m", "0s"}}},
+		},
+		{
+			job: batch.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "job12",
+					CreationTimestamp: metav1.Time{Time: time.Now().Add(1.9e9)},
+				},
+				Spec: batch.JobSpec{
+					Completions: ptr.To(int32(4)),
+				},
+				Status: batch.JobStatus{
+					Succeeded: 0,
+					Active:    2,
+					Ready:     ptr.To(int32(1)),
+					StartTime: &metav1.Time{Time: now.Add(-20 * time.Minute)},
+				},
+			},
+			options:  printers.GenerateOptions{},
+			expected: []metav1.TableRow{{Cells: []interface{}{"job12", "Running", "0/4", "20m", "0s"}}},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
kubectl/printers: Job table STATUS defaulted to Running for any in-progress Job; derive Pending when status.active>0 and status.ready is 0 so unscheduled/unready work is not shown as Running

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

**Root cause:** Job table printing (`printJob` in `pkg/printers/internalversion/printers.go`) set STATUS to **Running** for every non-terminal Job, without using `Job.status.active` or `Job.status.ready`. `active` counts both pending and running pods, so users could see **Running** while all pods were still **Pending** (or otherwise not ready), which is misleading when debugging scheduling or startup.

**Fix:** After existing condition checks (Complete, Failed, Suspended, etc.), set STATUS to **Pending** when `status.active > 0`, `status.ready` is non-nil, and `status.ready == 0`. If `status.ready` is nil, keep **Running** for backward compatibility with stored objects that omit `ready`.

Adds unit coverage in `TestPrintJob` for the pending vs running cases.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/138366

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

- Table output is server-side; this affects `kubectl get jobs` when server-side printing is used (default for recent kubectl against supported clusters).
- Pods that are **Running** but not **Ready** (e.g. failing readiness probes) will also show **Pending** in this column, because only Job status fields are available—not per-pod phase.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubectl: Job list/table STATUS may show `Pending` when the Job has active pods but none are ready yet, instead of showing `Running` for all in-progress Jobs.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```NONE
```
