### PR TITLE
Indicate probe failure threshold in container events

### DIFF
--- a/pkg/kubelet/prober/common_test.go
+++ b/pkg/kubelet/prober/common_test.go
@@ -165,7 +165,7 @@ func newTestManager() *manager {
 		&record.FakeRecorder{},
 	).(*manager)
 	// Don't actually execute probes.
-	m.prober.exec = fakeExecProber{probe.Success, nil}
+	m.prober.exec = fakeExecProber{probe.Success, "", nil}
 	return m
 }
 
@@ -177,11 +177,12 @@ func newTestWorker(m *manager, probeType probeType, probeSpec v1.Probe) *worker 
 
 type fakeExecProber struct {
 	result probe.Result
+	output string
 	err    error
 }
 
 func (p fakeExecProber) Probe(c exec.Cmd) (probe.Result, string, error) {
-	return p.result, "", p.err
+	return p.result, p.output, p.err
 }
 
 type syncExecProber struct {

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -80,7 +80,9 @@ func (pb *prober) recordContainerEvent(ctx context.Context, pod *v1.Pod, contain
 }
 
 // probe probes the container.
-func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (results.Result, error) {
+// Returns a results.Result, the output string from the probe, and an error.
+// The output is returned so callers (e.g., the worker) can include it in threshold-aware events.
+func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (results.Result, string, error) {
 	var probeSpec *v1.Probe
 	switch probeType {
 	case readiness:
@@ -90,13 +92,13 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 	case startup:
 		probeSpec = container.StartupProbe
 	default:
-		return results.Failure, fmt.Errorf("unknown probe type: %q", probeType)
+		return results.Failure, "", fmt.Errorf("unknown probe type: %q", probeType)
 	}
 
 	logger := klog.FromContext(ctx)
 	if probeSpec == nil {
 		logger.Info("Probe is nil", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name)
-		return results.Success, nil
+		return results.Success, "", nil
 	}
 
 	result, output, err := pb.runProbeWithRetries(ctx, probeType, probeSpec, pod, status, container, containerID, maxProbeRetries)
@@ -105,31 +107,31 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 		// Handle probe error
 		logger.V(1).Info("Probe errored", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result, "err", err)
 		pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe errored and resulted in %s state: %s", probeType, result, err)
-		return results.Failure, err
+		return results.Failure, output, err
 	}
 
 	switch result {
 	case probe.Success:
 		logger.V(3).Info("Probe succeeded", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name)
-		return results.Success, nil
+		return results.Success, output, nil
 
 	case probe.Warning:
 		pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerProbeWarning, "%s probe warning: %s", probeType, output)
 		logger.V(3).Info("Probe succeeded with a warning", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "output", output)
-		return results.Success, nil
+		return results.Success, output, nil
 
 	case probe.Failure:
 		logger.V(1).Info("Probe failed", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result, "output", output)
-		pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed: %s", probeType, output)
-		return results.Failure, nil
+		// The Unhealthy event is now emitted by the worker with threshold context.
+		return results.Failure, output, nil
 
 	case probe.Unknown:
 		logger.V(1).Info("Probe unknown without error", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result)
-		return results.Failure, nil
+		return results.Failure, output, nil
 
 	default:
 		logger.V(1).Info("Unsupported probe result", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result)
-		return results.Failure, nil
+		return results.Failure, output, nil
 	}
 }
 

--- a/pkg/kubelet/prober/prober_test.go
+++ b/pkg/kubelet/prober/prober_test.go
@@ -248,12 +248,12 @@ func TestProbe(t *testing.T) {
 				testContainer.StartupProbe = test.probe
 			}
 			if test.execError {
-				prober.exec = fakeExecProber{test.execResult, errors.New("exec error")}
+				prober.exec = fakeExecProber{test.execResult, "", errors.New("exec error")}
 			} else {
-				prober.exec = fakeExecProber{test.execResult, nil}
+				prober.exec = fakeExecProber{test.execResult, "", nil}
 			}
 
