### PR TITLE
avoid allocation in HasPossiblyMountedVolumesForPod

### DIFF
--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
@@ -156,11 +156,6 @@ type ActualStateOfWorld interface {
 	// the given name is mounted on the given pod.
 	GetMountedVolumeForPod(podName volumetypes.UniquePodName, volumeName v1.UniqueVolumeName) (MountedVolume, bool)
 
-	// GetPossiblyMountedVolumesForPod generates and returns a list of volumes for
-	// the specified pod that either are attached and mounted or are "uncertain",
-	// i.e. a volume plugin may be mounting the volume right now.
-	GetPossiblyMountedVolumesForPod(podName volumetypes.UniquePodName) []MountedVolume
-
 	// GetGloballyMountedVolumes generates and returns a list of all attached
 	// volumes that are globally mounted. This list can be used to determine
 	// which volumes should be reported as "in use" in the node's VolumesInUse
@@ -1122,26 +1117,6 @@ func (asw *actualStateOfWorld) GetMountedVolumeForPod(
 	}
 
 	return MountedVolume{}, false
-}
-
-func (asw *actualStateOfWorld) GetPossiblyMountedVolumesForPod(
-	podName volumetypes.UniquePodName) []MountedVolume {
-	asw.RLock()
-	defer asw.RUnlock()
-	mountedVolume := make([]MountedVolume, 0 /* len */, len(asw.attachedVolumes) /* cap */)
-	for _, volumeObj := range asw.attachedVolumes {
-		for mountedPodName, podObj := range volumeObj.mountedPods {
-			if mountedPodName == podName &&
-				(podObj.volumeMountStateForPod == operationexecutor.VolumeMounted ||
-					podObj.volumeMountStateForPod == operationexecutor.VolumeMountUncertain) {
-				mountedVolume = append(
-					mountedVolume,
-					getMountedVolume(&podObj, &volumeObj))
-			}
-		}
-	}
-
-	return mountedVolume
 }
 
 func (asw *actualStateOfWorld) GetGloballyMountedVolumes() []AttachedVolume {

--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
@@ -123,6 +123,9 @@ type ActualStateOfWorld interface {
 	// PodHasMountedVolumes returns true if any volume is mounted on the given pod
 	PodHasMountedVolumes(podName volumetypes.UniquePodName) bool
 
+	// PodHasPossiblyMountedVolumes returns true if any volume is mounted or "uncertain" on the given pod
+	PodHasPossiblyMountedVolumes(podName volumetypes.UniquePodName) bool
+
 	// VolumeExistsWithSpecName returns true if the given volume specified with the
 	// volume spec name (a.k.a., InnerVolumeSpecName) exists in the list of
 	// volumes that should be attached to this node.
@@ -958,6 +961,21 @@ func (asw *actualStateOfWorld) PodHasMountedVolumes(podName volumetypes.UniquePo
 	for _, volumeObj := range asw.attachedVolumes {
 		if podObj, hasPod := volumeObj.mountedPods[podName]; hasPod {
 			if podObj.volumeMountStateForPod == operationexecutor.VolumeMounted {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (asw *actualStateOfWorld) PodHasPossiblyMountedVolumes(podName volumetypes.UniquePodName) bool {
+	asw.RLock()
+	defer asw.RUnlock()
+	for _, volumeObj := range asw.attachedVolumes {
+		if podObj, hasPod := volumeObj.mountedPods[podName]; hasPod {
+			if podObj.volumeMountStateForPod == operationexecutor.VolumeMounted ||
+				podObj.volumeMountStateForPod == operationexecutor.VolumeMountUncertain {
 				return true
 			}
 		}

--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world_test.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world_test.go
@@ -1058,15 +1058,8 @@ func TestUncertainVolumeMounts(t *testing.T) {
 		t.Fatalf("expected volume %s to be not found in asw.GetMountedVolumesForPod", volumeSpec1.Name())
 	}
 
-	possiblyMountedVolumes := asw.GetPossiblyMountedVolumesForPod(podName1)
-	volumeFound = false
-	for _, volume := range possiblyMountedVolumes {
-		if volume.InnerVolumeSpecName == volumeSpec1.Name() {
-			volumeFound = true
-		}
-	}
-	if !volumeFound {
-		t.Fatalf("expected volume %s to be found in aws.GetPossiblyMountedVolumesForPod", volumeSpec1.Name())
+	if !asw.PodHasPossiblyMountedVolumes(podName1) {
+		t.Fatalf("expected pod %s to have possibly mounted volumes in asw", podName1)
 	}
 
 	volExists, _, _ := asw.PodExistsInVolume(logger, podName1, generatedVolumeName1, resource.Quantity{}, "")

--- a/pkg/kubelet/volumemanager/reconciler/reconstruct_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconstruct_test.go
@@ -58,10 +58,6 @@ func TestReconstructVolumes(t *testing.T) {
 				if len(allPods) != 2 {
 					return fmt.Errorf("expected 2 uncertain pods in asw got %d", len(allPods))
 				}
-				volumes := rcInstance.actualStateOfWorld.GetPossiblyMountedVolumesForPod("pod1")
-				if len(volumes) != 1 {
-					return fmt.Errorf("expected 1 uncertain volume in asw got %d", len(volumes))
-				}
 				// The volume should be marked as reconstructed in ASW
 				if reconstructed := rcInstance.actualStateOfWorld.IsVolumeReconstructed("fake-plugin/pvc-abcdef", "pod1"); !reconstructed {
 					t.Errorf("expected volume to be marked as reconstructed, got %v", reconstructed)

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -330,7 +330,7 @@ func (vm *volumeManager) GetMountedVolumesForPod(podName types.UniquePodName) co
 }
 
 func (vm *volumeManager) HasPossiblyMountedVolumesForPod(podName types.UniquePodName) bool {
-	return len(vm.actualStateOfWorld.GetPossiblyMountedVolumesForPod(podName)) > 0
+	return vm.actualStateOfWorld.PodHasPossiblyMountedVolumes(podName)
 }
 
 func (vm *volumeManager) GetExtraSupplementalGroupsForPod(pod *v1.Pod) []int64 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

While load testing kubelet with 1000+ Pods, paired with some cronjobs which create and delete pods in short intervals, we observed a lot of memory allocations caused by `SyncTerminatedPod` calling `GetPossiblyMountedVolumesForPod`. The result was only checked not to be empty.

<img width="1337" height="931" alt="image" src="https://github.com/user-attachments/assets/2b6610a3-0429-4f30-a2fd-df28d6f40aee" />

This change introduces a new method which avoids all allocations and simply checks if there is at least one possibly mounted volume for a given pod. 

We submitted a similiar PR (https://github.com/kubernetes/kubernetes/pull/126575) to introduce `PodHasMountedVolumes`. This change mirrors that one for possibly mounted volumes.

After the change has been applied:
<img width="341" height="477" alt="image (10)" src="https://github.com/user-attachments/assets/fceb2464-d52b-406c-8353-9cc9a419cc6a" />


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
`GetPossiblyMountedVolumesForPod` had no callers afterwards, which is why I decided to remove it entirely. I didn't want to leave unused methods behind. If it's desired to keep it around for future usage, I will remove the second commit again.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
