### PR TITLE
Refactor registry storage key function setup

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/storage_factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/storage_factory.go
@@ -37,7 +37,7 @@ func StorageWithCacher() generic.StorageDecorator {
 	return func(
 		storageConfig *storagebackend.ConfigForResource,
 		resourcePrefix string,
-		keyFunc func(obj runtime.Object) (string, error),
+		cacheKeyFunc func(obj runtime.Object) (string, error),
 		newFunc func() runtime.Object,
 		newListFunc func() runtime.Object,
 		getAttrsFunc storage.AttrFunc,
@@ -59,7 +59,7 @@ func StorageWithCacher() generic.StorageDecorator {
 			GroupResource:       storageConfig.GroupResource,
 			EventsHistoryWindow: storageConfig.EventsHistoryWindow,
 			ResourcePrefix:      resourcePrefix,
-			KeyFunc:             keyFunc,
+			KeyFunc:             cacheKeyFunc,
 			NewFunc:             newFunc,
 			NewListFunc:         newListFunc,
 			GetAttrsFunc:        getAttrsFunc,

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -307,6 +307,66 @@ func NoNamespaceKeyFunc(ctx context.Context, prefix string, name string) (string
 	return key, nil
 }
 
+type storeKeyFuncs struct {
+	// storageRootKeyFunc returns the resource-relative storage path prefix for
+	// list and watch requests, for example "/pods" or "/pods/<namespace>".
+	storageRootKeyFunc func(ctx context.Context) string
+	// storageKeyFunc returns the resource-relative storage path for one object,
+	// for example "/pods/<namespace>/<name>" or "/pods/<name>".
+	storageKeyFunc func(ctx context.Context, name string) (string, error)
+	// cacheKeyFunc returns the resource-relative storage path for one object.
+	// It is passed to cache layers that receive objects instead of request
+	// contexts, so it derives the namespace and name from object metadata.
+	cacheKeyFunc func(obj runtime.Object) (string, error)
+}
+
+func defaultStoreKeyFuncs(prefix string, isNamespaced bool) storeKeyFuncs {
+	if isNamespaced {
+		return newStoreKeyFuncs(
+			isNamespaced,
+			func(ctx context.Context) string {
+				return NamespaceKeyRootFunc(ctx, prefix)
+			},
+			func(ctx context.Context, name string) (string, error) {
+				return NamespaceKeyFunc(ctx, prefix, name)
+			},
+		)
+	}
+
+	return newStoreKeyFuncs(
+		isNamespaced,
+		func(ctx context.Context) string {
+			return prefix
+		},
+		func(ctx context.Context, name string) (string, error) {
+			return NoNamespaceKeyFunc(ctx, prefix, name)
+		},
+	)
+}
+
+func newStoreKeyFuncs(
+	isNamespaced bool,
+	storageRootKeyFunc func(ctx context.Context) string,
+	storageKeyFunc func(ctx context.Context, name string) (string, error),
+) storeKeyFuncs {
+	return storeKeyFuncs{
+		storageRootKeyFunc: storageRootKeyFunc,
+		storageKeyFunc:     storageKeyFunc,
+		cacheKeyFunc: func(obj runtime.Object) (string, error) {
+			accessor, err := meta.Accessor(obj)
+			if err != nil {
+				return "", err
+			}
+
+			ctx := genericapirequest.NewContext()
+			if isNamespaced {
+				ctx = genericapirequest.WithNamespace(ctx, accessor.GetNamespace())
+			}
+			return storageKeyFunc(ctx, accessor.GetName())
+		},
+	}
+}
+
 // New implements RESTStorage.New.
 func (e *Store) New() runtime.Object {
 	return e.NewFunc()
@@ -1586,39 +1646,14 @@ func (e *Store) CompleteWithOptions(options *generic.StoreOptions) error {
 		return fmt.Errorf("store for %s has an invalid prefix %q", e.DefaultQualifiedResource.String(), opts.ResourcePrefix)
 	}
 
-	// Set the default behavior for storage key generation
+	var keyFuncs storeKeyFuncs
 	if e.KeyRootFunc == nil && e.KeyFunc == nil {
-		if isNamespaced {
-			e.KeyRootFunc = func(ctx context.Context) string {
-				return NamespaceKeyRootFunc(ctx, prefix)
-			}
-			e.KeyFunc = func(ctx context.Context, name string) (string, error) {
-				return NamespaceKeyFunc(ctx, prefix, name)
-			}
-		} else {
-			e.KeyRootFunc = func(ctx context.Context) string {
-				return prefix
-			}
-			e.KeyFunc = func(ctx context.Context, name string) (string, error) {
-				return NoNamespaceKeyFunc(ctx, prefix, name)
-			}
-		}
+		keyFuncs = defaultStoreKeyFuncs(prefix, isNamespaced)
+	} else {
+		keyFuncs = newStoreKeyFuncs(isNamespaced, e.KeyRootFunc, e.KeyFunc)
 	}
-
-	// We adapt the store's keyFunc so that we can use it with the StorageDecorator
-	// without making any assumptions about where objects are stored in etcd
-	keyFunc := func(obj runtime.Object) (string, error) {
-		accessor, err := meta.Accessor(obj)
-		if err != nil {
-			return "", err
-		}
-
-		if isNamespaced {
-			return e.KeyFunc(genericapirequest.WithNamespace(genericapirequest.NewContext(), accessor.GetNamespace()), accessor.GetName())
-		}
-
-		return e.KeyFunc(genericapirequest.NewContext(), accessor.GetName())
-	}
+	e.KeyRootFunc = keyFuncs.storageRootKeyFunc
+	e.KeyFunc = keyFuncs.storageKeyFunc
 
 	if e.DeleteCollectionWorkers == 0 {
 		e.DeleteCollectionWorkers = opts.DeleteCollectionWorkers
@@ -1642,7 +1677,7 @@ func (e *Store) CompleteWithOptions(options *generic.StoreOptions) error {
 		e.Storage.Storage, e.DestroyFunc, err = opts.Decorator(
 			opts.StorageConfig,
 			prefix,
-			keyFunc,
+			keyFuncs.cacheKeyFunc,
 			e.NewFunc,
 			e.NewListFunc,
 			attrFunc,

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -145,6 +145,190 @@ func NewTestGenericStoreRegistry(t *testing.T) (factory.DestroyFunc, *Store) {
 	return newTestGenericStoreRegistry(t, scheme, false)
 }
 
+func TestCompleteWithOptionsDefaultsStoreKeyFuncs(t *testing.T) {
+	testCases := []struct {
+		name          string
+		namespaced    bool
+		ctx           context.Context
+		expectRootKey string
+		expectKey     string
+	}{
+		{
+			name:          "namespaced",
+			namespaced:    true,
+			ctx:           genericapirequest.WithNamespace(genericapirequest.NewContext(), "ns1"),
+			expectRootKey: "/pods/ns1",
+			expectKey:     "/pods/ns1/pod1",
+		},
+		{
+			name:          "cluster scoped",
+			namespaced:    false,
+			ctx:           genericapirequest.NewContext(),
+			expectRootKey: "/pods",
+			expectKey:     "/pods/pod1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			destroyFunc, store := NewTestGenericStoreRegistry(t)
+			defer destroyFunc()
+
+			strategy := &testRESTStrategy{scheme, names.SimpleNameGenerator, tc.namespaced, false, true}
+			store.CreateStrategy = strategy
+			store.UpdateStrategy = strategy
+			store.DeleteStrategy = strategy
+			store.KeyRootFunc = nil
+			store.KeyFunc = nil
+			store.TableConvertor = rest.NewDefaultTableConvertor(store.DefaultQualifiedResource)
+
+			if err := store.CompleteWithOptions(&generic.StoreOptions{
+				RESTOptions: generic.RESTOptions{ResourcePrefix: "pods"},
+			}); err != nil {
+				t.Fatalf("CompleteWithOptions failed: %v", err)
+			}
+
+			if store.KeyRootFunc == nil {
+				t.Fatal("KeyRootFunc was not defaulted")
+			}
+			if got := store.KeyRootFunc(tc.ctx); got != tc.expectRootKey {
+				t.Fatalf("KeyRootFunc returned %q, expect %q", got, tc.expectRootKey)
+			}
+
+			if store.KeyFunc == nil {
+				t.Fatal("KeyFunc was not defaulted")
+			}
+			got, err := store.KeyFunc(tc.ctx, "pod1")
+			if err != nil {
+				t.Fatalf("KeyFunc failed: %v", err)
+			}
+			if got != tc.expectKey {
+				t.Fatalf("KeyFunc returned %q, expect %q", got, tc.expectKey)
+			}
+		})
+	}
+}
+
+func TestDefaultStoreKeyFuncs(t *testing.T) {
+	testCases := []struct {
+		name              string
+		namespaced        bool
+		ctx               context.Context
+		obj               runtime.Object
+		keyName           string
+		expectRootKey     string
+		expectKey         string
+		expectKeyErr      bool
+		expectCacheKey    string
+		expectCacheKeyErr bool
+	}{
+		{
+			name:           "namespaced",
+			namespaced:     true,
+			ctx:            genericapirequest.WithNamespace(genericapirequest.NewContext(), "ns1"),
+			obj:            &example.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "pod1"}},
+			keyName:        "pod1",
+			expectRootKey:  "/pods/ns1",
+			expectKey:      "/pods/ns1/pod1",
+			expectCacheKey: "/pods/ns1/pod1",
+		},
+		{
+			name:              "namespaced no namespace",
+			namespaced:        true,
+			ctx:               genericapirequest.NewContext(),
+			obj:               &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}},
+			keyName:           "pod1",
+			expectRootKey:     "/pods",
+			expectKeyErr:      true,
+			expectCacheKeyErr: true,
+		},
+		{
+			name:              "namespaced empty name",
+			namespaced:        true,
+			ctx:               genericapirequest.WithNamespace(genericapirequest.NewContext(), "ns1"),
+			obj:               &example.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns1"}},
+			expectRootKey:     "/pods/ns1",
+			expectKeyErr:      true,
+			expectCacheKeyErr: true,
+		},
+		{
+			name:              "namespaced name containing slash",
+			namespaced:        true,
+			ctx:               genericapirequest.WithNamespace(genericapirequest.NewContext(), "ns1"),
+			obj:               &example.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "pod/1"}},
+			keyName:           "pod/1",
+			expectRootKey:     "/pods/ns1",
+			expectKeyErr:      true,
+			expectCacheKeyErr: true,
+		},
+		{
+			name:           "cluster scoped",
+			namespaced:     false,
+			ctx:            genericapirequest.NewContext(),
+			obj:            &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}},
+			keyName:        "pod1",
+			expectRootKey:  "/pods",
+			expectKey:      "/pods/pod1",
+			expectCacheKey: "/pods/pod1",
+		},
+		{
+			name:           "cluster scoped ignores unexpected namespace",
+			namespaced:     false,
+			ctx:            genericapirequest.WithNamespace(genericapirequest.NewContext(), "ns1"),
+			obj:            &example.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "pod1"}},
+			keyName:        "pod1",
+			expectRootKey:  "/pods",
+			expectKey:      "/pods/pod1",
+			expectCacheKey: "/pods/pod1",
+		},
+		{
+			name:              "cluster scoped empty name",
+			namespaced:        false,
+			ctx:               genericapirequest.NewContext(),
+			obj:               &example.Pod{},
+			expectRootKey:     "/pods",
+			expectKeyErr:      true,
+			expectCacheKeyErr: true,
+		},
+		{
+			name:              "cluster scoped name containing slash",
+			namespaced:        false,
+			ctx:               genericapirequest.NewContext(),
+			obj:               &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod/1"}},
+			keyName:           "pod/1",
+			expectRootKey:     "/pods",
+			expectKeyErr:      true,
+			expectCacheKeyErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			keyFuncs := defaultStoreKeyFuncs("/pods", tc.namespaced)
+
+			if got := keyFuncs.storageRootKeyFunc(tc.ctx); got != tc.expectRootKey {
+				t.Fatalf("storageRootKeyFunc returned %q, expect %q", got, tc.expectRootKey)
+			}
+
+			gotKey, err := keyFuncs.storageKeyFunc(tc.ctx, tc.keyName)
+			if (err != nil) != tc.expectKeyErr {
+				t.Fatalf("storageKeyFunc error = %v, expectErr %t", err, tc.expectKeyErr)
+			}
+			if err == nil && gotKey != tc.expectKey {
+				t.Fatalf("storageKeyFunc returned %q, expect %q", gotKey, tc.expectKey)
+			}
+
+			gotCacheKey, err := keyFuncs.cacheKeyFunc(tc.obj)
+			if (err != nil) != tc.expectCacheKeyErr {
+				t.Fatalf("cacheKeyFunc error = %v, expectErr %t", err, tc.expectCacheKeyErr)
+			}
+			if err == nil && gotCacheKey != tc.expectCacheKey {
+				t.Fatalf("cacheKeyFunc returned %q, expect %q", gotCacheKey, tc.expectCacheKey)
+			}
+		})
+	}
+}
+
 func getPodAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 	pod := obj.(*example.Pod)
 	return labels.Set{"name": pod.ObjectMeta.Name}, nil, nil

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/storage_decorator.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/storage_decorator.go
@@ -25,11 +25,12 @@ import (
 )
 
 // StorageDecorator is a function signature for producing a storage.Interface
