### PR TITLE
kubelet: remove OtherPods and allocated-pod admission plumbing

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager.go
+++ b/pkg/kubelet/allocation/allocation_manager.go
@@ -83,9 +83,7 @@ type Manager interface {
 	// The function returns a boolean value indicating whether the pod
 	// can be admitted, a brief single-word reason and a message explaining why
 	// the pod cannot be admitted.
-	// allocatedPods should represent the pods that have already been admitted, along with their
-	// admitted (allocated) resources.
-	AddPod(activePods []*v1.Pod, pod *v1.Pod) (ok bool, reason, message string)
+	AddPod(pod *v1.Pod) (ok bool, reason, message string)
 
 	// RemovePod removes any stored state for the given pod UID.
 	RemovePod(uid types.UID)
@@ -116,7 +114,6 @@ type manager struct {
 
 	ticker         *time.Ticker
 	triggerPodSync func(pod *v1.Pod)
-	getActivePods  func() []*v1.Pod
 	getPodByUID    func(types.UID) (*v1.Pod, bool)
 
 	allocationMutex        sync.Mutex
@@ -128,7 +125,6 @@ type manager struct {
 func NewManager(checkpointDirectory string,
 	statusManager status.Manager,
 	triggerPodSync func(pod *v1.Pod),
-	getActivePods func() []*v1.Pod,
 	getPodByUID func(types.UID) (*v1.Pod, bool),
 	sourcesReady config.SourcesReady,
 	recorder record.EventRecorderLogger,
@@ -145,7 +141,6 @@ func NewManager(checkpointDirectory string,
 
 		ticker:         time.NewTicker(initialRetryDelay),
 		triggerPodSync: triggerPodSync,
-		getActivePods:  getActivePods,
 		getPodByUID:    getPodByUID,
 		recorder:       recorder,
 	}
@@ -172,7 +167,6 @@ func newStateImpl(logger klog.Logger, checkpointDirectory, checkpointName string
 func NewInMemoryManager(
 	statusManager status.Manager,
 	triggerPodSync func(pod *v1.Pod),
-	getActivePods func() []*v1.Pod,
 	getPodByUID func(types.UID) (*v1.Pod, bool),
 	sourcesReady config.SourcesReady,
 	recorder record.EventRecorderLogger,
@@ -186,7 +180,6 @@ func NewInMemoryManager(
 
 		ticker:         time.NewTicker(initialRetryDelay),
 		triggerPodSync: triggerPodSync,
-		getActivePods:  getActivePods,
 		getPodByUID:    getPodByUID,
 		recorder:       recorder,
 	}
@@ -508,7 +501,7 @@ func (m *manager) AddPodAdmitHandlers(handlers lifecycle.PodAdmitHandlers) {
 	}
 }
 
-func (m *manager) AddPod(activePods []*v1.Pod, pod *v1.Pod) (bool, string, string) {
+func (m *manager) AddPod(pod *v1.Pod) (bool, string, string) {
 	// Use klog.TODO() because we currently do not have a proper logger to pass in.
 	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
 	logger := klog.TODO()
@@ -522,8 +515,7 @@ func (m *manager) AddPod(activePods []*v1.Pod, pod *v1.Pod) (bool, string, strin
 	}
 
 	// Check if we can admit the pod; if so, update the allocation.
-	allocatedPods := m.getAllocatedPods(activePods)
-	ok, reason, message := m.canAdmitPod(logger, allocatedPods, pod, lifecycle.AddOperation)
+	ok, reason, message := m.canAdmitPod(logger, pod, lifecycle.AddOperation)
 
 	if ok && utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		// Checkpoint the resource values at which the Pod has been admitted or resized.
@@ -559,7 +551,7 @@ func (m *manager) handlePodResourcesResize(logger klog.Logger, pod *v1.Pod) (boo
 	}
 
 	// Desired resources != allocated resources. Can we update the allocation to the desired resources?
-	fit, reason, message := m.canAdmitPod(logger, m.getAllocatedPods(m.getActivePods()), pod, lifecycle.ResizeOperation)
+	fit, reason, message := m.canAdmitPod(logger, pod, lifecycle.ResizeOperation)
 	if fit {
 		// Update pod resource allocation checkpoint
 		if err := m.SetAllocatedResources(pod); err != nil {
@@ -592,18 +584,11 @@ func (m *manager) handlePodResourcesResize(logger klog.Logger, pod *v1.Pod) (boo
 }
 
 // canAdmitPod determines if a pod can be admitted, and gives a reason if it
-// cannot. "pod" is new pod, while "pods" are all admitted pods
-// The function returns a boolean value indicating whether the pod
+// cannot. The function returns a boolean value indicating whether the pod
 // can be admitted, a brief single-word reason and a message explaining why
 // the pod cannot be admitted.
-// allocatedPods should represent the pods that have already been admitted, along with their
-// admitted (allocated) resources.
-func (m *manager) canAdmitPod(logger klog.Logger, allocatedPods []*v1.Pod, pod *v1.Pod, operation lifecycle.Operation) (bool, string, string) {
-	// Filter out the pod being evaluated.
-	allocatedPods = slices.DeleteFunc(allocatedPods, func(p *v1.Pod) bool { return p.UID == pod.UID })
-
-	// If any handler rejects, the pod is rejected.
-	attrs := &lifecycle.PodAdmitAttributes{Pod: pod, OtherPods: allocatedPods, Operation: operation}
+func (m *manager) canAdmitPod(logger klog.Logger, pod *v1.Pod, operation lifecycle.Operation) (bool, string, string) {
+	attrs := &lifecycle.PodAdmitAttributes{Pod: pod, Operation: operation}
 	for _, podAdmitHandler := range m.admitHandlers {
 		if result := podAdmitHandler.Admit(attrs); !result.Admit {
 			logger.Info("Pod admission denied", "podUID", attrs.Pod.UID, "pod", klog.KObj(attrs.Pod), "reason", result.Reason, "message", result.Message, "operation", operation)
@@ -612,18 +597,6 @@ func (m *manager) canAdmitPod(logger klog.Logger, allocatedPods []*v1.Pod, pod *
 	}
 
 	return true, "", ""
-}
-
-func (m *manager) getAllocatedPods(activePods []*v1.Pod) []*v1.Pod {
-	if !utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
-		return activePods
-	}
-
-	allocatedPods := make([]*v1.Pod, len(activePods))
-	for i, pod := range activePods {
-		allocatedPods[i], _ = m.UpdatePodFromAllocation(pod)
-	}
-	return allocatedPods
 }
 
 func IsResizableContainer(container *v1.Container, containerType podutil.ContainerType) bool {

--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -1751,7 +1751,7 @@ func TestAllocationManagerAddPodWithPLR(t *testing.T) {
 				allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{handler})
 			}
 
-			ok, reason, message := allocationManager.AddPod(tc.currentActivePods, tc.podToAdd)
+			ok, reason, message := allocationManager.AddPod(tc.podToAdd)
 			require.Equal(t, tc.expectAdmit, ok)
 			require.Equal(t, tc.admissionFailureReason, reason)
 			require.Equal(t, tc.admissionFailureMessage, message)
@@ -2007,7 +2007,7 @@ func TestAllocationManagerAddPod(t *testing.T) {
 				allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{handler})
 			}
 
-			ok, reason, message := allocationManager.AddPod(tc.currentActivePods, tc.podToAdd)
+			ok, reason, message := allocationManager.AddPod(tc.podToAdd)
 			require.Equal(t, tc.expectAdmit, ok)
 			require.Equal(t, tc.admissionFailureReason, reason)
 			require.Equal(t, tc.admissionFailureMessage, message)
@@ -2433,7 +2433,6 @@ func makeAllocationManager(t *testing.T, runtime *containertest.FakeRuntime, all
 			}
 			pod.Annotations["pod-sync-triggered"] = "true"
 		},
-		func() []*v1.Pod { return allocatedPods },
 		func(uid types.UID) (*v1.Pod, bool) {
 			for _, p := range allocatedPods {
 				if p.UID == uid {

--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -2461,8 +2461,7 @@ func makeAllocationManager(t *testing.T, runtime *containertest.FakeRuntime, all
 			},
 		}, nil
 	}
-
-	predicateHandler := lifecycle.NewPredicateAdmitHandler(getNode, lifecycle.NewAdmissionFailureHandlerStub(), containerManager.UpdatePluginResources)
+	predicateHandler := lifecycle.NewPredicateAdmitHandler(getNode, lifecycle.NewAdmissionFailureHandlerStub(), containerManager.UpdatePluginResources, lifecycle.NewNodeInfoProviderStubWithPods(allocatedPods))
 	resizeHandler := NewPodResizesAdmitHandler(containerManager, runtime, allocationManager, logger)
 	allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{resizeHandler, predicateHandler})
 	return allocationManager

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -706,7 +706,6 @@ func NewMainKubelet(ctx context.Context,
 		klet.getRootDir(),
 		klet.statusManager,
 		klet.syncPodNow,
-		klet.GetActivePods,
 		klet.podManager.GetPodByUID,
 		klet.sourcesReady,
 		kubeDeps.Recorder,
@@ -2885,9 +2884,7 @@ func (kl *Kubelet) HandlePodAdditions(ctx context.Context, pods []*v1.Pod) {
 		// We also do not try to admit the pod that is already in terminated state.
 		if !kl.podWorkers.IsPodTerminationRequested(pod.UID) && !podutil.IsPodPhaseTerminal(pod.Status.Phase) {
 			// Check if we can admit the pod; if not, reject it.
-			// We failed pods that we rejected, so activePods include all admitted
-			// pods that are alive.
-			if ok, reason, message := kl.allocationManager.AddPod(kl.GetActivePods(), pod); !ok {
+			if ok, reason, message := kl.allocationManager.AddPod(pod); !ok {
 				kl.rejectPod(ctx, pod, reason, message)
 				// We avoid recording the metric in canAdmitPod because it's called
 				// repeatedly during a resize, which would inflate the metric.

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -110,6 +110,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/pkg/kubelet/metrics/collectors"
 	"k8s.io/kubernetes/pkg/kubelet/network/dns"
+	"k8s.io/kubernetes/pkg/kubelet/nodeinfocache"
 	"k8s.io/kubernetes/pkg/kubelet/nodeshutdown"
 	oomwatcher "k8s.io/kubernetes/pkg/kubelet/oom"
 	"k8s.io/kubernetes/pkg/kubelet/pleg"
@@ -711,6 +712,11 @@ func NewMainKubelet(ctx context.Context,
 		kubeDeps.Recorder,
 	)
 
+	// Initialize NodeInfo cache for efficient pod admission.
+	// The node will be set when GetCachedNode is first called.
+	// Pods will be added incrementally via HandlePodAdditions.
+	klet.nodeInfoCache = nodeinfocache.New()
+
 	klet.resourceAnalyzer = serverstats.NewResourceAnalyzer(ctx, klet, kubeCfg.VolumeStatsAggPeriod.Duration, kubeDeps.Recorder)
 	klet.runtimeService = kubeDeps.RemoteRuntimeService
 
@@ -1115,7 +1121,7 @@ func NewMainKubelet(ctx context.Context,
 	handlers = append(handlers, klet.containerManager.GetAllocateResourcesPodAdmitHandler())
 
 	criticalPodAdmissionHandler := preemption.NewCriticalPodAdmissionHandler(klet.getAllocatedPods, killPodNow(ctx, klet.podWorkers, kubeDeps.Recorder), kubeDeps.Recorder)
-	handlers = append(handlers, lifecycle.NewPredicateAdmitHandler(klet.GetCachedNode, criticalPodAdmissionHandler, klet.containerManager.UpdatePluginResources))
+	handlers = append(handlers, lifecycle.NewPredicateAdmitHandler(klet.GetCachedNode, criticalPodAdmissionHandler, klet.containerManager.UpdatePluginResources, klet.nodeInfoCache))
 	// apply functional Option's
 	for _, opt := range kubeDeps.Options {
 		opt(klet)
@@ -1297,6 +1303,10 @@ type Kubelet struct {
 
 	// allocationManager manages allocated resources for pods.
 	allocationManager allocation.Manager
+
+	// nodeInfoCache caches NodeInfo for efficient pod admission.
+	// Updated incrementally when pods are added/removed/updated.
+	nodeInfoCache *nodeinfocache.Cache
 
 	// podCertificateManager is fed updates as pods are added and removed from
 	// the node, and requests certificates for them based on their configured
@@ -2886,6 +2896,11 @@ func (kl *Kubelet) HandlePodAdditions(ctx context.Context, pods []*v1.Pod) {
 				recordAdmissionRejection(reason)
 				continue
 			}
+			// Update NodeInfo cache after successful admission.
+			// Use allocated resources (not desired) so resource accounting
+			// reflects what is actually committed on the node.
+			allocatedPod, _ := kl.allocationManager.UpdatePodFromAllocation(pod)
+			kl.nodeInfoCache.AddPod(allocatedPod)
 
 			if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 				// Backfill the queue of pending resizes, but only after all the pods have
@@ -2923,6 +2938,14 @@ func (kl *Kubelet) HandlePodUpdates(ctx context.Context, pods []*v1.Pod) {
 	for _, pod := range pods {
 		oldPod, _ := kl.podManager.GetPodByUID(pod.UID)
 		kl.podManager.UpdatePod(pod)
+		// Update NodeInfo cache with allocated resources (not desired) so
+		// resource accounting reflects what is actually committed.
+		// oldPod is nil for mirror pods (stored separately in podManager),
+		// so the cache update is naturally skipped for mirror pod events.
+		if oldPod != nil {
+			allocatedPod, _ := kl.allocationManager.UpdatePodFromAllocation(pod)
+			kl.nodeInfoCache.UpdatePod(logger, oldPod, allocatedPod)
+		}
 
 		pod, mirrorPod, wasMirror := kl.podManager.GetPodAndMirrorPod(pod)
 		if wasMirror {
@@ -3070,6 +3093,8 @@ func (kl *Kubelet) HandlePodRemoves(ctx context.Context, pods []*v1.Pod) {
 	for _, pod := range pods {
 		kl.podCertificateManager.ForgetPod(ctx, pod)
 		kl.podManager.RemovePod(pod)
+		// Remove from NodeInfo cache
+		kl.nodeInfoCache.RemovePod(logger, pod)
 		kl.allocationManager.RemovePod(pod.UID)
 
 		pod, mirrorPod, wasMirror := kl.podManager.GetPodAndMirrorPod(pod)
@@ -3113,6 +3138,13 @@ func (kl *Kubelet) HandlePodReconcile(ctx context.Context, pods []*v1.Pod) {
 		// to the pod manager.
 		oldPod, _ := kl.podManager.GetPodByUID(pod.UID)
 		kl.podManager.UpdatePod(pod)
+		// Keep NodeInfo cache in sync — reconcile events carry the latest pod
+		// spec from the API server which may include resource changes.
+		// Use allocated resources so accounting reflects actual commitments.
+		if oldPod != nil {
+			allocatedPod, _ := kl.allocationManager.UpdatePodFromAllocation(pod)
+			kl.nodeInfoCache.UpdatePod(logger, oldPod, allocatedPod)
+		}
 
 		pod, mirrorPod, wasMirror := kl.podManager.GetPodAndMirrorPod(pod)
 		if wasMirror {

--- a/pkg/kubelet/kubelet_nodecache.go
+++ b/pkg/kubelet/kubelet_nodecache.go
@@ -48,7 +48,7 @@ func (kl *Kubelet) getCachedNode(ctx context.Context) (*v1.Node, error) {
 	}
 
 	if kl.cachedNode == nil {
-		kl.cachedNode = informerNode
+		kl.setCachedNode(informerNode)
 		return informerNode, nil
 	}
 
@@ -56,10 +56,10 @@ func (kl *Kubelet) getCachedNode(ctx context.Context) (*v1.Node, error) {
 	if err != nil {
 		// In error cases, default to the informer node.
 		logger.Error(err, "failed to check if node is newer; using informer node")
-		kl.cachedNode = informerNode
+		kl.setCachedNode(informerNode)
 	}
 	if isNewer {
-		kl.cachedNode = informerNode
+		kl.setCachedNode(informerNode)
 	}
 	return kl.cachedNode, nil
 }
@@ -74,8 +74,14 @@ func (kl *Kubelet) getNodeSync() (*v1.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	kl.cachedNode = node
+	kl.setCachedNode(node)
 	return node, nil
+}
+
+// setCachedNode updates both the Node object cache and the NodeInfo cache.
+func (kl *Kubelet) setCachedNode(node *v1.Node) {
+	kl.cachedNode = node
+	kl.nodeInfoCache.SetNode(node)
 }
 
 // isNewer checks if the informer node is newer than the cached node based on the ResourceVersion.

--- a/pkg/kubelet/kubelet_nodecache_test.go
+++ b/pkg/kubelet/kubelet_nodecache_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/kubernetes/pkg/kubelet/nodeinfocache"
 )
 
 func TestGetCachedNode(t *testing.T) {
@@ -111,9 +112,10 @@ func TestGetCachedNode(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			kl := Kubelet{
-				cachedNode: test.cachedNode,
-				nodeLister: newFakeNodeLister(test.nodeListerErr, test.informerNode),
-				kubeClient: &fake.Clientset{},
+				cachedNode:    test.cachedNode,
+				nodeLister:    newFakeNodeLister(test.nodeListerErr, test.informerNode),
+				kubeClient:    &fake.Clientset{},
+				nodeInfoCache: nodeinfocache.New(),
 			}
 			if test.expectedNode == nil {
 				var err error

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -345,7 +345,6 @@ func newTestKubeletWithImageList(
 	kubelet.allocationManager = allocation.NewInMemoryManager(
 		kubelet.statusManager,
 		func(pod *v1.Pod) { kubelet.HandlePodSyncs(tCtx, []*v1.Pod{pod}) },
-		kubelet.GetActivePods,
 		kubelet.podManager.GetPodByUID,
 		config.NewSourcesReady(func(_ sets.Set[string]) bool { return enableResizing }),
 		kubelet.recorder,

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -90,6 +90,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/logs"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/pkg/kubelet/network/dns"
+	"k8s.io/kubernetes/pkg/kubelet/nodeinfocache"
 	"k8s.io/kubernetes/pkg/kubelet/nodeshutdown"
 	"k8s.io/kubernetes/pkg/kubelet/pleg"
 	"k8s.io/kubernetes/pkg/kubelet/pluginmanager"
@@ -320,6 +321,7 @@ func newTestKubeletWithImageList(
 	kubelet.reasonCache = NewReasonCache()
 	podCache := containertest.NewFakeCache(kubelet.containerRuntime)
 	kubelet.podCache = podCache
+	kubelet.nodeInfoCache = nodeinfocache.New()
 	kubelet.podWorkers = &fakePodWorkers{
 		syncPodFn: kubelet.SyncPod,
 		cache:     kubelet.podCache,
@@ -425,7 +427,7 @@ func newTestKubeletWithImageList(
 	handlers = append(handlers, shutdownManager)
 
 	// Add this as cleanup predicate pod admitter
-	handlers = append(handlers, lifecycle.NewPredicateAdmitHandler(kubelet.GetCachedNode, lifecycle.NewAdmissionFailureHandlerStub(), kubelet.containerManager.UpdatePluginResources))
+	handlers = append(handlers, lifecycle.NewPredicateAdmitHandler(kubelet.GetCachedNode, lifecycle.NewAdmissionFailureHandlerStub(), kubelet.containerManager.UpdatePluginResources, kubelet.nodeInfoCache))
 
 	if !excludeAdmitHandlers {
 		kubelet.allocationManager.AddPodAdmitHandlers(handlers)
@@ -1264,7 +1266,7 @@ func TestHandlePluginResources(t *testing.T) {
 	}
 
 	// add updatePluginResourcesFunc to admission handler, to test it's behavior.
-	kl.allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{lifecycle.NewPredicateAdmitHandler(kl.GetCachedNode, lifecycle.NewAdmissionFailureHandlerStub(), updatePluginResourcesFunc)})
+	kl.allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{lifecycle.NewPredicateAdmitHandler(kl.GetCachedNode, lifecycle.NewAdmissionFailureHandlerStub(), updatePluginResourcesFunc, lifecycle.NewNodeInfoProviderStub())})
 
 	recorder := record.NewFakeRecorder(20)
 	nodeRef := &v1.ObjectReference{

--- a/pkg/kubelet/lifecycle/interfaces.go
+++ b/pkg/kubelet/lifecycle/interfaces.go
@@ -23,8 +23,6 @@ import v1 "k8s.io/api/core/v1"
 type PodAdmitAttributes struct {
 	// the pod to evaluate for admission
 	Pod *v1.Pod
-	// all pods bound to the kubelet excluding the pod being evaluated
-	OtherPods []*v1.Pod
 	// the operation being performed; either "add" or "resize"
 	Operation Operation
 }

--- a/pkg/kubelet/lifecycle/node_info_provider_stub.go
+++ b/pkg/kubelet/lifecycle/node_info_provider_stub.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle
+
+import (
+	v1 "k8s.io/api/core/v1"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+// NodeInfoProviderStub is a NodeInfoProvider that returns a configurable NodeInfo.
+// Used for testing when the NodeInfo cache behavior is not being tested.
+type NodeInfoProviderStub struct {
+	pods []*v1.Pod
+}
+
+var _ NodeInfoProvider = &NodeInfoProviderStub{}
+
+// NewNodeInfoProviderStub returns an instance of NodeInfoProviderStub with an empty NodeInfo.
+func NewNodeInfoProviderStub() *NodeInfoProviderStub {
+	return &NodeInfoProviderStub{}
+}
+
+// NewNodeInfoProviderStubWithPods returns an instance of NodeInfoProviderStub
+// pre-populated with the given pods.
+func NewNodeInfoProviderStubWithPods(pods []*v1.Pod) *NodeInfoProviderStub {
+	return &NodeInfoProviderStub{pods: pods}
+}
+
+// Snapshot returns a NodeInfo snapshot containing the configured pods.
+func (n *NodeInfoProviderStub) Snapshot() *schedulerframework.NodeInfo {
+	return schedulerframework.NewNodeInfo(n.pods...)
+}

--- a/pkg/kubelet/lifecycle/predicate.go
+++ b/pkg/kubelet/lifecycle/predicate.go
@@ -169,7 +169,8 @@ func (w *predicateAdmitHandler) Admit(attrs *PodAdmitAttributes) PodAdmitResult 
 	}
 
 	// Use cached NodeInfo snapshot instead of rebuilding from scratch.
-	// This is O(n) for the snapshot vs O(n*m) for NewNodeInfo where n=pods, m=containers.
+	// Snapshot copies pre-computed aggregates; NewNodeInfo recomputes from scratch
+	// by iterating all containers in all pods.
 	nodeInfo := w.nodeInfoProvider.Snapshot()
 	// Ensure node is current (cache may have slightly stale node if updated between events)
 	nodeInfo.SetNode(node)

--- a/pkg/kubelet/lifecycle/predicate.go
+++ b/pkg/kubelet/lifecycle/predicate.go
@@ -98,21 +98,31 @@ type AdmissionFailureHandler interface {
 	HandleAdmissionFailure(ctx context.Context, admitPod *v1.Pod, failureReasons []PredicateFailureReason) ([]PredicateFailureReason, error)
 }
 
+// NodeInfoProvider provides NodeInfo snapshots for admission decisions.
+// This interface allows the predicateAdmitHandler to use a cached NodeInfo
+// rather than rebuilding it from scratch on every admission.
+type NodeInfoProvider interface {
+	// Snapshot returns a deep copy of the cached NodeInfo for safe concurrent use.
+	Snapshot() *schedulerframework.NodeInfo
+}
+
 type predicateAdmitHandler struct {
 	getNodeAnyWayFunc        getNodeAnyWayFuncType
 	pluginResourceUpdateFunc pluginResourceUpdateFuncType
 	admissionFailureHandler  AdmissionFailureHandler
+	nodeInfoProvider         NodeInfoProvider
 }
 
 var _ PodAdmitHandler = &predicateAdmitHandler{}
 
-// NewPredicateAdmitHandler returns a PodAdmitHandler which is used to evaluates
+// NewPredicateAdmitHandler returns a PodAdmitHandler which is used to evaluate
 // if a pod can be admitted from the perspective of predicates.
-func NewPredicateAdmitHandler(getNodeAnyWayFunc getNodeAnyWayFuncType, admissionFailureHandler AdmissionFailureHandler, pluginResourceUpdateFunc pluginResourceUpdateFuncType) PodAdmitHandler {
+func NewPredicateAdmitHandler(getNodeAnyWayFunc getNodeAnyWayFuncType, admissionFailureHandler AdmissionFailureHandler, pluginResourceUpdateFunc pluginResourceUpdateFuncType, nodeInfoProvider NodeInfoProvider) PodAdmitHandler {
 	return &predicateAdmitHandler{
-		getNodeAnyWayFunc,
-		pluginResourceUpdateFunc,
-		admissionFailureHandler,
+		getNodeAnyWayFunc:        getNodeAnyWayFunc,
+		pluginResourceUpdateFunc: pluginResourceUpdateFunc,
+		admissionFailureHandler:  admissionFailureHandler,
+		nodeInfoProvider:         nodeInfoProvider,
 	}
 }
 
@@ -158,9 +168,23 @@ func (w *predicateAdmitHandler) Admit(attrs *PodAdmitAttributes) PodAdmitResult 
 		}
 	}
 
-	pods := attrs.OtherPods
-	nodeInfo := schedulerframework.NewNodeInfo(pods...)
+	// Use cached NodeInfo snapshot instead of rebuilding from scratch.
+	// This is O(n) for the snapshot vs O(n*m) for NewNodeInfo where n=pods, m=containers.
+	nodeInfo := w.nodeInfoProvider.Snapshot()
+	// Ensure node is current (cache may have slightly stale node if updated between events)
 	nodeInfo.SetNode(node)
+	// For resize operations, remove the old version of the pod from the snapshot
+	// so resource accounting reflects only the other pods on the node.
+	// New pods (AddOperation) are not in the cache yet, so no removal is needed.
+	if attrs.Operation == ResizeOperation {
+		if err := nodeInfo.RemovePod(logger, admitPod); err != nil {
+			// We continue despite the error. The snapshot still contains the old
+			// pod, so resource accounting double-counts this pod's resources,
+			// making admission more conservative (may reject a valid resize but
+			// will not admit one that would overcommit the node).
+			logger.Error(err, "Failed to remove pod from NodeInfo snapshot during resize admission; resource accounting may be inaccurate", "pod", klog.KObj(admitPod))
+		}
+	}
 
 	// ensure the node has enough plugin resources for that required in pods
 	if err = w.pluginResourceUpdateFunc(nodeInfo, attrs); err != nil {

--- a/pkg/kubelet/nodeinfocache/benchmark_test.go
+++ b/pkg/kubelet/nodeinfocache/benchmark_test.go
@@ -1,0 +1,328 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeinfocache
+
+import (
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2/ktesting"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+// generatePods creates n pods with realistic resource requests.
+// Each pod has 2 containers to simulate typical workloads.
+func generatePods(count int) []*v1.Pod {
+	pods := make([]*v1.Pod, count)
+	for i := range count {
+		pods[i] = &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("pod-%d", i),
+				Namespace: "default",
+				UID:       types.UID(fmt.Sprintf("uid-%d", i)),
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name: "main",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:              resource.MustParse("100m"),
+								v1.ResourceMemory:           resource.MustParse("256Mi"),
+								v1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+							},
+						},
+					},
+					{
+						Name: "sidecar",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("50m"),
+								v1.ResourceMemory: resource.MustParse("64Mi"),
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+	return pods
+}
+
+// generatePodsWithPrefix creates pods with a custom name prefix.
+func generatePodsWithPrefix(prefix string, count int) []*v1.Pod {
+	pods := generatePods(count)
+	for i, pod := range pods {
+		pod.Name = fmt.Sprintf("%s-%d", prefix, i)
+		pod.UID = types.UID(fmt.Sprintf("%s-uid-%d", prefix, i))
+	}
+	return pods
+}
+
+// makeNode creates a node with specified resources.
+func makeNode(name, cpu, memory string) *v1.Node {
+	return &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Status: v1.NodeStatus{
+			Allocatable: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse(cpu),
+				v1.ResourceMemory: resource.MustParse(memory),
+				v1.ResourcePods:   resource.MustParse("110"),
+			},
+		},
+	}
+}
+
+// BenchmarkNewNodeInfo measures the baseline: rebuilding NodeInfo from scratch.
+// This is the OLD approach used before caching.
+func BenchmarkNewNodeInfo(b *testing.B) {
+	pods := generatePods(100)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = schedulerframework.NewNodeInfo(pods...)
+	}
+}
+
+// BenchmarkCacheSnapshot measures the NEW approach: getting a snapshot from cache.
+func BenchmarkCacheSnapshot(b *testing.B) {
+	cache := New()
+	for _, pod := range generatePods(100) {
+		cache.AddPod(pod)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = cache.Snapshot()
+	}
+}
+
+// BenchmarkCacheAddPod measures the cost of adding a pod to the cache.
+func BenchmarkCacheAddPod(b *testing.B) {
+	pod := generatePods(1)[0]
+	b.ReportAllocs()
+	b.ResetTimer()
+	cache := New()
+	for b.Loop() {
+		cache.AddPod(pod)
+	}
+}
+
+// BenchmarkCacheRemovePod measures the cost of removing a pod from the cache.
+func BenchmarkCacheRemovePod(b *testing.B) {
+	logger, _ := ktesting.NewTestContext(b)
+	pod := generatePods(1)[0]
+	cache := New()
+	// Pre-populate with many pods so RemovePod has to search.
+	for _, p := range generatePods(100) {
+		cache.AddPod(p)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		cache.AddPod(pod)
+		cache.RemovePod(logger, pod)
+	}
+}
+
+// BenchmarkAdmissionE2E compares the full admission path: NodeInfo construction + SetNode.
+// This simulates a single pod admission for both new pods and resize operations.
+func BenchmarkAdmissionE2E(b *testing.B) {
+	logger, _ := ktesting.NewTestContext(b)
+	existingPods := generatePods(100)
+	node := makeNode("test-node", "8", "32Gi")
+	// Pick an existing pod to simulate resize admission
+	resizePod := existingPods[50]
+
+	b.Run("NewPod/Current-NewNodeInfo", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			nodeInfo := schedulerframework.NewNodeInfo(existingPods...)
+			nodeInfo.SetNode(node)
+		}
+	})
+
+	b.Run("NewPod/Cached-Snapshot", func(b *testing.B) {
+		cache := New()
+		cache.SetNode(node)
+		for _, pod := range existingPods {
+			cache.AddPod(pod)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			nodeInfo := cache.Snapshot()
+			nodeInfo.SetNode(node)
+		}
+	})
+
+	b.Run("Resize/Current-NewNodeInfo+RemovePod", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			nodeInfo := schedulerframework.NewNodeInfo(existingPods...)
+			nodeInfo.SetNode(node)
+			_ = nodeInfo.RemovePod(logger, resizePod)
+		}
+	})
+
+	b.Run("Resize/Cached-Snapshot+RemovePod", func(b *testing.B) {
+		cache := New()
+		cache.SetNode(node)
+		for _, pod := range existingPods {
+			cache.AddPod(pod)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			nodeInfo := cache.Snapshot()
+			nodeInfo.SetNode(node)
+			_ = nodeInfo.RemovePod(logger, resizePod)
+		}
+	})
+}
+
+// BenchmarkResizeRetryScenario simulates pending resize retries.
+// This is where caching provides the most benefit - the same pod set
+// is evaluated repeatedly while waiting for resources to become available.
+func BenchmarkResizeRetryScenario(b *testing.B) {
+	existingPods := generatePods(100)
+	node := makeNode("test-node", "8", "32Gi")
+	retryCount := 10 // Typical retries before resources free up
+
+	b.Run("Current-RebuildEachRetry", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			// Current: rebuild NodeInfo on every retry
+			for range retryCount {
+				nodeInfo := schedulerframework.NewNodeInfo(existingPods...)
+				nodeInfo.SetNode(node)
+			}
+		}
+	})
+
+	b.Run("Cached-SnapshotEachRetry", func(b *testing.B) {
+		cache := New()
+		cache.SetNode(node)
+		for _, pod := range existingPods {
+			cache.AddPod(pod)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			// New: snapshot from cache on each retry
+			for range retryCount {
+				nodeInfo := cache.Snapshot()
+				nodeInfo.SetNode(node)
+			}
+		}
+	})
+}
+
+// BenchmarkSequentialAdmissions simulates burst pod creation.
+// Tests the incremental update benefit when pods are admitted one after another.
+func BenchmarkSequentialAdmissions(b *testing.B) {
+	node := makeNode("test-node", "8", "32Gi")
+	basePodCount := 50
+	burstSize := 20
+
+	b.Run("Current-RebuildGrowingSet", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			pods := generatePods(basePodCount)
+			newPods := generatePodsWithPrefix("burst", burstSize)
+			// Admit burst pods sequentially
+			for _, newPod := range newPods {
+				nodeInfo := schedulerframework.NewNodeInfo(pods...)
+				nodeInfo.SetNode(node)
+				// After admission, pod joins the set
+				pods = append(pods, newPod)
+			}
+		}
+	})
+
+	b.Run("Cached-IncrementalAdd", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			cache := New()
+			cache.SetNode(node)
+			for _, pod := range generatePods(basePodCount) {
+				cache.AddPod(pod)
+			}
+			newPods := generatePodsWithPrefix("burst", burstSize)
+			// Admit burst pods sequentially
+			for _, newPod := range newPods {
+				_ = cache.Snapshot()
+				// After admission, add to cache (O(1))
+				cache.AddPod(newPod)
+			}
+		}
+	})
+}
+
+// BenchmarkScalingComparison tests performance across different node sizes.
+func BenchmarkScalingComparison(b *testing.B) {
+	node := makeNode("test-node", "96", "384Gi") // Large node
+
+	for _, podCount := range []int{10, 50, 100, 200} {
+		pods := generatePods(podCount)
+
+		b.Run(fmt.Sprintf("NewNodeInfo-%dPods", podCount), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				nodeInfo := schedulerframework.NewNodeInfo(pods...)
+				nodeInfo.SetNode(node)
+			}
+		})
+
+		b.Run(fmt.Sprintf("CacheSnapshot-%dPods", podCount), func(b *testing.B) {
+			cache := New()
+			cache.SetNode(node)
+			for _, pod := range pods {
+				cache.AddPod(pod)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				nodeInfo := cache.Snapshot()
+				nodeInfo.SetNode(node)
+			}
+		})
+	}
+}
+
+// BenchmarkConcurrentSnapshots tests snapshot performance under concurrent access.
+func BenchmarkConcurrentSnapshots(b *testing.B) {
+	cache := New()
+	cache.SetNode(makeNode("test-node", "8", "32Gi"))
+	for _, pod := range generatePods(100) {
+		cache.AddPod(pod)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = cache.Snapshot()
+		}
+	})
+}

--- a/pkg/kubelet/nodeinfocache/cache.go
+++ b/pkg/kubelet/nodeinfocache/cache.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeinfocache
+
+import (
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+// Cache maintains a cached NodeInfo for the kubelet's node.
+// Thread-safe wrapper around schedulerframework.NodeInfo with incremental updates.
+type Cache struct {
+	lock     sync.RWMutex
+	nodeInfo *schedulerframework.NodeInfo
+}
+
+// New creates a new empty NodeInfo cache.
+func New() *Cache {
+	ni := schedulerframework.NewNodeInfo()
+	// Set a placeholder node so that NodeInfo.RemovePod error messages
+	// can safely access Node().Name before SetNode is called.
+	ni.SetNode(&v1.Node{})
+	return &Cache{
+		nodeInfo: ni,
+	}
+}
+
+// SetNode updates the cached node metadata.
+func (c *Cache) SetNode(node *v1.Node) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.nodeInfo.SetNode(node)
+}
+
+// AddPod adds a pod to the cache incrementally.
+func (c *Cache) AddPod(pod *v1.Pod) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.nodeInfo.AddPod(pod)
+}
+
+// RemovePod removes a pod from the cache.
+// If the pod is not found (e.g. it was rejected during admission), the error is logged and ignored.
+func (c *Cache) RemovePod(logger klog.Logger, pod *v1.Pod) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if err := c.nodeInfo.RemovePod(logger, pod); err != nil {
+		logger.V(4).Info("Pod not found in cache during remove", "pod", klog.KObj(pod), "err", err)
+	}
+}
+
+// UpdatePod updates a pod in the cache (remove old, add new).
+// If the old pod is not found (e.g. it was rejected during admission or is
+// terminating), the update is skipped entirely — only admitted pods belong
+// in the cache.
+func (c *Cache) UpdatePod(logger klog.Logger, oldPod, newPod *v1.Pod) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if err := c.nodeInfo.RemovePod(logger, oldPod); err != nil {
+		logger.V(4).Info("Pod not found in cache during update, skipping add", "pod", klog.KObj(oldPod), "err", err)
+		return
+	}
+	c.nodeInfo.AddPod(newPod)
+}
+
+// Snapshot returns a deep copy of the cached NodeInfo for safe concurrent use.
+func (c *Cache) Snapshot() *schedulerframework.NodeInfo {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.nodeInfo.SnapshotConcrete()
+}
+
+// PodCount returns the number of pods in the cache.
+func (c *Cache) PodCount() int {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return len(c.nodeInfo.Pods)
+}

--- a/pkg/kubelet/nodeinfocache/cache_test.go
+++ b/pkg/kubelet/nodeinfocache/cache_test.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeinfocache
+
+import (
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2/ktesting"
+)
+
+func TestCacheAddRemovePod(t *testing.T) {
+	cache := New()
+	logger, _ := ktesting.NewTestContext(t)
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod", Namespace: "default", UID: types.UID("test-uid"),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("100m"),
+						v1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				},
+			}},
+		},
+	}
+
+	// Add pod
+	cache.AddPod(pod)
+	if cache.PodCount() != 1 {
+		t.Errorf("expected 1 pod, got %d", cache.PodCount())
+	}
+
+	// Verify resources in snapshot
+	snapshot := cache.Snapshot()
+	if snapshot.Requested.MilliCPU != 100 {
+		t.Errorf("expected 100 milliCPU, got %d", snapshot.Requested.MilliCPU)
+	}
+
+	// Remove pod
+	cache.RemovePod(logger, pod)
+	if cache.PodCount() != 0 {
+		t.Errorf("expected 0 pods, got %d", cache.PodCount())
+	}
+}
+
+func TestCacheSnapshotIsolation(t *testing.T) {
+	cache := New()
+
+	pod1 := makePod("pod1", "100m", "256Mi")
+	cache.AddPod(pod1)
+
+	// Take snapshot
+	snapshot := cache.Snapshot()
+	originalCPU := snapshot.Requested.MilliCPU
+
+	// Add another pod to cache
+	pod2 := makePod("pod2", "200m", "512Mi")
+	cache.AddPod(pod2)
+
+	// Snapshot should be unchanged (deep copy)
+	if snapshot.Requested.MilliCPU != originalCPU {
+		t.Error("snapshot was mutated after cache modification")
+	}
+}
+
+func TestCacheConcurrentAccess(t *testing.T) {
+	cache := New()
+	logger, _ := ktesting.NewTestContext(t)
+
+	done := make(chan bool)
+
+	// Writer goroutine
+	go func() {
+		for i := range 100 {
+			pod := makePod(fmt.Sprintf("pod-%d", i), "10m", "10Mi")
+			cache.AddPod(pod)
+			cache.RemovePod(logger, pod)
+		}
+		done <- true
+	}()
+
+	// Reader goroutine
+	go func() {
+		for range 100 {
+			_ = cache.Snapshot()
+			_ = cache.PodCount()
+		}
+		done <- true
+	}()
+
+	<-done
+	<-done
+}
+
+func TestCacheSetNode(t *testing.T) {
+	cache := New()
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+		Status: v1.NodeStatus{
+			Allocatable: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("4"),
+				v1.ResourceMemory: resource.MustParse("16Gi"),
+			},
+		},
+	}
+
+	cache.SetNode(node)
+
+	snapshot := cache.Snapshot()
+	if snapshot.Node() == nil {
+		t.Error("expected node to be set")
+	}
+	if snapshot.Node().Name != "test-node" {
+		t.Errorf("expected node name 'test-node', got '%s'", snapshot.Node().Name)
+	}
+}
+
+func TestCacheUpdatePod(t *testing.T) {
+	cache := New()
+	logger, _ := ktesting.NewTestContext(t)
+
+	oldPod := makePod("test-pod", "100m", "256Mi")
+	cache.AddPod(oldPod)
+
+	// Verify initial state
+	snapshot := cache.Snapshot()
+	if snapshot.Requested.MilliCPU != 100 {
+		t.Errorf("expected 100 milliCPU, got %d", snapshot.Requested.MilliCPU)
+	}
+
+	// Update pod with new resources
+	newPod := makePod("test-pod", "200m", "512Mi")
+	cache.UpdatePod(logger, oldPod, newPod)
+
+	// Verify updated state
+	snapshot = cache.Snapshot()
+	if snapshot.Requested.MilliCPU != 200 {
+		t.Errorf("expected 200 milliCPU after update, got %d", snapshot.Requested.MilliCPU)
+	}
+	if cache.PodCount() != 1 {
+		t.Errorf("expected 1 pod after update, got %d", cache.PodCount())
+	}
+}
+
+func TestCacheUpdatePodNotInCache(t *testing.T) {
+	cache := New()
+	logger, _ := ktesting.NewTestContext(t)
+
+	// Pod that was never added to the cache (e.g. rejected during admission).
+	oldPod := makePod("rejected-pod", "100m", "256Mi")
+	newPod := makePod("rejected-pod", "200m", "512Mi")
+
+	// UpdatePod should be a no-op: RemovePod fails, so AddPod must be skipped.
+	cache.UpdatePod(logger, oldPod, newPod)
+
+	if cache.PodCount() != 0 {
+		t.Errorf("expected 0 pods after updating a pod not in cache, got %d", cache.PodCount())
+	}
+	snapshot := cache.Snapshot()
+	if snapshot.Requested.MilliCPU != 0 {
+		t.Errorf("expected 0 milliCPU after updating a pod not in cache, got %d", snapshot.Requested.MilliCPU)
+	}
+}
+
+func makePod(name, cpu, memory string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: "default", UID: types.UID(name),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse(cpu),
+						v1.ResourceMemory: resource.MustParse(memory),
+					},
+				},
+			}},
+		},
+	}
+}

