### PR TITLE
fix: SRIOV resources cleanup in runTMScopeResourceAlignmentTestSuite

### DIFF
--- a/test/e2e_node/topology_manager_test.go
+++ b/test/e2e_node/topology_manager_test.go
@@ -661,6 +661,7 @@ func teardownSRIOVConfigOrFail(ctx context.Context, f *framework.Framework, sd *
 func runTMScopeResourceAlignmentTestSuite(ctx context.Context, f *framework.Framework, configMap *v1.ConfigMap, reservedSystemCPUs, policy string, numaNodes, coreCount int) {
 	smtLevel := smtLevelFromSysFS()
 	sd := setupSRIOVConfigOrFail(ctx, f, configMap)
+	ginkgo.DeferCleanup(teardownSRIOVConfigOrFail, f, sd)
 	var ctnAttrs, initCtnAttrs []tmCtnAttribute
 
 	waitForSRIOVResources(ctx, f, sd)
@@ -842,8 +843,6 @@ func runTMScopeResourceAlignmentTestSuite(ctx context.Context, f *framework.Fram
 		},
 	}
 	runTopologyManagerNegativeTest(ctx, f, ctnAttrs, initCtnAttrs, envInfo)
-
-	teardownSRIOVConfigOrFail(ctx, f, sd)
 }
 
 func runTopologyManagerNodeAlignmentSuiteTests(ctx context.Context, f *framework.Framework, sd *sriovData, reservedSystemCPUs, policy string, numaNodes, coreCount int) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

The test was calling `teardownSRIOVConfigOrFail` at the end of the function, which meant resources would not be cleaned up if any test failed midway. Using `ginkgo.DeferCleanup` ensures proper cleanup even on test failure.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
