### PR TITLE
DRA: add ResourceSlice field selector for pool name

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -16615,7 +16615,7 @@
           "type": "integer"
         },
         "name": {
-          "description": "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
+          "description": "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required. A field selector can be used to list only ResourceSlice objects belonging to a certain pool.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
           "type": "string"
         },
         "resourceSliceCount": {
@@ -18177,7 +18177,7 @@
           "type": "integer"
         },
         "name": {
-          "description": "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
+          "description": "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required. A field selector can be used to list only ResourceSlice objects belonging to a certain pool.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
           "type": "string"
         },
         "resourceSliceCount": {
@@ -19530,7 +19530,7 @@
           "type": "integer"
         },
         "name": {
-          "description": "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
+          "description": "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required. A field selector can be used to list only ResourceSlice objects belonging to a certain pool.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
           "type": "string"
         },
         "resourceSliceCount": {

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1_openapi.json
@@ -1510,7 +1510,7 @@
           },
           "name": {
             "default": "",
-            "description": "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
+            "description": "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required. A field selector can be used to list only ResourceSlice objects belonging to a certain pool.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
             "type": "string"
           },
           "resourceSliceCount": {

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1beta1_openapi.json
@@ -1353,7 +1353,7 @@
           },
           "name": {
             "default": "",
-            "description": "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
+            "description": "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required. A field selector can be used to list only ResourceSlice objects belonging to a certain pool.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
             "type": "string"
           },
           "resourceSliceCount": {

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1beta2_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1beta2_openapi.json
@@ -1510,7 +1510,7 @@
           },
           "name": {
             "default": "",
-            "description": "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
+            "description": "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required. A field selector can be used to list only ResourceSlice objects belonging to a certain pool.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
             "type": "string"
           },
           "resourceSliceCount": {

--- a/pkg/apis/resource/types.go
+++ b/pkg/apis/resource/types.go
@@ -95,6 +95,9 @@ const (
 	// ResourceSliceSelectorDriver can be used in a [metav1.ListOptions]
 	// field selector to filter based on [ResourceSliceSpec.Driver].
 	ResourceSliceSelectorDriver = "spec.driver"
+	// ResourceSliceSelectorPoolName can be used in a [metav1.ListOptions]
+	// field selector to filter based on [ResourceSliceSpec.Pool.Name].
+	ResourceSliceSelectorPoolName = "spec.pool.name"
 )
 
 // ResourceSliceSpec contains the information published by the driver in one ResourceSlice.

--- a/pkg/apis/resource/types.go
+++ b/pkg/apis/resource/types.go
@@ -223,6 +223,8 @@ const DriverNameMaxLength = 63
 type ResourcePool struct {
 	// Name is used to identify the pool. For node-local devices, this
 	// is often the node name, but this is not required.
+	// A field selector can be used to list only ResourceSlice objects
+	// belonging to a certain pool.
 	//
 	// It must not be longer than 253 characters and must consist of one or more DNS sub-domains
 	// separated by slashes. This field is immutable.

--- a/pkg/apis/resource/v1/conversion.go
+++ b/pkg/apis/resource/v1/conversion.go
@@ -27,7 +27,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("ResourceSlice"),
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "metadata.name", resourceapi.ResourceSliceSelectorNodeName, resourceapi.ResourceSliceSelectorDriver:
+			case "metadata.name", resourceapi.ResourceSliceSelectorNodeName, resourceapi.ResourceSliceSelectorDriver, resourceapi.ResourceSliceSelectorPoolName:
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported for %s: %s", SchemeGroupVersion.WithKind("ResourceSlice"), label)

--- a/pkg/apis/resource/v1beta1/conversion.go
+++ b/pkg/apis/resource/v1beta1/conversion.go
@@ -32,7 +32,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("ResourceSlice"),
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "metadata.name", resourcev1beta1.ResourceSliceSelectorNodeName, resourcev1beta1.ResourceSliceSelectorDriver:
+			case "metadata.name", resourcev1beta1.ResourceSliceSelectorNodeName, resourcev1beta1.ResourceSliceSelectorDriver, resourcev1beta1.ResourceSliceSelectorPoolName:
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported for %s: %s", SchemeGroupVersion.WithKind("ResourceSlice"), label)

--- a/pkg/apis/resource/v1beta2/conversion.go
+++ b/pkg/apis/resource/v1beta2/conversion.go
@@ -27,7 +27,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("ResourceSlice"),
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "metadata.name", resourceapi.ResourceSliceSelectorNodeName, resourceapi.ResourceSliceSelectorDriver:
+			case "metadata.name", resourceapi.ResourceSliceSelectorNodeName, resourceapi.ResourceSliceSelectorDriver, resourceapi.ResourceSliceSelectorPoolName:
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported for %s: %s", SchemeGroupVersion.WithKind("ResourceSlice"), label)

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -48641,7 +48641,7 @@ func schema_k8sio_api_resource_v1_ResourcePool(ref common.ReferenceCallback) com
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
+							Description: "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required. A field selector can be used to list only ResourceSlice objects belonging to a certain pool.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -51489,7 +51489,7 @@ func schema_k8sio_api_resource_v1beta1_ResourcePool(ref common.ReferenceCallback
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
+							Description: "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required. A field selector can be used to list only ResourceSlice objects belonging to a certain pool.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -53963,7 +53963,7 @@ func schema_k8sio_api_resource_v1beta2_ResourcePool(ref common.ReferenceCallback
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
+							Description: "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required. A field selector can be used to list only ResourceSlice objects belonging to a certain pool.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/pkg/registry/resource/resourceslice/strategy.go
+++ b/pkg/registry/resource/resourceslice/strategy.go
@@ -180,13 +180,14 @@ func toSelectableFields(slice *resource.ResourceSlice) fields.Set {
 	// amount of allocations needed to create the fields.Set. If you add any
 	// field here or the number of object-meta related fields changes, this should
 	// be adjusted.
-	fields := make(fields.Set, 3)
+	fields := make(fields.Set, 4)
 	if slice.Spec.NodeName == nil {
 		fields[resource.ResourceSliceSelectorNodeName] = ""
 	} else {
 		fields[resource.ResourceSliceSelectorNodeName] = *slice.Spec.NodeName
 	}
 	fields[resource.ResourceSliceSelectorDriver] = slice.Spec.Driver
+	fields[resource.ResourceSliceSelectorPoolName] = slice.Spec.Pool.Name
 
 	// Adds one field.
 	return generic.AddObjectMetaFieldsSet(fields, &slice.ObjectMeta, false)

--- a/pkg/registry/resource/resourceslice/strategy_test.go
+++ b/pkg/registry/resource/resourceslice/strategy_test.go
@@ -26,6 +26,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/version"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -946,6 +948,107 @@ func TestWarningsOnUpdate(t *testing.T) {
 				warnings = []string{}
 			}
 			require.Equal(t, tc.wantWarningMessages, warnings)
+		})
+	}
+}
+
+func TestMatch(t *testing.T) {
+	testCases := map[string]struct {
+		in            *resource.ResourceSlice
+		fieldSelector fields.Selector
+		expectMatch   bool
+	}{
+		"match-metadata-name": {
+			in: &resource.ResourceSlice{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+			},
+			fieldSelector: fields.ParseSelectorOrDie("metadata.name=foo"),
+			expectMatch:   true,
+		},
+		"not-match-metadata-name": {
+			in: &resource.ResourceSlice{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+			},
+			fieldSelector: fields.ParseSelectorOrDie("metadata.name=bar"),
+			expectMatch:   false,
+		},
+		"match-spec-driver": {
+			in: &resource.ResourceSlice{
+				Spec: resource.ResourceSliceSpec{
+					Driver: "foo",
+				},
+			},
+			fieldSelector: fields.ParseSelectorOrDie("spec.driver=foo"),
+			expectMatch:   true,
+		},
+		"not-match-spec-driver": {
+			in: &resource.ResourceSlice{
+				Spec: resource.ResourceSliceSpec{
+					Driver: "foo",
+				},
+			},
+			fieldSelector: fields.ParseSelectorOrDie("spec.driver=bar"),
+			expectMatch:   false,
+		},
+		"match-spec-node-name": {
+			in: &resource.ResourceSlice{
+				Spec: resource.ResourceSliceSpec{
+					NodeName: new("foo"),
+				},
+			},
+			fieldSelector: fields.ParseSelectorOrDie("spec.nodeName=foo"),
+			expectMatch:   true,
+		},
+		"not-match-spec-node-name": {
+			in: &resource.ResourceSlice{
+				Spec: resource.ResourceSliceSpec{
+					NodeName: new("foo"),
+				},
+			},
+			fieldSelector: fields.ParseSelectorOrDie("spec.nodeName=bar"),
+			expectMatch:   false,
+		},
+		"match-spec-pool-name": {
+			in: &resource.ResourceSlice{
+				Spec: resource.ResourceSliceSpec{
+					Pool: resource.ResourcePool{
+						Name: "foo",
+					},
+				},
+			},
+			fieldSelector: fields.ParseSelectorOrDie("spec.pool.name=foo"),
+			expectMatch:   true,
+		},
+		"not-match-spec-pool-name": {
+			in: &resource.ResourceSlice{
+				Spec: resource.ResourceSliceSpec{
+					Pool: resource.ResourcePool{
+						Name: "foo",
+					},
+				},
+			},
+			fieldSelector: fields.ParseSelectorOrDie("spec.pool.name=bar"),
+			expectMatch:   false,
+		},
+		"not-match-spec-pool-generation": {
+			in: &resource.ResourceSlice{
+				Spec: resource.ResourceSliceSpec{
+					Pool: resource.ResourcePool{
+						Generation: 1,
+					},
+				},
+			},
+			fieldSelector: fields.ParseSelectorOrDie("spec.pool.generation=1"),
+			expectMatch:   false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			m := Match(labels.Everything(), testCase.fieldSelector)
+			result, err := m.Matches(testCase.in)
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expectMatch, result, "selector: %s, resourceSlice: %+v", testCase.fieldSelector.String(), testCase.in)
 		})
 	}
 }

