### PR TITLE
cri-api: document CreateContainerRequest sandbox_config semantics

### DIFF
--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.pb.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.pb.go
@@ -5851,20 +5851,45 @@ type CreateContainerRequest struct {
 	//
 	// This field is not guaranteed to match the PodSandboxConfig that was
 	// originally passed to RunPodSandboxRequest for pod_sandbox_id. The kubelet
-	// may surface an updated view of the pod (for example after in-place
-	// resource resize via UpdatePodSandboxResourcesRequest, or other pod spec
-	// changes that affect sandbox configuration).
+	// may pass an updated or different view for reasons other than a changed
+	// core pod spec alone: in-place sandbox or resource changes (for example
+	// pod-level resource limits coordinated with the kubelet as part of a resize
+	// or other actuation), a kubelet restart with different feature gates or
+	// other kubelet settings (which can change the effective pod sandbox
+	// configuration the kubelet sends in sandbox_config), and any other case
+	// where the live kubelet state does not match what RunPodSandbox was told
+	// for this pod_sandbox_id.
+	//
+	// The CRI does not specify a global ordering between CreateContainer and
+	// other sandbox RPCs (for example UpdatePodSandboxResources) or a
+	// success-guarantee that must hold before a new container is created: a
+	// runtime MUST NOT assume the last UpdatePodSandboxResources (or any other
+	// sandbox update) for this pod_sandbox_id has already succeeded, or that
+	// the in-runtime pod sandbox matches every value the runtime last
+	// acknowledged, at the time CreateContainer is invoked. The kubelet
+	// interleaves pod- and container-level actuation in implementation-defined
+	// order (for example in-place resource updates adjust pod- and
+	// container-level cgroups with UpdatePodSandboxResources and
+	// UpdateContainerResources, often one resource at a time); an
+	// unrecoverable error in that pipeline can leave the actuation partially
+	// done while the kubelet may still call CreateContainer with
+	// sandbox_config reflecting the kubelet's current intent. This field is
+	// that intended pod sandbox for this create even when the in-runtime state
+	// may not yet match it.
 	//
 	// The container runtime MUST select the running sandbox using pod_sandbox_id.
 	// For information that affects the newly created container (including pod
 	// annotations the kubelet expects the workload to see at container creation
 	// time), the runtime MUST treat sandbox_config from this request as the
-	// kubelet's authoritative input, rather than inferring it solely from
+	// kubelet's input for the create, rather than inferring it solely from
 	// internal sandbox state that may be stale or modified out-of-band (for
-	// example by host-level extensions). If a requested value cannot be
-	// honored because it conflicts with the live sandbox, the runtime SHOULD
-	// fail this RPC with an error instead of silently diverging from the
-	// kubelet's requested configuration.
+	// example by host-level extensions). If the runtime can determine a
+	// requested value is incompatible with applying the kubelet's request for
+	// the new container, the runtime should return an error; otherwise,
+	// runtimes and versions differ in which conflicts can be detected and
+	// reported, and the kubelet supplies this field so the runtime can align
+	// the new container with the kubelet's current desired sandbox state
+	// independent of the runtime's internal view.
 	//
 	// Runtimes MUST NOT assume that fields omitted or unchanged in
 	// sandbox_config relative to an earlier RunPodSandboxRequest imply that no

--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.pb.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.pb.go
@@ -5846,10 +5846,29 @@ type CreateContainerRequest struct {
 	PodSandboxId string `protobuf:"bytes,1,opt,name=pod_sandbox_id,json=podSandboxId,proto3" json:"pod_sandbox_id,omitempty"`
 	// Config of the container.
 	Config *ContainerConfig `protobuf:"bytes,2,opt,name=config,proto3" json:"config,omitempty"`
-	// Config of the PodSandbox. This is the same config that was passed
-	// to RunPodSandboxRequest to create the PodSandbox. It is passed again
-	// here just for easy reference. The PodSandboxConfig is immutable and
-	// remains the same throughout the lifetime of the pod.
+	// PodSandboxConfig as understood by the kubelet at the time this container
+	// is created.
+	//
+	// This field is not guaranteed to match the PodSandboxConfig that was
+	// originally passed to RunPodSandboxRequest for pod_sandbox_id. The kubelet
+	// may surface an updated view of the pod (for example after in-place
+	// resource resize via UpdatePodSandboxResourcesRequest, or other pod spec
+	// changes that affect sandbox configuration).
+	//
+	// The container runtime MUST select the running sandbox using pod_sandbox_id.
+	// For information that affects the newly created container (including pod
+	// annotations the kubelet expects the workload to see at container creation
+	// time), the runtime MUST treat sandbox_config from this request as the
+	// kubelet's authoritative input, rather than inferring it solely from
+	// internal sandbox state that may be stale or modified out-of-band (for
+	// example by host-level extensions). If a requested value cannot be
+	// honored because it conflicts with the live sandbox, the runtime SHOULD
+	// fail this RPC with an error instead of silently diverging from the
+	// kubelet's requested configuration.
+	//
+	// Runtimes MUST NOT assume that fields omitted or unchanged in
+	// sandbox_config relative to an earlier RunPodSandboxRequest imply that no
+	// other sandbox mutation occurred in the meantime.
 	SandboxConfig *PodSandboxConfig `protobuf:"bytes,3,opt,name=sandbox_config,json=sandboxConfig,proto3" json:"sandbox_config,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.proto
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.proto
@@ -1369,10 +1369,29 @@ message CreateContainerRequest {
     string pod_sandbox_id = 1;
     // Config of the container.
     ContainerConfig config = 2;
-    // Config of the PodSandbox. This is the same config that was passed
-    // to RunPodSandboxRequest to create the PodSandbox. It is passed again
-    // here just for easy reference. The PodSandboxConfig is immutable and
-    // remains the same throughout the lifetime of the pod.
+    // PodSandboxConfig as understood by the kubelet at the time this container
+    // is created.
+    //
+    // This field is not guaranteed to match the PodSandboxConfig that was
+    // originally passed to RunPodSandboxRequest for pod_sandbox_id. The kubelet
+    // may surface an updated view of the pod (for example after in-place
+    // resource resize via UpdatePodSandboxResourcesRequest, or other pod spec
+    // changes that affect sandbox configuration).
+    //
+    // The container runtime MUST select the running sandbox using pod_sandbox_id.
+    // For information that affects the newly created container (including pod
+    // annotations the kubelet expects the workload to see at container creation
+    // time), the runtime MUST treat sandbox_config from this request as the
+    // kubelet's authoritative input, rather than inferring it solely from
+    // internal sandbox state that may be stale or modified out-of-band (for
+    // example by host-level extensions). If a requested value cannot be
+    // honored because it conflicts with the live sandbox, the runtime SHOULD
+    // fail this RPC with an error instead of silently diverging from the
+    // kubelet's requested configuration.
+    //
+    // Runtimes MUST NOT assume that fields omitted or unchanged in
+    // sandbox_config relative to an earlier RunPodSandboxRequest imply that no
+    // other sandbox mutation occurred in the meantime.
     PodSandboxConfig sandbox_config = 3;
 }
 

--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.proto
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.proto
@@ -1374,20 +1374,45 @@ message CreateContainerRequest {
     //
     // This field is not guaranteed to match the PodSandboxConfig that was
     // originally passed to RunPodSandboxRequest for pod_sandbox_id. The kubelet
-    // may surface an updated view of the pod (for example after in-place
-    // resource resize via UpdatePodSandboxResourcesRequest, or other pod spec
-    // changes that affect sandbox configuration).
+    // may pass an updated or different view for reasons other than a changed
+    // core pod spec alone: in-place sandbox or resource changes (for example
+    // pod-level resource limits coordinated with the kubelet as part of a resize
+    // or other actuation), a kubelet restart with different feature gates or
+    // other kubelet settings (which can change the effective pod sandbox
+    // configuration the kubelet sends in sandbox_config), and any other case
+    // where the live kubelet state does not match what RunPodSandbox was told
+    // for this pod_sandbox_id.
+    //
+    // The CRI does not specify a global ordering between CreateContainer and
+    // other sandbox RPCs (for example UpdatePodSandboxResources) or a
+    // success-guarantee that must hold before a new container is created: a
+    // runtime MUST NOT assume the last UpdatePodSandboxResources (or any other
+    // sandbox update) for this pod_sandbox_id has already succeeded, or that
+    // the in-runtime pod sandbox matches every value the runtime last
+    // acknowledged, at the time CreateContainer is invoked. The kubelet
+    // interleaves pod- and container-level actuation in implementation-defined
+    // order (for example in-place resource updates adjust pod- and
+    // container-level cgroups with UpdatePodSandboxResources and
+    // UpdateContainerResources, often one resource at a time); an
+    // unrecoverable error in that pipeline can leave the actuation partially
+    // done while the kubelet may still call CreateContainer with
+    // sandbox_config reflecting the kubelet's current intent. This field is
+    // that intended pod sandbox for this create even when the in-runtime state
+    // may not yet match it.
     //
     // The container runtime MUST select the running sandbox using pod_sandbox_id.
     // For information that affects the newly created container (including pod
     // annotations the kubelet expects the workload to see at container creation
     // time), the runtime MUST treat sandbox_config from this request as the
-    // kubelet's authoritative input, rather than inferring it solely from
+    // kubelet's input for the create, rather than inferring it solely from
     // internal sandbox state that may be stale or modified out-of-band (for
-    // example by host-level extensions). If a requested value cannot be
-    // honored because it conflicts with the live sandbox, the runtime SHOULD
-    // fail this RPC with an error instead of silently diverging from the
-    // kubelet's requested configuration.
+    // example by host-level extensions). If the runtime can determine a
+    // requested value is incompatible with applying the kubelet's request for
+    // the new container, the runtime should return an error; otherwise,
+    // runtimes and versions differ in which conflicts can be detected and
+    // reported, and the kubelet supplies this field so the runtime can align
+    // the new container with the kubelet's current desired sandbox state
+    // independent of the runtime's internal view.
     //
     // Runtimes MUST NOT assume that fields omitted or unchanged in
     // sandbox_config relative to an earlier RunPodSandboxRequest imply that no

--- a/staging/src/k8s.io/cri-api/pkg/apis/services.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/services.go
@@ -33,8 +33,10 @@ type RuntimeVersioner interface {
 // container runtime. The methods are thread-safe.
 type ContainerManager interface {
 	// CreateContainer creates a new container in specified PodSandbox.
-	// sandboxConfig is the kubelet's view of the pod sandbox at creation time;
-	// see CreateContainerRequest.sandbox_config in the CRI API for semantics.
+	// sandboxConfig is the kubelet's current requested pod sandbox for this
+	// create, which is not always identical to the PodSandboxConfig that was
+	// passed to RunPodSandbox; see CreateContainerRequest.sandbox_config in the
+	// CRI API for when and how it can differ, including from the live runtime.
 	CreateContainer(ctx context.Context, podSandboxID string, config *runtimeapi.ContainerConfig, sandboxConfig *runtimeapi.PodSandboxConfig) (string, error)
 	// StartContainer starts the container.
 	StartContainer(ctx context.Context, containerID string) error

--- a/staging/src/k8s.io/cri-api/pkg/apis/services.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/services.go
@@ -33,6 +33,8 @@ type RuntimeVersioner interface {
 // container runtime. The methods are thread-safe.
 type ContainerManager interface {
 	// CreateContainer creates a new container in specified PodSandbox.
+	// sandboxConfig is the kubelet's view of the pod sandbox at creation time;
+	// see CreateContainerRequest.sandbox_config in the CRI API for semantics.
 	CreateContainer(ctx context.Context, podSandboxID string, config *runtimeapi.ContainerConfig, sandboxConfig *runtimeapi.PodSandboxConfig) (string, error)
 	// StartContainer starts the container.
 	StartContainer(ctx context.Context, containerID string) error

--- a/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go
@@ -76,6 +76,12 @@ type FakeRuntimeService struct {
 	FakeLinuxConfiguration *runtimeapi.LinuxRuntimeConfiguration
 
 	ErrorOnSandboxCreate bool
+
+	// LastCreateContainerSandboxConfig holds a clone of the sandbox_config from
+	// the most recent successful CreateContainer call (nil if that argument was
+	// nil). It is intended for tests asserting CRI CreateContainerRequest
+	// semantics.
+	LastCreateContainerSandboxConfig *runtimeapi.PodSandboxConfig
 }
 
 // GetContainerID returns the unique container ID from the FakeRuntimeService.
@@ -366,6 +372,12 @@ func (r *FakeRuntimeService) CreateContainer(_ context.Context, podSandboxID str
 	r.Called = append(r.Called, "CreateContainer")
 	if err := r.popError("CreateContainer"); err != nil {
 		return "", err
+	}
+
+	if sandboxConfig != nil {
+		r.LastCreateContainerSandboxConfig = proto.Clone(sandboxConfig).(*runtimeapi.PodSandboxConfig)
+	} else {
+		r.LastCreateContainerSandboxConfig = nil
 	}
 
 	// ContainerID should be randomized for real container runtime, but here just use

--- a/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service_create_container_test.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service_create_container_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// TestCreateContainerSandboxConfigReflectsKubeletView documents that
+// CreateContainerRequest.sandbox_config may differ from the config used at
+// RunPodSandbox (see CRI api.proto). The fake records the latest sandbox_config
+// for test assertions.
+func TestCreateContainerSandboxConfigReflectsKubeletView(t *testing.T) {
+	ctx := context.Background()
+	r := NewFakeRuntimeService()
+
+	md := &runtimeapi.PodSandboxMetadata{Name: "pod", Uid: "uid", Namespace: "ns", Attempt: 0}
+	runCfg := &runtimeapi.PodSandboxConfig{
+		Metadata: md,
+		Annotations: map[string]string{
+			"key": "value-at-run-pod-sandbox",
+		},
+		Linux: &runtimeapi.LinuxPodSandboxConfig{},
+	}
+
+	sandboxID, err := r.RunPodSandbox(ctx, runCfg, "")
+	if err != nil {
+		t.Fatalf("RunPodSandbox: %v", err)
+	}
+
+	createCfg := proto.Clone(runCfg).(*runtimeapi.PodSandboxConfig)
+	createCfg.Annotations = map[string]string{
+		"key": "value-at-create-container",
+	}
+
+	_, err = r.CreateContainer(ctx, sandboxID, &runtimeapi.ContainerConfig{
+		Metadata: &runtimeapi.ContainerMetadata{Name: "ctr", Attempt: 0},
+		Image:    &runtimeapi.ImageSpec{Image: "busybox"},
+		Labels:   map[string]string{},
+	}, createCfg)
+	if err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+
+	r.Lock()
+	last := r.LastCreateContainerSandboxConfig
+	r.Unlock()
+	if last == nil {
+		t.Fatal("expected LastCreateContainerSandboxConfig to be set")
+	}
+	if got := last.Annotations["key"]; got != "value-at-create-container" {
+		t.Fatalf("expected kubelet view of annotations at CreateContainer, got %q", got)
+	}
+}
+
+func TestCreateContainerNilSandboxConfigClearsLast(t *testing.T) {
+	ctx := context.Background()
+	r := NewFakeRuntimeService()
+	md := &runtimeapi.PodSandboxMetadata{Name: "pod", Uid: "uid2", Namespace: "ns", Attempt: 0}
+	runCfg := &runtimeapi.PodSandboxConfig{
+		Metadata: md,
+		Linux:    &runtimeapi.LinuxPodSandboxConfig{},
+	}
+	sandboxID, err := r.RunPodSandbox(ctx, runCfg, "")
+	if err != nil {
+		t.Fatalf("RunPodSandbox: %v", err)
+	}
+
+	if _, err := r.CreateContainer(ctx, sandboxID, &runtimeapi.ContainerConfig{
+		Metadata: &runtimeapi.ContainerMetadata{Name: "c1", Attempt: 0},
+		Image:    &runtimeapi.ImageSpec{Image: "img"},
+		Labels:   map[string]string{},
+	}, runCfg); err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+	if _, err := r.CreateContainer(ctx, sandboxID, &runtimeapi.ContainerConfig{
+		Metadata: &runtimeapi.ContainerMetadata{Name: "c2", Attempt: 0},
+		Image:    &runtimeapi.ImageSpec{Image: "img"},
+		Labels:   map[string]string{},
+	}, nil); err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+
+	r.Lock()
+	last := r.LastCreateContainerSandboxConfig
+	r.Unlock()
+	if last != nil {
+		t.Fatalf("expected nil last config after CreateContainer with nil sandbox_config, got %+v", last)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Updates the `CreateContainerRequest.sandbox_config` documentation in the CRI v1 API: the previous text claimed the config matched `RunPodSandbox` and was immutable, which is no longer accurate (e.g. in-place resize and other pod updates). The new comments describe how runtimes should use `pod_sandbox_id` vs `sandbox_config`, including annotations and conflict handling.

Also documents the same intent on `ContainerManager.CreateContainer` in `pkg/apis/services.go`, records the last `sandbox_config` on the CRI fake for tests, and adds unit tests that assert the kubelet may pass an updated `sandbox_config` at container creation time.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/138429

#### Special notes for your reviewer:

- `api.pb.go` was regenerated from `api.proto` via the standard proto bindings script.
- Issue text asked for “critest”; this PR adds regression coverage in `k8s.io/cri-api/pkg/apis/testing` instead of kubernetes-sigs/cri-tools. Say if you want a follow-up critest change tracked separately.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```NONE
```
