### PR TITLE
kubelet: retry static pod admission on periodic sync after add-time d…

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1298,6 +1298,13 @@ type Kubelet struct {
 	// allocationManager manages allocated resources for pods.
 	allocationManager allocation.Manager
 
+	// staticPodsPendingAdmissionLock guards staticPodsPendingAdmission.
+	staticPodsPendingAdmissionLock sync.Mutex
+	// staticPodsPendingAdmission lists static pod UIDs whose kubelet admission
+	// failed on add (for example transient resource pressure). They are retried
+	// on each periodic sync without requiring a manifest change or kubelet restart.
+	staticPodsPendingAdmission sets.Set[types.UID]
+
 	// podCertificateManager is fed updates as pods are added and removed from
 	// the node, and requests certificates for them based on their configured
 	// pod certificate volumes.
@@ -2612,6 +2619,82 @@ func recordAdmissionRejection(reason string) {
 	}
 }
 
+func (kl *Kubelet) rememberStaticPodPendingAdmission(uid types.UID) {
+	kl.staticPodsPendingAdmissionLock.Lock()
+	defer kl.staticPodsPendingAdmissionLock.Unlock()
+	if kl.staticPodsPendingAdmission == nil {
+		kl.staticPodsPendingAdmission = sets.New[types.UID]()
+	}
+	kl.staticPodsPendingAdmission.Insert(uid)
+}
+
+func (kl *Kubelet) forgetStaticPodPendingAdmission(uid types.UID) {
+	kl.staticPodsPendingAdmissionLock.Lock()
+	defer kl.staticPodsPendingAdmissionLock.Unlock()
+	if kl.staticPodsPendingAdmission == nil {
+		return
+	}
+	kl.staticPodsPendingAdmission.Delete(uid)
+}
+
+// tryAdmitPendingStaticPods re-runs kubelet admission for static pods that failed
+// admission on their originating config add. File and HTTP sources may not emit
+// another update while the manifest is unchanged, so admission would otherwise
+// never be retried until kubelet restart.
+func (kl *Kubelet) tryAdmitPendingStaticPods(ctx context.Context) {
+	logger := klog.FromContext(ctx)
+	kl.staticPodsPendingAdmissionLock.Lock()
+	if kl.staticPodsPendingAdmission == nil || kl.staticPodsPendingAdmission.Len() == 0 {
+		kl.staticPodsPendingAdmissionLock.Unlock()
+		return
+	}
+	uids := kl.staticPodsPendingAdmission.UnsortedList()
+	kl.staticPodsPendingAdmissionLock.Unlock()
+
+	start := kl.clock.Now()
+	for _, uid := range uids {
+		pod, ok := kl.podManager.GetPodByUID(uid)
+		if !ok || !kubetypes.IsStaticPod(pod) {
+			kl.forgetStaticPodPendingAdmission(uid)
+			continue
+		}
+		if kl.podWorkers.IsPodTerminationRequested(pod.UID) {
+			continue
+		}
+		if ok, reason, message := kl.allocationManager.AddPod(kl.GetActivePods(), pod); !ok {
+			logger.V(4).Info("Static pod admission still denied, will retry on next periodic sync", "pod", klog.KObj(pod), "reason", reason, "message", message)
+			continue
+		}
+		kl.forgetStaticPodPendingAdmission(uid)
+		logger.Info("Static pod admission succeeded after earlier denial", "pod", klog.KObj(pod))
+		kl.statusManager.SetPodStatus(logger, pod, v1.PodStatus{
+			Phase:    v1.PodPending,
+			QOSClass: v1qos.GetPodQOS(pod),
+		})
+		pod, mirrorPod, _ := kl.podManager.GetPodAndMirrorPod(pod)
+		if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
+			var pendingResizes []types.UID
+			_, updatedFromAllocation := kl.allocationManager.UpdatePodFromAllocation(pod)
+			if updatedFromAllocation {
+				pendingResizes = append(pendingResizes, pod.UID)
+			}
+			kl.statusManager.BackfillPodResizeConditions([]*v1.Pod{pod})
+			for _, resizeUID := range pendingResizes {
+				kl.allocationManager.PushPendingResize(resizeUID)
+			}
+			if len(pendingResizes) > 0 {
+				kl.allocationManager.RetryPendingResizes(allocation.TriggerReasonPodsAdded)
+			}
+		}
+		kl.podWorkers.UpdatePod(ctx, UpdatePodOptions{
+			Pod:        pod,
+			MirrorPod:  mirrorPod,
+			UpdateType: kubetypes.SyncPodCreate,
+			StartTime:  start,
+		})
+	}
+}
+
 // syncLoop is the main loop for processing changes. It watches for changes from
 // three channels (file, apiserver, and http) and creates a union of them. For
 // any new change seen, will run a sync against desired state and running state. If
@@ -2748,6 +2831,8 @@ func (kl *Kubelet) syncLoopIteration(ctx context.Context, configCh <-chan kubety
 			}
 		}
 	case <-syncCh:
