### PR TITLE
Deflake PodCertificateRequest integration tests

### DIFF
--- a/test/integration/podcertificaterequests/podcertificate_integration_test.go
+++ b/test/integration/podcertificaterequests/podcertificate_integration_test.go
@@ -295,6 +295,7 @@ func TestNodeRestriction(t *testing.T) {
 		err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
 			_, err = node1Client.CertificatesV1beta1().PodCertificateRequests("default").Create(ctx, pcr, metav1.CreateOptions{})
 			if err != nil {
+				t.Logf("Create PodCertificateRequest default/pcr1 as node1 failed with error: %v, retrying...", err)
 				return false, nil
 			}
 			return true, nil
@@ -335,6 +336,7 @@ func TestNodeRestriction(t *testing.T) {
 			if err == nil || k8serrors.IsForbidden(err) {
 				return true, err
 			}
+			t.Logf("Create PodCertificateRequest default/pcr1 as node2 failed with non-Forbidden error: %v, retrying...", err)
 			return false, nil
 		})
 		if err == nil {
@@ -736,6 +738,7 @@ func TestNodeAuthorizerNamespaceNameConfusion(t *testing.T) {
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
 		_, err = node1Client.CertificatesV1beta1().PodCertificateRequests("bar").Create(ctx, pcrBarFoo, metav1.CreateOptions{})
 		if err != nil {
+			t.Logf("Create PodCertificateRequest bar/foo as node1 failed with error: %v, retrying...", err)
 			return false, nil
 		}
 		return true, nil
@@ -769,6 +772,7 @@ func TestNodeAuthorizerNamespaceNameConfusion(t *testing.T) {
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
 		_, err = node2Client.CertificatesV1beta1().PodCertificateRequests("foo").Create(ctx, pcrFooBar, metav1.CreateOptions{})
 		if err != nil {
+			t.Logf("Create PodCertificateRequest foo/bar as node2 failed with error: %v, retrying...", err)
 			return false, nil
 		}
 		return true, nil
@@ -778,14 +782,32 @@ func TestNodeAuthorizerNamespaceNameConfusion(t *testing.T) {
 	}
 
 	t.Run("node1 can directly get bar/foo", func(t *testing.T) {
-		_, err := node1Client.CertificatesV1beta1().PodCertificateRequests("bar").Get(ctx, "foo", metav1.GetOptions{})
+		// Getting the PCR could fail if there is lag in the node authorizer graph population.
+		// Poll until it succeeds.
+		err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
+			_, err := node1Client.CertificatesV1beta1().PodCertificateRequests("bar").Get(ctx, "foo", metav1.GetOptions{})
+			if err != nil {
+				t.Logf("Get PodCertificateRequest bar/foo as node1 failed with error: %v, retrying...", err)
+				return false, nil
+			}
+			return true, nil
+		})
 		if err != nil {
 			t.Fatalf("Unexpected error getting bar/foo as node1: %v", err)
 		}
 	})
 
 	t.Run("node2 can directly get foo/bar", func(t *testing.T) {
-		_, err := node2Client.CertificatesV1beta1().PodCertificateRequests("foo").Get(ctx, "bar", metav1.GetOptions{})
+		// Getting the PCR could fail if there is lag in the node authorizer graph population.
+		// Poll until it succeeds.
+		err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
+			_, err := node2Client.CertificatesV1beta1().PodCertificateRequests("foo").Get(ctx, "bar", metav1.GetOptions{})
+			if err != nil {
+				t.Logf("Get PodCertificateRequest foo/bar as node2 failed with error: %v, retrying...", err)
+				return false, nil
+			}
+			return true, nil
+		})
 		if err != nil {
 			t.Fatalf("Unexpected error getting foo/bar as node2: %v", err)
 		}

--- a/test/integration/podcertificaterequests/podcertificate_integration_test.go
+++ b/test/integration/podcertificaterequests/podcertificate_integration_test.go
@@ -295,7 +295,7 @@ func TestNodeRestriction(t *testing.T) {
 		err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
 			_, err = node1Client.CertificatesV1beta1().PodCertificateRequests("default").Create(ctx, pcr, metav1.CreateOptions{})
 			if err != nil {
-				return false, err
+				return false, nil
 			}
 			return true, nil
 		})
