### PR TITLE
scheduler_perf/dra: add missing performance labels for medium DRA scenarios

### DIFF
--- a/test/integration/scheduler_perf/dra/consumablecapacity/performance-config.yaml
+++ b/test/integration/scheduler_perf/dra/consumablecapacity/performance-config.yaml
@@ -82,6 +82,7 @@
       steadyState: false
       duration: 0s # unused
   - name: empty_100nodes
+    labels: [performance]
     params:
       nodesWithDRA: 100
       nodesWithoutDRA: 0
@@ -90,6 +91,7 @@
       steadyState: true
       duration: 10s
   - name: half_100nodes
+    labels: [performance]
     params:
       nodesWithDRA: 100
       nodesWithoutDRA: 0

--- a/test/integration/scheduler_perf/dra/extendedresource/performance-config.yaml
+++ b/test/integration/scheduler_perf/dra/extendedresource/performance-config.yaml
@@ -73,6 +73,7 @@
       measurePods: 10
       maxClaimsPerNode: 10
   - name: Explicit_25classes_2000pods_200nodes
+    labels: [performance]
     params:
       class: example.com/gpu
       classes: 25
@@ -93,6 +94,7 @@
       measurePods: 2500
       maxClaimsPerNode: 10
   - name: Explicit_50classes_2000pods_200nodes
+    labels: [performance]
     params:
       class: example.com/gpu
       classes: 50
@@ -113,6 +115,7 @@
       measurePods: 2500
       maxClaimsPerNode: 10
   - name: Implicit_25classes_2000pods_200nodes
+    labels: [performance]
     params:
       class: deviceclass.resource.kubernetes.io/test-class
       classes: 25

--- a/test/integration/scheduler_perf/dra/partitionabledevices/performance-config.yaml
+++ b/test/integration/scheduler_perf/dra/partitionabledevices/performance-config.yaml
@@ -71,6 +71,7 @@
       steadyState: false
       duration: 0s # unused
   - name: empty_100nodes
+    labels: [performance]
     params:
       nodesWithDRA: 100
       nodesWithoutDRA: 0


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/wg device-management
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

- Adds missing `performance` labels to selected DRA scheduler perf scenarios so they run in periodic performance jobs and show up in perf dashboards.

- This is phase 1 of the issue plan: improve scenario coverage first, then add/tune thresholds in a follow-up PR once enough data is collected.

#### Which issue(s) this PR is related to:

Fixes:  #135058 
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

- Scope is intentionally limited to label coverage (`labels: [performance]`) in DRA `performance-config.yaml` files.

- No threshold changes in this PR.

- No scheduler logic/code changes, config-only update.

#### Does this PR introduce a user-facing change?


<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
