### PR TITLE
Fix typos: 'wether' -> 'whether' in comments

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go
@@ -246,7 +246,7 @@ func splitReplicasPath(replicasPath string) []string {
 	return strings.Split(strings.TrimPrefix(replicasPath, "."), ".")
 }
 
-// scaleFromCustomResource returns a scale subresource for a customresource and a bool signalling wether
+// scaleFromCustomResource returns a scale subresource for a customresource and a bool signalling whether
 // the specReplicas value was found.
 func scaleFromCustomResource(cr *unstructured.Unstructured, specReplicasPath, statusReplicasPath, labelSelectorPath string) (*autoscalingv1.Scale, bool, error) {
 	specReplicas, foundSpecReplicas, err := unstructured.NestedInt64(cr.UnstructuredContent(), splitReplicasPath(specReplicasPath)...)

--- a/test/e2e/framework/node/resource.go
+++ b/test/e2e/framework/node/resource.go
@@ -364,7 +364,7 @@ func GetReadyNodesIncludingTainted(ctx context.Context, c clientset.Interface) (
 }
 
 // isNodeUntainted tests whether a fake pod can be scheduled on "node", given its current taints.
-// TODO: need to discuss wether to return bool and error type
+// TODO: need to discuss whether to return bool and error type
 func isNodeUntainted(logger klog.Logger, node *v1.Node) bool {
 	return isNodeUntaintedWithNonblocking(logger, node, "")
 }

--- a/test/integration/scheduler/queueing/queue.go
+++ b/test/integration/scheduler/queueing/queue.go
@@ -111,12 +111,12 @@ type CoreResourceEnqueueTestCase struct {
 	// PrioritySort and DefaultPreemption are enabled by default because they are required by the framework.
 	// If empty, all plugins are enabled.
 	EnablePlugins []string
-	// EnabledRAExtendedResource indicates wether the test case should run with feature gate
+	// EnabledRAExtendedResource indicates whether the test case should run with feature gate
 	// DRAExtendedResource enabled or not.
 	EnableDRAExtendedResource bool
 	// EnableNodeDeclaredFeatures indicates if the test case runs with the NodeDeclaredFeatures feature gate enabled.
 	EnableNodeDeclaredFeatures bool
-	// EnableGangScheduling indicates wether the test case should run with feature gates
+	// EnableGangScheduling indicates whether the test case should run with feature gates
 	// GenericWorkload and GangScheduling enabled or not.
 	EnableGangScheduling bool
 }


### PR DESCRIPTION

**Repo:** kubernetes/kubernetes (⭐ 108000)
**Type:** docs
**Files changed:** 3
**Lines:** +4/-4

## What
Corrects three instances of the misspelling "wether" to "whether" in
code comments across the apiextensions-apiserver custom resource scale
helper, the scheduler queueing integration test definitions, and the
e2e node framework resource helpers.

## Why
"wether" (a castrated ram) is a real but unrelated word, so spell
checkers and linters often miss it. The comments are clearly meant to
say "whether". Cleaning these up improves readability for contributors
grepping through the source and avoids the same typo being copied into
new code.

## Testing
Comment-only changes; no behavior is affected. Verified with `git diff`
that only doc comments were touched and surrounding text still parses
as Go (godoc). No build or tests required.

## Risk
Low — comment-only changes, no runtime effect.
