### PR TITLE
sample-controller: use AddEventHandlerWithOptions for contextual logging

### DIFF
--- a/staging/src/k8s.io/sample-controller/controller.go
+++ b/staging/src/k8s.io/sample-controller/controller.go
@@ -125,19 +125,20 @@ func NewController(
 
 	logger.Info("Setting up event handlers")
 	// Set up an event handler for when Foo resources change
-	fooInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := fooInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: controller.enqueueFoo,
 		UpdateFunc: func(old, new interface{}) {
 			controller.enqueueFoo(new)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
+	utilruntime.Must(err)
 	// Set up an event handler for when Deployment resources change. This
 	// handler will lookup the owner of the given Deployment, and if it is
 	// owned by a Foo resource then the handler will enqueue that Foo resource for
 	// processing. This way, we don't need to implement custom logic for
 	// handling Deployment resources. More info on this pattern:
 	// https://github.com/kubernetes/community/blob/8cafef897a22026d42f5e5bb3f104febe7e29830/contributors/devel/controllers.md
-	deploymentInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = deploymentInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: controller.handleObject,
 		UpdateFunc: func(old, new interface{}) {
 			newDepl := new.(*appsv1.Deployment)
@@ -150,7 +151,8 @@ func NewController(
 			controller.handleObject(new)
 		},
 		DeleteFunc: controller.handleObject,
-	})
+	}, cache.HandlerOptions{Logger: &logger})
+	utilruntime.Must(err)
 
 	return controller
 }


### PR DESCRIPTION
**What this PR does / why we need it:**

`NewController` in the sample-controller already receives a
`context.Context` and derives a `klog.Logger` via `klog.FromContext`.
However, the two `AddEventHandler` calls still use the plain variant,
which falls back to `klog.Background()` inside the shared informer.

This PR replaces both calls with `AddEventHandlerWithOptions` and passes
the derived logger through `cache.HandlerOptions{Logger: &logger}`, so
contextual log lines from these handlers carry the same key-value pairs
as the rest of the controller.

The sample-controller is a reference implementation, keeping it current
with best practices helps downstream users adopt the correct pattern.

**Which issue(s) this PR fixes:**

Refs: #126379

**Special notes for your reviewer:**

Change is isolated to two call sites in `NewController`; no interface or
signature changes. `go build ./...` and `go test ./...` pass inside
`staging/src/k8s.io/sample-controller`.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```
