### PR TITLE
kubelet: reject empty log path in container log Clean()

### DIFF
--- a/pkg/kubelet/logs/container_log_manager.go
+++ b/pkg/kubelet/logs/container_log_manager.go
@@ -167,7 +167,14 @@ func (c *containerLogManager) Clean(ctx context.Context, containerID string) err
 	if resp.GetStatus() == nil {
 		return fmt.Errorf("container status is nil for %q", containerID)
 	}
-	pattern := fmt.Sprintf("%s*", resp.GetStatus().GetLogPath())
+	logPath := resp.GetStatus().GetLogPath()
+	if logPath == "" {
+		// An empty log path would yield a pattern of "*", causing Glob to
+		// match every file in the kubelet's working directory and Remove
+		// to delete each one. Refuse to operate on an empty path.
+		return fmt.Errorf("container %q has an empty log path", containerID)
+	}
+	pattern := fmt.Sprintf("%s*", logPath)
 	logs, err := c.osInterface.Glob(pattern)
 	if err != nil {
 		return fmt.Errorf("failed to list all log files with pattern %q: %w", pattern, err)

--- a/pkg/kubelet/logs/container_log_manager_test.go
+++ b/pkg/kubelet/logs/container_log_manager_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/kubernetes/pkg/kubelet/container"
+	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	"k8s.io/kubernetes/test/utils/ktesting"
 
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -267,6 +268,45 @@ func TestClean(t *testing.T) {
 	assert.Equal(t, testLogs[1], logs[1].Name())
 	assert.Equal(t, testLogs[3], logs[2].Name())
 	assert.Equal(t, testLogs[4], logs[3].Name())
+}
+
+func TestCleanEmptyLogPath(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	f := critest.NewFakeRuntimeService()
+	fakeOS := &containertest.FakeOS{}
+	var globPatterns []string
+	fakeOS.GlobFn = func(pattern, path string) bool {
+		globPatterns = append(globPatterns, pattern)
+		return true
+	}
+	c := &containerLogManager{
+		runtimeService: f,
+		policy:         LogRotatePolicy{MaxSize: 10, MaxFiles: 3},
+		osInterface:    fakeOS,
+		clock:          testingclock.NewFakeClock(time.Now()),
+		mutex:          sync.Mutex{},
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "kubelet_log_rotate_manager"},
+		),
+		maxWorkers:       10,
+		monitoringPeriod: v1.Duration{Duration: 10 * time.Second},
+	}
+	f.SetFakeContainers([]*critest.FakeContainer{
+		{
+			ContainerStatus: runtimeapi.ContainerStatus{
+				Id:      "container-empty",
+				State:   runtimeapi.ContainerState_CONTAINER_EXITED,
+				LogPath: "",
+			},
+		},
+	})
+
+	err := c.Clean(tCtx, "container-empty")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty log path")
+	assert.Empty(t, globPatterns, "Glob must not be called when log path is empty")
+	assert.Empty(t, fakeOS.Removes, "Remove must not be called when log path is empty")
 }
 
 func TestCleanupUnusedLog(t *testing.T) {


### PR DESCRIPTION
The Clean() method in containerLogManager constructs a glob pattern directly from the LogPath returned by the CRI runtime's ContainerStatus response.  If the runtime returns an empty LogPath (the protobuf default for an unset string field, or as a result of a runtime bug or race during container creation), the resulting pattern is "*", which matches every file in the kubelet's working directory.  Each match is then passed to Remove() which would not be a good idea to have happen.

Reject an empty LogPath before constructing the glob pattern.  The sibling processContainer() path is naturally guarded by Stat("") returning ENOENT before reaching rotateLog().



/kind bug
```release-note
NONE
```

