### PR TITLE
fix external-snapshotter-e2e-tests bug fix

### DIFF
--- a/test/e2e/storage/testsuites/volume_group_snapshottable_stress.go
+++ b/test/e2e/storage/testsuites/volume_group_snapshottable_stress.go
@@ -257,6 +257,27 @@ func (t *volumeGroupSnapshottableStressTestSuite) DefineTests(driver storagefram
 		}
 		wg.Wait()
 
+		// Verify all volume group snapshots have actually been deleted. This
+		// guards against the CSI driver namespace being torn down while VGS
+		// objects are still Terminating (waiting for a finalizer that the
+		// sidecar can no longer remove).
+		framework.Logf("Verifying all volume group snapshots have been deleted from namespace %s", f.Namespace.Name)
+		dc := stressTest.config.Framework.DynamicClient
+		vgsList, listErr := dc.Resource(storageutils.VolumeGroupSnapshotGVR).Namespace(f.Namespace.Name).List(ctx, metav1.ListOptions{})
+		if listErr != nil {
+			mu.Lock()
+			errs = append(errs, fmt.Errorf("failed to list volume group snapshots for verification: %w", listErr))
+			mu.Unlock()
+		} else if len(vgsList.Items) > 0 {
+			remaining := make([]string, 0, len(vgsList.Items))
+			for _, item := range vgsList.Items {
+				remaining = append(remaining, item.GetName())
+			}
+			mu.Lock()
+			errs = append(errs, fmt.Errorf("%d volume group snapshot(s) still exist after cleanup: %v", len(remaining), remaining))
+			mu.Unlock()
+		}
+
 		// Clean up volumes
 		wg.Add(len(stressTest.volumeResources))
 		for _, volume := range stressTest.volumeResources {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes cleanup behavior in the external snapshotter volume group snapshot stress test.

After deleting VolumeGroupSnapshot objects, the test now verifies that all VolumeGroupSnapshot objects are actually gone before proceeding to clean up volumes and allowing the CSI driver namespace teardown to continue.

This prevents a race where VolumeGroupSnapshot objects may still be in `Terminating` state, waiting on finalizers, while the CSI sidecar/driver components are already being torn down. In that case, the sidecar may no longer be available to remove the finalizer, which can leave objects stuck and cause e2e cleanup failures.

The added verification lists remaining VolumeGroupSnapshot objects in the test namespace and reports a clear error if any still exist.



#### Does this PR introduce a user-facing change?

```release-note
NONE