### PR TITLE
validation-gen: allow required/optional tags on non-pointer struct fi…

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,42 +18,39 @@ package validators
 
 import (
 	"testing"
+
+	"k8s.io/gengo/v2/types"
 )
 
-func TestGetStability(t *testing.T) {
-	tests := []struct {
-		tagName     string
-		expected    TagStabilityLevel
-		expectError bool
-	}{
-		{
-			tagName:  "k8s:validateTrueAlpha",
-			expected: TagStabilityLevelAlpha,
-		},
-		{
-			tagName:  "k8s:validateTrueBeta",
-			expected: TagStabilityLevelBeta,
-		},
-		{
-			tagName:  "k8s:required",
-			expected: TagStabilityLevelStable,
-		},
-		{
-			tagName:     "k8s:unknownTag",
-			expected:    "",
-			expectError: true,
-		},
-	}
+func TestRequirednessTagsOnNonPointerStructsAreAccepted(t *testing.T) {
+	st := &types.Type{Kind: types.Struct, Name: types.Name{Name: "MyStruct"}}
+	member := &types.Member{Name: "field", Type: st, CommentLines: nil}
 
-	for _, tt := range tests {
-		t.Run(tt.tagName, func(t *testing.T) {
-			got, err := GetStability(tt.tagName)
-			if err != nil && !tt.expectError {
-				t.Errorf("Unexpected error: %v", err)
-			}
-			if got != tt.expected {
-				t.Errorf("GetStability(%q) = %v, want %v", tt.tagName, got, tt.expected)
-			}
-		})
-	}
+	t.Run("required", func(t *testing.T) {
+		rtv := requirednessTagValidator{requirednessRequired}
+		v, err := rtv.doRequired(Context{Scope: ScopeField, Type: st, Member: member})
+		if err != nil {
+			t.Fatalf("doRequired() unexpected error: %v", err)
+		}
+		if len(v.Functions) != 0 {
+			t.Fatalf("doRequired() expected no runtime validations for non-pointer struct, got %d", len(v.Functions))
+		}
+		if len(v.Comments) == 0 {
+			t.Fatalf("doRequired() expected documentation comment for non-pointer struct")
+		}
+	})
+
+	t.Run("optional", func(t *testing.T) {
+		rtv := requirednessTagValidator{requirednessOptional}
+		v, err := rtv.doOptional(Context{Scope: ScopeField, Type: st, Member: member})
+		if err != nil {
+			t.Fatalf("doOptional() unexpected error: %v", err)
+		}
+		if len(v.Functions) != 0 {
+			t.Fatalf("doOptional() expected no runtime validations for non-pointer struct, got %d", len(v.Functions))
+		}
+		if len(v.Comments) == 0 {
+			t.Fatalf("doOptional() expected documentation comment for non-pointer struct")
+		}
+	})
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
@@ -100,12 +100,18 @@ func (rtv requirednessTagValidator) doRequired(context Context) (Validations, er
 	case types.Pointer:
 		return Validations{Functions: []FunctionGen{Function(requiredTagName, ShortCircuit, requiredPointerValidator)}}, nil
 	case types.Struct:
-		// The +k8s:required tag on a non-pointer struct is not supported.
-		// If you encounter this error and believe you have a valid use case
-		// for forbiddening a non-pointer struct, please let us know! We need
-		// to understand your scenario to determine if we need to adjust
-		// this behavior or provide alternative validation mechanisms.
-		return Validations{}, fmt.Errorf("non-pointer structs cannot use the %q tag", requiredTagName)
+		// We cannot reliably enforce required presence semantics for non-pointer structs.
+		//
+		// Practically, a non-pointer struct becomes "implicitly required" if it has
+		// any validations which fail on the zero-value (e.g. required members, or
+		// union/oneOf semantics requiring at least one member to be set). If it has
+		// only optional members and no such semantic constraints, it is effectively
+		// optional at runtime.
+		//
+		// Still, OpenAPI +required / +optional are allowed on non-pointer structs,
+		// and we want to allow colocated declarative validation tags so linters can
+		// enforce tag pairing. Treat this tag as documentation-only.
+		return Validations{Comments: []string{"+k8s:required on non-pointer structs is accepted for schema/linting, but does not emit presence validation; requiredness may be implied by nested validations"}}, nil
 	}
 	return Validations{Functions: []FunctionGen{Function(requiredTagName, ShortCircuit, requiredValueValidator)}}, nil
 }
@@ -171,12 +177,15 @@ func (rtv requirednessTagValidator) doOptional(context Context) (Validations, er
 	case types.Pointer:
 		return Validations{Functions: []FunctionGen{Function(optionalTagName, ShortCircuit|NonError, optionalPointerValidator)}}, nil
 	case types.Struct:
-		// The +k8s:optional tag on a non-pointer struct is not supported.
-		// If you encounter this error and believe you have a valid use case
-		// for forbiddening a non-pointer struct, please let us know! We need
-		// to understand your scenario to determine if we need to adjust
-		// this behavior or provide alternative validation mechanisms.
-		return Validations{}, fmt.Errorf("non-pointer structs cannot use the %q tag", optionalTagName)
+		// We cannot reliably enforce optional presence semantics for non-pointer structs.
+		// See doRequired() for details.
+		//
+		// The Optional* validators are used primarily to short-circuit further
+		// field/type validations when a value was not specified
+		//
+		// Accept the tag to enable OpenAPI/declarative tag pairing (linting), but do
+		// not emit runtime validations.
+		return Validations{Comments: []string{"+k8s:optional on non-pointer structs is accepted for schema/linting, but does not emit presence validation; requiredness/optionality is determined by nested validations"}}, nil
 	}
 	return Validations{Functions: []FunctionGen{Function(optionalTagName, ShortCircuit|NonError, optionalValueValidator)}}, nil
 }
