### PR TITLE
apiserver/cacher: pre-size result slice in btreeStore.ListPrefix

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_btree.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_btree.go
@@ -257,7 +257,7 @@ func (s *btreeStore) ListPrefix(prefix, continueKey string) []interface{} {
 	if continueKey == "" {
 		continueKey = prefix
 	}
-	var result []interface{}
+	result := make([]interface{}, 0, s.listPrefixCapacityHint(prefix, continueKey))
 	s.tree.AscendGreaterOrEqual(&Element{Key: continueKey}, func(item *Element) bool {
 		if !strings.HasPrefix(item.Key, prefix) {
 			return false
@@ -266,6 +266,24 @@ func (s *btreeStore) ListPrefix(prefix, continueKey string) []interface{} {
 		return true
 	})
 	return result
+}
+
+// listPrefixCapacityHint returns the exact result size for ListPrefix when it
+// can be determined cheaply, or 0 otherwise. Keys matching a given prefix form
+// a contiguous range in key order, so if the tree's smallest key is at or after
+// continueKey and its largest key carries the prefix, every key in the tree will
+// be returned. This covers cluster-scoped LISTs, where the prefix matches every
+// key in the per-resource store.
+func (s *btreeStore) listPrefixCapacityHint(prefix, continueKey string) int {
+	minElem, hasMin := s.tree.Min()
+	maxElem, hasMax := s.tree.Max()
+	if hasMin && hasMax && minElem.Key >= continueKey && strings.HasPrefix(maxElem.Key, prefix) {
+		return s.tree.Len()
+	}
+	// TODO: when the prefix does not cover the whole tree, falling back to
+	// s.Count(prefix, continueKey) would size the result exactly at the cost
+	// of a second tree traversal over the matching range.
+	return 0
 }
 
 func (s *btreeStore) Count(prefix, continueKey string) (count int) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_btree_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_btree_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package store
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -68,6 +69,43 @@ func TestStoreListPrefix(t *testing.T) {
 	assert.Equal(t, []interface{}{
 		testStorageElement("bar", "baz", 4),
 	}, items)
+}
+
+func BenchmarkBtreeStoreListPrefix(b *testing.B) {
+	const namespaces = 100
+	const podsPerNamespace = 1000
+	store := newThreadedBtreeStoreIndexer(nil, btreeDegree)
+	for ns := range namespaces {
+		for pod := range podsPerNamespace {
+			if err := store.Add(testStorageElement(fmt.Sprintf("/pods/ns-%03d/pod-%04d", ns, pod), "data", ns*podsPerNamespace+pod)); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+	b.Run("Match=All", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if got := len(store.ListPrefix("/pods/", "")); got != namespaces*podsPerNamespace {
+				b.Fatalf("unexpected result size %d", got)
+			}
+		}
+	})
+	b.Run("Match=Namespace", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if got := len(store.ListPrefix("/pods/ns-042/", "")); got != podsPerNamespace {
+				b.Fatalf("unexpected result size %d", got)
+			}
+		}
+	})
+	b.Run("Match=Continue", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if got := len(store.ListPrefix("/pods/", "/pods/ns-050/")); got != namespaces/2*podsPerNamespace {
+				b.Fatalf("unexpected result size %d", got)
+			}
+		}
+	})
 }
 
 func TestStoreSnapshotter(t *testing.T) {


### PR DESCRIPTION
The result slice was grown from nil via repeated append, causing log(n) growslice reallocations per LIST served from the watch cache. On a large-cluster heap profile this accounted for ~3% of total apiserver lifetime allocation.

When the requested prefix covers the entire tree (cluster-scoped LIST, which is the dominant caller), pre-size to tree.Len(). Namespace-scoped and continuation LISTs are unaffected.


#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:

This PR helps improve performance and specifically reduces memory allocations

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:

Found by looking at cpu and heap profiling data from a large production cluster under realistic workloads

```
goos: linux
goarch: amd64
pkg: k8s.io/apiserver/pkg/storage/cacher/store
cpu: Intel(R) Xeon(R) 6975P-C
                                        │ /tmp/old.txt │            /tmp/new.txt             │
                                        │    sec/op    │   sec/op     vs base                │
BtreeStoreListPrefix/Match=All-96          3.055m ± 2%   1.035m ± 1%  -66.11% (p=0.000 n=10)
BtreeStoreListPrefix/Match=Namespace-96    13.79µ ± 0%   17.07µ ± 1%  +23.76% (p=0.000 n=10)
BtreeStoreListPrefix/Match=Continue-96    1158.9µ ± 1%   890.8µ ± 0%  -23.14% (p=0.000 n=10)
geomean                                    365.5µ        250.6µ       -31.44%

                                        │ /tmp/old.txt  │             /tmp/new.txt             │
                                        │     B/op      │     B/op      vs base                │
BtreeStoreListPrefix/Match=All-96          8.510Mi ± 0%   1.531Mi ± 0%  -82.01% (p=0.000 n=10)
BtreeStoreListPrefix/Match=Namespace-96    34.41Ki ± 0%   16.09Ki ± 0%  -53.22% (p=0.000 n=10)
BtreeStoreListPrefix/Match=Continue-96    4242.4Ki ± 0%   784.1Ki ± 0%  -81.52% (p=0.000 n=10)
geomean                                    1.058Mi        270.5Ki       -75.04%

                                        │ /tmp/old.txt │            /tmp/new.txt            │
                                        │  allocs/op   │ allocs/op   vs base                │
BtreeStoreListPrefix/Match=All-96          29.000 ± 0%   2.000 ± 0%  -93.10% (p=0.000 n=10)
BtreeStoreListPrefix/Match=Namespace-96    12.000 ± 0%   3.000 ± 0%  -75.00% (p=0.000 n=10)
BtreeStoreListPrefix/Match=Continue-96     26.000 ± 0%   3.000 ± 0%  -88.46% (p=0.000 n=10)
geomean                                     20.84        2.621       -87.42%
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
