### PR TITLE
HPA: Remove duplicated unit tests

### DIFF
--- a/pkg/controller/podautoscaler/replica_calculator_test.go
+++ b/pkg/controller/podautoscaler/replica_calculator_test.go
@@ -851,22 +851,6 @@ func TestReplicaCalcScaleUpCMObjectIgnoresUnreadyPods(t *testing.T) {
 	tc.runTest(t)
 }
 
-func TestReplicaCalcScaleUpCMExternal(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:  1,
-		expectedReplicas: 2,
-		metric: &metricInfo{
-			name:          "qps",
-			levels:        []int64{8600},
-			targetUsage:   4400,
-			expectedUsage: 8600,
-			selector:      &metav1.LabelSelector{MatchLabels: map[string]string{"label": "value"}},
-			metricType:    podMetric,
-		},
-	}
-	tc.runTest(t)
-}
-
 func TestReplicaCalcScaleUpCMExternalIgnoresUnreadyPods(t *testing.T) {
 	tc := replicaCalcTestCase{
 		currentReplicas:  3,
@@ -879,21 +863,6 @@ func TestReplicaCalcScaleUpCMExternalIgnoresUnreadyPods(t *testing.T) {
 			expectedUsage: 8600,
 			selector:      &metav1.LabelSelector{MatchLabels: map[string]string{"label": "value"}},
 			metricType:    externalMetric,
-		},
-	}
-	tc.runTest(t)
-}
-
-func TestReplicaCalcScaleUpCMExternalNoLabels(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:  1,
-		expectedReplicas: 2,
-		metric: &metricInfo{
-			name:          "qps",
-			levels:        []int64{8600},
-			targetUsage:   4400,
-			expectedUsage: 8600,
-			metricType:    podMetric,
 		},
 	}
 	tc.runTest(t)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
`TestReplicaCalcScaleUpCMExternal` and `TestReplicaCalcScaleUpCMExternalNoLabels` are functionally identical. Both use `metricType: podMetric` with the same inputs and expected outputs. The only difference is that one sets `metric.selector` and the other does not - but the `podMetric` branch in `runTest` routes through `GetMetricReplicas`, which never reads `metric.selector`, so that difference has no runtime effect.  I am removing both because the remaining `podMetric` scale-up path is still covered by `TestReplicaCalcScaleUpCM`.
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
