### PR TITLE
test: add unit coverage for pkg/proxy/metaproxier dual-stack dispatch

### DIFF
--- a/pkg/proxy/metaproxier/meta_proxier_test.go
+++ b/pkg/proxy/metaproxier/meta_proxier_test.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metaproxier
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/proxy"
+)
+
+// recordingProxier implements proxy.Provider and records each invocation so tests
+// can assert dual-stack dispatch without a full proxier implementation.
+type recordingProxier struct {
+	mu sync.Mutex
+
+	calls []string
+
+	// syncLoopExit, when non-nil, causes SyncLoop to block until the channel is closed.
+	syncLoopExit <-chan struct{}
+	// onSyncLoopEnter, when non-nil, is invoked after recording SyncLoop and before blocking.
+	onSyncLoopEnter func()
+}
+
+func (r *recordingProxier) record(method string, args ...string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, fmt.Sprintf("%s(%s)", method, strings.Join(args, ", ")))
+}
+
+func (r *recordingProxier) getCalls() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.calls))
+	copy(out, r.calls)
+	r.calls = nil
+	return out
+}
+
+func (r *recordingProxier) Sync() {
+	r.record("Sync")
+}
+
+func (r *recordingProxier) SyncLoop() {
+	r.record("SyncLoop")
+	if r.onSyncLoopEnter != nil {
+		r.onSyncLoopEnter()
+	}
+	if r.syncLoopExit != nil {
+		<-r.syncLoopExit
+	}
+}
+
+func (r *recordingProxier) OnServiceAdd(service *v1.Service) {
+	r.record("OnServiceAdd", service.Name)
+}
+
+func (r *recordingProxier) OnServiceUpdate(oldSvc, service *v1.Service) {
+	r.record("OnServiceUpdate", oldSvc.Name, service.Name)
+}
+
+func (r *recordingProxier) OnServiceDelete(service *v1.Service) {
+	r.record("OnServiceDelete", service.Name)
+}
+
+func (r *recordingProxier) OnServiceSynced() {
+	r.record("OnServiceSynced")
+}
+
+func (r *recordingProxier) OnEndpointSliceAdd(endpointSlice *discovery.EndpointSlice) {
+	r.record("OnEndpointSliceAdd", string(endpointSlice.AddressType))
+}
+
+func (r *recordingProxier) OnEndpointSliceUpdate(oldEs, newEs *discovery.EndpointSlice) {
+	r.record("OnEndpointSliceUpdate", string(oldEs.AddressType), string(newEs.AddressType))
+}
+
+func (r *recordingProxier) OnEndpointSliceDelete(endpointSlice *discovery.EndpointSlice) {
+	r.record("OnEndpointSliceDelete", string(endpointSlice.AddressType))
+}
+
+func (r *recordingProxier) OnEndpointSlicesSynced() {
+	r.record("OnEndpointSlicesSynced")
+}
+
+func (r *recordingProxier) OnTopologyChange(labels map[string]string) {
+	r.record("OnTopologyChange")
+}
+
+func (r *recordingProxier) OnServiceCIDRsChanged(cidrs []string) {
+	r.record("OnServiceCIDRsChanged", strings.Join(cidrs, ", "))
+}
+
+var _ proxy.Provider = (*recordingProxier)(nil)
+
+func TestMetaProxier_GenericCallbacksFanOutToBothProxiers(t *testing.T) {
+	ipv4 := &recordingProxier{}
+	ipv6 := &recordingProxier{}
+	mp := NewMetaProxier(ipv4, ipv6)
+
+	mp.Sync()
+
+	svcAdd := &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "add"}}
+	mp.OnServiceAdd(svcAdd)
+
+	oldSvc := &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "old"}}
+	newSvc := &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "new"}}
+	mp.OnServiceUpdate(oldSvc, newSvc)
+
+	del := &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "gone"}}
+	mp.OnServiceDelete(del)
+
+	mp.OnServiceSynced()
+
+	mp.OnEndpointSlicesSynced()
+
+	mp.OnTopologyChange(map[string]string{"topology.kubernetes.io/zone": "a"})
+	mp.OnServiceCIDRsChanged([]string{"10.0.0.0/16", "2001:db8::/64"})
+
+	want := []string{
+		"Sync()",
+		"OnServiceAdd(add)",
+		"OnServiceUpdate(old, new)",
+		"OnServiceDelete(gone)",
+		"OnServiceSynced()",
+		"OnEndpointSlicesSynced()",
+		"OnTopologyChange()",
+		"OnServiceCIDRsChanged(10.0.0.0/16, 2001:db8::/64)",
+	}
+	if diff := cmp.Diff(want, ipv4.getCalls()); diff != "" {
+		t.Errorf("ipv4 (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(want, ipv6.getCalls()); diff != "" {
+		t.Errorf("ipv6 (-want +got):\n%s", diff)
+	}
+}
+
+func TestMetaProxier_EndpointSlice_RoutesByAddressType(t *testing.T) {
+	ipv4 := &recordingProxier{}
+	ipv6 := &recordingProxier{}
+	mp := NewMetaProxier(ipv4, ipv6)
+
+	eps4 := &discovery.EndpointSlice{AddressType: discovery.AddressTypeIPv4}
+	eps6 := &discovery.EndpointSlice{AddressType: discovery.AddressTypeIPv6}
+
+	mp.OnEndpointSliceAdd(eps4)
+	mp.OnEndpointSliceAdd(eps6)
+
+	old4 := &discovery.EndpointSlice{AddressType: discovery.AddressTypeIPv4}
+	new4 := &discovery.EndpointSlice{AddressType: discovery.AddressTypeIPv4}
+	mp.OnEndpointSliceUpdate(old4, new4)
+
+	mp.OnEndpointSliceDelete(eps4)
+
+	if diff := cmp.Diff([]string{
+		"OnEndpointSliceAdd(IPv4)",
+		"OnEndpointSliceUpdate(IPv4, IPv4)",
+		"OnEndpointSliceDelete(IPv4)",
+	}, ipv4.getCalls()); diff != "" {
+		t.Errorf("ipv4 (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff([]string{
+		"OnEndpointSliceAdd(IPv6)",
+	}, ipv6.getCalls()); diff != "" {
+		t.Errorf("ipv6 (-want +got):\n%s", diff)
+	}
+}
+
+func TestMetaProxier_EndpointSlice_UnsupportedAddressType_NoDownstreamCalls(t *testing.T) {
+	ipv4 := &recordingProxier{}
+	ipv6 := &recordingProxier{}
+	mp := NewMetaProxier(ipv4, ipv6)
+
+	fqdnSlice := &discovery.EndpointSlice{AddressType: discovery.AddressTypeFQDN}
+
+	mp.OnEndpointSliceAdd(fqdnSlice)
+	mp.OnEndpointSliceUpdate(fqdnSlice, fqdnSlice)
+	mp.OnEndpointSliceDelete(fqdnSlice)
+
+	if got := ipv4.getCalls(); len(got) != 0 {
+		t.Errorf("expected ipv4 no calls for FQDN slices, got %v", got)
+	}
+	if got := ipv6.getCalls(); len(got) != 0 {
+		t.Errorf("expected ipv6 no calls for FQDN slices, got %v", got)
+	}
+}
+
+func TestMetaProxier_SyncLoop_InvokesBothChildSyncLoops(t *testing.T) {
+	exit := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	ipv4 := &recordingProxier{
+		syncLoopExit:    exit,
+		onSyncLoopEnter: wg.Done,
+	}
+	ipv6 := &recordingProxier{
+		syncLoopExit:    exit,
+		onSyncLoopEnter: wg.Done,
+	}
+	mp := NewMetaProxier(ipv4, ipv6)
+
+	stopped := make(chan struct{})
+	go func() {
+		mp.SyncLoop()
+		close(stopped)
+	}()
+
+	bothStarted := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(bothStarted)
+	}()
+
+	select {
+	case <-bothStarted:
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("timed out waiting for both child SyncLoop calls: ipv4=%v ipv6=%v", ipv4.getCalls(), ipv6.getCalls())
+	}
+
+	close(exit)
+
+	select {
+	case <-stopped:
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatal("SyncLoop did not return after unblocking children")
+	}
+
+	if diff := cmp.Diff([]string{"SyncLoop()"}, ipv4.getCalls()); diff != "" {
+		t.Errorf("ipv4 (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff([]string{"SyncLoop()"}, ipv6.getCalls()); diff != "" {
+		t.Errorf("ipv6 (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds unit tests for pkg/proxy/metaproxier, which implements dual-stack kube-proxy by wrapping separate IPv4 and IPv6 proxy.Provider implementations. This package previously had no tests, so routing and fan-out behavior were only covered indirectly.

- metaProxier is dispatch-only logic: wrong routing for EndpointSlice address types or mistakes in which proxier receives service/topology/CIDR callbacks are easy to regress without targeted tests.
- SyncLoop is easy to break: IPv6 runs in a goroutine and IPv4 blocks in the caller—tests document and verify that both child SyncLoop methods run.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NA
```
