### PR TITLE
Cleanup statefulset helpers and tests 

### DIFF
--- a/pkg/controller/statefulset/stateful_pod_control_test.go
+++ b/pkg/controller/statefulset/stateful_pod_control_test.go
@@ -462,63 +462,50 @@ func TestStatefulPodControlUpdatePodConflictSuccess(t *testing.T) {
 	}
 }
 
-func TestStatefulPodControlDeletesStatefulPod(t *testing.T) {
-	recorder := record.NewFakeRecorder(10)
-	set := newStatefulSet(3)
-	pod := newStatefulSetPod(set, 0)
-	fakeClient := &fake.Clientset{}
-	control := NewStatefulPodControl(fakeClient, nil, nil, recorder, consistency.NewNoopConsistencyStore())
-	fakeClient.AddReactor("delete", "pods", func(action core.Action) (bool, runtime.Object, error) {
-		return true, nil, nil
-	})
-	if err := control.DeleteStatefulPod(set, pod); err != nil {
-		t.Errorf("Error returned on successful delete: %s", err)
+func TestStatefulPodControlDeleteStatefulPod(t *testing.T) {
+	tests := []struct {
+		name          string
+		reactorErr    error
+		wantErr       bool
+		wantEventType string
+	}{
+		{
+			name:          "success",
+			wantEventType: v1.EventTypeNormal,
+		},
+		{
+			name:          "not found",
+			reactorErr:    apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "foo-0"),
+			wantEventType: v1.EventTypeNormal,
+		},
+		{
+			name:          "failure",
+			reactorErr:    apierrors.NewInternalError(errors.New("API server down")),
+			wantErr:       true,
+			wantEventType: v1.EventTypeWarning,
+		},
 	}
-	events := collectEvents(recorder.Events)
-	if eventCount := len(events); eventCount != 1 {
-		t.Errorf("delete successful: got %d events, but want 1", eventCount)
-	} else if !strings.Contains(events[0], v1.EventTypeNormal) {
-		t.Errorf("Found unexpected non-normal event %s", events[0])
-	}
-}
-
-func TestStatefulPodControlDeleteStatefulPodNotFound(t *testing.T) {
-	recorder := record.NewFakeRecorder(10)
-	set := newStatefulSet(3)
-	pod := newStatefulSetPod(set, 0)
-	fakeClient := &fake.Clientset{}
-	control := NewStatefulPodControl(fakeClient, nil, nil, recorder, consistency.NewNoopConsistencyStore())
-	fakeClient.AddReactor("delete", "pods", func(action core.Action) (bool, runtime.Object, error) {
-		return true, nil, apierrors.NewNotFound(action.GetResource().GroupResource(), pod.Name)
-	})
-	if err := control.DeleteStatefulPod(set, pod); err != nil {
-		t.Errorf("DeleteStatefulPod returned error for NotFound pod: %s", err)
-	}
-	events := collectEvents(recorder.Events)
-	if eventCount := len(events); eventCount != 1 {
-		t.Errorf("delete not-found: got %d events, but want 1", eventCount)
-	} else if !strings.Contains(events[0], v1.EventTypeNormal) {
-		t.Errorf("Found unexpected non-normal event %s", events[0])
-	}
-}
-
-func TestStatefulPodControlDeleteFailure(t *testing.T) {
-	recorder := record.NewFakeRecorder(10)
-	set := newStatefulSet(3)
-	pod := newStatefulSetPod(set, 0)
-	fakeClient := &fake.Clientset{}
-	control := NewStatefulPodControl(fakeClient, nil, nil, recorder, consistency.NewNoopConsistencyStore())
-	fakeClient.AddReactor("delete", "pods", func(action core.Action) (bool, runtime.Object, error) {
-		return true, nil, apierrors.NewInternalError(errors.New("API server down"))
-	})
-	if err := control.DeleteStatefulPod(set, pod); err == nil {
-		t.Error("Failed to return error on failed delete")
-	}
-	events := collectEvents(recorder.Events)
-	if eventCount := len(events); eventCount != 1 {
-		t.Errorf("delete failed: got %d events, but want 1", eventCount)
-	} else if !strings.Contains(events[0], v1.EventTypeWarning) {
-		t.Errorf("Found unexpected non-warning event %s", events[0])
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := record.NewFakeRecorder(10)
+			set := newStatefulSet(3)
+			pod := newStatefulSetPod(set, 0)
+			fakeClient := &fake.Clientset{}
+			control := NewStatefulPodControl(fakeClient, nil, nil, recorder, consistency.NewNoopConsistencyStore())
+			fakeClient.AddReactor("delete", "pods", func(action core.Action) (bool, runtime.Object, error) {
+				return true, nil, tc.reactorErr
+			})
+			err := control.DeleteStatefulPod(set, pod)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("DeleteStatefulPod() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			events := collectEvents(recorder.Events)
+			if eventCount := len(events); eventCount != 1 {
+				t.Errorf("got %d events, want 1", eventCount)
+			} else if !strings.Contains(events[0], tc.wantEventType) {
+				t.Errorf("got event %q, want %s event type", events[0], tc.wantEventType)
+			}
+		})
 	}
 }
 

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -422,7 +422,7 @@ func (ssc *defaultStatefulSetControl) processReplica(ctx context.Context, set *a
 	// (e.g. terminated on node reboot) is determined by the exit code of the
 	// container, not by the reason for pod termination. We should restart the pod
 	// regardless of the exit code.
-	if isFailed(replicas[i]) || isSucceeded(replicas[i]) {
+	if isTerminalPhase(replicas[i]) {
 		if replicas[i].DeletionTimestamp == nil {
 			if err := ssc.podControl.DeleteStatefulPod(set, replicas[i]); err != nil {
 				return true, err
@@ -818,8 +818,7 @@ func updateStatefulSetAfterInvariantEstablished(ctx context.Context, ssc *defaul
 		for target := len(replicas) - 1; target >= updateMin && remainingBudget > 0; target-- {
 			pod := replicas[target]
 			if getPodRevision(pod) != updateRevision.Name &&
-				isRunningAndAvailable(pod, set.Spec.MinReadySeconds, now) &&
-				!isTerminating(pod) {
+				!isUnavailable(pod, set.Spec.MinReadySeconds, now) {
 				logger.V(2).Info("StatefulSet terminating Pod for update",
 					"statefulSet", klog.KObj(set), "pod", klog.KObj(pod))
 				if err := ssc.podControl.DeleteStatefulPod(set, pod); err != nil {

--- a/pkg/controller/statefulset/stateful_set_status_updater_test.go
+++ b/pkg/controller/statefulset/stateful_set_status_updater_test.go
@@ -30,67 +30,89 @@ import (
 	appslisters "k8s.io/client-go/listers/apps/v1"
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/pkg/controller/util/consistency"
 )
 
-func TestStatefulSetUpdaterUpdatesSetStatus(t *testing.T) {
-	set := newStatefulSet(3)
-	status := apps.StatefulSetStatus{ObservedGeneration: 1, Replicas: 2}
-	fakeClient := &fake.Clientset{}
-	updater := NewRealStatefulSetStatusUpdater(fakeClient, nil, consistency.NewNoopConsistencyStore())
-	fakeClient.AddReactor("update", "statefulsets", func(action core.Action) (bool, runtime.Object, error) {
-		update := action.(core.UpdateAction)
-		return true, update.GetObject(), nil
-	})
-	if err := updater.UpdateStatefulSetStatus(context.TODO(), set, &status); err != nil {
-		t.Errorf("Error returned on successful status update: %s", err)
+func TestStatefulSetStatusUpdater(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     apps.StatefulSetStatus
+		reactorErr error
+		wantErr    bool
+		checkFn    func(*testing.T, apps.StatefulSetStatus)
+	}{
+		{
+			name:   "updates status",
+			status: apps.StatefulSetStatus{ObservedGeneration: 1, Replicas: 2},
+			checkFn: func(t *testing.T, status apps.StatefulSetStatus) {
+				if status.Replicas != 2 {
+					t.Errorf("UpdateStatefulSetStatus mutated the sets replicas %d", status.Replicas)
+				}
+			},
+		},
+		{
+			name:   "updates observed generation",
+			status: apps.StatefulSetStatus{ObservedGeneration: 3, Replicas: 2},
+			checkFn: func(t *testing.T, status apps.StatefulSetStatus) {
+				if status.ObservedGeneration != 3 {
+					t.Errorf("expected observedGeneration to be synced with generation for statefulset %d", status.ObservedGeneration)
+				}
+			},
+		},
+		{
+			name:   "updates available replicas",
+			status: apps.StatefulSetStatus{ObservedGeneration: 1, Replicas: 2, AvailableReplicas: 3},
+			checkFn: func(t *testing.T, status apps.StatefulSetStatus) {
+				if status.AvailableReplicas != 3 {
+					t.Errorf("UpdateStatefulSetStatus mutated the sets available replicas %d", status.AvailableReplicas)
+				}
+			},
+		},
+		{
+			name:       "update replicas server failure",
+			status:     apps.StatefulSetStatus{ObservedGeneration: 3, Replicas: 2},
+			reactorErr: apierrors.NewInternalError(errors.New("API server down")),
+			wantErr:    true,
+		},
+		{
+			name:       "update replicas conflict persists",
+			status:     apps.StatefulSetStatus{ObservedGeneration: 3, Replicas: 2},
+			reactorErr: apierrors.NewConflict(schema.GroupResource{Group: "apps", Resource: "statefulset"}, "foo", errors.New("object already exists")),
+			wantErr:    true,
+		},
 	}
-	if set.Status.Replicas != 2 {
-		t.Errorf("UpdateStatefulSetStatus mutated the sets replicas %d", set.Status.Replicas)
-	}
-}
-
-func TestStatefulSetStatusUpdaterUpdatesObservedGeneration(t *testing.T) {
-	set := newStatefulSet(3)
-	status := apps.StatefulSetStatus{ObservedGeneration: 3, Replicas: 2}
-	fakeClient := &fake.Clientset{}
-	updater := NewRealStatefulSetStatusUpdater(fakeClient, nil, consistency.NewNoopConsistencyStore())
-	fakeClient.AddReactor("update", "statefulsets", func(action core.Action) (bool, runtime.Object, error) {
-		update := action.(core.UpdateAction)
-		sts := update.GetObject().(*apps.StatefulSet)
-		if sts.Status.ObservedGeneration != 3 {
-			t.Errorf("expected observedGeneration to be synced with generation for statefulset %q", sts.Name)
-		}
-		return true, sts, nil
-	})
-	if err := updater.UpdateStatefulSetStatus(context.TODO(), set, &status); err != nil {
-		t.Errorf("Error returned on successful status update: %s", err)
-	}
-}
-
-func TestStatefulSetStatusUpdaterUpdateReplicasFailure(t *testing.T) {
-	set := newStatefulSet(3)
-	status := apps.StatefulSetStatus{ObservedGeneration: 3, Replicas: 2}
-	fakeClient := &fake.Clientset{}
-	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-	indexer.Add(set)
-	setLister := appslisters.NewStatefulSetLister(indexer)
-	updater := NewRealStatefulSetStatusUpdater(fakeClient, setLister, consistency.NewNoopConsistencyStore())
-	fakeClient.AddReactor("update", "statefulsets", func(action core.Action) (bool, runtime.Object, error) {
-		return true, nil, apierrors.NewInternalError(errors.New("API server down"))
-	})
-	if err := updater.UpdateStatefulSetStatus(context.TODO(), set, &status); err == nil {
-		t.Error("Failed update did not return error")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			set := newStatefulSet(3)
+			fakeClient := &fake.Clientset{}
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			indexer.Add(set) // nolint:errcheck
+			updater := NewRealStatefulSetStatusUpdater(fakeClient, appslisters.NewStatefulSetLister(indexer), consistency.NewNoopConsistencyStore())
+			fakeClient.AddReactor("update", "statefulsets", func(action core.Action) (bool, runtime.Object, error) {
+				update := action.(core.UpdateAction)
+				return true, update.GetObject(), tc.reactorErr
+			})
+			status := tc.status
+			if err := updater.UpdateStatefulSetStatus(ctx, set, &status); (err != nil) != tc.wantErr {
+				t.Errorf("UpdateStatefulSetStatus() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if tc.checkFn != nil {
+				tc.checkFn(t, status)
+			}
+		})
 	}
 }
 
 func TestStatefulSetStatusUpdaterUpdateReplicasConflict(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	set := newStatefulSet(3)
 	status := apps.StatefulSetStatus{ObservedGeneration: 3, Replicas: 2}
 	conflict := false
 	fakeClient := &fake.Clientset{}
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-	indexer.Add(set)
+	indexer.Add(set) // nolint:errcheck
 	setLister := appslisters.NewStatefulSetLister(indexer)
 	updater := NewRealStatefulSetStatusUpdater(fakeClient, setLister, consistency.NewNoopConsistencyStore())
 	fakeClient.AddReactor("update", "statefulsets", func(action core.Action) (bool, runtime.Object, error) {
@@ -102,45 +124,11 @@ func TestStatefulSetStatusUpdaterUpdateReplicasConflict(t *testing.T) {
 		return true, update.GetObject(), nil
 
 	})
-	if err := updater.UpdateStatefulSetStatus(context.TODO(), set, &status); err != nil {
+	if err := updater.UpdateStatefulSetStatus(ctx, set, &status); err != nil {
 		t.Errorf("UpdateStatefulSetStatus returned an error: %s", err)
 	}
 	if set.Status.Replicas != 2 {
 		t.Errorf("UpdateStatefulSetStatus mutated the sets replicas %d", set.Status.Replicas)
-	}
-}
-
-func TestStatefulSetStatusUpdaterUpdateReplicasConflictFailure(t *testing.T) {
-	set := newStatefulSet(3)
-	status := apps.StatefulSetStatus{ObservedGeneration: 3, Replicas: 2}
-	fakeClient := &fake.Clientset{}
-	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-	indexer.Add(set)
-	setLister := appslisters.NewStatefulSetLister(indexer)
-	updater := NewRealStatefulSetStatusUpdater(fakeClient, setLister, consistency.NewNoopConsistencyStore())
-	fakeClient.AddReactor("update", "statefulsets", func(action core.Action) (bool, runtime.Object, error) {
-		update := action.(core.UpdateAction)
-		return true, update.GetObject(), apierrors.NewConflict(action.GetResource().GroupResource(), set.Name, errors.New("object already exists"))
-	})
-	if err := updater.UpdateStatefulSetStatus(context.TODO(), set, &status); err == nil {
-		t.Error("UpdateStatefulSetStatus failed to return an error on get failure")
-	}
-}
-
-func TestStatefulSetStatusUpdaterGetAvailableReplicas(t *testing.T) {
-	set := newStatefulSet(3)
-	status := apps.StatefulSetStatus{ObservedGeneration: 1, Replicas: 2, AvailableReplicas: 3}
-	fakeClient := &fake.Clientset{}
-	updater := NewRealStatefulSetStatusUpdater(fakeClient, nil, consistency.NewNoopConsistencyStore())
-	fakeClient.AddReactor("update", "statefulsets", func(action core.Action) (bool, runtime.Object, error) {
-		update := action.(core.UpdateAction)
-		return true, update.GetObject(), nil
-	})
-	if err := updater.UpdateStatefulSetStatus(context.TODO(), set, &status); err != nil {
-		t.Errorf("Error returned on successful status update: %s", err)
-	}
-	if set.Status.AvailableReplicas != 3 {
-		t.Errorf("UpdateStatefulSetStatus mutated the sets replicas %d", set.Status.AvailableReplicas)
 	}
 }
 

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -74,12 +74,6 @@ func getParentNameAndOrdinal(pod *v1.Pod) (string, int) {
 	return parent, ordinal
 }
 
-// getParentName gets the name of pod's parent StatefulSet. If pod has not parent, the empty string is returned.
-func getParentName(pod *v1.Pod) string {
-	parent, _ := getParentNameAndOrdinal(pod)
-	return parent
-}
-
 // getOrdinal gets pod's ordinal. If pod has no ordinal, -1 is returned.
 func getOrdinal(pod *v1.Pod) int {
 	_, ordinal := getParentNameAndOrdinal(pod)
@@ -121,7 +115,8 @@ func getPersistentVolumeClaimName(set *apps.StatefulSet, claim *v1.PersistentVol
 
 // isMemberOf tests if pod is a member of set.
 func isMemberOf(set *apps.StatefulSet, pod *v1.Pod) bool {
-	return getParentName(pod) == set.Name
+	parent, _ := getParentNameAndOrdinal(pod)
+	return parent == set.Name
 }
 
 // identityMatches returns true if pod has a valid identity and network identity for a member of set.
@@ -472,14 +467,9 @@ func isPending(pod *v1.Pod) bool {
 	return pod.Status.Phase == v1.PodPending
 }
 
-// isFailed returns true if pod has a Phase of PodFailed
-func isFailed(pod *v1.Pod) bool {
-	return pod.Status.Phase == v1.PodFailed
-}
-
-// isSucceeded returns true if pod has a Phase of PodSucceeded
-func isSucceeded(pod *v1.Pod) bool {
-	return pod.Status.Phase == v1.PodSucceeded
+// isTerminalPhase returns true if pod has a Phase of PodFailed or PodSucceeded.
+func isTerminalPhase(pod *v1.Pod) bool {
+	return pod.Status.Phase == v1.PodFailed || pod.Status.Phase == v1.PodSucceeded
 }
 
 // isTerminating returns true if pod's DeletionTimestamp has been set


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig apps

#### What this PR does / why we need it:
I've noticed while going through several statefulset reviews recently that we have some repetitive places in the code. 
1. In the first commit, I went through duplicate and one-time used helpers and tried to limit the code removing unused or squashing together where possible. 
2. In the latter two commit, with the help from LLM I found tests which could be squashed into a table tests driven, the actual code changes were manual. These changes do not affect code coverage, since we're not removing any tests. 

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
/assign @helayoty 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
