### PR TITLE
validation: remove inconsistent strict finalizer name check

### DIFF
--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -303,17 +303,6 @@ func IsServiceIPSet(service *core.Service) bool {
 		service.Spec.ClusterIP != core.ClusterIPNone
 }
 
-var standardFinalizers = sets.New(
-	string(core.FinalizerKubernetes),
-	metav1.FinalizerOrphanDependents,
-	metav1.FinalizerDeleteDependents,
-)
-
-// IsStandardFinalizerName checks if the input string is a standard finalizer name
-func IsStandardFinalizerName(str string) bool {
-	return standardFinalizers.Has(str)
-}
-
 // GetAccessModesAsString returns a string representation of an array of access modes.
 // modes, when present, are always in the same order: RWO,ROX,RWX,RWOP.
 func GetAccessModesAsString(modes []core.PersistentVolumeAccessMode) string {

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -412,35 +412,19 @@ func ValidateImmutableAnnotation(newVal string, oldVal string, annotation string
 // ValidateObjectMetaWithOpts validates an object's metadata on creation. It expects that name generation has already
 // been performed.
 func ValidateObjectMetaWithOpts(meta *metav1.ObjectMeta, isNamespaced bool, nameFn ValidateNameFuncWithErrors, fldPath *field.Path) field.ErrorList {
-	allErrs := apimachineryvalidation.ValidateObjectMetaWithOpts(meta, isNamespaced, nameFn, fldPath)
-	// run additional checks for the finalizer name
-	for i := range meta.Finalizers {
-		allErrs = append(allErrs, validateKubeFinalizerName(string(meta.Finalizers[i]), fldPath.Child("finalizers").Index(i))...)
-	}
-	return allErrs
+	return apimachineryvalidation.ValidateObjectMetaWithOpts(meta, isNamespaced, nameFn, fldPath)
 }
 
 // ValidateObjectMeta validates an object's metadata on creation. It expects that name generation has already
 // been performed.
 // TODO: Remove calls to this method scattered in validations of specific resources, e.g., ValidatePodUpdate.
 func ValidateObjectMeta(meta *metav1.ObjectMeta, requiresNamespace bool, nameFn ValidateNameFunc, fldPath *field.Path) field.ErrorList {
-	allErrs := apimachineryvalidation.ValidateObjectMeta(meta, requiresNamespace, apimachineryvalidation.ValidateNameFunc(nameFn), fldPath)
-	// run additional checks for the finalizer name
-	for i := range meta.Finalizers {
-		allErrs = append(allErrs, validateKubeFinalizerName(string(meta.Finalizers[i]), fldPath.Child("finalizers").Index(i))...)
-	}
-	return allErrs
+	return apimachineryvalidation.ValidateObjectMeta(meta, requiresNamespace, apimachineryvalidation.ValidateNameFunc(nameFn), fldPath)
 }
 
 // ValidateObjectMetaUpdate validates an object's metadata when updated
 func ValidateObjectMetaUpdate(newMeta, oldMeta *metav1.ObjectMeta, fldPath *field.Path) field.ErrorList {
-	allErrs := apimachineryvalidation.ValidateObjectMetaUpdate(newMeta, oldMeta, fldPath)
-	// run additional checks for the finalizer name
-	for i := range newMeta.Finalizers {
-		allErrs = append(allErrs, validateKubeFinalizerName(string(newMeta.Finalizers[i]), fldPath.Child("finalizers").Index(i))...)
-	}
-
-	return allErrs
+	return apimachineryvalidation.ValidateObjectMetaUpdate(newMeta, oldMeta, fldPath)
 }
 
 func ValidateVolumes(volumes []core.Volume, podMeta *metav1.ObjectMeta, fldPath *field.Path, opts PodValidationOptions) (map[string]core.VolumeSource, field.ErrorList) {

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -8268,21 +8268,7 @@ func ValidateNamespace(namespace *core.Namespace) field.ErrorList {
 
 // Validate finalizer names
 func validateFinalizerName(stringValue string, fldPath *field.Path) field.ErrorList {
-	allErrs := apimachineryvalidation.ValidateFinalizerName(stringValue, fldPath)
-	allErrs = append(allErrs, validateKubeFinalizerName(stringValue, fldPath)...)
-	return allErrs
-}
-
-// validateKubeFinalizerName checks for "standard" names of legacy finalizer
-func validateKubeFinalizerName(stringValue string, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-	if len(strings.Split(stringValue, "/")) == 1 {
-		if !helper.IsStandardFinalizerName(stringValue) {
-			return append(allErrs, field.Invalid(fldPath, stringValue, "name is neither a standard finalizer name nor is it fully qualified"))
-		}
-	}
-
-	return allErrs
+	return apimachineryvalidation.ValidateFinalizerName(stringValue, fldPath)
 }
 
 // ValidateNamespaceUpdate tests to make sure a namespace update can be applied.


### PR DESCRIPTION
## Summary
Remove the strict `validateKubeFinalizerName` check that required unqualified finalizer names to be one of the standard names (kubernetes, orphan, foregroundDeletion). This check was only enforced on resources importing core validation, creating an inconsistency with admissionregistration, coordination, and node types that used the lax apimachinery path.

## Changes
- Remove strict finalizer check from `ValidateObjectMeta`, `ValidateObjectMetaWithOpts`, and `ValidateObjectMetaUpdate` for `metadata.finalizers`
- Remove strict finalizer check from `validateFinalizerName` for Namespace `spec.finalizers`
- Delete dead code: `validateKubeFinalizerName`, `IsStandardFinalizerName`, and `standardFinalizers`

Fixes: https://github.com/kubernetes/kubernetes/issues/138648