### PR TITLE
drain: skip eviction retry when pod rescheduled to different node

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -331,6 +331,11 @@ func (d *Helper) evictPods(pods []corev1.Pod, evictionGroupVersion schema.GroupV
 				freshPod, err := getPodFn(activePod.Namespace, activePod.Name)
 				// we ignore errors and let eviction sort it out with the original pod.
 				if err == nil {
+					// Pod has been rescheduled to a different node (e.g., StatefulSet pod
+					// recreated elsewhere while PDB blocked eviction). No eviction needed.
+					if freshPod.Spec.NodeName != pod.Spec.NodeName {
+						break
+					}
 					activePod = *freshPod
 				}
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/sig cli

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
During `kubectl drain`, when a PDB blocks eviction and returns 429, the drain command retries every few seconds. If the pod is rescheduled to a different node in the meantime (common with StatefulSets, the old pod is deleted, StatefulSet controller recreates it elsewhere with the same name), drain has no awareness of this and keeps retrying indefinitely against a pod that no longer lives on the node being drained.

This fix checks `spec.nodeName` of the freshly fetched pod against the original pod's node. If they differ, the pod has moved - we break out of the retry loop. The existing `waitForDelete` logic then exits immediately via its UID mismatch check (`p.ObjectMeta.UID != pod.ObjectMeta.UID`).

#### Which issue(s) this PR is related to:
Fixes #138229
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
The fix is intentionally minimal, only the retry loop in `evictPods` is changed. `waitForDelete` already handles the "pod recreated with same name but different UID" case correctly at: https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubectl/pkg/drain/drain.go#L431

No new behavior is introduced for the delete (non-eviction) path since that path does not have the same retry loop.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed `kubectl drain` getting stuck in an eviction retry loop when a pod (e.g., from a StatefulSet) is rescheduled to a different node while a PodDisruptionBudget is blocking eviction.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
