### PR TITLE
 Fix false success count in image volume mount metrics before CreateContainer

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1809,7 +1809,15 @@ func incrementImageVolumeMetrics(err error, msg string, container *v1.Container,
 		if _, exists := imageVolumes[m.Name]; exists {
 			if errors.Is(err, ErrCreateContainer) && strings.HasPrefix(msg, crierror.ErrImageVolumeMountFailed.Error()) {
 				metrics.ImageVolumeMountedErrorsTotal.Inc()
-			} else {
+			} else if err == nil ||
+				errors.Is(err, ErrCreateContainer) ||
+				errors.Is(err, ErrPreStartHook) ||
+				errors.Is(err, kubecontainer.ErrRunContainer) ||
+				errors.Is(err, ErrPostStartHook) {
+				// Only count success when CreateContainer was called and the
+				// image volume mount itself did not fail. For errors before
+				// CreateContainer (image pull failures, ErrCreateContainerConfig,
+				// ErrPreCreateHook), the mount was never attempted.
 				metrics.ImageVolumeMountedSucceedTotal.Inc()
 			}
 		}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -4965,6 +4965,69 @@ func TestIncrementImageVolumeMetrics(t *testing.T) {
         		kubelet_image_volume_requested_total 3
 			`,
 		},
+		"with image pull error": {
+			err: fmt.Errorf("image pull failed: unauthorized"),
+			msg: "Failed to pull image",
+			volumeMounts: []v1.VolumeMount{
+				{Name: "mount1"},
+			},
+			imageVolumes: kubecontainer.ImageVolumes{
+				"mount1": {Image: "image1"},
+			},
+			wants: `
+				# HELP kubelet_image_volume_mounted_errors_total [BETA] Number of failed image volume mounts.
+				# TYPE kubelet_image_volume_mounted_errors_total counter
+        		kubelet_image_volume_mounted_errors_total 0
+        		# HELP kubelet_image_volume_mounted_succeed_total [BETA] Number of successful image volume mounts.
+        		# TYPE kubelet_image_volume_mounted_succeed_total counter
+        		kubelet_image_volume_mounted_succeed_total 0
+        		# HELP kubelet_image_volume_requested_total [BETA] Number of requested image volumes.
+        		# TYPE kubelet_image_volume_requested_total counter
+        		kubelet_image_volume_requested_total 1
+			`,
+		},
+		"with ErrCreateContainerConfig": {
+			err: ErrCreateContainerConfig,
+			msg: "some config error",
+			volumeMounts: []v1.VolumeMount{
+				{Name: "mount1"},
+			},
+			imageVolumes: kubecontainer.ImageVolumes{
+				"mount1": {Image: "image1"},
+			},
+			wants: `
+				# HELP kubelet_image_volume_mounted_errors_total [BETA] Number of failed image volume mounts.
+				# TYPE kubelet_image_volume_mounted_errors_total counter
+        		kubelet_image_volume_mounted_errors_total 0
+        		# HELP kubelet_image_volume_mounted_succeed_total [BETA] Number of successful image volume mounts.
+        		# TYPE kubelet_image_volume_mounted_succeed_total counter
+        		kubelet_image_volume_mounted_succeed_total 0
+        		# HELP kubelet_image_volume_requested_total [BETA] Number of requested image volumes.
+        		# TYPE kubelet_image_volume_requested_total counter
+        		kubelet_image_volume_requested_total 1
+			`,
+		},
+		"with ErrPreCreateHook": {
+			err: ErrPreCreateHook,
+			msg: "hook failed",
+			volumeMounts: []v1.VolumeMount{
+				{Name: "mount1"},
+			},
+			imageVolumes: kubecontainer.ImageVolumes{
+				"mount1": {Image: "image1"},
+			},
+			wants: `
+				# HELP kubelet_image_volume_mounted_errors_total [BETA] Number of failed image volume mounts.
+				# TYPE kubelet_image_volume_mounted_errors_total counter
+        		kubelet_image_volume_mounted_errors_total 0
+        		# HELP kubelet_image_volume_mounted_succeed_total [BETA] Number of successful image volume mounts.
+        		# TYPE kubelet_image_volume_mounted_succeed_total counter
+        		kubelet_image_volume_mounted_succeed_total 0
+        		# HELP kubelet_image_volume_requested_total [BETA] Number of requested image volumes.
+        		# TYPE kubelet_image_volume_requested_total counter
+        		kubelet_image_volume_requested_total 1
+			`,
+		},
 		"without used volume": {
 			volumeMounts: []v1.VolumeMount{
 				{Name: "mount1"},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`incrementImageVolumeMetrics()` incorrectly increments `kubelet_image_volume_mounted_succeed_total` when `startContainer()` fails **before** CRI `CreateContainer` RPC is called (e.g., image pull failure, `ErrCreateContainerConfig`, `ErrPreCreateHook`). 
In these cases, no image volume mount was ever attempted, so neither the success nor error counter should be incremented.

So this PR changes the `else` to a whitelist of error types that indicate `CreateContainer` was actually called, so the mount status is only recorded when a mount was actually attempted.

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/issues/4639

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug where kubelet_image_volume_mounted_succeed_total metric was incorrectly incremented when container startup failed before the CRI CreateContainer call (e.g., image pull failure), even though no image volume mount was attempted.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
