### PR TITLE
feat(validation-gen): add eachVal + maxBytes validation for resource string values

### DIFF
--- a/pkg/apis/resource/v1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1/zz_generated.validations.go
@@ -939,6 +939,12 @@ func Validate_DeviceAttribute(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil,
+				func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 64)
+				}).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/pkg/apis/resource/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta1/zz_generated.validations.go
@@ -978,6 +978,12 @@ func Validate_DeviceAttribute(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil,
+				func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 64)
+				}).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/pkg/apis/resource/v1beta2/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta2/zz_generated.validations.go
@@ -954,6 +954,12 @@ func Validate_DeviceAttribute(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil,
+				func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 64)
+				}).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -1017,7 +1017,7 @@ func validateDeviceAttribute(attribute resource.DeviceAttribute, fldPath *field.
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("strings"), attribute.StringValues, "must not be empty if specified"))
 		}
 		for i, item := range attribute.StringValues {
-			allErrs = append(allErrs, validateDeviceAttributeStringValue(&item, fldPath.Child("strings").Index(i))...)
+			allErrs = append(allErrs, validateDeviceAttributeStringValue(&item, fldPath.Child("strings").Index(i)).WithOrigin("maxBytes").MarkCoveredByDeclarative()...)
 		}
 	}
 	if attribute.VersionValues != nil {

--- a/pkg/apis/resource/validation/validation_resourceslice_test.go
+++ b/pkg/apis/resource/validation/validation_resourceslice_test.go
@@ -503,7 +503,7 @@ func TestValidateResourceSlice(t *testing.T) {
 				field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key(goodName), badMultipleListValue, "exactly one value must be specified").WithOrigin("union").MarkCoveredByDeclarative(),
 				field.Invalid(field.NewPath("spec", "devices").Index(1).Child("attributes").Key(goodName).Child("strings"), []string{}, "must not be empty if specified"),
 				field.Invalid(field.NewPath("spec", "devices").Index(1).Child("attributes").Key(goodName), badMultipleListValueWithEmptyList, "exactly one value must be specified").WithOrigin("union").MarkCoveredByDeclarative(),
-				field.TooLongMaxLength(field.NewPath("spec", "devices").Index(2).Child("attributes").Key(goodName).Child("strings").Index(0), badListStringValueTooLong.StringValues[0], resourceapi.DeviceAttributeMaxValueLength),
+				field.TooLongMaxLength(field.NewPath("spec", "devices").Index(2).Child("attributes").Key(goodName).Child("strings").Index(0), badListStringValueTooLong.StringValues[0], resourceapi.DeviceAttributeMaxValueLength).WithOrigin("maxBytes").MarkCoveredByDeclarative(),
 				field.Invalid(field.NewPath("spec", "devices").Index(3).Child("attributes").Key(goodName).Child("versions").Index(0), badListVersionValueTooLong.VersionValues[0], "must be a string compatible with semver.org spec 2.0.0"),
 				field.TooLongMaxLength(field.NewPath("spec", "devices").Index(3).Child("attributes").Key(goodName).Child("versions").Index(0), badListVersionValueTooLong.VersionValues[0], resourceapi.DeviceAttributeMaxValueLength),
 				field.Invalid(field.NewPath("spec", "devices").Index(4).Child("attributes").Key(goodName).Child("bools"), []bool{}, "must not be empty if specified"),

--- a/pkg/registry/resource/resourceslice/declarative_validation_test.go
+++ b/pkg/registry/resource/resourceslice/declarative_validation_test.go
@@ -18,6 +18,7 @@ package resourceslice
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -118,6 +119,23 @@ func TestDeclarativeValidate(t *testing.T) {
 				},
 				"valid: device attribute list of strings": {
 					input: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/list_of_strings", resource.DeviceAttribute{StringValues: []string{"a", "b", "c"}})),
+				},
+				"valid: device attribute list of strings at max bytes": {
+					input: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/list_of_strings", resource.DeviceAttribute{
+						// The tag literal is 64, which must stay aligned with DeviceAttributeMaxValueLength.
+						// "é" is two bytes in UTF-8, so repeating it max/2 times verifies the exact maxBytes boundary.
+						StringValues: []string{strings.Repeat("é", resource.DeviceAttributeMaxValueLength/2)},
+					})),
+				},
+				"invalid: device attribute list of strings with too-long item": {
+					input: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/list_of_strings", resource.DeviceAttribute{
+						// The tag literal is 64, which must stay aligned with DeviceAttributeMaxValueLength.
+						// "é" is two bytes in UTF-8, so max/2+1 repeats exceeds the maxBytes boundary.
+						StringValues: []string{strings.Repeat("é", resource.DeviceAttributeMaxValueLength/2+1)},
+					})),
+					expectedErrs: field.ErrorList{
+						field.TooLong(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/list_of_strings").Child("strings").Index(0), "", resource.DeviceAttributeMaxValueLength).WithOrigin("maxBytes").MarkAlpha(),
+					},
 				},
 				"valid: device attribute list of versions": {
 					input: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/list_of_versions", resource.DeviceAttribute{VersionValues: []string{"1.2.3", "2.3.4"}})),
@@ -333,6 +351,25 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 					update: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/empty", resource.DeviceAttribute{})),
 					expectedErrs: field.ErrorList{
 						field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/empty"), "", "").WithOrigin("union").MarkAlpha(),
+					},
+				},
+				"valid update: device attribute list of strings at max bytes": {
+					old: mkResourceSliceWithDevices(),
+					update: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/list_of_strings", resource.DeviceAttribute{
+						// The tag literal is 64, which must stay aligned with DeviceAttributeMaxValueLength.
+						// "é" is two bytes in UTF-8, so repeating it max/2 times verifies the exact maxBytes boundary.
+						StringValues: []string{strings.Repeat("é", resource.DeviceAttributeMaxValueLength/2)},
+					})),
+				},
+				"invalid update: device attribute list of strings with too-long item": {
+					old: mkResourceSliceWithDevices(),
+					update: mkResourceSliceWithDevices(tweakDeviceAttribute("test.io/list_of_strings", resource.DeviceAttribute{
+						// The tag literal is 64, which must stay aligned with DeviceAttributeMaxValueLength.
+						// "é" is two bytes in UTF-8, so max/2+1 repeats exceeds the maxBytes boundary.
+						StringValues: []string{strings.Repeat("é", resource.DeviceAttributeMaxValueLength/2+1)},
+					})),
+					expectedErrs: field.ErrorList{
+						field.TooLong(field.NewPath("spec", "devices").Index(0).Child("attributes").Key("test.io/list_of_strings").Child("strings").Index(0), "", resource.DeviceAttributeMaxValueLength).WithOrigin("maxBytes").MarkAlpha(),
 					},
 				},
 				// spec.sharedCounters

