### PR TITLE
chore(validation-gen): graduate maximum and maxLength to Stable and minLength to Beta

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
@@ -86,7 +86,7 @@ func (maxLengthTagValidator) GetValidations(context Context, tag codetags.Tag) (
 func (mltv maxLengthTagValidator) Docs() TagDoc {
 	return TagDoc{
 		Tag:            mltv.TagName(),
-		StabilityLevel: TagStabilityLevelBeta,
+		StabilityLevel: TagStabilityLevelStable,
 		Scopes:         sets.List(mltv.ValidScopes()),
 		Description: `Indicates that a string field has a limit on its length in characters.
 		This could allow up to 4*N bytes if multi-byte characters are used.
@@ -493,7 +493,7 @@ func (minLengthTagValidator) GetValidations(context Context, tag codetags.Tag) (
 func (mltv minLengthTagValidator) Docs() TagDoc {
 	return TagDoc{
 		Tag:            mltv.TagName(),
-		StabilityLevel: TagStabilityLevelAlpha,
+		StabilityLevel: TagStabilityLevelBeta,
 		Scopes:         sets.List(mltv.ValidScopes()),
 		Description: `Indicates that a string field has a minimum length for its value in characters.
 		This means that the minimum size in bytes is a range from X to 4X if multi-byte characters are allowed.


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/kind cleanup

#### What this PR does / why we need it:

This PR graduates the stability level of several declarative validation tags in the `validation-gen` tool, as part of the work for [KEP-5073: Declarative Validation of Kubernetes Native Types](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen).

Here are the graduations and their rationales:

**Group 1: OpenAPI Style Tags (Graduating from Beta to Stable)**
*   **Tags**: `+k8s:maximum`, `+k8s:maxLength`
*   **Rationale**: These tags are straightforward mirrors of standard OpenAPI validations. Graduating them to Stable provides full stability guarantees for these fundamental validation rules. Both have active usage in the codebase (e.g., in `resource`, `scheduling`, and `storage` APIs).

**Group 2: OpenAPI Style Tag (Graduating from Alpha to Beta)**
*   **Tags**: `+k8s:minLength`
*   **Rationale**: This is also a straightforward OpenAPI style tag but was currently marked as Alpha in the code. We are promoting it to Beta to bring it closer to the other OpenAPI tags and prepare it for future graduation to Stable.

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen
KEP Issue: https://github.com/kubernetes/enhancements/issues/5073

#### Special notes for your reviewer:

*   `minLength` is only graduating to Beta (from Alpha) to follow the safe path.
*   **Unused Tags**: `minItems` and `maxProperties` are Beta but have no usage in the current APIs. We are keeping them in Beta for now.
*   I noticed a delta where `maxLength` was intended to be promoted to Stable in PR #135949 but remained Beta in the code; this PR rectifies that.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen
```