### PR TITLE
feat: add declarative-validation rule test coverage guardrail

### DIFF
--- a/hack/declarative-validation-coverage-allowlist.yaml
+++ b/hack/declarative-validation-coverage-allowlist.yaml
@@ -1,0 +1,80 @@
+# Suppressions for the declarative-validation coverage verifier.
+#
+# Each entry filters Uncovered rules by literal-equality on the named fields.
+# Any empty field acts as a wildcard. Combine fields to narrow the scope.
+# `reason` is required and read by sig-api-machinery reviewers — explain
+# why the rule cannot (or should not) be covered by a test.
+#
+# Available fields:
+#   group, version, kind  — GVK selector
+#   path                  — exact field path emitted by validation-gen
+#                           (e.g. "spec.config[*].opaque.driver")
+#   errorType             — field.Error type (e.g. FieldValueRequired,
+#                           FieldValueInvalid, FieldValueNotSupported,
+#                           FieldValueTooLong, FieldValueForbidden)
+#   origin                — origin tag from .WithOrigin (e.g. "minimum",
+#                           "maxLength", "format=k8s-long-name"). Empty
+#                           string matches rules without an origin.
+#   reason                — required, free-form
+#
+# Examples:
+#
+# 1) Whole group/version (use sparingly — see extensions/v1beta1 below):
+#
+#    - group: extensions
+#      version: v1beta1
+#      reason: deprecated group, not served
+#
+# 2) One specific field/error combination on a single Kind:
+#
+#    - group: autoscaling
+#      version: v1
+#      kind: Scale
+#      path: spec.replicas
+#      errorType: FieldValueInvalid
+#      origin: minimum
+#      reason: |
+#        Scale subresource is exercised through HPA tests, not as a
+#        standalone object; minimum-replicas check is covered indirectly.
+#
+# 3) Every error on one path (omit errorType / origin):
+#
+#    - group: resource.k8s.io
+#      version: v1
+#      kind: ResourceClaim
+#      path: status.allocation.devices.config[*].opaque.driver
+#      reason: tracked in #NNNNN — adding status fixture for opaque.driver
+#
+# 4) All rules with a particular origin across a Kind:
+#
+#    - kind: PriorityLevelConfiguration
+#      errorType: FieldValueRequired
+#      reason: discriminator-required gap; awaiting imperative fix
+#
+# Run hack/verify-declarative-validation-coverage.sh after editing.
+
+- group: extensions
+  version: v1beta1
+  reason: Not served by kube-apiserver.
+
+- kind: Scale
+  path: spec.replicas
+  errorType: FieldValueInvalid
+  origin: minimum
+  reason: Scale subresource has no dedicated Strategy; tested separately.
+
+- group: scheduling.k8s.io
+  version: v1alpha2
+  kind: PodGroup
+  path: spec.priority
+  errorType: FieldValueInvalid
+  origin: minimum
+  reason: Unreachable constraint (+k8s:minimum=-2147483648 on int32 = math.MinInt32).
+
+- group: scheduling.k8s.io
+  version: v1alpha2
+  kind: Workload
+  path: spec.podGroupTemplates[*].priority
+  errorType: FieldValueInvalid
+  origin: minimum
+  reason: Unreachable constraint (+k8s:minimum=-2147483648 on int32 = math.MinInt32).

