### PR TITLE
proxy: do not silently disable TLS verification when no TLSClientConf…

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/dial.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/dial.go
@@ -64,13 +64,13 @@ func DialURL(ctx context.Context, url *url.URL, transport http.RoundTripper) (ne
 				return nil, err
 			}
 			if tlsConfig == nil {
-				// tls.Client requires non-nil config
-				klog.FromContext(ctx).Info("Warning: using custom dialer with no TLSClientConfig, defaulting to InsecureSkipVerify")
-				// tls.Handshake() requires ServerName or InsecureSkipVerify
-				tlsConfig = &tls.Config{
-					InsecureSkipVerify: true,
-				}
-			} else if len(tlsConfig.ServerName) == 0 && !tlsConfig.InsecureSkipVerify {
+				// tls.Client requires a non-nil config. An *http.Transport with
+				// TLSClientConfig: nil verifies against the system CA pool by
+				// default; preserve that behavior here rather than silently
+				// disabling verification. ServerName is inferred below.
+				tlsConfig = &tls.Config{}
+			}
+			if len(tlsConfig.ServerName) == 0 && !tlsConfig.InsecureSkipVerify {
 				// tls.HandshakeContext() requires ServerName or InsecureSkipVerify
 				// infer the ServerName from the hostname we're connecting to.
 				inferredHost := dialAddr


### PR DESCRIPTION
…ig is set

DialURL extracts the TLSClientConfig from the supplied transport so it can drive the TLS handshake manually after using a custom dialer.  When the transport is an *http.Transport with TLSClientConfig: nil, the extraction returns nil.  Go's standard library treats this case as "verify against the system CA pool", but DialURL instead constructed a config with InsecureSkipVerify: true.

The result will be that a caller passing a transport with a custom DialContext but no explicit TLS configuration would silently get an unverified connection on https URLs, where the same transport handed directly to http.Client would verify.

No in-tree caller triggers this path: the kubelet client, aggregator proxy, and pod/node proxy all set TLSClientConfig explicitly.  But k8s.io/apimachinery is a public module and DialURL is exported.

Use an empty tls.Config and fall through to the existing ServerName inference, matching the standard-library default.  Callers that want to skip verification can continue to set InsecureSkipVerify explicitly.

/kind bug

```release-note
NONE
```
