### PR TITLE
Fixing prune-junit-xml directory walking so labels get applied for Windows too

### DIFF
--- a/cmd/prune-junit-xml/prunexml.go
+++ b/cmd/prune-junit-xml/prunexml.go
@@ -282,9 +282,10 @@ func (p *packageOwners) addOwner(name string) string {
 		dir = p.pkgs[name]
 	}
 
-	// Walk up starting from an absolute path until we hit the filesystem root. On Windows filepath (instead
-	// of path) is needed because "go list" returns backslash-separated paths.
-	for ; dir != "" && dir != "." && dir != "/" && dir != filepath.VolumeName(dir)+string(filepath.Separator); dir = filepath.Dir(dir) {
+	// Walk up starting from an absolute path until we hit the filesystem root.
+	// filepath.Dir returns dir itself at any root (/, C:\, \\server\share),
+	// so checking filepath.Dir(dir) != dir handles all path styles uniformly.
+	for ; dir != "" && filepath.Dir(dir) != dir; dir = filepath.Dir(dir) {
 		data, err := os.ReadFile(filepath.Join(dir, "OWNERS"))
 		if err != nil {
 			continue

--- a/cmd/prune-junit-xml/prunexml.go
+++ b/cmd/prune-junit-xml/prunexml.go
@@ -25,7 +25,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -282,9 +282,10 @@ func (p *packageOwners) addOwner(name string) string {
 		dir = p.pkgs[name]
 	}
 
-	// Walk up starting from an absolute path until we cannot go up further.
-	for ; dir != "" && dir != "." && dir != "/"; dir = path.Dir(dir) {
-		data, err := os.ReadFile(path.Join(dir, "OWNERS"))
+	// Walk up starting from an absolute path until we hit the filesystem root. On Windows filepath (instead
+	// of path) is needed because "go list" returns backslash-separated paths.
+	for ; dir != "" && dir != "." && dir != "/" && dir != filepath.VolumeName(dir)+string(filepath.Separator); dir = filepath.Dir(dir) {
+		data, err := os.ReadFile(filepath.Join(dir, "OWNERS"))
 		if err != nil {
 			continue
 		}

--- a/cmd/prune-junit-xml/prunexml_test.go
+++ b/cmd/prune-junit-xml/prunexml_test.go
@@ -19,6 +19,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -186,4 +187,48 @@ func TestPruneTESTS(t *testing.T) {
 	_ = streamXML(writer, suites)
 	_ = writer.Flush()
 	assert.Equal(t, outputXML, output.String(), "tests in xml was not pruned correctly")
+}
+
+func TestAddOwner(t *testing.T) {
+	// Use packages in k/k so we can validate addOwner() directory walking
+	// on both Linux and Windows for directories returned by "go list".
+	tests := []struct {
+		name       string
+		pkg        string
+		wantPrefix string
+	}{
+		{
+			name:       "finds sig-api-machinery for apimachinery package",
+			pkg:        "k8s.io/kubernetes/test/integration/apimachinery",
+			wantPrefix: "[sig-api-machinery] ",
+		},
+		{
+			name:       "finds sig-cloud-provider for gce package",
+			pkg:        "k8s.io/kubernetes/cluster/gce/gci",
+			wantPrefix: "[sig-cloud-provider] ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkgs := newPackageOwners(true)
+			result := pkgs.addOwner(tt.pkg)
+			assert.Equal(t, tt.wantPrefix+tt.pkg, result)
+		})
+	}
+}
+
+func TestAddOwnerUNCPath(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("UNC paths are Windows-only")
+	}
+
+	// Validate the directory walking loop in addOwner terminates for Windows UNC paths.
+	pkgs := newPackageOwners(true)
+	pkgName := "k8s.iofake/pkg"
+	pkgs.pkgs[pkgName] = `\\server\share\some\path`
+
+	result := pkgs.addOwner(pkgName)
+	// No OWNERS file will be found, so name should be unchanged.
+	assert.Equal(t, pkgName, result, "walk over UNC path should terminate and return name unchanged")
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation

/kind flake
/kind regression
-->
/kind failing-test

#### What this PR does / why we need it:

This PR fixes an issue in `prune-junit-xml` where directory walking isn't working on windows so some labels do not get applied to the test names

Ex:
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-unit-windows-master/2049515927573106688

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig windows