### PR TITLE
Add early-return based on mincount to pod group scheduling algorithm

### DIFF
--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -180,6 +180,21 @@ type PodGroupPostFilterPlugin interface {
 	PodGroupPostFilter(ctx context.Context, pg *v1alpha3.PodGroup, pods []*v1.Pod, pgSchedulingFunc PodGroupSchedulingFunc) (*PodGroupPostFilterResult, *fwk.Status)
 }
 
+// PlacementFeasiblePlugin is an interface for plugins that are called after each pod in a pod group is evaluated.
+// It is used to determine if a pod group is schedulable, may become schedulable or will not become schedulable regardless of the scheduling result of the remaining pods in the pod group.
+type PlacementFeasiblePlugin interface {
+	fwk.Plugin
+
+	// PlacementFeasible is called after each pod in a pod group is evaluated.
+	// Use placementCycleState to accumulate the results from the evaluated pods in current cycle.
+	// Return Unschedulable status if the pod group cannot be scheduled in the current state, but may become schedulable once more pods are evaluated.
+	// Return UnschedulableAndUnresolvable status if the pod group cannot be scheduled in the current placement.
+	// The scheduler will give up this placement and won't even evaluate remaining pods. The placement will remain eligible for preemption.
+	// Return Success status if the pod group can be scheduled in the current state.
+	// After returning Success, the plugin should keep returning Success for the remaining pods.
+	PlacementFeasible(ctx context.Context, placementCycleState fwk.PodGroupCycleState, podGroupInfo fwk.PodGroupInfo) *fwk.Status
+}
+
 // Framework manages the set of plugins in use by the scheduling framework.
 // Configured plugins are called at specified points in a scheduling context.
 type Framework interface {
@@ -261,6 +276,14 @@ type Framework interface {
 	// plugins returns "Wait", then this function will construct the pluginsWaitTime and return status with "Wait" code.
 	// This function itself will NOT create a waiting pod object and the caller should call AddWaitingPod method to do this.
 	RunPermitPlugins(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (pluginsWaitTime map[string]time.Duration, status *fwk.Status)
+
+	// RunPlacementFeasiblePlugins runs the set of configured Permit plugins that implement PlacementFeasible interface.
+	// The result will be Success if all plugins return Success.
+	// The only other valid statuses are UnschedulableAndUnresolvable and Unschedulable.
+	// If any plugin returns invalid status, the result will be Error and the remaining plugins won't be invoked.
+	// Otherwise, if at least 1 plugin returns UnschedulableAndUnresolvable, the remaining plugins won't be invoked and the result will be UnschdulableAndUnresolvable. The placement will remain eligible for preemption.
+	// Otherwise, if at least 1 plugin returns Unschedulable, the remaining plugins will be invoked and the result will be Unschedulable.
+	RunPlacementFeasiblePlugins(ctx context.Context, placementCycleState fwk.PodGroupCycleState, podGroupInfo fwk.PodGroupInfo) *fwk.Status
 
 	// AddWaitingPod creates a waiting pod instance and adds it to the framework.
 	// It takes the pluginsWaitTime map returned by the RunPermitPlugins.

--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -187,10 +187,10 @@ type PlacementFeasiblePlugin interface {
 
 	// PlacementFeasible is called after each pod in a pod group is evaluated.
 	// Use placementCycleState to accumulate the results from the evaluated pods in current cycle.
-	// Return Unschedulable status if the pod group cannot be scheduled in the current state, but may become schedulable once more pods are evaluated.
+	// Return Unschedulable status if the pod group cannot be scheduled in the current partially evaluated placement, but may become schedulable once more pods are evaluated.
 	// Return UnschedulableAndUnresolvable status if the pod group cannot be scheduled in the current placement.
 	// The scheduler will give up this placement and won't even evaluate remaining pods. The placement will remain eligible for preemption.
-	// Return Success status if the pod group can be scheduled in the current state.
+	// Return Success status if the pod group can be scheduled in the current partially evaluated placement.
 	// After returning Success, the plugin should keep returning Success for the remaining pods.
 	PlacementFeasible(ctx context.Context, placementCycleState fwk.PodGroupCycleState, podGroupInfo fwk.PodGroupInfo) *fwk.Status
 }

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
@@ -234,7 +234,7 @@ func getPlacementFeasibleState(placementCycleState fwk.PodGroupCycleState) *plac
 	return state.(*placementFeasibleState)
 }
 
-// PlacementFeasible is responsible for enforcing the gang's MinCount constraint.
+// PlacementFeasible is responsible for enforcing the gang's MinCount constraint in the pod group scheduling cycle.
 // The function will only return success once the gang's MinCount is satisfied or if the pod group is not using gang scheduling policy.
 // In case there are not enough remaining pods to satisfy the gang's MinCount, it returns UnschedulableAndUnresolvable which will terminate the pod group scheduling cycle early.
 func (pl *GangScheduling) PlacementFeasible(ctx context.Context, placementCycleState fwk.PodGroupCycleState, podGroupInfo fwk.PodGroupInfo) *fwk.Status {

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
@@ -28,6 +28,7 @@ import (
 	schedulinglisters "k8s.io/client-go/listers/scheduling/v1alpha3"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/helper"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
@@ -54,6 +55,7 @@ type GangScheduling struct {
 var _ fwk.EnqueueExtensions = &GangScheduling{}
 var _ fwk.PreEnqueuePlugin = &GangScheduling{}
 var _ fwk.PermitPlugin = &GangScheduling{}
+var _ framework.PlacementFeasiblePlugin = &GangScheduling{}
 
 // New initializes a new plugin and returns it.
 func New(_ context.Context, _ runtime.Object, fh fwk.Handle, fts feature.Features) (fwk.Plugin, error) {
@@ -182,15 +184,7 @@ func (pl *GangScheduling) Permit(ctx context.Context, state fwk.CycleState, pod 
 		return nil, 0
 	}
 
-	// Select a lister for the pod group state based on the currently executed scheduling phase.
-	// In the pod group scheduling cycle, it reads from the snapshot.
-	// Otherwise, it reads the runtime state of the pod group from the cache.
-	var podGroupStateLister fwk.PodGroupStateLister
-	if state.IsPodGroupSchedulingCycle() {
-		podGroupStateLister = pl.snapshotLister.PodGroupStates()
-	} else {
-		podGroupStateLister = pl.podGroupManager.PodGroupStates()
-	}
+	podGroupStateLister := pl.podGroupManager.PodGroupStates()
 	podGroupState, err := podGroupStateLister.Get(namespace, *schedulingGroup.PodGroupName)
 	if err != nil {
 		return fwk.AsStatus(err), 0
@@ -216,4 +210,72 @@ func (pl *GangScheduling) Permit(ctx context.Context, state fwk.CycleState, pod 
 	}
 
 	return nil, 0
+}
+
+const placementFeasibleStateKey = "PlacementFeasible" + Name
+
+type placementFeasibleState struct {
+	evaluated, succeeded int
+}
+
+func (s *placementFeasibleState) Clone() fwk.StateData {
+	return &placementFeasibleState{
+		evaluated: s.evaluated,
+		succeeded: s.succeeded,
+	}
+}
+
+func getPlacementFeasibleState(placementCycleState fwk.PodGroupCycleState) *placementFeasibleState {
+	state, err := placementCycleState.Read(placementFeasibleStateKey)
+	if err != nil {
+		state = &placementFeasibleState{}
+		placementCycleState.Write(placementFeasibleStateKey, state)
+	}
+	return state.(*placementFeasibleState)
+}
+
+// PlacementFeasible is responsible for enforcing the gang's MinCount constraint.
+// The function will only return success once the gang's MinCount is satisfied or if the pod group is not using gang scheduling policy.
+// In case there are not enough remaining pods to satisfy the gang's MinCount, it returns UnschedulableAndUnresolvable which will terminate the pod group scheduling cycle early.
+func (pl *GangScheduling) PlacementFeasible(ctx context.Context, placementCycleState fwk.PodGroupCycleState, podGroupInfo fwk.PodGroupInfo) *fwk.Status {
+	pg, err := pl.podGroupLister.PodGroups(podGroupInfo.GetNamespace()).Get(podGroupInfo.GetName())
+	if err != nil {
+		return fwk.AsStatus(fmt.Errorf("failed to get podGroup %s to compute gang feasibility: %w", klog.KObj(podGroupInfo), err))
+	}
+
+	gangPolicy := pg.Spec.SchedulingPolicy.Gang
+	// This plugin only cares about pods with a Gang scheduling policy.
+	if gangPolicy == nil {
+		return nil
+	}
+
+	podGroupState, err := pl.snapshotLister.PodGroupStates().Get(podGroupInfo.GetNamespace(), podGroupInfo.GetName())
+	if err != nil {
+		return fwk.AsStatus(fmt.Errorf("failed to get podGroup state for podGroup %s to compute gang feasibility: %w", klog.KObj(pg), err))
+	}
+
+	// We need to keep track of how many pods have already been evaluated in the current PodGroup scheduling cycle.
+	pgState := getPlacementFeasibleState(placementCycleState)
+	pgState.evaluated++
+
+	// remaining is the number of unscheduled pods that haven't been evaluated yet in the current PodGroup scheduling cycle.
+	remaining := len(podGroupInfo.GetUnscheduledPods()) - pgState.evaluated
+
+	// scheduled includes the pods that are assigned or assumed in the current PodGroup scheduling cycle.
+	scheduled := podGroupState.ScheduledPodsCount()
+
+	minCount := int(gangPolicy.MinCount)
+
+	if remaining+scheduled < minCount {
+		// minCount can't be satisfied because there are not enough remaining pods.
+		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, fmt.Sprintf("minCount (%d) cannot be satisfied: %d scheduled, %d remaining", minCount, scheduled, remaining))
+	}
+
+	if scheduled < minCount {
+		// minCount might be satisfied once more remaining pods are evaluated.
+		return fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("minCount (%d) is not yet satisfied: %d scheduled, %d remaining", minCount, scheduled, remaining))
+	}
+
+	// minCount is satisfied.
+	return nil
 }

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -596,7 +596,7 @@ func TestPlacementFeasible(t *testing.T) {
 			}
 
 			informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(pg), 0)
-			informerFactory.Scheduling().V1alpha2().PodGroups().Informer()
+			informerFactory.Scheduling().V1alpha3().PodGroups().Informer()
 			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSyncWithContext(ctx)
 

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -167,6 +167,31 @@ func (pam *podActivatorMock) Activate(_ klog.Logger, pods map[string]*v1.Pod) {
 	}
 }
 
+type mockPodGroupState struct {
+	fwk.PodGroupState
+	scheduledPodsCount int
+}
+
+func (m *mockPodGroupState) ScheduledPodsCount() int { return m.scheduledPodsCount }
+
+type mockPodGroupStateLister struct {
+	state *mockPodGroupState
+	err   error
+}
+
+func (m *mockPodGroupStateLister) Get(namespace, podGroupName string) (fwk.PodGroupState, error) {
+	return m.state, m.err
+}
+
+type mockSharedLister struct {
+	fwk.SharedLister
+	podGroupStateLister *mockPodGroupStateLister
+}
+
+func (m *mockSharedLister) PodGroupStates() fwk.PodGroupStateLister {
+	return m.podGroupStateLister
+}
+
 func TestGangSchedulingFlow(t *testing.T) {
 	gangPodGroup1 := st.MakePodGroup().Namespace("ns1").Name("pg1").TemplateRef("t1", "gang-wl").MinCount(3).Obj()
 	gangPodGroup2 := st.MakePodGroup().Namespace("ns1").Name("pg2").TemplateRef("t2", "gang-wl").MinCount(4).Obj()
@@ -243,17 +268,6 @@ func TestGangSchedulingFlow(t *testing.T) {
 			wantPreEnqueueStatus: nil,
 			wantPermitStatus:     nil,
 			wantAllowedPods:      []types.UID{"p1", "p2", "p3"},
-		},
-		{
-			name:                            "final gang pod arrives at Permit during pod group scheduling cycle",
-			pod:                             p1,
-			initialPods:                     []*v1.Pod{p2, p3, p4, p5},
-			initialPodGroups:                []*schedulingapi.PodGroup{gangPodGroup1, gangPodGroup2},
-			podsWaitingOnPermit:             []*v1.Pod{p2, p3, p4, p5},
-			isDuringPodGroupSchedulingCycle: true,
-			wantPreEnqueueStatus:            nil,
-			wantPermitStatus:                nil,
-			wantAllowedPods:                 []types.UID{"p1", "p2", "p3"},
 		},
 	}
 
@@ -380,3 +394,262 @@ func TestGangSchedulingFlow(t *testing.T) {
 		})
 	}
 }
