### PR TITLE
authn: preserve TokenReview cancellation without request values

### DIFF
--- a/pkg/registry/authentication/tokenreview/storage.go
+++ b/pkg/registry/authentication/tokenreview/storage.go
@@ -34,6 +34,14 @@ import (
 
 var badAuthenticatorAuds = apierrors.NewInternalError(errors.New("error validating audiences"))
 
+type valuelessContext struct {
+	context.Context
+}
+
+func (v valuelessContext) Value(key any) any {
+	return nil
+}
+
 type REST struct {
 	tokenAuthenticator authenticator.Request
 	apiAudiences       []string
@@ -90,17 +98,17 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 		return tokenReview, nil
 	}
 
-	// create a header that contains nothing but the token
-	fakeReq := &http.Request{Header: http.Header{}}
-	fakeReq.Header.Add("Authorization", "Bearer "+tokenReview.Spec.Token)
-
 	auds := tokenReview.Spec.Audiences
 	if len(auds) == 0 {
 		auds = r.apiAudiences
 	}
+	var reqCtx context.Context = valuelessContext{Context: ctx}
 	if len(auds) > 0 {
-		fakeReq = fakeReq.WithContext(authenticator.WithAudiences(fakeReq.Context(), auds))
+		reqCtx = authenticator.WithAudiences(reqCtx, auds)
 	}
+
+	fakeReq := (&http.Request{Header: http.Header{}}).WithContext(reqCtx)
+	fakeReq.Header.Add("Authorization", "Bearer "+tokenReview.Spec.Token)
 
 	resp, ok, err := r.tokenAuthenticator.AuthenticateRequest(fakeReq)
 	tokenReview.Status.Authenticated = ok

--- a/pkg/registry/authentication/tokenreview/storage_test.go
+++ b/pkg/registry/authentication/tokenreview/storage_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tokenreview
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/kubernetes/pkg/apis/authentication"
+)
+
+type testContextKey struct{}
+
+func TestCreatePropagatesCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	storage := NewREST(authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+		select {
+		case <-req.Context().Done():
+			return nil, false, req.Context().Err()
+		default:
+			return nil, false, errors.New("request context was not canceled")
+		}
+	}), nil)
+
+	obj, err := storage.Create(ctx, &authentication.TokenReview{
+		Spec: authentication.TokenReviewSpec{
+			Token: "test-token",
+		},
+	}, nil, &metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	tokenReview, ok := obj.(*authentication.TokenReview)
+	require.True(t, ok)
+	assert.Equal(t, context.Canceled.Error(), tokenReview.Status.Error)
+}
+
+func TestCreatePropagatesContextDeadline(t *testing.T) {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	storage := NewREST(authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+		select {
+		case <-req.Context().Done():
+			return nil, false, req.Context().Err()
+		default:
+			return nil, false, errors.New("request context deadline was not propagated")
+		}
+	}), []string{"api"})
+
+	obj, err := storage.Create(ctx, &authentication.TokenReview{
+		Spec: authentication.TokenReviewSpec{
+			Token: "test-token",
+		},
+	}, nil, &metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	tokenReview, ok := obj.(*authentication.TokenReview)
+	require.True(t, ok)
+	assert.Equal(t, context.DeadlineExceeded.Error(), tokenReview.Status.Error)
+}
+
+func TestCreateStripsParentContextValues(t *testing.T) {
+	ctx := context.WithValue(context.Background(), testContextKey{}, "sensitive-request-value")
+
+	storage := NewREST(authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+		if got := req.Context().Value(testContextKey{}); got != nil {
+			return nil, false, fmt.Errorf("unexpected context value %v", got)
+		}
+
+		auds, ok := authenticator.AudiencesFrom(req.Context())
+		if !ok {
+			return nil, false, errors.New("expected audiences")
+		}
+
+		return &authenticator.Response{
+			Audiences: auds,
+			User:      &user.DefaultInfo{Name: "test-user"},
+		}, true, nil
+	}), []string{"api"})
+
+	obj, err := storage.Create(ctx, &authentication.TokenReview{
+		Spec: authentication.TokenReviewSpec{
+			Token: "test-token",
+		},
+	}, nil, &metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	tokenReview, ok := obj.(*authentication.TokenReview)
+	require.True(t, ok)
+	assert.True(t, tokenReview.Status.Authenticated)
+	assert.Empty(t, tokenReview.Status.Error)
+	assert.Equal(t, []string{"api"}, tokenReview.Status.Audiences)
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The TokenReview REST handler was passing a synthetic request to the authenticator without preserving the caller's cancellation and deadline semantics.

This change builds the synthetic authenticator request from a context that keeps cancellation and deadline behavior from the original API request while intentionally dropping unrelated request-scoped values. It then layers audience information onto that context when needed. As a result, token authenticators continue to receive the correct cancellation and timeout signals without inheriting arbitrary parent context values.

The change also adds regression coverage for canceled and expired contexts, plus a test ensuring audiences are preserved while parent context values are not forwarded.

#### Which issue(s) this PR fixes:
Fixes #89702

#### Special notes for your reviewer:
Verified with:
- `go test ./pkg/registry/authentication/tokenreview`
- `go test ./pkg/registry/authentication/...`

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig auth