### PR TITLE
kubelet: use ActiveContainerStatuses to detect pod initialization

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -448,6 +448,17 @@ func (podStatus *PodStatus) FindContainerStatusByName(containerName string) *Sta
 	return nil
 }
 
+// FindActiveContainerStatusByName returns active container status in the pod status with the given name.
+// When there are multiple containers' statuses with the same name, the first match will be returned.
+func (podStatus *PodStatus) FindActiveContainerStatusByName(containerName string) *Status {
+	for _, containerStatus := range podStatus.ActiveContainerStatuses {
+		if containerStatus.Name == containerName {
+			return containerStatus
+		}
+	}
+	return nil
+}
+
 // GetRunningContainerStatuses returns container status of all the running containers in a pod
 func (podStatus *PodStatus) GetRunningContainerStatuses() []*Status {
 	runningContainerStatuses := []*Status{}

--- a/pkg/kubelet/container/runtime_test.go
+++ b/pkg/kubelet/container/runtime_test.go
@@ -143,6 +143,50 @@ func TestPodStatusFindContainerStatusByName(t *testing.T) {
 	}
 }
 
+func TestPodStatusFindActiveContainerStatusByName(t *testing.T) {
+	podStatus := &PodStatus{
+		ActiveContainerStatuses: []*Status{
+			{Name: "container1", State: ContainerStateRunning},
+			{Name: "container2", State: ContainerStateExited},
+			{Name: "container1", State: ContainerStateCreated}, // duplicate name
+		},
+	}
+
+	tests := []struct {
+		name           string
+		containerName  string
+		expectedStatus *Status
+	}{
+		{
+			name:           "find existing container",
+			containerName:  "container1",
+			expectedStatus: podStatus.ActiveContainerStatuses[0], // should return first match
+		},
+		{
+			name:           "find another existing container",
+			containerName:  "container2",
+			expectedStatus: podStatus.ActiveContainerStatuses[1],
+		},
+		{
+			name:           "find non-existing container",
+			containerName:  "nonexistent",
+			expectedStatus: nil,
+		},
+		{
+			name:           "empty container name",
+			containerName:  "",
+			expectedStatus: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := podStatus.FindActiveContainerStatusByName(tt.containerName)
+			assert.Equal(t, tt.expectedStatus, result, "FindActiveContainerStatusByName(%q)", tt.containerName)
+		})
+	}
+}
+
 func TestPodStatusGetRunningContainerStatuses(t *testing.T) {
 	podStatus := &PodStatus{
 		ContainerStatuses: []*Status{

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -1091,7 +1091,7 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(ctx context.Cont
 	// find the restartable init containers to restart.
 	for i := len(pod.Spec.InitContainers) - 1; i >= 0; i-- {
 		container := &pod.Spec.InitContainers[i]
-		status := podStatus.FindContainerStatusByName(container.Name)
+		status := podStatus.FindActiveContainerStatusByName(container.Name)
 		logger.V(4).Info("Computing init container action", "pod", klog.KObj(pod), "container", container.Name, "status", status)
 		if status == nil {
 			// If the container is previously initialized but its status is not

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -1062,35 +1062,16 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(ctx context.Cont
 		return true
 	}
 
-	// If any of the main containers have status and are Running, then all init containers must
-	// have been executed at some point in the past.  However, they could have been removed
-	// from the container runtime now, and if we proceed, it would appear as if they
-	// never ran and will re-execute improperly except for the restartable init containers.
-	podHasInitialized := false
-	for _, container := range pod.Spec.Containers {
-		status := podStatus.FindContainerStatusByName(container.Name)
-		if status == nil {
-			continue
-		}
-		switch status.State {
-		case kubecontainer.ContainerStateCreated,
-			kubecontainer.ContainerStateRunning:
-			podHasInitialized = true
-		case kubecontainer.ContainerStateExited:
-			// This is a workaround for the issue that the kubelet cannot
-			// differentiate the container statuses of the previous podSandbox
-			// from the current one.
-			// If the node is rebooted, all containers will be in the exited
-			// state and the kubelet will try to recreate a new podSandbox.
-			// In this case, the kubelet should not mistakenly think that
-			// the newly created podSandbox has been initialized.
-		default:
-			// Ignore other states
-		}
-		if podHasInitialized {
-			break
-		}
-	}
+	// If ActiveContainerStatuses contains any main container (i.e. from pod.Spec.Containers),
+	// a main container has started on the current sandbox, which implies all init containers
+	// have already completed. Treating the pod as initialized here prevents non-restartable
+	// init containers — which the runtime may have already garbage-collected — from being
+	// improperly re-executed.
+	//
+	// Using ActiveContainerStatuses scopes the check to the current sandbox, so a stale main
+	// container left over from a previous sandbox (e.g. after a node reboot) cannot falsely
+	// mark the pod as initialized.
+	podHasInitialized := kubecontainer.HasAnyActiveRegularContainerStarted(&pod.Spec, podStatus)
 
 	// isPreviouslyInitialized indicates if the current init container is
 	// previously initialized.

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -1969,6 +1969,24 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 				ContainersToKill:  getKillMapWithInitContainers(basePod, baseStatus, []int{}),
 			},
 		},
+		"stale main container from a previous sandbox must not mark pod as initialized": {
+			mutateStatusFn: func(status *kubecontainer.PodStatus) {
+				status.ContainerStatuses = []*kubecontainer.Status{
+					{
+						ID:    kubecontainer.ContainerID{ID: "id1"},
+						Name:  "foo1",
+						State: kubecontainer.ContainerStateCreated,
+					},
+				}
+				status.ActiveContainerStatuses = nil
+			},
+			actions: podActions{
+				SandboxID:             baseStatus.SandboxStatuses[0].Id,
+				InitContainersToStart: []int{0},
+				ContainersToStart:     []int{},
+				ContainersToKill:      getKillMapWithInitContainers(basePod, baseStatus, []int{}),
+			},
+		},
 		"an init container is in the created state due to an unknown error when starting container; restart it": {
 			mutatePodFn: func(pod *v1.Pod) { pod.Spec.RestartPolicy = v1.RestartPolicyAlways },
 			mutateStatusFn: func(status *kubecontainer.PodStatus) {
@@ -2495,6 +2513,28 @@ func TestComputePodActionsWithRestartableInitContainers(t *testing.T) {
 				SandboxID:             baseStatus.SandboxStatuses[0].Id,
 				InitContainersToStart: []int{0, 1},
 				ContainersToStart:     []int{0, 1, 2},
+				ContainersToKill:      getKillMapWithInitContainers(basePod, baseStatus, []int{}),
+			},
+		},
+		"stale main container with mixed restartable and non-restartable init containers; start the first one": {
+			mutatePodFn: func(pod *v1.Pod) {
+				// Make the second init container non-restartable while keeping the others restartable.
+				pod.Spec.InitContainers[1].RestartPolicy = nil
+			},
+			mutateStatusFn: func(pod *v1.Pod, status *kubecontainer.PodStatus) {
+				status.ContainerStatuses = []*kubecontainer.Status{
+					{
+						ID:    kubecontainer.ContainerID{ID: "id1"},
+						Name:  "foo1",
+						State: kubecontainer.ContainerStateCreated,
+					},
+				}
+				status.ActiveContainerStatuses = nil
+			},
+			actions: podActions{
+				SandboxID:             baseStatus.SandboxStatuses[0].Id,
+				InitContainersToStart: []int{0},
+				ContainersToStart:     []int{},
 				ContainersToKill:      getKillMapWithInitContainers(basePod, baseStatus, []int{}),
 			},
 		},

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -1808,6 +1808,7 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 		"no init containers have been started; start the first one": {
 			mutateStatusFn: func(status *kubecontainer.PodStatus) {
 				status.ContainerStatuses = nil
+				status.ActiveContainerStatuses = status.ContainerStatuses
 			},
 			actions: podActions{
 				SandboxID:             baseStatus.SandboxStatuses[0].Id,
@@ -1929,6 +1930,7 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 			mutateStatusFn: func(status *kubecontainer.PodStatus) {
 				status.SandboxStatuses[0].State = runtimeapi.PodSandboxState_SANDBOX_NOTREADY
 				status.ContainerStatuses = []*kubecontainer.Status{}
+				status.ActiveContainerStatuses = status.ContainerStatuses
 			},
 			actions: podActions{
 				KillPod:               true,
@@ -1961,6 +1963,7 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 			mutateStatusFn: func(status *kubecontainer.PodStatus) {
 				status.ContainerStatuses[2].State = kubecontainer.ContainerStateRunning
 				status.ContainerStatuses = status.ContainerStatuses[2:]
+				status.ActiveContainerStatuses = status.ContainerStatuses
 			},
 			actions: podActions{
 				KillPod:           false,
@@ -2009,6 +2012,7 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 			},
 			mutateStatusFn: func(status *kubecontainer.PodStatus) {
 				status.ContainerStatuses = nil
+				status.ActiveContainerStatuses = status.ContainerStatuses
 			},
 			actions: podActions{
 				KillPod:               false,
@@ -2028,6 +2032,7 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 			mutateStatusFn: func(status *kubecontainer.PodStatus) {
 				status.ContainerStatuses = status.ContainerStatuses[:1]
 				status.ContainerStatuses[0].State = kubecontainer.ContainerStateRunning
+				status.ActiveContainerStatuses = status.ContainerStatuses
 			},
 			actions: podActions{
 				KillPod:               false,
@@ -2076,6 +2081,7 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 			mutateStatusFn: func(status *kubecontainer.PodStatus) {
 				status.ContainerStatuses = status.ContainerStatuses[:1]
 				status.ContainerStatuses[0].State = kubecontainer.ContainerStateRunning
+				status.ActiveContainerStatuses = status.ContainerStatuses
 			},
 			actions: podActions{
 				KillPod:               false,
@@ -2163,6 +2169,7 @@ func makeBasePodAndStatusWithInitContainers() (*v1.Pod, *kubecontainer.PodStatus
 			Hash: kubecontainer.HashContainer(&pod.Spec.InitContainers[2]),
 		},
 	}
+	status.ActiveContainerStatuses = status.ContainerStatuses
 	return pod, status
 }
 
@@ -2196,6 +2203,7 @@ func TestComputePodActionsWithRestartableInitContainers(t *testing.T) {
 		"no init containers have been started; start the first one": {
 			mutateStatusFn: func(pod *v1.Pod, status *kubecontainer.PodStatus) {
 				status.ContainerStatuses = nil
+				status.ActiveContainerStatuses = status.ContainerStatuses
 			},
 			actions: podActions{
 				SandboxID:             baseStatus.SandboxStatuses[0].Id,
@@ -2220,6 +2228,7 @@ func TestComputePodActionsWithRestartableInitContainers(t *testing.T) {
 			mutatePodFn: func(pod *v1.Pod) { pod.Spec.RestartPolicy = v1.RestartPolicyAlways },
 			mutateStatusFn: func(pod *v1.Pod, status *kubecontainer.PodStatus) {
 				status.ContainerStatuses = status.ContainerStatuses[:1]
+				status.ActiveContainerStatuses = status.ContainerStatuses
 			},
 			actions: podActions{
 				SandboxID:             baseStatus.SandboxStatuses[0].Id,
@@ -2233,6 +2242,7 @@ func TestComputePodActionsWithRestartableInitContainers(t *testing.T) {
 			mutateStatusFn: func(pod *v1.Pod, status *kubecontainer.PodStatus) {
 				m.livenessManager.Remove(status.ContainerStatuses[1].ID)
 				status.ContainerStatuses = status.ContainerStatuses[:2]
+				status.ActiveContainerStatuses = status.ContainerStatuses
 			},
 			actions: podActions{
 				SandboxID:             baseStatus.SandboxStatuses[0].Id,
@@ -2246,6 +2256,7 @@ func TestComputePodActionsWithRestartableInitContainers(t *testing.T) {
 			mutateStatusFn: func(pod *v1.Pod, status *kubecontainer.PodStatus) {
 				m.livenessManager.Set(status.ContainerStatuses[1].ID, proberesults.Unknown, basePod)
 				status.ContainerStatuses = status.ContainerStatuses[:2]
+				status.ActiveContainerStatuses = status.ContainerStatuses
 			},
 			actions: podActions{
 				SandboxID:             baseStatus.SandboxStatuses[0].Id,
@@ -2261,6 +2272,7 @@ func TestComputePodActionsWithRestartableInitContainers(t *testing.T) {
 			mutatePodFn: func(pod *v1.Pod) { pod.Spec.RestartPolicy = v1.RestartPolicyAlways },
 			mutateStatusFn: func(pod *v1.Pod, status *kubecontainer.PodStatus) {
 				status.ContainerStatuses = status.ContainerStatuses[:2]
+				status.ActiveContainerStatuses = status.ContainerStatuses
 			},
 			actions: podActions{
 				SandboxID:             baseStatus.SandboxStatuses[0].Id,
@@ -2289,6 +2301,7 @@ func TestComputePodActionsWithRestartableInitContainers(t *testing.T) {
 			mutateStatusFn: func(pod *v1.Pod, status *kubecontainer.PodStatus) {
 				m.startupManager.Remove(status.ContainerStatuses[1].ID)
 				status.ContainerStatuses = status.ContainerStatuses[:2]
+				status.ActiveContainerStatuses = status.ContainerStatuses
 			},
 			actions: noAction,
 		},
@@ -2297,6 +2310,7 @@ func TestComputePodActionsWithRestartableInitContainers(t *testing.T) {
 			mutateStatusFn: func(pod *v1.Pod, status *kubecontainer.PodStatus) {
 				m.startupManager.Set(status.ContainerStatuses[1].ID, proberesults.Unknown, basePod)
 				status.ContainerStatuses = status.ContainerStatuses[:2]
+				status.ActiveContainerStatuses = status.ContainerStatuses
 			},
 			actions: noAction,
 			resetStatusFn: func(status *kubecontainer.PodStatus) {
@@ -2307,6 +2321,7 @@ func TestComputePodActionsWithRestartableInitContainers(t *testing.T) {
 			mutatePodFn: func(pod *v1.Pod) { pod.Spec.RestartPolicy = v1.RestartPolicyAlways },
 			mutateStatusFn: func(pod *v1.Pod, status *kubecontainer.PodStatus) {
 				status.ContainerStatuses = status.ContainerStatuses[:2]
+				status.ActiveContainerStatuses = status.ContainerStatuses
 			},
 			actions: podActions{
 				SandboxID:             baseStatus.SandboxStatuses[0].Id,
@@ -2508,6 +2523,7 @@ func TestComputePodActionsWithRestartableInitContainers(t *testing.T) {
 			mutatePodFn: func(pod *v1.Pod) { pod.Spec.RestartPolicy = v1.RestartPolicyAlways },
 			mutateStatusFn: func(pod *v1.Pod, status *kubecontainer.PodStatus) {
 				status.ContainerStatuses = status.ContainerStatuses[2:]
+				status.ActiveContainerStatuses = status.ContainerStatuses
 			},
 			actions: podActions{
 				SandboxID:             baseStatus.SandboxStatuses[0].Id,
@@ -2603,6 +2619,7 @@ func makeBasePodAndStatusWithRestartableInitContainers() (*v1.Pod, *kubecontaine
 			Hash: kubecontainer.HashContainer(&pod.Spec.InitContainers[2]),
 		},
 	}
+	status.ActiveContainerStatuses = status.ContainerStatuses
 	return pod, status
 }
 
@@ -2967,6 +2984,7 @@ func makeBasePodAndStatusWithInitAndEphemeralContainers() (*v1.Pod, *kubecontain
 		Name: "debug", State: kubecontainer.ContainerStateRunning,
 		Hash: kubecontainer.HashContainer((*v1.Container)(&pod.Spec.EphemeralContainers[0].EphemeralContainerCommon)),
 	})
+	status.ActiveContainerStatuses = status.ContainerStatuses
 	return pod, status
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind regression

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR changes the logic for deciding which init container to start so that the main container's status is fetched only from the active sandbox. With this change, the bug where init containers are skipped after a node reboot when the container runtime reports the previous-sandbox main container in CONTAINER_CREATED state is resolved.


#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/issues/137710

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
I also tested this PR with the script in [this comment](https://github.com/kubernetes/kubernetes/issues/137710#issuecomment-4293916366)

```console
$ kind build node-image --image kindest/node:upstream-fix .
...

$ ./reproduce-init-skip-bug.sh kindest/node:upstream-fix
...
Bug NOT reproduced. init-2 was correctly executed.

```


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix a kubelet bug where init containers could be skipped when a pod sandbox is recreated while a previous-sandbox main container is still known to the container runtime.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