--- a/staging/src/k8s.io/api/resource/v1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1/generated.proto
@@ -1797,6 +1797,8 @@ message ResourceClaimTemplateSpec {
 message ResourcePool {
   // Name is used to identify the pool. For node-local devices, this
   // is often the node name, but this is not required.
+  // A field selector can be used to list only ResourceSlice objects
+  // belonging to a certain pool.
   //
   // It must not be longer than 253 characters and must consist of one or more DNS sub-domains
   // separated by slashes. This field is immutable.

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -112,6 +112,9 @@ const (
 	// ResourceSliceSelectorDriver can be used in a [metav1.ListOptions]
 	// field selector to filter based on [ResourceSliceSpec.Driver].
 	ResourceSliceSelectorDriver = "spec.driver"
+	// ResourceSliceSelectorPoolName can be used in a [metav1.ListOptions]
+	// field selector to filter based on [ResourceSliceSpec.Pool.Name].
+	ResourceSliceSelectorPoolName = "spec.pool.name"
 )
 
 // ResourceSliceSpec contains the information published by the driver in one ResourceSlice.

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -251,6 +251,8 @@ const DriverNameMaxLength = 63
 type ResourcePool struct {
 	// Name is used to identify the pool. For node-local devices, this
 	// is often the node name, but this is not required.
+	// A field selector can be used to list only ResourceSlice objects
+	// belonging to a certain pool.
 	//
 	// It must not be longer than 253 characters and must consist of one or more DNS sub-domains
 	// separated by slashes. This field is immutable.

--- a/staging/src/k8s.io/api/resource/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/resource/v1/types_swagger_doc_generated.go
@@ -528,7 +528,7 @@ func (ResourceClaimTemplateSpec) SwaggerDoc() map[string]string {
 
 var map_ResourcePool = map[string]string{
 	"":                   "ResourcePool describes the pool that ResourceSlices belong to.",
-	"name":               "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
+	"name":               "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required. A field selector can be used to list only ResourceSlice objects belonging to a certain pool.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
 	"generation":         "Generation tracks the change in a pool over time. Whenever a driver changes something about one or more of the resources in a pool, it must change the generation in all ResourceSlices which are part of that pool. Consumers of ResourceSlices should only consider resources from the pool with the highest generation number. The generation may be reset by drivers, which should be fine for consumers, assuming that all ResourceSlices in a pool are updated to match or deleted.\n\nCombined with ResourceSliceCount, this mechanism enables consumers to detect pools which are comprised of multiple ResourceSlices and are in an incomplete state.",
 	"resourceSliceCount": "ResourceSliceCount is the total number of ResourceSlices in the pool at this generation number. Must be greater than zero.\n\nConsumers can use this to check whether they have seen all ResourceSlices belonging to the same pool.",
 }

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -1705,6 +1705,8 @@ message ResourceClaimTemplateSpec {
 message ResourcePool {
   // Name is used to identify the pool. For node-local devices, this
   // is often the node name, but this is not required.
+  // A field selector can be used to list only ResourceSlice objects
+  // belonging to a certain pool.
   //
   // It must not be longer than 253 characters and must consist of one or more DNS sub-domains
   // separated by slashes. This field is immutable.

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -97,6 +97,9 @@ const (
 	// ResourceSliceSelectorDriver can be used in a [metav1.ListOptions]
 	// field selector to filter based on [ResourceSliceSpec.Driver].
 	ResourceSliceSelectorDriver = "spec.driver"
+	// ResourceSliceSelectorPoolName can be used in a [metav1.ListOptions]
+	// field selector to filter based on [ResourceSliceSpec.Pool.Name].
+	ResourceSliceSelectorPoolName = "spec.pool.name"
 )
 
 // ResourceSliceSpec contains the information published by the driver in one ResourceSlice.

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -244,6 +244,8 @@ const DriverNameMaxLength = 63
 type ResourcePool struct {
 	// Name is used to identify the pool. For node-local devices, this
 	// is often the node name, but this is not required.
+	// A field selector can be used to list only ResourceSlice objects
+	// belonging to a certain pool.
 	//
 	// It must not be longer than 253 characters and must consist of one or more DNS sub-domains
 	// separated by slashes. This field is immutable.

--- a/staging/src/k8s.io/api/resource/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types_swagger_doc_generated.go
@@ -477,7 +477,7 @@ func (ResourceClaimTemplateSpec) SwaggerDoc() map[string]string {
 
 var map_ResourcePool = map[string]string{
 	"":                   "ResourcePool describes the pool that ResourceSlices belong to.",
-	"name":               "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
+	"name":               "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required. A field selector can be used to list only ResourceSlice objects belonging to a certain pool.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
 	"generation":         "Generation tracks the change in a pool over time. Whenever a driver changes something about one or more of the resources in a pool, it must change the generation in all ResourceSlices which are part of that pool. Consumers of ResourceSlices should only consider resources from the pool with the highest generation number. The generation may be reset by drivers, which should be fine for consumers, assuming that all ResourceSlices in a pool are updated to match or deleted.\n\nCombined with ResourceSliceCount, this mechanism enables consumers to detect pools which are comprised of multiple ResourceSlices and are in an incomplete state.",
 	"resourceSliceCount": "ResourceSliceCount is the total number of ResourceSlices in the pool at this generation number. Must be greater than zero.\n\nConsumers can use this to check whether they have seen all ResourceSlices belonging to the same pool.",
 }

--- a/staging/src/k8s.io/api/resource/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta2/generated.proto
@@ -1808,6 +1808,8 @@ message ResourceClaimTemplateSpec {
 message ResourcePool {
   // Name is used to identify the pool. For node-local devices, this
   // is often the node name, but this is not required.
+  // A field selector can be used to list only ResourceSlice objects
+  // belonging to a certain pool.
   //
   // It must not be longer than 253 characters and must consist of one or more DNS sub-domains
   // separated by slashes. This field is immutable.

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -97,6 +97,9 @@ const (
 	// ResourceSliceSelectorDriver can be used in a [metav1.ListOptions]
 	// field selector to filter based on [ResourceSliceSpec.Driver].
 	ResourceSliceSelectorDriver = "spec.driver"
+	// ResourceSliceSelectorPoolName can be used in a [metav1.ListOptions]
+	// field selector to filter based on [ResourceSliceSpec.Pool.Name].
+	ResourceSliceSelectorPoolName = "spec.pool.name"
 )
 
 // ResourceSliceSpec contains the information published by the driver in one ResourceSlice.

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -236,6 +236,8 @@ const DriverNameMaxLength = 63
 type ResourcePool struct {
 	// Name is used to identify the pool. For node-local devices, this
 	// is often the node name, but this is not required.
+	// A field selector can be used to list only ResourceSlice objects
+	// belonging to a certain pool.
 	//
 	// It must not be longer than 253 characters and must consist of one or more DNS sub-domains
 	// separated by slashes. This field is immutable.

--- a/staging/src/k8s.io/api/resource/v1beta2/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types_swagger_doc_generated.go
@@ -528,7 +528,7 @@ func (ResourceClaimTemplateSpec) SwaggerDoc() map[string]string {
 
 var map_ResourcePool = map[string]string{
 	"":                   "ResourcePool describes the pool that ResourceSlices belong to.",
-	"name":               "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
+	"name":               "Name is used to identify the pool. For node-local devices, this is often the node name, but this is not required. A field selector can be used to list only ResourceSlice objects belonging to a certain pool.\n\nIt must not be longer than 253 characters and must consist of one or more DNS sub-domains separated by slashes. This field is immutable.",
 	"generation":         "Generation tracks the change in a pool over time. Whenever a driver changes something about one or more of the resources in a pool, it must change the generation in all ResourceSlices which are part of that pool. Consumers of ResourceSlices should only consider resources from the pool with the highest generation number. The generation may be reset by drivers, which should be fine for consumers, assuming that all ResourceSlices in a pool are updated to match or deleted.\n\nCombined with ResourceSliceCount, this mechanism enables consumers to detect pools which are comprised of multiple ResourceSlices and are in an incomplete state.",
 	"resourceSliceCount": "ResourceSliceCount is the total number of ResourceSlices in the pool at this generation number. Must be greater than zero.\n\nConsumers can use this to check whether they have seen all ResourceSlices belonging to the same pool.",
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/resourcepool.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/resourcepool.go
@@ -25,6 +25,8 @@ package v1
 type ResourcePoolApplyConfiguration struct {
 	// Name is used to identify the pool. For node-local devices, this
 	// is often the node name, but this is not required.
+	// A field selector can be used to list only ResourceSlice objects
+	// belonging to a certain pool.
 	//
 	// It must not be longer than 253 characters and must consist of one or more DNS sub-domains
 	// separated by slashes. This field is immutable.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourcepool.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/resourcepool.go
@@ -25,6 +25,8 @@ package v1beta1
 type ResourcePoolApplyConfiguration struct {
 	// Name is used to identify the pool. For node-local devices, this
 	// is often the node name, but this is not required.
+	// A field selector can be used to list only ResourceSlice objects
+	// belonging to a certain pool.
 	//
 	// It must not be longer than 253 characters and must consist of one or more DNS sub-domains
 	// separated by slashes. This field is immutable.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/resourcepool.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/resourcepool.go
@@ -25,6 +25,8 @@ package v1beta2
 type ResourcePoolApplyConfiguration struct {
 	// Name is used to identify the pool. For node-local devices, this
 	// is often the node name, but this is not required.
+	// A field selector can be used to list only ResourceSlice objects
+	// belonging to a certain pool.
 	//
 	// It must not be longer than 253 characters and must consist of one or more DNS sub-domains
 	// separated by slashes. This field is immutable.

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
@@ -1173,6 +1173,14 @@ func isUnsupportedPoolNameFieldSelector(err error) bool {
 func filterSliceWatchByPoolName(ctx context.Context, w watch.Interface, poolName string) watch.Interface {
 	return newWrapWatcher(ctx, w, func(event watch.Event) bool {
 		resourceSlice, ok := event.Object.(*resourceapi.ResourceSlice)
-		return ok && resourceSlice.Spec.Pool.Name == poolName
+		if !ok {
+			// things like error events
+			return true
+		}
+		if resourceSlice == nil || (resourceSlice.Name == "" && resourceSlice.Spec.Pool.Name == "") {
+			// things like bookmark events
+			return true
+		}
+		return resourceSlice.Spec.Pool.Name == poolName
 	})
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
@@ -126,6 +126,11 @@ type Controller struct {
 
 	// Optional pool name to reconcile.
 	reconcilePoolWithName string
+
+	// usePoolNameFieldSelector is disabled when the API server rejects the
+	// spec.pool.name field selector. Access must be atomic because List and Watch
+	// can run concurrently.
+	usePoolNameFieldSelector atomic.Bool
 }
 
 // +k8s:deepcopy-gen=true
@@ -495,6 +500,7 @@ func newController(ctx context.Context, options Options) (*Controller, error) {
 			utilruntime.HandleErrorWithContext(ctx, err, msg)
 		}
 	}
+	c.usePoolNameFieldSelector.Store(c.reconcilePoolWithName != "")
 	if err := c.initInformer(ctx); err != nil {
 		return nil, err
 	}
@@ -508,19 +514,23 @@ func newController(ctx context.Context, options Options) (*Controller, error) {
 func (c *Controller) initInformer(ctx context.Context) error {
 	logger := klog.FromContext(ctx)
 
-	// We always filter by driver name, by node name only for node-local resources.
-	selector := fields.Set{
-		resourceapi.ResourceSliceSelectorDriver:   c.driverName,
-		resourceapi.ResourceSliceSelectorNodeName: "",
+	fieldSelector := func(includePoolName bool) string {
+		// We always filter by driver name, by node name only for node-local resources.
+		selector := fields.Set{
+			resourceapi.ResourceSliceSelectorDriver:   c.driverName,
+			resourceapi.ResourceSliceSelectorNodeName: "",
+		}
+		if c.owner != nil && c.owner.APIVersion == "v1" && c.owner.Kind == "Node" && c.reconcilePoolWithName == "" {
+			selector[resourceapi.ResourceSliceSelectorNodeName] = c.owner.Name
+		}
+		if includePoolName {
+			selector[resourceapi.ResourceSliceSelectorPoolName] = c.reconcilePoolWithName
+		}
+
+		return selector.String()
 	}
-	// TODO: We can list/watch ResourceSlices with field selectors for NodeName or Driver.
-	// There is no field selector for PoolName, so we apply additional client-side filtering in list/watch. Issue for adding a PoolName field selector:                                                     │
-	// https://github.com/kubernetes/kubernetes/issues/137413
-	if c.owner != nil && c.owner.APIVersion == "v1" && c.owner.Kind == "Node" && c.reconcilePoolWithName == "" {
-		selector[resourceapi.ResourceSliceSelectorNodeName] = c.owner.Name
-	}
-	tweakListOptions := func(options *metav1.ListOptions) {
-		options.FieldSelector = selector.String()
+	tweakListOptions := func(options *metav1.ListOptions, includePoolName bool) {
+		options.FieldSelector = fieldSelector(includePoolName)
 	}
 	indexers := cache.Indexers{
 		poolNameIndex: func(obj interface{}) ([]string, error) {
@@ -534,25 +544,39 @@ func (c *Controller) initInformer(ctx context.Context) error {
 	informer := cache.NewSharedIndexInformer(
 		cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
 			ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
-				tweakListOptions(&options)
+				usePoolNameFieldSelector := c.usePoolNameFieldSelector.Load()
+				tweakListOptions(&options, usePoolNameFieldSelector)
 				slices, err := c.resourceClient.ResourceSlices().List(ctx, options)
+				if err != nil && usePoolNameFieldSelector && isUnsupportedPoolNameFieldSelector(err) {
+					c.usePoolNameFieldSelector.Store(false)
+					usePoolNameFieldSelector = false
+					tweakListOptions(&options, usePoolNameFieldSelector)
+					slices, err = c.resourceClient.ResourceSlices().List(ctx, options)
+				}
 				if err == nil {
 					logger.V(5).Info("Listed ResourceSlices", "resourceAPI", c.resourceClient.CurrentAPI(), "numSlices", len(slices.Items), "listMeta", slices.ListMeta)
 				} else {
 					logger.V(5).Info("Listed ResourceSlices", "resourceAPI", c.resourceClient.CurrentAPI(), "err", err)
 				}
 
-				if c.reconcilePoolWithName != "" {
+				if err == nil && c.reconcilePoolWithName != "" && !usePoolNameFieldSelector {
 					retainSlicesByPoolName(slices, c.reconcilePoolWithName)
 				}
 				return slices, err
 			},
 			WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
-				tweakListOptions(&options)
+				usePoolNameFieldSelector := c.usePoolNameFieldSelector.Load()
+				tweakListOptions(&options, usePoolNameFieldSelector)
 				w, err := c.resourceClient.ResourceSlices().Watch(ctx, options)
+				if err != nil && usePoolNameFieldSelector && isUnsupportedPoolNameFieldSelector(err) {
+					c.usePoolNameFieldSelector.Store(false)
+					usePoolNameFieldSelector = false
+					tweakListOptions(&options, usePoolNameFieldSelector)
+					w, err = c.resourceClient.ResourceSlices().Watch(ctx, options)
+				}
 				logger.V(5).Info("Started watching ResourceSlices", "resourceAPI", c.resourceClient.CurrentAPI(), "err", err)
 
-				if c.reconcilePoolWithName != "" {
+				if err == nil && c.reconcilePoolWithName != "" && !usePoolNameFieldSelector {
 					return filterSliceWatchByPoolName(ctx, w, c.reconcilePoolWithName), nil
 				}
 
@@ -1138,6 +1162,12 @@ func retainSlicesByPoolName(sliceList *resourceapi.ResourceSliceList, poolName s
 	sliceList.Items = slices.DeleteFunc(sliceList.Items, func(slice resourceapi.ResourceSlice) bool {
 		return slice.Spec.Pool.Name != poolName
 	})
+}
+
+// isUnsupportedPoolNameFieldSelector is needed for backwards compatibility.
+// The client-side list and watch filtering fallback can be removed in the future.
+func isUnsupportedPoolNameFieldSelector(err error) bool {
+	return apierrors.IsBadRequest(err)
 }
 
 func filterSliceWatchByPoolName(ctx context.Context, w watch.Interface, poolName string) watch.Interface {

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller_test.go
@@ -34,11 +34,14 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/dynamic-resource-allocation/internal/workqueue"
@@ -1633,6 +1636,130 @@ func TestControllerUpdateReconcilePoolWithNameValidation(t *testing.T) {
 			ctrl.Update(tc.resources)
 		})
 	}
+}
+
+func TestControllerPoolNameFieldSelector(t *testing.T) {
+	const (
+		driverName = "test-driver"
+		poolName   = "pool-a"
+	)
+
+	testCases := map[string]struct {
+		rejectList                  bool
+		rejectWatch                 bool
+		initialObjects              []runtime.Object
+		expectedListSelectors       []bool
+		expectedWatchSelectors      []bool
+		checkListFallbackFiltering  bool
+		checkWatchFallbackFiltering bool
+	}{
+		"field-selector-supported": {
+			expectedListSelectors:  []bool{true},
+			expectedWatchSelectors: []bool{true},
+		},
+		"field-selector-unsupported-for-list": {
+			rejectList: true,
+			initialObjects: []runtime.Object{
+				resourceSliceForPool(poolName, "matching"),
+				resourceSliceForPool("other-pool", "other"),
+			},
+			expectedListSelectors:      []bool{true, false},
+			expectedWatchSelectors:     []bool{false},
+			checkListFallbackFiltering: true,
+		},
+		"field-selector-unsupported-for-watch": {
+			rejectWatch:                 true,
+			expectedListSelectors:       []bool{true},
+			expectedWatchSelectors:      []bool{true, false},
+			checkWatchFallbackFiltering: true,
+		},
+	}
+
+	badRequestError := apierrors.NewBadRequest(fmt.Sprintf("field label not supported for %s: %s", resourceapi.SchemeGroupVersion.WithKind("ResourceSlice"), resourceapi.ResourceSliceSelectorPoolName))
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx := t.Context()
+			kubeClient := fake.NewSimpleClientset(testCase.initialObjects...)
+			kubeClient.PrependReactor("list", "resourceslices", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+				if testCase.rejectList && hasPoolNameFieldSelector(action, poolName) {
+					return true, nil, badRequestError
+				}
+				return false, nil, nil
+			})
+			kubeClient.PrependWatchReactor("resourceslices", func(action k8stesting.Action) (handled bool, ret watch.Interface, err error) {
+				if testCase.rejectWatch && hasPoolNameFieldSelector(action, poolName) {
+					return true, nil, badRequestError
+				}
+				return false, nil, nil
+			})
+
+			ctrl, err := newController(ctx, Options{
+				DriverName:            driverName,
+				KubeClient:            kubeClient,
+				ReconcilePoolWithName: poolName,
+				SyncDelay:             new(time.Hour),
+			})
+			require.NoError(t, err)
+			t.Cleanup(ctrl.Stop)
+
+			require.Eventually(t, func() bool {
+				return len(resourceSliceSelectorRequests(kubeClient.Actions(), "watch", poolName)) == len(testCase.expectedWatchSelectors)
+			}, 5*time.Second, 10*time.Millisecond, "wait for ResourceSlice watch requests")
+			assert.Equal(t, testCase.expectedListSelectors, resourceSliceSelectorRequests(kubeClient.Actions(), "list", poolName))
+			assert.Equal(t, testCase.expectedWatchSelectors, resourceSliceSelectorRequests(kubeClient.Actions(), "watch", poolName))
+			assert.Equal(t, !testCase.rejectList && !testCase.rejectWatch, ctrl.usePoolNameFieldSelector.Load())
+
+			if testCase.checkListFallbackFiltering {
+				matching, err := ctrl.sliceStore.ByIndex(poolNameIndex, poolName)
+				require.NoError(t, err)
+				assert.Len(t, matching, 1)
+				other, err := ctrl.sliceStore.ByIndex(poolNameIndex, "other-pool")
+				require.NoError(t, err)
+				assert.Empty(t, other)
+			}
+
+			if testCase.checkWatchFallbackFiltering {
+				_, err := kubeClient.ResourceV1().ResourceSlices().Create(ctx, resourceSliceForPool(poolName, "matching"), metav1.CreateOptions{})
+				require.NoError(t, err)
+				_, err = kubeClient.ResourceV1().ResourceSlices().Create(ctx, resourceSliceForPool("other-pool", "other"), metav1.CreateOptions{})
+				require.NoError(t, err)
+				require.Eventually(t, func() bool {
+					matching, err := ctrl.sliceStore.ByIndex(poolNameIndex, poolName)
+					if err != nil || len(matching) != 1 {
+						return false
+					}
+					other, err := ctrl.sliceStore.ByIndex(poolNameIndex, "other-pool")
+					return err == nil && len(other) == 0
+				}, 5*time.Second, 10*time.Millisecond, "wait for the fallback watcher to filter ResourceSlices")
+			}
+		})
+	}
+}
+
+func hasPoolNameFieldSelector(action k8stesting.Action, poolName string) bool {
+	var fieldSelector fields.Selector
+	switch action := action.(type) {
+	case k8stesting.ListAction:
+		fieldSelector = action.GetListRestrictions().Fields
+	case k8stesting.WatchAction:
+		fieldSelector = action.GetWatchRestrictions().Fields
+	default:
+		return false
+	}
+
+	value, found := fieldSelector.RequiresExactMatch(resourceapi.ResourceSliceSelectorPoolName)
+	return found && value == poolName
+}
+
+func resourceSliceSelectorRequests(actions []k8stesting.Action, verb, poolName string) []bool {
+	var requests []bool
+	for _, action := range actions {
+		if action.Matches(verb, "resourceslices") {
+			requests = append(requests, hasPoolNameFieldSelector(action, poolName))
+		}
+	}
+	return requests
 }
 
 func joinErrors(errors []string) string {

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/watcher_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/watcher_test.go
@@ -34,7 +34,7 @@ func TestFilterSliceWatchByPoolName_FiltersByPoolName(t *testing.T) {
 func testFilterSliceWatchByPoolNameFiltersByPoolName(t *testing.T) {
 	poolName := "pool-a"
 
-	source := watch.NewFakeWithOptions(watch.FakeOptions{ChannelSize: 3})
+	source := watch.NewFakeWithOptions(watch.FakeOptions{ChannelSize: 5})
 	defer source.Stop()
 
 	wrapped := filterSliceWatchByPoolName(t.Context(), source, poolName)
@@ -43,6 +43,8 @@ func testFilterSliceWatchByPoolNameFiltersByPoolName(t *testing.T) {
 	source.Add(resourceSliceForPool("pool-a", "slice-a"))
 	source.Add(resourceSliceForPool("pool-b", "slice-b"))
 	source.Add(resourceSliceForPool("pool-a", "slice-a2"))
+	source.Action(watch.Bookmark, &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}})
+	source.Error(&metav1.Status{Status: metav1.StatusFailure})
 
 	event1 := <-wrapped.ResultChan()
 	require.Equal(t, watch.Added, event1.Type)
@@ -52,6 +54,12 @@ func testFilterSliceWatchByPoolNameFiltersByPoolName(t *testing.T) {
 	event2 := <-wrapped.ResultChan()
 	require.Equal(t, watch.Added, event2.Type)
 	require.Equal(t, "slice-a2", event2.Object.(*resourceapi.ResourceSlice).Name)
+
+	bookmark := <-wrapped.ResultChan()
+	require.Equal(t, watch.Bookmark, bookmark.Type)
+
+	errEvent := <-wrapped.ResultChan()
+	require.Equal(t, watch.Error, errEvent.Type)
 }
 
 func TestWrapWatcher_NilMatchPassesAll(t *testing.T) {

--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/client-go/rest"
 	metadata "k8s.io/dynamic-resource-allocation/api/metadata"
 	"k8s.io/dynamic-resource-allocation/devicemetadata"
+	"k8s.io/dynamic-resource-allocation/resourceslice"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/events"
@@ -1069,6 +1070,63 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 			gomega.Eventually(ctx, func(ctx context.Context) (*v1.Pod, error) {
 				return f.ClientSet.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 			}).WithTimeout(f.Timeouts.PodStartSlow).Should(gomega.HaveField("Status.ContainerStatuses", gomega.ContainElements(gomega.HaveField("RestartCount", gomega.BeNumerically(">=", 2)))))
+		})
+	})
+
+	f.Context("kubelet", feature.DynamicResourceAllocation, func() {
+		const poolName = "all-nodes-pool"
+
+		nodes := drautils.NewNodes(f, 1, 1)
+		driver := drautils.NewDriver(f, nodes, func(nodes *drautils.Nodes) map[string]resourceslice.DriverResources {
+			return map[string]resourceslice.DriverResources{
+				nodes.NodeNames[0]: {
+					Pools: map[string]resourceslice.Pool{
+						poolName: {
+							AllNodes: true,
+							Slices: []resourceslice.Slice{{
+								Devices: []resourceapi.Device{{Name: "device-00"}},
+							}},
+						},
+					},
+				},
+			}
+		})
+		driver.ReconcilePoolWithName = poolName
+		driver.UsePrivilegedClient = true
+
+		ginkgo.It("reconciles ResourceSlices with ReconcilePoolWithName", func(ctx context.Context) {
+			tCtx := f.TContext(ctx)
+			fieldSelector := fields.Set{
+				resourceapi.ResourceSliceSelectorDriver:   driver.Name,
+				resourceapi.ResourceSliceSelectorPoolName: poolName,
+			}.String()
+			getSlices := framework.ListObjects(f.ClientSet.ResourceV1().ResourceSlices().List, metav1.ListOptions{FieldSelector: fieldSelector})
+			resourceSliceMatcher := gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Spec": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"Driver":   gomega.Equal(driver.Name),
+					"NodeName": gomega.BeNil(),
+					"AllNodes": gomega.Equal(new(true)),
+					"Pool": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Name":               gomega.Equal(poolName),
+						"ResourceSliceCount": gomega.Equal(int64(1)),
+					}),
+				}),
+			})
+			expectedSlices := gomega.HaveField("Items", gomega.ConsistOf(resourceSliceMatcher))
+			ginkgo.By("waiting for the initial ResourceSlice")
+			tCtx.Eventually(getSlices).Should(expectedSlices)
+
+			slices, err := getSlices(tCtx)
+			tCtx.ExpectNoError(err, "list ResourceSlices for pool %q", poolName)
+			oldSlice := slices.Items[0]
+			err = f.ClientSet.ResourceV1().ResourceSlices().Delete(tCtx, oldSlice.Name, metav1.DeleteOptions{})
+			tCtx.ExpectNoError(err, "delete ResourceSlice %q", oldSlice.Name)
+
+			ginkgo.By("waiting for the recreated ResourceSlice")
+			tCtx.Eventually(getSlices).WithTimeout(50 * time.Second).Should(expectedSlices)
+			slices, err = getSlices(tCtx)
+			tCtx.ExpectNoError(err, "list recreated ResourceSlices for pool %q", poolName)
+			tCtx.Expect(slices.Items[0].UID).ToNot(gomega.Equal(oldSlice.UID), "ResourceSlice must be recreated after deletion")
 		})
 	})
 

--- a/test/e2e/dra/utils/deploy.go
+++ b/test/e2e/dra/utils/deploy.go
@@ -395,10 +395,19 @@ type Driver struct {
 	// Register the DRA test driver with the kubelet and expect DRA to work (= feature.DynamicResourceAllocation).
 	WithKubelet bool
 
+	// UsePrivilegedClient lets the test driver publish cluster-wide ResourceSlices.
+	// The default node-scoped client is intentionally restricted by admission to
+	// ResourceSlices for its own node.
+	UsePrivilegedClient bool
+
 	// Run driver pods. If false, only set up slices and class.
 	WithRealNodes bool
 
 	EnableDeviceMetadata bool
+
+	// ReconcilePoolWithName configures the ResourceSlice controller in each
+	// test driver plugin to reconcile only the pool with this name.
+	ReconcilePoolWithName string
 
 	mutex      sync.Mutex
 	fail       map[MethodInstance]bool
@@ -454,9 +463,11 @@ func (d *Driver) SetUp(tCtx ktesting.TContext, kubeletRootDir string, nodes *Nod
 	}
 
 	driverResource, useMultiHostDriverResources := driverResources[multiHostDriverResources]
-	if useMultiHostDriverResources || !d.WithKubelet {
+	if useMultiHostDriverResources || !d.WithKubelet || d.UsePrivilegedClient {
 		// We have to remove ResourceSlices ourselves.
-		// Otherwise the kubelet does it after unregistering the driver.
+		// Otherwise the kubelet does it after unregistering the driver. A
+		// privileged client can create cluster-wide slices which the kubelet
+		// does not own and therefore cannot remove.
 		tCtx.CleanupCtx(func(tCtx ktesting.TContext) {
 			err := tCtx.Client().ResourceV1().ResourceSlices().DeleteCollection(tCtx, metav1.DeleteOptions{}, metav1.ListOptions{FieldSelector: resourceapi.ResourceSliceSelectorDriver + "=" + d.Name})
 			tCtx.ExpectNoError(err, "delete ResourceSlices of the driver")
@@ -631,6 +642,9 @@ func (d *Driver) SetUp(tCtx ktesting.TContext, kubeletRootDir string, nodes *Nod
 		//
 		// Here we merely use impersonation, which is faster.
 		driverClient := d.ImpersonateKubeletPlugin(tCtx, &pod)
+		if d.UsePrivilegedClient {
+			driverClient = tCtx.Client()
+		}
 
 		logger := klog.LoggerWithValues(klog.LoggerWithName(logger, "kubelet-plugin"), "node", pod.Spec.NodeName, "pod", klog.KObj(&pod))
 		loggerCtx := klog.NewContext(tCtx, logger)
@@ -718,6 +732,9 @@ func (d *Driver) SetUp(tCtx ktesting.TContext, kubeletRootDir string, nodes *Nod
 			kubeletplugin.RegistrarListener(d.listen(tCtx, &pod, &listenerPort)),
 
 			kubeletplugin.EnableDeviceMetadata(d.EnableDeviceMetadata),
+		}
+		if d.ReconcilePoolWithName != "" {
+			pluginOpts = append(pluginOpts, kubeletplugin.ReconcilePoolWithName(d.ReconcilePoolWithName))
 		}
 		if d.EnableDeviceMetadata {
 			pluginOpts = append(pluginOpts,

--- a/test/e2e_dra/poolnamefieldselector_test.go
+++ b/test/e2e_dra/poolnamefieldselector_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2edra
+
+import (
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+
+	resourceapi "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/dynamic-resource-allocation/resourceslice"
+	drautils "k8s.io/kubernetes/test/e2e/dra/utils"
+	"k8s.io/kubernetes/test/utils/client-go/ktesting"
+)
+
+const poolNameFieldSelectorFallbackPool = "pool-name-field-selector-fallback"
+
+func poolNameFieldSelectorFallbackResources(nodes *drautils.Nodes) map[string]resourceslice.DriverResources {
+	return map[string]resourceslice.DriverResources{
+		nodes.NodeNames[0]: {
+			Pools: map[string]resourceslice.Pool{
+				poolNameFieldSelectorFallbackPool: {
+					AllNodes: true,
+					Slices: []resourceslice.Slice{{
+						Devices: []resourceapi.Device{{Name: "device-00"}},
+					}},
+				},
+			},
+		},
+	}
+}
+
+// poolNameFieldSelectorFallback verifies that the current ResourceSlice
+// controller keeps reconciling after the previous release rejects the
+// spec.pool.name field selector. The controller keeps using local filtering
+// after upgrade and downgrade.
+func poolNameFieldSelectorFallback(tCtx ktesting.TContext, b *drautils.Builder) upgradedTestFunc {
+	recreatePoolNameFieldSelectorFallbackSlice(tCtx, b)
+	return func(tCtx ktesting.TContext) downgradedTestFunc {
+		recreatePoolNameFieldSelectorFallbackSlice(tCtx, b)
+		return func(tCtx ktesting.TContext) {
+			recreatePoolNameFieldSelectorFallbackSlice(tCtx, b)
+		}
+	}
+}
+
+func recreatePoolNameFieldSelectorFallbackSlice(tCtx ktesting.TContext, b *drautils.Builder) {
+	getSlices := b.Driver.NewGetSlices()
+	resourceSliceMatcher := func() gomega.OmegaMatcher {
+		return gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+			"Spec": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Driver":   gomega.Equal(b.Driver.Name),
+				"NodeName": gomega.BeNil(),
+				"AllNodes": gomega.Equal(new(true)),
+				"Pool": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"Name":               gomega.Equal(poolNameFieldSelectorFallbackPool),
+					"ResourceSliceCount": gomega.Equal(int64(1)),
+				}),
+				"Devices": gomega.ConsistOf(resourceapi.Device{Name: "device-00"}),
+			}),
+		})
+	}
+	tCtx.Eventually(getSlices).Should(gomega.HaveField("Items", gomega.ConsistOf(resourceSliceMatcher())))
+	oldSlice := getSlices(tCtx).Items[0]
+	tCtx.ExpectNoError(b.Driver.ClientV1(tCtx).ResourceSlices().Delete(tCtx, oldSlice.Name, metav1.DeleteOptions{}), "delete ResourceSlice %q", oldSlice.Name)
+	tCtx.Eventually(getSlices).Should(gomega.HaveField("Items", gomega.ConsistOf(
+		gomega.And(
+			resourceSliceMatcher(),
+			gomega.HaveField("UID", gomega.Not(gomega.Equal(oldSlice.UID))),
+		),
+	)))
+}

--- a/test/e2e_dra/upgradedowngrade_test.go
+++ b/test/e2e_dra/upgradedowngrade_test.go
@@ -267,6 +267,7 @@ func testUpgradeDowngrade(tCtx ktesting.TContext) {
 	var subTests = map[string]struct {
 		test            initialTestFunc
 		driverResources map[string]resourceslice.DriverResources
+		configureDriver func(*drautils.Driver)
 	}{
 		"core-dra": {
 			test:            coreDRA,
@@ -290,6 +291,14 @@ func testUpgradeDowngrade(tCtx ktesting.TContext) {
 			test:            extendedResourceUpgradeDowngrade(resourceTypeImplicit),
 			driverResources: extendedResourcesDriverResources(nodes),
 		},
+		"pool-name-field-selector-fallback": {
+			test:            poolNameFieldSelectorFallback,
+			driverResources: poolNameFieldSelectorFallbackResources(nodes),
+			configureDriver: func(d *drautils.Driver) {
+				d.ReconcilePoolWithName = poolNameFieldSelectorFallbackPool
+				d.UsePrivilegedClient = true
+			},
+		},
 	}
 
 	// Create a driver and builder for each sub-test. Opening sockets locally
@@ -302,6 +311,9 @@ func testUpgradeDowngrade(tCtx ktesting.TContext) {
 		d := drautils.NewDriverInstance(tCtx)
 		d.SetNameSuffix(tCtx, name)
 		d.IsLocal = true
+		if def.configureDriver != nil {
+			def.configureDriver(d)
+		}
 		d.Run(tCtx, "/var/lib/kubelet", nodes, def.driverResources)
 		b := drautils.NewBuilderNow(tCtx, d)
 		b.SkipCleanup = true

--- a/test/integration/dra/core.go
+++ b/test/integration/dra/core.go
@@ -33,9 +33,12 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
+	resourcev1beta1 "k8s.io/api/resource/v1beta1"
+	resourcev1beta2 "k8s.io/api/resource/v1beta2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
@@ -90,6 +93,124 @@ func testConvert(tCtx ktesting.TContext) {
 	tCtx.ExpectNoError(err, "get claim")
 	// We could check more fields, but there are unit tests which cover this better.
 	assert.Equal(tCtx, claim.Name, claimBeta2.Name, "claim name")
+}
+
+// testResourceSliceFieldSelectors verifies that all supported ResourceSlice
+// field selectors return the same objects through all served API versions.
+func testResourceSliceFieldSelectors(tCtx ktesting.TContext) {
+	tCtx.Parallel()
+
+	type resourceSliceTestCase struct {
+		driverField   string
+		nodeNameField string
+		poolNameField string
+		list          func(ktesting.TContext, metav1.ListOptions) (runtime.Object, error)
+	}
+	testCases := map[string]resourceSliceTestCase{
+		"v1": {
+			driverField:   resourceapi.ResourceSliceSelectorDriver,
+			nodeNameField: resourceapi.ResourceSliceSelectorNodeName,
+			poolNameField: resourceapi.ResourceSliceSelectorPoolName,
+			list: func(tCtx ktesting.TContext, options metav1.ListOptions) (runtime.Object, error) {
+				return tCtx.Client().ResourceV1().ResourceSlices().List(tCtx, options)
+			},
+		},
+		"v1beta1": {
+			driverField:   resourcev1beta1.ResourceSliceSelectorDriver,
+			nodeNameField: resourcev1beta1.ResourceSliceSelectorNodeName,
+			poolNameField: resourcev1beta1.ResourceSliceSelectorPoolName,
+			list: func(tCtx ktesting.TContext, options metav1.ListOptions) (runtime.Object, error) {
+				return tCtx.Client().ResourceV1beta1().ResourceSlices().List(tCtx, options)
+			},
+		},
+		"v1beta2": {
+			driverField:   resourcev1beta2.ResourceSliceSelectorDriver,
+			nodeNameField: resourcev1beta2.ResourceSliceSelectorNodeName,
+			poolNameField: resourcev1beta2.ResourceSliceSelectorPoolName,
+			list: func(tCtx ktesting.TContext, options metav1.ListOptions) (runtime.Object, error) {
+				return tCtx.Client().ResourceV1beta2().ResourceSlices().List(tCtx, options)
+			},
+		},
+	}
+
+	for testName, testCase := range testCases {
+		tCtx.Run(testName, func(tCtx ktesting.TContext) {
+			namespace := createTestNamespace(tCtx, nil)
+			driverName := namespace + ".example.com"
+			nodeName := namespace + "-node"
+			poolName := namespace + "-pool"
+			metadataSliceName := namespace + "-metadata"
+			driverSliceName := namespace + "-driver"
+			otherDriverName := namespace + "-other.example.com"
+			otherNodeName := namespace + "-other-node"
+			otherPoolName := namespace + "-other-pool"
+
+			selectorTestCases := []struct {
+				name          string
+				driver        string
+				nodeName      string
+				poolName      string
+				fieldSelector string
+				value         string
+			}{
+				{
+					name:          metadataSliceName,
+					driver:        otherDriverName,
+					nodeName:      otherNodeName,
+					poolName:      otherPoolName,
+					fieldSelector: "metadata.name",
+					value:         metadataSliceName,
+				},
+				{
+					name:          driverSliceName,
+					driver:        driverName,
+					nodeName:      otherNodeName,
+					poolName:      otherPoolName,
+					fieldSelector: testCase.driverField,
+					value:         driverName,
+				},
+				{
+					name:          nodeName,
+					driver:        otherDriverName,
+					nodeName:      nodeName,
+					poolName:      otherPoolName,
+					fieldSelector: testCase.nodeNameField,
+					value:         nodeName,
+				},
+				{
+					name:          poolName,
+					driver:        otherDriverName,
+					nodeName:      otherNodeName,
+					poolName:      poolName,
+					fieldSelector: testCase.poolNameField,
+					value:         poolName,
+				},
+			}
+			for _, selectorTestCase := range selectorTestCases {
+				createSlice(tCtx, &resourceapi.ResourceSlice{
+					ObjectMeta: metav1.ObjectMeta{Name: selectorTestCase.name},
+					Spec: resourceapi.ResourceSliceSpec{
+						Driver:   selectorTestCase.driver,
+						NodeName: new(selectorTestCase.nodeName),
+						Pool: resourceapi.ResourcePool{
+							Name:               selectorTestCase.poolName,
+							ResourceSliceCount: 1,
+						},
+					},
+				})
+			}
+
+			for _, selectorTestCase := range selectorTestCases {
+				selector := selectorTestCase.fieldSelector + "=" + selectorTestCase.value
+				list, err := testCase.list(tCtx, metav1.ListOptions{FieldSelector: selector})
+				tCtx.ExpectNoError(err, "list ResourceSlices with field selector %q", selector)
+				names, err := listObjectNames(list)
+				tCtx.ExpectNoError(err, "extract ResourceSlices from list with field selector %q", selector)
+				require.Len(tCtx, names, 1, "field selector %q", selector)
+				assert.Equal(tCtx, selectorTestCase.name, names[0], "field selector %q", selector)
+			}
+		})
+	}
 }
 
 // testFilterTimeout covers the scheduler plugin's filter timeout configuration and behavior.

--- a/test/integration/dra/dra.go
+++ b/test/integration/dra/dra.go
@@ -281,6 +281,7 @@ func run(tCtx ktesting.TContext, whatRE string) {
 				runSubTest(tCtx, "AdminAccess", func(tCtx ktesting.TContext) { testAdminAccess(tCtx, true) })
 				runSubTest(tCtx, "Convert", testConvert)
 				runSubTest(tCtx, "ControllerManagerMetrics", testControllerManagerMetrics)
+				runSubTest(tCtx, "ResourceSliceFieldSelectors", testResourceSliceFieldSelectors)
 				runSubTest(tCtx, "DeviceBindingConditions", func(tCtx ktesting.TContext) { testDeviceBindingConditions(tCtx, true) })
 				runSubTest(tCtx, "PartitionableDevices", func(tCtx ktesting.TContext) { testPartitionableDevices(tCtx, true) })
 				runSubTest(tCtx, "PrioritizedList", func(tCtx ktesting.TContext) { testPrioritizedList(tCtx, true) })

--- a/test/integration/dra/helpers.go
+++ b/test/integration/dra/helpers.go
@@ -30,8 +30,10 @@ import (
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	"k8s.io/kubernetes/test/utils/client-go/ktesting"
 	"k8s.io/utils/ptr"
@@ -50,6 +52,22 @@ func must[R, P, O any](tCtx ktesting.TContext, call func(context.Context, P, O) 
 	r, err := call(tCtx, p, o)
 	tCtx.ExpectNoError(err)
 	return r
+}
+
+func listObjectNames(list runtime.Object) ([]string, error) {
+	items, err := meta.ExtractList(list)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		object, err := meta.Accessor(item)
+		if err != nil {
+			return nil, err
+		}
+		names = append(names, object.GetName())
+	}
+	return names, nil
 }
 
 // createTestNamespace creates a namespace with a name that is derived from the


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds field selector support for `ResourceSlice.spec.pool.name`.

That makes it possible to list `ResourceSlice` objects for a specific pool without fetching all slices first and filtering 
client-side, for example:

```bash
kubectl get resourceslice --field-selector=spec.pool.name=<pool name>
```

#### Which issue(s) this PR is related to:

Fixes #137413

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Added support for selecting ResourceSlices by pool name with the field selector `spec.pool.name`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
