### PR TITLE
code-generator: ignore blank identifier fields in deepcopy-gen

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/deepcopy-gen/generators/deepcopy.go
+++ b/staging/src/k8s.io/code-generator/cmd/deepcopy-gen/generators/deepcopy.go
@@ -797,6 +797,10 @@ func (g *genDeepCopy) doStruct(t *types.Type, sw *generator.SnippetWriter) {
 
 	// Now fix-up fields as needed.
 	for _, m := range ut.Members {
+		if m.Name == "_" {
+			continue
+		}
+
 		ft := m.Type
 		uft := underlyingType(ft)
 

--- a/staging/src/k8s.io/code-generator/cmd/deepcopy-gen/generators/deepcopy_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/deepcopy-gen/generators/deepcopy_test.go
@@ -17,9 +17,12 @@ limitations under the License.
 package generators
 
 import (
+	"bytes"
 	"reflect"
+	"strings"
 	"testing"
 
+	"k8s.io/gengo/v2/generator"
 	"k8s.io/gengo/v2/types"
 )
 
@@ -306,6 +309,34 @@ func Test_deepCopyMethod(t *testing.T) {
 		} else if !tc.error && (r != nil) != tc.expect {
 			t.Errorf("case[%d]: expected result %v, got: %v", i, tc.expect, r)
 		}
+	}
+}
+
+func TestDoStructIgnoresBlankIdentifierMembers(t *testing.T) {
+	g := &genDeepCopy{}
+	tpe := &types.Type{
+		Name: types.Name{Package: "pkgname", Name: "WithBlank"},
+		Kind: types.Struct,
+		Members: []types.Member{
+			{
+				Name: "_",
+				Type: &types.Type{
+					Kind: types.Struct,
+				},
+			},
+		},
+	}
+
+	var out bytes.Buffer
+	sw := generator.NewSnippetWriter(&out, &generator.Context{Namers: NameSystems()}, "$", "$")
+	g.doStruct(tpe, sw)
+	if err := sw.Error(); err != nil {
+		t.Fatalf("unexpected snippet writer error: %v", err)
+	}
+
+	generated := out.String()
+	if strings.Contains(generated, "out._") || strings.Contains(generated, "in._") {
+		t.Fatalf("generated deepcopy code references blank identifier field: %q", generated)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This fixes `deepcopy-gen` output for struct members named `_`.

`doStruct()` first emits `*out = *in`, then walks struct members to generate per-field deepcopy fix-ups when needed. That member walk currently treats `_` like a normal field name and can emit invalid selectors such as `out._ = in._`, which is not legal Go.

This change skips blank identifier members during the per-field fix-up pass and adds a regression test covering that generator output.

#### Which issue(s) this PR is related to:
Fixes #123838

#### Special notes for your reviewer:
This follows an existing pattern in `code-generator` for blank identifiers. For example, `go-to-protobuf` already skips `_`-named import specs in [parser.go#L477-L479](https://github.com/kubernetes/kubernetes/blob/ce14ead9b21873ce26a22e55f7c213f588d3a1b0/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/parser.go#L477-L479).

Tests run:
- `go test ./staging/src/k8s.io/code-generator/cmd/deepcopy-gen/generators -run '^TestDoStructIgnoresBlankIdentifierMembers$'`
- `go test ./staging/src/k8s.io/code-generator/cmd/deepcopy-gen/generators ./staging/src/k8s.io/code-generator/cmd/deepcopy-gen/output_tests`

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
```
