### PR TITLE
feat(validation-gen): promote declarative validation tags for v1.37

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
@@ -86,7 +86,7 @@ func (maxLengthTagValidator) GetValidations(context Context, tag codetags.Tag) (
 func (mltv maxLengthTagValidator) Docs() TagDoc {
 	return TagDoc{
 		Tag:            mltv.TagName(),
-		StabilityLevel: TagStabilityLevelBeta,
+		StabilityLevel: TagStabilityLevelStable,
 		Scopes:         sets.List(mltv.ValidScopes()),
 		Description: `Indicates that a string field has a limit on its length in characters.
 		This could allow up to 4*N bytes if multi-byte characters are used.
@@ -196,7 +196,7 @@ func (minItemsTagValidator) GetValidations(context Context, tag codetags.Tag) (V
 func (mitv minItemsTagValidator) Docs() TagDoc {
 	return TagDoc{
 		Tag:            mitv.TagName(),
-		StabilityLevel: TagStabilityLevelBeta,
+		StabilityLevel: TagStabilityLevelStable,
 		Scopes:         sets.List(mitv.ValidScopes()),
 		Description:    "Indicates that a list has a minimum size.",
 		Payloads: []TagPayloadDoc{{
@@ -314,7 +314,7 @@ func (maxPropertiesTagValidator) GetValidations(context Context, tag codetags.Ta
 func (mptv maxPropertiesTagValidator) Docs() TagDoc {
 	return TagDoc{
 		Tag:            mptv.TagName(),
-		StabilityLevel: TagStabilityLevelBeta,
+		StabilityLevel: TagStabilityLevelStable,
 		Scopes:         sets.List(mptv.ValidScopes()),
 		Description:    "maxProperties provides a limit on properties of an object as defined by JSON schema. In Kubernetes it may only be used to constrain the number of elements on a field defined as a golang map.",
 		Payloads: []TagPayloadDoc{{
@@ -436,7 +436,7 @@ func (maximumTagValidator) GetValidations(context Context, tag codetags.Tag) (Va
 func (mtv maximumTagValidator) Docs() TagDoc {
 	return TagDoc{
 		Tag:            mtv.TagName(),
-		StabilityLevel: TagStabilityLevelBeta,
+		StabilityLevel: TagStabilityLevelStable,
 		Scopes:         sets.List(mtv.ValidScopes()),
 		Description:    "Indicates that a numeric field has a maximum value.",
 		Payloads: []TagPayloadDoc{{
@@ -493,7 +493,7 @@ func (minLengthTagValidator) GetValidations(context Context, tag codetags.Tag) (
 func (mltv minLengthTagValidator) Docs() TagDoc {
 	return TagDoc{
 		Tag:            mltv.TagName(),
-		StabilityLevel: TagStabilityLevelAlpha,
+		StabilityLevel: TagStabilityLevelStable,
 		Scopes:         sets.List(mltv.ValidScopes()),
 		Description: `Indicates that a string field has a minimum length for its value in characters.
 		This means that the minimum size in bytes is a range from X to 4X if multi-byte characters are allowed.

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/mode.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/mode.go
@@ -130,7 +130,7 @@ func (mdtv *modeDiscriminatorTagValidator) GetValidations(context Context, tag c
 func (mdtv *modeDiscriminatorTagValidator) Docs() TagDoc {
 	return TagDoc{
 		Tag:            mdtv.TagName(),
-		StabilityLevel: TagStabilityLevelAlpha,
+		StabilityLevel: TagStabilityLevelBeta,
 		Scopes:         sets.List(mdtv.ValidScopes()),
 		Description:    "Indicates that this field is a discriminator for state-based validation.",
 		Args: []TagArgDoc{{
@@ -221,7 +221,7 @@ func (imtv *ifModeTagValidator) GetValidations(context Context, tag codetags.Tag
 func (imtv *ifModeTagValidator) Docs() TagDoc {
 	return TagDoc{
 		Tag:            imtv.TagName(),
-		StabilityLevel: TagStabilityLevelAlpha,
+		StabilityLevel: TagStabilityLevelBeta,
 		Scopes:         sets.List(imtv.ValidScopes()),
 		Description:    "Indicates that this field's validation depends on a mode discriminator.",
 		Args: []TagArgDoc{{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/kind cleanup

#### What this PR does / why we need it:

This PR promotes the stability level of several declarative validation tags for the v1.37 release.

The OpenAPI-style tags promoted here have fixed, well-established semantics and small/direct implementations. For these tags, there is no speculative part of the tag API surface to learn from a Kubernetes API migration soak. For  this reason we can promote them directly to `StabilityLevelStable` gives downstream users, including controller-tools and CRD authors, confidence that the declarative validation tag API is not expected to change.

This PR also promotes the mode-discriminator tags from alpha to beta. Those tags are not OpenAPI-style tags, so they are not being promoted directly to stable, but they now have Kubernetes API usage from v1.36 (soak 1 release) and are ready for beta stability.

The mismatch metrics for all tags remain at `0` meaning promotion is OK w.r.t soak:
- declarative_validation_mismatch_total
- declarative_validation_parity_discrepancies_total
- declarative_validation_panic_total
- declarative_validation_panics_total

Promotions in this PR:

| Tag | Promotion | Rationale |
|---|---|---|
| `+k8s:maxLength` | Beta -> Stable | Mirrors the OpenAPI `maxLength` validation for string character length. The tag API and semantics are fixed, and the implementation is direct. This tag has Kubernetes API usage that has soaked 2+ releases, including [`VolumeAttachmentSpec.Attacher`](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/storage/v1alpha1/types.go#L83), [`OpaqueDeviceConfiguration.Driver`](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/resource/v1/types.go#L1537), and [`DeviceRequestAllocationResult.Driver`](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/resource/v1/types.go#L1784). |
| `+k8s:maxProperties` | Beta -> Stable | Mirrors the OpenAPI `maxProperties` validation for object/map property count. The tag API and semantics are fixed and the implementation is a direct map-size check. There is no current Kubernetes API usage to soak, but because this is an OpenAPI-style tag with established semantics, additional soak would not provide meaningful signal about the tag API. |
| `+k8s:maximum` | Beta -> Stable | Mirrors the OpenAPI `maximum` validation for numeric upper bounds. The tag API and semantics are fixed, and the implementation is direct. This tag has Kubernetes API usage, including [`ResourcePoolStatusRequestSpec.Limit`](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/resource/v1alpha3/types.go#L422) and the WorkloadAwarePreemption [`Priority`](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/scheduling/v1alpha2/types.go#L203) fields. Given the OpenAPI-style semantics and in-tree usage, it is ready for stable. |
| `+k8s:minItems` | Beta -> Stable | Mirrors the OpenAPI `minItems` validation for list lower bounds. There are currently no useful native Kubernetes handwritten validation migration case beyond required/non-empty checks, so there is no current Kubernetes API usage to soak. Because this is an OpenAPI-style tag with fixed semantics, additional soak would not provide meaningful signal about the tag API. |
| `+k8s:minLength` | Alpha -> Stable | Mirrors the OpenAPI `minLength` validation for string character length. There are currently no useful native Kubernetes handwritten validation migration case: handwritten validations generally use required/non-empty checks, and no native API validation uses `field.TooShort`. Because this is an OpenAPI-style tag with fixed semantics, it can be promoted directly to stable even without Kubernetes API usage to soak. |
| `+k8s:modeDiscriminator` | Alpha -> Beta | This tag now has Kubernetes API usage for state-based validation, including [`PriorityLevelConfigurationSpec.Type`](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/flowcontrol/v1/types.go#L435) and [`LimitResponse.Type`](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/flowcontrol/v1/types.go#L578) and it has soaked for 1 release. It is not an OpenAPI-style tag, so this PR promotes it only to beta after initial in-tree usage. |
| `+k8s:ifMode` | Alpha -> Beta | This tag now has Kubernetes API usage together with `+k8s:modeDiscriminator`, including [`PriorityLevelConfigurationSpec.Limited`](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/flowcontrol/v1/types.go#L442), [`PriorityLevelConfigurationSpec.Exempt`](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/flowcontrol/v1/types.go#L452), and [`LimitResponse.Queuing`](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/flowcontrol/v1/types.go#L585) and it has soaked for 1 release. It is not an OpenAPI-style tag, so this PR promotes it only to beta after initial in-tree usage. |

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen
KEP Issue: https://github.com/kubernetes/enhancements/issues/5073

#### Special notes for your reviewer:

This PR only updates tag stability metadata in `validation-gen`. It does not add, remove, or change any Kubernetes API field validations.

`+k8s:minProperties` is not included because that tag does not exist yet in `validation-gen`.

`+k8s:maxBytes` is not included because it is Kubernetes-specific byte-length validation rather than a 1:1 OpenAPI validation tag.

`+k8s:eachVal`, `+k8s:eachKey`, and uniqueness-related tags are not included because they are not part of the OpenAPI-style tag promotion decision.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen
```