--- a/staging/src/k8s.io/api/resource/v1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1/generated.proto
@@ -612,6 +612,7 @@ message DeviceAttribute {
   // +k8s:listType=atomic
   // +k8s:alpha(since: "1.36")=+k8s:optional
   // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:alpha(since: "1.37")=+k8s:eachVal=+k8s:maxBytes=64
   // +featureGate=DRAListTypeAttributes
   repeated string strings = 8;
 

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -755,6 +755,7 @@ type DeviceAttribute struct {
 	// +k8s:listType=atomic
 	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:alpha(since: "1.37")=+k8s:eachVal=+k8s:maxBytes=64
 	// +featureGate=DRAListTypeAttributes
 	StringValues []string `json:"strings,omitempty" protobuf:"bytes,8,opt,name=strings"`
 

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -618,6 +618,7 @@ message DeviceAttribute {
   // +listType=atomic
   // +k8s:alpha(since: "1.36")=+k8s:optional
   // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:alpha(since: "1.37")=+k8s:eachVal=+k8s:maxBytes=64
   // +featureGate=DRAListTypeAttributes
   repeated string strings = 8;
 

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -746,6 +746,7 @@ type DeviceAttribute struct {
 	// +listType=atomic
 	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:alpha(since: "1.37")=+k8s:eachVal=+k8s:maxBytes=64
 	// +featureGate=DRAListTypeAttributes
 	StringValues []string `json:"strings,omitempty" protobuf:"bytes,8,opt,name=strings"`
 

--- a/staging/src/k8s.io/api/resource/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta2/generated.proto
@@ -612,6 +612,7 @@ message DeviceAttribute {
   // +k8s:listType=atomic
   // +k8s:alpha(since: "1.36")=+k8s:optional
   // +k8s:alpha(since: "1.36")=+k8s:unionMember
+  // +k8s:alpha(since: "1.37")=+k8s:eachVal=+k8s:maxBytes=64
   // +featureGate=DRAListTypeAttributes
   repeated string strings = 8;
 

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -740,6 +740,7 @@ type DeviceAttribute struct {
 	// +k8s:listType=atomic
 	// +k8s:alpha(since: "1.36")=+k8s:optional
 	// +k8s:alpha(since: "1.36")=+k8s:unionMember
+	// +k8s:alpha(since: "1.37")=+k8s:eachVal=+k8s:maxBytes=64
 	// +featureGate=DRAListTypeAttributes
 	StringValues []string `json:"strings,omitempty" protobuf:"bytes,8,opt,name=strings"`
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds declarative validation coverage for `resource.DeviceAttribute.StringValues` list elements using:

```go
// +k8s:alpha(since: "1.37")=+k8s:eachVal=+k8s:maxBytes=64
```

Migrate handwritten per-item byte-length validation for `ResourceSlice.spec.devices[*].attributes[*].strings[*]` to validation-gen while keeping handwritten validation authoritative. This migration is done in particular as currently +k8s:eachVal has no usage in k/k APIs and in order to graduate this tag to StabilityLevelBeta we need to use this tag and soak it for 1 release.  This starts that process.

The PR:

- Adds the `eachVal + maxBytes` tag chain to the `v1`, `v1beta1`, and `v1beta2` resource API types.
- Regenerates declarative validation code.
- Marks the matching handwritten validation error as covered by declarative validation.
- Adds ResourceSlice declarative validation equivalence coverage for valid and invalid `maxBytes` boundary cases on create and update.

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/issues/5073

#### Special notes for your reviewer:

This uses `+k8s:maxBytes=64` rather than `+k8s:maxLength=64` because the existing handwritten validation uses Go's `len(string)` and `field.TooLong`, which enforce a byte limit. The tests use `é`, a two-byte UTF-8 character, to verify byte-count semantics.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen
```

/area api-validation
/triage accepted
/sig api-machinery