### PR TITLE
Fix excessive events generated for image volumes

### DIFF
--- a/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
@@ -95,8 +95,7 @@ func (f *fakePodPullingTimeRecorder) RecordImageStartedPulling(podUID types.UID)
 
 func (f *fakePodPullingTimeRecorder) RecordImageFinishedPulling(podUID types.UID) {}
 
-func newFakeKubeRuntimeManager(ctx context.Context, runtimeService internalapi.RuntimeService, imageService internalapi.ImageManagerService, machineInfo *cadvisorapi.MachineInfo, osInterface kubecontainer.OSInterface, runtimeHelper kubecontainer.RuntimeHelper, tracer trace.Tracer) (*kubeGenericRuntimeManager, error) {
-	recorder := &record.FakeRecorder{}
+func newFakeKubeRuntimeManager(ctx context.Context, runtimeService internalapi.RuntimeService, imageService internalapi.ImageManagerService, machineInfo *cadvisorapi.MachineInfo, osInterface kubecontainer.OSInterface, runtimeHelper kubecontainer.RuntimeHelper, tracer trace.Tracer, recorder *record.FakeRecorder) (*kubeGenericRuntimeManager, error) {
 	kubeRuntimeManager := &kubeGenericRuntimeManager{
 		recorder:               recorder,
 		cpuCFSQuota:            false,

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1664,27 +1664,12 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 		podIP = podIPs[0]
 	}
 
-	// Get podSandboxConfig for containers to start.
-	podSandboxConfig, err := m.generatePodSandboxConfig(ctx, pod, podContainerChanges.Attempt)
-	if err != nil {
-		logger.Error(err, "GeneratePodSandboxConfig for pod failed", "pod", klog.KObj(pod))
-		result.Fail(fmt.Errorf("GeneratePodSandboxConfig for pod %q failed: %w", format.Pod(pod), err))
-		return
-	}
-
-	imageVolumePullResults, err := m.getImageVolumes(ctx, pod, podSandboxConfig, pullSecrets)
-	if err != nil {
-		logger.Error(err, "Get image volumes for pod failed", "pod", klog.KObj(pod))
-		result.Fail(err)
-		return
-	}
-
 	// Helper containing boilerplate common to starting all types of containers.
 	// typeName is a description used to describe this type of container in log messages,
 	// currently: "container", "init container" or "ephemeral container"
 	// metricLabel is the label used to describe this type of container in monitoring metrics.
 	// currently: "container", "init_container" or "ephemeral_container"
-	start := func(ctx context.Context, typeName, metricLabel string, spec *startSpec) error {
+	startWithInitState := func(ctx context.Context, typeName, metricLabel string, spec *startSpec, podSandboxConfig *runtimeapi.PodSandboxConfig, imageVolumePullResults imageVolumePulls) error {
 		startContainerResult := kubecontainer.NewSyncResult(kubecontainer.StartContainer, spec.container.Name)
 		result.AddSyncResult(startContainerResult)
 
@@ -1740,16 +1725,60 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 		return nil
 	}
 
+	// State required only if we need to start any containers.
+	var (
+		podSandboxConfig       *runtimeapi.PodSandboxConfig
+		imageVolumePullResults imageVolumePulls
+	)
+
+	// lazyStart initializes state required to start containers and returns a start function.
+	lazyStart := func() func(ctx context.Context, typeName, metricLabel string, spec *startSpec) error {
+		var err error
+
+		if podSandboxConfig == nil {
+			podSandboxConfig, err = m.generatePodSandboxConfig(ctx, pod, podContainerChanges.Attempt)
+			if err != nil {
+				logger.Error(err, "GeneratePodSandboxConfig for pod failed", "pod", klog.KObj(pod))
+				result.Fail(fmt.Errorf("GeneratePodSandboxConfig for pod %q failed: %w", format.Pod(pod), err))
+				return nil
+			}
+		}
+
+		if imageVolumePullResults == nil {
+			imageVolumePullResults, err = m.getImageVolumes(ctx, pod, podSandboxConfig, pullSecrets)
+			if err != nil {
+				// Don't start any containers until we have all image volumes.
+				logger.Error(err, "Get image volumes for pod failed", "pod", klog.KObj(pod))
+				result.Fail(err)
+				return nil
+			}
+		}
+
+		return func(ctx context.Context, typeName, metricLabel string, spec *startSpec) error {
+			return startWithInitState(ctx, typeName, metricLabel, spec, podSandboxConfig, imageVolumePullResults)
+		}
+	}
+
 	// Step 6: start ephemeral containers
 	// These are started "prior" to init containers to allow running ephemeral containers even when there
 	// are errors starting an init container. In practice init containers will start first since ephemeral
 	// containers cannot be specified on pod creation.
 	for _, idx := range podContainerChanges.EphemeralContainersToStart {
+		start := lazyStart()
+		if start == nil {
+			return
+		}
+
 		start(ctx, "ephemeral container", metrics.EphemeralContainer, ephemeralContainerStartSpec(&pod.Spec.EphemeralContainers[idx]))
 	}
 
 	// Step 7: start init containers.
 	for _, idx := range podContainerChanges.InitContainersToStart {
+		start := lazyStart()
+		if start == nil {
+			return
+		}
+
 		container := &pod.Spec.InitContainers[idx]
 		// Start the next init container.
 		if err := start(ctx, "init container", metrics.InitContainer, containerStartSpec(container)); err != nil {
@@ -1789,6 +1818,11 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 
 	// Step 9: start containers in podContainerChanges.ContainersToStart.
 	for _, idx := range podContainerChanges.ContainersToStart {
+		start := lazyStart()
+		if start == nil {
+			return
+		}
+
 		start(ctx, "container", metrics.Container, containerStartSpec(&pod.Spec.Containers[idx]))
 	}
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/flowcontrol"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/component-base/metrics/legacyregistry"
@@ -70,14 +71,38 @@ var (
 	containerRestartPolicyAlways       = v1.ContainerRestartPolicyAlways
 )
 
-func createTestRuntimeManager(tCtx ktesting.TContext) (*apitest.FakeRuntimeService, *apitest.FakeImageService, *kubeGenericRuntimeManager, error) {
-	return createTestRuntimeManagerWithErrors(tCtx, nil)
+type testRuntimeManagerOptions struct {
+	errors   map[string][]error
+	recorder *record.FakeRecorder
 }
 
-func createTestRuntimeManagerWithErrors(tCtx ktesting.TContext, errors map[string][]error) (*apitest.FakeRuntimeService, *apitest.FakeImageService, *kubeGenericRuntimeManager, error) {
+type testRuntimeManagerOption func(*testRuntimeManagerOptions)
+
+func withErrors(errors map[string][]error) testRuntimeManagerOption {
+	return func(o *testRuntimeManagerOptions) {
+		o.errors = errors
+	}
+}
+
+func withRecorder(recorder *record.FakeRecorder) testRuntimeManagerOption {
+	return func(o *testRuntimeManagerOptions) {
+		o.recorder = recorder
+	}
+}
+
+func createTestRuntimeManager(tCtx ktesting.TContext, opts ...testRuntimeManagerOption) (*apitest.FakeRuntimeService, *apitest.FakeImageService, *kubeGenericRuntimeManager, error) {
+	options := &testRuntimeManagerOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	if options.recorder == nil {
+		options.recorder = &record.FakeRecorder{}
+	}
+
 	fakeRuntimeService := apitest.NewFakeRuntimeService()
-	if errors != nil {
-		fakeRuntimeService.Errors = errors
+	if options.errors != nil {
+		fakeRuntimeService.Errors = options.errors
 	}
 	fakeImageService := apitest.NewFakeImageService()
 	// Only an empty machineInfo is needed here, because in unit test all containers are besteffort,
@@ -88,7 +113,7 @@ func createTestRuntimeManagerWithErrors(tCtx ktesting.TContext, errors map[strin
 		MemoryCapacity: uint64(memoryCapacityQuantity.Value()),
 	}
 	osInterface := &containertest.FakeOS{}
-	manager, err := newFakeKubeRuntimeManager(tCtx, fakeRuntimeService, fakeImageService, machineInfo, osInterface, &containertest.FakeRuntimeHelper{}, noopoteltrace.NewTracerProvider().Tracer(""))
+	manager, err := newFakeKubeRuntimeManager(tCtx, fakeRuntimeService, fakeImageService, machineInfo, osInterface, &containertest.FakeRuntimeHelper{}, noopoteltrace.NewTracerProvider().Tracer(""), options.recorder)
 	return fakeRuntimeService, fakeImageService, manager, err
 }
 
@@ -1008,6 +1033,95 @@ func TestSyncPodWithRestartAllContainers(t *testing.T) {
 		{name: initContainers[0].Name, attempt: 0, state: runtimeapi.ContainerState_CONTAINER_RUNNING},
 	}
 	verifyContainerStatuses(t, fakeRuntime, expected, "start only the init container")
+}
+
+func TestSyncPodNoEventsInSteadyState(t *testing.T) {
+	simplecontainer := v1.Container{
+		Name:            "foo1",
+		Image:           "busybox",
+		ImagePullPolicy: v1.PullIfNotPresent,
+	}
+
+	type testCase struct {
+		name    string
+		podspec v1.PodSpec
+	}
+
+	testCases := []testCase{
+		{
+			name: "simple pod",
+			podspec: v1.PodSpec{
+				Containers: []v1.Container{simplecontainer},
+			},
+		},
+		{
+			name: "pod with image volume",
+			podspec: v1.PodSpec{
+				Containers: []v1.Container{simplecontainer},
+				Volumes: []v1.Volume{
+					{
+						Name: "image-volume",
+						VolumeSource: v1.VolumeSource{
+							Image: &v1.ImageVolumeSource{Reference: "image1:latest", PullPolicy: v1.PullAlways},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	consumeEvents := func(recorder *record.FakeRecorder) []string {
+		var events []string
+		for {
+			select {
+			case ev := <-recorder.Events:
+				events = append(events, ev)
+			default:
+				return events
+			}
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a recorder with a large enough buffer to hold all events generated during a single sync
+			recorder := record.NewFakeRecorder(100)
+
+			tCtx := ktesting.Init(t)
+			_, _, m, err := createTestRuntimeManager(tCtx, withRecorder(recorder))
+			require.NoError(t, err)
+
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "12345678",
+					Name:      "foo",
+					Namespace: "new",
+				},
+				Spec: tc.podspec,
+			}
+
+			// Sync the pod and store the resulting pod status.
+			backOff := flowcontrol.NewBackOff(time.Second, time.Minute)
+			result := m.SyncPod(tCtx, pod, &kubecontainer.PodStatus{}, []v1.Secret{}, backOff, false)
+			require.NoError(t, result.Error())
+
+			runtimePod, err := m.GetPod(tCtx, pod.UID)
+			require.NoError(t, err)
+			podStatus, err := m.GetPodStatus(tCtx, runtimePod)
+			require.NoError(t, err)
+
+			// We need to consume events from the initial sync, but their content is not important.
+			events := consumeEvents(recorder)
+			t.Logf("recorded events during initial sync: %v", events)
+
+			// Sync again, passing in pod status from the previous sync. This should be steady state.
+			result = m.SyncPod(tCtx, pod, podStatus, []v1.Secret{}, backOff, false)
+			require.NoError(t, result.Error())
+
+			events = consumeEvents(recorder)
+			assert.Empty(t, events, "no events expected during steady state")
+		})
+	}
 }
 
 // A helper function to get a basic pod and its status assuming all sandbox and
@@ -4472,7 +4586,7 @@ func TestDoPodResizeAction(t *testing.T) {
 		},
 	} {
 		t.Run(tc.testName, func(t *testing.T) {
-			_, _, m, err := createTestRuntimeManagerWithErrors(tCtx, tc.runtimeErrors)
+			_, _, m, err := createTestRuntimeManager(tCtx, withErrors(tc.runtimeErrors))
 			require.NoError(t, err)
 			m.cpuCFSQuota = true // Enforce CPU Limits
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

kubelet was calling EnsureImageExists for every image volume on every invocation of SyncPod. EnsureImageExists will always generate an Event, so this rapidly generates an excessive number of events.

Instead, we only initialise images when the sync requires starting a container. We do the same for the pod sandbox, which is also only required when starting containers.

Adds a new SyncPod test that no events are generated during a steady state sync.

#### Which issue(s) this PR is related to:
Fixes: #138644

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug where kubelet would generate an event once per second for every image volume in a pod.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
