### PR TITLE
Fix getting sig prefixes from windows filepaths

### DIFF
--- a/cmd/prune-junit-xml/prunexml.go
+++ b/cmd/prune-junit-xml/prunexml.go
@@ -25,7 +25,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -283,8 +283,8 @@ func (p *packageOwners) addOwner(name string) string {
 	}
 
 	// Walk up starting from an absolute path until we cannot go up further.
-	for ; dir != "" && dir != "." && dir != "/"; dir = path.Dir(dir) {
-		data, err := os.ReadFile(path.Join(dir, "OWNERS"))
+	for ; dir != "" && dir != "." && dir != "/"; dir = filepath.Dir(dir) {
+		data, err := os.ReadFile(filepath.Join(dir, "OWNERS"))
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:
##### Changes
Replace `path.Dir()` with `filepath.Dir()` and `path.Join()` with `filepath.Join()`. The `path`package uses forward-slashes only for paths management. The `path/filepath` uses OS-native path separators for directory walking and path joining.

Using OS-native paths is required for getting sig- prefixes on Windows system for addOwner function, as `go list` returns paths with backslashes there. Without proper path splitting OWNER files are never found, causing TestPruneTESTS to fail in unit-windows-master tests.

##### Related patches:
* 5ceba3ca26e "test: inject [sig-...] prefix into unit and integration test names" - added owners prefixes feature
* 4e384549594 "test/integration: add missing sig labels" - added labels to integration tests

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
