### PR TITLE
Automated cherry pick of #138390: kubeadm: skip promote call when etcd member is already a voting member

### DIFF
--- a/cmd/kubeadm/app/util/etcd/etcd.go
+++ b/cmd/kubeadm/app/util/etcd/etcd.go
@@ -575,6 +575,8 @@ func (c *Client) getMemberStatus(memberID uint64) (isLearner bool, started bool,
 func (c *Client) MemberPromote(learnerID uint64) error {
 	var (
 		lastError     error
+		isLearner     bool
+		isStarted     bool
 		learnerIDUint = strconv.FormatUint(learnerID, 16)
 	)
 
@@ -582,7 +584,8 @@ func (c *Client) MemberPromote(learnerID uint64) error {
 
 	err := wait.PollUntilContextTimeout(context.Background(), constants.EtcdAPICallRetryInterval, kubeadmapi.GetActiveTimeouts().EtcdAPICall.Duration,
 		true, func(_ context.Context) (bool, error) {
-			isLearner, started, err := c.getMemberStatus(learnerID)
+			var err error
+			isLearner, isStarted, err = c.getMemberStatus(learnerID)
 			if err != nil {
 				lastError = errors.WithMessagef(err, "failed to get member %s status", learnerIDUint)
 				return false, nil
@@ -591,7 +594,7 @@ func (c *Client) MemberPromote(learnerID uint64) error {
 				klog.V(1).Infof("[etcd] Member %s was already promoted.", learnerIDUint)
 				return true, nil
 			}
-			if !started {
+			if !isStarted {
 				klog.V(1).Infof("[etcd] Member %s is not started yet. Waiting for it to be started.", learnerIDUint)
 				lastError = errors.Errorf("the etcd member %s is not started", learnerIDUint)
 				return false, nil
@@ -600,6 +603,10 @@ func (c *Client) MemberPromote(learnerID uint64) error {
 		})
 	if err != nil {
 		return lastError
+	}
+
+	if !isLearner {
+		return nil
 	}
 
 	klog.V(1).Infof("[etcd] Promoting a learner as a voting member: %s", learnerIDUint)


### PR DESCRIPTION
Cherry pick of #138390 on release-1.36.

#138390: kubeadm: skip promote call when etcd member is already a voting member

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubeadm: fix MemberPromote to skip the etcd promote API call when the member is already a voting member, avoiding unnecessary retries and timeout.
```