### PR TITLE
kubelet/dra: fix error check in unprepareResources

### DIFF
--- a/pkg/kubelet/cm/dra/manager.go
+++ b/pkg/kubelet/cm/dra/manager.go
@@ -665,7 +665,7 @@ func (m *Manager) unprepareResources(ctx context.Context, podUID types.UID, name
 	for driverName, claims := range batches {
 		// Call NodeUnprepareResources RPC for all resource handles.
 		plugin, err := m.draPlugins.GetPlugin(driverName)
-		if plugin == nil {
+		if err != nil {
 			// No wrapping, error includes driver name already.
 			return err
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Small one-line fix:
`GetPlugin` returns (nil, error) on failure. The error check in `unprepareResources` was comparing the plugin pointer to nil instead of checking the error, which is inconsistent with the identical call in `prepareResources` and could mask the actual error in future refactors.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
