### PR TITLE
scheduler: drop terminating assumed pods from PodGroupState on forget

### DIFF
--- a/pkg/scheduler/backend/cache/podgroupstate.go
+++ b/pkg/scheduler/backend/cache/podgroupstate.go
@@ -143,12 +143,19 @@ func (d *podGroupStateData) assumePod(pod *v1.Pod) {
 }
 
 // forgetPod moves a pod back from the assumed state to unscheduled within the pod group state.
+// If the pod is terminating (deletion timestamp set), it is removed from the group entirely so it
+// cannot remain stuck in unscheduledPods after the scheduler cache drops the assumed pod.
 func (d *podGroupStateData) forgetPod(podUID types.UID) {
 
 	pod := d.allPods[podUID]
 	// A scheduling pod may be removed from the cluster.
 	// In that case, we just ignore it.
 	if pod == nil {
+		return
+	}
+
+	if pod.DeletionTimestamp != nil {
+		d.deletePod(podUID)
 		return
 	}
 

--- a/pkg/scheduler/backend/cache/podgroupstate_test.go
+++ b/pkg/scheduler/backend/cache/podgroupstate_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 )
 
@@ -50,6 +51,32 @@ func TestPodGroupState_AssumeForget(t *testing.T) {
 	}
 	if !pgs.unscheduledPods.Has(pod.UID) {
 		t.Fatal("Pod should be in UnscheduledPods after ForgetPod")
+	}
+}
+
+// TestPodGroupState_ForgetPod_DeletionTimestamp verifies that forgetting an assumed pod which
+// is already terminating removes it from pod group tracking (regression for #138422).
+func TestPodGroupState_ForgetPod_DeletionTimestamp(t *testing.T) {
+	pgs := newPodGroupState()
+	pod := st.MakePod().Namespace("ns1").Name("p1").UID("p1").PodGroupName("pg1").Obj()
+	podTerminating := pod.DeepCopy()
+	now := metav1.Now()
+	podTerminating.DeletionTimestamp = &now
+
+	pgs.addPod(pod)
+	pgs.assumePod(pod)
+	pgs.updatePod(pod, podTerminating)
+
+	pgs.forgetPod(pod.UID)
+
+	if pgs.AllPods().Has(pod.UID) {
+		t.Fatal("terminating pod should be removed from pod group on forget")
+	}
+	if pgs.unscheduledPods.Has(pod.UID) {
+		t.Fatal("terminating pod must not remain in unscheduledPods")
+	}
+	if pgs.AssignedPods().Has(pod.UID) {
+		t.Fatal("terminating pod must not be moved to assignedPods on forget")
 	}
 }
 


### PR DESCRIPTION
When ForgetPod runs for an assumed pod that already has a deletion timestamp, podGroupState.forgetPod previously re-inserted the UID into unscheduledPods or assignedPods. Remove the pod from pod group tracking instead.

