### PR TITLE
fix: Refactor Kubelet to pass `klog.Logger` context for structured lo…

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -350,8 +350,6 @@ linters:
             contextual k8s.io/kubernetes/test/e2e/dra/.*
             contextual k8s.io/kubernetes/test/images/sample-device-plugin/.*
             contextual k8s.io/kubernetes/pkg/kubelet/.*
-            # Temporary carve-outs for PR1 split safety: these files still have legacy global klog calls.
-            # TODO: remove each exclusion as follow-up PRs migrate the file to contextual logging.
       sorted:
         # Installed there by hack/verify-golangci-lint.sh.
         path: _output/local/bin/sorted.so

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -350,6 +350,8 @@ linters:
             contextual k8s.io/kubernetes/test/e2e/dra/.*
             contextual k8s.io/kubernetes/test/images/sample-device-plugin/.*
             contextual k8s.io/kubernetes/pkg/kubelet/.*
+            # Temporary carve-outs for PR1 split safety: these files still have legacy global klog calls.
+            # TODO: remove each exclusion as follow-up PRs migrate the file to contextual logging.
       sorted:
         # Installed there by hack/verify-golangci-lint.sh.
         path: _output/local/bin/sorted.so

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -352,7 +352,6 @@ linters:
             contextual k8s.io/kubernetes/pkg/kubelet/.*
             # Temporary carve-outs for PR1 split safety: these files still have legacy global klog calls.
             # TODO: remove each exclusion as follow-up PRs migrate the file to contextual logging.
-            -contextual k8s.io/kubernetes/pkg/kubelet/volume_host.go
       sorted:
         # Installed there by hack/verify-golangci-lint.sh.
         path: _output/local/bin/sorted.so

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -352,8 +352,6 @@ linters:
             contextual k8s.io/kubernetes/pkg/kubelet/.*
             # Temporary carve-outs for PR1 split safety: these files still have legacy global klog calls.
             # TODO: remove each exclusion as follow-up PRs migrate the file to contextual logging.
-            -contextual k8s.io/kubernetes/pkg/kubelet/kubelet_resources.go
-            -contextual k8s.io/kubernetes/pkg/kubelet/kubelet_volumes.go
             -contextual k8s.io/kubernetes/pkg/kubelet/volume_host.go
       sorted:
         # Installed there by hack/verify-golangci-lint.sh.

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -365,8 +365,6 @@ linters:
             contextual k8s.io/kubernetes/pkg/kubelet/.*
             # Temporary carve-outs for PR1 split safety: these files still have legacy global klog calls.
             # TODO: remove each exclusion as follow-up PRs migrate the file to contextual logging.
-            -contextual k8s.io/kubernetes/pkg/kubelet/kubelet_resources.go
-            -contextual k8s.io/kubernetes/pkg/kubelet/kubelet_volumes.go
             -contextual k8s.io/kubernetes/pkg/kubelet/volume_host.go
       sorted:
         # Installed there by hack/verify-golangci-lint.sh.

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -363,8 +363,6 @@ linters:
             contextual k8s.io/kubernetes/test/e2e/dra/.*
             contextual k8s.io/kubernetes/test/images/sample-device-plugin/.*
             contextual k8s.io/kubernetes/pkg/kubelet/.*
-            # Temporary carve-outs for PR1 split safety: these files still have legacy global klog calls.
-            # TODO: remove each exclusion as follow-up PRs migrate the file to contextual logging.
       sorted:
         # Installed there by hack/verify-golangci-lint.sh.
         path: _output/local/bin/sorted.so

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -365,7 +365,6 @@ linters:
             contextual k8s.io/kubernetes/pkg/kubelet/.*
             # Temporary carve-outs for PR1 split safety: these files still have legacy global klog calls.
             # TODO: remove each exclusion as follow-up PRs migrate the file to contextual logging.
-            -contextual k8s.io/kubernetes/pkg/kubelet/volume_host.go
       sorted:
         # Installed there by hack/verify-golangci-lint.sh.
         path: _output/local/bin/sorted.so

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -363,6 +363,8 @@ linters:
             contextual k8s.io/kubernetes/test/e2e/dra/.*
             contextual k8s.io/kubernetes/test/images/sample-device-plugin/.*
             contextual k8s.io/kubernetes/pkg/kubelet/.*
