### PR TITLE
test: fill remaining gaps in declarative validation equivalence test

### DIFF
--- a/pkg/apis/resource/v1alpha3/zz_generated.validations.go
+++ b/pkg/apis/resource/v1alpha3/zz_generated.validations.go
@@ -96,7 +96,7 @@ func Validate_DeviceTaint(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -126,7 +126,7 @@ func Validate_DeviceTaintEffect(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *resourcev1alpha3.DeviceTaintEffect) (errs field.ErrorList) {
 
-	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTaintEffect, nil); len(e) != 0 {
+	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForDeviceTaintEffect, nil).MarkAlpha(); len(e) != 0 {
 		errs = append(errs, e...)
 	}
 

--- a/pkg/registry/rbac/clusterrolebinding/declarative_validation_test.go
+++ b/pkg/registry/rbac/clusterrolebinding/declarative_validation_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterrolebinding
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	rbac "k8s.io/kubernetes/pkg/apis/rbac"
+)
+
+var apiVersions = []string{"v1", "v1alpha1", "v1beta1"}
+
+func TestDeclarativeValidateForDeclarative(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		testDeclarativeValidateForDeclarative(t, apiVersion)
+	}
+}
+
+func testDeclarativeValidateForDeclarative(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:   "rbac.authorization.k8s.io",
+		APIVersion: apiVersion,
+	})
+	testCases := map[string]struct {
+		input        rbac.ClusterRoleBinding
+		expectedErrs field.ErrorList
+	}{
+		"valid": {
+			input: mkValidClusterRoleBinding(),
+		},
+		"missing roleRef.name": {
+			input: mkValidClusterRoleBinding(tweakRoleRefName("")),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("roleRef", "name"), "").MarkAlpha(),
+			},
+		},
+		"missing subjects[0].name": {
+			input: mkValidClusterRoleBinding(tweakSubjectName(0, "")),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("subjects").Index(0).Child("name"), "").MarkAlpha(),
+			},
+		},
+		// TODO: Add more test cases
+	}
+	for k, tc := range testCases {
+		t.Run(k, func(t *testing.T) {
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy, tc.expectedErrs)
+		})
+	}
+}
+
+func TestValidateUpdateForDeclarative(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		testValidateUpdateForDeclarative(t, apiVersion)
+	}
+}
+
+func testValidateUpdateForDeclarative(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:   "rbac.authorization.k8s.io",
+		APIVersion: apiVersion,
+	})
+	testCases := map[string]struct {
+		old          rbac.ClusterRoleBinding
+		update       rbac.ClusterRoleBinding
+		expectedErrs field.ErrorList
+	}{
+		"valid update": {
+			old:    mkValidClusterRoleBinding(),
+			update: mkValidClusterRoleBinding(),
+		},
+		"invalid update clearing subjects[0].name": {
+			old:    mkValidClusterRoleBinding(),
+			update: mkValidClusterRoleBinding(tweakSubjectName(0, "")),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("subjects").Index(0).Child("name"), "").MarkAlpha(),
+			},
+		},
+		// TODO: Add more test cases
+	}
+	for k, tc := range testCases {
+		t.Run(k, func(t *testing.T) {
+			tc.old.ResourceVersion = "1"
+			tc.update.ResourceVersion = "2"
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy, tc.expectedErrs)
+		})
+	}
+}
+
+func mkValidClusterRoleBinding(tweaks ...func(*rbac.ClusterRoleBinding)) rbac.ClusterRoleBinding {
+	crb := rbac.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "valid-cluster-role-binding",
+		},
+		RoleRef: rbac.RoleRef{
+			APIGroup: rbac.GroupName,
+			Kind:     "ClusterRole",
+			Name:     "admin",
+		},
+		Subjects: []rbac.Subject{
+			{Kind: rbac.UserKind, APIGroup: rbac.GroupName, Name: "user1"},
+		},
+	}
+
+	for _, tweak := range tweaks {
+		tweak(&crb)
+	}
+	return crb
+}
+
+func tweakRoleRefName(name string) func(*rbac.ClusterRoleBinding) {
+	return func(crb *rbac.ClusterRoleBinding) {
+		crb.RoleRef.Name = name
+	}
+}
+
+func tweakSubjectName(index int, name string) func(*rbac.ClusterRoleBinding) {
+	return func(crb *rbac.ClusterRoleBinding) {
+		if index < len(crb.Subjects) {
+			crb.Subjects[index].Name = name
+		}
+	}
+}