+
+func TestPlacementFeasible(t *testing.T) {
+	tests := []struct {
+		name                  string
+		minCount              int32
+		unscheduledPods       []*v1.Pod
+		podStatuses           []fwk.Code
+		expectedStatuses      []fwk.Code
+		initialScheduledCount int
+	}{
+		{
+			name:     "All pods succeed, minCount met at end",
+			minCount: 2,
+			unscheduledPods: []*v1.Pod{
+				st.MakePod().Name("p1").Obj(),
+				st.MakePod().Name("p2").Obj(),
+			},
+			podStatuses: []fwk.Code{
+				fwk.Success,
+				fwk.Success,
+			},
+			expectedStatuses: []fwk.Code{
+				fwk.Unschedulable,
+				fwk.Success,
+			},
+		},
+		{
+			name:     "First pod fails, minCount not satisfiable",
+			minCount: 3,
+			unscheduledPods: []*v1.Pod{
+				st.MakePod().Name("p1").Obj(),
+				st.MakePod().Name("p2").Obj(),
+				st.MakePod().Name("p3").Obj(),
+			},
+			podStatuses: []fwk.Code{
+				fwk.Unschedulable,
+			},
+			expectedStatuses: []fwk.Code{
+				fwk.UnschedulableAndUnresolvable,
+			},
+		},
+		{
+			name:     "Second pod fails, minCount not satisfiable",
+			minCount: 2,
+			unscheduledPods: []*v1.Pod{
+				st.MakePod().Name("p1").Obj(),
+				st.MakePod().Name("p2").Obj(),
+			},
+			podStatuses: []fwk.Code{
+				fwk.Success,
+				fwk.Unschedulable,
+			},
+			expectedStatuses: []fwk.Code{
+				fwk.Unschedulable,
+				fwk.UnschedulableAndUnresolvable,
+			},
+		},
+		{
+			name:            "Non-gang pod group ignored",
+			minCount:        0, // No gang policy
+			unscheduledPods: []*v1.Pod{st.MakePod().Name("p1").Obj()},
+			podStatuses: []fwk.Code{
+				fwk.Unschedulable,
+			},
+			expectedStatuses: []fwk.Code{
+				fwk.Success,
+			},
+		},
+		{
+			name:     "More than minCount pods, all succeed",
+			minCount: 2,
+			unscheduledPods: []*v1.Pod{
+				st.MakePod().Name("p1").Obj(),
+				st.MakePod().Name("p2").Obj(),
+				st.MakePod().Name("p3").Obj(),
+			},
+			podStatuses: []fwk.Code{
+				fwk.Success,
+				fwk.Success,
+				fwk.Success,
+			},
+			expectedStatuses: []fwk.Code{
+				fwk.Unschedulable,
+				fwk.Success,
+				fwk.Success,
+			},
+		},
+		{
+			name:     "More than minCount pods, first fails",
+			minCount: 2,
+			unscheduledPods: []*v1.Pod{
+				st.MakePod().Name("p1").Obj(),
+				st.MakePod().Name("p2").Obj(),
+				st.MakePod().Name("p3").Obj(),
+			},
+			podStatuses: []fwk.Code{
+				fwk.Unschedulable,
+				fwk.Success,
+				fwk.Success,
+			},
+			expectedStatuses: []fwk.Code{
+				fwk.Unschedulable,
+				fwk.Unschedulable,
+				fwk.Success,
+			},
+		},
+		{
+			name:     "More than minCount pods, minCount not satisfiable",
+			minCount: 2,
+			unscheduledPods: []*v1.Pod{
+				st.MakePod().Name("p1").Obj(),
+				st.MakePod().Name("p2").Obj(),
+				st.MakePod().Name("p3").Obj(),
+			},
+			podStatuses: []fwk.Code{
+				fwk.Unschedulable,
+				fwk.Unschedulable,
+				fwk.Success,
+			},
+			expectedStatuses: []fwk.Code{
+				fwk.Unschedulable,
+				fwk.UnschedulableAndUnresolvable,
+				fwk.UnschedulableAndUnresolvable,
+			},
+		},
+		{
+			name:     "1 pod scheduled, 2 unscheduled pods succeed, minCount 3 met",
+			minCount: 3,
+			unscheduledPods: []*v1.Pod{
+				st.MakePod().Name("p1").Obj(),
+				st.MakePod().Name("p2").Obj(),
+			},
+			podStatuses: []fwk.Code{
+				fwk.Success,
+				fwk.Success,
+			},
+			expectedStatuses: []fwk.Code{
+				fwk.Unschedulable,
+				fwk.Success,
+			},
+			initialScheduledCount: 1,
+		},
+		{
+			name:     "minCount already met by scheduled pods",
+			minCount: 2,
+			unscheduledPods: []*v1.Pod{
+				st.MakePod().Name("p1").Obj(),
+			},
+			podStatuses: []fwk.Code{
+				fwk.Unschedulable,
+			},
+			expectedStatuses: []fwk.Code{
+				fwk.Success,
+			},
+			initialScheduledCount: 2,
+		},
+		{
+			name:     "1 pod scheduled, minCount 3, first unscheduled fails, not enough remaining",
+			minCount: 3,
+			unscheduledPods: []*v1.Pod{
+				st.MakePod().Name("p1").Obj(),
+				st.MakePod().Name("p2").Obj(),
+			},
+			podStatuses: []fwk.Code{
+				fwk.Unschedulable,
+			},
+			expectedStatuses: []fwk.Code{
+				fwk.UnschedulableAndUnresolvable,
+			},
+			initialScheduledCount: 1,
+		},
+		{
+			name:     "1 pod scheduled, minCount 4, first unscheduled succeeds, not enough remaining",
+			minCount: 4,
+			unscheduledPods: []*v1.Pod{
+				st.MakePod().Name("p1").Obj(),
+				st.MakePod().Name("p2").Obj(),
+			},
+			podStatuses: []fwk.Code{
+				fwk.Success,
+			},
+			expectedStatuses: []fwk.Code{
+				fwk.UnschedulableAndUnresolvable,
+			},
+			initialScheduledCount: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+
+			pgName := "test-pg"
+			namespace := "default"
+			pg := st.MakePodGroup().Namespace(namespace).Name(pgName).Obj()
+			if tc.minCount > 0 {
+				pg.Spec.SchedulingPolicy.Gang = &schedulingapi.GangSchedulingPolicy{MinCount: tc.minCount}
+			} else {
+				pg.Spec.SchedulingPolicy.Basic = &schedulingapi.BasicSchedulingPolicy{}
+			}
+
+			informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(pg), 0)
+			informerFactory.Scheduling().V1alpha2().PodGroups().Informer()
+			informerFactory.StartWithContext(ctx)
+			informerFactory.WaitForCacheSyncWithContext(ctx)
+
+			mockState := &mockPodGroupState{scheduledPodsCount: tc.initialScheduledCount}
+			mockLister := &mockSharedLister{
+				podGroupStateLister: &mockPodGroupStateLister{state: mockState},
+			}
+
+			fh, err := frameworkruntime.NewFramework(ctx, nil, nil,
+				frameworkruntime.WithInformerFactory(informerFactory),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create framework: %v", err)
+			}
+
+			p, err := New(ctx, nil, fh, feature.Features{EnableGangScheduling: true})
+			if err != nil {
+				t.Fatalf("Failed to create plugin: %v", err)
+			}
+			pl := p.(*GangScheduling)
+
+			// Inject the mock lister
+			pl.snapshotLister = mockLister
+
+			pgInfo := &testPodGroupInfo{
+				namespace:       namespace,
+				name:            pgName,
+				unscheduledPods: tc.unscheduledPods,
+			}
+
+			cycleState := schedulerframework.NewCycleState()
+
+			for i, code := range tc.podStatuses {
+				if code == fwk.Success {
+					mockState.scheduledPodsCount++
+				}
+
+				gotStatus := pl.PlacementFeasible(ctx, cycleState, pgInfo)
+
+				if gotCode := gotStatus.Code(); gotCode != tc.expectedStatuses[i] {
+					t.Errorf("Step %d: expected status %v, got %v", i, tc.expectedStatuses[i], gotCode)
+				}
+			}
+		})
+	}
+}
+
+type testPodGroupInfo struct {
+	namespace       string
+	name            string
+	unscheduledPods []*v1.Pod
+}
+
+func (t *testPodGroupInfo) GetNamespace() string          { return t.namespace }
+func (t *testPodGroupInfo) GetName() string               { return t.name }
+func (t *testPodGroupInfo) GetUnscheduledPods() []*v1.Pod { return t.unscheduledPods }

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -78,6 +78,7 @@ type frameworkImpl struct {
 	podGroupPostFilterPlugins []framework.PodGroupPostFilterPlugin
 
 	placementGeneratePlugins   []fwk.PlacementGeneratePlugin
+	placementFeasiblePlugins   []framework.PlacementFeasiblePlugin
 	placementScorePlugins      []fwk.PlacementScorePlugin
 	placementScorePluginWeight map[string]int
 
@@ -484,6 +485,17 @@ func NewFramework(ctx context.Context, r Registry, profile *config.KubeScheduler
 			}
 		} else {
 			logger.V(2).Info("Workload Aware Preemption is enabled, but default preemption plugin is not set. Workload Aware Preemption will not be used.")
+		}
+	}
+
+	// Use GangScheduling plugin as the only PlacementFeasiblePlugin.
+	if utilfeature.DefaultFeatureGate.Enabled(features.GenericWorkload) {
+		if gs, ok := f.pluginsMap[names.GangScheduling]; ok {
+			if p, ok := gs.(framework.PlacementFeasiblePlugin); ok {
+				f.placementFeasiblePlugins = append(f.placementFeasiblePlugins, p)
+			} else {
+				logger.V(2).Info("GenericWorkload is enabled, but GangScheduling plugin does not fulfill PlacementFeasiblePlugin interface.")
+			}
 		}
 	}
 
