### PR TITLE
Fix gaps in API definition tests

### DIFF
--- a/pkg/registry/certificates/podcertificaterequest/strategy.go
+++ b/pkg/registry/certificates/podcertificaterequest/strategy.go
@@ -120,6 +120,7 @@ func NewStatusStrategy(strategy *Strategy, authorizer authorizer.Authorizer, clo
 func (s *StatusStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	fields := map[fieldpath.APIVersion]*fieldpath.Set{
 		"certificates.k8s.io/v1beta1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("metadata"),
 			fieldpath.MakePathOrDie("spec"),
 		),
 	}

--- a/test/integration/apiserver/apidefinitions/default_behaviors_test.go
+++ b/test/integration/apiserver/apidefinitions/default_behaviors_test.go
@@ -26,6 +26,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/util/retry"
 )
 
 // TestAllowCreateOnUpdate verifies that APIs prefer AllowCreateOnUpdate() = false.
@@ -61,6 +63,9 @@ func TestAllowCreateOnUpdate(t *testing.T) {
 		obj.SetResourceVersion("")
 		obj.SetUID("")
 		_, err := client.Update(context.TODO(), obj, metav1.UpdateOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			t.Fatalf("Unexpected error from Update: %v", err)
+		}
 		assertDefault(t, api.Mapping.Resource, "AllowCreateOnUpdate must be false", errors.IsNotFound(err), exempt)
 	})
 }
@@ -90,6 +95,9 @@ func TestGenerateName(t *testing.T) {
 		obj.SetResourceVersion("")
 		obj.SetUID("")
 		created, err := client.Create(context.TODO(), obj, metav1.CreateOptions{})
+		if err != nil && !errors.IsInvalid(err) {
+			t.Fatalf("Unexpected error from Create: %v", err)
+		}
 		generated := err == nil && strings.HasPrefix(created.GetName(), "default-behaviors-")
 		assertDefault(t, api.Mapping.Resource, "metadata.generateName must produce a server-generated name", generated, exempt)
 	})