--- a/pkg/registry/resource/devicetaintrule/declarative_validation_test.go
+++ b/pkg/registry/resource/devicetaintrule/declarative_validation_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package devicetaintrule
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/apis/resource"
+)
+
+var apiVersions = []string{"v1alpha3", "v1beta2"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:   "resource.k8s.io",
+		APIVersion: apiVersion,
+		Resource:   "devicetaintrules",
+	})
+
+	testCases := map[string]struct {
+		input        resource.DeviceTaintRule
+		expectedErrs field.ErrorList
+	}{
+		"valid": {
+			input: mkValidDeviceTaintRule(),
+		},
+		"missing taint.effect": {
+			input: mkValidDeviceTaintRule(tweakTaintEffect("")),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "taint", "effect"), "").MarkAlpha(),
+			},
+		},
+		"invalid taint.effect": {
+			input: mkValidDeviceTaintRule(tweakTaintEffect("BadEffect")),
+			expectedErrs: field.ErrorList{
+				field.NotSupported(field.NewPath("spec", "taint", "effect"), resource.DeviceTaintEffect("BadEffect"), []resource.DeviceTaintEffect{}).MarkAlpha(),
+			},
+		},
+		// TODO: Add more test cases
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy, tc.expectedErrs)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:   "resource.k8s.io",
+		APIVersion: apiVersion,
+		Resource:   "devicetaintrules",
+	})
+
+	testCases := map[string]struct {
+		old          resource.DeviceTaintRule
+		update       resource.DeviceTaintRule
+		expectedErrs field.ErrorList
+	}{
+		"valid update (no spec change)": {
+			old:    mkValidDeviceTaintRule(),
+			update: mkValidDeviceTaintRule(),
+		},
+		"valid update changing effect": {
+			old:    mkValidDeviceTaintRule(),
+			update: mkValidDeviceTaintRule(tweakTaintEffect(resource.DeviceTaintEffectNoSchedule)),
+		},
+		"invalid update clearing effect": {
+			old:    mkValidDeviceTaintRule(),
+			update: mkValidDeviceTaintRule(tweakTaintEffect("")),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "taint", "effect"), "").MarkAlpha(),
+			},
+		},
+		// TODO: Add more test cases
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tc.old.ResourceVersion = "1"
+			tc.update.ResourceVersion = "2"
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy, tc.expectedErrs)
+		})
+	}
+}
+
+func mkValidDeviceTaintRule(tweaks ...func(*resource.DeviceTaintRule)) resource.DeviceTaintRule {
+	rule := resource.DeviceTaintRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "valid-rule",
+		},
+		Spec: resource.DeviceTaintRuleSpec{
+			Taint: resource.DeviceTaint{
+				Key:    "example.com/tainted",
+				Effect: resource.DeviceTaintEffectNoExecute,
+			},
+		},
+	}
+	for _, tweak := range tweaks {
+		tweak(&rule)
+	}
+	return rule
+}
+
+func tweakTaintEffect(effect resource.DeviceTaintEffect) func(*resource.DeviceTaintRule) {
+	return func(r *resource.DeviceTaintRule) {
+		r.Spec.Taint.Effect = effect
+	}
+}

