### PR TITLE
Fix Summary API Test: fallback to cache if CRI reports zero UsageNanoCores

### DIFF
--- a/pkg/kubelet/server/stats/summary_test.go
+++ b/pkg/kubelet/server/stats/summary_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	statstest "k8s.io/kubernetes/pkg/kubelet/server/stats/testing"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -148,6 +149,55 @@ func TestSummaryProviderGetStatsNoSplitFileSystem(t *testing.T) {
 		IO:                 cgroupStatsMap["/pods"].cs.IO,
 	})
 	assert.Equal(summary.Pods, podStats)
+}
+
+func TestSummaryProviderGetStatsZeroUsageNanoCores(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KubeletPSI, true)
+	ctx := context.Background()
+	assert := assert.New(t)
+
+	// Setup pod stats with 0 UsageNanoCores
+	podStats := []statsapi.PodStats{
+		{
+			PodRef:    statsapi.PodReference{Name: "test-pod", Namespace: "test-namespace", UID: "UID_test-pod"},
+			StartTime: metav1.NewTime(time.Now()),
+			Containers: []statsapi.ContainerStats{
+				{
+					Name:      "test-container",
+					StartTime: metav1.NewTime(time.Now()),
+					CPU: &statsapi.CPUStats{
+						Time:           metav1.NewTime(time.Now()),
+						UsageNanoCores: ptr.To[uint64](0),
+					},
+				},
+			},
+		},
+	}
+
+	mockStatsProvider := statstest.NewMockProvider(t)
+	mockStatsProvider.EXPECT().GetNode(ctx).Return(node, nil)
+	mockStatsProvider.EXPECT().GetNodeConfig().Return(nodeConfig)
+	mockStatsProvider.EXPECT().GetPodCgroupRoot().Return(cgroupRoot)
+	mockStatsProvider.EXPECT().ListPodStatsAndUpdateCPUNanoCoreUsage(ctx).Return(podStats, nil)
+	mockStatsProvider.EXPECT().ImageFsStats(ctx).Return(imageFsStats, imageFsStats, nil)
+	mockStatsProvider.EXPECT().RootFsStats().Return(rootFsStats, nil)
+	mockStatsProvider.EXPECT().RlimitStats().Return(rlimitStats, nil)
+
+	// Mock system containers
+	mockStatsProvider.EXPECT().GetCgroupStats("/", true).Return(getContainerStats(), getNetworkStats(), nil)
+	mockStatsProvider.EXPECT().GetCgroupStats("/runtime", false).Return(getContainerStats(), getNetworkStats(), nil)
+	mockStatsProvider.EXPECT().GetCgroupStats("/misc", false).Return(getContainerStats(), getNetworkStats(), nil)
+	mockStatsProvider.EXPECT().GetCgroupStats("/kubelet", false).Return(getContainerStats(), getNetworkStats(), nil)
+	mockStatsProvider.EXPECT().GetCgroupStats("/kubepods", true).Return(getContainerStats(), getNetworkStats(), nil)
+
+	provider := summaryProviderImpl{kubeletCreationTime: metav1.Now(), systemBootTime: metav1.Now(), provider: mockStatsProvider}
+	summary, err := provider.Get(ctx, true)
+	assert.NoError(err)
+
+	assert.Len(summary.Pods, 1)
+	assert.Equal("test-container", summary.Pods[0].Containers[0].Name)
+	assert.NotNil(summary.Pods[0].Containers[0].CPU.UsageNanoCores)
+	assert.Equal(uint64(0), *summary.Pods[0].Containers[0].CPU.UsageNanoCores)
 }
 
 func TestSummaryProviderGetStatsSplitImageFs(t *testing.T) {

--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -998,8 +998,8 @@ func (p *criStatsProvider) getContainerUsageNanoCores(stats *runtimeapi.Containe
 		return nil
 	}
 
-	// Bypass the cache if the CRI implementation specified the UsageNanoCores.
-	if stats.Cpu != nil && stats.Cpu.UsageNanoCores != nil {
+	// Bypass the cache if the CRI implementation specified a non-zero UsageNanoCores.
+	if stats.Cpu != nil && stats.Cpu.UsageNanoCores != nil && stats.Cpu.UsageNanoCores.Value != 0 {
 		return &stats.Cpu.UsageNanoCores.Value
 	}
 
@@ -1022,8 +1022,8 @@ func (p *criStatsProvider) getAndUpdateContainerUsageNanoCores(logger klog.Logge
 	if stats == nil || stats.Attributes == nil || stats.Cpu == nil {
 		return nil
 	}
-	// Bypass the cache if the CRI implementation specified the UsageNanoCores.
-	if stats.Cpu.UsageNanoCores != nil {
+	// Bypass the cache if the CRI implementation specified a non-zero UsageNanoCores.
+	if stats.Cpu.UsageNanoCores != nil && stats.Cpu.UsageNanoCores.Value != 0 {
 		return &stats.Cpu.UsageNanoCores.Value
 	}
 	// If there is no UsageNanoCores, nor UsageCoreNanoSeconds, there is no information to use

--- a/pkg/kubelet/stats/cri_stats_provider_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_test.go
@@ -1512,6 +1512,34 @@ func TestGetContainerUsageNanoCores(t *testing.T) {
 			},
 			expected: nil,
 		},
+		{
+			desc: "should fall back to cache-based computation if CRI reports 0 UsageNanoCores",
+			stats: &runtimeapi.ContainerStats{
+				Attributes: &runtimeapi.ContainerAttributes{
+					Id: "1",
+				},
+				Cpu: &runtimeapi.CpuUsage{
+					Timestamp: int64(time.Second / time.Nanosecond),
+					UsageCoreNanoSeconds: &runtimeapi.UInt64Value{
+						Value: 20000000000,
+					},
+					UsageNanoCores: &runtimeapi.UInt64Value{
+						Value: 0,
+					},
+				},
+			},
+			cpuUsageCache: map[string]*cpuUsageRecord{
+				"1": {
+					stats: &runtimeapi.CpuUsage{
+						Timestamp: 0,
+						UsageCoreNanoSeconds: &runtimeapi.UInt64Value{
+							Value: 10000000000,
+						},
+					},
+				},
+			},
+			expected: &value1,
+		},
 	}
 	logger, _ := ktesting.NewTestContext(t)
 	for _, test := range tests {

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -489,6 +489,47 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 			}, 2*time.Minute, 15*time.Second).Should(gomega.Succeed())
 			framework.ExpectNoError(e2epod.NewPodClient(f).Delete(ctx, pod.Name, metav1.DeleteOptions{}))
 		})
