### PR TITLE
[Quantity] Fix scaledValue to round negative Quantity values away from zero

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_overflow_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_overflow_test.go
@@ -137,8 +137,8 @@ func quantityAccessorCases() []accessorCase {
 			wantSign:  -1,
 			wantValue: -math.MaxInt64,
 			wantMilli: 1000, milliTODO: saturateNeg,
-			wantScaledKilo: -9223372036854774, scaledTODO: "want -9223372036854776 once negatives round away from zero (#138510)",
-			wantAsInt64: 0, wantAsInt64OK: false,
+			wantScaledKilo: -9223372036854776,
+			wantAsInt64:    0, wantAsInt64OK: false,
 			wantFloat:  -9.223372036854776e+18,
 			wantString: "-9223372036854775807",
 		},
@@ -158,8 +158,8 @@ func quantityAccessorCases() []accessorCase {
 			wantSign:  -1,
 			wantValue: -math.MaxInt64,
 			wantMilli: 1000, milliTODO: saturateNeg,
-			wantScaledKilo: -9223372036854774, scaledTODO: "want -9223372036854776 once negatives round away from zero (#138510)",
-			wantAsInt64: 0, wantAsInt64OK: false,
+			wantScaledKilo: -9223372036854776,
+			wantAsInt64:    0, wantAsInt64OK: false,
 			wantFloat:  -9.223372036854776e+18,
 			wantString: "-9223372036854775807",
 		},
@@ -248,25 +248,27 @@ func quantityAccessorCases() []accessorCase {
 			wantString: "92233720368547758070", // lossless: the full unscaled value
 		},
 
-		// --- Negative 19-digit values routed through the Dec backend: only Sign stays honest. ---
+		// --- Negative 19-digit values routed through the Dec backend: MilliValue still overflows. ---
 		{
-			// MinInt64 from a string reads back as zero, unlike NewQuantity(MinInt64).
+			// MinInt64 from a string is Dec-backed, unlike NewQuantity(MinInt64), so the
+			// int64 accessors go through scaledValue.
 			name: "int64-min-parsed", load: func() Quantity { return MustParse("-9223372036854775808") },
 			wantSign:  -1,
-			wantValue: 0, valueTODO: "want math.MinInt64 once scaledValue sends the out-of-range negative coefficient through the big.Int path (#138510)",
+			wantValue: math.MinInt64,
 			wantMilli: 0, milliTODO: saturateNeg,
-			wantScaledKilo: 0, scaledTODO: "want -9223372036854776 once scaledValue rounds the Dec-backed negative away from zero (#138510)",
-			wantAsInt64: math.MinInt64, wantAsInt64OK: false, asInt64TODO: "want (math.MinInt64, true) once #138076 parses -2^63 via the int64 fast path",
-			wantFloat:  -9.223372036854776e+18,
-			wantString: "-9223372036854775808",
+			wantScaledKilo: -9223372036854776,
+			wantAsInt64:    math.MinInt64, wantAsInt64OK: false, asInt64TODO: "want (math.MinInt64, true) once #138076 parses -2^63 via the int64 fast path",
+			wantFloat:       -9.223372036854776e+18,
+			wantString:      "-9223372036854775808",
+			atInt64Boundary: true,
 		},
 		{
 			name: "int64-min-plus-one-parsed", load: func() Quantity { return MustParse("-9223372036854775807") },
 			wantSign:  -1,
-			wantValue: 1, valueTODO: "want math.MinInt64 + 1 once scaledValue fixes the wrong-signed Dec-backed negative projection (#138510)",
+			wantValue: math.MinInt64 + 1,
 			wantMilli: 1000, milliTODO: saturateNeg,
-			wantScaledKilo: 1, scaledTODO: "want -9223372036854776 once scaledValue rounds the Dec-backed negative away from zero (#138510)",
-			wantAsInt64: math.MinInt64 + 1, wantAsInt64OK: false, asInt64TODO: "want (math.MinInt64 + 1, true) once #138076 parses this via the int64 fast path",
+			wantScaledKilo: -9223372036854776,
+			wantAsInt64:    math.MinInt64 + 1, wantAsInt64OK: false, asInt64TODO: "want (math.MinInt64 + 1, true) once #138076 parses this via the int64 fast path",
 			wantFloat:  -9.223372036854776e+18,
 			wantString: "-9223372036854775807",
 		},
