### PR TITLE
Replace HandleErrorWithContext with HandleError

### DIFF
--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -408,7 +408,7 @@ func (dsc *DaemonSetsController) processNextWorkItem(ctx context.Context) bool {
 		return true
 	}
 
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	utilruntime.HandleErrorWithContext(ctx, fmt.Errorf("%v failed with : %v", dsKey, err), "sync daemon set error", "key", dsKey)
 	dsc.queue.AddRateLimited(dsKey)
 
 	return true

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -304,7 +304,7 @@ func (dsc *DaemonSetsController) updateDaemonset(logger klog.Logger, cur, old in
 	if curDS.UID != oldDS.UID {
 		key, err := controller.KeyFunc(oldDS)
 		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", oldDS, err))
+			utilruntime.HandleErrorWithLogger(logger, err, "couldn't get key for object", "oldDS", oldDS)
 			return
 		}
 		dsc.deleteDaemonset(logger, cache.DeletedFinalStateUnknown{
@@ -322,12 +322,12 @@ func (dsc *DaemonSetsController) deleteDaemonset(logger klog.Logger, obj interfa
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			utilruntime.HandleErrorWithLogger(logger, nil, "couldn't get object from tombstone", "obj", obj)
 			return
 		}
 		ds, ok = tombstone.Obj.(*apps.DaemonSet)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a DaemonSet %#v", obj))
+			utilruntime.HandleErrorWithLogger(logger, nil, "tombstone contained object that is not a DaemonSet", "obj", obj)
 			return
 		}
 	}
@@ -335,7 +335,7 @@ func (dsc *DaemonSetsController) deleteDaemonset(logger klog.Logger, obj interfa
 
 	key, err := controller.KeyFunc(ds)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", ds, err))
+		utilruntime.HandleErrorWithLogger(logger, err, "couldn't get key for object", "ds", ds)
 		return
 	}
 	dsc.consistencyStore.Clear(
@@ -408,7 +408,7 @@ func (dsc *DaemonSetsController) processNextWorkItem(ctx context.Context) bool {
 		return true
 	}
 
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %v", dsKey, err))
+	utilruntime.HandleErrorWithContext(ctx, err, "sync daemon set error", "key", dsKey)
 	dsc.queue.AddRateLimited(dsKey)
 
 	return true
@@ -559,12 +559,12 @@ func (dsc *DaemonSetsController) deleteHistory(logger klog.Logger, obj interface
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
+			utilruntime.HandleErrorWithLogger(logger, nil, "couldn't object from tombstone", "obj", obj)
 			return
 		}
 		history, ok = tombstone.Obj.(*apps.ControllerRevision)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a ControllerRevision %#v", obj))
+			utilruntime.HandleErrorWithLogger(logger, nil, "tombstone contained object that is not a ControllerRevision", "obj", obj)
 			return
 		}
 	}
@@ -696,12 +696,12 @@ func (dsc *DaemonSetsController) deletePod(logger klog.Logger, obj interface{}) 
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			utilruntime.HandleErrorWithLogger(logger, nil, "failed to get object from tombstone", "obj", obj)
 			return
 		}
 		pod, ok = tombstone.Obj.(*v1.Pod)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a pod %#v", obj))
+			utilruntime.HandleErrorWithLogger(logger, nil, "tombstone contained object that is not a pod", "obj", obj)
 			return
 		}
 	}
@@ -727,7 +727,7 @@ func (dsc *DaemonSetsController) deletePod(logger klog.Logger, obj interface{}) 
 func (dsc *DaemonSetsController) addNode(logger klog.Logger, obj interface{}) {
 	node, ok := obj.(*v1.Node)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("couldn't get node from object %#v", obj))
+		utilruntime.HandleErrorWithLogger(logger, nil, "couldn't get node from object", "obj", obj)
 		return
 	}
 
@@ -1094,10 +1094,9 @@ func (dsc *DaemonSetsController) syncNodes(ctx context.Context, ds *apps.DaemonS
 					}
 				}
 				if err != nil {
-					logger.V(2).Info("Failed creation, decrementing expectations for daemon set", "daemonset", klog.KObj(ds))
 					dsc.expectations.CreationObserved(logger, dsKey)
 					errCh <- err
-					utilruntime.HandleError(err)
+					utilruntime.HandleErrorWithLogger(logger, err, "Failed creation, decrementing expectations for daemon set", "daemonset", klog.KObj(ds))
 				}
 			}(i)
 		}
@@ -1122,9 +1121,8 @@ func (dsc *DaemonSetsController) syncNodes(ctx context.Context, ds *apps.DaemonS
 			if err := dsc.podControl.DeletePod(ctx, ds.Namespace, podsToDelete[ix], ds); err != nil {
 				dsc.expectations.DeletionObserved(logger, dsKey)
 				if !apierrors.IsNotFound(err) {
-					logger.V(2).Info("Failed deletion, decremented expectations for daemon set", "daemonset", klog.KObj(ds))
 					errCh <- err
-					utilruntime.HandleError(err)
+					utilruntime.HandleErrorWithLogger(logger, err, "Failed deletion, decremented expectations for daemon set", "daemonset", klog.KObj(ds))
 				}
 			}
 		}(i)
