### PR TITLE
fix: Fixing flaky TestEventSeries by ensuring first event is persiste…

### DIFF
--- a/test/integration/events/events_test.go
+++ b/test/integration/events/events_test.go
@@ -130,8 +130,24 @@ func TestEventSeries(t *testing.T) {
 	recorder := broadcaster.NewRecorder(scheme.Scheme, "k8s.io/kube-scheduler")
 	broadcaster.StartRecordingToSink(stopCh)
 	recorder.Eventf(regarding, related, v1.EventTypeNormal, "memoryPressure", "killed", "memory pressure")
+
+	// Wait for the first event to be persisted to the API server before firing
+	// the second. Without this, both events may be coalesced client-side before
+	// the first write, and the series counter may never reach 2 within the poll
+	// window, causing a flaky timeout on loaded CI machines.
+	if err := wait.PollUntilContextTimeout(context.TODO(), 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+		evs, err := client.EventsV1().Events("").List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, err
+		}
+		return len(evs.Items) == 1, nil
+	}); err != nil {
+		t.Fatalf("timed out waiting for first event to be persisted: %v", err)
+	}
+
 	recorder.Eventf(regarding, related, v1.EventTypeNormal, "memoryPressure", "killed", "memory pressure")
-	err = wait.PollImmediate(100*time.Millisecond, 20*time.Second, func() (done bool, err error) {
+	// Increase the poll timeout to give more headroom on slow CI machines.
+	err = wait.PollUntilContextTimeout(context.TODO(), 100*time.Millisecond, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 		events, err := client.EventsV1().Events("").List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return false, err


### PR DESCRIPTION
## What this PR does / why we need it

`TestEventSeries` in `test/integration/events` was flaking in
`pull-kubernetes-integration` with:

> error waiting for an Event with a non nil Series to be created: timed out waiting for the condition

The test fires two identical events back-to-back and polls for a single
event with `Series.Count == 2`. The flake is a race against the
client-side event recorder's internal dedup/aggregation cache:

- If both `Eventf` calls happen before the first event is flushed to the
  API server, both are coalesced client-side and the server never sees a
  series increment as a separate write.
- On a loaded CI machine (e.g. running alongside `TestAsyncPreemption`),
  the 20s poll window was insufficient for the aggregation flush to
  complete.

## Changes

- **Wait for the first event to land in the API server** before firing
  the second `Eventf`. This ensures the second call hits an
  already-stored event and triggers a server-side `Series.Count`
  increment rather than being silently merged client-side.
- **Increase the final poll timeout from 20s to 60s** to give the event
  aggregation flush enough headroom on slow CI runners.
- **Migrate from deprecated `wait.PollImmediate` to
  `wait.PollUntilContextTimeout`**, consistent with current patterns in
  the integration test suite (e.g. `test/integration/daemonset`).

## How to test

```bash
# Run once to verify it passes
go test ./test/integration/events/... -run TestEventSeries -v -count=1 -timeout 120s

# Stress test to confirm no flake
go test ./test/integration/events/... -run TestEventSeries -v -count=20 -timeout 600s
```

## Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Which issue(s) this PR fixes

Fixes #138679
```release-note
NONE
```