### PR TITLE
Wait a bit after creating CRD

### DIFF
--- a/test/cmd/events.sh
+++ b/test/cmd/events.sh
@@ -83,6 +83,7 @@ run_kubectl_events_tests() {
 }
 __EOF__
 
+    kubectl wait --timeout=2s --for=condition=Established=true crd/cronjobs.example.com
     ### Create a example.com/v1 Cronjob in a specific namespace
     kubectl create -f - << __EOF__
 {


### PR DESCRIPTION
#### What type of PR is this?
/kind flake
/sig cli

#### What this PR does / why we need it:
I've noticed this in this run https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/138566/pull-kubernetes-cmd/2047610944741183488. The problem is that we don't wait after creating CRD resource, and immediately after we try to create the CR, which fails. 

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
/assign @ardaguclu 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