@@ -1994,6 +2006,49 @@ func (f *frameworkImpl) runPermitPlugin(ctx context.Context, pl fwk.PermitPlugin
 	status, timeout := pl.Permit(ctx, state, pod, nodeName)
 	f.metricsRecorder.ObservePluginDurationAsync(metrics.Permit, pl.Name(), status.Code().String(), metrics.SinceInSeconds(startTime))
 	return status, timeout
+}
+
+// RunPlacementFeasiblePlugins runs the set of configured Permit plugins that implement PlacementFeasible interface.
+// The result will be Success if all plugins return Success.
+// The only other valid statuses are UnschedulableAndUnresolvable and Unschedulable.
+// If any plugin returns invalid status, the result will be Error and the remaining plugins won't be invoked.
+// Otherwise, if at least 1 plugin returns UnschedulableAndUnresolvable, the remaining plugins won't be invoked and the result will be UnschdulableAndUnresolvable.
+// Otherwise, if at least 1 plugin returns Unschedulable, the remaining plugins will be invoked and the result will be Unschedulable.
+func (f *frameworkImpl) RunPlacementFeasiblePlugins(ctx context.Context, placementCycleState fwk.PodGroupCycleState, podGroupInfo fwk.PodGroupInfo) (status *fwk.Status) {
+	startTime := time.Now()
+	defer func() {
+		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PlacementFeasible, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+	}()
+
+	for _, pl := range f.placementFeasiblePlugins {
+		plStatus := f.runPlacementFeasiblePlugin(ctx, pl, placementCycleState, podGroupInfo)
+		if plStatus.IsSuccess() {
+			continue
+		}
+		if plStatus.Code() == fwk.Unschedulable {
+			status = plStatus.WithPlugin(pl.Name())
+			continue
+		}
+		if plStatus.Code() == fwk.UnschedulableAndUnresolvable {
+			return plStatus.WithPlugin(pl.Name())
+		}
+		if plStatus.IsError() {
+			return fwk.AsStatus(fmt.Errorf("running PlacementFeasible plugin: %w", plStatus.AsError())).WithPlugin(pl.Name())
+		}
+		return fwk.AsStatus(fmt.Errorf("unexpected status from PlacementFeasible plugin: %v", plStatus.Code())).WithPlugin(pl.Name())
+	}
+
+	return status
+}
+
+func (f *frameworkImpl) runPlacementFeasiblePlugin(ctx context.Context, pl framework.PlacementFeasiblePlugin, state fwk.PodGroupCycleState, podGroup fwk.PodGroupInfo) *fwk.Status {
+	if !state.ShouldRecordPluginMetrics() {
+		return pl.PlacementFeasible(ctx, state, podGroup)
+	}
+	startTime := time.Now()
+	status := pl.PlacementFeasible(ctx, state, podGroup)
+	f.metricsRecorder.ObservePluginDurationAsync(metrics.PlacementFeasible, pl.Name(), status.Code().String(), metrics.SinceInSeconds(startTime))
+	return status
 }
 
 // AddWaitingPod creates a waiting pod instance and adds it to the framework.

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -228,6 +228,10 @@ func (pl *TestPlugin) PreFilter(ctx context.Context, state fwk.CycleState, p *v1
 	return pl.inj.PreFilterResult, fwk.NewStatus(fwk.Code(pl.inj.PreFilterStatus), injectReason)
 }
 
+func (pl *TestPlugin) PlacementFeasible(ctx context.Context, state fwk.PodGroupCycleState, podGroup fwk.PodGroupInfo) *fwk.Status {
+	return fwk.NewStatus(fwk.Code(pl.inj.PlacementFeasibleStatus), injectReason)
+}
+
 func (pl *TestPlugin) PreFilterExtensions() fwk.PreFilterExtensions {
 	return pl
 }
@@ -781,6 +785,116 @@ func TestPodGroupPostFilterPlugins(t *testing.T) {
 		})
 	}
 