@@ -1491,7 +1489,7 @@ func (dsc *DaemonSetsController) processNextNodeUpdate(ctx context.Context) bool
 		return true
 	}
 
-	utilruntime.HandleError(fmt.Errorf("%v failed with : %w", nodeName, err))
+	utilruntime.HandleErrorWithContext(ctx, err, "failed to update node", "nodeName", nodeName)
 	dsc.nodeUpdateQueue.AddRateLimited(nodeName)
 
 	return true

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -528,7 +528,7 @@ func (dc *DeploymentController) handleErr(ctx context.Context, err error, key st
 		return
 	}
 
-	utilruntime.HandleError(err)
+	utilruntime.HandleErrorWithContext(ctx, err, "sync deployment error", "key", key)
 	logger.V(2).Info("Dropping deployment out of the queue", "deployment", klog.KRef(ns, name), "err", err)
 	dc.queue.Forget(key)
 }

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -216,12 +216,12 @@ func (dc *DeploymentController) deleteDeployment(logger klog.Logger, obj interfa
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			utilruntime.HandleErrorWithLogger(logger, nil, "couldn't get object from tombstone", "obj", obj)
 			return
 		}
 		d, ok = tombstone.Obj.(*apps.Deployment)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Deployment %#v", obj))
+			utilruntime.HandleErrorWithLogger(logger, nil, "tombstone contained object that is not a Deployment", "obj", obj)
 			return
 		}
 	}
@@ -343,12 +343,12 @@ func (dc *DeploymentController) deleteReplicaSet(logger klog.Logger, obj interfa
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			utilruntime.HandleErrorWithLogger(logger, nil, "couldn't get object from tombstone", "obj", obj)
 			return
 		}
 		rs, ok = tombstone.Obj.(*apps.ReplicaSet)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a ReplicaSet %#v", obj))
+			utilruntime.HandleErrorWithLogger(logger, nil, "tombstone contained object that is not a ReplicaSet", "obj", obj, "rs", rs)
 			return
 		}
 	}
@@ -377,12 +377,12 @@ func (dc *DeploymentController) deletePod(logger klog.Logger, obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			utilruntime.HandleErrorWithLogger(logger, nil, "couldn't get object from tombstone", "obj", obj)
 			return
 		}
 		pod, ok = tombstone.Obj.(*v1.Pod)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a pod %#v", obj))
+			utilruntime.HandleErrorWithLogger(logger, nil, "tombstone contained object that is not a pod", "obj", obj)
 			return
 		}
 	}
@@ -528,8 +528,7 @@ func (dc *DeploymentController) handleErr(ctx context.Context, err error, key st
 		return
 	}
 
-	utilruntime.HandleError(err)
-	logger.V(2).Info("Dropping deployment out of the queue", "deployment", klog.KRef(ns, name), "err", err)
+	utilruntime.HandleErrorWithLogger(logger, err, "Dropping deployment out of the queue", "deployment", klog.KRef(ns, name))
 	dc.queue.Forget(key)
 }
 

--- a/pkg/controller/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/endpointslice/endpointslice_controller.go
@@ -295,10 +295,10 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	logger.V(2).Info("Starting service queue worker threads", "total", workers)
 	for i := 0; i < workers; i++ {
 		wg.Go(func() {
-			wait.Until(func() { c.serviceQueueWorker(logger) }, c.workerLoopPeriod, ctx.Done())
+			wait.Until(func() { c.serviceQueueWorker(ctx, logger) }, c.workerLoopPeriod, ctx.Done())
 		})
 		wg.Go(func() {
-			wait.Until(func() { c.podQueueWorker(logger) }, c.workerLoopPeriod, ctx.Done())
+			wait.Until(func() { c.podQueueWorker(ctx, logger) }, c.workerLoopPeriod, ctx.Done())
 		})
 	}
 
@@ -313,12 +313,12 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 // them, and marks them done. You may run as many of these in parallel as you
 // wish; the workqueue guarantees that they will not end up processing the same
 // service at the same time
