### PR TITLE
fix(scheduler): update snapshot affinity lists for assumed pods

### DIFF
--- a/pkg/scheduler/backend/cache/cache_test.go
+++ b/pkg/scheduler/backend/cache/cache_test.go
@@ -1867,6 +1867,13 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 			PodAffinityExists("foo", "", st.PodAffinityWithRequiredReq).Node(fmt.Sprintf("test-node%v", i)).Obj()
 		podsWithAffinity = append(podsWithAffinity, pod)
 	}
+	// Add a few pods with required anti-affinity.
+	var podsWithRequiredAntiAffinity []*v1.Pod
+	for i := range 20 {
+		pod := st.MakePod().Name(fmt.Sprintf("p-anti-affinity-%v", i)).Namespace("test-ns").UID(fmt.Sprintf("puid-anti-affinity-%v", i)).
+			PodAntiAffinityExists("foo", "kubernetes.io/hostname", st.PodAntiAffinityWithRequiredReq).Node(fmt.Sprintf("test-node%v", i)).Obj()
+		podsWithRequiredAntiAffinity = append(podsWithRequiredAntiAffinity, pod)
+	}
 
 	makePodWithPVC := func(podID int, node int, pvcID int) *v1.Pod {
 		return st.MakePod().Name(fmt.Sprintf("p-pvc-%v", podID)).Namespace("test-ns").UID(fmt.Sprintf("puid-pvc-%v", podID)).
@@ -1913,6 +1920,13 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 	addPodWithAffinity := func(i int) operation {
 		return func(t *testing.T) {
 			if err := cache.AddPod(logger, podsWithAffinity[i]); err != nil {
+				t.Error(err)
+			}
+		}
+	}
+	addPodWithRequiredAntiAffinity := func(i int) operation {
+		return func(t *testing.T) {
+			if err := cache.AddPod(logger, podsWithRequiredAntiAffinity[i]); err != nil {
 				t.Error(err)
 			}
 		}
@@ -2076,12 +2090,13 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                           string
-		operations                     []operation
-		expected                       []*v1.Node
-		expectedHavePodsWithAffinity   int
-		expectedPodGroupStatesSnapshot map[podGroupKey]*podGroupStateSnapshot
-		expectedUsedPVCSet             sets.Set[string]
+		name                                     string
+		operations                               []operation
+		expected                                 []*v1.Node
+		expectedHavePodsWithAffinity             int
+		expectedHavePodsWithRequiredAntiAffinity int
+		expectedPodGroupStatesSnapshot           map[podGroupKey]*podGroupStateSnapshot
+		expectedUsedPVCSet                       sets.Set[string]
 	}{
 		{
 			name:               "Empty cache",
@@ -2216,6 +2231,16 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 			expected:                     []*v1.Node{nodes[1], nodes[0]},
 			expectedHavePodsWithAffinity: 1,
 			expectedUsedPVCSet:           sets.New[string](),
+		},
+		{
+			name: "Add Pods with required anti-affinity",
+			operations: []operation{
+				addNode(0), addPodWithRequiredAntiAffinity(0), updateSnapshot(), addNode(1),
+			},
+			expected:                                 []*v1.Node{nodes[1], nodes[0]},
+			expectedHavePodsWithAffinity:             1,
+			expectedHavePodsWithRequiredAntiAffinity: 1,
+			expectedUsedPVCSet:                       sets.New[string](),
 		},
 		{
 			name: "Add Pods with PVC",
@@ -2384,6 +2409,9 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 			if len(snapshot.havePodsWithAffinityNodeInfoList) != test.expectedHavePodsWithAffinity {
 				t.Errorf("unexpected number of HavePodsWithAffinity nodes. Expected: %v, got: %v", test.expectedHavePodsWithAffinity, len(snapshot.havePodsWithAffinityNodeInfoList))
 			}
+			if len(snapshot.havePodsWithRequiredAntiAffinityNodeInfoList) != test.expectedHavePodsWithRequiredAntiAffinity {
+				t.Errorf("unexpected number of HavePodsWithRequiredAntiAffinity nodes. Expected: %v, got: %v", test.expectedHavePodsWithRequiredAntiAffinity, len(snapshot.havePodsWithRequiredAntiAffinityNodeInfoList))
+			}
 
 			// Compare content of the used PVC set
 			if diff := cmp.Diff(test.expectedUsedPVCSet, snapshot.usedPVCSet); diff != "" {
@@ -2398,6 +2426,43 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 				t.Error(err)
 			}
 		})
+	}
+}
+
+func TestSnapshotAssumePodUpdatesAffinityLists(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	node := st.MakeNode().Name("node1").Label("kubernetes.io/hostname", "node1").Obj()
+	pod := st.MakePod().Name("pod1").Namespace("ns").UID("pod1").
+		PodAntiAffinityExists("app", "kubernetes.io/hostname", st.PodAntiAffinityWithRequiredReq).
+		Node(node.Name).Obj()
+	podInfo, err := framework.NewPodInfo(pod)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	snapshot := NewSnapshot(nil, []*v1.Node{node})
+	if err := snapshot.AssumePod(podInfo); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := len(snapshot.havePodsWithAffinityNodeInfoList); got != 1 {
+		t.Fatalf("expected one node with affinity pods after assuming pod, got %d", got)
+	}
+	if got := len(snapshot.havePodsWithRequiredAntiAffinityNodeInfoList); got != 1 {
+		t.Fatalf("expected one node with required anti-affinity pods after assuming pod, got %d", got)
+	}
+	if snapshot.havePodsWithRequiredAntiAffinityNodeInfoList[0].Node().Name != node.Name {
+		t.Fatalf("expected node %q in required anti-affinity list, got %q", node.Name, snapshot.havePodsWithRequiredAntiAffinityNodeInfoList[0].Node().Name)
+	}
+
+	if err := snapshot.ForgetPod(logger, pod); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(snapshot.havePodsWithAffinityNodeInfoList); got != 0 {
+		t.Fatalf("expected no nodes with affinity pods after forgetting pod, got %d", got)
+	}
+	if got := len(snapshot.havePodsWithRequiredAntiAffinityNodeInfoList); got != 0 {
+		t.Fatalf("expected no nodes with required anti-affinity pods after forgetting pod, got %d", got)
 	}
 }
 
