### PR TITLE
decrease metrics for unscheduled plugin when removing pod from active or backoff queue

### DIFF
--- a/pkg/scheduler/backend/heap/heap.go
+++ b/pkg/scheduler/backend/heap/heap.go
@@ -154,17 +154,19 @@ func (h *Heap[T]) AddOrUpdate(obj T) {
 	}
 }
 
-// Delete removes an item.
-func (h *Heap[T]) Delete(obj T) error {
+// Delete removes an item and returns the deleted obj.
+func (h *Heap[T]) Delete(obj T) T {
 	key := h.data.keyFunc(obj)
 	if item, ok := h.data.items[key]; ok {
+		obj := item.obj
 		heap.Remove(h.data, item.index)
 		if h.metricRecorder != nil {
 			h.metricRecorder.Dec()
 		}
-		return nil
+		return obj
 	}
-	return fmt.Errorf("object not found")
+	var zero T
+	return zero
 }
 
 // Peek returns the head of the heap without removing it.

--- a/pkg/scheduler/backend/heap/heap_test.go
+++ b/pkg/scheduler/backend/heap/heap_test.go
@@ -119,7 +119,7 @@ func TestHeap_AddOrUpdate_Add(t *testing.T) {
 	if e, a := 11, item.val; err != nil || a != e {
 		t.Fatalf("expected %d, got %d", e, a)
 	}
-	if err := h.Delete(mkHeapObj("baz", 11)); err == nil { // Nothing is deleted.
+	if obj := h.Delete(mkHeapObj("baz", 11)); obj.name != "" { // Nothing is deleted.
 		t.Fatalf("nothing should be deleted from the heap")
 	}
 	h.AddOrUpdate(mkHeapObj("foo", 14)) // foo is updated.
@@ -143,7 +143,7 @@ func TestHeap_Delete(t *testing.T) {
 	h.AddOrUpdate(mkHeapObj("baz", 11))
 
 	// Delete head. Delete should work with "key" and doesn't care about the value.
-	if err := h.Delete(mkHeapObj("bar", 200)); err != nil {
+	if obj := h.Delete(mkHeapObj("bar", 200)); obj.name == "" {
 		t.Fatalf("Failed to delete head.")
 	}
 	item, err := h.Pop()
@@ -154,15 +154,15 @@ func TestHeap_Delete(t *testing.T) {
 	h.AddOrUpdate(mkHeapObj("faz", 30))
 	len := h.data.Len()
 	// Delete non-existing item.
-	if err = h.Delete(mkHeapObj("non-existent", 10)); err == nil || len != h.data.Len() {
+	if obj := h.Delete(mkHeapObj("non-existent", 10)); obj.name != "" || len != h.data.Len() {
 		t.Fatalf("Didn't expect any item removal")
 	}
 	// Delete tail.
-	if err = h.Delete(mkHeapObj("bal", 31)); err != nil {
+	if obj := h.Delete(mkHeapObj("bal", 31)); obj.name == "" {
 		t.Fatalf("Failed to delete tail.")
 	}
 	// Delete one of the items with value 30.
-	if err = h.Delete(mkHeapObj("zab", 30)); err != nil {
+	if obj := h.Delete(mkHeapObj("zab", 30)); obj.name == "" {
 		t.Fatalf("Failed to delete item.")
 	}
 	item, err = h.Pop()
@@ -283,8 +283,8 @@ func TestHeapWithRecorder(t *testing.T) {
 	if *metricRecorder != 4 {
 		t.Errorf("expected count to be 4 but got %d", *metricRecorder)
 	}
-	if err := h.Delete(mkHeapObj("bar", 1)); err != nil {
-		t.Fatal(err)
+	if obj := h.Delete(mkHeapObj("bar", 1)); obj.name == "" {
+		t.Fatalf("Failed to delete item")
 	}
 	if *metricRecorder != 3 {
 		t.Errorf("expected count to be 3 but got %d", *metricRecorder)

--- a/pkg/scheduler/backend/queue/active_queue.go
+++ b/pkg/scheduler/backend/queue/active_queue.go
@@ -37,7 +37,9 @@ type activeQueuer interface {
 	underLock(func(unlockedActiveQ unlockedActiveQueuer))
 	underRLock(func(unlockedActiveQ unlockedActiveQueueReader))
 
-	delete(pInfo *framework.QueuedPodInfo) error
+	// delete removes the pod from the activeQ.
+	// It returns the pod info if it was removed, nil otherwise.
+	delete(pInfo *framework.QueuedPodInfo) *framework.QueuedPodInfo
 	pop(logger klog.Logger) (*framework.QueuedPodInfo, error)
 	list() []*v1.Pod
 	len() int
@@ -259,8 +261,9 @@ func (aq *activeQueue) underRLock(fn func(unlockedActiveQ unlockedActiveQueueRea
 	fn(aq.unlockedQueue)
 }
 
-// delete deletes the pod info from activeQ.
-func (aq *activeQueue) delete(pInfo *framework.QueuedPodInfo) error {
+// delete removes the pod from the activeQ.
+// It returns the pod info if it was removed, nil otherwise.
+func (aq *activeQueue) delete(pInfo *framework.QueuedPodInfo) *framework.QueuedPodInfo {
 	aq.lock.Lock()
 	defer aq.lock.Unlock()
 

--- a/pkg/scheduler/backend/queue/backoff_queue.go
+++ b/pkg/scheduler/backend/queue/backoff_queue.go
@@ -65,8 +65,8 @@ type backoffQueuer interface {
 	// It returns new pod info if updated, nil otherwise.
 	update(newPod *v1.Pod, oldPodInfo *framework.QueuedPodInfo) *framework.QueuedPodInfo
 	// delete deletes the pInfo from backoffQueue.
-	// It returns true if the pod was deleted.
-	delete(pInfo *framework.QueuedPodInfo) bool
+	// It returns the removed pod object if found, nil otherwise.
+	delete(pInfo *framework.QueuedPodInfo) *framework.QueuedPodInfo
 	// get returns the pInfo matching given pInfoLookup, if exists.
 	get(pInfoLookup *framework.QueuedPodInfo) (*framework.QueuedPodInfo, bool)
 	// has inform if pInfo exists in the queue.
@@ -301,8 +301,7 @@ func (bq *backoffQueue) add(logger klog.Logger, pInfo *framework.QueuedPodInfo, 
 	if pInfo.UnschedulablePlugins.Len() == 0 && pInfo.PendingPlugins.Len() == 0 {
 		bq.podErrorBackoffQ.AddOrUpdate(pInfo)
 		// Ensure the pod is not in the podBackoffQ and report the error if it happens.
-		err := bq.podBackoffQ.Delete(pInfo)
-		if err == nil {
+		if deletedPod := bq.podBackoffQ.Delete(pInfo); deletedPod != nil {
 			logger.Error(nil, "BackoffQueue add() was called with a pod that was already in the podBackoffQ", "pod", klog.KObj(pInfo.Pod))
 			return
 		}
@@ -312,8 +311,7 @@ func (bq *backoffQueue) add(logger klog.Logger, pInfo *framework.QueuedPodInfo, 
 	}
 	bq.podBackoffQ.AddOrUpdate(pInfo)
 	// Ensure the pod is not in the podErrorBackoffQ and report the error if it happens.
-	err := bq.podErrorBackoffQ.Delete(pInfo)
-	if err == nil {
+	if deletedPod := bq.podErrorBackoffQ.Delete(pInfo); deletedPod != nil {
 		logger.Error(nil, "BackoffQueue add() was called with a pod that was already in the podErrorBackoffQ", "pod", klog.KObj(pInfo.Pod))
 		return
 	}
@@ -343,15 +341,15 @@ func (bq *backoffQueue) update(newPod *v1.Pod, oldPodInfo *framework.QueuedPodIn
 }
 
 // delete deletes the pInfo from backoffQueue.
-// It returns true if the pod was deleted.
-func (bq *backoffQueue) delete(pInfo *framework.QueuedPodInfo) bool {
+// It returns the removed pod object if found, nil otherwise.
+func (bq *backoffQueue) delete(pInfo *framework.QueuedPodInfo) *framework.QueuedPodInfo {
 	bq.lock.Lock()
 	defer bq.lock.Unlock()
 
-	if bq.podBackoffQ.Delete(pInfo) == nil {
-		return true
+	if pInfo := bq.podBackoffQ.Delete(pInfo); pInfo != nil {
+		return pInfo
 	}
-	return bq.podErrorBackoffQ.Delete(pInfo) == nil
+	return bq.podErrorBackoffQ.Delete(pInfo)
 }
 
 // popBackoff pops the pInfo from the podBackoffQ.

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -783,17 +783,10 @@ func (p *PriorityQueue) activate(logger klog.Logger, pod *v1.Pod) bool {
 	var movesFromBackoffQ bool
 	// Verify if the pod is present in unschedulablePods or backoffQ.
 	if pInfo = p.unschedulablePods.get(pod); pInfo == nil {
-		// If the pod doesn't belong to unschedulablePods or backoffQ, don't activate it.
-		// The pod can be already in activeQ.
-		var exists bool
-		pInfo, exists = p.backoffQ.get(newQueuedPodInfoForLookup(pod))
-		if !exists {
-			return false
-		}
-		// Delete pod from the backoffQ now to make sure it won't be popped from the backoffQ
-		// just before moving it to the activeQ
-		if deleted := p.backoffQ.delete(pInfo); !deleted {
-			// Pod was popped from the backoffQ in the meantime. Don't activate it.
+		// Pod may be present in the backoffQ. Try to delete the pod from the backoffQ now
+		// to make sure it won't be popped from the backoffQ just before moving it to the activeQ.
+		if pInfo = p.backoffQ.delete(newQueuedPodInfoForLookup(pod)); pInfo == nil {
+			// Pod is not present in the backoffQ. Don't activate it.
 			return false
 		}
 		movesFromBackoffQ = true
@@ -1025,16 +1018,11 @@ func (p *PriorityQueue) PopSpecificPod(logger klog.Logger, pod *v1.Pod) *framewo
 	// moved to the activeQ and popped from there.
 	_ = p.activate(logger, pod)
 
-	var pInfo *framework.QueuedPodInfo
-	p.activeQ.underRLock(func(unlockedActiveQ unlockedActiveQueueReader) {
-		pInfo, _ = unlockedActiveQ.get(pInfoLookup)
-	})
+	pInfo := p.activeQ.delete(pInfoLookup)
+
+	// nil value means that the pod disappeared from the activeQ in the meantime.
+	// Returning nil is fine.
 	if pInfo == nil {
-		return nil
-	}
-	if err := p.activeQ.delete(pInfo); err != nil {
-		// Error means that the pod disappeared from the activeQ in the meantime.
-		// Returning nil is fine.
 		return nil
 	}
 	err := p.activeQ.movePodToInFlight(pInfo)
@@ -1196,25 +1184,41 @@ func (p *PriorityQueue) Update(ctx context.Context, oldPod, newPod *v1.Pod) {
 	}
 }
 
+// decreaseUnschedulableReasonMetric decreases the metrics for the rejector plugins
+// which are both UnschedulablePlugins and PendingPlugins.
+func decreaseUnschedulableReasonMetric(pInfo *framework.QueuedPodInfo) {
+	for plugin := range pInfo.UnschedulablePlugins.Union(pInfo.PendingPlugins) {
+		metrics.UnschedulableReason(plugin, pInfo.Pod.Spec.SchedulerName).Dec()
+	}
+}
+
 // Delete deletes the item from either of the two queues. It assumes the pod is
 // only in one queue.
 func (p *PriorityQueue) Delete(pod *v1.Pod) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	p.DeleteNominatedPodIfExists(pod)
-	pInfo := newQueuedPodInfoForLookup(pod)
-	if err := p.activeQ.delete(pInfo); err == nil {
+	pInfoLookup := newQueuedPodInfoForLookup(pod)
+
+	// Check activeQ
+	if pInfo := p.activeQ.delete(pInfoLookup); pInfo != nil {
+		// Drop metric for deleted pod.
+		decreaseUnschedulableReasonMetric(pInfo)
 		return
 	}
-	if deleted := p.backoffQ.delete(pInfo); deleted {
+
+	// Check backoffQ
+	if pInfo := p.backoffQ.delete(pInfoLookup); pInfo != nil {
+		// Drop metric for deleted pod.
+		decreaseUnschedulableReasonMetric(pInfo)
 		return
 	}
-	if pInfo = p.unschedulablePods.get(pod); pInfo != nil {
+
+	// Check unschedulablePods
+	if pInfo := p.unschedulablePods.get(pod); pInfo != nil {
 		p.unschedulablePods.delete(pod, pInfo.Gated())
 		// Drop metric for deleted pod.
-		for plugin := range pInfo.UnschedulablePlugins.Union(pInfo.PendingPlugins) {
-			metrics.UnschedulableReason(plugin, pInfo.Pod.Spec.SchedulerName).Dec()
-		}
+		decreaseUnschedulableReasonMetric(pInfo)
 	}
 }
 

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -1505,26 +1505,155 @@ func TestPriorityQueue_UpdateWhenInflight(t *testing.T) {
 }
 
 func TestPriorityQueue_Delete(t *testing.T) {
-	objs := []runtime.Object{highPriorityPodInfo.Pod, unschedulablePodInfo.Pod}
-	_, ctx := ktesting.NewTestContext(t)
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), objs)
-	q.Update(ctx, highPriorityPodInfo.Pod, highPriNominatedPodInfo.Pod)
-	q.Add(ctx, unschedulablePodInfo.Pod)
-	q.Delete(highPriNominatedPodInfo.Pod)
-	if !q.activeQ.has(newQueuedPodInfoForLookup(unschedulablePodInfo.Pod)) {
-		t.Errorf("Expected %v to be in activeQ.", unschedulablePodInfo.Pod.Name)
+	metrics.Register()
+	timestamp := time.Now()
+
+	pod1 := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Obj()
+	pInfo1 := &framework.QueuedPodInfo{
+		PodInfo:              mustNewTestPodInfo(t, pod1),
+		Timestamp:            timestamp,
+		UnschedulablePlugins: sets.New("fakePlugin"),
+		PendingPlugins:       sets.New("fakePendingPlugin"),
 	}
-	if q.activeQ.has(newQueuedPodInfoForLookup(highPriNominatedPodInfo.Pod)) {
-		t.Errorf("Didn't expect %v to be in activeQ.", highPriorityPodInfo.Pod.Name)
+	pod2 := st.MakePod().Name("pod2").Namespace("ns1").UID("pod2").Obj()
+	pInfo2 := &framework.QueuedPodInfo{
+		PodInfo:              mustNewTestPodInfo(t, pod2),
+		Timestamp:            timestamp,
+		UnschedulablePlugins: sets.New("fakePlugin2"),
 	}
-	if len(q.nominator.nominatedPods) != 1 {
-		t.Errorf("Expected nominatedPods to have only 'unschedulablePodInfo': %v", q.nominator.nominatedPods)
+
+	tests := []struct {
+		name                string
+		operations          []operation
+		operands            []*framework.QueuedPodInfo
+		podToDelete         *v1.Pod
+		expectedAbsentPods  []*v1.Pod
+		expectedPresentPods []*v1.Pod
+		expectedMetrics     map[string]int
+	}{
+		{
+			name: "Delete pod from activeQ",
+			operations: []operation{
+				add,
+				add,
+			},
+			operands:            []*framework.QueuedPodInfo{pInfo1, pInfo2},
+			podToDelete:         pod1,
+			expectedAbsentPods:  []*v1.Pod{pod1},
+			expectedPresentPods: []*v1.Pod{pod2},
+			expectedMetrics: map[string]int{
+				"fakePlugin":        0,
+				"fakePendingPlugin": 0,
+				"fakePlugin2":       0,
+			},
+		},
+		{
+			name: "Delete pod from backoffQ",
+			operations: []operation{
+				popAndRequeueAsBackoff,
+				add,
+			},
+			operands:            []*framework.QueuedPodInfo{pInfo1, pInfo2},
+			podToDelete:         pod1,
+			expectedAbsentPods:  []*v1.Pod{pod1},
+			expectedPresentPods: []*v1.Pod{pod2},
+			expectedMetrics: map[string]int{
+				"fakePlugin":        0,
+				"fakePendingPlugin": 0,
+				"fakePlugin2":       0,
+			},
+		},
+		{
+			name: "Delete pod from unschedulablePods",
+			operations: []operation{
+				popAndRequeueAsUnschedulable,
+				popAndRequeueAsUnschedulable,
+			},
+			operands:            []*framework.QueuedPodInfo{pInfo1, pInfo2},
+			podToDelete:         pod1,
+			expectedAbsentPods:  []*v1.Pod{pod1},
+			expectedPresentPods: []*v1.Pod{pod2},
+			expectedMetrics: map[string]int{
+				"fakePlugin":        0,
+				"fakePendingPlugin": 0,
+				"fakePlugin2":       1,
+			},
+		},
+		{
+			name: "Delete nominated pod from activeQ",
+			operations: []operation{
+				add,
+			},
+			operands:           []*framework.QueuedPodInfo{{PodInfo: highPriNominatedPodInfo}},
+			podToDelete:        highPriNominatedPodInfo.Pod,
+			expectedAbsentPods: []*v1.Pod{highPriNominatedPodInfo.Pod},
+			expectedMetrics: map[string]int{
+				"fakePlugin":        0,
+				"fakePendingPlugin": 0,
+				"fakePlugin2":       0,
+			},
+		},
+		{
+			name: "Delete non-existing pod",
+			operations: []operation{
+				popAndRequeueAsUnschedulable,
+			},
+			operands:            []*framework.QueuedPodInfo{pInfo1},
+			podToDelete:         pod2,
+			expectedAbsentPods:  []*v1.Pod{pod2},
+			expectedPresentPods: []*v1.Pod{pod1},
+			expectedMetrics: map[string]int{
+				"fakePlugin":        1,
+				"fakePendingPlugin": 1,
+				"fakePlugin2":       0,
+			},
+		},
 	}
-	q.Delete(unschedulablePodInfo.Pod)
-	if len(q.nominator.nominatedPods) != 0 {
-		t.Errorf("Expected nominatedPods to be empty: %v", q.nominator)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+			q := NewTestQueue(tCtx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(timestamp)))
+
+			// Reset metrics for plugins used in the test
+			allPlugins := sets.New("fakePlugin", "fakePendingPlugin", "fakePlugin2")
+			for plugin := range allPlugins {
+				metrics.UnschedulableReason(plugin, pod1.Spec.SchedulerName).Set(0)
+			}
+
+			// Execute operations
+			for i, op := range tt.operations {
+				op(tCtx, q, tt.operands[i])
+			}
+
+			q.Delete(tt.podToDelete)
+
+			// Verification
+			for _, pod := range tt.expectedAbsentPods {
+				pInfoLookup := newQueuedPodInfoForLookup(pod)
+				if q.activeQ.has(pInfoLookup) || q.backoffQ.has(pInfoLookup) || q.unschedulablePods.get(pod) != nil {
+					t.Errorf("Expected pod %v to be absent, but it is present", pod.Name)
+				}
+			}
+
+			for _, pod := range tt.expectedPresentPods {
+				pInfoLookup := newQueuedPodInfoForLookup(pod)
+				if !q.activeQ.has(pInfoLookup) && !q.backoffQ.has(pInfoLookup) && q.unschedulablePods.get(pod) == nil {
+					t.Errorf("Expected pod %v to be present, but it is absent", pod.Name)
+				}
+			}
+
+			for plugin, expectedVal := range tt.expectedMetrics {
+				val, _ := testutil.GetGaugeMetricValue(metrics.UnschedulableReason(plugin, tt.podToDelete.Spec.SchedulerName))
+				if diff := cmp.Diff(float64(expectedVal), val); diff != "" {
+					t.Errorf("Unexpected metric value for plugin %v after delete (-want, +got):\n%s", plugin, diff)
+				}
+			}
+
+			if len(q.nominator.nominatedPods) != 0 || len(q.nominator.nominatedPodToNode) != 0 {
+				t.Errorf("Expected nominatedPods and nominatedPodToNode to be empty, but got %v and %v", q.nominator.nominatedPods, q.nominator.nominatedPodToNode)
+			}
+		})
 	}
 }
 
@@ -3363,9 +3492,10 @@ var (
 	}
 	popAndRequeueAsUnschedulable = func(tCtx ktesting.TContext, queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
 		// To simulate the pod is failed in scheduling in the real world, Pop() the pod from activeQ before AddUnschedulableIfNotPresent() below.
-		// UnschedulablePlugins will get cleared by Pop, so make a copy first.
+		// UnschedulablePlugins and PendingPlugins will get cleared by Pop, so make a copy first.
 		logger := klog.FromContext(tCtx)
 		unschedulablePlugins := pInfo.UnschedulablePlugins.Clone()
+		pendingPlugins := pInfo.PendingPlugins.Clone()
 		queue.Add(tCtx, pInfo.Pod)
 		p, err := queue.Pop(logger)
 		if err != nil {
@@ -3375,6 +3505,7 @@ var (
 		}
 		// Simulate plugins that are waiting for some events.
 		p.UnschedulablePlugins = unschedulablePlugins
+		p.PendingPlugins = pendingPlugins
 		if err := queue.AddUnschedulableIfNotPresent(logger, p, 1); err != nil {
 			tCtx.Fatalf("Unexpected error during AddUnschedulableIfNotPresent: %v", err)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR fixes a metric leak in the scheduling queue. Previously, when a pod was removed from the queue using the Delete method, the UnschedulableReason metric (which tracks the reason why pods are unschedulable) was only decremented if the pod was found in the unschedulablePods map. If the pod had been moved to activeQ or backoffQ (for example, after an event triggered Activate) and was subsequently deleted before being scheduled, the metrics associated with its previous unschedulable reasons were not cleared. This led to inflated and incorrect metric values.

To fix this, the Delete method in PriorityQueue has been updated to:

1. Retrieve the QueuedPodInfo when deleting a pod from activeQ or backoffQ.
2. Iterate over the union of UnschedulablePlugins and PendingPlugins stored in the QueuedPodInfo.
3. Decrement the UnschedulableReason metric for each of those plugins.


#### Which issue(s) this PR is related to:
Fixes #138444
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
This fixes a bug related to pods that were removed from the active or backoff queues before scheduling. Previously, the metrics associated with these removed pods were not adjusted; this PR introduces a fix that allows us to decrease metrics for such pods.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