+}
+
+type mockPlacementFeasiblePlugin struct {
+	name   string
+	status *fwk.Status
+	called bool
+}
+
+func (p *mockPlacementFeasiblePlugin) Name() string { return p.name }
+
+func (p *mockPlacementFeasiblePlugin) PlacementFeasible(ctx context.Context, state fwk.PodGroupCycleState, podGroup fwk.PodGroupInfo) *fwk.Status {
+	p.called = true
+	return p.status
+}
+
+func TestRunPlacementFeasiblePlugins(t *testing.T) {
+	tests := []struct {
+		name           string
+		plugins        []*mockPlacementFeasiblePlugin
+		expectedStatus *fwk.Status
+		expectedCalled []bool
+	}{
+		{
+			name: "All plugins succeed",
+			plugins: []*mockPlacementFeasiblePlugin{
+				{name: "p1", status: nil},
+				{name: "p2", status: nil},
+			},
+			expectedStatus: nil,
+			expectedCalled: []bool{true, true},
+		},
+		{
+			name: "First plugin returns Unschedulable, continues",
+			plugins: []*mockPlacementFeasiblePlugin{
+				{name: "p1", status: fwk.NewStatus(fwk.Unschedulable, "unschedulable")},
+				{name: "p2", status: nil},
+			},
+			expectedStatus: fwk.NewStatus(fwk.Unschedulable, "unschedulable").WithPlugin("p1"),
+			expectedCalled: []bool{true, true},
+		},
+		{
+			name: "First plugin returns UnschedulableAndUnresolvable, breaks",
+			plugins: []*mockPlacementFeasiblePlugin{
+				{name: "p1", status: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "unresolvable")},
+				{name: "p2", status: nil},
+			},
+			expectedStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "unresolvable").WithPlugin("p1"),
+			expectedCalled: []bool{true, false},
+		},
+		{
+			name: "First plugin returns Unschedulable, second returns UnschedulableAndUnresolvable, returns unresolvable",
+			plugins: []*mockPlacementFeasiblePlugin{
+				{name: "p1", status: fwk.NewStatus(fwk.Unschedulable, "unschedulable")},
+				{name: "p2", status: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "unresolvable")},
+			},
+			expectedStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "unresolvable").WithPlugin("p2"),
+			expectedCalled: []bool{true, true},
+		},
+		{
+			name: "First plugin returns Unschedulable, second returns Unschedulable, returns last unschedulable",
+			plugins: []*mockPlacementFeasiblePlugin{
+				{name: "p1", status: fwk.NewStatus(fwk.Unschedulable, "unschedulable1")},
+				{name: "p2", status: fwk.NewStatus(fwk.Unschedulable, "unschedulable2")},
+			},
+			expectedStatus: fwk.NewStatus(fwk.Unschedulable, "unschedulable2").WithPlugin("p2"),
+			expectedCalled: []bool{true, true},
+		},
+		{
+			name: "Plugin returns Error, breaks",
+			plugins: []*mockPlacementFeasiblePlugin{
+				{name: "p1", status: fwk.NewStatus(fwk.Error, "error")},
+				{name: "p2", status: nil},
+			},
+			expectedStatus: fwk.AsStatus(fmt.Errorf("running PlacementFeasible plugin: %w", errors.New("error"))).WithPlugin("p1"),
+			expectedCalled: []bool{true, false},
+		},
+		{
+			name: "Plugin returns unexpected status, breaks",
+			plugins: []*mockPlacementFeasiblePlugin{
+				{name: "p1", status: fwk.NewStatus(fwk.Skip, "error")},
+				{name: "p2", status: nil},
+			},
+			expectedStatus: fwk.AsStatus(fmt.Errorf("unexpected status from PlacementFeasible plugin: Skip")).WithPlugin("p1"),
+			expectedCalled: []bool{true, false},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			f := &frameworkImpl{
+				placementFeasiblePlugins: make([]framework.PlacementFeasiblePlugin, len(tc.plugins)),
+			}
+			for i, p := range tc.plugins {
+				f.placementFeasiblePlugins[i] = p
+			}
+
+			status := f.RunPlacementFeasiblePlugins(ctx, framework.NewCycleState(), nil)
+
+			if diff := cmp.Diff(tc.expectedStatus, status, statusCmpOpts...); diff != "" {
+				t.Errorf("Unexpected status (-want, +got):\n%s", diff)
+			}
+
+			for i, p := range tc.plugins {
+				if p.called != tc.expectedCalled[i] {
+					t.Errorf("Expected plugin %s called=%v, got %v", p.name, tc.expectedCalled[i], p.called)
+				}
+			}
+		})
+	}
 }
 
 func TestNewFrameworkMultiPointExpansion(t *testing.T) {
@@ -3557,6 +3671,14 @@ func TestRecordingMetrics(t *testing.T) {
 			wantExtensionPoint: "PlacementScore",
 			wantStatus:         fwk.Success,
 		},
+		{
+			name: "PlacementFeasible - Success",
+			action: func(ctx context.Context, f framework.Framework) {
+				f.RunPlacementFeasiblePlugins(ctx, state, nil)
+			},
+			wantExtensionPoint: "PlacementFeasible",
+			wantStatus:         fwk.Success,
+		},
 
 		{
 			name:               "PreFilter - Error",
@@ -3634,6 +3756,15 @@ func TestRecordingMetrics(t *testing.T) {
 			wantExtensionPoint: "PlacementScore",
 			wantStatus:         fwk.Error,
 		},
+		{
+			name: "PlacementFeasible - Error",
+			action: func(ctx context.Context, f framework.Framework) {
+				f.RunPlacementFeasiblePlugins(ctx, state, nil)
+			},
+			inject:             injectedResult{PlacementFeasibleStatus: int(fwk.Error)},
+			wantExtensionPoint: "PlacementFeasible",
+			wantStatus:         fwk.Error,
+		},
 	}
 
 	for _, tt := range tests {
@@ -3682,6 +3813,10 @@ func TestRecordingMetrics(t *testing.T) {
 			defer func() {
 				_ = f.Close()
 			}()
+
+			if tt.wantExtensionPoint == "PlacementFeasible" {
+				f.(*frameworkImpl).placementFeasiblePlugins = []framework.PlacementFeasiblePlugin{plugin}
+			}
 
 			tt.action(ctx, f)
 
@@ -4074,6 +4209,7 @@ type injectedResult struct {
 	GeneratePlacementsResult []*fwk.Placement     `json:"generatePlacementsResult,omitempty"`
 	GeneratePlacementsStatus int                  `json:"generatePlacementsStatus,omitempty"`
 	PlacementScoreStatus     int                  `json:"placementScoreStatus,omitempty"`
+	PlacementFeasibleStatus  int                  `json:"placementFeasibleStatus,omitempty"`
 }
 
 func setScoreRes(inj injectedResult) (int64, *fwk.Status) {

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -65,6 +65,7 @@ var ExtensionPoints = []string{
 	Permit,
 	Sign,
 	PlacementGenerate,
+	PlacementFeasible,
 }
 
 const (
@@ -85,6 +86,7 @@ const (
 	Permit                           = "Permit"
 	Sign                             = "Sign"
 	PlacementGenerate                = "PlacementGenerate"
+	PlacementFeasible                = "PlacementFeasible"
 	PlacementScore                   = "PlacementScore"
 	PlacementScoreExtensionNormalize = "PlacementScoreExtensionNormalize"
 )

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -68,7 +68,7 @@ func (sched *Scheduler) scheduleOnePodGroup(ctx context.Context, podGroupInfo *f
 	}
 	sched.skipPodGroupPodSchedule(ctx, schedFwk, podGroupInfo)
 	// skipPodGroupPodSchedule could remove some pods from the pod group.
-	// Pod group constraints will be re-evaluated on a Permit phase.
+	// Pod group constraints will be re-evaluated on a PlacementFeasible phase.
 	// Now, verify if it has any pods left.
 	if len(podGroupInfo.QueuedPodInfos) == 0 {
 		return
@@ -314,9 +314,6 @@ type algorithmResult struct {
 	requiresPreemption bool
 	// status is a scheduling algorithm status.
 	status *fwk.Status
-	// permitStatus is a status of the permit check.
-	// This is only set when the `status` is success or the `requiresPreemption` is true.
-	permitStatus *fwk.Status
 }
 
 // podGroupPostFilterMode defines how the pod group algorithm should run post filters plugins.
@@ -374,41 +371,62 @@ func (sched *Scheduler) podGroupSchedulingDefaultAlgorithm(ctx context.Context, 
 		waitingOnPreemption: false,
 	}
 
+	placementCycleState := framework.NewCycleState()
+	placementCycleState.SetRecordPluginMetrics(true)
+	placementCycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
+
 	logger := klog.FromContext(ctx)
 	logger.V(5).Info("Running a pod group scheduling algorithm", "podGroup", klog.KObj(podGroupInfo), "unscheduledPodsCount", len(podGroupInfo.QueuedPodInfos))
 
 	requiresPreemption := false
+	anyScheduled := false
 	for _, podInfo := range podGroupInfo.QueuedPodInfos {
 		podResult, revertFn := sched.podGroupPodSchedulingAlgorithm(ctx, schedFwk, podGroupCycleState, podGroupInfo, podInfo, postFilterMode)
 		result.podResults = append(result.podResults, podResult)
-		if !podResult.status.IsSuccess() && !podResult.requiresPreemption {
-			// When a pod is not feasible and doesn't require preemption, it means that it failed scheduling.
-			if podResult.status.IsRejected() {
-				// If the pod is rejected, the pod group can still be schedulable as long as the permit check can succeed.
-				continue
-			}
+		if revertFn != nil {
+			// We unreserve the pod at the end of the whole algorithm (via defer) because it should be ultimately returned to the queue,
+			// without binding it yet. We only assumed the pod to check feasibility of subsequent pods in the group.
+			defer revertFn()
+		}
+
+		if !podResult.status.IsSuccess() && !podResult.status.IsRejected() {
 			// When the algorithm returns error or unexpected status, stop evaluating the rest of the pods.
 			result.status = fwk.AsStatus(fmt.Errorf("failed to schedule other pod from a pod group: %w", podResult.status.AsError()))
-			// Clear the waiting on preemption flag that could have been set by previous pods.
-			result.waitingOnPreemption = false
 			break
 		}
-		// At this point, the pod has passed the scheduling algorithm with the Permit status being either Success or Wait.
-		// We unreserve the pod at the end of the whole algorithm (via defer) because it should be ultimately returned to the queue,
-		// without binding it yet. We only assumed the pod to check feasibility of subsequent pods in the group.
-		defer revertFn()
 
+		// PlacementFeasible plugins check if the pod group can meet its constraints.
+		// Those plugins need to be run after each pod is scheduled.
+		placementFeasibleStatus := schedFwk.RunPlacementFeasiblePlugins(ctx, placementCycleState, podGroupInfo)
+
+		if placementFeasibleStatus.IsError() {
+			// When the algorithm returns error or unexpected status, stop evaluating the rest of the pods.
+			result.status = fwk.AsStatus(fmt.Errorf("failed to evaluate placement feasibility: %w", placementFeasibleStatus.AsError()))
+			break
+		}
+
+		// UnschedulableAndUnresolvable from PlacementFeasible plugins indicates that the pod group
+		// cannot meet its constraints regardless of how many more pods we check.
+		// We can stop the scheduling loop early.
+		if placementFeasibleStatus.Code() == fwk.UnschedulableAndUnresolvable {
+			// We need to change the code to Unschedulable to make sure preemption can be fired.
+			result.status = fwk.NewStatus(fwk.Unschedulable).WithError(placementFeasibleStatus.AsError())
+			break
+		}
+
+		result.status = placementFeasibleStatus
 		requiresPreemption = requiresPreemption || podResult.requiresPreemption
-		if podResult.permitStatus.IsSuccess() {
-			// When the permit returns success for any pod, the pod group is schedulable.
-			if requiresPreemption {
-				// If any preemption is required, the whole pod group requires it to be feasible.
-				result.status = fwk.NewStatus(fwk.Unschedulable, "pod group is waiting for preemption to complete").WithError(errPodGroupUnschedulable)
-				// Set the waitingOnPreemption to true iff the pod group is feasible (Permit returned Success) and requires preemption.
-				result.waitingOnPreemption = true
-			} else {
-				result.status = nil // Success
-			}
+		anyScheduled = anyScheduled || podResult.status.IsSuccess()
+	}
+
+	if result.status.IsSuccess() {
+		if requiresPreemption {
+			// If any preemption is required, the whole pod group requires it to be feasible.
+			result.status = fwk.NewStatus(fwk.Unschedulable, "pod group is waiting for preemption to complete").WithError(errPodGroupUnschedulable)
+			result.waitingOnPreemption = true
+		} else if !anyScheduled {
+			// The framework requires at least 1 pod to be scheduled in order to return a success status.
+			result.status = fwk.NewStatus(fwk.Unschedulable).WithError(errPodGroupUnschedulable)
 		}
 	}
 
@@ -416,7 +434,7 @@ func (sched *Scheduler) podGroupSchedulingDefaultAlgorithm(ctx context.Context, 
 }
 
 // podGroupPodSchedulingAlgorithm runs a scheduling algorithm for individual pod from a pod group.
-// It returns the algorithm result and, if successful or the preemption is required, the permit status together with the revert function.
+// It returns the algorithm result together with the revert function.
 func (sched *Scheduler) podGroupPodSchedulingAlgorithm(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, podGroupInfo *framework.QueuedPodGroupInfo, podInfo *framework.QueuedPodInfo, postFilterMode podGroupPostFilterMode) (algorithmResult, func()) {
 	pod := podInfo.Pod
 	podCtx := initPodSchedulingContext(ctx, pod, podGroupCycleState, postFilterMode)
@@ -465,37 +483,12 @@ func (sched *Scheduler) podGroupPodSchedulingAlgorithm(ctx context.Context, sche
 		}
 	}
 
-	_, permitStatus := schedFwk.RunPermitPlugins(ctx, podCtx.state, assumedPodInfo.Pod, scheduleResult.SuggestedHost)
-	if !permitStatus.IsWait() && !permitStatus.IsSuccess() {
-		revertFn()
-		if permitStatus.IsRejected() {
-			fitErr := &framework.FitError{
-				NumAllNodes: 1,
-				Pod:         assumedPodInfo.Pod,
-				Diagnosis: framework.Diagnosis{
-					NodeToStatus: framework.NewDefaultNodeToStatus(),
-				},
-			}
-			fitErr.Diagnosis.NodeToStatus.Set(scheduleResult.SuggestedHost, permitStatus)
-			fitErr.Diagnosis.AddPluginStatus(permitStatus)
-			permitStatus = fwk.NewStatus(permitStatus.Code()).WithError(fitErr)
-		}
-		return algorithmResult{
-			pod:                pod,
-			scheduleResult:     ScheduleResult{nominatingInfo: clearNominatedNode},
-			podCtx:             podCtx,
-			schedulingDuration: time.Since(start),
-			status:             permitStatus,
-		}, nil
-	}
-
 	return algorithmResult{
 		pod:                pod,
 		scheduleResult:     scheduleResult,
 		podCtx:             podCtx,
 		schedulingDuration: time.Since(start),
 		status:             status,
-		permitStatus:       permitStatus,
 		requiresPreemption: requiresPreemption,
 	}, revertFn
 }
@@ -512,6 +505,7 @@ func completePodGroupAlgorithmResult(ctx context.Context, podGroupInfo *framewor
 	for i := numInResult; i < numInQueue; i++ {
 		pInfo := podGroupInfo.QueuedPodInfos[i]
 		newResults[i] = algorithmResult{
+			pod:    pInfo.Pod,
 			podCtx: initPodSchedulingContext(ctx, pInfo.Pod, podGroupState, postFilterMode),
 			status: podGroupResult.status.Clone(),
 		}
@@ -581,8 +575,8 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 					sched.FailureHandler(ctx, schedFwk, pInfo, podGroupResult.status, nominatingInfo, podSchedulingStart)
 				} else {
 					// Pod group is unschedulable, so the pod has to be marked as unschedulable.
-					// Its rejection status is set to its permit status message.
-					status := fwk.NewStatus(fwk.Unschedulable, podResult.permitStatus.Message()).WithError(errPodGroupUnschedulable)
+					// Its rejection status is set to the pod group's status message.
+					status := fwk.NewStatus(fwk.Unschedulable, podGroupResult.status.Message()).WithError(errPodGroupUnschedulable)
 					sched.FailureHandler(ctx, schedFwk, pInfo, status, clearNominatedNode, podSchedulingStart)
 				}
 				unschedulablePods++
@@ -596,8 +590,8 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 			// such as heterogeneous pod group or using inter-pod dependencies.
 			if podResult.requiresPreemption && !podGroupResult.waitingOnPreemption {
 				// Pod group is unschedulable, so the pod has to be marked as unschedulable, even if it just required preemption.
-				// Its rejection status is set to its permit status message, as the preemption message is no longer relevant.
-				status := fwk.NewStatus(fwk.Unschedulable, podResult.permitStatus.Message()).WithError(errPodGroupUnschedulable)
+				// Its rejection status is set to the pod group's status message, as the preemption message is no longer relevant.
+				status := fwk.NewStatus(fwk.Unschedulable, podGroupResult.status.Message()).WithError(errPodGroupUnschedulable)
 				sched.FailureHandler(ctx, schedFwk, pInfo, status, clearNominatedNode, podSchedulingStart)
 			} else {
 				// When a pod is unschedulable or preemption is required, just call the FailureHandler.

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -66,7 +67,6 @@ type fakePodGroupPlugin struct {
 	postFilterResult         map[string]*fwk.PostFilterResult
 	postFilterStatus         map[string]*fwk.Status
 	postFilterCalled         bool
-	permitStatus             map[string]*fwk.Status
 	podGroupPostFilterStatus *fwk.Status
 	podGroupPostFilterCalled bool
 	podGroupPostFilterResult map[string]*fwk.NominatingInfo
@@ -74,7 +74,6 @@ type fakePodGroupPlugin struct {
 
 var _ fwk.FilterPlugin = &fakePodGroupPlugin{}
 var _ fwk.PostFilterPlugin = &fakePodGroupPlugin{}
-var _ fwk.PermitPlugin = &fakePodGroupPlugin{}
 var _ framework.PodGroupPostFilterPlugin = &fakePodGroupPlugin{}
 
 func (mp *fakePodGroupPlugin) Name() string { return "FakePodGroupPlugin" }
@@ -95,10 +94,7 @@ func (mp *fakePodGroupPlugin) PostFilter(ctx context.Context, state fwk.CycleSta
 }
 
 func (mp *fakePodGroupPlugin) Permit(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (*fwk.Status, time.Duration) {
-	if status, ok := mp.permitStatus[pod.Name]; ok {
-		return status, 0
-	}
-	return fwk.NewStatus(fwk.Unschedulable, "default fake permit failure"), 0
+	return fwk.NewStatus(fwk.Error, "unexpected call to permit"), 0
 }
 
 func (mp *fakePodGroupPlugin) PodGroupPostFilter(ctx context.Context, pg *schedulingv1alpha3.PodGroup, pods []*v1.Pod, pgSchedulingFunc framework.PodGroupSchedulingFunc) (*framework.PodGroupPostFilterResult, *fwk.Status) {
@@ -114,6 +110,79 @@ func (mp *fakePodGroupPlugin) PodGroupPostFilter(ctx context.Context, pg *schedu
 		n[passedPod] = mp.podGroupPostFilterResult[passedPod.Name]
 	}
 	return &framework.PodGroupPostFilterResult{NominatedNodeNames: n}, mp.podGroupPostFilterStatus
+}
+
+type fakePlacementFeasibleState struct {
+	podCount int
+}
+
+func (s *fakePlacementFeasibleState) Clone() fwk.StateData {
+	return &fakePlacementFeasibleState{podCount: s.podCount}
+}
+
+const fakePlacementFeasibleStateKey fwk.StateKey = "fakePlacementFeasibleState"
+
+type fakePlacementFeasiblePlugin struct {
+	placementFeasibleStatuses [][]fwk.Code
+	placementCount            int
+}
+
+var _ framework.PlacementFeasiblePlugin = &fakePlacementFeasiblePlugin{}
+var _ fwk.PermitPlugin = &fakePlacementFeasiblePlugin{}
+
+func (mp *fakePlacementFeasiblePlugin) Name() string {
+	// Name has to be GangScheduling for the PlacementFeasible plugin to be used.
+	// TODO: Remove this once the restriction is taken off.
+	return names.GangScheduling
+}
+
+// PlacementFeasible simulates the evaluation of pod group placement constraints.
+// The mock uses a 2D slice (placementFeasibleStatuses) where:
+// - The outer slice represents distinct placements (e.g., when evaluating multiple topology placements).
+// - The inner slice represents the pod-by-pod evaluation within a single placement.
+// It uses placementCycleState to track how many pods have been evaluated in the current placement.
+func (mp *fakePlacementFeasiblePlugin) PlacementFeasible(ctx context.Context, placementCycleState fwk.PodGroupCycleState, podGroupInfo fwk.PodGroupInfo) *fwk.Status {
+	// If no mock statuses are configured, always succeed.
+	if len(mp.placementFeasibleStatuses) == 0 {
+		return nil
+	}
+
+	// Each placement gets a new placementCycleState. Check if this state has been initialized.
+	stateData, err := placementCycleState.Read(fakePlacementFeasibleStateKey)
+	if err != nil {
+		// We haven't considered this placement before (this is the first pod evaluated in this placement).
+		// Initialize the state and increment the placement count.
+		stateData = &fakePlacementFeasibleState{podCount: 0}
+		placementCycleState.Write(fakePlacementFeasibleStateKey, stateData)
+		mp.placementCount++
+	}
+
+	// Increment the count of pods evaluated for the current placement attempt.
+	state := stateData.(*fakePlacementFeasibleState)
+	state.podCount++
+
+	placementIndex := mp.placementCount - 1
+	podIndex := state.podCount - 1
+
+	// Ensure the indices are within the bounds of the injected statuses.
+	if placementIndex < len(mp.placementFeasibleStatuses) {
+		// If the specific placement has no pod statuses configured, treat it as always successful.
+		if len(mp.placementFeasibleStatuses[placementIndex]) == 0 {
+			return nil
+		}
+		if podIndex < len(mp.placementFeasibleStatuses[placementIndex]) {
+			code := mp.placementFeasibleStatuses[placementIndex][podIndex]
+			if code == fwk.Success {
+				return nil
+			}
+			return fwk.NewStatus(code, "injected placementFeasible status")
+		}
+	}
+	return fwk.AsStatus(fmt.Errorf("exceeded the expected call count"))
+}
+
+func (mp *fakePlacementFeasiblePlugin) Permit(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (*fwk.Status, time.Duration) {
+	return fwk.NewStatus(fwk.Error, "unexpected call to permit"), 0
 }
 
 func TestPodGroupInfoForPod(t *testing.T) {
@@ -462,11 +531,6 @@ func TestPodGroupCycle_FillsPodResultsOnFewerResults(t *testing.T) {
 			"p2": fwk.NewStatus(fwk.Error, "filter error for p2"),
 			"p3": nil,
 		},
-		permitStatus: map[string]*fwk.Status{
-			"p1": nil,
-			"p2": nil,
-			"p3": nil,
-		},
 	}
 
 	registry := []tf.RegisterPluginFunc{
@@ -733,6 +797,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 	tests := []struct {
 		name                             string
 		plugin                           *fakePodGroupPlugin
+		podGroupFeasibleStatuses         []fwk.Code
 		expectedGroupStatusCode          fwk.Code
 		expectedGroupWaitingOnPreemption bool
 		expectedPodStatus                map[string]*fwk.Status
@@ -748,11 +813,6 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 					"p2": nil,
 					"p3": nil,
 				},
-				permitStatus: map[string]*fwk.Status{
-					"p1": nil,
-					"p2": nil,
-					"p3": nil,
-				},
 			},
 			expectedGroupStatusCode: fwk.Success,
 			expectedPodStatus: map[string]*fwk.Status{
@@ -762,18 +822,18 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 			},
 		},
 		{
-			name: "All pods feasible, two waiting",
+			name: "All pods feasible, podGroup schedulable with 3 schedulable pods",
 			plugin: &fakePodGroupPlugin{
 				filterStatus: map[string]*fwk.Status{
 					"p1": nil,
 					"p2": nil,
 					"p3": nil,
 				},
-				permitStatus: map[string]*fwk.Status{
-					"p1": fwk.NewStatus(fwk.Wait),
-					"p2": fwk.NewStatus(fwk.Wait),
-					"p3": nil,
-				},
+			},
+			podGroupFeasibleStatuses: []fwk.Code{
+				fwk.Unschedulable,
+				fwk.Unschedulable,
+				fwk.Success,
 			},
 			expectedGroupStatusCode: fwk.Success,
 			expectedPodStatus: map[string]*fwk.Status{
@@ -783,18 +843,18 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 			},
 		},
 		{
-			name: "All pods feasible, but all waiting",
+			name: "All pods feasible, podGroup unschedulable",
 			plugin: &fakePodGroupPlugin{
 				filterStatus: map[string]*fwk.Status{
 					"p1": nil,
 					"p2": nil,
 					"p3": nil,
 				},
-				permitStatus: map[string]*fwk.Status{
-					"p1": fwk.NewStatus(fwk.Wait),
-					"p2": fwk.NewStatus(fwk.Wait),
-					"p3": fwk.NewStatus(fwk.Wait),
-				},
+			},
+			podGroupFeasibleStatuses: []fwk.Code{
+				fwk.Unschedulable,
+				fwk.Unschedulable,
+				fwk.Unschedulable,
 			},
 			expectedGroupStatusCode: fwk.Unschedulable,
 			expectedPodStatus: map[string]*fwk.Status{
@@ -804,45 +864,41 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 			},
 		},
 		{
-			name: "All pods feasible, but last waiting",
+			name: "All pods feasible, podGroup UnschedulableAndUnresolvable",
 			plugin: &fakePodGroupPlugin{
 				filterStatus: map[string]*fwk.Status{
 					"p1": nil,
 					"p2": nil,
 					"p3": nil,
 				},
-				permitStatus: map[string]*fwk.Status{
-					"p1": nil,
-					"p2": nil,
-					"p3": fwk.NewStatus(fwk.Wait),
-				},
 			},
-			expectedGroupStatusCode: fwk.Success,
+			podGroupFeasibleStatuses: []fwk.Code{
+				fwk.UnschedulableAndUnresolvable,
+			},
+			expectedGroupStatusCode: fwk.Unschedulable,
 			expectedPodStatus: map[string]*fwk.Status{
 				"p1": nil,
-				"p2": nil,
-				"p3": nil,
+				// The algorithm stopped evaluating the pods after UnschedulableAndUnresolvable was received from PlacementFeasible.
 			},
 		},
 		{
-			name: "All pods feasible, one waiting, one unschedulable",
+			name: "All pods feasible, podGroup UnschedulableAndUnresolvable with 2 pods",
 			plugin: &fakePodGroupPlugin{
 				filterStatus: map[string]*fwk.Status{
 					"p1": nil,
 					"p2": nil,
 					"p3": nil,
 				},
-				permitStatus: map[string]*fwk.Status{
-					"p1": fwk.NewStatus(fwk.Wait),
-					"p2": fwk.NewStatus(fwk.Unschedulable),
-					"p3": nil,
-				},
 			},
-			expectedGroupStatusCode: fwk.Success,
+			podGroupFeasibleStatuses: []fwk.Code{
+				fwk.Unschedulable,
+				fwk.UnschedulableAndUnresolvable,
+			},
+			expectedGroupStatusCode: fwk.Unschedulable,
 			expectedPodStatus: map[string]*fwk.Status{
 				"p1": nil,
-				"p2": fwk.NewStatus(fwk.Unschedulable),
-				"p3": nil,
+				"p2": nil,
+				// The algorithm stopped evaluating the pods after UnschedulableAndUnresolvable was received from PlacementFeasible.
 			},
 		},
 		{
@@ -863,11 +919,6 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 					"p2": {NominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride}},
 					"p3": {NominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride}},
 				},
-				permitStatus: map[string]*fwk.Status{
-					"p1": nil,
-					"p2": nil,
-					"p3": nil,
-				},
 			},
 			expectedGroupStatusCode:          fwk.Unschedulable,
 			expectedGroupWaitingOnPreemption: true,
@@ -884,45 +935,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 			skipForTAS: true,
 		},
 		{
-			name: "All pods require preemption, but waiting",
-			plugin: &fakePodGroupPlugin{
-				filterStatus: map[string]*fwk.Status{
-					"p1": fwk.NewStatus(fwk.Unschedulable),
-					"p2": fwk.NewStatus(fwk.Unschedulable),
-					"p3": fwk.NewStatus(fwk.Unschedulable),
-				},
-				postFilterStatus: map[string]*fwk.Status{
-					"p1": nil,
-					"p2": nil,
-					"p3": nil,
-				},
-				postFilterResult: map[string]*fwk.PostFilterResult{
-					"p1": {NominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride}},
-					"p2": {NominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride}},
-					"p3": {NominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride}},
-				},
-				permitStatus: map[string]*fwk.Status{
-					"p1": fwk.NewStatus(fwk.Wait),
-					"p2": fwk.NewStatus(fwk.Wait),
-					"p3": fwk.NewStatus(fwk.Wait),
-				},
-			},
-			expectedGroupStatusCode: fwk.Unschedulable,
-			expectedPodStatus: map[string]*fwk.Status{
-				"p1": fwk.NewStatus(fwk.Unschedulable),
-				"p2": fwk.NewStatus(fwk.Unschedulable),
-				"p3": fwk.NewStatus(fwk.Unschedulable),
-			},
-			expectedPreemption: map[string]bool{
-				"p1": true,
-				"p2": true,
-				"p3": true,
-			},
-			// preemption is not yet implemented for TAS
-			skipForTAS: true,
-		},
-		{
-			name: "One pod requires preemption, but waiting, two are feasible",
+			name: "One pod requires preemption, podGroup schedulable with 2 schedulable pods",
 			plugin: &fakePodGroupPlugin{
 				filterStatus: map[string]*fwk.Status{
 					"p1": fwk.NewStatus(fwk.Unschedulable),
@@ -935,11 +948,11 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 				postFilterResult: map[string]*fwk.PostFilterResult{
 					"p1": {NominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride}},
 				},
-				permitStatus: map[string]*fwk.Status{
-					"p1": fwk.NewStatus(fwk.Wait),
-					"p2": fwk.NewStatus(fwk.Wait),
-					"p3": nil,
-				},
+			},
+			podGroupFeasibleStatuses: []fwk.Code{
+				fwk.Unschedulable,
+				fwk.Unschedulable,
+				fwk.Success,
 			},
 			expectedGroupStatusCode:          fwk.Unschedulable,
 			expectedGroupWaitingOnPreemption: true,
@@ -972,10 +985,6 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 					"p1": {NominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride}},
 					"p2": {NominatingInfo: clearNominatedNode},
 				},
-				permitStatus: map[string]*fwk.Status{
-					"p1": nil,
-					"p3": nil,
-				},
 			},
 			expectedGroupStatusCode:          fwk.Unschedulable,
 			expectedGroupWaitingOnPreemption: true,
@@ -1001,6 +1010,11 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 					"p3": fwk.NewStatus(fwk.Unschedulable),
 				},
 			},
+			podGroupFeasibleStatuses: []fwk.Code{
+				fwk.Success,
+				fwk.Success,
+				fwk.Success,
+			},
 			expectedGroupStatusCode: fwk.Unschedulable,
 			expectedPodStatus: map[string]*fwk.Status{
 				"p1": fwk.NewStatus(fwk.Unschedulable),
@@ -1016,11 +1030,6 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 					"p2": fwk.NewStatus(fwk.Error),
 					"p3": nil,
 				},
-				permitStatus: map[string]*fwk.Status{
-					"p1": nil,
-					"p2": nil,
-					"p3": nil,
-				},
 			},
 			expectedGroupStatusCode: fwk.Error,
 			expectedPodStatus: map[string]*fwk.Status{
@@ -1030,23 +1039,22 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 			},
 		},
 		{
-			name: "Any permit returned Error",
+			name: "Any placementFeasible returned Error",
 			plugin: &fakePodGroupPlugin{
 				filterStatus: map[string]*fwk.Status{
 					"p1": nil,
 					"p2": nil,
 					"p3": nil,
 				},
-				permitStatus: map[string]*fwk.Status{
-					"p1": nil,
-					"p2": fwk.NewStatus(fwk.Error),
-					"p3": nil,
-				},
+			},
+			podGroupFeasibleStatuses: []fwk.Code{
+				fwk.Success,
+				fwk.Error,
 			},
 			expectedGroupStatusCode: fwk.Error,
 			expectedPodStatus: map[string]*fwk.Status{
 				"p1": nil,
-				"p2": fwk.NewStatus(fwk.Error),
+				"p2": nil,
 				// The algorithm stopped evaluating the pods after an error occurred, so a "p3" status is not expected.
 			},
 		},
