### PR TITLE
Fix deadlock in TestNodeSyncUpdate

### DIFF
--- a/pkg/controller/nodeipam/ipam/sync/sync_test.go
+++ b/pkg/controller/nodeipam/ipam/sync/sync_test.go
@@ -231,10 +231,8 @@ func TestNodeSyncResync(t *testing.T) {
 	fake := &fakeAPIs{
 		nodeRet:       nodeWithCIDRRange,
 		resyncTimeout: time.Millisecond,
-		// Allow one extra resync notification to land while the test is
-		// closing the loop down.
-		reportChan: make(chan struct{}, 1),
-		logger:     logger,
+		reportChan:    make(chan struct{}),
+		logger:        logger,
 	}
 	cidr, _ := cidrset.NewCIDRSet(clusterCIDRRange, 24)
 	sync := New(fake, fake, fake, SyncFromCluster, "node1", cidr)
@@ -244,8 +242,18 @@ func TestNodeSyncResync(t *testing.T) {
 	<-fake.reportChan
 	// Close the operation channel to stop the loop
 	close(sync.opChan)
+	// Run drainer goroutine to unblock sync loop()
+	drainerChan := make(chan struct{})
+	go func() {
+		defer close(drainerChan)
+		for range fake.reportChan {
+		}
+	}()
 	// Wait for the loop to complete
 	<-doneChan
+	// Close report chan and wait for drainer to complete
+	close(fake.reportChan)
+	<-drainerChan
 	fake.dumpTrace()
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

There is a deadlock in TestNodeSyncUpdate that causes test to timeout. It happens very seldom when test running environemnt is stressed.

##### Deadlock
1. The `Loop()` in `sync.go` runs a `select` between `opChan` and a 1ms resync timer
2. When the timer fires, it runs a resync and calls `ReportResult()`, which sends on `reportChan`
3. The test receives the first notification, then closes `opChan`
4. But with a 1ms resync interval, the loop can cycle multiple times before the `select` sees the closed `opChan`
5. Each cycle calls `ReportResult()` which sends to `reportChan`
6. The channel (originally unbuffered, later buffered to 1) fills up
7. `ReportResult()` blocks on the channel send → the loop can never reach the `select` that would see the closed `opChan`
8. The test blocks on `<-doneChan` → deadlock

##### Previous tries to fix the test
There were already two fixes to this test:
* 4795edadee0 "Fix goroutine leak in TestNodeSyncResync" - that fixed the goroutine leak, but also removed additional read from reportChan
* 5d3e8d9db65 "nodeipam: buffer TestNodeSyncResync report notifications"
  - that made the reportChan buffered (1)

But they are not enough as multiple writes still can cause deadlock.

##### Solution
This fix brings back the goroutine for draining the channel, but it now contains loop to drain the channel until it's closed. To avoid leaking the goroutine, test waits until goroutine is completed on separate channel.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
Issue fixed by this PR reproduces in stressed environment:
```
stress -c 10 -t 30 &
go test -race ./pkg/controller/nodeipam/ipam/sync -count=1000
```
#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
