### PR TITLE
Use slices.Contains in various places under staging.

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
@@ -4466,14 +4466,7 @@ func TestRatcheting(t *testing.T) {
 
 			// Check that the ratcheting disabled errors were raised as warnings
 			for _, expectedWarning := range c.warnings {
-				found := false
-				for _, warning := range recorder.Warnings() {
-					if warning == expectedWarning {
-						found = true
-						break
-					}
-				}
-				assert.True(t, found, "expected warning %q not found", expectedWarning)
+				assert.Contains(t, recorder.Warnings(), expectedWarning, "expected warning %q not found", expectedWarning)
 			}
 
 		})

--- a/staging/src/k8s.io/apimachinery/pkg/api/apitesting/naming/naming.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/apitesting/naming/naming.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -70,7 +71,7 @@ func ensureNoTags(gvk schema.GroupVersionKind, tp reflect.Type, parents []reflec
 	}
 
 	// Don't look at the same type multiple times
-	if containsType(parents, tp) {
+	if slices.Contains(parents, tp) {
 		return nil
 	}
 	parents = append(parents, tp)
@@ -111,7 +112,7 @@ func ensureTags(gvk schema.GroupVersionKind, tp reflect.Type, parents []reflect.
 	}
 
 	// Don't look at the same type multiple times
-	if containsType(parents, tp) {
+	if slices.Contains(parents, tp) {
 		return nil
 	}
 	parents = append(parents, tp)
@@ -151,14 +152,4 @@ func fmtParentString(parents []reflect.Type) string {
 		str += fmt.Sprintf("%s%v\n", strings.Repeat(" ", i), tp)
 	}
 	return str
-}
-
-// containsType returns true if s contains t, false otherwise
-func containsType(s []reflect.Type, t reflect.Type) bool {
-	for _, u := range s {
-		if t == u {
-			return true
-		}
-	}
-	return false
 }

--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
@@ -224,15 +224,6 @@ func NewRequirement(key string, op selection.Operator, vals []string, opts ...fi
 	return &Requirement{key: key, operator: op, strValues: vals}, allErrs.ToAggregate()
 }
 
-func (r *Requirement) hasValue(value string) bool {
-	for i := range r.strValues {
-		if r.strValues[i] == value {
-			return true
-		}
-	}
-	return false
-}
-
 // Matches returns true if the Requirement matches the input Labels.
 // There is a match in the following cases:
 //  1. The operator is Exists and Labels has the Requirement's key.
@@ -251,13 +242,13 @@ func (r *Requirement) Matches(ls Labels) bool {
 		if !exists {
 			return false
 		}
-		return r.hasValue(val)
+		return slices.Contains(r.strValues, val)
 	case selection.NotIn, selection.NotEquals:
 		val, exists := ls.Lookup(r.key)
 		if !exists {
 			return true
 		}
-		return !r.hasValue(val)
+		return !slices.Contains(r.strValues, val)
 	case selection.Exists:
 		return ls.Has(r.key)
 	case selection.DoesNotExist:

--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/set.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/set.go
@@ -91,12 +91,7 @@ func (s Set[T]) HasAll(items ...T) bool {
 
 // HasAny returns true if any items are contained in the set.
 func (s Set[T]) HasAny(items ...T) bool {
-	for _, item := range items {
-		if s.Has(item) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(items, s.Has)
 }
 
 // Clone returns a new set which is a copy of the current set.

--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/checker_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/checker_test.go
@@ -355,14 +355,7 @@ func TestUnionStages(t *testing.T) {
 		result := unionStages(tc.s1, tc.s2)
 		assert.Len(t, result, len(tc.exp))
 		for _, expStage := range tc.exp {
-			ok := false
-			for _, resultStage := range result {
-				if resultStage == expStage {
-					ok = true
-					break
-				}
-			}
-			assert.True(t, ok)
+			assert.Contains(t, result, expStage)
 		}
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/authorization/cel/compile.go
+++ b/staging/src/k8s.io/apiserver/pkg/authorization/cel/compile.go
@@ -18,6 +18,7 @@ package cel
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/google/cel-go/cel"
 	celast "github.com/google/cel-go/common/ast"
@@ -96,15 +97,8 @@ func (c compiler) CompileCELExpression(expressionAccessor ExpressionAccessor) (C
 	if issues != nil {
 		return resultError("compilation failed: "+issues.String(), apiservercel.ErrorTypeInvalid)
 	}
-	found := false
 	returnTypes := expressionAccessor.ReturnTypes()
-	for _, returnType := range returnTypes {
-		if ast.OutputType() == returnType {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !slices.Contains(returnTypes, ast.OutputType()) {
 		var reason string
 		if len(returnTypes) == 1 {
 			reason = fmt.Sprintf("must evaluate to %v but got %v", returnTypes[0].String(), ast.OutputType())

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation/impersonation.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation/impersonation.go
@@ -21,12 +21,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 
 	"k8s.io/klog/v2"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/audit"
@@ -143,15 +144,7 @@ func WithImpersonation(handler http.Handler, a authorizer.Authorizer, s runtime.
 				groups = append(groups, user.AllAuthenticated)
 			}
 		} else {
-			addUnauthenticated := true
-			for _, group := range groups {
-				if group == user.AllUnauthenticated {
-					addUnauthenticated = false
-					break
-				}
-			}
-
-			if addUnauthenticated {
+			if !slices.Contains(groups, user.AllUnauthenticated) {
 				groups = append(groups, user.AllUnauthenticated)
 			}
 		}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation/impersonation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation/impersonation_test.go
@@ -342,6 +342,34 @@ func TestImpersonationFilter(t *testing.T) {
 			expectedCode: http.StatusOK,
 		},
 		{
+			name: "anonymous-username-already-has-unauthenticated-group",
+			user: &user.DefaultInfo{
+				Name:   user.Anonymous,
+				Groups: []string{user.AllUnauthenticated},
+			},
+			impersonationUser: user.Anonymous,
+			expectedUser: &user.DefaultInfo{
+				Name:   user.Anonymous,
+				Groups: []string{user.AllUnauthenticated},
+				Extra:  map[string][]string{},
+			},
+			expectedCode: http.StatusOK,
+		},
+		{
+			name: "anonymous-username-adding-unauthenticated-group",
+			user: &user.DefaultInfo{
+				Name:   user.Anonymous,
+				Groups: []string{},
+			},
+			impersonationUser: user.Anonymous,
+			expectedUser: &user.DefaultInfo{
+				Name:   user.Anonymous,
+				Groups: []string{user.AllUnauthenticated},
+				Extra:  map[string][]string{},
+			},
+			expectedCode: http.StatusOK,
+		},
+		{
 			name: "unauthenticated-group-prevents-adding-authenticated-group",
 			user: &user.DefaultInfo{
 				Name: "system:admin",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/storageversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/storageversion.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -85,7 +86,7 @@ func WithStorageVersionPrecondition(handler http.Handler, svm storageversion.Man
 		u, hasUser := request.UserFrom(ctx)
 		if requestInfo.APIGroup == "" && requestInfo.Resource == "namespaces" &&
 			requestInfo.Verb == "create" && hasUser &&
-			u.GetName() == user.APIServerUser && contains(u.GetGroups(), user.SystemPrivilegedGroup) {
+			u.GetName() == user.APIServerUser && slices.Contains(u.GetGroups(), user.SystemPrivilegedGroup) {
 			handler.ServeHTTP(w, req)
 			return
 		}
@@ -109,13 +110,4 @@ func WithStorageVersionPrecondition(handler http.Handler, svm storageversion.Man
 		gv := schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}
 		responsewriters.ErrorNegotiated(apierrors.NewServiceUnavailable(fmt.Sprintf("wait for storage version registration to complete for resource: %v, last seen error: %v", gr, svm.LastUpdateError(gr))), s, gv, w, req)
 	})
-}
-
-func contains(s []string, e string) bool {
-	for _, a := range s {
-		if a == e {
-			return true
-		}
-	}
-	return false
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -1273,22 +1274,11 @@ func GetArticleForNoun(noun string, padding string) string {
 	}
 
 	article := "a"
-	if isVowel(rune(noun[0])) {
+	if slices.Contains([]rune{'a', 'e', 'i', 'o', 'u'}, unicode.ToLower(rune(noun[0]))) {
 		article = "an"
 	}
 
 	return fmt.Sprintf("%s%s%s", padding, article, padding)
-}
-
-// isVowel returns true if the rune is a vowel (case insensitive).
-func isVowel(c rune) bool {
-	vowels := []rune{'a', 'e', 'i', 'o', 'u'}
-	for _, value := range vowels {
-		if value == unicode.ToLower(c) {
-			return true
-		}
-	}
-	return false
 }
 
 func restfulListResource(r rest.Lister, rw rest.Watcher, scope handlers.RequestScope, forceWatch bool, minRequestTimeout time.Duration) restful.RouteFunction {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer_test.go
@@ -24,30 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestIsVowel(t *testing.T) {
-	tests := []struct {
-		name string
-		arg  rune
-		want bool
-	}{
-		{
-			name: "yes",
-			arg:  'E',
-			want: true,
-		},
-		{
-			name: "no",
-			arg:  'n',
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		if got := isVowel(tt.arg); got != tt.want {
-			t.Errorf("%q. IsVowel() = %v, want %v", tt.name, got, tt.want)
-		}
-	}
-}
-
 func TestGetArticleForNoun(t *testing.T) {
 	tests := []struct {
 		noun    string

--- a/staging/src/k8s.io/apiserver/pkg/quota/v1/resources.go
+++ b/staging/src/k8s.io/apiserver/pkg/quota/v1/resources.go
@@ -167,13 +167,10 @@ func ResourceNames(resources corev1.ResourceList) []corev1.ResourceName {
 }
 
 // Contains returns true if the specified item is in the list of items
+//
+//go:fix inline
 func Contains(items []corev1.ResourceName, item corev1.ResourceName) bool {
-	for _, i := range items {
-		if i == item {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(items, item)
 }
 
 // ContainsPrefix returns true if the specified item has a prefix that contained in given prefix Set
@@ -190,10 +187,10 @@ func ContainsPrefix(prefixSet []string, item corev1.ResourceName) bool {
 func Intersection(a []corev1.ResourceName, b []corev1.ResourceName) []corev1.ResourceName {
 	result := make([]corev1.ResourceName, 0, len(a))
 	for _, item := range a {
-		if Contains(result, item) {
+		if slices.Contains(result, item) {
 			continue
 		}
-		if !Contains(b, item) {
+		if !slices.Contains(b, item) {
 			continue
 		}
 		result = append(result, item)
@@ -206,7 +203,7 @@ func Intersection(a []corev1.ResourceName, b []corev1.ResourceName) []corev1.Res
 func Difference(a []corev1.ResourceName, b []corev1.ResourceName) []corev1.ResourceName {
 	result := make([]corev1.ResourceName, 0, len(a))
 	for _, item := range a {
-		if Contains(b, item) || Contains(result, item) {
+		if slices.Contains(b, item) || slices.Contains(result, item) {
 			continue
 		}
 		result = append(result, item)

--- a/staging/src/k8s.io/client-go/util/certificate/certificate_manager.go
+++ b/staging/src/k8s.io/client-go/util/certificate/certificate_manager.go
@@ -28,6 +28,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"sync"
 	"time"
 
@@ -336,7 +337,7 @@ func NewManager(config *Config) (Manager, error) {
 	if len(name) == 0 {
 		usages := getUsages(nil)
 		switch {
-		case hasKeyUsage(usages, certificates.UsageClientAuth):
+		case slices.Contains(usages, certificates.UsageClientAuth):
 			name = string(certificates.UsageClientAuth)
 		default:
 			name = "certificate"
@@ -797,13 +798,4 @@ func (m *manager) setLastRequest(cancel context.CancelFunc, r *x509.CertificateR
 	defer m.lastRequestLock.Unlock()
 	m.lastRequestCancel = cancel
 	m.lastRequest = r
-}
-
-func hasKeyUsage(usages []certificates.KeyUsage, usage certificates.KeyUsage) bool {
-	for _, u := range usages {
-		if u == usage {
-			return true
-		}
-	}
-	return false
 }

--- a/staging/src/k8s.io/component-helpers/auth/rbac/reconciliation/reconcile_rolebindings.go
+++ b/staging/src/k8s.io/component-helpers/auth/rbac/reconciliation/reconcile_rolebindings.go
@@ -19,6 +19,7 @@ package reconciliation
 import (
 	"fmt"
 	"reflect"
+	"slices"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -216,15 +217,6 @@ func computeReconciledRoleBinding(existing, expected RoleBinding, removeExtraSub
 	return result, nil
 }
 
-func contains(list []rbacv1.Subject, item rbacv1.Subject) bool {
-	for _, listItem := range list {
-		if listItem == item {
-			return true
-		}
-	}
-	return false
-}
-
 // diffSubjectLists returns lists containing the items unique to each provided list:
 //
 //	list1Only = list1 - list2
@@ -233,17 +225,13 @@ func contains(list []rbacv1.Subject, item rbacv1.Subject) bool {
 // if both returned lists are empty, the provided lists are equal
 func diffSubjectLists(list1 []rbacv1.Subject, list2 []rbacv1.Subject) (list1Only []rbacv1.Subject, list2Only []rbacv1.Subject) {
 	for _, list1Item := range list1 {
-		if !contains(list2, list1Item) {
-			if !contains(list1Only, list1Item) {
-				list1Only = append(list1Only, list1Item)
-			}
+		if !slices.Contains(list2, list1Item) && !slices.Contains(list1Only, list1Item) {
+			list1Only = append(list1Only, list1Item)
 		}
 	}
 	for _, list2Item := range list2 {
-		if !contains(list1, list2Item) {
-			if !contains(list2Only, list2Item) {
-				list2Only = append(list2Only, list2Item)
-			}
+		if !slices.Contains(list1, list2Item) && !slices.Contains(list2Only, list2Item) {
+			list2Only = append(list2Only, list2Item)
 		}
 	}
 	return

--- a/staging/src/k8s.io/component-helpers/auth/rbac/validation/policy_comparator.go
+++ b/staging/src/k8s.io/component-helpers/auth/rbac/validation/policy_comparator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validation
 
 import (
+	"slices"
 	"strings"
 
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -83,15 +84,6 @@ func BreakdownRule(rule rbacv1.PolicyRule) []rbacv1.PolicyRule {
 	return subrules
 }
 
-func has(set []string, ele string) bool {
-	for _, s := range set {
-		if s == ele {
-			return true
-		}
-	}
-	return false
-}
-
 func hasAll(set, contains []string) bool {
 	owning := make(map[string]struct{}, len(set))
 	for _, ele := range set {
@@ -107,13 +99,13 @@ func hasAll(set, contains []string) bool {
 
 func resourceCoversAll(setResources, coversResources []string) bool {
 	// if we have a star or an exact match on all resources, then we match
-	if has(setResources, rbacv1.ResourceAll) || hasAll(setResources, coversResources) {
+	if slices.Contains(setResources, rbacv1.ResourceAll) || hasAll(setResources, coversResources) {
 		return true
 	}
 
 	for _, path := range coversResources {
 		// if we have an exact match, then we match.
-		if has(setResources, path) {
+		if slices.Contains(setResources, path) {
 			continue
 		}
 		// if we're not a subresource, then we definitely don't match.  fail.
@@ -122,7 +114,7 @@ func resourceCoversAll(setResources, coversResources []string) bool {
 		}
 		tokens := strings.SplitN(path, "/", 2)
 		resourceToCheck := "*/" + tokens[1]
-		if !has(setResources, resourceToCheck) {
+		if !slices.Contains(setResources, resourceToCheck) {
 			return false
 		}
 	}
@@ -156,8 +148,8 @@ func nonResourceURLCovers(ownerPath, subPath string) bool {
 // ruleCovers determines whether the ownerRule (which may have multiple verbs, resources, and resourceNames) covers
 // the subrule (which may only contain at most one verb, resource, and resourceName)
 func ruleCovers(ownerRule, subRule rbacv1.PolicyRule) bool {
-	verbMatches := has(ownerRule.Verbs, rbacv1.VerbAll) || hasAll(ownerRule.Verbs, subRule.Verbs)
-	groupMatches := has(ownerRule.APIGroups, rbacv1.APIGroupAll) || hasAll(ownerRule.APIGroups, subRule.APIGroups)
+	verbMatches := slices.Contains(ownerRule.Verbs, rbacv1.VerbAll) || hasAll(ownerRule.Verbs, subRule.Verbs)
+	groupMatches := slices.Contains(ownerRule.APIGroups, rbacv1.APIGroupAll) || hasAll(ownerRule.APIGroups, subRule.APIGroups)
 	resourceMatches := resourceCoversAll(ownerRule.Resources, subRule.Resources)
 	nonResourceURLMatches := nonResourceURLsCoversAll(ownerRule.NonResourceURLs, subRule.NonResourceURLs)
 

--- a/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go
@@ -18,6 +18,7 @@ package testing
 
 import (
 	"context"
+	"slices"
 	"sync"
 	"testing"
 
@@ -121,17 +122,6 @@ func (r *FakeImageService) makeFakeImage(image *runtimeapi.ImageSpec) *runtimeap
 	}
 }
 
-// stringInSlice returns true if s is in list
-func stringInSlice(s string, list []string) bool {
-	for _, v := range list {
-		if v == s {
-			return true
-		}
-	}
-
-	return false
-}
-
 // InjectError sets the error message for the FakeImageService.
 func (r *FakeImageService) InjectError(f string, err error) {
 	r.Lock()
@@ -166,7 +156,7 @@ func (r *FakeImageService) ListImages(_ context.Context, filter *runtimeapi.Imag
 	images := make([]*runtimeapi.Image, 0)
 	for _, img := range r.Images {
 		if filter != nil && filter.Image != nil {
-			if !stringInSlice(filter.Image.Image, img.RepoTags) {
+			if !slices.Contains(img.RepoTags, filter.Image.Image) {
 				continue
 			}
 		}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole.go
@@ -19,6 +19,7 @@ package create
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -108,7 +109,7 @@ func (c *CreateClusterRoleOptions) Complete(f cmdutil.Factory, cmd *cobra.Comman
 	// Remove duplicate nonResourceURLs
 	nonResourceURLs := []string{}
 	for _, n := range c.NonResourceURLs {
-		if !arrayContains(nonResourceURLs, n) {
+		if !slices.Contains(nonResourceURLs, n) {
 			nonResourceURLs = append(nonResourceURLs, n)
 		}
 	}
@@ -142,7 +143,7 @@ func (c *CreateClusterRoleOptions) Validate() error {
 	// validate resources
 	if len(c.Resources) > 0 {
 		for _, v := range c.Verbs {
-			if !arrayContains(validResourceVerbs, v) {
+			if !slices.Contains(validResourceVerbs, v) {
 				fmt.Fprintf(c.ErrOut, "Warning: '%s' is not a standard resource verb\n", v)
 			}
 		}
@@ -154,7 +155,7 @@ func (c *CreateClusterRoleOptions) Validate() error {
 	//validate non-resource-url
 	if len(c.NonResourceURLs) > 0 {
 		for _, v := range c.Verbs {
-			if !arrayContains(validNonResourceVerbs, v) {
+			if !slices.Contains(validNonResourceVerbs, v) {
 				return fmt.Errorf("invalid verb: '%s' for nonResourceURL", v)
 			}
 		}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
@@ -19,6 +19,7 @@ package create
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -206,7 +207,7 @@ func (o *CreateRoleOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args
 			verbs = []string{"*"}
 			break
 		}
-		if !arrayContains(verbs, v) {
+		if !slices.Contains(verbs, v) {
 			verbs = append(verbs, v)
 		}
 	}
@@ -240,7 +241,7 @@ func (o *CreateRoleOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args
 	// Remove duplicate resource names.
 	resourceNames := []string{}
 	for _, n := range o.ResourceNames {
-		if !arrayContains(resourceNames, n) {
+		if !slices.Contains(resourceNames, n) {
 			resourceNames = append(resourceNames, n)
 		}
 	}
@@ -299,7 +300,7 @@ func (o *CreateRoleOptions) Validate() error {
 	}
 
 	for _, v := range o.Verbs {
-		if !arrayContains(validResourceVerbs, v) {
+		if !slices.Contains(validResourceVerbs, v) {
 			fmt.Fprintf(o.ErrOut, "Warning: '%s' is not a standard resource verb\n", v)
 		}
 	}
@@ -389,15 +390,6 @@ func (o *CreateRoleOptions) RunCreateRole() error {
 	return o.PrintObj(role)
 }
 
-func arrayContains(s []string, e string) bool {
-	for _, a := range s {
-		if a == e {
-			return true
-		}
-	}
-	return false
-}
-
 func generateResourcePolicyRules(mapper meta.RESTMapper, verbs []string, resources []ResourceOptions, resourceNames []string, nonResourceURLs []string) ([]rbacv1.PolicyRule, error) {
 	// groupResourceMapping is a apigroup-resource map. The key of this map is api group, while the value
 	// is a string array of resources under this api group.
@@ -418,7 +410,7 @@ func generateResourcePolicyRules(mapper meta.RESTMapper, verbs []string, resourc
 		if len(r.SubResource) > 0 {
 			resource.Resource = resource.Resource + "/" + r.SubResource
 		}
-		if !arrayContains(groupResourceMapping[resource.Group], resource.Resource) {
+		if !slices.Contains(groupResourceMapping[resource.Group], resource.Resource) {
 			groupResourceMapping[resource.Group] = append(groupResourceMapping[resource.Group], resource.Resource)
 		}
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/customcolumn_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/customcolumn_test.go
@@ -19,6 +19,7 @@ package get
 import (
 	"bytes"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -137,7 +138,7 @@ func TestNewColumnPrinterFromSpec(t *testing.T) {
 					t.Fatalf("An error occurred printing Pod: %#v", err)
 				}
 
-				if contains(strings.Fields(buffer.String()), "API_VERSION") {
+				if slices.Contains(strings.Fields(buffer.String()), "API_VERSION") {
 					t.Errorf("unexpected header API_VERSION")
 				}
 
@@ -146,15 +147,6 @@ func TestNewColumnPrinterFromSpec(t *testing.T) {
 			}
 		})
 	}
-}
-
-func contains(arr []string, s string) bool {
-	for i := range arr {
-		if arr[i] == s {
-			return true
-		}
-	}
-	return false
 }
 
 const exampleTemplateOne = `NAME               API_VERSION

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_subject.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_subject.go
@@ -18,6 +18,7 @@ package set
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -303,19 +304,10 @@ func addSubjects(existings []rbacv1.Subject, targets []rbacv1.Subject) (bool, []
 	transformed := false
 	updated := existings
 	for _, item := range targets {
-		if !contain(existings, item) {
+		if !slices.Contains(existings, item) {
 			updated = append(updated, item)
 			transformed = true
 		}
 	}
 	return transformed, updated
-}
-
-func contain(slice []rbacv1.Subject, item rbacv1.Subject) bool {
-	for _, v := range slice {
-		if v == item {
-			return true
-		}
-	}
-	return false
 }

--- a/staging/src/k8s.io/mount-utils/mount_linux_test.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux_test.go
@@ -25,6 +25,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -507,7 +508,7 @@ func TestSensitiveMountOptions(t *testing.T) {
 		// Assert
 		t.Logf("\r\nmountArgs =%q\r\nmountArgsLogStr=%q", mountArgs, mountArgsLogStr)
 		for _, mountFlag := range v.mountFlags {
-			if found := mountArgsContainString(t, mountArgs, mountFlag); !found {
+			if !slices.Contains(mountArgs, mountFlag) {
 				t.Errorf("Expected mountFlag (%q) to exist in returned mountArgs (%q), but it does not", mountFlag, mountArgs)
 			}
 			if !strings.Contains(mountArgsLogStr, mountFlag) {
@@ -539,15 +540,6 @@ func TestHasSystemd(t *testing.T) {
 	if mounter.withSystemd == nil {
 		t.Error("Failed to run detectSystemd()")
 	}
-}
-
-func mountArgsContainString(t *testing.T, mountArgs []string, wanted string) bool {
-	for _, mountArg := range mountArgs {
-		if mountArg == wanted {
-			return true
-		}
-	}
-	return false
 }
 
 func mountArgsContainOption(t *testing.T, mountArgs []string, option string) bool {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

I have found quite a lot of redefinition of functionality that `slices.Contains` now has.
In a single places, `assert.Contains` has also been used to simplify even further.

The changes were mostly generated with [modernize](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize#hdr-Analyzer_slicescontains) and then some post-editing was done to remove intermediate variables.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

```bash
GOTOOLCHAIN=go1.26.1 go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -slicescontains -fix -test ./staging/src/k8s.io/api/... ./staging/src/k8s.io/apiextensions-apiserver/... ./staging/src/k8s.io/apimachinery/... ./staging/src/k8s.io/apiserver/... ./staging/src/k8s.io/cli-runtime/... ./staging/src/k8s.io/client-go/... ./staging/src/k8s.io/cloud-provider/... ./staging/src/k8s.io/cluster-bootstrap/... ./staging/src/k8s.io/code-generator/... ./staging/src/k8s.io/component-base/... ./staging/src/k8s.io/component-helpers/... ./staging/src/k8s.io/controller-manager/... ./staging/src/k8s.io/cri-api/... ./staging/src/k8s.io/cri-client/... ./staging/src/k8s.io/cri-streaming/... ./staging/src/k8s.io/csi-translation-lib/... ./staging/src/k8s.io/dynamic-resource-allocation/... ./staging/src/k8s.io/endpointslice/... ./staging/src/k8s.io/externaljwt/... ./staging/src/k8s.io/kms/... ./staging/src/k8s.io/kube-aggregator/... ./staging/src/k8s.io/kube-controller-manager/... ./staging/src/k8s.io/kube-proxy/... ./staging/src/k8s.io/kube-scheduler/... ./staging/src/k8s.io/kubectl/... ./staging/src/k8s.io/kubelet/... ./staging/src/k8s.io/metrics/... ./staging/src/k8s.io/mount-utils/... ./staging/src/k8s.io/pod-security-admission/... ./staging/src/k8s.io/sample-apiserver/... ./staging/src/k8s.io/sample-cli-plugin/... ./staging/src/k8s.io/sample-controller/... ./staging/src/k8s.io/streaming/...
```

was used. I have not included everything in my PR.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```
