### PR TITLE
code-generator: align models-schema stderr output

### DIFF
--- a/pkg/generated/openapi/cmd/models-schema/main.go
+++ b/pkg/generated/openapi/cmd/models-schema/main.go
@@ -30,7 +30,7 @@ import (
 func main() {
 	err := output()
 	if err != nil {
-		os.Stderr.WriteString(fmt.Sprintf("Failed: %v", err)) // nolint:errcheck
+		fmt.Fprintf(os.Stderr, "Failed: %v", err) // nolint:errcheck
 		os.Exit(1)
 	}
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/hack/verify-codegen.sh
+++ b/staging/src/k8s.io/apiextensions-apiserver/hack/verify-codegen.sh
@@ -34,10 +34,9 @@ cleanup
 echo "Ensuring models-schema is up-to-date"
 K8S_MODELS_SCHEMA="${SCRIPT_ROOT}/../../../../pkg/generated/openapi/cmd/models-schema/main.go"
 APIEXTENSIONS_MODELS_SCHEMA="${SCRIPT_ROOT}/pkg/generated/openapi/cmd/models-schema/main.go"
-# These files intentionally differ in import lines and the local lint-safe stderr write.
+# These files intentionally differ in import lines.
 if ! diff -I "k8s.io/kubernetes/pkg/generated/openapi" \
   -I "k8s.io/apiextensions-apiserver/pkg/generated/openapi" \
-  -I "Failed: %v" \
   "${K8S_MODELS_SCHEMA}" "${APIEXTENSIONS_MODELS_SCHEMA}"; then
   echo "${APIEXTENSIONS_MODELS_SCHEMA} is out of date. Compare changes with ${K8S_MODELS_SCHEMA}"
   exit 1

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/cmd/models-schema/main.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/cmd/models-schema/main.go
@@ -30,7 +30,7 @@ import (
 func main() {
 	err := output()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed: %v", err) //nolint:errcheck
+		fmt.Fprintf(os.Stderr, "Failed: %v", err) // nolint:errcheck
 		os.Exit(1)
 	}
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/generated/openapi/cmd/models-schema/main.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/generated/openapi/cmd/models-schema/main.go
@@ -30,7 +30,7 @@ import (
 func main() {
 	err := output()
 	if err != nil {
-		os.Stderr.WriteString(fmt.Sprintf("Failed: %v", err)) // nolint:errcheck
+		fmt.Fprintf(os.Stderr, "Failed: %v", err) // nolint:errcheck
 		os.Exit(1)
 	}
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/openapi/cmd/models-schema/main.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/openapi/cmd/models-schema/main.go
@@ -30,7 +30,7 @@ import (
 func main() {
 	err := output()
 	if err != nil {
-		os.Stderr.WriteString(fmt.Sprintf("Failed: %v", err)) // nolint:errcheck
+		fmt.Fprintf(os.Stderr, "Failed: %v", err) // nolint:errcheck
 		os.Exit(1)
 	}
 }

--- a/staging/src/k8s.io/sample-controller/pkg/generated/openapi/cmd/models-schema/main.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/openapi/cmd/models-schema/main.go
@@ -30,7 +30,7 @@ import (
 func main() {
 	err := output()
 	if err != nil {
-		os.Stderr.WriteString(fmt.Sprintf("Failed: %v", err)) // nolint:errcheck
+		fmt.Fprintf(os.Stderr, "Failed: %v", err) // nolint:errcheck
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Align the shared `models-schema` helper and its staged copies to use `fmt.Fprintf(os.Stderr, ...)` consistently.

With that helper output aligned, this also removes the temporary `-I "Failed: %v"` exception from `staging/src/k8s.io/apiextensions-apiserver/hack/verify-codegen.sh`.

#### Which issue(s) this PR is related to:

Follow-up to pr conversation [#137980](https://github.com/kubernetes/kubernetes/pull/137980#discussion_r2978502077)

#### Special notes for your reviewer:

Verified with:
- `go test ./pkg/generated/openapi/cmd/models-schema ./staging/src/k8s.io/kube-aggregator/pkg/generated/openapi/cmd/models-schema ./staging/src/k8s.io/sample-apiserver/pkg/generated/openapi/cmd/models-schema ./staging/src/k8s.io/sample-controller/pkg/generated/openapi/cmd/models-schema ./staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/cmd/models-schema`
- `API_KNOWN_VIOLATIONS_DIR=$PWD/api/api-rules CODEGEN_PKG=$PWD/staging/src/k8s.io/code-generator /usr/local/bin/bash staging/src/k8s.io/apiextensions-apiserver/hack/verify-codegen.sh`
- `API_KNOWN_VIOLATIONS_DIR=$PWD/api/api-rules CODEGEN_PKG=$PWD/staging/src/k8s.io/code-generator /usr/local/bin/bash staging/src/k8s.io/kube-aggregator/hack/verify-codegen.sh`
- `API_KNOWN_VIOLATIONS_DIR=$PWD/api/api-rules CODEGEN_PKG=$PWD/staging/src/k8s.io/code-generator /usr/local/bin/bash staging/src/k8s.io/sample-apiserver/hack/verify-codegen.sh`
- `API_KNOWN_VIOLATIONS_DIR=$PWD/api/api-rules CODEGEN_PKG=$PWD/staging/src/k8s.io/code-generator /usr/local/bin/bash staging/src/k8s.io/sample-controller/hack/verify-codegen.sh`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```