+            # Temporary carve-outs for PR1 split safety: these files still have legacy global klog calls.
+            # TODO: remove each exclusion as follow-up PRs migrate the file to contextual logging.
       sorted:
         # Installed there by hack/verify-golangci-lint.sh.
         path: _output/local/bin/sorted.so

--- a/hack/logcheck.conf
+++ b/hack/logcheck.conf
@@ -67,6 +67,4 @@ contextual k8s.io/kubernetes/test/images/sample-device-plugin/.*
 contextual k8s.io/kubernetes/pkg/kubelet/.*
 # Temporary carve-outs for PR1 split safety: these files still have legacy global klog calls.
 # TODO: remove each exclusion as follow-up PRs migrate the file to contextual logging.
--contextual k8s.io/kubernetes/pkg/kubelet/kubelet_resources.go
--contextual k8s.io/kubernetes/pkg/kubelet/kubelet_volumes.go
 -contextual k8s.io/kubernetes/pkg/kubelet/volume_host.go

--- a/hack/logcheck.conf
+++ b/hack/logcheck.conf
@@ -67,4 +67,3 @@ contextual k8s.io/kubernetes/test/images/sample-device-plugin/.*
 contextual k8s.io/kubernetes/pkg/kubelet/.*
 # Temporary carve-outs for PR1 split safety: these files still have legacy global klog calls.
 # TODO: remove each exclusion as follow-up PRs migrate the file to contextual logging.
--contextual k8s.io/kubernetes/pkg/kubelet/volume_host.go

--- a/hack/logcheck.conf
+++ b/hack/logcheck.conf
@@ -65,5 +65,3 @@ contextual k8s.io/kubernetes/pkg/securitycontext/.*
 contextual k8s.io/kubernetes/test/e2e/dra/.*
 contextual k8s.io/kubernetes/test/images/sample-device-plugin/.*
 contextual k8s.io/kubernetes/pkg/kubelet/.*
-# Temporary carve-outs for PR1 split safety: these files still have legacy global klog calls.
-# TODO: remove each exclusion as follow-up PRs migrate the file to contextual logging.

--- a/hack/logcheck.conf
+++ b/hack/logcheck.conf
@@ -65,3 +65,5 @@ contextual k8s.io/kubernetes/pkg/securitycontext/.*
 contextual k8s.io/kubernetes/test/e2e/dra/.*
 contextual k8s.io/kubernetes/test/images/sample-device-plugin/.*
 contextual k8s.io/kubernetes/pkg/kubelet/.*
+# Temporary carve-outs for PR1 split safety: these files still have legacy global klog calls.
+# TODO: remove each exclusion as follow-up PRs migrate the file to contextual logging.

