### PR TITLE
kube-api-linter: enable noreferences linter

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -163,6 +163,11 @@ linters:
         path: "staging/src/k8s.io/api/resource/(v1|v1beta1|v1beta2)/types.go"
       
       
+      # noreferences: Legacy 'Reference' fields retained for backward compatibility
+      - text: 'noreferences: naming convention "reference-to-ref": field (SerializedReference|ImageVolumeSource).Reference: field names should use ''Ref'' instead of ''Reference'''
+        path: "staging/src/k8s.io/api/core/v1/types.go"
+      
+      
       # optionalfields - Ignore optionalfields issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
@@ -400,6 +405,7 @@ linters:
               - "duplicatemarkers" #Prevent identical markers from being present on types and fields
               - "dependenttags" # Ensure markers dependent on other markers are present.
               - "nodurations" # Ensure duration types are not used.
+              - "noreferences" # Ensure field names use 'Ref'/'Refs' instead of 'Reference'/'References'.
           lintersConfig:
             conditions:
               isFirstField: Ignore

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -178,6 +178,11 @@ linters:
         path: "staging/src/k8s.io/api/resource/(v1|v1beta1|v1beta2)/types.go"
       
       
+      # noreferences: Legacy 'Reference' fields retained for backward compatibility
+      - text: 'noreferences: naming convention "reference-to-ref": field (SerializedReference|ImageVolumeSource).Reference: field names should use ''Ref'' instead of ''Reference'''
+        path: "staging/src/k8s.io/api/core/v1/types.go"
+      
+      
       # optionalfields - Ignore optionalfields issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."
@@ -413,6 +418,7 @@ linters:
               - "duplicatemarkers" #Prevent identical markers from being present on types and fields
               - "dependenttags" # Ensure markers dependent on other markers are present.
               - "nodurations" # Ensure duration types are not used.
+              - "noreferences" # Ensure field names use 'Ref'/'Refs' instead of 'Reference'/'References'.
           lintersConfig:
             conditions:
               isFirstField: Ignore

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -39,6 +39,11 @@
   path: "staging/src/k8s.io/api/resource/(v1|v1beta1|v1beta2)/types.go"
 
 
+# noreferences: Legacy 'Reference' fields retained for backward compatibility
+- text: 'noreferences: naming convention "reference-to-ref": field (SerializedReference|ImageVolumeSource).Reference: field names should use ''Ref'' instead of ''Reference'''
+  path: "staging/src/k8s.io/api/core/v1/types.go"
+
+
 # optionalfields - Ignore optionalfields issues for existing API group
 # TODO: For each existing API group, we aim to remove it over time.
 - text: "optionalfields: field .* should (?:be a pointer|have the omitempty tag)\\."

--- a/hack/kube-api-linter/kube-api-linter.yaml
+++ b/hack/kube-api-linter/kube-api-linter.yaml
@@ -24,6 +24,7 @@ linters:
     - "duplicatemarkers" #Prevent identical markers from being present on types and fields
     - "dependenttags" # Ensure markers dependent on other markers are present.
     - "nodurations" # Ensure duration types are not used.
+    - "noreferences" # Ensure field names use 'Ref'/'Refs' instead of 'Reference'/'References'.
 lintersConfig:
   conditions:
     isFirstField: Ignore


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Enable noreferences rule for Kube API Linter

#### Which issue(s) this PR is related to:
Part of https://github.com/kubernetes/kubernetes/issues/134671

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