@@ -1058,11 +1066,6 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 					"p2": fwk.NewStatus(fwk.Error),
 					"p3": nil,
 				},
-				permitStatus: map[string]*fwk.Status{
-					"p1": nil,
-					"p2": nil,
-					"p3": nil,
-				},
 				postFilterResult: map[string]*fwk.PostFilterResult{
 					"p1": {NominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride}},
 				},
@@ -1075,26 +1078,25 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 			},
 		},
 		{
-			name: "Any permit returned Error while waiting on preemption",
+			name: "Any placementFeasible returned Error while waiting on preemption",
 			plugin: &fakePodGroupPlugin{
 				filterStatus: map[string]*fwk.Status{
 					"p1": fwk.NewStatus(fwk.Unschedulable),
 					"p2": nil,
 					"p3": nil,
 				},
-				permitStatus: map[string]*fwk.Status{
-					"p1": nil,
-					"p2": fwk.NewStatus(fwk.Error),
-					"p3": nil,
-				},
 				postFilterResult: map[string]*fwk.PostFilterResult{
 					"p1": {NominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride}},
 				},
 			},
+			podGroupFeasibleStatuses: []fwk.Code{
+				fwk.Success,
+				fwk.Error,
+			},
 			expectedGroupStatusCode: fwk.Error,
 			expectedPodStatus: map[string]*fwk.Status{
 				"p1": fwk.NewStatus(fwk.Unschedulable),
-				"p2": fwk.NewStatus(fwk.Error),
+				"p2": nil,
 				// The algorithm stopped evaluating the pods after an error occurred, so a "p3" status is not expected.
 			},
 		},
