### PR TITLE
DRA: overhaul declarative-validation test coverage

### DIFF
--- a/pkg/apis/resource/v1alpha3/zz_generated.validations.go
+++ b/pkg/apis/resource/v1alpha3/zz_generated.validations.go
@@ -801,11 +801,6 @@ func Validate_ResourcePoolStatusRequestStatus(
 			if earlyReturn {
 				return // do not proceed
 			}
-			// lists with map semantics require unique keys
-			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
-				func(a v1.Condition, b v1.Condition) bool { return a.Type == b.Type }); len(e) != 0 {
-				errs = append(errs, e...)
-			}
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/pkg/apis/resource/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta1/zz_generated.validations.go
@@ -1854,10 +1854,6 @@ func Validate_DeviceRequestAllocationResult(
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 16).MarkAlpha(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
 			if earlyReturn {
 				return // do not proceed
 			}

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -56,12 +56,18 @@ import (
 // (flattened fields) and v1/v1beta2 (fields under 'exactly') for validation error paths.
 var ResourceNormalizationRules = []field.NormalizationRule{
 	{
-		Regexp:      regexp.MustCompile(`spec.devices\.requests\[(\d+)\]\.(deviceClassName|selectors|allocationMode|count|adminAccess|tolerations)`),
+		// ResourceClaim
+		Regexp:      regexp.MustCompile(`spec\.devices\.requests\[(\d+)\]\.(deviceClassName|selectors|allocationMode|count|adminAccess|tolerations)`),
 		Replacement: "spec.devices.requests[$1].exactly.$2",
 	},
 	{
+		// ResourceClaimTemplate (RCT.Spec.Spec adds an extra "spec." prefix)
+		Regexp:      regexp.MustCompile(`spec\.spec\.devices\.requests\[(\d+)\]\.(deviceClassName|selectors|allocationMode|count|adminAccess|tolerations)`),
+		Replacement: "spec.spec.devices.requests[$1].exactly.$2",
+	},
+	{
 		// This v1beta1 'basic' to flattened rule is to support ResourceSlice
-		Regexp:      regexp.MustCompile(`spec.devices\[(\d+)\]\.basic\.`),
+		Regexp:      regexp.MustCompile(`spec\.devices\[(\d+)\]\.basic\.`),
 		Replacement: "spec.devices[$1].",
 	},
 }

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -522,6 +522,9 @@ func validateDeviceRequestAllocationResult(result resource.DeviceRequestAllocati
 	allErrs = append(allErrs, validatePoolName(result.Pool, fldPath.Child("pool")).MarkCoveredByDeclarative()...)
 	allErrs = append(allErrs, validateDeviceName(result.Device, fldPath.Child("device"))...)
 	allErrs = append(allErrs, validateDeviceBindingParameters(result.BindingConditions, result.BindingFailureConditions, fldPath)...)
+	for i, toleration := range result.Tolerations {
+		allErrs = append(allErrs, validateDeviceToleration(toleration, fldPath.Child("tolerations").Index(i))...)
+	}
 	if result.ShareID != nil {
 		allErrs = append(allErrs, validateUID(string(*result.ShareID), fldPath.Child("shareID")).MarkCoveredByDeclarative()...)
 	}

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -806,7 +806,7 @@ func validateCounterSet(counterSet resource.CounterSet, fldPath *field.Path) fie
 		allErrs = append(allErrs, validateCounterName(counterSet.Name, fldPath.Child("name"))...).MarkCoveredByDeclarative()
 	}
 	if len(counterSet.Counters) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("counters"), ""))
