### PR TITLE
kubelet: zero QoS-level memory.min / memory.low when MemoryQoS is disabled

### DIFF
--- a/pkg/kubelet/cm/qos_container_manager_linux.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux.go
@@ -300,7 +300,8 @@ func (m *qosContainerManagerImpl) setMemoryQoS(logger klog.Logger, configs map[v
 		logger.V(4).Info("MemoryQoS config for qos", "qos", qos, "key", key, "value", value)
 	}
 
-	if m.memoryReservationPolicy != kubeletconfig.TieredReservationMemoryReservationPolicy {
+	if !utilfeature.DefaultFeatureGate.Enabled(kubefeatures.MemoryQoS) ||
+		m.memoryReservationPolicy != kubeletconfig.TieredReservationMemoryReservationPolicy {
 		setUnified(v1.PodQOSGuaranteed, Cgroup2MemoryMin, 0)
 		setUnified(v1.PodQOSBurstable, Cgroup2MemoryLow, 0)
 		kubeletmetrics.MemoryQoSNodeMemoryMinBytes.Set(0)
@@ -353,9 +354,13 @@ func (m *qosContainerManagerImpl) UpdateCgroups(logger logr.Logger) error {
 		return err
 	}
 
-	// Update cgroup v2 memory.min settings. Called only when MemoryQoS is
-	// enabled and cgroups v2 is the unified mode.
-	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.MemoryQoS) && libcontainercgroups.IsCgroup2UnifiedMode() {
+	// Update cgroup v2 memory.min / memory.low settings. Called on every
+	// UpdateCgroups cycle when cgroups v2 is the unified mode so that
+	// previously written values are reset to zero when the MemoryQoS feature
+	// gate or the tiered reservation policy is disabled. The feature-gate
+	// check lives inside setMemoryQoS so only the populating branch is gated;
+	// the zero-out branch remains reachable and clears stale kernel values.
+	if libcontainercgroups.IsCgroup2UnifiedMode() {
 		m.setMemoryQoS(logger, qosConfigs)
 	}
 

--- a/pkg/kubelet/cm/qos_container_manager_linux_test.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux_test.go
@@ -34,8 +34,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
+	kubefeatures "k8s.io/kubernetes/pkg/features"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 )
 
@@ -285,6 +288,59 @@ func TestQoSContainerCgroupWithMemoryReservationPolicyNone(t *testing.T) {
 
 	assert.Equal(t, "0", qosConfigs[v1.PodQOSGuaranteed].ResourceParameters.Unified[Cgroup2MemoryMin])
 	assert.Equal(t, "0", qosConfigs[v1.PodQOSBurstable].ResourceParameters.Unified[Cgroup2MemoryLow])
+}
+
+// TestQoSContainerCgroupClearsWhenMemoryQoSFeatureGateDisabled verifies that
+// setMemoryQoS zeros QoS-level memory.min / memory.low even when the
+// MemoryQoS feature gate is disabled. This prevents stale kernel values from
+// persisting on nodes that previously ran with the gate enabled; without this
+// guarantee, operators rolling back the alpha feature would leave non-zero
+// memory.min / memory.low under /sys/fs/cgroup/kubepods.slice/... where the
+// kernel continues to honor them.
+func TestQoSContainerCgroupClearsWhenMemoryQoSFeatureGateDisabled(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, kubefeatures.MemoryQoS, false)
+
+	logger, _ := ktesting.NewTestContext(t)
+	fakeCM := &fakeCgroupManager{}
+	cgroupRoot := ParseCgroupfsToCgroupName("/")
+	cgroupRoot = NewCgroupName(cgroupRoot, defaultNodeAllocatableCgroupName)
+	m := &qosContainerManagerImpl{
+		cgroupManager: fakeCM,
+		cgroupRoot:    cgroupRoot,
+		activePods:    activeTestPods,
+		// TieredReservation would otherwise skip the zero-out branch via the
+		// policy check. With the gate off the zero-out branch must run
+		// regardless of the configured policy, so we deliberately exercise
+		// the TieredReservation case here.
+		memoryReservationPolicy: kubeletconfig.TieredReservationMemoryReservationPolicy,
+		qosContainersInfo: QOSContainersInfo{
+			Guaranteed: cgroupRoot,
+			Burstable:  NewCgroupName(cgroupRoot, "burstable"),
+			BestEffort: NewCgroupName(cgroupRoot, "besteffort"),
+		},
+	}
+
+	qosConfigs := map[v1.PodQOSClass]*CgroupConfig{
+		v1.PodQOSGuaranteed: {
+			Name:               m.qosContainersInfo.Guaranteed,
+			ResourceParameters: &ResourceConfig{},
+		},
+		v1.PodQOSBurstable: {
+			Name:               m.qosContainersInfo.Burstable,
+			ResourceParameters: &ResourceConfig{},
+		},
+		v1.PodQOSBestEffort: {
+			Name:               m.qosContainersInfo.BestEffort,
+			ResourceParameters: &ResourceConfig{},
+		},
+	}
+
+	m.setMemoryQoS(logger, qosConfigs)
+
+	assert.Equal(t, "0", qosConfigs[v1.PodQOSGuaranteed].ResourceParameters.Unified[Cgroup2MemoryMin],
+		"memory.min must be zeroed when MemoryQoS is disabled to clear stale values")
+	assert.Equal(t, "0", qosConfigs[v1.PodQOSBurstable].ResourceParameters.Unified[Cgroup2MemoryLow],
+		"memory.low must be zeroed when MemoryQoS is disabled to clear stale values")
 }
 
 // fakeCgroupManager is used because Start() requires a functional


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

**Problem.** #138430 gated the call to `setMemoryQoS` inside `UpdateCgroups` behind `utilfeature.DefaultFeatureGate.Enabled(kubefeatures.MemoryQoS)` on cgroup v2 unified mode. As a side effect, the zero-out branch in `setMemoryQoS` at [`pkg/kubelet/cm/qos_container_manager_linux.go#L303-L308`](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cm/qos_container_manager_linux.go#L303-L308) — which resets QoS-level `memory.min` and `memory.low` to 0 when `memoryReservationPolicy != TieredReservation` — is now unreachable whenever the gate is off. On nodes that previously ran with the alpha feature enabled, the QoS-level `memory.min` and `memory.low` values the kubelet wrote into `/sys/fs/cgroup/kubepods.slice/...` are retained after the gate is disabled, and the kernel continues to honor them.

**Why it matters.** Stale QoS-level protection values can bias the OOM killer: workloads can be protected from OOM that should not be, or peer workloads can be starved of reclaimable memory. This is the exact class of bug that motivated the pod-level reconciliation added in #137726, and issue #137674 explicitly documented the assumption that *"QoS-level cgroups are correctly reset via the periodic `setMemoryQoS()` loop"*. That assumption was silently invalidated by #138430. The pod-level fix in #137726 does not cover QoS-level cgroups, so the stale values persist indefinitely until reboot.

**Fix.** Keep `setMemoryQoS` unconditional on cgroup v2 unified mode and move the feature-gate check inside the function so only the *populating* branch is gated; the *zero-out* branch remains reachable when the gate is off and clears the stale kernel values on the next `UpdateCgroups` cycle. This preserves the original cleanup contract with the minimal surface-area change, and is structurally symmetric to the pod-level `ReconcilePodMemoryMin` approach from #137726.

**Alternative considered.** Adding a QoS-level analogue of `ReconcilePodMemoryMin` on `qosContainerManagerImpl`. I went with the in-place gate move because the diff is smaller, the existing zero-out branch is already correct, and the combined call-site + body change reads more locally. Happy to switch to the separate reconcile method if sig-node prefers the fully symmetric shape with #137726.

#### Which issue(s) this PR is related to:

Fixes #138436.

#### Special notes for your reviewer:

* Two-location change: the call site at `UpdateCgroups` (drops the gate check) and the first conditional inside `setMemoryQoS` (adds the gate check so the zero-out branch fires when the gate is disabled).
* New test `TestQoSContainerCgroupClearsWhenMemoryQoSFeatureGateDisabled` deliberately configures `TieredReservationMemoryReservationPolicy` with the gate disabled — that is the case that previously failed to reach the zero-out branch — and asserts `memory.min` / `memory.low` are set to `"0"`.
* Existing `TestQoSContainerCgroupWithMemoryReservationPolicyNone` continues to cover the gate-enabled-but-policy-None path.
* No user-facing behavior change when the gate is enabled.

#### Does this PR introduce a user-facing change?

```release-note
kubelet: QoS-level cgroup `memory.min` and `memory.low` values are now reset to 0 when the MemoryQoS feature gate is disabled, preventing stale protection values from persisting across a rollback of the alpha feature.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

/sig node
/area kubelet
/kind bug
/kind regression
/cc @roycaihw @SergeyKanzhelev @kannon92 @sohankunkerkar
