### PR TITLE
DRA: fix possible nil pointer deref

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/extendeddynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/extendeddynamicresources.go
@@ -120,7 +120,7 @@ func findExtendedResourceClaim(pod *v1.Pod, resourceClaims []*resourceapi.Resour
 	for _, c := range resourceClaims {
 		if c.Annotations[resourceapi.ExtendedResourceClaimAnnotation] == "true" {
 			for _, or := range c.OwnerReferences {
-				if or.Name == pod.Name && or.Controller != nil && *or.Controller && or.UID == pod.UID {
+				if or.Name == pod.Name && ptr.Deref(or.Controller, false) && or.UID == pod.UID {
 					return c
 				}
 			}

--- a/pkg/scheduler/framework/plugins/dynamicresources/extendeddynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/extendeddynamicresources.go
@@ -120,7 +120,7 @@ func findExtendedResourceClaim(pod *v1.Pod, resourceClaims []*resourceapi.Resour
 	for _, c := range resourceClaims {
 		if c.Annotations[resourceapi.ExtendedResourceClaimAnnotation] == "true" {
 			for _, or := range c.OwnerReferences {
-				if or.Name == pod.Name && *or.Controller && or.UID == pod.UID {
+				if or.Name == pod.Name && or.Controller != nil && *or.Controller && or.UID == pod.UID {
 					return c
 				}
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Added nil guard for `OwnerReference.Controller` in the `findExtendedResourceClaim` function to avoid panic if a ResourceClaim has an OwnerReference with the Controller field unset.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```