--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -460,7 +460,7 @@ func createPodWorkersWithLogger(_ klog.Logger) (*podWorkers, *containertest.Fake
 		time.Second,
 		time.Millisecond,
 		fakeCache,
-		allocation.NewInMemoryManager(nil, nil, nil, nil, nil, nil),
+		allocation.NewInMemoryManager(nil, nil, nil, nil, nil),
 	)
 	workers := w.(*podWorkers)
 	workers.clock = clock
@@ -2168,7 +2168,7 @@ func TestFakePodWorkers(t *testing.T) {
 		time.Second,
 		time.Second,
 		fakeCache,
-		allocation.NewInMemoryManager(nil, nil, nil, nil, nil, nil),
+		allocation.NewInMemoryManager(nil, nil, nil, nil, nil),
 	)
 	fakePodWorkers := &fakePodWorkers{
 		syncPodFn: kubeletForFakeWorkers.SyncPod,


### PR DESCRIPTION
Dead-code removal followup to #136356. Depends on #136356 merging first.

## What this PR does
Removes the parallel pod-list supply chain that fed
`schedulerframework.NewNodeInfo(attrs.OtherPods...)` in the kubelet
admission path. #136356 made this chain dead by switching admission to
read from the `nodeinfocache` snapshot.

Removed:
- `OtherPods` field on `PodAdmitAttributes`
- `getAllocatedPods` helper in `allocation.manager`
- `getActivePods` threading through `allocation.manager`
- `allocatedPods` parameter on `canAdmitPod`
- `activePods` parameter on `Manager.AddPod`

Diff: 7 files changed, 14 insertions(+), 47 deletions(-).

## Test plan
- [x] All existing unit tests pass (`go test ./pkg/kubelet/...` green under golang:1.26)
- [ ] Integration tests pass (Prow)
- [x] No behaviour change — dead-code removal only

```release-note
NONE
```

This PR was developed with assistance from Claude (Anthropic).

/sig node
/area kubelet
/kind cleanup