@@ -1107,12 +1109,10 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 			}
 			name := fmt.Sprintf("%s (TopologyAwareWorkloadScheduling=%v)", tt.name, tasEnabled)
 			t.Run(name, func(t *testing.T) {
-				if tasEnabled {
-					featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-						features.TopologyAwareWorkloadScheduling: true,
-						features.GenericWorkload:                 true,
-					})
-				}
+				featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+					features.TopologyAwareWorkloadScheduling: tasEnabled,
+					features.GenericWorkload:                 true,
+				})
 
 				logger, ctx := ktesting.NewTestContext(t)
 
@@ -1121,6 +1121,10 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 				queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
 				snapshot := internalcache.NewEmptySnapshot()
 
+				placementFeasiblePlugin := &fakePlacementFeasiblePlugin{
+					placementFeasibleStatuses: [][]fwk.Code{tt.podGroupFeasibleStatuses},
+				}
+
 				registry := []tf.RegisterPluginFunc{
 					tf.RegisterFilterPlugin(tt.plugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
 						return tt.plugin, nil
@@ -1128,8 +1132,8 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 					tf.RegisterPostFilterPlugin(tt.plugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
 						return tt.plugin, nil
 					}),
-					tf.RegisterPermitPlugin(tt.plugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
-						return tt.plugin, nil
+					tf.RegisterPermitPlugin(placementFeasiblePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+						return placementFeasiblePlugin, nil
 					}),
 				}
 				schedFwk, err := tf.NewFramework(ctx,
@@ -1187,17 +1191,9 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 						if podResult.scheduleResult.SuggestedHost != "node1" {
 							t.Errorf("Expected pod %s suggested host: node1, got: %v", podName, podResult.scheduleResult.SuggestedHost)
 						}
-						if expected, ok := tt.plugin.permitStatus[podName]; ok {
-							if podResult.permitStatus.Code() != expected.Code() {
-								t.Errorf("Expected pod %s permit status code: %v, got: %v", podName, expected.Code(), podResult.permitStatus.Code())
-							}
-						}
 					} else {
 						if podResult.scheduleResult.SuggestedHost != "" {
 							t.Errorf("Expected pod %s empty suggested host, got: %v", podName, podResult.scheduleResult.SuggestedHost)
-						}
-						if podResult.permitStatus != nil {
-							t.Errorf("Expected pod %s nil permit status, got: %v", podName, podResult.permitStatus)
 						}
 					}
 					if expected, ok := tt.expectedPreemption[podName]; ok {
@@ -1209,6 +1205,26 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 			})
 		}
 	}
