### PR TITLE
Allow for ResourceVersion to be passed on delete api calls

### DIFF
--- a/pkg/controller/testutil/test_utils.go
+++ b/pkg/controller/testutil/test_utils.go
@@ -203,6 +203,11 @@ func (m *FakeNodeHandler) Delete(_ context.Context, id string, opt metav1.Delete
 	return nil
 }
 
+// DeleteWithResult deletes the status of a Node from the fake store.
+func (m *FakeNodeHandler) DeleteWithResult(_ context.Context, name string, _ metav1.DeleteOptions) (metav1.APIResult, error) {
+	return nil, nil
+}
+
 // DeleteCollection deletes a collection of Nodes from the fake store.
 func (m *FakeNodeHandler) DeleteCollection(_ context.Context, opt metav1.DeleteOptions, listOpts metav1.ListOptions) error {
 	return nil

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/example.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/example.go
@@ -41,6 +41,7 @@ type ExampleInterface interface {
 	Create(ctx context.Context, example *crv1.Example, opts metav1.CreateOptions) (*crv1.Example, error)
 	Update(ctx context.Context, example *crv1.Example, opts metav1.UpdateOptions) (*crv1.Example, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*crv1.Example, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*crv1.ExampleList, error)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/customresourcedefinition.go
@@ -43,6 +43,7 @@ type CustomResourceDefinitionInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, customResourceDefinition *apiextensionsv1.CustomResourceDefinition, opts metav1.UpdateOptions) (*apiextensionsv1.CustomResourceDefinition, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*apiextensionsv1.CustomResourceDefinition, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*apiextensionsv1.CustomResourceDefinitionList, error)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/customresourcedefinition.go
@@ -43,6 +43,7 @@ type CustomResourceDefinitionInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, customResourceDefinition *apiextensionsv1beta1.CustomResourceDefinition, opts v1.UpdateOptions) (*apiextensionsv1beta1.CustomResourceDefinition, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*apiextensionsv1beta1.CustomResourceDefinition, error)
 	List(ctx context.Context, opts v1.ListOptions) (*apiextensionsv1beta1.CustomResourceDefinitionList, error)

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/meta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/meta.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -61,6 +62,13 @@ type Object interface {
 	SetOwnerReferences([]OwnerReference)
 	GetManagedFields() []ManagedFieldsEntry
 	SetManagedFields(managedFields []ManagedFieldsEntry)
+}
+
+// APIResult is an interface that represents the result of an API operation.
+type APIResult interface {
+	Get() (runtime.Object, error)
+	StatusCode(statusCode *int) APIResult
+	Error() error
 }
 
 // ListMetaAccessor retrieves the list interface from an object

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/meta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/meta.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -61,6 +62,23 @@ type Object interface {
 	SetOwnerReferences([]OwnerReference)
 	GetManagedFields() []ManagedFieldsEntry
 	SetManagedFields(managedFields []ManagedFieldsEntry)
+}
+
+// APIResult is an interface that represents the result of an API operation.
+type APIResult interface {
+	// Get returns the result as a runtime.Object, or an error if the operation failed.
+	// If Error() returns a non-nil error, Get will return nil, err.
+	Get() (runtime.Object, error)
+
+	// StatusCode returns the HTTP status code of the response and any error encountered.
+	// If Error() returns a non-nil error that prevented a response from being read (such as a network failure),
+	// StatusCode returns 0, err.
+	// If the error was returned from the server with an HTTP status code, StatusCode returns status, err.
+	// If the operation succeeded, StatusCode returns status, nil.
+	StatusCode() (int, error)
+
+	// Error returns the error executing the request, or nil if no error occurred.
+	Error() error
 }
 
 // ListMetaAccessor retrieves the list interface from an object

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -653,6 +653,26 @@ func ShouldDeleteDuringUpdate(ctx context.Context, key string, obj, existing run
 	return oldMeta.GetDeletionGracePeriodSeconds() == nil || *oldMeta.GetDeletionGracePeriodSeconds() == 0
 }
 
+func setRVFromNotFound(err error, lastKnown runtime.Object, returnDeletedObject bool) runtime.Object {
+	obj := lastKnown.DeepCopyObject()
+	accessor, aErr := meta.Accessor(obj)
+	if aErr != nil {
+		return obj
+	}
+	if returnDeletedObject {
+		// clear the resource version since we can't return an RV that corresponds to both the object content and the storage version
+		accessor.SetResourceVersion("")
+	} else {
+		if rv, ok := storage.ResourceVersion(err); ok && rv != "" {
+			accessor.SetResourceVersion(rv)
+		} else {
+			// clear the resource version since we don't know the storage version at this point
+			accessor.SetResourceVersion("")
+		}
+	}
+	return obj
+}
+
 // deleteWithoutFinalizers handles deleting an object ignoring its finalizer list.
 // Used for objects that are either been finalized or have never initialized.
 func (e *Store) deleteWithoutFinalizers(ctx context.Context, name, key string, obj runtime.Object, preconditions *storage.Preconditions, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
@@ -664,6 +684,7 @@ func (e *Store) deleteWithoutFinalizers(ctx context.Context, name, key string, o
 		// requests to remove all finalizers from the object, so we
 		// ignore the NotFound error.
 		if storage.IsNotFound(err) {
+			obj = setRVFromNotFound(err, obj, e.ReturnDeletedObject)
 			_, err := e.finalizeDelete(ctx, obj, true, options)
 			// clients are expecting an updated object if a PUT succeeded,
 			// but finalizeDelete returns a metav1.Status, so return
@@ -672,10 +693,15 @@ func (e *Store) deleteWithoutFinalizers(ctx context.Context, name, key string, o
 		}
 		return nil, false, storeerr.InterpretDeleteError(err, e.qualifiedResourceFromContext(ctx), name)
 	}
-	_, err := e.finalizeDelete(ctx, out, true, options)
-	// clients are expecting an updated object if a PUT succeeded, but
-	// finalizeDelete returns a metav1.Status, so return the object in
-	// the request instead.
+	// clients are expecting the updated object if a PUT succeeded. We preserve
+	// any other updates in 'obj' but update its resource version to match the
+	// actual deletion transaction.
+	if outAccessor, err := meta.Accessor(out); err == nil {
+		if objAccessor, err := meta.Accessor(obj); err == nil {
+			objAccessor.SetResourceVersion(outAccessor.GetResourceVersion())
+		}
+	}
+	_, err := e.finalizeDelete(ctx, obj, true, options)
 	return obj, false, err
 }
 
@@ -1282,6 +1308,7 @@ func (e *Store) Delete(ctx context.Context, name string, deleteValidation rest.V
 		if storage.IsNotFound(err) && ignoreNotFound && lastExisting != nil {
 			// The lastExisting object may not be the last state of the object
 			// before its deletion, but it's the best approximation.
+			lastExisting = setRVFromNotFound(err, lastExisting, e.ReturnDeletedObject)
 			out, err := e.finalizeDelete(ctx, lastExisting, true, options)
 			return out, true, err
 		}
@@ -1479,6 +1506,7 @@ func (e *Store) finalizeDelete(ctx context.Context, obj runtime.Object, runHooks
 		UID:   accessor.GetUID(),
 	}
 	status := &metav1.Status{Status: metav1.StatusSuccess, Details: details}
+	status.ResourceVersion = accessor.GetResourceVersion()
 	return status, nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -653,6 +653,26 @@ func ShouldDeleteDuringUpdate(ctx context.Context, key string, obj, existing run
 	return oldMeta.GetDeletionGracePeriodSeconds() == nil || *oldMeta.GetDeletionGracePeriodSeconds() == 0
 }
 
+func setRVFromNotFound(err error, lastKnown runtime.Object, returnDeletedObject bool) runtime.Object {
+	obj := lastKnown.DeepCopyObject()
+	accessor, aErr := meta.Accessor(obj)
+	if aErr != nil {
+		return obj
+	}
+	if returnDeletedObject {
+		// clear the resource version since we can't return an RV that corresponds to both the object content and the storage version
+		accessor.SetResourceVersion("")
+	} else {
+		if rv, ok := storage.ResourceVersion(err); ok && rv != "" {
+			accessor.SetResourceVersion(rv)
+		} else {
+			// clear the resource version since we don't know the storage version at this point
+			accessor.SetResourceVersion("")
+		}
+	}
+	return obj
+}
+
 // deleteWithoutFinalizers handles deleting an object ignoring its finalizer list.
 // Used for objects that are either been finalized or have never initialized.
 func (e *Store) deleteWithoutFinalizers(ctx context.Context, name, key string, obj runtime.Object, preconditions *storage.Preconditions, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
@@ -664,6 +684,7 @@ func (e *Store) deleteWithoutFinalizers(ctx context.Context, name, key string, o
 		// requests to remove all finalizers from the object, so we
 		// ignore the NotFound error.
 		if storage.IsNotFound(err) {
+			obj = setRVFromNotFound(err, obj, e.ReturnDeletedObject)
 			_, err := e.finalizeDelete(ctx, obj, true, options)
 			// clients are expecting an updated object if a PUT succeeded,
 			// but finalizeDelete returns a metav1.Status, so return
@@ -672,10 +693,15 @@ func (e *Store) deleteWithoutFinalizers(ctx context.Context, name, key string, o
 		}
 		return nil, false, storeerr.InterpretDeleteError(err, e.qualifiedResourceFromContext(ctx), name)
 	}
-	_, err := e.finalizeDelete(ctx, out, true, options)
-	// clients are expecting an updated object if a PUT succeeded, but
-	// finalizeDelete returns a metav1.Status, so return the object in
-	// the request instead.
+	// clients are expecting the updated object if a PUT succeeded. We preserve
+	// any other updates in 'obj' but update its resource version to match the
+	// actual deletion transaction.
+	if outAccessor, err := meta.Accessor(out); err == nil {
+		if objAccessor, err := meta.Accessor(obj); err == nil {
+			objAccessor.SetResourceVersion(outAccessor.GetResourceVersion())
+		}
+	}
+	_, err := e.finalizeDelete(ctx, obj, true, options)
 	return obj, false, err
 }
 
@@ -1132,6 +1158,7 @@ func (e *Store) updateForGracefulDeletionAndFinalizers(ctx context.Context, name
 				return nil, err
 			}
 			if pendingGraceful {
+				lastExisting = existing
 				return nil, errAlreadyDeleting
 			}
 
@@ -1191,7 +1218,11 @@ func (e *Store) updateForGracefulDeletionAndFinalizers(ctx context.Context, name
 		// we should fall through and truly delete the object.
 		return nil, false, true, out, lastExisting
 	case errAlreadyDeleting:
-		out, err = e.finalizeDelete(ctx, in, true, options)
+		target := in
+		if lastExisting != nil {
+			target = lastExisting
+		}
+		out, err = e.finalizeDelete(ctx, target, true, options)
 		return err, false, false, out, lastExisting
 	default:
 		return storeerr.InterpretUpdateError(err, e.qualifiedResourceFromContext(ctx), name), false, false, out, lastExisting
@@ -1282,6 +1313,7 @@ func (e *Store) Delete(ctx context.Context, name string, deleteValidation rest.V
 		if storage.IsNotFound(err) && ignoreNotFound && lastExisting != nil {
 			// The lastExisting object may not be the last state of the object
 			// before its deletion, but it's the best approximation.
+			lastExisting = setRVFromNotFound(err, lastExisting, e.ReturnDeletedObject)
 			out, err := e.finalizeDelete(ctx, lastExisting, true, options)
 			return out, true, err
 		}
@@ -1479,6 +1511,7 @@ func (e *Store) finalizeDelete(ctx context.Context, obj runtime.Object, runHooks
 		UID:   accessor.GetUID(),
 	}
 	status := &metav1.Status{Status: metav1.StatusSuccess, Details: details}
+	status.ResourceVersion = accessor.GetResourceVersion()
 	return status, nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -3135,4 +3136,203 @@ func TestValidateIndexers(t *testing.T) {
 			t.Errorf("%v: expected no error, but got %v", tc.name, err)
 		}
 	}
+}
+
+func TestUpdateEmptyFinalizersRV(t *testing.T) {
+	podName := "foo"
+	podWithFinalizer := &example.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: podName, Finalizers: []string{"foo.com/x"}},
+		Spec:       example.PodSpec{NodeName: "machine"},
+	}
+
+	ctx := genericapirequest.WithNamespace(genericapirequest.NewContext(), "test")
+	destroyFunc, registry := newTestGenericStoreRegistry(t, scheme, false)
+	defer destroyFunc()
+
+	// 1. Create the pod with finalizer
+	if _, err := registry.Create(ctx, podWithFinalizer, rest.ValidateAllObjectFunc, &metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// 2. Delete object with nil delete options to mark it as deleting but not delete it immediately
+	_, wasDeleted, err := registry.Delete(ctx, podName, rest.ValidateAllObjectFunc, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if wasDeleted {
+		t.Fatalf("Expected pod not to be deleted immediately")
+	}
+
+	// 3. Retrieve the pod to get the latest ResourceVersion with DeletionTimestamp set
+	obj, err := registry.Get(ctx, podName, &metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	podAfterDelete := obj.(*example.Pod)
+	if podAfterDelete.DeletionTimestamp == nil {
+		t.Fatalf("Expected DeletionTimestamp to be set")
+	}
+
+	// 4. Perform an Update that removes the finalizer AND makes another change (Spec.NodeName)
+	podWithNoFinalizer := &example.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: podName, ResourceVersion: podAfterDelete.ResourceVersion},
+		Spec:       example.PodSpec{NodeName: "anothermachine"},
+	}
+
+	// Enable ReturnDeletedObject on registry to return the full object
+	registry.ReturnDeletedObject = true
+
+	updatedObj, creating, err := registry.Update(ctx, podName, rest.DefaultUpdatedObjectInfo(podWithNoFinalizer), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false, &metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if creating {
+		t.Fatalf("Expected creating to be false")
+	}
+
+	updatedPod, ok := updatedObj.(*example.Pod)
+	if !ok {
+		t.Fatalf("Expected updated object to be *example.Pod, got %T", updatedObj)
+	}
+
+	// Verify that the finalizer is gone
+	if len(updatedPod.Finalizers) != 0 {
+		t.Errorf("Expected finalizers to be empty, but got %v", updatedPod.Finalizers)
+	}
+	// Verify that other changes (Spec.NodeName) are correctly reflected in the returned object
+	if updatedPod.Spec.NodeName != "anothermachine" {
+		t.Errorf("Expected Spec.NodeName to be %q, but got %q", "anothermachine", updatedPod.Spec.NodeName)
+	}
+	// Verify that the returned ResourceVersion is greater than the one before the update (indicating it represents the deletion transaction)
+	cmp, err := resourceversion.CompareResourceVersion(updatedPod.ResourceVersion, podAfterDelete.ResourceVersion)
+	if err != nil {
+		t.Fatalf("Unexpected error comparing resource versions: %v", err)
+	}
+	if cmp <= 0 {
+		t.Errorf("Expected ResourceVersion %q to be greater than the one before update %q", updatedPod.ResourceVersion, podAfterDelete.ResourceVersion)
+	}
+}
+
+func TestStoreDeleteRaceRV(t *testing.T) {
+	podName := "foo"
+	pod := &example.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: podName},
+		Spec:       example.PodSpec{NodeName: "machine"},
+	}
+	ctx := genericapirequest.WithNamespace(genericapirequest.NewContext(), "test")
+
+	testCases := []struct {
+		name                string
+		returnDeletedObject bool
+	}{
+		{"ReturnDeletedObject=true", true},
+		{"ReturnDeletedObject=false", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			destroyFunc, registry := newTestGenericStoreRegistry(t, scheme, false)
+			defer destroyFunc()
+
+			defaultDeleteStrategy := testRESTStrategy{scheme, names.SimpleNameGenerator, true, false, true}
+			registry.DeleteStrategy = testGracefulStrategy{defaultDeleteStrategy}
+			registry.ReturnDeletedObject = tc.returnDeletedObject
+
+			objCreated, err := registry.Create(ctx, pod, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			createdPod := objCreated.(*example.Pod)
+			podKey, _ := registry.KeyFunc(ctx, podName)
+
+			// Setup the racing delete storage wrapper
+			racingStorage := &racingDeleteStorage{
+				Interface:   registry.Storage.Storage,
+				t:           t,
+				keyToDelete: podKey,
+			}
+			registry.Storage.Storage = racingStorage
+
+			// Trigger deletion with grace period 0 to use graceful strategy but delete immediately.
+			gracePeriod := int64(0)
+			delOpts := &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}
+
+			obj, deleted, err := registry.Delete(ctx, podName, rest.ValidateAllObjectFunc, delOpts)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if !deleted {
+				t.Fatal("Expected object to be considered deleted")
+			}
+
+			var returnedRV string
+			if tc.returnDeletedObject {
+				returnedAccessor, err := meta.Accessor(obj)
+				if err != nil {
+					t.Fatalf("Failed to get accessor: %v", err)
+				}
+				returnedRV = returnedAccessor.GetResourceVersion()
+			} else {
+				statusObj, ok := obj.(*metav1.Status)
+				if !ok {
+					t.Fatalf("Expected *metav1.Status, got %T", obj)
+				}
+				returnedRV = statusObj.ResourceVersion
+			}
+
+			if tc.returnDeletedObject {
+				// If returnDeletedObject is true, setRVFromNotFound clears the ResourceVersion
+				if returnedRV != "" {
+					t.Errorf("Expected empty ResourceVersion, but got %q", returnedRV)
+				}
+			} else {
+				// If returnDeletedObject is false, it populates ResourceVersion from the NotFound error
+				if returnedRV == "" {
+					t.Errorf("Expected non-empty ResourceVersion")
+				}
+				cmp, err := resourceversion.CompareResourceVersion(returnedRV, createdPod.ResourceVersion)
+				if err != nil {
+					t.Fatalf("Unexpected error comparing resource versions: %v", err)
+				}
+				if cmp <= 0 {
+					t.Errorf("Expected final ResourceVersion %q to be greater than created ResourceVersion %q", returnedRV, createdPod.ResourceVersion)
+				}
+				// Ensure the returned ResourceVersion is identical to the actual deletion revision
+				racingStorage.capturedDeleteRVMux.Lock()
+				expectedRV := racingStorage.capturedDeleteRV
+				racingStorage.capturedDeleteRVMux.Unlock()
+				if returnedRV != expectedRV {
+					t.Errorf("Expected final ResourceVersion to be identical to actual deletion revision (%q), but got %q", expectedRV, returnedRV)
+				}
+			}
+		})
+	}
+}
+
+type racingDeleteStorage struct {
+	storage.Interface
+	t                   *testing.T
+	keyToDelete         string
+	once                sync.Once
+	capturedDeleteRV    string
+	capturedDeleteRVMux sync.Mutex
+}
+
+func (s *racingDeleteStorage) Delete(ctx context.Context, key string, out runtime.Object, preconditions *storage.Preconditions, validateDeletion storage.ValidateObjectFunc, cachedExistingObject runtime.Object, opts storage.DeleteOptions) error {
+	if key == s.keyToDelete {
+		s.once.Do(func() {
+			// Perform the delete operation directly against the underlying etcd storage.
+			// This deletes the key and increments etcd revision.
+			err := s.Interface.Delete(ctx, key, out, nil, validateDeletion, nil, opts)
+			if err != nil {
+				s.t.Errorf("Failed to delete key in racing goroutine: %v", err)
+			}
+			if acc, err := meta.Accessor(out); err == nil {
+				s.capturedDeleteRVMux.Lock()
+				s.capturedDeleteRV = acc.GetResourceVersion()
+				s.capturedDeleteRVMux.Unlock()
+			}
+		})
+	}
+	return s.Interface.Delete(ctx, key, out, preconditions, validateDeletion, cachedExistingObject, opts)
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -3134,5 +3135,347 @@ func TestValidateIndexers(t *testing.T) {
 		if !tc.expectedError && err != nil {
 			t.Errorf("%v: expected no error, but got %v", tc.name, err)
 		}
+	}
+}
+
+func TestUpdateEmptyFinalizersRV(t *testing.T) {
+	podName := "foo"
+	podWithFinalizer := &example.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: podName, Finalizers: []string{"foo.com/x"}},
+		Spec:       example.PodSpec{NodeName: "machine"},
+	}
+
+	ctx := genericapirequest.WithNamespace(genericapirequest.NewContext(), "test")
+	destroyFunc, registry := newTestGenericStoreRegistry(t, scheme, false)
+	defer destroyFunc()
+
+	// 1. Create the pod with finalizer
+	if _, err := registry.Create(ctx, podWithFinalizer, rest.ValidateAllObjectFunc, &metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// 2. Delete object with nil delete options to mark it as deleting but not delete it immediately
+	_, wasDeleted, err := registry.Delete(ctx, podName, rest.ValidateAllObjectFunc, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if wasDeleted {
+		t.Fatalf("Expected pod not to be deleted immediately")
+	}
+
+	// 3. Retrieve the pod to get the latest ResourceVersion with DeletionTimestamp set
+	obj, err := registry.Get(ctx, podName, &metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	podAfterDelete := obj.(*example.Pod)
+	if podAfterDelete.DeletionTimestamp == nil {
+		t.Fatalf("Expected DeletionTimestamp to be set")
+	}
+
+	// 4. Perform an Update that removes the finalizer AND makes another change (Spec.NodeName)
+	podWithNoFinalizer := &example.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: podName, ResourceVersion: podAfterDelete.ResourceVersion},
+		Spec:       example.PodSpec{NodeName: "anothermachine"},
+	}
+
+	// Enable ReturnDeletedObject on registry to return the full object
+	registry.ReturnDeletedObject = true
+
+	updatedObj, creating, err := registry.Update(ctx, podName, rest.DefaultUpdatedObjectInfo(podWithNoFinalizer), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false, &metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if creating {
+		t.Fatalf("Expected creating to be false")
+	}
+
+	updatedPod, ok := updatedObj.(*example.Pod)
+	if !ok {
+		t.Fatalf("Expected updated object to be *example.Pod, got %T", updatedObj)
+	}
+
+	// Verify that the finalizer is gone
+	if len(updatedPod.Finalizers) != 0 {
+		t.Errorf("Expected finalizers to be empty, but got %v", updatedPod.Finalizers)
+	}
+	// Verify that other changes (Spec.NodeName) are correctly reflected in the returned object
+	if updatedPod.Spec.NodeName != "anothermachine" {
+		t.Errorf("Expected Spec.NodeName to be %q, but got %q", "anothermachine", updatedPod.Spec.NodeName)
+	}
+	// Verify that the returned ResourceVersion is greater than the one before the update (indicating it represents the deletion transaction)
+	cmp, err := resourceversion.CompareResourceVersion(updatedPod.ResourceVersion, podAfterDelete.ResourceVersion)
+	if err != nil {
+		t.Fatalf("Unexpected error comparing resource versions: %v", err)
+	}
+	if cmp <= 0 {
+		t.Errorf("Expected ResourceVersion %q to be greater than the one before update %q", updatedPod.ResourceVersion, podAfterDelete.ResourceVersion)
+	}
+}
+
+func TestStoreDeleteRaceRV(t *testing.T) {
+	podName := "foo"
+	pod := &example.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: podName},
+		Spec:       example.PodSpec{NodeName: "machine"},
+	}
+	ctx := genericapirequest.WithNamespace(genericapirequest.NewContext(), "test")
+
+	testCases := []struct {
+		name                string
+		raceAlreadyDeleting bool
+		returnDeletedObject bool
+		expectedWasDeleted  bool
+		expectEmptyRV       bool
+	}{
+		{
+			name:                "404 Physical Deletion race, ReturnDeletedObject=true",
+			raceAlreadyDeleting: false,
+			returnDeletedObject: true,
+			expectedWasDeleted:  true,
+			expectEmptyRV:       true, // setRVFromNotFound clears RV when returning object
+		},
+		{
+			name:                "404 Physical Deletion race, ReturnDeletedObject=false",
+			raceAlreadyDeleting: false,
+			returnDeletedObject: false,
+			expectedWasDeleted:  true,
+			expectEmptyRV:       false, // setRVFromNotFound populates RV from NotFound error
+		},
+		{
+			name:                "AlreadyDeleting Update race, ReturnDeletedObject=true",
+			raceAlreadyDeleting: true,
+			returnDeletedObject: true,
+			expectedWasDeleted:  false, // object is not deleted immediately
+			expectEmptyRV:       false, // returns the deleting object with its RV
+		},
+		{
+			name:                "AlreadyDeleting Update race, ReturnDeletedObject=false",
+			raceAlreadyDeleting: true,
+			returnDeletedObject: false,
+			expectedWasDeleted:  false, // object is not deleted immediately
+			expectEmptyRV:       false, // returns Status with object's RV
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			destroyFunc, registry := newTestGenericStoreRegistry(t, scheme, false)
+			defer destroyFunc()
+
+			defaultDeleteStrategy := testRESTStrategy{scheme, names.SimpleNameGenerator, true, false, true}
+			registry.DeleteStrategy = testGracefulStrategy{defaultDeleteStrategy}
+			registry.ReturnDeletedObject = tc.returnDeletedObject
+
+			objCreated, err := registry.Create(ctx, pod, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			createdPod := objCreated.(*example.Pod)
+			podKey, _ := registry.KeyFunc(ctx, podName)
+
+			racingStorage := &racingDeleteStorage{
+				Interface:           registry.Storage.Storage,
+				t:                   t,
+				keyToRace:           podKey,
+				raceAlreadyDeleting: tc.raceAlreadyDeleting,
+			}
+			registry.Storage.Storage = racingStorage
+
+			var gracePeriod int64
+			if tc.raceAlreadyDeleting {
+				gracePeriod = 30 // graceful delete to trigger GuaranteedUpdate
+			} else {
+				gracePeriod = 0 // delete immediately to trigger storage.Delete
+			}
+			delOpts := &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}
+
+			obj, wasDeleted, err := registry.Delete(ctx, podName, rest.ValidateAllObjectFunc, delOpts)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if wasDeleted != tc.expectedWasDeleted {
+				t.Fatalf("Expected wasDeleted=%v, got %v", tc.expectedWasDeleted, wasDeleted)
+			}
+
+			var returnedRV string
+			if tc.returnDeletedObject {
+				returnedAccessor, err := meta.Accessor(obj)
+				if err != nil {
+					t.Fatalf("Failed to get accessor: %v", err)
+				}
+				returnedRV = returnedAccessor.GetResourceVersion()
+			} else {
+				statusObj, ok := obj.(*metav1.Status)
+				if !ok {
+					t.Fatalf("Expected *metav1.Status, got %T", obj)
+				}
+				returnedRV = statusObj.ResourceVersion
+			}
+
+			if tc.expectEmptyRV {
+				if returnedRV != "" {
+					t.Errorf("Expected empty ResourceVersion, but got %q", returnedRV)
+				}
+			} else {
+				if returnedRV == "" {
+					t.Errorf("Expected non-empty ResourceVersion")
+				}
+				cmp, err := resourceversion.CompareResourceVersion(returnedRV, createdPod.ResourceVersion)
+				if err != nil {
+					t.Fatalf("Unexpected error comparing resource versions: %v", err)
+				}
+				if cmp <= 0 {
+					t.Errorf("Expected final ResourceVersion %q to be greater than created ResourceVersion %q", returnedRV, createdPod.ResourceVersion)
+				}
+				racingStorage.capturedRVMux.Lock()
+				expectedRV := racingStorage.capturedRV
+				racingStorage.capturedRVMux.Unlock()
+				if returnedRV != expectedRV {
+					t.Errorf("Expected final ResourceVersion to be identical to actual deletion revision (%q), but got %q", expectedRV, returnedRV)
+				}
+			}
+		})
+	}
+}
+
+type racingDeleteStorage struct {
+	storage.Interface
+	t                   *testing.T
+	keyToRace           string
+	raceAlreadyDeleting bool
+	once                sync.Once
+	capturedRV          string
+	capturedRVMux       sync.Mutex
+}
+
+func (s *racingDeleteStorage) Delete(ctx context.Context, key string, out runtime.Object, preconditions *storage.Preconditions, validateDeletion storage.ValidateObjectFunc, cachedExistingObject runtime.Object, opts storage.DeleteOptions) error {
+	if key == s.keyToRace && !s.raceAlreadyDeleting {
+		s.once.Do(func() {
+			// Perform the delete operation directly against the underlying storage.
+			// This deletes the key and increments revision so the subsequent delete gets NotFound.
+			err := s.Interface.Delete(ctx, key, out, nil, validateDeletion, nil, opts)
+			if err != nil {
+				s.t.Errorf("Failed to delete key in racing goroutine: %v", err)
+			}
+			if acc, err := meta.Accessor(out); err == nil {
+				s.capturedRVMux.Lock()
+				s.capturedRV = acc.GetResourceVersion()
+				s.capturedRVMux.Unlock()
+			}
+		})
+	}
+	return s.Interface.Delete(ctx, key, out, preconditions, validateDeletion, cachedExistingObject, opts)
+}
+
+func (s *racingDeleteStorage) GuaranteedUpdate(ctx context.Context, key string, destination runtime.Object, ignoreNotFound bool, preconditions *storage.Preconditions, tryUpdate storage.UpdateFunc, cachedExistingObject runtime.Object) error {
+	if key == s.keyToRace && s.raceAlreadyDeleting {
+		s.once.Do(func() {
+			// Concurrently mark the object as deleting directly in storage before GuaranteedUpdate's update loop executes.
+			out := &example.Pod{}
+			err := s.Interface.GuaranteedUpdate(ctx, key, out, false, nil, storage.SimpleUpdate(func(existing runtime.Object) (runtime.Object, error) {
+				p := existing.(*example.Pod)
+				now := metav1.Now()
+				p.DeletionTimestamp = &now
+				period := int64(30)
+				p.DeletionGracePeriodSeconds = &period
+				return p, nil
+			}), nil)
+			if err != nil {
+				s.t.Fatalf("Failed to mark object as deleting in racing goroutine: %v", err)
+			}
+			acc, err := meta.Accessor(out)
+			if err != nil {
+				s.t.Fatalf("Failed to get accessor: %v", err)
+			}
+			s.capturedRVMux.Lock()
+			s.capturedRV = acc.GetResourceVersion()
+			s.capturedRVMux.Unlock()
+		})
+	}
+	return s.Interface.GuaranteedUpdate(ctx, key, destination, ignoreNotFound, preconditions, tryUpdate, cachedExistingObject)
+}
+
+func TestStorePendingGracefulDeleteRV(t *testing.T) {
+	podName := "foo"
+	pod := &example.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: podName},
+		Spec:       example.PodSpec{NodeName: "machine"},
+	}
+	ctx := genericapirequest.WithNamespace(genericapirequest.NewContext(), "test")
+
+	testCases := []struct {
+		name                string
+		returnDeletedObject bool
+	}{
+		{"ReturnDeletedObject=true", true},
+		{"ReturnDeletedObject=false", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			destroyFunc, registry := newTestGenericStoreRegistry(t, scheme, false)
+			defer destroyFunc()
+
+			defaultDeleteStrategy := testRESTStrategy{scheme, names.SimpleNameGenerator, true, false, true}
+			registry.DeleteStrategy = testGracefulStrategy{defaultDeleteStrategy}
+			registry.ReturnDeletedObject = tc.returnDeletedObject
+
+			// 1. Create pod
+			if _, err := registry.Create(ctx, pod, rest.ValidateAllObjectFunc, &metav1.CreateOptions{}); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			// 2. Perform initial graceful delete with 30s grace period to transition pod into pendingGraceful state
+			gracePeriod := int64(30)
+			delOpts := &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}
+			_, wasDeleted, err := registry.Delete(ctx, podName, rest.ValidateAllObjectFunc, delOpts)
+			if err != nil {
+				t.Fatalf("Unexpected error on initial delete: %v", err)
+			}
+			if wasDeleted {
+				t.Fatalf("Expected pod not to be deleted immediately")
+			}
+
+			// 3. Fetch current pod from storage to get the expected ResourceVersion after graceful deletion was initiated
+			obj, err := registry.Get(ctx, podName, &metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Unexpected error on Get(): %v", err)
+			}
+			podAfterFirstDelete := obj.(*example.Pod)
+			if podAfterFirstDelete.DeletionTimestamp == nil {
+				t.Fatalf("Expected DeletionTimestamp to be set")
+			}
+			expectedRV := podAfterFirstDelete.ResourceVersion
+
+			// 4. Perform second delete with equal or longer grace period (30s).
+			// This exercises the `if pendingGraceful` branch in Store.Delete().
+			resObj, wasDeleted, err := registry.Delete(ctx, podName, rest.ValidateAllObjectFunc, delOpts)
+			if err != nil {
+				t.Fatalf("Unexpected error on second delete: %v", err)
+			}
+			if wasDeleted {
+				t.Fatalf("Expected wasDeleted to be false for pending graceful delete")
+			}
+
+			var returnedRV string
+			if tc.returnDeletedObject {
+				returnedPod, ok := resObj.(*example.Pod)
+				if !ok {
+					t.Fatalf("Expected *example.Pod, got %T", resObj)
+				}
+				returnedRV = returnedPod.ResourceVersion
+			} else {
+				statusObj, ok := resObj.(*metav1.Status)
+				if !ok {
+					t.Fatalf("Expected *metav1.Status, got %T", resObj)
+				}
+				returnedRV = statusObj.ResourceVersion
+			}
+
+			if returnedRV != expectedRV {
+				t.Errorf("Expected ResourceVersion %q, got %q", expectedRV, returnedRV)
+			}
+		})
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/errors.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/errors.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"errors"
 	"fmt"
