### PR TITLE
apiextensions: make CEL property validation deterministic

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go
@@ -23,6 +23,7 @@ import (
 	"math"
 	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -826,8 +827,13 @@ func (s *Validator) validateMap(ctx context.Context, fldPath *field.Path, obj, o
 
 	correlatable := MapIsCorrelatable(s.Schema.XMapType)
 
+	if s.AdditionalProperties == nil && s.Properties == nil {
+		return errs, remainingBudget
+	}
+	keys := sortedMapKeys(obj)
 	if s.AdditionalProperties != nil {
-		for k, v := range obj {
+		for _, k := range keys {
+			v := obj[k]
 			var oldV interface{}
 			if correlatable {
 				oldV = oldObj[k] // +k8s:verify-mutation:reason=clone
@@ -842,7 +848,8 @@ func (s *Validator) validateMap(ctx context.Context, fldPath *field.Path, obj, o
 		}
 	}
 	if s.Properties != nil {
-		for k, v := range obj {
+		for _, k := range keys {
+			v := obj[k]
 			sub, ok := s.Properties[k]
 			if ok {
 				var oldV interface{}
@@ -861,6 +868,15 @@ func (s *Validator) validateMap(ctx context.Context, fldPath *field.Path, obj, o
 	}
 
 	return errs, remainingBudget
+}
+
+func sortedMapKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func (s *Validator) validateArray(ctx context.Context, fldPath *field.Path, obj, oldObj []interface{}, correlation ratchetingOptions, costBudget int64) (errs field.ErrorList, remainingBudget int64) {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
@@ -3459,6 +3459,54 @@ func TestReasonAndFldPath(t *testing.T) {
 	}
 }
 
+func TestValidationErrorsForPropertiesAreDeterministic(t *testing.T) {
+	properties := map[string]schema.Structural{
+		"alpha":   withRuleMessageAndMessageExpression(stringType, `self == "ok"`, "alpha must be ok", ""),
+		"bravo":   withRuleMessageAndMessageExpression(stringType, `self == "ok"`, "bravo must be ok", ""),
+		"charlie": withRuleMessageAndMessageExpression(stringType, `self == "ok"`, "charlie must be ok", ""),
+		"delta":   withRuleMessageAndMessageExpression(stringType, `self == "ok"`, "delta must be ok", ""),
+		"echo":    withRuleMessageAndMessageExpression(stringType, `self == "ok"`, "echo must be ok", ""),
+		"foxtrot": withRuleMessageAndMessageExpression(stringType, `self == "ok"`, "foxtrot must be ok", ""),
+		"golf":    withRuleMessageAndMessageExpression(stringType, `self == "ok"`, "golf must be ok", ""),
+		"hotel":   withRuleMessageAndMessageExpression(stringType, `self == "ok"`, "hotel must be ok", ""),
+	}
+	s := objectType(properties)
+	celValidator := NewValidator(&s, false, celconfig.PerCallLimit)
+	require.NotNil(t, celValidator)
+
+	obj := map[string]interface{}{
+		"alpha":   "bad",
+		"bravo":   "bad",
+		"charlie": "bad",
+		"delta":   "bad",
+		"echo":    "bad",
+		"foxtrot": "bad",
+		"golf":    "bad",
+		"hotel":   "bad",
+	}
+	expectedFields := []string{
+		"root.alpha",
+		"root.bravo",
+		"root.charlie",
+		"root.delta",
+		"root.echo",
+		"root.foxtrot",
+		"root.golf",
+		"root.hotel",
+	}
+
+	for i := range 100 {
+		errs, _ := celValidator.Validate(context.TODO(), field.NewPath("root"), &s, obj, nil, celconfig.RuntimeCELCostBudget)
+		require.Len(t, errs, len(expectedFields))
+
+		fields := make([]string, 0, len(errs))
+		for _, err := range errs {
+			fields = append(fields, err.Field)
+		}
+		require.Equal(t, expectedFields, fields, "iteration %d", i)
+	}
+}
+
 func TestValidateFieldPath(t *testing.T) {
 	sts := schema.Structural{
 		Generic: schema.Generic{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This makes CRD CEL validation for object/map child validators run in deterministic key order.

Before this change, `Validator.validateMap` iterated over the incoming `map[string]interface{}` directly. Go map iteration order is intentionally non-deterministic, so multiple CEL validation failures under sibling fields could be returned in different orders across validations. That also made the order of validation work before a runtime CEL cost budget is exhausted non-deterministic.

The change sorts the current object/map keys before recursing into `additionalProperties` and declared `properties`. It also avoids sorting when the validator has no child validators to visit.

#### Which issue(s) this PR is related to:

Fixes #130984

#### Special notes for your reviewer:

I checked the additional sort cost with temporary benchmarks that were not committed.

<details>
<summary>Benchmark script</summary>

```go
package cel

import (
    "context"
    "fmt"
    "testing"

    "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
    "k8s.io/apimachinery/pkg/util/validation/field"
    celconfig "k8s.io/apiserver/pkg/apis/cel"
)

var mapKeyOrderBenchmarkSink int

func BenchmarkMapKeyOrderOverhead(b *testing.B) {
    for _, n := range []int{10, 100, 1000, 10000} {
        m := makeBenchmarkMap(n)
        b.Run(fmt.Sprintf("range-%d", n), func(b *testing.B) {
            total := 0
            b.ReportAllocs()
            b.ResetTimer()
            for i := 0; i < b.N; i++ {
                for k, v := range m {
                    if v != nil {
                        total += len(k)
                    }
                }
            }
            mapKeyOrderBenchmarkSink = total
        })
        b.Run(fmt.Sprintf("sorted-%d", n), func(b *testing.B) {
            total := 0
            b.ReportAllocs()
            b.ResetTimer()
            for i := 0; i < b.N; i++ {
                keys := sortedMapKeys(m)
                for _, k := range keys {
                    if m[k] != nil {
                        total += len(k)
                    }
                }
            }
            mapKeyOrderBenchmarkSink = total
        })
    }
}

func BenchmarkMapValidationOrderOverhead(b *testing.B) {
    for _, n := range []int{10, 100, 1000, 10000} {
        _, v, obj := makeBenchmarkMapValidator(n)
        b.Run(fmt.Sprintf("unsorted-%d", n), func(b *testing.B) {
            total := 0
            b.ReportAllocs()
            b.ResetTimer()
            for i := 0; i < b.N; i++ {
                errs, remainingBudget := validateMapUnsortedForBenchmark(v, context.TODO(), field.NewPath("root"), obj, nil, ratchetingOptions{}, celconfig.RuntimeCELCostBudget)
                total += len(errs) + int(remainingBudget&1)
            }
            mapKeyOrderBenchmarkSink = total
        })
        b.Run(fmt.Sprintf("sorted-%d", n), func(b *testing.B) {
            total := 0
            b.ReportAllocs()
            b.ResetTimer()
            for i := 0; i < b.N; i++ {
                errs, remainingBudget := v.validateMap(context.TODO(), field.NewPath("root"), obj, nil, ratchetingOptions{}, celconfig.RuntimeCELCostBudget)
                total += len(errs) + int(remainingBudget&1)
            }
            mapKeyOrderBenchmarkSink = total
        })
    }
}

func makeBenchmarkMap(n int) map[string]interface{} {
    m := make(map[string]interface{}, n)
    for i := 0; i < n; i++ {
        m[fmt.Sprintf("key-%06d", i)] = i
    }
    return m
}

func makeBenchmarkMapValidator(n int) (*schema.Structural, *Validator, map[string]interface{}) {
    valueSchema := withRuleMessageAndMessageExpression(stringType, `self == "ok"`, "must be ok", "")
    s := mapType(&valueSchema)
    v := NewValidator(&s, false, celconfig.PerCallLimit)
    if v == nil {
        panic("expected non-nil validator")
    }

    obj := make(map[string]interface{}, n)
    for i := 0; i < n; i++ {
        obj[fmt.Sprintf("key-%06d", i)] = "ok"
    }
    return &s, v, obj
}
```

The `validateMapUnsortedForBenchmark` helper was a copy of the previous `validateMap` map-iteration behavior for comparison.

</details>

<details>
<summary>Benchmark results</summary>

Command:

```console
go test ./staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel -run '^$' -bench '^BenchmarkMapValidationOrderOverhead$' -benchmem -count=3 -benchtime=1s
```

End-to-end CEL validation path, with `additionalProperties` values each running a simple CEL rule:

| keys | previous unordered iteration | sorted iteration | delta |
|---:|---:|---:|---:|
| 10 | ~39.2 us/op | ~38.8 us/op | noise |
| 100 | ~384 us/op | ~394 us/op | ~+9.5 us, +2.5% |
| 1,000 | ~3.79 ms/op | ~3.98 ms/op | ~+0.19 ms, +5.1% |
| 10,000 | ~35.6 ms/op | ~37.9 ms/op | ~+2.27 ms, +6.4% |

I also ran a microbenchmark that only measured key traversal. That showed the raw sorting cost more clearly: about ~10.2 us for 100 keys, ~160 us for 1,000 keys, and ~2.05 ms for 10,000 keys, with one slice allocation for the sorted keys.

</details>

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

#### Test plan

```console
go test ./staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel -run TestValidationErrorsForPropertiesAreDeterministic -count=1
make test WHAT=./staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel
make quick-verify
_output/local/bin/golangci-lint run --config=hack/golangci.yaml ./staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel
```
