### PR TITLE
kubectl: deprecate run filename flag

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -178,6 +178,9 @@ func NewCmdRun(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Com
 	o.PrintFlags.AddFlags(cmd)
 	o.RecordFlags.AddFlags(cmd)
 
+	_ = cmd.Flags().MarkDeprecated("filename", "it is ignored by kubectl run and will be removed in a future release")
+	_ = cmd.Flags().MarkShorthandDeprecated("filename", "it is ignored by kubectl run and will be removed in a future release")
+
 	addRunFlags(cmd, o)
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddPodRunningTimeoutFlag(cmd, defaultPodAttachTimeout)


### PR DESCRIPTION
#### What type of PR is this?
/kind deprecation
#### What this PR does / why we need it:
`kubectl run` registers `--filename/-f` through `DeleteFlags`, but the run command does not consume `FilenameOptions`.
The command still builds the generated Pod from command-line arguments such as `NAME` and `--image`, and ignores the file passed through `--filename/-f`.
This PR starts the deprecation process for `kubectl run --filename/-f`.
#### Which issue(s) this PR is related to:
Follow-up to https://github.com/kubernetes/kubernetes/pull/138632
#### Special notes for your reviewer:
This follows up on maintainer feedback from https://github.com/kubernetes/kubernetes/pull/138632#issuecomment-4333274675.
The scope is intentionally limited to `--filename/-f`.
#### Does this PR introduce a user-facing change?
```release-note
Deprecated the ignored `--filename`/`-f` flag on `kubectl run`.
```