### PR TITLE
`AGE` column added to kubectl get crds -o wide table output

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/tableconvertor/tableconvertor.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/tableconvertor/tableconvertor.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/apiserver/pkg/registry/rest"
 )
 
@@ -45,6 +46,7 @@ func (c *crdConvertor) ConvertToTable(ctx context.Context, obj runtime.Object, t
 			{Name: "Scope", Type: "string", Description: "Cluster/Namespaced"},
 			{Name: "Versions", Type: "string", Description: "Served versions"},
 			{Name: "Created At", Type: "date", Description: metaDocs["creationTimestamp"]},
+			{Name: "Age", Type: "date", Priority: 1, Description: metaDocs["creationTimestamp"]},
 			{Name: "Group", Type: "string", Priority: 1, Description: "API group"},
 			{Name: "Kind", Type: "string", Priority: 1, Description: "CustomResource kind"},
 			{Name: "ShortNames", Type: "string", Priority: 1, Description: "Short names"},
@@ -75,6 +77,7 @@ func (c *crdConvertor) ConvertToTable(ctx context.Context, obj runtime.Object, t
 				string(cr.Spec.Scope),
 				strings.Join(versions, ","),
 				cr.CreationTimestamp.Time.UTC().Format(time.RFC3339),
+				translateTimestampSince(cr.CreationTimestamp),
 				cr.Spec.Group,
 				cr.Spec.Names.Kind,
 				shortNames,
@@ -116,4 +119,14 @@ func isEstablished(crd *apiextensions.CustomResourceDefinition) bool {
 		}
 	}
 	return false
+}
+
+// translateTimestampSince returns the elapsed time since timestamp in
+// human-readable approximation.
+func translateTimestampSince(timestamp metav1.Time) string {
+	if timestamp.IsZero() {
+		return "<unknown>"
+	}
+
+	return duration.HumanDuration(time.Since(timestamp.Time))
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/tableconvertor/tableconvertor_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/tableconvertor/tableconvertor_test.go
@@ -60,6 +60,7 @@ func TestPrintCRD(t *testing.T) {
 				"Namespaced",
 				"v1(storage),v1beta1",
 				"2025-05-03T16:36:32Z",
+				"356d",
 				"sample.example.com",
 				"Foo",
 				"f",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature


<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds an `AGE` column to the wide output (`-o wide`) for crds. AGE is derived from `metadata.creationTimestamp` and displayed as a relative duration which is more human readable then `CREATED AT`. The default output remains unchanged, while `CREATED AT` continues to show the exact timestamp.

#### Which issue(s) this PR is related to: https://github.com/kubernetes/kubectl/issues/1832
fixes: https://github.com/kubernetes/kubectl/issues/1832
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Yes
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
