### PR TITLE
Flaky volume test

### DIFF
--- a/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
@@ -2458,10 +2458,6 @@ func TestReconstructedVolumeShouldUnmountSucceedAfterSetupFailed(t *testing.T) {
 	volumePluginMgr, fakePlugin := volumetesting.GetTestKubeletVolumePluginMgr(t)
 	// fake Setup error
 	fakePlugin.SetUpHook = func(plugin volume.VolumePlugin, mounterArgs volume.MounterArgs) error {
-		if !mounterArgs.ReconstructedVolume {
-			// mock cleaned volume files while it's not a reconstructed volume
-			plugin.(*volumetesting.FakeVolumePlugin).NewUnmounterError = errors.New("unmounter failed to load volume data file")
-		}
 		return errors.New("csiRPCError")
 	}
 	seLinuxTranslator := util.NewFakeSELinuxLabelTranslator()

--- a/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
@@ -48,6 +48,7 @@ import (
 	volumetesting "k8s.io/kubernetes/pkg/volume/testing"
 	"k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/pkg/volume/util/hostutil"
+	"k8s.io/kubernetes/pkg/volume/util/nestedpendingoperations"
 	"k8s.io/kubernetes/pkg/volume/util/operationexecutor"
 	"k8s.io/kubernetes/pkg/volume/util/types"
 )
@@ -2009,24 +2010,20 @@ func waitForMount(
 	}
 }
 
-func waitForUnmount(
+func waitForPedingOperationsCompletion(
 	t *testing.T,
 	volumeName v1.UniqueVolumeName,
 	podName types.UniquePodName,
-	asw cache.ActualStateOfWorld) {
+	oex operationexecutor.OperationExecutor) {
 	err := retryWithExponentialBackOff(
 		testOperationBackOffDuration,
 		func() (bool, error) {
-			if asw.PodHasMountedVolumes(podName) {
-				return false, nil
-			}
-
-			return true, nil
+			return !oex.IsOperationPending(volumeName, podName, nestedpendingoperations.EmptyNodeName), nil
 		},
 	)
 
 	if err != nil {
-		t.Fatalf("Timed out waiting for pod %q to be unmount from volume %q.", podName, volumeName)
+		t.Fatalf("Timed out waiting for pod %q to complete pending operations for volume %q.", podName, volumeName)
 	}
 }
 
@@ -2586,13 +2583,11 @@ func TestReconstructedVolumeShouldUnmountSucceedAfterSetupFailed(t *testing.T) {
 
 	// Act first reconcile to trigger mount reconstructed volume
 	reconciler.reconcile(ctx)
-	waitForUncertainPodMount(t, generatedVolumeName, podName, asw)
+	waitForPedingOperationsCompletion(t, generatedVolumeName, podName, oex)
 
 	// mock remove pod
 	dsw.DeletePodFromVolume(podName, generatedVolumeName)
 	// Act second reconcile to trigger unmount reconstructed volume after removed pod from volume
 	reconciler.reconcile(ctx)
-
-	// assert volume unmount succeed
-	waitForUnmount(t, generatedVolumeName, podName, asw)
+	waitForPedingOperationsCompletion(t, generatedVolumeName, podName, oex)
 }

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -202,9 +202,6 @@ type FakeVolumePlugin struct {
 	UnmountDeviceHook func(globalMountPath string) error
 	SetUpHook         func(plugin volume.VolumePlugin, mounterArgs volume.MounterArgs) error
 
-	// Inject error to NewUnmounterError
-	NewUnmounterError error
-
 	Mounters             []*FakeVolume
 	Unmounters           []*FakeVolume
 	Attachers            []*FakeVolume
@@ -328,9 +325,6 @@ func (plugin *FakeVolumePlugin) GetMounters() (Mounters []*FakeVolume) {
 func (plugin *FakeVolumePlugin) NewUnmounter(volName string, podUID types.UID) (volume.Unmounter, error) {
 	plugin.Lock()
 	defer plugin.Unlock()
-	if plugin.NewUnmounterError != nil {
-		return nil, plugin.NewUnmounterError
-	}
 	fakeVolume := plugin.getFakeVolume(&plugin.Unmounters)
 	fakeVolume.Lock()
 	defer fakeVolume.Unlock()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

The `TestReconstructedVolumeShouldUnmountSucceedAfterSetupFailed` is flaky due to synchronization issues between the Operation Executor and the main test goroutine.

##### Issue details

The test consists of the following steps:
1. Mark volume as Uncertain so it will be reconstructed
2. 1st reconcile that triggers mounting
3. Waiting for uncertain pod mount
4. Removal of pod from desired state
5. 2nd reconcile that triggers unmounting
6. Waiting for unmount

Steps 2) and 5) trigger asynchronous actions. Steps 3) and 6) are supposed to wait for the asynchronous operations to complete. But they do not.
* `waitForUncertainPodMount` - returns immediately as the pod and volume exist in the actual state of world and are constantly in an uncertain state since the mounting operation fails (`csiRPCError` returned by `SetUpHook`).
* `waitForUnmount` - returns immediately as no volumes are ever mounted in this test.

Without synchronization, asynchronous operations might be in any state when the test ends. The unmounting operation might not even start if mounting is still in progress. This leads to issues with remaining filesystem artifacts causing failures during test cleanup, e.g.:
```
testing.go:1464: TempDir RemoveAll cleanup: unlinkat C:\Users\azureuser\AppData\Local\Temp\TestReconstructedVolumeShouldUnmountSucceedAfterSetupFailed3698421586\001: The directory is not empty.
--- FAIL: TestReconstructedVolumeShouldUnmountSucceedAfterSetupFailed (0.00s)
```

##### Fix
This commit fixes the test by providing proper synchronization. After each reconcile operation, a new function `waitForPendingOperationsCompletion` is called to wait until all operations on the volume are completed and only then continues with the following steps.

The `waitForUnmount` function is removed as it is no longer needed.

Separate patch removes also the unused NewUnmounterError mechanism from FakeVolumePlugin, that allowed blocking unmounting by returning an error when the plugin creates the unmounter.
The mechanism was never effective. It was introduced in `TestReconstructedVolumeShouldUnmountSucceedAfterSetupFailed` and set up only for non-reconstructed volumes. However, the volume used in the test is a reconstructed one, so the error was never actually injected — making it dead code.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
