### PR TITLE
Update DefaultKubeBinaryVersion to 1.37

### DIFF
--- a/staging/src/k8s.io/component-base/version/base.go
+++ b/staging/src/k8s.io/component-base/version/base.go
@@ -60,5 +60,5 @@ const (
 	// DefaultKubeBinaryVersion is the hard coded k8 binary version based on the latest K8s release.
 	// It is supposed to be consistent with gitMajor and gitMinor, except for local tests, where gitMajor and gitMinor are "".
 	// Should update for each minor release!
-	DefaultKubeBinaryVersion = "1.36"
+	DefaultKubeBinaryVersion = "1.37"
 )


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Updates the Kube Binary version to 1.37, needed to add new feature gates and pass tests. PRs that add new feature gates like https://github.com/kubernetes/kubernetes/pull/138228 are blocked on it. This is similar to https://github.com/kubernetes/kubernetes/pull/135947.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
/assign @dims

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
