### PR TITLE
kubelet: reject empty log path in container log Clean()

### DIFF
--- a/pkg/kubelet/logs/container_log_manager.go
+++ b/pkg/kubelet/logs/container_log_manager.go
@@ -167,7 +167,14 @@ func (c *containerLogManager) Clean(ctx context.Context, containerID string) err
 	if resp.GetStatus() == nil {
 		return fmt.Errorf("container status is nil for %q", containerID)
 	}
-	pattern := fmt.Sprintf("%s*", resp.GetStatus().GetLogPath())
+	logPath := resp.GetStatus().GetLogPath()
+	if logPath == "" {
+		// An empty log path would yield a pattern of "*", causing Glob to
+		// match every file in the kubelet's working directory and Remove
+		// to delete each one. Refuse to operate on an empty path.
+		return fmt.Errorf("container %q has an empty log path", containerID)
+	}
+	pattern := fmt.Sprintf("%s*", logPath)
 	logs, err := c.osInterface.Glob(pattern)
 	if err != nil {
 		return fmt.Errorf("failed to list all log files with pattern %q: %w", pattern, err)


### PR DESCRIPTION
The Clean() method in containerLogManager constructs a glob pattern directly from the LogPath returned by the CRI runtime's ContainerStatus response.  If the runtime returns an empty LogPath (the protobuf default for an unset string field, or as a result of a runtime bug or race during container creation), the resulting pattern is "*", which matches every file in the kubelet's working directory.  Each match is then passed to Remove() which would not be a good idea to have happen.

Reject an empty LogPath before constructing the glob pattern.  The sibling processContainer() path is naturally guarded by Stat("") returning ENOENT before reaching rotateLog().

/kind bug
NONE