### PR TITLE
kubelet/winstats: populate MachineInfo.Topology unconditionally on Windows

### DIFF
--- a/pkg/kubelet/winstats/perfcounter_nodestats_windows.go
+++ b/pkg/kubelet/winstats/perfcounter_nodestats_windows.go
@@ -35,9 +35,7 @@ import (
 	"golang.org/x/sys/windows/registry"
 
 	"k8s.io/apimachinery/pkg/util/wait"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog/v2"
-	kubefeatures "k8s.io/kubernetes/pkg/features"
 )
 
 const (
@@ -188,13 +186,19 @@ func (p *perfCounterNodeStatsClient) getMachineInfo(logger klog.Logger) (*cadvis
 		BootID:         bootId,
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.WindowsCPUAndMemoryAffinity) {
-		numOfPysicalCores, numOfSockets, topology, err := processorInfo(logger, relationAll)
-		if err != nil {
-			return nil, err
-		}
-
-		mi.NumPhysicalCores = numOfPysicalCores
+	// Topology must be populated unconditionally on Windows. It is consumed by
+	// kubelet startup validation (e.g. the ReservedSystemCPUs subset check in
+	// cmd/kubelet/app/server.go) and by the static CPU manager policy itself,
+	// neither of which is gated by WindowsCPUAndMemoryAffinity. The gate only
+	// controls whether kubelet pushes the resulting affinity to the runtime
+	// (see cpu_manager_windows.go and internal_container_lifecycle_windows.go),
+	// which is the actual feature surface — discovery of topology is not.
+	// This matches Linux, where cAdvisor always populates MachineInfo.Topology.
+	numOfPhysicalCores, numOfSockets, topology, err := processorInfo(logger, relationAll)
+	if err != nil {
+		logger.Error(err, "failed to discover Windows CPU topology; continuing without topology data")
+	} else {
+		mi.NumPhysicalCores = numOfPhysicalCores
 		mi.NumSockets = numOfSockets
 		mi.Topology = topology
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Topology discovery was previously gated behind WindowsCPUAndMemoryAffinity, but the kubelet's startup-time ReservedSystemCPUs subset check (cmd/kubelet/app/server.go) consumes MachineInfo.Topology regardless of that gate. With the gate off, Topology was nil and any non-empty ReservedSystemCPUs caused kubelet to exit with "reserved-cpus: <set> is not a subset of online-cpus: ".

Discover topology unconditionally and demote discovery failure from fatal to a logged warning so kubelet can still start when topology data is not required. The feature gate continues to control whether affinity is pushed to the runtime (cpu_manager_windows.go, internal_container_lifecycle_windows.go), which is the actual feature surface. This matches Linux, where cAdvisor always populates topology.
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```