### PR TITLE
apimachinery: ignore private fields in unstructured converter

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
@@ -376,6 +376,10 @@ func fieldInfoFromField(structType reflect.Type, field int) *fieldInfo {
 	// Cache miss - we need to compute the field name.
 	info := &fieldInfo{}
 	typeField := structType.Field(field)
+	if fieldShouldBeIgnored(typeField) {
+		info.name = "-"
+		return addFieldInfoToCache(structType, field, info)
+	}
 	jsonTag, exists := typeField.Tag.Lookup("json")
 	if !exists || len(jsonTag) == 0 {
 		if !typeField.Anonymous {
@@ -401,9 +405,27 @@ func fieldInfoFromField(structType reflect.Type, field int) *fieldInfo {
 	}
 	info.nameValue = reflect.ValueOf(info.name)
 
+	return addFieldInfoToCache(structType, field, info)
+}
+
+func fieldShouldBeIgnored(typeField reflect.StructField) bool {
+	if typeField.Anonymous {
+		t := typeField.Type
+		if t.Kind() == reflect.Pointer {
+			t = t.Elem()
+		}
+		// Match encoding/json: embedded unexported struct fields may still contribute
+		// exported fields, but other unexported embedded fields are ignored.
+		return !typeField.IsExported() && t.Kind() != reflect.Struct
+	}
+
+	return !typeField.IsExported()
+}
+
+func addFieldInfoToCache(structType reflect.Type, field int, info *fieldInfo) *fieldInfo {
 	fieldCache.Lock()
 	defer fieldCache.Unlock()
-	fieldCacheMap = fieldCache.value.Load().(fieldsCacheMap)
+	fieldCacheMap := fieldCache.value.Load().(fieldsCacheMap)
 	newFieldCacheMap := make(fieldsCacheMap)
 	for k, v := range fieldCacheMap {
 		newFieldCacheMap[k] = v
@@ -535,6 +557,9 @@ func structFromUnstructured(sv, dv reflect.Value, ctx *fromUnstructuredContext) 
 		fieldInfo := fieldInfoFromField(dt, i)
 		fv := dv.Field(i)
 
+		if fieldInfo.name == "-" {
+			continue
+		}
 		if len(fieldInfo.name) == 0 {
 			// This field is inlined, recurse into fromUnstructured again
 			// with the same set of matched keys.

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
@@ -169,6 +169,17 @@ func (c *CustomPointer) MarshalJSON() ([]byte, error) {
 	return c.data, nil
 }
 
+type PrivateFieldsObject struct {
+	Spec    PrivateFieldsSpec `json:"spec"`
+	Skipped string            `json:"-"`
+}
+
+type PrivateFieldsSpec struct {
+	Hidden  []byte `json:"-"`
+	private []byte `json:"private"`
+	Visible string `json:"visible"`
+}
+
 func doRoundTrip(t *testing.T, item interface{}) {
 	data, err := json.Marshal(item)
 	if err != nil {
@@ -978,6 +989,46 @@ func TestCustomToUnstructured(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConverterIgnoresPrivateAndSkippedFields(t *testing.T) {
+	t.Run("to-unstructured", func(t *testing.T) {
+		obj := &PrivateFieldsObject{
+			Spec: PrivateFieldsSpec{
+				Hidden:  []byte("hidden"),
+				private: []byte("private"),
+				Visible: "value",
+			},
+			Skipped: "skipped",
+		}
+
+		expectedJSON, err := json.Marshal(obj)
+		require.NoError(t, err)
+
+		expected := map[string]interface{}{}
+		require.NoError(t, json.Unmarshal(expectedJSON, &expected))
+
+		got, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+		require.NoError(t, err)
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("from-unstructured", func(t *testing.T) {
+		jsonData := []byte(`{"spec":{"visible":"value"}}`)
+
+		expected := &PrivateFieldsObject{}
+		require.NoError(t, json.Unmarshal(jsonData, expected))
+
+		unstr := map[string]interface{}{}
+		require.NoError(t, json.Unmarshal(jsonData, &unstr))
+
+		got := &PrivateFieldsObject{}
+		require.NotPanics(t, func() {
+			err := runtime.NewTestUnstructuredConverterWithValidation(simpleEquality).FromUnstructuredWithValidation(unstr, got, true)
+			require.NoError(t, err)
+		})
+		assert.Equal(t, expected, got)
+	})
 }
 
 func TestCustomToUnstructuredTopLevel(t *testing.T) {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
@@ -180,6 +180,22 @@ type PrivateFieldsSpec struct {
 	Visible string `json:"visible"`
 }
 
+type privateEmbeddedFields struct {
+	Hidden  []byte `json:"-"`
+	private []byte
+	Visible string `json:"visible"`
+}
+
+type PrivateEmbeddedFieldsObject struct {
+	privateEmbeddedFields
+	Skipped string `json:"-"`
+}
+
+type PrivateEmbeddedFieldsPointerObject struct {
+	*privateEmbeddedFields
+	Skipped string `json:"-"`
+}
+
 func doRoundTrip(t *testing.T, item interface{}) {
 	data, err := json.Marshal(item)
 	if err != nil {
@@ -1023,6 +1039,67 @@ func TestConverterIgnoresPrivateAndSkippedFields(t *testing.T) {
 		require.NoError(t, json.Unmarshal(jsonData, &unstr))
 
 		got := &PrivateFieldsObject{}
+		require.NotPanics(t, func() {
+			err := runtime.NewTestUnstructuredConverterWithValidation(simpleEquality).FromUnstructuredWithValidation(unstr, got, true)
+			require.NoError(t, err)
+		})
+		assert.Equal(t, expected, got)
+	})
+}
+
+func TestConverterMatchesJSONForUnexportedEmbeddedFields(t *testing.T) {
+	toUnstructuredCases := []struct {
+		name string
+		obj  interface{}
+	}{
+		{
+			name: "embedded value field",
+			obj: &PrivateEmbeddedFieldsObject{
+				privateEmbeddedFields: privateEmbeddedFields{
+					Hidden:  []byte("hidden"),
+					private: []byte("private"),
+					Visible: "value",
+				},
+				Skipped: "skipped",
+			},
+		},
+		{
+			name: "embedded pointer field",
+			obj: &PrivateEmbeddedFieldsPointerObject{
+				privateEmbeddedFields: &privateEmbeddedFields{
+					Hidden:  []byte("hidden"),
+					private: []byte("private"),
+					Visible: "value",
+				},
+				Skipped: "skipped",
+			},
+		},
+	}
+
+	for _, tc := range toUnstructuredCases {
+		t.Run("to-unstructured/"+tc.name, func(t *testing.T) {
+			expectedJSON, err := json.Marshal(tc.obj)
+			require.NoError(t, err)
+
+			expected := map[string]interface{}{}
+			require.NoError(t, json.Unmarshal(expectedJSON, &expected))
+
+			got, err := runtime.DefaultUnstructuredConverter.ToUnstructured(tc.obj)
+			require.NoError(t, err)
+			assert.Equal(t, expected, got)
+		})
+	}
+
+	t.Run("from-unstructured/embedded value field", func(t *testing.T) {
+		jsonData := []byte(`{"visible":"value"}`)
+
+		expected := &PrivateEmbeddedFieldsObject{}
+		require.NoError(t, json.Unmarshal(jsonData, expected))
+
+		unstr := map[string]interface{}{}
+		require.NoError(t, json.Unmarshal(jsonData, &unstr))
+
+		got := &PrivateEmbeddedFieldsObject{}
 		require.NotPanics(t, func() {
 			err := runtime.NewTestUnstructuredConverterWithValidation(simpleEquality).FromUnstructuredWithValidation(unstr, got, true)
 			require.NoError(t, err)

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
@@ -1047,7 +1047,7 @@ func TestConverterIgnoresPrivateAndSkippedFields(t *testing.T) {
 	})
 }
 
-func TestConverterMatchesJSONForUnexportedEmbeddedFields(t *testing.T) {
+func TestToUnstructuredMatchesJSONForUnexportedEmbeddedFields(t *testing.T) {
 	toUnstructuredCases := []struct {
 		name string
 		obj  interface{}
@@ -1089,23 +1089,23 @@ func TestConverterMatchesJSONForUnexportedEmbeddedFields(t *testing.T) {
 			assert.Equal(t, expected, got)
 		})
 	}
+}
 
-	t.Run("from-unstructured/embedded value field", func(t *testing.T) {
-		jsonData := []byte(`{"visible":"value"}`)
+func TestFromUnstructuredIgnoresUnexportedEmbeddedFields(t *testing.T) {
+	jsonData := []byte(`{"visible":"value"}`)
 
-		expected := &PrivateEmbeddedFieldsObject{}
-		require.NoError(t, json.Unmarshal(jsonData, expected))
+	expected := &PrivateEmbeddedFieldsObject{}
+	require.NoError(t, json.Unmarshal(jsonData, expected))
 
-		unstr := map[string]interface{}{}
-		require.NoError(t, json.Unmarshal(jsonData, &unstr))
+	unstr := map[string]interface{}{}
+	require.NoError(t, json.Unmarshal(jsonData, &unstr))
 
-		got := &PrivateEmbeddedFieldsObject{}
-		require.NotPanics(t, func() {
-			err := runtime.NewTestUnstructuredConverterWithValidation(simpleEquality).FromUnstructuredWithValidation(unstr, got, true)
-			require.NoError(t, err)
-		})
-		assert.Equal(t, expected, got)
+	got := &PrivateEmbeddedFieldsObject{}
+	require.NotPanics(t, func() {
+		err := runtime.NewTestUnstructuredConverterWithValidation(simpleEquality).FromUnstructuredWithValidation(unstr, got, true)
+		require.NoError(t, err)
 	})
+	assert.Equal(t, expected, got)
 }
 
 func TestCustomToUnstructuredTopLevel(t *testing.T) {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
@@ -176,7 +176,7 @@ type PrivateFieldsObject struct {
 
 type PrivateFieldsSpec struct {
 	Hidden  []byte `json:"-"`
-	private []byte `json:"private"`
+	private []byte
 	Visible string `json:"visible"`
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This change fixes a panic in the unstructured converter when the destination struct contains private fields.

Today, `FromUnstructured` walks every struct field, even fields that `encoding/json` would ignore. When it reaches an unexported field, it can end up calling `reflect.Value.Set` on a value that is not settable and panic, even if the input only contains public JSON fields.

This update makes the converter follow the same field-visibility rules as `encoding/json` for these cases:

- ignore unexported non-embedded fields
- ignore unexported embedded non-struct fields
- continue to allow embedded unexported struct fields to contribute exported fields
- skip `json:"-"` fields during `FromUnstructured`

#### How does this change work:
- taught `fieldInfoFromField` to mark JSON-ignored/private fields as skipped
- made `structFromUnstructured` skip those ignored fields
- added regression coverage for both `ToUnstructured` and `FromUnstructured`

#### Why this is safe:
The converter now matches the JSON encoder/decoder behavior more closely instead of trying to populate fields that JSON cannot address in the first place.

#### Which issue(s) this PR fixes:
Fixes #124154

#### Special notes for your reviewer:
Verified with:
- `go test ./staging/src/k8s.io/apimachinery/pkg/runtime -count=1`
- `go test ./staging/src/k8s.io/apimachinery/... -count=1`

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig api-machinery