+		// Retry kubelet admission for static pods that failed on add before syncing.
+		kl.tryAdmitPendingStaticPods(ctx)
 		// Sync pods waiting for sync
 		podsToSync := kl.getPodsToSync()
 		if len(podsToSync) == 0 {
@@ -2870,6 +2955,9 @@ func (kl *Kubelet) HandlePodAdditions(ctx context.Context, pods []*v1.Pod) {
 			// We failed pods that we rejected, so activePods include all admitted
 			// pods that are alive.
 			if ok, reason, message := kl.allocationManager.AddPod(kl.GetActivePods(), pod); !ok {
+				if kubetypes.IsStaticPod(pod) {
+					kl.rememberStaticPodPendingAdmission(pod.UID)
+				}
 				kl.rejectPod(ctx, pod, reason, message)
 				// We avoid recording the metric in canAdmitPod because it's called
 				// repeatedly during a resize, which would inflate the metric.
@@ -2877,6 +2965,9 @@ func (kl *Kubelet) HandlePodAdditions(ctx context.Context, pods []*v1.Pod) {
 				// and capture resize events separately.
 				recordAdmissionRejection(reason)
 				continue
+			}
+			if kubetypes.IsStaticPod(pod) {
+				kl.forgetStaticPodPendingAdmission(pod.UID)
 			}
 
 			if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
@@ -3060,6 +3151,7 @@ func (kl *Kubelet) HandlePodRemoves(ctx context.Context, pods []*v1.Pod) {
 	start := kl.clock.Now()
 	logger := klog.FromContext(ctx)
 	for _, pod := range pods {
+		kl.forgetStaticPodPendingAdmission(pod.UID)
 		kl.podCertificateManager.ForgetPod(ctx, pod)
 		kl.podManager.RemovePod(pod)
 		kl.allocationManager.RemovePod(pod.UID)

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -29,6 +29,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -2716,6 +2717,34 @@ func (a *testPodAdmitHandler) Admit(attrs *lifecycle.PodAdmitAttributes) lifecyc
 	return lifecycle.PodAdmitResult{Admit: true}
 }
 
+// countingRejectPodAdmitHandler fails the first rejectN Admit calls for a single pod UID.
+type countingRejectPodAdmitHandler struct {
+	mu       sync.Mutex
+	rejectN  int
+	attempts int
+	uid      types.UID
+}
+
+func (a *countingRejectPodAdmitHandler) Attempts() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.attempts
+}
+
+func (a *countingRejectPodAdmitHandler) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult {
+	if attrs.Pod.UID != a.uid {
+		return lifecycle.PodAdmitResult{Admit: true}
+	}
+	a.mu.Lock()
+	a.attempts++
+	attempt := a.attempts
+	a.mu.Unlock()
+	if attempt <= a.rejectN {
+		return lifecycle.PodAdmitResult{Admit: false, Reason: "Rejected", Message: "temporary denial for test"}
+	}
+	return lifecycle.PodAdmitResult{Admit: true}
+}
+
 // Test verifies that the kubelet invokes an admission handler during HandlePodAdditions.
 func TestHandlePodAdditionsInvokesPodAdmitHandlers(t *testing.T) {
 	tCtx := ktesting.Init(t)
@@ -2760,6 +2789,51 @@ func TestHandlePodAdditionsInvokesPodAdmitHandlers(t *testing.T) {
 	// Check pod status stored in the status map.
 	checkPodStatus(t, kl, podToReject, v1.PodFailed)
 	checkPodStatus(t, kl, podToAdmit, v1.PodPending)
+}
+
+func TestStaticPodAdmissionRetryAfterDeny(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+	kl.nodeLister = testNodeLister{nodes: []*v1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: string(kl.nodeName)},
+			Status: v1.NodeStatus{
+				Allocatable: v1.ResourceList{
+					v1.ResourcePods: *resource.NewQuantity(110, resource.DecimalSI),
+				},
+			},
+		},
+	}}
+
+	staticUID := types.UID("static-pod-admission-retry")
+	admitHandler := &countingRejectPodAdmitHandler{rejectN: 1, uid: staticUID}
+	kl.allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{admitHandler})
+
+	staticPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       staticUID,
+			Name:      "staticPod",
+			Namespace: "kube-system",
+			Annotations: map[string]string{
+				kubetypes.ConfigSourceAnnotationKey: kubetypes.FileSource,
+			},
+		},
+		Spec: v1.PodSpec{
+			HostNetwork: true,
+		},
+	}
+
+	kl.HandlePodAdditions(tCtx, []*v1.Pod{staticPod})
+	require.Equal(t, 1, admitHandler.Attempts())
+	checkPodStatus(t, kl, staticPod, v1.PodFailed)
+
+	kl.tryAdmitPendingStaticPods(tCtx)
+	require.Equal(t, 2, admitHandler.Attempts())
+	status, found := kl.statusManager.GetPodStatus(staticUID)
+	require.True(t, found)
+	require.NotEqual(t, v1.PodFailed, status.Phase, "pod should leave Failed after admission retry")
 }
 
 func TestPodResourceAllocationReset(t *testing.T) {


### PR DESCRIPTION
kubelet: retry static pod admission on periodic sync after add-time denial

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Static pods from file or HTTP sources only go through kubelet admission in `HandlePodAdditions`. When admission fails (for example transient resource pressure or an unexpected error from the critical-pod admission path), kubelet marks the pod failed and never calls `UpdatePod` for it. Those config sources do not emit another update while the manifest is unchanged, so admission is not retried until kubelet is restarted.

This change records static pod UIDs that failed admission on add, clears them when the pod is removed or admitted, and on each periodic sync tick (`syncCh`) re-runs admission. If admission succeeds, status is reset to `Pending` and `SyncPodCreate` is dispatched so the normal pod worker lifecycle runs.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/138391

#### Special notes for your reviewer:

- Retry cadence follows the existing periodic sync interval (same as `getPodsToSync`), not a separate timer.
- Only pods identified by `kubetypes.IsStaticPod` (non-API config source) are tracked; API-sourced pods already get updates from the apiserver informer.

#### Does this PR introduce a user-facing change?

```release-note
Kubelet now retries admission for static pods loaded from file or HTTP when admission initially fails, using the periodic sync interval, instead of requiring a manifest change or kubelet restart.
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```NONE
```