-			result, err := prober.probe(ctx, pType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
+			result, _, err := prober.probe(ctx, pType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
 
 			if test.expectError {
 				require.Error(t, err, "[%s] Expected probe error but no error was returned.", testID)
@@ -266,7 +266,7 @@ func TestProbe(t *testing.T) {
 			if len(test.expectCommand) > 0 {
 				prober.exec = execprobe.New()
 				prober.runner = &containertest.FakeContainerCommandRunner{}
-				_, err := prober.probe(ctx, pType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
+				_, _, err := prober.probe(ctx, pType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
 				require.NoError(t, err, "[%s] Didn't expect probe error ", testID)
 
 				if !reflect.DeepEqual(test.expectCommand, prober.runner.(*containertest.FakeContainerCommandRunner).Cmd) {

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -29,6 +29,7 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/prober/results"
 )
 
@@ -346,7 +347,7 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 	}
 
 	// Note, exec probe does NOT have access to pod environment variables or downward API
-	result, err := w.probeManager.prober.probe(ctx, w.probeType, w.pod, status, w.container, w.containerID)
+	result, output, err := w.probeManager.prober.probe(ctx, w.probeType, w.pod, status, w.container, w.containerID)
 	if err != nil {
 		// Prober error, throw away the result.
 		return true
@@ -373,7 +374,17 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 	if (result == results.Failure && w.resultRun < int(w.spec.FailureThreshold)) ||
 		(result == results.Success && w.resultRun < int(w.spec.SuccessThreshold)) {
 		// Success or failure is below threshold - leave the probe state unchanged.
+		if result == results.Failure {
+			w.probeManager.prober.recordContainerEvent(ctx, w.pod, &w.container, v1.EventTypeWarning, events.ContainerUnhealthy,
+				"%s probe failed: %s (failure %d of %d, threshold not yet reached)", w.probeType, output, w.resultRun, w.spec.FailureThreshold)
+		}
 		return true
+	}
+
+	// Emit the probe failure event when threshold is reached.
+	if result == results.Failure {
+		w.probeManager.prober.recordContainerEvent(ctx, w.pod, &w.container, v1.EventTypeWarning, events.ContainerUnhealthy,
+			"%s probe failed: %s (failure threshold %d reached)", w.probeType, output, w.spec.FailureThreshold)
 	}
 
 	w.resultsManager.Set(w.containerID, result, w.pod)

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -455,7 +455,7 @@ func TestFailureThreshold(t *testing.T) {
 
 	for i := 0; i < 2; i++ {
 		// First probe should succeed.
-		m.prober.exec = fakeExecProber{probe.Success, nil}
+		m.prober.exec = fakeExecProber{probe.Success, "", nil}
 
 		for j := 0; j < 3; j++ {
 			msg := fmt.Sprintf("%d success (%d)", j+1, i)
@@ -464,7 +464,7 @@ func TestFailureThreshold(t *testing.T) {
 		}
 
 		// Prober starts failing :(
-		m.prober.exec = fakeExecProber{probe.Failure, nil}
+		m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 
 		// Next 2 probes should still be "success".
 		for j := 0; j < 2; j++ {
@@ -507,13 +507,13 @@ func TestSuccessThreshold(t *testing.T) {
 		}
 
 		// Prober flakes :(
-		m.prober.exec = fakeExecProber{probe.Failure, nil}
+		m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 		msg := fmt.Sprintf("1 failure (%d)", i)
 		expectContinue(t, w, w.doProbe(ctx), msg)
 		expectResult(t, w, results.Failure, msg)
 
 		// Back to success.
-		m.prober.exec = fakeExecProber{probe.Success, nil}
+		m.prober.exec = fakeExecProber{probe.Success, "", nil}
 	}
 }
 
@@ -524,7 +524,7 @@ func TestStartupProbeSuccessThreshold(t *testing.T) {
 	failureThreshold := 3
 	w := newTestWorker(m, startup, v1.Probe{SuccessThreshold: int32(successThreshold), FailureThreshold: int32(failureThreshold)})
 	m.statusManager.SetPodStatus(logger, w.pod, getTestNotRunningStatus())
-	m.prober.exec = fakeExecProber{probe.Success, nil}
+	m.prober.exec = fakeExecProber{probe.Success, "", nil}
 
 	for i := 0; i < successThreshold+1; i++ {
 		if i < successThreshold {
@@ -557,7 +557,7 @@ func TestStartupProbeFailureThreshold(t *testing.T) {
 	failureThreshold := 3
 	w := newTestWorker(m, startup, v1.Probe{SuccessThreshold: int32(successThreshold), FailureThreshold: int32(failureThreshold)})
 	m.statusManager.SetPodStatus(logger, w.pod, getTestNotRunningStatus())
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 
 	for i := 0; i < failureThreshold+1; i++ {
 		if i < failureThreshold {
@@ -678,7 +678,7 @@ func TestOnHoldOnLivenessOrStartupCheckFailure(t *testing.T) {
 		m.statusManager.SetPodStatus(logger, w.pod, status)
 
 		// First probe should fail.
-		m.prober.exec = fakeExecProber{probe.Failure, nil}
+		m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 		msg := "first probe"
 		expectContinue(t, w, w.doProbe(ctx), msg)
 		expectResult(t, w, results.Failure, msg)
@@ -687,7 +687,7 @@ func TestOnHoldOnLivenessOrStartupCheckFailure(t *testing.T) {
 		}
 		// Set fakeExecProber to return success. However, the result will remain
 		// failure because the worker is on hold and won't probe.
-		m.prober.exec = fakeExecProber{probe.Success, nil}
+		m.prober.exec = fakeExecProber{probe.Success, "", nil}
 		msg = "while on hold"
 		expectContinue(t, w, w.doProbe(ctx), msg)
 		expectResult(t, w, results.Failure, msg)
@@ -715,7 +715,7 @@ func TestResultRunOnLivenessCheckFailure(t *testing.T) {
 	w := newTestWorker(m, liveness, v1.Probe{SuccessThreshold: 1, FailureThreshold: 3})
 	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatus())
 
-	m.prober.exec = fakeExecProber{probe.Success, nil}
+	m.prober.exec = fakeExecProber{probe.Success, "", nil}
 	msg := "initial probe success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
@@ -723,7 +723,7 @@ func TestResultRunOnLivenessCheckFailure(t *testing.T) {
 		t.Errorf("Prober resultRun should be 1")
 	}
 
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "probe failure, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
@@ -731,7 +731,7 @@ func TestResultRunOnLivenessCheckFailure(t *testing.T) {
 		t.Errorf("Prober resultRun should be 1")
 	}
 
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "2nd probe failure, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
@@ -742,7 +742,7 @@ func TestResultRunOnLivenessCheckFailure(t *testing.T) {
 	// Exceeding FailureThreshold should cause resultRun to
 	// reset to 0 so that the probe on the restarted pod
 	// also gets FailureThreshold attempts to succeed.
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "3rd probe failure, result failure"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Failure, msg)
@@ -760,7 +760,7 @@ func TestResultRunOnStartupCheckFailure(t *testing.T) {
 
 	// Below FailureThreshold leaves probe state unchanged
 	// which is failed for startup at first.
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg := "probe failure, result unknown"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Unknown, msg)
@@ -768,7 +768,7 @@ func TestResultRunOnStartupCheckFailure(t *testing.T) {
 		t.Errorf("Prober resultRun should be 1")
 	}
 
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "2nd probe failure, result unknown"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Unknown, msg)
@@ -779,7 +779,7 @@ func TestResultRunOnStartupCheckFailure(t *testing.T) {
 	// Exceeding FailureThreshold should cause resultRun to
 	// reset to 0 so that the probe on the restarted pod
 	// also gets FailureThreshold attempts to succeed.
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "3rd probe failure, result failure"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Failure, msg)
@@ -860,14 +860,14 @@ func TestLivenessProbeDisabledByStarted(t *testing.T) {
 	w := newTestWorker(m, liveness, v1.Probe{SuccessThreshold: 1, FailureThreshold: 1})
 	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatusWithStarted(false))
 	// livenessProbe fails, but is disabled
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg := "Not started, probe failure, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
 	// setting started state
 	m.statusManager.SetContainerStartup(logger, w.pod.UID, w.containerID, true)
 	// livenessProbe fails
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "Started, probe failure, result failure"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Failure, msg)
@@ -880,19 +880,19 @@ func TestStartupProbeDisabledByStarted(t *testing.T) {
 	w := newTestWorker(m, startup, v1.Probe{SuccessThreshold: 1, FailureThreshold: 2})
 	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatusWithStarted(false))
 	// startupProbe fails < FailureThreshold, stays unknown
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg := "Not started, probe failure, result unknown"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Unknown, msg)
 	// startupProbe succeeds
-	m.prober.exec = fakeExecProber{probe.Success, nil}
+	m.prober.exec = fakeExecProber{probe.Success, "", nil}
 	msg = "Started, probe success, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)
 	// setting started state
 	m.statusManager.SetContainerStartup(logger, w.pod.UID, w.containerID, true)
 	// startupProbe fails, but is disabled
-	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	m.prober.exec = fakeExecProber{probe.Failure, "", nil}
 	msg = "Started, probe failure, result success"
 	expectContinue(t, w, w.doProbe(ctx), msg)
 	expectResult(t, w, results.Success, msg)


### PR DESCRIPTION
## Summary

- Move probe failure event emission from the prober to the worker where threshold context is available
- When a probe fails within the FailureThreshold, the event now shows the current failure count (e.g., `Liveness probe failed:  (failure 1 of 3, threshold not yet reached)`)
- When the FailureThreshold is reached, the event explicitly states so (e.g., `Liveness probe failed:  (failure threshold 3 reached)`)
- Return the probe output string from `probe()` so the worker can include it in threshold-aware event messages

This gives end-users a clear signal in container events about whether a probe failure was tolerated (within threshold) or triggered control plane action (threshold reached), addressing the lack of information described in #115823.

Revives the approach from #115963 with a simpler, more focused implementation.

Fixes #115823

/sig node
/kind cleanup

## Test plan

- [x] All existing prober tests pass (`go test ./pkg/kubelet/prober/... -count=1`)
- [x] Verify event messages in a cluster with a pod that has `failureThreshold > 1` on a liveness probe
- [x] Confirm events show "failure X of Y, threshold not yet reached" for sub-threshold failures
- [x] Confirm events show "failure threshold Y reached" when threshold is met