+}
+
+// This is only needed because PlacementFeasiblePlugin mock doesn't know which placement it processes and has to assume the order of placements.
+// TODO: Remove this once the PlacementFeasiblePlugin becomes order-independent or another way of ordering placements is introduced.
+type orderedPlacementPlugin struct {
+	fwk.PlacementGeneratePlugin
+}
+
+func (p *orderedPlacementPlugin) Name() string {
+	return p.PlacementGeneratePlugin.Name() + "_Ordered"
+}
+
+func (p *orderedPlacementPlugin) GeneratePlacements(ctx context.Context, state fwk.PodGroupCycleState, podGroup fwk.PodGroupInfo, parentPlacement *fwk.Placement) (*fwk.GeneratePlacementsResult, *fwk.Status) {
+	result, status := p.PlacementGeneratePlugin.GeneratePlacements(ctx, state, podGroup, parentPlacement)
+	if status.IsSuccess() && result != nil {
+		sort.Slice(result.Placements, func(i, j int) bool {
+			return result.Placements[i].Name < result.Placements[j].Name
+		})
+	}
+	return result, status
 }
 
 func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
@@ -1251,15 +1267,12 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				podResults: []algorithmResult{{
 					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
 					status:         nil,
-					permitStatus:   nil,
 				}, {
 					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
 					status:         nil,
-					permitStatus:   nil,
 				}, {
 					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
 					status:         nil,
-					permitStatus:   nil,
 				}},
 			},
 			expectBound: sets.New("p1", "p2", "p3"),
@@ -1270,21 +1283,18 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			},
 		},
 		{
-			name: "All pods feasible, but all waiting",
+			name: "All pods feasible, but podGroup unschedulable",
 			algorithmResult: podGroupAlgorithmResult{
 				status: fwk.NewStatus(fwk.Unschedulable, "not enough capacity for the gang"),
 				podResults: []algorithmResult{{
 					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
 					status:         nil,
-					permitStatus:   fwk.NewStatus(fwk.Wait),
 				}, {
 					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
 					status:         nil,
-					permitStatus:   fwk.NewStatus(fwk.Wait),
 				}, {
 					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
 					status:         nil,
-					permitStatus:   fwk.NewStatus(fwk.Wait),
 				}},
 			},
 			expectFailed: sets.New("p1", "p2", "p3"),
@@ -1296,45 +1306,18 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			},
 		},
 		{
-			name: "All pods feasible, but last waiting",
+			name: "One unschedulable",
 			algorithmResult: podGroupAlgorithmResult{
 				status: nil,
 				podResults: []algorithmResult{{
 					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
 					status:         nil,
-					permitStatus:   nil,
-				}, {
-					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
-					status:         nil,
-					permitStatus:   nil,
-				}, {
-					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
-					status:         nil,
-					permitStatus:   fwk.NewStatus(fwk.Wait),
-				}},
-			},
-			expectBound: sets.New("p1", "p2", "p3"),
-			expectCondition: &metav1.Condition{
-				Type:   schedulingapi.PodGroupScheduled,
-				Status: metav1.ConditionTrue,
-				Reason: "Scheduled",
-			},
-		},
-		{
-			name: "All pods feasible, one waiting, one unschedulable",
-			algorithmResult: podGroupAlgorithmResult{
-				status: nil,
-				podResults: []algorithmResult{{
-					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
-					status:         nil,
-					permitStatus:   fwk.NewStatus(fwk.Wait),
 				}, {
 					scheduleResult: ScheduleResult{SuggestedHost: "", nominatingInfo: clearNominatedNode},
 					status:         fwk.NewStatus(fwk.Unschedulable),
 				}, {
 					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
 					status:         nil,
-					permitStatus:   nil,
 				}},
 			},
 			expectBound:  sets.New("p1", "p3"),
@@ -1357,7 +1340,6 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 					},
 					status:             fwk.NewStatus(fwk.Unschedulable),
 					requiresPreemption: true,
-					permitStatus:       nil,
 				}, {
 					scheduleResult: ScheduleResult{
 						SuggestedHost:  "node1",
@@ -1365,7 +1347,6 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 					},
 					status:             fwk.NewStatus(fwk.Unschedulable),
 					requiresPreemption: true,
-					permitStatus:       nil,
 				}, {
 					scheduleResult: ScheduleResult{
 						SuggestedHost:  "node1",
@@ -1373,7 +1354,6 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 					},
 					status:             fwk.NewStatus(fwk.Unschedulable),
 					requiresPreemption: true,
-					permitStatus:       nil,
 				}},
 			},
 			expectPreempting: sets.New("p1", "p2", "p3"),
