### PR TITLE
e2e_dra: reliability fixes

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -1468,7 +1468,6 @@ if [[ "${START_MODE}" != "kubeletonly" ]]; then
 fi
 
 kube::util::test_openssl_installed
-kube::util::ensure-cfssl
 
 ### IF the user didn't supply an output/ for the build... Then we detect.
 if [ "${GO_OUT}" == "" ]; then
@@ -1476,6 +1475,15 @@ if [ "${GO_OUT}" == "" ]; then
 fi
 echo "Detected host and ready to start services.  Doing some housekeeping first..."
 echo "Using GO_OUT ${GO_OUT}"
+
+# kube::util::ensure-cfssl downloads cfssl when cfssl is not found in PATH.
+# Point it at the persistent cache dir and apppend it to PATH so cfssl is
+# downloaded only on the first run and reused afterwards.
+KUBERNETES_SERVER_CACHE_DIR=${KUBERNETES_SERVER_CACHE_DIR:-"${GO_OUT}"}
+CFSSL_PATH="${KUBERNETES_SERVER_CACHE_DIR}/cfssl"
+PATH="${PATH}:${CFSSL_PATH}"
+kube::util::ensure-cfssl "${CFSSL_PATH}"
+
 export KUBELET_CIDFILE=${TMP_DIR}/kubelet.cid
 if [[ "${ENABLE_DAEMON}" = false ]]; then
   trap cleanup EXIT

--- a/test/e2e_dra/run.sh
+++ b/test/e2e_dra/run.sh
@@ -23,9 +23,12 @@ sudo mkdir /var/lib/kubelet/plugins
 sudo mkdir /var/run/cdi
 sudo chown "$(id -u)" /var/lib/kubelet/plugins_registry /var/lib/kubelet/plugins /var/run/cdi
 ARTIFACTS=/tmp/artifacts
+TMP_DIR=${ARTIFACTS}/tmp
+LOG_DIR=${ARTIFACTS}/logs
+TMPDIR=${TMP_DIR}
 KUBERNETES_SERVER_BIN_DIR="$(pwd)/_output/local/bin/$(go env GOOS)/$(go env GOARCH)"
 KUBERNETES_SERVER_CACHE_DIR="${KUBERNETES_SERVER_BIN_DIR}/cache-dir"
-
-export ARTIFACTS KUBERNETES_SERVER_BIN_DIR KUBERNETES_SERVER_CACHE_DIR
+mkdir -p "${TMP_DIR}" "${LOG_DIR}"
+export ARTIFACTS TMP_DIR LOG_DIR TMPDIR KUBERNETES_SERVER_BIN_DIR KUBERNETES_SERVER_CACHE_DIR
 
 exec "$@"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- e2e_dra: avoid downloading cfssl on every run
    
    Cached cfssl under KUBERNETES_SERVER_CACHE_DIR
    so it is downloaded only on the first run and reused afterwards.
    This should speed up test execution.

- test/e2e_dra: redirect all artifacts into one directory
    
    Pointed TMP_DIR, LOG_DIR, TMPDIR, and KUBE_TEMP under /tmp/artifacts so
    that all files created by hack/local-up-cluster.sh (config files, audit
    logs, etcd data dirs) land there instead of scattering across /tmp/.
    The rm -rf at the top of run.sh already removes /tmp/artifacts, so
    everything is cleaned up on the next run even if a test was killed
    mid-run and the shell cleanup trap did not execute.


#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
