### PR TITLE
cli-runtime/printers: fix column alignment regression from periodic tabwriter flush

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter.go
@@ -37,6 +37,11 @@ import (
 // Formfeed is included because tabwriter treats it as a newline.
 const cellBreakChars = "\f\n\r"
 
+// flushInterval is the number of rows between tabwriter flushes when
+// streaming a large table. Flushing bounds memory while preserving
+// alignment via tabwriter.RememberWidths after the first flush.
+const flushInterval = 100
+
 var _ ResourcePrinter = &HumanReadablePrinter{}
 
 type printHandler struct {
@@ -180,12 +185,15 @@ func printTable(table *metav1.Table, output io.Writer, options PrintOptions) err
 	// When writing to a tabwriter we flush periodically (see below) to bound
 	// memory. Because tabwriter's RememberWidths can only grow column widths
 	// on future flushes — not retroactively re-pad rows already written — we
-	// pre-scan all rows to learn the ultimate max cell width per column, then
-	// pad the header so the first flush sets widths matching the ultimate max.
-	// Without this, a wider cell appearing after row 100 causes misalignment.
+	// pre-scan all rows to learn the ultimate max cell width per column. We
+	// then pad either the header (with headers) or the first data row
+	// (NoHeaders) so the first flush sets widths matching the ultimate max.
+	// Without this, a wider cell appearing after row flushInterval causes
+	// misalignment. Width comparisons use byte length because tabwriter
+	// measures columns in bytes, not runes.
 	var maxCellWidths []int
-	_, writingToTabwriter := output.(*tabwriter.Writer)
-	if writingToTabwriter && !options.NoHeaders && len(table.Rows) > 0 {
+	tw, isTabwriter := output.(*tabwriter.Writer)
+	if isTabwriter && len(table.Rows) > 0 {
 		maxCellWidths = make([]int, numColDefs)
 		for _, row := range table.Rows {
 			for i, cell := range row.Cells {
@@ -211,21 +219,21 @@ func printTable(table *metav1.Table, output io.Writer, options PrintOptions) err
 		}
 	}
 
+	// Find the last visible column so we can skip padding it — padding the
+	// final column would leave trailing whitespace without any alignment
+	// benefit (tabwriter doesn't right-pad the last column for data rows).
+	lastVisibleCol := -1
+	for i, column := range table.ColumnDefinitions {
+		if !options.Wide && column.Priority != 0 {
+			continue
+		}
+		lastVisibleCol = i
+	}
+
 	if !options.NoHeaders {
 		// avoid printing headers if we have no rows to display
 		if len(table.Rows) == 0 {
 			return nil
-		}
-
-		// Find the last visible column so we skip padding it — padding the
-		// final column would leave trailing whitespace without any alignment
-		// benefit (tabwriter doesn't right-pad the last column for data rows).
-		lastVisibleCol := -1
-		for i, column := range table.ColumnDefinitions {
-			if !options.Wide && column.Priority != 0 {
-				continue
-			}
-			lastVisibleCol = i
 		}
 
 		first := true
@@ -257,11 +265,16 @@ func printTable(table *metav1.Table, output io.Writer, options PrintOptions) err
 	rowBuf := make([]byte, 0, numColDefs*40)
 
 	// When writing to a tabwriter with RememberWidths, flush periodically
-	// to bound memory usage. After the first flush the tabwriter remembers
-	// column widths, so subsequent flushes produce consistently aligned output.
-	// For small tables (< 100 rows) or non-tabwriter outputs, we skip this.
-	tw, isTabwriter := output.(*tabwriter.Writer)
-	const flushInterval = 100
+	// (flushInterval) to bound memory usage. After the first flush the
+	// tabwriter remembers column widths, so subsequent flushes produce
+	// consistently aligned output. For small tables or non-tabwriter
+	// outputs, no flushing happens here.
+	//
+	// NoHeaders mode: the header path above primes column widths by
+	// padding header cells to maxCellWidths. Without a header to prime
+	// widths, we instead pad the first data row's non-final cells using
+	// the same pre-scanned widths.
+	padFirstRow := isTabwriter && options.NoHeaders && len(maxCellWidths) > 0
 
 	for ri, row := range table.Rows {
 		rowBuf = rowBuf[:0]
@@ -280,12 +293,25 @@ func printTable(table *metav1.Table, output io.Writer, options PrintOptions) err
 			} else {
 				rowBuf = append(rowBuf, '\t')
 			}
+			// Track byte length of the cell string we're about to
+			// write so we can pad to maxCellWidths without measuring
+			// through rowBuf (appendCellValue's slow path flushes
+			// rowBuf directly, making post-write measurement unsafe).
+			cellLen := 0
 			if cell != nil {
+				var cellStr string
 				switch val := cell.(type) {
 				case string:
-					rowBuf = appendCellValue(output, rowBuf, val)
+					cellStr = val
 				default:
-					rowBuf = appendCellValue(output, rowBuf, fmt.Sprint(val))
+					cellStr = fmt.Sprint(val)
+				}
+				cellLen = len(cellStr)
+				rowBuf = appendCellValue(output, rowBuf, cellStr)
+			}
+			if padFirstRow && ri == 0 && i != lastVisibleCol && i < len(maxCellWidths) {
+				if pad := maxCellWidths[i] - cellLen; pad > 0 {
+					rowBuf = append(rowBuf, bytes.Repeat([]byte{' '}, pad)...)
 				}
 			}
 		}

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package printers
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"reflect"
@@ -174,14 +175,61 @@ func (h *HumanReadablePrinter) PrintObj(obj runtime.Object, output io.Writer) er
 // for wide columns and filtered rows. It filters out rows that are Completed. You should call
 // decorateTable if you receive a table from a remote server before calling printTable.
 func printTable(table *metav1.Table, output io.Writer, options PrintOptions) error {
+	numColDefs := len(table.ColumnDefinitions)
+
+	// When writing to a tabwriter we flush periodically (see below) to bound
+	// memory. Because tabwriter's RememberWidths can only grow column widths
+	// on future flushes — not retroactively re-pad rows already written — we
+	// pre-scan all rows to learn the ultimate max cell width per column, then
+	// pad the header so the first flush sets widths matching the ultimate max.
+	// Without this, a wider cell appearing after row 100 causes misalignment.
+	var maxCellWidths []int
+	_, writingToTabwriter := output.(*tabwriter.Writer)
+	if writingToTabwriter && !options.NoHeaders && len(table.Rows) > 0 {
+		maxCellWidths = make([]int, numColDefs)
+		for _, row := range table.Rows {
+			for i, cell := range row.Cells {
+				if i >= numColDefs {
+					break
+				}
+				if !options.Wide && table.ColumnDefinitions[i].Priority != 0 {
+					continue
+				}
+				if cell == nil {
+					continue
+				}
+				var l int
+				if s, ok := cell.(string); ok {
+					l = len(s)
+				} else {
+					l = len(fmt.Sprint(cell))
+				}
+				if l > maxCellWidths[i] {
+					maxCellWidths[i] = l
+				}
+			}
+		}
+	}
+
 	if !options.NoHeaders {
 		// avoid printing headers if we have no rows to display
 		if len(table.Rows) == 0 {
 			return nil
 		}
 
+		// Find the last visible column so we skip padding it — padding the
+		// final column would leave trailing whitespace without any alignment
+		// benefit (tabwriter doesn't right-pad the last column for data rows).
+		lastVisibleCol := -1
+		for i, column := range table.ColumnDefinitions {
+			if !options.Wide && column.Priority != 0 {
+				continue
+			}
+			lastVisibleCol = i
+		}
+
 		first := true
-		for _, column := range table.ColumnDefinitions {
+		for i, column := range table.ColumnDefinitions {
 			if !options.Wide && column.Priority != 0 {
 				continue
 			}
@@ -190,12 +238,17 @@ func printTable(table *metav1.Table, output io.Writer, options PrintOptions) err
 			} else {
 				output.Write([]byte{'\t'}) //nolint:errcheck
 			}
-			io.WriteString(output, strings.ToUpper(column.Name)) //nolint:errcheck
+			name := strings.ToUpper(column.Name)
+			io.WriteString(output, name) //nolint:errcheck
+			if i != lastVisibleCol && i < len(maxCellWidths) {
+				if pad := maxCellWidths[i] - len(name); pad > 0 {
+					output.Write(bytes.Repeat([]byte{' '}, pad)) //nolint:errcheck
+				}
+			}
 		}
 		output.Write([]byte{'\n'}) //nolint:errcheck
 	}
 
-	numColDefs := len(table.ColumnDefinitions)
 	// rowBuf accumulates tab-separated cell values for each row,
 	// reducing per-cell Write calls from ~3 (tab + value + truncation)
 	// down to 1 per row in the common case (no special characters).

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter_test.go
@@ -713,55 +713,75 @@ func TestPrintUnstructuredObject(t *testing.T) {
 // because tabwriter's RememberWidths can only grow widths on future flushes
 // and cannot retroactively re-pad already-flushed rows.
 func TestPrintTable_ConsistentAlignmentAcrossFlushes(t *testing.T) {
-	columns := []metav1.TableColumnDefinition{
-		{Name: "Name", Type: "string"},
-		{Name: "Status", Type: "string"},
-		{Name: "Age", Type: "string"},
-	}
-	// Use > 2 flush intervals (flushInterval=100) so we exercise multiple
-	// flushes, and place the widest Name cell in the final group so that
-	// the first flush fixes a narrower width than the overall max.
-	const rowCount = 250
+	// Exercise > 2 flush intervals so we cross multiple flush boundaries,
+	// and place the widest Name cell in the final group so the first flush
+	// would otherwise fix a narrower width than the overall max.
+	const rowCount = flushInterval*2 + flushInterval/2
 	const shortName = "a"
 	const longName = "a-name-that-is-significantly-wider"
-	rows := make([]metav1.TableRow, rowCount)
-	for i := range rows {
-		name := shortName
-		if i == rowCount-1 {
-			name = longName
-		}
-		rows[i] = metav1.TableRow{Cells: []interface{}{name, "Running", "5d"}}
-	}
-	table := &metav1.Table{ColumnDefinitions: columns, Rows: rows}
 
-	out := &bytes.Buffer{}
-	printer := NewTablePrinter(PrintOptions{})
-	if err := printer.PrintObj(table, out); err != nil {
-		t.Fatalf("PrintObj error: %v", err)
+	buildTable := func() *metav1.Table {
+		columns := []metav1.TableColumnDefinition{
+			{Name: "Name", Type: "string"},
+			{Name: "Status", Type: "string"},
+			{Name: "Age", Type: "string"},
+		}
+		rows := make([]metav1.TableRow, rowCount)
+		for i := range rows {
+			name := shortName
+			if i == rowCount-1 {
+				name = longName
+			}
+			rows[i] = metav1.TableRow{Cells: []interface{}{name, "Running", "5d"}}
+		}
+		return &metav1.Table{ColumnDefinitions: columns, Rows: rows}
 	}
 
-	lines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
-	if len(lines) != rowCount+1 {
-		t.Fatalf("expected %d lines (header + %d rows), got %d", rowCount+1, rowCount, len(lines))
-	}
-	// Compare the byte offset at which each non-first column starts, across
-	// all lines. Trailing content of the final column is ignored (the header's
-	// "AGE" is legitimately wider than data rows' "5d"), but every earlier
-	// column boundary must align identically for every line.
-	wantStarts := columnStartOffsets(lines[0])
-	for i, line := range lines {
-		gotStarts := columnStartOffsets(line)
-		if len(gotStarts) != len(wantStarts) {
-			t.Errorf("line %d: found %d column boundaries, want %d\nline: %q\nhdr:  %q", i, len(gotStarts), len(wantStarts), line, lines[0])
-			continue
+	assertAligned := func(t *testing.T, output string, expectedLines int) {
+		t.Helper()
+		lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+		if len(lines) != expectedLines {
+			t.Fatalf("expected %d lines, got %d", expectedLines, len(lines))
 		}
-		for j := range gotStarts {
-			if gotStarts[j] != wantStarts[j] {
-				t.Errorf("line %d: column %d starts at offset %d, want %d (misaligned across flush boundary)\nline: %q\nhdr:  %q", i, j+2, gotStarts[j], wantStarts[j], line, lines[0])
-				break
+		// Compare the byte offset at which each non-first column starts,
+		// across all lines. Trailing content of the final column is
+		// ignored (the header's "AGE" is legitimately wider than data
+		// rows' "5d"), but every earlier column boundary must align
+		// identically for every line.
+		wantStarts := columnStartOffsets(lines[0])
+		for i, line := range lines {
+			gotStarts := columnStartOffsets(line)
+			if len(gotStarts) != len(wantStarts) {
+				t.Errorf("line %d: found %d column boundaries, want %d\nline: %q\nref:  %q", i, len(gotStarts), len(wantStarts), line, lines[0])
+				continue
+			}
+			for j := range gotStarts {
+				if gotStarts[j] != wantStarts[j] {
+					t.Errorf("line %d: column %d starts at offset %d, want %d (misaligned across flush boundary)\nline: %q\nref:  %q", i, j+2, gotStarts[j], wantStarts[j], line, lines[0])
+					break
+				}
 			}
 		}
 	}
+
+	t.Run("WithHeaders", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		printer := NewTablePrinter(PrintOptions{})
+		if err := printer.PrintObj(buildTable(), out); err != nil {
+			t.Fatalf("PrintObj error: %v", err)
+		}
+		// header + rowCount data rows
+		assertAligned(t, out.String(), rowCount+1)
+	})
+
+	t.Run("NoHeaders", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		printer := NewTablePrinter(PrintOptions{NoHeaders: true})
+		if err := printer.PrintObj(buildTable(), out); err != nil {
+			t.Fatalf("PrintObj error: %v", err)
+		}
+		assertAligned(t, out.String(), rowCount)
+	})
 }
 
 // columnStartOffsets returns the byte offsets of the start of each non-first

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter_test.go
@@ -705,6 +705,79 @@ func TestPrintUnstructuredObject(t *testing.T) {
 	}
 }
 
+// TestPrintTable_ConsistentAlignmentAcrossFlushes verifies that every row in
+// the output is padded to the same column widths, even when the widest cell
+// value appears after the first periodic tabwriter flush. This is a regression
+// test for a bug where printTable's periodic flush (every 100 rows) caused
+// earlier rows to be written with narrower column widths than later rows,
+// because tabwriter's RememberWidths can only grow widths on future flushes
+// and cannot retroactively re-pad already-flushed rows.
+func TestPrintTable_ConsistentAlignmentAcrossFlushes(t *testing.T) {
+	columns := []metav1.TableColumnDefinition{
+		{Name: "Name", Type: "string"},
+		{Name: "Status", Type: "string"},
+		{Name: "Age", Type: "string"},
+	}
+	// Use > 2 flush intervals (flushInterval=100) so we exercise multiple
+	// flushes, and place the widest Name cell in the final group so that
+	// the first flush fixes a narrower width than the overall max.
+	const rowCount = 250
+	const shortName = "a"
+	const longName = "a-name-that-is-significantly-wider"
+	rows := make([]metav1.TableRow, rowCount)
+	for i := range rows {
+		name := shortName
+		if i == rowCount-1 {
+			name = longName
+		}
+		rows[i] = metav1.TableRow{Cells: []interface{}{name, "Running", "5d"}}
+	}
+	table := &metav1.Table{ColumnDefinitions: columns, Rows: rows}
+
+	out := &bytes.Buffer{}
+	printer := NewTablePrinter(PrintOptions{})
+	if err := printer.PrintObj(table, out); err != nil {
+		t.Fatalf("PrintObj error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
+	if len(lines) != rowCount+1 {
+		t.Fatalf("expected %d lines (header + %d rows), got %d", rowCount+1, rowCount, len(lines))
+	}
+	// Compare the byte offset at which each non-first column starts, across
+	// all lines. Trailing content of the final column is ignored (the header's
+	// "AGE" is legitimately wider than data rows' "5d"), but every earlier
+	// column boundary must align identically for every line.
+	wantStarts := columnStartOffsets(lines[0])
+	for i, line := range lines {
+		gotStarts := columnStartOffsets(line)
+		if len(gotStarts) != len(wantStarts) {
+			t.Errorf("line %d: found %d column boundaries, want %d\nline: %q\nhdr:  %q", i, len(gotStarts), len(wantStarts), line, lines[0])
+			continue
+		}
+		for j := range gotStarts {
+			if gotStarts[j] != wantStarts[j] {
+				t.Errorf("line %d: column %d starts at offset %d, want %d (misaligned across flush boundary)\nline: %q\nhdr:  %q", i, j+2, gotStarts[j], wantStarts[j], line, lines[0])
+				break
+			}
+		}
+	}
+}
+
+// columnStartOffsets returns the byte offsets of the start of each non-first
+// column on a tabwriter-formatted line. A column starts at the first non-space
+// byte following a run of >=2 spaces. This matches tabwriter's inter-column
+// padding and ignores the natural variability of the final column's contents.
+func columnStartOffsets(line string) []int {
+	var offsets []int
+	for i := 2; i < len(line); i++ {
+		if line[i] != ' ' && line[i-1] == ' ' && line[i-2] == ' ' {
+			offsets = append(offsets, i)
+		}
+	}
+	return offsets
+}
+
 // TestPrintTable_LargeRowCount verifies that the optimized printTable
 // produces correct output for large tables (the primary optimization target).
 func TestPrintTable_LargeRowCount(t *testing.T) {


### PR DESCRIPTION
The periodic tabwriter flush introduced in #138023 causes misaligned output when a cell wider than any seen in the first 100 rows appears later in the table. RememberWidths can only grow column widths on future flushes, it cannot retroactively re-pad rows already written, so earlier flush groups end up with narrower columns than later ones.

Pre-scan all rows to compute the maximum cell width per column, then pad each non-final header cell to that width before the first flush. The first flush latches onto widths matching the ultimate maximum, keeping all subsequent periodic flushes aligned.

The periodic flush itself is preserved, so the memory and CPU wins of identical allocation count and O(1) memory ceiling before and after this fix — 135 allocs/op and ~45KB/op across 10k, 100k, and 500k rows. The pre-scan adds ~3–7% CPU over the post-#138023 baseline, still a large improvement versus pre-#138023.

Adds a regression test that constructs a 250-row table with the widest NAME appearing in the final flush group, and asserts that column start offsets are identical across the header and all data rows.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind regression

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix regression in kubectl resource printing on bigger data sets (100+ rows)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