-func (c *Controller) serviceQueueWorker(logger klog.Logger) {
-	for c.processNextServiceWorkItem(logger) {
+func (c *Controller) serviceQueueWorker(ctx context.Context, logger klog.Logger) {
+	for c.processNextServiceWorkItem(ctx, logger) {
 	}
 }
 
-func (c *Controller) processNextServiceWorkItem(logger klog.Logger) bool {
+func (c *Controller) processNextServiceWorkItem(ctx context.Context, logger klog.Logger) bool {
 	cKey, quit := c.serviceQueue.Get()
 	if quit {
 		return false
@@ -326,7 +326,7 @@ func (c *Controller) processNextServiceWorkItem(logger klog.Logger) bool {
 	defer c.serviceQueue.Done(cKey)
 
 	err := c.syncService(logger, cKey)
-	c.handleErr(logger, err, cKey)
+	c.handleErr(ctx, logger, err, cKey)
 
 	return true
 }
@@ -346,7 +346,7 @@ func (c *Controller) processNextTopologyWorkItem(logger klog.Logger) bool {
 	return true
 }
 
-func (c *Controller) handleErr(logger klog.Logger, err error, key string) {
+func (c *Controller) handleErr(ctx context.Context, logger klog.Logger, err error, key string) {
 	trackSync(err)
 
 	if err == nil {
@@ -362,7 +362,7 @@ func (c *Controller) handleErr(logger klog.Logger, err error, key string) {
 
 	logger.Info("Retry budget exceeded, dropping service out of the queue", "key", key, "err", err)
 	c.serviceQueue.Forget(key)
-	utilruntime.HandleError(err)
+	utilruntime.HandleErrorWithContext(ctx, err, "Retry budget exceeded, dropping service out of the queue", "key", key)
 }
 
 func (c *Controller) syncService(logger klog.Logger, key string) error {
@@ -450,12 +450,12 @@ func (c *Controller) syncService(logger klog.Logger, key string) error {
 	return nil
 }
 
-func (c *Controller) podQueueWorker(logger klog.Logger) {
-	for c.processNextPodWorkItem(logger) {
+func (c *Controller) podQueueWorker(ctx context.Context, logger klog.Logger) {
+	for c.processNextPodWorkItem(ctx, logger) {
 	}
 }
 
-func (c *Controller) processNextPodWorkItem(logger klog.Logger) bool {
+func (c *Controller) processNextPodWorkItem(ctx context.Context, logger klog.Logger) bool {
 	cKey, quit := c.podQueue.Get()
 	if quit {
 		return false
@@ -463,12 +463,12 @@ func (c *Controller) processNextPodWorkItem(logger klog.Logger) bool {
 	defer c.podQueue.Done(cKey)
 
 	err := c.syncPod(logger, cKey)
-	c.handlePodErr(logger, err, cKey)
+	c.handlePodErr(ctx, logger, err, cKey)
 
 	return true
 }
 
-func (c *Controller) handlePodErr(logger klog.Logger, err error, key *endpointsliceutil.PodProjectionKey) {
+func (c *Controller) handlePodErr(ctx context.Context, logger klog.Logger, err error, key *endpointsliceutil.PodProjectionKey) {
 	if err == nil {
 		c.podQueue.Forget(key)
 		return
@@ -482,7 +482,7 @@ func (c *Controller) handlePodErr(logger klog.Logger, err error, key *endpointsl
 
 	logger.Info("Dropping pod out of the queue", "PodProjectionKey", *key)
 	c.podQueue.Forget(key)
-	utilruntime.HandleError(err)
+	utilruntime.HandleErrorWithContext(ctx, err, "Dropping pod out of the queue", "PodProjectionKey", *key)
 }
 
 func (c *Controller) syncPod(logger klog.Logger, key *endpointsliceutil.PodProjectionKey) error {

--- a/pkg/controller/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/endpointslice/endpointslice_controller.go
@@ -360,9 +360,8 @@ func (c *Controller) handleErr(logger klog.Logger, err error, key string) {
 		return
 	}
 
-	logger.Info("Retry budget exceeded, dropping service out of the queue", "key", key, "err", err)
 	c.serviceQueue.Forget(key)
-	utilruntime.HandleError(err)
+	utilruntime.HandleErrorWithLogger(logger, err, "Retry budget exceeded, dropping service out of the queue", "key", key)
 }
 
 func (c *Controller) syncService(logger klog.Logger, key string) error {
@@ -480,9 +479,8 @@ func (c *Controller) handlePodErr(logger klog.Logger, err error, key *endpointsl
 		return
 	}
 
-	logger.Info("Dropping pod out of the queue", "PodProjectionKey", *key)
 	c.podQueue.Forget(key)
-	utilruntime.HandleError(err)
+	utilruntime.HandleErrorWithLogger(logger, err, "Dropping pod out of the queue", "PodProjectionKey", *key)
 }
 
 func (c *Controller) syncPod(logger klog.Logger, key *endpointsliceutil.PodProjectionKey) error {
@@ -555,7 +553,7 @@ func (c *Controller) onEndpointSliceUpdate(logger klog.Logger, prevObj, obj inte
 	prevEndpointSlice := prevObj.(*discovery.EndpointSlice)
 	endpointSlice := obj.(*discovery.EndpointSlice)
 	if endpointSlice == nil || prevEndpointSlice == nil {
-		utilruntime.HandleError(fmt.Errorf("Invalid EndpointSlice provided to onEndpointSliceUpdate()"))
+		utilruntime.HandleErrorWithLogger(logger, nil, "Invalid EndpointSlice provided to onEndpointSliceUpdate()")
 		return
 	}
 	// EndpointSlice generation does not change when labels change. Although the

--- a/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
+++ b/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
@@ -263,12 +263,12 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 	defer c.queue.Done(cKey)
 
 	err := c.syncEndpoints(ctx, cKey)
-	c.handleErr(klog.FromContext(ctx), err, cKey)
+	c.handleErr(ctx, klog.FromContext(ctx), err, cKey)
 
 	return true
 }
 
-func (c *Controller) handleErr(logger klog.Logger, err error, key string) {
+func (c *Controller) handleErr(ctx context.Context, logger klog.Logger, err error, key string) {
 	if err == nil {
 		c.queue.Forget(key)
 		return
@@ -282,7 +282,7 @@ func (c *Controller) handleErr(logger klog.Logger, err error, key string) {
 
 	logger.Info("Retry budget exceeded, dropping Endpoints out of the queue", "key", key, "err", err)
 	c.queue.Forget(key)
-	utilruntime.HandleError(err)
+	utilruntime.HandleErrorWithContext(ctx, err, "Retry budget exceeded, dropping Endpoints out of the queue", "key", key)
 }
 
 func (c *Controller) syncEndpoints(ctx context.Context, key string) error {

--- a/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
+++ b/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
@@ -275,14 +275,13 @@ func (c *Controller) handleErr(logger klog.Logger, err error, key string) {
 	}
 
 	if c.queue.NumRequeues(key) < maxRetries {
-		logger.Info("Error mirroring EndpointSlices for Endpoints, retrying", "key", key, "err", err)
+		utilruntime.HandleErrorWithLogger(logger, err, "Error mirroring EndpointSlices for Endpoints, retrying", "key", key)
 		c.queue.AddRateLimited(key)
 		return
 	}
 
-	logger.Info("Retry budget exceeded, dropping Endpoints out of the queue", "key", key, "err", err)
 	c.queue.Forget(key)
-	utilruntime.HandleError(err)
+	utilruntime.HandleErrorWithLogger(logger, err, "Reported exhausted-retry error for EndpointSlice mirroring", "key", key)
 }
 
 func (c *Controller) syncEndpoints(ctx context.Context, key string) error {
@@ -418,7 +417,7 @@ func (c *Controller) onServiceDelete(obj interface{}) {
 func (c *Controller) onEndpointsAdd(logger klog.Logger, obj interface{}) {
 	endpoints := obj.(*v1.Endpoints)
 	if endpoints == nil {
-		utilruntime.HandleError(fmt.Errorf("onEndpointsAdd() expected type v1.Endpoints, got %T", obj))
+		utilruntime.HandleErrorWithLogger(logger, nil, "onEndpointsAdd() expected type v1.Endpoints", "obj", obj)
 		return
 	}
 	if !c.shouldMirror(endpoints) {
@@ -433,7 +432,7 @@ func (c *Controller) onEndpointsUpdate(logger klog.Logger, prevObj, obj interfac
 	endpoints := obj.(*v1.Endpoints)
 	prevEndpoints := prevObj.(*v1.Endpoints)
 	if endpoints == nil || prevEndpoints == nil {
-		utilruntime.HandleError(fmt.Errorf("onEndpointsUpdate() expected type v1.Endpoints, got %T, %T", prevObj, obj))
+		utilruntime.HandleErrorWithLogger(logger, nil, "onEndpointsUpdate() expected type v1.Endpoints", "prevObj", prevObj, "obj", obj)
 		return
 	}
 	if !c.shouldMirror(endpoints) && !c.shouldMirror(prevEndpoints) {
@@ -447,7 +446,7 @@ func (c *Controller) onEndpointsUpdate(logger klog.Logger, prevObj, obj interfac
 func (c *Controller) onEndpointsDelete(logger klog.Logger, obj interface{}) {
 	endpoints := getEndpointsFromDeleteAction(obj)
 	if endpoints == nil {
-		utilruntime.HandleError(fmt.Errorf("onEndpointsDelete() expected type v1.Endpoints, got %T", obj))
+		utilruntime.HandleErrorWithLogger(logger, nil, "onEndpointsDelete() expected type v1.Endpoints", "obj", obj)
 		return
 	}
 	if !c.shouldMirror(endpoints) {
@@ -479,7 +478,7 @@ func (c *Controller) onEndpointSliceUpdate(logger klog.Logger, prevObj, obj inte
 	endpointSlice := obj.(*discovery.EndpointSlice)
 	prevEndpointSlice := prevObj.(*discovery.EndpointSlice)
 	if endpointSlice == nil || prevEndpointSlice == nil {
-		utilruntime.HandleError(fmt.Errorf("onEndpointSliceUpdated() expected type discovery.EndpointSlice, got %T, %T", prevObj, obj))
+		utilruntime.HandleErrorWithLogger(logger, nil, "onEndpointSliceUpdated() expected type discovery.EndpointSlice", "prevObj", prevObj, "obj", obj)
 		return
 	}
 	// EndpointSlice generation does not change when labels change. Although the

--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -236,7 +236,7 @@ func (gc *GarbageCollector) Sync(ctx context.Context, discoveryClient discovery.
 		// case, the restMapper will fail to map some of newResources until the next
 		// attempt.
 		if err := gc.resyncMonitors(logger, newResources); err != nil {
-			utilruntime.HandleError(fmt.Errorf("failed to sync resource monitors: %w", err))
+			utilruntime.HandleErrorWithContext(ctx, fmt.Errorf("failed to sync resource monitors: %w", err), "resync monitors error")
 			metrics.GarbageCollectorResourcesSyncError.Inc()
 			return
 		}

--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -236,7 +236,7 @@ func (gc *GarbageCollector) Sync(ctx context.Context, discoveryClient discovery.
 		// case, the restMapper will fail to map some of newResources until the next
 		// attempt.
 		if err := gc.resyncMonitors(logger, newResources); err != nil {
-			utilruntime.HandleError(fmt.Errorf("failed to sync resource monitors: %w", err))
+			utilruntime.HandleErrorWithLogger(logger, err, "failed to sync resource monitors")
 			metrics.GarbageCollectorResourcesSyncError.Inc()
 			return
 		}
@@ -252,7 +252,7 @@ func (gc *GarbageCollector) Sync(ctx context.Context, discoveryClient discovery.
 		if cacheSynced {
 			logger.V(2).Info("synced garbage collector")
 		} else {
-			utilruntime.HandleError(fmt.Errorf("timed out waiting for dependency graph builder sync during GC sync"))
+			utilruntime.HandleErrorWithLogger(logger, nil, "timed out waiting for dependency graph builder sync during GC sync")
 			metrics.GarbageCollectorResourcesSyncError.Inc()
 		}
 
@@ -322,7 +322,7 @@ const (
 func (gc *GarbageCollector) attemptToDeleteWorker(ctx context.Context, item interface{}) workQueueItemAction {
 	n, ok := item.(*node)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("expect *node, got %#v", item))
+		utilruntime.HandleErrorWithContext(ctx, nil, "expect *node", "item", item)
 		return forgetItem
 	}
 
@@ -362,7 +362,7 @@ func (gc *GarbageCollector) attemptToDeleteWorker(ctx context.Context, item inte
 			// For now, log the error and retry.
 			logger.V(5).Info("error syncing item", "item", n.identity, "err", err)
 		} else {
-			utilruntime.HandleError(fmt.Errorf("error syncing item %s: %v", n, err))
+			utilruntime.HandleErrorWithLogger(logger, err, "error syncing item", "item", n)
 		}
 		// retry if garbage collection of an object failed.
 		return requeueItem
@@ -749,7 +749,7 @@ func (gc *GarbageCollector) processAttemptToOrphanWorker(logger klog.Logger) boo
 func (gc *GarbageCollector) attemptToOrphanWorker(logger klog.Logger, item interface{}) workQueueItemAction {
 	owner, ok := item.(*node)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("expect *node, got %#v", item))
+		utilruntime.HandleErrorWithLogger(logger, nil, "expect *node", "item", item)
 		return forgetItem
 	}
 	// we don't need to lock each element, because they never get updated
@@ -762,13 +762,13 @@ func (gc *GarbageCollector) attemptToOrphanWorker(logger klog.Logger, item inter
 
 	err := gc.orphanDependents(logger, owner.identity, dependents)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("orphanDependents for %s failed with %v", owner.identity, err))
+		utilruntime.HandleErrorWithLogger(logger, err, "orphanDependents failure", "owner", owner.identity)
 		return requeueItem
 	}
 	// update the owner, remove "orphaningFinalizer" from its finalizers list
 	err = gc.removeFinalizer(logger, owner, metav1.FinalizerOrphanDependents)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("removeOrphanFinalizer for %s failed with %v", owner.identity, err))
+		utilruntime.HandleErrorWithLogger(logger, err, "removeOrphanFinalizer failure", "owner", owner.identity)
 		return requeueItem
 	}
 	return forgetItem

--- a/pkg/controller/garbagecollector/graph_builder.go
+++ b/pkg/controller/garbagecollector/graph_builder.go
@@ -709,7 +709,7 @@ func (gb *GraphBuilder) processGraphChanges(logger klog.Logger) bool {
 	obj := item.obj
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("cannot access obj: %v", err))
+		utilruntime.HandleErrorWithLogger(logger, err, "object access denied", "obj", obj)
 		return true
 	}
 

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -746,7 +746,7 @@ func (jm *Controller) processNextWorkItem(ctx context.Context) bool {
 		return true
 	}
 
-	utilruntime.HandleError(fmt.Errorf("syncing job: %w", err))
+	utilruntime.HandleErrorWithContext(ctx, fmt.Errorf("syncing job: %w", err), "syncing job error", "key", key)
 	jm.queue.AddRateLimited(key)
 
 	return true
@@ -765,7 +765,7 @@ func (jm *Controller) processNextOrphanPod(ctx context.Context) bool {
 	defer jm.orphanQueue.Done(key)
 	err := jm.syncOrphanPod(ctx, key)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Error syncing orphan pod: %v", err))
+		utilruntime.HandleErrorWithContext(ctx, fmt.Errorf("error syncing orphan pod: %v", err), "syncing orphan pod error", "key", key)
 		jm.orphanQueue.AddRateLimited(key)
 	} else {
 		jm.orphanQueue.Forget(key)

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -530,12 +530,12 @@ func (jm *Controller) deletePod(logger klog.Logger, obj interface{}, final bool)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %+v", obj))
+			utilruntime.HandleErrorWithLogger(logger, nil, "couldn't get object from tombstone", "obj", obj)
 			return
 		}
 		pod, ok = tombstone.Obj.(*v1.Pod)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a pod %+v", obj))
+			utilruntime.HandleErrorWithLogger(logger, nil, "tombstone contained object that is not a pod", "obj", obj)
 			return
 		}
 	}
@@ -634,12 +634,12 @@ func (jm *Controller) deleteJob(logger klog.Logger, obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %+v", obj))
+			utilruntime.HandleErrorWithLogger(logger, nil, "couldn't get object from tombstone", "obj", obj)
 			return
 		}
 		jobObj, ok = tombstone.Obj.(*batch.Job)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a job %+v", obj))
+			utilruntime.HandleErrorWithLogger(logger, nil, "tombstone contained object that is not a job", "obj", obj)
 			return
 		}
 	}
@@ -653,7 +653,7 @@ func (jm *Controller) deleteJob(logger klog.Logger, obj interface{}) {
 	key := cache.MetaObjectToName(jobObj).String()
 	err := jm.podBackoffStore.removeBackoffRecord(key)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("error removing backoff record %w", err))
+		utilruntime.HandleErrorWithLogger(logger, err, "error removing backoff record", "key", key)
 	}
 }
 
@@ -703,7 +703,7 @@ func (jm *Controller) enqueueSyncJobWithDelay(logger klog.Logger, obj interface{
 func (jm *Controller) enqueueSyncJobInternal(logger klog.Logger, obj interface{}, delay time.Duration) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %+v: %v", obj, err))
+		utilruntime.HandleErrorWithLogger(logger, nil, "couldn't get key for object", "obj", obj)
 		return
 	}
 
@@ -746,7 +746,7 @@ func (jm *Controller) processNextWorkItem(ctx context.Context) bool {
 		return true
 	}
 
-	utilruntime.HandleError(fmt.Errorf("syncing job: %w", err))
+	utilruntime.HandleErrorWithContext(ctx, err, "syncing job error", "key", key)
 	jm.queue.AddRateLimited(key)
 
 	return true
@@ -765,7 +765,7 @@ func (jm *Controller) processNextOrphanPod(ctx context.Context) bool {
 	defer jm.orphanQueue.Done(key)
 	err := jm.syncOrphanPod(ctx, key)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Error syncing orphan pod: %v", err))
+		utilruntime.HandleErrorWithContext(ctx, err, "error syncing orphan pod", "key", key)
 		jm.orphanQueue.AddRateLimited(key)
 	} else {
 		jm.orphanQueue.Forget(key)
@@ -1253,7 +1253,7 @@ func (jm *Controller) deleteActivePods(ctx context.Context, job *batch.Job, pods
 			if err := jm.podControl.DeletePod(ctx, job.Namespace, pod.Name, job); err != nil && !apierrors.IsNotFound(err) {
 				atomic.AddInt32(&successfulDeletes, -1)
 				errCh <- err
-				utilruntime.HandleError(err)
+				utilruntime.HandleErrorWithContext(ctx, err, "error deleting pod")
 			}
 			if podutil.IsPodReady(pod) {
 				atomic.AddInt32(&deletedReady, 1)
@@ -1289,10 +1289,9 @@ func (jm *Controller) deleteJobPods(ctx context.Context, job *batch.Job, jobKey 
 		// Decrement the expected number of deletes because the informer won't observe this deletion
 		jm.expectations.DeletionObserved(logger, jobKey)
 		if !apierrors.IsNotFound(err) {
-			logger.V(2).Info("Failed to delete Pod", "job", klog.KObj(job), "pod", klog.KObj(pod), "err", err)
 			atomic.AddInt32(&successfulDeletes, -1)
 			errCh <- err
-			utilruntime.HandleError(err)
+			utilruntime.HandleErrorWithLogger(logger, err, "failed to delete Pod", "job", klog.KObj(job), "pod", klog.KObj(pod))
 		}
 	}
 
@@ -1613,7 +1612,7 @@ func (jm *Controller) removeTrackingFinalizerFromPods(ctx context.Context, jobKe
 					}
 					if !apierrors.IsNotFound(err) {
 						errCh <- err
-						utilruntime.HandleError(fmt.Errorf("removing tracking finalizer: %w", err))
+						utilruntime.HandleErrorWithLogger(logger, err, "removing tracking finalizer")
 						return
 					}
 				}
@@ -1778,7 +1777,7 @@ func (jm *Controller) manageJob(ctx context.Context, job *batch.Job, jobCtx *syn
 	parallelism := *job.Spec.Parallelism
 	jobKey, err := controller.KeyFunc(job)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for job %#v: %v", job, err))
+		utilruntime.HandleErrorWithLogger(logger, err, "couldn't get key for job", "job", job)
 		return 0, metrics.JobSyncActionTracking, nil
 	}
 
@@ -1950,9 +1949,8 @@ func (jm *Controller) manageJob(ctx context.Context, job *batch.Job, jobCtx *syn
 						}
 					}
 					if err != nil {
-						defer utilruntime.HandleError(err)
+						defer utilruntime.HandleErrorWithLogger(logger, err, "failed creation, decrementing expectations", "job", klog.KObj(job))
 						// Decrement the expected number of creates because the informer won't observe this pod
-						logger.V(2).Info("Failed creation, decrementing expectations", "job", klog.KObj(job))
 						jm.expectations.CreationObserved(logger, jobKey)
 						atomic.AddInt32(&active, -1)
 						errCh <- err

--- a/pkg/controller/job/job_scheduling_manager.go
+++ b/pkg/controller/job/job_scheduling_manager.go
@@ -140,8 +140,7 @@ func (jm *Controller) getOrCreateWorkload(ctx context.Context, job *batch.Job, p
 			result, err = jm.validateWorkloadStructure(logger, job, wl)
 			return err
 		default:
-			utilruntime.HandleError(fmt.Errorf("found %d Workloads referencing Job %s/%s, falling back to default scheduling",
-				len(matched), job.Namespace, job.Name))
+			utilruntime.HandleErrorWithLogger(logger, nil, "multiple Workloads referencing Job falling back to default scheduling", "workloadsCount", len(matched), "jobName", job.Name, "namespace", job.Namespace)
 			return nil
 		}
 	})
@@ -199,8 +198,7 @@ func (jm *Controller) getOrCreatePodGroup(ctx context.Context, job *batch.Job, w
 			result = pg
 			return nil
 		default:
-			utilruntime.HandleError(fmt.Errorf("found %d PodGroups referencing Workload %s/%s, falling back to default scheduling",
-				len(matched), workload.Namespace, workload.Name))
+			utilruntime.HandleErrorWithLogger(logger, nil, "multiple PodGroups referencing Workload falling back to default scheduling", "PodGroupsCount", len(matched), "workloadName", workload.Name, "namespace", workload.Namespace)
 			return nil
 		}
 	})

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -637,7 +637,7 @@ func (rsc *ReplicaSetController) processNextWorkItem(ctx context.Context) bool {
 		return true
 	}
 
-	utilruntime.HandleError(fmt.Errorf("sync %q failed with %v", key, err))
+	utilruntime.HandleErrorWithContext(ctx, fmt.Errorf("sync %q failed with %v", key, err), "sync replica set error", "key", key)
 	rsc.queue.AddRateLimited(key)
 
 	return true

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -308,13 +308,13 @@ func (rsc *ReplicaSetController) Run(ctx context.Context, workers int) {
 func (rsc *ReplicaSetController) getReplicaSetsWithSameController(logger klog.Logger, rs *apps.ReplicaSet) []*apps.ReplicaSet {
 	controllerRef := metav1.GetControllerOf(rs)
 	if controllerRef == nil {
-		utilruntime.HandleError(fmt.Errorf("ReplicaSet has no controller: %v", rs))
+		utilruntime.HandleErrorWithLogger(logger, nil, "ReplicaSet has no controller", "rs", rs)
 		return nil
 	}
 
 	objects, err := rsc.rsIndexer.ByIndex(controllerUIDIndex, string(controllerRef.UID))
 	if err != nil {
-		utilruntime.HandleError(err)
+		utilruntime.HandleErrorWithLogger(logger, err, "error retrieving ReplicaSets by controller UID")
 		return nil
 	}
 	relatedRSs := make([]*apps.ReplicaSet, 0, len(objects))
@@ -399,7 +399,7 @@ func (rsc *ReplicaSetController) updateRS(logger klog.Logger, old, cur interface
 	if curRS.UID != oldRS.UID {
 		key, err := controller.KeyFunc(oldRS)
 		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", oldRS, err))
+			utilruntime.HandleErrorWithLogger(logger, err, "couldn't get key for object", "oldRS", oldRS)
 			return
 		}
 		rsc.deleteRS(logger, cache.DeletedFinalStateUnknown{
@@ -431,19 +431,19 @@ func (rsc *ReplicaSetController) deleteRS(logger klog.Logger, obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			utilruntime.HandleErrorWithLogger(logger, nil, "couldn't get object from tombstone", "obj", obj)
 			return
 		}
 		rs, ok = tombstone.Obj.(*apps.ReplicaSet)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a ReplicaSet %#v", obj))
+			utilruntime.HandleErrorWithLogger(logger, nil, "tombstone contained object that is not a ReplicaSet", "obj", obj)
 			return
 		}
 	}
 
 	key, err := controller.KeyFunc(rs)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", rs, err))
+		utilruntime.HandleErrorWithLogger(logger, err, "couldn't get key for object", "rs", rs)
 		return
 	}
 
@@ -588,12 +588,12 @@ func (rsc *ReplicaSetController) deletePod(logger klog.Logger, obj interface{}) 
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %+v", obj))
+			utilruntime.HandleErrorWithLogger(logger, nil, "couldn't get object from tombstone", "obj", obj)
 			return
 		}
 		pod, ok = tombstone.Obj.(*v1.Pod)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a pod %#v", obj))
+			utilruntime.HandleErrorWithLogger(logger, nil, "tombstone contained object that is not a pod", "obj", obj)
 			return
 		}
 	}
@@ -609,7 +609,7 @@ func (rsc *ReplicaSetController) deletePod(logger klog.Logger, obj interface{}) 
 	}
 	rsKey, err := controller.KeyFunc(rs)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", rs, err))
+		utilruntime.HandleErrorWithLogger(logger, err, "couldn't get key for object", "rs", rs)
 		return
 	}
 	logger.V(4).Info("Pod deleted", "delete_by", utilruntime.GetCaller(), "deletion_timestamp", pod.DeletionTimestamp, "pod", klog.KObj(pod))
@@ -637,7 +637,7 @@ func (rsc *ReplicaSetController) processNextWorkItem(ctx context.Context) bool {
 		return true
 	}
 
-	utilruntime.HandleError(fmt.Errorf("sync %q failed with %v", key, err))
+	utilruntime.HandleErrorWithContext(ctx, err, "sync replica set error", "key", key)
 	rsc.queue.AddRateLimited(key)
 
 	return true
@@ -649,11 +649,11 @@ func (rsc *ReplicaSetController) processNextWorkItem(ctx context.Context) bool {
 func (rsc *ReplicaSetController) manageReplicas(ctx context.Context, activePods []*v1.Pod, rs *apps.ReplicaSet) error {
 	diff := len(activePods) - int(*(rs.Spec.Replicas))
 	rsKey, err := controller.KeyFunc(rs)
+	logger := klog.FromContext(ctx)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for %v %#v: %v", rsc.Kind, rs, err))
+		utilruntime.HandleErrorWithLogger(logger, err, "failed to retrieve key for replica set", "kind", rsc.Kind, "rs", rs)
 		return nil
 	}
-	logger := klog.FromContext(ctx)
 	if diff < 0 {
 		diff *= -1
 		if diff > rsc.burstReplicas {
@@ -704,7 +704,9 @@ func (rsc *ReplicaSetController) manageReplicas(ctx context.Context, activePods 
 		logger.V(2).Info("Too many replicas", "replicaSet", klog.KObj(rs), "need", *(rs.Spec.Replicas), "deleting", diff)
 
 		relatedPods, err := rsc.getIndirectlyRelatedPods(logger, rs)
-		utilruntime.HandleError(err)
+		if err != nil {
+			utilruntime.HandleErrorWithLogger(logger, err, "failed to retrieve indirectly related pods")
+		}
 
 		// Choose which Pods to delete, preferring those in earlier phases of startup.
 		podsToDelete := getPodsToDelete(activePods, relatedPods, diff)
@@ -789,7 +791,7 @@ func (rsc *ReplicaSetController) syncReplicaSet(ctx context.Context, key string)
 	rsNeedsSync := rsc.expectations.SatisfiedExpectations(logger, key)
 	selector, err := metav1.LabelSelectorAsSelector(rs.Spec.Selector)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("error converting pod selector to selector for rs %v/%v: %v", namespace, name, err))
+		utilruntime.HandleErrorWithLogger(logger, err, "error converting pod selector to selector for rs", "namespace", namespace, "name", name)
 		return nil
 	}
 

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -980,7 +980,7 @@ func (s *Server) getAttach(request *restful.Request, response *restful.Response)
 	params := getExecRequestParams(request)
 	streamOpts, err := remotecommandserver.NewOptions(request.Request)
 	if err != nil {
-		utilruntime.HandleError(err)
+		utilruntime.HandleErrorWithContext(request.Request.Context(), err, "new options error")
 		response.WriteError(http.StatusBadRequest, err)
 		return
 	}
@@ -1017,7 +1017,7 @@ func (s *Server) getExec(request *restful.Request, response *restful.Response) {
 	params := getExecRequestParams(request)
 	streamOpts, err := remotecommandserver.NewOptions(request.Request)
 	if err != nil {
-		utilruntime.HandleError(err)
+		utilruntime.HandleErrorWithContext(request.Request.Context(), err, "new options error")
 		response.WriteError(http.StatusBadRequest, err)
 		return
 	}
@@ -1096,7 +1096,7 @@ func (s *Server) getPortForward(request *restful.Request, response *restful.Resp
 	} else {
 		portForwardOptions, err = portforward.NewV4Options(request.Request)
 		if err != nil {
-			utilruntime.HandleError(err)
+			utilruntime.HandleErrorWithContext(request.Request.Context(), err, "new options error")
 			response.WriteError(http.StatusBadRequest, err) //nolint:errcheck
 			return
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This PR continues contextual logging migration in pkg/controller by replacing legacy utilruntime.HandleError(...) with context-aware variants:

  - utilruntime.HandleErrorWithContext(...) where a meaningful context.Context is already available.
  - utilruntime.HandleErrorWithLogger(...) where a logger is available but no context is naturally in scope.

Because pkg/controller has many call sites, this change is split into multiple focused PRs.

#### Which issue(s) this PR is related to:
Contributes to https://github.com/kubernetes/kubernetes/issues/126379

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
"NONE"

```release-note
NONE
```