### PR TITLE
scheduler: decrement UnschedulableReason when deleting pod from activ…

### DIFF
--- a/pkg/scheduler/backend/queue/active_queue.go
+++ b/pkg/scheduler/backend/queue/active_queue.go
@@ -38,6 +38,10 @@ type activeQueuer interface {
 	underRLock(func(unlockedActiveQ unlockedActiveQueueReader))
 
 	delete(pInfo *framework.QueuedPodInfo) error
+	// deleteReturningStoredPodInfo removes the pod from activeQ if present and returns
+	// the stored *QueuedPodInfo (including UnschedulablePlugins). If the pod is not
+	// present, it returns an error.
+	deleteReturningStoredPodInfo(pInfoLookup *framework.QueuedPodInfo) (*framework.QueuedPodInfo, error)
 	pop(logger klog.Logger) (*framework.QueuedPodInfo, error)
 	list() []*v1.Pod
 	len() int
@@ -265,6 +269,22 @@ func (aq *activeQueue) delete(pInfo *framework.QueuedPodInfo) error {
 	defer aq.lock.Unlock()
 
 	return aq.queue.Delete(pInfo)
+}
+
+// deleteReturningStoredPodInfo deletes the pod from activeQ if present and returns
+// the stored QueuedPodInfo (including UnschedulablePlugins metadata used by metrics).
+func (aq *activeQueue) deleteReturningStoredPodInfo(pInfoLookup *framework.QueuedPodInfo) (*framework.QueuedPodInfo, error) {
+	aq.lock.Lock()
+	defer aq.lock.Unlock()
+
+	stored, ok := aq.unlockedQueue.get(pInfoLookup)
+	if !ok {
+		return nil, fmt.Errorf("object not found")
+	}
+	if err := aq.queue.Delete(pInfoLookup); err != nil {
+		return nil, err
+	}
+	return stored, nil
 }
 
 // movePodToInFlight moves the pod to the in-flight state.

--- a/pkg/scheduler/backend/queue/backoff_queue.go
+++ b/pkg/scheduler/backend/queue/backoff_queue.go
@@ -17,6 +17,7 @@ limitations under the License.
 package queue
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -67,6 +68,9 @@ type backoffQueuer interface {
 	// delete deletes the pInfo from backoffQueue.
 	// It returns true if the pod was deleted.
 	delete(pInfo *framework.QueuedPodInfo) bool
+	// deleteReturningStoredPodInfo deletes the pInfo from backoffQueue if present and
+	// returns the stored *QueuedPodInfo. If the pod is not present, it returns an error.
+	deleteReturningStoredPodInfo(pInfoLookup *framework.QueuedPodInfo) (*framework.QueuedPodInfo, error)
 	// get returns the pInfo matching given pInfoLookup, if exists.
 	get(pInfoLookup *framework.QueuedPodInfo) (*framework.QueuedPodInfo, bool)
 	// has inform if pInfo exists in the queue.
@@ -352,6 +356,27 @@ func (bq *backoffQueue) delete(pInfo *framework.QueuedPodInfo) bool {
 		return true
 	}
 	return bq.podErrorBackoffQ.Delete(pInfo) == nil
+}
+
+// deleteReturningStoredPodInfo deletes the pInfo from backoffQueue if present and returns
+// the stored QueuedPodInfo (including UnschedulablePlugins metadata used by metrics).
+func (bq *backoffQueue) deleteReturningStoredPodInfo(pInfoLookup *framework.QueuedPodInfo) (*framework.QueuedPodInfo, error) {
+	bq.lock.Lock()
+	defer bq.lock.Unlock()
+
+	if stored, ok := bq.podBackoffQ.Get(pInfoLookup); ok {
+		if err := bq.podBackoffQ.Delete(pInfoLookup); err != nil {
+			return nil, err
+		}
+		return stored, nil
+	}
+	if stored, ok := bq.podErrorBackoffQ.Get(pInfoLookup); ok {
+		if err := bq.podErrorBackoffQ.Delete(pInfoLookup); err != nil {
+			return nil, err
+		}
+		return stored, nil
+	}
+	return nil, fmt.Errorf("object not found")
 }
 
 // popBackoff pops the pInfo from the podBackoffQ.

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -1202,19 +1202,27 @@ func (p *PriorityQueue) Delete(pod *v1.Pod) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	p.DeleteNominatedPodIfExists(pod)
-	pInfo := newQueuedPodInfoForLookup(pod)
-	if err := p.activeQ.delete(pInfo); err == nil {
+	pInfoLookup := newQueuedPodInfoForLookup(pod)
+	if stored, err := p.activeQ.deleteReturningStoredPodInfo(pInfoLookup); err == nil {
+		decUnschedulablePluginMetrics(stored)
 		return
 	}
-	if deleted := p.backoffQ.delete(pInfo); deleted {
+	if stored, err := p.backoffQ.deleteReturningStoredPodInfo(pInfoLookup); err == nil {
+		decUnschedulablePluginMetrics(stored)
 		return
 	}
-	if pInfo = p.unschedulablePods.get(pod); pInfo != nil {
+	if pInfo := p.unschedulablePods.get(pod); pInfo != nil {
 		p.unschedulablePods.delete(pod, pInfo.Gated())
-		// Drop metric for deleted pod.
-		for plugin := range pInfo.UnschedulablePlugins.Union(pInfo.PendingPlugins) {
-			metrics.UnschedulableReason(plugin, pInfo.Pod.Spec.SchedulerName).Dec()
-		}
+		decUnschedulablePluginMetrics(pInfo)
+	}
+}
+
+// decUnschedulablePluginMetrics drops unschedulable_pods (UnschedulableReason) gauge
+// labels for the given pod info. Caller must ensure this pairs with prior Inc calls
+// for the same pod scheduling state.
+func decUnschedulablePluginMetrics(pInfo *framework.QueuedPodInfo) {
+	for plugin := range pInfo.UnschedulablePlugins.Union(pInfo.PendingPlugins) {
+		metrics.UnschedulableReason(plugin, pInfo.Pod.Spec.SchedulerName).Dec()
 	}
 }
 

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -1058,6 +1058,103 @@ func TestPriorityQueue_AddUnschedulableIfNotPresent_Backoff(t *testing.T) {
 	}
 }
 
+// TestPriorityQueue_Delete_DecUnschedulablePluginMetrics tests that deleting a pod
+// from activeQ or backoffQ after a failed scheduling attempt decrements
+// UnschedulableReason metrics (regression for #138444).
+func TestPriorityQueue_Delete_DecUnschedulablePluginMetrics(t *testing.T) {
+	pluginActive := "testUnschedulablePluginActive"
+	pluginBackoff := "testUnschedulablePluginBackoff"
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	t.Run("activeQ", func(t *testing.T) {
+		metrics.UnschedulableReason(pluginActive, "").Set(0)
+		c := testingclock.NewFakeClock(time.Now())
+		q := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(c))
+		unschedulablePod := st.MakePod().Name("test-pod-active").Namespace("ns1").UID("tp-active").Priority(highPriority).Obj()
+		podutil.UpdatePodCondition(&unschedulablePod.Status, &v1.PodCondition{
+			Type: v1.PodScheduled, Status: v1.ConditionFalse, Reason: v1.PodReasonUnschedulable,
+		})
+		q.Add(ctx, unschedulablePod)
+		if _, err := q.Pop(logger); err != nil {
+			t.Fatalf("Pop: %v", err)
+		}
+		if err := q.AddUnschedulableIfNotPresent(logger, newQueuedPodInfoForLookup(unschedulablePod, pluginActive), q.SchedulingCycle()); err != nil {
+			t.Fatalf("AddUnschedulableIfNotPresent: %v", err)
+		}
+		c.Step(DefaultPodInitialBackoffDuration + time.Second)
+		q.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+		if !q.activeQ.has(newQueuedPodInfoForLookup(unschedulablePod)) {
+			t.Fatal("expected pod in activeQ")
+		}
+		val, err := testutil.GetGaugeMetricValue(metrics.UnschedulableReason(pluginActive, ""))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if int(val) != 1 {
+			t.Fatalf("expected UnschedulableReason metric 1 before Delete, got %v", val)
+		}
+		q.Delete(unschedulablePod)
+		val, err = testutil.GetGaugeMetricValue(metrics.UnschedulableReason(pluginActive, ""))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if int(val) != 0 {
+			t.Fatalf("expected UnschedulableReason metric 0 after Delete, got %v", val)
+		}
+	})
+
+	t.Run("backoffQ", func(t *testing.T) {
+		metrics.UnschedulableReason(pluginBackoff, "").Set(0)
+		q := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(time.Now())))
+		totalNum := 3
+		expectedPods := make([]v1.Pod, 0, totalNum)
+		for i := 0; i < totalNum; i++ {
+			p := st.MakePod().Name(fmt.Sprintf("pod%d", i)).Namespace(fmt.Sprintf("ns%d", i)).UID(fmt.Sprintf("upns%d", i)).Priority(int32(i)).Obj()
+			expectedPods = append(expectedPods, *p)
+			q.Add(ctx, p)
+		}
+		for i := totalNum - 1; i > 0; i-- {
+			if _, err := q.Pop(logger); err != nil {
+				t.Fatalf("Pop: %v", err)
+			}
+		}
+		q.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+		oldCycle := q.SchedulingCycle()
+		if _, err := q.Pop(logger); err != nil {
+			t.Fatalf("Pop: %v", err)
+		}
+		unschedPod := expectedPods[1].DeepCopy()
+		unschedPod.Status = v1.PodStatus{
+			Conditions: []v1.PodCondition{{
+				Type: v1.PodScheduled, Status: v1.ConditionFalse, Reason: v1.PodReasonUnschedulable,
+			}},
+		}
+		if err := q.AddUnschedulableIfNotPresent(logger, newQueuedPodInfoForLookup(unschedPod, pluginBackoff), oldCycle); err != nil {
+			t.Fatalf("AddUnschedulableIfNotPresent: %v", err)
+		}
+		if !q.backoffQ.has(newQueuedPodInfoForLookup(unschedPod)) {
+			t.Fatal("expected pod in backoffQ")
+		}
+		val, err := testutil.GetGaugeMetricValue(metrics.UnschedulableReason(pluginBackoff, ""))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if int(val) != 1 {
+			t.Fatalf("expected UnschedulableReason metric 1 before Delete, got %v", val)
+		}
+		q.Delete(unschedPod)
+		val, err = testutil.GetGaugeMetricValue(metrics.UnschedulableReason(pluginBackoff, ""))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if int(val) != 0 {
+			t.Fatalf("expected UnschedulableReason metric 0 after Delete, got %v", val)
+		}
+	})
+}
+
 // tryPop tries to pop one pod from the queue and returns it.
 // It waits 5 seconds before timing out, assuming the queue is then empty.
 func tryPop(t *testing.T, logger klog.Logger, q *PriorityQueue) *framework.QueuedPodInfo {


### PR DESCRIPTION
#### What this PR does

UnschedulableReason metrics are incremented when a failed scheduling attempt re-queues a pod with recorded unschedulable/pending plugins. They are decremented on the next successful `Pop`, or when the pod is deleted from unschedulablePods.

PriorityQueue.Delete also removes pods from activeQ and backoffQ, but previously returned without decrementing those metrics. If a pod was re-queued to activeQ / backoffQ (still carrying the plugin set from the last failure) and deleted before the next `Pop`, the gauges leaked.

This PR deletes from activeQ / backoffQ using an atomic get of the stored QueuedPodInfo plus removal, then applies the same decrement loop as the unschedulablePods delete path. The stored QueuedPodInfo is needed so decrements match prior increments (plugins and SchedulerName). A single inner queue lock avoids racing between lookup and removal.

#### Which issue(s) this PR is related to

Fixes #138444

#### Notes

- Regression test: TestPriorityQueue_Delete_DecUnschedulablePluginMetrics (activeQ and backoffQ).
- If another PR already fixes the same leak (e.g. #138482), happy to narrow this after review.

#### Does this PR introduce a user-facing change?

Fixed a scheduler metrics issuewhere`UnschedulableReason could remain elevated after deleting a pod that was waiting in the active or backoff queue following a failed scheduling attempt.