### PR TITLE
Fix volumeManager.WaitForUnmount to block on uncertain volumes

### DIFF
--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -516,7 +516,7 @@ func (vm *volumeManager) WaitForUnmount(ctx context.Context, pod *v1.Pod) error 
 
 	if err != nil {
 		var mountedVolumes []v1.UniqueVolumeName
-		for _, v := range vm.actualStateOfWorld.GetMountedVolumesForPod(uniquePodName) {
+		for _, v := range vm.actualStateOfWorld.GetPossiblyMountedVolumesForPod(uniquePodName) {
 			mountedVolumes = append(mountedVolumes, v.VolumeName)
 		}
 		if len(mountedVolumes) == 0 {
@@ -586,14 +586,17 @@ func (vm *volumeManager) verifyVolumesMountedFunc(podName types.UniquePodName, e
 	}
 }
 
-// verifyVolumesUnmountedFunc returns a method that is true when there are no mounted volumes for this
-// pod.
+// verifyVolumesUnmountedFunc returns a method that is true when there are no
+// mounted or uncertain volumes for this pod. An UnmountVolume.TearDown failure
+// leaves the volume in the uncertain state, and the predicate must keep
+// reporting not-done in that case so WaitForUnmount waits for the next retry
+// rather than declaring the pod cleanly terminated while the mount lingers.
 func (vm *volumeManager) verifyVolumesUnmountedFunc(podName types.UniquePodName) wait.ConditionWithContextFunc {
 	return func(_ context.Context) (done bool, err error) {
 		if errs := vm.desiredStateOfWorld.PopPodErrors(podName); len(errs) > 0 {
 			return true, errors.New(strings.Join(errs, "; "))
 		}
-		return !vm.actualStateOfWorld.PodHasMountedVolumes(podName), nil
+		return len(vm.actualStateOfWorld.GetPossiblyMountedVolumesForPod(podName)) == 0, nil
 	}
 }
 

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -47,11 +47,13 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
+	"k8s.io/kubernetes/pkg/kubelet/volumemanager/cache"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/emptydir"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 	"k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/pkg/volume/util/hostutil"
+	"k8s.io/kubernetes/pkg/volume/util/operationexecutor"
 	"k8s.io/kubernetes/pkg/volume/util/types"
 	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/mount-utils"
@@ -1065,5 +1067,61 @@ func TestVolumeManager_ResizeEphemeralVolume(t *testing.T) {
 			}
 
 		})
+	}
+}
+
+func TestVerifyVolumesUnmountedFuncTreatsUncertainAsMounted(t *testing.T) {
+	// Uncertain volumes must keep blocking unmount; see kubernetes#113563.
+	logger, ctx := ktesting.NewTestContext(t)
+
+	volumePluginMgr, plugin := volumetest.GetTestKubeletVolumePluginMgr(t)
+	asw := cache.NewActualStateOfWorld(testHostname, volumePluginMgr)
+	dsw := cache.NewDesiredStateOfWorld(volumePluginMgr, util.NewFakeSELinuxLabelTranslator())
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod1",
+			UID:  "pod1uid",
+		},
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{
+				{
+					Name: "volume-name-1",
+					VolumeSource: v1.VolumeSource{
+						GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
+							PDName: "fake-device",
+						},
+					},
+				},
+			},
+		},
+	}
+	volumeSpec := &volume.Spec{Volume: &pod.Spec.Volumes[0]}
+	volumeName, err := util.GetUniqueVolumeNameFromSpec(plugin, volumeSpec)
+	require.NoError(t, err)
+
+	require.NoError(t, asw.MarkVolumeAsAttached(logger, volumeName, volumeSpec, "" /* nodeName */, "fake/device/path"))
+
+	podName := util.GetUniquePodName(pod)
+	mounter, err := plugin.NewMounter(volumeSpec, pod)
+	require.NoError(t, err)
+
+	require.NoError(t, asw.MarkVolumeMountAsUncertain(operationexecutor.MarkVolumeOpts{
+		PodName:    podName,
+		PodUID:     pod.UID,
+		VolumeName: volumeName,
+		Mounter:    mounter,
+		VolumeSpec: volumeSpec,
+	}))
+
+	vm := &volumeManager{
+		desiredStateOfWorld: dsw,
+		actualStateOfWorld:  asw,
+	}
+
+	done, err := vm.verifyVolumesUnmountedFunc(podName)(ctx)
+	require.NoError(t, err)
+	if done {
+		t.Errorf("verifyVolumesUnmountedFunc reported done for a pod with an uncertain volume; uncertain volumes must keep blocking unmount completion")
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig storage
/sig node

#### What this PR does / why we need it:

**Symptom.** When `UnmountVolume.TearDown` fails, the volume is marked uncertain (per #100183). `WaitForUnmount` returns success while the bind mount is still on disk, `syncTerminatedPod` declares the pod terminated, and a later reconcile logs `Pod is terminated, but some volumes have not been cleaned up`. Reproduces with the `chattr +i` recipe in #113563.

**Root cause.** `verifyVolumesUnmountedFunc` checks `PodHasMountedVolumes`, which counts only `VolumeMounted` and excludes `VolumeMountUncertain`. The post-timeout error path has the same strict reading via `GetMountedVolumesForPod`.

**Fix.** Switch the predicate (and the post-timeout error enumeration) to `GetPossiblyMountedVolumesForPod`. `WaitForUnmount` now keeps polling until the unmount succeeds or `podAttachAndMountTimeout` fires; the timeout error names the lingering volume.

**Scope.** Two behavior-change lines plus a doc-comment update. Plugin-agnostic, so anything whose `TearDown` can fail benefits. The new test (`TestVerifyVolumesUnmountedFuncTreatsUncertainAsMounted`) covers the predicate; no e2e for non-emptyDir.

#### Which issue(s) this PR is related to:

Fixes #113563

#### Special notes for your reviewer:

- **Coordination with #138517.** @hensur, I'm adding a new caller of `GetPossiblyMountedVolumesForPod` in the post-timeout error path. If yours lands first I'll switch the predicate to `vm.HasPossiblyMountedVolumesForPod`; if mine does, you'll keep the slice accessor or rewrite my caller. Either order is fine.
- **Strictness, not looseness.** `WaitForUnmount` can only delay cleanup completion (until unmount succeeds or `podAttachAndMountTimeout` fires), never skip it.
- **Test.** Fails on master, passes on this branch. `go test -race ./pkg/kubelet/volumemanager/...` is green.

#### Does this PR introduce a user-facing change?

```release-note
Fixed kubelet `volumeManager.WaitForUnmount` to keep waiting when a previous unmount failed and left the volume in the uncertain state. Previously, `syncTerminatedPod` could mark the pod cleanly terminated while a bind mount was still on disk, surfacing as a "Pod is terminated, but some volumes have not been cleaned up" event seconds later.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
