### PR TITLE
Fix HPA tolerance drift during rolling updates

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -564,7 +564,7 @@ func (a *HorizontalController) computeStatusForObjectMetric(specReplicas, status
 		*status = metricStatus
 		return replicaCountProposal, timestampProposal, fmt.Sprintf("%s metric %s", metricSpec.Object.DescribedObject.Kind, metricSpec.Object.Metric.Name), autoscalingv2.HorizontalPodAutoscalerCondition{}, nil
 	} else if metricSpec.Object.Target.Type == autoscalingv2.AverageValueMetricType && metricSpec.Object.Target.AverageValue != nil {
-		replicaCountProposal, usageProposal, timestampProposal, err := a.replicaCalc.GetObjectPerPodMetricReplicas(statusReplicas, metricSpec.Object.Target.AverageValue.MilliValue(), metricSpec.Object.Metric.Name, tolerances, hpa.Namespace, &metricSpec.Object.DescribedObject, metricSelector)
+		replicaCountProposal, usageProposal, timestampProposal, err := a.replicaCalc.GetObjectPerPodMetricReplicas(statusReplicas, specReplicas, metricSpec.Object.Target.AverageValue.MilliValue(), metricSpec.Object.Metric.Name, tolerances, hpa.Namespace, &metricSpec.Object.DescribedObject, metricSelector)
 		if err != nil {
 			condition := a.getUnableComputeReplicaCountCondition(hpa, "FailedGetObjectMetric", err)
 			return 0, time.Time{}, "", condition, fmt.Errorf("failed to get %s object metric: %v", metricSpec.Object.Metric.Name, err)
@@ -703,7 +703,7 @@ func (a *HorizontalController) computeStatusForContainerResourceMetric(ctx conte
 func (a *HorizontalController) computeStatusForExternalMetric(specReplicas, statusReplicas int32, metricSpec autoscalingv2.MetricSpec, hpa *autoscalingv2.HorizontalPodAutoscaler, selector labels.Selector, status *autoscalingv2.MetricStatus) (replicaCountProposal int32, timestampProposal time.Time, metricNameProposal string, condition autoscalingv2.HorizontalPodAutoscalerCondition, err error) {
 	tolerances := a.tolerancesForHpa(hpa)
 	if metricSpec.External.Target.AverageValue != nil {
-		replicaCountProposal, usageProposal, timestampProposal, err := a.replicaCalc.GetExternalPerPodMetricReplicas(statusReplicas, metricSpec.External.Target.AverageValue.MilliValue(), metricSpec.External.Metric.Name, tolerances, hpa.Namespace, metricSpec.External.Metric.Selector)
+		replicaCountProposal, usageProposal, timestampProposal, err := a.replicaCalc.GetExternalPerPodMetricReplicas(statusReplicas, specReplicas, metricSpec.External.Target.AverageValue.MilliValue(), metricSpec.External.Metric.Name, tolerances, hpa.Namespace, metricSpec.External.Metric.Selector)
 		if err != nil {
 			condition = a.getUnableComputeReplicaCountCondition(hpa, "FailedGetExternalMetric", err)
 			return 0, time.Time{}, "", condition, fmt.Errorf("failed to get %s external metric: %v", metricSpec.External.Metric.Name, err)

--- a/pkg/controller/podautoscaler/replica_calculator.go
+++ b/pkg/controller/podautoscaler/replica_calculator.go
@@ -307,17 +307,19 @@ func (c *ReplicaCalculator) getUsageRatioReplicaCount(currentReplicas int32, usa
 }
 
 // GetObjectPerPodMetricReplicas calculates the desired replica count based on a target metric usage (as a milli-value)
-// for the given object in the given namespace, and the current replica count.
-func (c *ReplicaCalculator) GetObjectPerPodMetricReplicas(statusReplicas int32, targetAverageUsage int64, metricName string, tolerances Tolerances, namespace string, objectRef *autoscaling.CrossVersionObjectReference, metricSelector labels.Selector) (replicaCount int32, usage int64, timestamp time.Time, err error) {
+// for the given object in the given namespace. statusReplicas divides the usage ratio so it reflects actual load
+// distribution; specReplicas is returned when within tolerance so transient surges (e.g. rolling updates where
+// status > spec) do not drift spec upward.
+func (c *ReplicaCalculator) GetObjectPerPodMetricReplicas(statusReplicas, specReplicas int32, targetAverageUsage int64, metricName string, tolerances Tolerances, namespace string, objectRef *autoscaling.CrossVersionObjectReference, metricSelector labels.Selector) (replicaCount int32, usage int64, timestamp time.Time, err error) {
 	usage, timestamp, err = c.metricsClient.GetObjectMetric(metricName, namespace, objectRef, metricSelector)
 	if err != nil {
 		return 0, 0, time.Time{}, fmt.Errorf("unable to get metric %s: %v on %s %s/%s", metricName, objectRef.Kind, namespace, objectRef.Name, err)
 	}
 
-	replicaCount = statusReplicas
-	usageRatio := float64(usage) / (float64(targetAverageUsage) * float64(replicaCount))
-	if !tolerances.isWithin(usageRatio) {
-		// update number of replicas if change is large enough
+	usageRatio := float64(usage) / (float64(targetAverageUsage) * float64(statusReplicas))
+	if tolerances.isWithin(usageRatio) {
+		replicaCount = specReplicas
+	} else {
 		replicaCount = int32(math.Ceil(float64(usage) / float64(targetAverageUsage)))
 	}
 	usage = int64(math.Ceil(float64(usage) / float64(statusReplicas)))
@@ -376,10 +378,11 @@ func (c *ReplicaCalculator) GetExternalMetricReplicas(currentReplicas int32, tar
 	return replicaCount, usage, timestamp, err
 }
 
-// GetExternalPerPodMetricReplicas calculates the desired replica count based on a
-// target metric value per pod (as a milli-value) for the external metric in the
-// given namespace, and the current replica count.
-func (c *ReplicaCalculator) GetExternalPerPodMetricReplicas(statusReplicas int32, targetUsagePerPod int64, metricName string, tolerances Tolerances, namespace string, metricSelector *metav1.LabelSelector) (replicaCount int32, usage int64, timestamp time.Time, err error) {
+// GetExternalPerPodMetricReplicas calculates the desired replica count based on a target metric value per pod
+// (as a milli-value) for the external metric in the given namespace. statusReplicas divides the usage ratio so
+// it reflects actual load distribution; specReplicas is returned when within tolerance so transient surges
+// (e.g. rolling updates where status > spec) do not drift spec upward.
+func (c *ReplicaCalculator) GetExternalPerPodMetricReplicas(statusReplicas, specReplicas int32, targetUsagePerPod int64, metricName string, tolerances Tolerances, namespace string, metricSelector *metav1.LabelSelector) (replicaCount int32, usage int64, timestamp time.Time, err error) {
 	metricLabelSelector, err := metav1.LabelSelectorAsSelector(metricSelector)
 	if err != nil {
 		return 0, 0, time.Time{}, err
@@ -398,10 +401,10 @@ func (c *ReplicaCalculator) GetExternalPerPodMetricReplicas(statusReplicas int32
 		}
 	}
 
-	replicaCount = statusReplicas
-	usageRatio := float64(usage) / (float64(targetUsagePerPod) * float64(replicaCount))
-	if !tolerances.isWithin(usageRatio) {
-		// update number of replicas if the change is large enough
+	usageRatio := float64(usage) / (float64(targetUsagePerPod) * float64(statusReplicas))
+	if tolerances.isWithin(usageRatio) {
+		replicaCount = specReplicas
+	} else {
 		replicaCountResult := math.Ceil(float64(usage) / float64(targetUsagePerPod))
 		// Ensure that the result exceeds the bounds of an int32
 		if replicaCountResult > float64(math.MaxInt32) {

--- a/pkg/controller/podautoscaler/replica_calculator_test.go
+++ b/pkg/controller/podautoscaler/replica_calculator_test.go
@@ -88,7 +88,12 @@ type metricInfo struct {
 }
 
 type replicaCalcTestCase struct {
-	currentReplicas  int32
+	currentReplicas int32
+	// specReplicas overrides the spec.replicas value passed to PerPod metric
+	// calculators. When zero, currentReplicas is used for both status and spec
+	// (the steady-state assumption). Set this to exercise rolling-update
+	// scenarios where status.replicas temporarily differs from spec.replicas.
+	specReplicas     int32
 	expectedReplicas int32
 	expectedError    error
 
@@ -375,6 +380,12 @@ func (tc *replicaCalcTestCase) runTest(t *testing.T) {
 		tolerances = *tc.tolerances
 	}
 
+	// Default specReplicas to currentReplicas (steady state) unless explicitly set.
+	specReplicas := tc.specReplicas
+	if specReplicas == 0 {
+		specReplicas = tc.currentReplicas
+	}
+
 	if tc.resource != nil {
 		outReplicas, outUtilization, outRawValue, outTimestamp, err := replicaCalc.GetResourceReplicas(tCtx, tc.currentReplicas, tc.resource.targetUtilization, tc.resource.name, tolerances, testNamespace, selector, tc.container)
 
@@ -404,7 +415,7 @@ func (tc *replicaCalcTestCase) runTest(t *testing.T) {
 		if tc.metric.singleObject == nil {
 			t.Fatal("Metric specified as objectMetric but metric.singleObject is nil.")
 		}
-		outReplicas, outUsage, outTimestamp, err = replicaCalc.GetObjectPerPodMetricReplicas(tc.currentReplicas, tc.metric.perPodTargetUsage, tc.metric.name, tolerances, testNamespace, tc.metric.singleObject, nil)
+		outReplicas, outUsage, outTimestamp, err = replicaCalc.GetObjectPerPodMetricReplicas(tc.currentReplicas, specReplicas, tc.metric.perPodTargetUsage, tc.metric.name, tolerances, testNamespace, tc.metric.singleObject, nil)
 	case externalMetric:
 		if tc.metric.selector == nil {
 			t.Fatal("Metric specified as externalMetric but metric.selector is nil.")
@@ -421,7 +432,7 @@ func (tc *replicaCalcTestCase) runTest(t *testing.T) {
 			t.Fatalf("Metric specified as externalPerPodMetric but metric.perPodTargetUsage is %d which is <=0.", tc.metric.perPodTargetUsage)
 		}
 
-		outReplicas, outUsage, outTimestamp, err = replicaCalc.GetExternalPerPodMetricReplicas(tc.currentReplicas, tc.metric.perPodTargetUsage, tc.metric.name, tolerances, testNamespace, tc.metric.selector)
+		outReplicas, outUsage, outTimestamp, err = replicaCalc.GetExternalPerPodMetricReplicas(tc.currentReplicas, specReplicas, tc.metric.perPodTargetUsage, tc.metric.name, tolerances, testNamespace, tc.metric.selector)
 	case podMetric:
 		outReplicas, outUsage, outTimestamp, err = replicaCalc.GetMetricReplicas(tc.currentReplicas, tc.metric.targetUsage, tc.metric.name, tolerances, testNamespace, selector, nil)
 	default:
@@ -619,6 +630,88 @@ func TestExternalPerPodMetricUsageOverflow(t *testing.T) {
 			metricType:        externalPerPodMetric,
 			expectedUsage:     math.MaxInt64,
 			selector:          &metav1.LabelSelector{MatchLabels: map[string]string{"label": "value"}},
+		},
+	}
+	tc.runTest(t)
+}
+
+// During a rolling update, status.replicas can exceed spec.replicas due to maxSurge.
+// With per-pod external metric usage within tolerance, the calculator must return
+// spec.replicas, not status.replicas, to avoid drifting spec upward.
+func TestReplicaCalcExternalPerPodMetricWithinToleranceSurgeReturnsSpec(t *testing.T) {
+	tc := replicaCalcTestCase{
+		currentReplicas:  23, // status.replicas during surge
+		specReplicas:     22, // spec.replicas
+		expectedReplicas: 22,
+		metric: &metricInfo{
+			name:              "qps",
+			levels:            []int64{5500, 5500, 5500, 5500, 5500, 5500, 5500, 5500, 5500, 5500, 5500, 5500, 5500, 5500, 5500, 5500, 5500, 5500, 5500, 5500, 5500, 5500, 5500},
+			perPodTargetUsage: 5000,
+			metricType:        externalPerPodMetric,
+			expectedUsage:     5500,
+			selector:          &metav1.LabelSelector{MatchLabels: map[string]string{"label": "value"}},
+		},
+	}
+	tc.runTest(t)
+}
+
+// Symmetric case: status.replicas < spec.replicas while pods are still starting.
+// Within tolerance should preserve spec, not drift it downward.
+func TestReplicaCalcExternalPerPodMetricWithinToleranceStartupReturnsSpec(t *testing.T) {
+	tc := replicaCalcTestCase{
+		currentReplicas:  9, // status.replicas while pods still starting
+		specReplicas:     10,
+		expectedReplicas: 10,
+		metric: &metricInfo{
+			name:              "qps",
+			levels:            []int64{4500, 4500, 4500, 4500, 4500, 4500, 4500, 4500, 4500},
+			perPodTargetUsage: 5000,
+			metricType:        externalPerPodMetric,
+			expectedUsage:     4500,
+			selector:          &metav1.LabelSelector{MatchLabels: map[string]string{"label": "value"}},
+		},
+	}
+	tc.runTest(t)
+}
+
+// Same regression check for object per-pod metrics.
+func TestReplicaCalcObjectPerPodMetricWithinToleranceSurgeReturnsSpec(t *testing.T) {
+	tc := replicaCalcTestCase{
+		currentReplicas:  23,
+		specReplicas:     22,
+		expectedReplicas: 22,
+		metric: &metricInfo{
+			metricType:        objectPerPodMetric,
+			name:              "qps",
+			levels:            []int64{110000},
+			perPodTargetUsage: 5000,
+			expectedUsage:     4783,
+			singleObject: &autoscalingv2.CrossVersionObjectReference{
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+				Name:       "some-deployment",
+			},
+		},
+	}
+	tc.runTest(t)
+}
+
+func TestReplicaCalcObjectPerPodMetricWithinToleranceStartupReturnsSpec(t *testing.T) {
+	tc := replicaCalcTestCase{
+		currentReplicas:  9,
+		specReplicas:     10,
+		expectedReplicas: 10,
+		metric: &metricInfo{
+			metricType:        objectPerPodMetric,
+			name:              "qps",
+			levels:            []int64{45000},
+			perPodTargetUsage: 5000,
+			expectedUsage:     5000,
+			singleObject: &autoscalingv2.CrossVersionObjectReference{
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+				Name:       "some-deployment",
+			},
 		},
 	}
 	tc.runTest(t)

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling_external_metrics.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling_external_metrics.go
@@ -26,6 +26,7 @@ import (
 	v2 "k8s.io/api/autoscaling/v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -83,6 +84,95 @@ var _ = SIGDescribe(feature.HPA, "Horizontal pod autoscaling (external metrics)"
 
 		ginkgo.By("Waiting for HPA to scale down to min replicas")
 		rc.WaitForReplicas(ctx, int(*hpa.Spec.MinReplicas), maxResourceConsumerDelay+waitBuffer)
+	})
+
+	// Regression coverage for the per-pod metric tolerance path. During a rolling
+	// update, status.replicas transiently exceeds spec.replicas by maxSurge. If the
+	// per-pod metric aggregate scales with pod count (so the usage ratio stays within
+	// tolerance at the surged replica count), the HPA must leave spec.replicas alone
+	// instead of latching it to status.replicas.
+	ginkgo.It("should not drift spec.replicas during a rolling update when a per-pod external metric stays within tolerance", func(ctx context.Context) {
+		initPods := 3
+		perPodTarget := int64(100)
+		steadyMetricValue := int64(initPods) * perPodTarget       // ratio 1.0 at initPods pods
+		surgedMetricValue := (int64(initPods) + 1) * perPodTarget // ratio 1.0 while status.replicas = initPods+1
+
+		ginkgo.By("Creating the resource consumer deployment")
+		rc = e2eautoscaling.NewDynamicResourceConsumer(ctx,
+			hpaName, f.Namespace.Name, e2eautoscaling.KindDeployment, initPods,
+			0, 0, 0,
+			int64(podCPURequest), 200,
+			f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle,
+			nil)
+		ginkgo.DeferCleanup(rc.CleanUp)
+		rc.WaitForReplicas(ctx, initPods, maxResourceConsumerDelay+waitBuffer)
+
+		deployments := f.ClientSet.AppsV1().Deployments(f.Namespace.Name)
+
+		// minReadySeconds holds the surge pod "unavailable" long enough to span
+		// several HPA reconciles, so a buggy controller has multiple chances to
+		// latch spec.replicas to status.replicas.
+		ginkgo.By("Configuring the deployment for a prolonged surge (maxSurge=1, maxUnavailable=0, minReadySeconds=60s)")
+		_, err := deployments.Patch(ctx, hpaName, types.StrategicMergePatchType,
+			[]byte(`{"spec":{"minReadySeconds":60,"strategy":{"type":"RollingUpdate","rollingUpdate":{"maxSurge":1,"maxUnavailable":0}}}}`),
+			metav1.PatchOptions{})
+		framework.ExpectNoError(err)
+
+		metricName := "per_pod_tolerance_drift"
+		ginkgo.By(fmt.Sprintf("Creating external metric %q at %d (= %d replicas * %d target)", metricName, steadyMetricValue, initPods, perPodTarget))
+		framework.ExpectNoError(metricsController.CreateMetric(ctx, metricName, steadyMetricValue, nil, false))
+
+		ginkgo.By(fmt.Sprintf("Creating a per-pod external-metric HPA (AverageValue target=%d, min=%d, max=10)", perPodTarget, initPods))
+		hpa := e2eautoscaling.CreateExternalHorizontalPodAutoscaler(ctx, rc, metricName, nil,
+			v2.AverageValueMetricType, perPodTarget, int32(initPods), 10)
+		ginkgo.DeferCleanup(e2eautoscaling.DeleteHorizontalPodAutoscaler, rc, hpa.Name)
+
+		expectSpecReplicasStable := func(duration time.Duration) {
+			stableErr := framework.Gomega().Consistently(ctx, func(ctx context.Context) (int32, error) {
+				d, err := deployments.Get(ctx, hpaName, metav1.GetOptions{})
+				if err != nil {
+					return 0, err
+				}
+				if d.Spec.Replicas == nil {
+					return 0, fmt.Errorf("deployment %s has nil spec.replicas", d.Name)
+				}
+				return *d.Spec.Replicas, nil
+			}).WithTimeout(duration).WithPolling(10 * time.Second).Should(gomega.Equal(int32(initPods)))
+			framework.ExpectNoErrorWithOffset(1, stableErr, "deployment spec.replicas drifted from %d within %v", initPods, duration)
+		}
+
+		ginkgo.By("Letting the HPA stabilize at the initial replicas with the within-tolerance metric")
+		expectSpecReplicasStable(maxHPAReactionTime + maxResourceConsumerDelay)
+
+		ginkgo.By("Triggering a rolling update by annotating the pod template")
+		_, err = deployments.Patch(ctx, hpaName, types.StrategicMergePatchType,
+			[]byte(`{"spec":{"template":{"metadata":{"annotations":{"e2e.hpa-drift/rollout":"1"}}}}}`),
+			metav1.PatchOptions{})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Waiting for a surge pod to appear (deployment status.replicas > spec.replicas)")
+		surgeErr := framework.Gomega().Eventually(ctx, func(ctx context.Context) error {
+			d, err := deployments.Get(ctx, hpaName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if d.Spec.Replicas == nil {
+				return fmt.Errorf("deployment %s has nil spec.replicas", d.Name)
+			}
+			if d.Status.Replicas <= *d.Spec.Replicas {
+				return fmt.Errorf("no surge yet: status=%d spec=%d", d.Status.Replicas, *d.Spec.Replicas)
+			}
+			return nil
+		}).WithTimeout(60 * time.Second).WithPolling(2 * time.Second).Should(gomega.Succeed())
+		framework.ExpectNoError(surgeErr)
+
+		ginkgo.By(fmt.Sprintf("Raising the external metric to %d so the HPA observes within-tolerance while status.replicas > spec.replicas", surgedMetricValue))
+		framework.ExpectNoError(metricsController.SetMetricValue(ctx, metricName, surgedMetricValue, nil))
+
+		// Cover at least four HPA reconciles (~15s each) while status.replicas > spec.replicas.
+		// Without the fix, the very first reconcile in this window latches spec.replicas to status.replicas.
+		ginkgo.By("Asserting spec.replicas does not drift upward across HPA reconciles during the surge")
+		expectSpecReplicasStable(hpaReconciliationInterval*4 + actuationDelay)
 	})
 })
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig autoscaling

#### What this PR does / why we need it?

**Symptom.** During a rolling update with `maxSurge > 0`, an HPA using a per-pod object or external metric silently drifts `spec.replicas` upward — even when the metric is steady and within the tolerance band. Each reconcile bumps the value by the surge delta, compounding until `maxReplicas`.

**Root cause.** `GetObjectPerPodMetricReplicas` / `GetExternalPerPodMetricReplicas` returned `statusReplicas` when the usage ratio was within tolerance. During surge `statusReplicas > specReplicas`, so the "no change" branch becomes an unintended scale-up.

**Fix.** Return `specReplicas` when within tolerance. `statusReplicas` stays as the divisor of the usage ratio so load distribution is still computed against pods that actually exist. Behavior outside the tolerance band is unchanged.

**Scope.** PerPod variants only. The `Value`-type variants likely share the pattern but lack a clean reproduction; deferred to a follow-up.

#### Which issue(s) this PR is related to?

Fixes #138505

#### Special notes for your reviewer

- Signature change on two functions: both gain a `specReplicas int32` parameter. Only two call sites, both in `horizontal.go` where `specReplicas` is already in scope.
- Four regression tests cover both drift directions (`status > spec` surge, `status < spec` startup) × both metric types.
- Test harness gains an optional `specReplicas` field defaulting to `currentReplicas`, so every existing test case is byte-identical in behavior.
- Full `./pkg/controller/podautoscaler/...` suite passes; `gofmt` and `go vet` clean.

#### Does this PR introduce a user-facing change?

```release-note
Fixed HPA drifting `spec.replicas` upward during rolling updates for per-pod object and external metrics.
```