### PR TITLE
validation-gen: implement fail-fast multi cohort validation

### DIFF
--- a/pkg/apis/admissionregistration/v1/zz_generated.validations.go
+++ b/pkg/apis/admissionregistration/v1/zz_generated.validations.go
@@ -117,6 +117,9 @@ func Validate_ValidatingAdmissionPolicyBindingSpec(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -145,6 +148,9 @@ func Validate_ValidatingAdmissionPolicyBindingSpec(
 			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/pkg/apis/admissionregistration/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/admissionregistration/v1alpha1/zz_generated.validations.go
@@ -117,6 +117,9 @@ func Validate_ValidatingAdmissionPolicyBindingSpec(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -145,6 +148,9 @@ func Validate_ValidatingAdmissionPolicyBindingSpec(
 			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/pkg/apis/admissionregistration/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/admissionregistration/v1beta1/zz_generated.validations.go
@@ -117,6 +117,9 @@ func Validate_ValidatingAdmissionPolicyBindingSpec(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -145,6 +148,9 @@ func Validate_ValidatingAdmissionPolicyBindingSpec(
 			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/pkg/apis/autoscaling/v1/zz_generated.validations.go
+++ b/pkg/apis/autoscaling/v1/zz_generated.validations.go
@@ -146,6 +146,9 @@ func Validate_HorizontalPodAutoscalerSpec(
 				}).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -177,6 +180,9 @@ func Validate_HorizontalPodAutoscalerSpec(
 			}
 			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}

--- a/pkg/apis/autoscaling/v2/zz_generated.validations.go
+++ b/pkg/apis/autoscaling/v2/zz_generated.validations.go
@@ -131,6 +131,9 @@ func Validate_HorizontalPodAutoscalerSpec(
 				}).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -162,6 +165,9 @@ func Validate_HorizontalPodAutoscalerSpec(
 			}
 			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}

--- a/pkg/apis/batch/v1/zz_generated.validations.go
+++ b/pkg/apis/batch/v1/zz_generated.validations.go
@@ -118,6 +118,9 @@ func Validate_CronJobSpec(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/pkg/apis/batch/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/batch/v1beta1/zz_generated.validations.go
@@ -118,6 +118,9 @@ func Validate_CronJobSpec(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/pkg/apis/certificates/v1/zz_generated.validations.go
+++ b/pkg/apis/certificates/v1/zz_generated.validations.go
@@ -139,6 +139,9 @@ func Validate_CertificateSigningRequestStatus(
 				}).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/pkg/apis/certificates/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/certificates/v1beta1/zz_generated.validations.go
@@ -139,6 +139,9 @@ func Validate_CertificateSigningRequestStatus(
 				}).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/pkg/apis/core/v1/zz_generated.validations.go
+++ b/pkg/apis/core/v1/zz_generated.validations.go
@@ -78,8 +78,9 @@ func Validate_ReplicationController(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "name"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "name"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "name",
 					func(o *metav1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.OptionalValue).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 					earlyReturn = true
@@ -92,6 +93,9 @@ func Validate_ReplicationController(
 					errs = append(errs, e...)
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -156,6 +160,9 @@ func Validate_ReplicationControllerSpec(
 			}
 			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}

--- a/pkg/apis/discovery/v1/zz_generated.validations.go
+++ b/pkg/apis/discovery/v1/zz_generated.validations.go
@@ -103,6 +103,9 @@ func Validate_Endpoint(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -144,13 +147,25 @@ func Validate_EndpointSlice(
 			}
 			// call field-attached validations
 			earlyReturn := false
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -181,6 +196,9 @@ func Validate_EndpointSlice(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/pkg/apis/discovery/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/discovery/v1beta1/zz_generated.validations.go
@@ -103,6 +103,9 @@ func Validate_Endpoint(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -143,13 +146,25 @@ func Validate_EndpointSlice(
 			}
 			// call field-attached validations
 			earlyReturn := false
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -180,6 +195,9 @@ func Validate_EndpointSlice(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/pkg/apis/discovery/validation/validation.go
+++ b/pkg/apis/discovery/validation/validation.go
@@ -85,10 +85,11 @@ func ValidateEndpointSliceCreate(endpointSlice *discovery.EndpointSlice) field.E
 
 // ValidateEndpointSliceUpdate validates an EndpointSlice when it is updated.
 func ValidateEndpointSliceUpdate(newEndpointSlice, oldEndpointSlice *discovery.EndpointSlice) field.ErrorList {
-	allErrs := ValidateEndpointSlice(newEndpointSlice, oldEndpointSlice)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newEndpointSlice.AddressType, oldEndpointSlice.AddressType, field.NewPath("addressType")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
-
-	return allErrs
+	allErrs := apivalidation.ValidateImmutableField(newEndpointSlice.AddressType, oldEndpointSlice.AddressType, field.NewPath("addressType")).WithOrigin("immutable").MarkCoveredByDeclarative()
+	if len(allErrs) > 0 {
+		return allErrs
+	}
+	return ValidateEndpointSlice(newEndpointSlice, oldEndpointSlice)
 }
 
 func validateEndpoints(endpoints []discovery.Endpoint, addrType discovery.AddressType, fldPath *field.Path) field.ErrorList {

--- a/pkg/apis/flowcontrol/v1/zz_generated.validations.go
+++ b/pkg/apis/flowcontrol/v1/zz_generated.validations.go
@@ -112,6 +112,9 @@ func Validate_LimitResponse(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -136,6 +139,9 @@ func Validate_LimitResponse(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -312,6 +318,9 @@ func Validate_PriorityLevelConfigurationSpec(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -336,6 +345,9 @@ func Validate_PriorityLevelConfigurationSpec(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -366,6 +378,9 @@ func Validate_PriorityLevelConfigurationSpec(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/pkg/apis/flowcontrol/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/flowcontrol/v1beta1/zz_generated.validations.go
@@ -114,6 +114,9 @@ func Validate_LimitResponse(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -138,6 +141,9 @@ func Validate_LimitResponse(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -314,6 +320,9 @@ func Validate_PriorityLevelConfigurationSpec(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -338,6 +347,9 @@ func Validate_PriorityLevelConfigurationSpec(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -368,6 +380,9 @@ func Validate_PriorityLevelConfigurationSpec(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/pkg/apis/flowcontrol/v1beta2/zz_generated.validations.go
+++ b/pkg/apis/flowcontrol/v1beta2/zz_generated.validations.go
@@ -114,6 +114,9 @@ func Validate_LimitResponse(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -138,6 +141,9 @@ func Validate_LimitResponse(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -314,6 +320,9 @@ func Validate_PriorityLevelConfigurationSpec(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -338,6 +347,9 @@ func Validate_PriorityLevelConfigurationSpec(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -368,6 +380,9 @@ func Validate_PriorityLevelConfigurationSpec(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/pkg/apis/flowcontrol/v1beta3/zz_generated.validations.go
+++ b/pkg/apis/flowcontrol/v1beta3/zz_generated.validations.go
@@ -114,6 +114,9 @@ func Validate_LimitResponse(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -138,6 +141,9 @@ func Validate_LimitResponse(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -314,6 +320,9 @@ func Validate_PriorityLevelConfigurationSpec(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -338,6 +347,9 @@ func Validate_PriorityLevelConfigurationSpec(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -368,6 +380,9 @@ func Validate_PriorityLevelConfigurationSpec(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/pkg/apis/networking/v1/zz_generated.validations.go
+++ b/pkg/apis/networking/v1/zz_generated.validations.go
@@ -140,13 +140,25 @@ func Validate_IPAddressSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -187,6 +199,9 @@ func Validate_IPBlock(
 			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -266,6 +281,9 @@ func Validate_IngressClassParametersReference(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -291,6 +309,9 @@ func Validate_IngressClassParametersReference(
 			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -332,6 +353,9 @@ func Validate_IngressClassSpec(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -411,6 +435,9 @@ func Validate_NetworkPolicyEgressRule(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_NetworkPolicyPeer); len(e) != 0 {
 				errs = append(errs, e...)
@@ -450,6 +477,9 @@ func Validate_NetworkPolicyIngressRule(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -498,6 +528,9 @@ func Validate_NetworkPolicyPeer(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_IPBlock(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -539,6 +572,9 @@ func Validate_NetworkPolicySpec(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_NetworkPolicyIngressRule); len(e) != 0 {
 				errs = append(errs, e...)
@@ -567,6 +603,9 @@ func Validate_NetworkPolicySpec(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -616,6 +655,9 @@ func Validate_ParentReference(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -643,6 +685,9 @@ func Validate_ParentReference(
 			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/pkg/apis/networking/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/networking/v1beta1/zz_generated.validations.go
@@ -125,13 +125,25 @@ func Validate_IPAddressSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -212,6 +224,9 @@ func Validate_IngressClassParametersReference(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -237,6 +252,9 @@ func Validate_IngressClassParametersReference(
 			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -278,6 +296,9 @@ func Validate_IngressClassSpec(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -324,6 +345,9 @@ func Validate_ParentReference(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -351,6 +375,9 @@ func Validate_ParentReference(
 			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/pkg/apis/node/v1/zz_generated.validations.go
+++ b/pkg/apis/node/v1/zz_generated.validations.go
@@ -78,9 +78,18 @@ func Validate_RuntimeClass(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
+			if earlyReturn {
+				return // do not proceed
 			}
 			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
@@ -91,6 +100,9 @@ func Validate_RuntimeClass(
 			}
 			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}

--- a/pkg/apis/node/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/node/v1alpha1/zz_generated.validations.go
@@ -110,9 +110,18 @@ func Validate_RuntimeClassSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
+			if earlyReturn {
+				return // do not proceed
 			}
 			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
@@ -123,6 +132,9 @@ func Validate_RuntimeClassSpec(
 			}
 			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}

--- a/pkg/apis/node/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/node/v1beta1/zz_generated.validations.go
@@ -78,9 +78,18 @@ func Validate_RuntimeClass(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
+			if earlyReturn {
+				return // do not proceed
 			}
 			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
@@ -91,6 +100,9 @@ func Validate_RuntimeClass(
 			}
 			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}

--- a/pkg/apis/rbac/v1/zz_generated.validations.go
+++ b/pkg/apis/rbac/v1/zz_generated.validations.go
@@ -130,6 +130,9 @@ func Validate_ClusterRole(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_PolicyRule); len(e) != 0 {
 				errs = append(errs, e...)
@@ -171,6 +174,9 @@ func Validate_ClusterRoleBinding(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -239,6 +245,9 @@ func Validate_PolicyRule(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -279,6 +288,9 @@ func Validate_Role(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -327,6 +339,9 @@ func Validate_RoleBinding(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_Subject); len(e) != 0 {
 				errs = append(errs, e...)
@@ -353,10 +368,16 @@ func Validate_RoleBinding(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			if earlyReturn {
 				return // do not proceed
 			}
@@ -403,6 +424,9 @@ func Validate_RoleRef(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -440,6 +464,9 @@ func Validate_Subject(
 			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/pkg/apis/rbac/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/rbac/v1alpha1/zz_generated.validations.go
@@ -130,6 +130,9 @@ func Validate_ClusterRole(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_PolicyRule); len(e) != 0 {
 				errs = append(errs, e...)
@@ -171,6 +174,9 @@ func Validate_ClusterRoleBinding(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -239,6 +245,9 @@ func Validate_PolicyRule(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -279,6 +288,9 @@ func Validate_Role(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -327,6 +339,9 @@ func Validate_RoleBinding(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_Subject); len(e) != 0 {
 				errs = append(errs, e...)
@@ -353,10 +368,16 @@ func Validate_RoleBinding(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			if earlyReturn {
 				return // do not proceed
 			}
@@ -403,6 +424,9 @@ func Validate_RoleRef(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -440,6 +464,9 @@ func Validate_Subject(
 			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/pkg/apis/rbac/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/rbac/v1beta1/zz_generated.validations.go
@@ -130,6 +130,9 @@ func Validate_ClusterRole(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_PolicyRule); len(e) != 0 {
 				errs = append(errs, e...)
@@ -171,6 +174,9 @@ func Validate_ClusterRoleBinding(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -239,6 +245,9 @@ func Validate_PolicyRule(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -279,6 +288,9 @@ func Validate_Role(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -327,6 +339,9 @@ func Validate_RoleBinding(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_Subject); len(e) != 0 {
 				errs = append(errs, e...)
@@ -353,10 +368,16 @@ func Validate_RoleBinding(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			if earlyReturn {
 				return // do not proceed
 			}
@@ -403,6 +424,9 @@ func Validate_RoleRef(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -440,6 +464,9 @@ func Validate_Subject(
 			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/pkg/apis/rbac/validation/validation.go
+++ b/pkg/apis/rbac/validation/validation.go
@@ -158,10 +158,12 @@ func ValidateRoleBinding(roleBinding *rbac.RoleBinding) field.ErrorList {
 }
 
 func ValidateRoleBindingUpdate(roleBinding *rbac.RoleBinding, oldRoleBinding *rbac.RoleBinding) field.ErrorList {
-	allErrs := ValidateRoleBinding(roleBinding)
+	allErrs := validation.ValidateImmutableField(roleBinding.RoleRef, oldRoleBinding.RoleRef, field.NewPath("roleRef")).WithOrigin("immutable").MarkAlpha().MarkCoveredByDeclarative()
+	if len(allErrs) > 0 {
+		return allErrs
+	}
+	allErrs = append(allErrs, ValidateRoleBinding(roleBinding)...)
 	allErrs = append(allErrs, validation.ValidateObjectMetaUpdate(&roleBinding.ObjectMeta, &oldRoleBinding.ObjectMeta, field.NewPath("metadata"))...)
-
-	allErrs = append(allErrs, validation.ValidateImmutableField(roleBinding.RoleRef, oldRoleBinding.RoleRef, field.NewPath("roleRef")).WithOrigin("immutable").MarkAlpha().MarkCoveredByDeclarative()...)
 
 	return allErrs
 }

--- a/pkg/apis/resource/v1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1/zz_generated.validations.go
@@ -137,6 +137,9 @@ func Validate_AllocatedDeviceStatus(
 			if e := validate.UUID(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -164,6 +167,9 @@ func Validate_AllocatedDeviceStatus(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -259,6 +265,9 @@ func Validate_CounterSet(
 			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -290,6 +299,9 @@ func Validate_CounterSet(
 			}
 			if e := validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -326,6 +338,9 @@ func Validate_Device(
 			earlyReturn := false
 			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -375,6 +390,9 @@ func Validate_Device(
 				}).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj,
 				func(a resourcev1.DeviceCounterConsumption, b resourcev1.DeviceCounterConsumption) bool {
@@ -410,6 +428,9 @@ func Validate_Device(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -452,6 +473,9 @@ func Validate_Device(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -480,6 +504,9 @@ func Validate_Device(
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -524,6 +551,9 @@ func Validate_DeviceAllocationConfiguration(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_AllocationConfigSource(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -561,6 +591,9 @@ func Validate_DeviceAllocationConfiguration(
 			// lists with set semantics require unique values
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -640,6 +673,9 @@ func Validate_DeviceAllocationResult(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceRequestAllocationResult); len(e) != 0 {
 				errs = append(errs, e...)
@@ -672,6 +708,9 @@ func Validate_DeviceAllocationResult(
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 64).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -771,6 +810,9 @@ func Validate_DeviceAttribute(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -795,6 +837,9 @@ func Validate_DeviceAttribute(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -827,6 +872,9 @@ func Validate_DeviceAttribute(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -851,6 +899,9 @@ func Validate_DeviceAttribute(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -883,6 +934,9 @@ func Validate_DeviceAttribute(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -907,6 +961,9 @@ func Validate_DeviceAttribute(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -945,6 +1002,9 @@ func Validate_DeviceAttribute(
 				}).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -969,6 +1029,9 @@ func Validate_DeviceAttribute(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -1019,6 +1082,9 @@ func Validate_DeviceClaim(
 				func(a resourcev1.DeviceRequest, b resourcev1.DeviceRequest) bool { return a.Name == b.Name }).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj,
 				func(a resourcev1.DeviceRequest, b resourcev1.DeviceRequest) bool { return a.Name == b.Name }, validate.SemanticDeepEqual, Validate_DeviceRequest); len(e) != 0 {
@@ -1056,6 +1122,9 @@ func Validate_DeviceClaim(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceConstraint); len(e) != 0 {
 				errs = append(errs, e...)
@@ -1088,6 +1157,9 @@ func Validate_DeviceClaim(
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -1140,6 +1212,9 @@ func Validate_DeviceClaimConfiguration(
 			// lists with set semantics require unique values
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -1195,8 +1270,9 @@ func Validate_DeviceClass(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "name"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "name"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "name",
 					func(o *metav1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.OptionalValue).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 					earlyReturn = true
@@ -1209,6 +1285,9 @@ func Validate_DeviceClass(
 					errs = append(errs, e...)
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1303,6 +1382,9 @@ func Validate_DeviceClassSpec(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1331,6 +1413,9 @@ func Validate_DeviceClassSpec(
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -1370,6 +1455,9 @@ func Validate_DeviceClassSpec(
 			if e := validate.ExtendedResourceName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1403,6 +1491,9 @@ func Validate_DeviceConfiguration(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -1454,6 +1545,9 @@ func Validate_DeviceConstraint(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1484,6 +1578,9 @@ func Validate_DeviceConstraint(
 			}
 			if e := validate.ResourceFullyQualifiedName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -1527,6 +1624,9 @@ func Validate_DeviceCounterConsumption(
 			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1558,6 +1658,9 @@ func Validate_DeviceCounterConsumption(
 			}
 			if e := validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -1594,6 +1697,9 @@ func Validate_DeviceRequest(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -1636,6 +1742,9 @@ func Validate_DeviceRequest(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
 				func(a resourcev1.DeviceSubRequest, b resourcev1.DeviceSubRequest) bool { return a.Name == b.Name }).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj,
@@ -1688,6 +1797,9 @@ func Validate_DeviceRequestAllocationResult(
 			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1720,6 +1832,9 @@ func Validate_DeviceRequestAllocationResult(
 			if e := validate.ResourcePoolName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1747,6 +1862,9 @@ func Validate_DeviceRequestAllocationResult(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -1787,6 +1905,9 @@ func Validate_DeviceRequestAllocationResult(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1815,6 +1936,9 @@ func Validate_DeviceRequestAllocationResult(
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -1849,6 +1973,9 @@ func Validate_DeviceRequestAllocationResult(
 			}
 			if e := validate.UUID(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -1894,6 +2021,9 @@ func Validate_DeviceSubRequest(
 			if e := validate.LongName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1926,6 +2056,9 @@ func Validate_DeviceSubRequest(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1950,6 +2083,9 @@ func Validate_DeviceSubRequest(
 			earlyReturn := false
 			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -1982,6 +2118,9 @@ func Validate_DeviceSubRequest(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -2028,6 +2167,9 @@ func Validate_DeviceTaint(
 			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -2090,6 +2232,9 @@ func Validate_DeviceToleration(
 			if e := validate.LabelKey(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -2116,6 +2261,9 @@ func Validate_DeviceToleration(
 			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -2148,6 +2296,9 @@ func Validate_DeviceToleration(
 			earlyReturn := false
 			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -2213,6 +2364,9 @@ func Validate_ExactDeviceRequest(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -2237,6 +2391,9 @@ func Validate_ExactDeviceRequest(
 			earlyReturn := false
 			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -2270,6 +2427,9 @@ func Validate_ExactDeviceRequest(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -2319,6 +2479,9 @@ func Validate_NetworkDeviceData(
 			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 256).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -2355,6 +2518,9 @@ func Validate_NetworkDeviceData(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -2385,6 +2551,9 @@ func Validate_NetworkDeviceData(
 			}
 			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 128).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -2430,6 +2599,9 @@ func Validate_OpaqueDeviceConfiguration(
 			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -2465,10 +2637,16 @@ func Validate_ResourceClaim(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			if earlyReturn {
 				return // do not proceed
 			}
@@ -2558,12 +2736,24 @@ func Validate_ResourceClaimStatus(
 			}
 			// call field-attached validations
 			earlyReturn := false
+			func() {
+				// cohort = "update"
+				if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -2609,6 +2799,9 @@ func Validate_ResourceClaimStatus(
 				}).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -2643,6 +2836,9 @@ func Validate_ResourceClaimStatus(
 					return a.Driver == b.Driver && a.Device == b.Device && a.Pool == b.Pool && ((a.ShareID == nil && b.ShareID == nil) || (a.ShareID != nil && b.ShareID != nil && *a.ShareID == *b.ShareID))
 				}).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj,
@@ -2795,6 +2991,9 @@ func Validate_ResourceSliceSpec(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_Device); len(e) != 0 {
 				errs = append(errs, e...)
@@ -2837,6 +3036,9 @@ func Validate_ResourceSliceSpec(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
 				func(a resourcev1.CounterSet, b resourcev1.CounterSet) bool { return a.Name == b.Name }).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj,

--- a/pkg/apis/resource/v1alpha3/zz_generated.validations.go
+++ b/pkg/apis/resource/v1alpha3/zz_generated.validations.go
@@ -103,6 +103,9 @@ func Validate_DeviceTaint(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_DeviceTaintEffect(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -230,6 +233,9 @@ func Validate_PoolStatus(
 			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -261,6 +267,9 @@ func Validate_PoolStatus(
 			}
 			if e := validate.ResourcePoolName(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -294,6 +303,9 @@ func Validate_PoolStatus(
 			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -324,6 +336,9 @@ func Validate_PoolStatus(
 			}
 			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -356,6 +371,9 @@ func Validate_PoolStatus(
 			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -386,6 +404,9 @@ func Validate_PoolStatus(
 			}
 			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -418,6 +439,9 @@ func Validate_PoolStatus(
 			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -448,6 +472,9 @@ func Validate_PoolStatus(
 			}
 			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -480,6 +507,9 @@ func Validate_PoolStatus(
 			if e := validate.LongName(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -510,6 +540,9 @@ func Validate_PoolStatus(
 			}
 			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 256); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -545,10 +578,16 @@ func Validate_ResourcePoolStatusRequest(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			if earlyReturn {
 				return // do not proceed
 			}
@@ -578,6 +617,9 @@ func Validate_ResourcePoolStatusRequest(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -625,6 +667,9 @@ func Validate_ResourcePoolStatusRequestSpec(
 			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -655,6 +700,9 @@ func Validate_ResourcePoolStatusRequestSpec(
 			}
 			if e := validate.ResourcePoolName(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -691,6 +739,9 @@ func Validate_ResourcePoolStatusRequestSpec(
 			}
 			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -733,6 +784,9 @@ func Validate_ResourcePoolStatusRequestStatus(
 			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -761,6 +815,9 @@ func Validate_ResourcePoolStatusRequestStatus(
 			}
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -797,6 +854,9 @@ func Validate_ResourcePoolStatusRequestStatus(
 			}
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/pkg/apis/resource/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta1/zz_generated.validations.go
@@ -137,6 +137,9 @@ func Validate_AllocatedDeviceStatus(
 			if e := validate.UUID(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -164,6 +167,9 @@ func Validate_AllocatedDeviceStatus(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -255,6 +261,9 @@ func Validate_BasicDevice(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the map and call the value type's validation function
 			if e := validate.EachMapVal(ctx, op, fldPath, obj, oldObj, validate.SemanticDeepEqual, Validate_DeviceAttribute); len(e) != 0 {
 				errs = append(errs, e...)
@@ -300,6 +309,9 @@ func Validate_BasicDevice(
 				}).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj,
 				func(a resourcev1beta1.DeviceCounterConsumption, b resourcev1beta1.DeviceCounterConsumption) bool {
@@ -335,6 +347,9 @@ func Validate_BasicDevice(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -377,6 +392,9 @@ func Validate_BasicDevice(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -405,6 +423,9 @@ func Validate_BasicDevice(
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -452,6 +473,9 @@ func Validate_CounterSet(
 			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -483,6 +507,9 @@ func Validate_CounterSet(
 			}
 			if e := validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -519,6 +546,9 @@ func Validate_Device(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -563,6 +593,9 @@ func Validate_DeviceAllocationConfiguration(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_AllocationConfigSource(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -600,6 +633,9 @@ func Validate_DeviceAllocationConfiguration(
 			// lists with set semantics require unique values
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -679,6 +715,9 @@ func Validate_DeviceAllocationResult(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceRequestAllocationResult); len(e) != 0 {
 				errs = append(errs, e...)
@@ -711,6 +750,9 @@ func Validate_DeviceAllocationResult(
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 64).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -810,6 +852,9 @@ func Validate_DeviceAttribute(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -834,6 +879,9 @@ func Validate_DeviceAttribute(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -866,6 +914,9 @@ func Validate_DeviceAttribute(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -890,6 +941,9 @@ func Validate_DeviceAttribute(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -922,6 +976,9 @@ func Validate_DeviceAttribute(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -946,6 +1003,9 @@ func Validate_DeviceAttribute(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -984,6 +1044,9 @@ func Validate_DeviceAttribute(
 				}).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1008,6 +1071,9 @@ func Validate_DeviceAttribute(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -1058,6 +1124,9 @@ func Validate_DeviceClaim(
 				func(a resourcev1beta1.DeviceRequest, b resourcev1beta1.DeviceRequest) bool { return a.Name == b.Name }).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj,
 				func(a resourcev1beta1.DeviceRequest, b resourcev1beta1.DeviceRequest) bool { return a.Name == b.Name }, validate.SemanticDeepEqual, Validate_DeviceRequest); len(e) != 0 {
@@ -1095,6 +1164,9 @@ func Validate_DeviceClaim(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceConstraint); len(e) != 0 {
 				errs = append(errs, e...)
@@ -1127,6 +1199,9 @@ func Validate_DeviceClaim(
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -1179,6 +1254,9 @@ func Validate_DeviceClaimConfiguration(
 			// lists with set semantics require unique values
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -1234,8 +1312,9 @@ func Validate_DeviceClass(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "name"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "name"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "name",
 					func(o *v1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.OptionalValue).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 					earlyReturn = true
@@ -1248,6 +1327,9 @@ func Validate_DeviceClass(
 					errs = append(errs, e...)
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1342,6 +1424,9 @@ func Validate_DeviceClassSpec(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1370,6 +1455,9 @@ func Validate_DeviceClassSpec(
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -1409,6 +1497,9 @@ func Validate_DeviceClassSpec(
 			if e := validate.ExtendedResourceName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1442,6 +1533,9 @@ func Validate_DeviceConfiguration(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -1493,6 +1587,9 @@ func Validate_DeviceConstraint(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1523,6 +1620,9 @@ func Validate_DeviceConstraint(
 			}
 			if e := validate.ResourceFullyQualifiedName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -1566,6 +1666,9 @@ func Validate_DeviceCounterConsumption(
 			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1597,6 +1700,9 @@ func Validate_DeviceCounterConsumption(
 			}
 			if e := validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -1642,6 +1748,9 @@ func Validate_DeviceRequest(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1666,6 +1775,9 @@ func Validate_DeviceRequest(
 			earlyReturn := false
 			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -1714,6 +1826,9 @@ func Validate_DeviceRequest(
 				}).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj,
 				func(a resourcev1beta1.DeviceSubRequest, b resourcev1beta1.DeviceSubRequest) bool {
@@ -1745,6 +1860,9 @@ func Validate_DeviceRequest(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -1800,6 +1918,9 @@ func Validate_DeviceRequestAllocationResult(
 			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1832,6 +1953,9 @@ func Validate_DeviceRequestAllocationResult(
 			if e := validate.ResourcePoolName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1859,6 +1983,9 @@ func Validate_DeviceRequestAllocationResult(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -1899,6 +2026,9 @@ func Validate_DeviceRequestAllocationResult(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1927,6 +2057,9 @@ func Validate_DeviceRequestAllocationResult(
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -1961,6 +2094,9 @@ func Validate_DeviceRequestAllocationResult(
 			}
 			if e := validate.UUID(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -2006,6 +2142,9 @@ func Validate_DeviceSubRequest(
 			if e := validate.LongName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -2038,6 +2177,9 @@ func Validate_DeviceSubRequest(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -2062,6 +2204,9 @@ func Validate_DeviceSubRequest(
 			earlyReturn := false
 			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -2094,6 +2239,9 @@ func Validate_DeviceSubRequest(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -2140,6 +2288,9 @@ func Validate_DeviceTaint(
 			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -2202,6 +2353,9 @@ func Validate_DeviceToleration(
 			if e := validate.LabelKey(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -2228,6 +2382,9 @@ func Validate_DeviceToleration(
 			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -2260,6 +2417,9 @@ func Validate_DeviceToleration(
 			earlyReturn := false
 			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -2322,6 +2482,9 @@ func Validate_NetworkDeviceData(
 			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 256).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -2358,6 +2521,9 @@ func Validate_NetworkDeviceData(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -2388,6 +2554,9 @@ func Validate_NetworkDeviceData(
 			}
 			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 128).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -2433,6 +2602,9 @@ func Validate_OpaqueDeviceConfiguration(
 			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -2468,10 +2640,16 @@ func Validate_ResourceClaim(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			if earlyReturn {
 				return // do not proceed
 			}
@@ -2561,12 +2739,24 @@ func Validate_ResourceClaimStatus(
 			}
 			// call field-attached validations
 			earlyReturn := false
+			func() {
+				// cohort = "update"
+				if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -2612,6 +2802,9 @@ func Validate_ResourceClaimStatus(
 				}).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -2646,6 +2839,9 @@ func Validate_ResourceClaimStatus(
 					return a.Driver == b.Driver && a.Device == b.Device && a.Pool == b.Pool && ((a.ShareID == nil && b.ShareID == nil) || (a.ShareID != nil && b.ShareID != nil && *a.ShareID == *b.ShareID))
 				}).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj,
@@ -2798,6 +2994,9 @@ func Validate_ResourceSliceSpec(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_Device); len(e) != 0 {
 				errs = append(errs, e...)
@@ -2840,6 +3039,9 @@ func Validate_ResourceSliceSpec(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
 				func(a resourcev1beta1.CounterSet, b resourcev1beta1.CounterSet) bool { return a.Name == b.Name }).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj,

--- a/pkg/apis/resource/v1beta2/zz_generated.validations.go
+++ b/pkg/apis/resource/v1beta2/zz_generated.validations.go
@@ -152,6 +152,9 @@ func Validate_AllocatedDeviceStatus(
 			if e := validate.UUID(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -179,6 +182,9 @@ func Validate_AllocatedDeviceStatus(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -274,6 +280,9 @@ func Validate_CounterSet(
 			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -305,6 +314,9 @@ func Validate_CounterSet(
 			}
 			if e := validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -341,6 +353,9 @@ func Validate_Device(
 			earlyReturn := false
 			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -390,6 +405,9 @@ func Validate_Device(
 				}).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj,
 				func(a resourcev1beta2.DeviceCounterConsumption, b resourcev1beta2.DeviceCounterConsumption) bool {
@@ -425,6 +443,9 @@ func Validate_Device(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -467,6 +488,9 @@ func Validate_Device(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -495,6 +519,9 @@ func Validate_Device(
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -539,6 +566,9 @@ func Validate_DeviceAllocationConfiguration(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_AllocationConfigSource(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -576,6 +606,9 @@ func Validate_DeviceAllocationConfiguration(
 			// lists with set semantics require unique values
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -655,6 +688,9 @@ func Validate_DeviceAllocationResult(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceRequestAllocationResult); len(e) != 0 {
 				errs = append(errs, e...)
@@ -687,6 +723,9 @@ func Validate_DeviceAllocationResult(
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 64).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -786,6 +825,9 @@ func Validate_DeviceAttribute(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -810,6 +852,9 @@ func Validate_DeviceAttribute(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -842,6 +887,9 @@ func Validate_DeviceAttribute(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -866,6 +914,9 @@ func Validate_DeviceAttribute(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -898,6 +949,9 @@ func Validate_DeviceAttribute(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -922,6 +976,9 @@ func Validate_DeviceAttribute(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -960,6 +1017,9 @@ func Validate_DeviceAttribute(
 				}).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -984,6 +1044,9 @@ func Validate_DeviceAttribute(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -1034,6 +1097,9 @@ func Validate_DeviceClaim(
 				func(a resourcev1beta2.DeviceRequest, b resourcev1beta2.DeviceRequest) bool { return a.Name == b.Name }).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj,
 				func(a resourcev1beta2.DeviceRequest, b resourcev1beta2.DeviceRequest) bool { return a.Name == b.Name }, validate.SemanticDeepEqual, Validate_DeviceRequest); len(e) != 0 {
@@ -1071,6 +1137,9 @@ func Validate_DeviceClaim(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_DeviceConstraint); len(e) != 0 {
 				errs = append(errs, e...)
@@ -1103,6 +1172,9 @@ func Validate_DeviceClaim(
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -1155,6 +1227,9 @@ func Validate_DeviceClaimConfiguration(
 			// lists with set semantics require unique values
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -1210,8 +1285,9 @@ func Validate_DeviceClass(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "name"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "name"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "name",
 					func(o *v1.ObjectMeta) *string { return &o.Name }, validate.DirectEqualPtr, validate.OptionalValue).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 					earlyReturn = true
@@ -1224,6 +1300,9 @@ func Validate_DeviceClass(
 					errs = append(errs, e...)
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1318,6 +1397,9 @@ func Validate_DeviceClassSpec(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1346,6 +1428,9 @@ func Validate_DeviceClassSpec(
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 32).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -1385,6 +1470,9 @@ func Validate_DeviceClassSpec(
 			if e := validate.ExtendedResourceName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1418,6 +1506,9 @@ func Validate_DeviceConfiguration(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -1469,6 +1560,9 @@ func Validate_DeviceConstraint(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1499,6 +1593,9 @@ func Validate_DeviceConstraint(
 			}
 			if e := validate.ResourceFullyQualifiedName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -1542,6 +1639,9 @@ func Validate_DeviceCounterConsumption(
 			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1573,6 +1673,9 @@ func Validate_DeviceCounterConsumption(
 			}
 			if e := validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.ShortName).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -1609,6 +1712,9 @@ func Validate_DeviceRequest(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -1653,6 +1759,9 @@ func Validate_DeviceRequest(
 					return a.Name == b.Name
 				}).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj,
@@ -1707,6 +1816,9 @@ func Validate_DeviceRequestAllocationResult(
 			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1739,6 +1851,9 @@ func Validate_DeviceRequestAllocationResult(
 			if e := validate.ResourcePoolName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1766,6 +1881,9 @@ func Validate_DeviceRequestAllocationResult(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -1806,6 +1924,9 @@ func Validate_DeviceRequestAllocationResult(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1834,6 +1955,9 @@ func Validate_DeviceRequestAllocationResult(
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -1868,6 +1992,9 @@ func Validate_DeviceRequestAllocationResult(
 			}
 			if e := validate.UUID(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -1913,6 +2040,9 @@ func Validate_DeviceSubRequest(
 			if e := validate.LongName(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1945,6 +2075,9 @@ func Validate_DeviceSubRequest(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1969,6 +2102,9 @@ func Validate_DeviceSubRequest(
 			earlyReturn := false
 			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -2001,6 +2137,9 @@ func Validate_DeviceSubRequest(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -2047,6 +2186,9 @@ func Validate_DeviceTaint(
 			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -2177,6 +2319,9 @@ func Validate_DeviceToleration(
 			if e := validate.LabelKey(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -2203,6 +2348,9 @@ func Validate_DeviceToleration(
 			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -2235,6 +2383,9 @@ func Validate_DeviceToleration(
 			earlyReturn := false
 			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -2300,6 +2451,9 @@ func Validate_ExactDeviceRequest(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -2324,6 +2478,9 @@ func Validate_ExactDeviceRequest(
 			earlyReturn := false
 			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -2357,6 +2514,9 @@ func Validate_ExactDeviceRequest(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -2406,6 +2566,9 @@ func Validate_NetworkDeviceData(
 			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 256).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -2442,6 +2605,9 @@ func Validate_NetworkDeviceData(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -2472,6 +2638,9 @@ func Validate_NetworkDeviceData(
 			}
 			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 128).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -2517,6 +2686,9 @@ func Validate_OpaqueDeviceConfiguration(
 			if e := validate.LongNameCaseless(ctx, op, fldPath, obj, oldObj).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -2552,10 +2724,16 @@ func Validate_ResourceClaim(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			if earlyReturn {
 				return // do not proceed
 			}
@@ -2645,12 +2823,24 @@ func Validate_ResourceClaimStatus(
 			}
 			// call field-attached validations
 			earlyReturn := false
+			func() {
+				// cohort = "update"
+				if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -2696,6 +2886,9 @@ func Validate_ResourceClaimStatus(
 				}).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -2730,6 +2923,9 @@ func Validate_ResourceClaimStatus(
 					return a.Driver == b.Driver && a.Device == b.Device && a.Pool == b.Pool && ((a.ShareID == nil && b.ShareID == nil) || (a.ShareID != nil && b.ShareID != nil && *a.ShareID == *b.ShareID))
 				}).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj,
@@ -2882,6 +3078,9 @@ func Validate_ResourceSliceSpec(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_Device); len(e) != 0 {
 				errs = append(errs, e...)
@@ -2924,6 +3123,9 @@ func Validate_ResourceSliceSpec(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
 				func(a resourcev1beta2.CounterSet, b resourcev1beta2.CounterSet) bool { return a.Name == b.Name }).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj,

--- a/pkg/apis/scheduling/v1alpha2/zz_generated.validations.go
+++ b/pkg/apis/scheduling/v1alpha2/zz_generated.validations.go
@@ -117,6 +117,9 @@ func Validate_GangSchedulingPolicy(
 			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -232,6 +235,9 @@ func Validate_PodGroupResourceClaim(
 			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -263,6 +269,9 @@ func Validate_PodGroupResourceClaim(
 			if e := validate.LongName(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -293,6 +302,9 @@ func Validate_PodGroupResourceClaim(
 			}
 			if e := validate.LongName(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -336,6 +348,9 @@ func Validate_PodGroupResourceClaimStatus(
 			if e := validate.LongName(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -373,6 +388,9 @@ func Validate_PodGroupSchedulingConstraints(
 			}
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -436,6 +454,9 @@ func Validate_PodGroupSchedulingPolicy(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -460,6 +481,9 @@ func Validate_PodGroupSchedulingPolicy(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -497,12 +521,24 @@ func Validate_PodGroupSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
+			if earlyReturn {
+				return // do not proceed
 			}
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -531,10 +567,16 @@ func Validate_PodGroupSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			if earlyReturn {
 				return // do not proceed
 			}
@@ -579,6 +621,9 @@ func Validate_PodGroupSpec(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_PodGroupSchedulingConstraints(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -603,9 +648,18 @@ func Validate_PodGroupSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
+			if earlyReturn {
+				return // do not proceed
 			}
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
@@ -623,6 +677,9 @@ func Validate_PodGroupSpec(
 					return a.Name == b.Name
 				}); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj,
@@ -672,6 +729,9 @@ func Validate_PodGroupSpec(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_DisruptionMode(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -715,6 +775,9 @@ func Validate_PodGroupSpec(
 			}
 			if e := validate.IfOption(ctx, op, fldPath, obj, oldObj, "WorkloadAwarePreemption", true, validate.LongName); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -767,6 +830,9 @@ func Validate_PodGroupSpec(
 				}); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -817,6 +883,9 @@ func Validate_PodGroupStatus(
 				}); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj,
 				func(a schedulingv1alpha2.PodGroupResourceClaimStatus, b schedulingv1alpha2.PodGroupResourceClaimStatus) bool {
@@ -864,6 +933,9 @@ func Validate_PodGroupTemplate(
 			}
 			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -922,6 +994,9 @@ func Validate_PodGroupTemplate(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_PodGroupSchedulingConstraints(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -946,9 +1021,18 @@ func Validate_PodGroupTemplate(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
+			if earlyReturn {
+				return // do not proceed
 			}
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
@@ -966,6 +1050,9 @@ func Validate_PodGroupTemplate(
 					return a.Name == b.Name
 				}); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj,
@@ -1009,6 +1096,9 @@ func Validate_PodGroupTemplate(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_DisruptionMode(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -1048,6 +1138,9 @@ func Validate_PodGroupTemplate(
 			}
 			if e := validate.IfOption(ctx, op, fldPath, obj, oldObj, "WorkloadAwarePreemption", true, validate.LongName); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -1095,6 +1188,9 @@ func Validate_PodGroupTemplate(
 					return validate.Minimum(ctx, op, fldPath, obj, oldObj, -2147483648)
 				}); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -1145,6 +1241,9 @@ func Validate_PodGroupTemplateReference(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_WorkloadPodGroupTemplateReference(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -1188,6 +1287,9 @@ func Validate_TopologyConstraint(
 			if e := validate.LabelKey(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1228,6 +1330,9 @@ func Validate_TypedLocalObjectReference(
 			if e := validate.LongName(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1260,6 +1365,9 @@ func Validate_TypedLocalObjectReference(
 			if e := validate.PathSegmentName(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1291,6 +1399,9 @@ func Validate_TypedLocalObjectReference(
 			}
 			if e := validate.PathSegmentName(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -1367,6 +1478,9 @@ func Validate_WorkloadPodGroupTemplateReference(
 			if e := validate.LongName(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1399,6 +1513,9 @@ func Validate_WorkloadPodGroupTemplateReference(
 			if e := validate.ShortName(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1430,12 +1547,24 @@ func Validate_WorkloadSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
+			if earlyReturn {
+				return // do not proceed
 			}
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -1464,9 +1593,18 @@ func Validate_WorkloadSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
+			if earlyReturn {
+				return // do not proceed
 			}
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
@@ -1485,6 +1623,9 @@ func Validate_WorkloadSpec(
 					return a.Name == b.Name
 				}); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj,

--- a/pkg/apis/storage/v1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1/zz_generated.validations.go
@@ -95,13 +95,25 @@ func Validate_StorageClass(
 			}
 			// call field-attached validations
 			earlyReturn := false
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -128,12 +140,24 @@ func Validate_StorageClass(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
+			if earlyReturn {
+				return // do not proceed
 			}
 			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -160,12 +184,24 @@ func Validate_StorageClass(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
+			if earlyReturn {
+				return // do not proceed
 			}
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -195,12 +231,24 @@ func Validate_StorageClass(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
+			if earlyReturn {
+				return // do not proceed
 			}
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -240,10 +288,16 @@ func Validate_VolumeAttachment(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			if earlyReturn {
 				return // do not proceed
 			}
@@ -293,6 +347,9 @@ func Validate_VolumeAttachmentSpec(
 			}
 			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}

--- a/pkg/apis/storage/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1alpha1/zz_generated.validations.go
@@ -79,10 +79,16 @@ func Validate_VolumeAttachment(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			if earlyReturn {
 				return // do not proceed
 			}
@@ -132,6 +138,9 @@ func Validate_VolumeAttachmentSpec(
 			}
 			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}

--- a/pkg/apis/storage/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/storage/v1beta1/zz_generated.validations.go
@@ -95,13 +95,25 @@ func Validate_StorageClass(
 			}
 			// call field-attached validations
 			earlyReturn := false
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -128,12 +140,24 @@ func Validate_StorageClass(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
+			if earlyReturn {
+				return // do not proceed
 			}
 			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -160,12 +184,24 @@ func Validate_StorageClass(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
+			if earlyReturn {
+				return // do not proceed
 			}
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -195,12 +231,24 @@ func Validate_StorageClass(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
+			if earlyReturn {
+				return // do not proceed
 			}
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -240,10 +288,16 @@ func Validate_VolumeAttachment(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
+			func() {
+				// cohort = "update"
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			if earlyReturn {
 				return // do not proceed
 			}
@@ -293,6 +347,9 @@ func Validate_VolumeAttachmentSpec(
 			}
 			if e := validate.MaxLength(ctx, op, fldPath, obj, oldObj, 63).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}

--- a/pkg/apis/storage/validation/validation.go
+++ b/pkg/apis/storage/validation/validation.go
@@ -224,9 +224,11 @@ func validateVolumeError(e *storage.VolumeError, fldPath *field.Path) field.Erro
 
 // ValidateVolumeAttachmentUpdate validates a VolumeAttachment.
 func ValidateVolumeAttachmentUpdate(new, old *storage.VolumeAttachment) field.ErrorList {
-	allErrs := ValidateVolumeAttachment(new)
-	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(new.Spec, old.Spec, field.NewPath("spec")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
-	return allErrs
+	allErrs := apimachineryvalidation.ValidateImmutableField(new.Spec, old.Spec, field.NewPath("spec")).WithOrigin("immutable").MarkCoveredByDeclarative()
+	if len(allErrs) > 0 {
+		return allErrs
+	}
+	return ValidateVolumeAttachment(new)
 }
 
 var supportedVolumeBindingModes = sets.NewString(string(storage.VolumeBindingImmediate), string(storage.VolumeBindingWaitForFirstConsumer))

--- a/pkg/registry/networking/ipaddress/declarative_validation_test.go
+++ b/pkg/registry/networking/ipaddress/declarative_validation_test.go
@@ -138,7 +138,6 @@ func TestDeclarativeValidateIPAddressUpdate(t *testing.T) {
 						withNilParentRef,
 					),
 					expectedErrs: field.ErrorList{
-						field.Required(field.NewPath("spec", "parentRef"), "").MarkAlpha(),
 						func() *field.Error {
 							e := field.Invalid(field.NewPath("spec", "parentRef"), nil, "field is immutable")
 							e.Origin = "immutable"

--- a/pkg/registry/networking/ipaddress/strategy.go
+++ b/pkg/registry/networking/ipaddress/strategy.go
@@ -88,9 +88,11 @@ func (ipAddressStrategy) AllowCreateOnUpdate() bool {
 func (ipAddressStrategy) ValidateUpdate(ctx context.Context, new, old runtime.Object) field.ErrorList {
 	newIPAddress := new.(*networking.IPAddress)
 	oldIPAddress := old.(*networking.IPAddress)
-	errList := validation.ValidateIPAddress(newIPAddress)
-	errList = append(errList, validation.ValidateIPAddressUpdate(newIPAddress, oldIPAddress)...)
-	return errList
+	allErrs := validation.ValidateIPAddressUpdate(newIPAddress, oldIPAddress)
+	if len(allErrs) > 0 {
+		return allErrs
+	}
+	return validation.ValidateIPAddress(newIPAddress)
 }
 
 // AllowUnconditionalUpdate is the default update policy for IPAddress objects.

--- a/pkg/registry/rbac/rolebinding/declarative_validation_test.go
+++ b/pkg/registry/rbac/rolebinding/declarative_validation_test.go
@@ -153,9 +153,6 @@ func testDeclarativeValidateUpdateForDeclarative(t *testing.T, apiVersion string
 			oldObj:    mkValidRoleBinding(),
 			expectedErrs: field.ErrorList{
 				field.Invalid(field.NewPath("roleRef"), rbac.RoleRef{}, "field is immutable").WithOrigin("immutable").MarkAlpha(),
-				field.Required(field.NewPath("roleRef", "name"), "name is required").MarkShortCircuitedInDV(),
-				field.NotSupported(field.NewPath("roleRef", "kind"), "", []string{}).MarkFromImperative(),
-				field.NotSupported(field.NewPath("roleRef", "apiGroup"), "", []string{}).MarkFromImperative(),
 			},
 		},
 		// TODO: Add more test cases

--- a/pkg/registry/scheduling/workload/declarative_validation_test.go
+++ b/pkg/registry/scheduling/workload/declarative_validation_test.go
@@ -409,7 +409,6 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			oldObj:    mkValidWorkload(setResourceVersion("1")),
 			updateObj: mkValidWorkload(setResourceVersion("1"), setEmptyPodGroupTemplates()),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "podGroupTemplates"), "must have at least one item"),
 				field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "").WithOrigin("immutable"),
 			},
 		},
@@ -424,7 +423,6 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			oldObj:    mkValidWorkload(setResourceVersion("1")),
 			updateObj: mkValidWorkload(setResourceVersion("1"), setManyPodGroupTemplates(scheduling.WorkloadMaxPodGroupTemplates+1)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "podGroupTemplates"), scheduling.WorkloadMaxPodGroupTemplates+1, scheduling.WorkloadMaxPodGroupTemplates).WithOrigin("maxItems"),
 				field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "").WithOrigin("immutable"),
 			},
 		},

--- a/pkg/registry/storage/storageclass/declarative_validation_test.go
+++ b/pkg/registry/storage/storageclass/declarative_validation_test.go
@@ -107,7 +107,6 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			updateObj: mkValidStorageClass(TweakProvisioner("")),
 			expectedErrs: field.ErrorList{
 				field.Invalid(field.NewPath("provisioner"), "", "").WithOrigin("immutable").MarkAlpha(),
-				field.Required(field.NewPath("provisioner"), "").MarkAlpha(),
 			},
 		},
 		"invalid update parameters changed": {
@@ -170,7 +169,6 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			oldObj:    mkValidStorageClass(),
 			updateObj: mkValidStorageClass(TweakVolumeBindingModeNil()),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("volumeBindingMode"), "").MarkFromImperative(),
 				field.Invalid(field.NewPath("volumeBindingMode"), nil, "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},

--- a/pkg/registry/storage/storageclass/strategy.go
+++ b/pkg/registry/storage/storageclass/strategy.go
@@ -71,9 +71,11 @@ func (storageClassStrategy) PrepareForUpdate(ctx context.Context, obj, old runti
 }
 
 func (storageClassStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
-	allErrs := validation.ValidateStorageClass(obj.(*storage.StorageClass))
-	allErrs = append(allErrs, validation.ValidateStorageClassUpdate(obj.(*storage.StorageClass), old.(*storage.StorageClass))...)
-	return allErrs
+	allErrs := validation.ValidateStorageClassUpdate(obj.(*storage.StorageClass), old.(*storage.StorageClass))
+	if len(allErrs) > 0 {
+		return allErrs
+	}
+	return validation.ValidateStorageClass(obj.(*storage.StorageClass))
 }
 
 // WarningsOnUpdate returns warnings for the given update.

--- a/staging/src/k8s.io/api/extensions/v1beta1/zz_generated.validations.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/zz_generated.validations.go
@@ -97,6 +97,9 @@ func Validate_IPBlock(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -171,6 +174,9 @@ func Validate_NetworkPolicyEgressRule(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_NetworkPolicyPeer); len(e) != 0 {
 				errs = append(errs, e...)
@@ -210,6 +216,9 @@ func Validate_NetworkPolicyIngressRule(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -258,6 +267,9 @@ func Validate_NetworkPolicyPeer(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_IPBlock(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -299,6 +311,9 @@ func Validate_NetworkPolicySpec(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_NetworkPolicyIngressRule); len(e) != 0 {
 				errs = append(errs, e...)
@@ -327,6 +342,9 @@ func Validate_NetworkPolicySpec(
 			earlyReturn := false
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/cohorts/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/cohorts/zz_generated.validations.go
@@ -72,8 +72,11 @@ func Validate_T(
 	if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type T Regular"); len(e) != 0 {
 		errs = append(errs, e...)
 	}
-	func() { // cohort = "c2"
-		earlyReturn := false
+	if earlyReturn {
+		return // do not proceed
+	}
+	func() {
+		// cohort = "c2"
 		if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type T c2 ShortCircuit").MarkShortCircuit(); len(e) != 0 {
 			errs = append(errs, e...)
 			earlyReturn = true
@@ -85,8 +88,11 @@ func Validate_T(
 			errs = append(errs, e...)
 		}
 	}()
-	func() { // cohort = "c1"
-		earlyReturn := false
+	if earlyReturn {
+		return // do not proceed
+	}
+	func() {
+		// cohort = "c1"
 		if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "type T c1 ShortCircuit").MarkShortCircuit(); len(e) != 0 {
 			errs = append(errs, e...)
 			earlyReturn = true
@@ -98,6 +104,9 @@ func Validate_T(
 			errs = append(errs, e...)
 		}
 	}()
+	if earlyReturn {
+		return // do not proceed
+	}
 
 	// field T.TypeMeta has no validation
 
@@ -124,8 +133,11 @@ func Validate_T(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T.S Regular"); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			func() { // cohort = "c2"
-				earlyReturn := false
+			if earlyReturn {
+				return // do not proceed
+			}
+			func() {
+				// cohort = "c2"
 				if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T.S c2 ShortCircuit").MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -137,8 +149,11 @@ func Validate_T(
 					errs = append(errs, e...)
 				}
 			}()
-			func() { // cohort = "c1"
-				earlyReturn := false
+			if earlyReturn {
+				return // do not proceed
+			}
+			func() {
+				// cohort = "c1"
 				if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field T.S c1 ShortCircuit").MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -150,6 +165,9 @@ func Validate_T(
 					errs = append(errs, e...)
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ordering/structs/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ordering/structs/zz_generated.validations.go
@@ -301,6 +301,9 @@ func Validate_T02(
 	if earlyReturn {
 		return // do not proceed
 	}
+	if earlyReturn {
+		return // do not proceed
+	}
 
 	// field T02.TypeMeta has no validation
 
@@ -320,6 +323,9 @@ func Validate_T02(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T02.S, ShortCircuit").MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -353,6 +359,9 @@ func Validate_T02(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -378,6 +387,9 @@ func Validate_T02(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T02.T, ShortCircuit").MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -413,6 +425,9 @@ func Validate_T02(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_Tother(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -444,6 +459,9 @@ func Validate_T03(
 	if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T03, no flags"); len(e) != 0 {
 		errs = append(errs, e...)
 	}
+	if earlyReturn {
+		return // do not proceed
+	}
 
 	// field T03.TypeMeta has no validation
 
@@ -469,6 +487,9 @@ func Validate_T03(
 			}
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T03.S, no flags"); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -502,6 +523,9 @@ func Validate_T03(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T03.PS, no flags"); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -533,6 +557,9 @@ func Validate_T03(
 			}
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T03.T, no flags"); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_Tother(ctx, op, fldPath, obj, oldObj)...)
@@ -567,6 +594,9 @@ func Validate_T03(
 			}
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T03.PT, no flags"); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_Tother(ctx, op, fldPath, obj, oldObj)...)
@@ -609,6 +639,9 @@ func Validate_TMultiple(
 	if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple, no flags 2"); len(e) != 0 {
 		errs = append(errs, e...)
 	}
+	if earlyReturn {
+		return // do not proceed
+	}
 
 	// field TMultiple.TypeMeta has no validation
 
@@ -644,6 +677,9 @@ func Validate_TMultiple(
 			}
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple.S, no flags 2"); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -687,6 +723,9 @@ func Validate_TMultiple(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple.PS, no flags 2"); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -728,6 +767,9 @@ func Validate_TMultiple(
 			}
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple.T, no flags 2"); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_Tother(ctx, op, fldPath, obj, oldObj)...)
@@ -772,6 +814,9 @@ func Validate_TMultiple(
 			}
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "TMultiple.PT, no flags 2"); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_Tother(ctx, op, fldPath, obj, oldObj)...)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ordering/typedefs/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ordering/typedefs/zz_generated.validations.go
@@ -127,6 +127,9 @@ func Validate_E02(
 	if earlyReturn {
 		return // do not proceed
 	}
+	if earlyReturn {
+		return // do not proceed
+	}
 
 	return errs
 }
@@ -147,6 +150,9 @@ func Validate_E03(
 	}
 	if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "E03, no flags"); len(e) != 0 {
 		errs = append(errs, e...)
+	}
+	if earlyReturn {
+		return // do not proceed
 	}
 
 	return errs
@@ -178,6 +184,9 @@ func Validate_EMultiple(
 	}
 	if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "EMultiple, no flags 2"); len(e) != 0 {
 		errs = append(errs, e...)
+	}
+	if earlyReturn {
+		return // do not proceed
 	}
 
 	return errs

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/default_behavior/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/default_behavior/zz_generated.validations.go
@@ -667,6 +667,9 @@ func Validate_StructPrimitive(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field intPtrField"); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/subfield/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/subfield/zz_generated.validations.go
@@ -91,7 +91,8 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "intField"
+			func() {
+				// cohort = "intField"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "intField",
 					func(o *SubStruct) *int { return &o.IntField }, validate.DirectEqualPtr,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int) field.ErrorList {
@@ -100,7 +101,8 @@ func Validate_Struct(
 					errs = append(errs, e...)
 				}
 			}()
-			func() { // cohort = "intPtrField"
+			func() {
+				// cohort = "intPtrField"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "intPtrField",
 					func(o *SubStruct) *int { return o.IntPtrField }, validate.DirectEqualPtr,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int) field.ErrorList {
@@ -127,7 +129,8 @@ func Validate_StructWithSubfield(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *StructWithSubfield) (errs field.ErrorList) {
 
-	func() { // cohort = "intField"
+	func() {
+		// cohort = "intField"
 		if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "intField",
 			func(o *StructWithSubfield) *int { return &o.IntField }, validate.DirectEqualPtr,
 			func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int) field.ErrorList {
@@ -136,7 +139,8 @@ func Validate_StructWithSubfield(
 			errs = append(errs, e...)
 		}
 	}()
-	func() { // cohort = "intPtrField"
+	func() {
+		// cohort = "intPtrField"
 		if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "intPtrField",
 			func(o *StructWithSubfield) *int { return o.IntPtrField }, validate.DirectEqualPtr,
 			func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int) field.ErrorList {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/recursive/pointers/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/recursive/pointers/zz_generated.validations.go
@@ -111,6 +111,9 @@ func Validate_T1(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_T1(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -163,6 +166,9 @@ func Validate_T1(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_T2(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -202,6 +208,9 @@ func Validate_T2(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_T1(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -232,6 +241,9 @@ func Validate_T2(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_T2(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -258,6 +270,9 @@ func Validate_T2(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/forbidden/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/forbidden/zz_generated.validations.go
@@ -87,6 +87,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -115,6 +118,9 @@ func Validate_Struct(
 			}
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -151,6 +157,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -179,6 +188,9 @@ func Validate_Struct(
 			}
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -215,6 +227,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -243,6 +258,9 @@ func Validate_Struct(
 			}
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -279,6 +297,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -307,6 +328,9 @@ func Validate_Struct(
 			}
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -343,6 +367,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -371,6 +398,9 @@ func Validate_Struct(
 			}
 			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -407,6 +437,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -435,6 +468,9 @@ func Validate_Struct(
 			}
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -471,6 +507,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -499,6 +538,9 @@ func Validate_Struct(
 			}
 			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -535,6 +577,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -567,6 +612,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -595,6 +643,9 @@ func Validate_Struct(
 			}
 			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-extended-resource-name/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-extended-resource-name/zz_generated.validations.go
@@ -85,6 +85,9 @@ func Validate_MyType(
 			if e := validate.ExtendedResourceName(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -115,6 +118,9 @@ func Validate_MyType(
 			}
 			if e := validate.ExtendedResourceName(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-uuid/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-uuid/zz_generated.validations.go
@@ -85,6 +85,9 @@ func Validate_MyType(
 			if e := validate.UUID(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -115,6 +118,9 @@ func Validate_MyType(
 			}
 			if e := validate.UUID(ctx, op, fldPath, obj, oldObj); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/immutable/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/immutable/zz_generated.validations.go
@@ -62,14 +62,16 @@ func Validate_ImmutableType(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *ImmutableType) (errs field.ErrorList) {
 
-	earlyReturn := false
-	if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-		errs = append(errs, e...)
-		earlyReturn = true
-	}
-	if earlyReturn {
-		return // do not proceed
-	}
+	func() { // cohort = "update"
+		earlyReturn := false
+		if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+			errs = append(errs, e...)
+			earlyReturn = true
+		}
+		if earlyReturn {
+			return // do not proceed
+		}
+	}()
 
 	return errs
 }
@@ -94,14 +96,16 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -123,14 +127,16 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -152,14 +158,16 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -181,14 +189,16 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -210,14 +220,16 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -239,14 +251,16 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -268,14 +282,16 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -297,14 +313,16 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/immutable/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/immutable/zz_generated.validations.go
@@ -62,8 +62,9 @@ func Validate_ImmutableType(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *ImmutableType) (errs field.ErrorList) {
 
-	func() { // cohort = "update"
-		earlyReturn := false
+	earlyReturn := false
+	func() {
+		// cohort = "update"
 		if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 			errs = append(errs, e...)
 			earlyReturn = true
@@ -72,6 +73,9 @@ func Validate_ImmutableType(
 			return // do not proceed
 		}
 	}()
+	if earlyReturn {
+		return // do not proceed
+	}
 
 	return errs
 }
@@ -96,8 +100,9 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -106,6 +111,9 @@ func Validate_Struct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -127,8 +135,9 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -137,6 +146,9 @@ func Validate_Struct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -158,8 +170,9 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -168,6 +181,9 @@ func Validate_Struct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -189,8 +205,9 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -199,6 +216,9 @@ func Validate_Struct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -220,8 +240,9 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -230,6 +251,9 @@ func Validate_Struct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -251,8 +275,9 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -261,6 +286,9 @@ func Validate_Struct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -282,8 +310,9 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -292,6 +321,9 @@ func Validate_Struct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -313,8 +345,9 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -323,6 +356,9 @@ func Validate_Struct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/immutable_transitions/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/immutable_transitions/zz_generated.validations.go
@@ -76,13 +76,9 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			// lists with map semantics require unique keys
-			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
-				func(a Item, b Item) bool { return a.Key1 == b.Key1 }); len(e) != 0 {
-				errs = append(errs, e...)
-			}
-			func() { // cohort = "{"key1": "a"}"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update@{"key1": "a"}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *Item) bool { return item.Key1 == "a" }, validate.DirectEqual, validate.Immutable).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
@@ -92,8 +88,8 @@ func Validate_Struct(
 					return // do not proceed
 				}
 			}()
-			func() { // cohort = "{"key1": "b"}"
-				earlyReturn := false
+			func() {
+				// cohort = "update@stringField@{"key1": "b"}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *Item) bool { return item.Key1 == "b" }, validate.DirectEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Item) field.ErrorList {
@@ -107,6 +103,17 @@ func Validate_Struct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
+			// lists with map semantics require unique keys
+			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
+				func(a Item, b Item) bool { return a.Key1 == b.Key1 }); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/multiple_keys/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/multiple_keys/zz_generated.validations.go
@@ -83,7 +83,8 @@ func Validate_Struct(
 				}); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			func() { // cohort = "{"stringKey": "target", "intKey": 42, "boolKey": true}"
+			func() {
+				// cohort = "{"stringKey": "target", "intKey": 42, "boolKey": true}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *Item) bool { return item.StringKey == "target" && item.IntKey == 42 && item.BoolKey == true }, validate.DirectEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Item) field.ErrorList {
@@ -127,7 +128,8 @@ func Validate_Struct(
 				}); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			func() { // cohort = "{"boolKey": true, "stringKey": "target", "intKey": 42}"
+			func() {
+				// cohort = "{"boolKey": true, "stringKey": "target", "intKey": 42}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *Item) bool { return item.StringKey == "target" && item.IntKey == 42 && item.BoolKey == true }, validate.DirectEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Item) field.ErrorList {
@@ -164,7 +166,8 @@ func Validate_Struct(
 				}); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			func() { // cohort = "{"stringKey": "target-ptr", "intKey": 42, "boolKey": true}"
+			func() {
+				// cohort = "{"stringKey": "target-ptr", "intKey": 42, "boolKey": true}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *PtrItem) bool {
 						return item.StringKey != nil && *item.StringKey == "target-ptr" && item.IntKey == 42 && item.BoolKey == true
@@ -203,7 +206,8 @@ func Validate_Struct(
 				}); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			func() { // cohort = "{"stringPtrKey": "target-ptr", "stringKey": "target"}"
+			func() {
+				// cohort = "{"stringPtrKey": "target-ptr", "stringKey": "target"}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *MixedPtrItem) bool {
 						return item.StringPtrKey != nil && *item.StringPtrKey == "target-ptr" && item.StringKey == "target"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/single_key/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/single_key/zz_generated.validations.go
@@ -96,7 +96,8 @@ func Validate_Struct(
 				func(a Item, b Item) bool { return a.Key == b.Key }); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			func() { // cohort = "{"key": "target"}"
+			func() {
+				// cohort = "{"key": "target"}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *Item) bool { return item.Key == "target" }, validate.DirectEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Item) field.ErrorList {
@@ -138,7 +139,8 @@ func Validate_Struct(
 				func(a IntKeyItem, b IntKeyItem) bool { return a.IntField == b.IntField }); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			func() { // cohort = "{"intField": 42}"
+			func() {
+				// cohort = "{"intField": 42}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *IntKeyItem) bool { return item.IntField == 42 }, validate.DirectEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *IntKeyItem) field.ErrorList {
@@ -180,7 +182,8 @@ func Validate_Struct(
 				func(a BoolKeyItem, b BoolKeyItem) bool { return a.BoolField == b.BoolField }); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			func() { // cohort = "{"boolField": true}"
+			func() {
+				// cohort = "{"boolField": true}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *BoolKeyItem) bool { return item.BoolField == true }, validate.DirectEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *BoolKeyItem) field.ErrorList {
@@ -222,7 +225,8 @@ func Validate_Struct(
 				func(a TypedefItem, b TypedefItem) bool { return a.ID == b.ID }); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			func() { // cohort = "{"id": "typedef-target"}"
+			func() {
+				// cohort = "{"id": "typedef-target"}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *TypedefItem) bool { return item.ID == "typedef-target" }, validate.DirectEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *TypedefItem) field.ErrorList {
@@ -264,7 +268,8 @@ func Validate_Struct(
 				func(a Item, b Item) bool { return a.Key == b.Key }); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			func() { // cohort = "{"key": "target"}"
+			func() {
+				// cohort = "{"key": "target"}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *Item) bool { return item.Key == "target" }, validate.DirectEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Item) field.ErrorList {
@@ -301,7 +306,8 @@ func Validate_Struct(
 				}); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			func() { // cohort = "{"key": "target-ptr"}"
+			func() {
+				// cohort = "{"key": "target-ptr"}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *PtrKeyItem) bool { return item.Key != nil && *item.Key == "target-ptr" }, validate.SemanticDeepEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *PtrKeyItem) field.ErrorList {
@@ -347,7 +353,8 @@ func Validate_StructWithNestedTypedef(
 				func(a NestedTypedefItem, b NestedTypedefItem) bool { return a.Key == b.Key }); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			func() { // cohort = "{"key": "nested-target"}"
+			func() {
+				// cohort = "{"key": "nested-target"}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *NestedTypedefItem) bool { return item.Key == "nested-target" }, validate.DirectEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *NestedTypedefItem) field.ErrorList {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/subfield/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/subfield/zz_generated.validations.go
@@ -81,7 +81,8 @@ func Validate_Struct(
 				func(a Item, b Item) bool { return a.Key == b.Key }); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			func() { // cohort = "{"key": "target"}"
+			func() {
+				// cohort = "stringField@{"key": "target"}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *Item) bool { return item.Key == "target" }, validate.DirectEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Item) field.ErrorList {
@@ -120,7 +121,8 @@ func Validate_Struct(
 				func(a RatchetItem, b RatchetItem) bool { return a.Key == b.Key }); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			func() { // cohort = "{"key": "ratchet"}"
+			func() {
+				// cohort = "status@{"key": "ratchet"}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *RatchetItem) bool { return item.Key == "ratchet" }, validate.DirectEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *RatchetItem) field.ErrorList {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/typedef/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/typedef/zz_generated.validations.go
@@ -67,7 +67,8 @@ func Validate_ConflictingItemList(
 		func(a DualItem, b DualItem) bool { return a.ID == b.ID }); len(e) != 0 {
 		errs = append(errs, e...)
 	}
-	func() { // cohort = "{"id": "target"}"
+	func() {
+		// cohort = "{"id": "target"}"
 		if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 			func(item *DualItem) bool { return item.ID == "target" }, validate.DirectEqual,
 			func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *DualItem) field.ErrorList {
@@ -91,7 +92,8 @@ func Validate_DualItemList(
 		func(a DualItem, b DualItem) bool { return a.ID == b.ID }); len(e) != 0 {
 		errs = append(errs, e...)
 	}
-	func() { // cohort = "{"id": "typedef-target"}"
+	func() {
+		// cohort = "{"id": "typedef-target"}"
 		if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 			func(item *DualItem) bool { return item.ID == "typedef-target" }, validate.DirectEqual,
 			func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *DualItem) field.ErrorList {
@@ -110,13 +112,9 @@ func Validate_ItemList(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj ItemList) (errs field.ErrorList) {
 
-	// lists with map semantics require unique keys
-	if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
-		func(a Item, b Item) bool { return a.Key == b.Key }); len(e) != 0 {
-		errs = append(errs, e...)
-	}
-	func() { // cohort = "{"key": "immutable"}"
-		earlyReturn := false
+	earlyReturn := false
+	func() {
+		// cohort = "update@{"key": "immutable"}"
 		if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 			func(item *Item) bool { return item.Key == "immutable" }, validate.DirectEqual, validate.Immutable).MarkShortCircuit(); len(e) != 0 {
 			errs = append(errs, e...)
@@ -126,7 +124,19 @@ func Validate_ItemList(
 			return // do not proceed
 		}
 	}()
-	func() { // cohort = "{"key": "validated"}"
+	if earlyReturn {
+		return // do not proceed
+	}
+	// lists with map semantics require unique keys
+	if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
+		func(a Item, b Item) bool { return a.Key == b.Key }); len(e) != 0 {
+		errs = append(errs, e...)
+	}
+	if earlyReturn {
+		return // do not proceed
+	}
+	func() {
+		// cohort = "{"key": "validated"}"
 		if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 			func(item *Item) bool { return item.Key == "validated" }, validate.DirectEqual,
 			func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Item) field.ErrorList {
@@ -135,6 +145,9 @@ func Validate_ItemList(
 			errs = append(errs, e...)
 		}
 	}()
+	if earlyReturn {
+		return // do not proceed
+	}
 
 	return errs
 }
@@ -150,7 +163,8 @@ func Validate_ItemListAlias(
 		func(a Item, b Item) bool { return a.Key == b.Key }); len(e) != 0 {
 		errs = append(errs, e...)
 	}
-	func() { // cohort = "{"key": "aliased"}"
+	func() {
+		// cohort = "{"key": "aliased"}"
 		if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 			func(item *Item) bool { return item.Key == "aliased" }, validate.DirectEqual,
 			func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Item) field.ErrorList {
@@ -227,7 +241,8 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "{"id": "field-target"}"
+			func() {
+				// cohort = "{"id": "field-target"}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *DualItem) bool { return item.ID == "field-target" }, validate.DirectEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *DualItem) field.ErrorList {
@@ -259,7 +274,8 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "{"id": "target"}"
+			func() {
+				// cohort = "{"id": "target"}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *DualItem) bool { return item.ID == "target" }, validate.DirectEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *DualItem) field.ErrorList {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/listmapitem/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/listmapitem/zz_generated.validations.go
@@ -81,7 +81,8 @@ func Validate_ListMapItemStruct(
 				func(a MapItem, b MapItem) bool { return a.Key == b.Key }); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			func() { // cohort = "{"key": "foo"}"
+			func() {
+				// cohort = "value@{"key": "foo"}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *MapItem) bool { return item.Key == "foo" }, validate.DirectEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *MapItem) field.ErrorList {
@@ -120,7 +121,8 @@ func Validate_ListMapItemStruct(
 				func(a MapItem, b MapItem) bool { return a.Key == b.Key }); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			func() { // cohort = "{"key": "foo"}"
+			func() {
+				// cohort = "value@{"key": "foo"}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *MapItem) bool { return item.Key == "foo" }, validate.DirectEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *MapItem) field.ErrorList {
@@ -159,7 +161,8 @@ func Validate_ListMapItemStruct(
 				func(a MapItem, b MapItem) bool { return a.Key == b.Key }); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			func() { // cohort = "{"key": "foo"}"
+			func() {
+				// cohort = "value@{"key": "foo"}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *MapItem) bool { return item.Key == "foo" }, validate.DirectEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *MapItem) field.ErrorList {
@@ -198,7 +201,8 @@ func Validate_ListMapItemStruct(
 				func(a MapItem, b MapItem) bool { return a.Key == b.Key }); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			func() { // cohort = "{"key": "foo"}"
+			func() {
+				// cohort = "value@{"key": "foo"}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *MapItem) bool { return item.Key == "foo" }, validate.DirectEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *MapItem) field.ErrorList {
@@ -237,7 +241,8 @@ func Validate_ListMapItemStruct(
 				func(a MapItem, b MapItem) bool { return a.Key == b.Key }); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			func() { // cohort = "{"key": "foo"}"
+			func() {
+				// cohort = "value@{"key": "foo"}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *MapItem) bool { return item.Key == "foo" }, validate.DirectEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *MapItem) field.ErrorList {
@@ -276,7 +281,8 @@ func Validate_ListMapItemStruct(
 				func(a MapItem, b MapItem) bool { return a.Key == b.Key }); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			func() { // cohort = "{"key": "foo"}"
+			func() {
+				// cohort = "value@{"key": "foo"}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *MapItem) bool { return item.Key == "foo" }, validate.DirectEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *MapItem) field.ErrorList {
@@ -315,7 +321,8 @@ func Validate_ListMapItemStruct(
 				func(a MapItem, b MapItem) bool { return a.Key == b.Key }); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			func() { // cohort = "{"key": "foo"}"
+			func() {
+				// cohort = "value@{"key": "foo"}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *MapItem) bool { return item.Key == "foo" }, validate.DirectEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *MapItem) field.ErrorList {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/optionalrequired/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/optionalrequired/zz_generated.validations.go
@@ -83,6 +83,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -108,6 +111,9 @@ func Validate_Struct(
 			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/simple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/simple/zz_generated.validations.go
@@ -218,14 +218,16 @@ func Validate_SpecialValidationStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -247,14 +249,16 @@ func Validate_SpecialValidationStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkBeta().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -489,14 +493,16 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -518,14 +524,16 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/simple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/simple/zz_generated.validations.go
@@ -165,6 +165,9 @@ func Validate_SpecialValidationStruct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -197,6 +200,9 @@ func Validate_SpecialValidationStruct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -218,8 +224,9 @@ func Validate_SpecialValidationStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -228,6 +235,9 @@ func Validate_SpecialValidationStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -249,8 +259,9 @@ func Validate_SpecialValidationStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -259,6 +270,9 @@ func Validate_SpecialValidationStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -395,6 +409,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -420,6 +437,9 @@ func Validate_Struct(
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 2).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -493,8 +513,9 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -503,6 +524,9 @@ func Validate_Struct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -524,8 +548,9 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -534,6 +559,9 @@ func Validate_Struct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/structs/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/structs/zz_generated.validations.go
@@ -270,6 +270,9 @@ func Validate_MixedStruct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -299,6 +302,9 @@ func Validate_MixedStruct(
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 5).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/subfields/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/subfields/zz_generated.validations.go
@@ -78,7 +78,8 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "inner"
+			func() {
+				// cohort = "inner"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "inner",
 					func(o *SubStruct) *int { return &o.Inner }, validate.DirectEqualPtr,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int) field.ErrorList {
@@ -108,7 +109,8 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "inner"
+			func() {
+				// cohort = "inner"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "inner",
 					func(o *SubStruct) *int { return &o.Inner }, validate.DirectEqualPtr,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int) field.ErrorList {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/unions/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/unions/zz_generated.validations.go
@@ -292,6 +292,9 @@ func Validate_MyStruct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -316,6 +319,9 @@ func Validate_MyStruct(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -377,6 +383,9 @@ func Validate_MyStructBeta(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -401,6 +410,9 @@ func Validate_MyStructBeta(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -469,6 +481,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -493,6 +508,9 @@ func Validate_Struct(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -561,6 +579,9 @@ func Validate_UnionStructBeta(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -585,6 +606,9 @@ func Validate_UnionStructBeta(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/zz_generated.validations.go
@@ -111,6 +111,9 @@ func Validate_Struct(
 				}); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -150,6 +153,9 @@ func Validate_Struct(
 				}); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -178,6 +184,9 @@ func Validate_Struct(
 				}, validate.DirectEqual, validate.Immutable).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -286,7 +295,8 @@ func Validate_Struct(
 				}); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			func() { // cohort = "{"key1Field": "target-ptr", "key2Field": 42}"
+			func() {
+				// cohort = "{"key1Field": "target-ptr", "key2Field": 42}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *PtrKeyStruct) bool {
 						return item.Key1Field != nil && *item.Key1Field == "target-ptr" && item.Key2Field == 42
@@ -325,7 +335,8 @@ func Validate_Struct(
 				}); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			func() { // cohort = "{"stringPtrKey": "target-ptr", "stringKey": "target"}"
+			func() {
+				// cohort = "{"stringPtrKey": "target-ptr", "stringKey": "target"}"
 				if e := validate.SliceItem(ctx, op, fldPath, obj, oldObj,
 					func(item *MixedPtrKeyStruct) bool {
 						return item.StringPtrKey != nil && *item.StringPtrKey == "target-ptr" && item.StringKey == "target"

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/zz_generated.validations.go
@@ -105,6 +105,9 @@ func Validate_Struct(
 				func(a OtherStruct, b OtherStruct) bool { return a.KeyField == b.KeyField }); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -140,6 +143,9 @@ func Validate_Struct(
 				func(a OtherTypedefStruct, b OtherTypedefStruct) bool { return a.KeyField == b.KeyField }); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -166,6 +172,9 @@ func Validate_Struct(
 				func(a OtherStruct, b OtherStruct) bool { return a.KeyField == b.KeyField }, validate.DirectEqual, validate.Immutable).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listset/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listset/zz_generated.validations.go
@@ -99,6 +99,9 @@ func Validate_ImmutableStruct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -132,6 +135,9 @@ func Validate_ImmutableStruct(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -157,6 +163,9 @@ func Validate_ImmutableStruct(
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, validate.Immutable).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -194,6 +203,9 @@ func Validate_ImmutableStruct(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.SemanticDeepEqual); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -219,6 +231,9 @@ func Validate_ImmutableStruct(
 			if e := validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, validate.Immutable).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -256,6 +271,9 @@ func Validate_ImmutableStruct(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -288,6 +306,9 @@ func Validate_ImmutableStruct(
 			// lists with set semantics require unique values
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.SemanticDeepEqual); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/slice_of_primitive/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/slice_of_primitive/zz_generated.validations.go
@@ -84,6 +84,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -109,6 +112,9 @@ func Validate_Struct(
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 10).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -142,6 +148,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -167,6 +176,9 @@ func Validate_Struct(
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 10).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/slice_of_struct/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/slice_of_struct/zz_generated.validations.go
@@ -84,6 +84,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -109,6 +112,9 @@ func Validate_Struct(
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 10).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -142,6 +148,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -167,6 +176,9 @@ func Validate_Struct(
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 10).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/typedef_to_slice/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxitems/typedef_to_slice/zz_generated.validations.go
@@ -70,6 +70,9 @@ func Validate_Max0Type(
 	if earlyReturn {
 		return // do not proceed
 	}
+	if earlyReturn {
+		return // do not proceed
+	}
 
 	return errs
 }
@@ -84,6 +87,9 @@ func Validate_Max0TypedefType(
 	if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 0).MarkShortCircuit(); len(e) != 0 {
 		errs = append(errs, e...)
 		earlyReturn = true
+	}
+	if earlyReturn {
+		return // do not proceed
 	}
 	if earlyReturn {
 		return // do not proceed
@@ -106,6 +112,9 @@ func Validate_Max10Type(
 	if earlyReturn {
 		return // do not proceed
 	}
+	if earlyReturn {
+		return // do not proceed
+	}
 
 	return errs
 }
@@ -120,6 +129,9 @@ func Validate_Max10TypedefType(
 	if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 10).MarkShortCircuit(); len(e) != 0 {
 		errs = append(errs, e...)
 		earlyReturn = true
+	}
+	if earlyReturn {
+		return // do not proceed
 	}
 	if earlyReturn {
 		return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxproperties/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxproperties/zz_generated.validations.go
@@ -84,6 +84,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -109,6 +112,9 @@ func Validate_Struct(
 			if e := validate.MaxProperties(ctx, op, fldPath, obj, oldObj, 10).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -142,6 +148,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -167,6 +176,9 @@ func Validate_Struct(
 			if e := validate.MaxProperties(ctx, op, fldPath, obj, oldObj, 10).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/zz_generated.validations.go
@@ -486,6 +486,9 @@ func Validate_NegativeMinimumStruct(
 			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, -10); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -516,6 +519,9 @@ func Validate_NegativeMinimumStruct(
 			}
 			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, -10); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -549,6 +555,9 @@ func Validate_NegativeMinimumStruct(
 			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, -10); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -580,6 +589,9 @@ func Validate_NegativeMinimumStruct(
 			}
 			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, -10); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -623,6 +635,9 @@ func Validate_OptionalStruct(
 			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -654,6 +669,9 @@ func Validate_OptionalStruct(
 			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -678,6 +696,9 @@ func Validate_OptionalStruct(
 			earlyReturn := false
 			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -708,6 +729,9 @@ func Validate_OptionalStruct(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -757,6 +781,9 @@ func Validate_RequiredStruct(
 			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -789,6 +816,9 @@ func Validate_RequiredStruct(
 			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -814,6 +844,9 @@ func Validate_RequiredStruct(
 			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -845,6 +878,9 @@ func Validate_RequiredStruct(
 			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minlength/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minlength/zz_generated.validations.go
@@ -108,6 +108,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -138,6 +141,9 @@ func Validate_Struct(
 			}
 			if e := validate.MinLength(ctx, op, fldPath, obj, oldObj, 2).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -170,6 +176,9 @@ func Validate_Struct(
 			if e := validate.MinLength(ctx, op, fldPath, obj, oldObj, 2).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -200,6 +209,9 @@ func Validate_Struct(
 			}
 			if e := validate.MinLength(ctx, op, fldPath, obj, oldObj, 10).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -232,6 +244,9 @@ func Validate_Struct(
 			if e := validate.MinLength(ctx, op, fldPath, obj, oldObj, 10).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -262,6 +277,9 @@ func Validate_Struct(
 			}
 			if e := validate.MinLength(ctx, op, fldPath, obj, oldObj, 2).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -294,6 +312,9 @@ func Validate_Struct(
 			if e := validate.MinLength(ctx, op, fldPath, obj, oldObj, 2).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -324,6 +345,9 @@ func Validate_Struct(
 			}
 			if e := validate.MinLength(ctx, op, fldPath, obj, oldObj, 10).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -356,6 +380,9 @@ func Validate_Struct(
 			if e := validate.MinLength(ctx, op, fldPath, obj, oldObj, 10).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -380,6 +407,9 @@ func Validate_Struct(
 			earlyReturn := false
 			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -414,6 +444,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_Min2Type(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -444,6 +477,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_Min10Type(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -470,6 +506,9 @@ func Validate_Struct(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -507,6 +546,9 @@ func Validate_Struct(
 			if e := validate.MinLength(ctx, op, fldPath, obj, oldObj, 2).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -537,6 +579,9 @@ func Validate_Struct(
 			}
 			if e := validate.MinLength(ctx, op, fldPath, obj, oldObj, 2).MarkAlpha(); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/neq/neq/neqchained/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/neq/neq/neqchained/zz_generated.validations.go
@@ -76,7 +76,8 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "stringField"
+			func() {
+				// cohort = "stringField"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "stringField",
 					func(o *InnerStruct) *string { return &o.StringField }, validate.DirectEqualPtr,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
@@ -113,7 +114,11 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
-			func() { // cohort = "stringField"
+			if earlyReturn {
+				return // do not proceed
+			}
+			func() {
+				// cohort = "stringField"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "stringField",
 					func(o *InnerStruct) *string { return &o.StringField }, validate.DirectEqualPtr,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
@@ -122,6 +127,9 @@ func Validate_Struct(
 					errs = append(errs, e...)
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -265,7 +273,8 @@ func Validate_ValidatedInnerStruct(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *ValidatedInnerStruct) (errs field.ErrorList) {
 
-	func() { // cohort = "stringField"
+	func() {
+		// cohort = "stringField"
 		if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "stringField",
 			func(o *ValidatedInnerStruct) *string { return &o.StringField }, validate.DirectEqualPtr,
 			func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/zz_generated.validations.go
@@ -223,6 +223,9 @@ func Validate_Struct(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StructPtrField"); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_OtherStruct(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -280,6 +283,9 @@ func Validate_Struct(
 			}
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.OpaqueStructPtrField"); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/nonzero_defaults/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/nonzero_defaults/zz_generated.validations.go
@@ -84,6 +84,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -110,6 +113,9 @@ func Validate_Struct(
 			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -144,6 +150,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -170,6 +179,9 @@ func Validate_Struct(
 			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -204,6 +216,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -230,6 +245,9 @@ func Validate_Struct(
 			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/zero_defaults/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/zero_defaults/zz_generated.validations.go
@@ -99,6 +99,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -144,6 +147,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -185,6 +191,9 @@ func Validate_Struct(
 			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/zz_generated.validations.go
@@ -151,6 +151,9 @@ func Validate_Struct(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StringField"); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -182,6 +185,9 @@ func Validate_Struct(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StringPtrField"); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -212,6 +218,9 @@ func Validate_Struct(
 			}
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StringTypedefField"); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_StringType(ctx, op, fldPath, obj, oldObj)...)
@@ -246,6 +255,9 @@ func Validate_Struct(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StringTypedefPtrField"); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_StringType(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -279,6 +291,9 @@ func Validate_Struct(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.IntField"); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -310,6 +325,9 @@ func Validate_Struct(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.IntPtrField"); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -340,6 +358,9 @@ func Validate_Struct(
 			}
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.IntTypedefField"); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_IntType(ctx, op, fldPath, obj, oldObj)...)
@@ -374,6 +395,9 @@ func Validate_Struct(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.IntTypedefPtrField"); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_IntType(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -406,6 +430,9 @@ func Validate_Struct(
 			}
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.OtherStructPtrField"); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_OtherStruct(ctx, op, fldPath, obj, oldObj)...)
@@ -440,6 +467,9 @@ func Validate_Struct(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.SliceField"); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -470,6 +500,9 @@ func Validate_Struct(
 			}
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.SliceTypedefField"); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_SliceType(ctx, op, fldPath, obj, oldObj)...)
@@ -504,6 +537,9 @@ func Validate_Struct(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField"); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -534,6 +570,9 @@ func Validate_Struct(
 			}
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField"); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_MapType(ctx, op, fldPath, obj, oldObj)...)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/options/update/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/options/update/zz_generated.validations.go
@@ -83,6 +83,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -108,6 +111,9 @@ func Validate_Struct(
 			if e := validate.IfOption(ctx, op, fldPath, obj, oldObj, "FeatureX", false, validate.Immutable).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -144,6 +150,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -172,6 +181,9 @@ func Validate_Struct(
 				}).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/required/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/required/zz_generated.validations.go
@@ -152,6 +152,9 @@ func Validate_Struct(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StringField"); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -184,6 +187,9 @@ func Validate_Struct(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StringPtrField"); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -215,6 +221,9 @@ func Validate_Struct(
 			}
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StringTypedefField"); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_StringType(ctx, op, fldPath, obj, oldObj)...)
@@ -250,6 +259,9 @@ func Validate_Struct(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.StringTypedefPtrField"); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_StringType(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -284,6 +296,9 @@ func Validate_Struct(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.IntField"); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -316,6 +331,9 @@ func Validate_Struct(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.IntPtrField"); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -347,6 +365,9 @@ func Validate_Struct(
 			}
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.IntTypedefField"); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_IntType(ctx, op, fldPath, obj, oldObj)...)
@@ -382,6 +403,9 @@ func Validate_Struct(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.IntTypedefPtrField"); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_IntType(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -416,6 +440,9 @@ func Validate_Struct(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.BoolField"); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -447,6 +474,9 @@ func Validate_Struct(
 			}
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.FloatField"); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}
@@ -480,6 +510,9 @@ func Validate_Struct(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ByteField"); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -511,6 +544,9 @@ func Validate_Struct(
 			}
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.OtherStructPtrField"); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_OtherStruct(ctx, op, fldPath, obj, oldObj)...)
@@ -546,6 +582,9 @@ func Validate_Struct(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.SliceField"); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -577,6 +616,9 @@ func Validate_Struct(
 			}
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.SliceTypedefField"); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_SliceType(ctx, op, fldPath, obj, oldObj)...)
@@ -612,6 +654,9 @@ func Validate_Struct(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ByteArrayField"); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -644,6 +689,9 @@ func Validate_Struct(
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapField"); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -675,6 +723,9 @@ func Validate_Struct(
 			}
 			if e := validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.MapTypedefField"); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_MapType(ctx, op, fldPath, obj, oldObj)...)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/deep/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/deep/zz_generated.validations.go
@@ -76,7 +76,8 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "structField"
+			func() {
+				// cohort = "stringField@structField"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "structField",
 					func(o *OtherStruct) *SmallStruct { return &o.StructField }, validate.DirectEqualPtr,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *SmallStruct) field.ErrorList {
@@ -100,7 +101,8 @@ func Validate_Struct(
 					errs = append(errs, e...)
 				}
 			}()
-			func() { // cohort = "sliceField"
+			func() {
+				// cohort = "sliceField"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "sliceField",
 					func(o *OtherStruct) []SmallStruct { return o.SliceField }, validate.SemanticDeepEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []SmallStruct) field.ErrorList {
@@ -116,7 +118,8 @@ func Validate_Struct(
 					errs = append(errs, e...)
 				}
 			}()
-			func() { // cohort = "mapField"
+			func() {
+				// cohort = "mapField"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "mapField",
 					func(o *OtherStruct) map[string]SmallStruct { return o.MapField }, validate.SemanticDeepEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]SmallStruct) field.ErrorList {
@@ -153,7 +156,8 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "structField"
+			func() {
+				// cohort = "stringField@structField"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "structField",
 					func(o *OtherStruct) *SmallStruct { return &o.StructField }, validate.DirectEqualPtr,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *SmallStruct) field.ErrorList {
@@ -177,7 +181,8 @@ func Validate_Struct(
 					errs = append(errs, e...)
 				}
 			}()
-			func() { // cohort = "sliceField"
+			func() {
+				// cohort = "sliceField"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "sliceField",
 					func(o *OtherStruct) []SmallStruct { return o.SliceField }, validate.SemanticDeepEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []SmallStruct) field.ErrorList {
@@ -193,7 +198,8 @@ func Validate_Struct(
 					errs = append(errs, e...)
 				}
 			}()
-			func() { // cohort = "mapField"
+			func() {
+				// cohort = "mapField"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "mapField",
 					func(o *OtherStruct) map[string]SmallStruct { return o.MapField }, validate.SemanticDeepEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]SmallStruct) field.ErrorList {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/list/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/list/zz_generated.validations.go
@@ -77,7 +77,8 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "labels"
+			func() {
+				// cohort = "labels"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "labels",
 					func(o *v1.ObjectMeta) map[string]string { return o.Labels }, validate.SemanticDeepEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]string) field.ErrorList {
@@ -89,7 +90,8 @@ func Validate_Struct(
 					errs = append(errs, e...)
 				}
 			}()
-			func() { // cohort = "ownerReferences"
+			func() {
+				// cohort = "ownerReferences"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "ownerReferences",
 					func(o *v1.ObjectMeta) []v1.OwnerReference { return o.OwnerReferences }, validate.SemanticDeepEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []v1.OwnerReference) field.ErrorList {
@@ -114,7 +116,8 @@ func Validate_Struct(
 					errs = append(errs, e...)
 				}
 			}()
-			func() { // cohort = "finalizers"
+			func() {
+				// cohort = "finalizers"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "finalizers",
 					func(o *v1.ObjectMeta) []string { return o.Finalizers }, validate.SemanticDeepEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []string) field.ErrorList {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/nonincluded/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/nonincluded/zz_generated.validations.go
@@ -74,7 +74,8 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "stringField"
+			func() {
+				// cohort = "stringField"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "stringField",
 					func(o *other.StructType) *string { return &o.StringField }, validate.DirectEqualPtr,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/shallow/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/shallow/zz_generated.validations.go
@@ -76,7 +76,8 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "stringField"
+			func() {
+				// cohort = "stringField"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "stringField",
 					func(o *OtherStruct) *string { return &o.StringField }, validate.DirectEqualPtr,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
@@ -92,7 +93,8 @@ func Validate_Struct(
 					errs = append(errs, e...)
 				}
 			}()
-			func() { // cohort = "pointerField"
+			func() {
+				// cohort = "pointerField"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "pointerField",
 					func(o *OtherStruct) *string { return o.PointerField }, validate.DirectEqualPtr,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
@@ -101,7 +103,8 @@ func Validate_Struct(
 					errs = append(errs, e...)
 				}
 			}()
-			func() { // cohort = "structField"
+			func() {
+				// cohort = "structField"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "structField",
 					func(o *OtherStruct) *SmallStruct { return &o.StructField }, validate.DirectEqualPtr,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *SmallStruct) field.ErrorList {
@@ -110,7 +113,8 @@ func Validate_Struct(
 					errs = append(errs, e...)
 				}
 			}()
-			func() { // cohort = "sliceField"
+			func() {
+				// cohort = "sliceField"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "sliceField",
 					func(o *OtherStruct) []string { return o.SliceField }, validate.SemanticDeepEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []string) field.ErrorList {
@@ -119,7 +123,8 @@ func Validate_Struct(
 					errs = append(errs, e...)
 				}
 			}()
-			func() { // cohort = "mapField"
+			func() {
+				// cohort = "mapField"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "mapField",
 					func(o *OtherStruct) map[string]string { return o.MapField }, validate.SemanticDeepEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]string) field.ErrorList {
@@ -149,7 +154,8 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "stringField"
+			func() {
+				// cohort = "stringField"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "stringField",
 					func(o *OtherStruct) *string { return &o.StringField }, validate.DirectEqualPtr,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
@@ -165,7 +171,8 @@ func Validate_Struct(
 					errs = append(errs, e...)
 				}
 			}()
-			func() { // cohort = "pointerField"
+			func() {
+				// cohort = "pointerField"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "pointerField",
 					func(o *OtherStruct) *string { return o.PointerField }, validate.DirectEqualPtr,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
@@ -174,7 +181,8 @@ func Validate_Struct(
 					errs = append(errs, e...)
 				}
 			}()
-			func() { // cohort = "structField"
+			func() {
+				// cohort = "structField"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "structField",
 					func(o *OtherStruct) *SmallStruct { return &o.StructField }, validate.DirectEqualPtr,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *SmallStruct) field.ErrorList {
@@ -183,7 +191,8 @@ func Validate_Struct(
 					errs = append(errs, e...)
 				}
 			}()
-			func() { // cohort = "sliceField"
+			func() {
+				// cohort = "sliceField"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "sliceField",
 					func(o *OtherStruct) []string { return o.SliceField }, validate.SemanticDeepEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj []string) field.ErrorList {
@@ -192,7 +201,8 @@ func Validate_Struct(
 					errs = append(errs, e...)
 				}
 			}()
-			func() { // cohort = "mapField"
+			func() {
+				// cohort = "mapField"
 				if e := validate.Subfield(ctx, op, fldPath, obj, oldObj, "mapField",
 					func(o *OtherStruct) map[string]string { return o.MapField }, validate.SemanticDeepEqual,
 					func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj map[string]string) field.ErrorList {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/custom_members/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/custom_members/zz_generated.validations.go
@@ -107,6 +107,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -131,6 +134,9 @@ func Validate_Struct(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/multiple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/multiple/zz_generated.validations.go
@@ -129,6 +129,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -153,6 +156,9 @@ func Validate_Struct(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -187,6 +193,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -211,6 +220,9 @@ func Validate_Struct(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/simple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/simple/zz_generated.validations.go
@@ -120,6 +120,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -144,6 +147,9 @@ func Validate_Struct(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -176,6 +182,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -200,6 +209,9 @@ func Validate_Struct(
 			earlyReturn := false
 			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/sparse/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/discriminated/sparse/zz_generated.validations.go
@@ -101,6 +101,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/undiscriminated/custom_members/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/undiscriminated/custom_members/zz_generated.validations.go
@@ -101,6 +101,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -125,6 +128,9 @@ func Validate_Struct(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/undiscriminated/multiple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/undiscriminated/multiple/zz_generated.validations.go
@@ -117,6 +117,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -141,6 +144,9 @@ func Validate_Struct(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -173,6 +179,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -197,6 +206,9 @@ func Validate_Struct(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/undiscriminated/simple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/undiscriminated/simple/zz_generated.validations.go
@@ -127,6 +127,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -151,6 +154,9 @@ func Validate_Struct(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -183,6 +189,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -207,6 +216,9 @@ func Validate_Struct(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -239,6 +251,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -263,6 +278,9 @@ func Validate_Struct(
 			earlyReturn := false
 			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/update/lists/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/update/lists/zz_generated.validations.go
@@ -91,14 +91,16 @@ func Validate_UpdateListStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj, nil, validate.NoSet).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj, nil, validate.NoSet).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -120,14 +122,16 @@ func Validate_UpdateListStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj, nil, validate.NoUnset).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj, nil, validate.NoUnset).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -149,18 +153,20 @@ func Validate_UpdateListStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj, validate.DirectEqual, validate.NoAddItem).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
 			// lists with set semantics require unique values
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj, validate.DirectEqual, validate.NoAddItem).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -182,18 +188,20 @@ func Validate_UpdateListStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj, validate.DirectEqual, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
 			// lists with set semantics require unique values
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj, validate.DirectEqual, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -215,18 +223,20 @@ func Validate_UpdateListStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj, validate.DirectEqual, validate.NoAddItem, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
 			// lists with set semantics require unique values
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj, validate.DirectEqual, validate.NoAddItem, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -248,20 +258,22 @@ func Validate_UpdateListStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj,
-				func(a UpdateItem, b UpdateItem) bool { return a.Name == b.Name }, validate.NoAddItem).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
 			// lists with map semantics require unique keys
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
 				func(a UpdateItem, b UpdateItem) bool { return a.Name == b.Name }); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj,
+					func(a UpdateItem, b UpdateItem) bool { return a.Name == b.Name }, validate.NoAddItem).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -283,20 +295,22 @@ func Validate_UpdateListStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj,
-				func(a UpdateItem, b UpdateItem) bool { return a.Name == b.Name }, validate.NoAddItem, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
 			// lists with map semantics require unique keys
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
 				func(a UpdateItem, b UpdateItem) bool { return a.Name == b.Name }); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj,
+					func(a UpdateItem, b UpdateItem) bool { return a.Name == b.Name }, validate.NoAddItem, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -318,20 +332,22 @@ func Validate_UpdateListStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj,
-				func(a CompositeKeyItem, b CompositeKeyItem) bool { return a.Name == b.Name && a.Priority == b.Priority }, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
 			// lists with map semantics require unique keys
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
 				func(a CompositeKeyItem, b CompositeKeyItem) bool { return a.Name == b.Name && a.Priority == b.Priority }); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj,
+					func(a CompositeKeyItem, b CompositeKeyItem) bool { return a.Name == b.Name && a.Priority == b.Priority }, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -353,18 +369,20 @@ func Validate_UpdateListStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj, validate.DirectEqual, validate.NoAddItem).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
 			// lists with set semantics require unique values
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj, validate.DirectEqual, validate.NoAddItem).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -386,20 +404,22 @@ func Validate_UpdateListStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj,
-				func(a UpdateItem, b UpdateItem) bool { return a.Name == b.Name }, validate.NoAddItem, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
 			// lists with map semantics require unique keys
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
 				func(a UpdateItem, b UpdateItem) bool { return a.Name == b.Name }); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj,
+					func(a UpdateItem, b UpdateItem) bool { return a.Name == b.Name }, validate.NoAddItem, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -421,18 +441,20 @@ func Validate_UpdateListStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj, validate.SemanticDeepEqual, validate.NoAddItem, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
 			// lists with set semantics require unique values
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.SemanticDeepEqual); len(e) != 0 {
 				errs = append(errs, e...)
 			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj, validate.SemanticDeepEqual, validate.NoAddItem, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -454,15 +476,17 @@ func Validate_UpdateListStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj,
-				func(a UpdateItem, b UpdateItem) bool { return a.Name == b.Name }, validate.NoAddItem, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj,
+					func(a UpdateItem, b UpdateItem) bool { return a.Name == b.Name }, validate.NoAddItem, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			// call the type's validation function
 			errs = append(errs, Validate_FrozenUserList(ctx, op, fldPath, obj, oldObj)...)
 			return

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/update/lists/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/update/lists/zz_generated.validations.go
@@ -91,8 +91,9 @@ func Validate_UpdateListStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj, nil, validate.NoSet).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -101,6 +102,9 @@ func Validate_UpdateListStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -122,8 +126,9 @@ func Validate_UpdateListStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj, nil, validate.NoUnset).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -132,6 +137,9 @@ func Validate_UpdateListStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -153,12 +161,9 @@ func Validate_UpdateListStruct(
 				}
 			}
 			// call field-attached validations
-			// lists with set semantics require unique values
-			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual); len(e) != 0 {
-				errs = append(errs, e...)
-			}
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj, validate.DirectEqual, validate.NoAddItem).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -167,6 +172,16 @@ func Validate_UpdateListStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
+			// lists with set semantics require unique values
+			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -188,12 +203,9 @@ func Validate_UpdateListStruct(
 				}
 			}
 			// call field-attached validations
-			// lists with set semantics require unique values
-			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual); len(e) != 0 {
-				errs = append(errs, e...)
-			}
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj, validate.DirectEqual, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -202,6 +214,16 @@ func Validate_UpdateListStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
+			// lists with set semantics require unique values
+			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -223,12 +245,9 @@ func Validate_UpdateListStruct(
 				}
 			}
 			// call field-attached validations
-			// lists with set semantics require unique values
-			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual); len(e) != 0 {
-				errs = append(errs, e...)
-			}
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj, validate.DirectEqual, validate.NoAddItem, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -237,6 +256,16 @@ func Validate_UpdateListStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
+			// lists with set semantics require unique values
+			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -258,13 +287,9 @@ func Validate_UpdateListStruct(
 				}
 			}
 			// call field-attached validations
-			// lists with map semantics require unique keys
-			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
-				func(a UpdateItem, b UpdateItem) bool { return a.Name == b.Name }); len(e) != 0 {
-				errs = append(errs, e...)
-			}
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj,
 					func(a UpdateItem, b UpdateItem) bool { return a.Name == b.Name }, validate.NoAddItem).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
@@ -274,6 +299,17 @@ func Validate_UpdateListStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
+			// lists with map semantics require unique keys
+			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
+				func(a UpdateItem, b UpdateItem) bool { return a.Name == b.Name }); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -295,13 +331,9 @@ func Validate_UpdateListStruct(
 				}
 			}
 			// call field-attached validations
-			// lists with map semantics require unique keys
-			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
-				func(a UpdateItem, b UpdateItem) bool { return a.Name == b.Name }); len(e) != 0 {
-				errs = append(errs, e...)
-			}
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj,
 					func(a UpdateItem, b UpdateItem) bool { return a.Name == b.Name }, validate.NoAddItem, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
@@ -311,6 +343,17 @@ func Validate_UpdateListStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
+			// lists with map semantics require unique keys
+			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
+				func(a UpdateItem, b UpdateItem) bool { return a.Name == b.Name }); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -332,13 +375,9 @@ func Validate_UpdateListStruct(
 				}
 			}
 			// call field-attached validations
-			// lists with map semantics require unique keys
-			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
-				func(a CompositeKeyItem, b CompositeKeyItem) bool { return a.Name == b.Name && a.Priority == b.Priority }); len(e) != 0 {
-				errs = append(errs, e...)
-			}
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj,
 					func(a CompositeKeyItem, b CompositeKeyItem) bool { return a.Name == b.Name && a.Priority == b.Priority }, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
@@ -348,6 +387,17 @@ func Validate_UpdateListStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
+			// lists with map semantics require unique keys
+			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
+				func(a CompositeKeyItem, b CompositeKeyItem) bool { return a.Name == b.Name && a.Priority == b.Priority }); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -369,12 +419,9 @@ func Validate_UpdateListStruct(
 				}
 			}
 			// call field-attached validations
-			// lists with set semantics require unique values
-			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual); len(e) != 0 {
-				errs = append(errs, e...)
-			}
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj, validate.DirectEqual, validate.NoAddItem).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -383,6 +430,16 @@ func Validate_UpdateListStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
+			// lists with set semantics require unique values
+			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.DirectEqual); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -404,13 +461,9 @@ func Validate_UpdateListStruct(
 				}
 			}
 			// call field-attached validations
-			// lists with map semantics require unique keys
-			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
-				func(a UpdateItem, b UpdateItem) bool { return a.Name == b.Name }); len(e) != 0 {
-				errs = append(errs, e...)
-			}
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj,
 					func(a UpdateItem, b UpdateItem) bool { return a.Name == b.Name }, validate.NoAddItem, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
@@ -420,6 +473,17 @@ func Validate_UpdateListStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
+			// lists with map semantics require unique keys
+			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
+				func(a UpdateItem, b UpdateItem) bool { return a.Name == b.Name }); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -441,12 +505,9 @@ func Validate_UpdateListStruct(
 				}
 			}
 			// call field-attached validations
-			// lists with set semantics require unique values
-			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.SemanticDeepEqual); len(e) != 0 {
-				errs = append(errs, e...)
-			}
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj, validate.SemanticDeepEqual, validate.NoAddItem, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -455,6 +516,16 @@ func Validate_UpdateListStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
+			// lists with set semantics require unique values
+			if e := validate.Unique(ctx, op, fldPath, obj, oldObj, validate.SemanticDeepEqual); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -476,8 +547,9 @@ func Validate_UpdateListStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj,
 					func(a UpdateItem, b UpdateItem) bool { return a.Name == b.Name }, validate.NoAddItem, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
@@ -487,6 +559,9 @@ func Validate_UpdateListStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			// call the type's validation function
 			errs = append(errs, Validate_FrozenUserList(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -526,6 +601,9 @@ func Validate_UpdateListStruct(
 			if e := validate.Unique(ctx, op, fldPath, obj, oldObj,
 				func(a UpdateItem, b UpdateItem) bool { return a.Name == b.Name }); len(e) != 0 {
 				errs = append(errs, e...)
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			return
 		}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/update/maps/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/update/maps/zz_generated.validations.go
@@ -76,14 +76,16 @@ func Validate_UpdateMapStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateMap(ctx, op, fldPath, obj, oldObj, validate.NoSet).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateMap(ctx, op, fldPath, obj, oldObj, validate.NoSet).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -105,14 +107,16 @@ func Validate_UpdateMapStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateMap(ctx, op, fldPath, obj, oldObj, validate.NoUnset).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateMap(ctx, op, fldPath, obj, oldObj, validate.NoUnset).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -134,14 +138,16 @@ func Validate_UpdateMapStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateMap(ctx, op, fldPath, obj, oldObj, validate.NoAddItem).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateMap(ctx, op, fldPath, obj, oldObj, validate.NoAddItem).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -163,14 +169,16 @@ func Validate_UpdateMapStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateMap(ctx, op, fldPath, obj, oldObj, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateMap(ctx, op, fldPath, obj, oldObj, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -192,14 +200,16 @@ func Validate_UpdateMapStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateMap(ctx, op, fldPath, obj, oldObj, validate.NoAddItem, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateMap(ctx, op, fldPath, obj, oldObj, validate.NoAddItem, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -221,14 +231,16 @@ func Validate_UpdateMapStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateMap(ctx, op, fldPath, obj, oldObj, validate.NoSet, validate.NoAddItem).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateMap(ctx, op, fldPath, obj, oldObj, validate.NoSet, validate.NoAddItem).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/update/maps/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/update/maps/zz_generated.validations.go
@@ -76,8 +76,9 @@ func Validate_UpdateMapStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateMap(ctx, op, fldPath, obj, oldObj, validate.NoSet).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -86,6 +87,9 @@ func Validate_UpdateMapStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -107,8 +111,9 @@ func Validate_UpdateMapStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateMap(ctx, op, fldPath, obj, oldObj, validate.NoUnset).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -117,6 +122,9 @@ func Validate_UpdateMapStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -138,8 +146,9 @@ func Validate_UpdateMapStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateMap(ctx, op, fldPath, obj, oldObj, validate.NoAddItem).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -148,6 +157,9 @@ func Validate_UpdateMapStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -169,8 +181,9 @@ func Validate_UpdateMapStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateMap(ctx, op, fldPath, obj, oldObj, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -179,6 +192,9 @@ func Validate_UpdateMapStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -200,8 +216,9 @@ func Validate_UpdateMapStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateMap(ctx, op, fldPath, obj, oldObj, validate.NoAddItem, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -210,6 +227,9 @@ func Validate_UpdateMapStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -231,8 +251,9 @@ func Validate_UpdateMapStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateMap(ctx, op, fldPath, obj, oldObj, validate.NoSet, validate.NoAddItem).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -241,6 +262,9 @@ func Validate_UpdateMapStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -269,6 +293,9 @@ func Validate_UpdateMapStruct(
 				}).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/update/primitives/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/update/primitives/zz_generated.validations.go
@@ -76,14 +76,16 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoSet).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoSet).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -105,14 +107,16 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoUnset).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoUnset).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -134,14 +138,16 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -163,14 +169,16 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoSet, validate.NoUnset, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoSet, validate.NoUnset, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -192,14 +200,16 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoUnset, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoUnset, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -221,14 +231,16 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -250,14 +262,16 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -279,14 +293,16 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -308,14 +324,16 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -337,14 +355,16 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -366,14 +386,16 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -395,14 +417,16 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -424,14 +448,16 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -453,14 +479,16 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateStruct(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateStruct(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -482,14 +510,16 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateStruct(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateStruct(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -511,14 +541,16 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoSet).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoSet).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -540,14 +572,16 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoUnset).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoUnset).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -569,14 +603,16 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -598,14 +634,16 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoSet, validate.NoUnset, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoSet, validate.NoUnset, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -627,14 +665,16 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -656,14 +696,16 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -685,14 +727,16 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -714,14 +758,16 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -743,14 +789,16 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoSet).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoSet).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/update/primitives/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/update/primitives/zz_generated.validations.go
@@ -76,8 +76,9 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoSet).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -86,6 +87,9 @@ func Validate_UpdateTestStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -107,8 +111,9 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoUnset).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -117,6 +122,9 @@ func Validate_UpdateTestStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -138,8 +146,9 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -148,6 +157,9 @@ func Validate_UpdateTestStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -169,8 +181,9 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoSet, validate.NoUnset, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -179,6 +192,9 @@ func Validate_UpdateTestStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -200,8 +216,9 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoUnset, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -210,6 +227,9 @@ func Validate_UpdateTestStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -231,8 +251,9 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -241,6 +262,9 @@ func Validate_UpdateTestStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -262,8 +286,9 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -272,6 +297,9 @@ func Validate_UpdateTestStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -293,8 +321,9 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -303,6 +332,9 @@ func Validate_UpdateTestStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -324,8 +356,9 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -334,6 +367,9 @@ func Validate_UpdateTestStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -355,8 +391,9 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -365,6 +402,9 @@ func Validate_UpdateTestStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -386,8 +426,9 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -396,6 +437,9 @@ func Validate_UpdateTestStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -417,8 +461,9 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -427,6 +472,9 @@ func Validate_UpdateTestStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -448,8 +496,9 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -458,6 +507,9 @@ func Validate_UpdateTestStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -479,8 +531,9 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateStruct(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -489,6 +542,9 @@ func Validate_UpdateTestStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -510,8 +566,9 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateStruct(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -520,6 +577,9 @@ func Validate_UpdateTestStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -541,8 +601,9 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoSet).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -551,6 +612,9 @@ func Validate_UpdateTestStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -572,8 +636,9 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoUnset).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -582,6 +647,9 @@ func Validate_UpdateTestStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -603,8 +671,9 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -613,6 +682,9 @@ func Validate_UpdateTestStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -634,8 +706,9 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoSet, validate.NoUnset, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -644,6 +717,9 @@ func Validate_UpdateTestStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -665,8 +741,9 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -675,6 +752,9 @@ func Validate_UpdateTestStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -696,8 +776,9 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -706,6 +787,9 @@ func Validate_UpdateTestStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -727,8 +811,9 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -737,6 +822,9 @@ func Validate_UpdateTestStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -758,8 +846,9 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoModify).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -768,6 +857,9 @@ func Validate_UpdateTestStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -789,8 +881,9 @@ func Validate_UpdateTestStruct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoSet).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -799,6 +892,9 @@ func Validate_UpdateTestStruct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/zerooroneof/zerooroneof/custom_members/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/zerooroneof/zerooroneof/custom_members/zz_generated.validations.go
@@ -101,6 +101,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -125,6 +128,9 @@ func Validate_Struct(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/zerooroneof/zerooroneof/multiple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/zerooroneof/zerooroneof/multiple/zz_generated.validations.go
@@ -117,6 +117,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -141,6 +144,9 @@ func Validate_Struct(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -173,6 +179,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -197,6 +206,9 @@ func Validate_Struct(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/zerooroneof/zerooroneof/simple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/zerooroneof/zerooroneof/simple/zz_generated.validations.go
@@ -114,6 +114,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -138,6 +141,9 @@ func Validate_Struct(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed
@@ -170,6 +176,9 @@ func Validate_Struct(
 			if earlyReturn {
 				return // do not proceed
 			}
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -194,6 +203,9 @@ func Validate_Struct(
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			if earlyReturn {
 				return // do not proceed

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitive_pointers/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitive_pointers/zz_generated.validations.go
@@ -73,14 +73,16 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -102,14 +104,16 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -131,14 +135,16 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -160,14 +166,16 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitive_pointers/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitive_pointers/zz_generated.validations.go
@@ -73,8 +73,9 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -83,6 +84,9 @@ func Validate_Struct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -104,8 +108,9 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -114,6 +119,9 @@ func Validate_Struct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -135,8 +143,9 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -145,6 +154,9 @@ func Validate_Struct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -166,8 +178,9 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -176,6 +189,9 @@ func Validate_Struct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitives/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitives/zz_generated.validations.go
@@ -73,14 +73,16 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -102,14 +104,16 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -131,14 +135,16 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -160,14 +166,16 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
+			func() { // cohort = "update"
+				earlyReturn := false
+				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+					errs = append(errs, e...)
+					earlyReturn = true
+				}
+				if earlyReturn {
+					return // do not proceed
+				}
+			}()
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitives/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitives/zz_generated.validations.go
@@ -73,8 +73,9 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -83,6 +84,9 @@ func Validate_Struct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -104,8 +108,9 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -114,6 +119,9 @@ func Validate_Struct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -135,8 +143,9 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -145,6 +154,9 @@ func Validate_Struct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -166,8 +178,9 @@ func Validate_Struct(
 				}
 			}
 			// call field-attached validations
-			func() { // cohort = "update"
-				earlyReturn := false
+			earlyReturn := false
+			func() {
+				// cohort = "update"
 				if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 					errs = append(errs, e...)
 					earlyReturn = true
@@ -176,6 +189,9 @@ func Validate_Struct(
 					return // do not proceed
 				}
 			}()
+			if earlyReturn {
+				return // do not proceed
+			}
 			return
 		}
 		oldVal := safe.Field(oldObj,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -1520,6 +1520,13 @@ func emitCallsToValidators(c *generator.Context, validations []validators.Functi
 // calls are handled before others. The first cohort is always the
 // default cohort (named "") if it exists. Other cohorts are returned in
 // the order they were defined in the input.
+//
+// NOTE: There should be exactly two cohorts: the default cohort (for structural
+// validity checks like required/maxItems) and the update cohort (for
+// update-constraint checks like immutable). These two represent orthogonal
+// concerns: "is this value structurally valid?" vs "was this value illegally
+// modified?". Adding more cohorts would make the short-circuit semantics harder
+// to reason about and should be avoided.
 func sortIntoCohorts(in []validators.FunctionGen) [][]validators.FunctionGen {
 	defaultCohort := make([]validators.FunctionGen, 0, len(in))
 	namedCohorts := map[string][]validators.FunctionGen{}
@@ -1535,9 +1542,30 @@ func sortIntoCohorts(in []validators.FunctionGen) [][]validators.FunctionGen {
 			namedCohorts[key] = append(namedCohorts[key], fg)
 		}
 	}
-	if len(defaultCohort) > 0 {
-		idx = append([]string{""}, idx...)
+	// Special handling for the "update" cohort: it should always run before the
+	// default cohort. This ensures that update-related constraints (like
+	// +k8s:immutable) take precedence and short-circuit structural checks
+	// (like +k8s:required) if they fail, matching the behavior described in
+	// the UpdateCohort documentation.
+	updateIdx := -1
+	for i, key := range idx {
+		if key == validators.UpdateCohort {
+			updateIdx = i
+			break
+		}
 	}
+
+	newIdx := make([]string, 0, len(idx)+1)
+	if updateIdx != -1 {
+		newIdx = append(newIdx, validators.UpdateCohort)
+		// remove it from old idx so we don't add it again
+		idx = append(idx[:updateIdx], idx[updateIdx+1:]...)
+	}
+	if len(defaultCohort) > 0 {
+		newIdx = append(newIdx, "")
+	}
+	newIdx = append(newIdx, idx...)
+	idx = newIdx
 	// NOTE: we do not sort cohorts by name, because we want to preserve
 	// their definition order.
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -1393,10 +1393,28 @@ func emitCallsToValidators(c *generator.Context, validations []validators.Functi
 	// Group and sort the inputs.
 	cohorts := sortIntoCohorts(validations)
 
-	for _, validations := range cohorts {
+	hasAnyShortCircuit := false
+	for _, cohort := range cohorts {
+		for _, v := range cohort {
+			if v.Flags.IsSet(validators.ShortCircuit) {
+				hasAnyShortCircuit = true
+				break
+			}
+		}
+		if hasAnyShortCircuit {
+			break
+		}
+	}
+
+	if hasAnyShortCircuit {
+		sw.Do("earlyReturn := false\n", nil)
+	}
+
+	for i, validations := range cohorts {
 		cohortName := validations[0].Cohort
 		if cohortName != "" {
-			sw.Do("func() { // cohort = \"$.$\"\n", cohortName)
+			sw.Do("func() {\n", nil)
+			sw.Do("  // cohort = \"$.$\"\n", cohortName)
 		}
 
 		hasShortCircuits := false
@@ -1406,10 +1424,6 @@ func emitCallsToValidators(c *generator.Context, validations []validators.Functi
 				hasShortCircuits = true
 				lastShortCircuitIdx = i
 			}
-		}
-
-		if hasShortCircuits {
-			sw.Do("earlyReturn := false\n", nil)
 		}
 
 		for i, v := range validations {
@@ -1491,7 +1505,8 @@ func emitCallsToValidators(c *generator.Context, validations []validators.Functi
 				sw.Do("  earlyReturn = true\n", nil)
 				sw.Do("}\n", nil)
 
-				// Check for early return ONLY after the LAST short-circuit
+				// Check for early return ONLY after the LAST short-circuit in THIS cohort.
+				// This stops processing WITHIN the cohort (e.g. stop structural checks if required fails).
 				if hasShortCircuits && i == lastShortCircuitIdx {
 					sw.Do("if earlyReturn {\n", nil)
 					sw.Do("  return // do not proceed\n", nil)
@@ -1512,82 +1527,76 @@ func emitCallsToValidators(c *generator.Context, validations []validators.Functi
 		if cohortName != "" {
 			sw.Do("}()\n", nil)
 		}
+
+		// After each cohort, decide if we should stop entirely.
+		// We only stop entirely if we have completed the "update" stage and found errors,
+		// OR if the current cohort is the default one and it found errors.
+		// This allows multiple items to report their update-constraint failures together.
+		isUpdateStage := strings.HasPrefix(cohortName, validators.UpdateCohort)
+		isNextUpdateStage := false
+		if i+1 < len(cohorts) {
+			isNextUpdateStage = strings.HasPrefix(cohorts[i+1][0].Cohort, validators.UpdateCohort)
+		}
+
+		if hasAnyShortCircuit {
+			if (isUpdateStage && !isNextUpdateStage) || !isUpdateStage {
+				sw.Do("if earlyReturn {\n", nil)
+				sw.Do("  return // do not proceed\n", nil)
+				sw.Do("}\n", nil)
+			}
+		}
 	}
 }
 
 // sortIntoCohorts groups the inputs into a list of cohorts. Within each
 // cohort, function calls are sorted such that short-circuiting function
-// calls are handled before others. The first cohort is always the
-// default cohort (named "") if it exists. Other cohorts are returned in
-// the order they were defined in the input.
-//
-// NOTE: There should be exactly two cohorts: the default cohort (for structural
-// validity checks like required/maxItems) and the update cohort (for
-// update-constraint checks like immutable). These two represent orthogonal
-// concerns: "is this value structurally valid?" vs "was this value illegally
-// modified?". Adding more cohorts would make the short-circuit semantics harder
-// to reason about and should be avoided.
-func sortIntoCohorts(in []validators.FunctionGen) [][]validators.FunctionGen {
-	defaultCohort := make([]validators.FunctionGen, 0, len(in))
-	namedCohorts := map[string][]validators.FunctionGen{}
-	idx := make([]string, 0, len(in))
-	for _, fg := range in {
-		key := fg.Cohort
-		if key == "" {
-			defaultCohort = append(defaultCohort, fg)
-		} else {
-			if !slices.Contains(idx, key) {
-				idx = append(idx, key)
-			}
-			namedCohorts[key] = append(namedCohorts[key], fg)
+// calls are handled before others. The "update" stage cohorts (those starting
+// with validators.UpdateCohort) are always placed before default cohorts.
+func sortIntoCohorts(validations []validators.FunctionGen) [][]validators.FunctionGen {
+	cohortMap := make(map[string][]validators.FunctionGen)
+	cohortNames := []string{}
+	for _, v := range validations {
+		if _, ok := cohortMap[v.Cohort]; !ok {
+			cohortNames = append(cohortNames, v.Cohort)
 		}
+		cohortMap[v.Cohort] = append(cohortMap[v.Cohort], v)
 	}
-	// Special handling for the "update" cohort: it should always run before the
-	// default cohort. This ensures that update-related constraints (like
-	// +k8s:immutable) take precedence and short-circuit structural checks
-	// (like +k8s:required) if they fail, matching the behavior described in
-	// the UpdateCohort documentation.
-	updateIdx := -1
-	for i, key := range idx {
-		if key == validators.UpdateCohort {
-			updateIdx = i
-			break
+
+	// Sort cohort names such that update cohorts come first, then the default cohort,
+	// then others, while preserving original order within each group.
+	slices.SortStableFunc(cohortNames, func(aName, bName string) int {
+		if aName == bName {
+			return 0
 		}
-	}
-
-	newIdx := make([]string, 0, len(idx)+1)
-	if updateIdx != -1 {
-		newIdx = append(newIdx, validators.UpdateCohort)
-		// remove it from old idx so we don't add it again
-		idx = append(idx[:updateIdx], idx[updateIdx+1:]...)
-	}
-	if len(defaultCohort) > 0 {
-		newIdx = append(newIdx, "")
-	}
-	newIdx = append(newIdx, idx...)
-	idx = newIdx
-	// NOTE: we do not sort cohorts by name, because we want to preserve
-	// their definition order.
-
-	result := make([][]validators.FunctionGen, 0, len(in))
-	for _, key := range idx {
-		var cohort []validators.FunctionGen
-		if key == "" {
-			cohort = defaultCohort
-		} else {
-			cohort = namedCohorts[key]
+		aIsUpdate := strings.HasPrefix(aName, validators.UpdateCohort)
+		bIsUpdate := strings.HasPrefix(bName, validators.UpdateCohort)
+		if aIsUpdate && !bIsUpdate {
+			return -1
 		}
+		if bIsUpdate && !aIsUpdate {
+			return 1
+		}
+		if aName == "" {
+			return -1
+		}
+		if bName == "" {
+			return 1
+		}
+		// Preserve relative order for same stage
+		return 0
+	})
 
-		sooner := make([]validators.FunctionGen, 0, len(cohort))
-		later := make([]validators.FunctionGen, 0, len(cohort))
-
-		for _, fg := range cohort {
-			isShortCircuit := (fg.Flags.IsSet(validators.ShortCircuit))
-
-			if isShortCircuit {
-				sooner = append(sooner, fg)
+	result := [][]validators.FunctionGen{}
+	for _, name := range cohortNames {
+		cohortValidations := cohortMap[name]
+		// Within each cohort, sort short-circuiting functions first.
+		sooner := []validators.FunctionGen{}
+		later := []validators.FunctionGen{}
+		for _, v := range cohortValidations {
+			if v.Flags.IsSet(validators.ShortCircuit) {
+				sooner = append(sooner, v)
 			} else {
-				later = append(later, fg)
+				later = append(later, v)
 			}
 		}
 		sorted := sooner

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation_test.go
@@ -448,24 +448,17 @@ func TestSortIntoCohorts(t *testing.T) {
 			{TagName: "e", Cohort: "bar", Flags: validators.DefaultFlags},
 		}},
 	}, {
-		// default and non-default cohorts with short-circuit
+		// default and update cohorts with short-circuits
 		in: []validators.FunctionGen{
-			{TagName: "a", Cohort: "foo", Flags: validators.DefaultFlags},
-			{TagName: "b", Cohort: "bar", Flags: validators.DefaultFlags},
-			{TagName: "c", Cohort: "", Flags: validators.DefaultFlags},
-			{TagName: "d", Cohort: "foo", Flags: validators.ShortCircuit},
-			{TagName: "e", Cohort: "bar", Flags: validators.ShortCircuit},
-			{TagName: "f", Cohort: "", Flags: validators.ShortCircuit},
+			{TagName: "required", Cohort: "", Flags: validators.ShortCircuit},
+			{TagName: "maxItems", Cohort: "", Flags: validators.ShortCircuit},
+			{TagName: "immutable", Cohort: "update", Flags: validators.ShortCircuit},
 		},
 		expected: [][]validators.FunctionGen{{
-			{TagName: "f", Cohort: "", Flags: validators.ShortCircuit},
-			{TagName: "c", Cohort: "", Flags: validators.DefaultFlags},
+			{TagName: "immutable", Cohort: "update", Flags: validators.ShortCircuit},
 		}, {
-			{TagName: "d", Cohort: "foo", Flags: validators.ShortCircuit},
-			{TagName: "a", Cohort: "foo", Flags: validators.DefaultFlags},
-		}, {
-			{TagName: "e", Cohort: "bar", Flags: validators.ShortCircuit},
-			{TagName: "b", Cohort: "bar", Flags: validators.DefaultFlags},
+			{TagName: "required", Cohort: "", Flags: validators.ShortCircuit},
+			{TagName: "maxItems", Cohort: "", Flags: validators.ShortCircuit},
 		}},
 	}}
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/immutable.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/immutable.go
@@ -48,11 +48,31 @@ var (
 	immutableValidator = types.Name{Package: libValidationPkg, Name: "Immutable"}
 )
 
+// UpdateCohort is the name of the cohort used for update-related validations
+// (immutable, update constraints). This cohort runs independently from the
+// default cohort, ensuring that update-related errors are always reported even
+// when the default cohort short-circuits due to other failures (e.g. required
+// or maxItems).
+//
+// NOTE: There should be exactly two cohorts: the default cohort (for structural
+// validity checks like required/maxItems) and this update cohort (for
+// update-constraint checks like immutable). These two represent orthogonal
+// concerns: "is this value structurally valid?" vs "was this value illegally
+// modified?". Adding more cohorts would make the short-circuit semantics harder
+// to reason about and should be avoided.
+const UpdateCohort = "update"
+
 func (immutableTagValidator) GetValidations(context Context, _ codetags.Tag) (Validations, error) {
 	var result Validations
 
-	// Use ShortCircuit flag so immutable runs in the same group as +k8s:optional.
-	result.AddFunction(Function(immutableTagName, ShortCircuit, immutableValidator))
+	// Use ShortCircuit flag and put in the "update" cohort so that immutable
+	// checks run independently from the default cohort. This ensures that if a
+	// field has both +k8s:immutable and +k8s:required/+k8s:maxItems, the
+	// immutable error is always reported on updates even when the default cohort
+	// short-circuits.
+	fn := Function(immutableTagName, ShortCircuit, immutableValidator)
+	fn.Cohort = UpdateCohort
+	result.AddFunction(fn)
 	return result, nil
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/item.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/item.go
@@ -124,7 +124,11 @@ func (itv *itemTagValidator) GetValidations(context Context, tag codetags.Tag) (
 			deferredResult := Validations{}
 			for _, vfn := range validations.Functions {
 				f := Function(itemTagName, vfn.Flags, validateSliceItem, matchArg, equivArg, WrapperFunction{Function: vfn, ObjType: elemT})
-				f.Cohort = itemKey
+				if vfn.Cohort != "" {
+					f.Cohort = vfn.Cohort + "@" + itemKey
+				} else {
+					f.Cohort = itemKey
+				}
 				vfn = f
 				deferredResult.AddFunction(vfn)
 			}
@@ -168,7 +172,11 @@ func (itv *itemTagValidator) GetValidations(context Context, tag codetags.Tag) (
 					return fn
 				}
 				f := Function(itemTagName, fn.Flags, validateSliceItem, matchArg, equivArg, WrapperFunction{Function: fn, ObjType: elemT})
-				f.Cohort = itemKey
+				if fn.Cohort != "" {
+					f.Cohort = fn.Cohort + "@" + itemKey
+				} else {
+					f.Cohort = itemKey
+				}
 				return f
 			}, d.Scope), nil
 		}))

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/subfield.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/subfield.go
@@ -127,7 +127,11 @@ func (stv subfieldTagValidator) GetValidations(context Context, tag codetags.Tag
 			return fn
 		}
 		f := Function(subfieldTagName, fn.Flags, validateSubfield, subname, getFn, equivArg, WrapperFunction{fn, submemb.Type})
-		f.Cohort = subname
+		if fn.Cohort != "" {
+			f.Cohort = fn.Cohort + "@" + subname
+		} else {
+			f.Cohort = subname
+		}
 		return f
 	})
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/update.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/update.go
@@ -291,16 +291,20 @@ func generateSliceValidation(listByPath map[string]*listMetadata, context Contex
 
 	args := append([]any{matchArg}, constraintIdentifierArgs(constraints)...)
 
-	// Use ShortCircuit flag so these run in the same group as +k8s:optional
+	// Use ShortCircuit flag and put in the "update" cohort so these run
+	// independently from the default cohort (see UpdateCohort in immutable.go).
 	fn := Function(updateTagName, ShortCircuit, updateSliceValidator, args...)
+	fn.Cohort = UpdateCohort
 	return Validations{Functions: []FunctionGen{fn}}, nil
 }
 
 // generateMapValidation emits validate.UpdateMap. The map key is the item
 // identity, so no list metadata or match function is needed.
 func generateMapValidation(constraints []validate.UpdateConstraint) Validations {
-	// Use ShortCircuit flag so these run in the same group as +k8s:optional
+	// Use ShortCircuit flag and put in the "update" cohort so these run
+	// independently from the default cohort (see UpdateCohort in immutable.go).
 	fn := Function(updateTagName, ShortCircuit, updateMapValidator, constraintIdentifierArgs(constraints)...)
+	fn.Cohort = UpdateCohort
 	return Validations{Functions: []FunctionGen{fn}}
 }
 
@@ -327,8 +331,10 @@ func emitScalarUpdate(context Context, constraints []validate.UpdateConstraint) 
 		validatorFunc = updateValueByReflectValidator
 	}
 
-	// Use ShortCircuit flag so these run in the same group as +k8s:optional
+	// Use ShortCircuit flag and put in the "update" cohort so these run
+	// independently from the default cohort (see UpdateCohort in immutable.go).
 	fn := Function(updateTagName, ShortCircuit, validatorFunc, constraintIdentifierArgs(constraints)...)
+	fn.Cohort = UpdateCohort
 	return Validations{Functions: []FunctionGen{fn}}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area api-validation
/sig-api-machinery

#### What this PR does / why we need it:

This PR refactors `validation-gen` to support validation cohorts, allowing the execution to be split into two logical stages:
1. update specific: High-priority lifecycle checks (Immutability)
2. structural: Schema validation (Required, Min/Max).

The engine now guarantees that if stage 1 fails, the process halts immediately, suppressing all subsequent structural errors.

### Key changes
- Implemented `earlyReturn` propagation across IIFEs and added stage aware cohort prefixing for nested selectors (`item`,`subfield`).  
- Refactored hand-written `ValidateUpdate` logic for `StorageClass`, `VolumeAttachment` , `IPAddress`, `RoleBinding` , and `EndpointSlice`
- updated cohort sorting to strictly prioritize update-specific stages while maintaining stable ordering for structural checks.



#### Which issue(s) this PR is related to:
part of 
- https://github.com/kubernetes/kubernetes/issues/136262
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
