### PR TITLE
kubelet: enforce ephemeral-storage limits on restartable init containers

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -588,6 +588,15 @@ func (m *managerImpl) containerEphemeralStorageLimitEviction(logger klog.Logger,
 			thresholdsMap[container.Name] = ephemeralLimit
 		}
 	}
+	for i, container := range pod.Spec.InitContainers {
+		if !podutil.IsRestartableInitContainer(&pod.Spec.InitContainers[i]) {
+			continue
+		}
+		ephemeralLimit := container.Resources.Limits.StorageEphemeral()
+		if ephemeralLimit != nil && ephemeralLimit.Value() != 0 {
+			thresholdsMap[container.Name] = ephemeralLimit
+		}
+	}
 
 	for _, containerStat := range podStats.Containers {
 		containerUsed := diskUsage(containerStat.Logs)

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -588,8 +588,8 @@ func (m *managerImpl) containerEphemeralStorageLimitEviction(logger klog.Logger,
 			thresholdsMap[container.Name] = ephemeralLimit
 		}
 	}
-	for i, container := range pod.Spec.InitContainers {
-		if !podutil.IsRestartableInitContainer(&pod.Spec.InitContainers[i]) {
+	for _, container := range pod.Spec.InitContainers {
+		if !podutil.IsRestartableInitContainer(&container) {
 			continue
 		}
 		ephemeralLimit := container.Resources.Limits.StorageEphemeral()

--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -3095,3 +3095,79 @@ func TestManagerWithLocalStorageCapacityIsolationOpen(t *testing.T) {
 		t.Fatalf("Unexpected evicted pod (-want,+got):\n%s", diff)
 	}
 }
+
+func TestContainerEphemeralStorageLimitEvictionForRestartableInitContainers(t *testing.T) {
+	tCtx := ktesting.Init(t)
+
+	initContainer := newRestartableInitContainer("sidecar", newResourceList("", "", ""), newResourceList("", "", "10Mi"))
+	mainContainer := newContainer("main", newResourceList("", "", ""), newResourceList("", "", ""))
+
+	pod := newPod("sidecar-ephemeral-repro", 0, []v1.Container{mainContainer}, nil)
+	pod.Spec.InitContainers = []v1.Container{initContainer}
+
+	sidecarQuantity := resource.MustParse("50Mi")
+	sidecarUsed := uint64(sidecarQuantity.Value())
+	mainUsed := uint64(0)
+	podStats := statsapi.PodStats{
+		PodRef: statsapi.PodReference{
+			Name: pod.Name, Namespace: pod.Namespace, UID: string(pod.UID),
+		},
+		Containers: []statsapi.ContainerStats{
+			{
+				Name:   "sidecar",
+				Logs:   &statsapi.FsStats{UsedBytes: &sidecarUsed},
+				Rootfs: &statsapi.FsStats{UsedBytes: &sidecarUsed},
+			},
+			{
+				Name:   "main",
+				Logs:   &statsapi.FsStats{UsedBytes: &mainUsed},
+				Rootfs: &statsapi.FsStats{UsedBytes: &mainUsed},
+			},
+		},
+	}
+
+	diskStat := diskStats{
+		rootFsAvailableBytes:  "1Gi",
+		imageFsAvailableBytes: "200Mi",
+		podStats:              map[*v1.Pod]statsapi.PodStats{pod: podStats},
+	}
+	summaryProvider := &fakeSummaryProvider{result: makeDiskStats(diskStat)}
+
+	config := Config{
+		MaxPodGracePeriodSeconds: 5,
+		PressureTransitionPeriod: time.Minute * 5,
+		Thresholds:               []evictionapi.Threshold{},
+	}
+
+	podKiller := &mockPodKiller{}
+	nodeRef := &v1.ObjectReference{Kind: "Node", Name: "test", UID: types.UID("test"), Namespace: ""}
+	fakeClock := testingclock.NewFakeClock(time.Now())
+
+	mgr := &managerImpl{
+		clock:                         fakeClock,
+		killPodFunc:                   podKiller.killPodNow,
+		imageGC:                       &mockDiskGC{err: nil},
+		containerGC:                   &mockDiskGC{err: nil},
+		config:                        config,
+		recorder:                      &record.FakeRecorder{},
+		summaryProvider:               summaryProvider,
+		nodeRef:                       nodeRef,
+		localStorageCapacityIsolation: true,
+		dedicatedImageFs:              ptr.To(false),
+	}
+
+	activePodsFunc := func() []*v1.Pod {
+		return []*v1.Pod{pod}
+	}
+
+	evictedPods, err := mgr.synchronize(tCtx, &mockDiskInfoProvider{dedicatedImageFs: ptr.To(false)}, activePodsFunc)
+	if err != nil {
+		t.Fatalf("Manager should not have error but got %v", err)
+	}
+	if podKiller.pod == nil {
+		t.Fatalf("Manager should have evicted the pod for restartable init container exceeding ephemeral-storage limit")
+	}
+	if len(evictedPods) != 1 || evictedPods[0].Name != pod.Name {
+		t.Fatalf("Expected evicted pod %q, got %v", pod.Name, evictedPods)
+	}
+}

--- a/test/e2e_node/eviction_test.go
+++ b/test/e2e_node/eviction_test.go
@@ -435,6 +435,14 @@ var _ = SIGDescribe("LocalStorageCapacityIsolationEviction", framework.WithSlow(
 				evictionPriority: 0, // This pod should not be evicted because it uses less than its limit
 				pod:              diskConsumingPod("container-disk-below-sizelimit", useUnderLimit, nil, v1.ResourceRequirements{Limits: containerLimit}),
 			},
+			{
+				evictionPriority: 1, // The restartable init container (sidecar) exceeds its container ephemeral-storage limit, so the pod should be evicted.
+				pod:              diskConsumingSidecarPod("sidecar-container-disk-limit", useOverLimit, v1.ResourceRequirements{Limits: containerLimit}),
+			},
+			{
+				evictionPriority: 0, // The restartable init container (sidecar) stays under its limit, so the pod should not be evicted.
+				pod:              diskConsumingSidecarPod("sidecar-container-disk-below-sizelimit", useUnderLimit, v1.ResourceRequirements{Limits: containerLimit}),
+			},
 		})
 	})
 })
