### PR TITLE
Fix nil pointer dereference in Windows memory eviction threshold notifier

### DIFF
--- a/pkg/kubelet/eviction/memory_threshold_notifier_windows.go
+++ b/pkg/kubelet/eviction/memory_threshold_notifier_windows.go
@@ -67,14 +67,15 @@ func (m *windowsMemoryThresholdNotifier) checkMemoryUsage(logger klog.Logger) {
 	perfInfo, err := winstats.GetPerformanceInfo()
 	if err != nil {
 		logger.Error(err, "Eviction manager: error getting global memory status for node")
+		return
 	}
 
-	commmiLimitBytes := perfInfo.CommitLimitPages * perfInfo.PageSize
-	capacity := resource.NewQuantity(int64(commmiLimitBytes), resource.BinarySI)
+	commitLimitBytes := perfInfo.CommitLimitPages * perfInfo.PageSize
+	capacity := resource.NewQuantity(int64(commitLimitBytes), resource.BinarySI)
 	evictionThresholdQuantity := evictionapi.GetThresholdQuantity(m.threshold.Value, capacity)
 
 	commitTotalBytes := perfInfo.CommitTotalPages * perfInfo.PageSize
-	commitAvailableBytes := commmiLimitBytes - commitTotalBytes
+	commitAvailableBytes := commitLimitBytes - commitTotalBytes
 
 	if commitAvailableBytes <= uint64(evictionThresholdQuantity.Value()) {
 		m.events <- struct{}{}


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it

Fixes a nil pointer dereference bug in the Windows memory eviction threshold notifier.

In `checkMemoryUsage()` (`memory_threshold_notifier_windows.go`), when `GetPerformanceInfo()` fails, the error is logged but execution continues. The next line dereferences `perfInfo` (which is nil), causing a panic:

```go
perfInfo, err := winstats.GetPerformanceInfo()
if err != nil {
    logger.Error(err, "...")
    // missing return - falls through to nil dereference below
}
commitLimitBytes := perfInfo.CommitLimitPages * perfInfo.PageSize  // PANIC
```

### Fix

1. **Add early return** after the error log to prevent the nil dereference.
2. **Fix typo** in variable name: `commmiLimitBytes` → `commitLimitBytes` (triple 'm').

## Which issue(s) this PR fixes

None

## Does this PR introduce a user-facing change?

```release-note
Fix nil pointer dereference in Windows memory eviction threshold notifier when GetPerformanceInfo() fails.
```

## Additional documentation

N/A