@@ -335,7 +335,7 @@ func TestNodeRestriction(t *testing.T) {
 			if err == nil || k8serrors.IsForbidden(err) {
 				return true, err
 			}
-			return false, err
+			return false, nil
 		})
 		if err == nil {
 			t.Fatalf("PCR creation unexpectedly succeeded")
@@ -736,7 +736,7 @@ func TestNodeAuthorizerNamespaceNameConfusion(t *testing.T) {
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
 		_, err = node1Client.CertificatesV1beta1().PodCertificateRequests("bar").Create(ctx, pcrBarFoo, metav1.CreateOptions{})
 		if err != nil {
-			return false, err
+			return false, nil
 		}
 		return true, nil
 	})
@@ -769,7 +769,7 @@ func TestNodeAuthorizerNamespaceNameConfusion(t *testing.T) {
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
 		_, err = node2Client.CertificatesV1beta1().PodCertificateRequests("foo").Create(ctx, pcrFooBar, metav1.CreateOptions{})
 		if err != nil {
-			return false, err
+			return false, nil
 		}
 		return true, nil
 	})

--- a/test/integration/podcertificaterequests/podcertificate_integration_test.go
+++ b/test/integration/podcertificaterequests/podcertificate_integration_test.go
@@ -292,10 +292,14 @@ func TestNodeRestriction(t *testing.T) {
 
 		// Informer lag inside kube-apiserver could cause us to get transient
 		// errors.
+		var lastErr string
 		err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
 			_, err = node1Client.CertificatesV1beta1().PodCertificateRequests("default").Create(ctx, pcr, metav1.CreateOptions{})
 			if err != nil {
-				t.Logf("Create PodCertificateRequest default/pcr1 as node1 failed with error: %v, retrying...", err)
+				if errStr := err.Error(); errStr != lastErr {
+					t.Logf("Create PodCertificateRequest default/pcr1 as node1 failed with error: %v, retrying...", err)
+					lastErr = errStr
+				}
 				return false, nil
 			}
 			return true, nil
@@ -331,12 +335,16 @@ func TestNodeRestriction(t *testing.T) {
 		// non-Forbidden error from the noderestriction admission plugin.  This
 		// should be transient, so wait for some time to see if we reach our
 		// durable error condition.
+		var lastErr string
 		err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
 			_, err = node2Client.CertificatesV1beta1().PodCertificateRequests("default").Create(ctx, pcr, metav1.CreateOptions{})
 			if err == nil || k8serrors.IsForbidden(err) {
 				return true, err
 			}
-			t.Logf("Create PodCertificateRequest default/pcr1 as node2 failed with non-Forbidden error: %v, retrying...", err)
+			if errStr := err.Error(); errStr != lastErr {
+				t.Logf("Create PodCertificateRequest default/pcr1 as node2 failed with non-Forbidden error: %v, retrying...", err)
+				lastErr = errStr
+			}
 			return false, nil
 		})
 		if err == nil {
@@ -735,10 +743,14 @@ func TestNodeAuthorizerNamespaceNameConfusion(t *testing.T) {
 	}
 	// Creating the PCR could fail if there is informer lag in the
 	// noderestriction logic.  Poll until it succeeds.
+	var lastErrBarFoo string
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
 		_, err = node1Client.CertificatesV1beta1().PodCertificateRequests("bar").Create(ctx, pcrBarFoo, metav1.CreateOptions{})
 		if err != nil {
-			t.Logf("Create PodCertificateRequest bar/foo as node1 failed with error: %v, retrying...", err)
+			if errStr := err.Error(); errStr != lastErrBarFoo {
+				t.Logf("Create PodCertificateRequest bar/foo as node1 failed with error: %v, retrying...", err)
+				lastErrBarFoo = errStr
+			}
 			return false, nil
 		}
 		return true, nil
@@ -769,10 +781,14 @@ func TestNodeAuthorizerNamespaceNameConfusion(t *testing.T) {
 	}
 	// Creating the PCR could fail if there is informer lag in the
 	// noderestriction logic.  Poll until it succeeds.
+	var lastErrFooBar string
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
 		_, err = node2Client.CertificatesV1beta1().PodCertificateRequests("foo").Create(ctx, pcrFooBar, metav1.CreateOptions{})
 		if err != nil {
-			t.Logf("Create PodCertificateRequest foo/bar as node2 failed with error: %v, retrying...", err)
+			if errStr := err.Error(); errStr != lastErrFooBar {
+				t.Logf("Create PodCertificateRequest foo/bar as node2 failed with error: %v, retrying...", err)
+				lastErrFooBar = errStr
+			}
 			return false, nil
 		}
 		return true, nil
@@ -784,10 +800,14 @@ func TestNodeAuthorizerNamespaceNameConfusion(t *testing.T) {
 	t.Run("node1 can directly get bar/foo", func(t *testing.T) {
 		// Getting the PCR could fail if there is lag in the node authorizer graph population.
 		// Poll until it succeeds.
+		var lastErr string
 		err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
 			_, err := node1Client.CertificatesV1beta1().PodCertificateRequests("bar").Get(ctx, "foo", metav1.GetOptions{})
 			if err != nil {
-				t.Logf("Get PodCertificateRequest bar/foo as node1 failed with error: %v, retrying...", err)
+				if errStr := err.Error(); errStr != lastErr {
+					t.Logf("Get PodCertificateRequest bar/foo as node1 failed with error: %v, retrying...", err)
+					lastErr = errStr
+				}
 				return false, nil
 			}
 			return true, nil
@@ -800,10 +820,14 @@ func TestNodeAuthorizerNamespaceNameConfusion(t *testing.T) {
 	t.Run("node2 can directly get foo/bar", func(t *testing.T) {
 		// Getting the PCR could fail if there is lag in the node authorizer graph population.
 		// Poll until it succeeds.
+		var lastErr string
 		err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
 			_, err := node2Client.CertificatesV1beta1().PodCertificateRequests("foo").Get(ctx, "bar", metav1.GetOptions{})
 			if err != nil {
-				t.Logf("Get PodCertificateRequest foo/bar as node2 failed with error: %v, retrying...", err)
+				if errStr := err.Error(); errStr != lastErr {
+					t.Logf("Get PodCertificateRequest foo/bar as node2 failed with error: %v, retrying...", err)
+					lastErr = errStr
+				}
 				return false, nil
 			}
 			return true, nil

--- a/test/integration/podcertificaterequests/podcertificate_integration_test.go
+++ b/test/integration/podcertificaterequests/podcertificate_integration_test.go
@@ -743,13 +743,13 @@ func TestNodeAuthorizerNamespaceNameConfusion(t *testing.T) {
 	}
 	// Creating the PCR could fail if there is informer lag in the
 	// noderestriction logic.  Poll until it succeeds.
-	var lastErrBarFoo string
+	var lastErr string
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
 		_, err = node1Client.CertificatesV1beta1().PodCertificateRequests("bar").Create(ctx, pcrBarFoo, metav1.CreateOptions{})
 		if err != nil {
-			if errStr := err.Error(); errStr != lastErrBarFoo {
+			if errStr := err.Error(); errStr != lastErr {
 				t.Logf("Create PodCertificateRequest bar/foo as node1 failed with error: %v, retrying...", err)
-				lastErrBarFoo = errStr
+				lastErr = errStr
 			}
 			return false, nil
 		}
@@ -781,13 +781,13 @@ func TestNodeAuthorizerNamespaceNameConfusion(t *testing.T) {
 	}
 	// Creating the PCR could fail if there is informer lag in the
 	// noderestriction logic.  Poll until it succeeds.
-	var lastErrFooBar string
+	lastErr = ""
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 15*time.Second, true, func(ctx context.Context) (bool, error) {
 		_, err = node2Client.CertificatesV1beta1().PodCertificateRequests("foo").Create(ctx, pcrFooBar, metav1.CreateOptions{})
 		if err != nil {
-			if errStr := err.Error(); errStr != lastErrFooBar {
+			if errStr := err.Error(); errStr != lastErr {
 				t.Logf("Create PodCertificateRequest foo/bar as node2 failed with error: %v, retrying...", err)
-				lastErrFooBar = errStr
+				lastErr = errStr
 			}
 			return false, nil
 		}


### PR DESCRIPTION
The `wait.PollUntilContextTimeout` callbacks in `TestNodeAuthorization`, `TestNodeRestriction`, and `TestNodeAuthorizerNamespaceNameConfusion` returned `(false, err)` on transient errors caused by informer lag. Since `PollUntilContextTimeout` treats a non-nil error as terminal, this caused the poll to abort on the first failure instead of retrying.

The fix changes these to `return false, nil` so the poll keeps retrying, matching the pattern already used in the "node2 cannot create PCR for pod that doesn't exist" subtest.

Fixes https://github.com/kubernetes/kubernetes/issues/138461

/sig auth
/kind flake

```release-note
NONE
```