### PR TITLE
nftables: add unit tests for CleanupLeftovers

### DIFF
--- a/pkg/proxy/nftables/cleanup.go
+++ b/pkg/proxy/nftables/cleanup.go
@@ -27,23 +27,27 @@ import (
 
 // CleanupLeftovers removes all nftables rules and chains created by the Proxier
 // It returns true if an error was encountered. Errors are logged.
-func CleanupLeftovers(ctx context.Context) bool {
-	logger := klog.FromContext(ctx)
-	var encounteredError bool
-
+func CleanupLeftovers(ctx context.Context) (encounteredError bool) {
 	for _, family := range []knftables.Family{knftables.IPv4Family, knftables.IPv6Family} {
 		nft, err := knftables.New(family, kubeProxyTable)
 		if err != nil {
 			continue
 		}
-		tx := nft.NewTransaction()
-		tx.Delete(&knftables.Table{})
-		err = nft.Run(ctx, tx)
-		if err != nil && !knftables.IsNotFound(err) {
-			logger.Error(err, "Error cleaning up nftables rules")
-			encounteredError = true
-		}
+		encounteredError = cleanupLeftoversForFamily(ctx, nft) || encounteredError
+	}
+	return
+}
+
+func cleanupLeftoversForFamily(ctx context.Context, nft knftables.Interface) (encounteredError bool) {
+	logger := klog.FromContext(ctx)
+
+	tx := nft.NewTransaction()
+	tx.Delete(&knftables.Table{})
+	err := nft.Run(ctx, tx)
+	if err != nil && !knftables.IsNotFound(err) {
+		logger.Error(err, "Error cleaning up nftables rules")
+		return true
 	}
 
-	return encounteredError
+	return false
 }

--- a/pkg/proxy/nftables/cleanup_test.go
+++ b/pkg/proxy/nftables/cleanup_test.go
@@ -1,0 +1,85 @@
+//go:build linux
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nftables
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"sigs.k8s.io/knftables"
+)
+
+func addKubeProxyTable(t *testing.T, nft *knftables.Fake) {
+	t.Helper()
+	tx := nft.NewTransaction()
+	tx.Add(&knftables.Table{})
+	if err := nft.Run(context.Background(), tx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
+func TestCleanupLeftoversDeletesExistingTables(t *testing.T) {
+	ctx := context.Background()
+	ipv4 := knftables.NewFake(knftables.IPv4Family, kubeProxyTable)
+	ipv6 := knftables.NewFake(knftables.IPv6Family, kubeProxyTable)
+	addKubeProxyTable(t, ipv4)
+	addKubeProxyTable(t, ipv6)
+
+	if got := cleanupLeftoversForFamily(ctx, ipv4); got {
+		t.Fatalf("cleanupLeftoversForFamily(ipv4) = %v, want false", got)
+	}
+	if got := cleanupLeftoversForFamily(ctx, ipv6); got {
+		t.Fatalf("cleanupLeftoversForFamily(ipv6) = %v, want false", got)
+	}
+	if ipv4.Table != nil {
+		t.Error("IPv4 kube-proxy table still present after cleanup")
+	}
+	if ipv6.Table != nil {
+		t.Error("IPv6 kube-proxy table still present after cleanup")
+	}
+}
+
+func TestCleanupLeftoversNotFoundIgnored(t *testing.T) {
+	ctx := context.Background()
+	// No table added: delete is a no-op / NotFound on fake.
+	nft := knftables.NewFake(knftables.IPv4Family, kubeProxyTable)
+	if got := cleanupLeftoversForFamily(ctx, nft); got {
+		t.Fatalf("cleanupLeftoversForFamily() = %v, want false when table is absent", got)
+	}
+}
+
+// fakeWithRunErr embeds knftables.Fake and returns runErr from Run for testing non-NotFound failures.
+type fakeWithRunErr struct {
+	*knftables.Fake
+	runErr error
+}
+
+func (f *fakeWithRunErr) Run(ctx context.Context, tx *knftables.Transaction) error {
+	return f.runErr
+}
+
+func TestCleanupLeftoversRunErrorSetsEncountered(t *testing.T) {
+	ctx := context.Background()
+	runErr := errors.New("nft run failed")
+	nft := &fakeWithRunErr{Fake: knftables.NewFake(knftables.IPv4Family, kubeProxyTable), runErr: runErr}
+	if got := cleanupLeftoversForFamily(ctx, nft); !got {
+		t.Fatal("cleanupLeftoversForFamily() = false, want true when Run returns a non-NotFound error")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds pkg/proxy/nftables/cleanup_test.go with unit tests for the kube-proxy nftables leftover cleanup path. The production entry point CleanupLeftovers is unchanged for callers.

CleanupLeftovers had no direct unit coverage. It depends on knftables.New and Run, which makes pure tests awkward without a seam. Tests lock in intended behavior: try IPv4 and IPv6, ignore client creation failures, ignore NotFound on delete, and report failure only when Run returns a non–NotFound error

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