+		allErrs = append(allErrs, field.Required(fldPath.Child("counters"), "").MarkCoveredByDeclarative())
 	} else {
 		// The size limit is enforced for across all sets by the caller.
 		allErrs = append(allErrs, validateMap(counterSet.Counters, resource.ResourceSliceMaxCountersPerCounterSet, validation.DNS1123LabelMaxLength,
@@ -963,7 +963,7 @@ func validateDeviceCounterConsumption(deviceCounterConsumption resource.DeviceCo
 		allErrs = append(allErrs, validateCounterName(deviceCounterConsumption.CounterSet, fldPath.Child("counterSet"))...).MarkCoveredByDeclarative()
 	}
 	if len(deviceCounterConsumption.Counters) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("counters"), ""))
+		allErrs = append(allErrs, field.Required(fldPath.Child("counters"), "").MarkCoveredByDeclarative())
 	} else {
 		allErrs = append(allErrs, validateMap(deviceCounterConsumption.Counters, resource.ResourceSliceMaxCountersPerDeviceCounterConsumption,
 			validation.DNS1123LabelMaxLength, validateCounterName, validateDeviceCounter, fldPath.Child("counters"), keysCovered)...)

--- a/pkg/apis/resource/validation/validation_resourceslice_test.go
+++ b/pkg/apis/resource/validation/validation_resourceslice_test.go
@@ -1041,7 +1041,7 @@ func TestValidateResourceSlice(t *testing.T) {
 		},
 		"missing-counter-shared-counters": {
 			wantFailures: field.ErrorList{
-				field.Required(field.NewPath("spec", "sharedCounters").Index(0).Child("counters"), ""),
+				field.Required(field.NewPath("spec", "sharedCounters").Index(0).Child("counters"), "").MarkCoveredByDeclarative(),
 			},
 			slice: func() *resourceapi.ResourceSlice {
 				slice := testResourceSliceWithSharedCounters(goodName, goodName, driverName, 0)
@@ -1172,7 +1172,7 @@ func TestValidateResourceSlice(t *testing.T) {
 		},
 		"missing-counter-consumes-counter": {
 			wantFailures: field.ErrorList{
-				field.Required(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counters"), ""),
+				field.Required(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counters"), "").MarkCoveredByDeclarative(),
 			},
 			slice: func() *resourceapi.ResourceSlice {
 				slice := testResourceSlice(goodName, goodName, driverName, 1)

--- a/pkg/registry/resource/deviceclass/declarative_validation_test.go
+++ b/pkg/registry/resource/deviceclass/declarative_validation_test.go
@@ -103,6 +103,32 @@ func TestDeclarativeValidate(t *testing.T) {
 					input: mkDeviceClass(tweakConfig(32)),
 				},
 
+				// spec.config[*].opaque.driver
+				"valid opaque driver, lowercase": {
+					input: mkDeviceClass(tweakConfigOpaqueDriver("dra.example.com")),
+				},
+				"valid opaque driver, max length": {
+					input: mkDeviceClass(tweakConfigOpaqueDriver(strings.Repeat("a", 63))),
+				},
+				"invalid opaque driver, empty": {
+					input: mkDeviceClass(tweakConfigOpaqueDriver("")),
+					expectedErrs: field.ErrorList{
+						field.Required(field.NewPath("spec", "config").Index(0).Child("opaque", "driver"), "").MarkAlpha(),
+					},
+				},
+				"invalid opaque driver, too long": {
+					input: mkDeviceClass(tweakConfigOpaqueDriver(strings.Repeat("a", 64))),
+					expectedErrs: field.ErrorList{
+						field.TooLong(field.NewPath("spec", "config").Index(0).Child("opaque", "driver"), "", 63).WithOrigin("maxLength").MarkAlpha(),
+					},
+				},
+				"invalid opaque driver, invalid character": {
+					input: mkDeviceClass(tweakConfigOpaqueDriver("dra_example.com")),
+					expectedErrs: field.ErrorList{
+						field.Invalid(field.NewPath("spec", "config").Index(0).Child("opaque", "driver"), "dra_example.com", "").WithOrigin("format=k8s-long-name-caseless").MarkAlpha(),
+					},
+				},
+
 				// ExtendedResourceName
 				"valid extended resource name": {
 					input: mkDeviceClass(tweakExtendedResourceName("example.com/my-resource")),
@@ -323,6 +349,21 @@ func tweakConfig(count int) func(*resource.DeviceClass) {
 					},
 				},
 			})
+		}
+	}
+}
+
+func tweakConfigOpaqueDriver(driver string) func(*resource.DeviceClass) {
+	return func(dc *resource.DeviceClass) {
+		dc.Spec.Config = []resource.DeviceClassConfiguration{
+			{
+				DeviceConfiguration: resource.DeviceConfiguration{
+					Opaque: &resource.OpaqueDeviceConfiguration{
+						Driver:     driver,
+						Parameters: runtime.RawExtension{Raw: []byte(`{"key":"value"}`)},
+					},
+				},
+			},
 		}
 	}
 }

--- a/pkg/registry/resource/resourceclaim/declarative_validation_test.go
+++ b/pkg/registry/resource/resourceclaim/declarative_validation_test.go
@@ -850,6 +850,8 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 	poolPath := field.NewPath("status", "allocation", "devices", "results").Index(0).Child("pool")
 	configSourcePath := field.NewPath("status", "allocation", "devices", "config").Index(0).Child("source")
 	driverPath := field.NewPath("status", "allocation", "devices", "results").Index(0).Child("driver")
+	configOpaqueDriverPath := field.NewPath("status", "allocation", "devices", "config").Index(0).Child("opaque", "driver")
+	resultTolerationPath := field.NewPath("status", "allocation", "devices", "results").Index(0).Child("tolerations").Index(0)
 
 	testCases := map[string]struct {
 		old          resource.ResourceClaim
@@ -1150,6 +1152,79 @@ func testValidateStatusUpdateForDeclarative(t *testing.T, apiVersion string) {
 			update: mkResourceClaimWithStatus(tweakStatusAllocationConfigSource("invalid")),
 			expectedErrs: field.ErrorList{
 				field.NotSupported(configSourcePath, resource.AllocationConfigSource("invalid"), []string{string(resource.AllocationConfigSourceClaim), string(resource.AllocationConfigSourceClass)}).MarkCoveredByDeclarative().MarkAlpha(),
+			},
+		},
+		// .Status.Allocation.Devices.Config[%d].Opaque.Driver
+		"valid status.allocation.devices.config opaque driver, lowercase": {
+			old:    mkValidResourceClaim(),
+			update: mkResourceClaimWithStatus(tweakStatusAllocationConfigOpaqueDriver("dra.example.com")),
+		},
+		"valid status.allocation.devices.config opaque driver, max length": {
+			old:    mkValidResourceClaim(),
+			update: mkResourceClaimWithStatus(tweakStatusAllocationConfigOpaqueDriver(strings.Repeat("a", 63))),
+		},
+		"invalid status.allocation.devices.config opaque driver, empty": {
+			old:    mkValidResourceClaim(),
+			update: mkResourceClaimWithStatus(tweakStatusAllocationConfigOpaqueDriver("")),
+			expectedErrs: field.ErrorList{
+				field.Required(configOpaqueDriverPath, "").MarkAlpha(),
+			},
+		},
+		"invalid status.allocation.devices.config opaque driver, too long": {
+			old:    mkValidResourceClaim(),
+			update: mkResourceClaimWithStatus(tweakStatusAllocationConfigOpaqueDriver(strings.Repeat("a", 64))),
+			expectedErrs: field.ErrorList{
+				field.TooLong(configOpaqueDriverPath, "", 63).WithOrigin("maxLength").MarkAlpha(),
+			},
+		},
+		"invalid status.allocation.devices.config opaque driver, invalid character": {
+			old:    mkValidResourceClaim(),
+			update: mkResourceClaimWithStatus(tweakStatusAllocationConfigOpaqueDriver("dra_example.com")),
+			expectedErrs: field.ErrorList{
+				field.Invalid(configOpaqueDriverPath, "dra_example.com", "").WithOrigin("format=k8s-long-name-caseless").MarkAlpha(),
+			},
+		},
+		// .Status.Allocation.Devices.Results[%d].Tolerations
+		"valid status.allocation.devices.results tolerations": {
+			old: mkValidResourceClaim(),
+			update: mkResourceClaimWithStatus(tweakStatusAllocationResultTolerations([]resource.DeviceToleration{
+				{Key: "valid-key", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
+			})),
+		},
+		"invalid status.allocation.devices.results toleration, bad key": {
+			old: mkValidResourceClaim(),
+			update: mkResourceClaimWithStatus(tweakStatusAllocationResultTolerations([]resource.DeviceToleration{
+				{Key: "invalid_key!", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
+			})),
+			expectedErrs: field.ErrorList{
+				field.Invalid(resultTolerationPath.Child("key"), "invalid_key!", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
+			},
+		},
+		"invalid status.allocation.devices.results toleration, empty operator": {
+			old: mkValidResourceClaim(),
+			update: mkResourceClaimWithStatus(tweakStatusAllocationResultTolerations([]resource.DeviceToleration{
+				{Key: "key", Value: "value", Effect: resource.DeviceTaintEffectNoSchedule, Operator: ""},
+			})),
+			expectedErrs: field.ErrorList{
+				field.Required(resultTolerationPath.Child("operator"), "").MarkAlpha(),
+			},
+		},
+		"invalid status.allocation.devices.results toleration, bad operator": {
+			old: mkValidResourceClaim(),
+			update: mkResourceClaimWithStatus(tweakStatusAllocationResultTolerations([]resource.DeviceToleration{
+				{Key: "key", Operator: "InvalidOp", Value: "value", Effect: resource.DeviceTaintEffectNoSchedule},
+			})),
+			expectedErrs: field.ErrorList{
+				field.NotSupported(resultTolerationPath.Child("operator"), resource.DeviceTolerationOperator("InvalidOp"), []string{"Equal", "Exists"}).MarkAlpha(),
+			},
+		},
+		"invalid status.allocation.devices.results toleration, bad effect": {
+			old: mkValidResourceClaim(),
+			update: mkResourceClaimWithStatus(tweakStatusAllocationResultTolerations([]resource.DeviceToleration{
+				{Key: "key", Operator: resource.DeviceTolerationOpEqual, Value: "value", Effect: "InvalidEffect"},
+			})),
+			expectedErrs: field.ErrorList{
+				field.NotSupported(resultTolerationPath.Child("effect"), resource.DeviceTaintEffect("InvalidEffect"), []string{"NoExecute", "NoSchedule"}).MarkAlpha(),
 			},
 		},
 		// .Status.Devices
@@ -1738,6 +1813,37 @@ func addStatusAllocationResult(obj resource.ResourceClaim) resource.ResourceClai
 			})
 	}
 	return obj
+}
+
+func tweakStatusAllocationConfigOpaqueDriver(driver string) func(rc *resource.ResourceClaim) {
+	return func(rc *resource.ResourceClaim) {
+		if rc.Status.Allocation == nil {
+			rc.Status.Allocation = &resource.AllocationResult{}
+		}
+		rc.Status.Allocation.Devices.Config = []resource.DeviceAllocationConfiguration{
+			{
+				Source:   resource.AllocationConfigSourceClaim,
+				Requests: []string{"req-0"},
+				DeviceConfiguration: resource.DeviceConfiguration{
+					Opaque: &resource.OpaqueDeviceConfiguration{
+						Driver:     driver,
+						Parameters: runtime.RawExtension{Raw: []byte(`{"key":"value"}`)},
+					},
+				},
+			},
+		}
+	}
+}
+
+func tweakStatusAllocationResultTolerations(tolerations []resource.DeviceToleration) func(rc *resource.ResourceClaim) {
+	return func(rc *resource.ResourceClaim) {
+		if rc.Status.Allocation == nil {
+			return
+		}
+		for i := range rc.Status.Allocation.Devices.Results {
+			rc.Status.Allocation.Devices.Results[i].Tolerations = tolerations
+		}
+	}
 }
 
 func tweakStatusAllocationConfigSource(source resource.AllocationConfigSource) func(rc *resource.ResourceClaim) {

--- a/pkg/registry/resource/resourceclaimtemplate/declarative_validation_test.go
+++ b/pkg/registry/resource/resourceclaimtemplate/declarative_validation_test.go
@@ -18,14 +18,18 @@ package resourceclaimtemplate
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/kubernetes/fake"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/apis/resource"
+	"k8s.io/kubernetes/pkg/apis/resource/validation"
+	pointer "k8s.io/utils/ptr"
 )
 
 var apiVersions = []string{"v1beta1", "v1beta2", "v1"}
@@ -48,12 +52,23 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 	nsClient := fakeClient.CoreV1().Namespaces()
 	Strategy := NewStrategy(nsClient)
 
+	opaqueDriverPath := field.NewPath("spec", "spec", "devices", "config").Index(0).Child("opaque", "driver")
+
 	testCases := map[string]struct {
 		input        resource.ResourceClaimTemplate
 		expectedErrs field.ErrorList
 	}{
 		"valid": {
 			input: mkValidResourceClaimTemplate(),
+		},
+		"valid requests, max allowed": {
+			input: mkValidResourceClaimTemplate(tweakDevicesRequests(32)),
+		},
+		"valid constraints, max allowed": {
+			input: mkValidResourceClaimTemplate(tweakDevicesConstraints(32)),
+		},
+		"valid config, max allowed": {
+			input: mkValidResourceClaimTemplate(tweakDevicesConfigs(32)),
 		},
 		"invalid requests, too many": {
 			input: mkValidResourceClaimTemplate(tweakDevicesRequests(33)),
@@ -67,12 +82,330 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				field.Duplicate(field.NewPath("spec", "spec", "devices", "requests").Index(1), "req-0").MarkAlpha(),
 			},
 		},
+		"invalid constraints, too many": {
+			input: mkValidResourceClaimTemplate(tweakDevicesConstraints(33)),
+			expectedErrs: field.ErrorList{
+				field.TooMany(field.NewPath("spec", "spec", "devices", "constraints"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+			},
+		},
+		"invalid config, too many": {
+			input: mkValidResourceClaimTemplate(tweakDevicesConfigs(33)),
+			expectedErrs: field.ErrorList{
+				field.TooMany(field.NewPath("spec", "spec", "devices", "config"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+			},
+		},
+		"invalid firstAvailable, too many": {
+			input: mkValidResourceClaimTemplate(tweakFirstAvailable(9)),
+			expectedErrs: field.ErrorList{
+				field.TooMany(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable"), 9, 8).WithOrigin("maxItems").MarkAlpha(),
+			},
+		},
+		"invalid firstAvailable, duplicate name": {
+			input: mkValidResourceClaimTemplate(tweakDuplicateFirstAvailableName("sub-0")),
+			expectedErrs: field.ErrorList{
+				field.Duplicate(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(1), "sub-0").MarkAlpha(),
+			},
+		},
+		"invalid selectors, too many": {
+			input: mkValidResourceClaimTemplate(tweakExactlySelectors(33)),
+			expectedErrs: field.ErrorList{
+				field.TooMany(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("exactly", "selectors"), 33, 32).WithOrigin("maxItems").MarkCoveredByDeclarative().MarkAlpha(),
+			},
+		},
+		"invalid subrequest selectors, too many": {
+			input: mkValidResourceClaimTemplate(tweakSubRequestSelectors(33)),
+			expectedErrs: field.ErrorList{
+				field.TooMany(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("selectors"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+			},
+		},
+		"invalid constraint requests, too many": {
+			input: mkValidResourceClaimTemplate(tweakConstraintRequests(33)),
+			expectedErrs: field.ErrorList{
+				field.TooMany(field.NewPath("spec", "spec", "devices", "requests"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("spec", "spec", "devices", "constraints").Index(0).Child("requests"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+			},
+		},
+		"invalid config requests, too many": {
+			input: mkValidResourceClaimTemplate(tweakConfigRequests(33)),
+			expectedErrs: field.ErrorList{
+				field.TooMany(field.NewPath("spec", "spec", "devices", "requests"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+				field.TooMany(field.NewPath("spec", "spec", "devices", "config").Index(0).Child("requests"), 33, 32).WithOrigin("maxItems").MarkAlpha(),
+			},
+		},
+		"invalid constraint requests, duplicate name": {
+			input: mkValidResourceClaimTemplate(tweakDuplicateConstraintRequest("req-0")),
+			expectedErrs: field.ErrorList{
+				field.Duplicate(field.NewPath("spec", "spec", "devices", "constraints").Index(0).Child("requests").Index(1), "req-0").MarkAlpha(),
+			},
+		},
+		"invalid config requests, duplicate name": {
+			input: mkValidResourceClaimTemplate(tweakDuplicateConfigRequest("req-0")),
+			expectedErrs: field.ErrorList{
+				field.Duplicate(field.NewPath("spec", "spec", "devices", "config").Index(0).Child("requests").Index(1), "req-0").MarkAlpha(),
+			},
+		},
+		"valid opaque driver, lowercase": {
+			input: mkValidResourceClaimTemplate(tweakDeviceConfigWithDriver("dra.example.com")),
+		},
+		"valid opaque driver, mixed case": {
+			input: mkValidResourceClaimTemplate(tweakDeviceConfigWithDriver("DRA.Example.COM")),
+		},
+		"valid opaque driver, max length": {
+			input: mkValidResourceClaimTemplate(tweakDeviceConfigWithDriver(strings.Repeat("a", 63))),
+		},
+		"invalid opaque driver, empty": {
+			input: mkValidResourceClaimTemplate(tweakDeviceConfigWithDriver("")),
+			expectedErrs: field.ErrorList{
+				field.Required(opaqueDriverPath, "").MarkAlpha(),
+			},
+		},
+		"invalid opaque driver, too long - 64 characters": {
+			input: mkValidResourceClaimTemplate(tweakDeviceConfigWithDriver(strings.Repeat("a", 64))),
+			expectedErrs: field.ErrorList{
+				field.TooLong(opaqueDriverPath, "", 63).WithOrigin("maxLength").MarkAlpha(),
+			},
+		},
+		"invalid opaque driver, too long - 255 characters": {
+			input: mkValidResourceClaimTemplate(tweakDeviceConfigWithDriver(strings.Repeat("a", 255))),
+			expectedErrs: field.ErrorList{
+				field.TooLong(opaqueDriverPath, "", 63).WithOrigin("maxLength").MarkAlpha(),
+				field.Invalid(opaqueDriverPath, "", "").WithOrigin("format=k8s-long-name-caseless").MarkAlpha(),
+			},
+		},
+		"invalid opaque driver, invalid character": {
+			input: mkValidResourceClaimTemplate(tweakDeviceConfigWithDriver("dra_example.com")),
+			expectedErrs: field.ErrorList{
+				field.Invalid(opaqueDriverPath, "dra_example.com", "").WithOrigin("format=k8s-long-name-caseless").MarkAlpha(),
+			},
+		},
+		"invalid opaque driver, invalid DNS name (leading dot)": {
+			input: mkValidResourceClaimTemplate(tweakDeviceConfigWithDriver(".example.com")),
+			expectedErrs: field.ErrorList{
+				field.Invalid(opaqueDriverPath, ".example.com", "").WithOrigin("format=k8s-long-name-caseless").MarkAlpha(),
+			},
+		},
+		"valid Exactly.Tolerations.Key": {
+			input: mkValidResourceClaimTemplate(tweakExactlyTolerations([]resource.DeviceToleration{
+				{Key: "valid-key", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
+			})),
+		},
+		"valid Exactly.Tolerations.Key empty": {
+			input: mkValidResourceClaimTemplate(tweakExactlyTolerations([]resource.DeviceToleration{
+				{Key: "", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
+			})),
+		},
+		"invalid Exactly.Tolerations.Key": {
+			input: mkValidResourceClaimTemplate(tweakExactlyTolerations([]resource.DeviceToleration{
+				{Key: "invalid_key!", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
+			})),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("key"), "invalid_key!", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
+			},
+		},
+		"invalid Exactly.Tolerations.Key - multiple slashes": {
+			input: mkValidResourceClaimTemplate(tweakExactlyTolerations([]resource.DeviceToleration{
+				{Key: "a/b/c", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
+			})),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("key"), "a/b/c", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
+			},
+		},
+		"valid FirstAvailable.Tolerations.Key": {
+			input: mkValidResourceClaimTemplate(tweakFirstAvailable(1), tweakFirstAvailableTolerations([]resource.DeviceToleration{
+				{Key: "valid-key", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
+			})),
+		},
+		"valid FirstAvailable.Tolerations.Key empty": {
+			input: mkValidResourceClaimTemplate(tweakFirstAvailable(1), tweakFirstAvailableTolerations([]resource.DeviceToleration{
+				{Key: "", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
+			})),
+		},
+		"invalid FirstAvailable.Tolerations.Key": {
+			input: mkValidResourceClaimTemplate(tweakFirstAvailable(1), tweakFirstAvailableTolerations([]resource.DeviceToleration{
+				{Key: "invalid_key!", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
+			})),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("key"), "invalid_key!", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
+			},
+		},
+		"invalid FirstAvailable.Tolerations.Key - multiple slashes": {
+			input: mkValidResourceClaimTemplate(tweakFirstAvailable(1), tweakFirstAvailableTolerations([]resource.DeviceToleration{
+				{Key: "a/b/c", Operator: resource.DeviceTolerationOpExists, Effect: resource.DeviceTaintEffectNoSchedule},
+			})),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("key"), "a/b/c", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
+			},
+		},
+		"valid DeviceAllocationMode - All": {
+			input: mkValidResourceClaimTemplate(tweakExactlyAllocationMode(resource.DeviceAllocationModeAll, 0)),
+		},
+		"invalid DeviceAllocationMode - Exactly": {
+			input: mkValidResourceClaimTemplate(tweakExactlyAllocationMode("InvalidMode", 1)),
+			expectedErrs: field.ErrorList{
+				field.NotSupported(
+					field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("exactly", "allocationMode"),
+					resource.DeviceAllocationMode("InvalidMode"),
+					[]string{"All", "ExactCount"},
+				).MarkAlpha(),
+			},
+		},
+		"valid DeviceAllocationMode - FirstAvailable": {
+			input: mkValidResourceClaimTemplate(tweakFirstAvailableAllocationMode(resource.DeviceAllocationModeAll, 0)),
+		},
+		"invalid DeviceAllocationMode - FirstAvailable": {
+			input: mkValidResourceClaimTemplate(tweakFirstAvailableAllocationMode("InvalidMode", 1)),
+			expectedErrs: field.ErrorList{
+				field.NotSupported(
+					field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("allocationMode"),
+					resource.DeviceAllocationMode("InvalidMode"),
+					[]string{"All", "ExactCount"},
+				).MarkAlpha(),
+			},
+		},
+		"valid firstAvailable class name": {
+			input: mkValidResourceClaimTemplate(tweakFirstAvailableDeviceClassName("class")),
+		},
+		"invalid firstAvailable class name - invalid characters": {
+			input: mkValidResourceClaimTemplate(tweakFirstAvailableDeviceClassName("Class&")),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("deviceClassName"), "Class&", "").WithOrigin("format=k8s-long-name").MarkAlpha(),
+			},
+		},
+		"invalid firstAvailable class name - empty": {
+			input: mkValidResourceClaimTemplate(tweakFirstAvailableDeviceClassName("")),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("deviceClassName"), "").MarkAlpha(),
+			},
+		},
+		"valid DeviceTolerationOperator/Effect - Exactly": {
+			input: mkValidResourceClaimTemplate(tweakExactlyTolerations([]resource.DeviceToleration{
+				{
+					Key:      "key",
+					Operator: resource.DeviceTolerationOpEqual,
+					Value:    "value",
+					Effect:   resource.DeviceTaintEffectNoSchedule,
+				},
+			})),
+		},
+		"invalid DeviceTolerationOperator empty - Exactly": {
+			input: mkValidResourceClaimTemplate(
+				tweakExactlyTolerations([]resource.DeviceToleration{{Key: "key", Value: "value", Effect: resource.DeviceTaintEffectNoSchedule, Operator: ""}}),
+			),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("operator"), "").MarkAlpha(),
+			},
+		},
+		"invalid DeviceTolerationOperator - Exactly": {
+			input: mkValidResourceClaimTemplate(tweakExactlyTolerations([]resource.DeviceToleration{
+				{
+					Key:      "key",
+					Operator: "InvalidOp",
+					Value:    "value",
+					Effect:   resource.DeviceTaintEffectNoSchedule,
+				},
+			})),
+			expectedErrs: field.ErrorList{
+				field.NotSupported(
+					field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("operator"),
+					resource.DeviceTolerationOperator("InvalidOp"),
+					[]string{"Equal", "Exists"},
+				).MarkAlpha(),
+			},
+		},
+		"invalid DeviceTaintEffect - Exactly": {
+			input: mkValidResourceClaimTemplate(tweakExactlyTolerations([]resource.DeviceToleration{
+				{
+					Key:      "key",
+					Operator: resource.DeviceTolerationOpEqual,
+					Value:    "value",
+					Effect:   "InvalidEffect",
+				},
+			})),
+			expectedErrs: field.ErrorList{
+				field.NotSupported(
+					field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("exactly", "tolerations").Index(0).Child("effect"),
+					resource.DeviceTaintEffect("InvalidEffect"),
+					[]string{"NoExecute", "NoSchedule"},
+				).MarkAlpha(),
+			},
+		},
+		"valid DeviceTolerationOperator/Effect - FirstAvailable": {
+			input: mkValidResourceClaimTemplate(tweakFirstAvailable(1), tweakFirstAvailableTolerations([]resource.DeviceToleration{
+				{
+					Key:      "key",
+					Operator: resource.DeviceTolerationOpEqual,
+					Value:    "value",
+					Effect:   resource.DeviceTaintEffectNoSchedule,
+				},
+			})),
+		},
+		"invalid DeviceTolerationOperator empty - FirstAvailable": {
+			input: mkValidResourceClaimTemplate(
+				tweakFirstAvailable(1),
+				tweakFirstAvailableTolerations([]resource.DeviceToleration{{Key: "key", Value: "value", Effect: resource.DeviceTaintEffectNoSchedule, Operator: ""}}),
+			),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("operator"), "").MarkAlpha(),
+			},
+		},
+		"invalid DeviceTolerationOperator - FirstAvailable": {
+			input: mkValidResourceClaimTemplate(tweakFirstAvailable(1), tweakFirstAvailableTolerations([]resource.DeviceToleration{
+				{
+					Key:      "key",
+					Operator: "InvalidOp",
+					Value:    "value",
+					Effect:   resource.DeviceTaintEffectNoSchedule,
+				},
+			})),
+			expectedErrs: field.ErrorList{
+				field.NotSupported(
+					field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("operator"),
+					resource.DeviceTolerationOperator("InvalidOp"),
+					[]string{"Equal", "Exists"},
+				).MarkAlpha(),
+			},
+		},
+		"invalid DeviceTaintEffect - FirstAvailable": {
+			input: mkValidResourceClaimTemplate(tweakFirstAvailable(1), tweakFirstAvailableTolerations([]resource.DeviceToleration{
+				{
+					Key:      "key",
+					Operator: resource.DeviceTolerationOpEqual,
+					Value:    "value",
+					Effect:   "InvalidEffect",
+				},
+			})),
+			expectedErrs: field.ErrorList{
+				field.NotSupported(
+					field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("tolerations").Index(0).Child("effect"),
+					resource.DeviceTaintEffect("InvalidEffect"),
+					[]string{"NoExecute", "NoSchedule"},
+				).MarkAlpha(),
+			},
+		},
+		"invalid match attribute": {
+			input: mkValidResourceClaimTemplate(tweakMatchAttribute("invalid!")),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "spec", "devices", "constraints").Index(0).Child("matchAttribute"), "invalid!", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
+			},
+		},
+		"match attribute without domain": {
+			input: mkValidResourceClaimTemplate(tweakMatchAttribute("nodomain")),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "spec", "devices", "constraints").Index(0).Child("matchAttribute"), "nodomain", "a fully qualified name must be a domain and a name separated by a slash").WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
+			},
+		},
+		"match attribute empty": {
+			input: mkValidResourceClaimTemplate(tweakMatchAttribute("")),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkAlpha(),
+			},
+		},
 		// TODO: Add more test cases
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy, tc.expectedErrs)
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, Strategy, tc.expectedErrs, apitesting.WithNormalizationRules(validation.ResourceNormalizationRules...))
 		})
 	}
 }