+
+		ginkgo.It("should report 0 UsageNanoCores for a light command", func(ctx context.Context) {
+			podName := "light-pod"
+			ginkgo.By("Creating a pod with a light command")
+			podSpec := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: podName,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:    "light-container",
+							Image:   busyboxImage,
+							Command: []string{"sleep", "3600"},
+						},
+					},
+				},
+			}
+			pod := e2epod.NewPodClient(f).Create(ctx, podSpec)
+
+			ginkgo.By("Waiting for the pod to start")
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod))
+
+			ginkgo.By("Validating that CPU UsageNanoCores is 0")
+			gomega.Eventually(ctx, func(g gomega.Gomega) {
+				summary, err := getNodeSummary(ctx)
+				framework.ExpectNoError(err)
+				g.Expect(summary.Pods).To(gstruct.MatchElements(summaryObjectID, gstruct.IgnoreExtras, gstruct.Elements{
+					fmt.Sprintf("%s::%s", f.Namespace.Name, podName): gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Containers": gstruct.MatchAllElements(summaryObjectID, gstruct.Elements{
+							"light-container": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+								"CPU": gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+									"UsageNanoCores": gomega.PointTo(gomega.BeZero()),
+								})),
+							}),
+						}),
+					}),
+				}))
+			}, 2*time.Minute, 15*time.Second).Should(gomega.Succeed())
+			framework.ExpectNoError(e2epod.NewPodClient(f).Delete(ctx, pod.Name, metav1.DeleteOptions{}))
+		})
 	})
 })
 


### PR DESCRIPTION
/sig node
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
  /kind bug
  /kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When the ``PodAndContainerStatsFromCRI` feature is enabled, some CRI runtimes (like containerd) may report a 0 value for `UsageNanoCores` if the sampling window is too small or the container is idle. The Kubelet should treat a 0 value as 'not provided' and fall back to its own cache-based computation from cumulative counters to ensure more accurate reporting.

#### Which issue(s) this PR is related to:
Fix for #138402
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
