### PR TITLE
scheduler/dra: remove redundant nil check

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/nodeallocatabledynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/nodeallocatabledynamicresources.go
@@ -171,9 +171,6 @@ func (pl *DynamicResources) buildNodeAllocatableDRAInfo(pod *v1.Pod, nodeAllocat
 					quantity = resourceMap.AllocationMultiplier.DeepCopy()
 				}
 
-				if currentClaimStatus.Resources == nil {
-					currentClaimStatus.Resources = make(map[v1.ResourceName]resource.Quantity)
-				}
 				curQuantity, ok := currentClaimStatus.Resources[resourceName]
 				if !ok {
 					currentClaimStatus.Resources[resourceName] = quantity


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

currentClaimStatus.Resources is initialized as an empty map when the struct is constructed, so the nil check is a dead code.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```