### PR TITLE
Hard-code the otel http.target attribute

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/traces.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/traces.go
@@ -21,7 +21,6 @@ import (
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/endpoints/request"
@@ -55,7 +54,7 @@ func WithTracing(handler http.Handler, tp trace.TracerProvider) http.Handler {
 		// Workaround for https://github.com/open-telemetry/opentelemetry-go-contrib/issues/3743
 		span := trace.SpanFromContext(r.Context())
 		if r.URL != nil {
-			span.SetAttributes(semconv.HTTPTarget(r.URL.RequestURI()))
+			span.SetAttributes(attribute.Key("http.target").String(r.URL.RequestURI()))
 		}
 		// Add auditID attribute if available. This helps us connect traces to audit log entries
 		span.SetAttributes(attribute.String("audit-id", audit.GetAuditIDTruncated(r.Context())))

--- a/staging/src/k8s.io/component-base/tracing/utils.go
+++ b/staging/src/k8s.io/component-base/tracing/utils.go
@@ -21,16 +21,16 @@ import (
 	"net/http"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	noopoteltrace "go.opentelemetry.io/otel/trace/noop"
 
 	"k8s.io/client-go/transport"
-	"k8s.io/component-base/tracing/api/v1"
+	v1 "k8s.io/component-base/tracing/api/v1"
 )
 
 // TracerProvider is an OpenTelemetry TracerProvider which can be shut down
@@ -101,7 +101,7 @@ func WithTracing(handler http.Handler, tp oteltrace.TracerProvider, spanName str
 		// Add the http.target attribute to the otelhttp span
 		// Workaround for https://github.com/open-telemetry/opentelemetry-go-contrib/issues/3743
 		if r.URL != nil {
-			oteltrace.SpanFromContext(r.Context()).SetAttributes(semconv.HTTPTarget(r.URL.RequestURI()))
+			oteltrace.SpanFromContext(r.Context()).SetAttributes(attribute.Key("http.target").String(r.URL.RequestURI()))
 		}
 		handler.ServeHTTP(w, r)
 	})


### PR DESCRIPTION
#### What type of PR is this?

/kind dependency
/kind cleanup

#### What this PR does / why we need it:

The dependency on semconv v1.17.0 is only used for its definition of the http.target attribute; since that definition is used for a workaround, and the attribute has been removed in later versions of semconv (and is unlikely to come back), we might as well define it ourselves and avoid the dependency entirely.

Vendored files will be removed once etcd upgrades its semconv dependency (https://github.com/etcd-io/etcd/pull/21661).

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
