### PR TITLE
client-go/reflector: Add object count to reflector "Objects listed" trace step

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/help_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/help_test.go
@@ -398,6 +398,52 @@ func TestExtractList(t *testing.T) {
 	}
 }
 
+func TestLenList(t *testing.T) {
+	tests := []struct {
+		name string
+		list runtime.Object
+		want int
+	}{
+		{
+			name: "nil",
+			list: nil,
+			want: 0,
+		},
+		{
+			name: "empty FooList",
+			list: &FooList{},
+			want: 0,
+		},
+		{
+			name: "FooList",
+			list: fakeFooList(fakeObjectItemsNum),
+			want: fakeObjectItemsNum,
+		},
+		{
+			name: "SampleList",
+			list: fakeSampleList(fakeObjectItemsNum),
+			want: fakeObjectItemsNum,
+		},
+		{
+			name: "RawExtensionList",
+			list: fakeExtensionList(fakeObjectItemsNum),
+			want: fakeObjectItemsNum,
+		},
+		{
+			name: "UnstructuredList",
+			list: fakeUnstructuredList(fakeObjectItemsNum).(*unstructured.UnstructuredList),
+			want: fakeObjectItemsNum,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := LenList(tc.list); got != tc.want {
+				t.Errorf("LenList() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
 func BenchmarkExtractListItem(b *testing.B) {
 	tests := []struct {
 		name string

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -742,7 +742,7 @@ func (r *Reflector) list(ctx context.Context) error {
 	case <-listCh:
 	}
 
-	initTrace.Step("Objects listed", trace.Field{Key: "error", Value: err})
+	initTrace.Step("Objects listed", trace.Field{Key: "error", Value: err}, trace.Field{Key: "count", Value: meta.LenList(list)})
 	if err != nil {
 		return fmt.Errorf("failed to list %v: %w", r.typeDescription, err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
It add object count to the "Objects listed" reflector trace step so slow lists immediately show how many objects were fetched.

Before:
```
Trace[863568955]: "Reflector ListAndWatch" name:k8s.io/client-go@v0.0.0-20260420165437-4cff86bf8f9a/tools/cache/reflector.go:343 (21-Apr-2026 14:45:48.411) (total time: 11082ms):
Trace[863568955]: ---"Objects listed" error:<nil> 11037ms (14:45:59.448)
Trace[863568955]: ---"Resource version extracted" 0ms (14:45:59.448)
Trace[863568955]: ---"Objects extracted" count:56080 44ms (14:45:59.493)
Trace[863568955]: ---"SyncWith done" 0ms (14:45:59.493)
Trace[863568955]: ---"Resource version updated" 0ms (14:45:59.493)
Trace[863568955]: [11.082312749s] [11.082312749s] END
```

After:
```
Trace[1920423863]: "Reflector ListAndWatch" name:testing/testing.go:2036 (24-Apr-2026 15:10:28.045) (total time: 11001ms):
Trace[1920423863]: ---"Objects listed" error:<nil>,count:50 11001ms (15:10:39.047)
Trace[1920423863]: ---"Resource version extracted" 0ms (15:10:39.047)
Trace[1920423863]: ---"Objects extracted" 0ms (15:10:39.047)
Trace[1920423863]: ---"SyncWith done" 0ms (15:10:39.047)
Trace[1920423863]: ---"Resource version updated" 0ms (15:10:39.047)
Trace[1920423863]: [11.001378791s] [11.001378791s] END
```

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
