### PR TITLE
build: skip VCS stamping when git status fails inside container builds

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -949,10 +949,7 @@ kube::golang::build_binaries() {
       grpcnotrace=",grpcnotrace"
   fi
 
-  # If git cannot read the repository (e.g. host git wrote a multi-pack-index
-  # version the container git doesn't recognise), disable Go's VCS stamping so
-  # the build doesn't fail.  Kubernetes version info is embedded via -ldflags
-  # and is unaffected by this flag.
+  # Disable Go VCS stamping if git can't read the repo (e.g. multi-pack-index version mismatch).
   if ! git -C "${KUBE_ROOT}" status --porcelain &>/dev/null; then
     kube::log::warning "git status failed; disabling VCS stamping (-buildvcs=false)"
     goflags+=("-buildvcs=false")

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -949,6 +949,15 @@ kube::golang::build_binaries() {
       grpcnotrace=",grpcnotrace"
   fi
 
+  # If git cannot read the repository (e.g. host git wrote a multi-pack-index
+  # version the container git doesn't recognise), disable Go's VCS stamping so
+  # the build doesn't fail.  Kubernetes version info is embedded via -ldflags
+  # and is unaffected by this flag.
+  if ! git -C "${KUBE_ROOT}" status --porcelain &>/dev/null; then
+    kube::log::warning "git status failed; disabling VCS stamping (-buildvcs=false)"
+    goflags+=("-buildvcs=false")
+  fi
+
   # Extract tags if any specified in GOFLAGS
   gotags="selinux,notest${grpcnotrace},$(echo "${GOFLAGS:-}" | sed -ne 's|.*-tags=\([^-]*\).*|\1|p')"
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The kube-cross container ships an older git that cannot read multi-pack-index v2 written by newer host git, causing `go install` to fail VCS stamping and breaking `make quick-release-images` / `build/run.sh`. This probes `git status` and adds `-buildvcs=false` when it fails. Version info is already embedded via explicit ldflags, so nothing is lost.

#### Which issue(s) this PR is related to:

Fixes #138325

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
Fix containerized builds (`make quick-release-images`, `build/run.sh`) failing with "error obtaining VCS status" when the host git writes a multi-pack-index version newer than the container git understands.
```