### PR TITLE
Remove unused Close methods of mockRuntimeService in kubelet tests

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -173,10 +173,6 @@ func (rt mockRuntimeService) UpdateContainerResources(_ context.Context, id stri
 	return rt.err
 }
 
-func (rt mockRuntimeService) Close(_ context.Context) error {
-	return rt.err
-}
-
 type mockPodStatusProvider struct {
 	podStatus v1.PodStatus
 	found     bool

--- a/pkg/kubelet/cm/memorymanager/memory_manager_test.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager_test.go
@@ -131,10 +131,6 @@ func (rt mockRuntimeService) UpdateContainerResources(_ context.Context, id stri
 	return rt.err
 }
 
-func (rt mockRuntimeService) Close(_ context.Context) error {
-	return rt.err
-}
-
 type mockPodStatusProvider struct {
 	podStatus v1.PodStatus
 	found     bool


### PR DESCRIPTION
#### What type of PR is this?

<!--
/kind cleanup
-->

#### What this PR does / why we need it:
Remove unused Close methods of mockRuntimeService.

The methods Close for mockRuntimeService in CPUManager and MemoryManager tests are not used and are not part of the `runtimeService interface`

They were added during improving of passing context to CRI client: "CRI client: pass context to Close and use contextual logging", but are not part of that feature.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
