### PR TITLE
Fix ipamperf profile docs

### DIFF
--- a/test/integration/ipamperf/README.md
+++ b/test/integration/ipamperf/README.md
@@ -65,7 +65,7 @@ allows for also saving this JSON to a named file.
 ### Profiling the code
 It's possible to get the CPU and memory profiles of code during test execution by using the ```-p``` option.
 The CPU and memory profiles are generated in the same directory with the file names set to ```cpu-<id>.out```
-and ```cpu-<id>.out```, where ```<id>``` is the argument value. Typicall pattern is to put in the number
+and ```mem-<id>.out```, where ```<id>``` is the argument value. Typical pattern is to put in the number
 of nodes being simulated as the id, or 'all' in case running the full suite.
 
 ### Custom Test Configuration


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Fixes the `test/integration/ipamperf/README.md` profiling section so it documents
the actual profile output files created by `test-performance.sh`: `cpu-<id>.out`
and `mem-<id>.out`.

This also fixes the nearby `Typicall` typo.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

None

#### Validation:

- `git diff --check -- test/integration/ipamperf/README.md`
