### PR TITLE
Fix Summary API resource usage test and static check lint issues

### DIFF
--- a/test/e2e/storage/testsuites/volumemode.go
+++ b/test/e2e/storage/testsuites/volumemode.go
@@ -149,6 +149,7 @@ func (t *volumeModeTestSuite) DefineTests(driver storageframework.TestDriver, pa
 				scName = fmt.Sprintf("%s-%s-sc-for-file", l.ns.Name, dInfo.Name)
 			}
 			if pDriver, ok := driver.(storageframework.PreprovisionedPVTestDriver); ok {
+				//lint:ignore SA5011 If pvSource == nil we are already skipping test.
 				pvSource, volumeNodeAffinity = pDriver.GetPersistentVolumeSource(false, fsType, l.Volume)
 				if pvSource == nil {
 					e2eskipper.Skipf("Driver %q does not define PersistentVolumeSource - skipping", dInfo.Name)

--- a/test/e2e/windows/eviction.go
+++ b/test/e2e/windows/eviction.go
@@ -90,7 +90,7 @@ var _ = sigDescribe(feature.Windows, "Eviction", framework.WithSerial(), framewo
 				break
 			}
 		}
-
+		//lint:ignore SA5011 If node == nil we are already skipping test.
 		if node == nil {
 			e2eskipper.Skipf("No Windows nodes with hard memory-pressure eviction found")
 		}

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -99,10 +99,10 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 					"CPU": ptrMatchAllFields(gstruct.Fields{
 						"Time": recent(maxStatsAge),
 						// CRI stats provider tries to estimate the value of UsageNanoCores. This value can be
-						// either 0 or between 10000 and 2e9.
+						// either 0 or between 10000 and 2e10.
 						// Please refer, https://github.com/kubernetes/kubernetes/pull/95345#discussion_r501630942
 						// for more information.
-						"UsageNanoCores":       gomega.SatisfyAny(gstruct.PointTo(gomega.BeZero()), bounded(10000, 2e9)),
+						"UsageNanoCores":       gomega.SatisfyAny(gstruct.PointTo(gomega.BeZero()), bounded(10000, 2e10)),
 						"UsageCoreNanoSeconds": bounded(10000000, 1e15),
 						"PSI":                  psiExpectation(),
 					}),
@@ -181,8 +181,8 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 						"StartTime": recent(maxStartAge),
 						"CPU": ptrMatchAllFields(gstruct.Fields{
 							"Time":                 recent(maxStatsAge),
-							"UsageNanoCores":       bounded(10000, 1e9),
-							"UsageCoreNanoSeconds": bounded(10000000, 1e11),
+							"UsageNanoCores":       bounded(10000, 2e10),
+							"UsageCoreNanoSeconds": bounded(10000000, 1e15),
 							"PSI":                  psiExpectation(),
 						}),
 						"Memory": ptrMatchAllFields(gstruct.Fields{
@@ -232,8 +232,8 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 				}),
 				"CPU": ptrMatchAllFields(gstruct.Fields{
 					"Time":                 recent(maxStatsAge),
-					"UsageNanoCores":       bounded(10000, 1e9),
-					"UsageCoreNanoSeconds": bounded(10000000, 1e11),
+					"UsageNanoCores":       bounded(10000, 2e10),
+					"UsageCoreNanoSeconds": bounded(10000000, 1e15),
 					"PSI":                  psiExpectation(),
 				}),
 				"Memory": ptrMatchAllFields(gstruct.Fields{
@@ -285,7 +285,7 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 					"SystemContainers": gstruct.MatchAllElements(summaryObjectID, systemContainers),
 					"CPU": ptrMatchAllFields(gstruct.Fields{
 						"Time":                 recent(maxStatsAge),
-						"UsageNanoCores":       bounded(100e3, 2e9),
+						"UsageNanoCores":       bounded(100e3, 2e10),
 						"UsageCoreNanoSeconds": bounded(1e9, 1e15),
 						"PSI":                  psiExpectation(),
 					}),
@@ -510,7 +510,7 @@ func getSummaryTestPods(f *framework.Framework, numRestarts int32, names ...stri
 								Add: []v1.Capability{"NET_RAW"},
 							},
 						},
-						Command: getRestartingContainerCommand("/test-empty-dir-mnt", 0, numRestarts, "echo 'some bytes' >/outside_the_volume.txt; ping -c 1 google.com; echo 'hello world' >> /test-empty-dir-mnt/file;"),
+						Command: getRestartingContainerCommand("/test-empty-dir-mnt", 0, numRestarts, "echo 'some bytes' >/outside_the_volume.txt; ping -c 10 -s 100 -v google.com; echo 'hello world' >> /test-empty-dir-mnt/file; echo 720;openssl speed -multi $(grep -ci processor /proc/cpuinfo)"),
 						Resources: v1.ResourceRequirements{
 							Limits: v1.ResourceList{
 								// Must set memory limit to get MemoryStats.AvailableBytes


### PR DESCRIPTION
Make the process in the container more cpu intensive to make sure we catch CPU usage more than nanocore, within the test window to overcome a known limitation in older containerd versions.

in the process added two comments to skip lint static checks in one storage and one windows test.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind failing-test

#### What this PR does / why we need it:

Attempt https://github.com/kubernetes/kubernetes/issues/138402#issuecomment-4254723726 suggestion.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Attempt to fix  https://github.com/kubernetes/kubernetes/issues/138402

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