@@ -1385,45 +1365,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			},
 		},
 		{
-			name: "All pods require preemption, but waiting",
-			algorithmResult: podGroupAlgorithmResult{
-				status: fwk.NewStatus(fwk.Unschedulable, "preemption required but not feasible"),
-				podResults: []algorithmResult{{
-					scheduleResult: ScheduleResult{
-						SuggestedHost:  "node1",
-						nominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride},
-					},
-					status:             fwk.NewStatus(fwk.Unschedulable),
-					requiresPreemption: true,
-					permitStatus:       fwk.NewStatus(fwk.Wait),
-				}, {
-					scheduleResult: ScheduleResult{
-						SuggestedHost:  "node1",
-						nominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride},
-					},
-					status:             fwk.NewStatus(fwk.Unschedulable),
-					requiresPreemption: true,
-					permitStatus:       fwk.NewStatus(fwk.Wait),
-				}, {
-					scheduleResult: ScheduleResult{
-						SuggestedHost:  "node1",
-						nominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride},
-					},
-					status:             fwk.NewStatus(fwk.Unschedulable),
-					requiresPreemption: true,
-					permitStatus:       fwk.NewStatus(fwk.Wait),
-				}},
-			},
-			expectFailed: sets.New("p1", "p2", "p3"),
-			expectCondition: &metav1.Condition{
-				Type:    schedulingapi.PodGroupScheduled,
-				Status:  metav1.ConditionFalse,
-				Reason:  schedulingapi.PodGroupReasonUnschedulable,
-				Message: "preemption required but not feasible",
-			},
-		},
-		{
-			name: "One pod requires preemption, but waiting, two are feasible",
+			name: "One pod requires preemption, two are feasible",
 			algorithmResult: podGroupAlgorithmResult{
 				status:              fwk.NewStatus(fwk.Unschedulable, "waiting for preemption to complete"),
 				waitingOnPreemption: true,
@@ -1434,15 +1376,12 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 					},
 					status:             fwk.NewStatus(fwk.Unschedulable),
 					requiresPreemption: true,
-					permitStatus:       fwk.NewStatus(fwk.Wait),
 				}, {
 					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
 					status:         nil,
-					permitStatus:   fwk.NewStatus(fwk.Wait),
 				}, {
 					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
 					status:         nil,
-					permitStatus:   nil,
 				}},
 			},
 			expectPreempting: sets.New("p1", "p2", "p3"),
@@ -1465,7 +1404,6 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 					},
 					status:             fwk.NewStatus(fwk.Unschedulable),
 					requiresPreemption: true,
-					permitStatus:       nil,
 				}, {
 					scheduleResult: ScheduleResult{SuggestedHost: "", nominatingInfo: clearNominatedNode},
 					status:         fwk.NewStatus(fwk.Unschedulable),
@@ -1562,7 +1500,6 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				podResults: []algorithmResult{{
 					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
 					status:         nil,
-					permitStatus:   nil,
 				}, {
 					scheduleResult: ScheduleResult{SuggestedHost: "", nominatingInfo: clearNominatedNode},
 					status:         fwk.NewStatus(fwk.Error, "plugin returned error"),
@@ -1591,7 +1528,6 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 					},
 					status:             fwk.NewStatus(fwk.Unschedulable),
 					requiresPreemption: true,
-					permitStatus:       nil,
 				}, {
 					scheduleResult: ScheduleResult{SuggestedHost: "", nominatingInfo: clearNominatedNode},
 					status:         fwk.NewStatus(fwk.Error, "internal failure"),
@@ -1628,15 +1564,12 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				podResults: []algorithmResult{{
 					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
 					status:         nil,
-					permitStatus:   nil,
 				}, {
 					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
 					status:         nil,
-					permitStatus:   nil,
 				}, {
 					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
 					status:         nil,
-					permitStatus:   nil,
 				}},
 			},
 			expectBound: sets.New("p1", "p2", "p3"),
@@ -1700,7 +1633,6 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				podResults: []algorithmResult{{
 					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
 					status:         nil,
-					permitStatus:   nil,
 				}, {
 					scheduleResult: ScheduleResult{SuggestedHost: "", nominatingInfo: clearNominatedNode},
 					status:         fwk.NewStatus(fwk.Error),
@@ -1725,7 +1657,6 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				podResults: []algorithmResult{{
 					scheduleResult: ScheduleResult{SuggestedHost: "node1"},
 					status:         nil,
-					permitStatus:   nil,
 				}},
 			},
 			expectBound:  sets.New[string](),
@@ -2313,8 +2244,9 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 	podGroupPod := st.MakePod().Name("foo").UID("foo").PodGroupName("pg").Obj()
 
 	tests := map[string]struct {
-		placementPlugin fakePlacementPlugin
-		expectedResult  podGroupAlgorithmResult
+		placementPlugin           fakePlacementPlugin
+		placementFeasibleStatuses [][]fwk.Code
+		expectedResult            podGroupAlgorithmResult
 	}{
 		"respects higher score of placement1": {
 			placementPlugin: fakePlacementPlugin{
@@ -2371,7 +2303,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 				generatePlacementsResult: map[string][]string{},
 			},
 			expectedResult: podGroupAlgorithmResult{
-				status: fwk.NewStatus(fwk.Unschedulable, "no feasible placements found").WithPlugin("FakePlacementPlugin"),
+				status: fwk.NewStatus(fwk.Unschedulable, "no feasible placements found").WithPlugin("FakePlacementPlugin_Ordered"),
 			},
 		},
 		"when all placements are infeasible, returns unschedulable": {
@@ -2404,6 +2336,40 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 				status: fwk.NewStatus(fwk.Unschedulable, "0/2 placements are available, first placement status: pod group is unschedulable"),
 			},
 		},
+		"when all placements are infeasible, but pods are feasible, returns unschedulable": {
+			placementPlugin: fakePlacementPlugin{
+				generatePlacementsResult: map[string][]string{
+					"placement1": {nodes[0].Name},
+					"placement2": {nodes[1].Name},
+				},
+				scorePlacementsResult: map[string]int64{
+					"placement1": 1,
+					"placement2": 2,
+				},
+				filterStatus: map[string]*fwk.Status{
+					nodes[0].Name: nil,
+					nodes[1].Name: nil,
+				},
+			},
+			placementFeasibleStatuses: [][]fwk.Code{
+				{fwk.Unschedulable},
+				{fwk.Unschedulable},
+			},
+			expectedResult: podGroupAlgorithmResult{
+				podResults: []algorithmResult{
+					{
+						pod: podGroupPod,
+						scheduleResult: ScheduleResult{
+							SuggestedHost:  "node1",
+							EvaluatedNodes: 1,
+							FeasibleNodes:  1,
+						},
+						status: nil,
+					},
+				},
+				status: fwk.NewStatus(fwk.Unschedulable, "0/2 placements are available, first placement status: injected placementFeasible status"),
+			},
+		},
 		"filters out infeasible placements": {
 			placementPlugin: fakePlacementPlugin{
 				generatePlacementsResult: map[string][]string{
@@ -2416,6 +2382,38 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 				filterStatus: map[string]*fwk.Status{
 					nodes[1].Name: fwk.NewStatus(fwk.Unschedulable),
 				},
+			},
+			expectedResult: podGroupAlgorithmResult{
+				podResults: []algorithmResult{
+					{
+						pod: podGroupPod,
+						scheduleResult: ScheduleResult{
+							SuggestedHost:  nodes[0].Name,
+							EvaluatedNodes: 1,
+							FeasibleNodes:  1,
+						},
+					},
+				},
+				status: nil,
+			},
+		},
+		"filters out infeasible placements with feasible pods": {
+			placementPlugin: fakePlacementPlugin{
+				generatePlacementsResult: map[string][]string{
+					"placement1": {nodes[0].Name},
+					"placement2": {nodes[1].Name},
+				},
+				scorePlacementsResult: map[string]int64{
+					"placement1": 1,
+					"placement2": 2,
+				},
+				filterStatus: map[string]*fwk.Status{
+					nodes[1].Name: nil,
+				},
+			},
+			placementFeasibleStatuses: [][]fwk.Code{
+				{fwk.Success},       // placement1
+				{fwk.Unschedulable}, // placement2
 			},
 			expectedResult: podGroupAlgorithmResult{
 				podResults: []algorithmResult{
@@ -2466,15 +2464,24 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 
 			tt.placementPlugin.name = "FakePlacementPlugin"
 
+			orderedPlacementGeneratePlugin := &orderedPlacementPlugin{&tt.placementPlugin}
+
+			placementFeasiblePlugin := &fakePlacementFeasiblePlugin{
+				placementFeasibleStatuses: tt.placementFeasibleStatuses,
+			}
+
 			registry := []tf.RegisterPluginFunc{
-				tf.RegisterPlacementGeneratePlugin(tt.placementPlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
-					return &tt.placementPlugin, nil
+				tf.RegisterPlacementGeneratePlugin(orderedPlacementGeneratePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+					return orderedPlacementGeneratePlugin, nil
 				}),
 				tf.RegisterPlacementScorePlugin(tt.placementPlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
 					return &tt.placementPlugin, nil
 				}, 1),
 				tf.RegisterFilterPlugin(tt.placementPlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
 					return &tt.placementPlugin, nil
+				}),
+				tf.RegisterPermitPlugin(placementFeasiblePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+					return placementFeasiblePlugin, nil
 				}),
 			}
 

--- a/test/integration/scheduler/podgroup/podgroup_test.go
+++ b/test/integration/scheduler/podgroup/podgroup_test.go
@@ -830,11 +830,12 @@ func TestPostFilterInvocationCount(t *testing.T) {
 		}
 	}
 
-	// 5. Verify that MockPostFilter was called exactly 3 times
-	// It should be called for each pod from pod group in pod group cycle
+	// 5. Verify that MockPostFilter was called exactly once
+	// It should be called for each evaluated pod from pod group in pod group cycle
 	// but should not be called in WAP.
+	// Only one pod is evaluated for pod group because minCount=3 can't be satisfied with the remaining 2 pods.
 	err = wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 10*time.Second, false, func(ctx context.Context) (bool, error) {
-		if mockPlugin.count == 3 {
+		if mockPlugin.count == 1 {
 			return true, nil
 		}
 		return false, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

When there's not enough remaining pods to satisfy gang's minCount, we can abort iteration. Right now we always evaluate all pods, which is a missed opportunity for optimization.

The current extension points are not sufficient to support early return like this.

This solution adds a "pseudo extension point" (i.e. not exposed in the config), similar to PodGroupPostFilter, to support breaking out of the pod group scheduling cycle.

This new logic essentially obsoletes the GangScheduling's Permit plugin in WAS.

Unit tests have been written with AI assistance.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

Relevant slack thread discussing the approach: https://kubernetes.slack.com/archives/C09TP78DV/p1776782006344809

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added scheduler extension point "PlacementFeasible" to allow for early termination of PodGroup scheduling cycle. This extension point is used by the GangScheduling plugin to stop evaluating pods once minCount becomes unsatisfiable.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