@@ -111,10 +444,16 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 		t.Run(name, func(t *testing.T) {
 			tc.old.ResourceVersion = "1"
 			tc.update.ResourceVersion = "2"
-			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy, tc.expectedErrs)
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.update, &tc.old, Strategy, tc.expectedErrs, apitesting.WithNormalizationRules(validation.ResourceNormalizationRules...))
 		})
 	}
 }
+
+// --- Builders & tweaks ---
+//
+// These mirror the ones in pkg/registry/resource/resourceclaim/declarative_validation_test.go,
+// adapted to operate on ResourceClaimTemplate.Spec.Spec.Devices instead of
+// ResourceClaim.Spec.Devices. The structural shape is identical.
 
 func mkValidResourceClaimTemplate(tweaks ...func(rct *resource.ResourceClaimTemplate)) resource.ResourceClaimTemplate {
 	rct := resource.ResourceClaimTemplate{
@@ -149,6 +488,32 @@ func mkDeviceRequest(name string) resource.DeviceRequest {
 	}
 }
 
+func mkDeviceClaimConfiguration() resource.DeviceClaimConfiguration {
+	return resource.DeviceClaimConfiguration{
+		Requests: []string{"req-0"},
+		DeviceConfiguration: resource.DeviceConfiguration{
+			Opaque: &resource.OpaqueDeviceConfiguration{
+				Driver: "dra.example.com",
+				Parameters: runtime.RawExtension{
+					Raw: []byte(`{"kind": "foo", "apiVersion": "dra.example.com/v1"}`),
+				}},
+		},
+	}
+}
+
+func mkDeviceConstraint() resource.DeviceConstraint {
+	return resource.DeviceConstraint{
+		Requests:       []string{"req-0"},
+		MatchAttribute: pointer.To(resource.FullyQualifiedName("foo/bar")),
+	}
+}
+
+func tweakAddDeviceRequest(req resource.DeviceRequest) func(*resource.ResourceClaimTemplate) {
+	return func(rct *resource.ResourceClaimTemplate) {
+		rct.Spec.Spec.Devices.Requests = append(rct.Spec.Spec.Devices.Requests, req)
+	}
+}
+
 func tweakDevicesRequests(items int) func(*resource.ResourceClaimTemplate) {
 	return func(rct *resource.ResourceClaimTemplate) {
 		// The first request already exists in the valid template
@@ -158,8 +523,193 @@ func tweakDevicesRequests(items int) func(*resource.ResourceClaimTemplate) {
 	}
 }
 
-func tweakAddDeviceRequest(req resource.DeviceRequest) func(*resource.ResourceClaimTemplate) {
+func tweakDevicesConstraints(items int) func(*resource.ResourceClaimTemplate) {
 	return func(rct *resource.ResourceClaimTemplate) {
-		rct.Spec.Spec.Devices.Requests = append(rct.Spec.Spec.Devices.Requests, req)
+		for range items {
+			rct.Spec.Spec.Devices.Constraints = append(rct.Spec.Spec.Devices.Constraints, mkDeviceConstraint())
+		}
+	}
+}
+
+func tweakDevicesConfigs(items int) func(*resource.ResourceClaimTemplate) {
+	return func(rct *resource.ResourceClaimTemplate) {
+		for range items {
+			rct.Spec.Spec.Devices.Config = append(rct.Spec.Spec.Devices.Config, mkDeviceClaimConfiguration())
+		}
+	}
+}
+
+func tweakFirstAvailable(items int) func(*resource.ResourceClaimTemplate) {
+	return func(rct *resource.ResourceClaimTemplate) {
+		rct.Spec.Spec.Devices.Requests[0].Exactly = nil
+		for i := range items {
+			rct.Spec.Spec.Devices.Requests[0].FirstAvailable = append(rct.Spec.Spec.Devices.Requests[0].FirstAvailable,
+				resource.DeviceSubRequest{
+					Name:            fmt.Sprintf("sub-%d", i),
+					DeviceClassName: "class",
+					AllocationMode:  resource.DeviceAllocationModeAll,
+				},
+			)
+		}
+	}
+}
+
+func tweakDuplicateFirstAvailableName(name string) func(*resource.ResourceClaimTemplate) {
+	return func(rct *resource.ResourceClaimTemplate) {
+		rct.Spec.Spec.Devices.Requests[0].Exactly = nil
+		rct.Spec.Spec.Devices.Requests[0].FirstAvailable = []resource.DeviceSubRequest{
+			{Name: name, DeviceClassName: "class", AllocationMode: resource.DeviceAllocationModeAll},
+			{Name: name, DeviceClassName: "class", AllocationMode: resource.DeviceAllocationModeAll},
+		}
+	}
+}
+
+func tweakExactlySelectors(items int) func(*resource.ResourceClaimTemplate) {
+	return func(rct *resource.ResourceClaimTemplate) {
+		for i := range items {
+			rct.Spec.Spec.Devices.Requests[0].Exactly.Selectors = append(rct.Spec.Spec.Devices.Requests[0].Exactly.Selectors,
+				resource.DeviceSelector{
+					CEL: &resource.CELDeviceSelector{
+						Expression: fmt.Sprintf("device.driver == \"test.driver.io%d\"", i),
+					},
+				},
+			)
+		}
+	}
+}
+
+func tweakSubRequestSelectors(items int) func(*resource.ResourceClaimTemplate) {
+	return func(rct *resource.ResourceClaimTemplate) {
+		rct.Spec.Spec.Devices.Requests[0].Exactly = nil
+		rct.Spec.Spec.Devices.Requests[0].FirstAvailable = []resource.DeviceSubRequest{
+			{Name: "sub-0", DeviceClassName: "class", AllocationMode: resource.DeviceAllocationModeAll},
+		}
+		for i := range items {
+			rct.Spec.Spec.Devices.Requests[0].FirstAvailable[0].Selectors = append(rct.Spec.Spec.Devices.Requests[0].FirstAvailable[0].Selectors,
+				resource.DeviceSelector{
+					CEL: &resource.CELDeviceSelector{
+						Expression: fmt.Sprintf("device.driver == \"test.driver.io%d\"", i),
+					},
+				},
+			)
+		}
+	}
+}
+
+func tweakConstraintRequests(count int) func(*resource.ResourceClaimTemplate) {
+	return func(rct *resource.ResourceClaimTemplate) {
+		tweakDevicesRequests(count)(rct)
+		if len(rct.Spec.Spec.Devices.Constraints) == 0 {
+			rct.Spec.Spec.Devices.Constraints = append(rct.Spec.Spec.Devices.Constraints, mkDeviceConstraint())
+		}
+		rct.Spec.Spec.Devices.Constraints[0].Requests = []string{}
+		for i := range count {
+			rct.Spec.Spec.Devices.Constraints[0].Requests = append(rct.Spec.Spec.Devices.Constraints[0].Requests, fmt.Sprintf("req-%d", i))
+		}
+	}
+}
+
+func tweakConfigRequests(count int) func(*resource.ResourceClaimTemplate) {
+	return func(rct *resource.ResourceClaimTemplate) {
+		tweakDevicesRequests(count)(rct)
+		if len(rct.Spec.Spec.Devices.Config) == 0 {
+			rct.Spec.Spec.Devices.Config = append(rct.Spec.Spec.Devices.Config, mkDeviceClaimConfiguration())
+		}
+		rct.Spec.Spec.Devices.Config[0].Requests = []string{}
+		for i := range count {
+			rct.Spec.Spec.Devices.Config[0].Requests = append(rct.Spec.Spec.Devices.Config[0].Requests, fmt.Sprintf("req-%d", i))
+		}
+	}
+}
+
+func tweakDuplicateConstraintRequest(name string) func(*resource.ResourceClaimTemplate) {
+	return func(rct *resource.ResourceClaimTemplate) {
+		if len(rct.Spec.Spec.Devices.Constraints) == 0 {
+			rct.Spec.Spec.Devices.Constraints = append(rct.Spec.Spec.Devices.Constraints, mkDeviceConstraint())
+		}
+		rct.Spec.Spec.Devices.Constraints[0].Requests = append(rct.Spec.Spec.Devices.Constraints[0].Requests, name)
+	}
+}
+
+func tweakDuplicateConfigRequest(name string) func(*resource.ResourceClaimTemplate) {
+	return func(rct *resource.ResourceClaimTemplate) {
+		if len(rct.Spec.Spec.Devices.Config) == 0 {
+			rct.Spec.Spec.Devices.Config = append(rct.Spec.Spec.Devices.Config, mkDeviceClaimConfiguration())
+		}
+		rct.Spec.Spec.Devices.Config[0].Requests = append(rct.Spec.Spec.Devices.Config[0].Requests, name)
+	}
+}
+
+func tweakExactlyAllocationMode(mode resource.DeviceAllocationMode, count int64) func(*resource.ResourceClaimTemplate) {
+	return func(rct *resource.ResourceClaimTemplate) {
+		if len(rct.Spec.Spec.Devices.Requests) > 0 && rct.Spec.Spec.Devices.Requests[0].Exactly != nil {
+			rct.Spec.Spec.Devices.Requests[0].Exactly.AllocationMode = mode
+			rct.Spec.Spec.Devices.Requests[0].Exactly.Count = count
+		}
+	}
+}
+
+func tweakFirstAvailableAllocationMode(mode resource.DeviceAllocationMode, count int64) func(*resource.ResourceClaimTemplate) {
+	return func(rct *resource.ResourceClaimTemplate) {
+		if len(rct.Spec.Spec.Devices.Requests) > 0 {
+			rct.Spec.Spec.Devices.Requests[0].Exactly = nil
+			rct.Spec.Spec.Devices.Requests[0].FirstAvailable = []resource.DeviceSubRequest{
+				{Name: "sub-0", DeviceClassName: "class", AllocationMode: mode, Count: count},
+			}
+		}
+	}
+}
+
+func tweakFirstAvailableDeviceClassName(name string) func(*resource.ResourceClaimTemplate) {
+	return func(rct *resource.ResourceClaimTemplate) {
+		rct.Spec.Spec.Devices.Requests[0].Exactly = nil
+		rct.Spec.Spec.Devices.Requests[0].FirstAvailable = []resource.DeviceSubRequest{
+			{Name: "sub-0", DeviceClassName: name, AllocationMode: resource.DeviceAllocationModeAll},
+		}
+	}
+}
+
+func tweakDeviceConfigWithDriver(driverName string) func(*resource.ResourceClaimTemplate) {
+	return func(rct *resource.ResourceClaimTemplate) {
+		rct.Spec.Spec.Devices.Config = []resource.DeviceClaimConfiguration{
+			{
+				Requests: []string{"req-0"},
+				DeviceConfiguration: resource.DeviceConfiguration{
+					Opaque: &resource.OpaqueDeviceConfiguration{
+						Driver:     driverName,
+						Parameters: runtime.RawExtension{Raw: []byte(`{"key":"value"}`)},
+					},
+				},
+			},
+		}
+	}
+}
+
+func tweakExactlyTolerations(tolerations []resource.DeviceToleration) func(*resource.ResourceClaimTemplate) {
+	return func(rct *resource.ResourceClaimTemplate) {
+		for i := range rct.Spec.Spec.Devices.Requests {
+			if rct.Spec.Spec.Devices.Requests[i].Exactly != nil {
+				rct.Spec.Spec.Devices.Requests[i].Exactly.Tolerations = tolerations
+			}
+		}
+	}
+}
+
+func tweakFirstAvailableTolerations(tolerations []resource.DeviceToleration) func(*resource.ResourceClaimTemplate) {
+	return func(rct *resource.ResourceClaimTemplate) {
+		for i := range rct.Spec.Spec.Devices.Requests {
+			for j := range rct.Spec.Spec.Devices.Requests[i].FirstAvailable {
+				rct.Spec.Spec.Devices.Requests[i].FirstAvailable[j].Tolerations = tolerations
+			}
+		}
+	}
+}
+
+func tweakMatchAttribute(val string) func(*resource.ResourceClaimTemplate) {
+	return func(rct *resource.ResourceClaimTemplate) {
+		fullyQualifiedName := resource.FullyQualifiedName(val)
+		rct.Spec.Spec.Devices.Constraints = []resource.DeviceConstraint{
+			{MatchAttribute: &fullyQualifiedName},
+		}
 	}
 }

--- a/pkg/registry/resource/resourceclaimtemplate/strategy.go
+++ b/pkg/registry/resource/resourceclaimtemplate/strategy.go
@@ -66,6 +66,14 @@ func (s *resourceClaimTemplateStrategy) Validate(ctx context.Context, obj runtim
 	return append(allErrs, validation.ValidateResourceClaimTemplate(resourceClaimTemplate)...)
 }
 
+// DeclarativeValidationConfig supplies the same path-normalization rules used
+// by ResourceClaim, so the runtime mismatch comparator can pair v1beta1's
+// flattened request paths (e.g. spec.spec.devices.requests[i].tolerations) with
+// the handwritten paths under .exactly.* without false positives.
+func (*resourceClaimTemplateStrategy) DeclarativeValidationConfig(ctx context.Context, obj, oldObj runtime.Object) rest.DeclarativeValidationConfig {
+	return rest.DeclarativeValidationConfig{NormalizationRules: validation.ResourceNormalizationRules}
+}
+
 func (*resourceClaimTemplateStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
 	return nil
 }

--- a/pkg/registry/resource/resourcepoolstatusrequest/declarative_validation_test.go
+++ b/pkg/registry/resource/resourcepoolstatusrequest/declarative_validation_test.go
@@ -88,6 +88,13 @@ func TestDeclarativeValidate(t *testing.T) {
 				r.Spec.PoolName = nil
 			}),
 		},
+		"limit nil": {
+			// +k8s:required (standard DV) — pointer is nil
+			input: mkValidRPSR(func(r *resource.ResourcePoolStatusRequest) {
+				r.Spec.Limit = nil
+			}),
+			expectedErrs: field.ErrorList{field.Required(field.NewPath("spec", "limit"), "")},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -336,6 +343,24 @@ func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 				s.Pools = []resource.PoolStatus{pool}
 			})),
 			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("status", "pools").Index(0).Child("generation"), nil, "").WithOrigin("minimum")},
