### PR TITLE
e2e node conformance: fix the EnsureCredentialPulledImages test flakes

### DIFF
--- a/test/e2e_node/runtime_conformance_test.go
+++ b/test/e2e_node/runtime_conformance_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -100,9 +101,23 @@ var _ = SIGDescribe("Container Runtime Conformance Test", func() {
 
 					err := os.WriteFile(configFile, []byte(auth), 0644)
 					framework.ExpectNoError(err)
-					ginkgo.DeferCleanup(func() {
-						framework.ExpectNoError(os.Remove(configFile))
-						framework.ExpectNoError(os.RemoveAll(filepath.Join(services.KubeletRootDirectory, "image_manager")))
+					ginkgo.DeferCleanup(func(ctx context.Context) {
+						imageManagerDir := filepath.Join(services.KubeletRootDirectory, "image_manager")
+
+						// restart the kubelet
+						withStoppedKubelet(ctx, f, false, func() {
+							framework.ExpectNoError(os.Remove(configFile))
+							framework.ExpectNoError(os.RemoveAll(imageManagerDir))
+						})
+						framework.ExpectNoError(wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(_ context.Context) (bool, error) {
+							if _, err := os.Stat(imageManagerDir); err != nil {
+								f.Logf("waiting for %q to appear: %v", imageManagerDir, err)
+								return false, nil
+							}
+							return true, nil
+						}),
+							"directory %q never reappeared", imageManagerDir,
+						)
 					})
 
 					// checkContainerStatus checks whether the container status matches expectation.

--- a/test/e2e_node/util_kubeletconfig.go
+++ b/test/e2e_node/util_kubeletconfig.go
@@ -112,6 +112,19 @@ func tempRemoveImagePulledRecord(f *framework.Framework, imageID *string) {
 		// wait for the kubelet to create the record
 		err := wait.PollUntilContextTimeout(ctx, time.Second, 5*time.Second, true, func(_ context.Context) (bool, error) {
 			if _, err := os.Stat(origPath); err != nil {
+				f.Logf("failed to stat file %q: %v", origPath, err)
+				dirEntries, err := os.ReadDir(pulledRecordsDir)
+				if err != nil {
+					f.Logf("failed to read directory contents for %q: %v", pulledRecordsDir, err)
+					return false, nil
+				}
+				files := map[string]string{}
+				for _, entry := range dirEntries {
+					entryPath := filepath.Join(pulledRecordsDir, entry.Name())
+					content, _ := os.ReadFile(entryPath)
+					files[entryPath] = string(content)
+				}
+				f.Logf("contents of %q: %v", pulledRecordsDir, files)
 				return false, nil
 			}
 			return true, nil


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

Fixes a flaking test.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/138527

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc aramase
