### PR TITLE
POC: Per watch event lifecycle tracking

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
@@ -48,10 +48,17 @@ const (
 	cacheWatcherBookmarkSent
 )
 
+// inputEvent is what travels through a cacheWatcher's input channel; the event
+// pointer along with the enqueue timestamp as Unix nanoseconds.
+type inputEvent struct {
+	event      *watchCacheEvent
+	enqueuedAt int64
+}
+
 // cacheWatcher implements watch.Interface
 // this is not thread-safe
 type cacheWatcher struct {
-	input     chan *watchCacheEvent
+	input     chan inputEvent
 	result    chan watch.Event
 	done      chan struct{}
 	filter    filterWithAttrsFunc
@@ -100,7 +107,7 @@ func newCacheWatcher(
 	identifier string,
 ) *cacheWatcher {
 	return &cacheWatcher{
-		input:               make(chan *watchCacheEvent, chanSize),
+		input:               make(chan inputEvent, chanSize),
 		result:              make(chan watch.Event, chanSize),
 		done:                make(chan struct{}),
 		filter:              filter,
@@ -157,7 +164,7 @@ func (c *cacheWatcher) nonblockingAdd(event *watchCacheEvent) bool {
 		return false
 	}
 	select {
-	case c.input <- event:
+	case c.input <- inputEvent{event: event, enqueuedAt: time.Now().UnixNano()}:
 		c.markBookmarkAfterRvAsReceived(event)
 		return true
 	default:
@@ -217,7 +224,7 @@ func (c *cacheWatcher) add(event *watchCacheEvent, timer *time.Timer) bool {
 
 	// OK, block sending, but only until timer fires.
 	select {
-	case c.input <- event:
+	case c.input <- inputEvent{event: event, enqueuedAt: time.Now().UnixNano()}:
 		return true
 	case <-timer.C:
 		closeFunc()
@@ -536,17 +543,23 @@ func (c *cacheWatcher) process(ctx context.Context, resourceVersion uint64) {
 
 	for {
 		select {
-		case event, ok := <-c.input:
+		case ie, ok := <-c.input:
 			if !ok {
 				return
 			}
+			event := ie.event
 			// only send events newer than resourceVersion
 			// or a bookmark event with an RV equal to resourceVersion
 			// if we haven't sent one to the client
 			if event.ResourceVersion > resourceVersion || (event.Type == watch.Bookmark && event.ResourceVersion == resourceVersion && !c.wasBookmarkAfterRvSent()) {
+				dequeuedAt := time.Now()
 				sentAt := c.sendWatchCacheEvent(event)
 				if !sentAt.IsZero() {
-					c.recordLifecycleMetrics(event, sentAt)
+					var enqueuedAt time.Time
+					if ie.enqueuedAt > 0 {
+						enqueuedAt = time.Unix(0, ie.enqueuedAt)
+					}
+					c.recordLifecycleMetrics(event, enqueuedAt, dequeuedAt, sentAt)
 				}
 			}
 		case <-ctx.Done():
@@ -555,7 +568,10 @@ func (c *cacheWatcher) process(ctx context.Context, resourceVersion uint64) {
 	}
 }
 
-func (c *cacheWatcher) recordLifecycleMetrics(event *watchCacheEvent, sentAt time.Time) {
+func (c *cacheWatcher) recordLifecycleMetrics(event *watchCacheEvent, enqueuedAt, dequeuedAt, sentAt time.Time) {
+	if !enqueuedAt.IsZero() && !dequeuedAt.IsZero() {
+		c.watcherMetrics.ObserveQueueDuration(dequeuedAt.Sub(enqueuedAt))
+	}
 	if !sentAt.IsZero() && !event.RecordTime.IsZero() {
 		c.watcherMetrics.ObserveDelivered(sentAt.Sub(event.RecordTime))
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
@@ -223,10 +223,13 @@ func (c *cacheWatcher) add(event *watchCacheEvent, timer *time.Timer) bool {
 	}
 
 	// OK, block sending, but only until timer fires.
+	blockStart := time.Now()
 	select {
-	case c.input <- inputEvent{event: event, enqueuedAt: time.Now().UnixNano()}:
+	case c.input <- inputEvent{event: event, enqueuedAt: blockStart.UnixNano()}:
+		c.watcherMetrics.AddDispatchBlockedSeconds(time.Since(blockStart))
 		return true
 	case <-timer.C:
+		c.watcherMetrics.AddDispatchBlockedSeconds(time.Since(blockStart))
 		closeFunc()
 		return false
 	}
@@ -439,10 +442,12 @@ func (c *cacheWatcher) sendWatchCacheEvent(event *watchCacheEvent) (sentAt time.
 	default:
 	}
 
+	handoffStart := time.Now()
 	select {
 	case c.result <- *watchEvent:
 		c.markBookmarkAfterRvSent(event)
 		sentAt = time.Now()
+		c.watcherMetrics.AddHandoffBlockedSeconds(sentAt.Sub(handoffStart))
 	case <-c.done:
 	}
 	return

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
@@ -63,6 +63,7 @@ type cacheWatcher struct {
 	deadline            time.Time
 	allowWatchBookmarks bool
 	groupResource       schema.GroupResource
+	watcherMetrics      *metrics.WatcherMetricsObservers
 
 	// human readable identifier that helps assigning cacheWatcher
 	// instance with request
@@ -95,6 +96,7 @@ func newCacheWatcher(
 	deadline time.Time,
 	allowWatchBookmarks bool,
 	groupResource schema.GroupResource,
+	watcherMetrics *metrics.WatcherMetricsObservers,
 	identifier string,
 ) *cacheWatcher {
 	return &cacheWatcher{
@@ -108,6 +110,7 @@ func newCacheWatcher(
 		deadline:            deadline,
 		allowWatchBookmarks: allowWatchBookmarks,
 		groupResource:       groupResource,
+		watcherMetrics:      watcherMetrics,
 		identifier:          identifier,
 	}
 }
@@ -200,6 +203,9 @@ func (c *cacheWatcher) add(event *watchCacheEvent, timer *time.Timer) bool {
 			defer c.stateMutex.Unlock()
 			return c.state == cacheWatcherBookmarkReceived
 		}()
+		if !event.RecordTime.IsZero() {
+			c.watcherMetrics.ObserveTerminated(time.Since(event.RecordTime))
+		}
 		klog.V(1).Infof("Forcing %v watcher close due to unresponsiveness: %v. len(c.input) = %v, len(c.result) = %v, graceful = %v", c.groupResource.String(), c.identifier, len(c.input), len(c.result), graceful)
 		c.forget(graceful)
 	}
@@ -401,7 +407,7 @@ func (c *cacheWatcher) convertToWatchEvent(event *watchCacheEvent) *watch.Event 
 }
 
 // NOTE: sendWatchCacheEvent is assumed to not modify <event> !!!
-func (c *cacheWatcher) sendWatchCacheEvent(event *watchCacheEvent) {
+func (c *cacheWatcher) sendWatchCacheEvent(event *watchCacheEvent) (sentAt time.Time) {
 	watchEvent := c.convertToWatchEvent(event)
 	if watchEvent == nil {
 		// Watcher is not interested in that object.
@@ -429,8 +435,10 @@ func (c *cacheWatcher) sendWatchCacheEvent(event *watchCacheEvent) {
 	select {
 	case c.result <- *watchEvent:
 		c.markBookmarkAfterRvSent(event)
+		sentAt = time.Now()
 	case <-c.done:
 	}
+	return
 }
 
 func (c *cacheWatcher) processInterval(ctx context.Context, cacheInterval *watchCacheInterval, resourceVersion uint64) {
@@ -536,10 +544,19 @@ func (c *cacheWatcher) process(ctx context.Context, resourceVersion uint64) {
 			// or a bookmark event with an RV equal to resourceVersion
 			// if we haven't sent one to the client
 			if event.ResourceVersion > resourceVersion || (event.Type == watch.Bookmark && event.ResourceVersion == resourceVersion && !c.wasBookmarkAfterRvSent()) {
-				c.sendWatchCacheEvent(event)
+				sentAt := c.sendWatchCacheEvent(event)
+				if !sentAt.IsZero() {
+					c.recordLifecycleMetrics(event, sentAt)
+				}
 			}
 		case <-ctx.Done():
 			return
 		}
+	}
+}
+
+func (c *cacheWatcher) recordLifecycleMetrics(event *watchCacheEvent, sentAt time.Time) {
+	if !sentAt.IsZero() && !event.RecordTime.IsZero() {
+		c.watcherMetrics.ObserveDelivered(sentAt.Sub(event.RecordTime))
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/storage"
@@ -48,11 +49,59 @@ const (
 	cacheWatcherBookmarkSent
 )
 
+const (
+	// slowDispatchThreshold is the per (event, watcher) end-to-end
+	// dispatch latency above which a structured log line is emitted.
+	slowDispatchThreshold = 500 * time.Millisecond
+
+	// slowDispatchWatchLogInterval bounds the rate of per-event
+	// slow-dispatch log emission.
+	slowDispatchWatchLogInterval = time.Second
+)
+
+var slowDispatchLog = &slowDispatchLogger{
+	interval: slowDispatchWatchLogInterval,
+}
+
+// slowDispatchLogger emits at most one per-event slow-dispatch log line per
+// interval.
+type slowDispatchLogger struct {
+	interval     time.Duration
+	mu           sync.Mutex
+	lastLogTime  time.Time
+	skippedCount int
+}
+
 // inputEvent is what travels through a cacheWatcher's input channel; the event
 // pointer along with the enqueue timestamp as Unix nanoseconds.
 type inputEvent struct {
 	event      *watchCacheEvent
 	enqueuedAt int64
+}
+
+// timingInfo captures the full lifecycle timestamps of one event delivered
+// to one watcher, from receipt by the watch cache to enqueue on the watcher's
+// result channel.
+type timingInfo struct {
+	// Per-event (shared across all watchers receiving this event).
+	// The watch cache received the event from the storage layer.
+	receivedFromStorageAt time.Time
+	// The event was written to the watch cache's ring buffer.
+	ringBufferedAt time.Time
+	// The dispatcher picked the event up from the incoming channel for
+	// fan-out.
+	dispatchedAt time.Time
+
+	// Per-watcher (unique per delivery).
+	// The event was placed on this watcher's input channel.
+	enqueuedForWatcherAt time.Time
+	// The watcher's process goroutine dequeued the event from its
+	// input channel.
+	dequeuedByWatcherAt time.Time
+	// Filtering + conversion produced the outgoing watch.Event.
+	watchEventBuiltAt time.Time
+	// The watch.Event was enqueued on this watcher's result channel.
+	sentToResultChanAt time.Time
 }
 
 // cacheWatcher implements watch.Interface
@@ -75,6 +124,8 @@ type cacheWatcher struct {
 	// human readable identifier that helps assigning cacheWatcher
 	// instance with request
 	identifier string
+
+	auditID types.UID
 
 	// drainInputBuffer indicates whether we should delay closing this watcher
 	// and send all event in the input buffer.
@@ -105,6 +156,7 @@ func newCacheWatcher(
 	groupResource schema.GroupResource,
 	watcherMetrics *metrics.WatcherMetricsObservers,
 	identifier string,
+	auditID types.UID,
 ) *cacheWatcher {
 	return &cacheWatcher{
 		input:               make(chan inputEvent, chanSize),
@@ -119,6 +171,7 @@ func newCacheWatcher(
 		groupResource:       groupResource,
 		watcherMetrics:      watcherMetrics,
 		identifier:          identifier,
+		auditID:             auditID,
 	}
 }
 
@@ -210,10 +263,13 @@ func (c *cacheWatcher) add(event *watchCacheEvent, timer *time.Timer) bool {
 			defer c.stateMutex.Unlock()
 			return c.state == cacheWatcherBookmarkReceived
 		}()
+		undeliveredMs := int64(-1)
 		if !event.RecordTime.IsZero() {
-			c.watcherMetrics.ObserveTerminated(time.Since(event.RecordTime))
+			d := time.Since(event.RecordTime)
+			c.watcherMetrics.ObserveTerminated(d)
+			undeliveredMs = d.Milliseconds()
 		}
-		klog.V(1).Infof("Forcing %v watcher close due to unresponsiveness: %v. len(c.input) = %v, len(c.result) = %v, graceful = %v", c.groupResource.String(), c.identifier, len(c.input), len(c.result), graceful)
+		klog.V(1).Infof("Forcing %v watcher close due to unresponsiveness: %v. resourceversion = %v, undeliveredMs = %v, len(c.input) = %v, len(c.result) = %v, graceful = %v", c.groupResource.String(), c.identifier, event.ResourceVersion, undeliveredMs, len(c.input), len(c.result), graceful)
 		c.forget(graceful)
 	}
 
@@ -417,12 +473,13 @@ func (c *cacheWatcher) convertToWatchEvent(event *watchCacheEvent) *watch.Event 
 }
 
 // NOTE: sendWatchCacheEvent is assumed to not modify <event> !!!
-func (c *cacheWatcher) sendWatchCacheEvent(event *watchCacheEvent) (sentAt time.Time) {
+func (c *cacheWatcher) sendWatchCacheEvent(event *watchCacheEvent) (builtAt, sentAt time.Time) {
 	watchEvent := c.convertToWatchEvent(event)
 	if watchEvent == nil {
 		// Watcher is not interested in that object.
 		return
 	}
+	builtAt = time.Now()
 
 	// We need to ensure that if we put event X to the c.result, all
 	// previous events were already put into it before, no matter whether
@@ -558,13 +615,14 @@ func (c *cacheWatcher) process(ctx context.Context, resourceVersion uint64) {
 			// if we haven't sent one to the client
 			if event.ResourceVersion > resourceVersion || (event.Type == watch.Bookmark && event.ResourceVersion == resourceVersion && !c.wasBookmarkAfterRvSent()) {
 				dequeuedAt := time.Now()
-				sentAt := c.sendWatchCacheEvent(event)
+				builtAt, sentAt := c.sendWatchCacheEvent(event)
 				if !sentAt.IsZero() {
 					var enqueuedAt time.Time
 					if ie.enqueuedAt > 0 {
 						enqueuedAt = time.Unix(0, ie.enqueuedAt)
 					}
 					c.recordLifecycleMetrics(event, enqueuedAt, dequeuedAt, sentAt)
+					c.logIfSlow(event, enqueuedAt, dequeuedAt, builtAt, sentAt)
 				}
 			}
 		case <-ctx.Done():
@@ -580,4 +638,68 @@ func (c *cacheWatcher) recordLifecycleMetrics(event *watchCacheEvent, enqueuedAt
 	if !sentAt.IsZero() && !event.RecordTime.IsZero() {
 		c.watcherMetrics.ObserveDelivered(sentAt.Sub(event.RecordTime))
 	}
+}
+
+func (c *cacheWatcher) logIfSlow(event *watchCacheEvent, enqueuedAt, dequeuedAt, builtAt, sentAt time.Time) {
+	if sentAt.IsZero() || event.RecordTime.IsZero() {
+		return
+	}
+	total := sentAt.Sub(event.RecordTime)
+	if total < slowDispatchThreshold {
+		return
+	}
+
+	allow, skippedEventsCount := slowDispatchLog.allow()
+	if !allow {
+		return
+	}
+
+	var ringBufferedAt time.Time
+	if event.WatchCacheEnqueuedAt > 0 {
+		ringBufferedAt = time.Unix(0, event.WatchCacheEnqueuedAt)
+	}
+
+	var dispatchedAt time.Time
+	if event.WatchCacheDispatchedAt > 0 {
+		dispatchedAt = time.Unix(0, event.WatchCacheDispatchedAt)
+	}
+
+	timing := timingInfo{
+		receivedFromStorageAt: event.RecordTime,
+		ringBufferedAt:        ringBufferedAt,
+		dispatchedAt:          dispatchedAt,
+		enqueuedForWatcherAt:  enqueuedAt,
+		dequeuedByWatcherAt:   dequeuedAt,
+		watchEventBuiltAt:     builtAt,
+		sentToResultChanAt:    sentAt,
+	}
+
+	klog.InfoS("Slow watch cache processing",
+		"watcher", c.identifier,
+		"resource", c.groupResource,
+		"resourceversion", event.ResourceVersion,
+		"auditID", c.auditID,
+		"totalDurationSeconds", total.Seconds(),
+		"incomingQueueDurationSeconds", timing.ringBufferedAt.Sub(timing.receivedFromStorageAt).Seconds(),
+		"awaitingDispatchSeconds", timing.dispatchedAt.Sub(timing.ringBufferedAt).Seconds(),
+		"dispatchToWatcherSeconds", timing.enqueuedForWatcherAt.Sub(timing.dispatchedAt).Seconds(),
+		"awaitingWatcherSeconds", timing.dequeuedByWatcherAt.Sub(timing.enqueuedForWatcherAt).Seconds(),
+		"eventBuildSeconds", timing.watchEventBuiltAt.Sub(timing.dequeuedByWatcherAt).Seconds(),
+		"handoffSeconds", timing.sentToResultChanAt.Sub(timing.watchEventBuiltAt).Seconds(),
+		"skippedEventsSinceLastLog", skippedEventsCount,
+	)
+}
+
+func (l *slowDispatchLogger) allow() (bool, int) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	now := time.Now()
+	if now.Sub(l.lastLogTime) < l.interval {
+		l.skippedCount++
+		return false, 0
+	}
+	skipped := l.skippedCount
+	l.lastLogTime = now
+	l.skippedCount = 0
+	return true, skipped
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
@@ -65,7 +65,7 @@ func TestCacheWatcherCleanupNotBlockedByResult(t *testing.T) {
 	}
 	// set the size of the buffer of w.result to 0, so that the writes to
 	// w.result is blocked.
-	w = newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, time.Now(), false, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
+	w = newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, time.Now(), false, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "", "")
 	go w.processInterval(context.Background(), intervalFromEvents(initEvents), 0)
 	w.Stop()
 	if err := wait.PollImmediate(1*time.Second, 5*time.Second, func() (bool, error) {
@@ -185,7 +185,7 @@ TestCase:
 			testCase.events[j].ResourceVersion = uint64(j) + 1
 		}
 
-		w := newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, time.Now(), false, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
+		w := newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, time.Now(), false, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "", "")
 		go w.processInterval(context.Background(), intervalFromEvents(testCase.events), 0)
 
 		ch := w.ResultChan()
@@ -222,7 +222,7 @@ func TestCacheWatcherStoppedInAnotherGoroutine(t *testing.T) {
 	// timeout to zero and run the Stop goroutine concurrently.
 	// May sure that the watch will not be blocked on Stop.
 	for i := 0; i < maxRetriesToProduceTheRaceCondition; i++ {
-		w = newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, time.Now(), false, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
+		w = newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, time.Now(), false, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "", "")
 		go w.Stop()
 		select {
 		case <-done:
@@ -234,7 +234,7 @@ func TestCacheWatcherStoppedInAnotherGoroutine(t *testing.T) {
 	deadline := time.Now().Add(time.Hour)
 	// After that, verifies the cacheWatcher.process goroutine works correctly.
 	for i := 0; i < maxRetriesToProduceTheRaceCondition; i++ {
-		w = newCacheWatcher(2, filter, emptyFunc, storage.APIObjectVersioner{}, deadline, false, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
+		w = newCacheWatcher(2, filter, emptyFunc, storage.APIObjectVersioner{}, deadline, false, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "", "")
 		w.input <- inputEvent{event: &watchCacheEvent{Object: &v1.Pod{}, ResourceVersion: uint64(i + 1)}, enqueuedAt: time.Now().UnixNano()}
 		ctx, cancel := context.WithDeadline(context.Background(), deadline)
 		defer cancel()
@@ -307,7 +307,7 @@ func TestResourceVersionAfterInitEvents(t *testing.T) {
 	filter := func(_ string, _ labels.Set, _ fields.Set, _ runtime.Object) bool { return true }
 	forget := func(_ bool) {}
 	deadline := time.Now().Add(time.Minute)
-	w := newCacheWatcher(numObjects+1, filter, forget, storage.APIObjectVersioner{}, deadline, true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
+	w := newCacheWatcher(numObjects+1, filter, forget, storage.APIObjectVersioner{}, deadline, true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "", "")
 
 	// Simulate a situation when the last event will that was already in
 	// the state, wasn't yet processed by cacher and will be delivered
@@ -350,7 +350,7 @@ func TestTimeBucketWatchersBasic(t *testing.T) {
 	forget := func(bool) {}
 
 	newWatcher := func(deadline time.Time) *cacheWatcher {
-		w := newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, deadline, true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
+		w := newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, deadline, true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "", "")
 		w.setBookmarkAfterResourceVersion(0)
 		return w
 	}
@@ -383,7 +383,7 @@ func TestTimeBucketWatchersBasic(t *testing.T) {
 	clock.Step(12 * time.Second)
 	watchers2 := watchers.popExpiredWatchersThreadUnsafe()
 	if len(watchers2) != 1 || len(watchers2[0]) != 2 {
-		t.Errorf("unexpected bucket size: %#v", watchers2)
+		t.Errorf("unexpected bucket size: %v", watchers2)
 	}
 }
 
@@ -417,7 +417,7 @@ func TestCacheWatcherDraining(t *testing.T) {
 		makeWatchCacheEvent(5),
 		makeWatchCacheEvent(6),
 	}
-	w = newCacheWatcher(1, filter, forget, storage.APIObjectVersioner{}, time.Now(), true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
+	w = newCacheWatcher(1, filter, forget, storage.APIObjectVersioner{}, time.Now(), true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "", "")
 	go w.processInterval(context.Background(), intervalFromEvents(initEvents), 1)
 	if !w.add(makeWatchCacheEvent(7), time.NewTimer(1*time.Second)) {
 		t.Fatal("failed adding an even to the watcher")
@@ -458,7 +458,7 @@ func TestCacheWatcherDrainingRequestedButNotDrained(t *testing.T) {
 		makeWatchCacheEvent(5),
 		makeWatchCacheEvent(6),
 	}
-	w = newCacheWatcher(1, filter, forget, storage.APIObjectVersioner{}, time.Now(), true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
+	w = newCacheWatcher(1, filter, forget, storage.APIObjectVersioner{}, time.Now(), true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "", "")
 	go w.processInterval(context.Background(), intervalFromEvents(initEvents), 1)
 	if !w.add(makeWatchCacheEvent(7), time.NewTimer(1*time.Second)) {
 		t.Fatal("failed adding an even to the watcher")
@@ -495,7 +495,7 @@ func TestCacheWatcherDrainingNoBookmarkAfterResourceVersionReceived(t *testing.T
 		{Object: &v1.Pod{}},
 		{Object: &v1.Pod{}},
 	}
-	w = newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, time.Now(), true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
+	w = newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, time.Now(), true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "", "")
 	w.setBookmarkAfterResourceVersion(10)
 	go w.processInterval(context.Background(), intervalFromEvents(initEvents), 0)
 
@@ -553,7 +553,7 @@ func TestCacheWatcherDrainingNoBookmarkAfterResourceVersionSent(t *testing.T) {
 		w.stopLocked()
 	}
 	initEvents := []*watchCacheEvent{{Object: makePod(1)}, {Object: makePod(2)}}
-	w = newCacheWatcher(2, filter, forget, storage.APIObjectVersioner{}, time.Now(), true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
+	w = newCacheWatcher(2, filter, forget, storage.APIObjectVersioner{}, time.Now(), true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "", "")
 	w.setBookmarkAfterResourceVersion(10)
 	go w.processInterval(ctx, intervalFromEvents(initEvents), 0)
 	watchInitializationSignal.Wait()
@@ -607,7 +607,7 @@ func TestCacheWatcherDrainingNoBookmarkAfterResourceVersionSent(t *testing.T) {
 
 func TestBookmarkAfterResourceVersionWatchers(t *testing.T) {
 	newWatcher := func(id string, deadline time.Time) *cacheWatcher {
-		w := newCacheWatcher(0, func(_ string, _ labels.Set, _ fields.Set, _ runtime.Object) bool { return true }, func(bool) {}, storage.APIObjectVersioner{}, deadline, true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), id)
+		w := newCacheWatcher(0, func(_ string, _ labels.Set, _ fields.Set, _ runtime.Object) bool { return true }, func(bool) {}, storage.APIObjectVersioner{}, deadline, true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), id, "")
 		w.setBookmarkAfterResourceVersion(10)
 		return w
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
@@ -235,7 +235,7 @@ func TestCacheWatcherStoppedInAnotherGoroutine(t *testing.T) {
 	// After that, verifies the cacheWatcher.process goroutine works correctly.
 	for i := 0; i < maxRetriesToProduceTheRaceCondition; i++ {
 		w = newCacheWatcher(2, filter, emptyFunc, storage.APIObjectVersioner{}, deadline, false, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
-		w.input <- &watchCacheEvent{Object: &v1.Pod{}, ResourceVersion: uint64(i + 1)}
+		w.input <- inputEvent{event: &watchCacheEvent{Object: &v1.Pod{}, ResourceVersion: uint64(i + 1)}, enqueuedAt: time.Now().UnixNano()}
 		ctx, cancel := context.WithDeadline(context.Background(), deadline)
 		defer cancel()
 		go w.processInterval(ctx, intervalFromEvents(nil), 0)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/storage"
+	"k8s.io/apiserver/pkg/storage/cacher/metrics"
 	"k8s.io/apiserver/pkg/storage/cacher/store"
 	utilflowcontrol "k8s.io/apiserver/pkg/util/flowcontrol"
 	testingclock "k8s.io/utils/clock/testing"
@@ -64,7 +65,7 @@ func TestCacheWatcherCleanupNotBlockedByResult(t *testing.T) {
 	}
 	// set the size of the buffer of w.result to 0, so that the writes to
 	// w.result is blocked.
-	w = newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, time.Now(), false, schema.GroupResource{Resource: "pods"}, "")
+	w = newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, time.Now(), false, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
 	go w.processInterval(context.Background(), intervalFromEvents(initEvents), 0)
 	w.Stop()
 	if err := wait.PollImmediate(1*time.Second, 5*time.Second, func() (bool, error) {
@@ -184,7 +185,7 @@ TestCase:
 			testCase.events[j].ResourceVersion = uint64(j) + 1
 		}
 
-		w := newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, time.Now(), false, schema.GroupResource{Resource: "pods"}, "")
+		w := newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, time.Now(), false, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
 		go w.processInterval(context.Background(), intervalFromEvents(testCase.events), 0)
 
 		ch := w.ResultChan()
@@ -221,7 +222,7 @@ func TestCacheWatcherStoppedInAnotherGoroutine(t *testing.T) {
 	// timeout to zero and run the Stop goroutine concurrently.
 	// May sure that the watch will not be blocked on Stop.
 	for i := 0; i < maxRetriesToProduceTheRaceCondition; i++ {
-		w = newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, time.Now(), false, schema.GroupResource{Resource: "pods"}, "")
+		w = newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, time.Now(), false, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
 		go w.Stop()
 		select {
 		case <-done:
@@ -233,7 +234,7 @@ func TestCacheWatcherStoppedInAnotherGoroutine(t *testing.T) {
 	deadline := time.Now().Add(time.Hour)
 	// After that, verifies the cacheWatcher.process goroutine works correctly.
 	for i := 0; i < maxRetriesToProduceTheRaceCondition; i++ {
-		w = newCacheWatcher(2, filter, emptyFunc, storage.APIObjectVersioner{}, deadline, false, schema.GroupResource{Resource: "pods"}, "")
+		w = newCacheWatcher(2, filter, emptyFunc, storage.APIObjectVersioner{}, deadline, false, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
 		w.input <- &watchCacheEvent{Object: &v1.Pod{}, ResourceVersion: uint64(i + 1)}
 		ctx, cancel := context.WithDeadline(context.Background(), deadline)
 		defer cancel()
@@ -306,7 +307,7 @@ func TestResourceVersionAfterInitEvents(t *testing.T) {
 	filter := func(_ string, _ labels.Set, _ fields.Set, _ runtime.Object) bool { return true }
 	forget := func(_ bool) {}
 	deadline := time.Now().Add(time.Minute)
-	w := newCacheWatcher(numObjects+1, filter, forget, storage.APIObjectVersioner{}, deadline, true, schema.GroupResource{Resource: "pods"}, "")
+	w := newCacheWatcher(numObjects+1, filter, forget, storage.APIObjectVersioner{}, deadline, true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
 
 	// Simulate a situation when the last event will that was already in
 	// the state, wasn't yet processed by cacher and will be delivered
@@ -349,7 +350,7 @@ func TestTimeBucketWatchersBasic(t *testing.T) {
 	forget := func(bool) {}
 
 	newWatcher := func(deadline time.Time) *cacheWatcher {
-		w := newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, deadline, true, schema.GroupResource{Resource: "pods"}, "")
+		w := newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, deadline, true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
 		w.setBookmarkAfterResourceVersion(0)
 		return w
 	}
@@ -416,7 +417,7 @@ func TestCacheWatcherDraining(t *testing.T) {
 		makeWatchCacheEvent(5),
 		makeWatchCacheEvent(6),
 	}
-	w = newCacheWatcher(1, filter, forget, storage.APIObjectVersioner{}, time.Now(), true, schema.GroupResource{Resource: "pods"}, "")
+	w = newCacheWatcher(1, filter, forget, storage.APIObjectVersioner{}, time.Now(), true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
 	go w.processInterval(context.Background(), intervalFromEvents(initEvents), 1)
 	if !w.add(makeWatchCacheEvent(7), time.NewTimer(1*time.Second)) {
 		t.Fatal("failed adding an even to the watcher")
@@ -457,7 +458,7 @@ func TestCacheWatcherDrainingRequestedButNotDrained(t *testing.T) {
 		makeWatchCacheEvent(5),
 		makeWatchCacheEvent(6),
 	}
-	w = newCacheWatcher(1, filter, forget, storage.APIObjectVersioner{}, time.Now(), true, schema.GroupResource{Resource: "pods"}, "")
+	w = newCacheWatcher(1, filter, forget, storage.APIObjectVersioner{}, time.Now(), true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
 	go w.processInterval(context.Background(), intervalFromEvents(initEvents), 1)
 	if !w.add(makeWatchCacheEvent(7), time.NewTimer(1*time.Second)) {
 		t.Fatal("failed adding an even to the watcher")
@@ -494,7 +495,7 @@ func TestCacheWatcherDrainingNoBookmarkAfterResourceVersionReceived(t *testing.T
 		{Object: &v1.Pod{}},
 		{Object: &v1.Pod{}},
 	}
-	w = newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, time.Now(), true, schema.GroupResource{Resource: "pods"}, "")
+	w = newCacheWatcher(0, filter, forget, storage.APIObjectVersioner{}, time.Now(), true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
 	w.setBookmarkAfterResourceVersion(10)
 	go w.processInterval(context.Background(), intervalFromEvents(initEvents), 0)
 
@@ -552,7 +553,7 @@ func TestCacheWatcherDrainingNoBookmarkAfterResourceVersionSent(t *testing.T) {
 		w.stopLocked()
 	}
 	initEvents := []*watchCacheEvent{{Object: makePod(1)}, {Object: makePod(2)}}
-	w = newCacheWatcher(2, filter, forget, storage.APIObjectVersioner{}, time.Now(), true, schema.GroupResource{Resource: "pods"}, "")
+	w = newCacheWatcher(2, filter, forget, storage.APIObjectVersioner{}, time.Now(), true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), "")
 	w.setBookmarkAfterResourceVersion(10)
 	go w.processInterval(ctx, intervalFromEvents(initEvents), 0)
 	watchInitializationSignal.Wait()
@@ -606,7 +607,7 @@ func TestCacheWatcherDrainingNoBookmarkAfterResourceVersionSent(t *testing.T) {
 
 func TestBookmarkAfterResourceVersionWatchers(t *testing.T) {
 	newWatcher := func(id string, deadline time.Time) *cacheWatcher {
-		w := newCacheWatcher(0, func(_ string, _ labels.Set, _ fields.Set, _ runtime.Object) bool { return true }, func(bool) {}, storage.APIObjectVersioner{}, deadline, true, schema.GroupResource{Resource: "pods"}, id)
+		w := newCacheWatcher(0, func(_ string, _ labels.Set, _ fields.Set, _ runtime.Object) bool { return true }, func(bool) {}, storage.APIObjectVersioner{}, deadline, true, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), id)
 		w.setBookmarkAfterResourceVersion(10)
 		return w
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -972,6 +972,12 @@ func (c *Cacher) dispatchEvent(event *watchCacheEvent) {
 	defer c.finishDispatching()
 	// Watchers stopped after startDispatching will be delayed to finishDispatching,
 
+	dispatchedAt := c.clock.Now()
+	event.WatchCacheDispatchedAt = dispatchedAt.UnixNano()
+	if event.WatchCacheEnqueuedAt > 0 {
+		metrics.WatchCacheQueueDuration.WithLabelValues(c.groupResource.Group, c.groupResource.Resource).Observe(dispatchedAt.Sub(time.Unix(0, event.WatchCacheEnqueuedAt)).Seconds())
+	}
+
 	// Since add() can block, we explicitly add when cacher is unlocked.
 	// Dispatching event in nonblocking way first, which make faster watchers
 	// not be blocked by slower ones.

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -598,6 +598,7 @@ func (c *Cacher) Watch(ctx context.Context, key string, opts storage.ListOptions
 	// given that memory allocation may trigger GC and block the thread.
 	// Also note that emptyFunc is a placeholder, until we will be able
 	// to compute watcher.forget function (which has to happen under lock).
+	auditID, _ := audit.AuditIDFrom(ctx)
 	watcher := newCacheWatcher(
 		chanSize,
 		filterWithAttrsAndPrefixFunction(key, pred, c.groupResource),
@@ -608,6 +609,7 @@ func (c *Cacher) Watch(ctx context.Context, key string, opts storage.ListOptions
 		c.groupResource,
 		c.watcherMetrics,
 		identifier,
+		auditID,
 	)
 
 	// note that c.waitUntilWatchCacheFreshAndForceAllEvents must be called without

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -342,6 +342,7 @@ type Cacher struct {
 	// expiredBookmarkWatchers is a list of watchers that were expired and need to be schedule for a next bookmark event
 	expiredBookmarkWatchers []*cacheWatcher
 	compactor               *compactor
+	watcherMetrics          *metrics.WatcherMetricsObservers
 }
 
 // NewCacherFromConfig creates a new Cacher responsible for servicing WATCH and LIST requests from
@@ -414,6 +415,7 @@ func NewCacherFromConfig(config Config) (*Cacher, error) {
 		clock:            config.Clock,
 		timer:            time.NewTimer(time.Duration(0)),
 		bookmarkWatchers: newTimeBucketWatchers(config.Clock, defaultBookmarkFrequency),
+		watcherMetrics:   metrics.NewWatcherMetricsObservers(config.GroupResource),
 	}
 
 	// Ensure that timer is stopped.
@@ -604,6 +606,7 @@ func (c *Cacher) Watch(ctx context.Context, key string, opts storage.ListOptions
 		deadline,
 		pred.AllowWatchBookmarks,
 		c.groupResource,
+		c.watcherMetrics,
 		identifier,
 	)
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -2485,6 +2485,7 @@ func TestForgetWatcher(t *testing.T) {
 		groupResource,
 		metrics.NewNoopWatcherMetricsObservers(),
 		"1",
+		"",
 	)
 	forgetWatcherFn = forgetWatcher(cacher, w, 0, namespacedName{}, "", false)
 	addWatcher := func(w *cacheWatcher) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -2474,6 +2474,7 @@ func TestForgetWatcher(t *testing.T) {
 		forgetCounter++
 		forgetWatcherFn(drainWatcher)
 	}
+	groupResource := schema.GroupResource{Resource: "pods"}
 	w := newCacheWatcher(
 		0,
 		func(_ string, _ labels.Set, _ fields.Set, _ runtime.Object) bool { return true },
@@ -2481,7 +2482,8 @@ func TestForgetWatcher(t *testing.T) {
 		storage.APIObjectVersioner{},
 		testingclock.NewFakeClock(time.Now()).Now().Add(2*time.Minute),
 		true,
-		schema.GroupResource{Resource: "pods"},
+		groupResource,
+		metrics.NewNoopWatcherMetricsObservers(),
 		"1",
 	)
 	forgetWatcherFn = forgetWatcher(cacher, w, 0, namespacedName{}, "", false)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -266,6 +266,22 @@ var (
 			StabilityLevel: compbasemetrics.ALPHA,
 			Buckets:        []float64{0.001, 0.005, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 		}, []string{"group", "resource"})
+
+	watcherDispatchBlockedSeconds = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Namespace:      namespace,
+			Name:           "watcher_dispatch_blocked_seconds_total",
+			Help:           "Counter of cumulative time in seconds a watcher was blocked on the input channel.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		}, []string{"group", "resource"})
+
+	watcherHandoffBlockedSeconds = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Namespace:      namespace,
+			Name:           "watcher_handoff_blocked_seconds_total",
+			Help:           "Counter of cumulative time in seconds this watcher was blocked sending an event to the result channel.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		}, []string{"group", "resource"})
 )
 
 var registerMetrics sync.Once
@@ -298,6 +314,8 @@ func Register() {
 		legacyregistry.MustRegister(dispatchDuration)
 		legacyregistry.MustRegister(WatchCacheQueueDuration)
 		legacyregistry.MustRegister(watcherQueueDuration)
+		legacyregistry.MustRegister(watcherDispatchBlockedSeconds)
+		legacyregistry.MustRegister(watcherHandoffBlockedSeconds)
 	})
 }
 
@@ -342,22 +360,40 @@ func RecordsWatchCacheCapacityChange(groupResource schema.GroupResource, old, ne
 }
 
 type WatcherMetricsObservers struct {
-	queueDuration      compbasemetrics.ObserverMetric
-	deliveredDuration  compbasemetrics.ObserverMetric
-	terminatedDuration compbasemetrics.ObserverMetric
+	queueDuration          compbasemetrics.ObserverMetric
+	dispatchBlockedSeconds compbasemetrics.CounterMetric
+	handoffBlockedSeconds  compbasemetrics.CounterMetric
+	deliveredDuration      compbasemetrics.ObserverMetric
+	terminatedDuration     compbasemetrics.ObserverMetric
 }
 
 // NewWatcherMetricsObservers creates a pre-resolved metrics observer for watch connections.
 func NewWatcherMetricsObservers(groupResource schema.GroupResource) *WatcherMetricsObservers {
 	return &WatcherMetricsObservers{
-		queueDuration:      watcherQueueDuration.WithLabelValues(groupResource.Group, groupResource.Resource),
-		deliveredDuration:  dispatchDuration.WithLabelValues(groupResource.Group, groupResource.Resource, dispatchOutcomeDelivered),
-		terminatedDuration: dispatchDuration.WithLabelValues(groupResource.Group, groupResource.Resource, dispatchOutcomeTerminated),
+		queueDuration:          watcherQueueDuration.WithLabelValues(groupResource.Group, groupResource.Resource),
+		dispatchBlockedSeconds: watcherDispatchBlockedSeconds.WithLabelValues(groupResource.Group, groupResource.Resource),
+		handoffBlockedSeconds:  watcherHandoffBlockedSeconds.WithLabelValues(groupResource.Group, groupResource.Resource),
+		deliveredDuration:      dispatchDuration.WithLabelValues(groupResource.Group, groupResource.Resource, dispatchOutcomeDelivered),
+		terminatedDuration:     dispatchDuration.WithLabelValues(groupResource.Group, groupResource.Resource, dispatchOutcomeTerminated),
 	}
 }
 
 func (d *WatcherMetricsObservers) ObserveQueueDuration(duration time.Duration) {
 	observe(d.queueDuration, duration)
+}
+
+func (d *WatcherMetricsObservers) AddDispatchBlockedSeconds(duration time.Duration) {
+	if duration < 0 {
+		duration = 0
+	}
+	d.dispatchBlockedSeconds.Add(duration.Seconds())
+}
+
+func (d *WatcherMetricsObservers) AddHandoffBlockedSeconds(duration time.Duration) {
+	if duration < 0 {
+		duration = 0
+	}
+	d.handoffBlockedSeconds.Add(duration.Seconds())
 }
 
 func (d *WatcherMetricsObservers) ObserveDelivered(duration time.Duration) {
@@ -379,13 +415,24 @@ type noopObserver struct{}
 
 func (noopObserver) Observe(float64) {}
 
-var noopObs noopObserver
+type noopCounter struct{}
+
+func (noopCounter) Inc()        {}
+func (noopCounter) Add(float64) {}
+
+var (
+	noopObs noopObserver
+	noopCnt noopCounter
+)
 
 // NewNoopWatcherMetricsObservers returns a metrics observers struct that does nothing.
+// Used primarily for testing to avoid registering test-related metric series.
 func NewNoopWatcherMetricsObservers() *WatcherMetricsObservers {
 	return &WatcherMetricsObservers{
-		queueDuration:      noopObs,
-		deliveredDuration:  noopObs,
-		terminatedDuration: noopObs,
+		queueDuration:          noopObs,
+		dispatchBlockedSeconds: noopCnt,
+		handoffBlockedSeconds:  noopCnt,
+		deliveredDuration:      noopObs,
+		terminatedDuration:     noopObs,
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -257,6 +257,15 @@ var (
 			StabilityLevel: compbasemetrics.ALPHA,
 			Buckets:        []float64{0.001, 0.005, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 		}, []string{"group", "resource"})
+
+	watcherQueueDuration = compbasemetrics.NewHistogramVec(
+		&compbasemetrics.HistogramOpts{
+			Namespace:      namespace,
+			Name:           "watcher_queue_duration_seconds",
+			Help:           "Histogram of time spent waiting in a specific watcher's input channel.",
+			StabilityLevel: compbasemetrics.ALPHA,
+			Buckets:        []float64{0.001, 0.005, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		}, []string{"group", "resource"})
 )
 
 var registerMetrics sync.Once
@@ -288,6 +297,7 @@ func Register() {
 		}
 		legacyregistry.MustRegister(dispatchDuration)
 		legacyregistry.MustRegister(WatchCacheQueueDuration)
+		legacyregistry.MustRegister(watcherQueueDuration)
 	})
 }
 
@@ -332,6 +342,7 @@ func RecordsWatchCacheCapacityChange(groupResource schema.GroupResource, old, ne
 }
 
 type WatcherMetricsObservers struct {
+	queueDuration      compbasemetrics.ObserverMetric
 	deliveredDuration  compbasemetrics.ObserverMetric
 	terminatedDuration compbasemetrics.ObserverMetric
 }
@@ -339,9 +350,14 @@ type WatcherMetricsObservers struct {
 // NewWatcherMetricsObservers creates a pre-resolved metrics observer for watch connections.
 func NewWatcherMetricsObservers(groupResource schema.GroupResource) *WatcherMetricsObservers {
 	return &WatcherMetricsObservers{
+		queueDuration:      watcherQueueDuration.WithLabelValues(groupResource.Group, groupResource.Resource),
 		deliveredDuration:  dispatchDuration.WithLabelValues(groupResource.Group, groupResource.Resource, dispatchOutcomeDelivered),
 		terminatedDuration: dispatchDuration.WithLabelValues(groupResource.Group, groupResource.Resource, dispatchOutcomeTerminated),
 	}
+}
+
+func (d *WatcherMetricsObservers) ObserveQueueDuration(duration time.Duration) {
+	observe(d.queueDuration, duration)
 }
 
 func (d *WatcherMetricsObservers) ObserveDelivered(duration time.Duration) {
@@ -368,6 +384,7 @@ var noopObs noopObserver
 // NewNoopWatcherMetricsObservers returns a metrics observers struct that does nothing.
 func NewNoopWatcherMetricsObservers() *WatcherMetricsObservers {
 	return &WatcherMetricsObservers{
+		queueDuration:      noopObs,
 		deliveredDuration:  noopObs,
 		terminatedDuration: noopObs,
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"sync"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/features"
@@ -28,8 +29,10 @@ import (
 )
 
 const (
-	namespace = "apiserver"
-	subsystem = "watch_cache"
+	namespace                 = "apiserver"
+	subsystem                 = "watch_cache"
+	dispatchOutcomeDelivered  = "delivered"
+	dispatchOutcomeTerminated = "terminated"
 )
 
 /*
@@ -234,6 +237,16 @@ var (
 		},
 		[]string{"group", "resource"},
 	)
+
+	dispatchDuration = compbasemetrics.NewHistogramVec(
+		&compbasemetrics.HistogramOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "watcher_dispatch_duration_seconds",
+			Help:           "Histogram of time spent dispatching an event to a specific watcher, broken by resource type and outcome.",
+			StabilityLevel: compbasemetrics.ALPHA,
+			Buckets:        []float64{0.001, 0.005, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		}, []string{"group", "resource", "outcome"})
 )
 
 var registerMetrics sync.Once
@@ -263,6 +276,7 @@ func Register() {
 			legacyregistry.MustRegister(WatchShardsTotal)
 			legacyregistry.MustRegister(WatchFilteredEventsTotal)
 		}
+		legacyregistry.MustRegister(dispatchDuration)
 	})
 }
 
@@ -304,4 +318,46 @@ func RecordsWatchCacheCapacityChange(groupResource schema.GroupResource, old, ne
 		return
 	}
 	watchCacheCapacityDecreaseTotal.WithLabelValues(groupResource.Group, groupResource.Resource).Inc()
+}
+
+type WatcherMetricsObservers struct {
+	deliveredDuration  compbasemetrics.ObserverMetric
+	terminatedDuration compbasemetrics.ObserverMetric
+}
+
+// NewWatcherMetricsObservers creates a pre-resolved metrics observer for watch connections.
+func NewWatcherMetricsObservers(groupResource schema.GroupResource) *WatcherMetricsObservers {
+	return &WatcherMetricsObservers{
+		deliveredDuration:  dispatchDuration.WithLabelValues(groupResource.Group, groupResource.Resource, dispatchOutcomeDelivered),
+		terminatedDuration: dispatchDuration.WithLabelValues(groupResource.Group, groupResource.Resource, dispatchOutcomeTerminated),
+	}
+}
+
+func (d *WatcherMetricsObservers) ObserveDelivered(duration time.Duration) {
+	observe(d.deliveredDuration, duration)
+}
+
+func (d *WatcherMetricsObservers) ObserveTerminated(duration time.Duration) {
+	observe(d.terminatedDuration, duration)
+}
+
+func observe(m compbasemetrics.ObserverMetric, duration time.Duration) {
+	if duration < 0 {
+		duration = 0
+	}
+	m.Observe(duration.Seconds())
+}
+
+type noopObserver struct{}
+
+func (noopObserver) Observe(float64) {}
+
+var noopObs noopObserver
+
+// NewNoopWatcherMetricsObservers returns a metrics observers struct that does nothing.
+func NewNoopWatcherMetricsObservers() *WatcherMetricsObservers {
+	return &WatcherMetricsObservers{
+		deliveredDuration:  noopObs,
+		terminatedDuration: noopObs,
+	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -247,6 +247,16 @@ var (
 			StabilityLevel: compbasemetrics.ALPHA,
 			Buckets:        []float64{0.001, 0.005, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 		}, []string{"group", "resource", "outcome"})
+
+	WatchCacheQueueDuration = compbasemetrics.NewHistogramVec(
+		&compbasemetrics.HistogramOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "queue_duration_seconds",
+			Help:           "Histogram of time spent in the cacher's incoming channel before fan-out.",
+			StabilityLevel: compbasemetrics.ALPHA,
+			Buckets:        []float64{0.001, 0.005, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		}, []string{"group", "resource"})
 )
 
 var registerMetrics sync.Once
@@ -277,6 +287,7 @@ func Register() {
 			legacyregistry.MustRegister(WatchFilteredEventsTotal)
 		}
 		legacyregistry.MustRegister(dispatchDuration)
+		legacyregistry.MustRegister(WatchCacheQueueDuration)
 	})
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -66,7 +66,18 @@ type watchCacheEvent struct {
 	PrevObjFields   fields.Set
 	Key             string
 	ResourceVersion uint64
-	RecordTime      time.Time
+
+	// RecordTime represents when the watch cache first received the event
+	// from the storage layer (etcd)
+	RecordTime time.Time
+
+	// WatchCacheEnqueuedAt represents when the event was added to the watch
+	// cache's ring buffer. Stored as Unix nanoseconds.
+	WatchCacheEnqueuedAt int64
+
+	// WatchCacheDispatchedAt represents when the dispatcher picked the event
+	// up from the incoming channel for fan-out. Stored as Unix nanoseconds.
+	WatchCacheDispatchedAt int64
 }
 
 // watchCache implements a Store interface.
@@ -248,6 +259,7 @@ func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64) err
 		w.Lock()
 		defer w.Unlock()
 
+		wcEvent.WatchCacheEnqueuedAt = w.config.clock.Now().UnixNano()
 		w.history.updateCache(wcEvent)
 		w.resourceVersion = resourceVersion
 		defer w.cond.Broadcast()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

Adds observability for the apiserver's watch event delivery pipeline so operators can detect, alert on, and triage watch latency without enabling verbose logging. Currently, attribution of watch slowness is split between blockLogger (etcd3-side, log-only) and ad-hoc symptoms. There's no SLI to alert on, and no decomposition of which stage (cacher, fan-out, watcher, client) is the bottleneck.

This PR introduces the missing metric layer plus a rate-limited per-event diagnostic log.

The SLI:
- `apiserver_watch_cache_dispatch_duration_seconds{group,resource,outcome}` (histogram) - cacher-side dispatch latency ReceivedFromStorageAt → SentToResultChanAt, split by outcome={delivered,terminated} so force-closed watchers' tail stays visible

Per-stage decomposition:
- `apiserver_watcher_queue_duration_seconds{group,resource}` (histogram) - dwell in a specific watcher's input channel. Mild watcher slowness signal
- `apiserver_watcher_dispatch_blocked_seconds_total{group,resource}` (counter) - cumulative seconds the dispatcher was blocked pushing into a watcher's input channel. Signals "this slow watcher is hurting the shared dispatcher."
- `apiserver_watch_cache_queue_duration_seconds{group,resource}` (histogram) - dwell in the cacher's incoming channel before fan-out. Observed once per event; surfaces "cacher itself is the bottleneck."
- `apiserver_watcher_handoff_blocked_seconds_total{group,resource}` (counter) - cumulative seconds a watcher was blocked sending events to its result channel. Signals "The client is consuming events slowly."

Diagnostic log:
- Slow watch cache processing: rate-limited to one line per second process-wide, per-event lifecycle breakdown (cacheAdmitMs, awaitingDispatchMs, dispatchToWatcherMs, awaitingWatcherMs, eventBuildMs, handoffMs)

Triage chain this enables:
p99(dispatch_duration_seconds{outcome="delivered"}) high
   |
   |── watch_cache_queue_duration_seconds rising   → cacher itself behind (pre fan-out)
   |── watcher_dispatch_blocked rate rising                 → slow watcher hurting dispatcher
   |── watcher_queue_duration p99 rising                    → mild watcher buffering
   |── watcher_handoff_blocked rate rising                  → slow client backpressure
   |── (slow-log)                                                               → concrete per-event timeline

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Issue: https://github.com/kubernetes/kubernetes/issues/138774

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
