### PR TITLE
 defer metric creation to support feature-gate-dependent options via lazy finalization of registry

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/counter.go
+++ b/staging/src/k8s.io/component-base/metrics/counter.go
@@ -65,6 +65,9 @@ func (c *Counter) Desc() *prometheus.Desc {
 }
 
 func (c *Counter) Write(to *dto.Metric) error {
+	c.createLock.RLock()
+	defer c.createLock.RUnlock()
+	
 	return c.metric.Write(to)
 }
 
@@ -74,6 +77,22 @@ func (c *Counter) Reset() {
 		return
 	}
 	c.setPrometheusCounter(prometheus.NewCounter(c.CounterOpts.toPromCounterOpts()))
+}
+
+func (c *Counter) Inc() {
+	c.Add(1)
+}
+
+func (c *Counter) Add(v float64) {
+	if !c.IsCreated() {
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !c.IsCreated() {
+			return
+		}
+	}
+	c.CounterMetric.Add(v)
 }
 
 // setPrometheusCounter sets the underlying CounterMetric object, i.e. the thing that does the measurement.
@@ -104,6 +123,12 @@ func (c *Counter) initializeDeprecatedMetric() {
 
 // WithContext allows the normal Counter metric to pass in context.
 func (c *Counter) WithContext(ctx context.Context) CounterMetric {
+	if !c.IsCreated() {
+		if FinalizeDeferredRegistries != nil{
+			FinalizeDeferredRegistries()
+		
+		}
+	}
 	return &exemplarCounterMetric{ctx: ctx, delegate: c.CounterMetric}
 }
 
@@ -198,7 +223,12 @@ func (v *CounterVec) initializeDeprecatedMetric() {
 // has been registered to a metrics registry.
 func (v *CounterVec) WithLabelValues(lvs ...string) CounterMetric {
 	if !v.IsCreated() {
-		return noop // return no-op counter
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !v.IsCreated() {
+			return noop // return no-op counter
+		}
 	}
 
 	// Initialize label allow lists if not already initialized
@@ -218,13 +248,42 @@ func (v *CounterVec) WithLabelValues(lvs ...string) CounterMetric {
 	return v.CounterVec.WithLabelValues(lvs...)
 }
 
+func (v *CounterVec) GetMetricWithLabelValues(lvs ...string) (CounterMetric, error) {
+	if !v.IsCreated() {
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !v.IsCreated() {
+			return noop, errNotRegistered
+		}
+	}
+	return v.CounterVec.GetMetricWithLabelValues(lvs...)
+}
+
+func (v *CounterVec) GetMetricWith(labels map[string]string) (CounterMetric, error) {
+	if !v.IsCreated() {
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !v.IsCreated() {
+			return noop, errNotRegistered
+		}
+	}
+	return v.CounterVec.GetMetricWith(labels)
+}
+
 // With returns the Counter for the given Labels map (the label names
 // must match those of the VariableLabels in Desc). If that label map is
 // accessed for the first time, a new Counter is created IFF the counterVec has
 // been registered to a metrics registry.
 func (v *CounterVec) With(labels map[string]string) CounterMetric {
 	if !v.IsCreated() {
-		return noop // return no-op counter
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !v.IsCreated() {
+			return noop // return no-op counter
+		}
 	}
 
 	v.initializeLabelAllowListsOnce.Do(func() {

--- a/staging/src/k8s.io/component-base/metrics/features/kube_features.go
+++ b/staging/src/k8s.io/component-base/metrics/features/kube_features.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/component-base/featuregate"
 	internalmetrics "k8s.io/component-base/metrics/internal"
+	"k8s.io/component-base/metrics/legacyregistry"
 )
 
 const (
@@ -47,8 +48,10 @@ func AddFeatureGates(mutableFeatureGate featuregate.MutableVersionedFeatureGate)
 }
 
 // ApplyFeatureGates propagates the current feature gate state to the metrics
-// subsystem. It must be called after feature gates are finalised and before
-// any histogram metrics are registered.
+// subsystem and finalizes all deferred metric registrations so that
+// feature-gate-dependent options (e.g. native histograms) are applied.
+// It must be called after feature gates are finalized.
 func ApplyFeatureGates(featureGate featuregate.FeatureGate) {
 	internalmetrics.SetNativeHistogramsEnabled(featureGate.Enabled(NativeHistograms))
+	legacyregistry.FinalizeDeferredMetrics()
 }

--- a/staging/src/k8s.io/component-base/metrics/gauge.go
+++ b/staging/src/k8s.io/component-base/metrics/gauge.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 
 	"k8s.io/component-base/version"
 )
@@ -54,6 +55,38 @@ func NewGauge(opts *GaugeOpts) *Gauge {
 	return kc
 }
 
+func (g *Gauge) Set(v float64) {
+	if !g.IsCreated() {
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !g.IsCreated() {
+			return
+		}
+	}
+	g.GaugeMetric.Set(v)
+}
+
+func (g *Gauge) Inc() {
+	g.Add(1)
+}
+
+func (g *Gauge) Dec() {
+	g.Add(-1)
+}
+
+func (g *Gauge) Add(v float64) {
+	if !g.IsCreated() {
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !g.IsCreated() {
+			return
+		}
+	}
+	g.GaugeMetric.Add(v)
+}
+
 // setPrometheusGauge sets the underlying KubeGauge object, i.e. the thing that does the measurement.
 func (g *Gauge) setPrometheusGauge(gauge prometheus.Gauge) {
 	g.GaugeMetric = gauge
@@ -82,7 +115,18 @@ func (g *Gauge) initializeDeprecatedMetric() {
 
 // WithContext allows the normal Gauge metric to pass in context. The context is no-op now.
 func (g *Gauge) WithContext(ctx context.Context) GaugeMetric {
+	if !g.IsCreated() {
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+	}
 	return g.GaugeMetric
+}
+
+func (g *Gauge) Write(to *dto.Metric) error {
+	g.createLock.RLock()
+	defer g.createLock.RUnlock()
+	return g.GaugeMetric.Write(to)
 }
 
 // GaugeVec is the internal representation of our wrapping struct around prometheus
@@ -141,7 +185,12 @@ func (v *GaugeVec) WithLabelValuesChecked(lvs ...string) (GaugeMetric, error) {
 		if v.IsHidden() {
 			return noop, nil
 		}
-		return noop, errNotRegistered // return no-op gauge
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !v.IsCreated() {
+			return noop, errNotRegistered // return no-op gauge
+		}
 	}
 
 	// Initialize label allow lists if not already initialized
@@ -159,6 +208,30 @@ func (v *GaugeVec) WithLabelValuesChecked(lvs ...string) (GaugeMetric, error) {
 	}
 
 	return v.GetMetricWithLabelValues(lvs...)
+}
+
+func (v *GaugeVec) GetMetricWithLabelValues(lvs ...string) (GaugeMetric, error) {
+	if !v.IsCreated() {
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !v.IsCreated() {
+			return noop, errNotRegistered
+		}
+	}
+	return v.GaugeVec.GetMetricWithLabelValues(lvs...)
+}
+
+func (v *GaugeVec) GetMetricWith(labels map[string]string) (GaugeMetric, error) {
+	if !v.IsCreated() {
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !v.IsCreated() {
+			return noop, errNotRegistered
+		}
+	}
+	return v.GaugeVec.GetMetricWith(labels)
 }
 
 func (v *GaugeVec) DeleteLabelValuesChecked(lvs ...string) (bool, error) {
@@ -208,7 +281,12 @@ func (v *GaugeVec) WithChecked(labels map[string]string) (GaugeMetric, error) {
 		if v.IsHidden() {
 			return noop, nil
 		}
-		return noop, errNotRegistered // return no-op gauge
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !v.IsCreated() {
+			return noop, errNotRegistered // return no-op gauge
+		}
 	}
 
 	// Initialize label allow lists if not already initialized

--- a/staging/src/k8s.io/component-base/metrics/histogram.go
+++ b/staging/src/k8s.io/component-base/metrics/histogram.go
@@ -18,11 +18,13 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -77,6 +79,18 @@ func NewHistogram(opts *HistogramOpts) *Histogram {
 	return h
 }
 
+func (h *Histogram) Observe(v float64) {
+	if !h.IsCreated() {
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !h.IsCreated() {
+			return
+		}
+	}
+	h.ObserverMetric.Observe(v)
+}
+
 // setPrometheusHistogram sets the underlying KubeGauge object, i.e. the thing that does the measurement.
 func (h *Histogram) setPrometheusHistogram(histogram prometheus.Histogram) {
 	h.ObserverMetric = histogram
@@ -105,7 +119,21 @@ func (h *Histogram) initializeDeprecatedMetric() {
 
 // WithContext allows the normal Histogram metric to pass in context. The context is no-op now.
 func (h *Histogram) WithContext(ctx context.Context) ObserverMetric {
+	if !h.IsCreated() {
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+	}
 	return &exemplarHistogramMetric{ctx: ctx, delegate: h.ObserverMetric}
+}
+
+func (h *Histogram) Write(to *dto.Metric) error {
+	h.createLock.RLock()
+	defer h.createLock.RUnlock()
+	if m, ok := h.ObserverMetric.(prometheus.Metric); ok {
+		return m.Write(to)
+	}
+	return fmt.Errorf("underlying metric does not support Write")
 }
 
 // HistogramVec is the internal representation of our wrapping struct around prometheus
@@ -170,7 +198,12 @@ func (v *HistogramVec) initializeDeprecatedMetric() {
 // has been registered to a metrics registry.
 func (v *HistogramVec) WithLabelValues(lvs ...string) ObserverMetric {
 	if !v.IsCreated() {
-		return noop
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !v.IsCreated() {
+			return noop
+		}
 	}
 
 	// Initialize label allow lists if not already initialized
@@ -189,13 +222,42 @@ func (v *HistogramVec) WithLabelValues(lvs ...string) ObserverMetric {
 	return v.HistogramVec.WithLabelValues(lvs...)
 }
 
+func (v *HistogramVec) GetMetricWithLabelValues(lvs ...string) (ObserverMetric, error) {
+	if !v.IsCreated() {
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !v.IsCreated() {
+			return noop, errNotRegistered
+		}
+	}
+	return v.HistogramVec.GetMetricWithLabelValues(lvs...)
+}
+
+func (v *HistogramVec) GetMetricWith(labels map[string]string) (ObserverMetric, error) {
+	if !v.IsCreated() {
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !v.IsCreated() {
+			return noop, errNotRegistered
+		}
+	}
+	return v.HistogramVec.GetMetricWith(labels)
+}
+
 // With returns the ObserverMetric for the given Labels map (the label names
 // must match those of the VariableLabels in Desc). If that label map is
 // accessed for the first time, a new ObserverMetric is created IFF the HistogramVec has
 // been registered to a metrics registry.
 func (v *HistogramVec) With(labels map[string]string) ObserverMetric {
 	if !v.IsCreated() {
-		return noop
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !v.IsCreated() {
+			return noop
+		}
 	}
 
 	// Initialize label allow lists if not already initialized

--- a/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	defaultRegistry = metrics.NewKubeRegistry()
+	defaultRegistry = metrics.NewKubeRegistryWithDeferred()
 	// DefaultGatherer exposes the global registry gatherer
 	DefaultGatherer metrics.Gatherer = defaultRegistry
 	// Reset calls reset on the global registry
@@ -54,6 +54,12 @@ func init() {
 	RawMustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	RawMustRegister(collectors.NewGoCollector(collectors.WithGoCollectorRuntimeMetrics(collectors.MetricsAll)))
 	defaultRegistry.RegisterMetaMetrics()
+	// Enable deferred mode so that metrics registered by other packages'
+	// init() functions are not created until feature gates are applied.
+	// This ensures feature-gate-dependent options (e.g. native histograms)
+	// are available at metric creation time.
+	defaultRegistry.EnableDeferredCreation()
+	metrics.FinalizeDeferredRegistries = defaultRegistry.FinalizeDeferredMetrics
 	processStart = time.Now()
 }
 
@@ -89,6 +95,13 @@ func CustomMustRegister(cs ...metrics.StableCollector) {
 	for _, c := range cs {
 		prometheus.MustRegister(c)
 	}
+}
+
+// FinalizeDeferredMetrics creates all metrics that were deferred during
+// init() registration. It must be called after feature gates are applied
+// and before the first metrics scrape. See KubeRegistry.FinalizeDeferredMetrics.
+func FinalizeDeferredMetrics() {
+	defaultRegistry.FinalizeDeferredMetrics()
 }
 
 // GetProcessStart return processStart value

--- a/staging/src/k8s.io/component-base/metrics/metric.go
+++ b/staging/src/k8s.io/component-base/metrics/metric.go
@@ -28,6 +28,17 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// FinalizedDefferedRegistries is invoked from vec hot-path methods
+// (WithLabelValues, With) when a metric is not yet created, giving
+// registries that have opted into deferred mode (via EnableDeferredInit) a
+// chance to finalize their deferred metrics.
+//
+// legacyregistry sets this at init() time to point at its default registry's
+// FinalizeDeferredMetrics.
+//
+// It is not safe to state this var concurrently with reads. Set it from init() only.
+var FinalizeDeferredRegistries func()
+
 /*
 kubeCollector extends the prometheus.Collector interface to allow customization of the metric
 registration process. Defer metric initialization until Create() is called, which then
@@ -58,12 +69,6 @@ type lazyKubeMetric interface {
 	IsDeprecated() bool
 }
 
-/*
-lazyMetric implements lazyKubeMetric. A lazy metric is lazy because it waits until metric
-registration time before instantiation. Add it as an anonymous field to a struct that
-implements kubeCollector to get deferred registration behavior. You must call lazyInit
-with the kubeCollector itself as an argument.
-*/
 type lazyMetric struct {
 	fqName              string
 	isDeprecated        atomic.Bool

--- a/staging/src/k8s.io/component-base/metrics/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/registry.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metrics
 
 import (
+	"slices"
 	"strings"
 	"sync"
 
@@ -143,6 +144,24 @@ type KubeRegistry interface {
 	Gatherer() prometheus.Gatherer
 }
 
+// KubeRegistryWithDeferred extends KubeRegistry to support deferred metric creation.
+type KubeRegistryWithDeferred interface {
+	KubeRegistry
+	// EnableDeferredCreation puts the registry into deferred mode.
+	// While deferred, MustRegister and Register store metrics without
+	// creating the underlying prometheus objects. This allows
+	// feature-gate-dependent options (e.g. native histograms) to be
+	// configured before any metric is materialized.
+	EnableDeferredCreation()
+	// FinalizeDeferredMetrics creates all metrics that were deferred
+	// during registration and registers them with the underlying
+	// prometheus registry. After this call, subsequent MustRegister and
+	// Register calls create metrics immediately. It is safe to call
+	// multiple times; calls after the first are no-ops. Gather also
+	// calls this automatically as a safety net.
+	FinalizeDeferredMetrics()
+}
+
 // kubeRegistry is a wrapper around a prometheus registry-type object. Upon initialization
 // the kubernetes binary version information is loaded into the registry object, so that
 // automatic behavior can be configured for metric versioning.
@@ -155,6 +174,12 @@ type kubeRegistry struct {
 	stableCollectorsLock sync.RWMutex
 	resetLock            sync.RWMutex
 	resettables          []resettable
+
+	// deferLock guards deferredMode and the pending slices.
+	deferLock         sync.Mutex
+	deferredMode      bool
+	pendingCollectors []Registerable    // metrics deferred from MustRegister/Register
+	pendingCustom     []StableCollector // metrics deferred from CustomMustRegister/CustomRegister
 }
 
 // Register registers a new Collector to be included in metrics
@@ -163,6 +188,17 @@ type kubeRegistry struct {
 // already registered Collectors — do not fulfill the consistency and
 // uniqueness criteria described in the documentation of metric.Desc.
 func (kr *kubeRegistry) Register(c Registerable) error {
+	kr.deferLock.Lock()
+	if kr.deferredMode {
+		defer kr.deferLock.Unlock()
+		if slices.Contains(kr.pendingCollectors, c) {
+			return prometheus.AlreadyRegisteredError{ExistingCollector: c, NewCollector: c}
+		}
+		kr.pendingCollectors = append(kr.pendingCollectors, c)
+		return nil
+	}
+	kr.deferLock.Unlock()
+
 	if c.Create(&kr.version) {
 		defer kr.addResettable(c)
 		return kr.PromRegistry.Register(c)
@@ -186,20 +222,58 @@ func (kr *kubeRegistry) Gatherer() prometheus.Gatherer {
 // Collectors and panics upon the first registration that causes an
 // error.
 func (kr *kubeRegistry) MustRegister(cs ...Registerable) {
-	metrics := make([]prometheus.Collector, 0, len(cs))
+	kr.deferLock.Lock()
+	if kr.deferredMode {
+		defer kr.deferLock.Unlock()
+		for _, c := range cs {
+			if slices.Contains(kr.pendingCollectors, c) {
+				panic(prometheus.AlreadyRegisteredError{ExistingCollector: c, NewCollector: c})
+			}
+			kr.pendingCollectors = append(kr.pendingCollectors, c)
+		}
+		return
+	}
+	kr.deferLock.Unlock()
+
+	kr.mustRegisterImmediate(cs)
+}
+
+// mustRegisterImmediate performs the actual Create + PromRegistry.MustRegister
+// work for a batch of collectors. It does NOT consult deferredMode; callers
+// must have already handled the deferred-mode check (either by checking and
+// returning, or by holding deferLock and ensuring deferredMode is false).
+//
+// The deferLock is intentionally not taken here so that this helper can be
+// called from inside FinalizeDeferredMetrics, which holds deferLock across
+// the work to prevent concurrent FinalizeDeferredRegistries hook callers
+// from observing deferredMode=false while a metric's Create() is still in
+// flight.
+func (kr *kubeRegistry) mustRegisterImmediate(cs []Registerable) {
+	toRegister := make([]prometheus.Collector, 0, len(cs))
 	for _, c := range cs {
 		if c.Create(&kr.version) {
-			metrics = append(metrics, c)
+			toRegister = append(toRegister, c)
 			kr.addResettable(c)
 		} else {
 			kr.trackHiddenCollector(c)
 		}
 	}
-	kr.PromRegistry.MustRegister(metrics...)
+	kr.PromRegistry.MustRegister(toRegister...)
 }
 
 // CustomRegister registers a new custom collector.
 func (kr *kubeRegistry) CustomRegister(c StableCollector) error {
+	kr.deferLock.Lock()
+	if kr.deferredMode {
+		defer kr.deferLock.Unlock()
+		if slices.Contains(kr.pendingCustom, c) {
+			return prometheus.AlreadyRegisteredError{ExistingCollector: c, NewCollector: c}
+		}
+		kr.pendingCustom = append(kr.pendingCustom, c)
+		return nil
+	}
+	kr.deferLock.Unlock()
+
 	kr.trackStableCollectors(c)
 	defer kr.addResettable(c)
 	if c.Create(&kr.version, c) {
@@ -212,15 +286,35 @@ func (kr *kubeRegistry) CustomRegister(c StableCollector) error {
 // StableCollectors and panics upon the first registration that causes an
 // error.
 func (kr *kubeRegistry) CustomMustRegister(cs ...StableCollector) {
+	kr.deferLock.Lock()
+	if kr.deferredMode {
+		defer kr.deferLock.Unlock()
+		for _, c := range cs {
+			if slices.Contains(kr.pendingCustom, c) {
+				panic(prometheus.AlreadyRegisteredError{ExistingCollector: c, NewCollector: c})
+			}
+			kr.pendingCustom = append(kr.pendingCustom, c)
+		}
+		return
+	}
+	kr.deferLock.Unlock()
+
+	kr.customMustRegisterImmediate(cs)
+}
+
+// customMustRegisterImmediate is the StableCollector counterpart of
+// mustRegisterImmediate. Same locking contract: callers must have handled
+// the deferred-mode check.
+func (kr *kubeRegistry) customMustRegisterImmediate(cs []StableCollector) {
 	kr.trackStableCollectors(cs...)
-	collectors := make([]prometheus.Collector, 0, len(cs))
+	toRegister := make([]prometheus.Collector, 0, len(cs))
 	for _, c := range cs {
 		if c.Create(&kr.version, c) {
 			kr.addResettable(c)
-			collectors = append(collectors, c)
+			toRegister = append(toRegister, c)
 		}
 	}
-	kr.PromRegistry.MustRegister(collectors...)
+	kr.PromRegistry.MustRegister(toRegister...)
 }
 
 // RawMustRegister takes a native prometheus.Collector and registers the collector
@@ -262,8 +356,57 @@ func (kr *kubeRegistry) Unregister(collector Collector) bool {
 // for valid exposition. As an exception to the strict consistency
 // requirements described for metric.Desc, Gather will tolerate
 // different sets of label names for metrics of the same metric family.
+//
+// If the registry is still in deferred mode, Gather finalizes all
+// pending metrics first so that they are included in the result.
 func (kr *kubeRegistry) Gather() ([]*dto.MetricFamily, error) {
+	kr.FinalizeDeferredMetrics()
 	return kr.PromRegistry.Gather()
+}
+
+// EnableDeferredCreation switches the registry into deferred mode.
+func (kr *kubeRegistry) EnableDeferredCreation() {
+	kr.deferLock.Lock()
+	defer kr.deferLock.Unlock()
+	kr.deferredMode = true
+}
+
+// FinalizeDeferredMetrics processes all deferred metric registrations.
+// It creates the underlying prometheus objects for every metric that was
+// stored while the registry was in deferred mode, registers them, and
+// disables deferred mode so future registrations take effect immediately.
+// It is safe to call multiple times; calls after the first are no-ops.
+//
+// deferLock is held across the actual Create/Register work (not just the
+// flag flip). This ensures that concurrent callers — in particular the
+// FinalizeDeferredRegistries hook firing from multiple goroutines — block
+// until finalization is complete, instead of observing deferredMode=false
+// while a metric's Create() is still in flight (which would cause the
+// caller to fall through to a noop and drop the write).
+func (kr *kubeRegistry) FinalizeDeferredMetrics() {
+	kr.deferLock.Lock()
+	defer kr.deferLock.Unlock()
+	if !kr.deferredMode {
+		return
+	}
+	pending := kr.pendingCollectors
+	pendingCustom := kr.pendingCustom
+	kr.pendingCollectors = nil
+	kr.pendingCustom = nil
+	kr.deferredMode = false
+
+	// Use the *Immediate helpers so we don't recurse back through
+	// MustRegister/CustomMustRegister, which would deadlock on deferLock.
+	// The lock stays held across the work, ensuring concurrent finalize
+	// callers (e.g. parallel FinalizeDeferredRegistries hook firings)
+	// block until everything is created instead of observing
+	// deferredMode=false while Create() is still in flight.
+	if len(pending) > 0 {
+		kr.mustRegisterImmediate(pending)
+	}
+	if len(pendingCustom) > 0 {
+		kr.customMustRegisterImmediate(pendingCustom)
+	}
 }
 
 // trackHiddenCollector stores all hidden collectors.
@@ -354,6 +497,12 @@ func newKubeRegistry(v apimachineryversion.Info) *kubeRegistry {
 
 // NewKubeRegistry creates a new vanilla Registry
 func NewKubeRegistry() KubeRegistry {
+	r := newKubeRegistry(BuildVersion())
+	return r
+}
+
+// NewKubeRegistryWithDeferred creates a new Registry with deferred metric creation support.
+func NewKubeRegistryWithDeferred() KubeRegistryWithDeferred {
 	r := newKubeRegistry(BuildVersion())
 	return r
 }

--- a/staging/src/k8s.io/component-base/metrics/registry_test.go
+++ b/staging/src/k8s.io/component-base/metrics/registry_test.go
@@ -425,6 +425,168 @@ func TestMustRegister(t *testing.T) {
 
 }
 
+func TestDeferredMetricCreation(t *testing.T) {
+	resetMetricsGlobalState(t)
+
+	registry := newKubeRegistry(apimachineryversion.Info{
+		Major:      "1",
+		Minor:      "15",
+		GitVersion: "v1.15.0-alpha-1.12345",
+	})
+	registry.EnableDeferredCreation()
+
+	counter := NewCounter(&CounterOpts{
+		Namespace:      "deferred",
+		Name:           "test_counter",
+		Help:           "counter help",
+		StabilityLevel: ALPHA,
+	})
+	histogram := NewHistogram(&HistogramOpts{
+		Namespace:      "deferred",
+		Name:           "test_histogram",
+		Help:           "histogram help",
+		Buckets:        prometheus.DefBuckets,
+		StabilityLevel: ALPHA,
+	})
+
+	// Metrics registered while in deferred mode should not be created yet.
+	registry.MustRegister(counter)
+	registry.MustRegister(histogram)
+	if counter.IsCreated() {
+		t.Error("counter should not be created while in deferred mode")
+	}
+	if histogram.IsCreated() {
+		t.Error("histogram should not be created while in deferred mode")
+	}
+
+	// After finalization, metrics should be created.
+	registry.FinalizeDeferredMetrics()
+	if !counter.IsCreated() {
+		t.Error("counter should be created after finalization")
+	}
+	if !histogram.IsCreated() {
+		t.Error("histogram should be created after finalization")
+	}
+
+	// Subsequent registrations should take effect immediately.
+	lateCounter := NewCounter(&CounterOpts{
+		Namespace:      "deferred",
+		Name:           "late_counter",
+		Help:           "registered after finalization",
+		StabilityLevel: ALPHA,
+	})
+	registry.MustRegister(lateCounter)
+	if !lateCounter.IsCreated() {
+		t.Error("late counter should be created immediately after finalization")
+	}
+}
+
+func TestDeferredGatherSafetyNet(t *testing.T) {
+	resetMetricsGlobalState(t)
+
+	registry := newKubeRegistry(apimachineryversion.Info{
+		Major:      "1",
+		Minor:      "15",
+		GitVersion: "v1.15.0-alpha-1.12345",
+	})
+	registry.EnableDeferredCreation()
+
+	counter := NewCounter(&CounterOpts{
+		Namespace:      "deferred_gather",
+		Name:           "test_counter",
+		Help:           "counter help",
+		StabilityLevel: ALPHA,
+	})
+	registry.MustRegister(counter)
+
+	// Counter should not be created yet (deferred mode).
+	if counter.IsCreated() {
+		t.Error("counter should not be created before Gather")
+	}
+
+	// Gather should finalize deferred metrics automatically.
+	output := `
+		# HELP deferred_gather_test_counter [ALPHA] counter help
+		# TYPE deferred_gather_test_counter counter
+		deferred_gather_test_counter 0
+	`
+	if err := testutil.GatherAndCompare(registry, strings.NewReader(output), "deferred_gather_test_counter"); err != nil {
+		t.Fatal(err)
+	}
+	if !counter.IsCreated() {
+		t.Error("counter should be created after Gather")
+	}
+}
+
+func TestFinalizeDeferredMetricsIdempotent(t *testing.T) {
+	resetMetricsGlobalState(t)
+
+	registry := newKubeRegistry(apimachineryversion.Info{
+		Major:      "1",
+		Minor:      "15",
+		GitVersion: "v1.15.0-alpha-1.12345",
+	})
+	registry.EnableDeferredCreation()
+
+	counter := NewCounter(&CounterOpts{
+		Namespace:      "idempotent",
+		Name:           "test_counter",
+		Help:           "counter help",
+		StabilityLevel: ALPHA,
+	})
+	registry.MustRegister(counter)
+
+	// Multiple calls should not panic or double-register.
+	registry.FinalizeDeferredMetrics()
+	registry.FinalizeDeferredMetrics()
+	if !counter.IsCreated() {
+		t.Error("counter should be created after finalization")
+	}
+}
+
+func TestVecHookTriggersFinalize(t *testing.T) {
+	resetMetricsGlobalState(t)
+
+	registry := newKubeRegistry(apimachineryversion.Info{
+		Major:      "1",
+		Minor:      "15",
+		GitVersion: "v1.15.0-alpha-1.12345",
+	})
+	registry.EnableDeferredCreation()
+
+	counter := NewCounterVec(&CounterOpts{
+		Namespace:      "vec_hook",
+		Name:           "test_counter",
+		Help:           "counter help",
+		StabilityLevel: ALPHA,
+	}, []string{"label"})
+	registry.MustRegister(counter)
+
+	if counter.IsCreated() {
+		t.Error("vec should not be created while in deferred mode")
+	}
+
+	// Point the hook at this registry, mimicking what legacyregistry
+	// does at init() time for its default registry.
+	oldHook := FinalizeDeferredRegistries
+	FinalizeDeferredRegistries = registry.FinalizeDeferredMetrics
+	defer func() { FinalizeDeferredRegistries = oldHook }()
+
+	counter.WithLabelValues("foo").Inc()
+	if !counter.IsCreated() {
+		t.Error("vec should be created automatically after Inc")
+	}
+
+	output := `
+		# HELP vec_hook_test_counter [ALPHA] counter help
+		# TYPE vec_hook_test_counter counter
+		vec_hook_test_counter{label="foo"} 1
+	`
+	if err := testutil.GatherAndCompare(registry, strings.NewReader(output), "vec_hook_test_counter"); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRegistryReset(t *testing.T) {
 	currentVersion := apimachineryversion.Info{
 		Major:      "1",

--- a/staging/src/k8s.io/component-base/metrics/summary.go
+++ b/staging/src/k8s.io/component-base/metrics/summary.go
@@ -57,6 +57,18 @@ func NewSummary(opts *SummaryOpts) *Summary {
 	return s
 }
 
+func (s *Summary) Observe(v float64) {
+	if !s.IsCreated() {
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !s.IsCreated() {
+			return
+		}
+	}
+	s.ObserverMetric.Observe(v)
+}
+
 // setPrometheusSummary sets the underlying KubeGauge object, i.e. the thing that does the measurement.
 func (s *Summary) setPrometheusSummary(summary prometheus.Summary) {
 	s.ObserverMetric = summary
@@ -85,6 +97,11 @@ func (s *Summary) initializeDeprecatedMetric() {
 
 // WithContext allows the normal Summary metric to pass in context. The context is no-op now.
 func (s *Summary) WithContext(ctx context.Context) ObserverMetric {
+	if !s.IsCreated() {
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+	}
 	return s.ObserverMetric
 }
 
@@ -152,7 +169,12 @@ func (v *SummaryVec) initializeDeprecatedMetric() {
 // has been registered to a metrics registry.
 func (v *SummaryVec) WithLabelValues(lvs ...string) ObserverMetric {
 	if !v.IsCreated() {
-		return noop
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !v.IsCreated() {
+			return noop
+		}
 	}
 
 	// Initialize label allow lists if not already initialized
@@ -171,13 +193,42 @@ func (v *SummaryVec) WithLabelValues(lvs ...string) ObserverMetric {
 	return v.SummaryVec.WithLabelValues(lvs...)
 }
 
+func (v *SummaryVec) GetMetricWithLabelValues(lvs ...string) (ObserverMetric, error) {
+	if !v.IsCreated() {
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !v.IsCreated() {
+			return noop, errNotRegistered
+		}
+	}
+	return v.SummaryVec.GetMetricWithLabelValues(lvs...)
+}
+
+func (v *SummaryVec) GetMetricWith(labels map[string]string) (ObserverMetric, error) {
+	if !v.IsCreated() {
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !v.IsCreated() {
+			return noop, errNotRegistered
+		}
+	}
+	return v.SummaryVec.GetMetricWith(labels)
+}
+
 // With returns the ObserverMetric for the given Labels map (the label names
 // must match those of the VariableLabels in Desc). If that label map is
 // accessed for the first time, a new ObserverMetric is created IFF the summaryVec has
 // been registered to a metrics registry.
 func (v *SummaryVec) With(labels map[string]string) ObserverMetric {
 	if !v.IsCreated() {
-		return noop
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !v.IsCreated() {
+			return noop
+		}
 	}
 
 	v.initializeLabelAllowListsOnce.Do(func() {

--- a/staging/src/k8s.io/component-base/metrics/timing_histogram.go
+++ b/staging/src/k8s.io/component-base/metrics/timing_histogram.go
@@ -65,6 +65,38 @@ func NewTestableTimingHistogram(nowFunc func() time.Time, opts *TimingHistogramO
 	return h
 }
 
+func (h *TimingHistogram) Set(v float64) {
+	if !h.IsCreated() {
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !h.IsCreated() {
+			return
+		}
+	}
+	h.PrometheusTimingHistogram.Set(v)
+}
+
+func (h *TimingHistogram) Inc() {
+	h.Add(1)
+}
+
+func (h *TimingHistogram) Dec() {
+	h.Add(-1)
+}
+
+func (h *TimingHistogram) Add(v float64) {
+	if !h.IsCreated() {
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !h.IsCreated() {
+			return
+		}
+	}
+	h.PrometheusTimingHistogram.Add(v)
+}
+
 // setPrometheusHistogram sets the underlying KubeGauge object, i.e. the thing that does the measurement.
 func (h *TimingHistogram) setPrometheusHistogram(histogram promext.TimingHistogram) {
 	h.PrometheusTimingHistogram = histogram
@@ -97,6 +129,11 @@ func (h *TimingHistogram) initializeDeprecatedMetric() {
 
 // WithContext allows the normal TimingHistogram metric to pass in context. The context is no-op now.
 func (h *TimingHistogram) WithContext(ctx context.Context) GaugeMetric {
+	if !h.IsCreated() {
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+	}
 	return h.PrometheusTimingHistogram
 }
 
@@ -167,7 +204,12 @@ func (v *TimingHistogramVec) WithLabelValuesChecked(lvs ...string) (GaugeMetric,
 		if v.IsHidden() {
 			return noop, nil
 		}
-		return noop, errNotRegistered
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !v.IsCreated() {
+			return noop, errNotRegistered
+		}
 	}
 
 	// Initialize label allow lists if not already initialized
@@ -217,7 +259,12 @@ func (v *TimingHistogramVec) WithChecked(labels map[string]string) (GaugeMetric,
 		if v.IsHidden() {
 			return noop, nil
 		}
-		return noop, errNotRegistered
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !v.IsCreated() {
+			return noop, errNotRegistered
+		}
 	}
 
 	// Initialize label allow lists if not already initialized
@@ -250,6 +297,38 @@ func (v *TimingHistogramVec) With(labels map[string]string) GaugeMetric {
 		return ans
 	}
 	panic(err)
+}
+
+func (v *TimingHistogramVec) GetMetricWithLabelValues(lvs ...string) (GaugeMetric, error) {
+	if !v.IsCreated() {
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !v.IsCreated() {
+			return noop, errNotRegistered
+		}
+	}
+	ops, err := v.TimingHistogramVec.GetMetricWithLabelValues(lvs...)
+	if err != nil {
+		return noop, err
+	}
+	return ops.(GaugeMetric), err
+}
+
+func (v *TimingHistogramVec) GetMetricWith(labels map[string]string) (GaugeMetric, error) {
+	if !v.IsCreated() {
+		if FinalizeDeferredRegistries != nil {
+			FinalizeDeferredRegistries()
+		}
+		if !v.IsCreated() {
+			return noop, errNotRegistered
+		}
+	}
+	ops, err := v.TimingHistogramVec.GetMetricWith(labels)
+	if err != nil {
+		return noop, err
+	}
+	return ops.(GaugeMetric), err
 }
 
 // Delete deletes the metric where the variable labels are the same as those


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
This PR adds a mechanism to allow delaying the creation of underlying Prometheus metrics until after feature gates have been parsed. The motivation for this change is to be able to support options like Native Histograms, which depend on feature gates that are not available when global metrics are initialized and registered (in init()).

Changes include:
1. Added `EnableDeferredCreation` and `FinalizeDeferredMetrics` to the`kubeRegistry`. When in deferred mode, `MustRegister` and `Register` queue metrics in pending slices instead of creating them immediately
2. Updated `With()` and `WithLabelValues()` across all metric vectors (CounterVec, GaugeVec, HistogramVec, SummaryVec) to check if the metric is created. If not, they attempt to finalize the registry
3. Extended the deferred behavior to scalar metrics by implementing `Observe` for `Histogram`, `Inc`/`Add` for `Counter`, and `Set`/`Inc`/`Dec`/`Add` for `Gauge`.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Issue: https://github.com/kubernetes/kubernetes/issues/138320

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