--- a/pkg/registry/resource/resourceclaimtemplate/declarative_validation_test.go
+++ b/pkg/registry/resource/resourceclaimtemplate/declarative_validation_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourceclaimtemplate
+
+import (
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/kubernetes/fake"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/apis/resource"
+)
+
+var apiVersions = []string{"v1beta1", "v1beta2", "v1"}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:   "resource.k8s.io",
+		APIVersion: apiVersion,
+		Resource:   "resourceclaimtemplates",
+	})
+	fakeClient := fake.NewClientset()
+	nsClient := fakeClient.CoreV1().Namespaces()
+	Strategy := NewStrategy(nsClient)
+
+	testCases := map[string]struct {
+		input        resource.ResourceClaimTemplate
+		expectedErrs field.ErrorList
+	}{
+		"valid": {
+			input: mkValidResourceClaimTemplate(),
+		},
+		"invalid requests, too many": {
+			input: mkValidResourceClaimTemplate(tweakDevicesRequests(33)),
+			expectedErrs: field.ErrorList{
+				field.TooMany(field.NewPath("spec", "spec", "devices", "requests"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+			},
+		},
+		"invalid requests, duplicate name": {
+			input: mkValidResourceClaimTemplate(tweakAddDeviceRequest(mkDeviceRequest("req-0"))),
+			expectedErrs: field.ErrorList{
+				field.Duplicate(field.NewPath("spec", "spec", "devices", "requests").Index(1), "req-0").MarkAlpha(),
+			},
+		},
+		// TODO: Add more test cases
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy, tc.expectedErrs)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			testDeclarativeValidateUpdate(t, apiVersion)
+		})
+	}
+}
+
+func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:   "resource.k8s.io",
+		APIVersion: apiVersion,
+		Resource:   "resourceclaimtemplates",
+	})
+	fakeClient := fake.NewClientset()
+	nsClient := fakeClient.CoreV1().Namespaces()
+	Strategy := NewStrategy(nsClient)
+
+	testCases := map[string]struct {
+		old          resource.ResourceClaimTemplate
+		update       resource.ResourceClaimTemplate
+		expectedErrs field.ErrorList
+	}{
+		"valid update (no spec change)": {
+			old:    mkValidResourceClaimTemplate(),
+			update: mkValidResourceClaimTemplate(),
+		},
+		// TODO: Add more test cases
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tc.old.ResourceVersion = "1"
+			tc.update.ResourceVersion = "2"
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy, tc.expectedErrs)
+		})
+	}
+}
+
+func mkValidResourceClaimTemplate(tweaks ...func(rct *resource.ResourceClaimTemplate)) resource.ResourceClaimTemplate {
+	rct := resource.ResourceClaimTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "valid-claim-template",
+			Namespace: "default",
+		},
+		Spec: resource.ResourceClaimTemplateSpec{
+			Spec: resource.ResourceClaimSpec{
+				Devices: resource.DeviceClaim{
+					Requests: []resource.DeviceRequest{
+						mkDeviceRequest("req-0"),
+					},
+				},
+			},
+		},
+	}
+	for _, tweak := range tweaks {
+		tweak(&rct)
+	}
+	return rct
+}
+
+func mkDeviceRequest(name string) resource.DeviceRequest {
+	return resource.DeviceRequest{
+		Name: name,
+		Exactly: &resource.ExactDeviceRequest{
+			DeviceClassName: "class",
+			AllocationMode:  resource.DeviceAllocationModeExactCount,
+			Count:           1,
+		},
+	}
+}
+
+func tweakDevicesRequests(items int) func(*resource.ResourceClaimTemplate) {
+	return func(rct *resource.ResourceClaimTemplate) {
+		// The first request already exists in the valid template
+		for i := 1; i < items; i++ {
+			rct.Spec.Spec.Devices.Requests = append(rct.Spec.Spec.Devices.Requests, mkDeviceRequest(fmt.Sprintf("req-%d", i)))
+		}
+	}
+}
+
+func tweakAddDeviceRequest(req resource.DeviceRequest) func(*resource.ResourceClaimTemplate) {
+	return func(rct *resource.ResourceClaimTemplate) {
+		rct.Spec.Spec.Devices.Requests = append(rct.Spec.Spec.Devices.Requests, req)
+	}
+}

--- a/staging/src/k8s.io/api/resource/v1alpha3/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1alpha3/generated.proto
@@ -120,7 +120,7 @@ message DeviceTaint {
   // Consumers must treat unknown effects like None.
   //
   // +required
-  // +k8s:required
+  // +k8s:alpha(since: "1.36")=+k8s:required
   optional string effect = 3;
 
   // TimeAdded represents the time at which the taint was added or

--- a/staging/src/k8s.io/api/resource/v1alpha3/types.go
+++ b/staging/src/k8s.io/api/resource/v1alpha3/types.go
@@ -140,7 +140,7 @@ type DeviceTaint struct {
 	// Consumers must treat unknown effects like None.
 	//
 	// +required
-	// +k8s:required
+	// +k8s:alpha(since: "1.36")=+k8s:required
 	Effect DeviceTaintEffect `json:"effect" protobuf:"bytes,3,name=effect,casttype=DeviceTaintEffect"`
 
 	// ^^^^
@@ -179,7 +179,7 @@ type DeviceTaint struct {
 }
 
 // +enum
-// +k8s:enum
+// +k8s:alpha(since: "1.36")=+k8s:enum
 type DeviceTaintEffect string
 
 const (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
/kind api-change

#### What this PR does / why we need it:
A follow up of https://github.com/kubernetes/kubernetes/pull/138323

Adds `declarative_validation_test.go` for three resources whose strategies opt-in to declarative validation and have generated DV rules but lacked an HV/DV equivalence test:
  - pkg/registry/rbac/clusterrolebinding/ — covers roleRef.name and subjects[].name (both Alpha)
  - pkg/registry/resource/resourceclaimtemplate/ — covers spec.spec.devices.*  (delegates to the shared Validate_ResourceClaimSpec)
  - pkg/registry/resource/devicetaintrule/ — covers spec.taint.effect (Required + Enum)

  Also fixes a cross-version inconsistency surfaced while writing the test: DeviceTaint.Effect and DeviceTaintEffect were tagged `+k8s:required` / `+k8s:enum`  in v1alpha3 but `+k8s:alpha(since: "1.36")=+k8s:required` / =+k8s:enum in v1beta2. The same field/rule was at different maturities across versions of the same API. 

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Ref: https://github.com/kubernetes/kubernetes/issues/138697

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