--- a/hack/verify-declarative-validation-coverage.sh
+++ b/hack/verify-declarative-validation-coverage.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script verifies that every declared declarative-validation rule has at
+# least one matching observation from a declarative_validation_test.go run.
+# Intentional gaps may be suppressed via hack/declarative-validation-coverage-allowlist.yaml.
+# Usage: `hack/verify-declarative-validation-coverage.sh [group ...]`.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+kube::golang::setup_env
+
+cd "${KUBE_ROOT}"
+
+# Optional positional args filter both DV-tagged and test packages by group
+# name (matched as a directory segment under apis/, api/, or registry/).
+# Set OUT_DIR to a writable path to keep artifacts (the declared-rules JSON
+# and the per-package observation directory) for inspection; otherwise
+# everything lands in a tmpdir cleaned at exit.
+
+if [[ -n "${OUT_DIR:-}" ]]; then
+    TMP="${OUT_DIR}"
+    kube::log::status "Writing artifacts to OUT_DIR=${TMP} (no cleanup)"
+else
+    TMP="$(mktemp -d -t verify-dv-coverage.XXXXXX)"
+    kube::util::trap_add "rm -rf ${TMP}" EXIT
+fi
+mkdir -p "${TMP}/actual"
+
+# readonly_pkgs mirrors hack/update-codegen.sh's validation-gen invocation
+# (codegen::validation): types used transitively from API types whose
+# validations are referenced but not regenerated here.
+readonly_pkgs=(
+    k8s.io/apimachinery/pkg/apis/meta/v1
+    k8s.io/apimachinery/pkg/api/resource
+    k8s.io/apimachinery/pkg/runtime
+    k8s.io/apimachinery/pkg/types
+    k8s.io/apimachinery/pkg/util/intstr
+    time
+)
+
+# Discover every DV-tagged package (mirrors update-codegen.sh's discovery).
+dv_pkgs=()
+kube::util::read-array dv_pkgs < <(
+    git grep --untracked -l '+k8s:validation-gen=' \
+        ':!:vendor/*' ':(glob)pkg/apis/**/doc.go' ':(glob)staging/src/k8s.io/api/**/doc.go' \
+        | while read -r f; do echo "./$(dirname "${f}")"; done \
+        | sort -u
+)
+# Discover every package containing a declarative_validation_test.go file.
+test_pkgs=()
+kube::util::read-array test_pkgs < <(
+    git grep --untracked -l . \
+        ':(glob)**/declarative_validation_test.go' ':!:vendor/*' \
+        | while read -r f; do echo "./$(dirname "${f}")"; done \
+        | sort -u
+)
+# Per-subresource test files don't match the strict glob; list them explicitly.
+test_pkgs+=(
+    ./pkg/registry/core/replicationcontroller/storage
+)
+
+if [[ $# -gt 0 ]]; then
+    # matches returns 0 if $1 contains any of the remaining args as a directory
+    # segment under apis/, api/, or registry/. Outer loop is over packages so
+    # repeated args (e.g. "autoscaling autoscaling") don't duplicate matches.
+    matches() {
+        local p=$1; shift
+        local g
+        for g in "$@"; do
+            [[ "$p" == */apis/"$g"/* || "$p" == */api/"$g"/* || "$p" == */registry/"$g"/* ]] && return 0
+        done
+        return 1
+    }
+    filtered_dv=() filtered_test=()
+    for p in "${dv_pkgs[@]}";   do matches "$p" "$@" && filtered_dv+=("$p");   done
+    for p in "${test_pkgs[@]}"; do matches "$p" "$@" && filtered_test+=("$p"); done
+    if [[ ${#filtered_dv[@]} -eq 0 && ${#filtered_test[@]} -eq 0 ]]; then
+        kube::log::error "no DV packages or test packages matched groups: $*"
+        exit 1
+    fi
+    dv_pkgs=("${filtered_dv[@]}")
+    test_pkgs=("${filtered_test[@]}")
+    kube::log::status "Filtered to groups: $*"
+fi
+
+kube::log::status "Found ${#dv_pkgs[@]} DV-tagged packages"
+kube::log::status "Found ${#test_pkgs[@]} packages with declarative_validation_test.go"
+
+# 1. Declared rules: one big JSON array of Reports across every (Group, Version).
+kube::log::status "Generating declared rules report"
+readonly_args=()
+for p in "${readonly_pkgs[@]}"; do readonly_args+=(--readonly-pkg "$p"); done
+go run ./staging/src/k8s.io/code-generator/cmd/validation-gen \
+    --report-rules \
+    "${readonly_args[@]}" \
+    "${dv_pkgs[@]}" \
+    > "${TMP}/expected.json"
+
+# 2. Observed rules: per-package files written by declarative_validation_test.go runs.
+# Skip the run when no test packages were found (e.g. group filter matched
+# only deprecated/unserved groups); the verifier still runs against an empty
+# observation set so allowlists can suppress the resulting "uncovered".
+if (( ${#test_pkgs[@]} > 0 )); then
+    kube::log::status "Running declarative_validation_test.go suites"
+    VALIDATION_RULES_REPORT_DIR="${TMP}/actual" \
+        go test -count=1 "${test_pkgs[@]}"
+else
+    kube::log::status "No declarative_validation_test.go suites to run"
+fi
+
+# 3. Diff. The verifier exits non-zero on uncovered rules and prints them.
+ALLOWLIST="${KUBE_ROOT}/hack/declarative-validation-coverage-allowlist.yaml"
+allowlist_arg=()
+if [[ -f "${ALLOWLIST}" ]]; then
+    allowlist_arg=(--allowlist="${ALLOWLIST}")
+    kube::log::status "Using allowlist: ${ALLOWLIST}"
+fi
+kube::log::status "Verifying coverage"
+go run ./test/declarative_validation verify-coverage \
+    --expected-rules="${TMP}/expected.json" \
+    --actual-rules-dir="${TMP}/actual" \
+    "${allowlist_arg[@]}"

--- a/pkg/api/testing/validation.go
+++ b/pkg/api/testing/validation.go
@@ -19,8 +19,14 @@ package testing
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
 	"sort"
 	"strconv"
+	"sync"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/operation"
@@ -29,10 +35,12 @@ import (
 	runtimetest "k8s.io/apimachinery/pkg/runtime/testing"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/util/version"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/registry/rest"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	validationmetrics "k8s.io/apiserver/pkg/validation"
+	"k8s.io/code-generator/pkg/guardrails"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/component-base/metrics/testutil"
@@ -294,7 +302,7 @@ func VerifyValidationEquivalence(t *testing.T, ctx context.Context, obj runtime.
 			errs = dv.ValidateDeclaratively(c, obj, nil, errs, operation.Create, dv.DeclarativeValidationConfig(c, obj, nil))
 		}
 		return errs
-	}, ctx, opts)
+	}, ctx, opts, obj)
 	VerifyVersionedValidationEquivalence(t, obj, nil, testConfigs...)
 }
 
@@ -329,12 +337,12 @@ func VerifyUpdateValidationEquivalence(t *testing.T, ctx context.Context, obj, o
 			errs = dv.ValidateDeclaratively(c, obj, old, errs, operation.Update, dv.DeclarativeValidationConfig(c, obj, old))
 		}
 		return errs
-	}, ctx, opts)
+	}, ctx, opts, obj)
 	VerifyVersionedValidationEquivalence(t, obj, old, testConfigs...)
 }
 
 // verifyValidationEquivalence is a generic helper that verifies validation equivalence with and without declarative validation.
-func verifyValidationEquivalence(t *testing.T, expectedErrs field.ErrorList, runValidations func(context.Context) field.ErrorList, ctx context.Context, opt *validationOption) {
+func verifyValidationEquivalence(t *testing.T, expectedErrs field.ErrorList, runValidations func(context.Context) field.ErrorList, ctx context.Context, opt *validationOption, obj runtime.Object) {
 	t.Helper()
 	var declarativeBetaEnabledErrs field.ErrorList
 	var declarativeBetaDisabledErrs field.ErrorList
@@ -433,6 +441,13 @@ func verifyValidationEquivalence(t *testing.T, expectedErrs field.ErrorList, run
 				filteredExpectedErrors = append(filteredExpectedErrors, err)
 			}
 		}
+		// Capture the full set of declarative errors (incl. Alpha) so the
+		// rule-coverage verifier can diff them against the rules declared
+		// by validation-gen --report-rules.
+		if dir := os.Getenv("VALIDATION_RULES_REPORT_DIR"); dir != "" {
+			reportRules(t, dir, ctx, obj, allDeclarativeErrs)
+		}
+
 		// The matcher here is more specific to ensure that errors from Alpha rules
 		// are included and matched correctly.
 		// This also ensure that errors are coming from the declarative validations only.
@@ -489,4 +504,78 @@ func deDuplicateErrors(errs field.ErrorList, matcher field.ErrorMatcher) field.E
 		}
 	}
 	return deduped
+}
+
+// reports accumulates the rules observed during this test process — same
+// shape as validation-gen --report-rules output, so the coverage verifier
+// can diff the two. Rewritten to disk after each update; the verifier
+// normalizes raw runtime paths ("[0]", "[my-key]" → "[*]") before diffing.
+var (
+	reports   []*guardrails.Report
+	reportsMu sync.Mutex
+)
+
+func reportRules(t *testing.T, dir string, ctx context.Context, obj runtime.Object, errs field.ErrorList) {
+	info, ok := genericapirequest.RequestInfoFrom(ctx)
+	if !ok {
+		return
+	}
+	// Prefer the scheme's canonical Kind; fall back to the Go type name.
+	kind := reflect.TypeOf(obj).Elem().Name()
+	if gvks, _, err := legacyscheme.Scheme.ObjectKinds(obj); err == nil && len(gvks) > 0 {
+		kind = gvks[0].Kind
+	}
+
+	reportsMu.Lock()
+	defer reportsMu.Unlock()
+
+	// Find or create the (group, version) entry.
+	var r *guardrails.Report
+	for _, existing := range reports {
+		if existing.Group == info.APIGroup && existing.Version == info.APIVersion {
+			r = existing
+			break
+		}
+	}
+	if r == nil {
+		r = &guardrails.Report{
+			Group:   info.APIGroup,
+			Version: info.APIVersion,
+			Kinds:   map[string]map[string][]guardrails.Rule{},
+		}
+		reports = append(reports, r)
+	}
+	fields, ok := r.Kinds[kind]
+	if !ok {
+		fields = map[string][]guardrails.Rule{}
+		r.Kinds[kind] = fields
+	}
+	added := false
+	for _, e := range errs {
+		rule := guardrails.Rule{ErrorType: string(e.Type), Origin: e.Origin}
+		if !slices.Contains(fields[e.Field], rule) {
+			fields[e.Field] = append(fields[e.Field], rule)
+			added = true
+		}
+	}
+	if !added {
+		return
+	}
+
+	out, err := json.MarshalIndent(reports, "", "  ")
+	if err != nil {
+		t.Logf("VALIDATION_RULES_REPORT_DIR marshal failed: %v", err)
+		return
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Logf("VALIDATION_RULES_REPORT_DIR mkdir failed: %v", err)
+		return
+	}
+	pkgName := "unknown"
+	if cwd, err := os.Getwd(); err == nil {
+		pkgName = filepath.Base(cwd)
+	}
+	if err := os.WriteFile(filepath.Join(dir, pkgName+".json"), append(out, '\n'), 0o644); err != nil {
+		t.Logf("VALIDATION_RULES_REPORT_DIR write failed: %v", err)
+	}
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/main.go
@@ -78,6 +78,7 @@ type Args struct {
 	ReadOnlyPkgs []string // Always consider these as last-ditch possibilities for validations.
 	GoHeaderFile string
 	PrintDocs    bool
+	PrintRules   bool
 }
 
 // AddFlags add the generator flags to the flag set.
@@ -90,14 +91,15 @@ func (args *Args) AddFlags(fs *pflag.FlagSet) {
 		"the path to a file containing boilerplate header text; the string \"YEAR\" will be replaced with the current 4-digit year")
 	fs.BoolVar(&args.PrintDocs, "docs", false,
 		"print documentation for supported declarative validations, and then exit")
+	fs.BoolVar(&args.PrintRules, "report-rules", false,
+		"print declared validation rules per (Group, Version, Kind) as JSON to stdout, and skip code generation")
 }
 
 // Validate checks the given arguments.
 func (args *Args) Validate() error {
-	if len(args.OutputFile) == 0 {
+	if len(args.OutputFile) == 0 && !args.PrintRules {
 		return fmt.Errorf("--output-file must be specified")
 	}
-
 	return nil
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/report.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/report.go
@@ -1,0 +1,141 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"strings"
+
+	"k8s.io/code-generator/cmd/validation-gen/validators"
+	"k8s.io/code-generator/pkg/guardrails"
+	"k8s.io/gengo/v2/types"
+)
+
+// collectRules walks the typeNode tree at node and returns a field-path → rules
+// map. Empty if node has no declared rules.
+func collectRules(node *typeNode) map[string][]guardrails.Rule {
+	if node == nil {
+		return nil
+	}
+	rulesByPath := map[string][]guardrails.Rule{}
+	seen := map[*typeNode]bool{}
+
+	record := func(path string, fns []validators.FunctionGen) {
+		for _, fn := range fns {
+			recordEmission(rulesByPath, path, fn, "")
+		}
+	}
+
+	var walkNode func(*typeNode, string)
+	var walkChild func(*childNode, string)
+	walkNode = func(n *typeNode, path string) {
+		if n == nil || seen[n] {
+			return
+		}
+		seen[n] = true
+		defer delete(seen, n)
+
+		record(path, n.typeValidations.Functions)
+		if n.valueType == nil {
+			return
+		}
+		record(joinPath(path, "[*]"), n.typeValIterations.Functions)
+		record(path, n.typeKeyIterations.Functions) // keys validate at parent path
+
+		for _, fld := range n.fields {
+			walkChild(fld, joinPath(path, fld.jsonName))
+		}
+		if n.elem != nil {
+			walkChild(n.elem, joinPath(path, "[*]"))
+		}
+		if n.key != nil {
+			walkChild(n.key, path)
+		}
+		if n.underlying != nil {
+			walkChild(n.underlying, path)
+		}
+	}
+	walkChild = func(c *childNode, path string) {
+		if c == nil {
+			return
+		}
+		record(path, c.fieldValidations.Functions)
+		record(joinPath(path, "[*]"), c.fieldValIterations.Functions)
+		record(path, c.fieldKeyIterations.Functions)
+		walkNode(c.node, path)
+	}
+	walkNode(node, "")
+	return rulesByPath
+}
+
+// recordEmission descends fg, accumulating each Wrapper/MultiWrapperFunction
+// PathFragment into suffix, and records (basePath+suffix, Rule) once an
+// emitting function (Emits != nil) is reached.
+func recordEmission(rulesByPath map[string][]guardrails.Rule, basePath string, fg validators.FunctionGen, suffix string) {
+	if fg.Emits != nil {
+		path := basePath + suffix
+		rulesByPath[path] = append(rulesByPath[path], guardrails.Rule{
+			ErrorType: string(fg.Emits.Type),
+			Origin:    fg.Emits.Origin,
+		})
+		return
+	}
+	for _, arg := range fg.Args {
+		switch a := arg.(type) {
+		case validators.WrapperFunction:
+			recordEmission(rulesByPath, basePath, a.Function, suffix+a.PathFragment)
+		case validators.MultiWrapperFunction:
+			for _, child := range a.Functions {
+				recordEmission(rulesByPath, basePath, child, suffix+a.PathFragment)
+			}
+		}
+	}
+}
+
+// joinPath joins seg onto base. Empty seg is a no-op so inline-embedded
+// struct fields (whose jsonName is "") stay transparent.
+func joinPath(base, seg string) string {
+	if seg == "" {
+		return base
+	}
+	if base == "" {
+		return seg
+	}
+	if strings.HasPrefix(seg, "[") {
+		return base + seg
+	}
+	return base + "." + seg
+}
+
+// gvFor returns the (group, version) for a Go package. Group is read from the
+// package's GroupName const (set in every k8s.io/api/<group>/<version>/register.go);
+// pkg.Path is used as a last-resort identifier for non-API packages.
+// Version is parsed from the import path when it matches that layout.
+func gvFor(pkg *types.Package) (string, string) {
+	version := ""
+	if relPath, ok := strings.CutPrefix(pkg.Path, "k8s.io/api/"); ok {
+		if parts := strings.Split(relPath, "/"); len(parts) == 2 {
+			version = parts[1]
+		}
+	}
+
+	// ConstValue holds the un-quoted string literal for string-typed consts.
+	if c, ok := pkg.Constants["GroupName"]; ok && c.ConstValue != nil {
+		return *c.ConstValue, version
+	}
+
+	return pkg.Path, ""
+}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/report_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/report_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestJoinPath(t *testing.T) {
+	cases := []struct {
+		base, seg, want string
+	}{
+		{"", "", ""},
+		{"spec", "", "spec"}, // empty seg is a no-op (inline-embedded struct)
+		{"", "spec", "spec"}, // empty base
+		{"spec", "name", "spec.name"},
+		{"spec", "[*]", "spec[*]"}, // bracket-prefixed seg attaches without dot
+		{"", "[*]", "[*]"},
+	}
+	for _, c := range cases {
+		if got := joinPath(c.base, c.seg); got != c.want {
+			t.Errorf("joinPath(%q, %q) = %q, want %q", c.base, c.seg, got, c.want)
+		}
+	}
+}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/targets.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/targets.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"cmp"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"slices"
@@ -25,6 +26,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/code-generator/cmd/validation-gen/validators"
+	"k8s.io/code-generator/pkg/guardrails"
 	"k8s.io/gengo/v2"
 	"k8s.io/gengo/v2/codetags"
 	"k8s.io/gengo/v2/generator"
@@ -319,6 +321,10 @@ func GetTargets(context *generator.Context, args *Args) []generator.Target {
 	// Create a linter to collect errors as we go.
 	linter := newLinter(lintRules(validator)...)
 
+	// reports accumulates one entry per input package when --report-rules
+	// is set; printed as a single JSON array after the package loop.
+	var reports []guardrails.Report
+
 	// Build a cache of type->callNode for every type we need.
 	for _, input := range context.Inputs {
 		klog.V(2).InfoS("processing", "pkg", input)
@@ -397,6 +403,22 @@ func GetTargets(context *generator.Context, args *Args) []generator.Target {
 			}
 		}
 
+		// --report-rules short-circuit: build a Report for this
+		// package's (Group, Version) and skip code generation.
+		if args.PrintRules {
+			r := guardrails.Report{Kinds: map[string]map[string][]guardrails.Rule{}}
+			for _, t := range rootTypes {
+				if rules := collectRules(td.typeNodes[t]); len(rules) > 0 {
+					r.Kinds[t.Name.Name] = rules
+				}
+			}
+			if len(r.Kinds) > 0 {
+				r.Group, r.Version = gvFor(typesPkg)
+				reports = append(reports, r)
+			}
+			continue
+		}
+
 		extracted := codetags.Extract("+", pkg.Comments)
 		if _, ok := extracted["k8s:validation-gen-nolint"]; !ok {
 			for _, t := range rootTypes {
@@ -445,6 +467,13 @@ func GetTargets(context *generator.Context, args *Args) []generator.Target {
 			}
 		}
 		klog.Fatalf("lint failed:\n%s", buf.String())
+	}
+	if args.PrintRules && len(reports) > 0 {
+		out, err := json.MarshalIndent(reports, "", "  ")
+		if err != nil {
+			klog.Fatalf("failed to marshal rules: %v", err)
+		}
+		fmt.Println(string(out))
 	}
 	return targets
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
@@ -210,7 +210,7 @@ func (evtv eachValTagValidator) getListValidations(fldPath *field.Path, t *types
 	for _, vfn := range validations.Functions {
 		comm := vfn.Comments
 		vfn.Comments = nil
-		vfn = Function(eachValTagName, vfn.Flags, validateEachSliceVal, matchArg, equivArg, WrapperFunction{Function: vfn, ObjType: nt.Elem}).WithComments(comm...)
+		vfn = Function(eachValTagName, vfn.Flags, validateEachSliceVal, matchArg, equivArg, WrapperFunction{Function: vfn, ObjType: nt.Elem, PathFragment: "[*]"}).WithComments(comm...)
 		result.AddFunction(vfn)
 	}
 
@@ -231,7 +231,7 @@ func (evtv eachValTagValidator) getMapValidations(t *types.Type, validations Val
 	for _, vfn := range validations.Functions {
 		comm := vfn.Comments
 		vfn.Comments = nil
-		vfn = Function(eachValTagName, vfn.Flags, validateEachMapVal, equivArg, WrapperFunction{Function: vfn, ObjType: nt.Elem}).WithComments(comm...)
+		vfn = Function(eachValTagName, vfn.Flags, validateEachMapVal, equivArg, WrapperFunction{Function: vfn, ObjType: nt.Elem, PathFragment: "[*]"}).WithComments(comm...)
 		result.AddFunction(vfn)
 	}
 
@@ -310,7 +310,7 @@ func (ektv eachKeyTagValidator) getValidations(t *types.Type, validations Valida
 	for _, vfn := range validations.Functions {
 		comm := vfn.Comments
 		vfn.Comments = nil
-		f := Function(eachKeyTagName, vfn.Flags, validateEachMapKey, WrapperFunction{vfn, nt.Key}).WithComments(comm...)
+		f := Function(eachKeyTagName, vfn.Flags, validateEachMapKey, WrapperFunction{Function: vfn, ObjType: nt.Key}).WithComments(comm...)
 		result.AddFunction(f)
 	}
 	return result, nil

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/enum.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/enum.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/code-generator/cmd/validation-gen/util"
 	"k8s.io/gengo/v2/codetags"
 	"k8s.io/gengo/v2/types"
@@ -185,7 +186,8 @@ func (etv *enumTagValidator) GetValidations(context Context, _ codetags.Tag) (Va
 		}))
 		exclusions = exclusionsVar
 	}
-	fn := Function(enumTagName, DefaultFlags, enumValidator, symbolsVarName, exclusions)
+	fn := Function(enumTagName, DefaultFlags, enumValidator, symbolsVarName, exclusions).
+		WithEmits(Emission{field.ErrorTypeNotSupported, ""})
 	result.AddFunction(fn)
 
 	return result, nil

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/equality.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/equality.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/code-generator/cmd/validation-gen/util"
 	"k8s.io/gengo/v2/codetags"
 	"k8s.io/gengo/v2/types"
@@ -90,7 +91,8 @@ func (v neqTagValidator) GetValidations(context Context, tag codetags.Tag) (Vali
 		return Validations{}, fmt.Errorf("unsupported type for 'neq' tag: %s", t.Name)
 	}
 
-	fn := Function(v.TagName(), DefaultFlags, neqValidator, disallowedValue)
+	fn := Function(v.TagName(), DefaultFlags, neqValidator, disallowedValue).
+		WithEmits(Emission{field.ErrorTypeInvalid, "neq"})
 	return Validations{Functions: []FunctionGen{fn}}, nil
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/format.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/format.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/code-generator/cmd/validation-gen/util"
 	"k8s.io/gengo/v2/codetags"
 	"k8s.io/gengo/v2/types"
@@ -89,7 +90,8 @@ func getFormatValidationFunction(format string) (FunctionGen, error) {
 	switch format {
 	// Keep this sequence alphabetized.
 	case "k8s-extended-resource-name":
-		return Function(formatTagName, DefaultFlags, extendedResourceNameValidator), nil
+		return Function(formatTagName, DefaultFlags, extendedResourceNameValidator).
+			WithEmits(Emission{field.ErrorTypeInvalid, "format=k8s-extended-resource-name"}), nil
 	// TODO: uncomment the following when we've done the homework
 	// to be sure it works the current state of IP manual-ratcheting
 	/*
@@ -97,23 +99,32 @@ func getFormatValidationFunction(format string) (FunctionGen, error) {
 			return Function(formatTagName, DefaultFlags, ipSloppyValidator), nil
 	*/
 	case "k8s-label-key":
-		return Function(formatTagName, DefaultFlags, labelKeyValidator), nil
+		return Function(formatTagName, DefaultFlags, labelKeyValidator).
+			WithEmits(Emission{field.ErrorTypeInvalid, "format=k8s-label-key"}), nil
 	case "k8s-label-value":
-		return Function(formatTagName, DefaultFlags, labelValueValidator), nil
+		return Function(formatTagName, DefaultFlags, labelValueValidator).
+			WithEmits(Emission{field.ErrorTypeInvalid, "format=k8s-label-value"}), nil
 	case "k8s-long-name":
-		return Function(formatTagName, DefaultFlags, longNameValidator), nil
+		return Function(formatTagName, DefaultFlags, longNameValidator).
+			WithEmits(Emission{field.ErrorTypeInvalid, "format=k8s-long-name"}), nil
 	case "k8s-long-name-caseless":
-		return Function(formatTagName, DefaultFlags, longNameCaselessValidator), nil
+		return Function(formatTagName, DefaultFlags, longNameCaselessValidator).
+			WithEmits(Emission{field.ErrorTypeInvalid, "format=k8s-long-name-caseless"}), nil
 	case "k8s-path-segment-name":
-		return Function(formatTagName, DefaultFlags, pathSegmentValidator), nil
+		return Function(formatTagName, DefaultFlags, pathSegmentValidator).
+			WithEmits(Emission{field.ErrorTypeInvalid, "format=k8s-path-segment-name"}), nil
 	case "k8s-resource-fully-qualified-name":
-		return Function(formatTagName, DefaultFlags, resourceFullyQualifiedNameValidator), nil
+		return Function(formatTagName, DefaultFlags, resourceFullyQualifiedNameValidator).
+			WithEmits(Emission{field.ErrorTypeInvalid, "format=k8s-resource-fully-qualified-name"}), nil
 	case "k8s-resource-pool-name":
-		return Function(formatTagName, DefaultFlags, resourcePoolNameValidator), nil
+		return Function(formatTagName, DefaultFlags, resourcePoolNameValidator).
+			WithEmits(Emission{field.ErrorTypeInvalid, "format=k8s-resource-pool-name"}), nil
 	case "k8s-short-name":
-		return Function(formatTagName, DefaultFlags, shortNameValidator), nil
+		return Function(formatTagName, DefaultFlags, shortNameValidator).
+			WithEmits(Emission{field.ErrorTypeInvalid, "format=k8s-short-name"}), nil
 	case "k8s-uuid":
-		return Function(formatTagName, DefaultFlags, uuidValidator), nil
+		return Function(formatTagName, DefaultFlags, uuidValidator).
+			WithEmits(Emission{field.ErrorTypeInvalid, "format=k8s-uuid"}), nil
 	}
 	// TODO: Flesh out the list of validation functions
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/immutable.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/immutable.go
@@ -18,6 +18,7 @@ package validators
 
 import (
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/gengo/v2/codetags"
 	"k8s.io/gengo/v2/types"
 )
@@ -52,7 +53,8 @@ func (immutableTagValidator) GetValidations(context Context, _ codetags.Tag) (Va
 	var result Validations
 
 	// Use ShortCircuit flag so immutable runs in the same group as +k8s:optional.
-	result.AddFunction(Function(immutableTagName, ShortCircuit, immutableValidator))
+	result.AddFunction(Function(immutableTagName, ShortCircuit, immutableValidator).
+		WithEmits(Emission{field.ErrorTypeInvalid, "immutable"}))
 	return result, nil
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/code-generator/cmd/validation-gen/util"
 	"k8s.io/gengo/v2/codetags"
 	"k8s.io/gengo/v2/types"
@@ -79,7 +80,8 @@ func (maxLengthTagValidator) GetValidations(context Context, tag codetags.Tag) (
 	if intVal < 0 {
 		return result, fmt.Errorf("must be greater than or equal to zero")
 	}
-	result.AddFunction(Function(maxLengthTagName, DefaultFlags, maxLengthValidator, intVal))
+	result.AddFunction(Function(maxLengthTagName, DefaultFlags, maxLengthValidator, intVal).
+		WithEmits(Emission{field.ErrorTypeTooLong, "maxLength"}))
 	return result, nil
 }
 
@@ -132,7 +134,8 @@ func (maxBytesTagValidator) GetValidations(context Context, tag codetags.Tag) (V
 	if intVal < 0 {
 		return result, fmt.Errorf("must be greater than or equal to zero")
 	}
-	result.AddFunction(Function(maxBytesTagName, DefaultFlags, maxBytesValidator, intVal))
+	result.AddFunction(Function(maxBytesTagName, DefaultFlags, maxBytesValidator, intVal).
+		WithEmits(Emission{field.ErrorTypeTooLong, "maxBytes"}))
 	return result, nil
 }
 
@@ -189,7 +192,8 @@ func (minItemsTagValidator) GetValidations(context Context, tag codetags.Tag) (V
 	if intVal < 0 {
 		return result, fmt.Errorf("must be greater than or equal to zero")
 	}
-	result.AddFunction(Function(minItemsTagName, DefaultFlags, minItemsValidator, intVal))
+	result.AddFunction(Function(minItemsTagName, DefaultFlags, minItemsValidator, intVal).
+		WithEmits(Emission{field.ErrorTypeTooFew, "minItems"}))
 	return result, nil
 }
 
@@ -245,7 +249,8 @@ func (maxItemsTagValidator) GetValidations(context Context, tag codetags.Tag) (V
 		return result, fmt.Errorf("must be greater than or equal to zero")
 	}
 	// Note: maxItems short-circuits other validations for safety.
-	result.AddFunction(Function(maxItemsTagName, ShortCircuit, maxItemsValidator, intVal))
+	result.AddFunction(Function(maxItemsTagName, ShortCircuit, maxItemsValidator, intVal).
+		WithEmits(Emission{field.ErrorTypeTooMany, "maxItems"}))
 	return result, nil
 }
 
@@ -307,7 +312,8 @@ func (maxPropertiesTagValidator) GetValidations(context Context, tag codetags.Ta
 		return result, fmt.Errorf("must be less than or equal to 100000")
 	}
 	// Note: maxProperties short-circuits other validations.
-	result.AddFunction(Function(maxPropertiesTagName, ShortCircuit, maxPropertiesValidator, intVal))
+	result.AddFunction(Function(maxPropertiesTagName, ShortCircuit, maxPropertiesValidator, intVal).
+		WithEmits(Emission{field.ErrorTypeTooMany, "maxProperties"}))
 	return result, nil
 }
 
@@ -361,13 +367,15 @@ func (minimumTagValidator) GetValidations(context Context, tag codetags.Tag) (Va
 		if err != nil {
 			return result, fmt.Errorf("failed to parse tag payload: %w", err)
 		}
-		result.AddFunction(Function(minimumTagName, DefaultFlags, minimumValidator, uintVal))
+		result.AddFunction(Function(minimumTagName, DefaultFlags, minimumValidator, uintVal).
+			WithEmits(Emission{field.ErrorTypeInvalid, "minimum"}))
 	} else {
 		intVal, err := util.ParseSignedInt(tag.Value, bitSize)
 		if err != nil {
 			return result, fmt.Errorf("failed to parse tag payload: %w", err)
 		}
-		result.AddFunction(Function(minimumTagName, DefaultFlags, minimumValidator, intVal))
+		result.AddFunction(Function(minimumTagName, DefaultFlags, minimumValidator, intVal).
+			WithEmits(Emission{field.ErrorTypeInvalid, "minimum"}))
 	}
 	return result, nil
 }
@@ -422,13 +430,15 @@ func (maximumTagValidator) GetValidations(context Context, tag codetags.Tag) (Va
 		if err != nil {
 			return result, fmt.Errorf("failed to parse tag payload: %w", err)
 		}
-		result.AddFunction(Function(maximumTagName, DefaultFlags, maximumValidator, uintVal))
+		result.AddFunction(Function(maximumTagName, DefaultFlags, maximumValidator, uintVal).
+			WithEmits(Emission{field.ErrorTypeInvalid, "maximum"}))
 	} else {
 		intVal, err := util.ParseSignedInt(tag.Value, bitSize)
 		if err != nil {
 			return result, fmt.Errorf("failed to parse tag payload: %w", err)
 		}
-		result.AddFunction(Function(maximumTagName, DefaultFlags, maximumValidator, intVal))
+		result.AddFunction(Function(maximumTagName, DefaultFlags, maximumValidator, intVal).
+			WithEmits(Emission{field.ErrorTypeInvalid, "maximum"}))
 	}
 	return result, nil
 }
@@ -485,7 +495,8 @@ func (minLengthTagValidator) GetValidations(context Context, tag codetags.Tag) (
 	// any validation, we only add a validation function to the result if the
 	// minimum length constraint is > 0.
 	if intVal > 0 {
-		result.AddFunction(Function(minLengthTagName, DefaultFlags, minLengthValidator, intVal))
+		result.AddFunction(Function(minLengthTagName, DefaultFlags, minLengthValidator, intVal).
+			WithEmits(Emission{field.ErrorTypeTooShort, "minLength"}))
 	}
 	return result, nil
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/list.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/list.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/code-generator/cmd/validation-gen/util"
 	"k8s.io/gengo/v2/codetags"
 	"k8s.io/gengo/v2/types"
@@ -492,7 +493,8 @@ func getListValidations(byPath map[string]*listMetadata, context Context) (Valid
 		}
 		comment := "lists with set semantics require unique values"
 		f := Function("listValidator", DefaultFlags, validateUnique, Identifier(matchArg)).
-			WithComment(comment)
+			WithComment(comment).
+			WithEmits(Emission{field.ErrorTypeDuplicate, ""})
 		if lm.stabilityLevel != "" {
 			f = f.WithStabilityLevel(lm.stabilityLevel)
 		}
@@ -507,7 +509,9 @@ func getListValidations(byPath map[string]*listMetadata, context Context) (Valid
 		comment := "lists with map semantics require unique keys"
 
 		f := Function("listValidator", DefaultFlags, validateUnique, matchArg).
-			WithComment(comment).WithStabilityLevel(lm.stabilityLevel)
+			WithComment(comment).
+			WithStabilityLevel(lm.stabilityLevel).
+			WithEmits(Emission{field.ErrorTypeDuplicate, ""})
 		result.AddFunction(f)
 	}
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/mode.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/mode.go
@@ -22,6 +22,7 @@ import (
 	"slices"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/code-generator/cmd/validation-gen/util"
 	"k8s.io/gengo/v2/codetags"
 	"k8s.io/gengo/v2/parser/tags"
@@ -316,8 +317,9 @@ func generateMemberFieldValidation(structType *types.Type, group *discriminatorG
 		jsonName = jt.Name
 	}
 
-	// Default validation is Forbidden
-	defaultForbidden, err := getForbiddenValidation(fieldType)
+	// Default-Forbidden runs at structPath.Child(jsonName) inside the
+	// Discriminated runtime; attribute it to "." + jsonName.
+	defaultForbidden, err := getForbiddenValidation(fieldType, "."+jsonName)
 	if err != nil {
 		return Validations{}, err
 	}
@@ -370,6 +372,8 @@ func generateMemberFieldValidation(structType *types.Type, group *discriminatorG
 		wrapper := MultiWrapperFunction{
 			Functions: rulesByValue[val].Functions,
 			ObjType:   nilableFieldType,
+			// Per-mode rules also run at structPath.Child(jsonName).
+			PathFragment: "." + jsonName,
 		}
 
 		// Convert the string tag value to the appropriate typed Go literal
@@ -448,7 +452,10 @@ func uniformStabilityLevel(rules []memberRule) ValidationStabilityLevel {
 	return level
 }
 
-func getForbiddenValidation(t *types.Type) (any, error) {
+// getForbiddenValidation returns a MultiWrapperFunction wrapping the runtime
+// validate.Forbidden* call appropriate for t's kind. pathFragment is the
+// wrapper's PathFragment (see MultiWrapperFunction).
+func getForbiddenValidation(t *types.Type, pathFragment string) (any, error) {
 	var forbidden types.Name
 	nt := util.NativeType(t)
 	switch nt.Kind {
@@ -464,7 +471,8 @@ func getForbiddenValidation(t *types.Type) (any, error) {
 		forbidden = types.Name{Package: libValidationPkg, Name: "ForbiddenValue"}
 	}
 
-	fg := Function(forbiddenTagName, DefaultFlags, forbidden)
+	fg := Function(forbiddenTagName, DefaultFlags, forbidden).
+		WithEmits(Emission{field.ErrorTypeForbidden, ""})
 
 	// Use the nilable form to match standard validation function signatures.
 	wrapperObjType := t
@@ -473,8 +481,9 @@ func getForbiddenValidation(t *types.Type) (any, error) {
 	}
 
 	return MultiWrapperFunction{
-		Functions: []FunctionGen{fg},
-		ObjType:   wrapperObjType,
+		Functions:    []FunctionGen{fg},
+		ObjType:      wrapperObjType,
+		PathFragment: pathFragment,
 	}, nil
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/required.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/code-generator/cmd/validation-gen/util"
 	"k8s.io/gengo/v2"
 	"k8s.io/gengo/v2/codetags"
@@ -92,13 +93,14 @@ func (rtv requirednessTagValidator) doRequired(context Context) (Validations, er
 	// originally defined as a value-type or a pointer-type in the API.  This
 	// one does.  Since Go doesn't do partial specialization of templates, we
 	// do manual dispatch here.
+	emits := Emission{field.ErrorTypeRequired, ""}
 	switch util.NativeType(context.Type).Kind {
 	case types.Slice:
-		return Validations{Functions: []FunctionGen{Function(requiredTagName, ShortCircuit, requiredSliceValidator)}}, nil
+		return Validations{Functions: []FunctionGen{Function(requiredTagName, ShortCircuit, requiredSliceValidator).WithEmits(emits)}}, nil
 	case types.Map:
-		return Validations{Functions: []FunctionGen{Function(requiredTagName, ShortCircuit, requiredMapValidator)}}, nil
+		return Validations{Functions: []FunctionGen{Function(requiredTagName, ShortCircuit, requiredMapValidator).WithEmits(emits)}}, nil
 	case types.Pointer:
-		return Validations{Functions: []FunctionGen{Function(requiredTagName, ShortCircuit, requiredPointerValidator)}}, nil
+		return Validations{Functions: []FunctionGen{Function(requiredTagName, ShortCircuit, requiredPointerValidator).WithEmits(emits)}}, nil
 	case types.Struct:
 		// The +k8s:required tag on a non-pointer struct is not supported.
 		// If you encounter this error and believe you have a valid use case
@@ -107,7 +109,7 @@ func (rtv requirednessTagValidator) doRequired(context Context) (Validations, er
 		// this behavior or provide alternative validation mechanisms.
 		return Validations{}, fmt.Errorf("non-pointer structs cannot use the %q tag", requiredTagName)
 	}
-	return Validations{Functions: []FunctionGen{Function(requiredTagName, ShortCircuit, requiredValueValidator)}}, nil
+	return Validations{Functions: []FunctionGen{Function(requiredTagName, ShortCircuit, requiredValueValidator).WithEmits(emits)}}, nil
 }
 
 var (
@@ -263,25 +265,28 @@ func (requirednessTagValidator) doForbidden(context Context) (Validations, error
 	// optional check and short-circuit (but without error).  Why?  For
 	// example, this prevents any further validation from trying to run on a
 	// nil pointer.
+	// The optional* siblings carry the NonError flag (they don't produce
+	// errors, just short-circuit), so they get no Emission.
+	forbids := Emission{field.ErrorTypeForbidden, ""}
 	switch util.NativeType(context.Type).Kind {
 	case types.Slice:
 		return Validations{
 			Functions: []FunctionGen{
-				Function(forbiddenTagName, ShortCircuit, forbiddenSliceValidator),
+				Function(forbiddenTagName, ShortCircuit, forbiddenSliceValidator).WithEmits(forbids),
 				Function(forbiddenTagName, ShortCircuit|NonError, optionalSliceValidator),
 			},
 		}, nil
 	case types.Map:
 		return Validations{
 			Functions: []FunctionGen{
-				Function(forbiddenTagName, ShortCircuit, forbiddenMapValidator),
+				Function(forbiddenTagName, ShortCircuit, forbiddenMapValidator).WithEmits(forbids),
 				Function(forbiddenTagName, ShortCircuit|NonError, optionalMapValidator),
 			},
 		}, nil
 	case types.Pointer:
 		return Validations{
 			Functions: []FunctionGen{
-				Function(forbiddenTagName, ShortCircuit, forbiddenPointerValidator),
+				Function(forbiddenTagName, ShortCircuit, forbiddenPointerValidator).WithEmits(forbids),
 				Function(forbiddenTagName, ShortCircuit|NonError, optionalPointerValidator),
 			},
 		}, nil
@@ -295,7 +300,7 @@ func (requirednessTagValidator) doForbidden(context Context) (Validations, error
 	}
 	return Validations{
 		Functions: []FunctionGen{
-			Function(forbiddenTagName, ShortCircuit, forbiddenValueValidator),
+			Function(forbiddenTagName, ShortCircuit, forbiddenValueValidator).WithEmits(forbids),
 			Function(forbiddenTagName, ShortCircuit|NonError, optionalValueValidator),
 		},
 	}, nil

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/subfield.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/subfield.go
@@ -126,7 +126,8 @@ func (stv subfieldTagValidator) GetValidations(context Context, tag codetags.Tag
 		if scope == ParentContext {
 			return fn
 		}
-		f := Function(subfieldTagName, fn.Flags, validateSubfield, subname, getFn, equivArg, WrapperFunction{fn, submemb.Type})
+		f := Function(subfieldTagName, fn.Flags, validateSubfield, subname, getFn, equivArg,
+			WrapperFunction{Function: fn, ObjType: submemb.Type, PathFragment: "." + subname})
 		f.Cohort = subname
 		return f
 	})

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/testing.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/testing.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/gengo/v2/codetags"
 	"k8s.io/gengo/v2/types"
 )
@@ -87,7 +88,9 @@ func (frtv fixedResultTagValidator) GetValidations(context Context, tag codetags
 	if err != nil {
 		return result, fmt.Errorf("can't decode tag payload: %w", err)
 	}
-	fn := Function(frtv.TagName(), args.flags, fixedResultValidator, frtv.result, args.msg).WithTypeArgs(args.typeArgs...)
+	fn := Function(frtv.TagName(), args.flags, fixedResultValidator, frtv.result, args.msg).
+		WithTypeArgs(args.typeArgs...).
+		WithEmits(Emission{field.ErrorTypeInvalid, "validateFalse"})
 	fn.Cohort = args.cohort
 	result.AddFunction(fn)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/union.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/union.go
@@ -72,7 +72,8 @@ func getUnionValidations(shared map[string]unions, context Context) (Validations
 	delete(shared, structPath.String())
 
 	result, err := processUnionValidations(structPath, parentType, unions, unionVariablePrefix,
-		unionMemberTagName, unionValidator, discriminatedUnionValidator)
+		unionMemberTagName, unionValidator, discriminatedUnionValidator,
+		Emission{field.ErrorTypeInvalid, "union"})
 	return result, err
 }
 
@@ -226,7 +227,7 @@ func (us unions) getOrCreate(name string) *union {
 }
 
 func processUnionValidations(structPath *field.Path, parentType *types.Type, unions unions, varPrefix string,
-	tagName string, undiscriminatedValidator types.Name, discriminatedValidator types.Name,
+	tagName string, undiscriminatedValidator types.Name, discriminatedValidator types.Name, emits Emission,
 ) (Validations, error) {
 	result := Validations{}
 
@@ -299,14 +300,16 @@ func processUnionValidations(structPath *field.Path, parentType *types.Type, uni
 				}
 
 				extraArgs := append([]any{supportVarName, discriminatorExtractor}, extractorArgs...)
-				fn := Function(tagName, DefaultFlags, discriminatedValidator, extraArgs...)
+				fn := Function(tagName, DefaultFlags, discriminatedValidator, extraArgs...).
+					WithEmits(emits)
 				result.Functions = append(result.Functions, fn)
 			} else {
 				supportVar := Variable(supportVarName, Function(tagName, DefaultFlags, newUnionMembership, getMemberArgs(u, parentType, false)...))
 				result.Variables = append(result.Variables, supportVar)
 
 				extraArgs := append([]any{supportVarName}, extractorArgs...)
-				fn := Function(tagName, DefaultFlags, undiscriminatedValidator, extraArgs...)
+				fn := Function(tagName, DefaultFlags, undiscriminatedValidator, extraArgs...).
+					WithEmits(emits)
 				result.Functions = append(result.Functions, fn)
 			}
 		}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/update.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/update.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/validate"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/code-generator/cmd/validation-gen/util"
 	"k8s.io/gengo/v2/codetags"
 	"k8s.io/gengo/v2/types"
@@ -292,7 +293,8 @@ func generateSliceValidation(listByPath map[string]*listMetadata, context Contex
 	args := append([]any{matchArg}, constraintIdentifierArgs(constraints)...)
 
 	// Use ShortCircuit flag so these run in the same group as +k8s:optional
-	fn := Function(updateTagName, ShortCircuit, updateSliceValidator, args...)
+	fn := Function(updateTagName, ShortCircuit, updateSliceValidator, args...).
+		WithEmits(Emission{field.ErrorTypeInvalid, "update"})
 	return Validations{Functions: []FunctionGen{fn}}, nil
 }
 
@@ -300,7 +302,8 @@ func generateSliceValidation(listByPath map[string]*listMetadata, context Contex
 // identity, so no list metadata or match function is needed.
 func generateMapValidation(constraints []validate.UpdateConstraint) Validations {
 	// Use ShortCircuit flag so these run in the same group as +k8s:optional
-	fn := Function(updateTagName, ShortCircuit, updateMapValidator, constraintIdentifierArgs(constraints)...)
+	fn := Function(updateTagName, ShortCircuit, updateMapValidator, constraintIdentifierArgs(constraints)...).
+		WithEmits(Emission{field.ErrorTypeInvalid, "update"})
 	return Validations{Functions: []FunctionGen{fn}}
 }
 
@@ -328,7 +331,8 @@ func emitScalarUpdate(context Context, constraints []validate.UpdateConstraint) 
 	}
 
 	// Use ShortCircuit flag so these run in the same group as +k8s:optional
-	fn := Function(updateTagName, ShortCircuit, validatorFunc, constraintIdentifierArgs(constraints)...)
+	fn := Function(updateTagName, ShortCircuit, validatorFunc, constraintIdentifierArgs(constraints)...).
+		WithEmits(Emission{field.ErrorTypeInvalid, "update"})
 	return Validations{Functions: []FunctionGen{fn}}
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
@@ -515,6 +515,13 @@ type DeferredGen struct {
 	Callback func() (Validations, error)
 }
 
+// Emission describes the field.Error a runtime validator produces on failure.
+// Must match what the runtime function emits via .WithOrigin(...).
+type Emission struct {
+	Type   field.ErrorType
+	Origin string
+}
+
 // FunctionGen describes a function call that should be generated.
 type FunctionGen struct {
 	// TagName is the tag which triggered this function.
@@ -561,6 +568,11 @@ type FunctionGen struct {
 	// StabilityLevelSelfManaged indicates that the function already has stability levels
 	// embedded or handled, and should not be wrapped by levelTagValidator.
 	StabilityLevelSelfManaged bool
+
+	// Emits, when non-nil, declares the field.Error the runtime validator
+	// produces on failure. Set via WithEmits; nil for wrappers and
+	// non-emitting validators.
+	Emits *Emission
 }
 
 // WithTypeArgs returns a derived FunctionGen with type arguments.
@@ -592,6 +604,13 @@ func (fg FunctionGen) WithStabilityLevel(level ValidationStabilityLevel) Functio
 	return fg
 }
 
+// WithEmits returns a new FunctionGen that declares the field.Error the
+// runtime validator produces on failure.
+func (fg FunctionGen) WithEmits(emits Emission) FunctionGen {
+	fg.Emits = &emits
+	return fg
+}
+
 // Variable creates a VariableGen for a given variable name and init value.
 func Variable(variable PrivateVar, initializer any) VariableGen {
 	return VariableGen{
@@ -615,6 +634,11 @@ type VariableGen struct {
 type WrapperFunction struct {
 	Function FunctionGen
 	ObjType  *types.Type
+	// PathFragment, when non-empty, is the static field-path component the
+	// wrapping FunctionGen adds to fldPath before invoking Function (e.g.
+	// "[*]" for slice/map value iteration, ".<name>" for subfield). Used
+	// by tools that walk the FunctionGen tree to reconstruct field paths.
+	PathFragment string
 }
 
 // MultiWrapperFunction describes a function literal which has the fingerprint
@@ -623,6 +647,11 @@ type WrapperFunction struct {
 type MultiWrapperFunction struct {
 	Functions []FunctionGen
 	ObjType   *types.Type
+	// PathFragment, when non-empty, is the static field-path component the
+	// wrapping FunctionGen adds to fldPath before invoking the inner Functions
+	// (e.g. ".<jsonName>" for the discriminated-mode validator). Used by tools
+	// that walk the FunctionGen tree to reconstruct field paths.
+	PathFragment string
 }
 
 // Literal is a literal value that, when used as an argument to a validator,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/zeroorone.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/zeroorone.go
@@ -18,6 +18,7 @@ package validators
 
 import (
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/code-generator/cmd/validation-gen/util"
 	"k8s.io/gengo/v2/codetags"
 	"k8s.io/gengo/v2/types"
@@ -53,7 +54,8 @@ func getZeroOrOneOfValidations(shared map[string]unions, context Context) (Valid
 	delete(shared, structPath)
 
 	result, err := processUnionValidations(context.ParentPath, context.ParentType, unions, zeroOrOneOfVariablePrefix,
-		zeroOrOneOfMemberTagName, zeroOrOneOfUnionValidator, types.Name{})
+		zeroOrOneOfMemberTagName, zeroOrOneOfUnionValidator, types.Name{},
+		Emission{field.ErrorTypeInvalid, "zeroOrOneOf"})
 	return result, err
 }
 

--- a/staging/src/k8s.io/code-generator/pkg/guardrails/types.go
+++ b/staging/src/k8s.io/code-generator/pkg/guardrails/types.go
@@ -1,0 +1,38 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package guardrails defines the JSON schema (Rule, Report) emitted by
+// validation-gen --report-rules: the declarative-validation rules declared
+// by DV tags, indexed by (Group, Version, Kind, field path). The schema
+// feeds external "guardrail" tools (e.g. test-coverage verifiers) that
+// reason about the declared rule set.
+package guardrails
+
+// Rule is one declared field-validation error.
+type Rule struct {
+	ErrorType string `json:"errorType"`
+	Origin    string `json:"origin,omitempty"`
+}
+
+// Report is the marshaled output for one (Group, Version): every Kind's
+// field path → declared rules. Group is empty for the core API group;
+// Version is empty for non-API packages (in which case Group falls back
+// to the package import path).
+type Report struct {
+	Group   string                       `json:"group"`
+	Version string                       `json:"version"`
+	Kinds   map[string]map[string][]Rule `json:"kinds"`
+}

--- a/test/declarative_validation/cmd/root.go
+++ b/test/declarative_validation/cmd/root.go
@@ -1,0 +1,39 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "declarative-validation",
+	Short: "declarative-validation",
+	Long:  `declarative-validation runs verification and reporting for declarative-validation rules.`,
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(NewVerifyCoverageCommand())
+}

--- a/test/declarative_validation/cmd/verify_coverage.go
+++ b/test/declarative_validation/cmd/verify_coverage.go
@@ -1,0 +1,308 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"cmp"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/yaml"
+
+	"k8s.io/code-generator/pkg/guardrails"
+	"k8s.io/klog/v2"
+)
+
+var (
+	expectedRulesFile string
+	actualRulesDir    string
+	allowlistFile     string
+)
+
+// NewVerifyCoverageCommand returns the cobra command for "verify-coverage".
+func NewVerifyCoverageCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "verify-coverage",
+		Short: "Diff declared declarative-validation rules against rules observed during tests",
+		Long: `Compares the declared rules JSON (output of validation-gen --report-rules)
+against the per-package observation files written by declarative_validation_test.go
+runs (via VALIDATION_RULES_REPORT_DIR). Exits 0 if every declared rule has at
+least one matching observation, 1 otherwise (with the uncovered set printed
+to stderr). An optional YAML allowlist may suppress intentional gaps.`,
+		Run: verifyCoverageFunc,
+	}
+	cmd.Flags().StringVar(&expectedRulesFile, "expected-rules", "",
+		"path to the declared rules JSON (output of `validation-gen --report-rules`)")
+	cmd.Flags().StringVar(&actualRulesDir, "actual-rules-dir", "",
+		"directory of per-package observation JSON files written via VALIDATION_RULES_REPORT_DIR")
+	cmd.Flags().StringVar(&allowlistFile, "allowlist", "",
+		"optional YAML file listing rules to suppress from the uncovered output")
+	_ = cmd.MarkFlagRequired("expected-rules")
+	_ = cmd.MarkFlagRequired("actual-rules-dir")
+	return cmd
+}
+
+func verifyCoverageFunc(_ *cobra.Command, _ []string) {
+	expected, err := loadFile(expectedRulesFile)
+	if err != nil {
+		klog.Fatalf("Error reading --expected-rules: %v", err)
+	}
+	actual, err := loadDir(actualRulesDir)
+	if err != nil {
+		klog.Fatalf("Error reading --actual-rules-dir: %v", err)
+	}
+	allow, err := loadAllowlist(allowlistFile)
+	if err != nil {
+		klog.Fatalf("Error reading --allowlist: %v", err)
+	}
+	uncovered := filterAllowed(diff(expected, actual), allow)
+
+	total := 0
+	for _, r := range uncovered {
+		for _, fields := range r.Kinds {
+			for _, rules := range fields {
+				total += len(rules)
+			}
+		}
+	}
+	if total == 0 {
+		fmt.Println("All declared declarative-validation rules are covered by tests.")
+		os.Exit(0)
+	}
+
+	fmt.Fprintf(os.Stderr, "Uncovered declarative-validation rules: %d\n", total)
+	slices.SortFunc(uncovered, func(a, b guardrails.Report) int {
+		if c := cmp.Compare(a.Group, b.Group); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Version, b.Version)
+	})
+	for _, r := range uncovered {
+		for _, kind := range slices.Sorted(maps.Keys(r.Kinds)) {
+			fmt.Fprintf(os.Stderr, "\n%s/%s, Kind=%s:\n", r.Group, r.Version, kind)
+			for _, path := range slices.Sorted(maps.Keys(r.Kinds[kind])) {
+				for _, rule := range r.Kinds[kind][path] {
+					suffix := rule.ErrorType
+					if rule.Origin != "" {
+						suffix = fmt.Sprintf("%s origin=%q", rule.ErrorType, rule.Origin)
+					}
+					fmt.Fprintf(os.Stderr, "  %s  %s\n", path, suffix)
+				}
+			}
+		}
+	}
+	os.Exit(1)
+}
+
+// indexKeyRe normalizes runtime path subscripts ("[0]", "[my-key]") to "[*]"
+// so observed paths from runtime field.Error.Field line up with the canonical
+// paths emitted by validation-gen --report-rules.
+var indexKeyRe = regexp.MustCompile(`\[[^\]]+\]`)
+
+// allowEntry suppresses rules from the verifier's output. Any non-empty field
+// acts as a literal-equality filter; empty fields match any value. Reason is
+// required and free-form.
+type allowEntry struct {
+	Group     string `json:"group,omitempty"`
+	Version   string `json:"version,omitempty"`
+	Kind      string `json:"kind,omitempty"`
+	Path      string `json:"path,omitempty"`
+	ErrorType string `json:"errorType,omitempty"`
+	Origin    string `json:"origin,omitempty"`
+	Reason    string `json:"reason"`
+}
+
+func (a allowEntry) matches(group, version, kind, path string, r guardrails.Rule) bool {
+	if a.Group != "" && a.Group != group {
+		return false
+	}
+	if a.Version != "" && a.Version != version {
+		return false
+	}
+	if a.Kind != "" && a.Kind != kind {
+		return false
+	}
+	if a.Path != "" && a.Path != path {
+		return false
+	}
+	if a.ErrorType != "" && a.ErrorType != r.ErrorType {
+		return false
+	}
+	if a.Origin != "" && a.Origin != r.Origin {
+		return false
+	}
+	return true
+}
+
+// loadAllowlist reads a YAML file as []allowEntry. Returns nil if path is
+// empty (allowlist is optional).
+func loadAllowlist(path string) ([]allowEntry, error) {
+	if path == "" {
+		return nil, nil
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var entries []allowEntry
+	if err := yaml.Unmarshal(b, &entries); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	return entries, nil
+}
+
+// loadFile reads one JSON file as []guardrails.Report.
+func loadFile(path string) ([]guardrails.Report, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var r []guardrails.Report
+	if err := json.Unmarshal(b, &r); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	return r, nil
+}
+
+// loadDir reads every *.json file in dir and merges them by (Group, Version),
+// union-merging Kinds maps and dedup'ing rules at each path. Used to merge
+// the per-package observation files written by declarative_validation_test.go
+// runs into a single set for diffing against the declared rules.
+func loadDir(dir string) ([]guardrails.Report, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, "*.json"))
+	if err != nil {
+		return nil, err
+	}
+	merged := map[string]*guardrails.Report{}
+	for _, file := range matches {
+		part, err := loadFile(file)
+		if err != nil {
+			return nil, err
+		}
+		for i := range part {
+			p := &part[i]
+			key := p.Group + "|" + p.Version
+			r, ok := merged[key]
+			if !ok {
+				r = &guardrails.Report{Group: p.Group, Version: p.Version, Kinds: map[string]map[string][]guardrails.Rule{}}
+				merged[key] = r
+			}
+			for kind, fields := range p.Kinds {
+				existing, ok := r.Kinds[kind]
+				if !ok {
+					r.Kinds[kind] = fields
+					continue
+				}
+				for path, rules := range fields {
+					for _, rule := range rules {
+						if !slices.Contains(existing[path], rule) {
+							existing[path] = append(existing[path], rule)
+						}
+					}
+				}
+			}
+		}
+	}
+	out := make([]guardrails.Report, 0, len(merged))
+	for _, r := range merged {
+		out = append(out, *r)
+	}
+	return out, nil
+}
+
+// filterReports returns a deep copy of reports keeping only rules for which
+// keep returns true. Empty rule slices, paths, kinds, and reports are dropped.
+func filterReports(reports []guardrails.Report, keep func(group, version, kind, path string, r guardrails.Rule) bool) []guardrails.Report {
+	var out []guardrails.Report
+	for _, r := range reports {
+		kept := map[string]map[string][]guardrails.Rule{}
+		for kind, fields := range r.Kinds {
+			for path, rules := range fields {
+				var ks []guardrails.Rule
+				for _, rule := range rules {
+					if keep(r.Group, r.Version, kind, path, rule) {
+						ks = append(ks, rule)
+					}
+				}
+				if len(ks) > 0 {
+					if kept[kind] == nil {
+						kept[kind] = map[string][]guardrails.Rule{}
+					}
+					kept[kind][path] = ks
+				}
+			}
+		}
+		if len(kept) > 0 {
+			out = append(out, guardrails.Report{Group: r.Group, Version: r.Version, Kinds: kept})
+		}
+	}
+	return out
+}
+
+// diff returns the subset of expected with no matching observation in actual,
+// after normalizing actual paths via indexKeyRe. The result has the same
+// shape as expected; empty kinds/paths/rules are dropped. A rule matches if
+// (group, version, kind, path, errorType, origin) all coincide.
+func diff(expected, actual []guardrails.Report) []guardrails.Report {
+	type ruleKey struct{ gv, kind, path, errorType, origin string }
+	seen := map[ruleKey]struct{}{}
+	for _, r := range actual {
+		gv := r.Group + "/" + r.Version
+		for kind, fields := range r.Kinds {
+			for path, rules := range fields {
+				norm := indexKeyRe.ReplaceAllString(path, "[*]")
+				for _, rule := range rules {
+					seen[ruleKey{gv, kind, norm, rule.ErrorType, rule.Origin}] = struct{}{}
+					// Slice-level rules (e.g. +k8s:unique=set) are declared at
+					// "foo" but the runtime emits at the offending index,
+					// normalized to "foo[*]". Register both so the declared
+					// "foo" rule matches.
+					if stripped, ok := strings.CutSuffix(norm, "[*]"); ok {
+						seen[ruleKey{gv, kind, stripped, rule.ErrorType, rule.Origin}] = struct{}{}
+					}
+				}
+			}
+		}
+	}
+	return filterReports(expected, func(group, version, kind, path string, r guardrails.Rule) bool {
+		_, ok := seen[ruleKey{group + "/" + version, kind, path, r.ErrorType, r.Origin}]
+		return !ok
+	})
+}
+
+// filterAllowed returns reports with rules matched by any allow entry removed.
+func filterAllowed(reports []guardrails.Report, allow []allowEntry) []guardrails.Report {
+	if len(allow) == 0 {
+		return reports
+	}
+	return filterReports(reports, func(group, version, kind, path string, r guardrails.Rule) bool {
+		for _, a := range allow {
+			if a.matches(group, version, kind, path, r) {
+				return false
+			}
+		}
+		return true
+	})
+}

--- a/test/declarative_validation/cmd/verify_coverage_test.go
+++ b/test/declarative_validation/cmd/verify_coverage_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"slices"
+	"testing"
+
+	"k8s.io/code-generator/pkg/guardrails"
+)
+
+func TestAllowEntryMatches(t *testing.T) {
+	rule := guardrails.Rule{ErrorType: "FieldValueInvalid", Origin: "minimum"}
+	cases := []struct {
+		name  string
+		entry allowEntry
+		want  bool
+	}{
+		{"empty entry matches everything", allowEntry{}, true},
+		{"matching group", allowEntry{Group: "foo"}, true},
+		{"non-matching group", allowEntry{Group: "bar"}, false},
+		{"matching origin", allowEntry{Origin: "minimum"}, true},
+		{"non-matching origin", allowEntry{Origin: "format"}, false},
+		{"all fields match", allowEntry{
+			Group: "foo", Version: "v1", Kind: "Bar",
+			Path: "spec.x", ErrorType: "FieldValueInvalid", Origin: "minimum",
+		}, true},
+		{"one field mismatches", allowEntry{
+			Group: "foo", Version: "v1", Kind: "Bar",
+			Path: "spec.x", ErrorType: "FieldValueRequired", // wrong errorType
+		}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := c.entry.matches("foo", "v1", "Bar", "spec.x", rule)
+			if got != c.want {
+				t.Errorf("matches() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// makeReport is a tiny constructor for reports used by Diff/FilterAllowed tests.
+func makeReport(group, version, kind string, paths map[string][]guardrails.Rule) guardrails.Report {
+	return guardrails.Report{
+		Group: group, Version: version,
+		Kinds: map[string]map[string][]guardrails.Rule{kind: paths},
+	}
+}
+
+func TestDiff(t *testing.T) {
+	cases := []struct {
+		name              string
+		declared          map[string][]guardrails.Rule
+		observed          map[string][]guardrails.Rule
+		wantUncoveredKeys []string // paths remaining after diff (empty = fully covered)
+	}{
+		{
+			name: "covered rule removed, uncovered remains",
+			declared: map[string][]guardrails.Rule{
+				"spec.a": {{ErrorType: "X"}},
+				"spec.b": {{ErrorType: "Y", Origin: "minimum"}},
+			},
+			observed: map[string][]guardrails.Rule{
+				"spec.a": {{ErrorType: "X"}},
+			},
+			wantUncoveredKeys: []string{"spec.b"},
+		},
+		{
+			name: "concrete index normalizes to [*]",
+			declared: map[string][]guardrails.Rule{
+				"spec.items[*].name": {{ErrorType: "X"}},
+			},
+			observed: map[string][]guardrails.Rule{
+				"spec.items[3].name": {{ErrorType: "X"}}, // runtime path
+			},
+		},
+		{
+			name: "slice-level rule declared at foo matches runtime foo[2]",
+			declared: map[string][]guardrails.Rule{
+				"spec.items": {{ErrorType: "Duplicate"}},
+			},
+			observed: map[string][]guardrails.Rule{
+				"spec.items[2]": {{ErrorType: "Duplicate"}},
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := diff(
+				[]guardrails.Report{makeReport("foo", "v1", "Bar", c.declared)},
+				[]guardrails.Report{makeReport("foo", "v1", "Bar", c.observed)},
+			)
+			var gotKeys []string
+			for _, r := range got {
+				for path := range r.Kinds["Bar"] {
+					gotKeys = append(gotKeys, path)
+				}
+			}
+			slices.Sort(gotKeys)
+			slices.Sort(c.wantUncoveredKeys)
+			if !slices.Equal(gotKeys, c.wantUncoveredKeys) {
+				t.Errorf("uncovered = %v, want %v", gotKeys, c.wantUncoveredKeys)
+			}
+		})
+	}
+}
+
+func TestFilterAllowed(t *testing.T) {
+	rules := map[string][]guardrails.Rule{
+		"spec.a": {{ErrorType: "X"}},
+		"spec.b": {{ErrorType: "Y", Origin: "minimum"}},
+	}
+	cases := []struct {
+		name          string
+		allow         []allowEntry
+		wantRemaining []string // paths surviving the filter
+	}{
+		{
+			name:          "nil allowlist is no-op",
+			allow:         nil,
+			wantRemaining: []string{"spec.a", "spec.b"},
+		},
+		{
+			name:          "suppress by Path",
+			allow:         []allowEntry{{Path: "spec.a"}},
+			wantRemaining: []string{"spec.b"},
+		},
+		{
+			name:          "suppress by ErrorType",
+			allow:         []allowEntry{{ErrorType: "Y"}},
+			wantRemaining: []string{"spec.a"},
+		},
+		{
+			name:          "suppress by Origin",
+			allow:         []allowEntry{{Origin: "minimum"}},
+			wantRemaining: []string{"spec.a"},
+		},
+		{
+			name:          "non-matching entry leaves everything",
+			allow:         []allowEntry{{Group: "other"}},
+			wantRemaining: []string{"spec.a", "spec.b"},
+		},
+		{
+			name: "multiple entries — any match suppresses",
+			allow: []allowEntry{
+				{Path: "spec.a"},
+				{ErrorType: "Y"},
+			},
+			wantRemaining: nil,
+		},
+		{
+			name:          "Group match drops the whole report",
+			allow:         []allowEntry{{Group: "foo"}},
+			wantRemaining: nil,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			reports := []guardrails.Report{makeReport("foo", "v1", "Bar", rules)}
+			got := filterAllowed(reports, c.allow)
+			var gotKeys []string
+			for _, r := range got {
+				for path := range r.Kinds["Bar"] {
+					gotKeys = append(gotKeys, path)
+				}
+			}
+			slices.Sort(gotKeys)
+			slices.Sort(c.wantRemaining)
+			if !slices.Equal(gotKeys, c.wantRemaining) {
+				t.Errorf("remaining = %v, want %v", gotKeys, c.wantRemaining)
+			}
+		})
+	}
+}

--- a/test/declarative_validation/main.go
+++ b/test/declarative_validation/main.go
@@ -1,0 +1,23 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "k8s.io/kubernetes/test/declarative_validation/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
 /kind feature

#### What this PR does / why we need it:
 Adds a coverage guardrail for declarative-validation rules: every rule declared via DV tags (+k8s:required, +k8s:minimum, etc.) must be exercised by *at least one* declarative_validation_test.go case. Without this, it's easy to add a tag and forget the corresponding test fixture — the rule looks "enforced" but nothing actually triggers it.

  - validators package gains `Emission` (the field.Error each runtime validator produces) and `PathFragment` (the static path component each Wrapper adds), so external tools can walk the `FunctionGen` tree.
  - `validation-gen --report-rules` walks the typeNode tree and emits one JSON Report per (Group, Version, Kind, field-path → rule). New pkg/guardrails package defines the schema.
  - `pkg/api/testing` writes per-package observation JSON files when VALIDATION_RULES_REPORT_DIR is set during declarative_validation_test.go runs.
  - test/declarative_validation verify-coverage subcommand diffs the two and reports declared rules with no matching observation.
  - `hack/verify-declarative-validation-coverage.sh` wires the pipeline for presubmit; intentional gaps are suppressed by hack/declarative-validation-coverage-allowlist.yaml.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
- Run locally: `./hack/verify-declarative-validation-coverage.sh` (all groups) or with positional group filters (`./hack/verify-declarative-validation-coverage.sh autoscaling rbac`). It would first generate declared rules, then run tests to get the covered rules; and finally run verify-coverage to check test coverage.

For generating declared rules: 
```sh
~ go run ./staging/src/k8s.io/code-generator/cmd/validation-gen --readonly-pkg k8s.io/apimachinery/pkg/apis/meta/v1 --readonly-pkg k8s.io/apimachinery/pkg/api/resource --readonly-pkg k8s.io/apimachinery/pkg/runtime --readonly-pkg k8s.io/apimachinery/pkg/types --readonly-pkg k8s.io/apimachinery/pkg/util/intstr --readonly-pkg time --report-rules <target packages..>
```
e.g. output
```json
[
  {
    "group": "",
    "version": "v1",
    "kinds": {
      "ReplicationController": {
        "metadata.name": [
          {
            "errorType": "FieldValueInvalid",
            "origin": "format=k8s-long-name"
          }
        ],
        "spec.minReadySeconds": [
          {
            "errorType": "FieldValueInvalid",
            "origin": "minimum"
          }
        ],
        "spec.replicas": [
          {
            "errorType": "FieldValueRequired"
          },
          {
            "errorType": "FieldValueInvalid",
            "origin": "minimum"
          }
        ]
      }
    }
  },
  {
    "group": "resource.k8s.io",
    "version": "v1",
    "kinds": {
      "DeviceClass": {
        "metadata.name": [
          {
            "errorType": "FieldValueInvalid",
            "origin": "format=k8s-long-name"
          }
        ],
        "spec.config": [
          {
            "errorType": "FieldValueTooMany",
            "origin": "maxItems"
          
...
```
- For generate exercised validation rule through tests
```sh
VALIDATION_RULES_REPORT_DIR=/tmp/dv-actual go test -count=1 <test packages...>
```
e.g. output
```sh
~ cat /tmp/dv-actual/resourceclaim.json
[
  {
    "group": "resource.k8s.io",
    "version": "v1beta1",
    "kinds": {
      "ResourceClaim": {
        "spec": [
          {
            "errorType": "FieldValueInvalid",
            "origin": "immutable"
...
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
