### PR TITLE
Fix broken ignored failed pods test by proving failed pods are ignored

### DIFF
--- a/pkg/controller/podautoscaler/replica_calculator_test.go
+++ b/pkg/controller/podautoscaler/replica_calculator_test.go
@@ -1177,7 +1177,7 @@ func TestReplicaCalcScaleDownContainerIgnoresFailedPods(t *testing.T) {
 		resource: &resourceInfo{
 			name:     v1.ResourceCPU,
 			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   [][]int64{{1000, 100}, {1000, 300}, {1000, 500}, {1000, 250}, {1000, 250}, {9000, 9000},  {9000, 9000}},
+			levels:   [][]int64{{1000, 100}, {1000, 300}, {1000, 500}, {1000, 250}, {1000, 250}},
 
 			targetUtilization:   50,
 			expectedUtilization: 28,

--- a/pkg/controller/podautoscaler/replica_calculator_test.go
+++ b/pkg/controller/podautoscaler/replica_calculator_test.go
@@ -1177,7 +1177,7 @@ func TestReplicaCalcScaleDownContainerIgnoresFailedPods(t *testing.T) {
 		resource: &resourceInfo{
 			name:     v1.ResourceCPU,
 			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   [][]int64{{1000, 100}, {1000, 300}, {1000, 500}, {1000, 250}, {1000, 250}}, //TODO: Test is broken
+			levels:   [][]int64{{1000, 100}, {1000, 300}, {1000, 500}, {1000, 250}, {1000, 250}, {9000, 9000},  {9000, 9000}},
 
 			targetUtilization:   50,
 			expectedUtilization: 28,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind failing-test

#### What this PR does / why we need it:
The `TestReplicaCalcScaleDownContainerIgnoresFailedPods` was marked as broken and the test in does not actually verify that the failing pods are being ignored. The `levels` slice had 5 elements for 7 pods. The two failed pods did not have metrics in the metrics map. Therefore this test was not proving the calculator ignored the failed pods.

The fix contains the metric items for 2 failed pods and adopts a similar pattern as other tests. If the calculator used these two items, it would cause the test to fail.

#### Which issue(s) this PR is related to:
N/A

#### Does this PR introduce a user-facing change?
NONE 

```release-note
NONE
```