@@ -1278,6 +1286,41 @@ func diskConsumingPod(name string, diskConsumedMB int, volumeSource *v1.VolumeSo
 	}
 	// Each iteration writes 1 Mb, so do diskConsumedMB iterations.
 	return podWithCommand(volumeSource, resources, diskConsumedMB, name, fmt.Sprintf("dd if=/dev/urandom of=%s${i} bs=1048576 count=1 2>/dev/null; sleep .1;", filepath.Join(path, "file")), true)
+}
+
+// diskConsumingSidecarPod returns a pod whose restartable init container (sidecar)
+// writes diskConsumedMB MB to its writable layer, with the supplied resource
+// requirements applied to the sidecar. The main container only sleeps so that the
+// pod's eligibility for eviction is determined entirely by the sidecar's disk usage.
+func diskConsumingSidecarPod(name string, diskConsumedMB int, sidecarResources v1.ResourceRequirements) *v1.Pod {
+	var gracePeriod int64 = 1
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-pod", name)},
+		Spec: v1.PodSpec{
+			RestartPolicy:                 v1.RestartPolicyNever,
+			TerminationGracePeriodSeconds: &gracePeriod,
+			InitContainers: []v1.Container{
+				{
+					Image:         busyboxImage,
+					Name:          fmt.Sprintf("%s-sidecar", name),
+					RestartPolicy: &containerRestartPolicyAlways,
+					Command: []string{
+						"sh",
+						"-c",
+						fmt.Sprintf("i=0; while [ $i -lt %d ]; do dd if=/dev/urandom of=file${i} bs=1048576 count=1 2>/dev/null; sleep .1; i=$(($i+1)); done; while true; do sleep 5; done", diskConsumedMB),
+					},
+					Resources: sidecarResources,
+				},
+			},
+			Containers: []v1.Container{
+				{
+					Image:   busyboxImage,
+					Name:    fmt.Sprintf("%s-container", name),
+					Command: []string{"sh", "-c", "while true; do sleep 5; done"},
+				},
+			},
+		},
+	}
 }
 
 func pidConsumingPod(name string, numProcesses int) *v1.Pod {

--- a/test/e2e_node/eviction_test.go
+++ b/test/e2e_node/eviction_test.go
@@ -1316,7 +1316,7 @@ func diskConsumingSidecarPod(name string, diskConsumedMB int, sidecarResources v
 				{
 					Image:   busyboxImage,
 					Name:    fmt.Sprintf("%s-container", name),
-					Command: []string{"sh", "-c", "while true; do sleep 5; done"},
+					Command: []string{"sh", "-c", "sleep infinity"},
 				},
 			},
 		},


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

`containerEphemeralStorageLimitEviction()` only iterates `pod.Spec.Containers` when building the per-container ephemeral-storage threshold map. Restartable init containers (sidecars) are never added to `thresholdsMap`, so a sidecar can exceed its `limits.ephemeral-storage` indefinitely without triggering pod eviction.

This PR adds iteration over `pod.Spec.InitContainers` for restartable init containers when building the threshold map, so the existing per-container comparison covers them.

## Which issue(s) this PR fixes

Fixes #138371

#### Does this PR introduce a user-facing change?
-->
```release-note
Fixed a bug where the kubelet did not enforce per-container ephemeral-storage limits on restartable init containers (sidecar containers), allowing them to exceed their declared limit without triggering pod eviction.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A

#### AI Disclosure

AI tooling (Claude) was used to assist in preparing this PR. All changes have been reviewed and verified by the author.