### PR TITLE
[PodLevelResourceManagers] Report pod-level exclusive resources in PodResources API

### DIFF
--- a/pkg/kubelet/apis/podresources/server_v1.go
+++ b/pkg/kubelet/apis/podresources/server_v1.go
@@ -81,6 +81,10 @@ func (p *v1PodResourcesServer) List(ctx context.Context, req *podresourcesv1.Lis
 			Namespace:  pod.Namespace,
 			Containers: make([]*podresourcesv1.ContainerResources, 0, len(pod.Spec.Containers)),
 		}
+		if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.PodLevelResourceManagers) {
+			pRes.CpuIds = p.cpusProvider.GetPodCPUs(string(pod.UID))
+			pRes.Memory = p.memoryProvider.GetPodMemory(logger, string(pod.UID))
+		}
 
 		pRes.Containers = make([]*podresourcesv1.ContainerResources, 0, len(pod.Spec.InitContainers)+len(pod.Spec.Containers))
 		for _, container := range pod.Spec.InitContainers {
@@ -136,6 +140,10 @@ func (p *v1PodResourcesServer) Get(ctx context.Context, req *podresourcesv1.GetP
 		Namespace:  pod.Namespace,
 		Containers: make([]*podresourcesv1.ContainerResources, 0, len(pod.Spec.Containers)),
 	}
+	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.PodLevelResourceManagers) {
+		podResources.CpuIds = p.cpusProvider.GetPodCPUs(string(pod.UID))
+		podResources.Memory = p.memoryProvider.GetPodMemory(logger, string(pod.UID))
+	}
 
 	podResources.Containers = make([]*podresourcesv1.ContainerResources, 0, len(pod.Spec.InitContainers)+len(pod.Spec.Containers))
 	for _, container := range pod.Spec.InitContainers {
@@ -160,8 +168,8 @@ func (p *v1PodResourcesServer) getContainerResources(logger klog.Logger, pod *v1
 	containerResources := &podresourcesv1.ContainerResources{
 		Name:             container.Name,
 		Devices:          p.devicesProvider.GetDevices(string(pod.UID), container.Name),
-		CpuIds:           p.cpusProvider.GetCPUs(string(pod.UID), container.Name),
-		Memory:           p.memoryProvider.GetMemory(logger, string(pod.UID), container.Name),
+		CpuIds:           p.cpusProvider.GetCPUs(pod, container),
+		Memory:           p.memoryProvider.GetMemory(logger, pod, container),
 		DynamicResources: p.dynamicResourcesProvider.GetDynamicResources(logger, pod, container),
 	}
 	return containerResources

--- a/pkg/kubelet/apis/podresources/server_v1_test.go
+++ b/pkg/kubelet/apis/podresources/server_v1_test.go
@@ -26,9 +26,13 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
+	kubefeatures "k8s.io/kubernetes/pkg/features"
 	podresourcetest "k8s.io/kubernetes/pkg/kubelet/apis/podresources/testing"
 	"k8s.io/kubernetes/test/utils/ktesting"
 )
@@ -81,6 +85,57 @@ func TestListPodResourcesV1(t *testing.T) {
 			},
 		},
 	}
+	podsWithPodLevelResources := []*v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podName,
+				Namespace: podNamespace,
+				UID:       podUID,
+			},
+			Spec: v1.PodSpec{
+				Resources: &v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("5"),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Limits: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("5"),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+				},
+				Containers: containers,
+			},
+		},
+	}
+	podsWithMultipleContainers := []*v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podName,
+				Namespace: podNamespace,
+				UID:       podUID,
+			},
+			Spec: v1.PodSpec{
+				Resources: &v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("5"),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Limits: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("5"),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+				},
+				Containers: []v1.Container{
+					{
+						Name: "exclusive-container",
+					},
+					{
+						Name: "shared-container",
+					},
+				},
+			},
+		},
+	}
 
 	pluginCDIDevices := []*podresourcesapi.CDIDevice{{Name: "dra-dev0"}, {Name: "dra-dev1"}}
 	draDriverName := "dra.example.com"
