### PR TITLE
e2e: Skip Windows eviction test on Hyper-V nodes

### DIFF
--- a/test/e2e/windows/eviction.go
+++ b/test/e2e/windows/eviction.go
@@ -95,6 +95,16 @@ var _ = sigDescribe(feature.Windows, "Eviction", framework.WithSerial(), framewo
 			e2eskipper.Skipf("No Windows nodes with hard memory-pressure eviction found")
 		}
 
+		// Skip this test on Hyper-V nodes. Hyper-V containers run inside
+		// lightweight VMs with dynamic memory, so testlimit.exe inside a pod
+		// cannot create real host memory pressure — the balloon driver reclaims
+		// pages and the host pages out VM memory to its pagefile.
+		for _, rh := range node.Status.RuntimeHandlers {
+			if rh.Name == "runhcs-wcow-hypervisor" {
+				e2eskipper.Skipf("Eviction test is not supported on Hyper-V nodes (memory pressure cannot be created from inside a VM)")
+			}
+		}
+
 		framework.Logf("Node %q capacity: %v Mi", node.Name, nodeMem.capacity.Value()/(1024*1024))
 		framework.Logf("Node %q hard eviction threshold: %v Mi", node.Name, nodeMem.hardEviction.Value()/(1024*1024))
 		framework.Logf("Available memory before eviction: %v Mi", (nodeMem.capacity.Value()-nodeMem.hardEviction.Value())/(1024*1024))


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

Skip the Windows memory eviction e2e test on Hyper-V nodes. Hyper-V containers run inside lightweight VMs with dynamic memory — `testlimit.exe` inside a pod only exhausts the VM's internal memory, not the host's physical memory. The balloon driver reclaims pages and the host pages out VM memory to its pagefile, so kubelet never observes real host memory pressure and eviction never triggers.

Without this skip, the eviction test runs for 15+ minutes on Hyper-V clusters without triggering eviction, then fails. Because it's marked `[Disruptive]`, the stale memory pressure state causes cascade failures in subsequent serial tests (SchedulerPreemption, GarbageCollector, etc.).

## Which issue(s) this PR fixes:

None

## Special notes for your reviewer:

The skip uses `node.Status.RuntimeHandlers` to detect the `runhcs-wcow-hypervisor` runtime handler at test time — the same runtime detection pattern used elsewhere in the e2e suite. This is placed right after the existing node selection logic that already skips when no eviction-enabled node is found.

On non-Hyper-V (process isolation) clusters, the test continues to run normally.

## Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig windows
/area test
/priority important-soon