### PR TITLE
Add --applyset flag to kubectl diff for ApplySet-based pruning

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/applyset.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/applyset.go
@@ -258,6 +258,12 @@ func (a *ApplySet) AddLabels(objects ...*resource.Info) error {
 	return nil
 }
 
+// FetchParent fetches the current state of the ApplySet parent object.
+// This is a read-only operation suitable for use by diff and other read-only commands.
+func (a *ApplySet) FetchParent() error {
+	return a.fetchParent()
+}
+
 func (a *ApplySet) fetchParent() error {
 	helper := resource.NewHelper(a.client, a.parentRef.RESTMapping)
 	obj, err := helper.Get(a.parentRef.Namespace, a.parentRef.Name)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
@@ -17,6 +17,7 @@ limitations under the License.
 package diff
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -71,14 +72,22 @@ var (
 		 >1
 		Kubectl or diff failed with an error.
 
-		Note: KUBECTL_EXTERNAL_DIFF, if used, is expected to follow that convention.`))
+		Note: KUBECTL_EXTERNAL_DIFF, if used, is expected to follow that convention.
+
+		KUBECTL_APPLYSET (ALPHA - default disabled)
+		If set, enables the use of ApplySet-based pruning with --applyset.
+		ApplySets track which resources are managed, allowing accurate
+		preview of what would be pruned without the need for --prune-allowlist.`))
 
 	diffExample = templates.Examples(i18n.T(`
 		# Diff resources included in pod.json
 		kubectl diff -f pod.json
 
 		# Diff file read from stdin
-		cat service.yaml | kubectl diff -f -`))
+		cat service.yaml | kubectl diff -f -
+
+		# Diff resources and show what would be pruned with ApplySet (alpha; requires KUBECTL_APPLYSET=true)
+		kubectl diff -f manifest.yaml --prune --applyset=secret/my-set`))
 )
 
 // Number of times we try to diff before giving-up
@@ -118,6 +127,9 @@ type DiffOptions struct {
 	EnforceNamespace bool
 	Builder          *resource.Builder
 	Diff             *DiffProgram
+
+	ApplySetRef string
+	ApplySet    *apply.ApplySet
 
 	pruner  *pruner
 	tracker *tracker
@@ -169,6 +181,9 @@ func NewCmdDiff(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Co
 	usage := "contains the configuration to diff"
 	cmd.Flags().StringArray("prune-allowlist", []string{}, "Overwrite the default allowlist with <group/version/kind> for --prune")
 	cmd.Flags().Bool("prune", false, "Include resources that would be deleted by pruning. Can be used with -l and default shows all resources would be pruned")
+	if cmdutil.ApplySet.IsEnabled() {
+		cmd.Flags().StringVar(&options.ApplySetRef, "applyset", "", "[alpha] The name of the ApplySet that tracks which resources are being managed, for the purposes of determining what to prune. Format: [RESOURCE][.GROUP]/NAME")
+	}
 	cmd.Flags().BoolVar(&options.ShowManagedFields, "show-managed-fields", options.ShowManagedFields, "If true, include managed fields in the diff.")
 	cmd.Flags().BoolVar(&options.ShowSecrets, "show-secrets", false, "If true, do not mask secret values in the diff.")
 	cmd.Flags().IntVar(&options.Concurrency, "concurrency", 1, "Number of objects to process in parallel when diffing against the live version. Larger number = faster, but more memory, I/O and CPU over that shorter period of time.")
@@ -668,12 +683,32 @@ func (o *DiffOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []str
 			return err
 		}
 
-		resources, err := prune.ParseResources(mapper, cmdutil.GetFlagStringArray(cmd, "prune-allowlist"))
-		if err != nil {
-			return err
-		}
 		o.tracker = newTracker()
-		o.pruner = newPruner(o.DynamicClient, mapper, resources, o.Selector)
+
+		if o.ApplySetRef != "" {
+			if pruneAllowlist := cmdutil.GetFlagStringArray(cmd, "prune-allowlist"); len(pruneAllowlist) > 0 {
+				return fmt.Errorf("--prune-allowlist is incompatible with --applyset")
+			}
+			parent, err := apply.ParseApplySetParentRef(o.ApplySetRef, mapper)
+			if err != nil {
+				return fmt.Errorf("invalid parent reference %q: %w", o.ApplySetRef, err)
+			}
+			if o.EnforceNamespace && parent.IsNamespaced() {
+				parent.Namespace = o.CmdNamespace
+			}
+			tooling := apply.ApplySetTooling{Name: "kubectl", Version: apply.ApplySetToolVersion}
+			restClient, err := f.UnstructuredClientForMapping(parent.RESTMapping)
+			if err != nil {
+				return fmt.Errorf("failed to initialize RESTClient for ApplySet: %w", err)
+			}
+			o.ApplySet = apply.NewApplySet(parent, tooling, mapper, restClient)
+		} else {
+			resources, err := prune.ParseResources(mapper, cmdutil.GetFlagStringArray(cmd, "prune-allowlist"))
+			if err != nil {
+				return err
+			}
+			o.pruner = newPruner(o.DynamicClient, mapper, resources, o.Selector)
+		}
 	}
 
 	o.Builder = f.NewBuilder()
@@ -704,9 +739,21 @@ func (o *DiffOptions) Run() error {
 		return err
 	}
 
+	if o.ApplySet != nil {
+		if err := o.ApplySet.FetchParent(); err != nil {
+			return err
+		}
+	}
+
 	err = r.Visit(func(info *resource.Info, err error) error {
 		if err != nil {
 			return err
+		}
+
+		if o.ApplySet != nil {
+			if err := o.ApplySet.AddLabels(info); err != nil {
+				return err
+			}
 		}
 
 		local := info.Object.DeepCopyObject()
@@ -772,6 +819,22 @@ func (o *DiffOptions) Run() error {
 				return err
 			}
 		}
+	} else if o.ApplySet != nil {
+		prunedObjs, pruneErr := o.ApplySet.FindAllObjectsToPrune(context.TODO(), o.DynamicClient, o.tracker.VisitedUids())
+		if pruneErr != nil {
+			klog.Warningf("pruning failed and could not be evaluated err: %v", pruneErr)
+		}
+
+		for _, p := range prunedObjs {
+			name, err := getObjectName(p.Object)
+			if err != nil {
+				klog.Warningf("pruning failed and object name could not be retrieved: %v", err)
+				continue
+			}
+			if err := differ.From.Print(name, p.Object, printer); err != nil {
+				return err
+			}
+		}
 	}
 
 	if err != nil {
@@ -783,6 +846,17 @@ func (o *DiffOptions) Run() error {
 
 // Validate makes sure provided values for DiffOptions are valid
 func (o *DiffOptions) Validate() error {
+	if o.ApplySetRef != "" && o.ApplySet == nil && o.tracker == nil {
+		return fmt.Errorf("--applyset requires --prune")
+	}
+	if o.ApplySet != nil {
+		if o.Selector != "" {
+			return fmt.Errorf("--selector is incompatible with --applyset")
+		}
+		if err := o.ApplySet.Validate(context.TODO(), o.DynamicClient); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/prune.go
@@ -122,6 +122,11 @@ func (p *pruner) prune(tracker *tracker, namespace string, mapping *meta.RESTMap
 	return pobjs, nil
 }
 
+// VisitedUids returns the set of visited UIDs
+func (t *tracker) VisitedUids() sets.Set[types.UID] {
+	return t.visitedUids
+}
+
 // MarkVisited marks visited namespaces and uids
 func (t *tracker) MarkVisited(info *resource.Info) {
 	if info.Namespaced() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Add `--applyset` flag support to `kubectl diff --prune`, enabling users to preview what resources would be pruned when using ApplySet-based pruning.


#### Which issue(s) this PR is related to:

Resolve https://github.com/kubernetes/kubectl/issues/1435
KEP: https://github.com/kubernetes/enhancements/issues/3659


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubectl diff: Add --applyset flag to support ApplySet-based pruning preview (alpha, requires KUBECTL_APPLYSET=true).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-cli/3659-kubectl-apply-prune/README.md

/cc @soltysh