### PR TITLE
kubelet/memorymanager: include conflicting cross-NUMA hints as non-preferred

### DIFF
--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -933,20 +933,15 @@ func (p *staticPolicy) calculateHints(machineState state.NUMANodeMap, pod *v1.Po
 			return
 		}
 
-		for _, nodeID := range maskBits {
-			// the node already used for the memory allocation
-			if !singleNUMAHint && machineState[nodeID].NumberOfAssignments > 0 {
-				// the node used for the single NUMA memory allocation, it can not be used for the multi NUMA node allocation
-				if len(machineState[nodeID].Cells) == 1 {
-					return
-				}
-
-				// the node already used with different group of nodes, it can not be use with in the current hint
-				if !areGroupsEqual(machineState[nodeID].Cells, maskBits) {
-					return
-				}
-			}
-		}
+		// Cross-NUMA hints that conflict with existing single-NUMA allocations on
+		// one of the target nodes are no longer excluded outright. Excluding them
+		// leaves the TopologyManager unaware that Memory Manager has a preference
+		// against such topology, so in best-effort mode it may still choose a
+		// conflicting hint based on CPU/device affinity — and then Allocate() hard-
+		// fails. Instead, we include conflicting hints but force them non-preferred
+		// in the post-loop pass below, giving the TopologyManager a signal to avoid
+		// them when non-conflicting alternatives exist.
+		// See: https://github.com/kubernetes/kubernetes/issues/138495
 
 		// verify that for all memory types the node mask has enough free resources
 		for resourceName, requestedSize := range requestedResources {
@@ -972,7 +967,16 @@ func (p *staticPolicy) calculateHints(machineState state.NUMANodeMap, pod *v1.Po
 	// behaviour to prefer the minimal amount of NUMA nodes will be used
 	for resourceName := range requestedResources {
 		for i, hint := range hints[string(resourceName)] {
-			hints[string(resourceName)][i].Preferred = p.isHintPreferred(hint.NUMANodeAffinity.GetBits(), minAffinitySize)
+			preferred := p.isHintPreferred(hint.NUMANodeAffinity.GetBits(), minAffinitySize)
+			// Even if a hint has the minimum affinity size, downgrade it to
+			// non-preferred when it would violate the single-vs-cross NUMA
+			// allocation invariant for an already-allocated NUMA node. This
+			// steers the TopologyManager away from such hints in best-effort
+			// mode without removing them from the hint list entirely.
+			if preferred && isAffinityViolatingNUMAAllocations(machineState, hint.NUMANodeAffinity) {
+				preferred = false
+			}
+			hints[string(resourceName)][i].Preferred = preferred
 		}
 	}
 

--- a/pkg/kubelet/cm/memorymanager/policy_static_test.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static_test.go
@@ -3963,6 +3963,97 @@ func TestStaticPolicyGetTopologyHints(t *testing.T) {
 			podLevelResourcesEnabled:        true,
 			podLevelResourceManagersEnabled: true,
 		},
+		{
+			// When NUMA node 0 already has a single-NUMA allocation, a cross-NUMA
+			// hint {0,1} would violate the single-vs-cross allocation invariant.
+			// Previously such hints were excluded from the hint list entirely,
+			// leaving the TopologyManager blind to Memory Manager constraints
+			// and causing Allocate() to hard-fail in best-effort mode.
+			// The corrected behavior includes the conflicting hint as non-preferred
+			// so the TopologyManager can score it lower when better options exist.
+			description: "should include cross-NUMA hint as non-preferred when a target node already has a single-NUMA allocation",
+			machineState: state.NUMANodeMap{
+				0: &state.NUMANodeState{
+					MemoryMap: map[v1.ResourceName]*state.MemoryTable{
+						v1.ResourceMemory: {
+							Allocatable:    2 * gb,
+							Free:           gb,
+							Reserved:       gb,
+							SystemReserved: 512 * mb,
+							TotalMemSize:   3 * gb,
+						},
+						hugepages1Gi: {
+							Allocatable:    gb,
+							Free:           gb,
+							Reserved:       0,
+							SystemReserved: 0,
+							TotalMemSize:   gb,
+						},
+					},
+					Cells:               []int{0},
+					NumberOfAssignments: 1,
+				},
+				1: &state.NUMANodeState{
+					MemoryMap: map[v1.ResourceName]*state.MemoryTable{
+						v1.ResourceMemory: {
+							Allocatable:    2 * gb,
+							Free:           2 * gb,
+							Reserved:       0,
+							SystemReserved: 512 * mb,
+							TotalMemSize:   3 * gb,
+						},
+						hugepages1Gi: {
+							Allocatable:    gb,
+							Free:           gb,
+							Reserved:       0,
+							SystemReserved: 0,
+							TotalMemSize:   gb,
+						},
+					},
+					Cells:               []int{1},
+					NumberOfAssignments: 0,
+				},
+			},
+			systemReserved: systemReservedMemory{
+				0: map[v1.ResourceName]uint64{
+					v1.ResourceMemory: 512 * mb,
+				},
+				1: map[v1.ResourceName]uint64{
+					v1.ResourceMemory: 512 * mb,
+				},
+			},
+			pod: getPod("pod2", "container1", requirementsGuaranteed),
+			expectedTopologyHints: map[string][]topologymanager.TopologyHint{
+				string(v1.ResourceMemory): {
+					{
+						NUMANodeAffinity: newNUMAAffinity(0),
+						Preferred:        true,
+					},
+					{
+						NUMANodeAffinity: newNUMAAffinity(1),
+						Preferred:        true,
+					},
+					{
+						NUMANodeAffinity: newNUMAAffinity(0, 1),
+						Preferred:        false,
+					},
+				},
+				string(hugepages1Gi): {
+					{
+						NUMANodeAffinity: newNUMAAffinity(0),
+						Preferred:        true,
+					},
+					{
+						NUMANodeAffinity: newNUMAAffinity(1),
+						Preferred:        true,
+					},
+					{
+						NUMANodeAffinity: newNUMAAffinity(0, 1),
+						Preferred:        false,
+					},
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/sig node

**What this PR does / why we need it:**

When a NUMA node already holds a single-NUMA memory allocation,
`calculateHints()` previously excluded any cross-NUMA hint covering that
node from the returned hint list. The intent was to prevent the
TopologyManager from choosing a topology that violates the single-vs-cross
NUMA allocation invariant enforced by `Allocate()`.

The exclusion backfires in `best-effort` topology manager mode: without
those hints in the list, the TopologyManager has no signal that Memory
Manager dislikes that topology, so it can still select the conflicting
cross-NUMA affinity driven by CPU or device manager preferences.
`Allocate()` then hard-fails with:

```
[memorymanager] preferred hint violates NUMA node allocation
```

even though sufficient memory exists on a non-conflicting NUMA node.

**The fix:**

Instead of dropping conflicting cross-NUMA hints, include them in the
hint list with `Preferred: false`. The TopologyManager in best-effort
mode will then deprioritise those hints and favour non-conflicting
alternatives when they exist, avoiding the `Allocate()` failure path.

The `isAffinityViolatingNUMAAllocations` guard in `Allocate()` is kept
as a hard error for cases where no non-conflicting allocation is
possible.

**Changes:**

- `pkg/kubelet/cm/memorymanager/policy_static.go`: remove the
  early-return that excluded conflicting cross-NUMA hints from
  `calculateHints()`; add an `isAffinityViolatingNUMAAllocations` check
  in the post-loop preferred-setting pass to force such hints to
  `Preferred: false`.
- `pkg/kubelet/cm/memorymanager/policy_static_test.go`: add a test case
  verifying that a cross-NUMA hint covering an already-single-NUMA-
  allocated node is included in the hint list but marked non-preferred.

**Does this PR introduce a user-facing change?**

```release-note
Fixed a bug where Memory Manager static policy hard-failed with
"preferred hint violates NUMA node allocation" in best-effort
TopologyManager mode even when memory was available on a non-conflicting
NUMA node.
```

Fixes #138495