### PR TITLE
Add integration test for scheduler behavior across restarts

### DIFF
--- a/test/integration/scheduler/nominated_node_name/nominated_node_name_test.go
+++ b/test/integration/scheduler/nominated_node_name/nominated_node_name_test.go
@@ -731,3 +731,165 @@ func contains(pods []fwk.PodInfo, podName string) bool {
 	}
 	return false
 }
+
+type mockPreBindPlugin struct{}
+
+var _ fwk.PreBindPlugin = &mockPreBindPlugin{}
+
+func (p *mockPreBindPlugin) Name() string {
+	return "mockPreBindPlugin"
+}
+
+func (p *mockPreBindPlugin) PreBind(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *fwk.Status {
+	return nil
+}
+
+func (p *mockPreBindPlugin) PreBindPreFlight(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (*fwk.PreBindPreFlightResult, *fwk.Status) {
+	return &fwk.PreBindPreFlightResult{AllowParallel: false}, nil
+}
+
+type mockBindPlugin struct {
+	bindFn func() *fwk.Status
+}
+
+var _ fwk.BindPlugin = &mockBindPlugin{}
+
+func (p *mockBindPlugin) Name() string {
+	return "mockBindPlugin"
+}
+
+func (p *mockBindPlugin) Bind(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *fwk.Status {
+	return p.bindFn()
+}
+
+type mockQueueSortPlugin struct {
+	t     *testing.T
+	order map[string]int
+}
+
+var _ fwk.QueueSortPlugin = &mockQueueSortPlugin{}
+
+func (p *mockQueueSortPlugin) Name() string {
+	return "mockQueueSortPlugin"
+}
+
+func (p *mockQueueSortPlugin) Less(pInfo1, pInfo2 fwk.QueuedPodInfo) bool {
+	name1 := pInfo1.GetPodInfo().GetPod().Name
+	name2 := pInfo2.GetPodInfo().GetPod().Name
+	o1, ok1 := p.order[name1]
+	if !ok1 {
+		p.t.Errorf("order doesn't contain pod with the specified name: %s", name1)
+	}
+	o2, ok2 := p.order[name2]
+	if !ok2 {
+		p.t.Errorf("order doesn't contain pod with the specified name: %s", name2)
+	}
+	return o1 < o2
+}
+
+// TestSchedulerRestartWithNominatedNode checks that NNN properly reserves the pod's node despite scheduler restart during binding cycle.
+func TestSchedulerRestartWithNominatedNode(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NominatedNodeNameForExpectation, true)
+	testContext := testutils.InitTestAPIServer(t, "nnn-test", nil)
+	ctx, cancel := context.WithCancel(testContext.Ctx)
+	cs := testContext.ClientSet
+	defer cancel()
+
+	// nodePreferred can only hold a single pod
+	nodePreferred := st.MakeNode().Name("node-preferred").Capacity(map[v1.ResourceName]string{v1.ResourcePods: "1"}).Obj()
+	// nodeOther has taint with PreferNoSchedule
+	nodeOther := st.MakeNode().Name("node-other").Taints([]v1.Taint{{Key: "foo", Effect: v1.TaintEffectPreferNoSchedule}}).Obj()
+
+	for _, n := range []*v1.Node{nodePreferred, nodeOther} {
+		if _, err := testutils.CreateNode(cs, n); err != nil {
+			t.Fatalf("Failed to create node %s: %v", n.Name, err)
+		}
+	}
+
+	createPod := func(name string) *v1.Pod {
+		t.Helper()
+		pod, err := testutils.CreatePausePod(cs, testutils.InitPausePod(&testutils.PausePodConfig{
+			Name: name, Namespace: testContext.NS.Name}))
+		if err != nil {
+			t.Fatalf("Failed to create %s: %v", name, err)
+		}
+		return pod
+	}
+
+	podA := createPod("pod-a")
+
+	// Ensures desired pod order without affecting priorities, which could impact NNN logic.
+	mockQueueSort := &mockQueueSortPlugin{t: t, order: map[string]int{}}
+	// Ensures NNN is set
+	mockPreBind := &mockPreBindPlugin{}
+
+	initSched := func(additionalPlugins ...fwk.Plugin) (*testutils.TestContext, testutils.ShutdownFunc) {
+		var pls []fwk.Plugin
+		pls = append(pls, mockQueueSort, mockPreBind)
+		pls = append(pls, additionalPlugins...)
+		registry, prof := schedulerutils.InitRegistryAndConfig(t, nil, pls...)
+		return schedulerutils.InitTestSchedulerForFrameworkTest(t, testContext, 0,
+			false, /* do not run scheduler immediately after init */
+			scheduler.WithProfiles(prof),
+			scheduler.WithFrameworkOutOfTreeRegistry(registry),
+		)
+	}
+
+	// To allow triggering scheduler restart in binding phase, we need to initialize the scheduler
+	// and pass the testCtx.SchedulerCloseFn to the bind plugin before calling Scheduler.Run.
+	mockBind := &mockBindPlugin{}
+	testCtx, _ := initSched(mockBind)
+	// This will fail the binding cycle and stop the scheduler
+	// Scheduler should set NNN for podA before this step.
+	mockBind.bindFn = func() *fwk.Status {
+		testCtx.SchedulerCloseFn()
+		return fwk.NewStatus(fwk.Error, "simulated bind failure")
+	}
+	mockQueueSort.order[podA.Name] = 1
+
+	// Start scheduler
+	go testCtx.Scheduler.Run(testCtx.SchedulerCtx)
+
+	// We expect the scheduler will stop due to SchedulerCloseFn being called in bind
+	<-testCtx.SchedulerCtx.Done()
+
+	podA, err := testutils.GetPod(cs, podA.Name, podA.Namespace)
+	if err != nil {
+		t.Fatalf("Failed to get pod %s: %v", podA.Name, err)
+	}
+	if podA.Status.NominatedNodeName != nodePreferred.Name {
+		t.Errorf("Unexpected NominatedNodeName after scheduler abort for pod %s, got %s, want %s", podA.Name, podA.Status.NominatedNodeName, nodePreferred.Name)
+	}
+	if podA.Spec.NodeName != "" {
+		t.Errorf("Unexpected NodeName after scheduler abort for pod %s, got %s, want unset", podA.Name, podA.Spec.NodeName)
+	}
+
+	podB := createPod("pod-b")
+
+	// Make sure podB is evaluated before podA after scheduler restart
+	// The scheduler should see podA's nominated node and schedule podB elsewhere
+	mockQueueSort.order[podB.Name] = mockQueueSort.order[podA.Name] - 1
+
+	// This time use the default bind plugin
+	testCtx, teardown := initSched()
+	defer teardown()
+
+	// Start scheduler again
+	go testCtx.Scheduler.Run(testCtx.SchedulerCtx)
+
+	for _, pod := range []*v1.Pod{podA, podB} {
+		if err := testutils.WaitForPodToSchedule(ctx, cs, pod); err != nil {
+			t.Errorf("Failed waiting for pod %s: %v", pod.Name, err)
+		}
+	}
+
+	checkNode := func(pod *v1.Pod, expected string) {
+		t.Helper()
+		p, _ := testutils.GetPod(cs, pod.Name, pod.Namespace)
+		if p.Spec.NodeName != expected {
+			t.Errorf("%s scheduled on %s, wanted %s", pod.Name, p.Spec.NodeName, expected)
+		}
+	}
+	checkNode(podA, nodePreferred.Name)
+	checkNode(podB, nodeOther.Name)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

It's important to test that the NominatedNodeName is correctly set and interpreted by the scheduler when binding is interrupted.

Previous integration test coverage is only partial and doesn't cover the full flow.

This test checks the following scenario:
1. Initialize preferred-node with capacity for at most 1 pod
2. Initialize other-node with PreferNoSchedule taint
3. Set up PreBind plugin to cause scheduler shutdown
4. Schedule pod-a
5. Once pod-a reaches PreBind, the scheduler is shut down. By that point, pod-a should already have NominatedNodeName set to preferred-node
6. Restart scheduler
7. Schedule pod-b. Because pod-a has NominatedNodeName for preferred-node, pod-b has to choose other-node
8. Schedule pod-a
9. Verify pod-b is on other-node and pod-a is on preferred-node

I verified this scenario with the NNN feature gate disabled and it failed as expected.

Note that this same scenario would fail if instead of scheduler restart we invoked binding failure, as binding failure clears NNN.

Based on #135854. Some changes (refactoring) have been done with AI assistance.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Related to #135771

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
