### PR TITLE
kubectl: set KUBECTL_PATH environment variable during plugin execution

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -165,6 +167,10 @@ func TestKubectlSubcommandShadowPlugin(t *testing.T) {
 			if !cmp.Equal(pluginsHandler.withArgs, test.expectPluginArgs, cmpopts.EquateEmpty()) {
 				t.Fatalf("unexpected plugin execution args: expected %q, got %q", test.expectPluginArgs, pluginsHandler.withArgs)
 			}
+
+			if pluginsHandler.executed {
+				expectKubectlPathEnvironmentVariable(t, pluginsHandler.withEnv)
+			}
 		})
 	}
 }
@@ -297,7 +303,38 @@ func TestKubectlCommandHandlesPlugins(t *testing.T) {
 			if !cmp.Equal(pluginsHandler.withArgs, test.expectPluginArgs, cmpopts.EquateEmpty()) {
 				t.Fatalf("unexpected plugin execution args: expected %q, got %q", test.expectPluginArgs, pluginsHandler.withArgs)
 			}
+
+			if pluginsHandler.executed {
+				expectKubectlPathEnvironmentVariable(t, pluginsHandler.withEnv)
+			}
 		})
+	}
+}
+
+func TestPluginEnvironmentReplacesKubectlPath(t *testing.T) {
+	t.Setenv("KUBECTL_PATH", "some-other-value")
+	env, err := pluginEnvironment()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expectKubectlPathEnvironmentVariable(t, env)
+}
+
+func expectKubectlPathEnvironmentVariable(t *testing.T, env []string) {
+	t.Helper()
+	kubectlPaths := slices.DeleteFunc(env, func(e string) bool {
+		return !strings.HasPrefix(e, "KUBECTL_PATH=")
+	})
+	if len(kubectlPaths) > 1 {
+		t.Fatalf("unexpected multiple KUBECTL_PATH environment variables: got %q", kubectlPaths)
+	}
+	if len(kubectlPaths) == 0 {
+		t.Fatalf("unexpected missing KUBECTL_PATH environment variable")
+	}
+	if executable, err := os.Executable(); err != nil {
+		t.Fatalf("unexpected error when getting executable path: %v", err)
+	} else if kubectlPaths[0] != fmt.Sprintf("KUBECTL_PATH=%s", executable) {
+		t.Fatalf("unexpected KUBECTL_PATH environment variable value: expected %q, got %q", fmt.Sprintf("KUBECTL_PATH=%s", executable), kubectlPaths[0])
 	}
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin.go
@@ -145,12 +145,34 @@ func HandlePluginCommand(pluginHandler PluginHandler, cmdArgs []string, minArgs 
 		return nil
 	}
 
+	pluginEnv, err := pluginEnvironment()
+	if err != nil {
+		return err
+	}
+
 	// invoke cmd binary relaying the current environment and args given
-	if err := pluginHandler.Execute(foundBinaryPath, cmdArgs[len(remainingArgs):], os.Environ()); err != nil {
+	if err := pluginHandler.Execute(foundBinaryPath, cmdArgs[len(remainingArgs):], pluginEnv); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func pluginEnvironment() ([]string, error) {
+	env := os.Environ()
+	pluginEnv := make([]string, 0, len(env)+1)
+	for _, e := range env {
+		if !strings.HasPrefix(e, "KUBECTL_PATH=") {
+			pluginEnv = append(pluginEnv, e)
+		}
+	}
+
+	kubectlPath, err := os.Executable()
+	if err != nil {
+		return nil, err
+	}
+
+	return append(pluginEnv, "KUBECTL_PATH="+kubectlPath), nil
 }
 
 // IsSubcommandPluginAllowed returns the given command is allowed

--- a/test/cmd/plugins.sh
+++ b/test/cmd/plugins.sh
@@ -49,7 +49,7 @@ run_plugins_tests() {
   kube::test::if_has_string "${output_message}" 'plugin foo'
 
   # check arguments passed to the plugin
-  output_message=$(PATH=${PATH}:"test/fixtures/pkg/kubectl/plugins/bar" kubectl bar arg1)
+  output_message=$(PATH=${TEMP_PATH}:"test/fixtures/pkg/kubectl/plugins/bar" kubectl bar arg1)
   kube::test::if_has_string "${output_message}" 'test/fixtures/pkg/kubectl/plugins/bar/kubectl-bar arg1'
 
   # ensure that a kubectl command supersedes a plugin that overshadows it
@@ -66,21 +66,21 @@ run_plugins_tests() {
   kube::test::if_has_not_string "${output_message}" 'plugin cronjob as a subcommand of kubectl create command'
 
   # ensure that the KUBECTL_PATH environment variable is available to plugins
-  output_message=$(PATH=${PATH}:"test/fixtures/pkg/kubectl/plugins/baz" kubectl baz)
+  output_message=$(PATH=${TEMP_PATH}:"test/fixtures/pkg/kubectl/plugins/baz" kubectl baz)
   kube::test::if_has_string "${output_message}" "I am plugin baz"
-  kube::test::if_has_string "${output_message}" "KUBECTL_PATH=$(which kubectl)"
+  kube::test::if_has_string "${output_message}" "KUBECTL_PATH=/.*/kubectl"
   kube::test::if_has_string "${output_message}" "CUSTOM_ENV_VAR=<UNSET>"
 
   # ensure that the other environment variables are available to plugins
-  output_message=$(CUSTOM_ENV_VAR=abc PATH=${PATH}:"test/fixtures/pkg/kubectl/plugins/baz" kubectl baz)
+  output_message=$(PATH=${TEMP_PATH}:"test/fixtures/pkg/kubectl/plugins/baz" CUSTOM_ENV_VAR=abc kubectl baz)
   kube::test::if_has_string "${output_message}" "I am plugin baz"
-  kube::test::if_has_string "${output_message}" "KUBECTL_PATH=$(which kubectl)"
+  kube::test::if_has_string "${output_message}" "KUBECTL_PATH=/.*/kubectl"
   kube::test::if_has_string "${output_message}" "CUSTOM_ENV_VAR=abc"
 
   # ensure that the KUBECTL_PATH environment variable cannot be overridden by caller
-  output_message=$(KUBECTL_PATH=invalid PATH=${PATH}:"test/fixtures/pkg/kubectl/plugins/baz" kubectl baz)
+  output_message=$(PATH=${TEMP_PATH}:"test/fixtures/pkg/kubectl/plugins/baz" KUBECTL_PATH=invalid kubectl baz)
   kube::test::if_has_string "${output_message}" "I am plugin baz"
-  kube::test::if_has_string "${output_message}" "KUBECTL_PATH=$(which kubectl)"
+  kube::test::if_has_string "${output_message}" "KUBECTL_PATH=/.*/kubectl"
   kube::test::if_has_string "${output_message}" "CUSTOM_ENV_VAR=<UNSET>"
 
   rm -fr "${TEMP_PATH}"

--- a/test/cmd/plugins.sh
+++ b/test/cmd/plugins.sh
@@ -65,6 +65,24 @@ run_plugins_tests() {
   output_message=$(PATH=${TEMP_PATH}:"test/fixtures/pkg/kubectl/plugins/create" kubectl create cronjob --help)
   kube::test::if_has_not_string "${output_message}" 'plugin cronjob as a subcommand of kubectl create command'
 
+  # ensure that the KUBECTL_PATH environment variable is available to plugins
+  output_message=$(PATH=${PATH}:"test/fixtures/pkg/kubectl/plugins/baz" kubectl baz)
+  kube::test::if_has_string "${output_message}" "I am plugin baz"
+  kube::test::if_has_string "${output_message}" "KUBECTL_PATH=$(which kubectl)"
+  kube::test::if_has_string "${output_message}" "CUSTOM_ENV_VAR=<UNSET>"
+
+  # ensure that the other environment variables are available to plugins
+  output_message=$(CUSTOM_ENV_VAR=abc PATH=${PATH}:"test/fixtures/pkg/kubectl/plugins/baz" kubectl baz)
+  kube::test::if_has_string "${output_message}" "I am plugin baz"
+  kube::test::if_has_string "${output_message}" "KUBECTL_PATH=$(which kubectl)"
+  kube::test::if_has_string "${output_message}" "CUSTOM_ENV_VAR=abc"
+
+  # ensure that the KUBECTL_PATH environment variable cannot be overridden by caller
+  output_message=$(KUBECTL_PATH=invalid PATH=${PATH}:"test/fixtures/pkg/kubectl/plugins/baz" kubectl baz)
+  kube::test::if_has_string "${output_message}" "I am plugin baz"
+  kube::test::if_has_string "${output_message}" "KUBECTL_PATH=$(which kubectl)"
+  kube::test::if_has_string "${output_message}" "CUSTOM_ENV_VAR=<UNSET>"
+
   rm -fr "${TEMP_PATH}"
 
   set +o nounset

--- a/test/fixtures/pkg/kubectl/plugins/baz/kubectl-baz
+++ b/test/fixtures/pkg/kubectl/plugins/baz/kubectl-baz
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "I am plugin baz"
+echo "KUBECTL_PATH=${KUBECTL_PATH:-<UNSET>}"
+echo "CUSTOM_ENV_VAR=${CUSTOM_ENV_VAR:-<UNSET>}"


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR updates kubectl to set its executable path in the `KUBECTL_PATH` environment variable when executing a plugin.

A plugin can read `KUBECTL_PATH` if it needs to know which kubectl binary was used to invoke the plugin. This is important for certain plugins that need to re-invoke kubectl after performing some processing, especially when the kubectl executable exists outside of the system path or is named something other than kubectl.

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes/kubectl/issues/1841

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
kubectl now sets its path in the KUBECTL_PATH environment variable when executing a plugin.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
