### PR TITLE
test: resolve declarative validation test gaps in flowcontrol and scheduling APIs

### DIFF
--- a/pkg/apis/flowcontrol/validation/validation.go
+++ b/pkg/apis/flowcontrol/validation/validation.go
@@ -415,6 +415,8 @@ func ValidatePriorityLevelConfigurationSpec(spec *flowcontrol.PriorityLevelConfi
 		} else {
 			allErrs = append(allErrs, ValidateLimitedPriorityLevelConfiguration(spec.Limited, requestGV, fldPath.Child("limited"), opts)...)
 		}
+	case "":
+		allErrs = append(allErrs, field.Required(fldPath.Child("type"), "").MarkCoveredByDeclarative())
 	default:
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("type"), spec.Type, supportedPriorityLevelEnablement.List()))
 	}
@@ -474,6 +476,8 @@ func ValidateLimitResponse(lr flowcontrol.LimitResponse, fldPath *field.Path) fi
 		} else {
 			allErrs = append(allErrs, ValidatePriorityLevelQueuingConfiguration(lr.Queuing, fldPath.Child("queuing"))...)
 		}
+	case "":
+		allErrs = append(allErrs, field.Required(fldPath.Child("type"), "").MarkCoveredByDeclarative())
 	default:
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("type"), lr.Type, supportedLimitResponseType.List()))
 	}

--- a/pkg/apis/scheduling/v1alpha2/zz_generated.validations.go
+++ b/pkg/apis/scheduling/v1alpha2/zz_generated.validations.go
@@ -761,12 +761,6 @@ func Validate_PodGroupSpec(
 				}); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			if e := validate.IfOption(ctx, op, fldPath, obj, oldObj, "WorkloadAwarePreemption", true,
-				func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
-					return validate.Minimum(ctx, op, fldPath, obj, oldObj, -2147483648)
-				}); len(e) != 0 {
-				errs = append(errs, e...)
-			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -946,10 +940,6 @@ func Validate_PodGroupTemplate(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
@@ -1087,12 +1077,6 @@ func Validate_PodGroupTemplate(
 			if e := validate.IfOption(ctx, op, fldPath, obj, oldObj, "WorkloadAwarePreemption", true,
 				func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
 					return validate.Maximum(ctx, op, fldPath, obj, oldObj, 1000000000)
-				}); len(e) != 0 {
-				errs = append(errs, e...)
-			}
-			if e := validate.IfOption(ctx, op, fldPath, obj, oldObj, "WorkloadAwarePreemption", true,
-				func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
-					return validate.Minimum(ctx, op, fldPath, obj, oldObj, -2147483648)
 				}); len(e) != 0 {
 				errs = append(errs, e...)
 			}

--- a/pkg/registry/flowcontrol/prioritylevelconfiguration/declarative_validation_test.go
+++ b/pkg/registry/flowcontrol/prioritylevelconfiguration/declarative_validation_test.go
@@ -103,6 +103,18 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				field.Forbidden(specPath.Child("limited", "limitResponse", "queuing"), "").MarkCoveredByDeclarative().MarkAlpha(),
 			},
 		},
+		"spec.type: set to empty string": {
+			input: mkPLC(tweakType("")),
+			expectedErrs: field.ErrorList{
+				field.Required(specPath.Child("type"), "").MarkCoveredByDeclarative().MarkAlpha(),
+			},
+		},
+		"limitResponse.type: set to empty string": {
+			input: mkPLC(tweakLimitResponseType("")),
+			expectedErrs: field.ErrorList{
+				field.Required(specPath.Child("limited", "limitResponse", "type"), "").MarkCoveredByDeclarative().MarkAlpha(),
+			},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -168,6 +180,20 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				field.Forbidden(specPath.Child("limited", "limitResponse", "queuing"), "").MarkCoveredByDeclarative().MarkAlpha(),
 			},
 		},
