### PR TITLE
scheduler: optimize pod requeue on DRA ResourceClaim events

### DIFF
--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -128,6 +128,7 @@ type SchedulingQueue interface {
 	// (e.g., filter Pods based on added/updated Node's capacity, etc.)
 	// We know currently some do, but we'll eventually remove them in favor of the scheduling queue hint.
 	MoveAllToActiveOrBackoffQueue(logger klog.Logger, event fwk.ClusterEvent, oldObj, newObj interface{}, preCheck PreEnqueueCheck)
+	MoveOneToActiveOrBackoffQueue(logger klog.Logger, event fwk.ClusterEvent, oldObj, newObj interface{}, podKey string)
 	AssignedPodAdded(logger klog.Logger, pod *v1.Pod)
 	AssignedPodUpdated(logger klog.Logger, oldPod, newPod *v1.Pod, event fwk.ClusterEvent)
 
@@ -1157,6 +1158,21 @@ func (p *PriorityQueue) MoveAllToActiveOrBackoffQueue(logger klog.Logger, event 
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	p.moveAllToActiveOrBackoffQueue(logger, event, oldObj, newObj, preCheck)
+}
+
+// MoveOneToActiveOrBackoffQueue moves a single pod identified by podKey from
+// the unschedulable pod pool to the active or backoff queue. This is an O(1)
+// alternative to MoveAllToActiveOrBackoffQueue for events that affect only a
+// single known pod, such as ResourceClaim events for per-pod claims created
+// from ResourceClaimTemplates.
+func (p *PriorityQueue) MoveOneToActiveOrBackoffQueue(logger klog.Logger, event fwk.ClusterEvent, oldObj, newObj interface{}, podKey string) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	pInfo, exists := p.unschedulablePods.podInfoMap[podKey]
+	if !exists {
+		return
+	}
+	p.movePodsToActiveOrBackoffQueue(logger, []*framework.QueuedPodInfo{pInfo}, event, oldObj, newObj)
 }
 
 // requeuePodWithQueueingStrategy tries to requeue Pod to activeQ, backoffQ or unschedulable pod pool based on schedulingHint.

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -34,6 +34,7 @@ import (
 	corev1nodeaffinity "k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
 	"k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache"
 	resourceslicetracker "k8s.io/dynamic-resource-allocation/resourceslice/tracker"
+	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/features"
@@ -495,6 +496,12 @@ func addAllEventHandlers(
 			evt := fwk.ClusterEvent{Resource: resource, ActionType: fwk.Add}
 			funcs.AddFunc = func(obj interface{}) {
 				defer metrics.EventHandlingLatency.ObserveSince(time.Now(), evt.Label())()
+				if resource == fwk.ResourceClaim {
+					if podKey := claimOwnerPodKey(obj); podKey != "" {
+						sched.SchedulingQueue.MoveOneToActiveOrBackoffQueue(logger, evt, nil, obj, podKey)
+						return
+					}
+				}
 				sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, nil, obj, nil)
 			}
 		}
@@ -502,6 +509,13 @@ func addAllEventHandlers(
 			evt := fwk.ClusterEvent{Resource: resource, ActionType: fwk.Update}
 			funcs.UpdateFunc = func(old, obj interface{}) {
 				start := time.Now()
+				if resource == fwk.ResourceClaim {
+					if podKey := claimOwnerPodKey(obj); podKey != "" {
+						sched.SchedulingQueue.MoveOneToActiveOrBackoffQueue(logger, evt, old, obj, podKey)
+						metrics.EventHandlingLatency.WithLabelValues(evt.Label()).Observe(metrics.SinceInSeconds(start))
+						return
+					}
+				}
 				sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, old, obj, nil)
 				metrics.EventHandlingLatency.WithLabelValues(evt.Label()).Observe(metrics.SinceInSeconds(start))
 			}
@@ -709,4 +723,19 @@ type AdmissionResult struct {
 	Name                 string
 	Reason               string
 	InsufficientResource *noderesources.InsufficientResource
+}
+
+// claimOwnerPodKey returns the pod key (name_namespace) for a ResourceClaim
+// with a pod owner reference. Returns empty string otherwise.
+func claimOwnerPodKey(obj interface{}) string {
+	claim, ok := obj.(*resourceapi.ResourceClaim)
+	if !ok {
+		return ""
+	}
+	for _, ref := range claim.OwnerReferences {
+		if ref.Kind == "Pod" && ref.APIVersion == v1.SchemeGroupVersion.String() {
+			return ref.Name + "_" + claim.Namespace
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
Use O(1) pod lookup instead of scanning all unschedulable pods when requeuing on ResourceClaim events for ResourceClaimTemplate-based claims with a pod owner reference.

#### What type of PR is this?

   /kind cleanup

   #### What this PR does / why we need it:

   Optimizes pod requeue on DRA ResourceClaim events for ResourceClaimTemplate-based claims.

   Currently, when a ResourceClaim is added or updated, the scheduler calls `MoveAllToActiveOrBackoffQueue`, which iterates all unschedulable pods to find requeue candidates. For per-pod claims
   created from ResourceClaimTemplates, the owning pod is known from `OwnerReferences` — this PR adds `MoveOneToActiveOrBackoffQueue` which performs a direct O(1) map lookup by pod key instead of
   the O(n) scan.

   For shared claims without a single pod owner, the existing `MoveAll` path is used as fallback.

   #### Which issue(s) this PR is related to:

   https://github.com/kubernetes/kubernetes/issues/138095

   #### Special notes for your reviewer:

   Tested on a 10K-node KWOK cluster with 9K DRA pods on v1.36.0. CPU profile confirms `MoveAllToActiveOrBackoffQueue` and `isPodWorthRequeuing` are eliminated from the hot path with this change.

 AI tools (Kiro CLI) were used to assist with development and testing of this change.

   #### Does this PR introduce a user-facing change?

   ```release-note
   NONE

   Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

   NONE

