### PR TITLE
Pass complete KubeProxyConfiguration to NewProxier methods

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -217,8 +217,7 @@ func newProxyServer(ctx context.Context, config *kubeproxyconfig.KubeProxyConfig
 	}
 
 	// NodeManager makes an informer that selects for the node where this kube-proxy is running
-	s.NodeManager, err = proxy.NewNodeManager(ctx, s.Client, s.Config.ConfigSyncPeriod.Duration,
-		s.NodeName, s.Config.DetectLocalMode == kubeproxyconfig.LocalModeNodeCIDR)
+	s.NodeManager, err = proxy.NewNodeManager(ctx, s.Client, s.NodeName, s.Config)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kube-proxy/app/server_linux.go
+++ b/cmd/kube-proxy/app/server_linux.go
@@ -31,7 +31,7 @@ import (
 	utilsysctl "k8s.io/component-helpers/node/util/sysctl"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/proxy"
-	proxyconfigapi "k8s.io/kubernetes/pkg/proxy/apis/config"
+	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 	"k8s.io/kubernetes/pkg/proxy/conntrack"
 	"k8s.io/kubernetes/pkg/proxy/iptables"
 	"k8s.io/kubernetes/pkg/proxy/ipvs"
@@ -44,19 +44,19 @@ import (
 
 // platformApplyDefaults is called after parsing command-line flags and/or reading the
 // config file, to apply platform-specific default values to config.
-func (o *Options) platformApplyDefaults(config *proxyconfigapi.KubeProxyConfiguration) {
+func (o *Options) platformApplyDefaults(config *kubeproxyconfig.KubeProxyConfiguration) {
 	if config.Mode == "" {
 		o.logger.Info("Using iptables proxy")
-		config.Mode = proxyconfigapi.ProxyModeIPTables
+		config.Mode = kubeproxyconfig.ProxyModeIPTables
 	}
 
-	if config.Mode == proxyconfigapi.ProxyModeNFTables && len(config.NodePortAddresses) == 0 {
-		config.NodePortAddresses = []string{proxyconfigapi.NodePortAddressesPrimary}
+	if config.Mode == kubeproxyconfig.ProxyModeNFTables && len(config.NodePortAddresses) == 0 {
+		config.NodePortAddresses = []string{kubeproxyconfig.NodePortAddressesPrimary}
 	}
 
 	if config.DetectLocalMode == "" {
-		o.logger.V(4).Info("Defaulting detect-local-mode", "localModeClusterCIDR", string(proxyconfigapi.LocalModeClusterCIDR))
-		config.DetectLocalMode = proxyconfigapi.LocalModeClusterCIDR
+		o.logger.V(4).Info("Defaulting detect-local-mode", "localModeClusterCIDR", string(kubeproxyconfig.LocalModeClusterCIDR))
+		config.DetectLocalMode = kubeproxyconfig.LocalModeClusterCIDR
 	}
 	o.logger.V(2).Info("DetectLocalMode", "localMode", string(config.DetectLocalMode))
 }
@@ -73,8 +73,8 @@ func (s *ProxyServer) platformSetup(ctx context.Context) error {
 }
 
 // isIPTablesBased checks whether mode is based on iptables rather than nftables
-func isIPTablesBased(mode proxyconfigapi.ProxyMode) bool {
-	return mode == proxyconfigapi.ProxyModeIPTables || mode == proxyconfigapi.ProxyModeIPVS
+func isIPTablesBased(mode kubeproxyconfig.ProxyMode) bool {
+	return mode == kubeproxyconfig.ProxyModeIPTables || mode == kubeproxyconfig.ProxyModeIPVS
 }
 
 // platformCheckSupported is called immediately before creating the Proxier, to check
@@ -126,14 +126,14 @@ func (s *ProxyServer) platformCheckSupported(ctx context.Context) (ipv4Supported
 }
 
 // createProxier creates the proxy.Provider
-func (s *ProxyServer) createProxier(ctx context.Context, config *proxyconfigapi.KubeProxyConfiguration, dualStack, initOnly bool) (proxy.Provider, error) {
+func (s *ProxyServer) createProxier(ctx context.Context, config *kubeproxyconfig.KubeProxyConfiguration, dualStack, initOnly bool) (proxy.Provider, error) {
 	logger := klog.FromContext(ctx)
 	var proxier proxy.Provider
 	var err error
 
 	localDetectors := getLocalDetectors(logger, s.PrimaryIPFamily, config, s.podCIDRs)
 
-	if config.Mode == proxyconfigapi.ProxyModeIPTables {
+	if config.Mode == kubeproxyconfig.ProxyModeIPTables {
 		logger.Info("Using iptables Proxier")
 		ipts := utiliptables.NewBestEffort()
 
@@ -183,7 +183,7 @@ func (s *ProxyServer) createProxier(ctx context.Context, config *proxyconfigapi.
 		if err != nil {
 			return nil, fmt.Errorf("unable to create proxier: %v", err)
 		}
-	} else if config.Mode == proxyconfigapi.ProxyModeIPVS {
+	} else if config.Mode == kubeproxyconfig.ProxyModeIPVS {
 		ipsetInterface := utilipset.New()
 		ipvsInterface := utilipvs.New()
 		if err := ipvs.CanUseIPVSProxier(ctx, ipvsInterface, ipsetInterface, config.IPVS.Scheduler); err != nil {
@@ -250,7 +250,7 @@ func (s *ProxyServer) createProxier(ctx context.Context, config *proxyconfigapi.
 		if err != nil {
 			return nil, fmt.Errorf("unable to create proxier: %v", err)
 		}
-	} else if config.Mode == proxyconfigapi.ProxyModeNFTables {
+	} else if config.Mode == kubeproxyconfig.ProxyModeNFTables {
 		logger.Info("Using nftables Proxier")
 
 		if dualStack {
@@ -297,14 +297,14 @@ func (s *ProxyServer) createProxier(ctx context.Context, config *proxyconfigapi.
 	return proxier, nil
 }
 
-func getLocalDetectors(logger klog.Logger, primaryIPFamily v1.IPFamily, config *proxyconfigapi.KubeProxyConfiguration, nodePodCIDRs []string) map[v1.IPFamily]proxyutil.LocalTrafficDetector {
+func getLocalDetectors(logger klog.Logger, primaryIPFamily v1.IPFamily, config *kubeproxyconfig.KubeProxyConfiguration, nodePodCIDRs []string) map[v1.IPFamily]proxyutil.LocalTrafficDetector {
 	localDetectors := map[v1.IPFamily]proxyutil.LocalTrafficDetector{
 		v1.IPv4Protocol: proxyutil.NewNoOpLocalDetector(),
 		v1.IPv6Protocol: proxyutil.NewNoOpLocalDetector(),
 	}
 
 	switch config.DetectLocalMode {
-	case proxyconfigapi.LocalModeClusterCIDR:
+	case kubeproxyconfig.LocalModeClusterCIDR:
 		for family, cidrs := range proxyutil.MapCIDRsByIPFamily(config.DetectLocal.ClusterCIDRs) {
 			localDetectors[family] = proxyutil.NewDetectLocalByCIDR(cidrs[0].String())
 		}
@@ -312,7 +312,7 @@ func getLocalDetectors(logger klog.Logger, primaryIPFamily v1.IPFamily, config *
 			logger.Info("Detect-local-mode set to ClusterCIDR, but no cluster CIDR specified for primary IP family", "ipFamily", primaryIPFamily, "clusterCIDRs", config.DetectLocal.ClusterCIDRs)
 		}
 
-	case proxyconfigapi.LocalModeNodeCIDR:
+	case kubeproxyconfig.LocalModeNodeCIDR:
 		for family, cidrs := range proxyutil.MapCIDRsByIPFamily(nodePodCIDRs) {
 			localDetectors[family] = proxyutil.NewDetectLocalByCIDR(cidrs[0].String())
 		}
@@ -320,12 +320,12 @@ func getLocalDetectors(logger klog.Logger, primaryIPFamily v1.IPFamily, config *
 			logger.Info("Detect-local-mode set to NodeCIDR, but no PodCIDR defined at node for primary IP family", "ipFamily", primaryIPFamily, "podCIDRs", nodePodCIDRs)
 		}
 
-	case proxyconfigapi.LocalModeBridgeInterface:
+	case kubeproxyconfig.LocalModeBridgeInterface:
 		localDetector := proxyutil.NewDetectLocalByBridgeInterface(config.DetectLocal.BridgeInterface)
 		localDetectors[v1.IPv4Protocol] = localDetector
 		localDetectors[v1.IPv6Protocol] = localDetector
 
-	case proxyconfigapi.LocalModeInterfaceNamePrefix:
+	case kubeproxyconfig.LocalModeInterfaceNamePrefix:
 		localDetector := proxyutil.NewDetectLocalByInterfaceNamePrefix(config.DetectLocal.InterfaceNamePrefix)
 		localDetectors[v1.IPv4Protocol] = localDetector
 		localDetectors[v1.IPv6Protocol] = localDetector
@@ -341,7 +341,7 @@ func getLocalDetectors(logger klog.Logger, primaryIPFamily v1.IPFamily, config *
 // cleanupAndExit is true, it will attempt to remove rules from all known kube-proxy
 // modes. If it is false, it will only remove rules that are definitely not in use by the
 // currently-configured mode.
-func platformCleanup(ctx context.Context, mode proxyconfigapi.ProxyMode, cleanupAndExit bool) error {
+func platformCleanup(ctx context.Context, mode kubeproxyconfig.ProxyMode, cleanupAndExit bool) error {
 	var encounteredError bool
 
 	// Clean up iptables and ipvs rules if switching to nftables, or if cleanupAndExit

--- a/cmd/kube-proxy/app/server_linux.go
+++ b/cmd/kube-proxy/app/server_linux.go
@@ -141,19 +141,14 @@ func (s *ProxyServer) createProxier(ctx context.Context, config *kubeproxyconfig
 			// TODO this has side effects that should only happen when Run() is invoked.
 			proxier, err = iptables.NewDualStackProxier(
 				ctx,
+				config,
 				ipts,
 				utilsysctl.New(),
-				config.SyncPeriod.Duration,
-				config.MinSyncPeriod.Duration,
-				config.Linux.MasqueradeAll,
-				*config.IPTables.LocalhostNodePorts,
-				int(*config.IPTables.MasqueradeBit),
 				localDetectors,
 				s.NodeName,
 				s.NodeIPs,
 				s.Recorder,
 				s.HealthzServer,
-				config.NodePortAddresses,
 				initOnly,
 			)
 		} else {
@@ -162,20 +157,15 @@ func (s *ProxyServer) createProxier(ctx context.Context, config *kubeproxyconfig
 			// TODO this has side effects that should only happen when Run() is invoked.
 			proxier, err = iptables.NewProxier(
 				ctx,
+				config,
 				s.PrimaryIPFamily,
 				ipts[s.PrimaryIPFamily],
 				utilsysctl.New(),
-				config.SyncPeriod.Duration,
-				config.MinSyncPeriod.Duration,
-				config.Linux.MasqueradeAll,
-				*config.IPTables.LocalhostNodePorts,
-				int(*config.IPTables.MasqueradeBit),
 				localDetectors[s.PrimaryIPFamily],
 				s.NodeName,
 				s.NodeIPs[s.PrimaryIPFamily],
 				s.Recorder,
 				s.HealthzServer,
-				config.NodePortAddresses,
 				initOnly,
 			)
 		}
@@ -198,52 +188,32 @@ func (s *ProxyServer) createProxier(ctx context.Context, config *kubeproxyconfig
 		if dualStack {
 			proxier, err = ipvs.NewDualStackProxier(
 				ctx,
+				config,
 				ipts,
 				ipvsInterface,
 				ipsetInterface,
 				utilsysctl.New(),
-				config.SyncPeriod.Duration,
-				config.MinSyncPeriod.Duration,
-				config.IPVS.ExcludeCIDRs,
-				config.IPVS.StrictARP,
-				config.IPVS.TCPTimeout.Duration,
-				config.IPVS.TCPFinTimeout.Duration,
-				config.IPVS.UDPTimeout.Duration,
-				config.Linux.MasqueradeAll,
-				int(*config.IPTables.MasqueradeBit),
 				localDetectors,
 				s.NodeName,
 				s.NodeIPs,
 				s.Recorder,
 				s.HealthzServer,
-				config.IPVS.Scheduler,
-				config.NodePortAddresses,
 				initOnly,
 			)
 		} else {
 			proxier, err = ipvs.NewProxier(
 				ctx,
+				config,
 				s.PrimaryIPFamily,
 				ipts[s.PrimaryIPFamily],
 				ipvsInterface,
 				ipsetInterface,
 				utilsysctl.New(),
-				config.SyncPeriod.Duration,
-				config.MinSyncPeriod.Duration,
-				config.IPVS.ExcludeCIDRs,
-				config.IPVS.StrictARP,
-				config.IPVS.TCPTimeout.Duration,
-				config.IPVS.TCPFinTimeout.Duration,
-				config.IPVS.UDPTimeout.Duration,
-				config.Linux.MasqueradeAll,
-				int(*config.IPTables.MasqueradeBit),
 				localDetectors[s.PrimaryIPFamily],
 				s.NodeName,
 				s.NodeIPs[s.PrimaryIPFamily],
 				s.Recorder,
 				s.HealthzServer,
-				config.IPVS.Scheduler,
-				config.NodePortAddresses,
 				initOnly,
 			)
 		}
@@ -257,16 +227,12 @@ func (s *ProxyServer) createProxier(ctx context.Context, config *kubeproxyconfig
 			// TODO this has side effects that should only happen when Run() is invoked.
 			proxier, err = nftables.NewDualStackProxier(
 				ctx,
-				config.SyncPeriod.Duration,
-				config.MinSyncPeriod.Duration,
-				config.Linux.MasqueradeAll,
-				int(*config.NFTables.MasqueradeBit),
+				config,
 				localDetectors,
 				s.NodeName,
 				s.NodeIPs,
 				s.Recorder,
 				s.HealthzServer,
-				config.NodePortAddresses,
 				initOnly,
 			)
 		} else {
@@ -274,17 +240,13 @@ func (s *ProxyServer) createProxier(ctx context.Context, config *kubeproxyconfig
 			// TODO this has side effects that should only happen when Run() is invoked.
 			proxier, err = nftables.NewProxier(
 				ctx,
+				config,
 				s.PrimaryIPFamily,
-				config.SyncPeriod.Duration,
-				config.MinSyncPeriod.Duration,
-				config.Linux.MasqueradeAll,
-				int(*config.NFTables.MasqueradeBit),
 				localDetectors[s.PrimaryIPFamily],
 				s.NodeName,
 				s.NodeIPs[s.PrimaryIPFamily],
 				s.Recorder,
 				s.HealthzServer,
-				config.NodePortAddresses,
 				initOnly,
 			)
 		}

--- a/cmd/kube-proxy/app/server_linux_test.go
+++ b/cmd/kube-proxy/app/server_linux_test.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
-	proxyconfigapi "k8s.io/kubernetes/pkg/proxy/apis/config"
+	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
 	"k8s.io/kubernetes/test/utils/ktesting"
 )
@@ -37,51 +37,51 @@ import (
 func Test_platformApplyDefaults(t *testing.T) {
 	testCases := []struct {
 		name                string
-		mode                proxyconfigapi.ProxyMode
-		expectedMode        proxyconfigapi.ProxyMode
-		detectLocal         proxyconfigapi.LocalMode
-		expectedDetectLocal proxyconfigapi.LocalMode
+		mode                kubeproxyconfig.ProxyMode
+		expectedMode        kubeproxyconfig.ProxyMode
+		detectLocal         kubeproxyconfig.LocalMode
+		expectedDetectLocal kubeproxyconfig.LocalMode
 	}{
 		{
 			name:                "defaults",
 			mode:                "",
-			expectedMode:        proxyconfigapi.ProxyModeIPTables,
+			expectedMode:        kubeproxyconfig.ProxyModeIPTables,
 			detectLocal:         "",
-			expectedDetectLocal: proxyconfigapi.LocalModeClusterCIDR,
+			expectedDetectLocal: kubeproxyconfig.LocalModeClusterCIDR,
 		},
 		{
 			name:                "explicit",
-			mode:                proxyconfigapi.ProxyModeIPTables,
-			expectedMode:        proxyconfigapi.ProxyModeIPTables,
-			detectLocal:         proxyconfigapi.LocalModeClusterCIDR,
-			expectedDetectLocal: proxyconfigapi.LocalModeClusterCIDR,
+			mode:                kubeproxyconfig.ProxyModeIPTables,
+			expectedMode:        kubeproxyconfig.ProxyModeIPTables,
+			detectLocal:         kubeproxyconfig.LocalModeClusterCIDR,
+			expectedDetectLocal: kubeproxyconfig.LocalModeClusterCIDR,
 		},
 		{
 			name:                "override mode",
 			mode:                "ipvs",
-			expectedMode:        proxyconfigapi.ProxyModeIPVS,
+			expectedMode:        kubeproxyconfig.ProxyModeIPVS,
 			detectLocal:         "",
-			expectedDetectLocal: proxyconfigapi.LocalModeClusterCIDR,
+			expectedDetectLocal: kubeproxyconfig.LocalModeClusterCIDR,
 		},
 		{
 			name:                "override detect-local",
 			mode:                "",
-			expectedMode:        proxyconfigapi.ProxyModeIPTables,
+			expectedMode:        kubeproxyconfig.ProxyModeIPTables,
 			detectLocal:         "NodeCIDR",
-			expectedDetectLocal: proxyconfigapi.LocalModeNodeCIDR,
+			expectedDetectLocal: kubeproxyconfig.LocalModeNodeCIDR,
 		},
 		{
 			name:                "override both",
 			mode:                "ipvs",
-			expectedMode:        proxyconfigapi.ProxyModeIPVS,
+			expectedMode:        kubeproxyconfig.ProxyModeIPVS,
 			detectLocal:         "NodeCIDR",
-			expectedDetectLocal: proxyconfigapi.LocalModeNodeCIDR,
+			expectedDetectLocal: kubeproxyconfig.LocalModeNodeCIDR,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			options := NewOptions()
-			config := &proxyconfigapi.KubeProxyConfiguration{
+			config := &kubeproxyconfig.KubeProxyConfiguration{
 				Mode:            tc.mode,
 				DetectLocalMode: tc.detectLocal,
 			}
@@ -100,7 +100,7 @@ func Test_platformApplyDefaults(t *testing.T) {
 func Test_getLocalDetectors(t *testing.T) {
 	cases := []struct {
 		name            string
-		config          *proxyconfigapi.KubeProxyConfiguration
+		config          *kubeproxyconfig.KubeProxyConfiguration
 		primaryIPFamily v1.IPFamily
 		nodePodCIDRs    []string
 		expected        map[v1.IPFamily]proxyutil.LocalTrafficDetector
@@ -108,9 +108,9 @@ func Test_getLocalDetectors(t *testing.T) {
 		// LocalModeClusterCIDR
 		{
 			name: "LocalModeClusterCIDR, single-stack IPv4 cluster",
-			config: &proxyconfigapi.KubeProxyConfiguration{
-				DetectLocalMode: proxyconfigapi.LocalModeClusterCIDR,
-				DetectLocal: proxyconfigapi.DetectLocalConfiguration{
+			config: &kubeproxyconfig.KubeProxyConfiguration{
+				DetectLocalMode: kubeproxyconfig.LocalModeClusterCIDR,
+				DetectLocal: kubeproxyconfig.DetectLocalConfiguration{
 					ClusterCIDRs: []string{"10.0.0.0/14"},
 				},
 			},
@@ -122,9 +122,9 @@ func Test_getLocalDetectors(t *testing.T) {
 		},
 		{
 			name: "LocalModeClusterCIDR, single-stack IPv6 cluster",
-			config: &proxyconfigapi.KubeProxyConfiguration{
-				DetectLocalMode: proxyconfigapi.LocalModeClusterCIDR,
-				DetectLocal: proxyconfigapi.DetectLocalConfiguration{
+			config: &kubeproxyconfig.KubeProxyConfiguration{
+				DetectLocalMode: kubeproxyconfig.LocalModeClusterCIDR,
+				DetectLocal: kubeproxyconfig.DetectLocalConfiguration{
 					ClusterCIDRs: []string{"2002:0:0:1234::/64"},
 				},
 			},
@@ -136,9 +136,9 @@ func Test_getLocalDetectors(t *testing.T) {
 		},
 		{
 			name: "LocalModeClusterCIDR, single-stack IPv6 cluster with single-stack IPv4 config",
-			config: &proxyconfigapi.KubeProxyConfiguration{
-				DetectLocalMode: proxyconfigapi.LocalModeClusterCIDR,
-				DetectLocal: proxyconfigapi.DetectLocalConfiguration{
+			config: &kubeproxyconfig.KubeProxyConfiguration{
+				DetectLocalMode: kubeproxyconfig.LocalModeClusterCIDR,
+				DetectLocal: kubeproxyconfig.DetectLocalConfiguration{
 					ClusterCIDRs: []string{"10.0.0.0/14"},
 				},
 			},
@@ -152,9 +152,9 @@ func Test_getLocalDetectors(t *testing.T) {
 		},
 		{
 			name: "LocalModeClusterCIDR, single-stack IPv4 cluster with single-stack IPv6 config",
-			config: &proxyconfigapi.KubeProxyConfiguration{
-				DetectLocalMode: proxyconfigapi.LocalModeClusterCIDR,
-				DetectLocal: proxyconfigapi.DetectLocalConfiguration{
+			config: &kubeproxyconfig.KubeProxyConfiguration{
+				DetectLocalMode: kubeproxyconfig.LocalModeClusterCIDR,
+				DetectLocal: kubeproxyconfig.DetectLocalConfiguration{
 					ClusterCIDRs: []string{"2002:0:0:1234::/64"},
 				},
 			},
@@ -168,9 +168,9 @@ func Test_getLocalDetectors(t *testing.T) {
 		},
 		{
 			name: "LocalModeClusterCIDR, dual-stack IPv4-primary cluster",
-			config: &proxyconfigapi.KubeProxyConfiguration{
-				DetectLocalMode: proxyconfigapi.LocalModeClusterCIDR,
-				DetectLocal: proxyconfigapi.DetectLocalConfiguration{
+			config: &kubeproxyconfig.KubeProxyConfiguration{
+				DetectLocalMode: kubeproxyconfig.LocalModeClusterCIDR,
+				DetectLocal: kubeproxyconfig.DetectLocalConfiguration{
 					ClusterCIDRs: []string{"10.0.0.0/14", "2002:0:0:1234::/64"},
 				},
 			},
@@ -182,9 +182,9 @@ func Test_getLocalDetectors(t *testing.T) {
 		},
 		{
 			name: "LocalModeClusterCIDR, dual-stack IPv6-primary cluster",
-			config: &proxyconfigapi.KubeProxyConfiguration{
-				DetectLocalMode: proxyconfigapi.LocalModeClusterCIDR,
-				DetectLocal: proxyconfigapi.DetectLocalConfiguration{
+			config: &kubeproxyconfig.KubeProxyConfiguration{
+				DetectLocalMode: kubeproxyconfig.LocalModeClusterCIDR,
+				DetectLocal: kubeproxyconfig.DetectLocalConfiguration{
 					ClusterCIDRs: []string{"2002:0:0:1234::/64", "10.0.0.0/14"},
 				},
 			},
@@ -196,9 +196,9 @@ func Test_getLocalDetectors(t *testing.T) {
 		},
 		{
 			name: "LocalModeClusterCIDR, IPv4-primary kube-proxy / IPv6-primary config",
-			config: &proxyconfigapi.KubeProxyConfiguration{
-				DetectLocalMode: proxyconfigapi.LocalModeClusterCIDR,
-				DetectLocal: proxyconfigapi.DetectLocalConfiguration{
+			config: &kubeproxyconfig.KubeProxyConfiguration{
+				DetectLocalMode: kubeproxyconfig.LocalModeClusterCIDR,
+				DetectLocal: kubeproxyconfig.DetectLocalConfiguration{
 					ClusterCIDRs: []string{"2002:0:0:1234::/64", "10.0.0.0/14"},
 				},
 			},
@@ -210,9 +210,9 @@ func Test_getLocalDetectors(t *testing.T) {
 		},
 		{
 			name: "LocalModeClusterCIDR, no ClusterCIDR",
-			config: &proxyconfigapi.KubeProxyConfiguration{
-				DetectLocalMode: proxyconfigapi.LocalModeClusterCIDR,
-				DetectLocal: proxyconfigapi.DetectLocalConfiguration{
+			config: &kubeproxyconfig.KubeProxyConfiguration{
+				DetectLocalMode: kubeproxyconfig.LocalModeClusterCIDR,
+				DetectLocal: kubeproxyconfig.DetectLocalConfiguration{
 					ClusterCIDRs: []string{""},
 				},
 			},
@@ -225,9 +225,9 @@ func Test_getLocalDetectors(t *testing.T) {
 		// LocalModeNodeCIDR
 		{
 			name: "LocalModeNodeCIDR, single-stack IPv4 cluster",
-			config: &proxyconfigapi.KubeProxyConfiguration{
-				DetectLocalMode: proxyconfigapi.LocalModeNodeCIDR,
-				DetectLocal: proxyconfigapi.DetectLocalConfiguration{
+			config: &kubeproxyconfig.KubeProxyConfiguration{
+				DetectLocalMode: kubeproxyconfig.LocalModeNodeCIDR,
+				DetectLocal: kubeproxyconfig.DetectLocalConfiguration{
 					ClusterCIDRs: []string{"10.0.0.0/14"},
 				},
 			},
@@ -240,9 +240,9 @@ func Test_getLocalDetectors(t *testing.T) {
 		},
 		{
 			name: "LocalModeNodeCIDR, single-stack IPv6 cluster",
-			config: &proxyconfigapi.KubeProxyConfiguration{
-				DetectLocalMode: proxyconfigapi.LocalModeNodeCIDR,
-				DetectLocal: proxyconfigapi.DetectLocalConfiguration{
+			config: &kubeproxyconfig.KubeProxyConfiguration{
+				DetectLocalMode: kubeproxyconfig.LocalModeNodeCIDR,
+				DetectLocal: kubeproxyconfig.DetectLocalConfiguration{
 					ClusterCIDRs: []string{"2002:0:0:1234::/64"},
 				},
 			},
@@ -255,9 +255,9 @@ func Test_getLocalDetectors(t *testing.T) {
 		},
 		{
 			name: "LocalModeNodeCIDR, single-stack IPv6 cluster with single-stack IPv4 config",
-			config: &proxyconfigapi.KubeProxyConfiguration{
-				DetectLocalMode: proxyconfigapi.LocalModeNodeCIDR,
-				DetectLocal: proxyconfigapi.DetectLocalConfiguration{
+			config: &kubeproxyconfig.KubeProxyConfiguration{
+				DetectLocalMode: kubeproxyconfig.LocalModeNodeCIDR,
+				DetectLocal: kubeproxyconfig.DetectLocalConfiguration{
 					ClusterCIDRs: []string{"10.0.0.0/14"},
 				},
 			},
@@ -272,9 +272,9 @@ func Test_getLocalDetectors(t *testing.T) {
 		},
 		{
 			name: "LocalModeNodeCIDR, single-stack IPv4 cluster with single-stack IPv6 config",
-			config: &proxyconfigapi.KubeProxyConfiguration{
-				DetectLocalMode: proxyconfigapi.LocalModeNodeCIDR,
-				DetectLocal: proxyconfigapi.DetectLocalConfiguration{
+			config: &kubeproxyconfig.KubeProxyConfiguration{
+				DetectLocalMode: kubeproxyconfig.LocalModeNodeCIDR,
+				DetectLocal: kubeproxyconfig.DetectLocalConfiguration{
 					ClusterCIDRs: []string{"2002:0:0:1234::/64"},
 				},
 			},
@@ -289,9 +289,9 @@ func Test_getLocalDetectors(t *testing.T) {
 		},
 		{
 			name: "LocalModeNodeCIDR, dual-stack IPv4-primary cluster",
-			config: &proxyconfigapi.KubeProxyConfiguration{
-				DetectLocalMode: proxyconfigapi.LocalModeNodeCIDR,
-				DetectLocal: proxyconfigapi.DetectLocalConfiguration{
+			config: &kubeproxyconfig.KubeProxyConfiguration{
+				DetectLocalMode: kubeproxyconfig.LocalModeNodeCIDR,
+				DetectLocal: kubeproxyconfig.DetectLocalConfiguration{
 					ClusterCIDRs: []string{"10.0.0.0/14", "2002:0:0:1234::/64"},
 				},
 			},
@@ -304,9 +304,9 @@ func Test_getLocalDetectors(t *testing.T) {
 		},
 		{
 			name: "LocalModeNodeCIDR, dual-stack IPv6-primary cluster",
-			config: &proxyconfigapi.KubeProxyConfiguration{
-				DetectLocalMode: proxyconfigapi.LocalModeNodeCIDR,
-				DetectLocal: proxyconfigapi.DetectLocalConfiguration{
+			config: &kubeproxyconfig.KubeProxyConfiguration{
+				DetectLocalMode: kubeproxyconfig.LocalModeNodeCIDR,
+				DetectLocal: kubeproxyconfig.DetectLocalConfiguration{
 					ClusterCIDRs: []string{"2002:0:0:1234::/64", "10.0.0.0/14"},
 				},
 			},
@@ -319,9 +319,9 @@ func Test_getLocalDetectors(t *testing.T) {
 		},
 		{
 			name: "LocalModeNodeCIDR, IPv6-primary kube-proxy / IPv4-primary config",
-			config: &proxyconfigapi.KubeProxyConfiguration{
-				DetectLocalMode: proxyconfigapi.LocalModeNodeCIDR,
-				DetectLocal: proxyconfigapi.DetectLocalConfiguration{
+			config: &kubeproxyconfig.KubeProxyConfiguration{
+				DetectLocalMode: kubeproxyconfig.LocalModeNodeCIDR,
+				DetectLocal: kubeproxyconfig.DetectLocalConfiguration{
 					ClusterCIDRs: []string{"10.0.0.0/14", "2002:0:0:1234::/64"},
 				},
 			},
@@ -334,9 +334,9 @@ func Test_getLocalDetectors(t *testing.T) {
 		},
 		{
 			name: "LocalModeNodeCIDR, no PodCIDRs",
-			config: &proxyconfigapi.KubeProxyConfiguration{
-				DetectLocalMode: proxyconfigapi.LocalModeNodeCIDR,
-				DetectLocal: proxyconfigapi.DetectLocalConfiguration{
+			config: &kubeproxyconfig.KubeProxyConfiguration{
+				DetectLocalMode: kubeproxyconfig.LocalModeNodeCIDR,
+				DetectLocal: kubeproxyconfig.DetectLocalConfiguration{
 					ClusterCIDRs: []string{""},
 				},
 			},
@@ -350,9 +350,9 @@ func Test_getLocalDetectors(t *testing.T) {
 		// unknown mode
 		{
 			name: "unknown LocalMode",
-			config: &proxyconfigapi.KubeProxyConfiguration{
-				DetectLocalMode: proxyconfigapi.LocalMode("abcd"),
-				DetectLocal: proxyconfigapi.DetectLocalConfiguration{
+			config: &kubeproxyconfig.KubeProxyConfiguration{
+				DetectLocalMode: kubeproxyconfig.LocalMode("abcd"),
+				DetectLocal: kubeproxyconfig.DetectLocalConfiguration{
 					ClusterCIDRs: []string{"10.0.0.0/14"},
 				},
 			},
@@ -365,9 +365,9 @@ func Test_getLocalDetectors(t *testing.T) {
 		// LocalModeBridgeInterface
 		{
 			name: "LocalModeBridgeInterface",
-			config: &proxyconfigapi.KubeProxyConfiguration{
-				DetectLocalMode: proxyconfigapi.LocalModeBridgeInterface,
-				DetectLocal: proxyconfigapi.DetectLocalConfiguration{
+			config: &kubeproxyconfig.KubeProxyConfiguration{
+				DetectLocalMode: kubeproxyconfig.LocalModeBridgeInterface,
+				DetectLocal: kubeproxyconfig.DetectLocalConfiguration{
 					BridgeInterface: "eth",
 				},
 			},
@@ -379,9 +379,9 @@ func Test_getLocalDetectors(t *testing.T) {
 		},
 		{
 			name: "LocalModeBridgeInterface, strange bridge name",
-			config: &proxyconfigapi.KubeProxyConfiguration{
-				DetectLocalMode: proxyconfigapi.LocalModeBridgeInterface,
-				DetectLocal: proxyconfigapi.DetectLocalConfiguration{
+			config: &kubeproxyconfig.KubeProxyConfiguration{
+				DetectLocalMode: kubeproxyconfig.LocalModeBridgeInterface,
+				DetectLocal: kubeproxyconfig.DetectLocalConfiguration{
 					BridgeInterface: "1234567890123456789",
 				},
 			},
@@ -394,9 +394,9 @@ func Test_getLocalDetectors(t *testing.T) {
 		// LocalModeInterfaceNamePrefix
 		{
 			name: "LocalModeInterfaceNamePrefix",
-			config: &proxyconfigapi.KubeProxyConfiguration{
-				DetectLocalMode: proxyconfigapi.LocalModeInterfaceNamePrefix,
-				DetectLocal: proxyconfigapi.DetectLocalConfiguration{
+			config: &kubeproxyconfig.KubeProxyConfiguration{
+				DetectLocalMode: kubeproxyconfig.LocalModeInterfaceNamePrefix,
+				DetectLocal: kubeproxyconfig.DetectLocalConfiguration{
 					InterfaceNamePrefix: "eth",
 				},
 			},
@@ -408,9 +408,9 @@ func Test_getLocalDetectors(t *testing.T) {
 		},
 		{
 			name: "LocalModeInterfaceNamePrefix, strange interface name",
-			config: &proxyconfigapi.KubeProxyConfiguration{
-				DetectLocalMode: proxyconfigapi.LocalModeInterfaceNamePrefix,
-				DetectLocal: proxyconfigapi.DetectLocalConfiguration{
+			config: &kubeproxyconfig.KubeProxyConfiguration{
+				DetectLocalMode: kubeproxyconfig.LocalModeInterfaceNamePrefix,
+				DetectLocal: kubeproxyconfig.DetectLocalConfiguration{
 					InterfaceNamePrefix: "1234567890123456789",
 				},
 			},

--- a/cmd/kube-proxy/app/server_other.go
+++ b/cmd/kube-proxy/app/server_other.go
@@ -26,12 +26,12 @@ import (
 	"runtime"
 
 	"k8s.io/kubernetes/pkg/proxy"
-	proxyconfigapi "k8s.io/kubernetes/pkg/proxy/apis/config"
+	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 )
 
 // platformApplyDefaults is called after parsing command-line flags and/or reading the
 // config file, to apply platform-specific default values to config.
-func (o *Options) platformApplyDefaults(config *proxyconfigapi.KubeProxyConfiguration) {
+func (o *Options) platformApplyDefaults(config *kubeproxyconfig.KubeProxyConfiguration) {
 }
 
 var unsupportedError = fmt.Errorf(runtime.GOOS + "/" + runtime.GOARCH + "is unsupported")
@@ -50,11 +50,11 @@ func (s *ProxyServer) platformCheckSupported(ctx context.Context) (ipv4Supported
 }
 
 // createProxier creates the proxy.Provider
-func (s *ProxyServer) createProxier(ctx context.Context, config *proxyconfigapi.KubeProxyConfiguration, dualStackMode, initOnly bool) (proxy.Provider, error) {
+func (s *ProxyServer) createProxier(ctx context.Context, config *kubeproxyconfig.KubeProxyConfiguration, dualStackMode, initOnly bool) (proxy.Provider, error) {
 	return nil, unsupportedError
 }
 
 // platformCleanup removes stale kube-proxy rules that can be safely removed.
-func platformCleanup(ctx context.Context, mode proxyconfigapi.ProxyMode, cleanupAndExit bool) error {
+func platformCleanup(ctx context.Context, mode kubeproxyconfig.ProxyMode, cleanupAndExit bool) error {
 	return unsupportedError
 }

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -90,26 +90,20 @@ func (s *ProxyServer) createProxier(ctx context.Context, config *kubeproxyconfig
 
 	if dualStackMode {
 		proxier, err = winkernel.NewDualStackProxier(
-			config.SyncPeriod.Duration,
-			config.MinSyncPeriod.Duration,
+			config,
 			s.NodeName,
 			s.NodeIPs,
 			s.Recorder,
 			s.HealthzServer,
-			config.HealthzBindAddress,
-			config.Winkernel,
 		)
 	} else {
 		proxier, err = winkernel.NewProxier(
+			config,
 			s.PrimaryIPFamily,
-			config.SyncPeriod.Duration,
-			config.MinSyncPeriod.Duration,
 			s.NodeName,
 			s.NodeIPs[s.PrimaryIPFamily],
 			s.Recorder,
 			s.HealthzServer,
-			config.HealthzBindAddress,
-			config.Winkernel,
 		)
 	}
 	if err != nil {

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -31,15 +31,15 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/proxy"
-	proxyconfigapi "k8s.io/kubernetes/pkg/proxy/apis/config"
+	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 	"k8s.io/kubernetes/pkg/proxy/winkernel"
 )
 
 // platformApplyDefaults is called after parsing command-line flags and/or reading the
 // config file, to apply platform-specific default values to config.
-func (o *Options) platformApplyDefaults(config *proxyconfigapi.KubeProxyConfiguration) {
+func (o *Options) platformApplyDefaults(config *kubeproxyconfig.KubeProxyConfiguration) {
 	if config.Mode == "" {
-		config.Mode = proxyconfigapi.ProxyModeKernelspace
+		config.Mode = kubeproxyconfig.ProxyModeKernelspace
 	}
 	if config.Winkernel.RootHnsEndpointName == "" {
 		config.Winkernel.RootHnsEndpointName = "cbr0"
@@ -80,7 +80,7 @@ func (s *ProxyServer) platformCheckSupported(ctx context.Context) (ipv4Supported
 }
 
 // createProxier creates the proxy.Provider
-func (s *ProxyServer) createProxier(ctx context.Context, config *proxyconfigapi.KubeProxyConfiguration, dualStackMode, initOnly bool) (proxy.Provider, error) {
+func (s *ProxyServer) createProxier(ctx context.Context, config *kubeproxyconfig.KubeProxyConfiguration, dualStackMode, initOnly bool) (proxy.Provider, error) {
 	if initOnly {
 		return nil, fmt.Errorf("--init-only is not implemented on Windows")
 	}
@@ -120,7 +120,7 @@ func (s *ProxyServer) createProxier(ctx context.Context, config *proxyconfigapi.
 }
 
 // platformCleanup removes stale kube-proxy rules that can be safely removed.
-func platformCleanup(ctx context.Context, mode proxyconfigapi.ProxyMode, cleanupAndExit bool) error {
+func platformCleanup(ctx context.Context, mode kubeproxyconfig.ProxyMode, cleanupAndExit bool) error {
 	if cleanupAndExit {
 		return errors.New("--cleanup-and-exit is not implemented on Windows")
 	}

--- a/pkg/proxy/apis/config/scheme/scheme.go
+++ b/pkg/proxy/apis/config/scheme/scheme.go
@@ -20,8 +20,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/kubernetes/pkg/proxy/apis/config"
-	"k8s.io/kubernetes/pkg/proxy/apis/config/v1alpha1"
+	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
+	kubeproxyconfigv1alpha1 "k8s.io/kubernetes/pkg/proxy/apis/config/v1alpha1"
 )
 
 var (
@@ -38,6 +38,6 @@ func init() {
 
 // AddToScheme adds the types of this group into the given scheme.
 func AddToScheme(scheme *runtime.Scheme) {
-	utilruntime.Must(v1alpha1.AddToScheme(scheme))
-	utilruntime.Must(config.AddToScheme(scheme))
+	utilruntime.Must(kubeproxyconfigv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(kubeproxyconfig.AddToScheme(scheme))
 }

--- a/pkg/proxy/apis/config/v1alpha1/conversion.go
+++ b/pkg/proxy/apis/config/v1alpha1/conversion.go
@@ -21,11 +21,11 @@ import (
 
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/kube-proxy/config/v1alpha1"
-	"k8s.io/kubernetes/pkg/proxy/apis/config"
+	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 )
 
 // Convert_config_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguration is defined here, because public conversion is not auto-generated due to existing warnings.
-func Convert_config_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguration(in *config.KubeProxyConfiguration, out *v1alpha1.KubeProxyConfiguration, scope conversion.Scope) error {
+func Convert_config_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguration(in *kubeproxyconfig.KubeProxyConfiguration, out *v1alpha1.KubeProxyConfiguration, scope conversion.Scope) error {
 	if err := autoConvert_config_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguration(in, out, scope); err != nil {
 		return err
 	}
@@ -33,17 +33,17 @@ func Convert_config_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguration(in
 	out.Conntrack = v1alpha1.KubeProxyConntrackConfiguration(in.Linux.Conntrack)
 	out.OOMScoreAdj = in.Linux.OOMScoreAdj
 	switch in.Mode {
-	case config.ProxyModeNFTables:
+	case kubeproxyconfig.ProxyModeNFTables:
 		out.NFTables.MasqueradeAll = in.Linux.MasqueradeAll
 	default:
 		out.IPTables.MasqueradeAll = in.Linux.MasqueradeAll
 	}
 
 	switch in.Mode {
-	case config.ProxyModeIPVS:
+	case kubeproxyconfig.ProxyModeIPVS:
 		out.IPVS.SyncPeriod = in.SyncPeriod
 		out.IPVS.MinSyncPeriod = in.MinSyncPeriod
-	case config.ProxyModeNFTables:
+	case kubeproxyconfig.ProxyModeNFTables:
 		out.NFTables.SyncPeriod = in.SyncPeriod
 		out.NFTables.MinSyncPeriod = in.MinSyncPeriod
 	default:
@@ -58,25 +58,25 @@ func Convert_config_KubeProxyConfiguration_To_v1alpha1_KubeProxyConfiguration(in
 }
 
 // Convert_v1alpha1_KubeProxyConfiguration_To_config_KubeProxyConfiguration is defined here, because public conversion is not auto-generated due to existing warnings.
-func Convert_v1alpha1_KubeProxyConfiguration_To_config_KubeProxyConfiguration(in *v1alpha1.KubeProxyConfiguration, out *config.KubeProxyConfiguration, scope conversion.Scope) error {
+func Convert_v1alpha1_KubeProxyConfiguration_To_config_KubeProxyConfiguration(in *v1alpha1.KubeProxyConfiguration, out *kubeproxyconfig.KubeProxyConfiguration, scope conversion.Scope) error {
 	if err := autoConvert_v1alpha1_KubeProxyConfiguration_To_config_KubeProxyConfiguration(in, out, scope); err != nil {
 		return err
 	}
 	out.Windows.RunAsService = in.WindowsRunAsService
-	out.Linux.Conntrack = config.KubeProxyConntrackConfiguration(in.Conntrack)
+	out.Linux.Conntrack = kubeproxyconfig.KubeProxyConntrackConfiguration(in.Conntrack)
 	out.Linux.OOMScoreAdj = in.OOMScoreAdj
-	switch config.ProxyMode(in.Mode) {
-	case config.ProxyModeNFTables:
+	switch kubeproxyconfig.ProxyMode(in.Mode) {
+	case kubeproxyconfig.ProxyModeNFTables:
 		out.Linux.MasqueradeAll = in.NFTables.MasqueradeAll
 	default:
 		out.Linux.MasqueradeAll = in.IPTables.MasqueradeAll
 	}
 
-	switch config.ProxyMode(in.Mode) {
-	case config.ProxyModeIPVS:
+	switch kubeproxyconfig.ProxyMode(in.Mode) {
+	case kubeproxyconfig.ProxyModeIPVS:
 		out.SyncPeriod = in.IPVS.SyncPeriod
 		out.MinSyncPeriod = in.IPVS.MinSyncPeriod
-	case config.ProxyModeNFTables:
+	case kubeproxyconfig.ProxyModeNFTables:
 		out.SyncPeriod = in.NFTables.SyncPeriod
 		out.MinSyncPeriod = in.NFTables.MinSyncPeriod
 	default:
@@ -91,21 +91,21 @@ func Convert_v1alpha1_KubeProxyConfiguration_To_config_KubeProxyConfiguration(in
 }
 
 // Convert_v1alpha1_KubeProxyIPTablesConfiguration_To_config_KubeProxyIPTablesConfiguration is defined here, because public conversion is not auto-generated due to existing warnings.
-func Convert_v1alpha1_KubeProxyIPTablesConfiguration_To_config_KubeProxyIPTablesConfiguration(in *v1alpha1.KubeProxyIPTablesConfiguration, out *config.KubeProxyIPTablesConfiguration, scope conversion.Scope) error {
+func Convert_v1alpha1_KubeProxyIPTablesConfiguration_To_config_KubeProxyIPTablesConfiguration(in *v1alpha1.KubeProxyIPTablesConfiguration, out *kubeproxyconfig.KubeProxyIPTablesConfiguration, scope conversion.Scope) error {
 	return autoConvert_v1alpha1_KubeProxyIPTablesConfiguration_To_config_KubeProxyIPTablesConfiguration(in, out, scope)
 }
 
 // Convert_v1alpha1_KubeProxyIPVSConfiguration_To_config_KubeProxyIPVSConfiguration is defined here, because public conversion is not auto-generated due to existing warnings.
-func Convert_v1alpha1_KubeProxyIPVSConfiguration_To_config_KubeProxyIPVSConfiguration(in *v1alpha1.KubeProxyIPVSConfiguration, out *config.KubeProxyIPVSConfiguration, scope conversion.Scope) error {
+func Convert_v1alpha1_KubeProxyIPVSConfiguration_To_config_KubeProxyIPVSConfiguration(in *v1alpha1.KubeProxyIPVSConfiguration, out *kubeproxyconfig.KubeProxyIPVSConfiguration, scope conversion.Scope) error {
 	return autoConvert_v1alpha1_KubeProxyIPVSConfiguration_To_config_KubeProxyIPVSConfiguration(in, out, scope)
 }
 
 // Convert_v1alpha1_KubeProxyNFTablesConfiguration_To_config_KubeProxyNFTablesConfiguration is defined here, because public conversion is not auto-generated due to existing warnings.
-func Convert_v1alpha1_KubeProxyNFTablesConfiguration_To_config_KubeProxyNFTablesConfiguration(in *v1alpha1.KubeProxyNFTablesConfiguration, out *config.KubeProxyNFTablesConfiguration, scope conversion.Scope) error {
+func Convert_v1alpha1_KubeProxyNFTablesConfiguration_To_config_KubeProxyNFTablesConfiguration(in *v1alpha1.KubeProxyNFTablesConfiguration, out *kubeproxyconfig.KubeProxyNFTablesConfiguration, scope conversion.Scope) error {
 	return autoConvert_v1alpha1_KubeProxyNFTablesConfiguration_To_config_KubeProxyNFTablesConfiguration(in, out, scope)
 }
 
 // Convert_config_DetectLocalConfiguration_To_v1alpha1_DetectLocalConfiguration is defined here, because public conversion is not auto-generated due to existing warnings.
-func Convert_config_DetectLocalConfiguration_To_v1alpha1_DetectLocalConfiguration(in *config.DetectLocalConfiguration, out *v1alpha1.DetectLocalConfiguration, s conversion.Scope) error {
+func Convert_config_DetectLocalConfiguration_To_v1alpha1_DetectLocalConfiguration(in *kubeproxyconfig.DetectLocalConfiguration, out *v1alpha1.DetectLocalConfiguration, s conversion.Scope) error {
 	return autoConvert_config_DetectLocalConfiguration_To_v1alpha1_DetectLocalConfiguration(in, out, s)
 }

--- a/pkg/proxy/conntrack/sysctls.go
+++ b/pkg/proxy/conntrack/sysctls.go
@@ -31,10 +31,10 @@ import (
 
 	"k8s.io/component-helpers/node/util/sysctl"
 	"k8s.io/klog/v2"
-	proxyconfigapi "k8s.io/kubernetes/pkg/proxy/apis/config"
+	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 )
 
-func SetSysctls(ctx context.Context, config *proxyconfigapi.KubeProxyConntrackConfiguration) error {
+func SetSysctls(ctx context.Context, config *kubeproxyconfig.KubeProxyConntrackConfiguration) error {
 	return setSysctls(ctx, realConntrackConfigurer{}, config)
 }
 
@@ -57,7 +57,7 @@ type conntrackConfigurer interface {
 	SetUDPStreamTimeout(ctx context.Context, seconds int) error
 }
 
-func setSysctls(ctx context.Context, ct conntrackConfigurer, config *proxyconfigapi.KubeProxyConntrackConfiguration) error {
+func setSysctls(ctx context.Context, ct conntrackConfigurer, config *kubeproxyconfig.KubeProxyConntrackConfiguration) error {
 	max, err := getConntrackMax(ctx, config, detectNumCPU())
 	if err != nil {
 		return err
@@ -106,7 +106,7 @@ func setSysctls(ctx context.Context, ct conntrackConfigurer, config *proxyconfig
 	return nil
 }
 
-func getConntrackMax(ctx context.Context, config *proxyconfigapi.KubeProxyConntrackConfiguration, numCPU int) (int, error) {
+func getConntrackMax(ctx context.Context, config *kubeproxyconfig.KubeProxyConntrackConfiguration, numCPU int) (int, error) {
 	logger := klog.FromContext(ctx)
 	if config.MaxPerCore != nil && *config.MaxPerCore > 0 {
 		floor := 0

--- a/pkg/proxy/conntrack/sysctls_test.go
+++ b/pkg/proxy/conntrack/sysctls_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	proxyconfigapi "k8s.io/kubernetes/pkg/proxy/apis/config"
+	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/ptr"
 )
@@ -65,7 +65,7 @@ func TestGetConntrackMax(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		cfg := proxyconfigapi.KubeProxyConntrackConfiguration{
+		cfg := kubeproxyconfig.KubeProxyConntrackConfiguration{
 			Min:        ptr.To(tc.min),
 			MaxPerCore: ptr.To(tc.maxPerCore),
 		}
@@ -118,103 +118,103 @@ func TestSetupConntrack(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
 	tests := []struct {
 		name         string
-		config       proxyconfigapi.KubeProxyConntrackConfiguration
+		config       kubeproxyconfig.KubeProxyConntrackConfiguration
 		expect       []string
 		conntrackErr error
 		wantErr      bool
 	}{
 		{
 			name:   "do nothing if conntrack config is empty",
-			config: proxyconfigapi.KubeProxyConntrackConfiguration{},
+			config: kubeproxyconfig.KubeProxyConntrackConfiguration{},
 			expect: nil,
 		},
 		{
 			name: "SetMax is called if conntrack.maxPerCore is specified",
-			config: proxyconfigapi.KubeProxyConntrackConfiguration{
+			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
 				MaxPerCore: ptr.To(int32(12)),
 			},
 			expect: []string{"SetMax"},
 		},
 		{
 			name: "SetMax is not called if conntrack.maxPerCore is 0",
-			config: proxyconfigapi.KubeProxyConntrackConfiguration{
+			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
 				MaxPerCore: ptr.To(int32(0)),
 			},
 			expect: nil,
 		},
 		{
 			name: "SetTCPEstablishedTimeout is called if conntrack.tcpEstablishedTimeout is specified",
-			config: proxyconfigapi.KubeProxyConntrackConfiguration{
+			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
 				TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 			},
 			expect: []string{"SetTCPEstablishedTimeout(5)"},
 		},
 		{
 			name: "SetTCPEstablishedTimeout is not called if conntrack.tcpEstablishedTimeout is 0",
-			config: proxyconfigapi.KubeProxyConntrackConfiguration{
+			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
 				TCPEstablishedTimeout: &metav1.Duration{Duration: 0 * time.Second},
 			},
 			expect: nil,
 		},
 		{
 			name: "SetTCPCloseWaitTimeout is called if conntrack.tcpCloseWaitTimeout is specified",
-			config: proxyconfigapi.KubeProxyConntrackConfiguration{
+			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
 				TCPCloseWaitTimeout: &metav1.Duration{Duration: 5 * time.Second},
 			},
 			expect: []string{"SetTCPCloseWaitTimeout(5)"},
 		},
 		{
 			name: "SetTCPCloseWaitTimeout is not called if conntrack.tcpCloseWaitTimeout is 0",
-			config: proxyconfigapi.KubeProxyConntrackConfiguration{
+			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
 				TCPCloseWaitTimeout: &metav1.Duration{Duration: 0 * time.Second},
 			},
 			expect: nil,
 		},
 		{
 			name: "SetTCPBeLiberal is called if conntrack.tcpBeLiberal is true",
-			config: proxyconfigapi.KubeProxyConntrackConfiguration{
+			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
 				TCPBeLiberal: true,
 			},
 			expect: []string{"SetTCPBeLiberal(1)"},
 		},
 		{
 			name: "SetTCPBeLiberal is not called if conntrack.tcpBeLiberal is false",
-			config: proxyconfigapi.KubeProxyConntrackConfiguration{
+			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
 				TCPBeLiberal: false,
 			},
 			expect: nil,
 		},
 		{
 			name: "SetUDPTimeout is called if conntrack.udpTimeout is specified",
-			config: proxyconfigapi.KubeProxyConntrackConfiguration{
+			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
 				UDPTimeout: metav1.Duration{Duration: 5 * time.Second},
 			},
 			expect: []string{"SetUDPTimeout(5)"},
 		},
 		{
 			name: "SetUDPTimeout is called if conntrack.udpTimeout is zero",
-			config: proxyconfigapi.KubeProxyConntrackConfiguration{
+			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
 				UDPTimeout: metav1.Duration{Duration: 0 * time.Second},
 			},
 			expect: nil,
 		},
 		{
 			name: "SetUDPStreamTimeout is called if conntrack.udpStreamTimeout is specified",
-			config: proxyconfigapi.KubeProxyConntrackConfiguration{
+			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
 				UDPStreamTimeout: metav1.Duration{Duration: 5 * time.Second},
 			},
 			expect: []string{"SetUDPStreamTimeout(5)"},
 		},
 		{
 			name: "SetUDPStreamTimeout is called if conntrack.udpStreamTimeout is zero",
-			config: proxyconfigapi.KubeProxyConntrackConfiguration{
+			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
 				UDPStreamTimeout: metav1.Duration{Duration: 0 * time.Second},
 			},
 			expect: nil,
 		},
 		{
 			name: "an error is returned if conntrack.SetTCPEstablishedTimeout fails",
-			config: proxyconfigapi.KubeProxyConntrackConfiguration{
+			config: kubeproxyconfig.KubeProxyConntrackConfiguration{
 				TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
 			},
 			expect:       []string{"SetTCPEstablishedTimeout(5)"},
@@ -245,7 +245,7 @@ func TestGetConntrackMax_Capped(t *testing.T) {
 	numCPU := 512
 
 	maxPerCore := int32(32768)
-	cfg := proxyconfigapi.KubeProxyConntrackConfiguration{
+	cfg := kubeproxyconfig.KubeProxyConntrackConfiguration{
 		MaxPerCore: ptr.To(maxPerCore),
 		Min:        ptr.To(int32(0)),
 	}

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -40,6 +40,7 @@ import (
 	utilsysctl "k8s.io/component-helpers/node/util/sysctl"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/proxy"
+	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 	"k8s.io/kubernetes/pkg/proxy/conntrack"
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	"k8s.io/kubernetes/pkg/proxy/metaproxier"
@@ -92,34 +93,27 @@ const sysctlNFConntrackTCPBeLiberal = "net/netfilter/nf_conntrack_tcp_be_liberal
 // NewDualStackProxier creates a MetaProxier instance, with IPv4 and IPv6 proxies.
 func NewDualStackProxier(
 	ctx context.Context,
+	config *kubeproxyconfig.KubeProxyConfiguration,
 	ipts map[v1.IPFamily]utiliptables.Interface,
 	sysctl utilsysctl.Interface,
-	syncPeriod time.Duration,
-	minSyncPeriod time.Duration,
-	masqueradeAll bool,
-	localhostNodePorts bool,
-	masqueradeBit int,
 	localDetectors map[v1.IPFamily]proxyutil.LocalTrafficDetector,
 	nodeName string,
 	nodeIPs map[v1.IPFamily]net.IP,
 	recorder events.EventRecorder,
 	healthzServer *healthcheck.ProxyHealthServer,
-	nodePortAddresses []string,
 	initOnly bool,
 ) (proxy.Provider, error) {
 	// Create an ipv4 instance of the single-stack proxier
-	ipv4Proxier, err := NewProxier(ctx, v1.IPv4Protocol, ipts[v1.IPv4Protocol], sysctl,
-		syncPeriod, minSyncPeriod, masqueradeAll, localhostNodePorts, masqueradeBit,
+	ipv4Proxier, err := NewProxier(ctx, config, v1.IPv4Protocol, ipts[v1.IPv4Protocol], sysctl,
 		localDetectors[v1.IPv4Protocol], nodeName, nodeIPs[v1.IPv4Protocol],
-		recorder, healthzServer, nodePortAddresses, initOnly)
+		recorder, healthzServer, initOnly)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create ipv4 proxier: %v", err)
 	}
 
-	ipv6Proxier, err := NewProxier(ctx, v1.IPv6Protocol, ipts[v1.IPv6Protocol], sysctl,
-		syncPeriod, minSyncPeriod, masqueradeAll, false, masqueradeBit,
+	ipv6Proxier, err := NewProxier(ctx, config, v1.IPv6Protocol, ipts[v1.IPv6Protocol], sysctl,
 		localDetectors[v1.IPv6Protocol], nodeName, nodeIPs[v1.IPv6Protocol],
-		recorder, healthzServer, nodePortAddresses, initOnly)
+		recorder, healthzServer, initOnly)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create ipv6 proxier: %v", err)
 	}
@@ -213,25 +207,21 @@ var _ proxy.Provider = &Proxier{}
 
 // NewProxier returns a new single-stack IPTables proxier.
 func NewProxier(ctx context.Context,
+	config *kubeproxyconfig.KubeProxyConfiguration,
 	ipFamily v1.IPFamily,
 	ipt utiliptables.Interface,
 	sysctl utilsysctl.Interface,
-	syncPeriod time.Duration,
-	minSyncPeriod time.Duration,
-	masqueradeAll bool,
-	localhostNodePorts bool,
-	masqueradeBit int,
 	localDetector proxyutil.LocalTrafficDetector,
 	nodeName string,
 	nodeIP net.IP,
 	recorder events.EventRecorder,
 	healthzServer *healthcheck.ProxyHealthServer,
-	nodePortAddressStrings []string,
 	initOnly bool,
 ) (*Proxier, error) {
 	logger := klog.LoggerWithValues(klog.FromContext(ctx), "ipFamily", ipFamily)
-	nodePortAddresses := proxyutil.NewNodePortAddresses(ipFamily, nodePortAddressStrings)
 
+	localhostNodePorts := *config.IPTables.LocalhostNodePorts
+	nodePortAddresses := proxyutil.NewNodePortAddresses(ipFamily, config.NodePortAddresses)
 	if !nodePortAddresses.ContainsIPv4Loopback() {
 		localhostNodePorts = false
 	}
@@ -259,7 +249,7 @@ func NewProxier(ctx context.Context,
 	}
 
 	// Generate the masquerade mark to use for SNAT rules.
-	masqueradeValue := 1 << uint(masqueradeBit)
+	masqueradeValue := 1 << uint(*config.IPTables.MasqueradeBit)
 	masqueradeMark := fmt.Sprintf("%#08x", masqueradeValue)
 	logger.V(2).Info("Using iptables mark for masquerade", "mark", masqueradeMark)
 
@@ -268,6 +258,9 @@ func NewProxier(ctx context.Context,
 	if err != nil {
 		logger.Error(err, "Failed to create nfacct runner, nfacct based metrics won't be available")
 	}
+
+	syncPeriod := config.SyncPeriod.Duration
+	minSyncPeriod := config.MinSyncPeriod.Duration
 
 	proxier := &Proxier{
 		ipFamily:                 ipFamily,
@@ -278,7 +271,7 @@ func NewProxier(ctx context.Context,
 		needFullSync:             true,
 		syncPeriod:               syncPeriod,
 		iptables:                 ipt,
-		masqueradeAll:            masqueradeAll,
+		masqueradeAll:            config.Linux.MasqueradeAll,
 		masqueradeMark:           masqueradeMark,
 		conntrack:                conntrack.New(),
 		nfacct:                   nfacctRunner,

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -41,6 +41,7 @@ import (
 	utilsysctl "k8s.io/component-helpers/node/util/sysctl"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/proxy"
+	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 	"k8s.io/kubernetes/pkg/proxy/conntrack"
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	utilipset "k8s.io/kubernetes/pkg/proxy/ipvs/ipset"
@@ -108,43 +109,29 @@ const (
 // NewDualStackProxier returns a new Proxier for dual-stack operation
 func NewDualStackProxier(
 	ctx context.Context,
+	config *kubeproxyconfig.KubeProxyConfiguration,
 	ipts map[v1.IPFamily]utiliptables.Interface,
 	ipvs utilipvs.Interface,
 	ipset utilipset.Interface,
 	sysctl utilsysctl.Interface,
-	syncPeriod time.Duration,
-	minSyncPeriod time.Duration,
-	excludeCIDRs []string,
-	strictARP bool,
-	tcpTimeout time.Duration,
-	tcpFinTimeout time.Duration,
-	udpTimeout time.Duration,
-	masqueradeAll bool,
-	masqueradeBit int,
 	localDetectors map[v1.IPFamily]proxyutil.LocalTrafficDetector,
 	nodeName string,
 	nodeIPs map[v1.IPFamily]net.IP,
 	recorder events.EventRecorder,
 	healthzServer *healthcheck.ProxyHealthServer,
-	scheduler string,
-	nodePortAddresses []string,
 	initOnly bool,
 ) (proxy.Provider, error) {
 	// Create an ipv4 instance of the single-stack proxier
-	ipv4Proxier, err := NewProxier(ctx, v1.IPv4Protocol, ipts[v1.IPv4Protocol], ipvs, ipset, sysctl,
-		syncPeriod, minSyncPeriod, filterCIDRs(false, excludeCIDRs), strictARP,
-		tcpTimeout, tcpFinTimeout, udpTimeout, masqueradeAll, masqueradeBit,
+	ipv4Proxier, err := NewProxier(ctx, config, v1.IPv4Protocol, ipts[v1.IPv4Protocol], ipvs, ipset, sysctl,
 		localDetectors[v1.IPv4Protocol], nodeName, nodeIPs[v1.IPv4Protocol], recorder,
-		healthzServer, scheduler, nodePortAddresses, initOnly)
+		healthzServer, initOnly)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create ipv4 proxier: %v", err)
 	}
 
-	ipv6Proxier, err := NewProxier(ctx, v1.IPv6Protocol, ipts[v1.IPv6Protocol], ipvs, ipset, sysctl,
-		syncPeriod, minSyncPeriod, filterCIDRs(true, excludeCIDRs), strictARP,
-		tcpTimeout, tcpFinTimeout, udpTimeout, masqueradeAll, masqueradeBit,
+	ipv6Proxier, err := NewProxier(ctx, config, v1.IPv6Protocol, ipts[v1.IPv6Protocol], ipvs, ipset, sysctl,
 		localDetectors[v1.IPv6Protocol], nodeName, nodeIPs[v1.IPv6Protocol], recorder,
-		healthzServer, scheduler, nodePortAddresses, initOnly)
+		healthzServer, initOnly)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create ipv6 proxier: %v", err)
 	}
@@ -254,27 +241,17 @@ var _ proxy.Provider = &Proxier{}
 // NewProxier returns a new single-stack IPVS proxier.
 func NewProxier(
 	ctx context.Context,
+	config *kubeproxyconfig.KubeProxyConfiguration,
 	ipFamily v1.IPFamily,
 	ipt utiliptables.Interface,
 	ipvs utilipvs.Interface,
 	ipset utilipset.Interface,
 	sysctl utilsysctl.Interface,
-	syncPeriod time.Duration,
-	minSyncPeriod time.Duration,
-	excludeCIDRs []string,
-	strictARP bool,
-	tcpTimeout time.Duration,
-	tcpFinTimeout time.Duration,
-	udpTimeout time.Duration,
-	masqueradeAll bool,
-	masqueradeBit int,
 	localDetector proxyutil.LocalTrafficDetector,
 	nodeName string,
 	nodeIP net.IP,
 	recorder events.EventRecorder,
 	healthzServer *healthcheck.ProxyHealthServer,
-	scheduler string,
-	nodePortAddressStrings []string,
 	initOnly bool,
 ) (*Proxier, error) {
 	logger := klog.LoggerWithValues(klog.FromContext(ctx), "ipFamily", ipFamily)
@@ -315,7 +292,7 @@ func NewProxier(
 		return nil, err
 	}
 
-	if strictARP {
+	if config.IPVS.StrictARP {
 		// Set the arp_ignore sysctl we need for
 		if err := proxyutil.EnsureSysctl(sysctl, sysctlArpIgnore, 1); err != nil {
 			return nil, err
@@ -330,6 +307,9 @@ func NewProxier(
 	// Configure IPVS timeouts if any one of the timeout parameters have been set.
 	// This is the equivalent to running ipvsadm --set, a value of 0 indicates the
 	// current system timeout should be preserved
+	tcpTimeout := config.IPVS.TCPTimeout.Duration
+	tcpFinTimeout := config.IPVS.TCPFinTimeout.Duration
+	udpTimeout := config.IPVS.UDPTimeout.Duration
 	if tcpTimeout > 0 || tcpFinTimeout > 0 || udpTimeout > 0 {
 		if err := ipvs.ConfigureTimeouts(tcpTimeout, tcpFinTimeout, udpTimeout); err != nil {
 			logger.Error(err, "Failed to configure IPVS timeouts")
@@ -342,21 +322,25 @@ func NewProxier(
 	}
 
 	// Generate the masquerade mark to use for SNAT rules.
-	masqueradeValue := 1 << uint(masqueradeBit)
+	masqueradeValue := 1 << uint(*config.IPTables.MasqueradeBit)
 	masqueradeMark := fmt.Sprintf("%#08x", masqueradeValue)
 
 	logger.V(2).Info("Record nodeIP and family", "nodeIP", nodeIP, "family", ipFamily)
 
+	scheduler := config.IPVS.Scheduler
 	if len(scheduler) == 0 {
 		logger.Info("IPVS scheduler not specified, use rr by default")
 		scheduler = defaultScheduler
 	}
 
-	nodePortAddresses := proxyutil.NewNodePortAddresses(ipFamily, nodePortAddressStrings)
+	nodePortAddresses := proxyutil.NewNodePortAddresses(ipFamily, config.NodePortAddresses)
 
 	serviceHealthServer := healthcheck.NewServiceHealthServer(nodeName, recorder, nodePortAddresses, healthzServer, ipFamily)
 
-	// excludeCIDRs has been validated before, here we just parse it to IPNet list
+	syncPeriod := config.SyncPeriod.Duration
+	minSyncPeriod := config.MinSyncPeriod.Duration
+
+	excludeCIDRs := filterCIDRs(ipFamily == v1.IPv6Protocol, config.IPVS.ExcludeCIDRs)
 	parsedExcludeCIDRs, _ := netutils.ParseCIDRs(excludeCIDRs)
 
 	proxier := &Proxier{
@@ -370,7 +354,7 @@ func NewProxier(
 		minSyncPeriod:         minSyncPeriod,
 		excludeCIDRs:          parsedExcludeCIDRs,
 		iptables:              ipt,
-		masqueradeAll:         masqueradeAll,
+		masqueradeAll:         config.Linux.MasqueradeAll,
 		masqueradeMark:        masqueradeMark,
 		conntrack:             conntrack.New(),
 		localDetector:         localDetector,

--- a/pkg/proxy/kubemark/hollow_proxy.go
+++ b/pkg/proxy/kubemark/hollow_proxy.go
@@ -28,7 +28,7 @@ import (
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/events"
 	proxyapp "k8s.io/kubernetes/cmd/kube-proxy/app"
-	proxyconfigapi "k8s.io/kubernetes/pkg/proxy/apis/config"
+	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 	"k8s.io/utils/ptr"
 )
 
@@ -62,10 +62,10 @@ func NewHollowProxy(
 ) *HollowProxy {
 	return &HollowProxy{
 		ProxyServer: &proxyapp.ProxyServer{
-			Config: &proxyconfigapi.KubeProxyConfiguration{
-				Mode:             proxyconfigapi.ProxyMode("fake"),
+			Config: &kubeproxyconfig.KubeProxyConfiguration{
+				Mode:             kubeproxyconfig.ProxyMode("fake"),
 				ConfigSyncPeriod: metav1.Duration{Duration: 30 * time.Second},
-				Linux: proxyconfigapi.KubeProxyLinuxConfiguration{
+				Linux: kubeproxyconfig.KubeProxyLinuxConfiguration{
 					OOMScoreAdj: ptr.To[int32](0),
 				},
 			},

--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/client-go/tools/events"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/proxy"
+	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 	"k8s.io/kubernetes/pkg/proxy/conntrack"
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	"k8s.io/kubernetes/pkg/proxy/metaproxier"
@@ -100,31 +101,25 @@ const (
 // NewDualStackProxier creates a MetaProxier instance, with IPv4 and IPv6 proxies.
 func NewDualStackProxier(
 	ctx context.Context,
-	syncPeriod time.Duration,
-	minSyncPeriod time.Duration,
-	masqueradeAll bool,
-	masqueradeBit int,
+	config *kubeproxyconfig.KubeProxyConfiguration,
 	localDetectors map[v1.IPFamily]proxyutil.LocalTrafficDetector,
 	nodeName string,
 	nodeIPs map[v1.IPFamily]net.IP,
 	recorder events.EventRecorder,
 	healthzServer *healthcheck.ProxyHealthServer,
-	nodePortAddresses []string,
 	initOnly bool,
 ) (proxy.Provider, error) {
 	// Create an ipv4 instance of the single-stack proxier
-	ipv4Proxier, err := NewProxier(ctx, v1.IPv4Protocol,
-		syncPeriod, minSyncPeriod, masqueradeAll, masqueradeBit,
+	ipv4Proxier, err := NewProxier(ctx, config, v1.IPv4Protocol,
 		localDetectors[v1.IPv4Protocol], nodeName, nodeIPs[v1.IPv4Protocol],
-		recorder, healthzServer, nodePortAddresses, initOnly)
+		recorder, healthzServer, initOnly)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create ipv4 proxier: %v", err)
 	}
 
-	ipv6Proxier, err := NewProxier(ctx, v1.IPv6Protocol,
-		syncPeriod, minSyncPeriod, masqueradeAll, masqueradeBit,
+	ipv6Proxier, err := NewProxier(ctx, config, v1.IPv6Protocol,
 		localDetectors[v1.IPv6Protocol], nodeName, nodeIPs[v1.IPv6Protocol],
-		recorder, healthzServer, nodePortAddresses, initOnly)
+		recorder, healthzServer, initOnly)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create ipv6 proxier: %v", err)
 	}
@@ -205,17 +200,13 @@ var _ proxy.Provider = &Proxier{}
 
 // NewProxier returns a new single-stack NFTables proxier.
 func NewProxier(ctx context.Context,
+	config *kubeproxyconfig.KubeProxyConfiguration,
 	ipFamily v1.IPFamily,
-	syncPeriod time.Duration,
-	minSyncPeriod time.Duration,
-	masqueradeAll bool,
-	masqueradeBit int,
 	localDetector proxyutil.LocalTrafficDetector,
 	nodeName string,
 	nodeIP net.IP,
 	recorder events.EventRecorder,
 	healthzServer *healthcheck.ProxyHealthServer,
-	nodePortAddressStrings []string,
 	initOnly bool,
 ) (*Proxier, error) {
 	logger := klog.LoggerWithValues(klog.FromContext(ctx), "ipFamily", ipFamily)
@@ -231,13 +222,16 @@ func NewProxier(ctx context.Context,
 	}
 
 	// Generate the masquerade mark to use for SNAT rules.
-	masqueradeValue := 1 << uint(masqueradeBit)
+	masqueradeValue := 1 << uint(*config.NFTables.MasqueradeBit)
 	masqueradeMark := fmt.Sprintf("%#08x", masqueradeValue)
 	logger.V(2).Info("Using nftables mark for masquerade", "mark", masqueradeMark)
 
-	nodePortAddresses := proxyutil.NewNodePortAddresses(ipFamily, nodePortAddressStrings)
+	nodePortAddresses := proxyutil.NewNodePortAddresses(ipFamily, config.NodePortAddresses)
 
 	serviceHealthServer := healthcheck.NewServiceHealthServer(nodeName, recorder, nodePortAddresses, healthzServer, ipFamily)
+
+	syncPeriod := config.SyncPeriod.Duration
+	minSyncPeriod := config.MinSyncPeriod.Duration
 
 	proxier := &Proxier{
 		ipFamily:            ipFamily,
@@ -248,7 +242,7 @@ func NewProxier(ctx context.Context,
 		needFullSync:        true,
 		syncPeriod:          syncPeriod,
 		nftables:            nft,
-		masqueradeAll:       masqueradeAll,
+		masqueradeAll:       config.Linux.MasqueradeAll,
 		masqueradeMark:      masqueradeMark,
 		masqueradeRule:      fmt.Sprintf("mark set mark or %s", masqueradeMark),
 		conntrack:           conntrack.New(),

--- a/pkg/proxy/node.go
+++ b/pkg/proxy/node.go
@@ -35,6 +35,7 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 	utilnode "k8s.io/kubernetes/pkg/util/node"
 )
 
@@ -61,8 +62,10 @@ type NodeManager struct {
 // NewNodeManager doesn't return any error if it failed to retrieve NodeIPs and watchPodCIDRs
 // is false.
 func NewNodeManager(ctx context.Context, client clientset.Interface,
-	resyncInterval time.Duration, nodeName string, watchPodCIDRs bool,
+	nodeName string, config *kubeproxyconfig.KubeProxyConfiguration,
 ) (*NodeManager, error) {
+	resyncInterval := config.ConfigSyncPeriod.Duration
+	watchPodCIDRs := config.DetectLocalMode == kubeproxyconfig.LocalModeNodeCIDR
 	return newNodeManager(ctx, client, resyncInterval, nodeName, watchPodCIDRs, os.Exit, time.Second, 30*time.Second, 5*time.Minute)
 }
 

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -641,23 +641,20 @@ var _ proxy.Provider = &Proxier{}
 
 // NewProxier returns a new single-stack winkernel proxier.
 func NewProxier(
+	config *kubeproxyconfig.KubeProxyConfiguration,
 	ipFamily v1.IPFamily,
-	syncPeriod time.Duration,
-	minSyncPeriod time.Duration,
 	nodeName string,
 	nodeIP net.IP,
 	recorder events.EventRecorder,
 	healthzServer *healthcheck.ProxyHealthServer,
-	healthzBindAddress string,
-	config kubeproxyconfig.KubeProxyWinkernelConfiguration,
 ) (*Proxier, error) {
 	// windows listens to all node addresses
 	nodePortAddresses := proxyutil.NewNodePortAddresses(ipFamily, nil)
 	serviceHealthServer := healthcheck.NewServiceHealthServer(nodeName, recorder, nodePortAddresses, healthzServer, ipFamily)
 
 	var healthzPort int
-	if len(healthzBindAddress) > 0 {
-		_, port, _ := net.SplitHostPort(healthzBindAddress)
+	if len(config.HealthzBindAddress) > 0 {
+		_, port, _ := net.SplitHostPort(config.HealthzBindAddress)
 		healthzPort, _ = strconv.Atoi(port)
 	}
 
@@ -671,12 +668,15 @@ func NewProxier(
 		healthzPort,
 		hcnImpl,
 		&localHostMacProvider{},
-		config,
+		config.Winkernel,
 		true, // waitForHNSOverlay
 	)
 	if err != nil {
 		return nil, err
 	}
+
+	syncPeriod := config.SyncPeriod.Duration
+	minSyncPeriod := config.MinSyncPeriod.Duration
 
 	klog.V(3).Info("Record sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod, "maxSyncPeriod", syncPeriod)
 	proxier.syncRunner = runner.NewBoundedFrequencyRunner("sync-runner", proxier.syncProxyRules, minSyncPeriod, syncPeriod, syncPeriod)
@@ -799,28 +799,22 @@ func newProxierInternal(
 }
 
 func NewDualStackProxier(
-	syncPeriod time.Duration,
-	minSyncPeriod time.Duration,
+	config *kubeproxyconfig.KubeProxyConfiguration,
 	nodeName string,
 	nodeIPs map[v1.IPFamily]net.IP,
 	recorder events.EventRecorder,
 	healthzServer *healthcheck.ProxyHealthServer,
-	healthzBindAddress string,
-	config kubeproxyconfig.KubeProxyWinkernelConfiguration,
 ) (proxy.Provider, error) {
 
 	// Create an ipv4 instance of the single-stack proxier
-	ipv4Proxier, err := NewProxier(v1.IPv4Protocol, syncPeriod, minSyncPeriod,
-		nodeName, nodeIPs[v1.IPv4Protocol], recorder, healthzServer,
-		healthzBindAddress, config)
-
+	ipv4Proxier, err := NewProxier(config, v1.IPv4Protocol,
+		nodeName, nodeIPs[v1.IPv4Protocol], recorder, healthzServer)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create ipv4 proxier: %v, nodeName: %s, nodeIP:%v", err, nodeName, nodeIPs[v1.IPv4Protocol])
 	}
 
-	ipv6Proxier, err := NewProxier(v1.IPv6Protocol, syncPeriod, minSyncPeriod,
-		nodeName, nodeIPs[v1.IPv6Protocol], recorder, healthzServer,
-		healthzBindAddress, config)
+	ipv6Proxier, err := NewProxier(config, v1.IPv6Protocol,
+		nodeName, nodeIPs[v1.IPv6Protocol], recorder, healthzServer)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create ipv6 proxier: %v, nodeName: %s, nodeIP:%v", err, nodeName, nodeIPs[v1.IPv6Protocol])
 	}

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -42,7 +42,7 @@ import (
 	"k8s.io/klog/v2"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/proxy"
-	"k8s.io/kubernetes/pkg/proxy/apis/config"
+	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	"k8s.io/kubernetes/pkg/proxy/metaproxier"
 	"k8s.io/kubernetes/pkg/proxy/metrics"
@@ -649,7 +649,7 @@ func NewProxier(
 	recorder events.EventRecorder,
 	healthzServer *healthcheck.ProxyHealthServer,
 	healthzBindAddress string,
-	config config.KubeProxyWinkernelConfiguration,
+	config kubeproxyconfig.KubeProxyWinkernelConfiguration,
 ) (*Proxier, error) {
 	// windows listens to all node addresses
 	nodePortAddresses := proxyutil.NewNodePortAddresses(ipFamily, nil)
@@ -694,7 +694,7 @@ func newProxierInternal(
 	healthzPort int,
 	hcnImpl HcnService,
 	hostMacProvider HostMacProvider,
-	config config.KubeProxyWinkernelConfiguration,
+	config kubeproxyconfig.KubeProxyWinkernelConfiguration,
 	waitForHNSOverlay bool,
 ) (*Proxier, error) {
 	hns, supportedFeatures := newHostNetworkService(hcnImpl)
@@ -806,7 +806,7 @@ func NewDualStackProxier(
 	recorder events.EventRecorder,
 	healthzServer *healthcheck.ProxyHealthServer,
 	healthzBindAddress string,
-	config config.KubeProxyWinkernelConfiguration,
+	config kubeproxyconfig.KubeProxyWinkernelConfiguration,
 ) (proxy.Provider, error) {
 
 	// Create an ipv4 instance of the single-stack proxier

--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -37,7 +37,7 @@ import (
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/proxy"
-	"k8s.io/kubernetes/pkg/proxy/apis/config"
+	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
 	"k8s.io/kubernetes/pkg/proxy/healthcheck"
 	fakehcn "k8s.io/kubernetes/pkg/proxy/winkernel/testing"
 	netutils "k8s.io/utils/net"
@@ -113,7 +113,7 @@ func NewFakeProxier(t *testing.T, nodeName string, nodeIP net.IP, networkType st
 	// enable `WinDSR` feature gate
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, kubefeatures.WinDSR, true)
 
-	config := config.KubeProxyWinkernelConfiguration{
+	config := kubeproxyconfig.KubeProxyWinkernelConfiguration{
 		SourceVip:             sourceVip,
 		EnableDSR:             enableDSR,
 		NetworkName:           testNetwork,


### PR DESCRIPTION
/kind cleanup
/sig network
/area kube-proxy

#### What this PR does / why we need it:
Part of #135546; this makes all of the kube-proxy backends take a complete `kubeproxyconfig.KubeProxyConfiguration` object, rather than having the `cmd/kube-proxy` code need to know specifically which config items each backend cares about.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
