### PR TITLE
Unify string concatenation style across the codebase

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/waitcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/waitcontrolplane.go
@@ -68,8 +68,8 @@ func runWaitControlPlanePhase(c workflow.RunData) error {
 		return errors.Wrap(err, "error creating waiter")
 	}
 
-	fmt.Printf("[wait-control-plane] Waiting for the kubelet to boot up the control plane as static Pods"+
-		" from directory %q\n",
+	fmt.Printf("[wait-control-plane] Waiting for the kubelet to boot up the control plane as static Pods "+
+		"from directory %q\n",
 		data.ManifestDir())
 
 	waiter.SetTimeout(data.Cfg().Timeouts.KubeletHealthCheck.Duration)

--- a/cmd/kubeadm/app/discovery/token/token.go
+++ b/cmd/kubeadm/app/discovery/token/token.go
@@ -226,8 +226,8 @@ func getClusterInfo(client clientset.Interface, cfg *kubeadmapi.Discovery, inter
 				return true, lastError
 			}
 
-			klog.V(1).Infof("[discovery] Waiting for the cluster-info ConfigMap to receive a JWS signature"+
-				" for token ID %q", token.ID)
+			klog.V(1).Infof("[discovery] Waiting for the cluster-info ConfigMap to receive a JWS signature "+
+				"for token ID %q", token.ID)
 
 			cm, err = client.CoreV1().ConfigMaps(metav1.NamespacePublic).
 				Get(context.Background(), bootstrapapi.ConfigMapClusterInfo, metav1.GetOptions{})
@@ -238,8 +238,8 @@ func getClusterInfo(client clientset.Interface, cfg *kubeadmapi.Discovery, inter
 			}
 			// Even if the ConfigMap is available the JWS signature is patched-in a bit later.
 			if _, ok := cm.Data[bootstrapapi.JWSSignatureKeyPrefix+token.ID]; !ok {
-				lastError = errors.Errorf("could not find a JWS signature in the cluster-info ConfigMap"+
-					" for token ID %q", token.ID)
+				lastError = errors.Errorf("could not find a JWS signature in the cluster-info ConfigMap "+
+					"for token ID %q", token.ID)
 				if dryRun {
 					// Assume the user is dry-running with a token that will never appear in the cluster-info
 					// ConfigMap. Use the default dry-run token and CA cert hash.

--- a/cmd/kubeadm/app/phases/upgrade/compute.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute.go
@@ -88,8 +88,8 @@ func GetAvailableUpgrades(versionGetterImpl VersionGetter, experimentalUpgradesA
 		for version, nodes := range kubeAPIServerVersions {
 			verMsg = append(verMsg, fmt.Sprintf("%s on nodes %v", version, nodes))
 		}
-		klog.Warningf("Different API server versions in the cluster were discovered: %v. Please upgrade your control plane"+
-			" nodes to the same version of Kubernetes", strings.Join(verMsg, ", "))
+		klog.Warningf("Different API server versions in the cluster were discovered: %v. Please upgrade your control plane "+
+			"nodes to the same version of Kubernetes", strings.Join(verMsg, ", "))
 	}
 
 	// Get the latest cluster version

--- a/pkg/controller/volume/attachdetach/populator/desired_state_of_world_populator.go
+++ b/pkg/controller/volume/attachdetach/populator/desired_state_of_world_populator.go
@@ -168,8 +168,8 @@ func (dswp *desiredStateOfWorldPopulator) findAndRemoveDeletedPods(logger klog.L
 			for _, scheduledPod := range volumeToAttach.ScheduledPods {
 				podUID := volutil.GetUniquePodName(scheduledPod)
 				dswp.desiredStateOfWorld.DeletePod(podUID, volumeToAttach.VolumeName, volumeToAttach.NodeName)
-				logger.V(4).Info("Removing podUID and volume on node from desired state of world"+
-					" because of the change of volume attachability", "node", klog.KRef("", string(volumeToAttach.NodeName)), "podUID", podUID, "volumeName", volumeToAttach.VolumeName)
+				logger.V(4).Info("Removing podUID and volume on node from desired state of world "+
+					"because of the change of volume attachability", "node", klog.KRef("", string(volumeToAttach.NodeName)), "podUID", podUID, "volumeName", volumeToAttach.VolumeName)
 			}
 		}
 	}

--- a/pkg/controlplane/apiserver/server.go
+++ b/pkg/controlplane/apiserver/server.go
@@ -110,9 +110,9 @@ func (c completedConfig) New(name string, delegationTarget genericapiserver.Dele
 		// error, but continue on. We don't return the error because the
 		// metadata responses require additional, backwards incompatible
 		// validation of command-line options.
-		msg := fmt.Sprintf("Could not construct pre-rendered responses for"+
-			" ServiceAccountIssuerDiscovery endpoints. Endpoints will not be"+
-			" enabled. Error: %v", err)
+		msg := fmt.Sprintf("Could not construct pre-rendered responses for "+
+			"ServiceAccountIssuerDiscovery endpoints. Endpoints will not be "+
+			"enabled. Error: %v", err)
 		if c.ServiceAccountIssuerURL != "" {
 			// The user likely expects this feature to be enabled if issuer URL is
 			// set and the feature gate is enabled. In the future, if there is no

--- a/plugin/pkg/admission/defaulttolerationseconds/admission.go
+++ b/plugin/pkg/admission/defaulttolerationseconds/admission.go
@@ -51,11 +51,11 @@ func RegisterFlags(fs *pflag.FlagSet) {
 	defer tolerationSecondsMutex.Unlock()
 
 	fs.Int64Var(&defaultNotReadyTolerationSeconds, "default-not-ready-toleration-seconds", defaultNotReadyTolerationSeconds,
-		"Indicates the tolerationSeconds of the toleration for notReady:NoExecute"+
-			" that is added by default to every pod that does not already have such a toleration.")
+		"Indicates the tolerationSeconds of the toleration for notReady:NoExecute "+
+			"that is added by default to every pod that does not already have such a toleration.")
 	fs.Int64Var(&defaultUnreachableTolerationSeconds, "default-unreachable-toleration-seconds", defaultUnreachableTolerationSeconds,
-		"Indicates the tolerationSeconds of the toleration for unreachable:NoExecute"+
-			" that is added by default to every pod that does not already have such a toleration.")
+		"Indicates the tolerationSeconds of the toleration for unreachable:NoExecute "+
+			"that is added by default to every pod that does not already have such a toleration.")
 }
 
 // Register registers a plugin

--- a/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
@@ -360,9 +360,9 @@ func (o *AuditOptions) newPolicyRuleEvaluator() (audit.PolicyRuleEvaluator, erro
 
 func (o *AuditBatchOptions) AddFlags(pluginName string, fs *pflag.FlagSet) {
 	fs.StringVar(&o.Mode, fmt.Sprintf("audit-%s-mode", pluginName), o.Mode,
-		"Strategy for sending audit events. Blocking indicates sending events should block"+
-			" server responses. Batch causes the backend to buffer and write events"+
-			" asynchronously. Known modes are "+strings.Join(AllowedModes, ",")+".")
+		"Strategy for sending audit events. Blocking indicates sending events should block "+
+			"server responses. Batch causes the backend to buffer and write events "+
+			"asynchronously. Known modes are "+strings.Join(AllowedModes, ",")+".")
 	fs.IntVar(&o.BatchConfig.BufferSize, fmt.Sprintf("audit-%s-batch-buffer-size", pluginName),
 		o.BatchConfig.BufferSize, "The size of the buffer to store events before "+
 			"batching and writing. Only used in batch mode.")

--- a/test/e2e/storage/drivers/util.go
+++ b/test/e2e/storage/drivers/util.go
@@ -63,9 +63,9 @@ func createGCESecrets(client clientset.Interface, ns string) {
 
 	premadeSAFile, ok := os.LookupEnv(saEnv)
 	if !ok {
-		framework.Logf("Could not find env var %v, please either create cloud-sa"+
-			" secret manually or rerun test after setting %v to the filepath of"+
-			" the GCP Service Account to give to the GCE Persistent Disk CSI Driver", saEnv, saEnv)
+		framework.Logf("Could not find env var %v, please either create cloud-sa "+
+			"secret manually or rerun test after setting %v to the filepath of "+
+			"the GCP Service Account to give to the GCE Persistent Disk CSI Driver", saEnv, saEnv)
 		return
 	}
 


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it:**

Move whitespace from the beginning of continuation lines to the end of the preceding line in multi-line string concatenations, matching the majority pattern used across the codebase.

**Which issue(s) this PR fixes:**

Ref kubernetes#131558

**Does this PR introduce a user-facing change?**

```release-note
NONE
```