### PR TITLE
test/integration/etcd: restore ExpectedGVK pin for MutatingAdmissionPolicy rows

### DIFF
--- a/test/integration/etcd/data.go
+++ b/test/integration/etcd/data.go
@@ -492,12 +492,14 @@ func GetEtcdStorageDataForNamespaceServedAt(namespace string, v string, isEmulat
 		gvr("admissionregistration.k8s.io", "v1beta1", "mutatingadmissionpolicies"): {
 			Stub:              `{"metadata":{"name":"map1b1"},"spec":{"paramKind":{"apiVersion":"test.example.com/v1","kind":"Example"},"matchConstraints":{"resourceRules": [{"resourceNames": ["fakeName"], "apiGroups":["apps"],"apiVersions":["v1"],"operations":["CREATE", "UPDATE"], "resources":["deployments"]}]},"reinvocationPolicy": "IfNeeded","mutations":[{"applyConfiguration": {"expression":"Object{metadata: Object.metadata{labels: {'example':'true'}}}"}, "patchType":"ApplyConfiguration"}]}}`,
 			ExpectedEtcdPath:  "/registry/mutatingadmissionpolicies/map1b1",
+			ExpectedGVK:       gvkP("admissionregistration.k8s.io", "v1beta1", "MutatingAdmissionPolicy"),
 			IntroducedVersion: "1.34",
 			RemovedVersion:    "1.40",
 		},
 		gvr("admissionregistration.k8s.io", "v1beta1", "mutatingadmissionpolicybindings"): {
 			Stub:              `{"metadata":{"name":"mpb1b1"},"spec":{"policyName":"replicalimit-policy.example.com","paramRef":{"name":"replica-limit-test.example.com", "parameterNotFoundAction": "Allow"}}}`,
 			ExpectedEtcdPath:  "/registry/mutatingadmissionpolicybindings/mpb1b1",
+			ExpectedGVK:       gvkP("admissionregistration.k8s.io", "v1beta1", "MutatingAdmissionPolicyBinding"),
 			IntroducedVersion: "1.34",
 			RemovedVersion:    "1.40",
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#138281 pinned the `MutatingAdmissionPolicy` and `MutatingAdmissionPolicyBinding` storage version to `v1beta1` via `pkg/kubeapiserver/default_storage_factory_builder.go`, and as part of that change removed the `ExpectedGVK` field from the corresponding rows in `test/integration/etcd/data.go`. As a result, `test/integration/etcd/etcd_storage_path_test.go` now falls back to the apiserver's discovery mapping when it validates what was persisted in etcd:

* [`etcd_storage_path_test.go#L193-L198`](https://github.com/kubernetes/kubernetes/blob/master/test/integration/etcd/etcd_storage_path_test.go#L193-L198) — scheme registration falls back to `gvk` from the mapping when `ExpectedGVK` is nil.
* [`etcd_storage_path_test.go#L209-L212`](https://github.com/kubernetes/kubernetes/blob/master/test/integration/etcd/etcd_storage_path_test.go#L209-L212) — `expectedGVK := gvk` falls back to the mapping's GVK.
* [`etcd_storage_path_test.go#L257-L260`](https://github.com/kubernetes/kubernetes/blob/master/test/integration/etcd/etcd_storage_path_test.go#L257-L260) — the assertion then compares the etcd-stored GVK against the apiserver-inferred GVK.

Because both sides of that comparison derive from the same registration path, if the storage-version auto-calc ever regresses again (the exact class of bug #138281 fixed), both sides would drift together and the assertion would still pass silently.

Re-adding `ExpectedGVK` gives the test an independent pin, matching the convention used on every other non-cohabiting row in the same file (for example `autoscaling/v2 HorizontalPodAutoscaler` at line 185, `certificates.k8s.io/v1beta1 ClusterTrustBundle` at line 223, `storage.k8s.io/v1 VolumeAttributesClass` at line 391, `resource.k8s.io/v1 DeviceClass` at line 620). No runtime behavior is affected; this is test-only hardening.

#### Which issue(s) this PR is related to:

Follow-up to #138281.

#### Special notes for your reviewer:

* 2-line diff, test-only, zero runtime impact.
* Restores parity with the surrounding rows in `data.go`.
* The cross-group test at `test/integration/etcd/etcd_cross_group_test.go#L54-L58` also benefits from the pin since it groups resources by `ExpectedGVK` when present.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

/sig api-machinery
/kind cleanup
/cc @Jefftree @liggitt @deads2k @jpbetz