@@ -302,24 +304,24 @@ func quantityAccessorCases() []accessorCase {
 			wantString: "-1", stringTODO: `want "-1e21"; ` + suffixDrop,
 		},
 
-		// --- Negative rounding (#138510): magnitude fits int64 but the sign flips. ---
+		// --- Negative rounding: magnitude fits int64 and rounds away from zero. ---
 		{
 			name: "negative-9_5Gi", load: func() Quantity { return MustParse("-9.5Gi") },
-			wantSign:  -1,
-			wantValue: 8246196746, valueTODO: "want -10200547328 once scaledValue rounds negatives away from zero (#138510)",
-			wantMilli: 8246196745710, milliTODO: "want -10200547328000 once scaledValue rounds negatives away from zero (#138510)",
-			wantScaledKilo: 8246197, scaledTODO: "want -10200548 once scaledValue rounds negatives away from zero (#138510)",
-			wantAsInt64: 0, wantAsInt64OK: false,
+			wantSign:       -1,
+			wantValue:      -10200547328,
+			wantMilli:      -10200547328000,
+			wantScaledKilo: -10200548,
+			wantAsInt64:    0, wantAsInt64OK: false,
 			wantFloat:  -1.0200547328e+10,
 			wantString: "-9728Mi",
 		},
 		{
 			name: "negative-9_5000000001Gi", load: func() Quantity { return MustParse("-9.5000000001Gi") },
-			wantSign:  -1,
-			wantValue: 8246196746, valueTODO: "want -10200547329 once scaledValue rounds negatives away from zero (#138510)",
-			wantMilli: 8246196745603, milliTODO: "want -10200547328108 once scaledValue rounds negatives away from zero (#138510)",
-			wantScaledKilo: 8246197, scaledTODO: "want -10200548 once scaledValue rounds negatives away from zero (#138510)",
-			wantAsInt64: 0, wantAsInt64OK: false,
+			wantSign:       -1,
+			wantValue:      -10200547329,
+			wantMilli:      -10200547328108,
+			wantScaledKilo: -10200548,
+			wantAsInt64:    0, wantAsInt64OK: false,
 			wantFloat:  -1.0200547328107376e+10,
 			wantString: "-10200547328107374183n",
 		},
@@ -347,15 +349,14 @@ func quantityAccessorCases() []accessorCase {
 		},
 		{
 			// Dec-backed sibling of new-milli-min: ToDec routes Value and Kilo
-			// through the big.Int path, where #138510's away-from-zero fix lands.
-			// int64-backed new-milli-min is already correct, so this proves the fix
+			// through the big.Int path, so this proves away-from-zero rounding
 			// reaches the Dec backend too.
 			name: "new-milli-min-via-dec", load: func() Quantity { q := NewMilliQuantity(math.MinInt64, DecimalSI); q.ToDec(); return *q },
-			wantSign:  -1,
-			wantValue: -9223372036854774, valueTODO: "want -9223372036854776 once negatives round away from zero (#138510)",
+			wantSign:       -1,
+			wantValue:      -9223372036854776,
 			wantMilli:      math.MinInt64,
-			wantScaledKilo: -9223372036853, scaledTODO: "want -9223372036855 once negatives round away from zero (#138510)",
-			wantAsInt64: 0, wantAsInt64OK: false,
+			wantScaledKilo: -9223372036855,
+			wantAsInt64:    0, wantAsInt64OK: false,
 			wantFloat:  -9.223372036854776e+15,
 			wantString: "-9223372036854775808m",
 		},

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -1098,6 +1098,55 @@ func TestScaledValue(t *testing.T) {
 	}
 }
 
