### PR TITLE
test/e2e/node: make GPU sanity test work on arm64 (sbsa)

### DIFF
--- a/test/e2e/node/gpu.go
+++ b/test/e2e/node/gpu.go
@@ -222,9 +222,9 @@ else
 	# skipped on non-x86_64.
 	DEBIAN_FRONTEND=noninteractive apt-get install -y -o Acquire::Retries=5 git
 	git clone --depth 1 --branch v12.5 https://github.com/NVIDIA/cuda-samples.git /tmp/cuda-samples
-	cd /tmp/cuda-samples/Samples/1_Utilities/deviceQuery  && make && ./deviceQuery
-	cd /tmp/cuda-samples/Samples/0_Introduction/vectorAdd && make && ./vectorAdd
-	cd /tmp/cuda-samples/Samples/1_Utilities/bandwidthTest && make && ./bandwidthTest
+	(cd /tmp/cuda-samples/Samples/1_Utilities/deviceQuery  && make && ./deviceQuery)
+	(cd /tmp/cuda-samples/Samples/0_Introduction/vectorAdd && make && ./vectorAdd)
+	(cd /tmp/cuda-samples/Samples/1_Utilities/bandwidthTest && make && ./bandwidthTest)
 fi
 `,
 					},

--- a/test/e2e/node/gpu.go
+++ b/test/e2e/node/gpu.go
@@ -208,12 +208,24 @@ if [[ "${nvidia_smi_ready}" != "true" ]]; then
 	exit 1
 fi
 
-apt-get update -y -o Acquire::Retries=5 && \
+apt-get update -y -o Acquire::Retries=5
+if [ "$(uname -m)" = "x86_64" ]; then
 	DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated -o Acquire::Retries=5 cuda-demo-suite-12-5
-/usr/local/cuda/extras/demo_suite/deviceQuery
-/usr/local/cuda/extras/demo_suite/vectorAdd
-/usr/local/cuda/extras/demo_suite/bandwidthTest --device=all --csv
-/usr/local/cuda/extras/demo_suite/busGrind -a
+	/usr/local/cuda/extras/demo_suite/deviceQuery
+	/usr/local/cuda/extras/demo_suite/vectorAdd
+	/usr/local/cuda/extras/demo_suite/bandwidthTest --device=all --csv
+	/usr/local/cuda/extras/demo_suite/busGrind -a
+else
+	# NVIDIA does not publish cuda-demo-suite-* for sbsa/arm64. Build the
+	# equivalents from the public NVIDIA/cuda-samples repo instead. busGrind
+	# is bundled only in cuda-demo-suite (not in cuda-samples), so it is
+	# skipped on non-x86_64.
+	DEBIAN_FRONTEND=noninteractive apt-get install -y -o Acquire::Retries=5 git
+	git clone --depth 1 --branch v12.5 https://github.com/NVIDIA/cuda-samples.git /tmp/cuda-samples
+	cd /tmp/cuda-samples/Samples/1_Utilities/deviceQuery  && make && ./deviceQuery
+	cd /tmp/cuda-samples/Samples/0_Introduction/vectorAdd && make && ./vectorAdd
+	cd /tmp/cuda-samples/Samples/1_Utilities/bandwidthTest && make && ./bandwidthTest
+fi
 `,
 					},
 					Resources: v1.ResourceRequirements{

--- a/test/e2e/node/gpu.go
+++ b/test/e2e/node/gpu.go
@@ -220,6 +220,14 @@ else
 	# equivalents from the public NVIDIA/cuda-samples repo instead. busGrind
 	# is bundled only in cuda-demo-suite (not in cuda-samples), so it is
 	# skipped on non-x86_64.
+	#
+	# cuda-samples is pinned to v12.5 to match the CUDA 12.5 toolkit in the
+	# nvidia/cuda:12.5.0-devel-ubuntu22.04 base image above and the
+	# cuda-demo-suite-12-5 apt package used on the x86_64 branch; NVIDIA
+	# tags cuda-samples 1:1 with a toolkit version (v12.5 -> CUDA 12.5,
+	# v13.x -> CUDA 13.x), and v13+ also switched the build system from
+	# make to CMake, so bumping requires updating the base image, apt
+	# package, git tag, and build commands together.
 	DEBIAN_FRONTEND=noninteractive apt-get install -y -o Acquire::Retries=5 git
 	git clone --depth 1 --branch v12.5 https://github.com/NVIDIA/cuda-samples.git /tmp/cuda-samples
 	(cd /tmp/cuda-samples/Samples/1_Utilities/deviceQuery  && make && ./deviceQuery)


### PR DESCRIPTION
The [Feature:GPUDevicePlugin] Sanity test embeds
`apt-get install -y cuda-demo-suite-12-5` under `set -e`. NVIDIA's CUDA apt repo publishes cuda-demo-suite-* for x86_64 but NOT for sbsa (confirmed against the public Packages index on
developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/{sbsa,x86_64}/). On arm64 the install fails, the container exits 1, pod.Status.Phase becomes Failed, and the subsequent `gomega.Expect(... .Equal(Succeeded))` assertion trips.

Split the demo phase on architecture. On x86_64 keep the existing apt path unchanged. On anything else, build deviceQuery / vectorAdd / bandwidthTest from the public NVIDIA/cuda-samples repo instead. busGrind is exclusive to cuda-demo-suite (no source equivalent in cuda-samples) and is skipped on non-x86_64.

The pattern is the one already in production use by sigs.k8s.io/dra-driver-nvidia-gpu in tests/bats/specs/gpu-cuda-demo-suite.yaml, which has been green on Lambda gpu_1x_gh200.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