@@ -95,20 +150,24 @@ func TestListPodResourcesV1(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		desc             string
-		pods             []*v1.Pod
-		devices          []*podresourcesapi.ContainerDevices
-		cpus             []int64
-		memory           []*podresourcesapi.ContainerMemory
-		dynamicResources []*podresourcesapi.DynamicResource
-		expectedResponse *podresourcesapi.ListPodResourcesResponse
+		desc                     string
+		pods                     []*v1.Pod
+		devices                  []*podresourcesapi.ContainerDevices
+		containerCpus            []int64
+		containerMemory          []*podresourcesapi.ContainerMemory
+		podCpus                  []int64
+		podMemory                []*podresourcesapi.ContainerMemory
+		dynamicResources         []*podresourcesapi.DynamicResource
+		expectedResponse         *podresourcesapi.ListPodResourcesResponse
+		podLevelResourcesEnabled bool
+		targetContainerName      string
 	}{
 		{
 			desc:             "no pods",
 			pods:             []*v1.Pod{},
 			devices:          []*podresourcesapi.ContainerDevices{},
-			cpus:             []int64{},
-			memory:           []*podresourcesapi.ContainerMemory{},
+			containerCpus:    []int64{},
+			containerMemory:  []*podresourcesapi.ContainerMemory{},
 			dynamicResources: []*podresourcesapi.DynamicResource{},
 			expectedResponse: &podresourcesapi.ListPodResourcesResponse{},
 		},
@@ -116,8 +175,8 @@ func TestListPodResourcesV1(t *testing.T) {
 			desc:             "pod without devices",
 			pods:             pods,
 			devices:          []*podresourcesapi.ContainerDevices{},
-			cpus:             []int64{},
-			memory:           []*podresourcesapi.ContainerMemory{},
+			containerCpus:    []int64{},
+			containerMemory:  []*podresourcesapi.ContainerMemory{},
 			dynamicResources: []*podresourcesapi.DynamicResource{},
 			expectedResponse: &podresourcesapi.ListPodResourcesResponse{
 				PodResources: []*podresourcesapi.PodResources{
@@ -139,8 +198,8 @@ func TestListPodResourcesV1(t *testing.T) {
 			desc:             "pod with devices",
 			pods:             pods,
 			devices:          devs,
-			cpus:             cpus,
-			memory:           memory,
+			containerCpus:    cpus,
+			containerMemory:  memory,
 			dynamicResources: []*podresourcesapi.DynamicResource{},
 			expectedResponse: &podresourcesapi.ListPodResourcesResponse{
 				PodResources: []*podresourcesapi.PodResources{
@@ -161,11 +220,177 @@ func TestListPodResourcesV1(t *testing.T) {
 			},
 		},
 		{
+			desc:                     "Topology Manager scope: pod, pod-level resources, exclusive container",
+			pods:                     podsWithPodLevelResources,
+			devices:                  []*podresourcesapi.ContainerDevices{},
+			containerCpus:            cpus,
+			containerMemory:          memory,
+			podCpus:                  []int64{12, 23, 30, 31, 32},
+			podMemory:                []*podresourcesapi.ContainerMemory{{MemoryType: "memory", Size: 2147483648, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 1}}}}},
+			dynamicResources:         []*podresourcesapi.DynamicResource{},
+			podLevelResourcesEnabled: true,
+			expectedResponse: &podresourcesapi.ListPodResourcesResponse{
+				PodResources: []*podresourcesapi.PodResources{
+					{
+						Name:      podName,
+						Namespace: podNamespace,
+						CpuIds:    []int64{12, 23, 30, 31, 32},
+						Memory:    []*podresourcesapi.ContainerMemory{{MemoryType: "memory", Size: 2147483648, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 1}}}}},
+						Containers: []*podresourcesapi.ContainerResources{
+							{
+								Name:             containerName,
+								Devices:          []*podresourcesapi.ContainerDevices{},
+								CpuIds:           cpus,
+								Memory:           memory,
+								DynamicResources: []*podresourcesapi.DynamicResource{},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:                     "Topology Manager scope: pod, pod-level resources, shared pool container",
+			pods:                     podsWithPodLevelResources,
+			devices:                  []*podresourcesapi.ContainerDevices{},
+			containerCpus:            []int64{},
+			containerMemory:          []*podresourcesapi.ContainerMemory{},
+			podCpus:                  []int64{12, 23, 30, 31, 32},
+			podMemory:                []*podresourcesapi.ContainerMemory{{MemoryType: "memory", Size: 2147483648, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 1}}}}},
+			dynamicResources:         []*podresourcesapi.DynamicResource{},
+			podLevelResourcesEnabled: true,
+			expectedResponse: &podresourcesapi.ListPodResourcesResponse{
+				PodResources: []*podresourcesapi.PodResources{
+					{
+						Name:      podName,
+						Namespace: podNamespace,
+						CpuIds:    []int64{12, 23, 30, 31, 32},
+						Memory:    []*podresourcesapi.ContainerMemory{{MemoryType: "memory", Size: 2147483648, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 1}}}}},
+						Containers: []*podresourcesapi.ContainerResources{
+							{
+								Name:             containerName,
+								Devices:          []*podresourcesapi.ContainerDevices{},
+								CpuIds:           []int64{},
+								Memory:           []*podresourcesapi.ContainerMemory{},
+								DynamicResources: []*podresourcesapi.DynamicResource{},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:                     "Topology Manager scope: pod, pod-level resources, mix of exclusive and shared pool containers",
+			pods:                     podsWithMultipleContainers,
+			devices:                  []*podresourcesapi.ContainerDevices{},
+			containerCpus:            cpus,
+			containerMemory:          memory,
+			podCpus:                  []int64{12, 23, 30, 31, 32},
+			podMemory:                []*podresourcesapi.ContainerMemory{{MemoryType: "memory", Size: 2147483648, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 1}}}}},
+			dynamicResources:         []*podresourcesapi.DynamicResource{},
+			podLevelResourcesEnabled: true,
+			targetContainerName:      "exclusive-container",
+			expectedResponse: &podresourcesapi.ListPodResourcesResponse{
+				PodResources: []*podresourcesapi.PodResources{
+					{
+						Name:      podName,
+						Namespace: podNamespace,
+						CpuIds:    []int64{12, 23, 30, 31, 32},
+						Memory:    []*podresourcesapi.ContainerMemory{{MemoryType: "memory", Size: 2147483648, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 1}}}}},
+						Containers: []*podresourcesapi.ContainerResources{
+							{
+								Name:             "exclusive-container",
+								Devices:          []*podresourcesapi.ContainerDevices{},
+								CpuIds:           cpus,
+								Memory:           memory,
+								DynamicResources: []*podresourcesapi.DynamicResource{},
+							},
+							{
+								Name:             "shared-container",
+								Devices:          []*podresourcesapi.ContainerDevices{},
+								CpuIds:           []int64{},
+								Memory:           []*podresourcesapi.ContainerMemory{},
+								DynamicResources: []*podresourcesapi.DynamicResource{},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:                     "Topology Manager scope: container, pod-level resources, exclusive container",
+			pods:                     podsWithPodLevelResources,
+			devices:                  []*podresourcesapi.ContainerDevices{},
+			containerCpus:            cpus,
+			containerMemory:          memory,
+			podCpus:                  []int64{},
+			podMemory:                []*podresourcesapi.ContainerMemory{},
+			dynamicResources:         []*podresourcesapi.DynamicResource{},
+			podLevelResourcesEnabled: true,
+			expectedResponse: &podresourcesapi.ListPodResourcesResponse{
+				PodResources: []*podresourcesapi.PodResources{
+					{
+						Name:      podName,
+						Namespace: podNamespace,
+						CpuIds:    []int64{},
+						Memory:    []*podresourcesapi.ContainerMemory{},
+						Containers: []*podresourcesapi.ContainerResources{
+							{
+								Name:             containerName,
+								Devices:          []*podresourcesapi.ContainerDevices{},
+								CpuIds:           cpus,
+								Memory:           memory,
+								DynamicResources: []*podresourcesapi.DynamicResource{},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:                     "Topology Manager scope: container, pod-level resources, mix of exclusive and shared pool containers",
+			pods:                     podsWithMultipleContainers,
+			devices:                  []*podresourcesapi.ContainerDevices{},
+			containerCpus:            cpus,
+			containerMemory:          memory,
+			podCpus:                  []int64{},
+			podMemory:                []*podresourcesapi.ContainerMemory{},
+			dynamicResources:         []*podresourcesapi.DynamicResource{},
+			podLevelResourcesEnabled: true,
+			targetContainerName:      "exclusive-container",
+			expectedResponse: &podresourcesapi.ListPodResourcesResponse{
+				PodResources: []*podresourcesapi.PodResources{
+					{
+						Name:      podName,
+						Namespace: podNamespace,
+						CpuIds:    []int64{},
+						Memory:    []*podresourcesapi.ContainerMemory{},
+						Containers: []*podresourcesapi.ContainerResources{
+							{
+								Name:             "exclusive-container",
+								Devices:          []*podresourcesapi.ContainerDevices{},
+								CpuIds:           cpus,
+								Memory:           memory,
+								DynamicResources: []*podresourcesapi.DynamicResource{},
+							},
+							{
+								Name:             "shared-container",
+								Devices:          []*podresourcesapi.ContainerDevices{},
+								CpuIds:           []int64{},
+								Memory:           []*podresourcesapi.ContainerMemory{},
+								DynamicResources: []*podresourcesapi.DynamicResource{},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			desc:             "pod with dynamic resources",
 			pods:             pods,
 			devices:          []*podresourcesapi.ContainerDevices{},
-			cpus:             cpus,
-			memory:           memory,
+			containerCpus:    cpus,
+			containerMemory:  memory,
 			dynamicResources: draDevs,
 			expectedResponse: &podresourcesapi.ListPodResourcesResponse{
 				PodResources: []*podresourcesapi.PodResources{
@@ -189,8 +414,8 @@ func TestListPodResourcesV1(t *testing.T) {
 			desc:             "pod with dynamic resources and devices",
 			pods:             pods,
 			devices:          devs,
-			cpus:             cpus,
-			memory:           memory,
+			containerCpus:    cpus,
+			containerMemory:  memory,
 			dynamicResources: draDevs,
 			expectedResponse: &podresourcesapi.ListPodResourcesResponse{
 				PodResources: []*podresourcesapi.PodResources{
@@ -212,6 +437,11 @@ func TestListPodResourcesV1(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
+			if tc.podLevelResourcesEnabled {
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, kubefeatures.PodLevelResources, tc.podLevelResourcesEnabled)
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, kubefeatures.PodLevelResourceManagers, tc.podLevelResourcesEnabled)
+			}
+
 			mockDevicesProvider := podresourcetest.NewMockDevicesProvider(t)
 			mockPodsProvider := podresourcetest.NewMockPodsProvider(t)
 			mockCPUsProvider := podresourcetest.NewMockCPUsProvider(t)
@@ -220,14 +450,40 @@ func TestListPodResourcesV1(t *testing.T) {
 
 			mockPodsProvider.EXPECT().GetPods().Return(tc.pods).Maybe()
 			mockPodsProvider.EXPECT().GetActivePods().Return(tc.pods).Maybe()
-			mockDevicesProvider.EXPECT().GetDevices(string(podUID), containerName).Return(tc.devices).Maybe()
-			mockCPUsProvider.EXPECT().GetCPUs(string(podUID), containerName).Return(tc.cpus).Maybe()
-			mockMemoryProvider.EXPECT().GetMemory(logger, string(podUID), containerName).Return(tc.memory).Maybe()
-			mockDynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pods[0], &containers[0]).Return(tc.dynamicResources).Maybe()
-			mockDevicesProvider.EXPECT().UpdateAllocatedDevices(logger).Return().Maybe()
+			// 1. Setup specific mock overrides based on test case specs
+			targetName := tc.targetContainerName
+			if targetName == "" {
+				targetName = containerName
+			}
+
+			if len(tc.devices) > 0 {
+				mockDevicesProvider.EXPECT().GetDevices(string(podUID), targetName).Return(tc.devices).Maybe()
+			}
+			if len(tc.containerCpus) > 0 {
+				mockCPUsProvider.EXPECT().GetCPUs(mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == targetName })).Return(tc.containerCpus).Maybe()
+			}
+			if len(tc.containerMemory) > 0 {
+				mockMemoryProvider.EXPECT().GetMemory(logger, mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == targetName })).Return(tc.containerMemory).Maybe()
+			}
+			if tc.podLevelResourcesEnabled {
+				mockCPUsProvider.EXPECT().GetPodCPUs(string(podUID)).Return(tc.podCpus).Maybe()
+				mockMemoryProvider.EXPECT().GetPodMemory(logger, string(podUID)).Return(tc.podMemory).Maybe()
+			}
+			if len(tc.dynamicResources) > 0 {
+				mockDynamicResourcesProvider.EXPECT().GetDynamicResources(logger, mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == targetName })).Return(tc.dynamicResources).Maybe()
+			}
+
+			// 2. Setup default mock behaviors (returning empty slices/no-ops by default)
+			mockCPUsProvider.EXPECT().GetCPUs(mock.Anything, mock.Anything).Return([]int64{}).Maybe()
+			mockCPUsProvider.EXPECT().GetPodCPUs(mock.Anything).Return([]int64{}).Maybe()
 			mockCPUsProvider.EXPECT().GetAllocatableCPUs().Return([]int64{}).Maybe()
-			mockDevicesProvider.EXPECT().GetAllocatableDevices(logger).Return([]*podresourcesapi.ContainerDevices{}).Maybe()
+			mockMemoryProvider.EXPECT().GetMemory(logger, mock.Anything, mock.Anything).Return([]*podresourcesapi.ContainerMemory{}).Maybe()
+			mockMemoryProvider.EXPECT().GetPodMemory(logger, mock.Anything).Return([]*podresourcesapi.ContainerMemory{}).Maybe()
 			mockMemoryProvider.EXPECT().GetAllocatableMemory(logger).Return([]*podresourcesapi.ContainerMemory{}).Maybe()
+			mockDevicesProvider.EXPECT().GetDevices(mock.Anything, mock.Anything).Return([]*podresourcesapi.ContainerDevices{}).Maybe()
+			mockDevicesProvider.EXPECT().GetAllocatableDevices(logger).Return([]*podresourcesapi.ContainerDevices{}).Maybe()
+			mockDevicesProvider.EXPECT().UpdateAllocatedDevices(logger).Return().Maybe()
+			mockDynamicResourcesProvider.EXPECT().GetDynamicResources(logger, mock.Anything, mock.Anything).Return([]*podresourcesapi.DynamicResource{}).Maybe()
 
 			providers := PodResourcesProviders{
 				Pods:             mockPodsProvider,
@@ -303,6 +559,7 @@ func TestListPodResourcesUsesOnlyActivePodsV1(t *testing.T) {
 	}
 
 	cpus := []int64{1, 9}
+	podCpus := []int64{1, 9, 10, 11, 12}
 
 	mems := []*podresourcesapi.ContainerMemory{
 		{
@@ -318,9 +575,10 @@ func TestListPodResourcesUsesOnlyActivePodsV1(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		desc       string
-		pods       []*v1.Pod
-		activePods []*v1.Pod
+		desc                     string
+		pods                     []*v1.Pod
+		activePods               []*v1.Pod
+		podLevelResourcesEnabled bool
 	}{
 		{
 			desc:       "no pods",
@@ -363,8 +621,33 @@ func TestListPodResourcesUsesOnlyActivePodsV1(t *testing.T) {
 				makePod(6),
 			},
 		},
+		{
+			desc: "some terminated pods AND pod level resources enabled",
+			pods: []*v1.Pod{
+				makePod(1),
+				makePod(2),
+				makePod(3),
+				makePod(4),
+				makePod(5),
+				makePod(6),
+				makePod(7),
+			},
+			activePods: []*v1.Pod{
+				makePod(1),
+				makePod(3),
+				makePod(4),
+				makePod(5),
+				makePod(6),
+			},
+			podLevelResourcesEnabled: true,
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
+			if tc.podLevelResourcesEnabled {
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, kubefeatures.PodLevelResources, tc.podLevelResourcesEnabled)
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, kubefeatures.PodLevelResourceManagers, tc.podLevelResourcesEnabled)
+			}
+
 			mockDevicesProvider := podresourcetest.NewMockDevicesProvider(t)
 			mockPodsProvider := podresourcetest.NewMockPodsProvider(t)
 			mockCPUsProvider := podresourcetest.NewMockCPUsProvider(t)
@@ -375,6 +658,10 @@ func TestListPodResourcesUsesOnlyActivePodsV1(t *testing.T) {
 			mockPodsProvider.EXPECT().GetActivePods().Return(tc.activePods).Maybe()
 			mockDevicesProvider.EXPECT().GetDevices(mock.Anything, mock.Anything).Return(devs).Maybe()
 			mockCPUsProvider.EXPECT().GetCPUs(mock.Anything, mock.Anything).Return(cpus).Maybe()
+			if tc.podLevelResourcesEnabled {
+				mockCPUsProvider.EXPECT().GetPodCPUs(mock.Anything).Return(podCpus).Maybe()
+				mockMemoryProvider.EXPECT().GetPodMemory(logger, mock.Anything).Return([]*podresourcesapi.ContainerMemory{{MemoryType: "memory", Size: 2147483648, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 1}}}}}).Maybe()
+			}
 			mockMemoryProvider.EXPECT().GetMemory(logger, mock.Anything, mock.Anything).Return(mems).Maybe()
 			mockDevicesProvider.EXPECT().UpdateAllocatedDevices(logger).Return().Maybe()
 			mockCPUsProvider.EXPECT().GetAllocatableCPUs().Return([]int64{}).Maybe()
@@ -422,6 +709,7 @@ func TestListPodResourcesWithInitContainersV1(t *testing.T) {
 	}
 
 	cpus := []int64{12, 23, 30}
+	podCpus := []int64{12, 23, 30, 31, 32}
 
 	memory := []*podresourcesapi.ContainerMemory{
 		{
@@ -451,8 +739,153 @@ func TestListPodResourcesWithInitContainersV1(t *testing.T) {
 			*podresourcetest.MockCPUsProvider,
 			*podresourcetest.MockMemoryProvider,
 			*podresourcetest.MockDynamicResourcesProvider)
-		expectedResponse *podresourcesapi.ListPodResourcesResponse
+		expectedResponse         *podresourcesapi.ListPodResourcesResponse
+		podLevelResourcesEnabled bool
 	}{
+		{
+			desc: "pod having an init container AND pod level resources enabled",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      podName,
+						Namespace: podNamespace,
+						UID:       podUID,
+					},
+					Spec: v1.PodSpec{
+						Resources: &v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("5"),
+								v1.ResourceMemory: resource.MustParse("5Gi"),
+							},
+							Limits: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("5"),
+								v1.ResourceMemory: resource.MustParse("5Gi"),
+							},
+						},
+						InitContainers: []v1.Container{
+							{
+								Name: initContainerName,
+							},
+						},
+						Containers: containers,
+					},
+				},
+			},
+			mockFunc: func(
+				pods []*v1.Pod,
+				devicesProvider *podresourcetest.MockDevicesProvider,
+				cpusProvider *podresourcetest.MockCPUsProvider,
+				memoryProvider *podresourcetest.MockMemoryProvider,
+				dynamicResourcesProvider *podresourcetest.MockDynamicResourcesProvider) {
+				devicesProvider.EXPECT().UpdateAllocatedDevices(logger).Return().Maybe()
+				devicesProvider.EXPECT().GetDevices(string(podUID), containerName).Return([]*podresourcesapi.ContainerDevices{}).Maybe()
+				cpusProvider.EXPECT().GetCPUs(mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == containerName })).Return(cpus).Maybe()
+				memoryProvider.EXPECT().GetMemory(logger, mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == containerName })).Return(memory).Maybe()
+				dynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pods[0], &pods[0].Spec.Containers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
+
+				cpusProvider.EXPECT().GetPodCPUs(mock.Anything).Return(podCpus).Maybe()
+				memoryProvider.EXPECT().GetPodMemory(logger, mock.Anything).Return([]*podresourcesapi.ContainerMemory{{MemoryType: "memory", Size: 2147483648, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 1}}}}}).Maybe()
+			},
+			podLevelResourcesEnabled: true,
+			expectedResponse: &podresourcesapi.ListPodResourcesResponse{
+				PodResources: []*podresourcesapi.PodResources{
+					{
+						Name:      podName,
+						Namespace: podNamespace,
+						CpuIds:    podCpus,
+						Memory:    []*podresourcesapi.ContainerMemory{{MemoryType: "memory", Size: 2147483648, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 1}}}}},
+						Containers: []*podresourcesapi.ContainerResources{
+							{
+								Name:             containerName,
+								Devices:          []*podresourcesapi.ContainerDevices{},
+								CpuIds:           cpus,
+								Memory:           memory,
+								DynamicResources: []*podresourcesapi.DynamicResource{},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "pod having a restartable init container AND pod level resources enabled",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      podName,
+						Namespace: podNamespace,
+						UID:       podUID,
+					},
+					Spec: v1.PodSpec{
+						Resources: &v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("5"),
+								v1.ResourceMemory: resource.MustParse("5Gi"),
+							},
+							Limits: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("5"),
+								v1.ResourceMemory: resource.MustParse("5Gi"),
+							},
+						},
+						InitContainers: []v1.Container{
+							{
+								Name:          initContainerName,
+								RestartPolicy: &containerRestartPolicyAlways,
+							},
+						},
+						Containers: containers,
+					},
+				},
+			},
+			mockFunc: func(
+				pods []*v1.Pod,
+				devicesProvider *podresourcetest.MockDevicesProvider,
+				cpusProvider *podresourcetest.MockCPUsProvider,
+				memoryProvider *podresourcetest.MockMemoryProvider,
+				dynamicResourcesProvider *podresourcetest.MockDynamicResourcesProvider) {
+				devicesProvider.EXPECT().UpdateAllocatedDevices(logger).Return().Maybe()
+
+				devicesProvider.EXPECT().GetDevices(string(podUID), initContainerName).Return([]*podresourcesapi.ContainerDevices{}).Maybe()
+				cpusProvider.EXPECT().GetCPUs(mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == initContainerName })).Return(cpus).Maybe()
+				memoryProvider.EXPECT().GetMemory(logger, mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == initContainerName })).Return(memory).Maybe()
+				dynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pods[0], &pods[0].Spec.InitContainers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
+
+				devicesProvider.EXPECT().GetDevices(string(podUID), containerName).Return([]*podresourcesapi.ContainerDevices{}).Maybe()
+				cpusProvider.EXPECT().GetCPUs(mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == containerName })).Return(cpus).Maybe()
+				memoryProvider.EXPECT().GetMemory(logger, mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == containerName })).Return(memory).Maybe()
+				dynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pods[0], &pods[0].Spec.Containers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
+
+				cpusProvider.EXPECT().GetPodCPUs(mock.Anything).Return(podCpus).Maybe()
+				memoryProvider.EXPECT().GetPodMemory(logger, mock.Anything).Return([]*podresourcesapi.ContainerMemory{{MemoryType: "memory", Size: 2147483648, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 1}}}}}).Maybe()
+			},
+			podLevelResourcesEnabled: true,
+			expectedResponse: &podresourcesapi.ListPodResourcesResponse{
+				PodResources: []*podresourcesapi.PodResources{
+					{
+						Name:      podName,
+						Namespace: podNamespace,
+						CpuIds:    podCpus,
+						Memory:    []*podresourcesapi.ContainerMemory{{MemoryType: "memory", Size: 2147483648, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 1}}}}},
+						Containers: []*podresourcesapi.ContainerResources{
+							{
+								Name:             initContainerName,
+								Devices:          []*podresourcesapi.ContainerDevices{},
+								CpuIds:           cpus,
+								Memory:           memory,
+								DynamicResources: []*podresourcesapi.DynamicResource{},
+							},
+							{
+								Name:             containerName,
+								Devices:          []*podresourcesapi.ContainerDevices{},
+								CpuIds:           cpus,
+								Memory:           memory,
+								DynamicResources: []*podresourcesapi.DynamicResource{},
+							},
+						},
+					},
+				},
+			},
+		},
 		{
 			desc: "pod having an init container",
 			pods: []*v1.Pod{
@@ -480,8 +913,8 @@ func TestListPodResourcesWithInitContainersV1(t *testing.T) {
 				dynamicResourcesProvider *podresourcetest.MockDynamicResourcesProvider) {
 				devicesProvider.EXPECT().UpdateAllocatedDevices(logger).Return().Maybe()
 				devicesProvider.EXPECT().GetDevices(string(podUID), containerName).Return(devs).Maybe()
-				cpusProvider.EXPECT().GetCPUs(string(podUID), containerName).Return(cpus).Maybe()
-				memoryProvider.EXPECT().GetMemory(logger, string(podUID), containerName).Return(memory).Maybe()
+				cpusProvider.EXPECT().GetCPUs(mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == containerName })).Return(cpus).Maybe()
+				memoryProvider.EXPECT().GetMemory(logger, mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == containerName })).Return(memory).Maybe()
 				dynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pods[0], &pods[0].Spec.Containers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
 
 			},
@@ -532,13 +965,13 @@ func TestListPodResourcesWithInitContainersV1(t *testing.T) {
 				devicesProvider.EXPECT().UpdateAllocatedDevices(logger).Return().Maybe()
 
 				devicesProvider.EXPECT().GetDevices(string(podUID), initContainerName).Return(devs).Maybe()
-				cpusProvider.EXPECT().GetCPUs(string(podUID), initContainerName).Return(cpus).Maybe()
-				memoryProvider.EXPECT().GetMemory(logger, string(podUID), initContainerName).Return(memory).Maybe()
+				cpusProvider.EXPECT().GetCPUs(mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == initContainerName })).Return(cpus).Maybe()
+				memoryProvider.EXPECT().GetMemory(logger, mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == initContainerName })).Return(memory).Maybe()
 				dynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pods[0], &pods[0].Spec.InitContainers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
 
 				devicesProvider.EXPECT().GetDevices(string(podUID), containerName).Return(devs).Maybe()
