### PR TITLE
replace NewFake/NewRaceFreeFake with context-aware alternatives in watch tests

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/watch/filter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/filter_test.go
@@ -21,9 +21,11 @@ import (
 	"testing"
 
 	. "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/klog/v2/ktesting"
 )
 
 func TestFilter(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	table := []Event{
 		{Type: Added, Object: testType("foo")},
 		{Type: Added, Object: testType("bar")},
@@ -32,7 +34,7 @@ func TestFilter(t *testing.T) {
 		{Type: Added, Object: testType("zoo")},
 	}
 
-	source := NewFake()
+	source := NewFakeWithOptions(FakeOptions{Logger: &logger})
 	filtered := Filter(source, func(e Event) (Event, bool) {
 		return e, e.Object.(testType)[0] != 'b'
 	})
@@ -59,7 +61,8 @@ func TestFilter(t *testing.T) {
 }
 
 func TestFilterStop(t *testing.T) {
-	source := NewFake()
+	logger, _ := ktesting.NewTestContext(t)
+	source := NewFakeWithOptions(FakeOptions{Logger: &logger})
 	filtered := Filter(source, func(e Event) (Event, bool) {
 		return e, e.Object.(testType)[0] != 'b'
 	})
@@ -84,6 +87,7 @@ func TestFilterStop(t *testing.T) {
 }
 
 func TestRecorder(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	events := []Event{
 		{Type: Added, Object: testType("foo")},
 		{Type: Added, Object: testType("bar")},
@@ -92,7 +96,7 @@ func TestRecorder(t *testing.T) {
 		{Type: Added, Object: testType("zoo")},
 	}
 
-	source := NewFake()
+	source := NewFakeWithOptions(FakeOptions{Logger: &logger})
 	go func() {
 		for _, item := range events {
 			source.Action(item.Type, item.Object)

--- a/staging/src/k8s.io/apimachinery/pkg/watch/watch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/watch_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	. "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/klog/v2/ktesting"
 )
 
 type testType string
@@ -31,7 +32,8 @@ func (obj testType) GetObjectKind() schema.ObjectKind { return schema.EmptyObjec
 func (obj testType) DeepCopyObject() runtime.Object   { return obj }
 
 func TestFake(t *testing.T) {
-	f := NewFake()
+	logger, _ := ktesting.NewTestContext(t)
+	f := NewFakeWithOptions(FakeOptions{Logger: &logger})
 
 	table := []struct {
 		t EventType
@@ -78,7 +80,8 @@ func TestFake(t *testing.T) {
 }
 
 func TestRaceFreeFake(t *testing.T) {
-	f := NewRaceFreeFake()
+	logger, _ := ktesting.NewTestContext(t)
+	f := NewRaceFreeFakeWithLogger(logger)
 
 	table := []struct {
 		t EventType

--- a/staging/src/k8s.io/client-go/tools/watch/informerwatcher_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/informerwatcher_test.go
@@ -38,6 +38,7 @@ import (
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	testcore "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/dump"
 )
 
@@ -385,6 +386,7 @@ func TestNewInformerWatcher(t *testing.T) {
 //
 // Code from @liggitt
 func TestInformerWatcherDeletedFinalStateUnknown(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	listCalls := 0
 	watchCalls := 0
 	lw := toListWatcherWithUnSupportedWatchListSemantics(&cache.ListWatch{
@@ -402,7 +404,7 @@ func TestInformerWatcherDeletedFinalStateUnknown(t *testing.T) {
 			return retval, nil
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			w := watch.NewRaceFreeFake()
+			w := watch.NewRaceFreeFakeWithLogger(logger)
 			if options.ResourceVersion == "1" {
 				go func() {
 					// Close with a "Gone" error when trying to start a watch from the first list

--- a/staging/src/k8s.io/client-go/tools/watch/until_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/until_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	fakeclient "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2/ktesting"
 )
 
 type fakePod struct {
@@ -42,7 +43,8 @@ func (obj *fakePod) GetObjectKind() schema.ObjectKind { return schema.EmptyObjec
 func (obj *fakePod) DeepCopyObject() runtime.Object   { panic("DeepCopyObject not supported by fakePod") }
 
 func TestUntil(t *testing.T) {
-	fw := watch.NewFake()
+	logger, _ := ktesting.NewTestContext(t)
+	fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 	go func() {
 		var obj *fakePod
 		fw.Add(obj)
@@ -72,7 +74,8 @@ func TestUntil(t *testing.T) {
 }
 
 func TestUntilMultipleConditions(t *testing.T) {
-	fw := watch.NewFake()
+	logger, _ := ktesting.NewTestContext(t)
+	fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 	go func() {
 		var obj *fakePod
 		fw.Add(obj)
@@ -101,7 +104,8 @@ func TestUntilMultipleConditions(t *testing.T) {
 }
 
 func TestUntilMultipleConditionsFail(t *testing.T) {
-	fw := watch.NewFake()
+	logger, _ := ktesting.NewTestContext(t)
+	fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 	go func() {
 		var obj *fakePod
 		fw.Add(obj)
@@ -131,7 +135,8 @@ func TestUntilMultipleConditionsFail(t *testing.T) {
 }
 
 func TestUntilTimeout(t *testing.T) {
-	fw := watch.NewFake()
+	logger, _ := ktesting.NewTestContext(t)
+	fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 	go func() {
 		var obj *fakePod
 		fw.Add(obj)
@@ -162,7 +167,8 @@ func TestUntilTimeout(t *testing.T) {
 }
 
 func TestUntilErrorCondition(t *testing.T) {
-	fw := watch.NewFake()
+	logger, _ := ktesting.NewTestContext(t)
+	fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 	go func() {
 		var obj *fakePod
 		fw.Add(obj)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Migrates callers of `NewFake()` and `NewRaceFreeFake()` in the watch package tests to their context-aware alternatives (`NewFakeWithOptions` and `NewRaceFreeFakeWithLogger`), using `ktesting` loggers instead of the default `klog.Background()`.


#### Which issue(s) this PR is related to:

Ref https://github.com/kubernetes/kubernetes/issues/126379

#### Special notes for your reviewer:

All modified tests pass locally. This is a straightforward migration with no behavioral changes — only the logger source changes from `klog.Background()` to a test-scoped `ktesting` logger.

#### Does this PR introduce a user-facing change?

```release-note
NONE