+	"strconv"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -116,6 +117,20 @@ type StorageError struct {
 
 	// inner error
 	err error
+}
+
+func ResourceVersion(err error) (string, bool) {
+	if err == nil {
+		return "", false
+	}
+	var e *StorageError
+	if !errors.As(err, &e) {
+		return "", false
+	}
+	if e.ResourceVersion <= 0 {
+		return "", false
+	}
+	return strconv.FormatInt(e.ResourceVersion, 10), true
 }
 
 func (e *StorageError) Unwrap() error { return e.err }

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -435,7 +435,7 @@ func (s *store) conditionalDelete(
 		}
 		if !txnResp.Succeeded {
 			klog.V(4).Infof("deletion of %s failed because of a conflict, going to retry", key)
-			origState, err = s.getState(ctx, txnResp.KV, key, v, false, expectTransformOrDecodeError)
+			origState, err = s.getState(ctx, txnResp.KV, txnResp.Revision, key, v, false, expectTransformOrDecodeError)
 			if err != nil {
 				return err
 			}
@@ -601,7 +601,7 @@ func (s *store) GuaranteedUpdate(
 		span.AddEvent("Transaction committed")
 		if !txnResp.Succeeded {
 			klog.V(4).Infof("GuaranteedUpdate of %s failed because of a conflict, going to retry", preparedKey)
-			origState, err = s.getState(ctx, txnResp.KV, preparedKey, v, ignoreNotFound, false)
+			origState, err = s.getState(ctx, txnResp.KV, txnResp.Revision, preparedKey, v, ignoreNotFound, false)
 			if err != nil {
 				return err
 			}
@@ -993,7 +993,7 @@ func (s *store) getCurrentState(ctx context.Context, key string, v reflect.Value
 		if err != nil {
 			return nil, err
 		}
-		return s.getState(ctx, getResp.KV, key, v, ignoreNotFound, expectTransformOrDecodeError)
+		return s.getState(ctx, getResp.KV, getResp.Revision, key, v, ignoreNotFound, expectTransformOrDecodeError)
 	}
 }
 
@@ -1001,7 +1001,7 @@ func (s *store) getCurrentState(ctx context.Context, key string, v reflect.Value
 // expectTransformOrDecodeError is true and neither transformation nor decode fails, returns an
 // InvalidObj error; if either fails, the returned error and the 'obj' field of the returned
 // objState will both be nil.
-func (s *store) getState(ctx context.Context, kv *mvccpb.KeyValue, key string, v reflect.Value, ignoreNotFound bool, expectTransformOrDecodeError bool) (*objState, error) {
+func (s *store) getState(ctx context.Context, kv *mvccpb.KeyValue, rev int64, key string, v reflect.Value, ignoreNotFound bool, expectTransformOrDecodeError bool) (*objState, error) {
 	state := &objState{
 		meta: &storage.ResponseMeta{},
 	}
@@ -1014,7 +1014,7 @@ func (s *store) getState(ctx context.Context, kv *mvccpb.KeyValue, key string, v
 
 	if kv == nil {
 		if !ignoreNotFound {
-			return nil, storage.NewKeyNotFoundError(key, 0)
+			return nil, storage.NewKeyNotFoundError(key, rev)
 		}
 		if err := runtime.SetZeroValue(state.obj); err != nil {
 			return nil, err

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -454,7 +454,7 @@ func (s *store) conditionalDelete(
 		}
 		if !txnResp.Succeeded {
 			klog.V(4).Infof("deletion of %s failed because of a conflict, going to retry", key)
-			origState, err = s.getState(ctx, txnResp.KV, key, v, false, expectTransformOrDecodeError)
+			origState, err = s.getState(ctx, txnResp.KV, txnResp.Revision, key, v, false, expectTransformOrDecodeError)
 			if err != nil {
 				return err
 			}
@@ -620,7 +620,7 @@ func (s *store) GuaranteedUpdate(
 		span.AddEvent("Transaction committed")
 		if !txnResp.Succeeded {
 			klog.V(4).Infof("GuaranteedUpdate of %s failed because of a conflict, going to retry", preparedKey)
-			origState, err = s.getState(ctx, txnResp.KV, preparedKey, v, ignoreNotFound, false)
+			origState, err = s.getState(ctx, txnResp.KV, txnResp.Revision, preparedKey, v, ignoreNotFound, false)
 			if err != nil {
 				return err
 			}
@@ -1176,7 +1176,7 @@ func (s *store) getCurrentState(ctx context.Context, key string, v reflect.Value
 		if err != nil {
 			return nil, err
 		}
-		return s.getState(ctx, getResp.KV, key, v, ignoreNotFound, expectTransformOrDecodeError)
+		return s.getState(ctx, getResp.KV, getResp.Revision, key, v, ignoreNotFound, expectTransformOrDecodeError)
 	}
 }
 
@@ -1184,7 +1184,7 @@ func (s *store) getCurrentState(ctx context.Context, key string, v reflect.Value
 // expectTransformOrDecodeError is true and neither transformation nor decode fails, returns an
 // InvalidObj error; if either fails, the returned error and the 'obj' field of the returned
 // objState will both be nil.
-func (s *store) getState(ctx context.Context, kv *mvccpb.KeyValue, key string, v reflect.Value, ignoreNotFound bool, expectTransformOrDecodeError bool) (*objState, error) {
+func (s *store) getState(ctx context.Context, kv *mvccpb.KeyValue, rev int64, key string, v reflect.Value, ignoreNotFound bool, expectTransformOrDecodeError bool) (*objState, error) {
 	state := &objState{
 		meta: &storage.ResponseMeta{},
 	}
@@ -1197,7 +1197,7 @@ func (s *store) getState(ctx context.Context, kv *mvccpb.KeyValue, key string, v
 
 	if kv == nil {
 		if !ignoreNotFound {
-			return nil, storage.NewKeyNotFoundError(key, 0)
+			return nil, storage.NewKeyNotFoundError(key, rev)
 		}
 		if err := runtime.SetZeroValue(state.obj); err != nil {
 			return nil, err

--- a/staging/src/k8s.io/client-go/dynamic/fake/simple.go
+++ b/staging/src/k8s.io/client-go/dynamic/fake/simple.go
@@ -305,6 +305,47 @@ func (c *dynamicResourceClient) Delete(ctx context.Context, name string, opts me
 	return err
 }
 
+func (c *dynamicResourceClient) DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions, subresources ...string) (metav1.APIResult, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootDeleteActionWithOptions(c.resource, name, opts), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootDeleteSubresourceActionWithOptions(c.resource, strings.Join(subresources, "/"), name, opts), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewDeleteActionWithOptions(c.resource, c.namespace, name, opts), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewDeleteSubresourceActionWithOptions(c.resource, strings.Join(subresources, "/"), c.namespace, name, opts), &metav1.Status{Status: "dynamic delete fail"})
+	}
+
+	if err != nil {
+		fakeResult := testing.FakeAPIResult{Err: err}
+		if statusErr, ok := err.(interface{ Status() metav1.Status }); ok {
+			fakeResult.Code = int(statusErr.Status().Code)
+		}
+		return fakeResult, err
+	}
+	if uncastRet == nil {
+		return testing.FakeAPIResult{}, nil
+	}
+	if status, ok := uncastRet.(*metav1.Status); ok {
+		return testing.FakeAPIResult{Obj: status, Code: int(status.Code)}, nil
+	}
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return testing.FakeAPIResult{Obj: ret, Code: 200}, nil
+}
+
 func (c *dynamicResourceClient) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOptions metav1.ListOptions) error {
 	var err error
 	switch {

--- a/staging/src/k8s.io/client-go/dynamic/interface.go
+++ b/staging/src/k8s.io/client-go/dynamic/interface.go
@@ -35,6 +35,7 @@ type ResourceInterface interface {
 	Update(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error)
 	UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions) (*unstructured.Unstructured, error)
 	Delete(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error
+	DeleteWithResult(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, options metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error)

--- a/staging/src/k8s.io/client-go/dynamic/simple.go
+++ b/staging/src/k8s.io/client-go/dynamic/simple.go
@@ -19,6 +19,8 @@ package dynamic
 import (
 	"context"
 	"fmt"
+	"net/http"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -28,7 +30,6 @@ import (
 	"k8s.io/client-go/features"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/apply"
-	"net/http"
 )
 
 type DynamicClient struct {
@@ -211,6 +212,22 @@ func (c *dynamicResourceClient) Delete(ctx context.Context, name string, opts me
 		Body(&opts).
 		Do(ctx)
 	return result.Error()
+}
+
+func (c *dynamicResourceClient) DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions, subresources ...string) (metav1.APIResult, error) {
+	if len(name) == 0 {
+		return nil, fmt.Errorf("name is required")
+	}
+	if err := validateNamespaceWithOptionalName(c.namespace, name); err != nil {
+		return nil, err
+	}
+
+	result := c.client.client.
+		Delete().
+		AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		Body(&opts).
+		Do(ctx)
+	return rest.RestResultWrapper{Result: result}, result.Error()
 }
 
 func (c *dynamicResourceClient) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOptions metav1.ListOptions) error {

--- a/staging/src/k8s.io/client-go/dynamic/simple.go
+++ b/staging/src/k8s.io/client-go/dynamic/simple.go
@@ -214,6 +214,22 @@ func (c *dynamicResourceClient) Delete(ctx context.Context, name string, opts me
 	return result.Error()
 }
 
+func (c *dynamicResourceClient) DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions, subresources ...string) (metav1.APIResult, error) {
+	if len(name) == 0 {
+		return nil, fmt.Errorf("name is required")
+	}
+	if err := validateNamespaceWithOptionalName(c.namespace, name); err != nil {
+		return nil, err
+	}
+
+	result := c.client.client.
+		Delete().
+		AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		Body(&opts).
+		Do(ctx)
+	return rest.APIResultAdapter{Result: result}, result.Error()
+}
+
 func (c *dynamicResourceClient) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOptions metav1.ListOptions) error {
 	if err := validateNamespaceWithOptionalName(c.namespace); err != nil {
 		return err

--- a/staging/src/k8s.io/client-go/gentype/fake.go
+++ b/staging/src/k8s.io/client-go/gentype/fake.go
@@ -229,6 +229,28 @@ func (c *FakeClient[T]) Delete(ctx context.Context, name string, opts metav1.Del
 	return err
 }
 
+// DeleteWithResult takes name of the resource and deletes it. Returns an error if one occurs, or a metav1.APIResult on success.
+func (c *FakeClient[T]) DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewDeleteActionWithOptions(c.resource, c.ns, name, opts), &metav1.Status{})
+
+	fakeResult := testing.FakeAPIResult{
+		Obj: obj,
+		Err: err,
+	}
+	if err != nil {
+		if statusErr, ok := err.(interface{ Status() metav1.Status }); ok {
+			fakeResult.Code = int(statusErr.Status().Code)
+		}
+	} else if obj != nil {
+		fakeResult.Code = 200
+		if status, ok := obj.(*metav1.Status); ok {
+			fakeResult.Code = int(status.Code)
+		}
+	}
+	return fakeResult, err
+}
+
 // DeleteCollection deletes a collection of objects.
 func (l *alsoFakeLister[T, L]) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
 	_, err := l.client.Fake.

--- a/staging/src/k8s.io/client-go/gentype/type.go
+++ b/staging/src/k8s.io/client-go/gentype/type.go
@@ -258,6 +258,18 @@ func (c *Client[T]) Delete(ctx context.Context, name string, opts metav1.DeleteO
 		Error()
 }
 
+// DeleteWithResult takes name of the resource and deletes it. Returns an error if one occurs, or a metav1.APIResult on success.
+func (c *Client[T]) DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error) {
+	result := c.client.Delete().
+		UseProtobufAsDefaultIfPreferred(c.prefersProtobuf).
+		NamespaceIfScoped(c.namespace, c.namespace != "").
+		Resource(c.resource).
+		Name(name).
+		Body(&opts).
+		Do(ctx)
+	return rest.RestResultWrapper{Result: result}, result.Error()
+}
+
 // DeleteCollection deletes a collection of objects.
 func (l *alsoLister[T, L]) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
 	var timeout time.Duration

--- a/staging/src/k8s.io/client-go/gentype/type.go
+++ b/staging/src/k8s.io/client-go/gentype/type.go
@@ -258,6 +258,18 @@ func (c *Client[T]) Delete(ctx context.Context, name string, opts metav1.DeleteO
 		Error()
 }
 
+// DeleteWithResult takes name of the resource and deletes it. Returns an error if one occurs, or a metav1.APIResult on success.
+func (c *Client[T]) DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error) {
+	result := c.client.Delete().
+		UseProtobufAsDefaultIfPreferred(c.prefersProtobuf).
+		NamespaceIfScoped(c.namespace, c.namespace != "").
+		Resource(c.resource).
+		Name(name).
+		Body(&opts).
+		Do(ctx)
+	return rest.APIResultAdapter{Result: result}, result.Error()
+}
+
 // DeleteCollection deletes a collection of objects.
 func (l *alsoLister[T, L]) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
 	var timeout time.Duration

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/mutatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/mutatingadmissionpolicy.go
@@ -41,6 +41,7 @@ type MutatingAdmissionPolicyInterface interface {
 	Create(ctx context.Context, mutatingAdmissionPolicy *admissionregistrationv1.MutatingAdmissionPolicy, opts metav1.CreateOptions) (*admissionregistrationv1.MutatingAdmissionPolicy, error)
 	Update(ctx context.Context, mutatingAdmissionPolicy *admissionregistrationv1.MutatingAdmissionPolicy, opts metav1.UpdateOptions) (*admissionregistrationv1.MutatingAdmissionPolicy, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*admissionregistrationv1.MutatingAdmissionPolicy, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*admissionregistrationv1.MutatingAdmissionPolicyList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/mutatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/mutatingadmissionpolicybinding.go
@@ -41,6 +41,7 @@ type MutatingAdmissionPolicyBindingInterface interface {
 	Create(ctx context.Context, mutatingAdmissionPolicyBinding *admissionregistrationv1.MutatingAdmissionPolicyBinding, opts metav1.CreateOptions) (*admissionregistrationv1.MutatingAdmissionPolicyBinding, error)
 	Update(ctx context.Context, mutatingAdmissionPolicyBinding *admissionregistrationv1.MutatingAdmissionPolicyBinding, opts metav1.UpdateOptions) (*admissionregistrationv1.MutatingAdmissionPolicyBinding, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*admissionregistrationv1.MutatingAdmissionPolicyBinding, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*admissionregistrationv1.MutatingAdmissionPolicyBindingList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/mutatingwebhookconfiguration.go
@@ -41,6 +41,7 @@ type MutatingWebhookConfigurationInterface interface {
 	Create(ctx context.Context, mutatingWebhookConfiguration *admissionregistrationv1.MutatingWebhookConfiguration, opts metav1.CreateOptions) (*admissionregistrationv1.MutatingWebhookConfiguration, error)
 	Update(ctx context.Context, mutatingWebhookConfiguration *admissionregistrationv1.MutatingWebhookConfiguration, opts metav1.UpdateOptions) (*admissionregistrationv1.MutatingWebhookConfiguration, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*admissionregistrationv1.MutatingWebhookConfiguration, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*admissionregistrationv1.MutatingWebhookConfigurationList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingadmissionpolicy.go
@@ -43,6 +43,7 @@ type ValidatingAdmissionPolicyInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, validatingAdmissionPolicy *admissionregistrationv1.ValidatingAdmissionPolicy, opts metav1.UpdateOptions) (*admissionregistrationv1.ValidatingAdmissionPolicy, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*admissionregistrationv1.ValidatingAdmissionPolicy, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*admissionregistrationv1.ValidatingAdmissionPolicyList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingadmissionpolicybinding.go
@@ -41,6 +41,7 @@ type ValidatingAdmissionPolicyBindingInterface interface {
 	Create(ctx context.Context, validatingAdmissionPolicyBinding *admissionregistrationv1.ValidatingAdmissionPolicyBinding, opts metav1.CreateOptions) (*admissionregistrationv1.ValidatingAdmissionPolicyBinding, error)
 	Update(ctx context.Context, validatingAdmissionPolicyBinding *admissionregistrationv1.ValidatingAdmissionPolicyBinding, opts metav1.UpdateOptions) (*admissionregistrationv1.ValidatingAdmissionPolicyBinding, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*admissionregistrationv1.ValidatingAdmissionPolicyBinding, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*admissionregistrationv1.ValidatingAdmissionPolicyBindingList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingwebhookconfiguration.go
@@ -41,6 +41,7 @@ type ValidatingWebhookConfigurationInterface interface {
 	Create(ctx context.Context, validatingWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration, opts metav1.CreateOptions) (*admissionregistrationv1.ValidatingWebhookConfiguration, error)
 	Update(ctx context.Context, validatingWebhookConfiguration *admissionregistrationv1.ValidatingWebhookConfiguration, opts metav1.UpdateOptions) (*admissionregistrationv1.ValidatingWebhookConfiguration, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*admissionregistrationv1.ValidatingWebhookConfiguration, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*admissionregistrationv1.ValidatingWebhookConfigurationList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/mutatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/mutatingadmissionpolicy.go
@@ -41,6 +41,7 @@ type MutatingAdmissionPolicyInterface interface {
 	Create(ctx context.Context, mutatingAdmissionPolicy *admissionregistrationv1alpha1.MutatingAdmissionPolicy, opts v1.CreateOptions) (*admissionregistrationv1alpha1.MutatingAdmissionPolicy, error)
 	Update(ctx context.Context, mutatingAdmissionPolicy *admissionregistrationv1alpha1.MutatingAdmissionPolicy, opts v1.UpdateOptions) (*admissionregistrationv1alpha1.MutatingAdmissionPolicy, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*admissionregistrationv1alpha1.MutatingAdmissionPolicy, error)
 	List(ctx context.Context, opts v1.ListOptions) (*admissionregistrationv1alpha1.MutatingAdmissionPolicyList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/mutatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/mutatingadmissionpolicybinding.go
@@ -41,6 +41,7 @@ type MutatingAdmissionPolicyBindingInterface interface {
 	Create(ctx context.Context, mutatingAdmissionPolicyBinding *admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding, opts v1.CreateOptions) (*admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding, error)
 	Update(ctx context.Context, mutatingAdmissionPolicyBinding *admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding, opts v1.UpdateOptions) (*admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding, error)
 	List(ctx context.Context, opts v1.ListOptions) (*admissionregistrationv1alpha1.MutatingAdmissionPolicyBindingList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/validatingadmissionpolicy.go
@@ -43,6 +43,7 @@ type ValidatingAdmissionPolicyInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, validatingAdmissionPolicy *admissionregistrationv1alpha1.ValidatingAdmissionPolicy, opts v1.UpdateOptions) (*admissionregistrationv1alpha1.ValidatingAdmissionPolicy, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*admissionregistrationv1alpha1.ValidatingAdmissionPolicy, error)
 	List(ctx context.Context, opts v1.ListOptions) (*admissionregistrationv1alpha1.ValidatingAdmissionPolicyList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/validatingadmissionpolicybinding.go
@@ -41,6 +41,7 @@ type ValidatingAdmissionPolicyBindingInterface interface {
 	Create(ctx context.Context, validatingAdmissionPolicyBinding *admissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding, opts v1.CreateOptions) (*admissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding, error)
 	Update(ctx context.Context, validatingAdmissionPolicyBinding *admissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding, opts v1.UpdateOptions) (*admissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*admissionregistrationv1alpha1.ValidatingAdmissionPolicyBinding, error)
 	List(ctx context.Context, opts v1.ListOptions) (*admissionregistrationv1alpha1.ValidatingAdmissionPolicyBindingList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingadmissionpolicy.go
@@ -41,6 +41,7 @@ type MutatingAdmissionPolicyInterface interface {
 	Create(ctx context.Context, mutatingAdmissionPolicy *admissionregistrationv1beta1.MutatingAdmissionPolicy, opts v1.CreateOptions) (*admissionregistrationv1beta1.MutatingAdmissionPolicy, error)
 	Update(ctx context.Context, mutatingAdmissionPolicy *admissionregistrationv1beta1.MutatingAdmissionPolicy, opts v1.UpdateOptions) (*admissionregistrationv1beta1.MutatingAdmissionPolicy, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*admissionregistrationv1beta1.MutatingAdmissionPolicy, error)
 	List(ctx context.Context, opts v1.ListOptions) (*admissionregistrationv1beta1.MutatingAdmissionPolicyList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingadmissionpolicybinding.go
@@ -41,6 +41,7 @@ type MutatingAdmissionPolicyBindingInterface interface {
 	Create(ctx context.Context, mutatingAdmissionPolicyBinding *admissionregistrationv1beta1.MutatingAdmissionPolicyBinding, opts v1.CreateOptions) (*admissionregistrationv1beta1.MutatingAdmissionPolicyBinding, error)
 	Update(ctx context.Context, mutatingAdmissionPolicyBinding *admissionregistrationv1beta1.MutatingAdmissionPolicyBinding, opts v1.UpdateOptions) (*admissionregistrationv1beta1.MutatingAdmissionPolicyBinding, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*admissionregistrationv1beta1.MutatingAdmissionPolicyBinding, error)
 	List(ctx context.Context, opts v1.ListOptions) (*admissionregistrationv1beta1.MutatingAdmissionPolicyBindingList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
@@ -41,6 +41,7 @@ type MutatingWebhookConfigurationInterface interface {
 	Create(ctx context.Context, mutatingWebhookConfiguration *admissionregistrationv1beta1.MutatingWebhookConfiguration, opts v1.CreateOptions) (*admissionregistrationv1beta1.MutatingWebhookConfiguration, error)
 	Update(ctx context.Context, mutatingWebhookConfiguration *admissionregistrationv1beta1.MutatingWebhookConfiguration, opts v1.UpdateOptions) (*admissionregistrationv1beta1.MutatingWebhookConfiguration, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*admissionregistrationv1beta1.MutatingWebhookConfiguration, error)
 	List(ctx context.Context, opts v1.ListOptions) (*admissionregistrationv1beta1.MutatingWebhookConfigurationList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingadmissionpolicy.go
@@ -43,6 +43,7 @@ type ValidatingAdmissionPolicyInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, validatingAdmissionPolicy *admissionregistrationv1beta1.ValidatingAdmissionPolicy, opts v1.UpdateOptions) (*admissionregistrationv1beta1.ValidatingAdmissionPolicy, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*admissionregistrationv1beta1.ValidatingAdmissionPolicy, error)
 	List(ctx context.Context, opts v1.ListOptions) (*admissionregistrationv1beta1.ValidatingAdmissionPolicyList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingadmissionpolicybinding.go
@@ -41,6 +41,7 @@ type ValidatingAdmissionPolicyBindingInterface interface {
 	Create(ctx context.Context, validatingAdmissionPolicyBinding *admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding, opts v1.CreateOptions) (*admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding, error)
 	Update(ctx context.Context, validatingAdmissionPolicyBinding *admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding, opts v1.UpdateOptions) (*admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding, error)
 	List(ctx context.Context, opts v1.ListOptions) (*admissionregistrationv1beta1.ValidatingAdmissionPolicyBindingList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -41,6 +41,7 @@ type ValidatingWebhookConfigurationInterface interface {
 	Create(ctx context.Context, validatingWebhookConfiguration *admissionregistrationv1beta1.ValidatingWebhookConfiguration, opts v1.CreateOptions) (*admissionregistrationv1beta1.ValidatingWebhookConfiguration, error)
 	Update(ctx context.Context, validatingWebhookConfiguration *admissionregistrationv1beta1.ValidatingWebhookConfiguration, opts v1.UpdateOptions) (*admissionregistrationv1beta1.ValidatingWebhookConfiguration, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*admissionregistrationv1beta1.ValidatingWebhookConfiguration, error)
 	List(ctx context.Context, opts v1.ListOptions) (*admissionregistrationv1beta1.ValidatingWebhookConfigurationList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1/storageversion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apiserverinternal/v1alpha1/storageversion.go
@@ -43,6 +43,7 @@ type StorageVersionInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, storageVersion *apiserverinternalv1alpha1.StorageVersion, opts v1.UpdateOptions) (*apiserverinternalv1alpha1.StorageVersion, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*apiserverinternalv1alpha1.StorageVersion, error)
 	List(ctx context.Context, opts v1.ListOptions) (*apiserverinternalv1alpha1.StorageVersionList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/controllerrevision.go
@@ -41,6 +41,7 @@ type ControllerRevisionInterface interface {
 	Create(ctx context.Context, controllerRevision *appsv1.ControllerRevision, opts metav1.CreateOptions) (*appsv1.ControllerRevision, error)
 	Update(ctx context.Context, controllerRevision *appsv1.ControllerRevision, opts metav1.UpdateOptions) (*appsv1.ControllerRevision, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*appsv1.ControllerRevision, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*appsv1.ControllerRevisionList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/daemonset.go
@@ -43,6 +43,7 @@ type DaemonSetInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, daemonSet *appsv1.DaemonSet, opts metav1.UpdateOptions) (*appsv1.DaemonSet, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*appsv1.DaemonSet, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*appsv1.DaemonSetList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/deployment.go
@@ -47,6 +47,7 @@ type DeploymentInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, deployment *appsv1.Deployment, opts metav1.UpdateOptions) (*appsv1.Deployment, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*appsv1.Deployment, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*appsv1.DeploymentList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/replicaset.go
@@ -47,6 +47,7 @@ type ReplicaSetInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, replicaSet *appsv1.ReplicaSet, opts metav1.UpdateOptions) (*appsv1.ReplicaSet, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*appsv1.ReplicaSet, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*appsv1.ReplicaSetList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/statefulset.go
@@ -47,6 +47,7 @@ type StatefulSetInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, statefulSet *appsv1.StatefulSet, opts metav1.UpdateOptions) (*appsv1.StatefulSet, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*appsv1.StatefulSet, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*appsv1.StatefulSetList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
@@ -41,6 +41,7 @@ type ControllerRevisionInterface interface {
 	Create(ctx context.Context, controllerRevision *appsv1beta1.ControllerRevision, opts v1.CreateOptions) (*appsv1beta1.ControllerRevision, error)
 	Update(ctx context.Context, controllerRevision *appsv1beta1.ControllerRevision, opts v1.UpdateOptions) (*appsv1beta1.ControllerRevision, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*appsv1beta1.ControllerRevision, error)
 	List(ctx context.Context, opts v1.ListOptions) (*appsv1beta1.ControllerRevisionList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/deployment.go
@@ -43,6 +43,7 @@ type DeploymentInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, deployment *appsv1beta1.Deployment, opts v1.UpdateOptions) (*appsv1beta1.Deployment, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*appsv1beta1.Deployment, error)
 	List(ctx context.Context, opts v1.ListOptions) (*appsv1beta1.DeploymentList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/statefulset.go
@@ -43,6 +43,7 @@ type StatefulSetInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, statefulSet *appsv1beta1.StatefulSet, opts v1.UpdateOptions) (*appsv1beta1.StatefulSet, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*appsv1beta1.StatefulSet, error)
 	List(ctx context.Context, opts v1.ListOptions) (*appsv1beta1.StatefulSetList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/controllerrevision.go
@@ -41,6 +41,7 @@ type ControllerRevisionInterface interface {
 	Create(ctx context.Context, controllerRevision *appsv1beta2.ControllerRevision, opts v1.CreateOptions) (*appsv1beta2.ControllerRevision, error)
 	Update(ctx context.Context, controllerRevision *appsv1beta2.ControllerRevision, opts v1.UpdateOptions) (*appsv1beta2.ControllerRevision, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*appsv1beta2.ControllerRevision, error)
 	List(ctx context.Context, opts v1.ListOptions) (*appsv1beta2.ControllerRevisionList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/daemonset.go
@@ -43,6 +43,7 @@ type DaemonSetInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, daemonSet *appsv1beta2.DaemonSet, opts v1.UpdateOptions) (*appsv1beta2.DaemonSet, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*appsv1beta2.DaemonSet, error)
 	List(ctx context.Context, opts v1.ListOptions) (*appsv1beta2.DaemonSetList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/deployment.go
@@ -43,6 +43,7 @@ type DeploymentInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, deployment *appsv1beta2.Deployment, opts v1.UpdateOptions) (*appsv1beta2.Deployment, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*appsv1beta2.Deployment, error)
 	List(ctx context.Context, opts v1.ListOptions) (*appsv1beta2.DeploymentList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/replicaset.go
@@ -43,6 +43,7 @@ type ReplicaSetInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, replicaSet *appsv1beta2.ReplicaSet, opts v1.UpdateOptions) (*appsv1beta2.ReplicaSet, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*appsv1beta2.ReplicaSet, error)
 	List(ctx context.Context, opts v1.ListOptions) (*appsv1beta2.ReplicaSetList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
@@ -45,6 +45,7 @@ type StatefulSetInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, statefulSet *appsv1beta2.StatefulSet, opts v1.UpdateOptions) (*appsv1beta2.StatefulSet, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*appsv1beta2.StatefulSet, error)
 	List(ctx context.Context, opts v1.ListOptions) (*appsv1beta2.StatefulSetList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
@@ -43,6 +43,7 @@ type HorizontalPodAutoscalerInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, horizontalPodAutoscaler *autoscalingv1.HorizontalPodAutoscaler, opts metav1.UpdateOptions) (*autoscalingv1.HorizontalPodAutoscaler, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*autoscalingv1.HorizontalPodAutoscaler, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*autoscalingv1.HorizontalPodAutoscalerList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2/horizontalpodautoscaler.go
@@ -43,6 +43,7 @@ type HorizontalPodAutoscalerInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, horizontalPodAutoscaler *autoscalingv2.HorizontalPodAutoscaler, opts v1.UpdateOptions) (*autoscalingv2.HorizontalPodAutoscaler, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*autoscalingv2.HorizontalPodAutoscaler, error)
 	List(ctx context.Context, opts v1.ListOptions) (*autoscalingv2.HorizontalPodAutoscalerList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/cronjob.go
@@ -43,6 +43,7 @@ type CronJobInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, cronJob *batchv1.CronJob, opts metav1.UpdateOptions) (*batchv1.CronJob, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*batchv1.CronJob, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*batchv1.CronJobList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/job.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/job.go
@@ -43,6 +43,7 @@ type JobInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, job *batchv1.Job, opts metav1.UpdateOptions) (*batchv1.Job, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*batchv1.Job, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*batchv1.JobList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/cronjob.go
@@ -43,6 +43,7 @@ type CronJobInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, cronJob *batchv1beta1.CronJob, opts v1.UpdateOptions) (*batchv1beta1.CronJob, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*batchv1beta1.CronJob, error)
 	List(ctx context.Context, opts v1.ListOptions) (*batchv1beta1.CronJobList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/certificatesigningrequest.go
@@ -43,6 +43,7 @@ type CertificateSigningRequestInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, certificateSigningRequest *certificatesv1.CertificateSigningRequest, opts metav1.UpdateOptions) (*certificatesv1.CertificateSigningRequest, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*certificatesv1.CertificateSigningRequest, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*certificatesv1.CertificateSigningRequestList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/clustertrustbundle.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/clustertrustbundle.go
@@ -41,6 +41,7 @@ type ClusterTrustBundleInterface interface {
 	Create(ctx context.Context, clusterTrustBundle *certificatesv1.ClusterTrustBundle, opts metav1.CreateOptions) (*certificatesv1.ClusterTrustBundle, error)
 	Update(ctx context.Context, clusterTrustBundle *certificatesv1.ClusterTrustBundle, opts metav1.UpdateOptions) (*certificatesv1.ClusterTrustBundle, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*certificatesv1.ClusterTrustBundle, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*certificatesv1.ClusterTrustBundleList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/podcertificaterequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1/podcertificaterequest.go
@@ -43,6 +43,7 @@ type PodCertificateRequestInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, podCertificateRequest *certificatesv1.PodCertificateRequest, opts metav1.UpdateOptions) (*certificatesv1.PodCertificateRequest, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*certificatesv1.PodCertificateRequest, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*certificatesv1.PodCertificateRequestList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1alpha1/clustertrustbundle.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1alpha1/clustertrustbundle.go
@@ -41,6 +41,7 @@ type ClusterTrustBundleInterface interface {
 	Create(ctx context.Context, clusterTrustBundle *certificatesv1alpha1.ClusterTrustBundle, opts v1.CreateOptions) (*certificatesv1alpha1.ClusterTrustBundle, error)
 	Update(ctx context.Context, clusterTrustBundle *certificatesv1alpha1.ClusterTrustBundle, opts v1.UpdateOptions) (*certificatesv1alpha1.ClusterTrustBundle, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*certificatesv1alpha1.ClusterTrustBundle, error)
 	List(ctx context.Context, opts v1.ListOptions) (*certificatesv1alpha1.ClusterTrustBundleList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest.go
@@ -43,6 +43,7 @@ type CertificateSigningRequestInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, certificateSigningRequest *certificatesv1beta1.CertificateSigningRequest, opts v1.UpdateOptions) (*certificatesv1beta1.CertificateSigningRequest, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*certificatesv1beta1.CertificateSigningRequest, error)
 	List(ctx context.Context, opts v1.ListOptions) (*certificatesv1beta1.CertificateSigningRequestList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/clustertrustbundle.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/clustertrustbundle.go
@@ -41,6 +41,7 @@ type ClusterTrustBundleInterface interface {
 	Create(ctx context.Context, clusterTrustBundle *certificatesv1beta1.ClusterTrustBundle, opts v1.CreateOptions) (*certificatesv1beta1.ClusterTrustBundle, error)
 	Update(ctx context.Context, clusterTrustBundle *certificatesv1beta1.ClusterTrustBundle, opts v1.UpdateOptions) (*certificatesv1beta1.ClusterTrustBundle, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*certificatesv1beta1.ClusterTrustBundle, error)
 	List(ctx context.Context, opts v1.ListOptions) (*certificatesv1beta1.ClusterTrustBundleList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/podcertificaterequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/podcertificaterequest.go
@@ -43,6 +43,7 @@ type PodCertificateRequestInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, podCertificateRequest *certificatesv1beta1.PodCertificateRequest, opts v1.UpdateOptions) (*certificatesv1beta1.PodCertificateRequest, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*certificatesv1beta1.PodCertificateRequest, error)
 	List(ctx context.Context, opts v1.ListOptions) (*certificatesv1beta1.PodCertificateRequestList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/lease.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/lease.go
@@ -41,6 +41,7 @@ type LeaseInterface interface {
 	Create(ctx context.Context, lease *coordinationv1.Lease, opts metav1.CreateOptions) (*coordinationv1.Lease, error)
 	Update(ctx context.Context, lease *coordinationv1.Lease, opts metav1.UpdateOptions) (*coordinationv1.Lease, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*coordinationv1.Lease, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*coordinationv1.LeaseList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1alpha2/leasecandidate.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1alpha2/leasecandidate.go
@@ -41,6 +41,7 @@ type LeaseCandidateInterface interface {
 	Create(ctx context.Context, leaseCandidate *coordinationv1alpha2.LeaseCandidate, opts v1.CreateOptions) (*coordinationv1alpha2.LeaseCandidate, error)
 	Update(ctx context.Context, leaseCandidate *coordinationv1alpha2.LeaseCandidate, opts v1.UpdateOptions) (*coordinationv1alpha2.LeaseCandidate, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*coordinationv1alpha2.LeaseCandidate, error)
 	List(ctx context.Context, opts v1.ListOptions) (*coordinationv1alpha2.LeaseCandidateList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/lease.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/lease.go
@@ -41,6 +41,7 @@ type LeaseInterface interface {
 	Create(ctx context.Context, lease *coordinationv1beta1.Lease, opts v1.CreateOptions) (*coordinationv1beta1.Lease, error)
 	Update(ctx context.Context, lease *coordinationv1beta1.Lease, opts v1.UpdateOptions) (*coordinationv1beta1.Lease, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*coordinationv1beta1.Lease, error)
 	List(ctx context.Context, opts v1.ListOptions) (*coordinationv1beta1.LeaseList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/leasecandidate.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/leasecandidate.go
@@ -41,6 +41,7 @@ type LeaseCandidateInterface interface {
 	Create(ctx context.Context, leaseCandidate *coordinationv1beta1.LeaseCandidate, opts v1.CreateOptions) (*coordinationv1beta1.LeaseCandidate, error)
 	Update(ctx context.Context, leaseCandidate *coordinationv1beta1.LeaseCandidate, opts v1.UpdateOptions) (*coordinationv1beta1.LeaseCandidate, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*coordinationv1beta1.LeaseCandidate, error)
 	List(ctx context.Context, opts v1.ListOptions) (*coordinationv1beta1.LeaseCandidateList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/componentstatus.go
@@ -41,6 +41,7 @@ type ComponentStatusInterface interface {
 	Create(ctx context.Context, componentStatus *corev1.ComponentStatus, opts metav1.CreateOptions) (*corev1.ComponentStatus, error)
 	Update(ctx context.Context, componentStatus *corev1.ComponentStatus, opts metav1.UpdateOptions) (*corev1.ComponentStatus, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.ComponentStatus, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*corev1.ComponentStatusList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/configmap.go
@@ -41,6 +41,7 @@ type ConfigMapInterface interface {
 	Create(ctx context.Context, configMap *corev1.ConfigMap, opts metav1.CreateOptions) (*corev1.ConfigMap, error)
 	Update(ctx context.Context, configMap *corev1.ConfigMap, opts metav1.UpdateOptions) (*corev1.ConfigMap, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.ConfigMap, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*corev1.ConfigMapList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/endpoints.go
@@ -41,6 +41,7 @@ type EndpointsInterface interface {
 	Create(ctx context.Context, endpoints *corev1.Endpoints, opts metav1.CreateOptions) (*corev1.Endpoints, error)
 	Update(ctx context.Context, endpoints *corev1.Endpoints, opts metav1.UpdateOptions) (*corev1.Endpoints, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.Endpoints, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*corev1.EndpointsList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event.go
@@ -41,6 +41,7 @@ type EventInterface interface {
 	Create(ctx context.Context, event *corev1.Event, opts metav1.CreateOptions) (*corev1.Event, error)
 	Update(ctx context.Context, event *corev1.Event, opts metav1.UpdateOptions) (*corev1.Event, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.Event, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*corev1.EventList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/limitrange.go
@@ -41,6 +41,7 @@ type LimitRangeInterface interface {
 	Create(ctx context.Context, limitRange *corev1.LimitRange, opts metav1.CreateOptions) (*corev1.LimitRange, error)
 	Update(ctx context.Context, limitRange *corev1.LimitRange, opts metav1.UpdateOptions) (*corev1.LimitRange, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.LimitRange, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*corev1.LimitRangeList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/namespace.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/namespace.go
@@ -43,6 +43,7 @@ type NamespaceInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, namespace *corev1.Namespace, opts metav1.UpdateOptions) (*corev1.Namespace, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.Namespace, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*corev1.NamespaceList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node.go
@@ -43,6 +43,7 @@ type NodeInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, node *corev1.Node, opts metav1.UpdateOptions) (*corev1.Node, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.Node, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*corev1.NodeList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolume.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolume.go
@@ -43,6 +43,7 @@ type PersistentVolumeInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, persistentVolume *corev1.PersistentVolume, opts metav1.UpdateOptions) (*corev1.PersistentVolume, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.PersistentVolume, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*corev1.PersistentVolumeList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
@@ -43,6 +43,7 @@ type PersistentVolumeClaimInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, persistentVolumeClaim *corev1.PersistentVolumeClaim, opts metav1.UpdateOptions) (*corev1.PersistentVolumeClaim, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.PersistentVolumeClaim, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*corev1.PersistentVolumeClaimList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
@@ -43,6 +43,7 @@ type PodInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, pod *corev1.Pod, opts metav1.UpdateOptions) (*corev1.Pod, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.Pod, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*corev1.PodList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/podtemplate.go
@@ -41,6 +41,7 @@ type PodTemplateInterface interface {
 	Create(ctx context.Context, podTemplate *corev1.PodTemplate, opts metav1.CreateOptions) (*corev1.PodTemplate, error)
 	Update(ctx context.Context, podTemplate *corev1.PodTemplate, opts metav1.UpdateOptions) (*corev1.PodTemplate, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.PodTemplate, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*corev1.PodTemplateList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/replicationcontroller.go
@@ -44,6 +44,7 @@ type ReplicationControllerInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, replicationController *corev1.ReplicationController, opts metav1.UpdateOptions) (*corev1.ReplicationController, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.ReplicationController, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*corev1.ReplicationControllerList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/resourcequota.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/resourcequota.go
@@ -43,6 +43,7 @@ type ResourceQuotaInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, resourceQuota *corev1.ResourceQuota, opts metav1.UpdateOptions) (*corev1.ResourceQuota, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.ResourceQuota, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*corev1.ResourceQuotaList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/secret.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/secret.go
@@ -41,6 +41,7 @@ type SecretInterface interface {
 	Create(ctx context.Context, secret *corev1.Secret, opts metav1.CreateOptions) (*corev1.Secret, error)
 	Update(ctx context.Context, secret *corev1.Secret, opts metav1.UpdateOptions) (*corev1.Secret, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.Secret, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*corev1.SecretList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/service.go
@@ -43,6 +43,7 @@ type ServiceInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, service *corev1.Service, opts metav1.UpdateOptions) (*corev1.Service, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.Service, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*corev1.ServiceList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount.go
@@ -42,6 +42,7 @@ type ServiceAccountInterface interface {
 	Create(ctx context.Context, serviceAccount *corev1.ServiceAccount, opts metav1.CreateOptions) (*corev1.ServiceAccount, error)
 	Update(ctx context.Context, serviceAccount *corev1.ServiceAccount, opts metav1.UpdateOptions) (*corev1.ServiceAccount, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.ServiceAccount, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*corev1.ServiceAccountList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1/endpointslice.go
@@ -41,6 +41,7 @@ type EndpointSliceInterface interface {
 	Create(ctx context.Context, endpointSlice *discoveryv1.EndpointSlice, opts metav1.CreateOptions) (*discoveryv1.EndpointSlice, error)
 	Update(ctx context.Context, endpointSlice *discoveryv1.EndpointSlice, opts metav1.UpdateOptions) (*discoveryv1.EndpointSlice, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*discoveryv1.EndpointSlice, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*discoveryv1.EndpointSliceList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/endpointslice.go
@@ -41,6 +41,7 @@ type EndpointSliceInterface interface {
 	Create(ctx context.Context, endpointSlice *discoveryv1beta1.EndpointSlice, opts v1.CreateOptions) (*discoveryv1beta1.EndpointSlice, error)
 	Update(ctx context.Context, endpointSlice *discoveryv1beta1.EndpointSlice, opts v1.UpdateOptions) (*discoveryv1beta1.EndpointSlice, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*discoveryv1beta1.EndpointSlice, error)
 	List(ctx context.Context, opts v1.ListOptions) (*discoveryv1beta1.EndpointSliceList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1/event.go
@@ -41,6 +41,7 @@ type EventInterface interface {
 	Create(ctx context.Context, event *eventsv1.Event, opts metav1.CreateOptions) (*eventsv1.Event, error)
 	Update(ctx context.Context, event *eventsv1.Event, opts metav1.UpdateOptions) (*eventsv1.Event, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*eventsv1.Event, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*eventsv1.EventList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event.go
@@ -41,6 +41,7 @@ type EventInterface interface {
 	Create(ctx context.Context, event *eventsv1beta1.Event, opts v1.CreateOptions) (*eventsv1beta1.Event, error)
 	Update(ctx context.Context, event *eventsv1beta1.Event, opts v1.UpdateOptions) (*eventsv1beta1.Event, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*eventsv1beta1.Event, error)
 	List(ctx context.Context, opts v1.ListOptions) (*eventsv1beta1.EventList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
@@ -43,6 +43,7 @@ type DaemonSetInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, daemonSet *extensionsv1beta1.DaemonSet, opts v1.UpdateOptions) (*extensionsv1beta1.DaemonSet, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*extensionsv1beta1.DaemonSet, error)
 	List(ctx context.Context, opts v1.ListOptions) (*extensionsv1beta1.DaemonSetList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
@@ -45,6 +45,7 @@ type DeploymentInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, deployment *extensionsv1beta1.Deployment, opts v1.UpdateOptions) (*extensionsv1beta1.Deployment, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*extensionsv1beta1.Deployment, error)
 	List(ctx context.Context, opts v1.ListOptions) (*extensionsv1beta1.DeploymentList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
@@ -43,6 +43,7 @@ type IngressInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, ingress *extensionsv1beta1.Ingress, opts v1.UpdateOptions) (*extensionsv1beta1.Ingress, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*extensionsv1beta1.Ingress, error)
 	List(ctx context.Context, opts v1.ListOptions) (*extensionsv1beta1.IngressList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/networkpolicy.go
@@ -41,6 +41,7 @@ type NetworkPolicyInterface interface {
 	Create(ctx context.Context, networkPolicy *extensionsv1beta1.NetworkPolicy, opts v1.CreateOptions) (*extensionsv1beta1.NetworkPolicy, error)
 	Update(ctx context.Context, networkPolicy *extensionsv1beta1.NetworkPolicy, opts v1.UpdateOptions) (*extensionsv1beta1.NetworkPolicy, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*extensionsv1beta1.NetworkPolicy, error)
 	List(ctx context.Context, opts v1.ListOptions) (*extensionsv1beta1.NetworkPolicyList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
@@ -45,6 +45,7 @@ type ReplicaSetInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, replicaSet *extensionsv1beta1.ReplicaSet, opts v1.UpdateOptions) (*extensionsv1beta1.ReplicaSet, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*extensionsv1beta1.ReplicaSet, error)
 	List(ctx context.Context, opts v1.ListOptions) (*extensionsv1beta1.ReplicaSetList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1/flowschema.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1/flowschema.go
@@ -43,6 +43,7 @@ type FlowSchemaInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, flowSchema *flowcontrolv1.FlowSchema, opts metav1.UpdateOptions) (*flowcontrolv1.FlowSchema, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*flowcontrolv1.FlowSchema, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*flowcontrolv1.FlowSchemaList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1/prioritylevelconfiguration.go
@@ -43,6 +43,7 @@ type PriorityLevelConfigurationInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, priorityLevelConfiguration *flowcontrolv1.PriorityLevelConfiguration, opts metav1.UpdateOptions) (*flowcontrolv1.PriorityLevelConfiguration, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*flowcontrolv1.PriorityLevelConfiguration, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*flowcontrolv1.PriorityLevelConfigurationList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/flowschema.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/flowschema.go
@@ -43,6 +43,7 @@ type FlowSchemaInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, flowSchema *flowcontrolv1beta1.FlowSchema, opts v1.UpdateOptions) (*flowcontrolv1beta1.FlowSchema, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*flowcontrolv1beta1.FlowSchema, error)
 	List(ctx context.Context, opts v1.ListOptions) (*flowcontrolv1beta1.FlowSchemaList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta1/prioritylevelconfiguration.go
@@ -43,6 +43,7 @@ type PriorityLevelConfigurationInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, priorityLevelConfiguration *flowcontrolv1beta1.PriorityLevelConfiguration, opts v1.UpdateOptions) (*flowcontrolv1beta1.PriorityLevelConfiguration, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*flowcontrolv1beta1.PriorityLevelConfiguration, error)
 	List(ctx context.Context, opts v1.ListOptions) (*flowcontrolv1beta1.PriorityLevelConfigurationList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/flowschema.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/flowschema.go
@@ -43,6 +43,7 @@ type FlowSchemaInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, flowSchema *flowcontrolv1beta2.FlowSchema, opts v1.UpdateOptions) (*flowcontrolv1beta2.FlowSchema, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*flowcontrolv1beta2.FlowSchema, error)
 	List(ctx context.Context, opts v1.ListOptions) (*flowcontrolv1beta2.FlowSchemaList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta2/prioritylevelconfiguration.go
@@ -43,6 +43,7 @@ type PriorityLevelConfigurationInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, priorityLevelConfiguration *flowcontrolv1beta2.PriorityLevelConfiguration, opts v1.UpdateOptions) (*flowcontrolv1beta2.PriorityLevelConfiguration, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*flowcontrolv1beta2.PriorityLevelConfiguration, error)
 	List(ctx context.Context, opts v1.ListOptions) (*flowcontrolv1beta2.PriorityLevelConfigurationList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta3/flowschema.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta3/flowschema.go
@@ -43,6 +43,7 @@ type FlowSchemaInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, flowSchema *flowcontrolv1beta3.FlowSchema, opts v1.UpdateOptions) (*flowcontrolv1beta3.FlowSchema, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*flowcontrolv1beta3.FlowSchema, error)
 	List(ctx context.Context, opts v1.ListOptions) (*flowcontrolv1beta3.FlowSchemaList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta3/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1beta3/prioritylevelconfiguration.go
@@ -43,6 +43,7 @@ type PriorityLevelConfigurationInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, priorityLevelConfiguration *flowcontrolv1beta3.PriorityLevelConfiguration, opts v1.UpdateOptions) (*flowcontrolv1beta3.PriorityLevelConfiguration, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*flowcontrolv1beta3.PriorityLevelConfiguration, error)
 	List(ctx context.Context, opts v1.ListOptions) (*flowcontrolv1beta3.PriorityLevelConfigurationList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/lifecycle/v1alpha1/eviction.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/lifecycle/v1alpha1/eviction.go
@@ -43,6 +43,7 @@ type EvictionInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, eviction *lifecyclev1alpha1.Eviction, opts v1.UpdateOptions) (*lifecyclev1alpha1.Eviction, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*lifecyclev1alpha1.Eviction, error)
 	List(ctx context.Context, opts v1.ListOptions) (*lifecyclev1alpha1.EvictionList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/lifecycle/v1alpha1/evictionrequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/lifecycle/v1alpha1/evictionrequest.go
@@ -43,6 +43,7 @@ type EvictionRequestInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, evictionRequest *lifecyclev1alpha1.EvictionRequest, opts v1.UpdateOptions) (*lifecyclev1alpha1.EvictionRequest, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*lifecyclev1alpha1.EvictionRequest, error)
 	List(ctx context.Context, opts v1.ListOptions) (*lifecyclev1alpha1.EvictionRequestList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/ingress.go
@@ -43,6 +43,7 @@ type IngressInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, ingress *networkingv1.Ingress, opts metav1.UpdateOptions) (*networkingv1.Ingress, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*networkingv1.Ingress, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*networkingv1.IngressList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/ingressclass.go
@@ -41,6 +41,7 @@ type IngressClassInterface interface {
 	Create(ctx context.Context, ingressClass *networkingv1.IngressClass, opts metav1.CreateOptions) (*networkingv1.IngressClass, error)
 	Update(ctx context.Context, ingressClass *networkingv1.IngressClass, opts metav1.UpdateOptions) (*networkingv1.IngressClass, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*networkingv1.IngressClass, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*networkingv1.IngressClassList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/ipaddress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/ipaddress.go
@@ -41,6 +41,7 @@ type IPAddressInterface interface {
 	Create(ctx context.Context, iPAddress *networkingv1.IPAddress, opts metav1.CreateOptions) (*networkingv1.IPAddress, error)
 	Update(ctx context.Context, iPAddress *networkingv1.IPAddress, opts metav1.UpdateOptions) (*networkingv1.IPAddress, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*networkingv1.IPAddress, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*networkingv1.IPAddressList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networkpolicy.go
@@ -41,6 +41,7 @@ type NetworkPolicyInterface interface {
 	Create(ctx context.Context, networkPolicy *networkingv1.NetworkPolicy, opts metav1.CreateOptions) (*networkingv1.NetworkPolicy, error)
 	Update(ctx context.Context, networkPolicy *networkingv1.NetworkPolicy, opts metav1.UpdateOptions) (*networkingv1.NetworkPolicy, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*networkingv1.NetworkPolicy, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*networkingv1.NetworkPolicyList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/servicecidr.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/servicecidr.go
@@ -43,6 +43,7 @@ type ServiceCIDRInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, serviceCIDR *networkingv1.ServiceCIDR, opts metav1.UpdateOptions) (*networkingv1.ServiceCIDR, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*networkingv1.ServiceCIDR, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*networkingv1.ServiceCIDRList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingress.go
@@ -43,6 +43,7 @@ type IngressInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, ingress *networkingv1beta1.Ingress, opts v1.UpdateOptions) (*networkingv1beta1.Ingress, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*networkingv1beta1.Ingress, error)
 	List(ctx context.Context, opts v1.ListOptions) (*networkingv1beta1.IngressList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingressclass.go
@@ -41,6 +41,7 @@ type IngressClassInterface interface {
 	Create(ctx context.Context, ingressClass *networkingv1beta1.IngressClass, opts v1.CreateOptions) (*networkingv1beta1.IngressClass, error)
 	Update(ctx context.Context, ingressClass *networkingv1beta1.IngressClass, opts v1.UpdateOptions) (*networkingv1beta1.IngressClass, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*networkingv1beta1.IngressClass, error)
 	List(ctx context.Context, opts v1.ListOptions) (*networkingv1beta1.IngressClassList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ipaddress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ipaddress.go
@@ -41,6 +41,7 @@ type IPAddressInterface interface {
 	Create(ctx context.Context, iPAddress *networkingv1beta1.IPAddress, opts v1.CreateOptions) (*networkingv1beta1.IPAddress, error)
 	Update(ctx context.Context, iPAddress *networkingv1beta1.IPAddress, opts v1.UpdateOptions) (*networkingv1beta1.IPAddress, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*networkingv1beta1.IPAddress, error)
 	List(ctx context.Context, opts v1.ListOptions) (*networkingv1beta1.IPAddressList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/servicecidr.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/servicecidr.go
@@ -43,6 +43,7 @@ type ServiceCIDRInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, serviceCIDR *networkingv1beta1.ServiceCIDR, opts v1.UpdateOptions) (*networkingv1beta1.ServiceCIDR, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*networkingv1beta1.ServiceCIDR, error)
 	List(ctx context.Context, opts v1.ListOptions) (*networkingv1beta1.ServiceCIDRList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1/runtimeclass.go
@@ -41,6 +41,7 @@ type RuntimeClassInterface interface {
 	Create(ctx context.Context, runtimeClass *nodev1.RuntimeClass, opts metav1.CreateOptions) (*nodev1.RuntimeClass, error)
 	Update(ctx context.Context, runtimeClass *nodev1.RuntimeClass, opts metav1.UpdateOptions) (*nodev1.RuntimeClass, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*nodev1.RuntimeClass, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*nodev1.RuntimeClassList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/runtimeclass.go
@@ -41,6 +41,7 @@ type RuntimeClassInterface interface {
 	Create(ctx context.Context, runtimeClass *nodev1alpha1.RuntimeClass, opts v1.CreateOptions) (*nodev1alpha1.RuntimeClass, error)
 	Update(ctx context.Context, runtimeClass *nodev1alpha1.RuntimeClass, opts v1.UpdateOptions) (*nodev1alpha1.RuntimeClass, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*nodev1alpha1.RuntimeClass, error)
 	List(ctx context.Context, opts v1.ListOptions) (*nodev1alpha1.RuntimeClassList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/runtimeclass.go
@@ -41,6 +41,7 @@ type RuntimeClassInterface interface {
 	Create(ctx context.Context, runtimeClass *nodev1beta1.RuntimeClass, opts v1.CreateOptions) (*nodev1beta1.RuntimeClass, error)
 	Update(ctx context.Context, runtimeClass *nodev1beta1.RuntimeClass, opts v1.UpdateOptions) (*nodev1beta1.RuntimeClass, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*nodev1beta1.RuntimeClass, error)
 	List(ctx context.Context, opts v1.ListOptions) (*nodev1beta1.RuntimeClassList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1/poddisruptionbudget.go
@@ -43,6 +43,7 @@ type PodDisruptionBudgetInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, podDisruptionBudget *policyv1.PodDisruptionBudget, opts metav1.UpdateOptions) (*policyv1.PodDisruptionBudget, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*policyv1.PodDisruptionBudget, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*policyv1.PodDisruptionBudgetList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go
@@ -43,6 +43,7 @@ type PodDisruptionBudgetInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, podDisruptionBudget *policyv1beta1.PodDisruptionBudget, opts v1.UpdateOptions) (*policyv1beta1.PodDisruptionBudget, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*policyv1beta1.PodDisruptionBudget, error)
 	List(ctx context.Context, opts v1.ListOptions) (*policyv1beta1.PodDisruptionBudgetList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrole.go
@@ -41,6 +41,7 @@ type ClusterRoleInterface interface {
 	Create(ctx context.Context, clusterRole *rbacv1.ClusterRole, opts metav1.CreateOptions) (*rbacv1.ClusterRole, error)
 	Update(ctx context.Context, clusterRole *rbacv1.ClusterRole, opts metav1.UpdateOptions) (*rbacv1.ClusterRole, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*rbacv1.ClusterRole, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*rbacv1.ClusterRoleList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrolebinding.go
@@ -41,6 +41,7 @@ type ClusterRoleBindingInterface interface {
 	Create(ctx context.Context, clusterRoleBinding *rbacv1.ClusterRoleBinding, opts metav1.CreateOptions) (*rbacv1.ClusterRoleBinding, error)
 	Update(ctx context.Context, clusterRoleBinding *rbacv1.ClusterRoleBinding, opts metav1.UpdateOptions) (*rbacv1.ClusterRoleBinding, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*rbacv1.ClusterRoleBinding, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*rbacv1.ClusterRoleBindingList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/role.go
@@ -41,6 +41,7 @@ type RoleInterface interface {
 	Create(ctx context.Context, role *rbacv1.Role, opts metav1.CreateOptions) (*rbacv1.Role, error)
 	Update(ctx context.Context, role *rbacv1.Role, opts metav1.UpdateOptions) (*rbacv1.Role, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*rbacv1.Role, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*rbacv1.RoleList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rolebinding.go
@@ -41,6 +41,7 @@ type RoleBindingInterface interface {
 	Create(ctx context.Context, roleBinding *rbacv1.RoleBinding, opts metav1.CreateOptions) (*rbacv1.RoleBinding, error)
 	Update(ctx context.Context, roleBinding *rbacv1.RoleBinding, opts metav1.UpdateOptions) (*rbacv1.RoleBinding, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*rbacv1.RoleBinding, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*rbacv1.RoleBindingList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrole.go
@@ -41,6 +41,7 @@ type ClusterRoleInterface interface {
 	Create(ctx context.Context, clusterRole *rbacv1alpha1.ClusterRole, opts v1.CreateOptions) (*rbacv1alpha1.ClusterRole, error)
 	Update(ctx context.Context, clusterRole *rbacv1alpha1.ClusterRole, opts v1.UpdateOptions) (*rbacv1alpha1.ClusterRole, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*rbacv1alpha1.ClusterRole, error)
 	List(ctx context.Context, opts v1.ListOptions) (*rbacv1alpha1.ClusterRoleList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrolebinding.go
@@ -41,6 +41,7 @@ type ClusterRoleBindingInterface interface {
 	Create(ctx context.Context, clusterRoleBinding *rbacv1alpha1.ClusterRoleBinding, opts v1.CreateOptions) (*rbacv1alpha1.ClusterRoleBinding, error)
 	Update(ctx context.Context, clusterRoleBinding *rbacv1alpha1.ClusterRoleBinding, opts v1.UpdateOptions) (*rbacv1alpha1.ClusterRoleBinding, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*rbacv1alpha1.ClusterRoleBinding, error)
 	List(ctx context.Context, opts v1.ListOptions) (*rbacv1alpha1.ClusterRoleBindingList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/role.go
@@ -41,6 +41,7 @@ type RoleInterface interface {
 	Create(ctx context.Context, role *rbacv1alpha1.Role, opts v1.CreateOptions) (*rbacv1alpha1.Role, error)
 	Update(ctx context.Context, role *rbacv1alpha1.Role, opts v1.UpdateOptions) (*rbacv1alpha1.Role, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*rbacv1alpha1.Role, error)
 	List(ctx context.Context, opts v1.ListOptions) (*rbacv1alpha1.RoleList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
@@ -41,6 +41,7 @@ type RoleBindingInterface interface {
 	Create(ctx context.Context, roleBinding *rbacv1alpha1.RoleBinding, opts v1.CreateOptions) (*rbacv1alpha1.RoleBinding, error)
 	Update(ctx context.Context, roleBinding *rbacv1alpha1.RoleBinding, opts v1.UpdateOptions) (*rbacv1alpha1.RoleBinding, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*rbacv1alpha1.RoleBinding, error)
 	List(ctx context.Context, opts v1.ListOptions) (*rbacv1alpha1.RoleBindingList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
@@ -41,6 +41,7 @@ type ClusterRoleInterface interface {
 	Create(ctx context.Context, clusterRole *rbacv1beta1.ClusterRole, opts v1.CreateOptions) (*rbacv1beta1.ClusterRole, error)
 	Update(ctx context.Context, clusterRole *rbacv1beta1.ClusterRole, opts v1.UpdateOptions) (*rbacv1beta1.ClusterRole, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*rbacv1beta1.ClusterRole, error)
 	List(ctx context.Context, opts v1.ListOptions) (*rbacv1beta1.ClusterRoleList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrolebinding.go
@@ -41,6 +41,7 @@ type ClusterRoleBindingInterface interface {
 	Create(ctx context.Context, clusterRoleBinding *rbacv1beta1.ClusterRoleBinding, opts v1.CreateOptions) (*rbacv1beta1.ClusterRoleBinding, error)
 	Update(ctx context.Context, clusterRoleBinding *rbacv1beta1.ClusterRoleBinding, opts v1.UpdateOptions) (*rbacv1beta1.ClusterRoleBinding, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*rbacv1beta1.ClusterRoleBinding, error)
 	List(ctx context.Context, opts v1.ListOptions) (*rbacv1beta1.ClusterRoleBindingList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/role.go
@@ -41,6 +41,7 @@ type RoleInterface interface {
 	Create(ctx context.Context, role *rbacv1beta1.Role, opts v1.CreateOptions) (*rbacv1beta1.Role, error)
 	Update(ctx context.Context, role *rbacv1beta1.Role, opts v1.UpdateOptions) (*rbacv1beta1.Role, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*rbacv1beta1.Role, error)
 	List(ctx context.Context, opts v1.ListOptions) (*rbacv1beta1.RoleList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
@@ -41,6 +41,7 @@ type RoleBindingInterface interface {
 	Create(ctx context.Context, roleBinding *rbacv1beta1.RoleBinding, opts v1.CreateOptions) (*rbacv1beta1.RoleBinding, error)
 	Update(ctx context.Context, roleBinding *rbacv1beta1.RoleBinding, opts v1.UpdateOptions) (*rbacv1beta1.RoleBinding, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*rbacv1beta1.RoleBinding, error)
 	List(ctx context.Context, opts v1.ListOptions) (*rbacv1beta1.RoleBindingList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1/deviceclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1/deviceclass.go
@@ -41,6 +41,7 @@ type DeviceClassInterface interface {
 	Create(ctx context.Context, deviceClass *resourcev1.DeviceClass, opts metav1.CreateOptions) (*resourcev1.DeviceClass, error)
 	Update(ctx context.Context, deviceClass *resourcev1.DeviceClass, opts metav1.UpdateOptions) (*resourcev1.DeviceClass, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*resourcev1.DeviceClass, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*resourcev1.DeviceClassList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1/devicetaintrule.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1/devicetaintrule.go
@@ -43,6 +43,7 @@ type DeviceTaintRuleInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, deviceTaintRule *resourcev1.DeviceTaintRule, opts metav1.UpdateOptions) (*resourcev1.DeviceTaintRule, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*resourcev1.DeviceTaintRule, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*resourcev1.DeviceTaintRuleList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1/resourceclaim.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1/resourceclaim.go
@@ -43,6 +43,7 @@ type ResourceClaimInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, resourceClaim *resourcev1.ResourceClaim, opts metav1.UpdateOptions) (*resourcev1.ResourceClaim, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*resourcev1.ResourceClaim, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*resourcev1.ResourceClaimList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1/resourceclaimtemplate.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1/resourceclaimtemplate.go
@@ -41,6 +41,7 @@ type ResourceClaimTemplateInterface interface {
 	Create(ctx context.Context, resourceClaimTemplate *resourcev1.ResourceClaimTemplate, opts metav1.CreateOptions) (*resourcev1.ResourceClaimTemplate, error)
 	Update(ctx context.Context, resourceClaimTemplate *resourcev1.ResourceClaimTemplate, opts metav1.UpdateOptions) (*resourcev1.ResourceClaimTemplate, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*resourcev1.ResourceClaimTemplate, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*resourcev1.ResourceClaimTemplateList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1/resourceslice.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1/resourceslice.go
@@ -41,6 +41,7 @@ type ResourceSliceInterface interface {
 	Create(ctx context.Context, resourceSlice *resourcev1.ResourceSlice, opts metav1.CreateOptions) (*resourcev1.ResourceSlice, error)
 	Update(ctx context.Context, resourceSlice *resourcev1.ResourceSlice, opts metav1.UpdateOptions) (*resourcev1.ResourceSlice, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*resourcev1.ResourceSlice, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*resourcev1.ResourceSliceList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha3/devicetaintrule.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha3/devicetaintrule.go
@@ -43,6 +43,7 @@ type DeviceTaintRuleInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, deviceTaintRule *resourcev1alpha3.DeviceTaintRule, opts v1.UpdateOptions) (*resourcev1alpha3.DeviceTaintRule, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*resourcev1alpha3.DeviceTaintRule, error)
 	List(ctx context.Context, opts v1.ListOptions) (*resourcev1alpha3.DeviceTaintRuleList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha3/resourcepoolstatusrequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1alpha3/resourcepoolstatusrequest.go
@@ -43,6 +43,7 @@ type ResourcePoolStatusRequestInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, resourcePoolStatusRequest *resourcev1alpha3.ResourcePoolStatusRequest, opts v1.UpdateOptions) (*resourcev1alpha3.ResourcePoolStatusRequest, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*resourcev1alpha3.ResourcePoolStatusRequest, error)
 	List(ctx context.Context, opts v1.ListOptions) (*resourcev1alpha3.ResourcePoolStatusRequestList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1beta1/deviceclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1beta1/deviceclass.go
@@ -41,6 +41,7 @@ type DeviceClassInterface interface {
 	Create(ctx context.Context, deviceClass *resourcev1beta1.DeviceClass, opts v1.CreateOptions) (*resourcev1beta1.DeviceClass, error)
 	Update(ctx context.Context, deviceClass *resourcev1beta1.DeviceClass, opts v1.UpdateOptions) (*resourcev1beta1.DeviceClass, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*resourcev1beta1.DeviceClass, error)
 	List(ctx context.Context, opts v1.ListOptions) (*resourcev1beta1.DeviceClassList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1beta1/resourceclaim.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1beta1/resourceclaim.go
@@ -43,6 +43,7 @@ type ResourceClaimInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, resourceClaim *resourcev1beta1.ResourceClaim, opts v1.UpdateOptions) (*resourcev1beta1.ResourceClaim, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*resourcev1beta1.ResourceClaim, error)
 	List(ctx context.Context, opts v1.ListOptions) (*resourcev1beta1.ResourceClaimList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1beta1/resourceclaimtemplate.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1beta1/resourceclaimtemplate.go
@@ -41,6 +41,7 @@ type ResourceClaimTemplateInterface interface {
 	Create(ctx context.Context, resourceClaimTemplate *resourcev1beta1.ResourceClaimTemplate, opts v1.CreateOptions) (*resourcev1beta1.ResourceClaimTemplate, error)
 	Update(ctx context.Context, resourceClaimTemplate *resourcev1beta1.ResourceClaimTemplate, opts v1.UpdateOptions) (*resourcev1beta1.ResourceClaimTemplate, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*resourcev1beta1.ResourceClaimTemplate, error)
 	List(ctx context.Context, opts v1.ListOptions) (*resourcev1beta1.ResourceClaimTemplateList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1beta1/resourceslice.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1beta1/resourceslice.go
@@ -41,6 +41,7 @@ type ResourceSliceInterface interface {
 	Create(ctx context.Context, resourceSlice *resourcev1beta1.ResourceSlice, opts v1.CreateOptions) (*resourcev1beta1.ResourceSlice, error)
 	Update(ctx context.Context, resourceSlice *resourcev1beta1.ResourceSlice, opts v1.UpdateOptions) (*resourcev1beta1.ResourceSlice, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*resourcev1beta1.ResourceSlice, error)
 	List(ctx context.Context, opts v1.ListOptions) (*resourcev1beta1.ResourceSliceList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1beta2/deviceclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1beta2/deviceclass.go
@@ -41,6 +41,7 @@ type DeviceClassInterface interface {
 	Create(ctx context.Context, deviceClass *resourcev1beta2.DeviceClass, opts v1.CreateOptions) (*resourcev1beta2.DeviceClass, error)
 	Update(ctx context.Context, deviceClass *resourcev1beta2.DeviceClass, opts v1.UpdateOptions) (*resourcev1beta2.DeviceClass, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*resourcev1beta2.DeviceClass, error)
 	List(ctx context.Context, opts v1.ListOptions) (*resourcev1beta2.DeviceClassList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1beta2/devicetaintrule.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1beta2/devicetaintrule.go
@@ -43,6 +43,7 @@ type DeviceTaintRuleInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, deviceTaintRule *resourcev1beta2.DeviceTaintRule, opts v1.UpdateOptions) (*resourcev1beta2.DeviceTaintRule, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*resourcev1beta2.DeviceTaintRule, error)
 	List(ctx context.Context, opts v1.ListOptions) (*resourcev1beta2.DeviceTaintRuleList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1beta2/resourceclaim.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1beta2/resourceclaim.go
@@ -43,6 +43,7 @@ type ResourceClaimInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, resourceClaim *resourcev1beta2.ResourceClaim, opts v1.UpdateOptions) (*resourcev1beta2.ResourceClaim, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*resourcev1beta2.ResourceClaim, error)
 	List(ctx context.Context, opts v1.ListOptions) (*resourcev1beta2.ResourceClaimList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1beta2/resourceclaimtemplate.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1beta2/resourceclaimtemplate.go
@@ -41,6 +41,7 @@ type ResourceClaimTemplateInterface interface {
 	Create(ctx context.Context, resourceClaimTemplate *resourcev1beta2.ResourceClaimTemplate, opts v1.CreateOptions) (*resourcev1beta2.ResourceClaimTemplate, error)
 	Update(ctx context.Context, resourceClaimTemplate *resourcev1beta2.ResourceClaimTemplate, opts v1.UpdateOptions) (*resourcev1beta2.ResourceClaimTemplate, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*resourcev1beta2.ResourceClaimTemplate, error)
 	List(ctx context.Context, opts v1.ListOptions) (*resourcev1beta2.ResourceClaimTemplateList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1beta2/resourceslice.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/resource/v1beta2/resourceslice.go
@@ -41,6 +41,7 @@ type ResourceSliceInterface interface {
 	Create(ctx context.Context, resourceSlice *resourcev1beta2.ResourceSlice, opts v1.CreateOptions) (*resourcev1beta2.ResourceSlice, error)
 	Update(ctx context.Context, resourceSlice *resourcev1beta2.ResourceSlice, opts v1.UpdateOptions) (*resourcev1beta2.ResourceSlice, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*resourcev1beta2.ResourceSlice, error)
 	List(ctx context.Context, opts v1.ListOptions) (*resourcev1beta2.ResourceSliceList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/priorityclass.go
@@ -41,6 +41,7 @@ type PriorityClassInterface interface {
 	Create(ctx context.Context, priorityClass *schedulingv1.PriorityClass, opts metav1.CreateOptions) (*schedulingv1.PriorityClass, error)
 	Update(ctx context.Context, priorityClass *schedulingv1.PriorityClass, opts metav1.UpdateOptions) (*schedulingv1.PriorityClass, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*schedulingv1.PriorityClass, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*schedulingv1.PriorityClassList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha3/compositepodgroup.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha3/compositepodgroup.go
@@ -43,6 +43,7 @@ type CompositePodGroupInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, compositePodGroup *schedulingv1alpha3.CompositePodGroup, opts v1.UpdateOptions) (*schedulingv1alpha3.CompositePodGroup, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*schedulingv1alpha3.CompositePodGroup, error)
 	List(ctx context.Context, opts v1.ListOptions) (*schedulingv1alpha3.CompositePodGroupList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha3/podgroup.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha3/podgroup.go
@@ -43,6 +43,7 @@ type PodGroupInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, podGroup *schedulingv1alpha3.PodGroup, opts v1.UpdateOptions) (*schedulingv1alpha3.PodGroup, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*schedulingv1alpha3.PodGroup, error)
 	List(ctx context.Context, opts v1.ListOptions) (*schedulingv1alpha3.PodGroupList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha3/workload.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha3/workload.go
@@ -41,6 +41,7 @@ type WorkloadInterface interface {
 	Create(ctx context.Context, workload *schedulingv1alpha3.Workload, opts v1.CreateOptions) (*schedulingv1alpha3.Workload, error)
 	Update(ctx context.Context, workload *schedulingv1alpha3.Workload, opts v1.UpdateOptions) (*schedulingv1alpha3.Workload, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*schedulingv1alpha3.Workload, error)
 	List(ctx context.Context, opts v1.ListOptions) (*schedulingv1alpha3.WorkloadList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/podgroup.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/podgroup.go
@@ -43,6 +43,7 @@ type PodGroupInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, podGroup *schedulingv1beta1.PodGroup, opts v1.UpdateOptions) (*schedulingv1beta1.PodGroup, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*schedulingv1beta1.PodGroup, error)
 	List(ctx context.Context, opts v1.ListOptions) (*schedulingv1beta1.PodGroupList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/priorityclass.go
@@ -41,6 +41,7 @@ type PriorityClassInterface interface {
 	Create(ctx context.Context, priorityClass *schedulingv1beta1.PriorityClass, opts v1.CreateOptions) (*schedulingv1beta1.PriorityClass, error)
 	Update(ctx context.Context, priorityClass *schedulingv1beta1.PriorityClass, opts v1.UpdateOptions) (*schedulingv1beta1.PriorityClass, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*schedulingv1beta1.PriorityClass, error)
 	List(ctx context.Context, opts v1.ListOptions) (*schedulingv1beta1.PriorityClassList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/workload.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/workload.go
@@ -41,6 +41,7 @@ type WorkloadInterface interface {
 	Create(ctx context.Context, workload *schedulingv1beta1.Workload, opts v1.CreateOptions) (*schedulingv1beta1.Workload, error)
 	Update(ctx context.Context, workload *schedulingv1beta1.Workload, opts v1.UpdateOptions) (*schedulingv1beta1.Workload, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*schedulingv1beta1.Workload, error)
 	List(ctx context.Context, opts v1.ListOptions) (*schedulingv1beta1.WorkloadList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csidriver.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csidriver.go
@@ -41,6 +41,7 @@ type CSIDriverInterface interface {
 	Create(ctx context.Context, cSIDriver *storagev1.CSIDriver, opts metav1.CreateOptions) (*storagev1.CSIDriver, error)
 	Update(ctx context.Context, cSIDriver *storagev1.CSIDriver, opts metav1.UpdateOptions) (*storagev1.CSIDriver, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*storagev1.CSIDriver, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*storagev1.CSIDriverList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csinode.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csinode.go
@@ -41,6 +41,7 @@ type CSINodeInterface interface {
 	Create(ctx context.Context, cSINode *storagev1.CSINode, opts metav1.CreateOptions) (*storagev1.CSINode, error)
 	Update(ctx context.Context, cSINode *storagev1.CSINode, opts metav1.UpdateOptions) (*storagev1.CSINode, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*storagev1.CSINode, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*storagev1.CSINodeList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csinode.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csinode.go
@@ -43,6 +43,7 @@ type CSINodeInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, cSINode *storagev1.CSINode, opts metav1.UpdateOptions) (*storagev1.CSINode, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*storagev1.CSINode, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*storagev1.CSINodeList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csistoragecapacity.go
@@ -41,6 +41,7 @@ type CSIStorageCapacityInterface interface {
 	Create(ctx context.Context, cSIStorageCapacity *storagev1.CSIStorageCapacity, opts metav1.CreateOptions) (*storagev1.CSIStorageCapacity, error)
 	Update(ctx context.Context, cSIStorageCapacity *storagev1.CSIStorageCapacity, opts metav1.UpdateOptions) (*storagev1.CSIStorageCapacity, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*storagev1.CSIStorageCapacity, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*storagev1.CSIStorageCapacityList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storageclass.go
@@ -41,6 +41,7 @@ type StorageClassInterface interface {
 	Create(ctx context.Context, storageClass *storagev1.StorageClass, opts metav1.CreateOptions) (*storagev1.StorageClass, error)
 	Update(ctx context.Context, storageClass *storagev1.StorageClass, opts metav1.UpdateOptions) (*storagev1.StorageClass, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*storagev1.StorageClass, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*storagev1.StorageClassList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/volumeattachment.go
@@ -43,6 +43,7 @@ type VolumeAttachmentInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, volumeAttachment *storagev1.VolumeAttachment, opts metav1.UpdateOptions) (*storagev1.VolumeAttachment, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*storagev1.VolumeAttachment, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*storagev1.VolumeAttachmentList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/volumeattributesclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/volumeattributesclass.go
@@ -41,6 +41,7 @@ type VolumeAttributesClassInterface interface {
 	Create(ctx context.Context, volumeAttributesClass *storagev1.VolumeAttributesClass, opts metav1.CreateOptions) (*storagev1.VolumeAttributesClass, error)
 	Update(ctx context.Context, volumeAttributesClass *storagev1.VolumeAttributesClass, opts metav1.UpdateOptions) (*storagev1.VolumeAttributesClass, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*storagev1.VolumeAttributesClass, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*storagev1.VolumeAttributesClassList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/csistoragecapacity.go
@@ -41,6 +41,7 @@ type CSIStorageCapacityInterface interface {
 	Create(ctx context.Context, cSIStorageCapacity *storagev1alpha1.CSIStorageCapacity, opts v1.CreateOptions) (*storagev1alpha1.CSIStorageCapacity, error)
 	Update(ctx context.Context, cSIStorageCapacity *storagev1alpha1.CSIStorageCapacity, opts v1.UpdateOptions) (*storagev1alpha1.CSIStorageCapacity, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*storagev1alpha1.CSIStorageCapacity, error)
 	List(ctx context.Context, opts v1.ListOptions) (*storagev1alpha1.CSIStorageCapacityList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattachment.go
@@ -43,6 +43,7 @@ type VolumeAttachmentInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, volumeAttachment *storagev1alpha1.VolumeAttachment, opts v1.UpdateOptions) (*storagev1alpha1.VolumeAttachment, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*storagev1alpha1.VolumeAttachment, error)
 	List(ctx context.Context, opts v1.ListOptions) (*storagev1alpha1.VolumeAttachmentList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattributesclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattributesclass.go
@@ -41,6 +41,7 @@ type VolumeAttributesClassInterface interface {
 	Create(ctx context.Context, volumeAttributesClass *storagev1alpha1.VolumeAttributesClass, opts v1.CreateOptions) (*storagev1alpha1.VolumeAttributesClass, error)
 	Update(ctx context.Context, volumeAttributesClass *storagev1alpha1.VolumeAttributesClass, opts v1.UpdateOptions) (*storagev1alpha1.VolumeAttributesClass, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*storagev1alpha1.VolumeAttributesClass, error)
 	List(ctx context.Context, opts v1.ListOptions) (*storagev1alpha1.VolumeAttributesClassList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csidriver.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csidriver.go
@@ -41,6 +41,7 @@ type CSIDriverInterface interface {
 	Create(ctx context.Context, cSIDriver *storagev1beta1.CSIDriver, opts v1.CreateOptions) (*storagev1beta1.CSIDriver, error)
 	Update(ctx context.Context, cSIDriver *storagev1beta1.CSIDriver, opts v1.UpdateOptions) (*storagev1beta1.CSIDriver, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*storagev1beta1.CSIDriver, error)
 	List(ctx context.Context, opts v1.ListOptions) (*storagev1beta1.CSIDriverList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csinode.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csinode.go
@@ -41,6 +41,7 @@ type CSINodeInterface interface {
 	Create(ctx context.Context, cSINode *storagev1beta1.CSINode, opts v1.CreateOptions) (*storagev1beta1.CSINode, error)
 	Update(ctx context.Context, cSINode *storagev1beta1.CSINode, opts v1.UpdateOptions) (*storagev1beta1.CSINode, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*storagev1beta1.CSINode, error)
 	List(ctx context.Context, opts v1.ListOptions) (*storagev1beta1.CSINodeList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csinode.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csinode.go
@@ -43,6 +43,7 @@ type CSINodeInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, cSINode *storagev1beta1.CSINode, opts v1.UpdateOptions) (*storagev1beta1.CSINode, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*storagev1beta1.CSINode, error)
 	List(ctx context.Context, opts v1.ListOptions) (*storagev1beta1.CSINodeList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csistoragecapacity.go
@@ -41,6 +41,7 @@ type CSIStorageCapacityInterface interface {
 	Create(ctx context.Context, cSIStorageCapacity *storagev1beta1.CSIStorageCapacity, opts v1.CreateOptions) (*storagev1beta1.CSIStorageCapacity, error)
 	Update(ctx context.Context, cSIStorageCapacity *storagev1beta1.CSIStorageCapacity, opts v1.UpdateOptions) (*storagev1beta1.CSIStorageCapacity, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*storagev1beta1.CSIStorageCapacity, error)
 	List(ctx context.Context, opts v1.ListOptions) (*storagev1beta1.CSIStorageCapacityList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
@@ -41,6 +41,7 @@ type StorageClassInterface interface {
 	Create(ctx context.Context, storageClass *storagev1beta1.StorageClass, opts v1.CreateOptions) (*storagev1beta1.StorageClass, error)
 	Update(ctx context.Context, storageClass *storagev1beta1.StorageClass, opts v1.UpdateOptions) (*storagev1beta1.StorageClass, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*storagev1beta1.StorageClass, error)
 	List(ctx context.Context, opts v1.ListOptions) (*storagev1beta1.StorageClassList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/volumeattachment.go
@@ -43,6 +43,7 @@ type VolumeAttachmentInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, volumeAttachment *storagev1beta1.VolumeAttachment, opts v1.UpdateOptions) (*storagev1beta1.VolumeAttachment, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*storagev1beta1.VolumeAttachment, error)
 	List(ctx context.Context, opts v1.ListOptions) (*storagev1beta1.VolumeAttachmentList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/volumeattributesclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/volumeattributesclass.go
@@ -41,6 +41,7 @@ type VolumeAttributesClassInterface interface {
 	Create(ctx context.Context, volumeAttributesClass *storagev1beta1.VolumeAttributesClass, opts v1.CreateOptions) (*storagev1beta1.VolumeAttributesClass, error)
 	Update(ctx context.Context, volumeAttributesClass *storagev1beta1.VolumeAttributesClass, opts v1.UpdateOptions) (*storagev1beta1.VolumeAttributesClass, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*storagev1beta1.VolumeAttributesClass, error)
 	List(ctx context.Context, opts v1.ListOptions) (*storagev1beta1.VolumeAttributesClassList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storagemigration/v1/storageversionmigration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storagemigration/v1/storageversionmigration.go
@@ -43,6 +43,7 @@ type StorageVersionMigrationInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, storageVersionMigration *storagemigrationv1.StorageVersionMigration, opts metav1.UpdateOptions) (*storagemigrationv1.StorageVersionMigration, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*storagemigrationv1.StorageVersionMigration, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*storagemigrationv1.StorageVersionMigrationList, error)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storagemigration/v1beta1/storageversionmigration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storagemigration/v1beta1/storageversionmigration.go
@@ -43,6 +43,7 @@ type StorageVersionMigrationInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, storageVersionMigration *storagemigrationv1beta1.StorageVersionMigration, opts v1.UpdateOptions) (*storagemigrationv1beta1.StorageVersionMigration, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*storagemigrationv1beta1.StorageVersionMigration, error)
 	List(ctx context.Context, opts v1.ListOptions) (*storagemigrationv1beta1.StorageVersionMigrationList, error)

--- a/staging/src/k8s.io/client-go/metadata/fake/simple.go
+++ b/staging/src/k8s.io/client-go/metadata/fake/simple.go
@@ -261,6 +261,45 @@ func (c *metadataResourceClient) Delete(ctx context.Context, name string, opts m
 	return err
 }
 
+// DeleteWithResult records the object deletion and processes it via the reactor, returning status or object.
+func (c *metadataResourceClient) DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions, subresources ...string) (metav1.APIResult, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootDeleteActionWithOptions(c.resource, name, opts), &metav1.Status{Status: "metadata delete fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootDeleteSubresourceActionWithOptions(c.resource, strings.Join(subresources, "/"), name, opts), &metav1.Status{Status: "metadata delete fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewDeleteActionWithOptions(c.resource, c.namespace, name, opts), &metav1.Status{Status: "metadata delete fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewDeleteSubresourceActionWithOptions(c.resource, strings.Join(subresources, "/"), c.namespace, name, opts), &metav1.Status{Status: "metadata delete fail"})
+	}
+
+	if err != nil {
+		fakeResult := testing.FakeAPIResult{Err: err}
+		if statusErr, ok := err.(interface{ Status() metav1.Status }); ok {
+			fakeResult.Code = int(statusErr.Status().Code)
+		}
+		return fakeResult, err
+	}
+	if uncastRet == nil {
+		return testing.FakeAPIResult{}, nil
+	}
+	fakeResult := testing.FakeAPIResult{Obj: uncastRet, Code: 200}
+	if status, ok := uncastRet.(*metav1.Status); ok {
+		fakeResult.Code = int(status.Code)
+	}
+	return fakeResult, nil
+}
+
 // DeleteCollection records the object collection deletion and processes it via the reactor.
 func (c *metadataResourceClient) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOptions metav1.ListOptions) error {
 	var err error

--- a/staging/src/k8s.io/client-go/metadata/interface.go
+++ b/staging/src/k8s.io/client-go/metadata/interface.go
@@ -35,6 +35,7 @@ type Interface interface {
 // Update is not supported by the server, but Patch can be used for the actions Update would handle.
 type ResourceInterface interface {
 	Delete(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error
+	DeleteWithResult(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, options metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*metav1.PartialObjectMetadata, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*metav1.PartialObjectMetadataList, error)

--- a/staging/src/k8s.io/client-go/metadata/metadata.go
+++ b/staging/src/k8s.io/client-go/metadata/metadata.go
@@ -65,7 +65,7 @@ func ConfigFor(inConfig *rest.Config) *rest.Config {
 	config := rest.CopyConfig(inConfig)
 	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
 	config.ContentType = "application/vnd.kubernetes.protobuf"
-	config.NegotiatedSerializer = metainternalversionscheme.Codecs.WithoutConversion()
+	config.NegotiatedSerializer = &metadataNegotiatedSerializer{metainternalversionscheme.Codecs.WithoutConversion()}
 	if config.UserAgent == "" {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}
@@ -157,6 +157,32 @@ func (c *client) Delete(ctx context.Context, name string, opts metav1.DeleteOpti
 		Body(deleteOptionsByte).
 		Do(ctx)
 	return result.Error()
+}
+
+// DeleteWithResult removes the provided resource from the server.
+func (c *client) DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions, subresources ...string) (metav1.APIResult, error) {
+	if len(name) == 0 {
+		return nil, fmt.Errorf("name is required")
+	}
+	// if DeleteOptions are delivered to Negotiator for serialization,
+	// HTTP-Request header will bring "Content-Type: application/vnd.kubernetes.protobuf"
+	// apiextensions-apiserver uses unstructuredNegotiatedSerializer to decode the input,
+	// server-side will reply with 406 errors.
+	// The special treatment here is to be compatible with CRD Handler
+	// see: https://github.com/kubernetes/kubernetes/blob/1a845ccd076bbf1b03420fe694c85a5cd3bd6bed/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go#L843
+	deleteOptionsByte, err := runtime.Encode(deleteOptionsCodec.LegacyCodec(schema.GroupVersion{Version: "v1"}), &opts)
+	if err != nil {
+		return nil, err
+	}
+
+	result := c.client.client.
+		Delete().
+		AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		SetHeader("Content-Type", runtime.ContentTypeJSON).
+		SetHeader("Accept", "application/vnd.kubernetes.protobuf;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json").
+		Body(deleteOptionsByte).
+		Do(ctx)
+	return rest.RestResultWrapper{Result: result}, result.Error()
 }
 
 // DeleteCollection triggers deletion of all resources in the specified scope (namespace or cluster).
@@ -328,4 +354,51 @@ func (c *client) makeURLSegments(name string) []string {
 
 func isLikelyObjectMetadata(meta *metav1.PartialObjectMetadata) bool {
 	return len(meta.UID) > 0 || !meta.CreationTimestamp.IsZero() || len(meta.Name) > 0 || len(meta.GenerateName) > 0
+}
+
+type metadataNegotiatedSerializer struct {
+	runtime.NegotiatedSerializer
+}
+
+func (s *metadataNegotiatedSerializer) DecoderToVersion(serializer runtime.Decoder, gv runtime.GroupVersioner) runtime.Decoder {
+	originalDecoder := s.NegotiatedSerializer.DecoderToVersion(serializer, gv)
+	return &metadataDecoder{delegate: originalDecoder}
+}
+
+type metadataDecoder struct {
+	delegate runtime.Decoder
+}
+
+func (d *metadataDecoder) Decode(data []byte, defaults *schema.GroupVersionKind, into runtime.Object) (runtime.Object, *schema.GroupVersionKind, error) {
+	obj, gvk, err := d.delegate.Decode(data, defaults, into)
+	if err == nil {
+		return obj, gvk, nil
+	}
+
+	if runtime.IsNotRegisteredError(err) {
+		// Check if the raw JSON payload is a List (contains a root-level "items" array)
+		var objMap map[string]interface{}
+		if jsonErr := json.Unmarshal(data, &objMap); jsonErr == nil {
+			if items, hasItems := objMap["items"]; hasItems {
+				if _, isSlice := items.([]interface{}); isSlice {
+					var partialList metav1.PartialObjectMetadataList
+					if jsonErr := json.Unmarshal(data, &partialList); jsonErr == nil {
+						partialList.TypeMeta = metav1.TypeMeta{}
+						return &partialList, &schema.GroupVersionKind{Group: "meta.k8s.io", Version: "v1", Kind: "PartialObjectMetadataList"}, nil
+					}
+				}
+			}
+		}
+
+		// Otherwise, decode as a single PartialObjectMetadata
+		var partial metav1.PartialObjectMetadata
+		if jsonErr := json.Unmarshal(data, &partial); jsonErr == nil {
+			if isLikelyObjectMetadata(&partial) {
+				partial.TypeMeta = metav1.TypeMeta{}
+				return &partial, &schema.GroupVersionKind{Group: "meta.k8s.io", Version: "v1", Kind: "PartialObjectMetadata"}, nil
+			}
+		}
+	}
+
+	return nil, nil, err
 }

--- a/staging/src/k8s.io/client-go/metadata/metadata.go
+++ b/staging/src/k8s.io/client-go/metadata/metadata.go
@@ -159,6 +159,32 @@ func (c *client) Delete(ctx context.Context, name string, opts metav1.DeleteOpti
 	return result.Error()
 }
 
+// DeleteWithResult removes the provided resource from the server.
+func (c *client) DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions, subresources ...string) (metav1.APIResult, error) {
+	if len(name) == 0 {
+		return nil, fmt.Errorf("name is required")
+	}
+	// if DeleteOptions are delivered to Negotiator for serialization,
+	// HTTP-Request header will bring "Content-Type: application/vnd.kubernetes.protobuf"
+	// apiextensions-apiserver uses unstructuredNegotiatedSerializer to decode the input,
+	// server-side will reply with 406 errors.
+	// The special treatment here is to be compatible with CRD Handler
+	// see: https://github.com/kubernetes/kubernetes/blob/1a845ccd076bbf1b03420fe694c85a5cd3bd6bed/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go#L843
+	deleteOptionsByte, err := runtime.Encode(deleteOptionsCodec.LegacyCodec(schema.GroupVersion{Version: "v1"}), &opts)
+	if err != nil {
+		return nil, err
+	}
+
+	result := c.client.client.
+		Delete().
+		AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		SetHeader("Content-Type", runtime.ContentTypeJSON).
+		SetHeader("Accept", "application/vnd.kubernetes.protobuf;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json").
+		Body(deleteOptionsByte).
+		Do(ctx)
+	return metadataResult{rest.APIResultAdapter{Result: result}}, result.Error()
+}
+
 // DeleteCollection triggers deletion of all resources in the specified scope (namespace or cluster).
 func (c *client) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOptions metav1.ListOptions) error {
 	// See comment on Delete
@@ -328,4 +354,28 @@ func (c *client) makeURLSegments(name string) []string {
 
 func isLikelyObjectMetadata(meta *metav1.PartialObjectMetadata) bool {
 	return len(meta.UID) > 0 || !meta.CreationTimestamp.IsZero() || len(meta.Name) > 0 || len(meta.GenerateName) > 0
+}
+
+type metadataResult struct {
+	rest.APIResultAdapter
+}
+
+func (r metadataResult) Get() (runtime.Object, error) {
+	obj, err := r.Result.Get()
+	if runtime.IsNotRegisteredError(err) {
+		rawBytes, err := r.Result.Raw()
+		if err != nil {
+			return nil, err
+		}
+		var partial metav1.PartialObjectMetadata
+		if err := json.Unmarshal(rawBytes, &partial); err != nil {
+			return nil, fmt.Errorf("unable to decode returned object as PartialObjectMetadata: %w", err)
+		}
+		if !isLikelyObjectMetadata(&partial) {
+			return nil, fmt.Errorf("object does not appear to match the ObjectMeta schema: %#v", partial)
+		}
+		partial.TypeMeta = metav1.TypeMeta{}
+		return &partial, nil
+	}
+	return obj, err
 }

--- a/staging/src/k8s.io/client-go/metadata/metadata_test.go
+++ b/staging/src/k8s.io/client-go/metadata/metadata_test.go
@@ -301,6 +301,82 @@ func TestClient(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "DeleteWithResult is able to convert a JSON object to PartialObjectMetadata",
+			handler: func(t *testing.T, w http.ResponseWriter, req *http.Request) {
+				if req.Header.Get("Accept") != "application/vnd.kubernetes.protobuf;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json" {
+					t.Fatal(req.Header.Get("Accept"))
+				}
+				if req.Method != http.MethodDelete && req.URL.String() != "/apis/group/v1/namespaces/ns/resource/name" {
+					t.Fatal(req.URL.String())
+				}
+				writeJSON(t, w, &corev1.Pod{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Pod",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "name",
+						Namespace: "ns",
+					},
+				})
+			},
+			want: func(ctx context.Context, t *testing.T, client *Client) {
+				res, err := client.Resource(gvr).Namespace("ns").DeleteWithResult(ctx, "name", metav1.DeleteOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				obj, err := res.Get()
+				if err != nil {
+					t.Fatal(err)
+				}
+				expect := &metav1.PartialObjectMetadata{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "name",
+						Namespace: "ns",
+					},
+				}
+				if !reflect.DeepEqual(expect, obj) {
+					t.Fatal(cmp.Diff(expect, obj))
+				}
+			},
+		},
+		{
+			name: "DeleteWithResult is able to decode status successfully",
+			handler: func(t *testing.T, w http.ResponseWriter, req *http.Request) {
+				if req.Header.Get("Accept") != "application/vnd.kubernetes.protobuf;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json" {
+					t.Fatal(req.Header.Get("Accept"))
+				}
+				if req.Method != http.MethodDelete && req.URL.String() != "/apis/group/v1/namespaces/ns/resource/name" {
+					t.Fatal(req.URL.String())
+				}
+				writeJSON(t, w, &metav1.Status{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Status",
+						APIVersion: "v1",
+					},
+					Status: metav1.StatusSuccess,
+					Code:   http.StatusOK,
+				})
+			},
+			want: func(ctx context.Context, t *testing.T, client *Client) {
+				res, err := client.Resource(gvr).Namespace("ns").DeleteWithResult(ctx, "name", metav1.DeleteOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				obj, err := res.Get()
+				if err != nil {
+					t.Fatal(err)
+				}
+				expect := &metav1.Status{
+					Status: metav1.StatusSuccess,
+					Code:   http.StatusOK,
+				}
+				if !reflect.DeepEqual(expect, obj) {
+					t.Fatal(cmp.Diff(expect, obj))
+				}
+			},
+		},
 	}
 
 	for _, tt := range testCases {

--- a/staging/src/k8s.io/client-go/rest/api_result.go
+++ b/staging/src/k8s.io/client-go/rest/api_result.go
@@ -1,0 +1,34 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// RestResultWrapper wraps a rest.Result to implement metav1.APIResult.
+type RestResultWrapper struct {
+	Result
+}
+
+var _ metav1.APIResult = RestResultWrapper{}
+
+// StatusCode overrides Result.StatusCode to return metav1.APIResult.
+func (w RestResultWrapper) StatusCode(statusCode *int) metav1.APIResult {
+	w.Result.StatusCode(statusCode)
+	return w
+}

--- a/staging/src/k8s.io/client-go/rest/api_result.go
+++ b/staging/src/k8s.io/client-go/rest/api_result.go
@@ -42,4 +42,3 @@ func (a APIResultAdapter) StatusCode() (int, error) {
 func (a APIResultAdapter) Error() error {
 	return a.Result.Error()
 }
-

--- a/staging/src/k8s.io/client-go/rest/api_result.go
+++ b/staging/src/k8s.io/client-go/rest/api_result.go
@@ -1,0 +1,45 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// APIResultAdapter lets a rest.Result implement the metav1.APIResult interface.
+type APIResultAdapter struct {
+	Result Result
+}
+
+var _ metav1.APIResult = APIResultAdapter{}
+
+// Get implements metav1.APIResult.
+func (a APIResultAdapter) Get() (runtime.Object, error) {
+	return a.Result.Get()
+}
+
+// StatusCode returns the HTTP status code of the response and any error from the underlying Result.
+func (a APIResultAdapter) StatusCode() (int, error) {
+	return a.Result.statusCode, a.Result.Error()
+}
+
+// Error implements metav1.APIResult.
+func (a APIResultAdapter) Error() error {
+	return a.Result.Error()
+}
+

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -1561,3 +1561,21 @@ func ValidatePathSegmentName(name string, prefix bool) []string {
 	}
 	return IsValidPathSegmentName(name)
 }
+
+type staticDecoder struct {
+	obj runtime.Object
+}
+
+func (d staticDecoder) Decode(data []byte, defaults *schema.GroupVersionKind, into runtime.Object) (runtime.Object, *schema.GroupVersionKind, error) {
+	return d.obj, nil, nil
+}
+
+// NewResultWithObject returns a Result that contains the decoded object.
+func NewResultWithObject(obj runtime.Object, err error, statusCode int) Result {
+	return Result{
+		err:        err,
+		statusCode: statusCode,
+		body:       []byte("static"),
+		decoder:    staticDecoder{obj},
+	}
+}

--- a/staging/src/k8s.io/client-go/testing/fake_api_result.go
+++ b/staging/src/k8s.io/client-go/testing/fake_api_result.go
@@ -1,0 +1,49 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// FakeAPIResult implements metav1.APIResult for testing.
+type FakeAPIResult struct {
+	Obj  runtime.Object
+	Err  error
+	Code int
+}
+
+var _ metav1.APIResult = FakeAPIResult{}
+
+// Get returns the object and error.
+func (f FakeAPIResult) Get() (runtime.Object, error) {
+	return f.Obj, f.Err
+}
+
+// StatusCode populates the status code and returns itself.
+func (f FakeAPIResult) StatusCode(statusCode *int) metav1.APIResult {
+	if statusCode != nil {
+		*statusCode = f.Code
+	}
+	return f
+}
+
+// Error returns the error.
+func (f FakeAPIResult) Error() error {
+	return f.Err
+}

--- a/staging/src/k8s.io/client-go/testing/fake_api_result.go
+++ b/staging/src/k8s.io/client-go/testing/fake_api_result.go
@@ -1,0 +1,49 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// FakeAPIResult implements metav1.APIResult for testing.
+type FakeAPIResult struct {
+	Obj  runtime.Object
+	Err  error
+	Code int
+}
+
+var _ metav1.APIResult = FakeAPIResult{}
+
+// Get implements metav1.APIResult.
+func (f FakeAPIResult) Get() (runtime.Object, error) {
+	if f.Err != nil {
+		return nil, f.Err
+	}
+	return f.Obj, nil
+}
+
+// StatusCode returns the configured HTTP status code and error.
+func (f FakeAPIResult) StatusCode() (int, error) {
+	return f.Code, f.Err
+}
+
+// Error implements metav1.APIResult.
+func (f FakeAPIResult) Error() error {
+	return f.Err
+}

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_type.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_type.go
@@ -163,6 +163,8 @@ func (g *genClientForType) GenerateType(c *generator.Context, t *types.Type, w i
 		"GroupGoName":               g.groupGoName,
 		"prefersProtobuf":           g.prefersProtobuf,
 		"Version":                   namer.IC(g.version),
+		"runtimeObject":             c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/runtime", Name: "Object"}),
+		"APIResult":                 c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "APIResult"}),
 		"CreateOptions":             c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "CreateOptions"}),
 		"DeleteOptions":             c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "DeleteOptions"}),
 		"GetOptions":                c.Universe.Type(types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "GetOptions"}),
@@ -370,6 +372,7 @@ func buildDefaultVerbTemplates(generateApply bool) map[string]string {
 		"updateStatus": `// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 UpdateStatus(ctx $.context|raw$, $.inputType|private$ *$.type|raw$, opts $.UpdateOptions|raw$) (*$.type|raw$, error)`,
 		"delete":           `Delete(ctx $.context|raw$, name string, opts $.DeleteOptions|raw$) error`,
+		"deleteWithResult": `DeleteWithResult(ctx $.context|raw$, name string, opts $.DeleteOptions|raw$) ($.APIResult|raw$, error)`,
 		"deleteCollection": `DeleteCollection(ctx $.context|raw$, opts $.DeleteOptions|raw$, listOpts $.ListOptions|raw$) error`,
 		"get":              `Get(ctx $.context|raw$, name string, opts $.GetOptions|raw$) (*$.resultType|raw$, error)`,
 		"list":             `List(ctx $.context|raw$, opts $.ListOptions|raw$) (*$.resultType|raw$List, error)`,

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/util/tags.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/util/tags.go
@@ -41,6 +41,7 @@ var SupportedVerbs = []string{
 	"update",
 	"updateStatus",
 	"delete",
+	"deleteWithResult",
 	"deleteCollection",
 	"get",
 	"list",
@@ -64,6 +65,7 @@ const genClientPrefix = "genclient:"
 // extension client functions for.
 var unsupportedExtensionVerbs = []string{
 	"updateStatus",
+	"deleteWithResult",
 	"deleteCollection",
 	"watch",
 	"delete",

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/util/tags_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/util/tags_test.go
@@ -57,11 +57,11 @@ func TestParseTags(t *testing.T) {
 		},
 		"genclient:onlyVerbs": {
 			lines:      []string{`+genclient`, `+genclient:onlyVerbs=create,delete`},
-			expectTags: Tags{GenerateClient: true, SkipVerbs: []string{"update", "updateStatus", "deleteCollection", "get", "list", "watch", "patch", "apply", "applyStatus"}},
+			expectTags: Tags{GenerateClient: true, SkipVerbs: []string{"update", "updateStatus", "deleteWithResult", "deleteCollection", "get", "list", "watch", "patch", "apply", "applyStatus"}},
 		},
 		"genclient:readonly": {
 			lines:      []string{`+genclient`, `+genclient:readonly`},
-			expectTags: Tags{GenerateClient: true, SkipVerbs: []string{"create", "update", "updateStatus", "delete", "deleteCollection", "patch", "apply", "applyStatus"}},
+			expectTags: Tags{GenerateClient: true, SkipVerbs: []string{"create", "update", "updateStatus", "delete", "deleteWithResult", "deleteCollection", "patch", "apply", "applyStatus"}},
 		},
 		"genclient:conflict": {
 			lines:       []string{`+genclient`, `+genclient:onlyVerbs=create`, `+genclient:skipVerbs=create`},

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -44,6 +44,7 @@ type ClusterTestTypeInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, clusterTestType *examplev1.ClusterTestType, opts metav1.UpdateOptions) (*examplev1.ClusterTestType, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*examplev1.ClusterTestType, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*examplev1.ClusterTestTypeList, error)

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/clientset/versioned/typed/example/v1/testtype.go
@@ -43,6 +43,7 @@ type TestTypeInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, testType *examplev1.TestType, opts metav1.UpdateOptions) (*examplev1.TestType, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*examplev1.TestType, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*examplev1.TestTypeList, error)

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -44,6 +44,7 @@ type ClusterTestTypeInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, clusterTestType *examplev1.ClusterTestType, opts metav1.UpdateOptions) (*examplev1.ClusterTestType, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*examplev1.ClusterTestType, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*examplev1.ClusterTestTypeList, error)

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/clientset/versioned/typed/example/v1/testtype.go
@@ -43,6 +43,7 @@ type TestTypeInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, testType *examplev1.TestType, opts metav1.UpdateOptions) (*examplev1.TestType, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*examplev1.TestType, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*examplev1.TestTypeList, error)

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/core/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/core/v1/testtype.go
@@ -42,6 +42,7 @@ type TestTypeInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, testType *corev1.TestType, opts metav1.UpdateOptions) (*corev1.TestType, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.TestType, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*corev1.TestTypeList, error)

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example/v1/testtype.go
@@ -42,6 +42,7 @@ type TestTypeInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, testType *examplev1.TestType, opts metav1.UpdateOptions) (*examplev1.TestType, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*examplev1.TestType, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*examplev1.TestTypeList, error)

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example2/v1/testtype.go
@@ -42,6 +42,7 @@ type TestTypeInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, testType *example2v1.TestType, opts metav1.UpdateOptions) (*example2v1.TestType, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*example2v1.TestType, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*example2v1.TestTypeList, error)

--- a/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example3.io/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/clientset/versioned/typed/example3.io/v1/testtype.go
@@ -42,6 +42,7 @@ type TestTypeInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, testType *example3iov1.TestType, opts metav1.UpdateOptions) (*example3iov1.TestType, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*example3iov1.TestType, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*example3iov1.TestTypeList, error)

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/conflicting/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/conflicting/v1/testtype.go
@@ -43,6 +43,7 @@ type TestTypeInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, testType *conflictingv1.TestType, opts metav1.UpdateOptions) (*conflictingv1.TestType, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*conflictingv1.TestType, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*conflictingv1.TestTypeList, error)

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -44,6 +44,7 @@ type ClusterTestTypeInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, clusterTestType *examplev1.ClusterTestType, opts metav1.UpdateOptions) (*examplev1.ClusterTestType, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*examplev1.ClusterTestType, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*examplev1.ClusterTestTypeList, error)

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example/v1/testtype.go
@@ -43,6 +43,7 @@ type TestTypeInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, testType *examplev1.TestType, opts metav1.UpdateOptions) (*examplev1.TestType, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*examplev1.TestType, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*examplev1.TestTypeList, error)

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/example2/v1/testtype.go
@@ -43,6 +43,7 @@ type TestTypeInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, testType *example2v1.TestType, opts metav1.UpdateOptions) (*example2v1.TestType, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*example2v1.TestType, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*example2v1.TestTypeList, error)

--- a/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/extensions/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/clientset/versioned/typed/extensions/v1/testtype.go
@@ -46,6 +46,7 @@ type TestTypeInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, testType *extensionsv1.TestType, opts metav1.UpdateOptions) (*extensionsv1.TestType, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*extensionsv1.TestType, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*extensionsv1.TestTypeList, error)

--- a/staging/src/k8s.io/code-generator/examples/single/clientset/versioned/typed/api/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/examples/single/clientset/versioned/typed/api/v1/clustertesttype.go
@@ -44,6 +44,7 @@ type ClusterTestTypeInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, clusterTestType *apiv1.ClusterTestType, opts metav1.UpdateOptions) (*apiv1.ClusterTestType, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*apiv1.ClusterTestType, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*apiv1.ClusterTestTypeList, error)

--- a/staging/src/k8s.io/code-generator/examples/single/clientset/versioned/typed/api/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/examples/single/clientset/versioned/typed/api/v1/testtype.go
@@ -43,6 +43,7 @@ type TestTypeInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, testType *apiv1.TestType, opts metav1.UpdateOptions) (*apiv1.TestType, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*apiv1.TestType, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*apiv1.TestTypeList, error)

--- a/staging/src/k8s.io/dynamic-resource-allocation/client/generic.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/client/generic.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -67,6 +68,7 @@ type funcs[T, TL, TAC any] interface {
 	Create(context.Context, *T, metav1.CreateOptions) (*T, error)
 	Update(context.Context, *T, metav1.UpdateOptions) (*T, error)
 	Delete(context.Context, string, metav1.DeleteOptions) error
+	DeleteWithResult(context.Context, string, metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(context.Context, metav1.DeleteOptions, metav1.ListOptions) error
 	Get(context.Context, string, metav1.GetOptions) (*T, error)
 	List(context.Context, metav1.ListOptions) (*TL, error)
@@ -147,6 +149,24 @@ func (t *convertingClient[NP, N, NL, NAC, OP, O, OL, OAC, O2P, O2, O2L, O2AC]) D
 	})
 	_, err := apis.run()
 	return err
+}
+
+func (t *convertingClient[NP, N, NL, NAC, OP, O, OL, OAC, O2P, O2, O2L, O2AC]) DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error) {
+	apis := newCall(t.c, func(currentAPI int32) (metav1.APIResult, error) {
+		switch currentAPI {
+		case useV1beta1API:
+			return deleteWithConversion[N, O, NP, OP](func() (metav1.APIResult, error) {
+				return t.v1beta1.DeleteWithResult(ctx, name, opts)
+			})
+		case useV1beta2API:
+			return deleteWithConversion[N, O2, NP, O2P](func() (metav1.APIResult, error) {
+				return t.v1beta2.DeleteWithResult(ctx, name, opts)
+			})
+		default:
+			return t.native.DeleteWithResult(ctx, name, opts)
+		}
+	})
+	return apis.run()
 }
 
 func (t *convertingClient[NP, N, NL, NAC, OP, O, OL, OAC, O2P, O2, O2L, O2AC]) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
@@ -293,6 +313,48 @@ func getWithConversion[N, O any](call func() (*O, error)) (*N, error) {
 		return nil, err
 	}
 	return value, nil
+}
+
+func deleteWithConversion[N, O any, NP objectPtr[N], OP objectPtr[O]](call func() (metav1.APIResult, error)) (metav1.APIResult, error) {
+	res, err := call()
+	if err != nil {
+		return res, err
+	}
+	if res == nil {
+		return nil, nil
+	}
+	obj, err := res.Get()
+	if err != nil {
+		return res, err
+	}
+	if _, ok := obj.(*metav1.Status); ok {
+		return res, nil
+	}
+	typedIn, ok := obj.(OP)
+	if !ok {
+		return nil, fmt.Errorf("unexpected return type %T, expected %T", obj, typedIn)
+	}
+	value := NP(new(N))
+	if err := scheme.Convert(typedIn, value, nil); err != nil {
+		return nil, err
+	}
+	return convertingAPIResult{
+		APIResult:    res,
+		convertedObj: value,
+	}, nil
+}
+
+type convertingAPIResult struct {
+	metav1.APIResult
+	convertedObj runtime.Object
+}
+
+func (c convertingAPIResult) Get() (runtime.Object, error) {
+	return c.convertedObj, nil
+}
+
+func (c convertingAPIResult) Into(obj runtime.Object) error {
+	return scheme.Convert(c.convertedObj, obj, nil)
 }
 
 func watchWithConversion[NP objectPtr[N], N any, OP runtime.Object](call func() (watch.Interface, error)) (watch.Interface, error) {

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiservice.go
@@ -43,6 +43,7 @@ type APIServiceInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, aPIService *apiregistrationv1.APIService, opts metav1.UpdateOptions) (*apiregistrationv1.APIService, error)
 	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts metav1.DeleteOptions) (metav1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*apiregistrationv1.APIService, error)
 	List(ctx context.Context, opts metav1.ListOptions) (*apiregistrationv1.APIServiceList, error)

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiservice.go
@@ -43,6 +43,7 @@ type APIServiceInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, aPIService *apiregistrationv1beta1.APIService, opts v1.UpdateOptions) (*apiregistrationv1beta1.APIService, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*apiregistrationv1beta1.APIService, error)
 	List(ctx context.Context, opts v1.ListOptions) (*apiregistrationv1beta1.APIServiceList, error)

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fischer.go
@@ -41,6 +41,7 @@ type FischerInterface interface {
 	Create(ctx context.Context, fischer *wardlev1alpha1.Fischer, opts v1.CreateOptions) (*wardlev1alpha1.Fischer, error)
 	Update(ctx context.Context, fischer *wardlev1alpha1.Fischer, opts v1.UpdateOptions) (*wardlev1alpha1.Fischer, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*wardlev1alpha1.Fischer, error)
 	List(ctx context.Context, opts v1.ListOptions) (*wardlev1alpha1.FischerList, error)

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/flunder.go
@@ -43,6 +43,7 @@ type FlunderInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, flunder *wardlev1alpha1.Flunder, opts v1.UpdateOptions) (*wardlev1alpha1.Flunder, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*wardlev1alpha1.Flunder, error)
 	List(ctx context.Context, opts v1.ListOptions) (*wardlev1alpha1.FlunderList, error)

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/flunder.go
@@ -43,6 +43,7 @@ type FlunderInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, flunder *wardlev1beta1.Flunder, opts v1.UpdateOptions) (*wardlev1beta1.Flunder, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*wardlev1beta1.Flunder, error)
 	List(ctx context.Context, opts v1.ListOptions) (*wardlev1beta1.FlunderList, error)

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/foo.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/foo.go
@@ -43,6 +43,7 @@ type FooInterface interface {
 	// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 	UpdateStatus(ctx context.Context, foo *samplecontrollerv1alpha1.Foo, opts v1.UpdateOptions) (*samplecontrollerv1alpha1.Foo, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
+	DeleteWithResult(ctx context.Context, name string, opts v1.DeleteOptions) (v1.APIResult, error)
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*samplecontrollerv1alpha1.Foo, error)
 	List(ctx context.Context, opts v1.ListOptions) (*samplecontrollerv1alpha1.FooList, error)

--- a/test/integration/apiserver/delete_with_result_test.go
+++ b/test/integration/apiserver/delete_with_result_test.go
@@ -1,0 +1,493 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/metadata"
+	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/utils/ptr"
+)
+
+func TestDeleteResult(t *testing.T) {
+	ctx, clientSet, kubeConfig, tearDownFn := setup(t)
+	defer tearDownFn()
+
+	dynamicClient, err := dynamic.NewForConfig(kubeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	metadataClient, err := metadata.NewForConfig(kubeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ns := framework.CreateNamespaceOrDie(clientSet, "delete-status", t)
+	defer framework.DeleteNamespaceOrDie(clientSet, ns, t)
+
+	sa := &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: ns.Name}}
+	if _, err := clientSet.CoreV1().ServiceAccounts(ns.Name).Create(ctx, sa, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create default service account: %v", err)
+	}
+
+	podGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	cmGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+
+	// 1. Test ReturnDeletedObject = true with Pods
+	t.Run("ReturnDeletedObject=true", func(t *testing.T) {
+		// a. Typed Client
+		{
+			pod1 := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: ns.Name},
+				Spec:       v1.PodSpec{Containers: []v1.Container{{Name: "c", Image: "nginx"}}},
+			}
+			if _, err := clientSet.CoreV1().Pods(ns.Name).Create(ctx, pod1, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("failed to create pod: %v", err)
+			}
+			res, err := clientSet.CoreV1().Pods(ns.Name).DeleteWithResult(ctx, "pod1", metav1.DeleteOptions{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			var statusCode int
+			res.StatusCode(&statusCode)
+			if statusCode != 200 && statusCode != 202 {
+				t.Errorf("expected status code 200 or 202, got %d", statusCode)
+			}
+			obj, err := res.Get()
+			if err != nil {
+				t.Fatalf("unexpected error on Get(): %v", err)
+			}
+			podObj, ok := obj.(*v1.Pod)
+			if !ok {
+				t.Fatalf("expected *v1.Pod, got %T", obj)
+			}
+			if podObj.ResourceVersion == "" {
+				t.Fatalf("expected ResourceVersion to be populated, got empty string")
+			}
+		}
+
+		// b. Dynamic Client
+		{
+			pod2 := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: ns.Name},
+				Spec:       v1.PodSpec{Containers: []v1.Container{{Name: "c", Image: "nginx"}}},
+			}
+			if _, err := clientSet.CoreV1().Pods(ns.Name).Create(ctx, pod2, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("failed to create pod: %v", err)
+			}
+			res, err := dynamicClient.Resource(podGVR).Namespace(ns.Name).DeleteWithResult(ctx, "pod2", metav1.DeleteOptions{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			var statusCode int
+			res.StatusCode(&statusCode)
+			if statusCode != 200 && statusCode != 202 {
+				t.Errorf("expected status code 200 or 202, got %d", statusCode)
+			}
+			obj, err := res.Get()
+			if err != nil {
+				t.Fatalf("unexpected error on Get(): %v", err)
+			}
+			unstObj, ok := obj.(*unstructured.Unstructured)
+			if !ok {
+				t.Fatalf("expected *unstructured.Unstructured, got %T", obj)
+			}
+			if unstObj.GetResourceVersion() == "" {
+				t.Fatalf("expected ResourceVersion to be populated, got empty string")
+			}
+		}
+
+		// c. Metadata Client
+		{
+			pod3 := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod3", Namespace: ns.Name},
+				Spec:       v1.PodSpec{Containers: []v1.Container{{Name: "c", Image: "nginx"}}},
+			}
+			if _, err := clientSet.CoreV1().Pods(ns.Name).Create(ctx, pod3, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("failed to create pod: %v", err)
+			}
+			res, err := metadataClient.Resource(podGVR).Namespace(ns.Name).DeleteWithResult(ctx, "pod3", metav1.DeleteOptions{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			var statusCode int
+			res.StatusCode(&statusCode)
+			if statusCode != 200 && statusCode != 202 {
+				t.Errorf("expected status code 200 or 202, got %d", statusCode)
+			}
+			obj, err := res.Get()
+			if err != nil {
+				t.Fatalf("unexpected error on Get(): %v", err)
+			}
+			metaObj, ok := obj.(*metav1.PartialObjectMetadata)
+			if !ok {
+				t.Fatalf("expected *metav1.PartialObjectMetadata, got %T", obj)
+			}
+			if metaObj.ResourceVersion == "" {
+				t.Fatalf("expected ResourceVersion to be populated, got empty string")
+			}
+		}
+	})
+
+	// 2. Test ReturnDeletedObject = false with ConfigMaps
+	t.Run("ReturnDeletedObject=false", func(t *testing.T) {
+		// a. Typed Client
+		{
+			cm1 := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "cm1", Namespace: ns.Name},
+				Data:       map[string]string{"foo": "bar"},
+			}
+			if _, err := clientSet.CoreV1().ConfigMaps(ns.Name).Create(ctx, cm1, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("failed to create cm: %v", err)
+			}
+			res, err := clientSet.CoreV1().ConfigMaps(ns.Name).DeleteWithResult(ctx, "cm1", metav1.DeleteOptions{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			var statusCode int
+			res.StatusCode(&statusCode)
+			if statusCode != 200 {
+				t.Errorf("expected status code 200, got %d", statusCode)
+			}
+			obj, err := res.Get()
+			if err != nil {
+				t.Fatalf("unexpected error on Get(): %v", err)
+			}
+			statusObj, ok := obj.(*metav1.Status)
+			if !ok {
+				t.Fatalf("expected *metav1.Status, got %T", obj)
+			}
+			if statusObj.ResourceVersion == "" {
+				t.Fatalf("expected ResourceVersion to be populated, got empty string")
+			}
+		}
+
+		// b. Dynamic Client
+		{
+			cm2 := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "cm2", Namespace: ns.Name},
+				Data:       map[string]string{"foo": "bar"},
+			}
+			if _, err := clientSet.CoreV1().ConfigMaps(ns.Name).Create(ctx, cm2, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("failed to create cm: %v", err)
+			}
+			res, err := dynamicClient.Resource(cmGVR).Namespace(ns.Name).DeleteWithResult(ctx, "cm2", metav1.DeleteOptions{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			var statusCode int
+			res.StatusCode(&statusCode)
+			if statusCode != 200 {
+				t.Errorf("expected status code 200, got %d", statusCode)
+			}
+			obj, err := res.Get()
+			if err != nil {
+				t.Fatalf("unexpected error on Get(): %v", err)
+			}
+			statusObj2, ok := obj.(*metav1.Status)
+			if !ok {
+				t.Fatalf("expected *metav1.Status, got %T", obj)
+			}
+			if statusObj2.ResourceVersion == "" {
+				t.Fatalf("expected ResourceVersion to be populated, got empty string")
+			}
+		}
+
+		// c. Metadata Client
+		{
+			cm3 := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "cm3", Namespace: ns.Name},
+				Data:       map[string]string{"foo": "bar"},
+			}
+			if _, err := clientSet.CoreV1().ConfigMaps(ns.Name).Create(ctx, cm3, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("failed to create cm: %v", err)
+			}
+			res, err := metadataClient.Resource(cmGVR).Namespace(ns.Name).DeleteWithResult(ctx, "cm3", metav1.DeleteOptions{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			var statusCode int
+			res.StatusCode(&statusCode)
+			if statusCode != 200 {
+				t.Errorf("expected status code 200, got %d", statusCode)
+			}
+			obj, err := res.Get()
+			if err != nil {
+				t.Fatalf("unexpected error on Get(): %v", err)
+			}
+			statusObj3, ok := obj.(*metav1.Status)
+			if !ok {
+				t.Fatalf("expected *metav1.Status, got %T", obj)
+			}
+			if statusObj3.ResourceVersion == "" {
+				t.Fatalf("expected ResourceVersion to be populated, got empty string")
+			}
+		}
+	})
+
+	// 3. Test Error Case (Get HTTP code from error and result)
+	t.Run("ErrorCase", func(t *testing.T) {
+		res, err := clientSet.CoreV1().Pods(ns.Name).DeleteWithResult(ctx, "non-existent-pod", metav1.DeleteOptions{})
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if res != nil {
+			var statusCode int
+			res.StatusCode(&statusCode)
+			if statusCode != 404 {
+				t.Errorf("expected status code 404 from result, got %d", statusCode)
+			}
+		}
+		var statusErr *apierrors.StatusError
+		if !errors.As(err, &statusErr) {
+			t.Fatalf("expected *apierrors.StatusError, got %T (%v)", err, err)
+		}
+		if statusErr.ErrStatus.Code != 404 {
+			t.Errorf("expected HTTP status 404, got %d", statusErr.ErrStatus.Code)
+		}
+		if statusErr.Status().Code != 404 {
+			t.Errorf("expected APIStatus code 404, got %d", statusErr.Status().Code)
+		}
+	})
+}
+
+func TestDeletionResponseMatrix(t *testing.T) {
+	ctx, clientSet, _, tearDownFn := setup(t)
+	defer tearDownFn()
+
+	ns := framework.CreateNamespaceOrDie(clientSet, "matrix-test", t)
+	defer framework.DeleteNamespaceOrDie(clientSet, ns, t)
+
+	// Explicitly create the default service account in the namespace before creating Pods
+	sa := &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: ns.Name}}
+	if _, err := clientSet.CoreV1().ServiceAccounts(ns.Name).Create(ctx, sa, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create default service account: %v", err)
+	}
+
+	testCases := []struct {
+		name         string
+		resource     string // "pods", "serviceaccounts", "configmaps"
+		initialDT    bool
+		initialFin   bool
+		deleteType   string // "Normal", "Orphan", "Foreground", "Shorten Future", "Shorten Past"
+		expectedType string
+		expectedCode int
+		expectRVInc  bool // true if we expect RV to increment, false if we expect it to stay equal
+	}{
+		// 1. Pods (Graceful Deletion)
+		{"Pod_No_dT_No_Fin_Normal_Normal", "pods", false, false, "Normal", "*v1.Pod", 200, true},
+		{"Pod_No_dT_No_Fin_Orphan_Normal", "pods", false, false, "Orphan", "*v1.Pod", 200, true},
+		{"Pod_No_dT_No_Fin_Foreground_Normal", "pods", false, false, "Foreground", "*v1.Pod", 200, true},
+		{"Pod_No_dT_No_Fin_Shorten_Future_Normal", "pods", false, false, "Shorten Future", "*v1.Pod", 200, true},
+		{"Pod_No_dT_No_Fin_Shorten_Past_Normal", "pods", false, false, "Shorten Past", "*v1.Pod", 200, true},
+		{"Pod_dT_set_No_Fin_Normal_Normal", "pods", true, false, "Normal", "*v1.Pod", 200, false},
+		{"Pod_dT_set_No_Fin_Shorten_Future_Normal", "pods", true, false, "Shorten Future", "*v1.Pod", 200, true},
+		{"Pod_dT_set_No_Fin_Shorten_Past_Normal", "pods", true, false, "Shorten Past", "*v1.Pod", 200, true},
+		{"Pod_dT_set_Active_Fin_Normal_Normal", "pods", true, true, "Normal", "*v1.Pod", 200, false},
+		{"Pod_dT_set_Active_Fin_Orphan_Normal", "pods", true, true, "Orphan", "*v1.Pod", 200, false},
+		{"Pod_dT_set_Active_Fin_Foreground_Normal", "pods", true, true, "Foreground", "*v1.Pod", 200, false},
+		{"Pod_dT_set_Active_Fin_Shorten_Future_Normal", "pods", true, true, "Shorten Future", "*v1.Pod", 200, true},
+		{"Pod_dT_set_Active_Fin_Shorten_Past_Normal", "pods", true, true, "Shorten Past", "*v1.Pod", 200, true},
+
+		// 2. ServiceAccount (ReturnDeletedObject=true)
+		{"SA_No_dT_No_Fin_Normal_Normal", "serviceaccounts", false, false, "Normal", "*v1.ServiceAccount", 200, true},
+		{"SA_No_dT_No_Fin_Orphan_Normal", "serviceaccounts", false, false, "Orphan", "*v1.ServiceAccount", 200, true},
+		{"SA_No_dT_No_Fin_Foreground_Normal", "serviceaccounts", false, false, "Foreground", "*v1.ServiceAccount", 200, true},
+		{"SA_dT_set_Active_Fin_Normal_Normal", "serviceaccounts", true, true, "Normal", "*v1.ServiceAccount", 200, false},
+		{"SA_dT_set_Active_Fin_Orphan_Normal", "serviceaccounts", true, true, "Orphan", "*v1.ServiceAccount", 200, true},
+		{"SA_dT_set_Active_Fin_Foreground_Normal", "serviceaccounts", true, true, "Foreground", "*v1.ServiceAccount", 200, true},
+
+		// 3. ConfigMap (ReturnDeletedObject=false)
+		{"CM_No_dT_No_Fin_Normal_Normal", "configmaps", false, false, "Normal", "*metav1.Status", 200, true},
+		{"CM_No_dT_No_Fin_Orphan_Normal", "configmaps", false, false, "Orphan", "*v1.ConfigMap", 200, true},
+		{"CM_No_dT_No_Fin_Foreground_Normal", "configmaps", false, false, "Foreground", "*v1.ConfigMap", 200, true},
+		{"CM_dT_set_Active_Fin_Normal_Normal", "configmaps", true, true, "Normal", "*v1.ConfigMap", 200, false},
+		{"CM_dT_set_Active_Fin_Orphan_Normal", "configmaps", true, true, "Orphan", "*v1.ConfigMap", 200, true},
+		{"CM_dT_set_Active_Fin_Foreground_Normal", "configmaps", true, true, "Foreground", "*v1.ConfigMap", 200, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			objName := strings.ToLower(strings.ReplaceAll("obj-"+tc.name, "_", "-"))
+			var finalizers []string
+			if tc.initialFin {
+				finalizers = []string{"kubernetes.io/finalizer"}
+			}
+
+			// 1. Create object
+			switch tc.resource {
+			case "pods":
+				pod := &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: objName, Namespace: ns.Name, Finalizers: finalizers},
+					Spec:       v1.PodSpec{NodeName: "node1", Containers: []v1.Container{{Name: "c", Image: "nginx"}}},
+				}
+				if _, err := clientSet.CoreV1().Pods(ns.Name).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("failed to create pod: %v", err)
+				}
+			case "serviceaccounts":
+				sa := &v1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{Name: objName, Namespace: ns.Name, Finalizers: finalizers},
+				}
+				if _, err := clientSet.CoreV1().ServiceAccounts(ns.Name).Create(ctx, sa, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("failed to create sa: %v", err)
+				}
+			case "configmaps":
+				cm := &v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: objName, Namespace: ns.Name, Finalizers: finalizers},
+					Data:       map[string]string{"foo": "bar"},
+				}
+				if _, err := clientSet.CoreV1().ConfigMaps(ns.Name).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("failed to create cm: %v", err)
+				}
+			}
+
+			// 2. Establish Initial State if dT set
+			if tc.initialDT && !tc.initialFin {
+				// Delete with grace period 30s so dT is set but Pod remains
+				err := clientSet.CoreV1().Pods(ns.Name).Delete(ctx, objName, metav1.DeleteOptions{GracePeriodSeconds: ptr.To[int64](30)})
+				if err != nil {
+					t.Fatalf("failed to establish initial state dT set, No Fin: %v", err)
+				}
+			} else if tc.initialDT && tc.initialFin {
+				// Delete with default options. Since it has a finalizer, dT is set but object remains
+				var err error
+				switch tc.resource {
+				case "pods":
+					err = clientSet.CoreV1().Pods(ns.Name).Delete(ctx, objName, metav1.DeleteOptions{GracePeriodSeconds: ptr.To[int64](30)})
+				case "serviceaccounts":
+					err = clientSet.CoreV1().ServiceAccounts(ns.Name).Delete(ctx, objName, metav1.DeleteOptions{})
+				case "configmaps":
+					err = clientSet.CoreV1().ConfigMaps(ns.Name).Delete(ctx, objName, metav1.DeleteOptions{})
+				}
+				if err != nil {
+					t.Fatalf("failed to establish initial state dT set, Active Fin: %v", err)
+				}
+			}
+
+			var preDeleteRV string
+			switch tc.resource {
+			case "pods":
+				p, err := clientSet.CoreV1().Pods(ns.Name).Get(ctx, objName, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("failed to get pod before delete: %v", err)
+				}
+				preDeleteRV = p.ResourceVersion
+			case "serviceaccounts":
+				sa, err := clientSet.CoreV1().ServiceAccounts(ns.Name).Get(ctx, objName, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("failed to get sa before delete: %v", err)
+				}
+				preDeleteRV = sa.ResourceVersion
+			case "configmaps":
+				cm, err := clientSet.CoreV1().ConfigMaps(ns.Name).Get(ctx, objName, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("failed to get cm before delete: %v", err)
+				}
+				preDeleteRV = cm.ResourceVersion
+			}
+
+			// 3. Prepare DeleteOptions for main request
+			opts := metav1.DeleteOptions{}
+			switch tc.deleteType {
+			case "Orphan":
+				opts.PropagationPolicy = ptr.To(metav1.DeletePropagationOrphan)
+			case "Foreground":
+				opts.PropagationPolicy = ptr.To(metav1.DeletePropagationForeground)
+			case "Shorten Future":
+				opts.GracePeriodSeconds = ptr.To[int64](15)
+			case "Shorten Past":
+				opts.GracePeriodSeconds = ptr.To[int64](0)
+			}
+
+			// 4. Execute main delete request
+			var statusCode int
+			res := clientSet.CoreV1().RESTClient().Delete().
+				Resource(tc.resource).
+				Namespace(ns.Name).
+				Name(objName).
+				Body(&opts).
+				Do(ctx).
+				StatusCode(&statusCode)
+
+			obj, err := res.Get()
+			var retType string
+			var rv string
+			if err != nil {
+				var statusErr *apierrors.StatusError
+				if errors.As(err, &statusErr) {
+					retType = fmt.Sprintf("*metav1.Status (%s)", statusErr.ErrStatus.Reason)
+					rv = statusErr.ErrStatus.ResourceVersion
+				} else {
+					retType = fmt.Sprintf("error (%v)", err)
+				}
+			} else {
+				switch o := obj.(type) {
+				case *v1.Pod:
+					retType = "*v1.Pod"
+					rv = o.ResourceVersion
+				case *v1.ServiceAccount:
+					retType = "*v1.ServiceAccount"
+					rv = o.ResourceVersion
+				case *v1.ConfigMap:
+					retType = "*v1.ConfigMap"
+					rv = o.ResourceVersion
+				case *metav1.Status:
+					retType = "*metav1.Status"
+					rv = o.ResourceVersion
+				default:
+					retType = fmt.Sprintf("%T", obj)
+				}
+			}
+
+			if retType != tc.expectedType {
+				t.Errorf("expected type %s, got %s", tc.expectedType, retType)
+			}
+			if statusCode != tc.expectedCode {
+				t.Errorf("expected status code %d, got %d", tc.expectedCode, statusCode)
+			}
+			if rv == "" {
+				t.Errorf("expected non-empty ResourceVersion")
+			} else {
+				cmp, err := resourceversion.CompareResourceVersion(rv, preDeleteRV)
+				if err != nil {
+					t.Errorf("failed to compare resource versions: %v", err)
+				} else if tc.expectRVInc {
+					if cmp <= 0 {
+						t.Errorf("expected returned ResourceVersion %q to be greater than pre-deletion ResourceVersion %q", rv, preDeleteRV)
+					}
+				} else {
+					if cmp != 0 {
+						t.Errorf("expected returned ResourceVersion %q to be equal to pre-deletion ResourceVersion %q", rv, preDeleteRV)
+					}
+				}
+			}
+		})
+
+	}
+}

--- a/test/integration/apiserver/delete_with_result_test.go
+++ b/test/integration/apiserver/delete_with_result_test.go
@@ -1,0 +1,514 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/metadata"
+	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/utils/ptr"
+)
+
+func TestDeleteResult(t *testing.T) {
+	ctx, clientSet, kubeConfig, tearDownFn := setup(t)
+	defer tearDownFn()
+
+	dynamicClient, err := dynamic.NewForConfig(kubeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	metadataClient, err := metadata.NewForConfig(kubeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ns := framework.CreateNamespaceOrDie(clientSet, "delete-status", t)
+	defer framework.DeleteNamespaceOrDie(clientSet, ns, t)
+
+	sa := &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: ns.Name}}
+	if _, err := clientSet.CoreV1().ServiceAccounts(ns.Name).Create(ctx, sa, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create default service account: %v", err)
+	}
+
+	podGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	cmGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+
+	// 1. Test ReturnDeletedObject = true with Pods
+	t.Run("ReturnDeletedObject=true", func(t *testing.T) {
+		// a. Typed Client
+		{
+			pod1 := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: ns.Name},
+				Spec:       v1.PodSpec{Containers: []v1.Container{{Name: "c", Image: "nginx"}}},
+			}
+			if _, err := clientSet.CoreV1().Pods(ns.Name).Create(ctx, pod1, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("failed to create pod: %v", err)
+			}
+			res, err := clientSet.CoreV1().Pods(ns.Name).DeleteWithResult(ctx, "pod1", metav1.DeleteOptions{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			statusCode, err := res.StatusCode()
+			if err != nil {
+				t.Fatalf("unexpected error on StatusCode(): %v", err)
+			}
+			if statusCode != 200 && statusCode != 202 {
+				t.Errorf("expected status code 200 or 202, got %d", statusCode)
+			}
+			obj, err := res.Get()
+			if err != nil {
+				t.Fatalf("unexpected error on Get(): %v", err)
+			}
+			podObj, ok := obj.(*v1.Pod)
+			if !ok {
+				t.Fatalf("expected *v1.Pod, got %T", obj)
+			}
+			if podObj.ResourceVersion == "" {
+				t.Fatalf("expected ResourceVersion to be populated, got empty string")
+			}
+		}
+
+		// b. Dynamic Client
+		{
+			pod2 := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: ns.Name},
+				Spec:       v1.PodSpec{Containers: []v1.Container{{Name: "c", Image: "nginx"}}},
+			}
+			if _, err := clientSet.CoreV1().Pods(ns.Name).Create(ctx, pod2, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("failed to create pod: %v", err)
+			}
+			res, err := dynamicClient.Resource(podGVR).Namespace(ns.Name).DeleteWithResult(ctx, "pod2", metav1.DeleteOptions{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			statusCode, err := res.StatusCode()
+			if err != nil {
+				t.Fatalf("unexpected error on StatusCode(): %v", err)
+			}
+			if statusCode != 200 && statusCode != 202 {
+				t.Errorf("expected status code 200 or 202, got %d", statusCode)
+			}
+			obj, err := res.Get()
+			if err != nil {
+				t.Fatalf("unexpected error on Get(): %v", err)
+			}
+			unstObj, ok := obj.(*unstructured.Unstructured)
+			if !ok {
+				t.Fatalf("expected *unstructured.Unstructured, got %T", obj)
+			}
+			if unstObj.GetResourceVersion() == "" {
+				t.Fatalf("expected ResourceVersion to be populated, got empty string")
+			}
+		}
+
+		// c. Metadata Client
+		{
+			pod3 := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod3", Namespace: ns.Name},
+				Spec:       v1.PodSpec{Containers: []v1.Container{{Name: "c", Image: "nginx"}}},
+			}
+			if _, err := clientSet.CoreV1().Pods(ns.Name).Create(ctx, pod3, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("failed to create pod: %v", err)
+			}
+			res, err := metadataClient.Resource(podGVR).Namespace(ns.Name).DeleteWithResult(ctx, "pod3", metav1.DeleteOptions{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			statusCode, err := res.StatusCode()
+			if err != nil {
+				t.Fatalf("unexpected error on StatusCode(): %v", err)
+			}
+			if statusCode != 200 && statusCode != 202 {
+				t.Errorf("expected status code 200 or 202, got %d", statusCode)
+			}
+			obj, err := res.Get()
+			if err != nil {
+				t.Fatalf("unexpected error on Get(): %v", err)
+			}
+			metaObj, ok := obj.(*metav1.PartialObjectMetadata)
+			if !ok {
+				t.Fatalf("expected *metav1.PartialObjectMetadata, got %T", obj)
+			}
+			if metaObj.ResourceVersion == "" {
+				t.Fatalf("expected ResourceVersion to be populated, got empty string")
+			}
+		}
+	})
+
+	// 2. Test ReturnDeletedObject = false with ConfigMaps
+	t.Run("ReturnDeletedObject=false", func(t *testing.T) {
+		// a. Typed Client
+		{
+			cm1 := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "cm1", Namespace: ns.Name},
+				Data:       map[string]string{"foo": "bar"},
+			}
+			if _, err := clientSet.CoreV1().ConfigMaps(ns.Name).Create(ctx, cm1, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("failed to create cm: %v", err)
+			}
+			res, err := clientSet.CoreV1().ConfigMaps(ns.Name).DeleteWithResult(ctx, "cm1", metav1.DeleteOptions{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			statusCode, err := res.StatusCode()
+			if err != nil {
+				t.Fatalf("unexpected error on StatusCode(): %v", err)
+			}
+			if statusCode != 200 {
+				t.Errorf("expected status code 200, got %d", statusCode)
+			}
+			obj, err := res.Get()
+			if err != nil {
+				t.Fatalf("unexpected error on Get(): %v", err)
+			}
+			statusObj, ok := obj.(*metav1.Status)
+			if !ok {
+				t.Fatalf("expected *metav1.Status, got %T", obj)
+			}
+			if statusObj.ResourceVersion == "" {
+				t.Fatalf("expected ResourceVersion to be populated, got empty string")
+			}
+		}
+
+		// b. Dynamic Client
+		{
+			cm2 := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "cm2", Namespace: ns.Name},
+				Data:       map[string]string{"foo": "bar"},
+			}
+			if _, err := clientSet.CoreV1().ConfigMaps(ns.Name).Create(ctx, cm2, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("failed to create cm: %v", err)
+			}
+			res, err := dynamicClient.Resource(cmGVR).Namespace(ns.Name).DeleteWithResult(ctx, "cm2", metav1.DeleteOptions{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			statusCode, err := res.StatusCode()
+			if err != nil {
+				t.Fatalf("unexpected error on StatusCode(): %v", err)
+			}
+			if statusCode != 200 {
+				t.Errorf("expected status code 200, got %d", statusCode)
+			}
+			obj, err := res.Get()
+			if err != nil {
+				t.Fatalf("unexpected error on Get(): %v", err)
+			}
+			statusObj2, ok := obj.(*metav1.Status)
+			if !ok {
+				t.Fatalf("expected *metav1.Status, got %T", obj)
+			}
+			if statusObj2.ResourceVersion == "" {
+				t.Fatalf("expected ResourceVersion to be populated, got empty string")
+			}
+		}
+
+		// c. Metadata Client
+		{
+			cm3 := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "cm3", Namespace: ns.Name},
+				Data:       map[string]string{"foo": "bar"},
+			}
+			if _, err := clientSet.CoreV1().ConfigMaps(ns.Name).Create(ctx, cm3, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("failed to create cm: %v", err)
+			}
+			res, err := metadataClient.Resource(cmGVR).Namespace(ns.Name).DeleteWithResult(ctx, "cm3", metav1.DeleteOptions{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			statusCode, err := res.StatusCode()
+			if err != nil {
+				t.Fatalf("unexpected error on StatusCode(): %v", err)
+			}
+			if statusCode != 200 {
+				t.Errorf("expected status code 200, got %d", statusCode)
+			}
+			obj, err := res.Get()
+			if err != nil {
+				t.Fatalf("unexpected error on Get(): %v", err)
+			}
+			statusObj3, ok := obj.(*metav1.Status)
+			if !ok {
+				t.Fatalf("expected *metav1.Status, got %T", obj)
+			}
+			if statusObj3.ResourceVersion == "" {
+				t.Fatalf("expected ResourceVersion to be populated, got empty string")
+			}
+		}
+	})
+
+	// 3. Test Error Case (Get HTTP code from error and result)
+	t.Run("ErrorCase", func(t *testing.T) {
+		res, err := clientSet.CoreV1().Pods(ns.Name).DeleteWithResult(ctx, "non-existent-pod", metav1.DeleteOptions{})
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if res != nil {
+			statusCode, codeErr := res.StatusCode()
+			if codeErr == nil {
+				t.Errorf("expected error from StatusCode(), got nil")
+			}
+			if statusCode != 404 {
+				t.Errorf("expected status code 404 from result, got %d", statusCode)
+			}
+			obj, getErr := res.Get()
+			if getErr == nil {
+				t.Errorf("expected error from Get(), got nil")
+			}
+			if obj != nil {
+				t.Errorf("expected nil object from Get(), got %v", obj)
+			}
+		}
+		var statusErr *apierrors.StatusError
+		if !errors.As(err, &statusErr) {
+			t.Fatalf("expected *apierrors.StatusError, got %T (%v)", err, err)
+		}
+		if statusErr.ErrStatus.Code != 404 {
+			t.Errorf("expected HTTP status 404, got %d", statusErr.ErrStatus.Code)
+		}
+		if statusErr.Status().Code != 404 {
+			t.Errorf("expected APIStatus code 404, got %d", statusErr.Status().Code)
+		}
+	})
+}
+
+func TestDeletionResponseMatrix(t *testing.T) {
+	ctx, clientSet, _, tearDownFn := setup(t)
+	defer tearDownFn()
+
+	ns := framework.CreateNamespaceOrDie(clientSet, "matrix-test", t)
+	defer framework.DeleteNamespaceOrDie(clientSet, ns, t)
+
+	// Explicitly create the default service account in the namespace before creating Pods
+	sa := &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: ns.Name}}
+	if _, err := clientSet.CoreV1().ServiceAccounts(ns.Name).Create(ctx, sa, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create default service account: %v", err)
+	}
+
+	testCases := []struct {
+		name         string
+		resource     string // "pods", "serviceaccounts", "configmaps"
+		initialDT    bool
+		initialFin   bool
+		deleteType   string // "Normal", "Orphan", "Foreground", "Shorten Future", "Shorten Past"
+		expectedType string
+		expectedCode int
+		expectRVInc  bool // true if we expect RV to increment, false if we expect it to stay equal
+	}{
+		// 1. Pods (Graceful Deletion)
+		{"Pod_No_dT_No_Fin_Normal_Normal", "pods", false, false, "Normal", "*v1.Pod", 200, true},
+		{"Pod_No_dT_No_Fin_Orphan_Normal", "pods", false, false, "Orphan", "*v1.Pod", 200, true},
+		{"Pod_No_dT_No_Fin_Foreground_Normal", "pods", false, false, "Foreground", "*v1.Pod", 200, true},
+		{"Pod_No_dT_No_Fin_Shorten_Future_Normal", "pods", false, false, "Shorten Future", "*v1.Pod", 200, true},
+		{"Pod_No_dT_No_Fin_Shorten_Past_Normal", "pods", false, false, "Shorten Past", "*v1.Pod", 200, true},
+		{"Pod_dT_set_No_Fin_Normal_Normal", "pods", true, false, "Normal", "*v1.Pod", 200, false},
+		{"Pod_dT_set_No_Fin_Shorten_Future_Normal", "pods", true, false, "Shorten Future", "*v1.Pod", 200, true},
+		{"Pod_dT_set_No_Fin_Shorten_Past_Normal", "pods", true, false, "Shorten Past", "*v1.Pod", 200, true},
+		{"Pod_dT_set_Active_Fin_Normal_Normal", "pods", true, true, "Normal", "*v1.Pod", 200, false},
+		{"Pod_dT_set_Active_Fin_Orphan_Normal", "pods", true, true, "Orphan", "*v1.Pod", 200, false},
+		{"Pod_dT_set_Active_Fin_Foreground_Normal", "pods", true, true, "Foreground", "*v1.Pod", 200, false},
+		{"Pod_dT_set_Active_Fin_Shorten_Future_Normal", "pods", true, true, "Shorten Future", "*v1.Pod", 200, true},
+		{"Pod_dT_set_Active_Fin_Shorten_Past_Normal", "pods", true, true, "Shorten Past", "*v1.Pod", 200, true},
+
+		// 2. ServiceAccount (ReturnDeletedObject=true)
+		{"SA_No_dT_No_Fin_Normal_Normal", "serviceaccounts", false, false, "Normal", "*v1.ServiceAccount", 200, true},
+		{"SA_No_dT_No_Fin_Orphan_Normal", "serviceaccounts", false, false, "Orphan", "*v1.ServiceAccount", 200, true},
+		{"SA_No_dT_No_Fin_Foreground_Normal", "serviceaccounts", false, false, "Foreground", "*v1.ServiceAccount", 200, true},
+		{"SA_dT_set_Active_Fin_Normal_Normal", "serviceaccounts", true, true, "Normal", "*v1.ServiceAccount", 200, false},
+		{"SA_dT_set_Active_Fin_Orphan_Normal", "serviceaccounts", true, true, "Orphan", "*v1.ServiceAccount", 200, true},
+		{"SA_dT_set_Active_Fin_Foreground_Normal", "serviceaccounts", true, true, "Foreground", "*v1.ServiceAccount", 200, true},
+
+		// 3. ConfigMap (ReturnDeletedObject=false)
+		{"CM_No_dT_No_Fin_Normal_Normal", "configmaps", false, false, "Normal", "*metav1.Status", 200, true},
+		{"CM_No_dT_No_Fin_Orphan_Normal", "configmaps", false, false, "Orphan", "*v1.ConfigMap", 200, true},
+		{"CM_No_dT_No_Fin_Foreground_Normal", "configmaps", false, false, "Foreground", "*v1.ConfigMap", 200, true},
+		{"CM_dT_set_Active_Fin_Normal_Normal", "configmaps", true, true, "Normal", "*v1.ConfigMap", 200, false},
+		{"CM_dT_set_Active_Fin_Orphan_Normal", "configmaps", true, true, "Orphan", "*v1.ConfigMap", 200, true},
+		{"CM_dT_set_Active_Fin_Foreground_Normal", "configmaps", true, true, "Foreground", "*v1.ConfigMap", 200, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			objName := strings.ToLower(strings.ReplaceAll("obj-"+tc.name, "_", "-"))
+			var finalizers []string
+			if tc.initialFin {
+				finalizers = []string{"kubernetes.io/finalizer"}
+			}
+
+			// 1. Create object
+			switch tc.resource {
+			case "pods":
+				pod := &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: objName, Namespace: ns.Name, Finalizers: finalizers},
+					Spec:       v1.PodSpec{NodeName: "node1", Containers: []v1.Container{{Name: "c", Image: "nginx"}}},
+				}
+				if _, err := clientSet.CoreV1().Pods(ns.Name).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("failed to create pod: %v", err)
+				}
+			case "serviceaccounts":
+				sa := &v1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{Name: objName, Namespace: ns.Name, Finalizers: finalizers},
+				}
+				if _, err := clientSet.CoreV1().ServiceAccounts(ns.Name).Create(ctx, sa, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("failed to create sa: %v", err)
+				}
+			case "configmaps":
+				cm := &v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: objName, Namespace: ns.Name, Finalizers: finalizers},
+					Data:       map[string]string{"foo": "bar"},
+				}
+				if _, err := clientSet.CoreV1().ConfigMaps(ns.Name).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("failed to create cm: %v", err)
+				}
+			}
+
+			// 2. Establish Initial State if dT set
+			if tc.initialDT && !tc.initialFin {
+				// Delete with grace period 30s so dT is set but Pod remains
+				err := clientSet.CoreV1().Pods(ns.Name).Delete(ctx, objName, metav1.DeleteOptions{GracePeriodSeconds: ptr.To[int64](30)})
+				if err != nil {
+					t.Fatalf("failed to establish initial state dT set, No Fin: %v", err)
+				}
+			} else if tc.initialDT && tc.initialFin {
+				// Delete with default options. Since it has a finalizer, dT is set but object remains
+				var err error
+				switch tc.resource {
+				case "pods":
+					err = clientSet.CoreV1().Pods(ns.Name).Delete(ctx, objName, metav1.DeleteOptions{GracePeriodSeconds: ptr.To[int64](30)})
+				case "serviceaccounts":
+					err = clientSet.CoreV1().ServiceAccounts(ns.Name).Delete(ctx, objName, metav1.DeleteOptions{})
+				case "configmaps":
+					err = clientSet.CoreV1().ConfigMaps(ns.Name).Delete(ctx, objName, metav1.DeleteOptions{})
+				}
+				if err != nil {
+					t.Fatalf("failed to establish initial state dT set, Active Fin: %v", err)
+				}
+			}
+
+			var preDeleteRV string
+			switch tc.resource {
+			case "pods":
+				p, err := clientSet.CoreV1().Pods(ns.Name).Get(ctx, objName, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("failed to get pod before delete: %v", err)
+				}
+				preDeleteRV = p.ResourceVersion
+			case "serviceaccounts":
+				sa, err := clientSet.CoreV1().ServiceAccounts(ns.Name).Get(ctx, objName, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("failed to get sa before delete: %v", err)
+				}
+				preDeleteRV = sa.ResourceVersion
+			case "configmaps":
+				cm, err := clientSet.CoreV1().ConfigMaps(ns.Name).Get(ctx, objName, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("failed to get cm before delete: %v", err)
+				}
+				preDeleteRV = cm.ResourceVersion
+			}
+
+			// 3. Prepare DeleteOptions for main request
+			opts := metav1.DeleteOptions{}
+			switch tc.deleteType {
+			case "Orphan":
+				opts.PropagationPolicy = ptr.To(metav1.DeletePropagationOrphan)
+			case "Foreground":
+				opts.PropagationPolicy = ptr.To(metav1.DeletePropagationForeground)
+			case "Shorten Future":
+				opts.GracePeriodSeconds = ptr.To[int64](15)
+			case "Shorten Past":
+				opts.GracePeriodSeconds = ptr.To[int64](0)
+			}
+
+			// 4. Execute main delete request
+			var statusCode int
+			res := clientSet.CoreV1().RESTClient().Delete().
+				Resource(tc.resource).
+				Namespace(ns.Name).
+				Name(objName).
+				Body(&opts).
+				Do(ctx).
+				StatusCode(&statusCode)
+
+			obj, err := res.Get()
+			var retType string
+			var rv string
+			if err != nil {
+				var statusErr *apierrors.StatusError
+				if errors.As(err, &statusErr) {
+					retType = fmt.Sprintf("*metav1.Status (%s)", statusErr.ErrStatus.Reason)
+					rv = statusErr.ErrStatus.ResourceVersion
+				} else {
+					retType = fmt.Sprintf("error (%v)", err)
+				}
+			} else {
+				switch o := obj.(type) {
+				case *v1.Pod:
+					retType = "*v1.Pod"
+					rv = o.ResourceVersion
+				case *v1.ServiceAccount:
+					retType = "*v1.ServiceAccount"
+					rv = o.ResourceVersion
+				case *v1.ConfigMap:
+					retType = "*v1.ConfigMap"
+					rv = o.ResourceVersion
+				case *metav1.Status:
+					retType = "*metav1.Status"
+					rv = o.ResourceVersion
+				default:
+					retType = fmt.Sprintf("%T", obj)
+				}
+			}
+
+			if retType != tc.expectedType {
+				t.Errorf("expected type %s, got %s", tc.expectedType, retType)
+			}
+			if statusCode != tc.expectedCode {
+				t.Errorf("expected status code %d, got %d", tc.expectedCode, statusCode)
+			}
+			if rv == "" {
+				t.Errorf("expected non-empty ResourceVersion")
+			} else {
+				cmp, err := resourceversion.CompareResourceVersion(rv, preDeleteRV)
+				if err != nil {
+					t.Errorf("failed to compare resource versions: %v", err)
+				} else if tc.expectRVInc {
+					if cmp <= 0 {
+						t.Errorf("expected returned ResourceVersion %q to be greater than pre-deletion ResourceVersion %q", rv, preDeleteRV)
+					}
+				} else {
+					if cmp != 0 {
+						t.Errorf("expected returned ResourceVersion %q to be equal to pre-deletion ResourceVersion %q", rv, preDeleteRV)
+					}
+				}
+			}
+		})
+
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds the ability for clients to view the resource version that a resource is deleted at. Previously this would be empty, with the addition of https://github.com/kubernetes/enhancements/issues/5647 we have motivation to track resource versions from the client side to ensure staleness guarantees. 

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/5647
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
Open to other implementations of client facing code, but this seemed easiest. Discussed other options like putting it into the context to prevent api changes but that seemed too indirect.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Clients will now receive resource versions on delete when deleting objects. This resource version is either the actual delete or a version when the object was observed to be deleted at.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
