### PR TITLE
workqueue: bound failures map size in Typed rate limiters

### DIFF
--- a/staging/src/k8s.io/client-go/util/workqueue/default_rate_limiters.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/default_rate_limiters.go
@@ -24,6 +24,11 @@ import (
 	"golang.org/x/time/rate"
 )
 
+// DefaultMaxFailureEntries is the maximum number of entries
+// tracked in the failure map. This prevents unbounded memory
+// growth when Forget() is not called by the controller author.
+const DefaultMaxFailureEntries = 1000
+
 // Deprecated: RateLimiter is deprecated, use TypedRateLimiter instead.
 type RateLimiter TypedRateLimiter[any]
 
@@ -84,6 +89,7 @@ type ItemExponentialFailureRateLimiter = TypedItemExponentialFailureRateLimiter[
 type TypedItemExponentialFailureRateLimiter[T comparable] struct {
 	failuresLock sync.Mutex
 	failures     map[T]int
+	maxEntries   int
 
 	baseDelay time.Duration
 	maxDelay  time.Duration
@@ -98,9 +104,10 @@ func NewItemExponentialFailureRateLimiter(baseDelay time.Duration, maxDelay time
 
 func NewTypedItemExponentialFailureRateLimiter[T comparable](baseDelay time.Duration, maxDelay time.Duration) TypedRateLimiter[T] {
 	return &TypedItemExponentialFailureRateLimiter[T]{
-		failures:  map[T]int{},
-		baseDelay: baseDelay,
-		maxDelay:  maxDelay,
+		failures:   map[T]int{},
+		maxEntries: DefaultMaxFailureEntries,
+		baseDelay:  baseDelay,
+		maxDelay:   maxDelay,
 	}
 }
 
@@ -116,6 +123,12 @@ func DefaultTypedItemBasedRateLimiter[T comparable]() TypedRateLimiter[T] {
 func (r *TypedItemExponentialFailureRateLimiter[T]) When(item T) time.Duration {
 	r.failuresLock.Lock()
 	defer r.failuresLock.Unlock()
+
+	if _, exists := r.failures[item]; !exists {
+		if len(r.failures) >= r.maxEntries {
+			return r.maxDelay
+		}
+	}
 
 	exp := r.failures[item]
 	r.failures[item] = r.failures[item] + 1
@@ -156,6 +169,7 @@ type ItemFastSlowRateLimiter = TypedItemFastSlowRateLimiter[any]
 type TypedItemFastSlowRateLimiter[T comparable] struct {
 	failuresLock sync.Mutex
 	failures     map[T]int
+	maxEntries   int
 
 	maxFastAttempts int
 	fastDelay       time.Duration
@@ -172,6 +186,7 @@ func NewItemFastSlowRateLimiter(fastDelay, slowDelay time.Duration, maxFastAttem
 func NewTypedItemFastSlowRateLimiter[T comparable](fastDelay, slowDelay time.Duration, maxFastAttempts int) TypedRateLimiter[T] {
 	return &TypedItemFastSlowRateLimiter[T]{
 		failures:        map[T]int{},
+		maxEntries:      DefaultMaxFailureEntries,
 		fastDelay:       fastDelay,
 		slowDelay:       slowDelay,
 		maxFastAttempts: maxFastAttempts,
@@ -181,6 +196,12 @@ func NewTypedItemFastSlowRateLimiter[T comparable](fastDelay, slowDelay time.Dur
 func (r *TypedItemFastSlowRateLimiter[T]) When(item T) time.Duration {
 	r.failuresLock.Lock()
 	defer r.failuresLock.Unlock()
+
+	if _, exists := r.failures[item]; !exists {
+		if len(r.failures) >= r.maxEntries {
+			return r.fastDelay
+		}
+	}
 
 	r.failures[item] = r.failures[item] + 1
 

--- a/staging/src/k8s.io/client-go/util/workqueue/default_rate_limiters_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/default_rate_limiters_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package workqueue
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -96,6 +97,30 @@ func TestItemExponentialFailureRateLimiterOverFlow(t *testing.T) {
 
 }
 
+func TestTypedItemExponentialFailureRateLimiterBound(t *testing.T) {
+	limiter := NewTypedItemExponentialFailureRateLimiter[string](
+		1*time.Millisecond,
+		1*time.Second,
+	)
+
+	// Fill internal tracking capacity with unique items.
+	for i := 0; i < DefaultMaxFailureEntries; i++ {
+		limiter.When(fmt.Sprintf("item-%d", i))
+	}
+
+	// Existing tracked item should continue exponential behavior.
+	if delay := limiter.When("item-0"); delay != 2*time.Millisecond {
+		t.Errorf("expected 2ms for second failure of item-0, got %v", delay)
+	}
+
+	// A new item when full should always get maxDelay (it cannot be tracked).
+	for i := 0; i < 3; i++ {
+		if delay := limiter.When("overflow-item"); delay != 1*time.Second {
+			t.Errorf("expected maxDelay 1s for overflow-item, got %v", delay)
+		}
+	}
+}
+
 func TestItemFastSlowRateLimiter(t *testing.T) {
 	limiter := NewItemFastSlowRateLimiter(5*time.Millisecond, 10*time.Second, 3)
 
@@ -138,6 +163,36 @@ func TestItemFastSlowRateLimiter(t *testing.T) {
 
 }
 
+func TestTypedItemFastSlowRateLimiterBound(t *testing.T) {
+	limiter := NewTypedItemFastSlowRateLimiter[string](
+		5*time.Millisecond,
+		10*time.Minute,
+		3,
+	)
+
+	// Fill internal tracking capacity with unique items.
+	for i := 0; i < DefaultMaxFailureEntries; i++ {
+		limiter.When(fmt.Sprintf("item-%d", i))
+	}
+
+	// Existing tracked item should transition from fast to slow.
+	if delay := limiter.When("item-0"); delay != 5*time.Millisecond {
+		t.Errorf("expected fastDelay 5ms for second failure of item-0, got %v", delay)
+	}
+	if delay := limiter.When("item-0"); delay != 5*time.Millisecond {
+		t.Errorf("expected fastDelay 5ms for third failure of item-0, got %v", delay)
+	}
+	if delay := limiter.When("item-0"); delay != 10*time.Minute {
+		t.Errorf("expected slowDelay 10m for fourth failure of item-0, got %v", delay)
+	}
+
+	// A new item when full should always get fastDelay (it cannot be tracked).
+	for i := 0; i < 5; i++ {
+		if delay := limiter.When("overflow-item"); delay != 5*time.Millisecond {
+			t.Errorf("expected fastDelay 5ms for overflow-item, got %v", delay)
+		}
+	}
+}
 func TestMaxOfRateLimiter(t *testing.T) {
 	limiter := NewMaxOfRateLimiter(
 		NewItemFastSlowRateLimiter(5*time.Millisecond, 3*time.Second, 3),


### PR DESCRIPTION
The failures map in TypedItemExponentialFailureRateLimiter and TypedItemFastSlowRateLimiter grows unbounded when Forget() is not called by the controller author on successful reconciliation.

Add DefaultMaxFailureEntries=1000 as the maximum number of entries tracked in the failures map. When the map is full, new items return maxDelay/fastDelay without being stored, preventing unbounded memory growth in long-running controllers.

The old untyped versions delegate to the Typed versions and are fixed automatically — no caller changes required.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The failures map in TypedItemExponentialFailureRateLimiter and
TypedItemFastSlowRateLimiter grows unbounded when Forget() is not
called by the controller author on successful reconciliation.

In long-running controllers processing thousands of unique keys
over weeks, this causes slow but unbounded memory growth.

Adds DefaultMaxFailureEntries=1000. When the map is full, new items
return maxDelay/fastDelay without being stored. Existing tracked
items are unaffected. No caller changes required.

#### Which issue(s) this PR is related to:
N/A
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

The old untyped versions (ItemExponentialFailureRateLimiter and
ItemFastSlowRateLimiter) delegate to the Typed versions and are
fixed automatically.

#### Does this PR introduce a user-facing change?

Bound the failures map size in TypedItemExponentialFailureRateLimiter
and TypedItemFastSlowRateLimiter to prevent unbounded memory growth
in long-running controllers.

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig api-machinery