@@ -304,18 +313,20 @@ func (requirednessTagValidator) doForbidden(context Context) (Validations, error
 func (rtv requirednessTagValidator) Docs() TagDoc {
 	doc := TagDoc{
 		Tag:    rtv.TagName(),
-		Scopes: sets.List(rtv.ValidScopes()),
+		Scopes: rtv.ValidScopes().UnsortedList(),
 	}
 
 	switch rtv.mode {
 	case requirednessRequired:
 		doc.StabilityLevel = TagStabilityLevelStable
 		doc.Description = "Indicates that a field must be specified by clients."
+		doc.Docs = "Note: for non-pointer struct fields, validation-gen cannot detect presence vs omission; this tag is accepted for schema/linting but may not emit runtime presence validation."
 	case requirednessOptional:
 		doc.StabilityLevel = TagStabilityLevelStable
 		doc.Description = "Indicates that a field is optional to clients."
+		doc.Docs = "Note: for non-pointer struct fields, validation-gen cannot detect presence vs omission; this tag is accepted for schema/linting but may not emit runtime presence validation."
 	case requirednessForbidden:
-		doc.StabilityLevel = TagStabilityLevelBeta
+		doc.StabilityLevel = TagStabilityLevelAlpha
 		doc.Description = "Indicates that a field may not be specified."
 	default:
 		panic(fmt.Sprintf("unknown requiredness mode: %q", rtv.mode))


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig api-machinery

#### What this PR does / why we need it:

`validation-gen` previously returned a hard error when `+k8s:required` or `+k8s:optional` tags were used on non-pointer struct fields.

This blocked legitimate use cases where authors want these tags for OpenAPI schema generation and linter tag-pairing, even though runtime presence validation is impossible for non-pointer structs because Go always zero-initializes them.

This PR allows those tags on non-pointer struct fields, but emits only a documentation comment instead of runtime validators.

This follows the direction from kubernetes/kubernetes#136779, originally proposed by @arcceus.
#### Which issue(s) this PR is related to:

Related to kubernetes/kubernetes#136779
Related to kubernetes/kubernetes#136612

#### Special notes for your reviewer:

No runtime behavior changes are introduced.

Existing types using these tags were previously failing at codegen time, not runtime. The only observable change is that codegen now succeeds and emits a comment explaining that runtime presence validation is not generated for non-pointer struct fields.

This PR intentionally treats `+k8s:required` and `+k8s:optional` on non-pointer struct fields as documentation-only for validation-gen purposes.

#### Does this PR introduce a user-facing change?

```release-note
validation-gen now accepts +k8s:required and +k8s:optional tags on non-pointer struct fields. These tags previously caused a codegen error; they are now accepted as documentation-only and do not emit runtime presence validation.