+		"update: spec.type changed to empty string": {
+			old: mkPLC(),
+			update: mkPLC(tweakType("")),
+			expectedErrs: field.ErrorList{
+				field.Required(specPath.Child("type"), "").MarkCoveredByDeclarative().MarkAlpha(),
+			},
+		},
+		"update: limitResponse.type changed to empty string": {
+			old: mkPLC(),
+			update: mkPLC(tweakLimitResponseType("")),
+			expectedErrs: field.ErrorList{
+				field.Required(specPath.Child("limited", "limitResponse", "type"), "").MarkCoveredByDeclarative().MarkAlpha(),
+			},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -216,6 +242,16 @@ func tweakExempt() func(*flowcontrol.PriorityLevelConfiguration) {
 		obj.Name = "exempt"
 		obj.Spec.Type = flowcontrol.PriorityLevelEnablementExempt
 		obj.Spec.Limited = nil
+	}
+}
+
+// tweakType sets the Type field directly and clears Limited if empty.
+func tweakType(t flowcontrol.PriorityLevelEnablement) func(*flowcontrol.PriorityLevelConfiguration) {
+	return func(obj *flowcontrol.PriorityLevelConfiguration) {
+		obj.Spec.Type = t
+		if t == "" {
+			obj.Spec.Limited = nil
+		}
 	}
 }
 

--- a/pkg/registry/scheduling/podgroup/declarative_validation_test.go
+++ b/pkg/registry/scheduling/podgroup/declarative_validation_test.go
@@ -281,6 +281,14 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				field.Duplicate(field.NewPath("spec", "resourceClaims").Index(1), nil),
 			},
 		},
