### PR TITLE
devicemanager: reject device plugin endpoints that escape the socket …

### DIFF
--- a/pkg/kubelet/cm/devicemanager/plugin/v1beta1/server.go
+++ b/pkg/kubelet/cm/devicemanager/plugin/v1beta1/server.go
@@ -173,7 +173,17 @@ func (s *server) Register(ctx context.Context, r *api.RegisterRequest) (*api.Emp
 		return &api.Empty{}, err
 	}
 
-	if err := s.connectClient(ctx, r.ResourceName, filepath.Join(s.socketDir, r.Endpoint)); err != nil {
+	// The API contract documents Endpoint as "Name of the unix socket the device
+	// plugin is listening on", joined under DevicePluginPath. Reject endpoints that
+	// resolve outside the socket directory after Join+Clean.
+	socketPath := filepath.Join(s.socketDir, r.Endpoint)
+	if filepath.Dir(socketPath) != filepath.Clean(s.socketDir) {
+		err := fmt.Errorf("invalid endpoint %q: must name a socket directly within the device plugin directory", r.Endpoint)
+		logger.Error(err, "Bad registration request from device plugin", "resourceName", r.ResourceName)
+		return &api.Empty{}, err
+	}
+
+	if err := s.connectClient(ctx, r.ResourceName, socketPath); err != nil {
 		logger.Error(err, "Error connecting to device plugin client")
 		return &api.Empty{}, err
 	}

--- a/pkg/kubelet/cm/devicemanager/plugin/v1beta1/server_test.go
+++ b/pkg/kubelet/cm/devicemanager/plugin/v1beta1/server_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	api "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+)
+
+func TestRegisterRejectsEndpointOutsideSocketDir(t *testing.T) {
+	const socketDir = "/var/lib/kubelet/device-plugins/"
+
+	for _, tc := range []struct {
+		name     string
+		endpoint string
+	}{
+		{"parent traversal", "../../../../tmp/evil.sock"},
+		{"traversal back into dir then out", "../device-plugins/../../tmp/evil.sock"},
+		{"subdirectory", "sub/dir.sock"},
+		{"absolute path", "/tmp/evil.sock"},
+		{"empty", ""},
+		{"dot", "."},
+		{"dotdot", ".."},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &server{
+				socketDir: socketDir,
+				clients:   make(map[string]Client),
+			}
+			_, err := s.Register(context.Background(), &api.RegisterRequest{
+				Version:      api.Version,
+				Endpoint:     tc.endpoint,
+				ResourceName: "example.com/device",
+			})
+			if err == nil {
+				t.Fatalf("endpoint %q: expected an error, got nil", tc.endpoint)
+			}
+			const want = "must name a socket directly within the device plugin directory"
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("endpoint %q: expected invalid-endpoint error, got: %v", tc.endpoint, err)
+			}
+			if len(s.clients) != 0 {
+				t.Fatalf("endpoint %q: connectClient was reached, clients=%v", tc.endpoint, s.clients)
+			}
+		})
+	}
+}


### PR DESCRIPTION
…directory

The legacy v1beta1 device plugin Register RPC accepts an Endpoint field documented as "Name of the unix socket the device plugin is listening on", which kubelet joins under the device-plugin socket directory before dialling back.  The endpoint was passed to filepath.Join without bounds checking, so an endpoint like "../../../../tmp/foo.sock" resolved to a path outside the device-plugin directory.

Under the documented trust model, anything that can connect to the registration socket (which lives in a 0750 root-owned directory) is already a trusted device plugin and could simply be a malicious gRPC server on its own socket.  The traversal does not cross a privilege boundary today.

Enforce the documented contract anyway: the joined path's directory must equal the cleaned socket directory.  This rejects parent-directory traversal, subdirectory paths, and the empty endpoint, all of which are outside the API's documented semantics.

/kind bug

```release-note
NONE
```
