### PR TITLE
kubectl: improve apply -f flag usage description

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -184,7 +184,7 @@ var ApplySetToolVersion = version.Get().GitVersion
 func NewApplyFlags(streams genericiooptions.IOStreams) *ApplyFlags {
 	return &ApplyFlags{
 		RecordFlags: genericclioptions.NewRecordFlags(),
-		DeleteFlags: cmddelete.NewDeleteFlags("The files that contain the configurations to apply."),
+		DeleteFlags: cmddelete.NewDeleteFlags("The files, directories or URLs that contain the configurations to apply."),
 		PrintFlags:  genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
 
 		Overwrite:    true,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
@@ -102,7 +102,7 @@ type ReplaceOptions struct {
 func NewReplaceOptions(streams genericiooptions.IOStreams) *ReplaceOptions {
 	return &ReplaceOptions{
 		PrintFlags:  genericclioptions.NewPrintFlags("replaced"),
-		DeleteFlags: delete.NewDeleteFlags("The files that contain the configurations to replace."),
+		DeleteFlags: delete.NewDeleteFlags("The files, directories or URLs that contain the configurations to replace."),
 
 		IOStreams: streams,
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:
Update the usage string and help description for `kubectl apply -f` to accurately reflect its capabilities.
The current usage only shows FILENAME, which is misleading since `-f` also supports:
- Directories (e.g. `kubectl apply -f ./manifests/`)
- URLs
- Stdin (e.g. `kubectl apply -f -`)
- File patterns
#### Which issue(s) this PR is related to:
Fixes kubernetes/kubectl#1844
#### Special notes for your reviewer:
Changes are limited to `staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go`:
1. `Use` field: `apply (-f FILENAME | -k DIRECTORY)` → `apply (-f FILE | DIR | URL | - | -k DIRECTORY)`
2. `Usage` string: `"The files that contain the configurations to apply."` → `"The files, directories, URLs, or stdin (-) that contain the configurations to apply."`
Note: Added spaces around `|` to avoid `|-` ligature rendering issues in some terminals.
#### Does this PR introduce a user-facing change?
```release-note
kubectl apply -f flag usage and help description now accurately reflects that it supports files, directories, URLs, and stdin, not just filenames.
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: