### PR TITLE
Treat sandbox network setup failures as network not ready

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2277,6 +2277,11 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	}
 
 	err = result.Error()
+	if err != nil {
+		if networkErr := sandboxNetworkNotReadyError(result); networkErr != nil {
+			err = fmt.Errorf("%s: %w", NetworkNotReadyErrorMsg, networkErr)
+		}
+	}
 	if len(result.SyncResults) > 0 && err == nil {
 		postSync = func() {
 			kl.RequestPodRelist(pod.UID)
@@ -2284,6 +2289,26 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	}
 
 	return false, postSync, err
+}
+
+func sandboxNetworkNotReadyError(result kubecontainer.PodSyncResult) error {
+	for _, r := range result.SyncResults {
+		if r.Action != kubecontainer.CreatePodSandbox || !errors.Is(r.Error, kubecontainer.ErrCreatePodSandbox) {
+			continue
+		}
+		msg := strings.ToLower(r.Message)
+		switch {
+		case strings.Contains(msg, "network is not ready"):
+			return fmt.Errorf("%s: %s", r.Error, r.Message)
+		case strings.Contains(msg, "cni plugin not initialized"):
+			return fmt.Errorf("%s: %s", r.Error, r.Message)
+		case strings.Contains(msg, "failed to setup network for sandbox") && strings.Contains(msg, "no such file or directory"):
+			return fmt.Errorf("%s: %s", r.Error, r.Message)
+		case strings.Contains(msg, "failed to set up sandbox container") && strings.Contains(msg, "network"):
+			return fmt.Errorf("%s: %s", r.Error, r.Message)
+		}
+	}
+	return nil
 }
 
 // SyncTerminatingPod is expected to terminate all running containers in a pod. Once this method

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1692,6 +1692,34 @@ func TestNetworkErrorsWithoutHostNetwork(t *testing.T) {
 	}
 }
 
+func TestSyncPodTreatsSandboxCNISetupMissingFileAsNetworkNotReady(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+	kubelet := testKubelet.kubelet
+
+	pod := podWithUIDNameNsSpec("12345678", "flannel-race", "new", v1.PodSpec{
+		Containers: []v1.Container{
+			{Name: "foo"},
+		},
+	})
+	kubelet.podManager.SetPods([]*v1.Pod{pod})
+	testKubelet.fakeRuntime.SyncResults = &kubecontainer.PodSyncResult{
+		SyncResults: []*kubecontainer.SyncResult{{
+			Action:  kubecontainer.CreatePodSandbox,
+			Target:  pod.UID,
+			Error:   kubecontainer.ErrCreatePodSandbox,
+			Message: `rpc error: code = Unknown desc = failed to setup network for sandbox "sandbox-id": plugin type="flannel" failed (add): failed to load flannel 'subnet.env' file: open /run/flannel/subnet.env: no such file or directory`,
+		}},
+	}
+
+	isTerminal, _, err := kubelet.SyncPod(tCtx, kubetypes.SyncPodUpdate, pod, nil, &kubecontainer.PodStatus{})
+	require.False(t, isTerminal)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), NetworkNotReadyErrorMsg)
+	assert.Contains(t, err.Error(), "CreatePodSandboxError")
+}
+
 func TestFilterOutInactivePods(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)


### PR DESCRIPTION
## What changed

This updates kubelet SyncPod error handling so selected CreatePodSandbox failures caused by CNI/network setup not being ready are normalized to the existing network is not ready path.

The change covers sandbox creation messages such as flannel failing to load /run/flannel/subnet.env before it has been created, plus existing generic CNI/network-not-ready message shapes.

## Why

Kubelet already gates non-hostNetwork pod startup when the CRI reports NetworkReady=false. In the reported flannel startup race, the CRI may still report network ready, and the first visible failure happens later during CreatePodSandbox when the CNI plugin cannot complete network setup yet.

Normalizing those sandbox network setup failures lets the pod worker use the existing short transient retry behavior for NetworkNotReady instead of treating the error like a generic sandbox creation failure.

Fixes #138633

## Validation

- gofmt -w pkg/kubelet/kubelet.go pkg/kubelet/kubelet_test.go
- git diff --check
- GOCACHE=/private/tmp/k8s-go-build-cache go test ./pkg/kubelet -run 'TestSyncPodTreatsSandboxCNISetupMissingFileAsNetworkNotReady|TestNetworkErrorsWithoutHostNetwork|TestSyncPodWithErrorsDuringInPlacePodResize'