+func TestNegativeValueRoundsAwayFromZero(t *testing.T) {
+	// Value() and MilliValue() are documented to round to the nearest integer
+	// away from zero, but the big.Int-backed rounding path used for quantities
+	// parsed via the inf.Dec code path was rounding toward positive infinity,
+	// producing 1 for small negative values like -.484785E-7466. See #110653.
+	table := []struct {
+		input       string
+		expectValue int64
+		expectMilli int64
+	}{
+		// small negative values parsed via the inf.Dec path (large exponent
+		// forces the canonicalization to round to -1n)
+		{"-.484785E-7466", -1, -1},
+		{".484785E-7466", 1, 1},
+
+		// values representable via the int64 fast path
+		{"-.484785E-1", -1, -49},
+		{".484785E-1", 1, 49},
+		{"-0.0005", -1, -1},
+		{"0.0005", 1, 1},
+		{"-1500m", -2, -1500},
+		{"1500m", 2, 1500},
+
+		// binary-suffix values with a fractional part large enough to force the
+		// big.Int rounding path with a non-zero remainder
+		// exact value is +/-10200547328.1073741824
+		{"-9.5000000001Gi", -10200547329, -10200547328108},
+		{"9.5000000001Gi", 10200547329, 10200547328108},
+
+		// exact integers, no rounding
+		{"-1", -1, -1000},
+		{"1", 1, 1000},
+		{"0", 0, 0},
+	}
+	for _, item := range table {
+		q, err := ParseQuantity(item.input)
+		if err != nil {
+			t.Errorf("ParseQuantity(%q) unexpected error: %v", item.input, err)
+			continue
+		}
+		if got := q.Value(); got != item.expectValue {
+			t.Errorf("ParseQuantity(%q).Value() = %d, want %d", item.input, got, item.expectValue)
+		}
+		if got := q.MilliValue(); got != item.expectMilli {
+			t.Errorf("ParseQuantity(%q).MilliValue() = %d, want %d", item.input, got, item.expectMilli)
+		}
+	}
+}
+
 func TestUninitializedNoCrash(t *testing.T) {
 	var q Quantity
 

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -1099,6 +1099,55 @@ func TestScaledValue(t *testing.T) {
 	}
 }
 