+		"resource claim name empty": {
+			input: mkValidPodGroup(addResourceClaims(
+				scheduling.PodGroupResourceClaim{Name: "", ResourceClaimName: new("resource-claim")},
+			)),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "resourceClaims").Index(0).Child("name"), ""),
+			},
+		},
 		"resource claim source empty": {
 			input: mkValidPodGroup(addResourceClaims(
 				scheduling.PodGroupResourceClaim{Name: "my-claim"},
@@ -639,6 +647,27 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 			),
 			expectedErrs: field.ErrorList{
 				field.Invalid(field.NewPath("status", "resourceClaimStatuses").Index(0).Child("name"), nil, "").MarkFromImperative(),
+			},
+		},
+		"too many resource claim statuses": {
+			oldObj: mkValidPodGroup(setResourceVersion("1")),
+			updateObj: mkValidPodGroup(
+				setResourceVersion("1"),
+				addResourceClaimStatuses(
+					scheduling.PodGroupResourceClaimStatus{Name: "claim-1"},
+					scheduling.PodGroupResourceClaimStatus{Name: "claim-2"},
+					scheduling.PodGroupResourceClaimStatus{Name: "claim-3"},
+					scheduling.PodGroupResourceClaimStatus{Name: "claim-4"},
+					scheduling.PodGroupResourceClaimStatus{Name: "claim-5"},
+				),
+			),
+			expectedErrs: field.ErrorList{
+				field.TooMany(field.NewPath("status", "resourceClaimStatuses"), 5, scheduling.MaxPodGroupResourceClaims).WithOrigin("maxItems"),
+				field.Invalid(field.NewPath("status", "resourceClaimStatuses").Index(0).Child("name"), nil, "").MarkFromImperative(),
+				field.Invalid(field.NewPath("status", "resourceClaimStatuses").Index(1).Child("name"), nil, "").MarkFromImperative(),
+				field.Invalid(field.NewPath("status", "resourceClaimStatuses").Index(2).Child("name"), nil, "").MarkFromImperative(),
+				field.Invalid(field.NewPath("status", "resourceClaimStatuses").Index(3).Child("name"), nil, "").MarkFromImperative(),
+				field.Invalid(field.NewPath("status", "resourceClaimStatuses").Index(4).Child("name"), nil, "").MarkFromImperative(),
 			},
 		},
 		"invalid resource claim name": {

--- a/pkg/registry/scheduling/workload/declarative_validation_test.go
+++ b/pkg/registry/scheduling/workload/declarative_validation_test.go
@@ -153,6 +153,10 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			input:                         mkValidWorkload(addTopologyConstraint(0, "foo")),
 			enableTopologyAwareScheduling: true,
 		},
+		"with schedulingConstraints and TAS disabled": {
+			input:        mkValidWorkload(addTopologyConstraint(0, "foo")),
+			expectedErrs: field.ErrorList{field.Forbidden(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingConstraints"), "")},
+		},
 		"valid with empty schedulingConstraints": {
 			input:                         mkValidWorkload(setSchedulingConstraints(0)),
 			enableTopologyAwareScheduling: true,
@@ -306,6 +310,14 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			)),
 			expectedErrs: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("resourceClaims").Index(0), nil, "").WithOrigin("union"),
+			},
+		},
+		"resource claim name empty": {
+			input: mkValidWorkload(addResourceClaims(
+				scheduling.PodGroupResourceClaim{Name: "", ResourceClaimName: new("resource-claim")},
+			)),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "podGroupTemplates").Index(0).Child("resourceClaims").Index(0).Child("name"), ""),
 			},
 		},
 		"resource claim reference and template": {

--- a/staging/src/k8s.io/api/scheduling/v1alpha2/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1alpha2/generated.proto
@@ -288,7 +288,6 @@ message PodGroupSpec {
   // +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:optional
   // +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:immutable
   // +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:maximum=1000000000 # HighestUserDefinablePriority
-  // +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:minimum=-2147483648
   optional int32 priority = 7;
 }
 
@@ -376,7 +375,6 @@ message PodGroupTemplate {
   // +k8s:listType=map
   // +k8s:listMapKey=name
   // +k8s:maxItems=4
-  // +k8s:immutable
   // +featureGate=DRAWorkloadResourceClaims
   repeated PodGroupResourceClaim resourceClaims = 4;
 
@@ -418,7 +416,6 @@ message PodGroupTemplate {
   // +k8s:ifDisabled("WorkloadAwarePreemption")=+k8s:forbidden
   // +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:optional
   // +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:maximum=1000000000 # HighestUserDefinablePriority
-  // +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:minimum=-2147483648
   optional int32 priority = 7;
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1alpha2/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha2/types.go
@@ -159,7 +159,6 @@ type PodGroupTemplate struct {
 	// +k8s:listType=map
 	// +k8s:listMapKey=name
 	// +k8s:maxItems=4
-	// +k8s:immutable
 	// +featureGate=DRAWorkloadResourceClaims
 	ResourceClaims []PodGroupResourceClaim `json:"resourceClaims,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name" protobuf:"bytes,4,rep,name=resourceClaims"`
 
@@ -201,7 +200,6 @@ type PodGroupTemplate struct {
 	// +k8s:ifDisabled("WorkloadAwarePreemption")=+k8s:forbidden
 	// +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:optional
 	// +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:maximum=1000000000 # HighestUserDefinablePriority
-	// +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:minimum=-2147483648
 	Priority *int32 `json:"priority,omitempty" protobuf:"varint,7,opt,name=priority"`
 }
 
@@ -456,7 +454,6 @@ type PodGroupSpec struct {
 	// +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:optional
 	// +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:immutable
 	// +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:maximum=1000000000 # HighestUserDefinablePriority
-	// +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:minimum=-2147483648
 	Priority *int32 `json:"priority,omitempty" protobuf:"varint,7,opt,name=priority"`
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:
This PR resolves the test gaps surfaced by the declarative validation coverage guardrail for the `flowcontrol.apiserver.k8s.io` and `scheduling.k8s.io` API groups.

- Reverts `+k8s:immutable` on `PodGroupTemplate.ResourceClaims`. The parent `PodgroupTemplates` list  is natively immutable meaning nested modifications are rejected at the parent level before this tag can ever be evaluated.
- Reverts `+k8s:minimum=-2147483648` on `Priority` fields. Go's `int32` inherently guarantees this lower limit (`math.MinInt32`), making it mathematically impossible to parse an out-of-bounds value and observe the `origin="minimum"` declarative error.

Adding missing equivalence tests:
- `PriorityLevelConfiguration` : Adds missing requiredness tests for `spec.type` and `spec.limited.limitResponse.type`.
- `PodGroup` : Covers `spec.resourceClaims[*].name` (`FieldValueRequired`) and `status.resourceClaimStatuses` (`FieldValueTooMany origin="maxItems"`).
- `Workload` (v1alpha2): Covers `spec.podGroupTemplates[*].resourceClaims[*].name` (`FieldValueRequired`) and `spec.podGroupTemplates[*].schedulingConstraints` (`FieldValueForbidden`).
 

#### Which issue(s) this PR is related to:

part of  
- https://github.com/kubernetes/kubernetes/issues/138697

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
