### PR TITLE
kubelet: fix segfault from log line

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1107,7 +1107,7 @@ func (m *kubeGenericRuntimeManager) validateMemoryResizeAction(
 				errs = append(errs, fmt.Errorf("missing container %q memory usage", cStats.Name))
 			} else if *cStats.Memory.UsageBytes >= uint64(desiredLimit) {
 				errs = append(errs, fmt.Errorf("attempting to set container %q memory limit (%d) below current usage (%d)",
-					cStats.Name, desiredLimit, *podUsageStats.Memory.UsageBytes))
+					cStats.Name, desiredLimit, *cStats.Memory.UsageBytes))
 			}
 		}
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -4637,7 +4637,8 @@ func TestValidatePodResizeAction(t *testing.T) {
 		testName                               string
 		currentResources, desiredResources     resourceRequirements
 		currentPodMemLimit, desiredPodMemLimit *int64
-		containerMemoryUsage, podMemoryUsage   *uint64
+		containerMemoryUsage                   *uint64
+		podMemory                              *statsapi.MemoryStats
 		expectedError                          bool
 	}{
 		{
@@ -4661,7 +4662,7 @@ func TestValidatePodResizeAction(t *testing.T) {
 				memoryRequest: 100, memoryLimit: 100,
 			},
 			containerMemoryUsage: ptr.To[uint64](10),
-			podMemoryUsage:       ptr.To[uint64](10),
+			podMemory:            &statsapi.MemoryStats{UsageBytes: ptr.To[uint64](10)},
 			expectedError:        false,
 		},
 		{
@@ -4673,7 +4674,7 @@ func TestValidatePodResizeAction(t *testing.T) {
 				memoryRequest: 100, memoryLimit: 100,
 			},
 			containerMemoryUsage: ptr.To[uint64](200),
-			podMemoryUsage:       ptr.To[uint64](200),
+			podMemory:            &statsapi.MemoryStats{UsageBytes: ptr.To[uint64](200)},
 			expectedError:        true,
 		},
 		{
@@ -4684,8 +4685,8 @@ func TestValidatePodResizeAction(t *testing.T) {
 			desiredResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 100,
 			},
-			podMemoryUsage: ptr.To[uint64](10),
-			expectedError:  true,
+			podMemory:     &statsapi.MemoryStats{UsageBytes: ptr.To[uint64](10)},
+			expectedError: true,
 		},
 		{
 			testName: "Add container limits, missing pod usage",
@@ -4717,7 +4718,7 @@ func TestValidatePodResizeAction(t *testing.T) {
 				memoryRequest: 100, memoryLimit: 100,
 			},
 			containerMemoryUsage: ptr.To[uint64](20),
-			podMemoryUsage:       ptr.To[uint64](20),
+			podMemory:            &statsapi.MemoryStats{UsageBytes: ptr.To[uint64](20)},
 			expectedError:        false,
 		},
 		{
@@ -4729,7 +4730,7 @@ func TestValidatePodResizeAction(t *testing.T) {
 				memoryRequest: 100, memoryLimit: 100,
 			},
 			containerMemoryUsage: ptr.To[uint64](150),
-			podMemoryUsage:       ptr.To[uint64](150),
+			podMemory:            &statsapi.MemoryStats{UsageBytes: ptr.To[uint64](150)},
 			expectedError:        true,
 		},
 		{
@@ -4742,7 +4743,7 @@ func TestValidatePodResizeAction(t *testing.T) {
 			},
 			desiredPodMemLimit:   ptr.To[int64](100),
 			containerMemoryUsage: ptr.To[uint64](20),
-			podMemoryUsage:       ptr.To[uint64](20),
+			podMemory:            &statsapi.MemoryStats{UsageBytes: ptr.To[uint64](20)},
 			expectedError:        false,
 		},
 		{
@@ -4755,7 +4756,7 @@ func TestValidatePodResizeAction(t *testing.T) {
 			},
 			desiredPodMemLimit:   ptr.To[int64](100),
 			containerMemoryUsage: ptr.To[uint64](20),
-			podMemoryUsage:       ptr.To[uint64](200),
+			podMemory:            &statsapi.MemoryStats{UsageBytes: ptr.To[uint64](200)},
 			expectedError:        true,
 		},
 		{
@@ -4769,7 +4770,7 @@ func TestValidatePodResizeAction(t *testing.T) {
 			currentPodMemLimit:   ptr.To[int64](100),
 			desiredPodMemLimit:   ptr.To[int64](200),
 			containerMemoryUsage: ptr.To[uint64](20),
-			podMemoryUsage:       ptr.To[uint64](20),
+			podMemory:            &statsapi.MemoryStats{UsageBytes: ptr.To[uint64](20)},
 			expectedError:        false,
 		},
 		{
@@ -4783,7 +4784,7 @@ func TestValidatePodResizeAction(t *testing.T) {
 			currentPodMemLimit:   ptr.To[int64](200),
 			desiredPodMemLimit:   ptr.To[int64](100),
 			containerMemoryUsage: ptr.To[uint64](20),
-			podMemoryUsage:       ptr.To[uint64](20),
+			podMemory:            &statsapi.MemoryStats{UsageBytes: ptr.To[uint64](20)},
 			expectedError:        false,
 		},
 		{
@@ -4797,7 +4798,7 @@ func TestValidatePodResizeAction(t *testing.T) {
 			currentPodMemLimit:   ptr.To[int64](200),
 			desiredPodMemLimit:   ptr.To[int64](100),
 			containerMemoryUsage: ptr.To[uint64](50),
-			podMemoryUsage:       ptr.To[uint64](150),
+			podMemory:            &statsapi.MemoryStats{UsageBytes: ptr.To[uint64](150)},
 			expectedError:        true,
 		},
 		{
@@ -4811,7 +4812,21 @@ func TestValidatePodResizeAction(t *testing.T) {
 			currentPodMemLimit:   ptr.To[int64](200),
 			desiredPodMemLimit:   ptr.To[int64](100),
 			containerMemoryUsage: ptr.To[uint64](50),
-			podMemoryUsage:       nil,
+			podMemory:            nil,
+			expectedError:        true,
+		},
+		{
+			testName: "Decrease container limits, missing usage",
+			currentResources: resourceRequirements{
+				memoryRequest: 200, memoryLimit: 200,
+			},
+			desiredResources: resourceRequirements{
+				memoryRequest: 100, memoryLimit: 100,
+			},
+			currentPodMemLimit:   ptr.To[int64](200),
+			desiredPodMemLimit:   ptr.To[int64](100),
+			containerMemoryUsage: ptr.To[uint64](200),
+			podMemory:            nil,
 			expectedError:        true,
 		},
 	} {
@@ -4853,9 +4868,7 @@ func TestValidatePodResizeAction(t *testing.T) {
 					Namespace: pod.Namespace,
 					UID:       string(pod.UID),
 				},
-				Memory: &statsapi.MemoryStats{
-					UsageBytes: tc.podMemoryUsage,
-				},
+				Memory: tc.podMemory,
 			}
 			for _, container := range pod.Spec.Containers {
 				podStats.Containers = append(podStats.Containers, statsapi.ContainerStats{


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:
segfault caught in openshift CI, probably pretty rare:

k8s.io/kubernetes/pkg/kubelet/kuberuntime.(*kubeGenericRuntimeManager).validateMemoryResizeAction(0xc00068e9c0, {0x29dac20, 0xc007ae6e10}, 0xc003345908, 0xc0035f4000, 0xc006a9e350?, 0xc004583100, {0x0, 0x0, {0xc000f98900, ...}, ...}) k8s.io/kubernetes/pkg/kubelet/kuberuntime/kuberuntime_manager.go:1055 +0x5ae

unit test verifies the fix. I am not fully convinced unit test changes are worth the churn given it's just to catch this one bug, but :shrug:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