-// and an associated DestroyFunc from given parameters.
+// and an associated DestroyFunc from given parameters. cacheKeyFunc is used by
+// cache layers to compute resource keys from objects.
 type StorageDecorator func(
 	config *storagebackend.ConfigForResource,
 	resourcePrefix string,
-	keyFunc func(obj runtime.Object) (string, error),
+	cacheKeyFunc func(obj runtime.Object) (string, error),
 	newFunc func() runtime.Object,
 	newListFunc func() runtime.Object,
 	getAttrsFunc storage.AttrFunc,
@@ -41,7 +42,7 @@ type StorageDecorator func(
 func UndecoratedStorage(
 	config *storagebackend.ConfigForResource,
 	resourcePrefix string,
-	keyFunc func(obj runtime.Object) (string, error),
+	cacheKeyFunc func(obj runtime.Object) (string, error),
 	newFunc func() runtime.Object,
 	newListFunc func() runtime.Object,
 	getAttrsFunc storage.AttrFunc,


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This refactors the registry store storage key function setup without changing behavior.

It extracts the default `KeyRootFunc`/`KeyFunc` setup into a helper and names the object-to-storage-key function passed to cacher as `cacheKeyFunc`, making the layering clearer for follow-up storage changes.

This was split out from #131862 based on review feedback.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
No behavior change intended.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

Verified with:
```sh
go test ./staging/src/k8s.io/apiserver/pkg/registry/generic ./staging/src/k8s.io/apiserver/pkg/registry/generic/registry
git diff --check
```