### PR TITLE
Validate PodLevelResources: reject pod requests above aggregate container limits when pod limits unset

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -4471,6 +4471,10 @@ type PodValidationOptions struct {
 	// Indicates whether InPlacePodLevelResourcesVerticalScaling feature is enabled
 	// or disabled.
 	InPlacePodLevelResourcesVerticalScalingEnabled bool
+	// ValidateAsPodResize indicates validation is running in the context of ValidatePodResize,
+	// where aggregate container limits may temporarily be lower than pod-level requests
+	// during in-place vertical scaling.
+	ValidateAsPodResize bool
 	// Allow sidecar containers resize policy for backward compatibility
 	AllowSidecarResizePolicy bool
 	// Allow invalid label-value in RequiredNodeSelector
@@ -4761,14 +4765,15 @@ func validatePodResources(spec *core.PodSpec, podClaimNames sets.Set[string], fl
 	// validatePodResourceRequirements checks if resource names and quantities are
 	// valid, and requests are less than limits.
 	allErrs = append(allErrs, validatePodResourceRequirements(spec.Resources, podClaimNames, resourcesFldPath, opts)...)
-	allErrs = append(allErrs, validatePodResourceConsistency(spec, resourcesFldPath)...)
+	allErrs = append(allErrs, validatePodResourceConsistency(spec, resourcesFldPath, opts)...)
 	return allErrs
 }
 
 // validatePodResourceConsistency checks if aggregate container-level requests are
-// less than or equal to pod-level requests, and individual container-level limits
-// are less than or equal to pod-level limits.
-func validatePodResourceConsistency(spec *core.PodSpec, fldPath *field.Path) field.ErrorList {
+// less than or equal to pod-level requests, pod-level requests do not exceed
+// aggregate container limits when pod-level limits are unset, and individual
+// container-level limits are less than or equal to pod-level limits.
+func validatePodResourceConsistency(spec *core.PodSpec, fldPath *field.Path, opts PodValidationOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	// Convert the *core.PodSpec to *v1.PodSpec to satisfy the call to
@@ -4789,6 +4794,7 @@ func validatePodResourceConsistency(spec *core.PodSpec, fldPath *field.Path) fie
 	// to the AggregateContainerRequests method to facilitate proper resource
 	// calculation without modifying AggregateContainerRequests method.
 	aggrContainerReqs := resourcehelper.AggregateContainerRequests(&v1.Pod{Spec: *v1PodSpec}, resourcehelper.PodResourcesOptions{})
+	aggrContainerLims := resourcehelper.AggregateContainerLimits(&v1.Pod{Spec: *v1PodSpec}, resourcehelper.PodResourcesOptions{})
 
 	// Pod-level requests must be >= aggregate requests of all containers in a pod.
 	for resourceName, ctrReqs := range aggrContainerReqs {
@@ -4804,6 +4810,31 @@ func validatePodResourceConsistency(spec *core.PodSpec, fldPath *field.Path) fie
 		}
 	}
 
+	// When pod-level limits are not set for a supported resource, effective limits are
+	// derived from the aggregate of container limits (see resource.PodLimits). Pod-level
+	// requests must not exceed those effective limits.
+	//
+	// Skip during ValidatePodResize: in-place vertical scaling may apply new container
+	// limits in a separate step while pod-level requests are unchanged.
+	if !opts.ValidateAsPodResize {
+		for resourceName, podReq := range spec.Resources.Requests {
+			v1ResName := v1.ResourceName(resourceName)
+			if !resourcehelper.IsSupportedPodLevelResource(v1ResName) {
+				continue
+			}
+			if _, podLimitSet := spec.Resources.Limits[resourceName]; podLimitSet {
+				continue
+			}
+			ctrLim, ok := aggrContainerLims[v1ResName]
+			if !ok {
+				continue
+			}
+			if podReq.Cmp(ctrLim) > 0 {
+				allErrs = append(allErrs, field.Invalid(reqPath.Key(string(resourceName)), podReq.String(), fmt.Sprintf("must be less than or equal to aggregate container limits of %s when pod limits are not set", ctrLim.String())))
+			}
+		}
+	}
+
 	// Pod level hugepage limits must be always equal or greater than the aggregated
 	// container level hugepage limits, this is due to the hugepage resources being
 	// treated as a non overcommitable resource (request and limit must be equal)
@@ -4811,7 +4842,6 @@ func validatePodResourceConsistency(spec *core.PodSpec, fldPath *field.Path) fie
 	// This is also why hugepages overcommitment is not allowed in pod level resources,
 	// the pod cgroup values must reflect the request/limit set at pod level, and the
 	// container level cgroup values must be within that limit.
-	aggrContainerLims := resourcehelper.AggregateContainerLimits(&v1.Pod{Spec: *v1PodSpec}, resourcehelper.PodResourcesOptions{})
 	for resourceName, ctrLims := range aggrContainerLims {
 		if !helper.IsHugePageResourceName(core.ResourceName(resourceName)) {
 			continue
@@ -6307,7 +6337,9 @@ func ValidatePodResize(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
 	// Part 1: Validate newPod's spec and updates to metadata
 	fldPath := field.NewPath("metadata")
 	allErrs := ValidateObjectMetaUpdate(&newPod.ObjectMeta, &oldPod.ObjectMeta, fldPath)
-	allErrs = append(allErrs, validatePodMetadataAndSpec(newPod, opts)...)
+	resizeOpts := opts
+	resizeOpts.ValidateAsPodResize = true
+	allErrs = append(allErrs, validatePodMetadataAndSpec(newPod, resizeOpts)...)
 
 	// static pods cannot be resized.
 	if _, ok := oldPod.Annotations[core.MirrorPodAnnotationKey]; ok {

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -21181,13 +21181,13 @@ func TestValidatePodResourceConsistency(t *testing.T) {
 			{
 				Resources: core.ResourceRequirements{
 					Requests: core.ResourceList{
-						core.ResourceCPU:                                      resource.MustParse("1"),
-						core.ResourceMemory:                                   resource.MustParse("200Mi"),
+						core.ResourceCPU:    resource.MustParse("1"),
+						core.ResourceMemory: resource.MustParse("200Mi"),
 						core.ResourceName(core.ResourceHugePagesPrefix + "1Gi"): resource.MustParse("1Gi"),
 					},
 					Limits: core.ResourceList{
-						core.ResourceCPU:                                      resource.MustParse("1"),
-						core.ResourceMemory:                                   resource.MustParse("200Mi"),
+						core.ResourceCPU:    resource.MustParse("1"),
+						core.ResourceMemory: resource.MustParse("200Mi"),
 						core.ResourceName(core.ResourceHugePagesPrefix + "1Gi"): resource.MustParse("1Gi"),
 					},
 				},

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -21170,6 +21170,80 @@ func TestValidatePodResourceConsistency(t *testing.T) {
 		},
 		expectedErrors: []string{"must be greater than or equal to aggregate container requests", "must be greater than or equal to aggregate container requests"},
 	}, {
+		name: "pod requests exceed aggregate container limits when pod limits not set",
+		podResources: core.ResourceRequirements{
+			Requests: core.ResourceList{
+				core.ResourceCPU:    resource.MustParse("3"),
+				core.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		},
+		containers: []core.Container{
+			{
+				Resources: core.ResourceRequirements{
+					Requests: core.ResourceList{
+						core.ResourceCPU:                                      resource.MustParse("1"),
+						core.ResourceMemory:                                   resource.MustParse("200Mi"),
+						core.ResourceName(core.ResourceHugePagesPrefix + "1Gi"): resource.MustParse("1Gi"),
+					},
+					Limits: core.ResourceList{
+						core.ResourceCPU:                                      resource.MustParse("1"),
+						core.ResourceMemory:                                   resource.MustParse("200Mi"),
+						core.ResourceName(core.ResourceHugePagesPrefix + "1Gi"): resource.MustParse("1Gi"),
+					},
+				},
+			},
+			{
+				Resources: core.ResourceRequirements{
+					Requests: core.ResourceList{
+						core.ResourceCPU:    resource.MustParse("1"),
+						core.ResourceMemory: resource.MustParse("200Mi"),
+					},
+					Limits: core.ResourceList{
+						core.ResourceCPU:    resource.MustParse("1.5"),
+						core.ResourceMemory: resource.MustParse("300Mi"),
+					},
+				},
+			},
+		},
+		expectedErrors: []string{
+			"must be less than or equal to aggregate container limits",
+			"must be less than or equal to aggregate container limits",
+		},
+	}, {
+		name: "pod requests equal aggregate container limits when pod limits not set",
+		podResources: core.ResourceRequirements{
+			Requests: core.ResourceList{
+				core.ResourceCPU:    resource.MustParse("2.5"),
+				core.ResourceMemory: resource.MustParse("500Mi"),
+			},
+		},
+		containers: []core.Container{
+			{
+				Resources: core.ResourceRequirements{
+					Requests: core.ResourceList{
+						core.ResourceCPU:    resource.MustParse("1"),
+						core.ResourceMemory: resource.MustParse("200Mi"),
+					},
+					Limits: core.ResourceList{
+						core.ResourceCPU:    resource.MustParse("1"),
+						core.ResourceMemory: resource.MustParse("200Mi"),
+					},
+				},
+			},
+			{
+				Resources: core.ResourceRequirements{
+					Requests: core.ResourceList{
+						core.ResourceCPU:    resource.MustParse("1"),
+						core.ResourceMemory: resource.MustParse("200Mi"),
+					},
+					Limits: core.ResourceList{
+						core.ResourceCPU:    resource.MustParse("1.5"),
+						core.ResourceMemory: resource.MustParse("300Mi"),
+					},
+				},
+			},
+		},
+	}, {
 		name: "container requests with resources unsupported at pod-level",
 		podResources: core.ResourceRequirements{
 			Requests: core.ResourceList{
@@ -21340,7 +21414,7 @@ func TestValidatePodResourceConsistency(t *testing.T) {
 				Resources:  &tc.podResources,
 				Containers: tc.containers,
 			}
-			errs := validatePodResourceConsistency(&spec, path)
+			errs := validatePodResourceConsistency(&spec, path, PodValidationOptions{})
 			if len(errs) != len(tc.expectedErrors) {
 				t.Errorf("expected %d errors, got %d errors, got errors: %v", len(tc.expectedErrors), len(errs), errs)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

When pod-level `resources.limits` are unset for a supported pod-level resource, effective limits come from aggregate container limits. This PR extends `validatePodResourceConsistency` so pod-level `resources.requests` must not exceed those aggregate limits. The check is skipped when `ValidateAsPodResize` is set so in-place vertical scaling can apply new container limits separately. Unit tests are added in `pkg/apis/core/validation/validation_test.go`.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes https://github.com/kubernetes/kubernetes/issues/138473

#### Special notes for your reviewer:

Only applies to resources for which `resourcehelper.IsSupportedPodLevelResource` is true and pod-level limits for that resource are unset. Please confirm the `ValidateAsPodResize` skip matches the intended pod-level resource resize flow.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed API validation for pod-level resources: when pod-level limits are unset for a supported resource, pod-level requests must not exceed aggregate container limits. Pods that previously passed validation incorrectly may now be rejected at admission.
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```NONE
```
