### PR TITLE
drop rules for 1.32 EOL release

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -22,11 +22,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/apimachinery
-  - name: release-1.32
-    source:
-      branch: release-1.32
-      dirs:
-      - staging/src/k8s.io/apimachinery
   - name: release-1.33
     source:
       branch: release-1.33
@@ -61,14 +56,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/api
-  - name: release-1.32
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.32
-    source:
-      branch: release-1.32
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.33
@@ -118,20 +105,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/client-go
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod ./...
-      go test -mod=mod ./...
-  - name: release-1.32
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.32
-    - repository: api
-      branch: release-1.32
-    source:
-      branch: release-1.32
       dirs:
       - staging/src/k8s.io/client-go
     smoke-test: |
@@ -209,14 +182,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/code-generator
-  - name: release-1.32
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.32
-    source:
-      branch: release-1.32
-      dirs:
-      - staging/src/k8s.io/code-generator
   - name: release-1.33
     dependencies:
     - repository: apimachinery
@@ -265,18 +230,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/component-base
-  - name: release-1.32
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.32
-    - repository: api
-      branch: release-1.32
-    - repository: client-go
-      branch: release-1.32
-    source:
-      branch: release-1.32
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.33
@@ -346,18 +299,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/component-helpers
-  - name: release-1.32
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.32
-    - repository: api
-      branch: release-1.32
-    - repository: client-go
-      branch: release-1.32
-    source:
-      branch: release-1.32
-      dirs:
-      - staging/src/k8s.io/component-helpers
   - name: release-1.33
     dependencies:
     - repository: apimachinery
@@ -419,14 +360,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/kms
-  - name: release-1.32
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.32
-    source:
-      branch: release-1.32
-      dirs:
-      - staging/src/k8s.io/kms
   - name: release-1.33
     dependencies:
     - repository: apimachinery
@@ -478,22 +411,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/apiserver
-  - name: release-1.32
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.32
-    - repository: api
-      branch: release-1.32
-    - repository: client-go
-      branch: release-1.32
-    - repository: component-base
-      branch: release-1.32
-    - repository: kms
-      branch: release-1.32
-    source:
-      branch: release-1.32
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.33
@@ -585,26 +502,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/kube-aggregator
-  - name: release-1.32
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.32
-    - repository: api
-      branch: release-1.32
-    - repository: client-go
-      branch: release-1.32
-    - repository: apiserver
-      branch: release-1.32
-    - repository: component-base
-      branch: release-1.32
-    - repository: kms
-      branch: release-1.32
-    - repository: code-generator
-      branch: release-1.32
-    source:
-      branch: release-1.32
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.33
@@ -711,31 +608,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/sample-apiserver
-    required-packages:
-    - k8s.io/code-generator
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod .
-  - name: release-1.32
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.32
-    - repository: api
-      branch: release-1.32
-    - repository: client-go
-      branch: release-1.32
-    - repository: apiserver
-      branch: release-1.32
-    - repository: code-generator
-      branch: release-1.32
-    - repository: kms
-      branch: release-1.32
-    - repository: component-base
-      branch: release-1.32
-    source:
-      branch: release-1.32
       dirs:
       - staging/src/k8s.io/sample-apiserver
     required-packages:
@@ -868,25 +740,6 @@ rules:
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
-  - name: release-1.32
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.32
-    - repository: api
-      branch: release-1.32
-    - repository: client-go
-      branch: release-1.32
-    - repository: code-generator
-      branch: release-1.32
-    source:
-      branch: release-1.32
-      dirs:
-      - staging/src/k8s.io/sample-controller
-    required-packages:
-    - k8s.io/code-generator
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod .
   - name: release-1.33
     dependencies:
     - repository: apimachinery
@@ -987,28 +840,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/apiextensions-apiserver
-    required-packages:
-    - k8s.io/code-generator
-  - name: release-1.32
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.32
-    - repository: api
-      branch: release-1.32
-    - repository: client-go
-      branch: release-1.32
-    - repository: apiserver
-      branch: release-1.32
-    - repository: code-generator
-      branch: release-1.32
-    - repository: component-base
-      branch: release-1.32
-    - repository: kms
-      branch: release-1.32
-    source:
-      branch: release-1.32
       dirs:
       - staging/src/k8s.io/apiextensions-apiserver
     required-packages:
