### PR TITLE
Enable defaultorrequired kube api linter rule

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -382,6 +382,7 @@ linters:
               - "commentstart" # Ensure comments start with the serialized version of the field name.
               - "conditions" # Ensure conditions have the correct json tags and markers.
               - "conflictingmarkers" # Detect mutually exclusive markers on the same field.
+              - "defaultorrequired" # Prevent the usage of default tags with required fields.
               - "integers" # Ensure only int32 and int64 are used for integers.
               - "jsontags" # Ensure every field has a json tag.
               # - "maxlength" # Ensure all strings and arrays have maximum lengths/maximum items. ONLY for CRDs until declarative markers exist in core types.

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -413,11 +413,6 @@ linters:
                 - ["k8s:optional", "optional", "kubebuilder:validation:Optional"]
                 - ["k8s:required", "required", "kubebuilder:validation:Required"]
                 description: "fields cannot be both optional and required"
-              - name: "required_vs_default"
-                sets:
-                - ["k8s:required", "required", "kubebuilder:validation:Required"]
-                - ["default"]
-                description: "fields with default values are always optional"
             dependenttags:
               rules:
                 - identifier: "k8s:unionMember"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -426,11 +426,6 @@ linters:
                 - ["k8s:optional", "optional", "kubebuilder:validation:Optional"]
                 - ["k8s:required", "required", "kubebuilder:validation:Required"]
                 description: "fields cannot be both optional and required"
-              - name: "required_vs_default"
-                sets:
-                - ["k8s:required", "required", "kubebuilder:validation:Required"]
-                - ["default"]
-                description: "fields with default values are always optional"
             dependenttags:
               rules:
                 - identifier: "k8s:unionMember"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -395,6 +395,7 @@ linters:
               - "commentstart" # Ensure comments start with the serialized version of the field name.
               - "conditions" # Ensure conditions have the correct json tags and markers.
               - "conflictingmarkers" # Detect mutually exclusive markers on the same field.
+              - "defaultorrequired" # Prevent the usage of default tags with required fields.
               - "integers" # Ensure only int32 and int64 are used for integers.
               - "jsontags" # Ensure every field has a json tag.
               # - "maxlength" # Ensure all strings and arrays have maximum lengths/maximum items. ONLY for CRDs until declarative markers exist in core types.

--- a/hack/kube-api-linter/kube-api-linter.yaml
+++ b/hack/kube-api-linter/kube-api-linter.yaml
@@ -6,6 +6,7 @@ linters:
     - "commentstart" # Ensure comments start with the serialized version of the field name.
     - "conditions" # Ensure conditions have the correct json tags and markers.
     - "conflictingmarkers" # Detect mutually exclusive markers on the same field.
+    - "defaultorrequired" # Prevent the usage of default tags with required fields.
     - "integers" # Ensure only int32 and int64 are used for integers.
     - "jsontags" # Ensure every field has a json tag.
     # - "maxlength" # Ensure all strings and arrays have maximum lengths/maximum items. ONLY for CRDs until declarative markers exist in core types.

--- a/hack/kube-api-linter/kube-api-linter.yaml
+++ b/hack/kube-api-linter/kube-api-linter.yaml
@@ -37,11 +37,6 @@ lintersConfig:
       - ["k8s:optional", "optional", "kubebuilder:validation:Optional"]
       - ["k8s:required", "required", "kubebuilder:validation:Required"]
       description: "fields cannot be both optional and required"
-    - name: "required_vs_default"
-      sets:
-      - ["k8s:required", "required", "kubebuilder:validation:Required"]
-      - ["default"]
-      description: "fields with default values are always optional"
   dependenttags:
     rules:
       - identifier: "k8s:unionMember"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind api-change
/label api-review

#### What this PR does / why we need it:

Enables the `defaultorrequired` rule from KAL
There are currently no exceptions picked up so this one was easy to enable.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Related to #136881 and #134671

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
