### PR TITLE
HPA: add SelectorMatchesExtraPods condition

### DIFF
--- a/pkg/apis/autoscaling/types.go
+++ b/pkg/apis/autoscaling/types.go
@@ -435,6 +435,9 @@ const (
 	ScalingLimited HorizontalPodAutoscalerConditionType = "ScalingLimited"
 	// ScaledToZero indicates that the HPA controller scaled the workload to zero.
 	ScaledToZero HorizontalPodAutoscalerConditionType = "ScaledToZero"
+	// SelectorMatchesExtraPods indicates that the HPA's selector matches more pods
+	// than the scale target reports as owned, which may skew metric averages.
+	SelectorMatchesExtraPods HorizontalPodAutoscalerConditionType = "SelectorMatchesExtraPods"
 )
 
 // HorizontalPodAutoscalerCondition describes the state of

--- a/pkg/apis/autoscaling/types.go
+++ b/pkg/apis/autoscaling/types.go
@@ -431,6 +431,9 @@ const (
 	ScalingLimited HorizontalPodAutoscalerConditionType = "ScalingLimited"
 	// ScaledToZero indicates that the HPA controller scaled the workload to zero.
 	ScaledToZero HorizontalPodAutoscalerConditionType = "ScaledToZero"
+	// SelectorMatchesExtraPods indicates that the HPA's selector matches more pods
+	// than the scale target reports as owned, which may skew metric averages.
+	SelectorMatchesExtraPods HorizontalPodAutoscalerConditionType = "SelectorMatchesExtraPods"
 )
 
 // HorizontalPodAutoscalerCondition describes the state of

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -326,6 +326,30 @@ func (a *HorizontalController) computeReplicasForMetrics(ctx context.Context, hp
 	var invalidMetricError error
 	var invalidMetricCondition autoscalingv2.HorizontalPodAutoscalerCondition
 
+	// Surface a condition when the selector matches more active pods than the
+	// scale target owns. This usually indicates two workloads share a label,
+	// which causes HPA to average metrics across pods it does not control and
+	// scale incorrectly. Terminating and failed pods are excluded to match the
+	// set of pods the replica calculator considers; the condition can still
+	// fire transiently during rolling updates - treat it as advisory.
+	podList, err := a.podLister.Pods(hpa.Namespace).List(selector)
+	if err != nil {
+		return -1, "", nil, time.Time{}, fmt.Errorf("unable to list pods for selector %v: %w", selector, err)
+	}
+	activePodsCount := 0
+	for _, pod := range podList {
+		if pod.DeletionTimestamp != nil || pod.Status.Phase == v1.PodFailed {
+			continue
+		}
+		activePodsCount++
+	}
+	if activePodsCount > int(scale.Status.Replicas) {
+		msg := fmt.Sprintf("selector %v matches %d active pods, more than the %d replicas on the scale target; selector may overlap with another workload", selector, activePodsCount, scale.Spec.Replicas)
+		setCondition(hpa, autoscalingv2.SelectorMatchesExtraPods, v1.ConditionTrue, "SelectorOverlap", "%s", msg)
+	} else {
+		removeCondition(hpa, autoscalingv2.SelectorMatchesExtraPods)
+	}
+
 	for i, metricSpec := range metricSpecs {
 		replicaCountProposal, metricNameProposal, timestampProposal, condition, err := a.computeReplicasForMetric(ctx, hpa, metricSpec, specReplicas, statusReplicas, selector, &statuses[i])
 

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -391,6 +391,30 @@ func (a *HorizontalController) computeReplicasForMetrics(ctx context.Context, hp
 	var invalidMetricError error
 	var invalidMetricCondition autoscalingv2.HorizontalPodAutoscalerCondition
 
+	// Surface a condition when the selector matches more active pods than the
+	// scale target owns. This usually indicates two workloads share a label,
+	// which causes HPA to average metrics across pods it does not control and
+	// scale incorrectly. Terminating and failed pods are excluded to match the
+	// set of pods the replica calculator considers; the condition can still
+	// fire transiently during rolling updates - treat it as advisory.
+	podList, err := a.podLister.Pods(hpa.Namespace).List(selector)
+	if err != nil {
+		return -1, "", nil, time.Time{}, fmt.Errorf("unable to list pods for selector %v: %w", selector, err)
+	}
+	activePodsCount := 0
+	for _, pod := range podList {
+		if pod.DeletionTimestamp != nil || pod.Status.Phase == v1.PodFailed {
+			continue
+		}
+		activePodsCount++
+	}
+	if activePodsCount > int(scale.Status.Replicas) {
+		msg := fmt.Sprintf("selector %v matches %d active pods, more than the %d replicas on the scale target; selector may overlap with another workload", selector, activePodsCount, scale.Spec.Replicas)
+		setCondition(hpa, autoscalingv2.SelectorMatchesExtraPods, v1.ConditionTrue, "SelectorOverlap", "%s", msg)
+	} else {
+		removeCondition(hpa, autoscalingv2.SelectorMatchesExtraPods)
+	}
+
 	for i, metricSpec := range metricSpecs {
 		replicaCountProposal, metricNameProposal, timestampProposal, condition, err := a.computeReplicasForMetric(ctx, hpa, metricSpec, specReplicas, statusReplicas, selector, &statuses[i])
 

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -3195,7 +3195,7 @@ func TestUpscaleCapGreaterThanMaxReplicas(t *testing.T) {
 	tc.runTest(t)
 }
 
-func TestMoreReplicasThanSpecNoScale(t *testing.T) {
+func TestMoreReplicasThanStatusNoScale(t *testing.T) {
 	// TODO: Remove skip once this issue is resolved: https://github.com/kubernetes/kubernetes/issues/124083
 	if goruntime.GOOS == "windows" {
 		t.Skip("Skip flaking test on Windows.")
@@ -3207,8 +3207,9 @@ func TestMoreReplicasThanSpecNoScale(t *testing.T) {
 		statusReplicas:          5, // Deployment update with 25% surge.
 		expectedDesiredReplicas: 4,
 		CPUTarget:               50,
-		reportedLevels:          []uint64{500, 500, 500, 500, 500},
+		reportedLevels:          []uint64{500, 500, 500, 500, 500, 500},
 		reportedCPURequests: []resource.Quantity{
+			resource.MustParse("1"),
 			resource.MustParse("1"),
 			resource.MustParse("1"),
 			resource.MustParse("1"),
@@ -3216,11 +3217,12 @@ func TestMoreReplicasThanSpecNoScale(t *testing.T) {
 			resource.MustParse("1"),
 		},
 		useMetricsAPI: true,
-		expectedConditions: statusOkWithOverrides(autoscalingv2.HorizontalPodAutoscalerCondition{
-			Type:   autoscalingv2.AbleToScale,
-			Status: v1.ConditionTrue,
-			Reason: "ReadyForNewScale",
-		}),
+		expectedConditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+			{Type: autoscalingv2.AbleToScale, Status: v1.ConditionTrue, Reason: "ReadyForNewScale"},
+			{Type: autoscalingv2.SelectorMatchesExtraPods, Status: v1.ConditionTrue, Reason: "SelectorOverlap"},
+			{Type: autoscalingv2.ScalingActive, Status: v1.ConditionTrue, Reason: "ValidMetricFound"},
+			{Type: autoscalingv2.ScalingLimited, Status: v1.ConditionFalse, Reason: "DesiredWithinRange"},
+		},
 		expectedReportedReconciliationActionLabel: monitor.ActionLabelNone,
 		expectedReportedReconciliationErrorLabel:  monitor.ErrorLabelNone,
 		expectedReportedMetricComputationActionLabels: map[autoscalingv2.MetricSourceType]monitor.ActionLabel{
@@ -4090,6 +4092,13 @@ func TestAvoidUnnecessaryUpdates(t *testing.T) {
 								LastTransitionTime: *tc.lastScaleTime,
 								Reason:             "ReadyForNewScale",
 								Message:            "recommended size matches current size",
+							},
+							{
+								Type:               autoscalingv2.SelectorMatchesExtraPods,
+								Status:             v1.ConditionTrue,
+								LastTransitionTime: *tc.lastScaleTime,
+								Reason:             "SelectorOverlap",
+								Message:            fmt.Sprintf("selector name=%s matches 3 active pods, more than the 2 replicas on the scale target; selector may overlap with another workload", podNamePrefix),
 							},
 							{
 								Type:               autoscalingv2.ScalingActive,

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -3683,8 +3683,9 @@ func TestMetricsEdgeCases(t *testing.T) {
 				specReplicas:   4,
 				statusReplicas: 5,
 				CPUTarget:      50,
-				reportedLevels: []uint64{500, 500, 500, 500, 500},
+				reportedLevels: []uint64{500, 500, 500, 500, 500, 500},
 				reportedCPURequests: []resource.Quantity{
+					resource.MustParse("1"),
 					resource.MustParse("1"),
 					resource.MustParse("1"),
 					resource.MustParse("1"),
@@ -3701,11 +3702,12 @@ func TestMetricsEdgeCases(t *testing.T) {
 			expectedScaleUpdated:    false,
 			expectedActionLabel:     monitor.ActionLabelNone,
 			expectedErrorLabel:      monitor.ErrorLabelNone,
-			expectedConditions: statusOkWithOverrides(autoscalingv2.HorizontalPodAutoscalerCondition{
-				Type:   autoscalingv2.AbleToScale,
-				Status: v1.ConditionTrue,
-				Reason: "ReadyForNewScale",
-			}),
+			expectedConditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+				{Type: autoscalingv2.AbleToScale, Status: v1.ConditionTrue, Reason: "ReadyForNewScale"},
+				{Type: autoscalingv2.SelectorMatchesExtraPods, Status: v1.ConditionTrue, Reason: "SelectorOverlap"},
+				{Type: autoscalingv2.ScalingActive, Status: v1.ConditionTrue, Reason: "ValidMetricFound"},
+				{Type: autoscalingv2.ScalingLimited, Status: v1.ConditionFalse, Reason: "DesiredWithinRange"},
+			},
 			expectedMetricComputationActionLabels: map[autoscalingv2.MetricSourceType]monitor.ActionLabel{
 				autoscalingv2.ResourceMetricSourceType: monitor.ActionLabelNone,
 			},

--- a/staging/src/k8s.io/api/autoscaling/v1/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v1/types.go
@@ -416,6 +416,9 @@ const (
 	ScalingLimited HorizontalPodAutoscalerConditionType = "ScalingLimited"
 	// ScaledToZero indicates that the HPA controller scaled the workload to zero.
 	ScaledToZero HorizontalPodAutoscalerConditionType = "ScaledToZero"
+	// SelectorMatchesExtraPods indicates that the HPA's selector matches more pods
+	// than the scale target reports as owned, which may skew metric averages.
+	SelectorMatchesExtraPods HorizontalPodAutoscalerConditionType = "SelectorMatchesExtraPods"
 )
 
 // HorizontalPodAutoscalerCondition describes the state of

--- a/staging/src/k8s.io/api/autoscaling/v1/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v1/types.go
@@ -420,6 +420,9 @@ const (
 	ScalingLimited HorizontalPodAutoscalerConditionType = "ScalingLimited"
 	// ScaledToZero indicates that the HPA controller scaled the workload to zero.
 	ScaledToZero HorizontalPodAutoscalerConditionType = "ScaledToZero"
+	// SelectorMatchesExtraPods indicates that the HPA's selector matches more pods
+	// than the scale target reports as owned, which may skew metric averages.
+	SelectorMatchesExtraPods HorizontalPodAutoscalerConditionType = "SelectorMatchesExtraPods"
 )
 
 // HorizontalPodAutoscalerCondition describes the state of

--- a/staging/src/k8s.io/api/autoscaling/v2/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v2/types.go
@@ -452,6 +452,9 @@ const (
 	ScalingLimited HorizontalPodAutoscalerConditionType = "ScalingLimited"
 	// ScaledToZero indicates that the HPA controller scaled the workload to zero.
 	ScaledToZero HorizontalPodAutoscalerConditionType = "ScaledToZero"
+	// SelectorMatchesExtraPods indicates that the HPA's selector matches more pods
+	// than the scale target reports as owned, which may skew metric averages.
+	SelectorMatchesExtraPods HorizontalPodAutoscalerConditionType = "SelectorMatchesExtraPods"
 )
 
 // HorizontalPodAutoscalerCondition describes the state of

--- a/staging/src/k8s.io/api/autoscaling/v2/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v2/types.go
@@ -455,6 +455,9 @@ const (
 	ScalingLimited HorizontalPodAutoscalerConditionType = "ScalingLimited"
 	// ScaledToZero indicates that the HPA controller scaled the workload to zero.
 	ScaledToZero HorizontalPodAutoscalerConditionType = "ScaledToZero"
+	// SelectorMatchesExtraPods indicates that the HPA's selector matches more pods
+	// than the scale target reports as owned, which may skew metric averages.
+	SelectorMatchesExtraPods HorizontalPodAutoscalerConditionType = "SelectorMatchesExtraPods"
 )
 
 // HorizontalPodAutoscalerCondition describes the state of


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Until we land a long-term solution for [kubernetes/enhancements#5325](https://github.com/kubernetes/enhancements/issues/5325), this PR adds a new HPA status condition, `SelectorMatchesExtraPods`, that the controller sets whenever the HPA's selector matches more active pods than the `.status.replicas` reported by the scale subresource.

This surfaces a common misconfiguration - two workloads sharing a selector label - where the HPA unknowingly averages metrics across pods it does not own and makes incorrect scaling decisions.
The condition is advisory: scaling still reconciles, but cluster administrators can now detect the overlap from the HPA status instead of debugging mysterious scaling behavior.

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
