### PR TITLE
Fix pod updated with deletion timestamp not being removed from cached podGroupState

### DIFF
--- a/pkg/scheduler/backend/cache/cache.go
+++ b/pkg/scheduler/backend/cache/cache.go
@@ -409,6 +409,21 @@ func (cache *cacheImpl) AssumePod(logger klog.Logger, pod *v1.Pod) error {
 	return cache.addPod(logger, pod, true)
 }
 
+// validateAssumedPod checks that the given pod is currently assumed.
+// Assumes that lock is already acquired.
+func (cache *cacheImpl) validateAssumedPod(pod *v1.Pod, key string, currState *podState) error {
+	if currState.pod.Spec.NodeName != pod.Spec.NodeName {
+		return fmt.Errorf("pod %v(%v) was assumed on %v but assigned to %v", key, klog.KObj(pod), pod.Spec.NodeName, currState.pod.Spec.NodeName)
+	}
+	if !cache.assumedPods.Has(key) {
+		return fmt.Errorf("pod %v(%v) is not assumed, so it cannot be removed or forgotten", key, klog.KObj(pod))
+	}
+	return nil
+}
+
+// ForgetPod forgets an assumed pod from the cache. It should be called when the pod
+// still exists, as an undo operation for AssumePod.
+// If the pod is a pod group member, it is moved from assumed to unscheduled pods of that pod group state in cache.
 func (cache *cacheImpl) ForgetPod(logger klog.Logger, pod *v1.Pod) error {
 	key, err := framework.GetPodKey(pod)
 	if err != nil {
@@ -423,14 +438,34 @@ func (cache *cacheImpl) ForgetPod(logger klog.Logger, pod *v1.Pod) error {
 		// Pod does not exist in the cache anymore.
 		return nil
 	}
-	if currState.pod.Spec.NodeName != pod.Spec.NodeName {
-		return fmt.Errorf("pod %v(%v) was assumed on %v but assigned to %v", key, klog.KObj(pod), pod.Spec.NodeName, currState.pod.Spec.NodeName)
+	if err := cache.validateAssumedPod(pod, key, currState); err != nil {
+		return err
 	}
-	// Only assumed pod can be forgotten.
-	if cache.assumedPods.Has(key) {
-		return cache.removePod(logger, pod, true)
+	return cache.removePod(logger, pod, true)
+}
+
+// RemoveAssumedPod removes an assumed pod from the cache. It should be called when the assumed
+// pod was removed from the cluster to correctly clean up internal state.
+// It differs from ForgetPod in how it handles pod group members, as it removes the pod from
+// the pod group state in the cache.
+func (cache *cacheImpl) RemoveAssumedPod(logger klog.Logger, pod *v1.Pod) error {
+	key, err := framework.GetPodKey(pod)
+	if err != nil {
+		return err
 	}
-	return fmt.Errorf("pod %v(%v) wasn't assumed so cannot be forgotten", key, klog.KObj(pod))
+
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	currState, ok := cache.podStates[key]
+	if !ok {
+		// Pod does not exist in the cache anymore.
+		return nil
+	}
+	if err := cache.validateAssumedPod(pod, key, currState); err != nil {
+		return err
+	}
+	return cache.removePod(logger, pod, false)
 }
 
 // Assumes that lock is already acquired.

--- a/pkg/scheduler/backend/cache/cache_test.go
+++ b/pkg/scheduler/backend/cache/cache_test.go
@@ -690,13 +690,9 @@ func TestEphemeralStorageResource(t *testing.T) {
 }
 
 func Test_AddPodGroupMember(t *testing.T) {
-	podGroupName := "pg"
-	// Pod with no pod group name.
-	pod1 := st.MakePod().Namespace("namespace").Name("non-workload-pod").Obj()
-	// Unscheduled pod with a pod group name.
-	pod2 := st.MakePod().Namespace("namespace").Name("unscheduled-pod").PodGroupName(podGroupName).Obj()
-	// Assigned pod with the same pod group name.
-	pod3 := st.MakePod().Namespace("namespace").Name("assigned-pod").Node("node1").PodGroupName(podGroupName).Obj()
+	podWithNoPodGroup := st.MakePod().Namespace("namespace").Name("non-workload-pod").Obj()
+	unscheduledPodGroupMember := st.MakePod().Namespace("namespace").Name("unscheduled-pod").PodGroupName("pg").Obj()
+	assignedPodGroupMember := st.MakePod().Namespace("namespace").Name("assigned-pod").Node("node1").PodGroupName("pg").Obj()
 
 	tests := []struct {
 		name                    string
@@ -706,24 +702,24 @@ func Test_AddPodGroupMember(t *testing.T) {
 		expectInAssignedPods    bool
 	}{
 		{
-			name:                   "generic workload disabled",
-			pod:                    pod2,
+			name:                   "add pod group member with GenericWorkload disabled should be no-op",
+			pod:                    unscheduledPodGroupMember,
 			genericWorkloadEnabled: false,
 		},
 		{
-			name:                   "pod with no pod group name",
-			pod:                    pod1,
+			name:                   "add pod with no pod group name",
+			pod:                    podWithNoPodGroup,
 			genericWorkloadEnabled: true,
 		},
 		{
-			name:                    "unscheduled pod with a pod group name",
-			pod:                     pod2,
+			name:                    "add unscheduled pod group member",
+			pod:                     unscheduledPodGroupMember,
 			genericWorkloadEnabled:  true,
 			expectInUnscheduledPods: true,
 		},
 		{
-			name:                   "assigned pod with a pod group name",
-			pod:                    pod3,
+			name:                   "add assigned pod group member",
+			pod:                    assignedPodGroupMember,
 			genericWorkloadEnabled: true,
 			expectInAssignedPods:   true,
 		},
@@ -734,19 +730,16 @@ func Test_AddPodGroupMember(t *testing.T) {
 			cache := newCache(context.Background(), time.Second, nil, tt.genericWorkloadEnabled)
 			cache.AddPodGroupMember(tt.pod)
 
-			if tt.pod.Spec.SchedulingGroup == nil {
-				if tt.expectInAssignedPods || tt.expectInUnscheduledPods {
-					t.Errorf("Expected pod group to exist, but pod has no pod group")
+			if !tt.genericWorkloadEnabled || tt.pod.Spec.SchedulingGroup == nil {
+				if count := len(cache.podGroupStates); count != 0 {
+					t.Errorf("Expected no pod groups states to exist in cache, but found %d", count)
 				}
 				return
 			}
 
 			podGroupState, err := cache.PodGroupStates().Get(tt.pod.Namespace, *tt.pod.Spec.SchedulingGroup.PodGroupName)
 			if err != nil {
-				if tt.genericWorkloadEnabled {
-					t.Errorf("Expected pod group to exist, but got error: %v", err)
-				}
-				return
+				t.Fatalf("Unexpected error getting pod group state: %v", err)
 			}
 
 			_, inUnscheduledPods := podGroupState.UnscheduledPods()[tt.pod.Name]
@@ -788,20 +781,19 @@ func Test_UpdatePodGroupMember(t *testing.T) {
 		expectInAssignedPods    bool
 	}{
 		{
-			name:                    "updating a pod with genericWorkload disabled should be a no-op",
-			oldPod:                  pod,
-			newPod:                  updatedPod,
-			genericWorkloadEnabled:  false,
-			expectInUnscheduledPods: true,
+			name:                   "update a pod group member with GenericWorkload disabled should be a no-op",
+			oldPod:                 pod,
+			newPod:                 updatedPod,
+			genericWorkloadEnabled: false,
 		},
 		{
-			name:                   "update a pod with no pod group name should be a no-op",
+			name:                   "update a pod with no pod group name",
 			oldPod:                 noPodGroupPod,
 			newPod:                 updatedNoPodGroupPod,
 			genericWorkloadEnabled: true,
 		},
 		{
-			name:                    "update a pod",
+			name:                    "update a pod group member, add label",
 			isAssumedPod:            true,
 			oldPod:                  pod,
 			newPod:                  updatedPod,
@@ -809,7 +801,7 @@ func Test_UpdatePodGroupMember(t *testing.T) {
 			expectInUnscheduledPods: true,
 		},
 		{
-			name:                   "update a pod, move to assigned",
+			name:                   "update an unscheduled pod group member, set NodeName",
 			isAssumedPod:           true,
 			oldPod:                 pod,
 			newPod:                 assignedPod,
@@ -821,9 +813,8 @@ func Test_UpdatePodGroupMember(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			logger, _ := ktesting.NewTestContext(t)
-			cache := newCache(context.Background(), time.Second, nil, true)
+			cache := newCache(context.Background(), time.Second, nil, tt.genericWorkloadEnabled)
 			cache.AddPodGroupMember(tt.oldPod)
-			cache.genericWorkloadEnabled = tt.genericWorkloadEnabled
 
 			newPod := tt.newPod
 			if newPod == nil {
@@ -831,16 +822,16 @@ func Test_UpdatePodGroupMember(t *testing.T) {
 			}
 			cache.UpdatePodGroupMember(logger, tt.oldPod, newPod)
 
-			if newPod.Spec.SchedulingGroup == nil {
-				if tt.expectInAssumedPods || tt.expectInUnscheduledPods || tt.expectInAssignedPods {
-					t.Errorf("Expected pod group to exist, but pod has no SchedulingGroup")
+			if !tt.genericWorkloadEnabled || newPod.Spec.SchedulingGroup == nil {
+				if count := len(cache.podGroupStates); count != 0 {
+					t.Errorf("Expected no pod groups states to exist in cache, but found %d", count)
 				}
 				return
 			}
 
 			podGroupState, err := cache.PodGroupStates().Get(newPod.Namespace, *newPod.Spec.SchedulingGroup.PodGroupName)
 			if err != nil {
-				return
+				t.Fatalf("Unexpected error getting pod group state: %v", err)
 			}
 
 			_, inUnscheduledPods := podGroupState.UnscheduledPods()[newPod.Name]
@@ -854,10 +845,6 @@ func Test_UpdatePodGroupMember(t *testing.T) {
 
 			if inAssumedPods := podGroupState.AssumedPods().Has(newPod.UID); inAssumedPods != tt.expectInAssumedPods {
 				t.Errorf("expected pod in AssumedPods: %v, got %v", tt.expectInAssumedPods, inAssumedPods)
-			}
-
-			if !tt.genericWorkloadEnabled {
-				return
 			}
 
 			podGroupKey := newPodGroupKey(newPod.Namespace, *newPod.Spec.SchedulingGroup.PodGroupName)
@@ -904,13 +891,7 @@ func Test_RemovePodGroupMember(t *testing.T) {
 			genericWorkloadEnabled:   true,
 		},
 		{
-			name:                     "remove a non-existent pod from a group should be a no-op",
-			podToDelete:              pod1,
-			expectPodGroupStateCount: 0,
-			genericWorkloadEnabled:   true,
-		},
-		{
-			name:                     "remove a pod while generic workload disabled should be a no-op",
+			name:                     "remove a pod with GenericWorkload disabled should be a no-op",
 			initPods:                 []*v1.Pod{pod1},
 			expectPodGroupStateCount: 0,
 			podToDelete:              pod1,
@@ -1025,51 +1006,68 @@ func TestUpdatePodGroupStateSnapshot(t *testing.T) {
 	}
 }
 
-// TestBindingPodGroupMember simulates binding and tests that when an assumed pod
-// gets bound, its state within pod group transitions from assumed to assigned.
+// TestBindingPodGroupMember simulates binding and tests that when an assumed or
+// unscheduled pod gets bound, its state within pod group becomes assigned.
 func TestBindingPodGroupMember(t *testing.T) {
-	logger, ctx := ktesting.NewTestContext(t)
-	cache := newCache(ctx, time.Second, nil, true)
-	podGroupName := "pg"
-	pod := st.MakePod().Namespace("namespace").Name("pod1").UID("pod1-uid").
-		PodGroupName(podGroupName).Obj()
-
-	// Simulate the informer firing an Add event for an unscheduled
-	// pod (no NodeName set) reflecting on PodGroupStates.
-	cache.AddPodGroupMember(pod)
-
-	// Simulate the scheduler assuming the pod on a node.
-	assumedPod := pod.DeepCopy()
-	assumedPod.Spec.NodeName = "node1"
-	if err := cache.AssumePod(logger, assumedPod); err != nil {
-		t.Fatalf("AssumePod failed: %v", err)
+	tests := []struct {
+		name         string
+		pod          *v1.Pod
+		assumedPod   *v1.Pod
+		scheduledPod *v1.Pod
+	}{
+		{
+			name: "bind unscheduled pod group member",
+			pod: st.MakePod().Namespace("namespace").Name("pod1").UID("pod1-uid").
+				PodGroupName("pg").Obj(),
+			scheduledPod: st.MakePod().Namespace("namespace").Name("pod1").UID("pod1-uid").
+				PodGroupName("pg").Node("node1").Obj(),
+		},
+		{
+			name: "bind assumed pod group member",
+			pod: st.MakePod().Namespace("namespace").Name("pod1").UID("pod1-uid").
+				PodGroupName("pg").Obj(),
+			assumedPod: st.MakePod().Namespace("namespace").Name("pod1").UID("pod1-uid").
+				PodGroupName("pg").Node("node1").Obj(),
+			scheduledPod: st.MakePod().Namespace("namespace").Name("pod1").UID("pod1-uid").
+				PodGroupName("pg").Node("node1").Obj(),
+		},
 	}
 
-	podGroupState, err := cache.PodGroupStates().Get(pod.Namespace, podGroupName)
-	if err != nil {
-		t.Fatalf("Unexpected error getting pod group state after AssumePod: %v", err)
-	}
-	if !podGroupState.AssumedPods().Has(assumedPod.UID) {
-		t.Errorf("Expected pod to be in AssumedPods after AssumePod")
-	}
-	if podGroupState.AssignedPods().Has(assumedPod.UID) {
-		t.Errorf("Expected pod NOT to be in AssignedPods after AssumePod")
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			cache := newCache(ctx, time.Second, nil, true)
 
-	// Simulate binding confirmation: the informer fires an Add event with NodeName set.
-	if err := cache.AddPod(logger, assumedPod); err != nil {
-		t.Fatalf("AddPod (binding confirmation) failed: %v", err)
-	}
+			// Simulate the informer firing an Add event for an unscheduled pod.
+			cache.AddPodGroupMember(tt.pod)
 
-	podGroupState, err = cache.PodGroupStates().Get(pod.Namespace, podGroupName)
-	if err != nil {
-		t.Fatalf("Unexpected error getting pod group state after AddPod: %v", err)
-	}
-	if podGroupState.AssumedPods().Has(assumedPod.UID) {
-		t.Errorf("Expected pod not to be in AssumedPods after binding confirmation")
-	}
-	if !podGroupState.AssignedPods().Has(assumedPod.UID) {
-		t.Errorf("Expected pod to be in AssignedPods after binding confirmation")
+			if tt.assumedPod != nil {
+				if err := cache.AssumePod(logger, tt.assumedPod); err != nil {
+					t.Fatalf("AssumePod failed: %v", err)
+				}
+			}
+
+			// Simulate the informer firing an Add event with NodeName set to bind a pod.
+			if err := cache.AddPod(logger, tt.scheduledPod); err != nil {
+				t.Fatalf("AddPod (binding) failed: %v", err)
+			}
+
+			podGroupState, err := cache.PodGroupStates().Get(tt.pod.Namespace, *tt.pod.Spec.SchedulingGroup.PodGroupName)
+			if err != nil {
+				t.Fatalf("Unexpected error getting pod group state: %v", err)
+			}
+			if !podGroupState.AssignedPods().Has(tt.pod.UID) {
+				t.Errorf("Expected pod to be in AssignedPods after binding")
+			}
+			if podGroupState.AssumedPods().Has(tt.pod.UID) {
+				t.Errorf("Expected pod not to be in AssumedPods after binding")
+			}
+			if podGroupState.UnscheduledPods()[tt.pod.Name] != nil {
+				t.Errorf("Expected pod not to be in UnscheduledPods after binding")
+			}
+		})
 	}
 }
 
@@ -1192,6 +1190,145 @@ func TestForgetPod(t *testing.T) {
 		if err := cache.ForgetPod(logger, pod); err != nil {
 			t.Error("expected no error, error found")
 		}
+	}
+}
+
+func TestForgetPodGroupMember(t *testing.T) {
+	pod := st.MakePod().Namespace("test-ns").Name("pod-0").UID("uid-0").
+		PodGroupName("pg").Obj()
+	podWithNodeName := st.MakePod().Namespace("test-ns").Name("pod-0").UID("uid-0").
+		Node("node-1").PodGroupName("pg").Obj()
+
+	tests := []struct {
+		name                   string
+		pod                    *v1.Pod
+		expectInAssigned       bool
+		expectInUnscheduled    bool
+		genericWorkloadEnabled bool
+	}{
+		{
+			name: "forget pod group member with GenericWorkload disabled",
+			pod:  pod,
+		},
+		{
+			name:                   "add pod group member without NodeName, then call assume and forget",
+			pod:                    pod,
+			genericWorkloadEnabled: true,
+			expectInUnscheduled:    true,
+		},
+		{
+			name:                   "add pod group member with NodeName, then call assume and forget",
+			pod:                    podWithNodeName,
+			genericWorkloadEnabled: true,
+			expectInAssigned:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			cache := newCache(ctx, time.Second, nil, tt.genericWorkloadEnabled)
+			cache.AddPodGroupMember(tt.pod)
+			if err := cache.AssumePod(logger, podWithNodeName); err != nil {
+				t.Fatalf("AssumePod failed: %v", err)
+			}
+
+			if err := cache.ForgetPod(logger, podWithNodeName); err != nil {
+				t.Fatalf("ForgetPod failed: %v", err)
+			}
+
+			if !tt.genericWorkloadEnabled {
+				if count := len(cache.podGroupStates); count != 0 {
+					t.Errorf("Expected no pod group states to exist in cache, but found %d", count)
+				}
+				return
+			}
+
+			pgs, err := cache.PodGroupStates().Get("test-ns", *tt.pod.Spec.SchedulingGroup.PodGroupName)
+			if err != nil {
+				t.Fatalf("expected pod group state to exist, but got error: %v", err)
+			}
+
+			if pgs.AssumedPods().Has(tt.pod.UID) {
+				t.Fatalf("pod cannot be in AssumedPods after ForgetPod")
+			}
+
+			if inAssigned := pgs.AssignedPods().Has(tt.pod.UID); inAssigned != tt.expectInAssigned {
+				t.Errorf("pod in assignedPods: got %v, want %v", inAssigned, tt.expectInAssigned)
+			}
+			if inUnscheduled := pgs.UnscheduledPods()[tt.pod.Name] != nil; inUnscheduled != tt.expectInUnscheduled {
+				t.Errorf("pod in unscheduledPods: got %v, want %v", inUnscheduled, tt.expectInUnscheduled)
+			}
+		})
+	}
+}
+
+func TestAssumePodGroupMember(t *testing.T) {
+	pod := st.MakePod().Namespace("test-ns").Name("pod-0").UID("uid-0").
+		PodGroupName("pg").Obj()
+	podWithNodeName := st.MakePod().Namespace("test-ns").Name("pod-0").UID("uid-0").
+		Node("node-1").PodGroupName("pg").Obj()
+
+	tests := []struct {
+		name                   string
+		genericWorkloadEnabled bool
+		pod                    *v1.Pod
+		expectInAssumed        bool
+		expectInAssigned       bool
+	}{
+		{
+			name: "assume a pod group member with GenericWorkload disabled",
+			pod:  pod,
+		},
+		{
+			name:                   "add pod group member without NodeName, then call assume",
+			pod:                    pod,
+			genericWorkloadEnabled: true,
+			expectInAssumed:        true,
+		},
+		{
+			name:                   "add pod group member with NodeName, then call assume",
+			pod:                    podWithNodeName,
+			genericWorkloadEnabled: true,
+			expectInAssigned:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			cache := newCache(ctx, time.Second, nil, tt.genericWorkloadEnabled)
+			cache.AddPodGroupMember(tt.pod)
+
+			if err := cache.AssumePod(logger, podWithNodeName); err != nil {
+				t.Fatalf("AssumePod failed: %v", err)
+			}
+
+			if !tt.genericWorkloadEnabled {
+				if count := len(cache.podGroupStates); count != 0 {
+					t.Errorf("Expected no pod group states to exist in cache, but found %d", count)
+				}
+				return
+			}
+
+			pgs, err := cache.PodGroupStates().Get("test-ns", *pod.Spec.SchedulingGroup.PodGroupName)
+			if err != nil {
+				t.Fatalf("unexpected error getting pod group state: %v", err)
+			}
+
+			if inAssigned := pgs.AssignedPods().Has(tt.pod.UID); inAssigned != tt.expectInAssigned {
+				t.Errorf("pod in assignedPods: got %v, want %v", inAssigned, tt.expectInAssigned)
+			}
+			if inAssumed := pgs.AssumedPods().Has(tt.pod.UID); inAssumed != tt.expectInAssumed {
+				t.Errorf("pod in assumedPods: got %v, want %v", inAssumed, tt.expectInAssumed)
+			}
+		})
 	}
 }
 

--- a/pkg/scheduler/backend/cache/cache_test.go
+++ b/pkg/scheduler/backend/cache/cache_test.go
@@ -1266,6 +1266,112 @@ func TestForgetPodGroupMember(t *testing.T) {
 	}
 }
 
+func TestRemoveAssumedPod(t *testing.T) {
+	pod := st.MakePod().Namespace("test-ns").Name("pod-0").UID("uid-0").Obj()
+	assumedPod := st.MakePod().Namespace("test-ns").Name("pod-0").UID("uid-0").Node("node-1").Obj()
+	assumedPodOnDifferentNode := st.MakePod().Namespace("test-ns").Name("pod-0").UID("uid-0").Node("node-2").Obj()
+	assumedPodWithPodGroup := st.MakePod().Namespace("test-ns").Name("pod-0").UID("uid-0").Node("node-1").PodGroupName("pg").Obj()
+
+	tests := []struct {
+		name                   string
+		addPod                 *v1.Pod
+		assumedPod             *v1.Pod
+		removePod              *v1.Pod
+		genericWorkloadEnabled bool
+		expectErr              bool
+	}{
+		{
+			name:       "remove assumed pod",
+			assumedPod: assumedPod,
+			removePod:  assumedPod,
+		},
+		{
+			name:      "pod is not assumed",
+			addPod:    pod,
+			removePod: pod,
+			expectErr: true,
+		},
+		{
+			name:      "pod doesn't exist in the cache",
+			removePod: assumedPod,
+		},
+		{
+			name:       "remove assumed pod with different node name",
+			assumedPod: assumedPod,
+			removePod:  assumedPodOnDifferentNode,
+			expectErr:  true,
+		},
+		{
+			name:       "remove assumed pod group member with GenericWorkload disabled",
+			assumedPod: assumedPodWithPodGroup,
+			removePod:  assumedPodWithPodGroup,
+		},
+		{
+			name:                   "remove assumed pod without a pod group",
+			assumedPod:             assumedPod,
+			removePod:              assumedPod,
+			genericWorkloadEnabled: true,
+		},
+		{
+			name:                   "remove assumed pod group member",
+			assumedPod:             assumedPodWithPodGroup,
+			removePod:              assumedPodWithPodGroup,
+			genericWorkloadEnabled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			cache := newCache(ctx, time.Second, nil, tt.genericWorkloadEnabled)
+
+			if tt.addPod != nil {
+				if err := cache.AddPod(logger, tt.addPod); err != nil {
+					t.Fatalf("AddPod failed: %v", err)
+				}
+			} else if tt.assumedPod != nil {
+				if err := cache.AssumePod(logger, tt.assumedPod); err != nil {
+					t.Fatalf("AssumePod failed: %v", err)
+				}
+			}
+
+			pod := tt.addPod
+			if pod == nil {
+				pod = tt.assumedPod
+			}
+
+			if pod != nil && pod.Spec.SchedulingGroup != nil {
+				count := len(cache.podGroupStates)
+				if !tt.genericWorkloadEnabled && count == 1 {
+					t.Fatalf("Expected no pod group states to exist in cache, but found %d", count)
+				} else if tt.genericWorkloadEnabled && count == 0 {
+					t.Fatalf("Expected pod group state to exist in cache, but found none")
+				}
+			}
+
+			if err := cache.RemoveAssumedPod(logger, tt.removePod); err != nil {
+				if tt.expectErr {
+					return
+				}
+				t.Fatalf("RemoveAssumedPod failed: %v", err)
+			} else if tt.expectErr {
+				t.Fatalf("expected error but got nil")
+			}
+
+			if err := isForgottenFromCache(tt.removePod, cache); err != nil {
+				t.Errorf("pod %q not forgotten: %v", tt.removePod.Name, err)
+			}
+
+			if count := len(cache.podGroupStates); count != 0 {
+				t.Errorf("Expected no pod group states to exist in cache after removal, but found %d", count)
+			}
+		})
+	}
+}
+
 func TestAssumePodGroupMember(t *testing.T) {
 	pod := st.MakePod().Namespace("test-ns").Name("pod-0").UID("uid-0").
 		PodGroupName("pg").Obj()

--- a/pkg/scheduler/backend/cache/interface.go
+++ b/pkg/scheduler/backend/cache/interface.go
@@ -69,8 +69,13 @@ type Cache interface {
 	// AssumePod assumes a pod scheduled and aggregates the pod's information into its node.
 	AssumePod(logger klog.Logger, pod *v1.Pod) error
 
-	// ForgetPod removes an assumed pod from cache.
+	// ForgetPod forgets an assumed pod from the cache. It should be called when the pod
+	// still exists, as an undo operation for AssumePod.
 	ForgetPod(logger klog.Logger, pod *v1.Pod) error
+
+	// RemoveAssumedPod removes an assumed pod from the cache. It should be called when the assumed
+	// pod was removed from the cluster to correctly clean up internal state.
+	RemoveAssumedPod(logger klog.Logger, pod *v1.Pod) error
 
 	// AddPod confirms an assumed pod, or adds a newly assigned pod to the cache.
 	AddPod(logger klog.Logger, pod *v1.Pod) error

--- a/pkg/scheduler/backend/cache/podgroupstate.go
+++ b/pkg/scheduler/backend/cache/podgroupstate.go
@@ -95,6 +95,10 @@ func (d *podGroupStateData) addPod(pod *v1.Pod) {
 	d.allPods[pod.UID] = pod
 	if pod.Spec.NodeName != "" {
 		d.assignedPods.Insert(pod.UID)
+		// Clear from unscheduled or assumed in case the pod previously existed in the pod group
+		// in a different state, e.g., external binding of a previously-queued pod group member.
+		d.unscheduledPods.Delete(pod.UID)
+		delete(d.assumedPods, pod.UID)
 	} else {
 		d.unscheduledPods.Insert(pod.UID)
 	}

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -262,8 +262,8 @@ func (sched *Scheduler) handleAssumedPodDeletion(pod *v1.Pod) {
 	if !fwk.RejectWaitingPod(pod.UID) {
 		// 2. If the pod is no longer waiting (e.g., it's in PreBind or Bind), we can't quickly reject it.
 		//    We must explicitly remove it from the cache here to free up its assumed resources.
-		if err := sched.Cache.ForgetPod(logger, pod); err != nil {
-			utilruntime.HandleErrorWithLogger(logger, err, "Scheduler cache ForgetPod failed", "pod", klog.KObj(pod))
+		if err := sched.Cache.RemoveAssumedPod(logger, pod); err != nil {
+			utilruntime.HandleErrorWithLogger(logger, err, "Scheduler cache RemoveAssumedPod failed", "pod", klog.KObj(pod))
 		}
 	}
 
@@ -340,7 +340,6 @@ func (sched *Scheduler) deletePodFromSchedulingQueue(pod *v1.Pod, inBinding bool
 		// once the https://github.com/kubernetes/kubernetes/issues/134859 is fixed.
 		return
 	}
-	sched.Cache.RemovePodGroupMember(pod)
 	isAssumed, err := sched.Cache.IsAssumedPod(pod)
 	if err != nil {
 		utilruntime.HandleErrorWithLogger(logger, err, "Failed to check whether pod is assumed", "pod", klog.KObj(pod))
@@ -349,7 +348,11 @@ func (sched *Scheduler) deletePodFromSchedulingQueue(pod *v1.Pod, inBinding bool
 		// Assumed pod is deleted. We should handle that differently,
 		// because we can't delete such pod from any structure directly.
 		sched.handleAssumedPodDeletion(pod)
-	} else if pod.Status.NominatedNodeName != "" {
+		return
+	}
+	// If the pod is not assumed, we must clean pod group state explicitly here.
+	sched.Cache.RemovePodGroupMember(pod)
+	if pod.Status.NominatedNodeName != "" {
 		// When a pod that had nominated node is deleted, it can unblock scheduling of other pods,
 		// because the lower or equal priority pods treat such a pod as if it was assigned.
 		// Note that a nominated pod can fall into `handleAssumedPodDeletion` case as well,

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -828,25 +828,51 @@ func TestAdmissionCheck(t *testing.T) {
 }
 
 func TestAddPod(t *testing.T) {
+	basePod := func() *st.PodWrapper {
+		return st.MakePod().Name("pod1").SchedulerName("supported-scheduler").Namespace("ns1").UID("pod1")
+	}
+
 	tests := []struct {
-		name          string
-		pod           *v1.Pod
-		expectInQueue bool
-		expectInCache bool
+		name                             string
+		pod                              *v1.Pod
+		genericWorkloadEnabled           bool
+		expectInQueue                    bool
+		expectInCache                    bool
+		expectInPodGroupStateUnscheduled bool
+		expectInPodGroupStateAssigned    bool
 	}{
 		{
 			name:          "add unscheduled pod",
-			pod:           st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").SchedulerName("supported-scheduler").Obj(),
+			pod:           basePod().Obj(),
 			expectInQueue: true,
 		},
 		{
 			name: "add unscheduled pod with other scheduler name",
-			pod:  st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").SchedulerName("other-scheduler").Obj(),
+			pod:  basePod().SchedulerName("other-scheduler").Obj(),
 		},
 		{
 			name:          "add scheduled pod",
-			pod:           st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Node("node1").Obj(),
+			pod:           basePod().Node("node1").Obj(),
 			expectInCache: true,
+		},
+		{
+			name:          "add a pod group member with GenericWorkload disabled",
+			pod:           basePod().PodGroupName("pg1").Obj(),
+			expectInQueue: true,
+		},
+		{
+			name:                             "add an unscheduled pod group member",
+			pod:                              basePod().PodGroupName("pg1").Obj(),
+			genericWorkloadEnabled:           true,
+			expectInQueue:                    true,
+			expectInPodGroupStateUnscheduled: true,
+		},
+		{
+			name:                          "add a scheduled pod group member",
+			pod:                           basePod().Node("node1").PodGroupName("pg1").Obj(),
+			genericWorkloadEnabled:        true,
+			expectInCache:                 true,
+			expectInPodGroupStateAssigned: true,
 		},
 	}
 	for _, tt := range tests {
@@ -856,7 +882,7 @@ func TestAddPod(t *testing.T) {
 			defer cancel()
 
 			sched := &Scheduler{
-				Cache:           internalcache.New(ctx, nil, false),
+				Cache:           internalcache.New(ctx, nil, tt.genericWorkloadEnabled),
 				SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
 				logger:          logger,
 				Profiles: profile.Map{
@@ -877,6 +903,31 @@ func TestAddPod(t *testing.T) {
 				t.Errorf("Expected pod to be in cache: %v", err)
 			} else if !tt.expectInCache && err == nil {
 				t.Errorf("Expected pod not to be in cache")
+			}
+
+			if tt.pod.Spec.SchedulingGroup == nil {
+				// Pod has no pod group, so there is no pod group state to check, the test can complete.
+				return
+			}
+
+			pgs, err := sched.Cache.PodGroupStates().Get(tt.pod.Namespace, *tt.pod.Spec.SchedulingGroup.PodGroupName)
+
+			if !tt.genericWorkloadEnabled {
+				if err == nil {
+					t.Errorf("Expected no pod group state to exist when GenericWorkload is disabled, but found one")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Expected pod group state to exist, got error: %v", err)
+			}
+
+			if inUnscheduled := pgs.UnscheduledPods()[tt.pod.Name] != nil; inUnscheduled != tt.expectInPodGroupStateUnscheduled {
+				t.Errorf("Expected pod in UnscheduledPods of PodGroupState: got %v, want %v", inUnscheduled, tt.expectInPodGroupStateUnscheduled)
+			}
+			if inAssigned := pgs.AssignedPods().Has(tt.pod.UID); inAssigned != tt.expectInPodGroupStateAssigned {
+				t.Errorf("Expected pod in AssignedPods of PodGroupState: got %v, want %v", inAssigned, tt.expectInPodGroupStateAssigned)
 			}
 		})
 	}
@@ -899,13 +950,23 @@ func TestUpdatePod(t *testing.T) {
 
 	scheduledPodOtherNode := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Node("node2").SchedulerName("supported-scheduler").Obj()
 
+	unscheduledPodGroupMember := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
+	unscheduledPodGroupMemberWithLabels := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").Labels(map[string]string{"foo": "bar"}).ResourceVersion("2").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
+	scheduledPodGroupMember := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").Node("node1").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
+	scheduledPodGroupMemberWithLabels := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").Labels(map[string]string{"foo": "bar"}).ResourceVersion("2").Node("node1").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
+	scheduledPodGroupMemberWithOtherNode := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").Node("node2").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
+
 	tests := []struct {
-		name          string
-		oldPod        *v1.Pod
-		assumedPod    *v1.Pod
-		newPod        *v1.Pod
-		expectInQueue *v1.Pod
-		expectInCache *v1.Pod
+		name                             string
+		oldPod                           *v1.Pod
+		assumedPod                       *v1.Pod
+		newPod                           *v1.Pod
+		genericWorkloadEnabled           bool
+		expectInQueue                    *v1.Pod
+		expectInCache                    *v1.Pod
+		expectInPodGroupStateUnscheduled bool
+		expectInPodGroupStateAssumed     bool
+		expectInPodGroupStateAssigned    bool
 	}{
 		{
 			name:          "update unscheduled pod",
@@ -969,6 +1030,63 @@ func TestUpdatePod(t *testing.T) {
 			assumedPod: scheduledPod,
 			newPod:     podWithDeletionTimestamp,
 		},
+		{
+			name:          "update pod group member with GenericWorkload disabled",
+			oldPod:        unscheduledPodGroupMember,
+			newPod:        unscheduledPodGroupMemberWithLabels,
+			expectInQueue: unscheduledPodGroupMemberWithLabels,
+		},
+		{
+			name:                             "update unscheduled pod group member, add label",
+			oldPod:                           unscheduledPodGroupMember,
+			newPod:                           unscheduledPodGroupMemberWithLabels,
+			expectInQueue:                    unscheduledPodGroupMemberWithLabels,
+			genericWorkloadEnabled:           true,
+			expectInPodGroupStateUnscheduled: true,
+		},
+		{
+			name:                         "update assumed pod group member, add label",
+			oldPod:                       unscheduledPodGroupMember,
+			assumedPod:                   scheduledPodGroupMember,
+			newPod:                       unscheduledPodGroupMemberWithLabels,
+			expectInCache:                scheduledPodGroupMember,
+			genericWorkloadEnabled:       true,
+			expectInPodGroupStateAssumed: true,
+		},
+		{
+			name:                          "update scheduled pod group member, add label",
+			oldPod:                        scheduledPodGroupMember,
+			newPod:                        scheduledPodGroupMemberWithLabels,
+			expectInCache:                 scheduledPodGroupMemberWithLabels,
+			genericWorkloadEnabled:        true,
+			expectInPodGroupStateAssigned: true,
+		},
+		{
+			name:                          "bind unscheduled pod group member",
+			oldPod:                        unscheduledPodGroupMember,
+			newPod:                        scheduledPodGroupMember,
+			expectInCache:                 scheduledPodGroupMember,
+			genericWorkloadEnabled:        true,
+			expectInPodGroupStateAssigned: true,
+		},
+		{
+			name:                          "bind assumed pod group member",
+			oldPod:                        unscheduledPodGroupMember,
+			assumedPod:                    scheduledPodGroupMember,
+			newPod:                        scheduledPodGroupMember,
+			expectInCache:                 scheduledPodGroupMember,
+			genericWorkloadEnabled:        true,
+			expectInPodGroupStateAssigned: true,
+		},
+		{
+			name:                          "bind assumed pod group member to a different node",
+			oldPod:                        unscheduledPodGroupMember,
+			assumedPod:                    scheduledPodGroupMember,
+			newPod:                        scheduledPodGroupMemberWithOtherNode,
+			expectInCache:                 scheduledPodGroupMemberWithOtherNode,
+			genericWorkloadEnabled:        true,
+			expectInPodGroupStateAssigned: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -991,7 +1109,7 @@ func TestUpdatePod(t *testing.T) {
 				t.Fatalf("Failed to create framework: %v", err)
 			}
 			sched := &Scheduler{
-				Cache:           internalcache.New(ctx, nil, false),
+				Cache:           internalcache.New(ctx, nil, tt.genericWorkloadEnabled),
 				SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
 				logger:          logger,
 				Profiles: profile.Map{
@@ -1000,6 +1118,9 @@ func TestUpdatePod(t *testing.T) {
 			}
 
 			if tt.assumedPod != nil {
+				if tt.oldPod.Spec.SchedulingGroup != nil {
+					sched.Cache.AddPodGroupMember(tt.oldPod)
+				}
 				err := sched.Cache.AssumePod(logger, tt.assumedPod)
 				if err != nil {
 					t.Fatalf("Failed to assume pod: %v", err)
@@ -1030,6 +1151,33 @@ func TestUpdatePod(t *testing.T) {
 			} else if err == nil {
 				t.Errorf("Expected pod not to be in cache")
 			}
+
+			if tt.newPod.Spec.SchedulingGroup == nil {
+				// Pod has no pod group, so there is no pod group state to check, the test can complete.
+				return
+			}
+			pgs, err := sched.Cache.PodGroupStates().Get(tt.oldPod.Namespace, *tt.oldPod.Spec.SchedulingGroup.PodGroupName)
+
+			if !tt.genericWorkloadEnabled {
+				if err == nil {
+					t.Errorf("Expected no pod group state to exist when GenericWorkload is disabled, but found one")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Expected pod group state to exist, got error: %v", err)
+			}
+
+			if inUnscheduled := pgs.UnscheduledPods()[tt.newPod.Name] != nil; inUnscheduled != tt.expectInPodGroupStateUnscheduled {
+				t.Errorf("pod in UnscheduledPods of PodGroupState: got %v, want %v", inUnscheduled, tt.expectInPodGroupStateUnscheduled)
+			}
+			if inAssumed := pgs.AssumedPods().Has(tt.newPod.UID); inAssumed != tt.expectInPodGroupStateAssumed {
+				t.Errorf("pod in AssumedPods of PodGroupState: got %v, want %v", inAssumed, tt.expectInPodGroupStateAssumed)
+			}
+			if inAssigned := pgs.AssignedPods().Has(tt.newPod.UID); inAssigned != tt.expectInPodGroupStateAssigned {
+				t.Errorf("pod in AssignedPods of PodGroupState: got %v, want %v", inAssigned, tt.expectInPodGroupStateAssigned)
+			}
 		})
 	}
 }
@@ -1039,13 +1187,16 @@ func TestDeletePod(t *testing.T) {
 	otherPod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").SchedulerName("other-scheduler").Obj()
 	scheduledPod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Node("node1").SchedulerName("supported-scheduler").Obj()
 	otherScheduledPod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Node("node1").SchedulerName("other-scheduler").Obj()
+	podGroupMember := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
+	scheduledPodGroupMember := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").Node("node1").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
 
 	tests := []struct {
-		name            string
-		initialPod      *v1.Pod
-		assumed         bool
-		waitingOnPermit bool
-		podToDelete     any
+		name                   string
+		initialPod             *v1.Pod
+		assumed                bool
+		waitingOnPermit        bool
+		podToDelete            any
+		genericWorkloadEnabled bool
 	}{
 		{
 			name:        "delete unscheduled pod",
@@ -1088,6 +1239,23 @@ func TestDeletePod(t *testing.T) {
 			initialPod:  scheduledPod,
 			podToDelete: cache.DeletedFinalStateUnknown{Obj: pod},
 		},
+		{
+			name:        "delete a pod group member, GenericWorkload disabled",
+			initialPod:  podGroupMember,
+			podToDelete: podGroupMember,
+		},
+		{
+			name:                   "delete an unscheduled pod group member",
+			initialPod:             podGroupMember,
+			podToDelete:            podGroupMember,
+			genericWorkloadEnabled: true,
+		},
+		{
+			name:                   "delete a scheduled pod group member",
+			initialPod:             scheduledPodGroupMember,
+			podToDelete:            scheduledPodGroupMember,
+			genericWorkloadEnabled: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1110,7 +1278,7 @@ func TestDeletePod(t *testing.T) {
 				t.Fatalf("Failed to create framework: %v", err)
 			}
 			sched := &Scheduler{
-				Cache:           internalcache.New(ctx, nil, false),
+				Cache:           internalcache.New(ctx, nil, tt.genericWorkloadEnabled),
 				SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
 				logger:          logger,
 				Profiles: profile.Map{
@@ -1136,6 +1304,15 @@ func TestDeletePod(t *testing.T) {
 			_, ok := sched.SchedulingQueue.GetPod(tt.initialPod.Name, tt.initialPod.Namespace)
 			if ok {
 				t.Errorf("Unexpected pod in scheduling queue after removal")
+			}
+
+			if tt.initialPod.Spec.SchedulingGroup == nil {
+				// Pod has no pod group, so there is no pod group state to check, the test can complete.
+				return
+			}
+			_, err = sched.Cache.PodGroupStates().Get(tt.initialPod.Namespace, *tt.initialPod.Spec.SchedulingGroup.PodGroupName)
+			if err == nil {
+				t.Errorf("Unexpected pod group state in cache after pod removal")
 			}
 		})
 	}

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	dyfake "k8s.io/client-go/dynamic/fake"
@@ -800,6 +801,7 @@ func TestUpdatePod(t *testing.T) {
 	scheduledPodGroupMember := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").Node("node1").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
 	scheduledPodGroupMemberWithLabels := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").Labels(map[string]string{"foo": "bar"}).ResourceVersion("2").Node("node1").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
 	scheduledPodGroupMemberWithOtherNode := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").Node("node2").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
+	podGroupMemberWithDeletionTimestamp := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").Terminating().ResourceVersion("2").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
 
 	tests := []struct {
 		name                             string
@@ -807,11 +809,13 @@ func TestUpdatePod(t *testing.T) {
 		assumedPod                       *v1.Pod
 		newPod                           *v1.Pod
 		genericWorkloadEnabled           bool
+		waitingOnPermit                  bool
 		expectInQueue                    *v1.Pod
 		expectInCache                    *v1.Pod
 		expectInPodGroupStateUnscheduled bool
 		expectInPodGroupStateAssumed     bool
 		expectInPodGroupStateAssigned    bool
+		expectPodGroupStateDeleted       bool
 	}{
 		{
 			name:          "update unscheduled pod",
@@ -851,9 +855,9 @@ func TestUpdatePod(t *testing.T) {
 		},
 		{
 			name:          "bind unscheduled pod with other scheduler name",
-			oldPod:        pod,
-			newPod:        scheduledPod,
-			expectInCache: scheduledPod,
+			oldPod:        otherPod,
+			newPod:        otherScheduledPod,
+			expectInCache: otherScheduledPod,
 		},
 		{
 			name:          "bind assumed pod",
@@ -870,10 +874,18 @@ func TestUpdatePod(t *testing.T) {
 			expectInCache: scheduledPodOtherNode,
 		},
 		{
-			name:       "delete assumed pod with deletion timestamp",
+			name:       "update assumed pod with deletion timestamp",
 			oldPod:     pod,
 			assumedPod: scheduledPod,
 			newPod:     podWithDeletionTimestamp,
+		},
+		{
+			name:            "update assumed pod waiting on permit with deletion timestamp",
+			oldPod:          pod,
+			assumedPod:      scheduledPod,
+			newPod:          podWithDeletionTimestamp,
+			waitingOnPermit: true,
+			expectInCache:   scheduledPod,
 		},
 		{
 			name:          "update pod group member with GenericWorkload disabled",
@@ -932,6 +944,24 @@ func TestUpdatePod(t *testing.T) {
 			genericWorkloadEnabled:        true,
 			expectInPodGroupStateAssigned: true,
 		},
+		{
+			name:                       "update assumed pod group member with deletion timestamp",
+			oldPod:                     unscheduledPodGroupMember,
+			assumedPod:                 scheduledPodGroupMember,
+			newPod:                     podGroupMemberWithDeletionTimestamp,
+			genericWorkloadEnabled:     true,
+			expectPodGroupStateDeleted: true,
+		},
+		{
+			name:                         "update assumed pod group member waiting on permit with deletion timestamp",
+			oldPod:                       unscheduledPodGroupMember,
+			assumedPod:                   scheduledPodGroupMember,
+			newPod:                       podGroupMemberWithDeletionTimestamp,
+			genericWorkloadEnabled:       true,
+			waitingOnPermit:              true,
+			expectInCache:                scheduledPodGroupMember,
+			expectInPodGroupStateAssumed: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -962,6 +992,7 @@ func TestUpdatePod(t *testing.T) {
 				},
 			}
 
+			var waitOnPermitDone chan struct{}
 			if tt.assumedPod != nil {
 				if tt.oldPod.Spec.SchedulingGroup != nil {
 					sched.Cache.AddPodGroupMember(tt.oldPod)
@@ -970,11 +1001,33 @@ func TestUpdatePod(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Failed to assume pod: %v", err)
 				}
+				if tt.waitingOnPermit {
+					waitOnPermitDone = make(chan struct{})
+					schedFramework.AddWaitingPod(tt.assumedPod, nil)
+					go func() {
+						defer close(waitOnPermitDone)
+						schedFramework.WaitOnPermit(ctx, tt.assumedPod)
+					}()
+				}
 			} else {
 				sched.addPod(tt.oldPod)
 			}
 
 			sched.updatePod(tt.oldPod, tt.newPod)
+
+			if tt.waitingOnPermit {
+				err := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+					return schedFramework.GetWaitingPod(tt.assumedPod.UID) == nil, nil
+				})
+				if err != nil {
+					t.Errorf("Expected pod %v to be removed from waiting pods", tt.assumedPod.UID)
+				}
+				select {
+				case <-waitOnPermitDone:
+				case <-time.After(wait.ForeverTestTimeout):
+					t.Fatalf("timeout on WaitOnPermit %v", tt.assumedPod.UID)
+				}
+			}
 
 			qPod, ok := sched.SchedulingQueue.GetPod(tt.newPod.Name, tt.newPod.Namespace, tt.newPod.Spec.SchedulingGroup)
 			if tt.expectInQueue != nil {
@@ -1003,9 +1056,9 @@ func TestUpdatePod(t *testing.T) {
 			}
 			pgs, err := sched.Cache.PodGroupStates().Get(tt.oldPod.Namespace, *tt.oldPod.Spec.SchedulingGroup.PodGroupName)
 
-			if !tt.genericWorkloadEnabled {
+			if !tt.genericWorkloadEnabled || tt.expectPodGroupStateDeleted {
 				if err == nil {
-					t.Errorf("Expected no pod group state to exist when GenericWorkload is disabled, but found one")
+					t.Errorf("Expected pod group state to not exist, but it still exists")
 				}
 				return
 			}
@@ -1036,12 +1089,14 @@ func TestDeletePod(t *testing.T) {
 	scheduledPodGroupMember := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").Node("node1").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
 
 	tests := []struct {
-		name                   string
-		initialPod             *v1.Pod
-		assumed                bool
-		waitingOnPermit        bool
-		podToDelete            any
-		genericWorkloadEnabled bool
+		name                         string
+		initialPod                   *v1.Pod
+		assumedPod                   *v1.Pod
+		waitingOnPermit              bool
+		podToDelete                  any
+		genericWorkloadEnabled       bool
+		expectInCache                bool
+		expectInPodGroupStateAssumed bool
 	}{
 		{
 			name:        "delete unscheduled pod",
@@ -1060,8 +1115,8 @@ func TestDeletePod(t *testing.T) {
 		},
 		{
 			name:        "delete assumed pod",
-			initialPod:  scheduledPod,
-			assumed:     true,
+			initialPod:  pod,
+			assumedPod:  scheduledPod,
 			podToDelete: pod,
 		},
 		{
@@ -1101,6 +1156,23 @@ func TestDeletePod(t *testing.T) {
 			podToDelete:            scheduledPodGroupMember,
 			genericWorkloadEnabled: true,
 		},
+		{
+			name:                   "delete an assumed pod group member",
+			initialPod:             podGroupMember,
+			assumedPod:             scheduledPodGroupMember,
+			podToDelete:            scheduledPodGroupMember,
+			genericWorkloadEnabled: true,
+		},
+		{
+			name:                         "delete an assumed pod group member waiting on permit",
+			initialPod:                   podGroupMember,
+			assumedPod:                   scheduledPodGroupMember,
+			podToDelete:                  podGroupMember,
+			genericWorkloadEnabled:       true,
+			waitingOnPermit:              true,
+			expectInCache:                true,
+			expectInPodGroupStateAssumed: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1131,10 +1203,22 @@ func TestDeletePod(t *testing.T) {
 				},
 			}
 
-			if tt.assumed {
-				err := sched.Cache.AssumePod(logger, tt.initialPod)
+			var waitOnPermitDone chan struct{}
+			if tt.assumedPod != nil {
+				if tt.initialPod.Spec.SchedulingGroup != nil {
+					sched.Cache.AddPodGroupMember(tt.initialPod)
+				}
+				err := sched.Cache.AssumePod(logger, tt.assumedPod)
 				if err != nil {
 					t.Fatalf("Failed to assume pod: %v", err)
+				}
+				if tt.waitingOnPermit {
+					waitOnPermitDone = make(chan struct{})
+					schedFramework.AddWaitingPod(tt.assumedPod, nil)
+					go func() {
+						defer close(waitOnPermitDone)
+						schedFramework.WaitOnPermit(ctx, tt.assumedPod)
+					}()
 				}
 			} else {
 				sched.addPod(tt.initialPod)
@@ -1142,8 +1226,27 @@ func TestDeletePod(t *testing.T) {
 
 			sched.deletePod(tt.podToDelete)
 
+			if tt.waitingOnPermit {
+				err := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+					return schedFramework.GetWaitingPod(tt.assumedPod.UID) == nil, nil
+				})
+				if err != nil {
+					t.Errorf("Expected pod %v to be removed from waiting pods", tt.assumedPod.UID)
+				}
+
+				select {
+				case <-waitOnPermitDone:
+				case <-time.After(wait.ForeverTestTimeout):
+					t.Fatalf("timeout on WaitOnPermit %v", tt.assumedPod.UID)
+				}
+			}
+
 			_, err = sched.Cache.GetPod(tt.initialPod)
-			if err == nil {
+			if tt.expectInCache {
+				if err != nil {
+					t.Errorf("Expected pod to still be in cache: %v", err)
+				}
+			} else if err == nil {
 				t.Errorf("Unexpected pod in cache after removal")
 			}
 			_, ok := sched.SchedulingQueue.GetPod(tt.initialPod.Name, tt.initialPod.Namespace, tt.initialPod.Spec.SchedulingGroup)
@@ -1155,8 +1258,15 @@ func TestDeletePod(t *testing.T) {
 				// Pod has no pod group, so there is no pod group state to check, the test can complete.
 				return
 			}
-			_, err = sched.Cache.PodGroupStates().Get(tt.initialPod.Namespace, *tt.initialPod.Spec.SchedulingGroup.PodGroupName)
-			if err == nil {
+			pgs, err := sched.Cache.PodGroupStates().Get(tt.initialPod.Namespace, *tt.initialPod.Spec.SchedulingGroup.PodGroupName)
+			if tt.expectInPodGroupStateAssumed {
+				if err != nil {
+					t.Fatalf("Unexpected error getting pod group state: %v", err)
+				}
+				if inAssumed := pgs.AssumedPods().Has(tt.assumedPod.UID); !inAssumed {
+					t.Errorf("Expected pod to be in AssumedPods of PodGroupState")
+				}
+			} else if err == nil {
 				t.Errorf("Unexpected pod group state in cache after pod removal")
 			}
 		})


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig scheduling

#### What this PR does / why we need it:
- **Scenario:** When an assumed pod is updated with a deletion timestamp, `sched.handleAssumedPodDeletion()` is called, which eventually calls `sched.Cache.ForgetPod()`, and consequently `Cache.forgetPodGroupMember()`.
- **Expected:** pod is removed from relevant `PodGroupState`, and remove such`PodGroupState` if it became empty.
- **Actual:** pod moves from `assumedPods` to `unschedulablePods`, and stays there either indefinitely or until the eventual `deletePod` request comes.
- **Solution:** Make sure `Cache.removePodGroupMember()` is called in that case.

#### Additional Notes:
- After introduction of podGroupStates in cache, there is a confusion between intention and action of `cache.RemovePod()` and `cache.ForgetPod()`.
- The current state is that: `cache.ForgetPod()` is called when a pod is getting deleted like the scenario mentioned above, while the intention should be `RemovePod()`.
- Ideally, `cache.ForgetPod()` should be called when a scenario like "unreserve and forget happens" only, while `cache.RemovePod()`should be called for **ANY** scenario that involves "pod deletion. Although there will be shared functionality (e.g. removing pod from assumed in cache, and cleaning cache up). but there are differences specially when that pod is a **podgroup** member.
- Based on these notes, we can discuss further a small refactor in these to align intentions with actions.

#### Which issue(s) this PR is related to:
Fixes [#<138422>](https://github.com/kubernetes/kubernetes/issues/138422)

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
```release-note
An assumed pod is correctly removed from podGroupStates in cache, when it gets updated with deletion timestamp.
```