--- a/pkg/kubelet/kubelet_resources.go
+++ b/pkg/kubelet/kubelet_resources.go
@@ -37,6 +37,8 @@ import (
 // If neither container-level nor pod-level resources limits are specified, it defaults
 // to the node's allocatable resources.
 func (kl *Kubelet) defaultPodLimitsForDownwardAPI(ctx context.Context, pod *corev1.Pod, container *corev1.Container) (*corev1.Pod, *corev1.Container, error) {
+	logger := klog.FromContext(ctx)
+
 	if pod == nil {
 		return nil, nil, fmt.Errorf("invalid input, pod cannot be nil")
 	}
@@ -62,7 +64,7 @@ func (kl *Kubelet) defaultPodLimitsForDownwardAPI(ctx context.Context, pod *core
 		}
 	}
 
-	klog.InfoS("Allocatable", "allocatable", allocatable)
+	logger.Info("Allocatable", "allocatable", allocatable)
 	outputPod := pod.DeepCopy()
 	for idx := range outputPod.Spec.Containers {
 		resource.MergeContainerResourceLimits(&outputPod.Spec.Containers[idx], allocatable)

--- a/pkg/kubelet/kubelet_volumes.go
+++ b/pkg/kubelet/kubelet_volumes.go
@@ -98,7 +98,7 @@ func (kl *Kubelet) podVolumesExist(logger klog.Logger, podUID types.UID) bool {
 // newVolumeMounterFromPlugins attempts to find a plugin by volume spec, pod
 // and volume options and then creates a Mounter.
 // Returns a valid mounter or an error.
-func (kl *Kubelet) newVolumeMounterFromPlugins(spec *volume.Spec, pod *v1.Pod) (volume.Mounter, error) {
+func (kl *Kubelet) newVolumeMounterFromPlugins(logger klog.Logger, spec *volume.Spec, pod *v1.Pod) (volume.Mounter, error) {
 	plugin, err := kl.volumePluginMgr.FindPluginBySpec(spec)
 	if err != nil {
 		return nil, fmt.Errorf("can't use volume plugins for %s: %v", spec.Name(), err)
@@ -107,7 +107,7 @@ func (kl *Kubelet) newVolumeMounterFromPlugins(spec *volume.Spec, pod *v1.Pod) (
 	if err != nil {
 		return nil, fmt.Errorf("failed to instantiate mounter for volume: %s using plugin: %s with a root cause: %v", spec.Name(), plugin.GetPluginName(), err)
 	}
-	klog.V(10).InfoS("Using volume plugin for mount", "volumePluginName", plugin.GetPluginName(), "volumeName", spec.Name())
+	logger.V(10).Info("Using volume plugin for mount", "volumePluginName", plugin.GetPluginName(), "volumeName", spec.Name())
 	return physicalMounter, nil
 }
 
@@ -130,7 +130,7 @@ func (kl *Kubelet) removeOrphanedPodVolumeDirs(logger klog.Logger, uid types.UID
 			if err := syscall.Rmdir(volumePath); err != nil {
 				orphanVolumeErrors = append(orphanVolumeErrors, fmt.Errorf("orphaned pod %q found, but failed to rmdir() volume at path %v: %v", uid, volumePath, err))
 			} else {
-				klog.InfoS("Cleaned up orphaned volume from pod", "podUID", uid, "path", volumePath)
+				logger.Info("Cleaned up orphaned volume from pod", "podUID", uid, "path", volumePath)
 			}
 		}
 	}
@@ -147,7 +147,7 @@ func (kl *Kubelet) removeOrphanedPodVolumeDirs(logger klog.Logger, uid types.UID
 			if err := os.Remove(subpathVolumePath); err != nil {
 				orphanVolumeErrors = append(orphanVolumeErrors, fmt.Errorf("orphaned pod %q found, but failed to remove subpath at path %v: %w", uid, subpathVolumePath, err))
 			} else {
-				klog.InfoS("Cleaned up orphaned volume subpath from pod", "podUID", uid, "path", subpathVolumePath)
+				logger.Info("Cleaned up orphaned volume subpath from pod", "podUID", uid, "path", subpathVolumePath)
 			}
 		}
 	}
@@ -158,7 +158,7 @@ func (kl *Kubelet) removeOrphanedPodVolumeDirs(logger klog.Logger, uid types.UID
 	if err := removeall.RemoveDirsOneFilesystem(kl.mounter, podVolDir); err != nil {
 		orphanVolumeErrors = append(orphanVolumeErrors, fmt.Errorf("orphaned pod %q found, but error occurred when trying to remove the volumes dir: %v", uid, err))
 	} else {
-		klog.InfoS("Cleaned up orphaned pod volumes dir", "podUID", uid, "path", podVolDir)
+		logger.Info("Cleaned up orphaned pod volumes dir", "podUID", uid, "path", podVolDir)
 	}
 
 	return orphanVolumeErrors
@@ -219,7 +219,7 @@ func (kl *Kubelet) cleanupOrphanedPodDirs(logger klog.Logger, pods []*v1.Pod, ru
 		podSubdirs, err := os.ReadDir(podDir)
 		if err != nil {
 			errorPods++
-			klog.ErrorS(err, "Could not read directory", "path", podDir)
+			logger.Error(err, "Could not read directory", "path", podDir)
 			orphanRemovalErrors = append(orphanRemovalErrors, fmt.Errorf("orphaned pod %q found, but error occurred during reading the pod dir from disk: %v", uid, err))
 			continue
 		}
@@ -234,21 +234,21 @@ func (kl *Kubelet) cleanupOrphanedPodDirs(logger klog.Logger, pods []*v1.Pod, ru
 			if podSubdirName == "volumes" {
 				cleanupFailed = true
 				err := fmt.Errorf("volumes subdir was found after it was removed")
-				klog.ErrorS(err, "Orphaned pod found, but failed to remove volumes subdir", "podUID", uid, "path", podSubdirPath)
+				logger.Error(err, "Orphaned pod found, but failed to remove volumes subdir", "podUID", uid, "path", podSubdirPath)
 				continue
 			}
 			if err := removeall.RemoveAllOneFilesystem(kl.mounter, podSubdirPath); err != nil {
 				cleanupFailed = true
-				klog.ErrorS(err, "Failed to remove orphaned pod subdir", "podUID", uid, "path", podSubdirPath)
+				logger.Error(err, "Failed to remove orphaned pod subdir", "podUID", uid, "path", podSubdirPath)
 				orphanRemovalErrors = append(orphanRemovalErrors, fmt.Errorf("orphaned pod %q found, but error occurred when trying to remove subdir %q: %v", uid, podSubdirPath, err))
 			}
 		}
 
 		// Rmdir the pod dir, which should be empty if everything above was successful
-		klog.V(3).InfoS("Orphaned pod found, removing", "podUID", uid)
+		logger.V(3).Info("Cleaned up orphaned pod dir", "podUID", uid, "path", podDir)
 		if err := syscall.Rmdir(podDir); err != nil {
 			cleanupFailed = true
-			klog.ErrorS(err, "Failed to remove orphaned pod dir", "podUID", uid)
+			logger.Error(err, "Failed to remove orphaned pod dir", "podUID", uid, "path", podDir)
 			orphanRemovalErrors = append(orphanRemovalErrors, fmt.Errorf("orphaned pod %q found, but error occurred when trying to remove the pod directory: %v", uid, err))
 		}
 		if cleanupFailed {
@@ -258,9 +258,9 @@ func (kl *Kubelet) cleanupOrphanedPodDirs(logger klog.Logger, pods []*v1.Pod, ru
 
 	logSpew := func(errs []error) {
 		if len(errs) > 0 {
-			klog.ErrorS(errs[0], "There were many similar errors. Turn up verbosity to see them.", "numErrs", len(errs))
+			logger.Error(errs[0], "There were many similar errors. Turn up verbosity to see them.", "numErrs", len(errs))
 			for _, err := range errs {
-				klog.V(5).InfoS("Orphan pod", "err", err)
+				logger.V(5).Info("Orphan pod", "err", err)
 			}
 		}
 	}

--- a/pkg/kubelet/kubelet_volumes.go
+++ b/pkg/kubelet/kubelet_volumes.go
@@ -245,10 +245,10 @@ func (kl *Kubelet) cleanupOrphanedPodDirs(logger klog.Logger, pods []*v1.Pod, ru
 		}
 
 		// Rmdir the pod dir, which should be empty if everything above was successful
-		logger.V(3).Info("Orphaned pod found, removing", "podUID", uid, "path", podDir)
+		logger.V(3).Info("Orphaned pod found, removing", "podUID", uid)
 		if err := syscall.Rmdir(podDir); err != nil {
 			cleanupFailed = true
-			logger.Error(err, "Failed to remove orphaned pod dir", "podUID", uid, "path", podDir)
+			logger.Error(err, "Failed to remove orphaned pod dir", "podUID", uid)
 			orphanRemovalErrors = append(orphanRemovalErrors, fmt.Errorf("orphaned pod %q found, but error occurred when trying to remove the pod directory: %v", uid, err))
 		}
 		if cleanupFailed {

--- a/pkg/kubelet/kubelet_volumes.go
+++ b/pkg/kubelet/kubelet_volumes.go
@@ -245,7 +245,7 @@ func (kl *Kubelet) cleanupOrphanedPodDirs(logger klog.Logger, pods []*v1.Pod, ru
 		}
 
 		// Rmdir the pod dir, which should be empty if everything above was successful
-		logger.V(3).Info("Cleaned up orphaned pod dir", "podUID", uid, "path", podDir)
+		logger.V(3).Info("Orphaned pod found, removing", "podUID", uid, "path", podDir)
 		if err := syscall.Rmdir(podDir); err != nil {
 			cleanupFailed = true
 			logger.Error(err, "Failed to remove orphaned pod dir", "podUID", uid, "path", podDir)

--- a/pkg/kubelet/volume_host.go
+++ b/pkg/kubelet/volume_host.go
@@ -60,6 +60,10 @@ func NewInitializedVolumePluginMgr(
 	plugins []volume.VolumePlugin,
 	prober volume.DynamicPluginProber) (*volume.VolumePluginMgr, error) {
 
+	// Use context.TODO() because we currently do not have a proper context to pass in.
+	// Replace this with an appropriate context when refactoring this function to accept a context parameter.
+	logger := klog.FromContext(context.TODO())
+
 	// Initialize csiDriverLister before calling InitPlugins
 	var informerFactory informers.SharedInformerFactory
 	var csiDriverLister storagelisters.CSIDriverLister
@@ -73,7 +77,7 @@ func NewInitializedVolumePluginMgr(
 		csiDriversSynced = csiDriverInformer.Informer().HasSynced
 
 	} else {
-		klog.InfoS("KubeClient is nil. Skip initialization of CSIDriverLister")
+		logger.Info("KubeClient is nil. Skip initialization of CSIDriverLister")
 	}
 
 	kvh := &kubeletVolumeHost{
@@ -173,14 +177,17 @@ func (kvh *kubeletVolumeHost) CSIDriversSynced() cache.InformerSynced {
 
 // WaitForCacheSync is a helper function that waits for cache sync for CSIDriverLister
 func (kvh *kubeletVolumeHost) WaitForCacheSync() error {
+	// Use context.TODO() because we currently do not have a proper context to pass in.
+	// Replace this with an appropriate context when refactoring this function to accept a context parameter.
+	logger := klog.FromContext(context.TODO())
 	if kvh.csiDriversSynced == nil {
-		klog.ErrorS(nil, "CsiDriversSynced not found on KubeletVolumeHost")
+		logger.Error(nil, "CsiDriversSynced not found on KubeletVolumeHost")
 		return fmt.Errorf("csiDriversSynced not found on KubeletVolumeHost")
 	}
 
 	synced := []cache.InformerSynced{kvh.csiDriversSynced}
 	if !cache.WaitForCacheSync(wait.NeverStop, synced...) {
-		klog.InfoS("Failed to wait for cache sync for CSIDriverLister")
+		logger.Info("Failed to wait for cache sync for CSIDriverLister")
 		return fmt.Errorf("failed to wait for cache sync for CSIDriverLister")
 	}
 

--- a/pkg/kubelet/volume_host.go
+++ b/pkg/kubelet/volume_host.go
@@ -191,13 +191,16 @@ func (kvh *kubeletVolumeHost) NewWrapperMounter(
 	volName string,
 	spec volume.Spec,
 	pod *v1.Pod) (volume.Mounter, error) {
+	// Use context.TODO() because we currently do not have a proper context to pass in.
+	// Replace this with an appropriate context when refactoring this function to accept a context parameter.
+	logger := klog.FromContext(context.TODO())
+
 	// The name of wrapper volume is set to "wrapped_{wrapped_volume_name}"
 	wrapperVolumeName := "wrapped_" + volName
 	if spec.Volume != nil {
 		spec.Volume.Name = wrapperVolumeName
 	}
 
-	logger := klog.FromContext(context.TODO())
 	return kvh.kubelet.newVolumeMounterFromPlugins(logger, &spec, pod)
 }
 

--- a/pkg/kubelet/volume_host.go
+++ b/pkg/kubelet/volume_host.go
@@ -197,7 +197,8 @@ func (kvh *kubeletVolumeHost) NewWrapperMounter(
 		spec.Volume.Name = wrapperVolumeName
 	}
 
-	return kvh.kubelet.newVolumeMounterFromPlugins(&spec, pod)
+	logger := klog.FromContext(context.TODO())
+	return kvh.kubelet.newVolumeMounterFromPlugins(logger, &spec, pod)
 }
 
 func (kvh *kubeletVolumeHost) NewWrapperUnmounter(volName string, spec volume.Spec, podUID types.UID) (volume.Unmounter, error) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR continues contextual logging migration in `pkg/kubelet/kubelet_volumes.go` and `pkg/kubelet/kubelet_resources.go`.

NewWrapperMounter() now uses a logger-bound context.TODO(), since wiring a proper context there requires additional refactoring in upstream callers.

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/kubernetes/issues/130069

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
https://github.com/kubernetes/community/blob/main/contributors/devel/sig-instrumentation/migration-to-structured-logging.md
```
