### PR TITLE
Fix CPUManager pre-start cpuset application for dedicated CPUs

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -304,11 +304,20 @@ func (m *manager) AllocatePod(pod *v1.Pod) error {
 
 func (m *manager) AddContainer(logger logr.Logger, pod *v1.Pod, container *v1.Container, containerID string) {
 	m.Lock()
-	defer m.Unlock()
-	if cset, exists := m.state.GetCPUSet(string(pod.UID), container.Name); exists {
-		m.lastUpdateState.SetCPUSet(string(pod.UID), container.Name, cset)
-	}
 	m.containerMap.Add(string(pod.UID), container.Name, containerID)
+	cset, hasDedicatedCPUs := m.state.GetCPUSet(string(pod.UID), container.Name)
+	m.Unlock()
+
+	if hasDedicatedCPUs && !cset.IsEmpty() {
+		if err := m.updateContainerCPUSet(context.TODO(), containerID, cset); err != nil {
+			logger.Error(err, "Failed to apply cpuset before container start", "containerID", containerID, "cpuSet", cset)
+		} else {
+			m.Lock()
+			m.lastUpdateState.SetCPUSet(string(pod.UID), container.Name, cset)
+			m.Unlock()
+		}
+	}
+
 	logger.V(4).Info("Added Container", "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "containerID", containerID)
 }
 

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -173,6 +173,20 @@ func (rt mockRuntimeService) UpdateContainerResources(_ context.Context, id stri
 	return rt.err
 }
 
+type trackingRuntimeService struct {
+	err       error
+	calls     int
+	id        string
+	resources *runtimeapi.ContainerResources
+}
+
+func (rt *trackingRuntimeService) UpdateContainerResources(_ context.Context, id string, resources *runtimeapi.ContainerResources) error {
+	rt.calls++
+	rt.id = id
+	rt.resources = resources
+	return rt.err
+}
+
 type mockPodStatusProvider struct {
 	podStatus v1.PodStatus
 	found     bool
@@ -432,6 +446,122 @@ func TestCPUManagerAdd(t *testing.T) {
 			t.Errorf("CPU Manager AddContainer() error (%v). expected cpuset: %v but got: %v",
 				testCase.description, testCase.expCPUSet, mgr.state.GetDefaultCPUSet())
 		}
+	}
+}
+
+func TestAddContainerAppliesDedicatedCPUSetBeforeStart(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("verifies Linux/non-Windows cpuset behavior")
+	}
+
+	logger, _ := ktesting.NewTestContext(t)
+
+	pod := makePod("fakePod", "fakeContainer", "2", "2")
+	container := &pod.Spec.Containers[0]
+	dedicatedCPUs := cpuset.New(3, 4)
+	runtimeService := &trackingRuntimeService{}
+
+	mgr := &manager{
+		policy: &mockPolicy{},
+		state: &mockState{
+			assignments: state.ContainerCPUAssignments{
+				string(pod.UID): {container.Name: dedicatedCPUs},
+			},
+			defaultCPUSet: cpuset.New(1, 2),
+		},
+		lastUpdateState:   state.NewMemoryState(logger),
+		containerRuntime:  runtimeService,
+		containerMap:      containermap.NewContainerMap(),
+		podStatusProvider: mockPodStatusProvider{},
+		sourcesReady:      &sourcesReadyStub{},
+	}
+
+	mgr.AddContainer(logger, pod, container, "fakeID")
+
+	lastCset, exists := mgr.lastUpdateState.GetCPUSet(string(pod.UID), container.Name)
+	if !exists {
+		t.Fatal("expected lastUpdateState to be recorded after a successful cpuset write")
+	}
+	if !dedicatedCPUs.Equals(lastCset) {
+		t.Fatalf("expected lastUpdateState cpuset %v, got %v", dedicatedCPUs, lastCset)
+	}
+	if runtimeService.calls != 1 {
+		t.Fatalf("expected one runtime update call, got %d", runtimeService.calls)
+	}
+	if runtimeService.id != "fakeID" {
+		t.Fatalf("expected runtime update for container fakeID, got %q", runtimeService.id)
+	}
+	if runtimeService.resources == nil || runtimeService.resources.GetLinux() == nil {
+		t.Fatal("expected runtime update resources to include linux settings")
+	}
+	if runtimeService.resources.GetLinux().GetCpusetCpus() != dedicatedCPUs.String() {
+		t.Fatalf("expected runtime cpuset %q, got %q", dedicatedCPUs.String(), runtimeService.resources.GetLinux().GetCpusetCpus())
+	}
+}
+
+func TestAddContainerLeavesLastUpdateStateUnsetOnRuntimeFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("verifies Linux/non-Windows cpuset behavior")
+	}
+
+	logger, _ := ktesting.NewTestContext(t)
+
+	pod := makePod("fakePod", "fakeContainer", "2", "2")
+	container := &pod.Spec.Containers[0]
+	runtimeService := &trackingRuntimeService{err: fmt.Errorf("runtime unavailable")}
+
+	mgr := &manager{
+		policy: &mockPolicy{},
+		state: &mockState{
+			assignments: state.ContainerCPUAssignments{
+				string(pod.UID): {container.Name: cpuset.New(3, 4)},
+			},
+			defaultCPUSet: cpuset.New(1, 2),
+		},
+		lastUpdateState:   state.NewMemoryState(logger),
+		containerRuntime:  runtimeService,
+		containerMap:      containermap.NewContainerMap(),
+		podStatusProvider: mockPodStatusProvider{},
+		sourcesReady:      &sourcesReadyStub{},
+	}
+
+	mgr.AddContainer(logger, pod, container, "fakeID")
+
+	if _, exists := mgr.lastUpdateState.GetCPUSet(string(pod.UID), container.Name); exists {
+		t.Fatal("expected lastUpdateState to remain unset when runtime update fails")
+	}
+	if runtimeService.calls != 1 {
+		t.Fatalf("expected one runtime update attempt, got %d", runtimeService.calls)
+	}
+}
+
+func TestAddContainerSkipsRuntimeUpdateWithoutDedicatedCPUs(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
+	pod := makePod("fakePod", "fakeContainer", "100m", "100m")
+	container := &pod.Spec.Containers[0]
+	runtimeService := &trackingRuntimeService{}
+
+	mgr := &manager{
+		policy: &mockPolicy{},
+		state: &mockState{
+			assignments:   state.ContainerCPUAssignments{},
+			defaultCPUSet: cpuset.New(0, 1, 2, 3),
+		},
+		lastUpdateState:   state.NewMemoryState(logger),
+		containerRuntime:  runtimeService,
+		containerMap:      containermap.NewContainerMap(),
+		podStatusProvider: mockPodStatusProvider{},
+		sourcesReady:      &sourcesReadyStub{},
+	}
+
+	mgr.AddContainer(logger, pod, container, "fakeID")
+
+	if _, exists := mgr.lastUpdateState.GetCPUSet(string(pod.UID), container.Name); exists {
+		t.Fatal("expected lastUpdateState to remain unset when no dedicated cpuset exists")
+	}
+	if runtimeService.calls != 0 {
+		t.Fatalf("expected no runtime update attempts, got %d", runtimeService.calls)
 	}
 }
 


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Symptom
  cpumanager.AddContainer is called during the container PreStartContainer phase, but it only updates lastUpdateState and does not apply the container’s dedicated cpuset to the runtime/cgroup.
  As a result, a container may briefly start with the pod-level cpuset instead of its dedicated cpuset. Components such as KubeVirt that read cpuset.cpus.effective during startup may observe the wrong CPU set and derive invalid NUMA or memory affinity settings, which can lead to errors such as set_mempolicy: Invalid argument.
  The reconciler may also fail to repair this state because lastUpdateState has already been updated, making CPUManager believe the cpuset was successfully applied.


Expected Behavior
  If a container has a dedicated cpuset, CPUManager should apply that cpuset to the container runtime/cgroup before the container starts executing.
  lastUpdateState should represent the cpuset that was successfully applied to the runtime, not merely the desired cpuset.
  If applying the cpuset fails, lastUpdateState should remain unchanged so the reconciler can retry later.


Root Cause
  In pkg/kubelet/cm/cpumanager/cpu_manager.go, AddContainer reads the container’s assigned cpuset from CPUManager state and writes it directly into lastUpdateState.  However, it does not call updateContainerCPUSet.
  reconcileState decides whether to update the runtime by comparing the desired cpuset with lastUpdateState. Because AddContainer prematurely marks the cpuset as updated,
  the reconciler can be short-circuited even though the runtime/cgroup was never actually updated.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/138731

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

no

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
