### PR TITLE
fix: properly format DebugError output in kubectl StandardErrorMessage

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -243,7 +243,8 @@ func statusCausesToAggrError(scs []metav1.StatusCause) utilerrors.Aggregate {
 // commands.
 func StandardErrorMessage(err error) (string, bool) {
 	if debugErr, ok := err.(debugError); ok {
-		klog.V(4).Info(debugErr.DebugError())
+		msg, args := debugErr.DebugError()
+		klog.V(4).Infof(msg, args...)
 	}
 	status, isStatus := err.(apierrors.APIStatus)
 	switch {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Fixes the `DebugError()` output formatting in [StandardErrorMessage()](https://github.com/kubernetes/kubernetes/blob/03779bbd00da25c7fcd03711ddfe466a3322e1d7/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go#L244).  Previously, `klog.V(4).Info(debugErr.DebugError())` was used, which treats its arguments as plain values and concatenates them. Since `DebugError()` returns a format string [server response object: %s](https://github.com/kubernetes/kubernetes/blob/03779bbd00da25c7fcd03711ddfe466a3322e1d7/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go#L82-L87) and args `([]interface{}{jsonString})`, the `%s`  verb was never substituted, producing malformed log output like:

<img width="2446" height="740" alt="image" src="https://github.com/user-attachments/assets/2194f31b-0056-4168-99df-f16e16a19f6d" />

This PR unpacks the format string and args, and passes them to `klog.V(4).Infof()` so the format verb is properly consumed, producing the expected output:

<img width="2190" height="748" alt="image" src="https://github.com/user-attachments/assets/29e2378a-9c3e-4c03-91dc-01a12a425cf0" />

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
