### PR TITLE
Add CRI streaming authorization hook

### DIFF
--- a/staging/src/k8s.io/cri-streaming/pkg/streaming/server.go
+++ b/staging/src/k8s.io/cri-streaming/pkg/streaming/server.go
@@ -90,6 +90,15 @@ type Config struct {
 
 	// The config for serving over TLS. If nil, TLS will not be used.
 	TLSConfig *tls.Config
+
+	// AuthorizeStream, if non-nil, is called after a stream URL token has been
+	// validated and before the stream is served. Implementations can authenticate
+	// the HTTP request and authorize access to the cached CRI stream request.
+	//
+	// A nil AuthorizeStream means the server relies on the caller only issuing
+	// short-lived, single-use stream URLs after authorizing the original CRI
+	// Exec, Attach, or PortForward request.
+	AuthorizeStream func(req *http.Request, streamRequest any) error
 }
 
 // DefaultConfig provides default values for server Config. The DefaultConfig is partial, so
@@ -102,7 +111,6 @@ var DefaultConfig = Config{
 }
 
 // NewServer creates a new Server for stream requests.
-// TODO(tallclair): Add auth(n/z) interface & handling.
 func NewServer(config Config, runtime Runtime) (Server, error) {
 	s := &server{
 		config:  config,
@@ -260,6 +268,13 @@ func (s *server) buildURL(method, token string) string {
 	}).String()
 }
 
+func (s *server) authorize(req *http.Request, streamRequest any) bool {
+	if s.config.AuthorizeStream == nil {
+		return true
+	}
+	return s.config.AuthorizeStream(req, streamRequest) == nil
+}
+
 func (s *server) serveExec(req *restful.Request, resp *restful.Response) {
 	token := req.PathParameter("token")
 	cachedRequest, ok := s.cache.Consume(token)
@@ -270,6 +285,10 @@ func (s *server) serveExec(req *restful.Request, resp *restful.Response) {
 	exec, ok := cachedRequest.(*runtimeapi.ExecRequest)
 	if !ok {
 		http.NotFound(resp.ResponseWriter, req.Request)
+		return
+	}
+	if !s.authorize(req.Request, exec) {
+		http.Error(resp.ResponseWriter, "forbidden", http.StatusForbidden)
 		return
 	}
 
@@ -306,6 +325,10 @@ func (s *server) serveAttach(req *restful.Request, resp *restful.Response) {
 		http.NotFound(resp.ResponseWriter, req.Request)
 		return
 	}
+	if !s.authorize(req.Request, attach) {
+		http.Error(resp.ResponseWriter, "forbidden", http.StatusForbidden)
+		return
+	}
 
 	streamOpts := &remotecommandserver.Options{
 		Stdin:  attach.Stdin,
@@ -336,6 +359,10 @@ func (s *server) servePortForward(req *restful.Request, resp *restful.Response) 
 	pf, ok := cachedRequest.(*runtimeapi.PortForwardRequest)
 	if !ok {
 		http.NotFound(resp.ResponseWriter, req.Request)
+		return
+	}
+	if !s.authorize(req.Request, pf) {
+		http.Error(resp.ResponseWriter, "forbidden", http.StatusForbidden)
 		return
 	}
 

--- a/staging/src/k8s.io/cri-streaming/pkg/streaming/server_test.go
+++ b/staging/src/k8s.io/cri-streaming/pkg/streaming/server_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/binary"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -291,6 +292,42 @@ func TestServePortForward(t *testing.T) {
 	requireWebSocketPayload(t, wsConn, 0, []byte("portforward"+testOutput), false)
 }
 
+func TestServeExecAuthorizesStream(t *testing.T) {
+	var s Server
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.ServeHTTP(w, r)
+	}))
+	defer testServer.Close()
+
+	testURL, err := url.Parse(testServer.URL)
+	require.NoError(t, err)
+
+	config := DefaultConfig
+	config.BaseURL = testURL
+	config.AuthorizeStream = func(req *http.Request, streamRequest any) error {
+		assert.Equal(t, http.MethodGet, req.Method)
+		execReq, ok := streamRequest.(*runtimeapi.ExecRequest)
+		require.True(t, ok)
+		assert.Equal(t, testContainerID, execReq.ContainerId)
+		return errors.New("denied")
+	}
+
+	s, err = NewServer(config, &panicRuntime{})
+	require.NoError(t, err)
+
+	resp, err := s.GetExec(&runtimeapi.ExecRequest{
+		ContainerId: testContainerID,
+		Cmd:         []string{"echo"},
+		Stdout:      true,
+	})
+	require.NoError(t, err)
+
+	httpResp, err := http.Get(resp.Url)
+	require.NoError(t, err)
+	defer httpResp.Body.Close()
+	assert.Equal(t, http.StatusForbidden, httpResp.StatusCode)
+}
+
 // Run the remote command test.
 // commandType is either "exec" or "attach".
 func runRemoteCommandTest(t *testing.T, commandType string) {
@@ -377,6 +414,20 @@ func newFakeRuntime(t *testing.T) *fakeRuntime {
 
 type fakeRuntime struct {
 	t *testing.T
+}
+
+type panicRuntime struct{}
+
+func (p *panicRuntime) Exec(context.Context, string, []string, io.Reader, io.WriteCloser, io.WriteCloser, bool, <-chan remotecommandserver.TerminalSize) error {
+	panic("Exec should not be called")
+}
+
+func (p *panicRuntime) Attach(context.Context, string, io.Reader, io.WriteCloser, io.WriteCloser, bool, <-chan remotecommandserver.TerminalSize) error {
+	panic("Attach should not be called")
+}
+
+func (p *panicRuntime) PortForward(context.Context, string, int32, io.ReadWriteCloser) error {
+	panic("PortForward should not be called")
 }
 
 func (f *fakeRuntime) Exec(_ context.Context, containerID string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommandserver.TerminalSize) error {


### PR DESCRIPTION
## What changed

Adds an optional `AuthorizeStream` hook to the CRI streaming server config. The hook runs after a short-lived stream URL token is validated and before exec, attach, or port-forward streams are served.

## Why

The CRI streaming package previously relied entirely on callers issuing single-use stream URLs only after authorizing the original CRI request. This change makes that security boundary explicit and gives embedders a concrete stream-time authorization point.

## Impact

Existing callers keep the previous behavior when `AuthorizeStream` is nil. Callers that need additional authentication or authorization on the HTTP stream request can provide a hook that rejects unauthorized connections with `403 Forbidden` before runtime execution is reached.

```release-note
Added an optional `AuthorizeStream` hook to the CRI streaming server config for stream-time authorization.
```