@@ -1121,20 +952,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/metrics
-  - name: release-1.32
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.32
-    - repository: api
-      branch: release-1.32
-    - repository: client-go
-      branch: release-1.32
-    - repository: code-generator
-      branch: release-1.32
-    source:
-      branch: release-1.32
-      dirs:
-      - staging/src/k8s.io/metrics
   - name: release-1.33
     dependencies:
     - repository: apimachinery
@@ -1210,18 +1027,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/cli-runtime
-  - name: release-1.32
-    dependencies:
-    - repository: api
-      branch: release-1.32
-    - repository: apimachinery
-      branch: release-1.32
-    - repository: client-go
-      branch: release-1.32
-    source:
-      branch: release-1.32
-      dirs:
-      - staging/src/k8s.io/cli-runtime
   - name: release-1.33
     dependencies:
     - repository: api
@@ -1289,20 +1094,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/sample-cli-plugin
-  - name: release-1.32
-    dependencies:
-    - repository: api
-      branch: release-1.32
-    - repository: apimachinery
-      branch: release-1.32
-    - repository: cli-runtime
-      branch: release-1.32
-    - repository: client-go
-      branch: release-1.32
-    source:
-      branch: release-1.32
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.33
@@ -1381,20 +1172,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/kube-proxy
-  - name: release-1.32
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.32
-    - repository: component-base
-      branch: release-1.32
-    - repository: api
-      branch: release-1.32
-    - repository: client-go
-      branch: release-1.32
-    source:
-      branch: release-1.32
-      dirs:
-      - staging/src/k8s.io/kube-proxy
   - name: release-1.33
     dependencies:
     - repository: apimachinery
@@ -1461,11 +1238,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/cri-api
-  - name: release-1.32
-    source:
-      branch: release-1.32
-      dirs:
-      - staging/src/k8s.io/cri-api
   - name: release-1.33
     source:
       branch: release-1.33
@@ -1503,22 +1275,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/cri-client
-  - name: release-1.32
-    dependencies:
-    - repository: api
-      branch: release-1.32
-    - repository: apimachinery
-      branch: release-1.32
-    - repository: client-go
-      branch: release-1.32
-    - repository: component-base
-      branch: release-1.32
-    - repository: cri-api
-      branch: release-1.32
-    source:
-      branch: release-1.32
       dirs:
       - staging/src/k8s.io/cri-client
   - name: release-1.33
@@ -1627,26 +1383,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/kubelet
-  - name: release-1.32
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.32
-    - repository: apiserver
-      branch: release-1.32
-    - repository: api
-      branch: release-1.32
-    - repository: client-go
-      branch: release-1.32
-    - repository: cri-api
-      branch: release-1.32
-    - repository: component-base
-      branch: release-1.32
-    - repository: kms
-      branch: release-1.32
-    source:
-      branch: release-1.32
-      dirs:
-      - staging/src/k8s.io/kubelet
   - name: release-1.33
     dependencies:
     - repository: apimachinery
@@ -1744,24 +1480,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/controller-manager
-  - name: release-1.32
-    dependencies:
-    - repository: api
-      branch: release-1.32
-    - repository: apimachinery
-      branch: release-1.32
-    - repository: client-go
-      branch: release-1.32
-    - repository: component-base
-      branch: release-1.32
-    - repository: apiserver
-      branch: release-1.32
-    - repository: kms
-      branch: release-1.32
-    source:
-      branch: release-1.32
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.33
@@ -1863,28 +1581,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/cloud-provider
-  - name: release-1.32
-    dependencies:
-    - repository: api
-      branch: release-1.32
-    - repository: apimachinery
-      branch: release-1.32
-    - repository: apiserver
-      branch: release-1.32
-    - repository: client-go
-      branch: release-1.32
-    - repository: component-base
-      branch: release-1.32
-    - repository: controller-manager
-      branch: release-1.32
-    - repository: component-helpers
-      branch: release-1.32
-    - repository: kms
-      branch: release-1.32
-    source:
-      branch: release-1.32
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.33
@@ -2006,30 +1702,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/kube-controller-manager
-  - name: release-1.32
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.32
-    - repository: apiserver
-      branch: release-1.32
-    - repository: component-base
-      branch: release-1.32
-    - repository: api
-      branch: release-1.32
-    - repository: client-go
-      branch: release-1.32
-    - repository: controller-manager
-      branch: release-1.32
-    - repository: cloud-provider
-      branch: release-1.32
-    - repository: component-helpers
-      branch: release-1.32
-    - repository: kms
-      branch: release-1.32
-    source:
-      branch: release-1.32
-      dirs:
-      - staging/src/k8s.io/kube-controller-manager
   - name: release-1.33
     dependencies:
     - repository: apimachinery
