### PR TITLE
E2E framework: avoid duplicate FeatureGate tags

### DIFF
--- a/test/e2e/framework/ginkgowrapper.go
+++ b/test/e2e/framework/ginkgowrapper.go
@@ -293,13 +293,16 @@ func expandGinkgoArgs(leafNode bool, offset ginkgo.Offset, text string, args []a
 	if text != "" {
 		texts = append(texts, text)
 	}
+	previousText := ""
 
 	// All labels for a leaf node, from parent and added in this call.
 	allLabels := sets.New[string]()
 	if leafNode {
 		// May only be called during tree construction, i.e. not for the top-level node,
 		// so we have to be a bit careful.
-		allLabels = sets.New[string](ginkgo.CurrentTreeConstructionNodeReport().Labels()...)
+		report := ginkgo.CurrentTreeConstructionNodeReport()
+		previousText = report.FullText()
+		allLabels = sets.New[string](report.Labels()...)
 	}
 	addLabel := func(label string) {
 		ginkgoArgs = append(ginkgoArgs, ginkgo.Label(label))
@@ -404,7 +407,15 @@ func expandGinkgoArgs(leafNode bool, offset ginkgo.Offset, text string, args []a
 
 		slices.Sort(delayedLabels)
 		for _, label := range delayedLabels {
-			texts = append(texts, fmt.Sprintf("[%s]", label))
+			text := fmt.Sprintf("[%s]", label)
+			if strings.Contains(previousText, text) ||
+				slices.Contains(texts, text) {
+				// Never repeat text at the end which was already included earlier.
+				// In practice, this can happen for a FeatureGate when it was both
+				// explicitly mentioned and a dependency.
+				continue
+			}
+			texts = append(texts, text)
 			// This keeps validateText happy.
 			ginkgoArgs = append(ginkgoArgs, ginkgo.Label(label))
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

75448c416b9e31 added feature gate dependencies at the end of a test name. However, if those tags were already part of the previous text, either because they were explicitly added in the current node or in some parent node, then redundant tags were added.

Now this special case is detected and such redundant tags do not get added again.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/pull/134686#issuecomment-4333840396

#### Special notes for your reviewer:

Removes the following redundant tags (in `[-...-]` brackets):

```diff
diff --git a/tmp/before b/tmp/after
index 08882f90474..8ff55e1b9ad 100644
--- a/tmp/before
+++ b/tmp/after
@@ -247 +247 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    apps/job.go:1337: [sig-apps] Job containers restarted by container restart policy should not trigger PodFailurePolicy [FeatureGate:ContainerRestartRules] [Beta][-[FeatureGate:ContainerRestartRules]-] [NodeConformance]
@@ -256 +256 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    apps/job.go:1382: [sig-apps] Job should create Workload and PodGroup for gang-eligible Job [FeatureGate:GenericWorkload] [FeatureGate:WorkloadWithJob] [Alpha] [Feature:OffByDefault][-[FeatureGate:GenericWorkload]-]
@@ -333,6 +333,6 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    auth/projected_podcertificate.go:232: [sig-auth] Projected PodCertificate [FeatureGate:PodCertificateRequest] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] MaxExpirationSeconds validations should fail pod startup when MaxExpirationSeconds exceeds maximum (91d) [Beta] [Feature:OffByDefault] [FeatureGate:AuthorizeNodeWithSelectors] [FeatureGate:AuthorizeWithSelectors][-[FeatureGate:ClusterTrustBundle]-]
    auth/projected_podcertificate.go:251: [sig-auth] Projected PodCertificate [FeatureGate:PodCertificateRequest] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] MaxExpirationSeconds validations should fail pod startup when MaxExpirationSeconds is less than minimum (1h) [Beta] [Feature:OffByDefault] [FeatureGate:AuthorizeNodeWithSelectors] [FeatureGate:AuthorizeWithSelectors][-[FeatureGate:ClusterTrustBundle]-]
    auth/projected_podcertificate.go:161: [sig-auth] Projected PodCertificate [FeatureGate:PodCertificateRequest] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] MaxExpirationSeconds validations should issue certificate with default life time (24h) when MaxExpirationSeconds is not set [Beta] [Feature:OffByDefault] [FeatureGate:AuthorizeNodeWithSelectors] [FeatureGate:AuthorizeWithSelectors][-[FeatureGate:ClusterTrustBundle]-]
    auth/projected_podcertificate.go:196: [sig-auth] Projected PodCertificate [FeatureGate:PodCertificateRequest] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] MaxExpirationSeconds validations should issue certificate with specified duration (1h) when MaxExpirationSeconds is set [Beta] [Feature:OffByDefault] [FeatureGate:AuthorizeNodeWithSelectors] [FeatureGate:AuthorizeWithSelectors][-[FeatureGate:ClusterTrustBundle]-]
    auth/projected_podcertificate.go:73: [sig-auth] Projected PodCertificate [FeatureGate:PodCertificateRequest] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] should allow server and client pods to establish an mTLS connection [Beta] [Feature:OffByDefault] [FeatureGate:AuthorizeNodeWithSelectors] [FeatureGate:AuthorizeWithSelectors][-[FeatureGate:ClusterTrustBundle]-]
    auth/projected_podcertificate.go:112: [sig-auth] Projected PodCertificate [FeatureGate:PodCertificateRequest] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] should honor UserAnnotations for SPIFFE URI path [Beta] [Feature:OffByDefault] [FeatureGate:AuthorizeNodeWithSelectors] [FeatureGate:AuthorizeWithSelectors][-[FeatureGate:ClusterTrustBundle]-]
@@ -364,9 +364,9 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    auth/projected_clustertrustbundle.go:266: [sig-auth] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] should be able to mount a big number (>100) of CTBs [Beta] [Feature:OffByDefault][-[FeatureGate:ClusterTrustBundle]-]
    auth/projected_clustertrustbundle.go:71: [sig-auth] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] should be able to mount a single ClusterTrustBundle by name [Beta] [Feature:OffByDefault][-[FeatureGate:ClusterTrustBundle]-]
    auth/projected_clustertrustbundle.go:238: [sig-auth] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] should be able to specify multiple CTB volumes [Beta] [Feature:OffByDefault][-[FeatureGate:ClusterTrustBundle]-]
    auth/projected_clustertrustbundle.go:147: [sig-auth] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] should be capable to mount multiple trust bundles by signer+labels can combine all signer CTBs with an empty label selector [Beta] [Feature:OffByDefault][-[FeatureGate:ClusterTrustBundle]-]
    auth/projected_clustertrustbundle.go:147: [sig-auth] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] should be capable to mount multiple trust bundles by signer+labels can combine multiple CTBs with signer name and label selector [Beta] [Feature:OffByDefault][-[FeatureGate:ClusterTrustBundle]-]
    auth/projected_clustertrustbundle.go:147: [sig-auth] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] should be capable to mount multiple trust bundles by signer+labels should start if only signer name and explicit label selector matches nothing + optional=true [Beta] [Feature:OffByDefault][-[FeatureGate:ClusterTrustBundle]-]
    auth/projected_clustertrustbundle.go:147: [sig-auth] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] should be capable to mount multiple trust bundles by signer+labels should start if only signer name and nil label selector + optional=true [Beta] [Feature:OffByDefault][-[FeatureGate:ClusterTrustBundle]-]
    auth/projected_clustertrustbundle.go:193: [sig-auth] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] should prevent a pod from starting if: sets optional=false and no trust bundle matches query [Beta] [Feature:OffByDefault][-[FeatureGate:ClusterTrustBundle]-]
    auth/projected_clustertrustbundle.go:193: [sig-auth] [FeatureGate:ClusterTrustBundle] [FeatureGate:ClusterTrustBundleProjection] should prevent a pod from starting if: sets optional=false and the configured CTB does not exist [Beta] [Feature:OffByDefault][-[FeatureGate:ClusterTrustBundle]-]
@@ -410,2 +410,2 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    autoscaling/horizontal_pod_autoscaling.go:79: [sig-autoscaling] [Feature:HPA] Horizontal pod autoscaling (scale resource: CPU) Deployment (Pod-level Resources ContainerResource Metric) [FeatureGate:PodLevelResources] Should scale from 1 pod to 3 pods and then from 3 pods to 5 pods using Average Utilization for aggregation [Beta][-[FeatureGate:PodLevelResources]-]
    autoscaling/horizontal_pod_autoscaling.go:73: [sig-autoscaling] [Feature:HPA] Horizontal pod autoscaling (scale resource: CPU) Deployment (Pod-level Resources Resource Metric) [FeatureGate:PodLevelResources] Should scale from 1 pod to 3 pods and then from 3 pods to 5 pods using Average Utilization for aggregation [Beta][-[FeatureGate:PodLevelResources]-]
@@ -829,2 +829,2 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    common/node/downwardapi.go:425: [sig-node] Downward API [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Downward API tests for pod level resources should provide default limits.cpu/memory from pod level resources [Beta][-[FeatureGate:PodLevelResources]-]
    common/node/downwardapi.go:484: [sig-node] Downward API [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Downward API tests for pod level resources should provide default limits.cpu/memory from pod level resources or node allocatable [Beta][-[FeatureGate:PodLevelResources]-]
@@ -1021,32 +1021,32 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    common/node/container_restart_policy.go:387: [sig-node] Pod Extended (RestartAllContainers) [FeatureGate:ContainerRestartRules] [FeatureGate:RestartAllContainersOnContainerExits] RestartAllContainers should allow multiple RestartAllContainers actions and not introduce a loop [Beta][-[FeatureGate:ContainerRestartRules]-] [FeatureGate:NodeDeclaredFeatures]
    common/node/container_restart_policy.go:440: [sig-node] Pod Extended (RestartAllContainers) [FeatureGate:ContainerRestartRules] [FeatureGate:RestartAllContainersOnContainerExits] RestartAllContainers should restart all containers on a previously restarted regular container exit [Beta][-[FeatureGate:ContainerRestartRules]-] [FeatureGate:NodeDeclaredFeatures]
    common/node/container_restart_policy.go:196: [sig-node] Pod Extended (RestartAllContainers) [FeatureGate:ContainerRestartRules] [FeatureGate:RestartAllContainersOnContainerExits] RestartAllContainers should restart all containers on regular container exit [Beta][-[FeatureGate:ContainerRestartRules]-] [FeatureGate:NodeDeclaredFeatures]
    common/node/container_restart_policy.go:260: [sig-node] Pod Extended (RestartAllContainers) [FeatureGate:ContainerRestartRules] [FeatureGate:RestartAllContainersOnContainerExits] RestartAllContainers should restart all containers on sidecar container exit [Beta][-[FeatureGate:ContainerRestartRules]-] [FeatureGate:NodeDeclaredFeatures]
    common/node/container_restart_policy.go:324: [sig-node] Pod Extended (RestartAllContainers) [FeatureGate:ContainerRestartRules] [FeatureGate:RestartAllContainersOnContainerExits] RestartAllContainers should restart init and sidecar containers on init container exit [Beta][-[FeatureGate:ContainerRestartRules]-] [FeatureGate:NodeDeclaredFeatures]
    common/node/container_restart_policy.go:78: [sig-node] Pod Extended (container restart policy) [FeatureGate:ContainerRestartRules] Container Restart Rules should not restart container on rule mismatch, container restart policy Never [Beta][-[FeatureGate:ContainerRestartRules]-]
    common/node/container_restart_policy.go:131: [sig-node] Pod Extended (container restart policy) [FeatureGate:ContainerRestartRules] Container Restart Rules should restart container on container-level restart policy Always [Beta][-[FeatureGate:ContainerRestartRules]-]
    common/node/container_restart_policy.go:109: [sig-node] Pod Extended (container restart policy) [FeatureGate:ContainerRestartRules] Container Restart Rules should restart container on container-level restart policy Never [Beta][-[FeatureGate:ContainerRestartRules]-]
    common/node/container_restart_policy.go:153: [sig-node] Pod Extended (container restart policy) [FeatureGate:ContainerRestartRules] Container Restart Rules should restart container on pod-level restart policy Always when no container-level restart policy [Beta][-[FeatureGate:ContainerRestartRules]-]
    common/node/container_restart_policy.go:47: [sig-node] Pod Extended (container restart policy) [FeatureGate:ContainerRestartRules] Container Restart Rules should restart container on rule match [Beta][-[FeatureGate:ContainerRestartRules]-]
    node/pod_resize.go:698: [sig-node] Pod InPlace Resize Container (deferred-resizes) [FeatureGate:InPlacePodVerticalScaling] pod-resize-retry-deferred-test-1[-[FeatureGate:InPlacePodVerticalScaling]-] [Serial]
    node/pod_resize.go:821: [sig-node] Pod InPlace Resize Container (deferred-resizes) [FeatureGate:InPlacePodVerticalScaling] pod-resize-retry-deferred-test-2[-[FeatureGate:InPlacePodVerticalScaling]-] [Serial]
    node/pod_resize.go:1044: [sig-node] Pod InPlace Resize Container (deferred-resizes) [FeatureGate:InPlacePodVerticalScaling] pod-resize-retry-deferred-test-3[-[FeatureGate:InPlacePodVerticalScaling]-] [Serial]
    node/pod_resize.go:331: [sig-node] Pod InPlace Resize Container (limit-ranger) [FeatureGate:InPlacePodVerticalScaling] pod-resize-limit-ranger-test exceed maximum CPU[-[FeatureGate:InPlacePodVerticalScaling]-]
    node/pod_resize.go:342: [sig-node] Pod InPlace Resize Container (limit-ranger) [FeatureGate:InPlacePodVerticalScaling] pod-resize-limit-ranger-test exceed maximum Memory[-[FeatureGate:InPlacePodVerticalScaling]-]
    node/pod_resize.go:353: [sig-node] Pod InPlace Resize Container (limit-ranger) [FeatureGate:InPlacePodVerticalScaling] pod-resize-limit-ranger-test exceed maximum Memory and CPU[-[FeatureGate:InPlacePodVerticalScaling]-]
    node/pod_resize.go:364: [sig-node] Pod InPlace Resize Container (limit-ranger) [FeatureGate:InPlacePodVerticalScaling] pod-resize-limit-ranger-test request below min CPU[-[FeatureGate:InPlacePodVerticalScaling]-]
    node/pod_resize.go:386: [sig-node] Pod InPlace Resize Container (limit-ranger) [FeatureGate:InPlacePodVerticalScaling] pod-resize-limit-ranger-test request below min CPU and min Memory[-[FeatureGate:InPlacePodVerticalScaling]-]
    node/pod_resize.go:375: [sig-node] Pod InPlace Resize Container (limit-ranger) [FeatureGate:InPlacePodVerticalScaling] pod-resize-limit-ranger-test request below min Memory[-[FeatureGate:InPlacePodVerticalScaling]-]
    node/pod_resize.go:461: [sig-node] Pod InPlace Resize Container (limit-ranger) [FeatureGate:InPlacePodVerticalScaling] pod-resize-limit-ranger-test valid decrease of CPU[-[FeatureGate:InPlacePodVerticalScaling]-]
    node/pod_resize.go:477: [sig-node] Pod InPlace Resize Container (limit-ranger) [FeatureGate:InPlacePodVerticalScaling] pod-resize-limit-ranger-test valid decrease of CPU and Memory[-[FeatureGate:InPlacePodVerticalScaling]-]
    node/pod_resize.go:445: [sig-node] Pod InPlace Resize Container (limit-ranger) [FeatureGate:InPlacePodVerticalScaling] pod-resize-limit-ranger-test valid decrease of Memory[-[FeatureGate:InPlacePodVerticalScaling]-]
    node/pod_resize.go:397: [sig-node] Pod InPlace Resize Container (limit-ranger) [FeatureGate:InPlacePodVerticalScaling] pod-resize-limit-ranger-test valid increase of CPU[-[FeatureGate:InPlacePodVerticalScaling]-]
    node/pod_resize.go:429: [sig-node] Pod InPlace Resize Container (limit-ranger) [FeatureGate:InPlacePodVerticalScaling] pod-resize-limit-ranger-test valid increase of CPU and Memory[-[FeatureGate:InPlacePodVerticalScaling]-]
    node/pod_resize.go:413: [sig-node] Pod InPlace Resize Container (limit-ranger) [FeatureGate:InPlacePodVerticalScaling] pod-resize-limit-ranger-test valid increase of Memory[-[FeatureGate:InPlacePodVerticalScaling]-]
    node/pod_resize.go:136: [sig-node] Pod InPlace Resize Container (resource-quota) [FeatureGate:InPlacePodVerticalScaling] pod-resize-resource-quota-test exceed maximum CPU[-[FeatureGate:InPlacePodVerticalScaling]-]
    node/pod_resize.go:158: [sig-node] Pod InPlace Resize Container (resource-quota) [FeatureGate:InPlacePodVerticalScaling] pod-resize-resource-quota-test exceed maximum CPU and Memory[-[FeatureGate:InPlacePodVerticalScaling]-]
    node/pod_resize.go:147: [sig-node] Pod InPlace Resize Container (resource-quota) [FeatureGate:InPlacePodVerticalScaling] pod-resize-resource-quota-test exceed maximum Memory[-[FeatureGate:InPlacePodVerticalScaling]-]
    node/pod_resize.go:201: [sig-node] Pod InPlace Resize Container (resource-quota) [FeatureGate:InPlacePodVerticalScaling] pod-resize-resource-quota-test valid increase for both CPU and Memory[-[FeatureGate:InPlacePodVerticalScaling]-]
    node/pod_resize.go:169: [sig-node] Pod InPlace Resize Container (resource-quota) [FeatureGate:InPlacePodVerticalScaling] pod-resize-resource-quota-test valid increase of CPU[-[FeatureGate:InPlacePodVerticalScaling]-]
    node/pod_resize.go:185: [sig-node] Pod InPlace Resize Container (resource-quota) [FeatureGate:InPlacePodVerticalScaling] pod-resize-resource-quota-test valid increase of Memory[-[FeatureGate:InPlacePodVerticalScaling]-]
    node/pod_resize.go:496: [sig-node] Pod InPlace Resize Container (scheduler-focused) [FeatureGate:InPlacePodVerticalScaling] pod-resize-scheduler-tests[-[FeatureGate:InPlacePodVerticalScaling]-] [Serial]
@@ -1123,20 +1123,20 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] BestEffort QoS no pod resources, no container resources [Beta][-[FeatureGate:PodLevelResources]-] [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod with yet some other container resources [Beta][-[FeatureGate:PodLevelResources]-] [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, 1 container with resources [Beta][-[FeatureGate:PodLevelResources]-] [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, no container resources [Beta][-[FeatureGate:PodLevelResources]-] [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, partial requests in pod level resources, 1 container with guaranteed resources [Beta][-[FeatureGate:PodLevelResources]-] [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, pod resources limits, container resources limits [Beta][-[FeatureGate:PodLevelResources]-] [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, pod resources limits, container resources requests [Beta][-[FeatureGate:PodLevelResources]-] [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, pod resources requests and limits, container resources limits [Beta][-[FeatureGate:PodLevelResources]-] [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, pod resources requests and limits, container resources requests [Beta][-[FeatureGate:PodLevelResources]-] [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, pod resources requests, container resources limits [Beta][-[FeatureGate:PodLevelResources]-] [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, pod resources requests, container resources requests [Beta][-[FeatureGate:PodLevelResources]-] [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, pod resources requests, container resources requests and limits [Beta][-[FeatureGate:PodLevelResources]-] [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, pod resources requests, container resources requests and partial limits [Beta][-[FeatureGate:PodLevelResources]-] [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, pod resources requests, no container resources [Beta][-[FeatureGate:PodLevelResources]-] [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Burstable QoS pod, pod resources requests, partial container resources limits [Beta][-[FeatureGate:PodLevelResources]-] [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Guaranteed QoS pod with only container resources [Beta][-[FeatureGate:PodLevelResources]-] [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Guaranteed QoS pod with other container resources [Beta][-[FeatureGate:PodLevelResources]-] [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Guaranteed QoS pod, 1 container with resources [Beta][-[FeatureGate:PodLevelResources]-] [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Guaranteed QoS pod, no container resources [Beta][-[FeatureGate:PodLevelResources]-] [Serial]
    common/node/pod_level_resources.go:420: [sig-node] Pod Level Resources [Feature:PodLevelResources] [FeatureGate:PodLevelResources] Guaranteed QoS pod, pod resources limits, no container resources [Beta][-[FeatureGate:PodLevelResources]-] [Serial]
@@ -1347,3 +1347,3 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    dra/dra.go:2213: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRADeviceTaints] DeviceTaintRule evicts pod [FeatureGate:DRADeviceTaintRules] [Beta] [Feature:OffByDefault][-[FeatureGate:DRADeviceTaints]-] [FeatureGate:DynamicResourceAllocation]
    dra/dra.go:2382: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRADeviceTaints] NoExecute can be tolerated [Beta][-[FeatureGate:DRADeviceTaints]-] [FeatureGate:DynamicResourceAllocation]
    dra/dra.go:2375: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRADeviceTaints] NoExecute keeps pod pending [Beta][-[FeatureGate:DRADeviceTaints]-] [FeatureGate:DynamicResourceAllocation]
@@ -1352,3 +1352,3 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    dra/dra.go:2299: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRADeviceTaints] [FeatureGate:DRAWorkloadResourceClaims] [FeatureGate:GenericWorkload] [KubeletMinVersion:1.36] DeviceTaintRule evicts pod with PodGroup claim [FeatureGate:DRADeviceTaintRules] [Alpha] [Beta] [Feature:OffByDefault][-[FeatureGate:DRADeviceTaints]-] [FeatureGate:DynamicResourceAllocation][-[FeatureGate:GenericWorkload]-]
    dra/dra.go:2285: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRADeviceTaints] [FeatureGate:DRAWorkloadResourceClaims] [FeatureGate:GenericWorkload] [KubeletMinVersion:1.36] NoSchedule can be tolerated for PodGroup claims [Alpha] [Beta] [Feature:OffByDefault][-[FeatureGate:DRADeviceTaints]-] [FeatureGate:DynamicResourceAllocation][-[FeatureGate:GenericWorkload]-]
    dra/dra.go:2276: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRADeviceTaints] [FeatureGate:DRAWorkloadResourceClaims] [FeatureGate:GenericWorkload] [KubeletMinVersion:1.36] NoSchedule keeps pod with PodGroup claim pending [Alpha] [Beta] [Feature:OffByDefault][-[FeatureGate:DRADeviceTaints]-] [FeatureGate:DynamicResourceAllocation][-[FeatureGate:GenericWorkload]-]
@@ -1360,2 +1360,2 @@ The following spec names can be used with 'ginkgo run --focus/skip':
    dra/dra.go:2142: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:GenericWorkload] [FeatureGate:DRAWorkloadResourceClaims] [KubeletMinVersion:1.36] allocates devices for PodGroups [Alpha] [Feature:OffByDefault] [FeatureGate:DynamicResourceAllocation][-[FeatureGate:GenericWorkload]-]
    dra/dra.go:2153: [sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:GenericWorkload] [FeatureGate:DRAWorkloadResourceClaims] [KubeletMinVersion:1.36] generates claims from templates for PodGroups [Alpha] [Feature:OffByDefault] [FeatureGate:DynamicResourceAllocation][-[FeatureGate:GenericWorkload]-]
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @BenTheElder 