-				cpusProvider.EXPECT().GetCPUs(string(podUID), containerName).Return(cpus).Maybe()
-				memoryProvider.EXPECT().GetMemory(logger, string(podUID), containerName).Return(memory).Maybe()
+				cpusProvider.EXPECT().GetCPUs(mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == containerName })).Return(cpus).Maybe()
+				memoryProvider.EXPECT().GetMemory(logger, mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == containerName })).Return(memory).Maybe()
 				dynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pods[0], &pods[0].Spec.Containers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
 
 			},
@@ -569,6 +1002,11 @@ func TestListPodResourcesWithInitContainersV1(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
+			if tc.podLevelResourcesEnabled {
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, kubefeatures.PodLevelResources, tc.podLevelResourcesEnabled)
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, kubefeatures.PodLevelResourceManagers, tc.podLevelResourcesEnabled)
+			}
+
 			mockDevicesProvider := podresourcetest.NewMockDevicesProvider(t)
 			mockPodsProvider := podresourcetest.NewMockPodsProvider(t)
 			mockCPUsProvider := podresourcetest.NewMockCPUsProvider(t)
@@ -863,8 +1301,8 @@ func TestAllocatableResources(t *testing.T) {
 			mockMemoryProvider := podresourcetest.NewMockMemoryProvider(t)
 
 			mockDevicesProvider.EXPECT().GetDevices("", "").Return([]*podresourcesapi.ContainerDevices{}).Maybe()
-			mockCPUsProvider.EXPECT().GetCPUs("", "").Return([]int64{}).Maybe()
-			mockMemoryProvider.EXPECT().GetMemory(logger, "", "").Return([]*podresourcesapi.ContainerMemory{}).Maybe()
+			mockCPUsProvider.EXPECT().GetCPUs(mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == "" }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == "" })).Return([]int64{}).Maybe()
+			mockMemoryProvider.EXPECT().GetMemory(logger, mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == "" }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == "" })).Return([]*podresourcesapi.ContainerMemory{}).Maybe()
 			mockDevicesProvider.EXPECT().UpdateAllocatedDevices(logger).Return().Maybe()
 			mockDevicesProvider.EXPECT().GetAllocatableDevices(logger).Return(tc.allDevices).Maybe()
 			mockCPUsProvider.EXPECT().GetAllocatableCPUs().Return(tc.allCPUs).Maybe()
@@ -907,6 +1345,7 @@ func TestGetPodResourcesV1(t *testing.T) {
 	}
 
 	cpus := []int64{12, 23, 30}
+	podCpus := []int64{12, 23, 30, 31, 32}
 
 	memory := []*podresourcesapi.ContainerMemory{
 		{
@@ -937,6 +1376,53 @@ func TestGetPodResourcesV1(t *testing.T) {
 			Containers: containers,
 		},
 	}
+	podWithPodLevelResources := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: podNamespace,
+			UID:       podUID,
+		},
+		Spec: v1.PodSpec{
+			Resources: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("5"),
+					v1.ResourceMemory: resource.MustParse("5Gi"),
+				},
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("5"),
+					v1.ResourceMemory: resource.MustParse("5Gi"),
+				},
+			},
+			Containers: containers,
+		},
+	}
+	podWithMultipleContainers := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: podNamespace,
+			UID:       podUID,
+		},
+		Spec: v1.PodSpec{
+			Resources: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("5"),
+					v1.ResourceMemory: resource.MustParse("5Gi"),
+				},
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("5"),
+					v1.ResourceMemory: resource.MustParse("5Gi"),
+				},
+			},
+			Containers: []v1.Container{
+				{
+					Name: "exclusive-container",
+				},
+				{
+					Name: "shared-container",
+				},
+			},
+		},
+	}
 
 	pluginCDIDevices := []*podresourcesapi.CDIDevice{{Name: "dra-dev0"}, {Name: "dra-dev1"}}
 	draDriverName := "dra.example.com"
@@ -951,15 +1437,19 @@ func TestGetPodResourcesV1(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		desc             string
-		err              error
-		exist            bool
-		pod              *v1.Pod
-		devices          []*podresourcesapi.ContainerDevices
-		cpus             []int64
-		memory           []*podresourcesapi.ContainerMemory
-		dynamicResources []*podresourcesapi.DynamicResource
-		expectedResponse *podresourcesapi.GetPodResourcesResponse
+		desc                     string
+		err                      error
+		exist                    bool
+		pod                      *v1.Pod
+		devices                  []*podresourcesapi.ContainerDevices
+		containerCpus            []int64
+		containerMemory          []*podresourcesapi.ContainerMemory
+		podCpus                  []int64
+		podMemory                []*podresourcesapi.ContainerMemory
+		dynamicResources         []*podresourcesapi.DynamicResource
+		expectedResponse         *podresourcesapi.GetPodResourcesResponse
+		podLevelResourcesEnabled bool
+		targetContainerName      string
 	}{
 		{
 			desc:             "pod not exist",
@@ -967,8 +1457,8 @@ func TestGetPodResourcesV1(t *testing.T) {
 			exist:            false,
 			pod:              nil,
 			devices:          []*podresourcesapi.ContainerDevices{},
-			cpus:             []int64{},
-			memory:           []*podresourcesapi.ContainerMemory{},
+			containerCpus:    []int64{},
+			containerMemory:  []*podresourcesapi.ContainerMemory{},
 			dynamicResources: []*podresourcesapi.DynamicResource{},
 
 			expectedResponse: &podresourcesapi.GetPodResourcesResponse{},
@@ -979,8 +1469,8 @@ func TestGetPodResourcesV1(t *testing.T) {
 			exist:            true,
 			pod:              pod,
 			devices:          []*podresourcesapi.ContainerDevices{},
-			cpus:             []int64{},
-			memory:           []*podresourcesapi.ContainerMemory{},
+			containerCpus:    []int64{},
+			containerMemory:  []*podresourcesapi.ContainerMemory{},
 			dynamicResources: []*podresourcesapi.DynamicResource{},
 			expectedResponse: &podresourcesapi.GetPodResourcesResponse{
 				PodResources: &podresourcesapi.PodResources{
@@ -1002,8 +1492,8 @@ func TestGetPodResourcesV1(t *testing.T) {
 			exist:            true,
 			pod:              pod,
 			devices:          devs,
-			cpus:             cpus,
-			memory:           memory,
+			containerCpus:    cpus,
+			containerMemory:  memory,
 			dynamicResources: draDevs,
 			expectedResponse: &podresourcesapi.GetPodResourcesResponse{
 				PodResources: &podresourcesapi.PodResources{
@@ -1021,8 +1511,179 @@ func TestGetPodResourcesV1(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc:                     "Topology Manager scope: pod, pod-level resources, exclusive container",
+			err:                      nil,
+			exist:                    true,
+			pod:                      podWithPodLevelResources,
+			devices:                  []*podresourcesapi.ContainerDevices{},
+			containerCpus:            cpus,
+			containerMemory:          memory,
+			podCpus:                  podCpus,
+			podMemory:                []*podresourcesapi.ContainerMemory{{MemoryType: "memory", Size: 2147483648, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 1}}}}},
+			dynamicResources:         []*podresourcesapi.DynamicResource{},
+			podLevelResourcesEnabled: true,
+			expectedResponse: &podresourcesapi.GetPodResourcesResponse{
+				PodResources: &podresourcesapi.PodResources{
+					Name:      podName,
+					Namespace: podNamespace,
+					CpuIds:    podCpus,
+					Memory:    []*podresourcesapi.ContainerMemory{{MemoryType: "memory", Size: 2147483648, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 1}}}}},
+					Containers: []*podresourcesapi.ContainerResources{
+						{
+							Name:             containerName,
+							Devices:          []*podresourcesapi.ContainerDevices{},
+							CpuIds:           cpus,
+							Memory:           memory,
+							DynamicResources: []*podresourcesapi.DynamicResource{},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:                     "Topology Manager scope: pod, pod-level resources, shared pool container",
+			err:                      nil,
+			exist:                    true,
+			pod:                      podWithPodLevelResources,
+			devices:                  []*podresourcesapi.ContainerDevices{},
+			containerCpus:            []int64{},
+			containerMemory:          []*podresourcesapi.ContainerMemory{},
+			podCpus:                  podCpus,
+			podMemory:                []*podresourcesapi.ContainerMemory{{MemoryType: "memory", Size: 2147483648, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 1}}}}},
+			dynamicResources:         []*podresourcesapi.DynamicResource{},
+			podLevelResourcesEnabled: true,
+			expectedResponse: &podresourcesapi.GetPodResourcesResponse{
+				PodResources: &podresourcesapi.PodResources{
+					Name:      podName,
+					Namespace: podNamespace,
+					CpuIds:    podCpus,
+					Memory:    []*podresourcesapi.ContainerMemory{{MemoryType: "memory", Size: 2147483648, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 1}}}}},
+					Containers: []*podresourcesapi.ContainerResources{
+						{
+							Name:             containerName,
+							Devices:          []*podresourcesapi.ContainerDevices{},
+							CpuIds:           []int64{},
+							Memory:           []*podresourcesapi.ContainerMemory{},
+							DynamicResources: []*podresourcesapi.DynamicResource{},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:                     "Topology Manager scope: pod, pod-level resources, mix of exclusive and shared pool containers",
+			err:                      nil,
+			exist:                    true,
+			pod:                      podWithMultipleContainers,
+			devices:                  []*podresourcesapi.ContainerDevices{},
+			containerCpus:            cpus,
+			containerMemory:          memory,
+			podCpus:                  podCpus,
+			podMemory:                []*podresourcesapi.ContainerMemory{{MemoryType: "memory", Size: 2147483648, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 1}}}}},
+			dynamicResources:         []*podresourcesapi.DynamicResource{},
+			podLevelResourcesEnabled: true,
+			targetContainerName:      "exclusive-container",
+			expectedResponse: &podresourcesapi.GetPodResourcesResponse{
+				PodResources: &podresourcesapi.PodResources{
+					Name:      podName,
+					Namespace: podNamespace,
+					CpuIds:    podCpus,
+					Memory:    []*podresourcesapi.ContainerMemory{{MemoryType: "memory", Size: 2147483648, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 1}}}}},
+					Containers: []*podresourcesapi.ContainerResources{
+						{
+							Name:             "exclusive-container",
+							Devices:          []*podresourcesapi.ContainerDevices{},
+							CpuIds:           cpus,
+							Memory:           memory,
+							DynamicResources: []*podresourcesapi.DynamicResource{},
+						},
+						{
+							Name:             "shared-container",
+							Devices:          []*podresourcesapi.ContainerDevices{},
+							CpuIds:           []int64{},
+							Memory:           []*podresourcesapi.ContainerMemory{},
+							DynamicResources: []*podresourcesapi.DynamicResource{},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:                     "Topology Manager scope: container, pod-level resources, exclusive container",
+			err:                      nil,
+			exist:                    true,
+			pod:                      podWithPodLevelResources,
+			devices:                  []*podresourcesapi.ContainerDevices{},
+			containerCpus:            cpus,
+			containerMemory:          memory,
+			podCpus:                  []int64{},
+			podMemory:                []*podresourcesapi.ContainerMemory{},
+			dynamicResources:         []*podresourcesapi.DynamicResource{},
+			podLevelResourcesEnabled: true,
+			expectedResponse: &podresourcesapi.GetPodResourcesResponse{
+				PodResources: &podresourcesapi.PodResources{
+					Name:      podName,
+					Namespace: podNamespace,
+					CpuIds:    []int64{},
+					Memory:    []*podresourcesapi.ContainerMemory{},
+					Containers: []*podresourcesapi.ContainerResources{
+						{
+							Name:             containerName,
+							Devices:          []*podresourcesapi.ContainerDevices{},
+							CpuIds:           cpus,
+							Memory:           memory,
+							DynamicResources: []*podresourcesapi.DynamicResource{},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:                     "Topology Manager scope: container, pod-level resources, mix of exclusive and shared pool containers",
+			err:                      nil,
+			exist:                    true,
+			pod:                      podWithMultipleContainers,
+			devices:                  []*podresourcesapi.ContainerDevices{},
+			containerCpus:            cpus,
+			containerMemory:          memory,
+			podCpus:                  []int64{},
+			podMemory:                []*podresourcesapi.ContainerMemory{},
+			dynamicResources:         []*podresourcesapi.DynamicResource{},
+			podLevelResourcesEnabled: true,
+			targetContainerName:      "exclusive-container",
+			expectedResponse: &podresourcesapi.GetPodResourcesResponse{
+				PodResources: &podresourcesapi.PodResources{
+					Name:      podName,
+					Namespace: podNamespace,
+					CpuIds:    []int64{},
+					Memory:    []*podresourcesapi.ContainerMemory{},
+					Containers: []*podresourcesapi.ContainerResources{
+						{
+							Name:             "exclusive-container",
+							Devices:          []*podresourcesapi.ContainerDevices{},
+							CpuIds:           cpus,
+							Memory:           memory,
+							DynamicResources: []*podresourcesapi.DynamicResource{},
+						},
+						{
+							Name:             "shared-container",
+							Devices:          []*podresourcesapi.ContainerDevices{},
+							CpuIds:           []int64{},
+							Memory:           []*podresourcesapi.ContainerMemory{},
+							DynamicResources: []*podresourcesapi.DynamicResource{},
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
+			if tc.podLevelResourcesEnabled {
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, kubefeatures.PodLevelResources, tc.podLevelResourcesEnabled)
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, kubefeatures.PodLevelResourceManagers, tc.podLevelResourcesEnabled)
+			}
+
 			mockDevicesProvider := podresourcetest.NewMockDevicesProvider(t)
 			mockPodsProvider := podresourcetest.NewMockPodsProvider(t)
 			mockCPUsProvider := podresourcetest.NewMockCPUsProvider(t)
@@ -1030,14 +1691,40 @@ func TestGetPodResourcesV1(t *testing.T) {
 			mockDynamicResourcesProvider := podresourcetest.NewMockDynamicResourcesProvider(t)
 
 			mockPodsProvider.EXPECT().GetPodByName(podNamespace, podName).Return(tc.pod, tc.exist).Maybe()
-			mockDevicesProvider.EXPECT().GetDevices(string(podUID), containerName).Return(tc.devices).Maybe()
-			mockCPUsProvider.EXPECT().GetCPUs(string(podUID), containerName).Return(tc.cpus).Maybe()
-			mockMemoryProvider.EXPECT().GetMemory(logger, string(podUID), containerName).Return(tc.memory).Maybe()
-			mockDynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pod, &containers[0]).Return(tc.dynamicResources).Maybe()
-			mockDevicesProvider.EXPECT().UpdateAllocatedDevices(logger).Return().Maybe()
+			// 1. Setup specific mock overrides based on test case specs
+			targetName := tc.targetContainerName
+			if targetName == "" {
+				targetName = containerName
+			}
+
+			if len(tc.devices) > 0 {
+				mockDevicesProvider.EXPECT().GetDevices(string(podUID), targetName).Return(tc.devices).Maybe()
+			}
+			if len(tc.containerCpus) > 0 {
+				mockCPUsProvider.EXPECT().GetCPUs(mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == targetName })).Return(tc.containerCpus).Maybe()
+			}
+			if len(tc.containerMemory) > 0 {
+				mockMemoryProvider.EXPECT().GetMemory(logger, mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == targetName })).Return(tc.containerMemory).Maybe()
+			}
+			if tc.podLevelResourcesEnabled {
+				mockCPUsProvider.EXPECT().GetPodCPUs(string(podUID)).Return(tc.podCpus).Maybe()
+				mockMemoryProvider.EXPECT().GetPodMemory(logger, string(podUID)).Return(tc.podMemory).Maybe()
+			}
+			if len(tc.dynamicResources) > 0 {
+				mockDynamicResourcesProvider.EXPECT().GetDynamicResources(logger, mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == targetName })).Return(tc.dynamicResources).Maybe()
+			}
+
+			// 2. Setup default mock behaviors (returning empty slices/no-ops by default)
+			mockCPUsProvider.EXPECT().GetCPUs(mock.Anything, mock.Anything).Return([]int64{}).Maybe()
+			mockCPUsProvider.EXPECT().GetPodCPUs(mock.Anything).Return([]int64{}).Maybe()
 			mockCPUsProvider.EXPECT().GetAllocatableCPUs().Return([]int64{}).Maybe()
-			mockDevicesProvider.EXPECT().GetAllocatableDevices(logger).Return([]*podresourcesapi.ContainerDevices{}).Maybe()
+			mockMemoryProvider.EXPECT().GetMemory(logger, mock.Anything, mock.Anything).Return([]*podresourcesapi.ContainerMemory{}).Maybe()
+			mockMemoryProvider.EXPECT().GetPodMemory(logger, mock.Anything).Return([]*podresourcesapi.ContainerMemory{}).Maybe()
 			mockMemoryProvider.EXPECT().GetAllocatableMemory(logger).Return([]*podresourcesapi.ContainerMemory{}).Maybe()
+			mockDevicesProvider.EXPECT().GetDevices(mock.Anything, mock.Anything).Return([]*podresourcesapi.ContainerDevices{}).Maybe()
+			mockDevicesProvider.EXPECT().GetAllocatableDevices(logger).Return([]*podresourcesapi.ContainerDevices{}).Maybe()
+			mockDevicesProvider.EXPECT().UpdateAllocatedDevices(logger).Return().Maybe()
+			mockDynamicResourcesProvider.EXPECT().GetDynamicResources(logger, mock.Anything, mock.Anything).Return([]*podresourcesapi.DynamicResource{}).Maybe()
 
 			providers := PodResourcesProviders{
 				Pods:             mockPodsProvider,
@@ -1087,6 +1774,7 @@ func TestGetPodResourcesWithInitContainersV1(t *testing.T) {
 	}
 
 	cpus := []int64{12, 23, 30}
+	podCpus := []int64{12, 23, 30, 31, 32}
 
 	memory := []*podresourcesapi.ContainerMemory{
 		{
@@ -1116,8 +1804,145 @@ func TestGetPodResourcesWithInitContainersV1(t *testing.T) {
 			*podresourcetest.MockCPUsProvider,
 			*podresourcetest.MockMemoryProvider,
 			*podresourcetest.MockDynamicResourcesProvider)
-		expectedResponse *podresourcesapi.GetPodResourcesResponse
+		expectedResponse         *podresourcesapi.GetPodResourcesResponse
+		podLevelResourcesEnabled bool
 	}{
+		{
+			desc: "pod having an init container AND pod level resources enabled",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: podNamespace,
+					UID:       podUID,
+				},
+				Spec: v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("5"),
+							v1.ResourceMemory: resource.MustParse("5Gi"),
+						},
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("5"),
+							v1.ResourceMemory: resource.MustParse("5Gi"),
+						},
+					},
+					InitContainers: []v1.Container{
+						{
+							Name: initContainerName,
+						},
+					},
+					Containers: containers,
+				},
+			},
+			mockFunc: func(
+				pod *v1.Pod,
+				devicesProvider *podresourcetest.MockDevicesProvider,
+				cpusProvider *podresourcetest.MockCPUsProvider,
+				memoryProvider *podresourcetest.MockMemoryProvider,
+				dynamicResourcesProvider *podresourcetest.MockDynamicResourcesProvider) {
+				devicesProvider.EXPECT().UpdateAllocatedDevices(logger).Return().Maybe()
+				devicesProvider.EXPECT().GetDevices(string(podUID), containerName).Return([]*podresourcesapi.ContainerDevices{}).Maybe()
+				cpusProvider.EXPECT().GetCPUs(mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == containerName })).Return(cpus).Maybe()
+				memoryProvider.EXPECT().GetMemory(logger, mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == containerName })).Return(memory).Maybe()
+				dynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pod, &pod.Spec.Containers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
+
+				cpusProvider.EXPECT().GetPodCPUs(mock.Anything).Return(podCpus).Maybe()
+				memoryProvider.EXPECT().GetPodMemory(logger, mock.Anything).Return([]*podresourcesapi.ContainerMemory{{MemoryType: "memory", Size: 2147483648, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 1}}}}}).Maybe()
+			},
+			podLevelResourcesEnabled: true,
+			expectedResponse: &podresourcesapi.GetPodResourcesResponse{
+				PodResources: &podresourcesapi.PodResources{
+					Name:      podName,
+					Namespace: podNamespace,
+					CpuIds:    podCpus,
+					Memory:    []*podresourcesapi.ContainerMemory{{MemoryType: "memory", Size: 2147483648, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 1}}}}},
+					Containers: []*podresourcesapi.ContainerResources{
+						{
+							Name:             containerName,
+							Devices:          []*podresourcesapi.ContainerDevices{},
+							CpuIds:           cpus,
+							Memory:           memory,
+							DynamicResources: []*podresourcesapi.DynamicResource{},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "pod having a restartable init container AND pod level resources enabled",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: podNamespace,
+					UID:       podUID,
+				},
+				Spec: v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("5"),
+							v1.ResourceMemory: resource.MustParse("5Gi"),
+						},
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("5"),
+							v1.ResourceMemory: resource.MustParse("5Gi"),
+						},
+					},
+					InitContainers: []v1.Container{
+						{
+							Name:          initContainerName,
+							RestartPolicy: &containerRestartPolicyAlways,
+						},
+					},
+					Containers: containers,
+				},
+			},
+			mockFunc: func(
+				pod *v1.Pod,
+				devicesProvider *podresourcetest.MockDevicesProvider,
+				cpusProvider *podresourcetest.MockCPUsProvider,
+				memoryProvider *podresourcetest.MockMemoryProvider,
+				dynamicResourcesProvider *podresourcetest.MockDynamicResourcesProvider) {
+				devicesProvider.EXPECT().UpdateAllocatedDevices(logger).Return().Maybe()
+
+				devicesProvider.EXPECT().GetDevices(string(podUID), initContainerName).Return([]*podresourcesapi.ContainerDevices{}).Maybe()
+				cpusProvider.EXPECT().GetCPUs(mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == initContainerName })).Return(cpus).Maybe()
+				memoryProvider.EXPECT().GetMemory(logger, mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == initContainerName })).Return(memory).Maybe()
+				dynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pod, &pod.Spec.InitContainers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
+
+				devicesProvider.EXPECT().GetDevices(string(podUID), containerName).Return([]*podresourcesapi.ContainerDevices{}).Maybe()
+				cpusProvider.EXPECT().GetCPUs(mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == containerName })).Return(cpus).Maybe()
+				memoryProvider.EXPECT().GetMemory(logger, mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == containerName })).Return(memory).Maybe()
+				dynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pod, &pod.Spec.Containers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
+
+				cpusProvider.EXPECT().GetPodCPUs(mock.Anything).Return(podCpus).Maybe()
+				memoryProvider.EXPECT().GetPodMemory(logger, mock.Anything).Return([]*podresourcesapi.ContainerMemory{{MemoryType: "memory", Size: 2147483648, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 1}}}}}).Maybe()
+			},
+			podLevelResourcesEnabled: true,
+			expectedResponse: &podresourcesapi.GetPodResourcesResponse{
+				PodResources: &podresourcesapi.PodResources{
+					Name:      podName,
+					Namespace: podNamespace,
+					CpuIds:    podCpus,
+					Memory:    []*podresourcesapi.ContainerMemory{{MemoryType: "memory", Size: 2147483648, Topology: &podresourcesapi.TopologyInfo{Nodes: []*podresourcesapi.NUMANode{{ID: 1}}}}},
+					Containers: []*podresourcesapi.ContainerResources{
+						{
+							Name:             initContainerName,
+							Devices:          []*podresourcesapi.ContainerDevices{},
+							CpuIds:           cpus,
+							Memory:           memory,
+							DynamicResources: []*podresourcesapi.DynamicResource{},
+						},
+						{
+							Name:             containerName,
+							Devices:          []*podresourcesapi.ContainerDevices{},
+							CpuIds:           cpus,
+							Memory:           memory,
+							DynamicResources: []*podresourcesapi.DynamicResource{},
+						},
+					},
+				},
+			},
+		},
 		{
 			desc: "pod having an init container",
 			pod: &v1.Pod{
@@ -1143,8 +1968,8 @@ func TestGetPodResourcesWithInitContainersV1(t *testing.T) {
 				dynamicResourcesProvider *podresourcetest.MockDynamicResourcesProvider) {
 				devicesProvider.EXPECT().UpdateAllocatedDevices(logger).Return().Maybe()
 				devicesProvider.EXPECT().GetDevices(string(podUID), containerName).Return(devs).Maybe()
-				cpusProvider.EXPECT().GetCPUs(string(podUID), containerName).Return(cpus).Maybe()
-				memoryProvider.EXPECT().GetMemory(logger, string(podUID), containerName).Return(memory).Maybe()
+				cpusProvider.EXPECT().GetCPUs(mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == containerName })).Return(cpus).Maybe()
+				memoryProvider.EXPECT().GetMemory(logger, mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == containerName })).Return(memory).Maybe()
 				dynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pod, &pod.Spec.Containers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
 
 			},
