### PR TITLE
Fix: namespace not found

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -566,6 +566,16 @@ func (o *GetOptions) Run(f cmdutil.Factory, args []string) error {
 	if trackingWriter.Written == 0 && !o.IgnoreNotFound && len(allErrs) == 0 {
 		// if we wrote no output, and had no errors, and are not ignoring NotFound, be sure we output something
 		if allResourcesNamespaced {
+			// Check if the namespace exists before printing "No resources found"
+			if o.Namespace != "" && o.Namespace != metav1.NamespaceAll {
+				clientSet, err := f.KubernetesClientSet()
+				if err == nil {
+					_, err = clientSet.CoreV1().Namespaces().Get(context.TODO(), o.Namespace, metav1.GetOptions{})
+					if apierrors.IsNotFound(err) {
+						return apierrors.NewNotFound(corev1.Resource("namespaces"), o.Namespace)
+					}
+				}
+			}
 			fmt.Fprintf(o.ErrOut, "No resources found in %s namespace.\n", o.Namespace)
 		} else {
 			fmt.Fprintln(o.ErrOut, "No resources found")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

When a user runs `kubectl get <resource> -n <nonexistent-namespace>`,
kubectl silently prints "No resources found in X namespace." with exit
code 0, even when the namespace does not exist at all.

This is misleading because:
- The exit code 0 makes scripts and CI pipelines think the command succeeded
- Users have no way to distinguish a typo in namespace name from an empty namespace
- A namespace typo like `kubectl get pods -n producton` silently passes

This PR fixes kubectl to correctly surface the NotFound error from the
API server when the specified namespace does not exist.


#### Which issue(s) this PR is related to:

Related to #60974 (closed/stale, bug was never fixed)
Related to #31753 (closed/stale, bug was never fixed)

#### Special notes for your reviewer:

The fix propagates the NotFound error returned by the API server
when the namespace does not exist, instead of swallowing it and
printing the generic "No resources found" message.

Before this fix (stock kubectl):
  $ kubectl get pods -n nonexistent
  No resources found in nonexistent namespace.   ← exit code 0

After this fix:
  $ kubectl get pods -n nonexistent
  Error from server (NotFound): namespaces "nonexistent" not found  ← correct


#### Does this PR introduce a user-facing change?
```release-note
kubectl now returns an error when the specified namespace does not
exist, instead of silently printing "No resources found in X namespace."
```

#### Additional documentation: N/A

