### PR TITLE
kubelet: run setMemoryQoS on cgroup v2 when MemoryQoS is disabled

### DIFF
--- a/pkg/kubelet/cm/qos_container_manager_linux.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux.go
@@ -353,9 +353,9 @@ func (m *qosContainerManagerImpl) UpdateCgroups(logger logr.Logger) error {
 		return err
 	}
 
-	// Update cgroup v2 memory.min settings. Called only when MemoryQoS is
-	// enabled and cgroups v2 is the unified mode.
-	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.MemoryQoS) && libcontainercgroups.IsCgroup2UnifiedMode() {
+	// Update cgroup v2 memory.min settings. Called regardless of the MemoryQoS
+	// feature gate to clear stale values when the feature is disabled.
+	if libcontainercgroups.IsCgroup2UnifiedMode() {
 		m.setMemoryQoS(logger, qosConfigs)
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

PR #138430 gated the periodic QoS cgroup update (`setMemoryQoS`) on the `MemoryQoS` feature gate. When the gate is turned off, that path no longer ran, so cgroup v2 **QoS-class** settings (for example `memory.low` on the burstable parent cgroup) were never reset. The node e2e **feature rollback** test then saw `memory.low` stuck at the previous aggregate (e.g. 128Mi) instead of `0`.

This change restores calling `setMemoryQoS` whenever the node uses cgroup v2 unified mode. `setMemoryQoS` already clears `memory.min` / `memory.low` when `memoryReservationPolicy` is not `TieredReservation`, which matches valid configuration with MemoryQoS disabled.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/138471

#### Special notes for your reviewer:

- Behavior matches the pre-#138430 comment: reconcile QoS-level memory protection on cgroup v2 regardless of the MemoryQoS gate so rollback clears stale values.
- Validation still prevents `TieredReservation` with MemoryQoS off; no change to tiered math when the gate and policy are both enabled.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a regression where disabling the `MemoryQoS` feature gate could leave cgroup v2 burstable QoS `memory.low` unchanged until the next tiered configuration. The kubelet again reconciles QoS-class memory protection on cgroup v2 when the gate is off so values clear after rollback.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```NONE
```