### PR TITLE
etcd: update etcd image to v3.6.11

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -64,7 +64,7 @@ dependencies:
 
   # etcd
   - name: "etcd"
-    version: 3.6.10
+    version: 3.6.11
     refPaths:
     - path: cluster/gce/manifests/etcd.manifest
       match: etcd_docker_tag|etcd_version

--- a/cluster/gce/manifests/etcd.manifest
+++ b/cluster/gce/manifests/etcd.manifest
@@ -18,7 +18,7 @@
     {
     "name": "etcd-container",
     {{security_context}}
-    "image": "{{ pillar.get('etcd_docker_repository', 'registry.k8s.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.6.10-0') }}",
+    "image": "{{ pillar.get('etcd_docker_repository', 'registry.k8s.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.6.11-0') }}",
     "resources": {
       "requests": {
         "cpu": {{ cpulimit }}
@@ -43,7 +43,7 @@
         "value": "{{ pillar.get('storage_backend', 'etcd3') }}"
       },
       { "name": "TARGET_VERSION",
-        "value": "{{ pillar.get('etcd_version', '3.6.10') }}"
+        "value": "{{ pillar.get('etcd_version', '3.6.11') }}"
       },
       {
         "name": "DO_NOT_MOVE_BINARIES",

--- a/cluster/gce/upgrade-aliases.sh
+++ b/cluster/gce/upgrade-aliases.sh
@@ -170,8 +170,8 @@ export KUBE_GCE_ENABLE_IP_ALIASES=true
 export SECONDARY_RANGE_NAME="pods-default"
 export STORAGE_BACKEND="etcd3"
 export STORAGE_MEDIA_TYPE="application/vnd.kubernetes.protobuf"
-export ETCD_IMAGE=3.6.10-0
-export ETCD_VERSION=3.6.10
+export ETCD_IMAGE=3.6.11-0
+export ETCD_VERSION=3.6.11
 
 # Upgrade master with updated kube envs
 "${KUBE_ROOT}/cluster/gce/upgrade.sh" -M -l

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -326,7 +326,7 @@ const (
 	MinExternalEtcdVersion = "3.5.24-0"
 
 	// DefaultEtcdVersion indicates the default etcd version that kubeadm uses
-	DefaultEtcdVersion = "3.6.10-0"
+	DefaultEtcdVersion = "3.6.11-0"
 
 	// Etcd defines variable used internally when referring to etcd component
 	Etcd = "etcd"
@@ -508,9 +508,9 @@ var (
 	// an etcd version even if the map is not yet updated before a release. The user will
 	// get a warning in that case, so ideally the map should be updated for each release.
 	SupportedEtcdVersion = map[uint8]string{
-		34: "3.6.10-0",
-		35: "3.6.10-0",
-		36: "3.6.10-0",
+		34: "3.6.11-0",
+		35: "3.6.11-0",
+		36: "3.6.11-0",
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows

--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -16,7 +16,7 @@
 
 # A set of helpers for starting/running etcd for tests
 
-ETCD_VERSION=${ETCD_VERSION:-3.6.10}
+ETCD_VERSION=${ETCD_VERSION:-3.6.11}
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 ETCD_PORT=${ETCD_PORT:-2379}
 # This is intentionally not called ETCD_LOG_LEVEL:

--- a/staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
+++ b/staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
@@ -26,4 +26,4 @@ spec:
         imagePullPolicy: Never
         args: [ "--etcd-servers=http://localhost:2379" ]
       - name: etcd
-        image: registry.k8s.io/etcd:v3.6.10
+        image: registry.k8s.io/etcd:v3.6.11

--- a/test/e2e/testing-manifests/statefulset/etcd/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/etcd/statefulset.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: etcd
-        image: registry.k8s.io/etcd:3.6.10-0
+        image: registry.k8s.io/etcd:3.6.11-0
         imagePullPolicy: Always
         ports:
         - containerPort: 2380

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -215,7 +215,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[AppArmorLoader] = Config{list.PromoterE2eRegistry, "apparmor-loader", "1.4"}
 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.37.0-1"}
 	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.9.1"}
-	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.6.10-0"}
+	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.6.11-0"}
 	configs[InvalidRegistryImage] = Config{list.InvalidRegistry, "alpine", "3.1"}
 	configs[IpcUtils] = Config{list.PromoterE2eRegistry, "ipc-utils", "1.4"}
 	configs[GlibcDnsTesting] = Config{list.PromoterE2eRegistry, "glibc-dns-testing", "2.0.0"}


### PR DESCRIPTION
Update etcd images to v3.6.11 across build dependencies, kubeadm defaults, GCE manifests, test manifests, and sample-apiserver deployment.

#### What type of PR is this?

#### What this PR does / why we need it:
- Update etcd image to latest release v3.6.11

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
kubeadm: updated the supported etcd version to v3.6.11 for supported control plane versions v1.34, v1.35, and v1.36
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```

/cc @ahrtr @ivanvc @hakman @humblec @ArkaSaha30