### PR TITLE
Kubelet synctest speedup

### DIFF
--- a/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager_test.go
+++ b/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager_test.go
@@ -109,14 +109,14 @@ var betaFunctionsBundle = testingFunctionBundle[certificatesv1beta1.ClusterTrust
 }
 
 func TestGetTrustAnchorsByName(t *testing.T) {
-	t.Run("v1alpha1", func(t *testing.T) { testGetTrustAnchorsByName(t, alphaFunctionsBundle) })
-	t.Run("v1beta1", func(t *testing.T) { testGetTrustAnchorsByName(t, betaFunctionsBundle) })
+	tCtx := ktesting.Init(t)
+	tCtx.SyncTest("v1alpha1", func(tCtx ktesting.TContext) { testGetTrustAnchorsByName(tCtx, alphaFunctionsBundle) })
+	tCtx.SyncTest("v1beta1", func(tCtx ktesting.TContext) { testGetTrustAnchorsByName(tCtx, betaFunctionsBundle) })
 }
 
-func testGetTrustAnchorsByName[T clusterTrustBundle](t *testing.T, b testingFunctionBundle[T]) {
-	tCtx := ktesting.Init(t)
-	ctx, cancel := context.WithTimeout(tCtx, 5*time.Second)
-	defer cancel()
+func testGetTrustAnchorsByName[T clusterTrustBundle](tCtx ktesting.TContext, b testingFunctionBundle[T]) {
+	defer tCtx.Cancel("test completed")
+	t := tCtx.TB()
 
 	ctb1Bundle := mustMakeRoot(t, "root1")
 	ctb1 := b.ctbConstructor("ctb1", "", nil, ctb1Bundle)
@@ -129,9 +129,9 @@ func testGetTrustAnchorsByName[T clusterTrustBundle](t *testing.T, b testingFunc
 
 	ctbManager, _ := b.informerManagerConstructor(tCtx, informerFactory, 256, 5*time.Minute)
 
-	informerFactory.Start(ctx.Done())
+	informerFactory.Start(tCtx.Done())
 	ctbInformer := b.informerGetter(informerFactory)
-	if !cache.WaitForCacheSync(ctx.Done(), ctbInformer.HasSynced) {
+	if !cache.WaitForCacheSync(tCtx.Done(), ctbInformer.HasSynced) {
 		t.Fatalf("Timed out waiting for informer to sync")
 	}
 
@@ -165,14 +165,14 @@ func testGetTrustAnchorsByName[T clusterTrustBundle](t *testing.T, b testingFunc
 }
 
 func TestGetTrustAnchorsByNameCaching(t *testing.T) {
-	t.Run("v1alpha1", func(t *testing.T) { testGetTrustAnchorsByNameCaching(t, alphaFunctionsBundle) })
-	t.Run("v1beta1", func(t *testing.T) { testGetTrustAnchorsByNameCaching(t, betaFunctionsBundle) })
+	tCtx := ktesting.Init(t)
+	tCtx.SyncTest("v1alpha1", func(tCtx ktesting.TContext) { testGetTrustAnchorsByNameCaching(tCtx, alphaFunctionsBundle) })
+	tCtx.SyncTest("v1beta1", func(tCtx ktesting.TContext) { testGetTrustAnchorsByNameCaching(tCtx, betaFunctionsBundle) })
 }
 
-func testGetTrustAnchorsByNameCaching[T clusterTrustBundle](t *testing.T, b testingFunctionBundle[T]) {
-	tCtx := ktesting.Init(t)
-	ctx, cancel := context.WithTimeout(tCtx, 20*time.Second)
-	defer cancel()
+func testGetTrustAnchorsByNameCaching[T clusterTrustBundle](tCtx ktesting.TContext, b testingFunctionBundle[T]) {
+	defer tCtx.Cancel("test completed")
+	t := tCtx.TB()
 
 	ctb1Bundle := mustMakeRoot(t, "root1")
 	ctb1 := b.ctbConstructor("foo", "", nil, ctb1Bundle)
@@ -186,13 +186,14 @@ func testGetTrustAnchorsByNameCaching[T clusterTrustBundle](t *testing.T, b test
 
 	ctbManager, _ := b.informerManagerConstructor(tCtx, informerFactory, 256, 5*time.Minute)
 
-	informerFactory.Start(ctx.Done())
+	informerFactory.Start(tCtx.Done())
 	ctbInformer := b.informerGetter(informerFactory)
-	if !cache.WaitForCacheSync(ctx.Done(), ctbInformer.HasSynced) {
+	if !cache.WaitForCacheSync(tCtx.Done(), ctbInformer.HasSynced) {
 		t.Fatalf("Timed out waiting for informer to sync")
 	}
 
-	t.Run("foo should yield the first certificate", func(t *testing.T) {
+	func() {
+		t.Log("foo should yield the first certificate")
 		gotBundle, err := ctbManager.GetTrustAnchorsByName(tCtx, "foo", false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
@@ -203,9 +204,10 @@ func testGetTrustAnchorsByNameCaching[T clusterTrustBundle](t *testing.T, b test
 		if diff := diffBundles(gotBundle, []byte(wantBundle)); diff != "" {
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
-	})
+	}()
 
-	t.Run("foo should still yield the first certificate", func(t *testing.T) {
+	func() {
+		t.Log("foo should still yield the first certificate")
 		gotBundle, err := ctbManager.GetTrustAnchorsByName(tCtx, "foo", false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
@@ -216,14 +218,14 @@ func testGetTrustAnchorsByNameCaching[T clusterTrustBundle](t *testing.T, b test
 		if diff := diffBundles(gotBundle, []byte(wantBundle)); diff != "" {
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
-	})
+	}()
 
 	client := b.clientGetter(kc)
 
-	if err := client.Delete(ctx, "foo", metav1.DeleteOptions{}); err != nil {
+	if err := client.Delete(tCtx, "foo", metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("Error while deleting the old CTB: %v", err)
 	}
-	if _, err := client.Create(ctx, ctb2, metav1.CreateOptions{}); err != nil {
+	if _, err := client.Create(tCtx, ctb2, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Error while adding new CTB: %v", err)
 	}
 
@@ -232,7 +234,8 @@ func testGetTrustAnchorsByNameCaching[T clusterTrustBundle](t *testing.T, b test
 	// This shows us that the informer is properly clearing the cache.
 	time.Sleep(5 * time.Second)
 
-	t.Run("foo should yield the new certificate", func(t *testing.T) {
+	func() {
+		t.Log("foo should yield the new certificate")
 		gotBundle, err := ctbManager.GetTrustAnchorsByName(tCtx, "foo", false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
@@ -242,18 +245,18 @@ func testGetTrustAnchorsByNameCaching[T clusterTrustBundle](t *testing.T, b test
 		if diff := diffBundles(gotBundle, []byte(wantBundle)); diff != "" {
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
-	})
+	}()
 }
 
 func TestGetTrustAnchorsBySignerName(t *testing.T) {
-	t.Run("v1alpha1", func(t *testing.T) { testGetTrustAnchorsBySignerName(t, alphaFunctionsBundle) })
-	t.Run("v1beta1", func(t *testing.T) { testGetTrustAnchorsBySignerName(t, betaFunctionsBundle) })
+	tCtx := ktesting.Init(t)
+	tCtx.SyncTest("v1alpha1", func(tCtx ktesting.TContext) { testGetTrustAnchorsBySignerName(tCtx, alphaFunctionsBundle) })
+	tCtx.SyncTest("v1beta1", func(tCtx ktesting.TContext) { testGetTrustAnchorsBySignerName(tCtx, betaFunctionsBundle) })
 }
 
-func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testingFunctionBundle[T]) {
-	tCtx := ktesting.Init(t)
-	ctx, cancel := context.WithTimeout(tCtx, 5*time.Second)
-	defer cancel()
+func testGetTrustAnchorsBySignerName[T clusterTrustBundle](tCtx ktesting.TContext, b testingFunctionBundle[T]) {
+	defer tCtx.Cancel("test completed")
+	t := tCtx.TB()
 
 	ctb1 := b.ctbConstructor("signer-a-label-a-1", "foo.bar/a", map[string]string{"label": "a"}, mustMakeRoot(t, "0"))
 	ctb2 := b.ctbConstructor("signer-a-label-a-2", "foo.bar/a", map[string]string{"label": "a"}, mustMakeRoot(t, "1"))
@@ -267,13 +270,14 @@ func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testi
 
 	ctbManager, _ := b.informerManagerConstructor(tCtx, informerFactory, 256, 5*time.Minute)
 
-	informerFactory.Start(ctx.Done())
+	informerFactory.Start(tCtx.Done())
 	ctbInformer := b.informerGetter(informerFactory)
-	if !cache.WaitForCacheSync(ctx.Done(), ctbInformer.HasSynced) {
+	if !cache.WaitForCacheSync(tCtx.Done(), ctbInformer.HasSynced) {
 		t.Fatalf("Timed out waiting for informer to sync")
 	}
 
-	t.Run("big labelselector should cause error", func(t *testing.T) {
+	func() {
+		t.Log("big labelselector should cause error")
 		longString := strings.Builder{}
 		for i := 0; i < 63; i++ {
 			longString.WriteString("v")
@@ -287,9 +291,10 @@ func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testi
 		if err == nil || !strings.Contains(err.Error(), "label selector length") {
 			t.Fatalf("Bad error, got %v, wanted it to contain \"label selector length\"", err)
 		}
-	})
+	}()
 
-	t.Run("signer-a label-a should yield two sorted certificates", func(t *testing.T) {
+	func() {
+		t.Log("signer-a label-a should yield two sorted certificates")
 		gotBundle, err := ctbManager.GetTrustAnchorsBySigner(tCtx, "foo.bar/a", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "a"}}, false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
@@ -300,9 +305,10 @@ func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testi
 		if diff := diffBundles(gotBundle, []byte(wantBundle)); diff != "" {
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
-	})
+	}()
 
-	t.Run("signer-a with nil selector should yield zero certificates", func(t *testing.T) {
+	func() {
+		t.Log("signer-a with nil selector should yield zero certificates")
 		gotBundle, err := ctbManager.GetTrustAnchorsBySigner(tCtx, "foo.bar/a", nil, true)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
@@ -313,9 +319,10 @@ func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testi
 		if diff := diffBundles(gotBundle, []byte(wantBundle)); diff != "" {
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
-	})
+	}()
 
-	t.Run("signer-b with empty selector should yield one certificates", func(t *testing.T) {
+	func() {
+		t.Log("signer-b with empty selector should yield one certificates")
 		gotBundle, err := ctbManager.GetTrustAnchorsBySigner(tCtx, "foo.bar/b", &metav1.LabelSelector{}, false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
@@ -324,9 +331,10 @@ func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testi
 		if diff := diffBundles(gotBundle, []byte(b.ctbTrustBundle(ctb4))); diff != "" {
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
-	})
+	}()
 
-	t.Run("signer-a label-b should yield one certificate", func(t *testing.T) {
+	func() {
+		t.Log("signer-a label-b should yield one certificate")
 		gotBundle, err := ctbManager.GetTrustAnchorsBySigner(tCtx, "foo.bar/a", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "b"}}, false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
@@ -335,9 +343,10 @@ func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testi
 		if diff := diffBundles(gotBundle, []byte(b.ctbTrustBundle(ctb3))); diff != "" {
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
-	})
+	}()
 
-	t.Run("signer-b label-a should yield one certificate", func(t *testing.T) {
+	func() {
+		t.Log("signer-b label-a should yield one certificate")
 		gotBundle, err := ctbManager.GetTrustAnchorsBySigner(tCtx, "foo.bar/b", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "a"}}, false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
@@ -346,9 +355,10 @@ func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testi
 		if diff := diffBundles(gotBundle, []byte(b.ctbTrustBundle(ctb4))); diff != "" {
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
-	})
+	}()
 
-	t.Run("signer-b label-b allowMissing=true should yield zero certificates", func(t *testing.T) {
+	func() {
+		t.Log("signer-b label-b allowMissing=true should yield zero certificates")
 		gotBundle, err := ctbManager.GetTrustAnchorsBySigner(tCtx, "foo.bar/b", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "b"}}, true)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
@@ -357,25 +367,26 @@ func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testi
 		if diff := diffBundles(gotBundle, []byte{}); diff != "" {
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
-	})
+	}()
 
-	t.Run("signer-b label-b allowMissing=false should yield zero certificates (error)", func(t *testing.T) {
+	func() {
+		t.Log("signer-b label-b allowMissing=false should yield zero certificates (error)")
 		_, err := ctbManager.GetTrustAnchorsBySigner(tCtx, "foo.bar/b", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "b"}}, false)
 		if err == nil { // EQUALS nil
 			t.Fatalf("Got nil error while calling GetTrustAnchorsBySigner, wanted non-nil")
 		}
-	})
+	}()
 }
 
 func TestGetTrustAnchorsBySignerNameCaching(t *testing.T) {
-	t.Run("v1alpha1", func(t *testing.T) { testGetTrustAnchorsBySignerNameCaching(t, alphaFunctionsBundle) })
-	t.Run("v1beta1", func(t *testing.T) { testGetTrustAnchorsBySignerNameCaching(t, betaFunctionsBundle) })
+	tCtx := ktesting.Init(t)
+	tCtx.SyncTest("v1alpha1", func(tCtx ktesting.TContext) { testGetTrustAnchorsBySignerNameCaching(tCtx, alphaFunctionsBundle) })
+	tCtx.SyncTest("v1beta1", func(tCtx ktesting.TContext) { testGetTrustAnchorsBySignerNameCaching(tCtx, betaFunctionsBundle) })
 }
 
-func testGetTrustAnchorsBySignerNameCaching[T clusterTrustBundle](t *testing.T, b testingFunctionBundle[T]) {
-	tCtx := ktesting.Init(t)
-	ctx, cancel := context.WithTimeout(tCtx, 20*time.Second)
-	defer cancel()
+func testGetTrustAnchorsBySignerNameCaching[T clusterTrustBundle](tCtx ktesting.TContext, b testingFunctionBundle[T]) {
+	defer tCtx.Cancel("test completed")
+	t := tCtx.TB()
 
 	ctb1 := b.ctbConstructor("signer-a-label-a-1", "foo.bar/a", map[string]string{"label": "a"}, mustMakeRoot(t, "0"))
 	ctb2 := b.ctbConstructor("signer-a-label-a-2", "foo.bar/a", map[string]string{"label": "a"}, mustMakeRoot(t, "1"))
@@ -386,13 +397,14 @@ func testGetTrustAnchorsBySignerNameCaching[T clusterTrustBundle](t *testing.T, 
 
 	ctbManager, _ := b.informerManagerConstructor(tCtx, informerFactory, 256, 5*time.Minute)
 
-	informerFactory.Start(ctx.Done())
+	informerFactory.Start(tCtx.Done())
 	ctbInformer := b.informerGetter(informerFactory)
-	if !cache.WaitForCacheSync(ctx.Done(), ctbInformer.HasSynced) {
+	if !cache.WaitForCacheSync(tCtx.Done(), ctbInformer.HasSynced) {
 		t.Fatalf("Timed out waiting for informer to sync")
 	}
 
-	t.Run("signer-a label-a should yield one certificate", func(t *testing.T) {
+	func() {
+		t.Log("signer-a label-a should yield one certificate")
 		gotBundle, err := ctbManager.GetTrustAnchorsBySigner(tCtx, "foo.bar/a", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "a"}}, false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
@@ -403,9 +415,10 @@ func testGetTrustAnchorsBySignerNameCaching[T clusterTrustBundle](t *testing.T, 
 		if diff := diffBundles(gotBundle, []byte(wantBundle)); diff != "" {
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
-	})
+	}()
 
-	t.Run("signer-a label-a should yield the same result when called again", func(t *testing.T) {
+	func() {
+		t.Log("signer-a label-a should yield the same result when called again")
 		gotBundle, err := ctbManager.GetTrustAnchorsBySigner(tCtx, "foo.bar/a", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "a"}}, false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
@@ -416,13 +429,13 @@ func testGetTrustAnchorsBySignerNameCaching[T clusterTrustBundle](t *testing.T, 
 		if diff := diffBundles(gotBundle, []byte(wantBundle)); diff != "" {
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
-	})
+	}()
 
 	client := b.clientGetter(kc)
-	if err := client.Delete(ctx, "signer-a-label-a-1", metav1.DeleteOptions{}); err != nil {
+	if err := client.Delete(tCtx, "signer-a-label-a-1", metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("Error while deleting the old CTB: %v", err)
 	}
-	if _, err := client.Create(ctx, ctb2, metav1.CreateOptions{}); err != nil {
+	if _, err := client.Create(tCtx, ctb2, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Error while adding new CTB: %v", err)
 	}
 
@@ -431,7 +444,8 @@ func testGetTrustAnchorsBySignerNameCaching[T clusterTrustBundle](t *testing.T, 
 	// This shows us that the informer is properly clearing the cache.
 	time.Sleep(5 * time.Second)
 
-	t.Run("signer-a label-a should return the new certificate", func(t *testing.T) {
+	func() {
+		t.Log("signer-a label-a should return the new certificate")
 		gotBundle, err := ctbManager.GetTrustAnchorsBySigner(tCtx, "foo.bar/a", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "a"}}, false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
@@ -442,10 +456,10 @@ func testGetTrustAnchorsBySignerNameCaching[T clusterTrustBundle](t *testing.T, 
 		if diff := diffBundles(gotBundle, []byte(wantBundle)); diff != "" {
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
-	})
+	}()
 }
 
-func mustMakeRoot(t *testing.T, cn string) string {
+func mustMakeRoot(t ktesting.TB, cn string) string {
 	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatalf("Error while generating key: %v", err)

--- a/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager_test.go
+++ b/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager_test.go
@@ -109,14 +109,14 @@ var betaFunctionsBundle = testingFunctionBundle[certificatesv1beta1.ClusterTrust
 }
 
 func TestGetTrustAnchorsByName(t *testing.T) {
-	t.Run("v1alpha1", func(t *testing.T) { testGetTrustAnchorsByName(t, alphaFunctionsBundle) })
-	t.Run("v1beta1", func(t *testing.T) { testGetTrustAnchorsByName(t, betaFunctionsBundle) })
+	tCtx := ktesting.Init(t)
+	tCtx.SyncTest("v1alpha1", func(tCtx ktesting.TContext) { testGetTrustAnchorsByName(tCtx, alphaFunctionsBundle) })
+	tCtx.SyncTest("v1beta1", func(tCtx ktesting.TContext) { testGetTrustAnchorsByName(tCtx, betaFunctionsBundle) })
 }
 
-func testGetTrustAnchorsByName[T clusterTrustBundle](t *testing.T, b testingFunctionBundle[T]) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	tCtx := ktesting.Init(t)
-	defer cancel()
+func testGetTrustAnchorsByName[T clusterTrustBundle](tCtx ktesting.TContext, b testingFunctionBundle[T]) {
+	defer tCtx.Cancel("test completed")
+	t := tCtx.TB()
 
 	ctb1Bundle := mustMakeRoot(t, "root1")
 	ctb1 := b.ctbConstructor("ctb1", "", nil, ctb1Bundle)
@@ -129,9 +129,9 @@ func testGetTrustAnchorsByName[T clusterTrustBundle](t *testing.T, b testingFunc
 
 	ctbManager, _ := b.informerManagerConstructor(tCtx, informerFactory, 256, 5*time.Minute)
 
-	informerFactory.Start(ctx.Done())
+	informerFactory.Start(tCtx.Done())
 	ctbInformer := b.informerGetter(informerFactory)
-	if !cache.WaitForCacheSync(ctx.Done(), ctbInformer.HasSynced) {
+	if !cache.WaitForCacheSync(tCtx.Done(), ctbInformer.HasSynced) {
 		t.Fatalf("Timed out waiting for informer to sync")
 	}
 
@@ -165,14 +165,14 @@ func testGetTrustAnchorsByName[T clusterTrustBundle](t *testing.T, b testingFunc
 }
 
 func TestGetTrustAnchorsByNameCaching(t *testing.T) {
-	t.Run("v1alpha1", func(t *testing.T) { testGetTrustAnchorsByNameCaching(t, alphaFunctionsBundle) })
-	t.Run("v1beta1", func(t *testing.T) { testGetTrustAnchorsByNameCaching(t, betaFunctionsBundle) })
+	tCtx := ktesting.Init(t)
+	tCtx.SyncTest("v1alpha1", func(tCtx ktesting.TContext) { testGetTrustAnchorsByNameCaching(tCtx, alphaFunctionsBundle) })
+	tCtx.SyncTest("v1beta1", func(tCtx ktesting.TContext) { testGetTrustAnchorsByNameCaching(tCtx, betaFunctionsBundle) })
 }
 
-func testGetTrustAnchorsByNameCaching[T clusterTrustBundle](t *testing.T, b testingFunctionBundle[T]) {
-	tCtx := ktesting.Init(t)
-	ctx, cancel := context.WithTimeout(tCtx, 20*time.Second)
-	defer cancel()
+func testGetTrustAnchorsByNameCaching[T clusterTrustBundle](tCtx ktesting.TContext, b testingFunctionBundle[T]) {
+	defer tCtx.Cancel("test completed")
+	t := tCtx.TB()
 
 	ctb1Bundle := mustMakeRoot(t, "root1")
 	ctb1 := b.ctbConstructor("foo", "", nil, ctb1Bundle)
@@ -186,13 +186,14 @@ func testGetTrustAnchorsByNameCaching[T clusterTrustBundle](t *testing.T, b test
 
 	ctbManager, _ := b.informerManagerConstructor(tCtx, informerFactory, 256, 5*time.Minute)
 
-	informerFactory.Start(ctx.Done())
+	informerFactory.Start(tCtx.Done())
 	ctbInformer := b.informerGetter(informerFactory)
-	if !cache.WaitForCacheSync(ctx.Done(), ctbInformer.HasSynced) {
+	if !cache.WaitForCacheSync(tCtx.Done(), ctbInformer.HasSynced) {
 		t.Fatalf("Timed out waiting for informer to sync")
 	}
 
-	t.Run("foo should yield the first certificate", func(t *testing.T) {
+	func() {
+		t.Log("foo should yield the first certificate")
 		gotBundle, err := ctbManager.GetTrustAnchorsByName("foo", false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
@@ -203,9 +204,10 @@ func testGetTrustAnchorsByNameCaching[T clusterTrustBundle](t *testing.T, b test
 		if diff := diffBundles(gotBundle, []byte(wantBundle)); diff != "" {
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
-	})
+	}()
 
-	t.Run("foo should still yield the first certificate", func(t *testing.T) {
+	func() {
+		t.Log("foo should still yield the first certificate")
 		gotBundle, err := ctbManager.GetTrustAnchorsByName("foo", false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
@@ -216,14 +218,14 @@ func testGetTrustAnchorsByNameCaching[T clusterTrustBundle](t *testing.T, b test
 		if diff := diffBundles(gotBundle, []byte(wantBundle)); diff != "" {
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
-	})
+	}()
 
 	client := b.clientGetter(kc)
 
-	if err := client.Delete(ctx, "foo", metav1.DeleteOptions{}); err != nil {
+	if err := client.Delete(tCtx, "foo", metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("Error while deleting the old CTB: %v", err)
 	}
-	if _, err := client.Create(ctx, ctb2, metav1.CreateOptions{}); err != nil {
+	if _, err := client.Create(tCtx, ctb2, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Error while adding new CTB: %v", err)
 	}
 
@@ -232,7 +234,8 @@ func testGetTrustAnchorsByNameCaching[T clusterTrustBundle](t *testing.T, b test
 	// This shows us that the informer is properly clearing the cache.
 	time.Sleep(5 * time.Second)
 
-	t.Run("foo should yield the new certificate", func(t *testing.T) {
+	func() {
+		t.Log("foo should yield the new certificate")
 		gotBundle, err := ctbManager.GetTrustAnchorsByName("foo", false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
@@ -242,18 +245,18 @@ func testGetTrustAnchorsByNameCaching[T clusterTrustBundle](t *testing.T, b test
 		if diff := diffBundles(gotBundle, []byte(wantBundle)); diff != "" {
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
-	})
+	}()
 }
 
 func TestGetTrustAnchorsBySignerName(t *testing.T) {
-	t.Run("v1alpha1", func(t *testing.T) { testGetTrustAnchorsBySignerName(t, alphaFunctionsBundle) })
-	t.Run("v1beta1", func(t *testing.T) { testGetTrustAnchorsBySignerName(t, betaFunctionsBundle) })
+	tCtx := ktesting.Init(t)
+	tCtx.SyncTest("v1alpha1", func(tCtx ktesting.TContext) { testGetTrustAnchorsBySignerName(tCtx, alphaFunctionsBundle) })
+	tCtx.SyncTest("v1beta1", func(tCtx ktesting.TContext) { testGetTrustAnchorsBySignerName(tCtx, betaFunctionsBundle) })
 }
 
-func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testingFunctionBundle[T]) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	tCtx := ktesting.Init(t)
-	defer cancel()
+func testGetTrustAnchorsBySignerName[T clusterTrustBundle](tCtx ktesting.TContext, b testingFunctionBundle[T]) {
+	defer tCtx.Cancel("test completed")
+	t := tCtx.TB()
 
 	ctb1 := b.ctbConstructor("signer-a-label-a-1", "foo.bar/a", map[string]string{"label": "a"}, mustMakeRoot(t, "0"))
 	ctb2 := b.ctbConstructor("signer-a-label-a-2", "foo.bar/a", map[string]string{"label": "a"}, mustMakeRoot(t, "1"))
@@ -267,13 +270,14 @@ func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testi
 
 	ctbManager, _ := b.informerManagerConstructor(tCtx, informerFactory, 256, 5*time.Minute)
 
-	informerFactory.Start(ctx.Done())
+	informerFactory.Start(tCtx.Done())
 	ctbInformer := b.informerGetter(informerFactory)
-	if !cache.WaitForCacheSync(ctx.Done(), ctbInformer.HasSynced) {
+	if !cache.WaitForCacheSync(tCtx.Done(), ctbInformer.HasSynced) {
 		t.Fatalf("Timed out waiting for informer to sync")
 	}
 
-	t.Run("big labelselector should cause error", func(t *testing.T) {
+	func() {
+		t.Log("big labelselector should cause error")
 		longString := strings.Builder{}
 		for i := 0; i < 63; i++ {
 			longString.WriteString("v")
@@ -287,9 +291,10 @@ func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testi
 		if err == nil || !strings.Contains(err.Error(), "label selector length") {
 			t.Fatalf("Bad error, got %v, wanted it to contain \"label selector length\"", err)
 		}
-	})
+	}()
 
-	t.Run("signer-a label-a should yield two sorted certificates", func(t *testing.T) {
+	func() {
+		t.Log("signer-a label-a should yield two sorted certificates")
 		gotBundle, err := ctbManager.GetTrustAnchorsBySigner("foo.bar/a", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "a"}}, false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
@@ -300,9 +305,10 @@ func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testi
 		if diff := diffBundles(gotBundle, []byte(wantBundle)); diff != "" {
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
-	})
+	}()
 
-	t.Run("signer-a with nil selector should yield zero certificates", func(t *testing.T) {
+	func() {
+		t.Log("signer-a with nil selector should yield zero certificates")
 		gotBundle, err := ctbManager.GetTrustAnchorsBySigner("foo.bar/a", nil, true)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
@@ -313,9 +319,10 @@ func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testi
 		if diff := diffBundles(gotBundle, []byte(wantBundle)); diff != "" {
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
-	})
+	}()
 
-	t.Run("signer-b with empty selector should yield one certificates", func(t *testing.T) {
+	func() {
+		t.Log("signer-b with empty selector should yield one certificates")
 		gotBundle, err := ctbManager.GetTrustAnchorsBySigner("foo.bar/b", &metav1.LabelSelector{}, false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
@@ -324,9 +331,10 @@ func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testi
 		if diff := diffBundles(gotBundle, []byte(b.ctbTrustBundle(ctb4))); diff != "" {
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
-	})
+	}()
 
-	t.Run("signer-a label-b should yield one certificate", func(t *testing.T) {
+	func() {
+		t.Log("signer-a label-b should yield one certificate")
 		gotBundle, err := ctbManager.GetTrustAnchorsBySigner("foo.bar/a", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "b"}}, false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
@@ -335,9 +343,10 @@ func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testi
 		if diff := diffBundles(gotBundle, []byte(b.ctbTrustBundle(ctb3))); diff != "" {
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
-	})
+	}()
 
-	t.Run("signer-b label-a should yield one certificate", func(t *testing.T) {
+	func() {
+		t.Log("signer-b label-a should yield one certificate")
 		gotBundle, err := ctbManager.GetTrustAnchorsBySigner("foo.bar/b", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "a"}}, false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
@@ -346,9 +355,10 @@ func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testi
 		if diff := diffBundles(gotBundle, []byte(b.ctbTrustBundle(ctb4))); diff != "" {
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
-	})
+	}()
 
-	t.Run("signer-b label-b allowMissing=true should yield zero certificates", func(t *testing.T) {
+	func() {
+		t.Log("signer-b label-b allowMissing=true should yield zero certificates")
 		gotBundle, err := ctbManager.GetTrustAnchorsBySigner("foo.bar/b", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "b"}}, true)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
@@ -357,25 +367,26 @@ func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testi
 		if diff := diffBundles(gotBundle, []byte{}); diff != "" {
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
-	})
+	}()
 
-	t.Run("signer-b label-b allowMissing=false should yield zero certificates (error)", func(t *testing.T) {
+	func() {
+		t.Log("signer-b label-b allowMissing=false should yield zero certificates (error)")
 		_, err := ctbManager.GetTrustAnchorsBySigner("foo.bar/b", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "b"}}, false)
 		if err == nil { // EQUALS nil
 			t.Fatalf("Got nil error while calling GetTrustAnchorsBySigner, wanted non-nil")
 		}
-	})
+	}()
 }
 
 func TestGetTrustAnchorsBySignerNameCaching(t *testing.T) {
-	t.Run("v1alpha1", func(t *testing.T) { testGetTrustAnchorsBySignerNameCaching(t, alphaFunctionsBundle) })
-	t.Run("v1beta1", func(t *testing.T) { testGetTrustAnchorsBySignerNameCaching(t, betaFunctionsBundle) })
+	tCtx := ktesting.Init(t)
+	tCtx.SyncTest("v1alpha1", func(tCtx ktesting.TContext) { testGetTrustAnchorsBySignerNameCaching(tCtx, alphaFunctionsBundle) })
+	tCtx.SyncTest("v1beta1", func(tCtx ktesting.TContext) { testGetTrustAnchorsBySignerNameCaching(tCtx, betaFunctionsBundle) })
 }
 
-func testGetTrustAnchorsBySignerNameCaching[T clusterTrustBundle](t *testing.T, b testingFunctionBundle[T]) {
-	tCtx := ktesting.Init(t)
-	ctx, cancel := context.WithTimeout(tCtx, 20*time.Second)
-	defer cancel()
+func testGetTrustAnchorsBySignerNameCaching[T clusterTrustBundle](tCtx ktesting.TContext, b testingFunctionBundle[T]) {
+	defer tCtx.Cancel("test completed")
+	t := tCtx.TB()
 
 	ctb1 := b.ctbConstructor("signer-a-label-a-1", "foo.bar/a", map[string]string{"label": "a"}, mustMakeRoot(t, "0"))
 	ctb2 := b.ctbConstructor("signer-a-label-a-2", "foo.bar/a", map[string]string{"label": "a"}, mustMakeRoot(t, "1"))
@@ -386,13 +397,14 @@ func testGetTrustAnchorsBySignerNameCaching[T clusterTrustBundle](t *testing.T, 
 
 	ctbManager, _ := b.informerManagerConstructor(tCtx, informerFactory, 256, 5*time.Minute)
 
-	informerFactory.Start(ctx.Done())
+	informerFactory.Start(tCtx.Done())
 	ctbInformer := b.informerGetter(informerFactory)
-	if !cache.WaitForCacheSync(ctx.Done(), ctbInformer.HasSynced) {
+	if !cache.WaitForCacheSync(tCtx.Done(), ctbInformer.HasSynced) {
 		t.Fatalf("Timed out waiting for informer to sync")
 	}
 
-	t.Run("signer-a label-a should yield one certificate", func(t *testing.T) {
+	func() {
+		t.Log("signer-a label-a should yield one certificate")
 		gotBundle, err := ctbManager.GetTrustAnchorsBySigner("foo.bar/a", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "a"}}, false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
@@ -403,9 +415,10 @@ func testGetTrustAnchorsBySignerNameCaching[T clusterTrustBundle](t *testing.T, 
 		if diff := diffBundles(gotBundle, []byte(wantBundle)); diff != "" {
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
-	})
+	}()
 
-	t.Run("signer-a label-a should yield the same result when called again", func(t *testing.T) {
+	func() {
+		t.Log("signer-a label-a should yield the same result when called again")
 		gotBundle, err := ctbManager.GetTrustAnchorsBySigner("foo.bar/a", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "a"}}, false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
@@ -416,13 +429,13 @@ func testGetTrustAnchorsBySignerNameCaching[T clusterTrustBundle](t *testing.T, 
 		if diff := diffBundles(gotBundle, []byte(wantBundle)); diff != "" {
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
-	})
+	}()
 
 	client := b.clientGetter(kc)
-	if err := client.Delete(ctx, "signer-a-label-a-1", metav1.DeleteOptions{}); err != nil {
+	if err := client.Delete(tCtx, "signer-a-label-a-1", metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("Error while deleting the old CTB: %v", err)
 	}
-	if _, err := client.Create(ctx, ctb2, metav1.CreateOptions{}); err != nil {
+	if _, err := client.Create(tCtx, ctb2, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Error while adding new CTB: %v", err)
 	}
 
@@ -431,7 +444,8 @@ func testGetTrustAnchorsBySignerNameCaching[T clusterTrustBundle](t *testing.T, 
 	// This shows us that the informer is properly clearing the cache.
 	time.Sleep(5 * time.Second)
 
-	t.Run("signer-a label-a should return the new certificate", func(t *testing.T) {
+	func() {
+		t.Log("signer-a label-a should return the new certificate")
 		gotBundle, err := ctbManager.GetTrustAnchorsBySigner("foo.bar/a", &metav1.LabelSelector{MatchLabels: map[string]string{"label": "a"}}, false)
 		if err != nil {
 			t.Fatalf("Got error while calling GetTrustAnchorsBySigner: %v", err)
@@ -442,10 +456,10 @@ func testGetTrustAnchorsBySignerNameCaching[T clusterTrustBundle](t *testing.T, 
 		if diff := diffBundles(gotBundle, []byte(wantBundle)); diff != "" {
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
-	})
+	}()
 }
 
-func mustMakeRoot(t *testing.T, cn string) string {
+func mustMakeRoot(t ktesting.TB, cn string) string {
 	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatalf("Error while generating key: %v", err)

--- a/pkg/kubelet/images/image_gc_manager.go
+++ b/pkg/kubelet/images/image_gc_manager.go
@@ -217,22 +217,22 @@ func NewImageGCManager(runtime container.Runtime, statsProvider StatsProvider, p
 
 func (im *realImageGCManager) Start(ctx context.Context) {
 	logger := klog.FromContext(ctx)
-	go wait.Until(func() {
+	go wait.UntilWithContext(ctx, func(ctx context.Context) {
 		_, err := im.detectImages(ctx, time.Now())
 		if err != nil {
 			logger.Info("Failed to monitor images", "err", err)
 		}
-	}, 5*time.Minute, wait.NeverStop)
+	}, 5*time.Minute)
 
 	// Start a goroutine periodically updates image cache.
-	go wait.Until(func() {
+	go wait.UntilWithContext(ctx, func(ctx context.Context) {
 		images, err := im.runtime.ListImages(ctx)
 		if err != nil {
 			logger.Info("Failed to update image list", "err", err)
 		} else {
 			im.imageCache.set(images)
 		}
-	}, 30*time.Second, wait.NeverStop)
+	}, 30*time.Second)
 
 }
 

--- a/pkg/kubelet/images/image_gc_manager_test.go
+++ b/pkg/kubelet/images/image_gc_manager_test.go
@@ -499,7 +499,12 @@ func TestDeleteUnusedImagesRemoveAllUnusedImages(t *testing.T) {
 }
 
 func TestDeleteUnusedImagesLimitByImageLiveTime(t *testing.T) {
-	ctx := ktesting.Init(t)
+	ktesting.Init(t).SyncTest("", testDeleteUnusedImagesLimitByImageLiveTime)
+}
+
+func testDeleteUnusedImagesLimitByImageLiveTime(tCtx ktesting.TContext) {
+	defer tCtx.Cancel("test completed")
+	t := tCtx.TB()
 	mockStatsProvider := statstest.NewMockProvider(t)
 
 	manager, fakeRuntime := newRealImageGCManager(ImageGCPolicy{
@@ -518,15 +523,15 @@ func TestDeleteUnusedImagesLimitByImageLiveTime(t *testing.T) {
 		}},
 	}
 	// start to detect images
-	manager.Start(ctx)
+	manager.Start(tCtx)
 	// try to delete images, but images are not old enough,so no image will be deleted
-	err := manager.DeleteUnusedImages(ctx)
+	err := manager.DeleteUnusedImages(tCtx)
 	assert := assert.New(t)
 	require.NoError(t, err)
 	assert.Len(fakeRuntime.ImageList, 3)
 	// sleep 3 seconds, then images will be old enough to be deleted
 	time.Sleep(time.Second * 3)
-	err = manager.DeleteUnusedImages(ctx)
+	err = manager.DeleteUnusedImages(tCtx)
 	require.NoError(t, err)
 	assert.Len(fakeRuntime.ImageList, 1)
 }

--- a/pkg/kubelet/images/image_manager_test.go
+++ b/pkg/kubelet/images/image_manager_test.go
@@ -821,7 +821,7 @@ func (m *mockDockerKeyringWithTrackedCreds) Lookup(image string) ([]credentialpr
 }
 
 func pullerTestEnv(
-	t *testing.T,
+	t ktesting.TB,
 	c pullerTestCase,
 	serialized bool,
 	maxParallelImagePulls *int32,
@@ -1125,7 +1125,13 @@ func TestPullAndListImageWithRuntimeHandlerInImageCriAPIFeatureGate(t *testing.T
 }
 
 func TestMaxParallelImagePullsLimit(t *testing.T) {
-	ctx := ktesting.Init(t)
+	ktesting.Init(t).SyncTest("", func(tCtx ktesting.TContext) {
+		testMaxParallelImagePullsLimit(tCtx)
+	})
+}
+
+func testMaxParallelImagePullsLimit(tCtx ktesting.TContext) {
+	t := tCtx.TB()
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "test_pod",
@@ -1165,7 +1171,7 @@ func TestMaxParallelImagePullsLimit(t *testing.T) {
 	for i := 0; i < maxParallelImagePulls; i++ {
 		wg.Add(1)
 		go func() {
-			_, _, err := puller.EnsureImageExists(ctx, nil, pod, container.Image, testCase.pullSecrets, podSandboxConfig, "", container.ImagePullPolicy)
+			_, _, err := puller.EnsureImageExists(tCtx, nil, pod, container.Image, testCase.pullSecrets, podSandboxConfig, "", container.ImagePullPolicy)
 			assert.NoError(t, err)
 			wg.Done()
 		}()
@@ -1177,7 +1183,7 @@ func TestMaxParallelImagePullsLimit(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		wg.Add(1)
 		go func() {
-			_, _, err := puller.EnsureImageExists(ctx, nil, pod, container.Image, testCase.pullSecrets, podSandboxConfig, "", container.ImagePullPolicy)
+			_, _, err := puller.EnsureImageExists(tCtx, nil, pod, container.Image, testCase.pullSecrets, podSandboxConfig, "", container.ImagePullPolicy)
 			assert.NoError(t, err)
 			wg.Done()
 		}()
@@ -1198,7 +1204,13 @@ func TestMaxParallelImagePullsLimit(t *testing.T) {
 }
 
 func TestParallelPodPullingTimeRecorderWithErr(t *testing.T) {
-	tCtx := ktesting.Init(t)
+	ktesting.Init(t).SyncTest("", func(tCtx ktesting.TContext) {
+		testParallelPodPullingTimeRecorderWithErr(tCtx)
+	})
+}
+
+func testParallelPodPullingTimeRecorderWithErr(tCtx ktesting.TContext) {
+	t := tCtx.TB()
 	pod1 := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "test_pod1",

--- a/pkg/kubelet/images/image_manager_test.go
+++ b/pkg/kubelet/images/image_manager_test.go
@@ -821,7 +821,7 @@ func (m *mockDockerKeyringWithTrackedCreds) Lookup(image string) ([]credentialpr
 }
 
 func pullerTestEnv(
-	t *testing.T,
+	t ktesting.TB,
 	c pullerTestCase,
 	serialized bool,
 	maxParallelImagePulls *int32,
@@ -1125,7 +1125,13 @@ func TestPullAndListImageWithRuntimeHandlerInImageCriAPIFeatureGate(t *testing.T
 }
 
 func TestMaxParallelImagePullsLimit(t *testing.T) {
-	ctx := ktesting.Init(t)
+	ktesting.Init(t).SyncTest("", func(tCtx ktesting.TContext) {
+		testMaxParallelImagePullsLimit(tCtx)
+	})
+}
+
+func testMaxParallelImagePullsLimit(tCtx ktesting.TContext) {
+	t := tCtx.TB()
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "test_pod",
@@ -1165,7 +1171,7 @@ func TestMaxParallelImagePullsLimit(t *testing.T) {
 	for i := 0; i < maxParallelImagePulls; i++ {
 		wg.Add(1)
 		go func() {
-			_, _, err := puller.EnsureImageExists(ctx, nil, pod, container.Image, testCase.pullSecrets, podSandboxConfig, "", container.ImagePullPolicy)
+			_, _, err := puller.EnsureImageExists(tCtx, nil, pod, container.Image, testCase.pullSecrets, podSandboxConfig, "", container.ImagePullPolicy)
 			assert.NoError(t, err)
 			wg.Done()
 		}()
@@ -1177,7 +1183,7 @@ func TestMaxParallelImagePullsLimit(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		wg.Add(1)
 		go func() {
-			_, _, err := puller.EnsureImageExists(ctx, nil, pod, container.Image, testCase.pullSecrets, podSandboxConfig, "", container.ImagePullPolicy)
+			_, _, err := puller.EnsureImageExists(tCtx, nil, pod, container.Image, testCase.pullSecrets, podSandboxConfig, "", container.ImagePullPolicy)
 			assert.NoError(t, err)
 			wg.Done()
 		}()
@@ -1198,7 +1204,13 @@ func TestMaxParallelImagePullsLimit(t *testing.T) {
 }
 
 func TestParallelPodPullingTimeRecorderWithErr(t *testing.T) {
-	ctx := context.Background()
+	ktesting.Init(t).SyncTest("", func(tCtx ktesting.TContext) {
+		testParallelPodPullingTimeRecorderWithErr(tCtx)
+	})
+}
+
+func testParallelPodPullingTimeRecorderWithErr(tCtx ktesting.TContext) {
+	t := tCtx.TB()
 	pod1 := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "test_pod1",
@@ -1256,7 +1268,7 @@ func TestParallelPodPullingTimeRecorderWithErr(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		wg.Add(1)
 		go func(i int) {
-			_, _, _ = puller.EnsureImageExists(ctx, nil, pods[i], container.Image, testCase.pullSecrets, podSandboxes[i], "", container.ImagePullPolicy)
+			_, _, _ = puller.EnsureImageExists(tCtx, nil, pods[i], container.Image, testCase.pullSecrets, podSandboxes[i], "", container.ImagePullPolicy)
 			wg.Done()
 		}(i)
 	}
@@ -1284,7 +1296,7 @@ func TestParallelPodPullingTimeRecorderWithErr(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		wg.Add(1)
 		go func(i int) {
-			_, _, err := puller.EnsureImageExists(ctx, nil, pods[i], container.Image, testCase.pullSecrets, podSandboxes[i], "", container.ImagePullPolicy)
+			_, _, err := puller.EnsureImageExists(tCtx, nil, pods[i], container.Image, testCase.pullSecrets, podSandboxes[i], "", container.ImagePullPolicy)
 			assert.NoError(t, err)
 			wg.Done()
 		}(i)

--- a/pkg/kubelet/kuberuntime/kuberuntime_termination_order_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_termination_order_test.go
@@ -19,6 +19,7 @@ package kuberuntime
 import (
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -26,6 +27,9 @@ import (
 )
 
 func TestTerminationOrderingSidecarStopAfterMain(t *testing.T) {
+	synctest.Test(t, testTerminationOrderingSidecarStopAfterMain)
+}
+func testTerminationOrderingSidecarStopAfterMain(t *testing.T) {
 	restartPolicy := v1.ContainerRestartPolicyAlways
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -83,6 +87,9 @@ func TestTerminationOrderingSidecarStopAfterMain(t *testing.T) {
 }
 
 func TestTerminationOrderingSidecarsInReverseOrder(t *testing.T) {
+	synctest.Test(t, testTerminationOrderingSidecarsInReverseOrder)
+}
+func testTerminationOrderingSidecarsInReverseOrder(t *testing.T) {
 	restartPolicy := v1.ContainerRestartPolicyAlways
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -185,6 +192,9 @@ func TestTerminationOrderingSidecarsInReverseOrder(t *testing.T) {
 }
 
 func TestTerminationOrderingObeysGrace(t *testing.T) {
+	synctest.Test(t, testTerminationOrderingObeysGrace)
+}
+func testTerminationOrderingObeysGrace(t *testing.T) {
 	restartPolicy := v1.ContainerRestartPolicyAlways
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/kubelet/lifecycle/handlers_test.go
+++ b/pkg/kubelet/lifecycle/handlers_test.go
@@ -792,6 +792,7 @@ func TestIsHTTPResponseError(t *testing.T) {
 }
 
 func TestRunSleepHandler(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	handlerRunner := NewHandlerRunner(&fakeHTTP{}, &fakeContainerCommandRunner{}, nil, nil)
 	containerID := kubecontainer.ContainerID{Type: "test", ID: "abc1234"}
 	containerName := "containerFoo"
@@ -828,8 +829,8 @@ func TestRunSleepHandler(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, tCtx := ktesting.NewTestContext(t)
+		tCtx.SyncTest(tt.name, func(tCtx ktesting.TContext) {
+			t := tCtx.TB()
 			pod.Spec.Containers[0].Lifecycle.PreStop.Sleep = &v1.SleepAction{Seconds: tt.sleepSeconds}
 			ctx, cancel := context.WithTimeout(tCtx, time.Duration(tt.terminationGracePeriodSeconds)*time.Second)
 			defer cancel()

--- a/pkg/kubelet/lifecycle/handlers_test.go
+++ b/pkg/kubelet/lifecycle/handlers_test.go
@@ -787,6 +787,7 @@ func TestIsHTTPResponseError(t *testing.T) {
 }
 
 func TestRunSleepHandler(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	handlerRunner := NewHandlerRunner(&fakeHTTP{}, &fakeContainerCommandRunner{}, nil, nil)
 	containerID := kubecontainer.ContainerID{Type: "test", ID: "abc1234"}
 	containerName := "containerFoo"
@@ -823,8 +824,8 @@ func TestRunSleepHandler(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, tCtx := ktesting.NewTestContext(t)
+		tCtx.SyncTest(tt.name, func(tCtx ktesting.TContext) {
+			t := tCtx.TB()
 			pod.Spec.Containers[0].Lifecycle.PreStop.Sleep = &v1.SleepAction{Seconds: tt.sleepSeconds}
 			ctx, cancel := context.WithTimeout(tCtx, time.Duration(tt.terminationGracePeriodSeconds)*time.Second)
 			defer cancel()

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
@@ -287,7 +287,7 @@ func (m *managerImpl) start(ctx context.Context) (chan struct{}, error) {
 				return
 			case isShuttingDown, ok := <-events:
 				if !ok {
-					m.logger.Error(err, "Ended to watching the node for shutdown events")
+					m.logger.Error(nil, "Ended to watching the node for shutdown events")
 					close(stop)
 					return
 				}

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
@@ -152,10 +152,19 @@ func (m *managerImpl) Start(ctx context.Context) error {
 	go func() {
 		for {
 			if stop != nil {
-				<-stop
+				select {
+				case <-ctx.Done():
+					return
+				case <-stop:
+				}
 			}
 
-			time.Sleep(dbusReconnectPeriod)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(dbusReconnectPeriod):
+			}
+
 			m.logger.V(1).Info("Restarting watch for node shutdown events")
 			stop, err = m.start(ctx)
 			if err != nil {
@@ -248,9 +257,11 @@ func (m *managerImpl) start(ctx context.Context) (chan struct{}, error) {
 		// 3. When shutdown(false) event is received, this indicates a previous shutdown was cancelled. In this case, acquire the inhibit lock again.
 		for {
 			select {
+			case <-ctx.Done():
+				return
 			case isShuttingDown, ok := <-events:
 				if !ok {
-					m.logger.Error(err, "Ended to watching the node for shutdown events")
+					m.logger.Error(nil, "Ended to watching the node for shutdown events")
 					close(stop)
 					return
 				}

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux_test.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux_test.go
@@ -38,7 +38,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/ktesting"
+	klogtesting "k8s.io/klog/v2/ktesting"
 	_ "k8s.io/klog/v2/ktesting/init" // activate ktesting command line flags
 	"k8s.io/kubernetes/pkg/apis/scheduling"
 	pkgfeatures "k8s.io/kubernetes/pkg/features"
@@ -46,7 +46,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/eviction"
 	"k8s.io/kubernetes/pkg/kubelet/nodeshutdown/systemd"
 	"k8s.io/kubernetes/pkg/kubelet/volumemanager"
-	testutilsktesting "k8s.io/kubernetes/test/utils/ktesting"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
 )
@@ -111,6 +111,7 @@ func (f *fakeDbus) OverrideInhibitDelay(inhibitDelayMax time.Duration) error {
 }
 
 func TestManager(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	systemDbusTmp := systemDbus
 	defer func() {
 		systemDbus = systemDbusTmp
@@ -321,8 +322,10 @@ func TestManager(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.desc, func(t *testing.T) {
-			logger, tCtx := ktesting.NewTestContext(t)
+		tCtx.SyncTest(tc.desc, func(tCtx ktesting.TContext) {
+			defer tCtx.Cancel("test completed")
+			t := tCtx.TB()
+			logger := tCtx.Logger()
 
 			activePodsFunc := func() []*v1.Pod {
 				return tc.activePods
@@ -479,10 +482,13 @@ func TestFeatureEnabled(t *testing.T) {
 }
 
 func TestRestart(t *testing.T) {
-	logger, tCtx := ktesting.NewTestContext(t)
-	ctx, cancel := context.WithCancel(tCtx)
-	defer cancel()
+	ktesting.Init(t).SyncTest("", testRestart)
+}
 
+func testRestart(tCtx ktesting.TContext) {
+	defer tCtx.Cancel("test completed")
+	logger := tCtx.Logger()
+	t := tCtx.TB()
 	systemDbusTmp := systemDbus
 	defer func() {
 		systemDbus = systemDbusTmp
@@ -533,7 +539,7 @@ func TestRestart(t *testing.T) {
 		StateDirectory:                  os.TempDir(),
 	})
 
-	err := manager.Start(ctx)
+	err := manager.Start(tCtx)
 	lock.Unlock()
 
 	if err != nil {
@@ -554,9 +560,13 @@ func TestRestart(t *testing.T) {
 }
 
 func TestStartDoesNotReconnectAfterContextCancel(t *testing.T) {
-	logger, tCtx := ktesting.NewTestContext(t)
-	ctx, cancel := context.WithCancel(tCtx)
-	defer cancel()
+	ktesting.Init(t).SyncTest("", testStartDoesNotReconnectAfterContextCancel)
+}
+
+func testStartDoesNotReconnectAfterContextCancel(tCtx ktesting.TContext) {
+	defer tCtx.Cancel("test completed")
+	logger := tCtx.Logger()
+	t := tCtx.TB()
 
 	systemDbusTmp := systemDbus
 	defer func() {
@@ -594,6 +604,7 @@ func TestStartDoesNotReconnectAfterContextCancel(t *testing.T) {
 		StateDirectory:                  os.TempDir(),
 	})
 
+	ctx, cancel := context.WithCancel(tCtx.Context)
 	err := manager.Start(ctx)
 	lock.Unlock()
 	require.NoError(t, err)
@@ -616,7 +627,7 @@ func TestStartDoesNotReconnectAfterContextCancel(t *testing.T) {
 }
 
 func Test_managerImpl_processShutdownEvent(t *testing.T) {
-	tCtx := testutilsktesting.Init(t)
+	tCtx := ktesting.Init(t)
 
 	var (
 		fakeRecorder      = &record.FakeRecorder{}
@@ -682,10 +693,9 @@ func Test_managerImpl_processShutdownEvent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Use a buffered logger because this test asserts log output.
-			logger := ktesting.NewLogger(t,
-				ktesting.NewConfig(
-					ktesting.BufferLogs(true),
+			logger := klogtesting.NewLogger(t,
+				klogtesting.NewConfig(
+					klogtesting.BufferLogs(true),
 				),
 			)
 			m := &managerImpl{
@@ -713,7 +723,7 @@ func Test_managerImpl_processShutdownEvent(t *testing.T) {
 				require.NoError(t, err, "managerImpl.processShutdownEvent() should not return an error")
 			}
 
-			underlier, ok := logger.GetSink().(ktesting.Underlier)
+			underlier, ok := logger.GetSink().(klogtesting.Underlier)
 			if !ok {
 				t.Fatalf("Should have had a ktesting LogSink, got %T", logger.GetSink())
 			}
@@ -729,8 +739,11 @@ func Test_managerImpl_processShutdownEvent(t *testing.T) {
 }
 
 func Test_processShutdownEvent_VolumeUnmountTimeout(t *testing.T) {
-	tCtx := testutilsktesting.Init(t)
+	ktesting.Init(t).SyncTest("", testProcessShutdownEventVolumeUnmountTimeout)
+}
 
+func testProcessShutdownEventVolumeUnmountTimeout(tCtx ktesting.TContext) {
+	t := tCtx.TB()
 	var (
 		fakeRecorder               = &record.FakeRecorder{}
 		syncNodeStatus             = func(context.Context) {}
@@ -746,7 +759,7 @@ func Test_processShutdownEvent_VolumeUnmountTimeout(t *testing.T) {
 		fmt.Errorf("unmount timeout"), false,
 	)
 	// Use a buffered logger because this test asserts log output.
-	logger := ktesting.NewLogger(t, ktesting.NewConfig(ktesting.BufferLogs(true)))
+	logger := klogtesting.NewLogger(t, klogtesting.NewConfig(klogtesting.BufferLogs(true)))
 	m := &managerImpl{
 		logger:   logger,
 		recorder: fakeRecorder,
@@ -784,7 +797,7 @@ func Test_processShutdownEvent_VolumeUnmountTimeout(t *testing.T) {
 	actualDuration := int(end.Sub(start).Seconds())
 	assert.LessOrEqual(t, actualDuration, shutdownGracePeriodSeconds, "processShutdownEvent took too long")
 
-	underlier, ok := logger.GetSink().(ktesting.Underlier)
+	underlier, ok := logger.GetSink().(klogtesting.Underlier)
 	if !ok {
 		t.Fatalf("Should have had a ktesting LogSink, got %T", logger.GetSink())
 	}
@@ -848,7 +861,14 @@ func TestStartDbusConnectionClosedOnError(t *testing.T) {
 // reconnects, the old dbus connection is closed before a new one is created.
 // See #120613.
 func TestRestartClosesOldConnection(t *testing.T) {
-	logger, tCtx := ktesting.NewTestContext(t)
+	ktesting.Init(t).SyncTest("", testRestartClosesOldConnection)
+}
+
+func testRestartClosesOldConnection(tCtx ktesting.TContext) {
+	defer tCtx.Cancel("test completed")
+	logger := tCtx.Logger()
+	t := tCtx.TB()
+
 	systemDbusTmp := systemDbus
 	defer func() {
 		systemDbus = systemDbusTmp

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux_test.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux_test.go
@@ -38,7 +38,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/ktesting"
+	klogtesting "k8s.io/klog/v2/ktesting"
 	_ "k8s.io/klog/v2/ktesting/init" // activate ktesting command line flags
 	"k8s.io/kubernetes/pkg/apis/scheduling"
 	pkgfeatures "k8s.io/kubernetes/pkg/features"
@@ -46,6 +46,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/eviction"
 	"k8s.io/kubernetes/pkg/kubelet/nodeshutdown/systemd"
 	"k8s.io/kubernetes/pkg/kubelet/volumemanager"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
 )
@@ -92,6 +93,7 @@ func (f *fakeDbus) OverrideInhibitDelay(inhibitDelayMax time.Duration) error {
 }
 
 func TestManager(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	systemDbusTmp := systemDbus
 	defer func() {
 		systemDbus = systemDbusTmp
@@ -302,8 +304,10 @@ func TestManager(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.desc, func(t *testing.T) {
-			logger, tCtx := ktesting.NewTestContext(t)
+		tCtx.SyncTest(tc.desc, func(tCtx ktesting.TContext) {
+			defer tCtx.Cancel("test completed")
+			t := tCtx.TB()
+			logger := tCtx.Logger()
 
 			activePodsFunc := func() []*v1.Pod {
 				return tc.activePods
@@ -460,7 +464,13 @@ func TestFeatureEnabled(t *testing.T) {
 }
 
 func TestRestart(t *testing.T) {
-	logger, tCtx := ktesting.NewTestContext(t)
+	ktesting.Init(t).SyncTest("", testRestart)
+}
+
+func testRestart(tCtx ktesting.TContext) {
+	defer tCtx.Cancel("test completed")
+	logger := tCtx.Logger()
+	t := tCtx.TB()
 	systemDbusTmp := systemDbus
 	defer func() {
 		systemDbus = systemDbusTmp
@@ -596,9 +606,9 @@ func Test_managerImpl_processShutdownEvent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger := ktesting.NewLogger(t,
-				ktesting.NewConfig(
-					ktesting.BufferLogs(true),
+			logger := klogtesting.NewLogger(t,
+				klogtesting.NewConfig(
+					klogtesting.BufferLogs(true),
 				),
 			)
 			m := &managerImpl{
@@ -623,7 +633,7 @@ func Test_managerImpl_processShutdownEvent(t *testing.T) {
 				t.Errorf("managerImpl.processShutdownEvent() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			underlier, ok := logger.GetSink().(ktesting.Underlier)
+			underlier, ok := logger.GetSink().(klogtesting.Underlier)
 			if !ok {
 				t.Fatalf("Should have had a ktesting LogSink, got %T", logger.GetSink())
 			}
@@ -639,6 +649,11 @@ func Test_managerImpl_processShutdownEvent(t *testing.T) {
 }
 
 func Test_processShutdownEvent_VolumeUnmountTimeout(t *testing.T) {
+	ktesting.Init(t).SyncTest("", testProcessShutdownEventVolumeUnmountTimeout)
+}
+
+func testProcessShutdownEventVolumeUnmountTimeout(tCtx ktesting.TContext) {
+	t := tCtx.TB()
 	var (
 		fakeRecorder               = &record.FakeRecorder{}
 		syncNodeStatus             = func(context.Context) {}
@@ -653,7 +668,7 @@ func Test_processShutdownEvent_VolumeUnmountTimeout(t *testing.T) {
 		// for volume unmount operations that take longer than the allowed grace period.
 		fmt.Errorf("unmount timeout"), false,
 	)
-	logger := ktesting.NewLogger(t, ktesting.NewConfig(ktesting.BufferLogs(true)))
+	logger := klogtesting.NewLogger(t, klogtesting.NewConfig(klogtesting.BufferLogs(true)))
 	m := &managerImpl{
 		logger:   logger,
 		recorder: fakeRecorder,
@@ -691,7 +706,7 @@ func Test_processShutdownEvent_VolumeUnmountTimeout(t *testing.T) {
 	actualDuration := int(end.Sub(start).Seconds())
 	assert.LessOrEqual(t, actualDuration, shutdownGracePeriodSeconds, "processShutdownEvent took too long")
 
-	underlier, ok := logger.GetSink().(ktesting.Underlier)
+	underlier, ok := logger.GetSink().(klogtesting.Underlier)
 	if !ok {
 		t.Fatalf("Should have had a ktesting LogSink, got %T", logger.GetSink())
 	}

--- a/pkg/kubelet/podcertificate/podcertificatemanager_test.go
+++ b/pkg/kubelet/podcertificate/podcertificatemanager_test.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/test/utils/hermeticpodcertificatesigner"
 	"k8s.io/kubernetes/test/utils/ktesting"
+	"k8s.io/utils/clock"
 	testclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 )
@@ -309,10 +310,14 @@ func TestPCRDeletedWhileWaiting(t *testing.T) {
 }
 
 func TestFullFlow(t *testing.T) {
-	ctx, cancel := context.WithCancel(ktesting.Init(t))
-	defer cancel()
+	ktesting.Init(t).SyncTest("", testFullFlow)
+}
 
-	clock := testclock.NewFakeClock(mustRFC3339(t, "2010-01-01T00:00:00Z"))
+func testFullFlow(tCtx ktesting.TContext) {
+	defer tCtx.Cancel("test completed")
+	t := tCtx.TB()
+	ctx := tCtx.Context
+
 	kc := fake.NewSimpleClientset()
 
 	// Assign PCR name and creationTimeStamp
@@ -323,7 +328,7 @@ func TestFullFlow(t *testing.T) {
 			if obj.Name == "" {
 				obj.Name = fmt.Sprintf("%s-pcr-%d", obj.Spec.PodName, rand.Int63n(1_000_000))
 			}
-			obj.CreationTimestamp = metav1.NewTime(clock.Now())
+			obj.CreationTimestamp = metav1.NewTime(time.Now())
 
 			return false, obj, nil // allow normal processing
 		})
@@ -368,7 +373,7 @@ func TestFullFlow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error generating CA hierarchy: %v", err)
 	}
-	pcrSigner := hermeticpodcertificatesigner.New(clock, signerName, caKeys, caCerts, kc)
+	pcrSigner := hermeticpodcertificatesigner.New(clock.RealClock{}, signerName, caKeys, caCerts, kc)
 	go pcrSigner.Run(ctx)
 	//
 	// Configure and boot up enough Kubelet subsystems to run an IssuingManager.
@@ -394,7 +399,7 @@ func TestFullFlow(t *testing.T) {
 		informerFactory.Certificates().V1beta1().PodCertificateRequests(),
 		informerFactory.Core().V1().Nodes(),
 		types.NodeName(node1.ObjectMeta.Name),
-		clock,
+		clock.RealClock{},
 	)
 	// Start informers
 	informerFactory.Start(ctx.Done())
@@ -617,8 +622,10 @@ func TestFullFlow(t *testing.T) {
 		t.Fatalf("PodCertificate manager returned bad cert chain; diff (-got +want)\n%s", diff)
 	}
 
+	oldPCRName := gotPCR.ObjectMeta.Name
+
 	// Fast-forward time until it is past beginRefreshAt (including the possible 5-minute jitter).
-	clock.Step(23*time.Hour + 37*time.Minute)
+	time.Sleep(23*time.Hour + 37*time.Minute)
 
 	// Within a few seconds, we should see a new PodCertificateRequest created for
 	// this pod.
@@ -628,15 +635,18 @@ func TestFullFlow(t *testing.T) {
 			return false, fmt.Errorf("while listing PodCertificateRequests: %w", err)
 		}
 
-		if len(pcrs.Items) == 0 {
-			return false, nil
+		for _, pcr := range pcrs.Items {
+			// Old PCR is still there, make sure we get the new one.
+			if pcr.ObjectMeta.Name != oldPCRName {
+				gotPCR = &pcr
+				return true, nil
+			}
 		}
 
-		gotPCR = &pcrs.Items[0]
-		return true, nil
+		return false, nil
 	})
 	if err != nil {
-		t.Fatalf("Error while waiting for PCR to be created: %v", err)
+		t.Fatalf("Error while waiting for new PCR to be created: %v", err)
 	}
 
 	// We will assume that the created PCR matches our expectations.
@@ -648,11 +658,17 @@ func TestFullFlow(t *testing.T) {
 			return false, fmt.Errorf("while listing PodCertificateRequests: %w", err)
 		}
 
-		if len(pcrs.Items) == 0 {
+		var updatedPCR *certsv1beta1.PodCertificateRequest
+		for _, pcr := range pcrs.Items {
+			if pcr.ObjectMeta.Name == gotPCR.ObjectMeta.Name {
+				updatedPCR = &pcr
+				break
+			}
+		}
+		if updatedPCR == nil {
 			return false, nil
 		}
-
-		gotPCR = &pcrs.Items[0]
+		gotPCR = updatedPCR
 
 		for _, cond := range gotPCR.Status.Conditions {
 			switch cond.Type {

--- a/pkg/kubelet/prober/prober_manager_test.go
+++ b/pkg/kubelet/prober/prober_manager_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -48,7 +49,12 @@ var defaultProbe = &v1.Probe{
 }
 
 func TestAddRemovePods(t *testing.T) {
-	ctx := ktesting.Init(t)
+	ktesting.Init(t).SyncTest("", testAddRemovePods)
+}
+
+func testAddRemovePods(tCtx ktesting.TContext) {
+	t := tCtx.TB()
+
 	noProbePod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID: "no_probe_pod",
@@ -95,13 +101,13 @@ func TestAddRemovePods(t *testing.T) {
 	}
 
 	// Adding a pod with no probes should be a no-op.
-	m.AddPod(ctx, &noProbePod)
+	m.AddPod(tCtx, &noProbePod)
 	if err := expectProbes(m, nil); err != nil {
 		t.Error(err)
 	}
 
 	// Adding a pod with probes.
-	m.AddPod(ctx, &probePod)
+	m.AddPod(tCtx, &probePod)
 	probePaths := []probeKey{
 		{"probe_pod", "readiness", readiness},
 		{"probe_pod", "liveness", liveness},
@@ -134,7 +140,13 @@ func TestAddRemovePods(t *testing.T) {
 }
 
 func TestAddPodContinuesAfterExistingWorker(t *testing.T) {
-	ctx := ktesting.Init(t)
+	ktesting.Init(t).SyncTest("", testAddPodContinuesAfterExistingWorker)
+}
+
+func testAddPodContinuesAfterExistingWorker(tCtx ktesting.TContext) {
+	defer tCtx.Cancel("test completed")
+	t := tCtx.TB()
+	ctx := tCtx.Context
 
 	pod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -167,9 +179,8 @@ func TestAddPodContinuesAfterExistingWorker(t *testing.T) {
 	}
 
 	// Simulate container_b's worker being removed while container_a's is still present.
-	m.workerLock.Lock()
-	delete(m.workers, probeKey{"test_pod", "container_b", readiness})
-	m.workerLock.Unlock()
+	m.workers[probeKey{"test_pod", "container_b", readiness}].stop()
+	synctest.Wait()
 
 	// Second AddPod: should re-register container_b's missing worker.
 	// Previously, hitting container_a's existing worker caused an early return,
@@ -185,6 +196,7 @@ func TestAddPodContinuesAfterExistingWorker(t *testing.T) {
 }
 
 func TestAddRemovePodsWithRestartableInitContainer(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	m := newTestManager()
 	defer cleanup(t, m)
 	if err := expectProbes(m, nil); err != nil {
@@ -221,8 +233,8 @@ func TestAddRemovePodsWithRestartableInitContainer(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			ctx := ktesting.Init(t)
+		tCtx.SyncTest(tc.desc, func(tCtx ktesting.TContext) {
+			t := tCtx.TB()
 			probePod := v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					UID: "restartable_init_container_pod",
@@ -244,7 +256,7 @@ func TestAddRemovePodsWithRestartableInitContainer(t *testing.T) {
 			}
 
 			// Adding a pod with probes.
-			m.AddPod(ctx, &probePod)
+			m.AddPod(tCtx, &probePod)
 			if err := expectProbes(m, tc.probePaths); err != nil {
 				t.Error(err)
 			}
@@ -268,7 +280,11 @@ func TestAddRemovePodsWithRestartableInitContainer(t *testing.T) {
 }
 
 func TestCleanupPods(t *testing.T) {
-	ctx := ktesting.Init(t)
+	ktesting.Init(t).SyncTest("", testCleanupPods)
+}
+
+func testCleanupPods(tCtx ktesting.TContext) {
+	t := tCtx.TB()
 	m := newTestManager()
 	defer cleanup(t, m)
 	podToCleanup := v1.Pod{
@@ -305,8 +321,8 @@ func TestCleanupPods(t *testing.T) {
 			}},
 		},
 	}
-	m.AddPod(ctx, &podToCleanup)
-	m.AddPod(ctx, &podToKeep)
+	m.AddPod(tCtx, &podToCleanup)
+	m.AddPod(tCtx, &podToKeep)
 
 	desiredPods := map[types.UID]sets.Empty{}
 	desiredPods[podToKeep.UID] = sets.Empty{}
@@ -331,7 +347,11 @@ func TestCleanupPods(t *testing.T) {
 }
 
 func TestCleanupRepeated(t *testing.T) {
-	ctx := ktesting.Init(t)
+	ktesting.Init(t).SyncTest("", testCleanupRepeated)
+}
+
+func testCleanupRepeated(tCtx ktesting.TContext) {
+	t := tCtx.TB()
 	m := newTestManager()
 	defer cleanup(t, m)
 	podTemplate := v1.Pod{
@@ -349,7 +369,7 @@ func TestCleanupRepeated(t *testing.T) {
 	for i := 0; i < numTestPods; i++ {
 		pod := podTemplate
 		pod.UID = types.UID(strconv.Itoa(i))
-		m.AddPod(ctx, &pod)
+		m.AddPod(tCtx, &pod)
 	}
 
 	for i := 0; i < 10; i++ {
@@ -616,7 +636,12 @@ func (m *manager) extractedReadinessHandling(logger klog.Logger) {
 }
 
 func TestUpdateReadiness(t *testing.T) {
-	logger, ctx := ktesting.NewTestContext(t)
+	ktesting.Init(t).SyncTest("", testUpdateReadiness)
+}
+
+func testUpdateReadiness(tCtx ktesting.TContext) {
+	t := tCtx.TB()
+	logger := tCtx.Logger()
 	testPod := getTestPod()
 	setTestProbe(testPod, readiness, v1.Probe{})
 	m := newTestManager()
@@ -637,7 +662,7 @@ func TestUpdateReadiness(t *testing.T) {
 
 	m.statusManager.SetPodStatus(logger, testPod, getTestRunningStatus())
 
-	m.AddPod(ctx, testPod)
+	m.AddPod(tCtx, testPod)
 	probePaths := []probeKey{{testPodUID, testContainerName, readiness}}
 	if err := expectProbes(m, probePaths); err != nil {
 		t.Error(err)
@@ -686,7 +711,7 @@ outer:
 const interval = 1 * time.Second
 
 // Wait for the given workers to exit & clean up.
-func waitForWorkerExit(t *testing.T, m *manager, workerPaths []probeKey) error {
+func waitForWorkerExit(t ktesting.TB, m *manager, workerPaths []probeKey) error {
 	for _, w := range workerPaths {
 		condition := func() (bool, error) {
 			_, exists := m.getWorker(w.podUID, w.containerName, w.probeType)
@@ -705,7 +730,7 @@ func waitForWorkerExit(t *testing.T, m *manager, workerPaths []probeKey) error {
 }
 
 // Wait for the given workers to exit & clean up.
-func waitForReadyStatus(t *testing.T, m *manager, ready bool) error {
+func waitForReadyStatus(t ktesting.TB, m *manager, ready bool) error {
 	condition := func() (bool, error) {
 		status, ok := m.statusManager.GetPodStatus(testPodUID)
 		if !ok {
@@ -729,7 +754,7 @@ func waitForReadyStatus(t *testing.T, m *manager, ready bool) error {
 }
 
 // cleanup running probes to avoid leaking goroutines.
-func cleanup(t *testing.T, m *manager) {
+func cleanup(t ktesting.TB, m *manager) {
 	m.CleanupPods(nil)
 
 	condition := func() (bool, error) {

--- a/pkg/kubelet/prober/prober_manager_test.go
+++ b/pkg/kubelet/prober/prober_manager_test.go
@@ -48,7 +48,12 @@ var defaultProbe = &v1.Probe{
 }
 
 func TestAddRemovePods(t *testing.T) {
-	ctx := ktesting.Init(t)
+	ktesting.Init(t).SyncTest("", testAddRemovePods)
+}
+
+func testAddRemovePods(tCtx ktesting.TContext) {
+	t := tCtx.TB()
+
 	noProbePod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID: "no_probe_pod",
@@ -95,13 +100,13 @@ func TestAddRemovePods(t *testing.T) {
 	}
 
 	// Adding a pod with no probes should be a no-op.
-	m.AddPod(ctx, &noProbePod)
+	m.AddPod(tCtx, &noProbePod)
 	if err := expectProbes(m, nil); err != nil {
 		t.Error(err)
 	}
 
 	// Adding a pod with probes.
-	m.AddPod(ctx, &probePod)
+	m.AddPod(tCtx, &probePod)
 	probePaths := []probeKey{
 		{"probe_pod", "readiness", readiness},
 		{"probe_pod", "liveness", liveness},
@@ -134,6 +139,7 @@ func TestAddRemovePods(t *testing.T) {
 }
 
 func TestAddRemovePodsWithRestartableInitContainer(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	m := newTestManager()
 	defer cleanup(t, m)
 	if err := expectProbes(m, nil); err != nil {
@@ -170,8 +176,8 @@ func TestAddRemovePodsWithRestartableInitContainer(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			ctx := ktesting.Init(t)
+		tCtx.SyncTest(tc.desc, func(tCtx ktesting.TContext) {
+			t := tCtx.TB()
 			probePod := v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					UID: "restartable_init_container_pod",
@@ -193,7 +199,7 @@ func TestAddRemovePodsWithRestartableInitContainer(t *testing.T) {
 			}
 
 			// Adding a pod with probes.
-			m.AddPod(ctx, &probePod)
+			m.AddPod(tCtx, &probePod)
 			if err := expectProbes(m, tc.probePaths); err != nil {
 				t.Error(err)
 			}
@@ -217,7 +223,11 @@ func TestAddRemovePodsWithRestartableInitContainer(t *testing.T) {
 }
 
 func TestCleanupPods(t *testing.T) {
-	ctx := ktesting.Init(t)
+	ktesting.Init(t).SyncTest("", testCleanupPods)
+}
+
+func testCleanupPods(tCtx ktesting.TContext) {
+	t := tCtx.TB()
 	m := newTestManager()
 	defer cleanup(t, m)
 	podToCleanup := v1.Pod{
@@ -254,8 +264,8 @@ func TestCleanupPods(t *testing.T) {
 			}},
 		},
 	}
-	m.AddPod(ctx, &podToCleanup)
-	m.AddPod(ctx, &podToKeep)
+	m.AddPod(tCtx, &podToCleanup)
+	m.AddPod(tCtx, &podToKeep)
 
 	desiredPods := map[types.UID]sets.Empty{}
 	desiredPods[podToKeep.UID] = sets.Empty{}
@@ -280,7 +290,11 @@ func TestCleanupPods(t *testing.T) {
 }
 
 func TestCleanupRepeated(t *testing.T) {
-	ctx := ktesting.Init(t)
+	ktesting.Init(t).SyncTest("", testCleanupRepeated)
+}
+
+func testCleanupRepeated(tCtx ktesting.TContext) {
+	t := tCtx.TB()
 	m := newTestManager()
 	defer cleanup(t, m)
 	podTemplate := v1.Pod{
@@ -298,7 +312,7 @@ func TestCleanupRepeated(t *testing.T) {
 	for i := 0; i < numTestPods; i++ {
 		pod := podTemplate
 		pod.UID = types.UID(strconv.Itoa(i))
-		m.AddPod(ctx, &pod)
+		m.AddPod(tCtx, &pod)
 	}
 
 	for i := 0; i < 10; i++ {
@@ -563,7 +577,12 @@ func (m *manager) extractedReadinessHandling(logger klog.Logger) {
 }
 
 func TestUpdateReadiness(t *testing.T) {
-	logger, ctx := ktesting.NewTestContext(t)
+	ktesting.Init(t).SyncTest("", testUpdateReadiness)
+}
+
+func testUpdateReadiness(tCtx ktesting.TContext) {
+	t := tCtx.TB()
+	logger := tCtx.Logger()
 	testPod := getTestPod()
 	setTestProbe(testPod, readiness, v1.Probe{})
 	m := newTestManager()
@@ -584,7 +603,7 @@ func TestUpdateReadiness(t *testing.T) {
 
 	m.statusManager.SetPodStatus(logger, testPod, getTestRunningStatus())
 
-	m.AddPod(ctx, testPod)
+	m.AddPod(tCtx, testPod)
 	probePaths := []probeKey{{testPodUID, testContainerName, readiness}}
 	if err := expectProbes(m, probePaths); err != nil {
 		t.Error(err)
@@ -633,7 +652,7 @@ outer:
 const interval = 1 * time.Second
 
 // Wait for the given workers to exit & clean up.
-func waitForWorkerExit(t *testing.T, m *manager, workerPaths []probeKey) error {
+func waitForWorkerExit(t ktesting.TB, m *manager, workerPaths []probeKey) error {
 	for _, w := range workerPaths {
 		condition := func() (bool, error) {
 			_, exists := m.getWorker(w.podUID, w.containerName, w.probeType)
@@ -652,7 +671,7 @@ func waitForWorkerExit(t *testing.T, m *manager, workerPaths []probeKey) error {
 }
 
 // Wait for the given workers to exit & clean up.
-func waitForReadyStatus(t *testing.T, m *manager, ready bool) error {
+func waitForReadyStatus(t ktesting.TB, m *manager, ready bool) error {
 	condition := func() (bool, error) {
 		status, ok := m.statusManager.GetPodStatus(testPodUID)
 		if !ok {
@@ -676,7 +695,7 @@ func waitForReadyStatus(t *testing.T, m *manager, ready bool) error {
 }
 
 // cleanup running probes to avoid leaking goroutines.
-func cleanup(t *testing.T, m *manager) {
+func cleanup(t ktesting.TB, m *manager) {
 	m.CleanupPods(nil)
 
 	condition := func() (bool, error) {

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -603,14 +603,18 @@ func TestStartupProbeFailureThreshold(t *testing.T) {
 }
 
 func TestCleanUp(t *testing.T) {
-	logger, ctx := ktesting.NewTestContext(t)
+	ktesting.Init(t).SyncTest("", testCleanUp)
+}
+
+func testCleanUp(tCtx ktesting.TContext) {
+	t := tCtx.TB()
 	m := newTestManager()
 
 	for _, probeType := range [...]probeType{liveness, readiness, startup} {
 		key := probeKey{testPodUID, testContainerName, probeType}
 		w := newTestWorker(m, probeType, v1.Probe{})
-		m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatusWithStarted(probeType != startup))
-		go w.run(ctx)
+		m.statusManager.SetPodStatus(tCtx.Logger(), w.pod, getTestRunningStatusWithStarted(probeType != startup))
+		go w.run(tCtx)
 		m.workers[key] = w
 
 		// Wait for worker to run.

--- a/pkg/kubelet/server/stats/volume_stat_calculator_test.go
+++ b/pkg/kubelet/server/stats/volume_stat_calculator_test.go
@@ -105,7 +105,12 @@ var (
 )
 
 func TestPVCRef(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	ktesting.Init(t).SyncTest("", testPVCRef)
+}
+
+func testPVCRef(tCtx ktesting.TContext) {
+	t := tCtx.TB()
+	logger := tCtx.Logger()
 	// Setup mock stats provider
 	mockStats := statstest.NewMockProvider(t)
 	volumes := map[string]volume.Volume{vol0: &fakeVolume{}, vol1: &fakeVolume{}, vol3: &fakeVolume{}}
@@ -163,7 +168,12 @@ func TestPVCRef(t *testing.T) {
 }
 
 func TestNormalVolumeEvent(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	ktesting.Init(t).SyncTest("", testNormalVolumeEvent)
+}
+
+func testNormalVolumeEvent(tCtx ktesting.TContext) {
+	t := tCtx.TB()
+	logger := tCtx.Logger()
 	mockStats := statstest.NewMockProvider(t)
 
 	volumes := map[string]volume.Volume{vol0: &fakeVolume{}, vol1: &fakeVolume{}}
@@ -186,7 +196,12 @@ func TestNormalVolumeEvent(t *testing.T) {
 }
 
 func TestAbnormalVolumeEvent(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
+	ktesting.Init(t).SyncTest("", testAbnormalVolumeEvent)
+}
+
+func testAbnormalVolumeEvent(tCtx ktesting.TContext) {
+	t := tCtx.TB()
+	logger := tCtx.Logger()
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIVolumeHealth, true)
 
 	// Setup mock stats provider

--- a/pkg/kubelet/watchdog/watchdog_linux_test.go
+++ b/pkg/kubelet/watchdog/watchdog_linux_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/kubernetes/test/utils/ktesting/initoption"
 )
@@ -96,6 +97,8 @@ func TestNewHealthChecker(t *testing.T) {
 
 // TestHealthCheckerStart tests the Start method of the healthChecker.
 func TestHealthCheckerStart(t *testing.T) {
+	tCtx := ktesting.Init(t)
+
 	// Test cases
 	tests := []struct {
 		name           string
@@ -150,8 +153,8 @@ func TestHealthCheckerStart(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tCtx := ktesting.Init(t, initoption.BufferLogs(true))
+		tCtx.SyncTest(tt.name, func(tCtx ktesting.TContext) {
+			tCtx = ktesting.Init(tCtx, initoption.BufferLogs(true))
 			logger := tCtx.Logger()
 			defer func() {
 				tCtx.Cancel("test has completed")
@@ -170,7 +173,11 @@ func TestHealthCheckerStart(t *testing.T) {
 				t.Fatalf("NewHealthChecker() failed: %v", err)
 			}
 			if !tt.noCheckers {
-				hc.SetHealthCheckers(&mockSyncLoopHealthChecker{healthCheckErr: tt.healthCheckErr}, nil)
+				// Bypass SetHealthCheckers because it adds LogHealthz, which leaks a background
+				// goroutine that doesn't play well with SyncTest.
+				hc.(*healthChecker).checkers.Store([]healthz.HealthChecker{
+					healthz.NamedCheck("syncloop", (&mockSyncLoopHealthChecker{healthCheckErr: tt.healthCheckErr}).SyncLoopHealthCheck),
+				})
 			}
 
 			// Start the health checker


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

A lot of tests that currently rely on `time.Sleep` or `time.After` (or variations with polling) can be trivially sped up by switching to use SyncTest. This PR goes after some of the low-hanging fruit. This also exposed several places where we're leaking background goroutines, so I plumbed `context.Done` for some of those.

Without this PR:
```
> time go test -count 1 ./pkg/kubelet/{clustertrustbundle,images,kuberuntime,lifecycle,nodeshutdown,podcertificate,prober,server/stats,watchdog}
ok      k8s.io/kubernetes/pkg/kubelet/clustertrustbundle	20.996s
ok  	k8s.io/kubernetes/pkg/kubelet/images	8.283s
ok  	k8s.io/kubernetes/pkg/kubelet/kuberuntime	9.371s
ok  	k8s.io/kubernetes/pkg/kubelet/lifecycle	7.110s
ok  	k8s.io/kubernetes/pkg/kubelet/nodeshutdown	7.105s
ok  	k8s.io/kubernetes/pkg/kubelet/podcertificate	2.265s
ok  	k8s.io/kubernetes/pkg/kubelet/prober	11.115s
ok  	k8s.io/kubernetes/pkg/kubelet/server/stats	5.106s
ok  	k8s.io/kubernetes/pkg/kubelet/watchdog	40.053s

________________________________________________________
Executed in   43.89 secs    fish           external
   usr time   24.25 secs    0.00 millis   24.25 secs
   sys time    7.43 secs    1.61 millis    7.43 secs
```

With these changes:
```
> time go test -count 1 ./pkg/kubelet/{clustertrustbundle,images,kuberuntime,lifecycle,nodeshutdown,podcertificate,prober,server/stats,watchdog}
ok  	k8s.io/kubernetes/pkg/kubelet/clustertrustbundle	0.192s
ok  	k8s.io/kubernetes/pkg/kubelet/images	0.293s
ok  	k8s.io/kubernetes/pkg/kubelet/kuberuntime	0.344s
ok  	k8s.io/kubernetes/pkg/kubelet/lifecycle	0.107s
ok  	k8s.io/kubernetes/pkg/kubelet/nodeshutdown	0.104s
ok  	k8s.io/kubernetes/pkg/kubelet/podcertificate	0.223s
ok  	k8s.io/kubernetes/pkg/kubelet/prober	0.117s
ok  	k8s.io/kubernetes/pkg/kubelet/server/stats	0.093s
ok  	k8s.io/kubernetes/pkg/kubelet/watchdog	0.053s

________________________________________________________
Executed in    3.95 secs    fish           external
   usr time   23.24 secs    0.00 millis   23.24 secs
   sys time    7.09 secs    1.44 millis    7.09 secs
```

#### Special notes for your reviewer:

Switching the podcertificate test to synctest revealed a bug in the test, hence the extra changes to that test.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node