### PR TITLE
apiserver: fall back to next Accept media type when encoder can't represent the object

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go
@@ -18,6 +18,7 @@ package protobuf
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -60,10 +61,13 @@ func (e errNotMarshalable) Status() metav1.Status {
 	}
 }
 
-// IsNotMarshalable checks the type of error, returns a boolean true if error is not nil and not marshalable false otherwise
+// IsNotMarshalable checks the type of error, returns a boolean true if error is not nil and not marshalable false otherwise.
 func IsNotMarshalable(err error) bool {
-	_, ok := err.(errNotMarshalable)
-	return err != nil && ok
+	if err == nil {
+		return false
+	}
+	var target errNotMarshalable
+	return errors.As(err, &target)
 }
 
 // NewSerializer creates a Protobuf serializer that handles encoding versioned objects into the proper wire form. If a typer

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/negotiate.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/negotiate.go
@@ -62,6 +62,27 @@ func NegotiateOutputMediaType(req *http.Request, ns runtime.NegotiatedSerializer
 	return mediaType, info, nil
 }
 
+// NegotiateOutputMediaTypes returns all acceptable media type matches from the Accept
+// header in quality order, or NewNotAcceptableError if none match. Callers that want to
+// fall through to the next candidate when an encoder cannot represent the object should
+// use this instead of NegotiateOutputMediaType. The pretty serializer override is folded
+// into each result's Accepted serializer.
+func NegotiateOutputMediaTypes(req *http.Request, ns runtime.NegotiatedSerializer, restrictions EndpointRestrictions) ([]MediaTypeOptions, error) {
+	mediaTypes := negotiateAllMediaTypeOptions(req.Header.Get("Accept"), ns.SupportedMediaTypes(), restrictions)
+	if len(mediaTypes) == 0 {
+		supported, _ := MediaTypesForSerializer(ns)
+		return nil, NewNotAcceptableError(supported)
+	}
+	pretty := isPrettyPrint(req)
+	for i := range mediaTypes {
+		accepted := &mediaTypes[i].Accepted
+		if (mediaTypes[i].Pretty || pretty) && accepted.PrettySerializer != nil {
+			accepted.Serializer = accepted.PrettySerializer
+		}
+	}
+	return mediaTypes, nil
+}
+
 // NegotiateOutputMediaTypeStream returns a stream serializer for the given request.
 func NegotiateOutputMediaTypeStream(req *http.Request, ns runtime.NegotiatedSerializer, restrictions EndpointRestrictions) (runtime.SerializerInfo, error) {
 	mediaType, ok := NegotiateMediaTypeOptions(req.Header.Get("Accept"), ns.SupportedMediaTypes(), restrictions)
@@ -247,6 +268,22 @@ func acceptMediaTypeOptions(params map[string]string, accepts *runtime.Serialize
 	return options, true
 }
 
+// matchedMediaTypeOptions reports whether the serializer satisfies the Accept clause and,
+// if so, returns the negotiated options. Shared by the singular and plural negotiators.
+func matchedMediaTypeOptions(clause *goautoneg.Accept, accepts *runtime.SerializerInfo, endpoint EndpointRestrictions) (MediaTypeOptions, bool) {
+	// q=0 means "not acceptable" per RFC 9110 §12.5.1, so the client is rejecting this media type.
+	if clause.Q <= 0 {
+		return MediaTypeOptions{}, false
+	}
+	switch {
+	case clause.Type == accepts.MediaTypeType && clause.SubType == accepts.MediaTypeSubType,
+		clause.Type == accepts.MediaTypeType && clause.SubType == "*",
+		clause.Type == "*" && clause.SubType == "*":
+		return acceptMediaTypeOptions(clause.Params, accepts, endpoint)
+	}
+	return MediaTypeOptions{}, false
+}
+
 // NegotiateMediaTypeOptions returns the most appropriate content type given the accept header and
 // a list of alternatives along with the accepted media type parameters.
 func NegotiateMediaTypeOptions(header string, accepted []runtime.SerializerInfo, endpoint EndpointRestrictions) (MediaTypeOptions, bool) {
@@ -257,20 +294,87 @@ func NegotiateMediaTypeOptions(header string, accepted []runtime.SerializerInfo,
 	}
 
 	clauses := goautoneg.ParseAccept(header)
+	rejected := rejectedMediaTypes(clauses, accepted)
 	for i := range clauses {
-		clause := &clauses[i]
-		for i := range accepted {
-			accepts := &accepted[i]
-			switch {
-			case clause.Type == accepts.MediaTypeType && clause.SubType == accepts.MediaTypeSubType,
-				clause.Type == accepts.MediaTypeType && clause.SubType == "*",
-				clause.Type == "*" && clause.SubType == "*":
-				if retVal, ret := acceptMediaTypeOptions(clause.Params, accepts, endpoint); ret {
-					return retVal, true
-				}
+		for j := range accepted {
+			if rejected[j] {
+				continue
+			}
+			if retVal, ok := matchedMediaTypeOptions(&clauses[i], &accepted[j], endpoint); ok {
+				return retVal, true
 			}
 		}
 	}
 
 	return MediaTypeOptions{}, false
+}
+
+// negotiateAllMediaTypeOptions is the plural counterpart to NegotiateMediaTypeOptions:
+// it returns every accepted serializer in quality order, deduplicated so a wildcard clause
+// does not re-emit a serializer an earlier clause already matched.
+func negotiateAllMediaTypeOptions(header string, accepted []runtime.SerializerInfo, endpoint EndpointRestrictions) []MediaTypeOptions {
+	if len(header) == 0 && len(accepted) > 0 {
+		return []MediaTypeOptions{{Accepted: accepted[0]}}
+	}
+
+	clauses := goautoneg.ParseAccept(header)
+	rejected := rejectedMediaTypes(clauses, accepted)
+
+	var results []MediaTypeOptions
+	seen := make(map[string]struct{})
+	for i := range clauses {
+		for j := range accepted {
+			if rejected[j] {
+				continue
+			}
+			retVal, ok := matchedMediaTypeOptions(&clauses[i], &accepted[j], endpoint)
+			if !ok {
+				continue
+			}
+			// An earlier, higher-priority clause may have already emitted this serializer.
+			key := accepted[j].MediaType
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+			results = append(results, retVal)
+		}
+	}
+
+	return results
+}
+
+// rejectedMediaTypes reports, per serializer, whether the Accept clauses reject it: a
+// serializer is rejected when its most specific matching clause has q<=0 ("not acceptable",
+// RFC 9110 §12.5.1). Clauses are quality-sorted, so a specificity tie keeps the highest q.
+// This lets application/json;q=0 override a */* that would accept it, while */* still serves
+// as a fallback for types that are not rejected. Both negotiators use it so they agree on
+// acceptability.
+func rejectedMediaTypes(clauses []goautoneg.Accept, accepted []runtime.SerializerInfo) []bool {
+	rejected := make([]bool, len(accepted))
+	for j := range accepted {
+		best := -1
+		for i := range clauses {
+			if spec := clauseSpecificity(&clauses[i], &accepted[j]); spec > best {
+				best = spec
+				rejected[j] = clauses[i].Q <= 0
+			}
+		}
+	}
+	return rejected
+}
+
+// clauseSpecificity ranks how specifically a clause matches a serializer: 2 for an exact
+// match, 1 for type/*, 0 for */*, -1 for no match. Quality is ignored so a specific q=0
+// rejection still outranks a wildcard.
+func clauseSpecificity(clause *goautoneg.Accept, accepts *runtime.SerializerInfo) int {
+	switch {
+	case clause.Type == accepts.MediaTypeType && clause.SubType == accepts.MediaTypeSubType:
+		return 2
+	case clause.Type == accepts.MediaTypeType && clause.SubType == "*":
+		return 1
+	case clause.Type == "*" && clause.SubType == "*":
+		return 0
+	}
+	return -1
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/negotiate_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/negotiate_test.go
@@ -150,6 +150,38 @@ func TestNegotiate(t *testing.T) {
 			params:      map[string]string{"pretty": "1"},
 		},
 
+		// q=0 means "not acceptable": fall through to a type the client still accepts
+		{
+			accept:      "application/json;q=0,application/protobuf",
+			contentType: "application/protobuf",
+			ns:          &fakeNegotiater{serializer: fakeCodec, types: []string{"application/json", "application/protobuf"}},
+			serializer:  fakeCodec,
+		},
+		// q=0 on the only supported type leaves nothing acceptable
+		{
+			accept: "application/json;q=0",
+			ns:     &fakeNegotiater{serializer: fakeCodec, types: []string{"application/json"}},
+			errFn: func(err error) bool {
+				return err.Error() == "only the following media types are accepted: application/json"
+			},
+		},
+		// a wildcard q=0 rejects everything
+		{
+			accept: "*/*;q=0",
+			ns:     &fakeNegotiater{serializer: fakeCodec, types: []string{"application/json"}},
+			errFn: func(err error) bool {
+				return err.Error() == "only the following media types are accepted: application/json"
+			},
+		},
+		// a specific q=0 overrides a wildcard, so the only supported type is rejected
+		{
+			accept: "*/*,application/json;q=0",
+			ns:     &fakeNegotiater{serializer: fakeCodec, types: []string{"application/json"}},
+			errFn: func(err error) bool {
+				return err.Error() == "only the following media types are accepted: application/json"
+			},
+		},
+
 		// query param triggers pretty
 		{
 			req: &http.Request{
@@ -305,5 +337,130 @@ func BenchmarkNegotiateMediaTypeOptions(b *testing.B) {
 		if options.Accepted != accepted[1] {
 			b.Errorf("Unexpected result")
 		}
+	}
+}
+
+// TestNegotiateAllMediaTypeOptions exercises the plural matcher used by the Accept
+// fallback path.
+func TestNegotiateAllMediaTypeOptions(t *testing.T) {
+	accepted := fakeSerializerInfoSlice() // [json, protobuf]
+
+	testCases := []struct {
+		name   string
+		header string
+		want   []string // MediaType strings in expected order
+	}{
+		{
+			name:   "empty header defaults to first supported",
+			header: "",
+			want:   []string{"application/json"},
+		},
+		{
+			name:   "single preferred type",
+			header: "application/json",
+			want:   []string{"application/json"},
+		},
+		{
+			name:   "proto then json preserves order",
+			header: "application/vnd.kubernetes.protobuf,application/json",
+			want:   []string{"application/vnd.kubernetes.protobuf", "application/json"},
+		},
+		{
+			name:   "json then proto preserves order",
+			header: "application/json,application/vnd.kubernetes.protobuf",
+			want:   []string{"application/json", "application/vnd.kubernetes.protobuf"},
+		},
+		{
+			name:   "wildcard expands to all supported without duplicates",
+			header: "application/vnd.kubernetes.protobuf,*/*",
+			want:   []string{"application/vnd.kubernetes.protobuf", "application/json"},
+		},
+		{
+			name:   "unsupported returns empty",
+			header: "unrecognized/stuff",
+			want:   nil,
+		},
+		{
+			name:   "quality-weighted order",
+			header: "application/json;q=0.5,application/vnd.kubernetes.protobuf;q=1.0",
+			want:   []string{"application/vnd.kubernetes.protobuf", "application/json"},
+		},
+		{
+			name:   "q=0 excludes the rejected type",
+			header: "application/vnd.kubernetes.protobuf,application/json;q=0",
+			want:   []string{"application/vnd.kubernetes.protobuf"},
+		},
+		{
+			name:   "q=0 wildcard excludes everything",
+			header: "*/*;q=0",
+			want:   nil,
+		},
+		{
+			name:   "specific q=0 overrides wildcard",
+			header: "application/vnd.kubernetes.protobuf,*/*,application/json;q=0",
+			want:   []string{"application/vnd.kubernetes.protobuf"},
+		},
+		{
+			name:   "wildcard accepts the rest while a specific q=0 is rejected",
+			header: "*/*,application/json;q=0",
+			want:   []string{"application/vnd.kubernetes.protobuf"},
+		},
+		{
+			name:   "wildcard is a fallback when a specific clause fails on params",
+			header: "application/json;as=Table,*/*",
+			want:   []string{"application/json", "application/vnd.kubernetes.protobuf"},
+		},
+		{
+			name:   "type wildcard expands to all matching subtypes",
+			header: "application/*",
+			want:   []string{"application/json", "application/vnd.kubernetes.protobuf"},
+		},
+		{
+			name:   "type wildcard q=0 rejects all matching subtypes",
+			header: "application/*;q=0",
+			want:   nil,
+		},
+		{
+			name:   "exact clause overrides a type wildcard q=0",
+			header: "application/json,application/*;q=0",
+			want:   []string{"application/json"},
+		},
+		{
+			name:   "lone q=0 rejection matches nothing",
+			header: "application/json;q=0",
+			want:   nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := negotiateAllMediaTypeOptions(tc.header, accepted, DefaultEndpointRestrictions)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d results, want %d: %+v", len(got), len(tc.want), got)
+			}
+			for i := range got {
+				if got[i].Accepted.MediaType != tc.want[i] {
+					t.Errorf("position %d: got %q, want %q", i, got[i].Accepted.MediaType, tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestNegotiateOutputMediaTypes_NotAcceptable verifies the plural API returns a
+// NotAcceptableError when no clause matches any supported serializer.
+func TestNegotiateOutputMediaTypes_NotAcceptable(t *testing.T) {
+	ns := &fakeNegotiater{serializer: fakeCodec, types: []string{"application/json"}}
+	req := &http.Request{Header: http.Header{"Accept": []string{"text/html"}}}
+	mts, err := NegotiateOutputMediaTypes(req, ns, DefaultEndpointRestrictions)
+	if err == nil {
+		t.Fatalf("expected NotAcceptableError, got nil; mts=%v", mts)
+	}
+	s, ok := err.(statusError)
+	if !ok {
+		t.Fatalf("expected statusError, got %T", err)
+	}
+	if s.Status().Code != http.StatusNotAcceptable {
+		t.Errorf("expected 406, got %d", s.Status().Code)
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -32,6 +32,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/protobuf"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/endpoints/handlers/negotiation"
@@ -88,6 +89,14 @@ func StreamObject(statusCode int, gv schema.GroupVersion, s runtime.NegotiatedSe
 // The context is optional and can be nil. This method will perform optional content compression if requested by
 // a client and the feature gate for APIResponseCompression is enabled.
 func SerializeObject(mediaType string, encoder runtime.Encoder, hw http.ResponseWriter, req *http.Request, statusCode int, object runtime.Object) {
+	_ = trySerializeObject(mediaType, encoder, hw, req, statusCode, object, false)
+}
+
+// trySerializeObject is the implementation behind SerializeObject. When allowRetry is
+// true and the encoder cannot represent the object (protobuf.IsNotMarshalable) before
+// any bytes have been flushed, it returns false so the caller can try the next
+// serializer. Otherwise it writes the response and returns true.
+func trySerializeObject(mediaType string, encoder runtime.Encoder, hw http.ResponseWriter, req *http.Request, statusCode int, object runtime.Object, allowRetry bool) (committed bool) {
 	ctx := req.Context()
 	ctx, span := tracing.Start(ctx, "SerializeObject",
 		attribute.String("audit-id", audit.GetAuditIDTruncated(ctx)),
@@ -123,7 +132,14 @@ func SerializeObject(mediaType string, encoder runtime.Encoder, hw http.Response
 			// we cannot write an error to the writer anymore as the Encode call was successful.
 			utilruntime.HandleError(fmt.Errorf("apiserver was unable to close cleanly the response writer: %v", err))
 		}
-		return
+		return true
+	}
+	// If the encoder can't represent this object and nothing has been committed yet,
+	// signal the caller to try the next acceptable serializer. The predicate is narrow
+	// by design; if other serializers grow the same failure mode, a shared marker
+	// interface in apimachinery would be the natural generalization.
+	if allowRetry && !w.hasWritten && !w.hasBuffered && protobuf.IsNotMarshalable(err) {
+		return false
 	}
 
 	// make a best effort to write the object if a failure is detected
@@ -143,6 +159,7 @@ func SerializeObject(mediaType string, encoder runtime.Encoder, hw http.Response
 		utilruntime.HandleError(fmt.Errorf("apiserver was unable to write a fallback JSON response: %v", err))
 	}
 	w.Close()
+	return true
 }
 
 var gzipPool = NewGzipWriterPoolOrDie()
@@ -297,7 +314,9 @@ func WriteObjectNegotiated(s runtime.NegotiatedSerializer, restrictions negotiat
 		return
 	}
 
-	mediaType, serializer, err := negotiation.NegotiateOutputMediaType(req, s, restrictions)
+	// Try candidates in Accept quality order; fall through if an encoder can't
+	// represent the object and nothing has been written yet.
+	mediaTypes, err := negotiation.NegotiateOutputMediaTypes(req, s, restrictions)
 	if err != nil {
 		// if original statusCode was not successful we need to return the original error
 		// we cannot hide it behind negotiation problems
@@ -312,19 +331,28 @@ func WriteObjectNegotiated(s runtime.NegotiatedSerializer, restrictions negotiat
 
 	audit.LogResponseObject(req.Context(), object, gv, s)
 
-	var encoder runtime.Encoder
-	if utilfeature.DefaultFeatureGate.Enabled(features.CBORServingAndStorage) {
-		encoder = s.EncoderForVersion(runtime.UseNondeterministicEncoding(serializer.Serializer), gv)
-	} else {
-		encoder = s.EncoderForVersion(serializer.Serializer, gv)
-	}
-	request.TrackSerializeResponseObjectLatency(req.Context(), func() {
-		if listGVKInContentType {
-			SerializeObject(generateMediaTypeWithGVK(serializer.MediaType, mediaType.Convert), encoder, w, req, statusCode, object)
+	for i := range mediaTypes {
+		serializer := mediaTypes[i].Accepted
+		var encoder runtime.Encoder
+		if utilfeature.DefaultFeatureGate.Enabled(features.CBORServingAndStorage) {
+			encoder = s.EncoderForVersion(runtime.UseNondeterministicEncoding(serializer.Serializer), gv)
 		} else {
-			SerializeObject(serializer.MediaType, encoder, w, req, statusCode, object)
+			encoder = s.EncoderForVersion(serializer.Serializer, gv)
 		}
-	})
+		// The last candidate must commit so the client always gets a response.
+		allowRetry := i < len(mediaTypes)-1
+		mt := serializer.MediaType
+		if listGVKInContentType {
+			mt = generateMediaTypeWithGVK(serializer.MediaType, mediaTypes[i].Convert)
+		}
+		var committed bool
+		request.TrackSerializeResponseObjectLatency(req.Context(), func() {
+			committed = trySerializeObject(mt, encoder, w, req, statusCode, object, allowRetry)
+		})
+		if committed {
+			return
+		}
+	}
 }
 
 func generateMediaTypeWithGVK(mediaType string, gvk *schema.GroupVersionKind) string {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
@@ -30,6 +30,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 
 	"sigs.k8s.io/yaml"
@@ -45,6 +46,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/protobuf"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apiserver/pkg/endpoints/handlers/negotiation"
 	"k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -1049,4 +1051,160 @@ func BenchmarkJSONStreaming(b *testing.B) {
 			}
 		}
 	})
+}
+
+// fakeNonProtoObject is a runtime.Object that intentionally does NOT implement
+// the Kubernetes protobuf marshalling interface, so the protobuf serializer
+// will return errNotMarshalable for it.
+type fakeNonProtoObject struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Value      string `json:"value"`
+}
+
+func (f *fakeNonProtoObject) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKind }
+func (f *fakeNonProtoObject) DeepCopyObject() runtime.Object {
+	out := *f
+	return &out
+}
+
+// fakeNegotiatedSerializer exposes an ordered list of media types and returns
+// the supplied serializers as-is from EncoderForVersion (no version wrapping).
+type fakeNegotiatedSerializer struct {
+	infos []runtime.SerializerInfo
+}
+
+func (f *fakeNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerInfo {
+	return f.infos
+}
+func (f *fakeNegotiatedSerializer) EncoderForVersion(e runtime.Encoder, _ runtime.GroupVersioner) runtime.Encoder {
+	return e
+}
+func (f *fakeNegotiatedSerializer) DecoderToVersion(d runtime.Decoder, _ runtime.GroupVersioner) runtime.Decoder {
+	return d
+}
+
+func TestTrySerializeObject_FallbackSignal(t *testing.T) {
+	pbSer := protobuf.NewSerializerWithOptions(nil, nil, protobuf.SerializerOptions{})
+	obj := &fakeNonProtoObject{
+		APIVersion: "v1", Kind: "Fake",
+		Value: "hello",
+	}
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+
+	// allowRetry=true: encoder reports not-marshalable before any flush → caller
+	// should get (committed=false) so it can try the next candidate.
+	rec := httptest.NewRecorder()
+	committed := trySerializeObject("application/vnd.kubernetes.protobuf", pbSer, rec, req, http.StatusOK, obj, true)
+	if committed {
+		t.Fatalf("expected committed=false when the encoder cannot represent the object and retry is allowed")
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("expected no response body, got %q", rec.Body.String())
+	}
+
+	// allowRetry=false: current behavior must be preserved — a 406 body is
+	// written using the protobuf encoder (Status implements proto).
+	rec = httptest.NewRecorder()
+	committed = trySerializeObject("application/vnd.kubernetes.protobuf", pbSer, rec, req, http.StatusOK, obj, false)
+	if !committed {
+		t.Fatalf("expected committed=true in non-retry mode")
+	}
+	if rec.Code != http.StatusNotAcceptable {
+		t.Errorf("expected 406 status, got %d", rec.Code)
+	}
+}
+
+func TestTrySerializeObject_JSONSucceeds(t *testing.T) {
+	jsonSer := jsonserializer.NewSerializerWithOptions(jsonserializer.DefaultMetaFactory, nil, nil, jsonserializer.SerializerOptions{})
+	obj := &fakeNonProtoObject{
+		APIVersion: "v1", Kind: "Fake",
+		Value: "hello",
+	}
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+
+	rec := httptest.NewRecorder()
+	committed := trySerializeObject("application/json", jsonSer, rec, req, http.StatusOK, obj, true)
+	if !committed {
+		t.Fatalf("expected committed=true on successful JSON encode")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `"value":"hello"`) {
+		t.Errorf("expected JSON body to contain value, got %q", rec.Body.String())
+	}
+}
+
+func TestWriteObjectNegotiated_FallsBackFromProtoToJSON(t *testing.T) {
+	pbSer := protobuf.NewSerializerWithOptions(nil, nil, protobuf.SerializerOptions{})
+	jsonSer := jsonserializer.NewSerializerWithOptions(jsonserializer.DefaultMetaFactory, nil, nil, jsonserializer.SerializerOptions{})
+	ns := &fakeNegotiatedSerializer{infos: []runtime.SerializerInfo{
+		{
+			MediaType:        "application/vnd.kubernetes.protobuf",
+			MediaTypeType:    "application",
+			MediaTypeSubType: "vnd.kubernetes.protobuf",
+			Serializer:       pbSer,
+		},
+		{
+			MediaType:        "application/json",
+			MediaTypeType:    "application",
+			MediaTypeSubType: "json",
+			Serializer:       jsonSer,
+		},
+	}}
+	obj := &fakeNonProtoObject{
+		APIVersion: "v1", Kind: "Fake",
+		Value: "hello",
+	}
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Header.Set("Accept", "application/vnd.kubernetes.protobuf,application/json")
+
+	rec := httptest.NewRecorder()
+	WriteObjectNegotiated(ns, negotiation.DefaultEndpointRestrictions, schema.GroupVersion{}, rec, req, http.StatusOK, obj, false)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK after fallback to JSON, got %d; body=%q", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+	if !strings.Contains(rec.Body.String(), `"value":"hello"`) {
+		t.Errorf("expected JSON body, got %q", rec.Body.String())
+	}
+}
+
+func TestWriteObjectNegotiated_ProtoOnlyStillReturns406(t *testing.T) {
+	// Regression guard: clients that accept only protobuf and hit a non-proto
+	// object must continue to receive a 406 — we do not invent a JSON response
+	// when JSON was not requested.
+	pbSer := protobuf.NewSerializerWithOptions(nil, nil, protobuf.SerializerOptions{})
+	jsonSer := jsonserializer.NewSerializerWithOptions(jsonserializer.DefaultMetaFactory, nil, nil, jsonserializer.SerializerOptions{})
+	ns := &fakeNegotiatedSerializer{infos: []runtime.SerializerInfo{
+		{
+			MediaType:        "application/vnd.kubernetes.protobuf",
+			MediaTypeType:    "application",
+			MediaTypeSubType: "vnd.kubernetes.protobuf",
+			Serializer:       pbSer,
+		},
+		{
+			MediaType:        "application/json",
+			MediaTypeType:    "application",
+			MediaTypeSubType: "json",
+			Serializer:       jsonSer,
+		},
+	}}
+	obj := &fakeNonProtoObject{
+		APIVersion: "v1", Kind: "Fake",
+		Value: "hello",
+	}
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Header.Set("Accept", "application/vnd.kubernetes.protobuf")
+
+	rec := httptest.NewRecorder()
+	WriteObjectNegotiated(ns, negotiation.DefaultEndpointRestrictions, schema.GroupVersion{}, rec, req, http.StatusOK, obj, false)
+
+	if rec.Code != http.StatusNotAcceptable {
+		t.Fatalf("expected 406, got %d; body=%q", rec.Code, rec.Body.String())
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

("[fixing old bugs](https://github.com/kubernetes/community/blob/main/contributors/devel/sig-release/release.md#issuepr-kind-label)")

#### What this PR does / why we need it:

Fixes a content-negotiation gap where a client sending `Accept: application/vnd.kubernetes.protobuf,application/json` receives "HTTP 406 Not Acceptable" instead of a JSON response when the object doesn't implement the Kubernetes protobuf marshalling interface. Examples are aggregated-API types like sample-apiserver's `Flunder`, or consumers of the`ProvisioningRequest` CRD through Cluster Autoscaler.

The apiserver now walks the `Accept` header in quality order, falling through to the next acceptable serializer when an encoder reports it cannot represent the object, provided no bytes have been committed to the wire yet.

##### Changes

- New `negotiation.NegotiateOutputMediaTypes` (plural) returning an ordered candidate list; singular `NegotiateOutputMediaType` is unchanged.
- `responsewriters.WriteObjectNegotiated` iterates candidates and retries when the current encoder returns `protobuf.IsNotMarshalable` and nothing has been flushed. The last candidate always commits.
- Unit tests for the plural negotiation path and the writer fallback, plus a regression guard for the existing protobuf-capable path.

##### Behavior

- Only affects multiple-Accept client requests that currently 406 with `errNotMarshalable`.

#### Which issue(s) this PR is related to:

Fixes #86253

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