+func TestNegativeValueRoundsAwayFromZero(t *testing.T) {
+	// Value() and MilliValue() are documented to round to the nearest integer
+	// away from zero, but the big.Int-backed rounding path used for quantities
+	// parsed via the inf.Dec code path was rounding toward positive infinity,
+	// producing 1 for small negative values like -.484785E-7466. See #110653.
+	table := []struct {
+		input       string
+		expectValue int64
+		expectMilli int64
+	}{
+		// small negative values parsed via the inf.Dec path (large exponent
+		// forces the canonicalization to round to -1n)
+		{"-.484785E-7466", -1, -1},
+		{".484785E-7466", 1, 1},
+
+		// values representable via the int64 fast path
+		{"-.484785E-1", -1, -49},
+		{".484785E-1", 1, 49},
+		{"-0.0005", -1, -1},
+		{"0.0005", 1, 1},
+		{"-1500m", -2, -1500},
+		{"1500m", 2, 1500},
+
+		// binary-suffix values with a fractional part large enough to force the
+		// big.Int rounding path with a non-zero remainder
+		// exact value is +/-10200547328.1073741824
+		{"-9.5000000001Gi", -10200547329, -10200547328108},
+		{"9.5000000001Gi", 10200547329, 10200547328108},
+
+		// exact integers, no rounding
+		{"-1", -1, -1000},
+		{"1", 1, 1000},
+		{"0", 0, 0},
+	}
+	for _, item := range table {
+		q, err := ParseQuantity(item.input)
+		if err != nil {
+			t.Errorf("ParseQuantity(%q) unexpected error: %v", item.input, err)
+			continue
+		}
+		if got := q.Value(); got != item.expectValue {
+			t.Errorf("ParseQuantity(%q).Value() = %d, want %d", item.input, got, item.expectValue)
+		}
+		if got := q.MilliValue(); got != item.expectMilli {
+			t.Errorf("ParseQuantity(%q).MilliValue() = %d, want %d", item.input, got, item.expectMilli)
+		}
+	}
+}
+
 func TestUninitializedNoCrash(t *testing.T) {
 	var q Quantity
 

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/scale_int.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/scale_int.go
@@ -26,6 +26,7 @@ var (
 	// A sync pool to reduce allocation.
 	intPool  sync.Pool
 	maxInt64 = big.NewInt(math.MaxInt64)
+	minInt64 = big.NewInt(math.MinInt64)
 )
 
 func init() {
@@ -35,8 +36,9 @@ func init() {
 }
 
 // scaledValue scales given unscaled value from scale to new Scale and returns
-// an int64. It ALWAYS rounds up the result when scale down. The final result might
-// overflow.
+// an int64. When scaling down, the result is rounded away from zero (e.g. 1.5
+// becomes 2 and -1.5 becomes -2), matching the behavior documented on
+// Quantity.Value. The final result might overflow.
 //
 // scale, newScale represents the scale of the unscaled decimal.
 // The mathematical value of the decimal is unscaled * 10**(-scale).
@@ -56,14 +58,20 @@ func scaledValue(unscaled *big.Int, scale, newScale int) int64 {
 	// Handle scale down
 	// We have to be careful about the intermediate operations.
 
-	// fast path when unscaled < max.Int64 and exp(10,dif) < max.Int64
+	// fast path when |unscaled| < max.Int64 and exp(10,dif) < max.Int64
 	const log10MaxInt64 = 19
-	if unscaled.Cmp(maxInt64) < 0 && dif < log10MaxInt64 {
+	if unscaled.Cmp(maxInt64) < 0 && unscaled.Cmp(minInt64) > 0 && dif < log10MaxInt64 {
 		divide := int64(math.Pow10(dif))
 		result := unscaled.Int64() / divide
 		mod := unscaled.Int64() % divide
-		if mod != 0 {
+		// Go integer division truncates toward zero and mod takes the sign of the
+		// dividend, so a non-zero mod means we need to nudge the result one step
+		// further from zero to round away from it.
+		if mod > 0 {
 			return result + 1
+		}
+		if mod < 0 {
+			return result - 1
 		}
 		return result
 	}
@@ -86,8 +94,12 @@ func scaledValue(unscaled *big.Int, scale, newScale int) int64 {
 
 	// result = unscaled / divisor
 	// remainder = unscaled % divisor
+	// big.Int.DivMod is Euclidean: remainder is always in [0, divisor). For a
+	// negative dividend the quotient is already floored (further from zero), so
+	// no adjustment is needed. For a positive dividend with a non-zero remainder
+	// we step the quotient up by one to round away from zero.
 	result.DivMod(unscaled, divisor, remainder)
-	if remainder.Sign() != 0 {
+	if remainder.Sign() != 0 && unscaled.Sign() > 0 {
 		return result.Int64() + 1
 	}
 

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/scale_int_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/scale_int_test.go
@@ -32,21 +32,36 @@ func TestScaledValueInternal(t *testing.T) {
 	}{
 		// remain scale
 		{big.NewInt(1000), 0, 0, 1000},
+		{big.NewInt(-1000), 0, 0, -1000},
 
 		// scale down
 		{big.NewInt(1000), 0, -3, 1},
 		{big.NewInt(1000), 3, 0, 1},
+		{big.NewInt(-1000), 3, 0, -1},
 		{big.NewInt(0), 3, 0, 0},
 
-		// always round up
+		// scale down rounds away from zero
 		{big.NewInt(999), 3, 0, 1},
 		{big.NewInt(500), 3, 0, 1},
 		{big.NewInt(499), 3, 0, 1},
 		{big.NewInt(1), 3, 0, 1},
+		{big.NewInt(-1), 3, 0, -1},
+		{big.NewInt(-499), 3, 0, -1},
+		{big.NewInt(-500), 3, 0, -1},
+		{big.NewInt(-999), 3, 0, -1},
+		{big.NewInt(-1500), 3, 0, -2},
 		// large scaled value does not lose precision
 		{big.NewInt(0).Sub(maxInt64, bigOne), 1, 0, (math.MaxInt64-1)/10 + 1},
-		// large intermediate result.
+		// large intermediate result, positive and negative, forces the big.Int path
 		{big.NewInt(1).Exp(big.NewInt(10), big.NewInt(100), nil), 100, 0, 1},
+		{big.NewInt(0).Neg(big.NewInt(1).Exp(big.NewInt(10), big.NewInt(100), nil)), 100, 0, -1},
+		// a dif at or above log10MaxInt64 (19) forces the big.Int path with a
+		// non-zero remainder, exercising the DivMod rounding in both signs.
+		{big.NewInt(5), 19, 0, 1},
+		{big.NewInt(-5), 19, 0, -1},
+		// negative unscaled values outside the int64 range force the big.Int path;
+		// result fits in int64 after scaling.
+		{big.NewInt(0).Mul(minInt64, bigThousand), 3, 0, math.MinInt64},
 
 		// scale up
 		{big.NewInt(0), 0, 3, 0},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`resource.Quantity.Value()` and `MilliValue()` are documented to round *"to the nearest integer away from zero,"* but small negative values were rounding toward positive infinity. `ParseQuantity("-.484785E-7466").Value()` returned `+1` instead of `-1`.

The bug is in `scaledValue` in `staging/src/k8s.io/apimachinery/pkg/api/resource/scale_int.go`, which has two scale-down paths; both were wrong for negative inputs:

**int64 fast path.** Go's integer division truncates toward zero and `mod` takes the sign of the dividend. The old code added `1` whenever `mod != 0`, so `-1500 / 1000` returned `-1` instead of `-2`. Now a positive `mod` adds `1` and a negative `mod` subtracts `1`, moving the result further from zero in both cases.

The fast-path guard was also a single signed comparison, `unscaled.Cmp(maxInt64) < 0`, which holds for every negative value however large, so negatives at or below `math.MinInt64` reached `unscaled.Int64()` out of range. The guard now also requires `unscaled.Cmp(minInt64) > 0`, so those values fall through to the big.Int path.

**big.Int path.** `big.Int.DivMod` is Euclidean: the remainder is always in `[0, divisor)`. For a negative dividend the quotient is already floored, which *is* the away-from-zero direction for negatives, so no adjustment is needed. The old code incremented unconditionally; now only the positive-dividend case with a non-zero remainder gets the `+1`.

#### Which issue(s) this PR is related to:

Fixes #110653

#### Special notes for your reviewer:

Behavior change is strictly from wrong-direction rounding to the documented direction for negative values:

| Input | Old `Value()` | New `Value()` |
| --- | --- | --- |
| `-.484785E-7466` | `1` | `-1` |
| `-1500m` | `-1` | `-2` |
| `-0.0005` | `1` | `-1` |

Positive values are unaffected (same `+1` when remainder is non-zero, same no-op when zero). Exact multiples are unaffected in both signs.

Coverage:
- `TestScaledValueInternal`: negative cases across remain-scale, scale-down, round-away-from-zero, and both big.Int paths (including `minInt64 * 1000` scaling back into range).
- `TestNegativeValueRoundsAwayFromZero`: new public test exercising `Value()` / `MilliValue()` across the int64 fast path and the inf.Dec path.
- `TestQuantityAccessorBaseline`: the rows that pinned the pre-fix negative rounding (`-9.5Gi`, `-9.5000000001Gi`, `-8Ei`, `-20Ei`, parsed `MinInt64` and `MinInt64 + 1`, Dec-backed `NewMilliQuantity(MinInt64)`) now pin the fixed values.

#### Does this PR introduce a user-facing change?

```release-note
Fixed `resource.Quantity.Value()` and `MilliValue()` to round negative values away from zero, as documented. Previously, small negative quantities could round toward positive infinity (e.g. `ParseQuantity("-.484785E-7466").Value()` returned `1` instead of `-1`).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

