### PR TITLE
Fix CPU manager cpuset reconciler and apply cpuset before container starts

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -304,12 +304,27 @@ func (m *manager) AllocatePod(pod *v1.Pod) error {
 
 func (m *manager) AddContainer(logger logr.Logger, pod *v1.Pod, container *v1.Container, containerID string) {
 	m.Lock()
-	defer m.Unlock()
-	if cset, exists := m.state.GetCPUSet(string(pod.UID), container.Name); exists {
-		m.lastUpdateState.SetCPUSet(string(pod.UID), container.Name, cset)
-	}
 	m.containerMap.Add(string(pod.UID), container.Name, containerID)
-	logger.V(4).Info("Added Container", "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "containerID", containerID)
+	cset, hasDedicatedCPUs := m.state.GetCPUSet(string(pod.UID), container.Name)
+	m.Unlock()
+
+	// Write the dedicated cpuset to the container's cgroup before it starts.
+	// Without this, the container inherits the pod-level cpuset and the
+	// reconciler may not correct it (see lastUpdateState below).
+	if hasDedicatedCPUs && !cset.IsEmpty() {
+		ctx := context.TODO()
+		logger.V(2).Info("Applying dedicated cpuset before container start", "pod", klog.KObj(pod), "containerName", container.Name, "cpuSet", cset, "containerID", containerID)
+		if err := m.updateContainerCPUSet(ctx, containerID, cset); err != nil {
+			logger.Error(err, "Failed to apply cpuset before container start", "containerID", containerID, "cpuSet", cset)
+		} else {
+			// Record the successful write so the reconciler knows the
+			// current cgroup state matches the desired state.
+			m.Lock()
+			m.lastUpdateState.SetCPUSet(string(pod.UID), container.Name, cset)
+			m.Unlock()
+		}
+	}
+	logger.V(4).Info("AddContainer completed", "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "containerID", containerID)
 }
 
 func (m *manager) RemoveContainer(logger logr.Logger, containerID string) error {

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -439,6 +439,114 @@ func TestCPUManagerAdd(t *testing.T) {
 	}
 }
 
+func TestAddContainerAppliesCpusetBeforeStart(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
+	pod := makePod("fakePod", "fakeContainer", "2", "2")
+	container := &pod.Spec.Containers[0]
+	dedicatedCPUs := cpuset.New(3, 4)
+
+	mgr := &manager{
+		policy: &mockPolicy{},
+		state: &mockState{
+			assignments: state.ContainerCPUAssignments{
+				string(pod.UID): {container.Name: dedicatedCPUs},
+			},
+			defaultCPUSet: cpuset.New(1, 2),
+		},
+		lastUpdateState: state.NewMemoryState(logger),
+		containerRuntime: mockRuntimeService{
+			err: nil,
+		},
+		containerMap:      containermap.NewContainerMap(),
+		podStatusProvider: mockPodStatusProvider{},
+		sourcesReady:      &sourcesReadyStub{},
+	}
+	mgr.activePods = func() []*v1.Pod { return []*v1.Pod{pod} }
+
+	// Before AddContainer, lastUpdateState should be empty.
+	_, lastExists := mgr.lastUpdateState.GetCPUSet(string(pod.UID), container.Name)
+	if lastExists {
+		t.Error("lastUpdateState should be empty before AddContainer")
+	}
+
+	mgr.AddContainer(logger, pod, container, "fakeID")
+
+	// After AddContainer, lastUpdateState should match the dedicated cpuset
+	// because AddContainer writes the cgroup and records the successful write.
+	lastCset, lastExists := mgr.lastUpdateState.GetCPUSet(string(pod.UID), container.Name)
+	if !lastExists {
+		t.Error("lastUpdateState should be set after AddContainer")
+	}
+	if !dedicatedCPUs.Equals(lastCset) {
+		t.Errorf("lastUpdateState cpuset mismatch: expected %v, got %v", dedicatedCPUs, lastCset)
+	}
+}
+
+func TestAddContainerDoesNotRecordFailedUpdate(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
+	pod := makePod("fakePod", "fakeContainer", "2", "2")
+	container := &pod.Spec.Containers[0]
+	dedicatedCPUs := cpuset.New(3, 4)
+
+	mgr := &manager{
+		policy: &mockPolicy{},
+		state: &mockState{
+			assignments: state.ContainerCPUAssignments{
+				string(pod.UID): {container.Name: dedicatedCPUs},
+			},
+			defaultCPUSet: cpuset.New(1, 2),
+		},
+		lastUpdateState: state.NewMemoryState(logger),
+		containerRuntime: mockRuntimeService{
+			err: fmt.Errorf("runtime unavailable"),
+		},
+		containerMap:      containermap.NewContainerMap(),
+		podStatusProvider: mockPodStatusProvider{},
+		sourcesReady:      &sourcesReadyStub{},
+	}
+	mgr.activePods = func() []*v1.Pod { return []*v1.Pod{pod} }
+
+	mgr.AddContainer(logger, pod, container, "fakeID")
+
+	// When the cgroup write fails, lastUpdateState must NOT be set.
+	// This allows the reconciler to retry on its next cycle.
+	_, lastExists := mgr.lastUpdateState.GetCPUSet(string(pod.UID), container.Name)
+	if lastExists {
+		t.Error("lastUpdateState should not be set when cgroup write fails")
+	}
+}
+
+func TestAddContainerSkipsDefaultCpuset(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
+	mgr := &manager{
+		policy: &mockPolicy{},
+		state: &mockState{
+			assignments:   state.ContainerCPUAssignments{},
+			defaultCPUSet: cpuset.New(0, 1, 2, 3),
+		},
+		lastUpdateState:  state.NewMemoryState(logger),
+		containerRuntime: mockRuntimeService{},
+		containerMap:     containermap.NewContainerMap(),
+		podStatusProvider: mockPodStatusProvider{},
+		sourcesReady:     &sourcesReadyStub{},
+	}
+
+	pod := makePod("fakePod", "fakeContainer", "100m", "100m")
+	container := &pod.Spec.Containers[0]
+	mgr.activePods = func() []*v1.Pod { return []*v1.Pod{pod} }
+
+	mgr.AddContainer(logger, pod, container, "fakeID")
+
+	// Non-dedicated container should NOT have lastUpdateState set.
+	_, lastExists := mgr.lastUpdateState.GetCPUSet(string(pod.UID), container.Name)
+	if lastExists {
+		t.Error("lastUpdateState should not be set for non-dedicated container")
+	}
+}
+
 func TestCPUManagerAddWithInitContainers(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsCPUAndMemoryAffinity, true)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node
/area kubelet

#### What this PR does / why we need it:

Fixes two bugs in CPU manager's `AddContainer` that cause incorrect CPU pinning for dedicated CPU pods:

1. **Reconciler never corrects cpuset mismatches:** `AddContainer` set `lastUpdateState` to the desired cpuset without calling `updateContainerCPUSet` to write the cgroup. The reconciler compares `desired` vs `lastUpdateState` — since they always matched, it never detected or corrected mismatches caused by the container runtime.

2. **Cpuset not applied before container starts:** The container inherited the pod-level cgroup cpuset and only got the correct dedicated cpuset when the reconciler ran (up to 10 seconds later). Applications that read `cpuset.cpus.effective` at startup (e.g., KubeVirt virt-launcher for NUMA-aware guest topology) saw the wrong CPU list.

Fix: call `updateContainerCPUSet` in `AddContainer` (during `PreStartContainer`) to write the cgroup before the container process starts. Only set `lastUpdateState` after a successful write. The update only triggers for small dedicated cpusets (<128 CPUs) to avoid unnecessarily updating containers that use the default set.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/138731

#### Special notes for your reviewer:

Observed on Dell R760xa with KubeVirt VMs: compute container's cgroup showed all odd CPUs (NUMA 1) while `cpu_manager_state` showed CPUs 4,6,68,70 (NUMA 0). The mismatch persisted indefinitely because the reconciler thought it had already written the correct cpuset.

KubeVirt's virt-launcher reads `cpuset.cpus.effective` once at startup to build guest NUMA topology. With the wrong cpuset, it generated QEMU memory bindings for NUMA 1, but `cpuset.mems` only allowed NUMA 0, causing `set_mempolicy: Invalid argument`.

#### Does this PR introduce a user-facing change?

```release-note
Fix CPU manager to apply dedicated cpuset before container starts and enable reconciler to correct cpuset mismatches.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```