### PR TITLE
bump cos-gpu-installer to v2.5.8 for COS M125

### DIFF
--- a/test/e2e/testing-manifests/gpu/gce/nvidia-driver-installer.yaml
+++ b/test/e2e/testing-manifests/gpu/gce/nvidia-driver-installer.yaml
@@ -78,8 +78,8 @@ spec:
           # Refer to details about the installer in https://cos.googlesource.com/cos/tools/+/refs/heads/master/src/cmd/cos_gpu_installer/
           # and the COS release notes (https://cloud.google.com/container-optimized-os/docs/release-notes) to determine version COS GPU installer for a given version of COS.
 
-          # Maps to gcr.io/cos-cloud/cos-gpu-installer:v2.5.7 - suitable for COS M121 as per https://cloud.google.com/container-optimized-os/docs/release-notes/m121
-        - image: "gcr.io/cos-cloud/cos-gpu-installer:v2.5.7"
+          # Maps to gcr.io/cos-cloud/cos-gpu-installer:v2.5.8 - suitable for COS M125 as per https://cloud.google.com/container-optimized-os/docs/release-notes/m125
+        - image: "gcr.io/cos-cloud/cos-gpu-installer:v2.5.8"
           name: nvidia-driver-installer
           resources:
             requests:


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

`ci-kubernetes-e2e-gce-device-plugin-gpu` and `ci-kubernetes-e2e-gce-device-plugin-gpu-1-36` have been failing since ~2026-04-28 00:00 UTC with:

```
Timed out after 600.000s.
nvidia GPUs not available on Node: "kt2-a3452892-ed42-minion-group-4w11"
```

The GCE node image family in `cluster/gce/config-default.sh` was updated to `cos-125-lts` but `test/e2e/testing-manifests/gpu/gce/nvidia-driver-installer.yaml` was never updated to match. `cos-gpu-installer:v2.5.7` is only suitable for COS M121 — on `cos-125-19216-220-150` nodes it crashes immediately into `CrashLoopBackOff`, so the NVIDIA driver is never installed, `nvidia.com/gpu` never appears in node capacity, and all GPU tests time out. Both green and red builds ran the identical Kubernetes commit SHA, confirming this is a pure infrastructure failure.

Bumps the installer image to `v2.5.8`, the first version listed in the [COS M125 release notes](https://cloud.google.com/container-optimized-os/docs/release-notes/m125). Same fix pattern as PR #134495 (M109→M121) and test-infra PR #35661.

#### Which issue(s) this PR is related to:

Related: #136378
Related: #138650

#### Special notes for your reviewer:

One-line change to the driver installer DaemonSet image tag plus the accompanying comment. No code changes.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```