### PR TITLE
test-cmd.sh: use mktemp -t to avoid temp file creation in local directory

### DIFF
--- a/hack/make-rules/test-cmd.sh
+++ b/hack/make-rules/test-cmd.sh
@@ -104,7 +104,7 @@ function run_kube_controller_manager() {
   # Start controller manager
   kube::log::status 'Generate kubeconfig for controller-manager'
   local config
-  config="$(mktemp controller-manager.kubeconfig.XXXXX)"
+  config="$(mktemp -t controller-manager.kubeconfig.XXXXX)"
   cat <<EOF > "$config"
 kind: Config
 users:


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Each time you run `make test-cmd`, the `test-cmd.sh` script creates a new temp file in the local directory for kube-controller-manager. These files unnecessarily accumulate over time as "untracked files" by git:
```
~/projects/kubernetes (kubectl-1841) % git status
On branch kubectl-1841
Your branch is up to date with 'origin/kubectl-1841'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        controller-manager.kubeconfig.KSnHk
        controller-manager.kubeconfig.LeD1B
        controller-manager.kubeconfig.Ou6le
        controller-manager.kubeconfig.WRcek
        controller-manager.kubeconfig.ZDP5J
        controller-manager.kubeconfig.ZXvDh
        controller-manager.kubeconfig.gLeGL
        controller-manager.kubeconfig.hzXGW
        controller-manager.kubeconfig.ih8Rc
        controller-manager.kubeconfig.x2BUI

nothing added to commit but untracked files present (use "git add" to track)
```

This PR uses the `-t` flag of `mktemp` so that the files will be created in the temp directory instead.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