+		},
+		"poolCount nil": {
+			// +k8s:required (standard DV) — pointer is nil
+			oldObj: mkValidRPSRForUpdate(),
+			updateObj: mkValidRPSRForUpdate(withStatus(func(s *resource.ResourcePoolStatusRequestStatus) {
+				s.PoolCount = nil
+			})),
+			expectedErrs: field.ErrorList{field.Required(field.NewPath("status", "poolCount"), "")},
+		},
+		"pool zero generation": {
+			// +k8s:required (standard DV) — zero is the zero value for int64
+			oldObj: mkValidRPSRForUpdate(),
+			updateObj: mkValidRPSRForUpdate(withStatus(func(s *resource.ResourcePoolStatusRequestStatus) {
+				pool := mkValidPoolStatus()
+				pool.Generation = 0
+				s.Pools = []resource.PoolStatus{pool}
+			})),
+			expectedErrs: field.ErrorList{field.Required(field.NewPath("status", "pools").Index(0).Child("generation"), "")},
 		},
 	}
 

--- a/pkg/registry/resource/resourceslice/declarative_validation_test.go
+++ b/pkg/registry/resource/resourceslice/declarative_validation_test.go
@@ -224,6 +224,12 @@ func TestDeclarativeValidate(t *testing.T) {
 				"valid: shared counter key": {
 					input: mkResourceSliceWithSharedCounters(tweakSharedCounter(counters("valid-key"))),
 				},
+				"invalid: shared counters empty": {
+					input: mkResourceSliceWithSharedCounters(tweakSharedCounter(nil)),
+					expectedErrs: field.ErrorList{
+						field.Required(field.NewPath("spec", "sharedCounters").Index(0).Child("counters"), "").MarkAlpha(),
+					},
+				},
 				// spec.devices.consumesCounters.counters
 				"invalid: device counter key with uppercase": {
 					input: mkResourceSliceWithDevices(tweakDeviceCounter(counters("InvalidKey"))),
@@ -233,6 +239,12 @@ func TestDeclarativeValidate(t *testing.T) {
 				},
 				"valid: device counter key": {
 					input: mkResourceSliceWithDevices(tweakDeviceCounter(counters("valid-key"))),
+				},
+				"invalid: device counters empty": {
+					input: mkResourceSliceWithDevices(tweakDeviceCounter(nil)),
+					expectedErrs: field.ErrorList{
+						field.Required(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counters"), "").MarkAlpha(),
+					},
 				},
 				// TODO: Add more test cases
 			}

--- a/staging/src/k8s.io/api/resource/v1alpha3/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1alpha3/generated.proto
@@ -456,9 +456,7 @@ message ResourcePoolStatusRequestStatus {
   // +optional
   // +k8s:optional
   // +listType=map
-  // +k8s:listType=map
   // +listMapKey=type
-  // +k8s:listMapKey=type
   // +patchStrategy=merge
   // +patchMergeKey=type
   // +k8s:maxItems=10

--- a/staging/src/k8s.io/api/resource/v1alpha3/types.go
+++ b/staging/src/k8s.io/api/resource/v1alpha3/types.go
@@ -463,9 +463,7 @@ type ResourcePoolStatusRequestStatus struct {
 	// +optional
 	// +k8s:optional
 	// +listType=map
-	// +k8s:listType=map
 	// +listMapKey=type
-	// +k8s:listMapKey=type
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +k8s:maxItems=10

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -1141,7 +1141,6 @@ message DeviceRequestAllocationResult {
   // +listType=atomic
   // +featureGate=DRADeviceTaints
   // +k8s:alpha(since: "1.36")=+k8s:optional
-  // +k8s:alpha(since: "1.36")=+k8s:maxItems=16
   repeated DeviceToleration tolerations = 6;
 
   // BindingConditions contains a copy of the BindingConditions

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -1822,7 +1822,6 @@ type DeviceRequestAllocationResult struct {
 	// +listType=atomic
 	// +featureGate=DRADeviceTaints
 	// +k8s:alpha(since: "1.36")=+k8s:optional
-	// +k8s:alpha(since: "1.36")=+k8s:maxItems=16
 	Tolerations []DeviceToleration `json:"tolerations,omitempty" protobuf:"bytes,6,opt,name=tolerations"`
 
 	// BindingConditions contains a copy of the BindingConditions


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
Closes the DRA-related test gaps from the declarative-validation coverage guardrail and fixes a few Handwritten validation / API tags misses uncovered while writing those  tests.

By type:
  - **ResourceClaimTemplate**: add the missing `NormalizationRules` to the strategy (ResourceClaim strategy had it, ResourceClaimTemplate was missed) and expand the equivalence test to cover rules under `spec.spec.devices.*`.
  - **ResourceClaim**: add Handwritten validation for `status.allocation.devices.results[].tolerations[]` (DV had tags on `DeviceToleration`; HV was silent at this call site, causing runtime mismatch metrics on every status update with tolerations) and add status-side equivalence tests for `config[].opaque.driver` and `tolerations[]`. Also revert a stray `+k8s:maxItems=16` tag on v1beta1 `result.Tolerations`.
  - **DeviceClass**: add equivalence tests for `spec.config[].opaque.driver` (Required / TooLong / Invalid).
  - **ResourceSlice**: mark HV Required(counters) covered by declarative validation and add the missing equivalence tests.
  - **ResourcePoolStatusRequest**: add equivalence tests for `spec.limit` / `status.poolCount` / `status.pools[].generation` . Also drop the redundant `+k8s:listType=map` / `+k8s:listMapKey=type` tags on `status.conditions`

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
 Part of 
- https://github.com/kubernetes/kubernetes/issues/138697

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