@@ -1191,13 +2016,13 @@ func TestGetPodResourcesWithInitContainersV1(t *testing.T) {
 				devicesProvider.EXPECT().UpdateAllocatedDevices(logger).Return().Maybe()
 
 				devicesProvider.EXPECT().GetDevices(string(podUID), initContainerName).Return(devs).Maybe()
-				cpusProvider.EXPECT().GetCPUs(string(podUID), initContainerName).Return(cpus).Maybe()
-				memoryProvider.EXPECT().GetMemory(logger, string(podUID), initContainerName).Return(memory).Maybe()
+				cpusProvider.EXPECT().GetCPUs(mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == initContainerName })).Return(cpus).Maybe()
+				memoryProvider.EXPECT().GetMemory(logger, mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == initContainerName })).Return(memory).Maybe()
 				dynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pod, &pod.Spec.InitContainers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
 
 				devicesProvider.EXPECT().GetDevices(string(podUID), containerName).Return(devs).Maybe()
-				cpusProvider.EXPECT().GetCPUs(string(podUID), containerName).Return(cpus).Maybe()
-				memoryProvider.EXPECT().GetMemory(logger, string(podUID), containerName).Return(memory).Maybe()
+				cpusProvider.EXPECT().GetCPUs(mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == containerName })).Return(cpus).Maybe()
+				memoryProvider.EXPECT().GetMemory(logger, mock.MatchedBy(func(p *v1.Pod) bool { return string(p.UID) == string(podUID) }), mock.MatchedBy(func(c *v1.Container) bool { return c.Name == containerName })).Return(memory).Maybe()
 				dynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pod, &pod.Spec.Containers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
 			},
 			expectedResponse: &podresourcesapi.GetPodResourcesResponse{
@@ -1225,6 +2050,11 @@ func TestGetPodResourcesWithInitContainersV1(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
+			if tc.podLevelResourcesEnabled {
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, kubefeatures.PodLevelResources, tc.podLevelResourcesEnabled)
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, kubefeatures.PodLevelResourceManagers, tc.podLevelResourcesEnabled)
+			}
+
 			mockDevicesProvider := podresourcetest.NewMockDevicesProvider(t)
 			mockPodsProvider := podresourcetest.NewMockPodsProvider(t)
 			mockCPUsProvider := podresourcetest.NewMockCPUsProvider(t)

--- a/pkg/kubelet/apis/podresources/testing/mocks.go
+++ b/pkg/kubelet/apis/podresources/testing/mocks.go
@@ -467,16 +467,16 @@ func (_c *MockCPUsProvider_GetAllocatableCPUs_Call) RunAndReturn(run func() []in
 }
 
 // GetCPUs provides a mock function for the type MockCPUsProvider
