### PR TITLE
Fix swagger doc generation for JSON field names containing "inline"

### DIFF
--- a/staging/src/k8s.io/api/storage/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/storage/v1/types_swagger_doc_generated.go
@@ -190,6 +190,7 @@ func (VolumeAttachmentList) SwaggerDoc() map[string]string {
 var map_VolumeAttachmentSource = map[string]string{
 	"":                     "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistentVolumes can be attached via external attacher, in the future we may allow also inline volumes in pods. Exactly one member can be set.",
 	"persistentVolumeName": "persistentVolumeName represents the name of the persistent volume to attach.",
+	"inlineVolumeSpec":     "inlineVolumeSpec contains all the information necessary to attach a persistent volume defined by a pod's inline VolumeSource. This field is populated only for the CSIMigration feature. It contains translated fields from a pod's inline VolumeSource to a PersistentVolumeSpec. This field is beta-level and is only honored by servers that enabled the CSIMigration feature.",
 }
 
 func (VolumeAttachmentSource) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/storage/v1alpha1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/storage/v1alpha1/types_swagger_doc_generated.go
@@ -74,6 +74,7 @@ func (VolumeAttachmentList) SwaggerDoc() map[string]string {
 var map_VolumeAttachmentSource = map[string]string{
 	"":                     "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistentVolumes can be attached via external attacher, in the future we may allow also inline volumes in pods. Exactly one member can be set.",
 	"persistentVolumeName": "persistentVolumeName represents the name of the persistent volume to attach.",
+	"inlineVolumeSpec":     "inlineVolumeSpec contains all the information necessary to attach a persistent volume defined by a pod's inline VolumeSource. This field is populated only for the CSIMigration feature. It contains translated fields from a pod's inline VolumeSource to a PersistentVolumeSpec. This field is alpha-level and is only honored by servers that enabled the CSIMigration feature.",
 }
 
 func (VolumeAttachmentSource) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/storage/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/types_swagger_doc_generated.go
@@ -190,6 +190,7 @@ func (VolumeAttachmentList) SwaggerDoc() map[string]string {
 var map_VolumeAttachmentSource = map[string]string{
 	"":                     "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistentVolumes can be attached via external attacher, in the future we may allow also inline volumes in pods. Exactly one member can be set.",
 	"persistentVolumeName": "persistentVolumeName represents the name of the persistent volume to attach.",
+	"inlineVolumeSpec":     "inlineVolumeSpec contains all the information necessary to attach a persistent volume defined by a pod's inline VolumeSource. This field is populated only for the CSIMigration feature. It contains translated fields from a pod's inline VolumeSource to a PersistentVolumeSpec. This field is beta-level and is only honored by servers that enabled the CSIMigration feature.",
 }
 
 func (VolumeAttachmentSource) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/swagger_doc_generator.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/swagger_doc_generator.go
@@ -98,7 +98,7 @@ func fieldName(field *ast.Field) string {
 	jsonTag := ""
 	if field.Tag != nil {
 		jsonTag = reflect.StructTag(field.Tag.Value[1 : len(field.Tag.Value)-1]).Get("json") // Delete first and last quotation
-		if strings.Contains(jsonTag, "inline") {
+		if hasJSONTagOption(jsonTag, "inline") {
 			return "-"
 		}
 	}
@@ -111,6 +111,21 @@ func fieldName(field *ast.Field) string {
 		return field.Type.(*ast.Ident).Name
 	}
 	return jsonTag
+}
+
+// hasJSONTagOption reports whether option appears as a comma-separated
+// JSON tag option (e.g. "inline" in `json:",inline"`). The first comma-
+// separated component is the JSON field name, never an option, and is
+// skipped. This avoids substring false-positives such as a field named
+// inlineVolumeSpec being mistaken for a `,inline` embedded struct.
+func hasJSONTagOption(jsonTag, option string) bool {
+	parts := strings.Split(jsonTag, ",")
+	for _, part := range parts[1:] {
+		if part == option {
+			return true
+		}
+	}
+	return false
 }
 
 // A buffer of lines that will be written.

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/swagger_doc_generator_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/swagger_doc_generator_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package runtime
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"testing"
 )
 
@@ -40,4 +43,53 @@ func TestFmtRawDoc(t *testing.T) {
 			t.Fatalf("Expected: %q, got %q", test.expected, o)
 		}
 	}
+}
+
+func TestFieldNameJSONInlineOption(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "embedded inline field is skipped",
+			src:  "TypeMeta `json:\",inline\"`",
+			want: "-",
+		},
+		{
+			name: "field name containing the substring inline is retained",
+			src:  "InlineVolumeSpec *PersistentVolumeSpec `json:\"inlineVolumeSpec,omitempty\"`",
+			want: "inlineVolumeSpec",
+		},
+		{
+			name: "field whose JSON name is exactly inline is retained",
+			src:  "Inline string `json:\"inline,omitempty\"`",
+			want: "inline",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field := mustParseStructField(t, tt.src)
+			if got := fieldName(field); got != tt.want {
+				t.Fatalf("fieldName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func mustParseStructField(t *testing.T, fieldSrc string) *ast.Field {
+	t.Helper()
+
+	src := "package p\n\ntype T struct {\n" + fieldSrc + "\n}\n"
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "test.go", src, 0)
+	if err != nil {
+		t.Fatalf("ParseFile() error = %v", err)
+	}
+
+	decl := f.Decls[0].(*ast.GenDecl)
+	spec := decl.Specs[0].(*ast.TypeSpec)
+	st := spec.Type.(*ast.StructType)
+	return st.Fields.List[0]
 }


### PR DESCRIPTION
### What this PR does

Fixes swagger doc generation for JSON field names that contain the substring `inline`.

The swagger doc generator currently treats any JSON tag containing `inline` as a field to skip:

```go
if strings.Contains(jsonTag, "inline") {
    return "-"
}
```

That correctly skips embedded fields tagged `json:",inline"`, but it also skips ordinary fields whose JSON field name contains the substring `inline`.

One current example is:

```go
InlineVolumeSpec *v1.PersistentVolumeSpec `json:"inlineVolumeSpec,omitempty"`
```

Because `inlineVolumeSpec` contains `inline`, the generated `map_VolumeAttachmentSource` omits the field's description in the affected storage API versions (`storage/v1`, `storage/v1alpha1`, `storage/v1beta1`).

### Why

`inline` is a JSON tag option, not a substring match over the entire JSON tag. The first comma-separated component is the JSON field name; only subsequent components should be treated as options.

This PR changes the generator to split the JSON tag on commas and exact-match `inline` only among the tag options. A small `hasJSONTagOption` helper makes the check reusable and the test cleaner.

### Result

After regenerating swagger docs, `inlineVolumeSpec` appears in the generated `VolumeAttachmentSource` swagger doc maps for the three affected storage versions.

The change is additive in the generated API docs: one new entry per affected file. No existing generated descriptions change.

### Tests

Added a regression test in `staging/src/k8s.io/apimachinery/pkg/runtime/swagger_doc_generator_test.go` covering:

* `json:",inline"` is still skipped (existing behavior preserved)
* `json:"inlineVolumeSpec,omitempty"` is retained (the bug's case)
* `json:"inline,omitempty"` is retained as a normal JSON field name

Ran locally:

```bash
go test ./staging/src/k8s.io/apimachinery/pkg/runtime/
```

Both `TestFmtRawDoc` and the new `TestFieldNameJSONInlineOption` pass.

The three regenerated `types_swagger_doc_generated.go` files were produced by `cmd/genswaggertypedocs` against the corresponding `types.go`, mirroring the `gen_types_swagger_doc` function in `hack/update-codegen.sh`. The diff is exactly one added map entry per file, all describing the same `inlineVolumeSpec` field. I did not run `hack/update-codegen.sh` / `hack/verify-codegen.sh` / `hack/verify-description.sh` locally; the prow checks will exercise those.

### Notes

The bug has been latent since `swagger_doc_generator.go` was introduced. `hack/verify-description.sh` does not catch it because it invokes the same `genswaggertypedocs` binary and so shares the buggy `fieldName()` predicate; the on-disk artifact matches the verifier's regenerated output, so the verify step reports clean by construction.

---

*AI disclosure: AI tools were used in preparing this PR. As the author I have reviewed and verified every change, and can speak to any aspect on review.*

/sig api-machinery
/sig storage
/kind bug


```release-note
Fix swagger doc generation for JSON field names containing the substring "inline". Previously, such fields (notably `storage.k8s.io/v1.VolumeAttachmentSource.inlineVolumeSpec`) were silently dropped from `types_swagger_doc_generated.go` because the generator's predicate substring-matched on `inline` rather than exact-matching it as a comma-separated JSON tag option. Restored documentation now appears in `kubectl explain` output for affected fields.
```
