### PR TITLE
cleanup: use constants for controller names in kube-controller-manager

### DIFF
--- a/cmd/kube-controller-manager/app/apps.go
+++ b/cmd/kube-controller-manager/app/apps.go
@@ -73,7 +73,7 @@ func newStatefulSetControllerDescriptor() *ControllerDescriptor {
 }
 
 func newStatefulSetController(ctx context.Context, controllerContext ControllerContext, controllerName string) (Controller, error) {
-	client, err := controllerContext.NewClient("statefulset-controller")
+	client, err := controllerContext.NewClient(names.StatefulSetController)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ func newReplicaSetControllerDescriptor() *ControllerDescriptor {
 }
 
 func newReplicaSetController(ctx context.Context, controllerContext ControllerContext, controllerName string) (Controller, error) {
-	client, err := controllerContext.NewClient("replicaset-controller")
+	client, err := controllerContext.NewClient(names.ReplicaSetController)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func newDeploymentControllerDescriptor() *ControllerDescriptor {
 }
 
 func newDeploymentController(ctx context.Context, controllerContext ControllerContext, controllerName string) (Controller, error) {
-	client, err := controllerContext.NewClient("deployment-controller")
+	client, err := controllerContext.NewClient(names.DeploymentController)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kube-controller-manager/app/batch.go
+++ b/cmd/kube-controller-manager/app/batch.go
@@ -41,7 +41,7 @@ func newJobControllerDescriptor() *ControllerDescriptor {
 }
 
 func newJobController(ctx context.Context, controllerContext ControllerContext, controllerName string) (Controller, error) {
-	client, err := controllerContext.NewClient("job-controller")
+	client, err := controllerContext.NewClient(names.JobController)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func newCronJobControllerDescriptor() *ControllerDescriptor {
 }
 
 func newCronJobController(ctx context.Context, controllerContext ControllerContext, controllerName string) (Controller, error) {
-	client, err := controllerContext.NewClient("cronjob-controller")
+	client, err := controllerContext.NewClient(names.CronJobController)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -403,7 +403,7 @@ func newEphemeralVolumeControllerDescriptor() *ControllerDescriptor {
 }
 
 func newEphemeralVolumeController(ctx context.Context, controllerContext ControllerContext, controllerName string) (Controller, error) {
-	client, err := controllerContext.NewClient("ephemeral-volume-controller")
+	client, err := controllerContext.NewClient(names.EphemeralVolumeController)
 	if err != nil {
 		return nil, err
 	}
@@ -509,12 +509,12 @@ func newResourceQuotaControllerDescriptor() *ControllerDescriptor {
 }
 
 func newResourceQuotaController(ctx context.Context, controllerContext ControllerContext, controllerName string) (Controller, error) {
-	resourceQuotaControllerClient, err := controllerContext.NewClient("resourcequota-controller")
+	resourceQuotaControllerClient, err := controllerContext.NewClient(names.ResourceQuotaController)
 	if err != nil {
 		return nil, err
 	}
 
-	resourceQuotaControllerDiscoveryClient, err := controllerContext.ClientBuilder.DiscoveryClient("resourcequota-controller")
+	resourceQuotaControllerDiscoveryClient, err := controllerContext.ClientBuilder.DiscoveryClient(names.ResourceQuotaController)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the discovery client: %w", err)
 	}
@@ -565,7 +565,7 @@ func newNamespaceController(ctx context.Context, controllerContext ControllerCon
 	// the namespace cleanup controller is very chatty.  It makes lots of discovery calls and then it makes lots of delete calls
 	// the ratelimiter negatively affects its speed.  Deleting 100 total items in a namespace (that's only a few of each resource
 	// including events), takes ~10 seconds by default.
-	nsKubeconfig, err := controllerContext.NewClientConfig("namespace-controller")
+	nsKubeconfig, err := controllerContext.NewClientConfig(names.NamespaceController)
 	if err != nil {
 		return nil, err
 	}
@@ -646,7 +646,7 @@ func newTTLControllerDescriptor() *ControllerDescriptor {
 }
 
 func newTTLController(ctx context.Context, controllerContext ControllerContext, controllerName string) (Controller, error) {
-	client, err := controllerContext.NewClient("ttl-controller")
+	client, err := controllerContext.NewClient(names.TTLController)
 	if err != nil {
 		return nil, err
 	}
@@ -810,7 +810,7 @@ func newVolumeAttributesClassProtectionControllerDescriptor() *ControllerDescrip
 }
 
 func newVolumeAttributesClassProtectionController(ctx context.Context, controllerContext ControllerContext, controllerName string) (Controller, error) {
-	client, err := controllerContext.NewClient("volumeattributesclass-protection-controller")
+	client, err := controllerContext.NewClient(names.VolumeAttributesClassProtectionController)
 	if err != nil {
 		return nil, err
 	}
@@ -840,7 +840,7 @@ func newTTLAfterFinishedControllerDescriptor() *ControllerDescriptor {
 }
 
 func newTTLAfterFinishedController(ctx context.Context, controllerContext ControllerContext, controllerName string) (Controller, error) {
-	client, err := controllerContext.NewClient("ttl-after-finished-controller")
+	client, err := controllerContext.NewClient(names.TTLAfterFinishedController)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kube-controller-manager/app/core_test.go
+++ b/cmd/kube-controller-manager/app/core_test.go
@@ -156,7 +156,7 @@ func TestController_DiscoveryError(t *testing.T) {
 
 			namespaceController, err := newModifiedNamespaceController(
 				ctx, controllerContext, names.NamespaceController,
-				testClientset, testClientBuilder.ConfigOrDie("namespace-controller"))
+				testClientset, testClientBuilder.ConfigOrDie(names.NamespaceController))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/kube-controller-manager/app/discovery.go
+++ b/cmd/kube-controller-manager/app/discovery.go
@@ -36,7 +36,7 @@ func newEndpointSliceControllerDescriptor() *ControllerDescriptor {
 }
 
 func newEndpointSliceController(ctx context.Context, controllerContext ControllerContext, controllerName string) (Controller, error) {
-	client, err := controllerContext.NewClient("endpointslice-controller")
+	client, err := controllerContext.NewClient(names.EndpointSliceController)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kube-controller-manager/app/policy.go
+++ b/cmd/kube-controller-manager/app/policy.go
@@ -36,12 +36,12 @@ func newDisruptionControllerDescriptor() *ControllerDescriptor {
 }
 
 func newDisruptionController(ctx context.Context, controllerContext ControllerContext, controllerName string) (Controller, error) {
-	client, err := controllerContext.NewClient("disruption-controller")
+	client, err := controllerContext.NewClient(names.DisruptionController)
 	if err != nil {
 		return nil, err
 	}
 
-	config, err := controllerContext.NewClientConfig("disruption-controller")
+	config, err := controllerContext.NewClientConfig(names.DisruptionController)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kube-controller-manager/app/rbac.go
+++ b/cmd/kube-controller-manager/app/rbac.go
@@ -32,7 +32,7 @@ func newClusterRoleAggregrationControllerDescriptor() *ControllerDescriptor {
 }
 
 func newClusterRoleAggregationController(ctx context.Context, controllerContext ControllerContext, controllerName string) (Controller, error) {
-	client, err := controllerContext.NewClient("clusterrole-aggregation-controller")
+	client, err := controllerContext.NewClient(names.ClusterRoleAggregationController)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kube-controller-manager/app/resource.go
+++ b/cmd/kube-controller-manager/app/resource.go
@@ -115,7 +115,7 @@ func newResourcePoolStatusRequestControllerDescriptor() *ControllerDescriptor {
 }
 
 func newResourcePoolStatusRequestController(ctx context.Context, controllerContext ControllerContext, controllerName string) (Controller, error) {
-	client, err := controllerContext.NewClient("resourcepoolstatusrequest-controller")
+	client, err := controllerContext.NewClient(names.ResourcePoolStatusRequestController)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR replaces hardcoded strings with constants from the names package in `kube-controller-manager`. 
Specifically, it updates the NewClient, NewClientConfig, and DiscoveryClient calls in the controller initialization logic.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

Refactor was done selectively, only controllers where the names constant value exactly matches the existing hardcoded string were updated.
Controllers with legacy naming inconsistencies (where the constant differs from the historical string identity) were purposely left untouched

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