-func (_mock *MockCPUsProvider) GetCPUs(podUID string, containerName string) []int64 {
-	ret := _mock.Called(podUID, containerName)
+func (_mock *MockCPUsProvider) GetCPUs(pod *v10.Pod, container *v10.Container) []int64 {
+	ret := _mock.Called(pod, container)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCPUs")
 	}
 
 	var r0 []int64
-	if returnFunc, ok := ret.Get(0).(func(string, string) []int64); ok {
-		r0 = returnFunc(podUID, containerName)
+	if returnFunc, ok := ret.Get(0).(func(*v10.Pod, *v10.Container) []int64); ok {
+		r0 = returnFunc(pod, container)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]int64)
@@ -491,21 +491,21 @@ type MockCPUsProvider_GetCPUs_Call struct {
 }
 
 // GetCPUs is a helper method to define mock.On call
-//   - podUID string
-//   - containerName string
-func (_e *MockCPUsProvider_Expecter) GetCPUs(podUID interface{}, containerName interface{}) *MockCPUsProvider_GetCPUs_Call {
-	return &MockCPUsProvider_GetCPUs_Call{Call: _e.mock.On("GetCPUs", podUID, containerName)}
+//   - pod *v10.Pod
+//   - container *v10.Container
+func (_e *MockCPUsProvider_Expecter) GetCPUs(pod interface{}, container interface{}) *MockCPUsProvider_GetCPUs_Call {
+	return &MockCPUsProvider_GetCPUs_Call{Call: _e.mock.On("GetCPUs", pod, container)}
 }
 
-func (_c *MockCPUsProvider_GetCPUs_Call) Run(run func(podUID string, containerName string)) *MockCPUsProvider_GetCPUs_Call {
+func (_c *MockCPUsProvider_GetCPUs_Call) Run(run func(pod *v10.Pod, container *v10.Container)) *MockCPUsProvider_GetCPUs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 *v10.Pod
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(*v10.Pod)
 		}
-		var arg1 string
+		var arg1 *v10.Container
 		if args[1] != nil {
-			arg1 = args[1].(string)
+			arg1 = args[1].(*v10.Container)
 		}
 		run(
 			arg0,
@@ -520,7 +520,60 @@ func (_c *MockCPUsProvider_GetCPUs_Call) Return(int64s []int64) *MockCPUsProvide
 	return _c
 }
 
-func (_c *MockCPUsProvider_GetCPUs_Call) RunAndReturn(run func(podUID string, containerName string) []int64) *MockCPUsProvider_GetCPUs_Call {
+func (_c *MockCPUsProvider_GetCPUs_Call) RunAndReturn(run func(pod *v10.Pod, container *v10.Container) []int64) *MockCPUsProvider_GetCPUs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetPodCPUs provides a mock function for the type MockCPUsProvider
+func (_mock *MockCPUsProvider) GetPodCPUs(podUID string) []int64 {
+	ret := _mock.Called(podUID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPodCPUs")
+	}
+
+	var r0 []int64
+	if returnFunc, ok := ret.Get(0).(func(string) []int64); ok {
+		r0 = returnFunc(podUID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]int64)
+		}
+	}
+	return r0
+}
+
+// MockCPUsProvider_GetPodCPUs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetPodCPUs'
+type MockCPUsProvider_GetPodCPUs_Call struct {
+	*mock.Call
+}
+
+// GetPodCPUs is a helper method to define mock.On call
+//   - podUID string
+func (_e *MockCPUsProvider_Expecter) GetPodCPUs(podUID interface{}) *MockCPUsProvider_GetPodCPUs_Call {
+	return &MockCPUsProvider_GetPodCPUs_Call{Call: _e.mock.On("GetPodCPUs", podUID)}
+}
+
+func (_c *MockCPUsProvider_GetPodCPUs_Call) Run(run func(podUID string)) *MockCPUsProvider_GetPodCPUs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockCPUsProvider_GetPodCPUs_Call) Return(int64s []int64) *MockCPUsProvider_GetPodCPUs_Call {
+	_c.Call.Return(int64s)
+	return _c
+}
+
+func (_c *MockCPUsProvider_GetPodCPUs_Call) RunAndReturn(run func(podUID string) []int64) *MockCPUsProvider_GetPodCPUs_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -606,16 +659,16 @@ func (_c *MockMemoryProvider_GetAllocatableMemory_Call) RunAndReturn(run func(lo
 }
 
 // GetMemory provides a mock function for the type MockMemoryProvider
-func (_mock *MockMemoryProvider) GetMemory(logger klog.Logger, podUID string, containerName string) []*v1.ContainerMemory {
-	ret := _mock.Called(logger, podUID, containerName)
+func (_mock *MockMemoryProvider) GetMemory(logger klog.Logger, pod *v10.Pod, container *v10.Container) []*v1.ContainerMemory {
+	ret := _mock.Called(logger, pod, container)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetMemory")
 	}
 
 	var r0 []*v1.ContainerMemory
-	if returnFunc, ok := ret.Get(0).(func(klog.Logger, string, string) []*v1.ContainerMemory); ok {
-		r0 = returnFunc(logger, podUID, containerName)
+	if returnFunc, ok := ret.Get(0).(func(klog.Logger, *v10.Pod, *v10.Container) []*v1.ContainerMemory); ok {
+		r0 = returnFunc(logger, pod, container)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*v1.ContainerMemory)
@@ -631,25 +684,25 @@ type MockMemoryProvider_GetMemory_Call struct {
 
 // GetMemory is a helper method to define mock.On call
 //   - logger klog.Logger
-//   - podUID string
-//   - containerName string
-func (_e *MockMemoryProvider_Expecter) GetMemory(logger interface{}, podUID interface{}, containerName interface{}) *MockMemoryProvider_GetMemory_Call {
-	return &MockMemoryProvider_GetMemory_Call{Call: _e.mock.On("GetMemory", logger, podUID, containerName)}
+//   - pod *v10.Pod
+//   - container *v10.Container
+func (_e *MockMemoryProvider_Expecter) GetMemory(logger interface{}, pod interface{}, container interface{}) *MockMemoryProvider_GetMemory_Call {
+	return &MockMemoryProvider_GetMemory_Call{Call: _e.mock.On("GetMemory", logger, pod, container)}
 }
 
-func (_c *MockMemoryProvider_GetMemory_Call) Run(run func(logger klog.Logger, podUID string, containerName string)) *MockMemoryProvider_GetMemory_Call {
+func (_c *MockMemoryProvider_GetMemory_Call) Run(run func(logger klog.Logger, pod *v10.Pod, container *v10.Container)) *MockMemoryProvider_GetMemory_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 klog.Logger
 		if args[0] != nil {
 			arg0 = args[0].(klog.Logger)
 		}
-		var arg1 string
+		var arg1 *v10.Pod
 		if args[1] != nil {
-			arg1 = args[1].(string)
+			arg1 = args[1].(*v10.Pod)
 		}
-		var arg2 string
+		var arg2 *v10.Container
 		if args[2] != nil {
-			arg2 = args[2].(string)
+			arg2 = args[2].(*v10.Container)
 		}
 		run(
 			arg0,
@@ -665,7 +718,66 @@ func (_c *MockMemoryProvider_GetMemory_Call) Return(containerMemorys []*v1.Conta
 	return _c
 }
 
-func (_c *MockMemoryProvider_GetMemory_Call) RunAndReturn(run func(logger klog.Logger, podUID string, containerName string) []*v1.ContainerMemory) *MockMemoryProvider_GetMemory_Call {
+func (_c *MockMemoryProvider_GetMemory_Call) RunAndReturn(run func(logger klog.Logger, pod *v10.Pod, container *v10.Container) []*v1.ContainerMemory) *MockMemoryProvider_GetMemory_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetPodMemory provides a mock function for the type MockMemoryProvider
+func (_mock *MockMemoryProvider) GetPodMemory(logger klog.Logger, podUID string) []*v1.ContainerMemory {
+	ret := _mock.Called(logger, podUID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPodMemory")
+	}
+
+	var r0 []*v1.ContainerMemory
+	if returnFunc, ok := ret.Get(0).(func(klog.Logger, string) []*v1.ContainerMemory); ok {
+		r0 = returnFunc(logger, podUID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*v1.ContainerMemory)
+		}
+	}
+	return r0
+}
+
+// MockMemoryProvider_GetPodMemory_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetPodMemory'
+type MockMemoryProvider_GetPodMemory_Call struct {
+	*mock.Call
+}
+
+// GetPodMemory is a helper method to define mock.On call
+//   - logger klog.Logger
+//   - podUID string
+func (_e *MockMemoryProvider_Expecter) GetPodMemory(logger interface{}, podUID interface{}) *MockMemoryProvider_GetPodMemory_Call {
+	return &MockMemoryProvider_GetPodMemory_Call{Call: _e.mock.On("GetPodMemory", logger, podUID)}
+}
+
+func (_c *MockMemoryProvider_GetPodMemory_Call) Run(run func(logger klog.Logger, podUID string)) *MockMemoryProvider_GetPodMemory_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 klog.Logger
+		if args[0] != nil {
+			arg0 = args[0].(klog.Logger)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockMemoryProvider_GetPodMemory_Call) Return(containerMemorys []*v1.ContainerMemory) *MockMemoryProvider_GetPodMemory_Call {
+	_c.Call.Return(containerMemorys)
+	return _c
+}
+
+func (_c *MockMemoryProvider_GetPodMemory_Call) RunAndReturn(run func(logger klog.Logger, podUID string) []*v1.ContainerMemory) *MockMemoryProvider_GetPodMemory_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/kubelet/apis/podresources/types.go
+++ b/pkg/kubelet/apis/podresources/types.go
@@ -42,15 +42,19 @@ type PodsProvider interface {
 
 // CPUsProvider knows how to provide the cpus used by the given container
 type CPUsProvider interface {
-	// GetCPUs returns information about the cpus assigned to pods and containers
-	GetCPUs(podUID, containerName string) []int64
-	// GetAllocatableCPUs returns the allocatable (not allocated) CPUs
+	// GetCPUs returns information about the cpus assigned to containers
+	GetCPUs(pod *v1.Pod, container *v1.Container) []int64
+	// GetPodCPUs returns information about the cpus assigned to a pod
+	GetPodCPUs(podUID string) []int64
+	// GetAllocatableCPUs returns the allocatable cpus from the node
 	GetAllocatableCPUs() []int64
 }
 
 type MemoryProvider interface {
 	// GetMemory returns information about the memory assigned to containers
-	GetMemory(logger klog.Logger, podUID, containerName string) []*podresourcesapi.ContainerMemory
+	GetMemory(logger klog.Logger, pod *v1.Pod, container *v1.Container) []*podresourcesapi.ContainerMemory
+	// GetPodMemory returns information about the memory assigned to a pod
+	GetPodMemory(logger klog.Logger, podUID string) []*podresourcesapi.ContainerMemory
 	// GetAllocatableMemory returns the allocatable memory from the node
 	GetAllocatableMemory(logger klog.Logger) []*podresourcesapi.ContainerMemory
 }

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -1004,11 +1004,25 @@ func (cm *containerManagerImpl) GetAllocatableDevices(logger klog.Logger) []*pod
 	return containerDevicesFromResourceDeviceInstances(cm.deviceManager.GetAllocatableDevices(logger))
 }
 
-func (cm *containerManagerImpl) GetCPUs(podUID, containerName string) []int64 {
+func (cm *containerManagerImpl) GetCPUs(pod *v1.Pod, container *v1.Container) []int64 {
 	if cm.cpuManager != nil {
-		return int64Slice(cm.cpuManager.GetExclusiveCPUs(podUID, containerName).UnsortedList())
+		// Only report container-level CPUs if the container has exclusive CPUs
+		// (ResourceIsolationContainer). If the container runs on a shared pool
+		// (ResourceIsolationPod or ResourceIsolationHost), we return empty since
+		// these resources are shared and reported at the pod level instead.
+		if cm.cpuManager.GetResourceIsolationLevel(pod, container) != cmqos.ResourceIsolationContainer {
+			return []int64{}
+		}
+		return int64Slice(cm.cpuManager.GetExclusiveCPUs(string(pod.UID), container.Name).UnsortedList())
 	}
 	return []int64{}
+}
+
+func (cm *containerManagerImpl) GetPodCPUs(podUID string) []int64 {
+	if cm.cpuManager == nil {
+		return []int64{}
+	}
+	return int64Slice(cm.cpuManager.GetPodCPUs(podUID).UnsortedList())
 }
 
 func (cm *containerManagerImpl) GetAllocatableCPUs() []int64 {
@@ -1018,22 +1032,35 @@ func (cm *containerManagerImpl) GetAllocatableCPUs() []int64 {
 	return []int64{}
 }
 
-func (cm *containerManagerImpl) GetMemory(logger klog.Logger, podUID, containerName string) []*podresourcesapi.ContainerMemory {
+func (cm *containerManagerImpl) GetMemory(logger klog.Logger, pod *v1.Pod, container *v1.Container) []*podresourcesapi.ContainerMemory {
 	if cm.memoryManager == nil {
 		return []*podresourcesapi.ContainerMemory{}
 	}
 
-	return containerMemoryFromBlock(cm.memoryManager.GetMemory(logger, podUID, containerName))
+	// Only report container-level memory if the container has exclusive memory
+	// (ResourceIsolationContainer). If the container runs on a shared pool
+	// (ResourceIsolationPod or ResourceIsolationHost), we return empty since
+	// these resources are shared and reported at the pod level instead.
+	if cm.memoryManager.GetResourceIsolationLevel(pod, container) != cmqos.ResourceIsolationContainer {
+		return []*podresourcesapi.ContainerMemory{}
+	}
+
+	return containerMemoryFromBlock(cm.memoryManager.GetMemory(logger, string(pod.UID), container.Name))
 }
 
 func (cm *containerManagerImpl) GetAllocatableMemory(logger klog.Logger) []*podresourcesapi.ContainerMemory {
 	if cm.memoryManager == nil {
 		return []*podresourcesapi.ContainerMemory{}
 	}
-
-	// This is tempporary as part of migration of memory manager to Contextual logging.
-	// Direct context to be passed when container manager is migrated.
 	return containerMemoryFromBlock(cm.memoryManager.GetAllocatableMemory(logger))
+}
+
+func (cm *containerManagerImpl) GetPodMemory(logger klog.Logger, podUID string) []*podresourcesapi.ContainerMemory {
+	if cm.memoryManager == nil {
+		return []*podresourcesapi.ContainerMemory{}
+	}
+
+	return containerMemoryFromBlock(cm.memoryManager.GetPodMemory(podUID))
 }
 
 func (cm *containerManagerImpl) GetDynamicResources(logger klog.Logger, pod *v1.Pod, container *v1.Container) []*podresourcesapi.DynamicResource {

--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -157,7 +157,11 @@ func (cm *containerManagerStub) UpdateAllocatedDevices(_ klog.Logger) {
 	return
 }
 
-func (cm *containerManagerStub) GetCPUs(_, _ string) []int64 {
+func (cm *containerManagerStub) GetCPUs(pod *v1.Pod, container *v1.Container) []int64 {
+	return nil
+}
+
+func (cm *containerManagerStub) GetPodCPUs(_ string) []int64 {
 	return nil
 }
 
@@ -165,7 +169,11 @@ func (cm *containerManagerStub) GetAllocatableCPUs() []int64 {
 	return nil
 }
 
-func (cm *containerManagerStub) GetMemory(_ klog.Logger, _, _ string) []*podresourcesapi.ContainerMemory {
+func (cm *containerManagerStub) GetMemory(_ klog.Logger, pod *v1.Pod, container *v1.Container) []*podresourcesapi.ContainerMemory {
+	return nil
+}
+
+func (cm *containerManagerStub) GetPodMemory(_ klog.Logger, _ string) []*podresourcesapi.ContainerMemory {
 	return nil
 }
 

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -327,13 +327,17 @@ func (cm *containerManagerImpl) UpdateAllocatedDevices(_ klog.Logger) {
 	return
 }
 
-func (cm *containerManagerImpl) GetCPUs(podUID, containerName string) []int64 {
+func (cm *containerManagerImpl) GetCPUs(pod *v1.Pod, container *v1.Container) []int64 {
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.WindowsCPUAndMemoryAffinity) {
 		if cm.cpuManager != nil {
-			return int64Slice(cm.cpuManager.GetExclusiveCPUs(podUID, containerName).UnsortedList())
+			return int64Slice(cm.cpuManager.GetExclusiveCPUs(string(pod.UID), container.Name).UnsortedList())
 		}
 		return []int64{}
 	}
+	return nil
+}
+
+func (cm *containerManagerImpl) GetPodCPUs(podUID string) []int64 {
 	return nil
 }
 
@@ -347,7 +351,11 @@ func (cm *containerManagerImpl) GetAllocatableCPUs() []int64 {
 	return nil
 }
 
-func (cm *containerManagerImpl) GetMemory(_ klog.Logger, _, _ string) []*podresourcesapi.ContainerMemory {
+func (cm *containerManagerImpl) GetMemory(_ klog.Logger, pod *v1.Pod, container *v1.Container) []*podresourcesapi.ContainerMemory {
+	return nil
+}
+
+func (cm *containerManagerImpl) GetPodMemory(_ klog.Logger, _ string) []*podresourcesapi.ContainerMemory {
 	return nil
 }
 

--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -89,6 +89,10 @@ type Manager interface {
 	// exclusively allocated cpus for the container
 	GetExclusiveCPUs(podUID, containerName string) cpuset.CPUSet
 
+	// GetPodCPUs implements the podresources.CPUsProvider interface to provide
+	// the total cpuset allocated to the pod
+	GetPodCPUs(podUID string) cpuset.CPUSet
+
 	// GetPodTopologyHints implements the topologymanager.HintProvider Interface
 	// and is consulted to achieve NUMA aware resource alignment per Pod
 	// among this and other resource controllers.
@@ -557,6 +561,13 @@ func findContainerStatusByName(status *v1.PodStatus, name string) (*v1.Container
 
 func (m *manager) GetExclusiveCPUs(podUID, containerName string) cpuset.CPUSet {
 	if result, ok := m.state.GetCPUSet(podUID, containerName); ok {
+		return result
+	}
+	return cpuset.New()
+}
+
+func (m *manager) GetPodCPUs(podUID string) cpuset.CPUSet {
+	if result, ok := m.state.GetPodCPUSet(podUID); ok {
 		return result
 	}
 	return cpuset.New()

--- a/pkg/kubelet/cm/cpumanager/fake_cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/fake_cpu_manager.go
@@ -87,6 +87,11 @@ func (m *fakeManager) GetExclusiveCPUs(podUID, containerName string) cpuset.CPUS
 	return cpuset.New()
 }
 
+func (m *fakeManager) GetPodCPUs(podUID string) cpuset.CPUSet {
+	m.logger.Info("GetPodCPUs", "podUID", podUID)
+	return cpuset.New()
+}
+
 func (m *fakeManager) GetAllocatableCPUs() cpuset.CPUSet {
 	m.logger.Info("Get Allocatable CPUs")
 	return cpuset.New()

--- a/pkg/kubelet/cm/fake_container_manager.go
+++ b/pkg/kubelet/cm/fake_container_manager.go
@@ -229,10 +229,17 @@ func (cm *FakeContainerManager) UpdateAllocatedDevices(_ klog.Logger) {
 	return
 }
 
-func (cm *FakeContainerManager) GetCPUs(_, _ string) []int64 {
+func (cm *FakeContainerManager) GetCPUs(pod *v1.Pod, container *v1.Container) []int64 {
 	cm.Lock()
 	defer cm.Unlock()
 	cm.CalledFunctions = append(cm.CalledFunctions, "GetCPUs")
+	return nil
+}
+
+func (cm *FakeContainerManager) GetPodCPUs(_ string) []int64 {
+	cm.Lock()
+	defer cm.Unlock()
+	cm.CalledFunctions = append(cm.CalledFunctions, "GetPodCPUs")
 	return nil
 }
 
@@ -242,10 +249,17 @@ func (cm *FakeContainerManager) GetAllocatableCPUs() []int64 {
 	return nil
 }
 
-func (cm *FakeContainerManager) GetMemory(_ klog.Logger, _, _ string) []*podresourcesapi.ContainerMemory {
+func (cm *FakeContainerManager) GetMemory(_ klog.Logger, pod *v1.Pod, container *v1.Container) []*podresourcesapi.ContainerMemory {
 	cm.Lock()
 	defer cm.Unlock()
 	cm.CalledFunctions = append(cm.CalledFunctions, "GetMemory")
+	return nil
+}
+
+func (cm *FakeContainerManager) GetPodMemory(_ klog.Logger, _ string) []*podresourcesapi.ContainerMemory {
+	cm.Lock()
+	defer cm.Unlock()
+	cm.CalledFunctions = append(cm.CalledFunctions, "GetPodMemory")
 	return nil
 }
 

--- a/pkg/kubelet/cm/memorymanager/fake_memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/fake_memory_manager.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager/state"
+	cmqos "k8s.io/kubernetes/pkg/kubelet/cm/qos"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
@@ -95,6 +96,17 @@ func (m *fakeManager) GetMemory(logger klog.Logger, podUID, containerName string
 	logger = klog.LoggerWithValues(logger, "podUID", podUID, "containerName", containerName)
 	logger.Info("Get Memory")
 	return []state.Block{}
+}
+
+// GetPodMemory returns the memory allocated by a pod from NUMA nodes
+func (m *fakeManager) GetPodMemory(podUID string) []state.Block {
+	logger := klog.LoggerWithValues(klog.TODO(), "podUID", podUID)
+	logger.Info("Get Pod Memory")
+	return []state.Block{}
+}
+
+func (m *fakeManager) GetResourceIsolationLevel(pod *v1.Pod, container *v1.Container) cmqos.ResourceIsolationLevel {
+	return cmqos.ResourceIsolationContainer
 }
 
 // NewFakeManager creates empty/fake memory manager

--- a/pkg/kubelet/cm/memorymanager/memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager.go
@@ -27,13 +27,17 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/util/feature"
+	resourcehelper "k8s.io/component-helpers/resource"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	corev1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
+	"k8s.io/kubernetes/pkg/features"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager/state"
+	cmqos "k8s.io/kubernetes/pkg/kubelet/cm/qos"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
@@ -96,6 +100,12 @@ type Manager interface {
 
 	// GetMemory returns the memory allocated by a container from NUMA nodes
 	GetMemory(logger klog.Logger, podUID, containerName string) []state.Block
+
+	// GetPodMemory returns the memory allocated by a pod from NUMA nodes
+	GetPodMemory(podUID string) []state.Block
+
+	// GetResourceIsolationLevel returns the isolation level of the container.
+	GetResourceIsolationLevel(pod *v1.Pod, container *v1.Container) cmqos.ResourceIsolationLevel
 }
 
 type manager struct {
@@ -489,4 +499,22 @@ func (m *manager) GetAllocatableMemory(_ klog.Logger) []state.Block {
 // GetMemory returns the memory allocated by a container from NUMA nodes
 func (m *manager) GetMemory(_ klog.Logger, podUID, containerName string) []state.Block {
 	return m.state.GetMemoryBlocks(podUID, containerName)
+}
+
+// GetPodMemory returns the memory allocated by a pod from NUMA nodes
+func (m *manager) GetPodMemory(podUID string) []state.Block {
+	return m.state.GetPodMemoryBlocks(podUID)
+}
+
+// GetResourceIsolationLevel returns the isolation level of the container.
+func (m *manager) GetResourceIsolationLevel(pod *v1.Pod, container *v1.Container) cmqos.ResourceIsolationLevel {
+	if len(m.state.GetMemoryBlocks(string(pod.UID), container.Name)) == 0 {
+		return cmqos.ResourceIsolationHost
+	}
+
+	if feature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) && resourcehelper.IsPodLevelResourcesSet(pod) && !cmqos.IsContainerEquivalentQOSGuaranteed(container) {
+		return cmqos.ResourceIsolationPod
+	}
+
+	return cmqos.ResourceIsolationContainer
 }

--- a/pkg/kubelet/cm/testing/mocks.go
+++ b/pkg/kubelet/cm/testing/mocks.go
@@ -336,16 +336,16 @@ func (_c *MockContainerManager_GetAllocateResourcesPodAdmitHandler_Call) RunAndR
 }
 
 // GetCPUs provides a mock function for the type MockContainerManager
-func (_mock *MockContainerManager) GetCPUs(podUID string, containerName string) []int64 {
-	ret := _mock.Called(podUID, containerName)
+func (_mock *MockContainerManager) GetCPUs(pod *v1.Pod, container *v1.Container) []int64 {
+	ret := _mock.Called(pod, container)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCPUs")
 	}
 
 	var r0 []int64
-	if returnFunc, ok := ret.Get(0).(func(string, string) []int64); ok {
-		r0 = returnFunc(podUID, containerName)
+	if returnFunc, ok := ret.Get(0).(func(*v1.Pod, *v1.Container) []int64); ok {
+		r0 = returnFunc(pod, container)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]int64)
@@ -360,21 +360,21 @@ type MockContainerManager_GetCPUs_Call struct {
 }
 
 // GetCPUs is a helper method to define mock.On call
-//   - podUID string
-//   - containerName string
-func (_e *MockContainerManager_Expecter) GetCPUs(podUID interface{}, containerName interface{}) *MockContainerManager_GetCPUs_Call {
-	return &MockContainerManager_GetCPUs_Call{Call: _e.mock.On("GetCPUs", podUID, containerName)}
+//   - pod *v1.Pod
+//   - container *v1.Container
+func (_e *MockContainerManager_Expecter) GetCPUs(pod interface{}, container interface{}) *MockContainerManager_GetCPUs_Call {
+	return &MockContainerManager_GetCPUs_Call{Call: _e.mock.On("GetCPUs", pod, container)}
 }
 
-func (_c *MockContainerManager_GetCPUs_Call) Run(run func(podUID string, containerName string)) *MockContainerManager_GetCPUs_Call {
+func (_c *MockContainerManager_GetCPUs_Call) Run(run func(pod *v1.Pod, container *v1.Container)) *MockContainerManager_GetCPUs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 *v1.Pod
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(*v1.Pod)
 		}
-		var arg1 string
+		var arg1 *v1.Container
 		if args[1] != nil {
-			arg1 = args[1].(string)
+			arg1 = args[1].(*v1.Container)
 		}
 		run(
 			arg0,
@@ -389,7 +389,7 @@ func (_c *MockContainerManager_GetCPUs_Call) Return(int64s []int64) *MockContain
 	return _c
 }
 
-func (_c *MockContainerManager_GetCPUs_Call) RunAndReturn(run func(podUID string, containerName string) []int64) *MockContainerManager_GetCPUs_Call {
+func (_c *MockContainerManager_GetCPUs_Call) RunAndReturn(run func(pod *v1.Pod, container *v1.Container) []int64) *MockContainerManager_GetCPUs_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -696,16 +696,16 @@ func (_c *MockContainerManager_GetHealthCheckers_Call) RunAndReturn(run func() [
 }
 
 // GetMemory provides a mock function for the type MockContainerManager
-func (_mock *MockContainerManager) GetMemory(logger klog.Logger, podUID string, containerName string) []*v10.ContainerMemory {
-	ret := _mock.Called(logger, podUID, containerName)
+func (_mock *MockContainerManager) GetMemory(logger klog.Logger, pod *v1.Pod, container *v1.Container) []*v10.ContainerMemory {
+	ret := _mock.Called(logger, pod, container)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetMemory")
 	}
 
 	var r0 []*v10.ContainerMemory
-	if returnFunc, ok := ret.Get(0).(func(klog.Logger, string, string) []*v10.ContainerMemory); ok {
-		r0 = returnFunc(logger, podUID, containerName)
+	if returnFunc, ok := ret.Get(0).(func(klog.Logger, *v1.Pod, *v1.Container) []*v10.ContainerMemory); ok {
+		r0 = returnFunc(logger, pod, container)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*v10.ContainerMemory)
@@ -721,25 +721,25 @@ type MockContainerManager_GetMemory_Call struct {
 
 // GetMemory is a helper method to define mock.On call
 //   - logger klog.Logger
-//   - podUID string
-//   - containerName string
-func (_e *MockContainerManager_Expecter) GetMemory(logger interface{}, podUID interface{}, containerName interface{}) *MockContainerManager_GetMemory_Call {
-	return &MockContainerManager_GetMemory_Call{Call: _e.mock.On("GetMemory", logger, podUID, containerName)}
+//   - pod *v1.Pod
+//   - container *v1.Container
+func (_e *MockContainerManager_Expecter) GetMemory(logger interface{}, pod interface{}, container interface{}) *MockContainerManager_GetMemory_Call {
+	return &MockContainerManager_GetMemory_Call{Call: _e.mock.On("GetMemory", logger, pod, container)}
 }
 
-func (_c *MockContainerManager_GetMemory_Call) Run(run func(logger klog.Logger, podUID string, containerName string)) *MockContainerManager_GetMemory_Call {
+func (_c *MockContainerManager_GetMemory_Call) Run(run func(logger klog.Logger, pod *v1.Pod, container *v1.Container)) *MockContainerManager_GetMemory_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 klog.Logger
 		if args[0] != nil {
 			arg0 = args[0].(klog.Logger)
 		}
-		var arg1 string
+		var arg1 *v1.Pod
 		if args[1] != nil {
-			arg1 = args[1].(string)
+			arg1 = args[1].(*v1.Pod)
 		}
-		var arg2 string
+		var arg2 *v1.Container
 		if args[2] != nil {
-			arg2 = args[2].(string)
+			arg2 = args[2].(*v1.Container)
 		}
 		run(
 			arg0,
@@ -755,7 +755,7 @@ func (_c *MockContainerManager_GetMemory_Call) Return(containerMemorys []*v10.Co
 	return _c
 }
 
-func (_c *MockContainerManager_GetMemory_Call) RunAndReturn(run func(logger klog.Logger, podUID string, containerName string) []*v10.ContainerMemory) *MockContainerManager_GetMemory_Call {
+func (_c *MockContainerManager_GetMemory_Call) RunAndReturn(run func(logger klog.Logger, pod *v1.Pod, container *v1.Container) []*v10.ContainerMemory) *MockContainerManager_GetMemory_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -988,6 +988,59 @@ func (_c *MockContainerManager_GetPluginRegistrationHandlers_Call) RunAndReturn(
 	return _c
 }
 
+// GetPodCPUs provides a mock function for the type MockContainerManager
+func (_mock *MockContainerManager) GetPodCPUs(podUID string) []int64 {
+	ret := _mock.Called(podUID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPodCPUs")
+	}
+
+	var r0 []int64
+	if returnFunc, ok := ret.Get(0).(func(string) []int64); ok {
+		r0 = returnFunc(podUID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]int64)
+		}
+	}
+	return r0
+}
+
+// MockContainerManager_GetPodCPUs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetPodCPUs'
+type MockContainerManager_GetPodCPUs_Call struct {
+	*mock.Call
+}
+
+// GetPodCPUs is a helper method to define mock.On call
+//   - podUID string
+func (_e *MockContainerManager_Expecter) GetPodCPUs(podUID interface{}) *MockContainerManager_GetPodCPUs_Call {
+	return &MockContainerManager_GetPodCPUs_Call{Call: _e.mock.On("GetPodCPUs", podUID)}
+}
+
+func (_c *MockContainerManager_GetPodCPUs_Call) Run(run func(podUID string)) *MockContainerManager_GetPodCPUs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockContainerManager_GetPodCPUs_Call) Return(int64s []int64) *MockContainerManager_GetPodCPUs_Call {
+	_c.Call.Return(int64s)
+	return _c
+}
+
+func (_c *MockContainerManager_GetPodCPUs_Call) RunAndReturn(run func(podUID string) []int64) *MockContainerManager_GetPodCPUs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetPodCgroupRoot provides a mock function for the type MockContainerManager
 func (_mock *MockContainerManager) GetPodCgroupRoot() string {
 	ret := _mock.Called()
@@ -1028,6 +1081,65 @@ func (_c *MockContainerManager_GetPodCgroupRoot_Call) Return(s string) *MockCont
 }
 
 func (_c *MockContainerManager_GetPodCgroupRoot_Call) RunAndReturn(run func() string) *MockContainerManager_GetPodCgroupRoot_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetPodMemory provides a mock function for the type MockContainerManager
+func (_mock *MockContainerManager) GetPodMemory(logger klog.Logger, podUID string) []*v10.ContainerMemory {
+	ret := _mock.Called(logger, podUID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPodMemory")
+	}
+
+	var r0 []*v10.ContainerMemory
+	if returnFunc, ok := ret.Get(0).(func(klog.Logger, string) []*v10.ContainerMemory); ok {
+		r0 = returnFunc(logger, podUID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*v10.ContainerMemory)
+		}
+	}
+	return r0
+}
+
+// MockContainerManager_GetPodMemory_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetPodMemory'
+type MockContainerManager_GetPodMemory_Call struct {
+	*mock.Call
+}
+
+// GetPodMemory is a helper method to define mock.On call
+//   - logger klog.Logger
+//   - podUID string
+func (_e *MockContainerManager_Expecter) GetPodMemory(logger interface{}, podUID interface{}) *MockContainerManager_GetPodMemory_Call {
+	return &MockContainerManager_GetPodMemory_Call{Call: _e.mock.On("GetPodMemory", logger, podUID)}
+}
+
+func (_c *MockContainerManager_GetPodMemory_Call) Run(run func(logger klog.Logger, podUID string)) *MockContainerManager_GetPodMemory_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 klog.Logger
+		if args[0] != nil {
+			arg0 = args[0].(klog.Logger)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockContainerManager_GetPodMemory_Call) Return(containerMemorys []*v10.ContainerMemory) *MockContainerManager_GetPodMemory_Call {
+	_c.Call.Return(containerMemorys)
+	return _c
+}
+
+func (_c *MockContainerManager_GetPodMemory_Call) RunAndReturn(run func(logger klog.Logger, podUID string) []*v10.ContainerMemory) *MockContainerManager_GetPodMemory_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/staging/src/k8s.io/kubelet/pkg/apis/podresources/v1/api.pb.go
+++ b/staging/src/k8s.io/kubelet/pkg/apis/podresources/v1/api.pb.go
@@ -220,10 +220,18 @@ func (x *ListPodResourcesResponse) GetPodResources() []*PodResources {
 
 // PodResources contains information about the node resources assigned to a pod
 type PodResources struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Namespace     string                 `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`
-	Containers    []*ContainerResources  `protobuf:"bytes,3,rep,name=containers,proto3" json:"containers,omitempty"`
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	Name       string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Namespace  string                 `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	Containers []*ContainerResources  `protobuf:"bytes,3,rep,name=containers,proto3" json:"containers,omitempty"`
+	// List of exclusive CPU ids allocated at the pod level. Populated only when
+	// the pod has a pod-level exclusive allocation. CPUs exclusively assigned
+	// to individual containers within the pod are also included here, so
+	// pod-level and container-level cpu_ids intentionally overlap.
+	CpuIds []int64 `protobuf:"varint,4,rep,packed,name=cpu_ids,json=cpuIds,proto3" json:"cpu_ids,omitempty"`
+	// List of memory blocks allocated at the pod level, following the same
+	// population and overlap semantics as cpu_ids.
+	Memory        []*ContainerMemory `protobuf:"bytes,5,rep,name=memory,proto3" json:"memory,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -275,6 +283,20 @@ func (x *PodResources) GetNamespace() string {
 func (x *PodResources) GetContainers() []*ContainerResources {
 	if x != nil {
 		return x.Containers
+	}
+	return nil
+}
+
+func (x *PodResources) GetCpuIds() []int64 {
+	if x != nil {
+		return x.CpuIds
+	}
+	return nil
+}
+
+func (x *PodResources) GetMemory() []*ContainerMemory {
+	if x != nil {
+		return x.Memory
 	}
 	return nil
 }
@@ -356,7 +378,7 @@ func (x *ContainerResources) GetDynamicResources() []*DynamicResource {
 	return nil
 }
 
-// ContainerMemory contains information about memory and hugepages assigned to a container
+// ContainerMemory contains information about memory and hugepages assigned to a pod / container
 type ContainerMemory struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	MemoryType    string                 `protobuf:"bytes,1,opt,name=memory_type,json=memoryType,proto3" json:"memory_type,omitempty"`
@@ -870,13 +892,15 @@ const file_staging_src_k8s_io_kubelet_pkg_apis_podresources_v1_api_proto_rawDesc
 	"\x06memory\x18\x03 \x03(\v2\x13.v1.ContainerMemoryR\x06memory\"\x19\n" +
 	"\x17ListPodResourcesRequest\"Q\n" +
 	"\x18ListPodResourcesResponse\x125\n" +
-	"\rpod_resources\x18\x01 \x03(\v2\x10.v1.PodResourcesR\fpodResources\"x\n" +
+	"\rpod_resources\x18\x01 \x03(\v2\x10.v1.PodResourcesR\fpodResources\"\xbe\x01\n" +
 	"\fPodResources\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1c\n" +
 	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x126\n" +
 	"\n" +
 	"containers\x18\x03 \x03(\v2\x16.v1.ContainerResourcesR\n" +
-	"containers\"\xe0\x01\n" +
+	"containers\x12\x17\n" +
+	"\acpu_ids\x18\x04 \x03(\x03R\x06cpuIds\x12+\n" +
+	"\x06memory\x18\x05 \x03(\v2\x13.v1.ContainerMemoryR\x06memory\"\xe0\x01\n" +
 	"\x12ContainerResources\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12.\n" +
 	"\adevices\x18\x02 \x03(\v2\x14.v1.ContainerDevicesR\adevices\x12\x17\n" +
@@ -959,26 +983,27 @@ var file_staging_src_k8s_io_kubelet_pkg_apis_podresources_v1_api_proto_depIdxs =
 	6,  // 1: v1.AllocatableResourcesResponse.memory:type_name -> v1.ContainerMemory
 	4,  // 2: v1.ListPodResourcesResponse.pod_resources:type_name -> v1.PodResources
 	5,  // 3: v1.PodResources.containers:type_name -> v1.ContainerResources
-	7,  // 4: v1.ContainerResources.devices:type_name -> v1.ContainerDevices
-	6,  // 5: v1.ContainerResources.memory:type_name -> v1.ContainerMemory
-	10, // 6: v1.ContainerResources.dynamic_resources:type_name -> v1.DynamicResource
-	8,  // 7: v1.ContainerMemory.topology:type_name -> v1.TopologyInfo
-	8,  // 8: v1.ContainerDevices.topology:type_name -> v1.TopologyInfo
-	9,  // 9: v1.TopologyInfo.nodes:type_name -> v1.NUMANode
-	11, // 10: v1.DynamicResource.claim_resources:type_name -> v1.ClaimResource
-	12, // 11: v1.ClaimResource.cdi_devices:type_name -> v1.CDIDevice
-	4,  // 12: v1.GetPodResourcesResponse.pod_resources:type_name -> v1.PodResources
-	2,  // 13: v1.PodResourcesLister.List:input_type -> v1.ListPodResourcesRequest
-	0,  // 14: v1.PodResourcesLister.GetAllocatableResources:input_type -> v1.AllocatableResourcesRequest
-	13, // 15: v1.PodResourcesLister.Get:input_type -> v1.GetPodResourcesRequest
-	3,  // 16: v1.PodResourcesLister.List:output_type -> v1.ListPodResourcesResponse
-	1,  // 17: v1.PodResourcesLister.GetAllocatableResources:output_type -> v1.AllocatableResourcesResponse
-	14, // 18: v1.PodResourcesLister.Get:output_type -> v1.GetPodResourcesResponse
-	16, // [16:19] is the sub-list for method output_type
-	13, // [13:16] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	6,  // 4: v1.PodResources.memory:type_name -> v1.ContainerMemory
+	7,  // 5: v1.ContainerResources.devices:type_name -> v1.ContainerDevices
+	6,  // 6: v1.ContainerResources.memory:type_name -> v1.ContainerMemory
+	10, // 7: v1.ContainerResources.dynamic_resources:type_name -> v1.DynamicResource
+	8,  // 8: v1.ContainerMemory.topology:type_name -> v1.TopologyInfo
+	8,  // 9: v1.ContainerDevices.topology:type_name -> v1.TopologyInfo
+	9,  // 10: v1.TopologyInfo.nodes:type_name -> v1.NUMANode
+	11, // 11: v1.DynamicResource.claim_resources:type_name -> v1.ClaimResource
+	12, // 12: v1.ClaimResource.cdi_devices:type_name -> v1.CDIDevice
+	4,  // 13: v1.GetPodResourcesResponse.pod_resources:type_name -> v1.PodResources
+	2,  // 14: v1.PodResourcesLister.List:input_type -> v1.ListPodResourcesRequest
+	0,  // 15: v1.PodResourcesLister.GetAllocatableResources:input_type -> v1.AllocatableResourcesRequest
+	13, // 16: v1.PodResourcesLister.Get:input_type -> v1.GetPodResourcesRequest
+	3,  // 17: v1.PodResourcesLister.List:output_type -> v1.ListPodResourcesResponse
+	1,  // 18: v1.PodResourcesLister.GetAllocatableResources:output_type -> v1.AllocatableResourcesResponse
+	14, // 19: v1.PodResourcesLister.Get:output_type -> v1.GetPodResourcesResponse
+	17, // [17:20] is the sub-list for method output_type
+	14, // [14:17] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_staging_src_k8s_io_kubelet_pkg_apis_podresources_v1_api_proto_init() }

--- a/staging/src/k8s.io/kubelet/pkg/apis/podresources/v1/api.proto
+++ b/staging/src/k8s.io/kubelet/pkg/apis/podresources/v1/api.proto
@@ -35,6 +35,14 @@ message PodResources {
     string name = 1;
     string namespace = 2;
     repeated ContainerResources containers = 3;
+    // List of exclusive CPU ids allocated at the pod level. Populated only when
+    // the pod has a pod-level exclusive allocation. CPUs exclusively assigned
+    // to individual containers within the pod are also included here, so
+    // pod-level and container-level cpu_ids intentionally overlap.
+    repeated int64 cpu_ids = 4;
+    // List of memory blocks allocated at the pod level, following the same
+    // population and overlap semantics as cpu_ids.
+    repeated ContainerMemory memory = 5;
 }
 
 // ContainerResources contains information about the resources assigned to a container
@@ -46,7 +54,7 @@ message ContainerResources {
     repeated DynamicResource dynamic_resources = 5;
 }
 
-// ContainerMemory contains information about memory and hugepages assigned to a container
+// ContainerMemory contains information about memory and hugepages assigned to a pod / container
 message ContainerMemory {
     string memory_type = 1;
     uint64 size = 2;

--- a/test/e2e_node/memory_manager_test.go
+++ b/test/e2e_node/memory_manager_test.go
@@ -262,7 +262,7 @@ func verifyMemoryPinning(f *framework.Framework, ctx context.Context, pod *v1.Po
 	gomega.Expect(numaNodeIDs).To(gomega.Equal(currentNUMANodeIDs.List()))
 }
 
-func verifyMemoryManagerAllocations(ctx context.Context, pod *v1.Pod, expectedGuaranteedContainers []string, expectedSharedMemorySize int64) {
+func verifyMemoryManagerAllocations(ctx context.Context, pod *v1.Pod, expectedGuaranteedContainers []string, expectedPodLevelMemorySize int64) {
 	ginkgo.GinkgoHelper()
 	ginkgo.By("Verifying memory manager allocations via pod resource API")
 	endpoint, err := util.LocalEndpoint(defaultPodResourcesPath, podresources.Socket)
@@ -284,6 +284,16 @@ func verifyMemoryManagerAllocations(ctx context.Context, pod *v1.Pod, expectedGu
 	for _, podResource := range resp.PodResources {
 		if podResource.Name != pod.Name {
 			continue
+		}
+
+		if expectedPodLevelMemorySize > 0 {
+			var totalAllocated uint64
+			for _, mem := range podResource.Memory {
+				totalAllocated += mem.Size
+			}
+			gomega.Expect(totalAllocated).To(gomega.BeEquivalentTo(expectedPodLevelMemorySize), "pod %s memory should match expected pod-level memory", podResource.Name)
+		} else {
+			gomega.Expect(podResource.Memory).To(gomega.BeEmpty(), "expected no pod-level memory resources for pod %s", podResource.Name)
 		}
 
 		for _, containerResource := range podResource.Containers {
@@ -315,16 +325,7 @@ func verifyMemoryManagerAllocations(ctx context.Context, pod *v1.Pod, expectedGu
 					gomega.Expect(val).To(gomega.BeEquivalentTo(mem.Size))
 				}
 			} else {
-				if expectedSharedMemorySize > 0 {
-					gomega.Expect(containerResource.Memory).ToNot(gomega.BeEmpty(), "expected memory resources for non-guaranteed container %s", containerResource.Name)
-					var totalAllocated uint64
-					for _, mem := range containerResource.Memory {
-						totalAllocated += mem.Size
-					}
-					gomega.Expect(totalAllocated).To(gomega.BeEquivalentTo(expectedSharedMemorySize), "container %s memory should match shared pool size", containerResource.Name)
-				} else {
-					gomega.Expect(containerResource.Memory).To(gomega.BeEmpty(), "expected no memory resources for container %s", containerResource.Name)
-				}
+				gomega.Expect(containerResource.Memory).To(gomega.BeEmpty(), "expected no container-level memory resources for non-guaranteed container %s", containerResource.Name)
 			}
 		}
 	}
@@ -925,7 +926,7 @@ var _ = SIGDescribe("Memory Manager Pod Level Resources", ginkgo.Ordered, ginkgo
 
 				verifyMemoryManagerAllocations(ctx, testPod, []string{
 					"gu-container",
-				}, 0)
+				}, 128*1024*1024)
 
 				if !*isMultiNUMASupported {
 					framework.Logf("Skipping memory pinning verification on single-NUMA machine")
@@ -1037,7 +1038,7 @@ var _ = SIGDescribe("Memory Manager Pod Level Resources", ginkgo.Ordered, ginkgo
 				ginkgo.By("Running the test pod")
 				testPod = createPodSync(ctx, testPod)
 
-				verifyMemoryManagerAllocations(ctx, testPod, []string{"gu-container"}, 64*1024*1024)
+				verifyMemoryManagerAllocations(ctx, testPod, []string{"gu-container"}, 128*1024*1024)
 
 				if !*isMultiNUMASupported {
 					framework.Logf("Skipping memory pinning verification on single-NUMA machine")
@@ -1099,7 +1100,7 @@ var _ = SIGDescribe("Memory Manager Pod Level Resources", ginkgo.Ordered, ginkgo
 				ginkgo.By("Running the test pod")
 				testPod = createPodSync(ctx, testPod)
 
-				verifyMemoryManagerAllocations(ctx, testPod, []string{"gu-init-container", "gu-container"}, 64*1024*1024)
+				verifyMemoryManagerAllocations(ctx, testPod, []string{"gu-init-container", "gu-container"}, 128*1024*1024)
 
 				if !*isMultiNUMASupported {
 					framework.Logf("Skipping memory pinning verification on single-NUMA machine")

--- a/test/e2e_node/podresources_test.go
+++ b/test/e2e_node/podresources_test.go
@@ -40,10 +40,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeletdevicepluginv1beta1 "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 	kubeletpodresourcesv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
+	"k8s.io/kubernetes/pkg/features"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	apisgrpc "k8s.io/kubernetes/pkg/kubelet/apis/grpc"
 	"k8s.io/kubernetes/pkg/kubelet/apis/podresources"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 	"k8s.io/kubernetes/pkg/kubelet/util"
 	testutils "k8s.io/kubernetes/test/utils"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -2200,6 +2203,20 @@ func getPodResourcesFromList(ctx context.Context, cli kubeletpodresourcesv1.PodR
 	return nil, fmt.Errorf("pod %s/%s not found in List() response", podNamespace, podName)
 }
 
+func sanitizeMemory(mem []*kubeletpodresourcesv1.ContainerMemory) {
+	// We sort memory blocks to ensure deterministic ordering of memory types
+	// (since they can be returned in non-deterministic orders from map traversals)
+	// and clear Topology info because NUMA node layouts are hardware-dependent and
+	// not part of the API List vs Get consistency checks.
+	//nolint:modernize // keep sort.Slice for compatibility with supported Go versions
+	sort.Slice(mem, func(i, j int) bool {
+		return mem[i].GetMemoryType() < mem[j].GetMemoryType()
+	})
+	for _, m := range mem {
+		m.Topology = nil
+	}
+}
+
 func preparePodResourcesListVsGet(pr *kubeletpodresourcesv1.PodResources) *kubeletpodresourcesv1.PodResources {
 	if pr == nil {
 		return nil
@@ -2212,6 +2229,14 @@ func preparePodResourcesListVsGet(pr *kubeletpodresourcesv1.PodResources) *kubel
 	sort.Slice(out.Containers, func(i, j int) bool {
 		return out.Containers[i].GetName() < out.Containers[j].GetName()
 	})
+
+	// sort pod-level CPU IDs.
+	//nolint:modernize // keep sort.Slice for compatibility with supported Go versions
+	sort.Slice(out.CpuIds, func(i, j int) bool {
+		return out.CpuIds[i] < out.CpuIds[j]
+	})
+
+	sanitizeMemory(out.Memory)
 
 	for _, c := range out.Containers {
 		// sort CPU IDs.
@@ -2232,8 +2257,7 @@ func preparePodResourcesListVsGet(pr *kubeletpodresourcesv1.PodResources) *kubel
 			d.Topology = nil
 		}
 
-		// also ignore memory and DRA checks for a lightweight comparison.
-		c.Memory = nil
+		sanitizeMemory(c.Memory)
 		c.DynamicResources = nil
 	}
 
@@ -2332,3 +2356,262 @@ func waitForPodResourcesV1Serving(ctx context.Context) {
 		"PodResources endpoint did not become ready (last err: %v)", lastErr,
 	)
 }
+
+func makeMixPodWithPodLevelResources(podName, podCPURequest, containerCPURequest, memRequest string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: podName,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "exclusive-container",
+					Image: busyboxImage,
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse(containerCPURequest),
+							v1.ResourceMemory: resource.MustParse("100Mi"),
+						},
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse(containerCPURequest),
+							v1.ResourceMemory: resource.MustParse("100Mi"),
+						},
+					},
+					Command: []string{"sh", "-c", "sleep 1d"},
+				},
+				{
+					Name:  "shared-container",
+					Image: busyboxImage,
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("100Mi"),
+						},
+						Limits: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("100Mi"),
+						},
+					},
+					Command: []string{"sh", "-c", "sleep 1d"},
+				},
+			},
+			Resources: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse(podCPURequest),
+					v1.ResourceMemory: resource.MustParse(memRequest),
+				},
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse(podCPURequest),
+					v1.ResourceMemory: resource.MustParse(memRequest),
+				},
+			},
+		},
+	}
+}
+
+func configureStaticResourceManagers(initialConfig *kubeletconfig.KubeletConfiguration, reservedCPUs string) {
+	initialConfig.CPUManagerPolicy = string(cpumanager.PolicyStatic)
+	initialConfig.CPUManagerReconcilePeriod = metav1.Duration{Duration: 1 * time.Second}
+	initialConfig.ReservedSystemCPUs = reservedCPUs
+
+	initialConfig.MemoryManagerPolicy = string(memorymanager.PolicyTypeStatic)
+	initialConfig.ReservedMemory = []kubeletconfig.MemoryReservation{
+		{
+			NumaNode: 0,
+			Limits: v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("1100Mi"),
+			},
+		},
+	}
+	if initialConfig.SystemReserved == nil {
+		initialConfig.SystemReserved = map[string]string{}
+	}
+	initialConfig.SystemReserved[string(v1.ResourceMemory)] = "500Mi"
+	if initialConfig.KubeReserved == nil {
+		initialConfig.KubeReserved = map[string]string{}
+	}
+	initialConfig.KubeReserved[string(v1.ResourceMemory)] = "500Mi"
+	if initialConfig.EvictionHard == nil {
+		initialConfig.EvictionHard = map[string]string{}
+	}
+	initialConfig.EvictionHard["memory.available"] = "100Mi"
+	if initialConfig.FeatureGates == nil {
+		initialConfig.FeatureGates = make(map[string]bool)
+	}
+	initialConfig.FeatureGates[string(features.PodLevelResources)] = true
+	initialConfig.FeatureGates[string(features.PodLevelResourceManagers)] = true
+}
+
+var _ = SIGDescribe("Pod Resources API Pod Level Resources", framework.WithSerial(), feature.PodResourcesAPI, feature.PodLevelResources, feature.PodLevelResourceManagers, framework.WithFeatureGate(features.PodLevelResources), framework.WithFeatureGate(features.PodLevelResourceManagers), func() {
+	f := framework.NewDefaultFramework("podresources-pod-level-resources-test")
+	addBeforeEachForCleaningUpPods(f)
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	var reservedSystemCPUs cpuset.CPUSet
+
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		reservedSystemCPUs = cpuset.New(1)
+		// Ensure system has enough CPUs (at least 2 cores)
+		_, cpuAlloc, _ := getLocalNodeCPUDetails(ctx, f)
+		if cpuAlloc < 2 {
+			e2eskipper.Skipf("Skipping tests since the CPU allocatable < 2 cores")
+		}
+	})
+
+	ginkgo.Context("with CPU manager Static policy", func() {
+		ginkgo.Context("when the topology manager scope is 'pod'", func() {
+			tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
+				configureStaticResourceManagers(initialConfig, reservedSystemCPUs.String())
+				initialConfig.TopologyManagerPolicy = string(topologymanager.PolicyRestricted)
+				initialConfig.TopologyManagerScope = string(topologymanager.PodTopologyScope)
+			})
+
+			ginkgo.It("should return pod-level CPU and Memory, container-level CPU and Memory, and empty container-level CPU and Memory for shared container in a guaranteed pod", func(ctx context.Context) {
+				waitForPodResourcesV1Serving(ctx)
+
+				// Create a pod with pod-level resources requesting 2 exclusive CPUs and 200Mi memory,
+				// containing an exclusive container requesting 1 CPU and 100Mi memory and a shared
+				// container requesting 100Mi memory
+				pod := makeMixPodWithPodLevelResources("pod-scope-pod", "2", "1", "200Mi")
+
+				ginkgo.By("creating the test pod")
+				pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+				defer e2epod.NewPodClient(f).DeleteSync(ctx, pod.Name, metav1.DeleteOptions{}, 2*time.Minute)
+
+				endpoint, err := util.LocalEndpoint(defaultPodResourcesPath, podresources.Socket)
+				framework.ExpectNoError(err)
+				cli, conn, err := podresources.GetV1Client(ctx, endpoint, defaultPodResourcesTimeout, defaultPodResourcesMaxSize)
+				framework.ExpectNoError(err)
+				defer func() { framework.ExpectNoError(conn.Close()) }()
+
+				// Fetch and match
+				gomega.Eventually(ctx, func(ctx context.Context) error {
+					resp, err := cli.Get(ctx, &kubeletpodresourcesv1.GetPodResourcesRequest{
+						PodName:      pod.Name,
+						PodNamespace: pod.Namespace,
+					})
+					if err != nil {
+						return err
+					}
+
+					podRes := resp.GetPodResources()
+					if len(podRes.GetCpuIds()) != 2 {
+						return fmt.Errorf("expected 2 pod-level CPUs, got %v", podRes.GetCpuIds())
+					}
+					if len(podRes.GetMemory()) != 1 {
+						return fmt.Errorf("expected 1 pod-level memory block, got %v", podRes.GetMemory())
+					}
+					if podRes.GetMemory()[0].GetSize() != 200*1024*1024 {
+						return fmt.Errorf("expected 200Mi pod-level memory block size, got %d", podRes.GetMemory()[0].GetSize())
+					}
+
+					var foundExclusive, foundShared bool
+					for _, cRes := range podRes.GetContainers() {
+						if cRes.GetName() == "exclusive-container" {
+							foundExclusive = true
+							if len(cRes.GetCpuIds()) != 1 {
+								return fmt.Errorf("expected 1 container-level CPU for exclusive-container, got %v", cRes.GetCpuIds())
+							}
+							if len(cRes.GetMemory()) != 1 {
+								return fmt.Errorf("expected 1 container-level memory block for exclusive-container, got %v", cRes.GetMemory())
+							}
+							if cRes.GetMemory()[0].GetSize() != 100*1024*1024 {
+								return fmt.Errorf("expected 100Mi container-level memory block size for exclusive-container, got %d", cRes.GetMemory()[0].GetSize())
+							}
+						}
+						if cRes.GetName() == "shared-container" {
+							foundShared = true
+							if len(cRes.GetCpuIds()) > 0 {
+								return fmt.Errorf("expected empty container-level CPUs for shared-container, got %v", cRes.GetCpuIds())
+							}
+							if len(cRes.GetMemory()) > 0 {
+								return fmt.Errorf("expected empty container-level memory for shared-container, got %v", cRes.GetMemory())
+							}
+						}
+					}
+					if !foundExclusive || !foundShared {
+						return fmt.Errorf("exclusive-container or shared-container resources not found")
+					}
+					return nil
+				}).WithTimeout(1 * time.Minute).WithPolling(5 * time.Second).Should(gomega.Succeed())
+
+				expectListAndGetConsistent(ctx, cli, pod.Name, pod.Namespace)
+			})
+		})
+
+		ginkgo.Context("when the topology manager scope is 'container'", func() {
+			tempSetCurrentKubeletConfig(f, func(ctx context.Context, initialConfig *kubeletconfig.KubeletConfiguration) {
+				configureStaticResourceManagers(initialConfig, reservedSystemCPUs.String())
+				initialConfig.TopologyManagerPolicy = string(topologymanager.PolicyRestricted)
+				initialConfig.TopologyManagerScope = string(topologymanager.ContainerTopologyScope)
+			})
+
+			ginkgo.It("should return empty pod-level CPU and Memory, container-level CPU and Memory, and empty container-level CPU and Memory for shared container in a guaranteed pod", func(ctx context.Context) {
+				waitForPodResourcesV1Serving(ctx)
+
+				// Create a pod with pod-level resources requesting 2 exclusive CPUs and 200Mi memory,
+				// containing an exclusive container requesting 1 CPU and 100Mi memory and a shared
+				// container requesting 100Mi memory
+				pod := makeMixPodWithPodLevelResources("container-scope-pod", "2", "1", "200Mi")
+
+				ginkgo.By("creating the test pod")
+				pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+				defer e2epod.NewPodClient(f).DeleteSync(ctx, pod.Name, metav1.DeleteOptions{}, 2*time.Minute)
+
+				endpoint, err := util.LocalEndpoint(defaultPodResourcesPath, podresources.Socket)
+				framework.ExpectNoError(err)
+				cli, conn, err := podresources.GetV1Client(ctx, endpoint, defaultPodResourcesTimeout, defaultPodResourcesMaxSize)
+				framework.ExpectNoError(err)
+				defer func() { framework.ExpectNoError(conn.Close()) }()
+
+				// Fetch and match
+				gomega.Eventually(ctx, func(ctx context.Context) error {
+					resp, err := cli.Get(ctx, &kubeletpodresourcesv1.GetPodResourcesRequest{
+						PodName:      pod.Name,
+						PodNamespace: pod.Namespace,
+					})
+					if err != nil {
+						return err
+					}
+
+					podRes := resp.GetPodResources()
+					if len(podRes.GetCpuIds()) > 0 {
+						return fmt.Errorf("expected empty pod-level CPU, got %v", podRes.GetCpuIds())
+					}
+					if len(podRes.GetMemory()) > 0 {
+						return fmt.Errorf("expected empty pod-level memory, got %v", podRes.GetMemory())
+					}
+
+					var foundExclusive, foundShared bool
+					for _, cRes := range podRes.GetContainers() {
+						if cRes.GetName() == "exclusive-container" {
+							foundExclusive = true
+							if len(cRes.GetCpuIds()) != 1 {
+								return fmt.Errorf("expected 1 container-level CPU for exclusive-container, got %v", cRes.GetCpuIds())
+							}
+							if len(cRes.GetMemory()) != 1 {
+								return fmt.Errorf("expected 1 container-level memory block for exclusive-container, got %v", cRes.GetMemory())
+							}
+							if cRes.GetMemory()[0].GetSize() != 100*1024*1024 {
+								return fmt.Errorf("expected 100Mi container-level memory block size for exclusive-container, got %d", cRes.GetMemory()[0].GetSize())
+							}
+						}
+						if cRes.GetName() == "shared-container" {
+							foundShared = true
+							if len(cRes.GetCpuIds()) > 0 {
+								return fmt.Errorf("expected empty container-level CPUs for shared-container, got %v", cRes.GetCpuIds())
+							}
+							if len(cRes.GetMemory()) > 0 {
+								return fmt.Errorf("expected empty container-level memory for shared-container, got %v", cRes.GetMemory())
+							}
+						}
+					}
+					if !foundExclusive || !foundShared {
+						return fmt.Errorf("exclusive-container or shared-container resources not found")
+					}
+					return nil
+				}).WithTimeout(1 * time.Minute).WithPolling(5 * time.Second).Should(gomega.Succeed())
+
+				expectListAndGetConsistent(ctx, cli, pod.Name, pod.Namespace)
+			})
+		})
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

* Extends the PodResources API to report pod-level exclusive resources.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

- Issue: https://github.com/kubernetes/enhancements/issues/5526
- KEP: [KEP-5526: Pod Level Resource Managers](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/5526-pod-level-resource-managers/README.md)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add `cpu_ids` and `memory` fields at the pod level to the `PodResources` v1 API to
report total allocated pod resources, while only return container-level allocations for
container-isolated containers.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/5526-pod-level-resource-managers/README.md
```
