### PR TITLE
Preserve container resource claims during pod resize validation

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -6547,7 +6547,7 @@ func dropCPUMemoryUpdates(resourceList, oldResourceList core.ResourceList) core.
 func dropCPUMemoryResourcesFromContainer(container *core.Container, oldPodSpecContainer *core.Container) {
 	lim := dropCPUMemoryUpdates(container.Resources.Limits, oldPodSpecContainer.Resources.Limits)
 	req := dropCPUMemoryUpdates(container.Resources.Requests, oldPodSpecContainer.Resources.Requests)
-	container.Resources = core.ResourceRequirements{Limits: lim, Requests: req}
+	container.Resources = core.ResourceRequirements{Limits: lim, Requests: req, Claims: container.Resources.Claims}
 }
 
 // dropCPUMemoryResourceRequirementsUpdates deletes the cpu and memory resources


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

During pod resize validation, Kubernetes masks allowed CPU and memory resource updates before comparing the updated container against the old container.

However, `dropCPUMemoryResourcesFromContainer` rebuilds `ResourceRequirements` using only `Limits` and `Requests`. This drops `Resources.Claims`, even when the user did not modify the container resource claims.

As a result, a CPU/memory-only resize request can be rejected with:

`only cpu and memory resources are mutable`

when the container uses unchanged DRA resource claims.

This PR preserves `container.Resources.Claims` while masking CPU and memory updates. This keeps the current validation semantics:

- CPU and memory resource updates are still masked as allowed resize changes.
- Unchanged container resource claims no longer cause a false-positive `DeepEqual` mismatch.
- Modified container resource claims are still rejected, because the preserved new claims are compared against the old container.
- Pods with `status.nodeAllocatableResourceClaimStatuses` are still rejected by the existing validation check.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This PR does not enable in-place resize for pods with node-allocatable resource claims. The existing restriction remains unchanged.

The fix is limited to preserving immutable container `Resources.Claims` while masking CPU and memory updates for the existing equality check.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a validation bug where CPU/memory-only pod resize could be rejected when a container used unchanged DRA resource claims.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```