@@ -2422,6 +2487,7 @@ func compareCacheWithNodeInfoSnapshot(t *testing.T, cache *cacheImpl, snapshot *
 
 	expectedNodeInfoList := make([]fwk.NodeInfo, 0, cache.nodeTree.numNodes)
 	expectedHavePodsWithAffinityNodeInfoList := make([]fwk.NodeInfo, 0, cache.nodeTree.numNodes)
+	expectedHavePodsWithRequiredAntiAffinityNodeInfoList := make([]fwk.NodeInfo, 0, cache.nodeTree.numNodes)
 	expectedUsedPVCSet := sets.New[string]()
 	nodesList, err := cache.nodeTree.list()
 	if err != nil {
@@ -2432,6 +2498,9 @@ func compareCacheWithNodeInfoSnapshot(t *testing.T, cache *cacheImpl, snapshot *
 			expectedNodeInfoList = append(expectedNodeInfoList, n)
 			if len(n.PodsWithAffinity) > 0 {
 				expectedHavePodsWithAffinityNodeInfoList = append(expectedHavePodsWithAffinityNodeInfoList, n)
+			}
+			if len(n.PodsWithRequiredAntiAffinity) > 0 {
+				expectedHavePodsWithRequiredAntiAffinityNodeInfoList = append(expectedHavePodsWithRequiredAntiAffinityNodeInfoList, n)
 			}
 			for key := range n.PVCRefCounts {
 				expectedUsedPVCSet.Insert(key)
@@ -2452,6 +2521,16 @@ func compareCacheWithNodeInfoSnapshot(t *testing.T, cache *cacheImpl, snapshot *
 		got := snapshot.havePodsWithAffinityNodeInfoList[i]
 		if expected != got {
 			return fmt.Errorf("unexpected NodeInfo pointer in HavePodsWithAffinityNodeInfoList. Expected: %p, got: %p", expected, got)
+		}
+	}
+
+	if len(snapshot.havePodsWithRequiredAntiAffinityNodeInfoList) != len(expectedHavePodsWithRequiredAntiAffinityNodeInfoList) {
+		return fmt.Errorf("unexpected number of HavePodsWithRequiredAntiAffinity nodes. Expected: %v, got: %v", len(expectedHavePodsWithRequiredAntiAffinityNodeInfoList), len(snapshot.havePodsWithRequiredAntiAffinityNodeInfoList))
+	}
+	for i, expected := range expectedHavePodsWithRequiredAntiAffinityNodeInfoList {
+		got := snapshot.havePodsWithRequiredAntiAffinityNodeInfoList[i]
+		if expected != got {
+			return fmt.Errorf("unexpected NodeInfo pointer in HavePodsWithRequiredAntiAffinityNodeInfoList. Expected: %p, got: %p", expected, got)
 		}
 	}
 

--- a/pkg/scheduler/backend/cache/snapshot.go
+++ b/pkg/scheduler/backend/cache/snapshot.go
@@ -351,8 +351,11 @@ func (s *Snapshot) AssumePod(podInfo *framework.PodInfo) error {
 	// Since this operation only affects the snapshot,
 	// we should keep the old number to remain consistent with the cached value.
 	oldGeneration := nodeInfo.Generation
+	hadPodsWithAffinity := len(nodeInfo.PodsWithAffinity) > 0
+	hadPodsWithRequiredAntiAffinity := len(nodeInfo.PodsWithRequiredAntiAffinity) > 0
 	nodeInfo.AddPodInfo(podInfo)
 	nodeInfo.Generation = oldGeneration
+	s.updateAffinityListsForNode(nodeInfo, hadPodsWithAffinity, hadPodsWithRequiredAntiAffinity)
 	s.assumedPods[key] = pod
 	// Update the pod group state in the snapshot if the pod belongs to a pod group.
 	if !s.genericWorkloadEnabled || pod.Spec.SchedulingGroup == nil {
@@ -383,11 +386,14 @@ func (s *Snapshot) ForgetPod(logger klog.Logger, pod *v1.Pod) error {
 		// Since this operation only affects the snapshot,
 		// we should keep the old number to remain consistent with the cached value.
 		oldGeneration := nodeInfo.Generation
+		hadPodsWithAffinity := len(nodeInfo.PodsWithAffinity) > 0
+		hadPodsWithRequiredAntiAffinity := len(nodeInfo.PodsWithRequiredAntiAffinity) > 0
 		err := nodeInfo.RemovePod(logger, pod)
 		if err != nil {
 			return err
 		}
 		nodeInfo.Generation = oldGeneration
+		s.updateAffinityListsForNode(nodeInfo, hadPodsWithAffinity, hadPodsWithRequiredAntiAffinity)
 		if len(nodeInfo.Pods) == 0 && nodeInfo.Node() == nil {
 			delete(s.nodeInfoMap, nodeName)
 		}
@@ -401,6 +407,70 @@ func (s *Snapshot) ForgetPod(logger klog.Logger, pod *v1.Pod) error {
 		pgs.forgetPod(assumedPod.UID)
 	}
 	return nil
+}
+
+func (s *Snapshot) updateAffinityListsForNode(nodeInfo *framework.NodeInfo, hadPodsWithAffinity, hadPodsWithRequiredAntiAffinity bool) {
+	nowHasPodsWithAffinity := len(nodeInfo.PodsWithAffinity) > 0
+	if !hadPodsWithAffinity && nowHasPodsWithAffinity {
+		s.havePodsWithAffinityNodeInfoList = addNodeInfoInSnapshotOrder(s.havePodsWithAffinityNodeInfoList, nodeInfo, s.nodeInfoList)
+	} else if hadPodsWithAffinity && !nowHasPodsWithAffinity {
+		s.havePodsWithAffinityNodeInfoList = removeNodeInfo(s.havePodsWithAffinityNodeInfoList, nodeInfo)
+	}
+
+	nowHasPodsWithRequiredAntiAffinity := len(nodeInfo.PodsWithRequiredAntiAffinity) > 0
+	if !hadPodsWithRequiredAntiAffinity && nowHasPodsWithRequiredAntiAffinity {
+		s.havePodsWithRequiredAntiAffinityNodeInfoList = addNodeInfoInSnapshotOrder(s.havePodsWithRequiredAntiAffinityNodeInfoList, nodeInfo, s.nodeInfoList)
+	} else if hadPodsWithRequiredAntiAffinity && !nowHasPodsWithRequiredAntiAffinity {
+		s.havePodsWithRequiredAntiAffinityNodeInfoList = removeNodeInfo(s.havePodsWithRequiredAntiAffinityNodeInfoList, nodeInfo)
+	}
+}
+
+func addNodeInfoInSnapshotOrder(nodeInfoList []fwk.NodeInfo, nodeInfo *framework.NodeInfo, snapshotNodeInfoList []fwk.NodeInfo) []fwk.NodeInfo {
+	for _, ni := range nodeInfoList {
+		if ni == nodeInfo {
+			return nodeInfoList
+		}
+	}
+
+	nodeInfoIndex := -1
+	for i, ni := range snapshotNodeInfoList {
+		if ni == nodeInfo {
+			nodeInfoIndex = i
+			break
+		}
+	}
+	if nodeInfoIndex == -1 {
+		return nodeInfoList
+	}
+
+	insertIndex := len(nodeInfoList)
+	for i, ni := range nodeInfoList {
+		for j, snapshotNodeInfo := range snapshotNodeInfoList {
+			if ni == snapshotNodeInfo {
+				if nodeInfoIndex < j {
+					insertIndex = i
+				}
+				break
+			}
+		}
+		if insertIndex != len(nodeInfoList) {
+			break
+		}
+	}
+
+	nodeInfoList = append(nodeInfoList, nil)
+	copy(nodeInfoList[insertIndex+1:], nodeInfoList[insertIndex:])
+	nodeInfoList[insertIndex] = nodeInfo
+	return nodeInfoList
+}
+
+func removeNodeInfo(nodeInfoList []fwk.NodeInfo, nodeInfo *framework.NodeInfo) []fwk.NodeInfo {
+	for i, ni := range nodeInfoList {
+		if ni == nodeInfo {
+			return append(nodeInfoList[:i], nodeInfoList[i+1:]...)
+		}
+	}
+	return nodeInfoList
 }
 
 // forgetAllAssumedPods forgets all assumed pods from the snapshot.

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -72,6 +72,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/imagelocality"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/interpodaffinity"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeports"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/podtopologyspread"
@@ -2043,6 +2044,74 @@ func TestSchedulerNoPhantomPodAfterDelete(t *testing.T) {
 				}
 			case <-time.After(wait.ForeverTestTimeout):
 				t.Fatalf("timeout in binding after %v", wait.ForeverTestTimeout)
+			}
+		})
+	}
+}
+
+func TestSchedulerConsidersAssumedPodsForRequiredPodAntiAffinity(t *testing.T) {
+	for _, asyncAPICallsEnabled := range []bool{true, false} {
+		t.Run(fmt.Sprintf("Async API calls enabled: %v", asyncAPICallsEnabled), func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			queuedPodStore := clientcache.NewFIFO(clientcache.MetaNamespaceKeyFunc)
+			client := clientsetfake.NewClientset()
+			bindingChan := interruptOnBind(client)
+
+			var apiDispatcher *apidispatcher.APIDispatcher
+			if asyncAPICallsEnabled {
+				apiDispatcher = apidispatcher.New(client, 16, apicalls.Relevances)
+				apiDispatcher.Run(logger)
+				defer apiDispatcher.Close()
+			}
+
+			scache := internalcache.New(ctx, apiDispatcher, false)
+			node := v1.Node{ObjectMeta: metav1.ObjectMeta{
+				Name: "node1",
+				UID:  types.UID("node1"),
+				Labels: map[string]string{
+					v1.LabelHostname: "node1",
+				},
+			}}
+			scache.AddNode(logger, &node)
+			makeAntiAffinityPod := func(name string) *v1.Pod {
+				return st.MakePod().Name(name).UID(name).SchedulerName(testSchedulerName).Labels(map[string]string{"app": "demo"}).
+					PodAntiAffinityIn("app", v1.LabelHostname, []string{"demo"}, st.PodAntiAffinityWithRequiredReq).Obj()
+			}
+			firstPod := makeAntiAffinityPod("foo")
+			fns := []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				tf.RegisterPluginAsExtensions(interpodaffinity.Name, frameworkruntime.FactoryAdapter(feature.Features{}, interpodaffinity.New), "PreFilter", "Filter"),
+			}
+			scheduler, errChan := setupTestSchedulerWithOnePodOnNode(ctx, t, client, queuedPodStore, scache, apiDispatcher, firstPod, &node, bindingChan, fns...)
+
+			secondPod := makeAntiAffinityPod("bar")
+			if err := queuedPodStore.Add(secondPod); err != nil {
+				t.Fatal(err)
+			}
+
+			scheduler.ScheduleOne(ctx)
+			select {
+			case err := <-errChan:
+				expectErr := &framework.FitError{
+					Pod:         secondPod,
+					NumAllNodes: 1,
+					Diagnosis: framework.Diagnosis{
+						NodeToStatus: framework.NewNodeToStatus(map[string]*fwk.Status{
+							node.Name: fwk.NewStatus(fwk.Unschedulable, interpodaffinity.ErrReasonAntiAffinityRulesNotMatch).WithPlugin(interpodaffinity.Name),
+						}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
+						UnschedulablePlugins: sets.New(interpodaffinity.Name),
+					},
+				}
+				if diff := cmp.Diff(expectErr, err, schedulerCmpOpts...); diff != "" {
+					t.Errorf("unexpected error (-want,+got):\n%s", diff)
+				}
+			case b := <-bindingChan:
+				t.Fatalf("expected second pod to be unschedulable while first pod is assumed, got binding %#v", b)
+			case <-time.After(wait.ForeverTestTimeout):
+				t.Fatalf("timeout in fitting after %v", wait.ForeverTestTimeout)
 			}
 		})
 	}


### PR DESCRIPTION
## What type of PR is this?
/kind bug
/sig scheduling

## What this PR does / why we need it

When a pod is assumed directly in a scheduler snapshot, the snapshot NodeInfo is updated but the optimized affinity node lists were not kept in sync. In particular, pods with required pod anti-affinity were added to NodeInfo.PodsWithRequiredAntiAffinity without also updating havePodsWithRequiredAntiAffinityNodeInfoList.

InterPodAffinity uses these optimized lists while computing existing pods' required anti-affinity matches. Keeping the lists in sync ensures assumed pods are visible to anti-affinity checks during the same scheduling flow.

This PR updates Snapshot.AssumePod and Snapshot.ForgetPod to maintain:
- havePodsWithAffinityNodeInfoList
- havePodsWithRequiredAntiAffinityNodeInfoList

It also adds regression coverage for both the snapshot-level list maintenance and the scheduler behavior where a second pod with required pod anti-affinity must not bind to a node that already has a conflicting assumed pod.

## Which issue(s) this PR fixes

Fixes #138546

## Special notes for your reviewer

The regular scheduler cache AssumePod path already updates NodeInfo correctly; this fix targets snapshot-local assumptions and keeps snapshot lister indexes consistent with the mutated NodeInfo.

## Does this PR introduce a user-facing change?

```release-note
Fixed scheduler snapshot bookkeeping so assumed pods are reflected in inter-pod affinity and required anti-affinity node lists.
```

## Test Plan

- `make test WHAT=./pkg/scheduler/backend/cache KUBE_TEST_ARGS='-run TestSchedulerCache_UpdateSnapshot -count=1'`
- `make test WHAT=./pkg/scheduler/backend/cache KUBE_TEST_ARGS='-run TestSnapshotAssumePodUpdatesAffinityLists -count=1'`
- `make test WHAT=./pkg/scheduler KUBE_TEST_ARGS='-run TestSchedulerConsidersAssumedPodsForRequiredPodAntiAffinity -count=1'`
- `./hack/verify-gofmt.sh pkg/scheduler/backend/cache/snapshot.go pkg/scheduler/backend/cache/cache_test.go pkg/scheduler/schedule_one_test.go`
- `git diff --check`