@@ -102,19 +110,13 @@ func TestGenerateName(t *testing.T) {
 func TestAllowUnconditionalUpdate(t *testing.T) {
 	exempt := sets.New(
 		// Grandfathered APIs:
-		"apiservices.v1.apiregistration.k8s.io",
 		"certificatesigningrequests.v1.certificates.k8s.io",
 		"clusterrolebindings.v1.rbac.authorization.k8s.io",
 		"clusterroles.v1.rbac.authorization.k8s.io",
 		"clustertrustbundles.v1alpha1.certificates.k8s.io",
-		"clustertrustbundles.v1beta1.certificates.k8s.io",
 		"configmaps.v1",
 		"controllerrevisions.v1.apps",
 		"cronjobs.v1.batch",
-		"csidrivers.v1.storage.k8s.io",
-		"csinodes.v1.storage.k8s.io",
-		"csistoragecapacities.v1.storage.k8s.io",
-		"customresourcedefinitions.v1.apiextensions.k8s.io",
 		"daemonsets.v1.apps",
 		"deployments.v1.apps",
 		"deviceclasses.v1.resource.k8s.io",
@@ -127,37 +129,20 @@ func TestAllowUnconditionalUpdate(t *testing.T) {
 		"events.v1.events.k8s.io",
 		"events.v1",
 		"flowschemas.v1.flowcontrol.apiserver.k8s.io",
-		"foos.v1.cr.bar.com",
 		"horizontalpodautoscalers.v1.autoscaling",
 		"horizontalpodautoscalers.v2.autoscaling",
 		"ingressclasses.v1.networking.k8s.io",
 		"ingresses.v1.networking.k8s.io",
-		"integers.v1.random.numbers.com",
 		"ipaddresses.v1.networking.k8s.io",
 		"jobs.v1.batch",
-		"leasecandidates.v1alpha2.coordination.k8s.io",
-		"leasecandidates.v1beta1.coordination.k8s.io",
-		"leases.v1.coordination.k8s.io",
 		"limitranges.v1",
-		"mutatingadmissionpolicies.v1.admissionregistration.k8s.io",
-		"mutatingadmissionpolicies.v1alpha1.admissionregistration.k8s.io",
-		"mutatingadmissionpolicies.v1beta1.admissionregistration.k8s.io",
-		"mutatingadmissionpolicybindings.v1.admissionregistration.k8s.io",
-		"mutatingadmissionpolicybindings.v1alpha1.admissionregistration.k8s.io",
-		"mutatingadmissionpolicybindings.v1beta1.admissionregistration.k8s.io",
-		"mutatingwebhookconfigurations.v1.admissionregistration.k8s.io",
 		"namespaces.v1",
 		"networkpolicies.v1.networking.k8s.io",
 		"nodes.v1",
-		"pandas.v1.awesome.bears.com",
-		"pandas.v3.awesome.bears.com",
 		"pants.v1.custom.fancy.com",
-		"pants.v2.custom.fancy.com",
 		"persistentvolumeclaims.v1",
 		"persistentvolumes.v1",
 		"podcertificaterequests.v1alpha1.certificates.k8s.io",
-		"podcertificaterequests.v1beta1.certificates.k8s.io",
-		"poddisruptionbudgets.v1.policy",
 		"podgroups.v1alpha2.scheduling.k8s.io",
 		"pods.v1",
 		"podtemplates.v1",
@@ -171,28 +156,20 @@ func TestAllowUnconditionalUpdate(t *testing.T) {
 		"resourceclaimtemplates.v1.resource.k8s.io",
 		"resourceclaimtemplates.v1beta1.resource.k8s.io",
 		"resourceclaimtemplates.v1beta2.resource.k8s.io",
-		"resourcepoolstatusrequests.v1alpha3.resource.k8s.io",
 		"resourcequotas.v1",
 		"resourceslices.v1.resource.k8s.io",
 		"resourceslices.v1beta1.resource.k8s.io",
 		"resourceslices.v1beta2.resource.k8s.io",
 		"rolebindings.v1.rbac.authorization.k8s.io",
 		"roles.v1.rbac.authorization.k8s.io",
-		"runtimeclasses.v1.node.k8s.io",
 		"secrets.v1",
 		"serviceaccounts.v1",
 		"servicecidrs.v1.networking.k8s.io",
 		"services.v1",
 		"statefulsets.v1.apps",
 		"storageclasses.v1.storage.k8s.io",
-		"storageversionmigrations.v1beta1.storagemigration.k8s.io",
-		"storageversions.v1alpha1.internal.apiserver.k8s.io",
-		"validatingadmissionpolicies.v1.admissionregistration.k8s.io",
 		"validatingadmissionpolicies.v1beta1.admissionregistration.k8s.io",
-		"validatingadmissionpolicybindings.v1.admissionregistration.k8s.io",
 		"validatingadmissionpolicybindings.v1beta1.admissionregistration.k8s.io",
-		"validatingwebhookconfigurations.v1.admissionregistration.k8s.io",
-		"volumeattachments.v1.storage.k8s.io",
 		"volumeattributesclasses.v1.storage.k8s.io",
 		"workloads.v1alpha2.scheduling.k8s.io",
 	)
@@ -210,8 +187,11 @@ func TestAllowUnconditionalUpdate(t *testing.T) {
 
 		created.SetResourceVersion("")
 		_, err = client.Update(context.TODO(), created, metav1.UpdateOptions{})
-
-		assertDefault(t, api.Mapping.Resource, "AllowUnconditionalUpdate must be false", errors.IsConflict(err), exempt)
+		rejected := errors.IsConflict(err) || isInvalidResourceVersion(err)
+		if err != nil && !rejected {
+			t.Fatalf("Unexpected error from Update: %v", err)
+		}
+		assertDefault(t, api.Mapping.Resource, "AllowUnconditionalUpdate must be false", rejected, exempt)
 	})
 }
 
@@ -238,6 +218,7 @@ func TestDefaultGarbageCollectionPolicy(t *testing.T) {
 		// Events are intended to be high-volume leaf nodes.
 		"events.v1",
 		"events.v1.events.k8s.io",
+		"customresourcedefinitions.v1.apiextensions.k8s.io",
 	)
 	TestAllDefinitions(t, "default-gc-policy", func(t *testing.T, api Definition) {
 		if !api.HasVerb("create") || !api.HasVerb("get") || !api.HasVerb("update") || !api.HasVerb("delete") {
@@ -250,17 +231,10 @@ func TestDefaultGarbageCollectionPolicy(t *testing.T) {
 		if _, err := client.Create(context.TODO(), obj, metav1.CreateOptions{}); err != nil {
 			t.Fatalf("Failed to create: %v", err)
 		}
-		latest, err := client.Get(context.TODO(), name, metav1.GetOptions{})
-		if err != nil {
-			t.Fatalf("Failed to get latest: %v", err)
-		}
-
 		// A blocking finalizer is added first, so the object is not removed
 		// before we can observe the result of each delete.
-		latest.SetFinalizers(append(latest.GetFinalizers(), "test.k8s.io/block"))
-		if _, err := client.Update(context.TODO(), latest, metav1.UpdateOptions{}); err != nil {
-			t.Logf("Could not set test finalizer, skipping GC policy check: %v", err)
-			return
+		if err := addBlockingFinalizer(client, name); err != nil {
+			t.Fatalf("Could not set test finalizer: %v", err)
 		}
 		if err := client.Delete(context.TODO(), name, metav1.DeleteOptions{}); err != nil {
 			t.Fatalf("Failed to delete: %v", err)
@@ -298,17 +272,10 @@ func TestDefaultGarbageCollectionPolicy(t *testing.T) {
 		if _, err := client.Create(context.TODO(), obj, metav1.CreateOptions{}); err != nil {
 			t.Fatalf("Failed to create: %v", err)
 		}
-		latest, err := client.Get(context.TODO(), name, metav1.GetOptions{})
-		if err != nil {
-			t.Fatalf("Failed to get latest: %v", err)
-		}
-
 		// A blocking finalizer is added first, so the object is not removed
 		// before we can observe the result of each delete.
-		latest.SetFinalizers(append(latest.GetFinalizers(), "test.k8s.io/block"))
-		if _, err := client.Update(context.TODO(), latest, metav1.UpdateOptions{}); err != nil {
-			t.Logf("Could not set test finalizer, skipping GC policy check: %v", err)
-			return
+		if err := addBlockingFinalizer(client, name); err != nil {
+			t.Fatalf("Could not set test finalizer: %v", err)
 		}
 
 		// Also check for APIs using Unsupported garbage collection policy
@@ -354,6 +321,9 @@ func TestCheckGracefulDelete(t *testing.T) {
 			t.Fatalf("Failed to delete with grace period: %v", err)
 		}
 		after, err := rsc.Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			t.Fatalf("Unexpected error from Get after delete: %v", err)
+		}
 
 		isGraceful := false
 		if err == nil {
@@ -364,6 +334,36 @@ func TestCheckGracefulDelete(t *testing.T) {
 
 		assertDefault(t, api.Mapping.Resource, "CheckGracefulDelete must not be implemented", !isGraceful, exempt)
 	})
+}
+
+// addBlockingFinalizer appends a test finalizer to name, retrying on conflict.
+func addBlockingFinalizer(client dynamic.ResourceInterface, name string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest, err := client.Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		latest.SetFinalizers(append(latest.GetFinalizers(), "test.k8s.io/block"))
+		_, err = client.Update(context.TODO(), latest, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+// isInvalidResourceVersion reports whether err is an Invalid status error caused by metadata.resourceVersion.
+func isInvalidResourceVersion(err error) bool {
+	if !errors.IsInvalid(err) {
+		return false
+	}
+	statusErr, ok := err.(*errors.StatusError)
+	if !ok || statusErr.ErrStatus.Details == nil {
+		return false
+	}
+	for _, cause := range statusErr.ErrStatus.Details.Causes {
+		if cause.Field == "metadata.resourceVersion" {
+			return true
+		}
+	}
+	return false
 }
 
 // assertDefault checks that expected behavior conforms, unless the gvr is in the allow list, in which the behavor is

--- a/test/integration/apiserver/apidefinitions/default_behaviors_test.go
+++ b/test/integration/apiserver/apidefinitions/default_behaviors_test.go
@@ -18,11 +18,12 @@ package apidefinitions
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"strings"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -63,10 +64,10 @@ func TestAllowCreateOnUpdate(t *testing.T) {
 		obj.SetResourceVersion("")
 		obj.SetUID("")
 		_, err := client.Update(context.TODO(), obj, metav1.UpdateOptions{})
-		if err != nil && !errors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			t.Fatalf("Unexpected error from Update: %v", err)
 		}
-		assertDefault(t, api.Mapping.Resource, "AllowCreateOnUpdate must be false", errors.IsNotFound(err), exempt)
+		assertDefault(t, api.Mapping.Resource, "AllowCreateOnUpdate must be false", apierrors.IsNotFound(err), exempt)
 	})
 }
 
@@ -95,7 +96,7 @@ func TestGenerateName(t *testing.T) {
 		obj.SetResourceVersion("")
 		obj.SetUID("")
 		created, err := client.Create(context.TODO(), obj, metav1.CreateOptions{})
-		if err != nil && !errors.IsInvalid(err) {
+		if err != nil && !apierrors.IsInvalid(err) {
 			t.Fatalf("Unexpected error from Create: %v", err)
 		}
 		generated := err == nil && strings.HasPrefix(created.GetName(), "default-behaviors-")
@@ -187,7 +188,7 @@ func TestAllowUnconditionalUpdate(t *testing.T) {
 
 		created.SetResourceVersion("")
 		_, err = client.Update(context.TODO(), created, metav1.UpdateOptions{})
-		rejected := errors.IsConflict(err) || isInvalidResourceVersion(err)
+		rejected := apierrors.IsConflict(err) || isInvalidResourceVersion(err)
 		if err != nil && !rejected {
 			t.Fatalf("Unexpected error from Update: %v", err)
 		}
@@ -321,7 +322,7 @@ func TestCheckGracefulDelete(t *testing.T) {
 			t.Fatalf("Failed to delete with grace period: %v", err)
 		}
 		after, err := rsc.Get(context.TODO(), name, metav1.GetOptions{})
-		if err != nil && !errors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			t.Fatalf("Unexpected error from Get after delete: %v", err)
 		}
 
@@ -351,11 +352,11 @@ func addBlockingFinalizer(client dynamic.ResourceInterface, name string) error {
 
 // isInvalidResourceVersion reports whether err is an Invalid status error caused by metadata.resourceVersion.
 func isInvalidResourceVersion(err error) bool {
-	if !errors.IsInvalid(err) {
+	if !apierrors.IsInvalid(err) {
 		return false
 	}
-	statusErr, ok := err.(*errors.StatusError)
-	if !ok || statusErr.ErrStatus.Details == nil {
+	var statusErr *apierrors.StatusError
+	if !errors.As(err, &statusErr) || statusErr.ErrStatus.Details == nil {
 		return false
 	}
 	for _, cause := range statusErr.ErrStatus.Details.Causes {

--- a/test/integration/apiserver/apidefinitions/default_behaviors_test.go
+++ b/test/integration/apiserver/apidefinitions/default_behaviors_test.go
@@ -36,20 +36,21 @@ import (
 func TestAllowCreateOnUpdate(t *testing.T) {
 	exempt := sets.New(
 		// Leases are maintained exclusively via PUT requests.
-		"leasecandidates.coordination.k8s.io",
-		"leases.coordination.k8s.io",
+		"leasecandidates.v1alpha2.coordination.k8s.io",
+		"leasecandidates.v1beta1.coordination.k8s.io",
+		"leases.v1.coordination.k8s.io",
 
 		// Grandfathered APIs with no clear rationale:
-		"clusterrolebindings.rbac.authorization.k8s.io",
-		"clusterroles.rbac.authorization.k8s.io",
-		"endpoints",
-		"events.events.k8s.io",
-		"events",
-		"limitranges",
-		"rolebindings.rbac.authorization.k8s.io",
-		"roles.rbac.authorization.k8s.io",
-		"runtimeclasses.node.k8s.io",
-		"services",
+		"clusterrolebindings.v1.rbac.authorization.k8s.io",
+		"clusterroles.v1.rbac.authorization.k8s.io",
+		"endpoints.v1",
+		"events.v1.events.k8s.io",
+		"events.v1",
+		"limitranges.v1",
+		"rolebindings.v1.rbac.authorization.k8s.io",
+		"roles.v1.rbac.authorization.k8s.io",
+		"runtimeclasses.v1.node.k8s.io",
+		"services.v1",
 	)
 	TestAllDefinitions(t, "allow-create-on-update", func(t *testing.T, api Definition) {
 		if !api.HasVerb("create") || !api.HasVerb("get") || !api.HasVerb("update") || !api.HasVerb("delete") {
@@ -71,9 +72,12 @@ func TestAllowCreateOnUpdate(t *testing.T) {
 func TestGenerateName(t *testing.T) {
 	exempt := sets.New(
 		// APIs with specific naming requirements that to not support generateName:
-		"apiservices.apiregistration.k8s.io",
-		"customresourcedefinitions.apiextensions.k8s.io",
-		"ipaddresses.networking.k8s.io",
+		"apiservices.v1.apiregistration.k8s.io",
+		"clustertrustbundles.v1alpha1.certificates.k8s.io",
+		"clustertrustbundles.v1beta1.certificates.k8s.io",
+		"customresourcedefinitions.v1.apiextensions.k8s.io",
+		"ipaddresses.v1.networking.k8s.io",
+		"storageversions.v1alpha1.internal.apiserver.k8s.io",
 	)
 	TestAllDefinitions(t, "generate-name", func(t *testing.T, api Definition) {
 		if !api.HasVerb("create") || !api.HasVerb("get") || !api.HasVerb("update") || !api.HasVerb("delete") {
@@ -98,49 +102,63 @@ func TestGenerateName(t *testing.T) {
 func TestAllowUnconditionalUpdate(t *testing.T) {
 	exempt := sets.New(
 		// Grandfathered APIs:
-		"apiservices.apiregistration.k8s.io",
+		"apiservices.v1.apiregistration.k8s.io",
 		"certificatesigningrequests.v1.certificates.k8s.io",
 		"clusterrolebindings.v1.rbac.authorization.k8s.io",
 		"clusterroles.v1.rbac.authorization.k8s.io",
-		"clustertrustbundles.certificates.k8s.io",
+		"clustertrustbundles.v1alpha1.certificates.k8s.io",
+		"clustertrustbundles.v1beta1.certificates.k8s.io",
 		"configmaps.v1",
 		"controllerrevisions.v1.apps",
 		"cronjobs.v1.batch",
-		"csidrivers.storage.k8s.io",
-		"csinodes.storage.k8s.io",
-		"csistoragecapacities.storage.k8s.io",
-		"customresourcedefinitions.apiextensions.k8s.io",
+		"csidrivers.v1.storage.k8s.io",
+		"csinodes.v1.storage.k8s.io",
+		"csistoragecapacities.v1.storage.k8s.io",
+		"customresourcedefinitions.v1.apiextensions.k8s.io",
 		"daemonsets.v1.apps",
 		"deployments.v1.apps",
 		"deviceclasses.v1.resource.k8s.io",
+		"deviceclasses.v1beta1.resource.k8s.io",
+		"deviceclasses.v1beta2.resource.k8s.io",
+		"devicetaintrules.v1alpha3.resource.k8s.io",
+		"devicetaintrules.v1beta2.resource.k8s.io",
 		"endpoints.v1",
 		"endpointslices.v1.discovery.k8s.io",
 		"events.v1.events.k8s.io",
 		"events.v1",
 		"flowschemas.v1.flowcontrol.apiserver.k8s.io",
-		"foos.cr.bar.com",
+		"foos.v1.cr.bar.com",
 		"horizontalpodautoscalers.v1.autoscaling",
 		"horizontalpodautoscalers.v2.autoscaling",
 		"ingressclasses.v1.networking.k8s.io",
 		"ingresses.v1.networking.k8s.io",
-		"integers.random.numbers.com",
+		"integers.v1.random.numbers.com",
 		"ipaddresses.v1.networking.k8s.io",
 		"jobs.v1.batch",
-		"leasecandidates.coordination.k8s.io",
-		"leases.coordination.k8s.io",
+		"leasecandidates.v1alpha2.coordination.k8s.io",
+		"leasecandidates.v1beta1.coordination.k8s.io",
+		"leases.v1.coordination.k8s.io",
 		"limitranges.v1",
-		"mutatingadmissionpolicies.admissionregistration.k8s.io",
-		"mutatingadmissionpolicybindings.admissionregistration.k8s.io",
-		"mutatingwebhookconfigurations.admissionregistration.k8s.io",
+		"mutatingadmissionpolicies.v1.admissionregistration.k8s.io",
+		"mutatingadmissionpolicies.v1alpha1.admissionregistration.k8s.io",
+		"mutatingadmissionpolicies.v1beta1.admissionregistration.k8s.io",
+		"mutatingadmissionpolicybindings.v1.admissionregistration.k8s.io",
+		"mutatingadmissionpolicybindings.v1alpha1.admissionregistration.k8s.io",
+		"mutatingadmissionpolicybindings.v1beta1.admissionregistration.k8s.io",
+		"mutatingwebhookconfigurations.v1.admissionregistration.k8s.io",
 		"namespaces.v1",
 		"networkpolicies.v1.networking.k8s.io",
 		"nodes.v1",
-		"pandas.awesome.bears.com",
-		"pants.custom.fancy.com",
+		"pandas.v1.awesome.bears.com",
+		"pandas.v3.awesome.bears.com",
+		"pants.v1.custom.fancy.com",
+		"pants.v2.custom.fancy.com",
 		"persistentvolumeclaims.v1",
 		"persistentvolumes.v1",
-		"podcertificaterequests.certificates.k8s.io",
-		"poddisruptionbudgets.policy",
+		"podcertificaterequests.v1alpha1.certificates.k8s.io",
+		"podcertificaterequests.v1beta1.certificates.k8s.io",
+		"poddisruptionbudgets.v1.policy",
+		"podgroups.v1alpha2.scheduling.k8s.io",
 		"pods.v1",
 		"podtemplates.v1",
 		"priorityclasses.v1.scheduling.k8s.io",
@@ -148,25 +166,35 @@ func TestAllowUnconditionalUpdate(t *testing.T) {
 		"replicasets.v1.apps",
 		"replicationcontrollers.v1",
 		"resourceclaims.v1.resource.k8s.io",
+		"resourceclaims.v1beta1.resource.k8s.io",
+		"resourceclaims.v1beta2.resource.k8s.io",
 		"resourceclaimtemplates.v1.resource.k8s.io",
+		"resourceclaimtemplates.v1beta1.resource.k8s.io",
+		"resourceclaimtemplates.v1beta2.resource.k8s.io",
+		"resourcepoolstatusrequests.v1alpha3.resource.k8s.io",
 		"resourcequotas.v1",
 		"resourceslices.v1.resource.k8s.io",
+		"resourceslices.v1beta1.resource.k8s.io",
+		"resourceslices.v1beta2.resource.k8s.io",
 		"rolebindings.v1.rbac.authorization.k8s.io",
 		"roles.v1.rbac.authorization.k8s.io",
-		"runtimeclasses.node.k8s.io",
+		"runtimeclasses.v1.node.k8s.io",
 		"secrets.v1",
 		"serviceaccounts.v1",
 		"servicecidrs.v1.networking.k8s.io",
 		"services.v1",
 		"statefulsets.v1.apps",
 		"storageclasses.v1.storage.k8s.io",
-		"storageversionmigrations.storagemigration.k8s.io",
-		"storageversions.internal.apiserver.k8s.io",
-		"validatingadmissionpolicies.admissionregistration.k8s.io",
-		"validatingadmissionpolicybindings.admissionregistration.k8s.io",
-		"validatingwebhookconfigurations.admissionregistration.k8s.io",
-		"volumeattachments.storage.k8s.io",
+		"storageversionmigrations.v1beta1.storagemigration.k8s.io",
+		"storageversions.v1alpha1.internal.apiserver.k8s.io",
+		"validatingadmissionpolicies.v1.admissionregistration.k8s.io",
+		"validatingadmissionpolicies.v1beta1.admissionregistration.k8s.io",
+		"validatingadmissionpolicybindings.v1.admissionregistration.k8s.io",
+		"validatingadmissionpolicybindings.v1beta1.admissionregistration.k8s.io",
+		"validatingwebhookconfigurations.v1.admissionregistration.k8s.io",
+		"volumeattachments.v1.storage.k8s.io",
 		"volumeattributesclasses.v1.storage.k8s.io",
+		"workloads.v1alpha2.scheduling.k8s.io",
 	)
 	TestAllDefinitions(t, "unconditional-update", func(t *testing.T, api Definition) {
 		if !api.HasVerb("create") || !api.HasVerb("get") || !api.HasVerb("update") || !api.HasVerb("delete") {
@@ -197,8 +225,8 @@ func TestDefaultGarbageCollectionPolicy(t *testing.T) {
 	// APIs that use OrphanDependents garbage collection policy
 	orphanDependentsExempt := sets.New(
 		// Grandfathered APIs that use OrphanDependants for backward compatibility
-		"jobs.batch",
-		"replicationcontrollers",
+		"jobs.v1.batch",
+		"replicationcontrollers.v1",
 
 		// non-GA APIs that use OrphanDependants, such as cronjobs, exist but is no longer served
 	)
@@ -208,8 +236,8 @@ func TestDefaultGarbageCollectionPolicy(t *testing.T) {
 	// APIs that use Unsupported garbage collection policy
 	unsupportedExempt := sets.New(
 		// Events are intended to be high-volume leaf nodes.
-		"events",
-		"events.events.k8s.io",
+		"events.v1",
+		"events.v1.events.k8s.io",
 	)
 	TestAllDefinitions(t, "default-gc-policy", func(t *testing.T, api Definition) {
 		if !api.HasVerb("create") || !api.HasVerb("get") || !api.HasVerb("update") || !api.HasVerb("delete") {
@@ -246,14 +274,15 @@ func TestDefaultGarbageCollectionPolicy(t *testing.T) {
 		isBackground := !hasOrphan && !hasForegroundDeletion
 
 		assertDefault(t, api.Mapping.Resource, "DefaultGarbageCollectionPolicy must be unset, to indicate that dependents are background deleted", isBackground, orphanDependentsExempt.Union(foregroundExempt))
-		if orphanDependentsExempt.Has(api.Mapping.Resource.GroupResource().String()) {
+		resName := ResourceString(api.Mapping.Resource)
+		if orphanDependentsExempt.Has(resName) {
 			if !hasOrphan {
-				t.Errorf("%s: DefaultGarbageCollectionPolicy expected to be OrphanDependents", api.Mapping.Resource.GroupResource().String())
+				t.Errorf("%s: DefaultGarbageCollectionPolicy expected to be OrphanDependents", resName)
 			}
 		}
-		if foregroundExempt.Has(api.Mapping.Resource.GroupResource().String()) {
+		if foregroundExempt.Has(resName) {
 			if !hasForegroundDeletion {
-				t.Errorf("%s: DefaultGarbageCollectionPolicy expected to be DeleteDependents", api.Mapping.Resource.GroupResource().String())
+				t.Errorf("%s: DefaultGarbageCollectionPolicy expected to be DeleteDependents", resName)
 			}
 		}
 	})
@@ -303,7 +332,7 @@ func TestCheckGracefulDelete(t *testing.T) {
 	exempt := sets.New(
 		// Pods support a grace period window to send SIGTERM and let containers shut down
 		// cleanly before the object is removed.
-		"pods",
+		"pods.v1",
 	)
 	TestAllDefinitions(t, "check-graceful-delete", func(t *testing.T, api Definition) {
 		if !api.HasVerb("create") || !api.HasVerb("get") || !api.HasVerb("update") || !api.HasVerb("delete") {
@@ -337,7 +366,8 @@ func TestCheckGracefulDelete(t *testing.T) {
 	})
 }
 
-// assertDefault checks that a default behavior holds, with an allowlist for known exceptions.
+// assertDefault checks that expected behavior conforms, unless the gvr is in the allow list, in which the behavor is
+// expected to continue to not confirm.
 func assertDefault(t *testing.T, gvr schema.GroupVersionResource, msg string, conforms bool, allowed sets.Set[string]) {
 	t.Helper()
 	name := ResourceString(gvr)

--- a/test/integration/apiserver/apidefinitions/fields_wiping_test.go
+++ b/test/integration/apiserver/apidefinitions/fields_wiping_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -145,8 +146,10 @@ func TestFieldsWipingConsistency(t *testing.T) {
 		if baselineSpec != nil && differentSpec != "" {
 			result, err := rsc.Patch(context.TODO(), name, types.MergePatchType, []byte(differentSpec), metav1.PatchOptions{}, "status")
 			if err != nil {
+				if !errors.IsInvalid(err) {
+					t.Fatalf("Unexpected error from Patch to status endpoint with different spec: %v", err)
+				}
 				statusWipesSpec = true
-				t.Logf("Patch to status endpoint with different spec returned an error (OK if validation rejects it): %v", err)
 			} else {
 				statusWipesSpec = !checkPatch(t, differentSpec, "spec", result.Object)
 			}

--- a/test/integration/apiserver/apidefinitions/fields_wiping_test.go
+++ b/test/integration/apiserver/apidefinitions/fields_wiping_test.go
@@ -34,33 +34,34 @@ func TestFieldsWipingConsistency(t *testing.T) {
 	// APIs where creating via the main endpoint does not wipe status.
 	createDoesNotWipeStatus := sets.New(
 		// Nodes allow all fields, including status, to be set on create.
-		"nodes",
+		"nodes.v1",
 	)
 
 	// APIs where updating via the /status endpoint does not wipe metadata.
 	// All new APIs should use ResetObjectMetaForStatus.
 	statusDoesNotWipeMetadata := sets.New(
 		// https://github.com/kubernetes/kubernetes/issues/137681
-		"customresourcedefinitions.apiextensions.k8s.io",
+		"customresourcedefinitions.v1.apiextensions.k8s.io",
 
 		// APIs that do not use ResetObjectMetaForStatus:
-		"certificatesigningrequests.certificates.k8s.io",
-		"cronjobs.batch",
-		"daemonsets.apps",
-		"horizontalpodautoscalers.autoscaling",
-		"ingresses.networking.k8s.io",
-		"jobs.batch",
-		"namespaces",
-		"nodes",
-		"persistentvolumeclaims",
-		"persistentvolumes",
-		"poddisruptionbudgets.policy",
-		"pods",
-		"replicasets.apps",
-		"replicationcontrollers",
-		"resourcequotas",
-		"services",
-		"statefulsets.apps",
+		"certificatesigningrequests.v1.certificates.k8s.io",
+		"cronjobs.v1.batch",
+		"daemonsets.v1.apps",
+		"horizontalpodautoscalers.v1.autoscaling",
+		"horizontalpodautoscalers.v2.autoscaling",
+		"ingresses.v1.networking.k8s.io",
+		"jobs.v1.batch",
+		"namespaces.v1",
+		"nodes.v1",
+		"persistentvolumeclaims.v1",
+		"persistentvolumes.v1",
+		"poddisruptionbudgets.v1.policy",
+		"pods.v1",
+		"replicasets.v1.apps",
+		"replicationcontrollers.v1",
+		"resourcequotas.v1",
+		"services.v1",
+		"statefulsets.v1.apps",
 	)
 
 	TestAllDefinitions(t, "reset-fields-test", func(t *testing.T, api Definition) {

--- a/test/integration/apiserver/apidefinitions/generation_test.go
+++ b/test/integration/apiserver/apidefinitions/generation_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -111,8 +112,12 @@ func TestGenerationManagement(t *testing.T) {
 		// Verify that updating spec does bump generation.
 		result, err := rsc.Patch(context.TODO(), name, types.MergePatchType, []byte(differentSpec), metav1.PatchOptions{})
 		if err != nil {
-			t.Logf("Patch to main endpoint failed: %v", err)
-		} else if result.GetGeneration() <= afterStatus.GetGeneration() {
+			if !errors.IsInvalid(err) {
+				t.Fatalf("Patch to main endpoint failed with unexpected error: %v", err)
+			}
+			return
+		}
+		if result.GetGeneration() <= afterStatus.GetGeneration() {
 			if matchesException(api.Mapping.Resource, generationExempt) {
 				if result.GetGeneration() != 0 {
 					t.Errorf("Expected generation exempt resource always have generation 0, but got %v", result.GetGeneration())

--- a/test/integration/apiserver/apidefinitions/generation_test.go
+++ b/test/integration/apiserver/apidefinitions/generation_test.go
@@ -36,17 +36,20 @@ func TestGenerationManagement(t *testing.T) {
 	// DO NOT ADD NEW ENTRIES HERE.
 	// This tracks resources that have status but do not manage generation.
 	generationExempt := sets.New(
-		"apiservices.apiregistration.k8s.io",
-		"certificatesigningrequests.certificates.k8s.io",
-		"namespaces",
-		"nodes",
-		"persistentvolumeclaims",
-		"persistentvolumes",
-		"resourceclaims.resource.k8s.io",
-		"resourcequotas",
-		"servicecidrs.networking.k8s.io",
-		"services",
-		"volumeattachments.storage.k8s.io",
+		"apiservices.v1.apiregistration.k8s.io",
+		"certificatesigningrequests.v1.certificates.k8s.io",
+		"namespaces.v1",
+		"nodes.v1",
+		"persistentvolumeclaims.v1",
+		"persistentvolumes.v1",
+		"resourceclaims.v1.resource.k8s.io",
+		"resourceclaims.v1beta1.resource.k8s.io",
+		"resourceclaims.v1beta2.resource.k8s.io",
+		"resourcequotas.v1",
+		"servicecidrs.v1.networking.k8s.io",
+		"services.v1",
+		"storageversions.v1alpha1.internal.apiserver.k8s.io",
+		"volumeattachments.v1.storage.k8s.io",
 	)
 
 	TestAllDefinitions(t, "generation-namespace", func(t *testing.T, api Definition) {

--- a/test/integration/apiserver/apidefinitions/helper.go
+++ b/test/integration/apiserver/apidefinitions/helper.go
@@ -22,15 +22,13 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/util/json"
-
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
 	v1 "k8s.io/api/core/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"

--- a/test/integration/apiserver/apidefinitions/helper.go
+++ b/test/integration/apiserver/apidefinitions/helper.go
@@ -18,10 +18,11 @@ package apidefinitions
 
 import (
 	"context"
-	"encoding/json"
 	"slices"
 	"strings"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/util/json"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -77,7 +78,12 @@ func (d *Definition) ResourceClient() dynamic.ResourceInterface {
 // discoverable resource. It registers a fixed set of CRDs so that a sample
 // set of custom resources discoverable and tested.
 func TestAllDefinitions(t *testing.T, testNamespace string, testFunc DefinitionTestFunc) {
-	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), []string{"--disable-admission-plugins", "ServiceAccount,TaintNodesByCondition"}, framework.SharedEtcd())
+	server, err := apiservertesting.StartTestServer(t, apiservertesting.NewDefaultTestServerOptions(), []string{
+		"--disable-admission-plugins", "ServiceAccount,TaintNodesByCondition",
+		// Enable all APIs and features
+		"--runtime-config=api/all=true",
+		"--feature-gates=AllAlpha=true,AllBeta=true",
+	}, framework.SharedEtcd())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -182,16 +188,10 @@ func ResourceString(gvr schema.GroupVersionResource) string {
 	return gvr.Resource + "." + gvr.Version + "." + gvr.Group
 }
 
-// matchesException returns true if gvr matches any entry in exceptions.
-// Each entry must be a kubectl-style resource string in either
-// "resource.group" form (e.g. "pods", "deployments.apps",
-// "customresourcedefinitions.apiextensions.k8s.io"), which matches all
-// versions of that resource, or "resource.version.group" form (e.g.
-// "pods.v1", "deployments.v1.apps"), which matches a single version.
+// matchesException returns true if gvr matches an entry in exceptions.
+// Excepttions are of the form "resource.version.group". For example,
+// "pods.v1" or "deployments.v1.apps".
 func matchesException(gvr schema.GroupVersionResource, exceptions sets.Set[string]) bool {
-	if exceptions.Has(gvr.GroupResource().String()) {
-		return true
-	}
 	return exceptions.Has(ResourceString(gvr))
 }
 

--- a/test/integration/etcd/data.go
+++ b/test/integration/etcd/data.go
@@ -271,9 +271,11 @@ func GetEtcdStorageDataForNamespaceServedAt(namespace string, v string, isEmulat
 			RemovedVersion:    "1.39",
 		},
 		gvr("certificates.k8s.io", "v1beta1", "podcertificaterequests"): {
-			Stub:              `{"metadata": {"name": "req-1"}, "spec": {"signerName":"example.com/signer", "podName":"pod-1", "podUID":"pod-uid-1", "serviceAccountName":"sa-1", "serviceAccountUID":"sa-uid-1", "nodeName":"node-1", "nodeUID":"node-uid-1", "maxExpirationSeconds":86400, "pkixPublicKey":"MCowBQYDK2VwAyEA5g+rk9q/hjojtc2nwHJ660RdX5w1f4AK0/kP391QyLY=", "proofOfPossession":"SuGHX7SMyPHuN5cD5wjKLXGNbhdlCYUnTH65JkTx17iWlLynQ/g9GiTYObftSHNzqRh0ofdgAGqK6a379O7RBw=="}, "userConfig": {"test/foo":"bar"}}`,
+			Stub:              `{"metadata": {"name": "req-1"}, "spec": {"signerName":"example.com/signer", "podName":"pod-1", "podUID":"pod-uid-1", "serviceAccountName":"sa-1", "serviceAccountUID":"sa-uid-1", "nodeName":"node-1", "nodeUID":"node-uid-1", "maxExpirationSeconds":86400, "pkixPublicKey":"MCowBQYDK2VwAyEA5g+rk9q/hjojtc2nwHJ660RdX5w1f4AK0/kP391QyLY=", "proofOfPossession":"SuGHX7SMyPHuN5cD5wjKLXGNbhdlCYUnTH65JkTx17iWlLynQ/g9GiTYObftSHNzqRh0ofdgAGqK6a379O7RBw=="}}`,
 			ExpectedEtcdPath:  "/registry/podcertificaterequests/" + namespace + "/req-1",
 			ExpectedGVK:       gvkP("certificates.k8s.io", "v1beta1", "PodCertificateRequest"),
+			StatusStub:        `{"status": {"conditions": [{"type": "Denied", "status":"True", "lastTransitionTime": "2020-01-01T00:00:00Z", "reason": "TestReason", "message": "test message"}]}}`,
+			MutatedStatusStub: `{"status": {"conditions": [{"type": "Denied", "status":"False", "lastTransitionTime": "2020-01-01T00:00:00Z", "reason": "TestReason", "message": "test message"}]}}`,
 			IntroducedVersion: "1.35",
 			RemovedVersion:    "1.39",
 		},
@@ -651,7 +653,7 @@ func GetEtcdStorageDataForNamespaceServedAt(namespace string, v string, isEmulat
 		// k8s.io/kubernetes/pkg/apis/resource/v1alpha3
 		gvr("resource.k8s.io", "v1alpha3", "devicetaintrules"): {
 			Stub:              `{"metadata": {"name": "taint1name"}, "spec": {"taint": {"key": "example.com/taintkey", "value": "taintvalue", "effect": "NoSchedule"}}}`,
-			MutatedStub:       `{"metadata": {"labels":{"a":"c"}}}`,
+			MutatedStub:       `{"spec": {"taint": {"key": "example.com/taintkey", "value": "newtaintvalue", "effect": "NoSchedule"}}}`,
 			ExpectedEtcdPath:  "/registry/devicetaintrules/taint1name",
 			IntroducedVersion: "1.33",
 			RemovedVersion:    "1.39",
@@ -659,6 +661,8 @@ func GetEtcdStorageDataForNamespaceServedAt(namespace string, v string, isEmulat
 		gvr("resource.k8s.io", "v1alpha3", "resourcepoolstatusrequests"): {
 			Stub:              `{"metadata": {"name": "rpsr1name"}, "spec": {"driver": "test-driver.example.com"}}`,
 			ExpectedEtcdPath:  "/registry/resourcepoolstatusrequests/rpsr1name",
+			StatusStub:        `{"status": {"poolCount": 0}}`,
+			MutatedStatusStub: `{"status": {"poolCount": 1}}`,
 			IntroducedVersion: "1.36",
 			RemovedVersion:    "1.42",
 		},
@@ -714,7 +718,7 @@ func GetEtcdStorageDataForNamespaceServedAt(namespace string, v string, isEmulat
 		},
 		gvr("resource.k8s.io", "v1beta2", "devicetaintrules"): {
 			Stub:              `{"metadata": {"name": "taint2name"}, "spec": {"taint": {"key": "example.com/taintkey", "value": "taintvalue", "effect": "NoSchedule"}}}`,
-			MutatedStub:       `{"metadata": {"labels":{"a":"c"}}}`,
+			MutatedStub:       `{"spec": {"taint": {"key": "example.com/taintkey", "value": "newtaintvalue", "effect": "NoSchedule"}}}`,
 			ExpectedEtcdPath:  "/registry/devicetaintrules/taint2name",
 			ExpectedGVK:       gvkP("resource.k8s.io", "v1alpha3", "DeviceTaintRule"), // v1beta2 has higher priority, but to support downgrades v1alpha3 is picked automatically.
 			IntroducedVersion: "1.36",
@@ -911,10 +915,11 @@ func storageVersionAtEmulationVersion(key schema.GroupVersionResource, expectedG
 type StorageData struct {
 	// Stub is a valid JSON object used to create the resource.
 	Stub string
-	// MutatedStub is Stub with at least one spec or metadata field changed to a different value.
-	// This should mutate a spec field if possible. Only mutate a metadata field if the entire spec is immutable.
-	// This mutation is applied using a server-side apply patch.
-	// Required for resources that have a status subresource; leave empty otherwise.
+	// MutatedStub valid JSON spec with at least one spec field changed to a different value.
+	// For resources with a status subresource, MutatedStub MUST mutate a spec field.
+	// For resources without a status subresource, MutatedStub may mutate any field
+	// or be left empty.
+	// The mutation is applied as a patch.
 	// Example: if Stub has `"replicas": 1`, MutatedStub might have `"replicas": 2`.
 	MutatedStub string
 	// StatusStub is a valid JSON status payload used to write to the /status subresource.

--- a/test/integration/etcd/data.go
+++ b/test/integration/etcd/data.go
@@ -653,7 +653,7 @@ func GetEtcdStorageDataForNamespaceServedAt(namespace string, v string, isEmulat
 		// k8s.io/kubernetes/pkg/apis/resource/v1alpha3
 		gvr("resource.k8s.io", "v1alpha3", "devicetaintrules"): {
 			Stub:              `{"metadata": {"name": "taint1name"}, "spec": {"taint": {"key": "example.com/taintkey", "value": "taintvalue", "effect": "NoSchedule"}}}`,
-			MutatedStub:       `{"spec": {"taint": {"key": "example.com/taintkey", "value": "newtaintvalue", "effect": "NoSchedule"}}}`,
+			MutatedStub:       `{"spec": {"taint": {"effect": "NoExecute"}}}`,
 			ExpectedEtcdPath:  "/registry/devicetaintrules/taint1name",
 			IntroducedVersion: "1.33",
 			RemovedVersion:    "1.39",
@@ -718,7 +718,7 @@ func GetEtcdStorageDataForNamespaceServedAt(namespace string, v string, isEmulat
 		},
 		gvr("resource.k8s.io", "v1beta2", "devicetaintrules"): {
 			Stub:              `{"metadata": {"name": "taint2name"}, "spec": {"taint": {"key": "example.com/taintkey", "value": "taintvalue", "effect": "NoSchedule"}}}`,
-			MutatedStub:       `{"spec": {"taint": {"key": "example.com/taintkey", "value": "newtaintvalue", "effect": "NoSchedule"}}}`,
+			MutatedStub:       `{"spec": {"taint": {"effect": "NoExecute"}}}`,
 			ExpectedEtcdPath:  "/registry/devicetaintrules/taint2name",
 			ExpectedGVK:       gvkP("resource.k8s.io", "v1alpha3", "DeviceTaintRule"), // v1beta2 has higher priority, but to support downgrades v1alpha3 is picked automatically.
 			IntroducedVersion: "1.36",
@@ -915,10 +915,11 @@ func storageVersionAtEmulationVersion(key schema.GroupVersionResource, expectedG
 type StorageData struct {
 	// Stub is a valid JSON object used to create the resource.
 	Stub string
-	// MutatedStub valid JSON spec with at least one spec field changed to a different value.
-	// For resources with a status subresource, MutatedStub MUST mutate a spec field.
+	// MutatedStub is partial update of Sub as a JSON object, with at least one field
+	// changed to a different value. For resources with a status subresource, MutatedStub
+	// MUST mutate a spec field. If a resource is immutable, do not set MutatedStub.
 	// For resources without a status subresource, MutatedStub may mutate any field
-	// or be left empty.
+	// or be left empty ("", do not set this field to "{}" as a noop apply will confuse tests).
 	// The mutation is applied as a patch.
 	// Example: if Stub has `"replicas": 1`, MutatedStub might have `"replicas": 2`.
 	MutatedStub string


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

A few problems were identified with  the new API definition tests:

- Exemptions specified using a GR accidentally apply to new version of an API.  We instead want each API version to have to opt-in to the exception.
- Off-by-default APIs were not tested!
- The guidance around MutatedStub, which is used to test metadata.generation suggested it is fine to use metdata, which is wrong. The correct approach is to only increment generation for spec changes.

This fixes all those issues.

Once fixed, this also found a bug in podcertificaterequest status field resetting, which is fixed in this PR as well.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