@@ -2143,16 +1815,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
-  - name: release-1.32
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.32
-    - repository: api
-      branch: release-1.32
-    source:
-      branch: release-1.32
-      dirs:
-      - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.33
     dependencies:
     - repository: apimachinery
@@ -2210,16 +1872,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/csi-translation-lib
-  - name: release-1.32
-    dependencies:
-    - repository: api
-      branch: release-1.32
-    - repository: apimachinery
-      branch: release-1.32
-    source:
-      branch: release-1.32
-      dirs:
-      - staging/src/k8s.io/csi-translation-lib
   - name: release-1.33
     dependencies:
     - repository: api
@@ -2270,11 +1922,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/mount-utils
-  - name: release-1.32
-    source:
-      branch: release-1.32
-      dirs:
-      - staging/src/k8s.io/mount-utils
   - name: release-1.33
     source:
       branch: release-1.33
@@ -2320,28 +1967,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/kubectl
-  - name: release-1.32
-    dependencies:
-    - repository: api
-      branch: release-1.32
-    - repository: apimachinery
-      branch: release-1.32
-    - repository: cli-runtime
-      branch: release-1.32
-    - repository: client-go
-      branch: release-1.32
-    - repository: code-generator
-      branch: release-1.32
-    - repository: component-base
-      branch: release-1.32
-    - repository: component-helpers
-      branch: release-1.32
-    - repository: metrics
-      branch: release-1.32
-    source:
-      branch: release-1.32
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.33
@@ -2457,24 +2082,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/pod-security-admission
-  - name: release-1.32
-    dependencies:
-    - repository: api
-      branch: release-1.32
-    - repository: apimachinery
-      branch: release-1.32
-    - repository: apiserver
-      branch: release-1.32
-    - repository: client-go
-      branch: release-1.32
-    - repository: component-base
-      branch: release-1.32
-    - repository: kms
-      branch: release-1.32
-    source:
-      branch: release-1.32
-      dirs:
-      - staging/src/k8s.io/pod-security-admission
   - name: release-1.33
     dependencies:
     - repository: api
@@ -2574,30 +2181,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/dynamic-resource-allocation
-  - name: release-1.32
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.32
-    - repository: apiserver
-      branch: release-1.32
-    - repository: api
-      branch: release-1.32
-    - repository: client-go
-      branch: release-1.32
-    - repository: cri-api
-      branch: release-1.32
-    - repository: component-base
-      branch: release-1.32
-    - repository: component-helpers
-      branch: release-1.32
-    - repository: kms
-      branch: release-1.32
-    - repository: kubelet
-      branch: release-1.32
-    source:
-      branch: release-1.32
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.33
@@ -2724,20 +2307,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/kube-scheduler
-  - name: release-1.32
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.32
-    - repository: component-base
-      branch: release-1.32
-    - repository: api
-      branch: release-1.32
-    - repository: client-go
-      branch: release-1.32
-    source:
-      branch: release-1.32
-      dirs:
-      - staging/src/k8s.io/kube-scheduler
   - name: release-1.33
     dependencies:
     - repository: apimachinery
@@ -2845,20 +2414,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/endpointslice
-  - name: release-1.32
-    dependencies:
-    - repository: api
-      branch: release-1.32
-    - repository: apimachinery
-      branch: release-1.32
-    - repository: client-go
-      branch: release-1.32
-    - repository: component-base
-      branch: release-1.32
-    source:
-      branch: release-1.32
-      dirs:
-      - staging/src/k8s.io/endpointslice
   - name: release-1.33
     dependencies:
     - repository: api
@@ -2922,11 +2477,6 @@ rules:
   - name: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/externaljwt
-  - name: release-1.32
-    source:
-      branch: release-1.32
       dirs:
       - staging/src/k8s.io/externaljwt
   - name: release-1.33


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

remove publishing rules for release-1.32 branch as it is EOL

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

Done using
```
update-rules -branch release-1.32 -delete -o rules.yaml -rules https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/publishing/rules.yaml
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
