### PR TITLE
fix: do not generate uint64 in structToUnstructured

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
@@ -680,11 +680,11 @@ func toUnstructured(sv, dv reflect.Value) error {
 		dv.Set(reflect.ValueOf(sv.Int()))
 		return nil
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		uVal := sv.Uint()
-		if uVal > math.MaxInt64 {
-			return fmt.Errorf("unsigned value %d does not fit into int64 (overflow)", uVal)
+		val, err := uintToUnstructuredHelper(sv.Uint())
+		if err != nil {
+			return err
 		}
-		dv.Set(reflect.ValueOf(int64(uVal)))
+		dv.Set(reflect.ValueOf(val))
 		return nil
 	case reflect.Float32, reflect.Float64:
 		dv.Set(reflect.ValueOf(sv.Float()))
@@ -846,7 +846,11 @@ func structToUnstructured(sv, dv reflect.Value) error {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 			realMap[fieldInfo.name] = fv.Int()
 		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			realMap[fieldInfo.name] = fv.Uint()
+			val, err := uintToUnstructuredHelper(sv.Uint())
+			if err != nil {
+				return err
+			}
+			realMap[fieldInfo.name] = val
 		case reflect.Float32, reflect.Float64:
 			realMap[fieldInfo.name] = fv.Float()
 		default:
@@ -866,4 +870,11 @@ func interfaceToUnstructured(sv, dv reflect.Value) error {
 		return nil
 	}
 	return toUnstructured(sv.Elem(), dv)
+}
+
+func uintToUnstructuredHelper(uVal uint64) (int64, error) {
+	if uVal > math.MaxInt64 {
+		return 0, fmt.Errorf("unsigned value %d does not fit into int64 (overflow)", uVal)
+	}
+	return int64(uVal), nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
@@ -846,7 +846,7 @@ func structToUnstructured(sv, dv reflect.Value) error {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 			realMap[fieldInfo.name] = fv.Int()
 		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			val, err := uintToUnstructuredHelper(sv.Uint())
+			val, err := uintToUnstructuredHelper(fv.Uint())
 			if err != nil {
 				return err
 			}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
@@ -52,6 +52,7 @@ type A struct {
 	A int    `json:"aa,omitempty"`
 	B string `json:"ab,omitempty"`
 	C bool   `json:"ac,omitempty"`
+	D uint   `json:"ad,omitempty"`
 }
 
 type B struct {
@@ -206,6 +207,14 @@ func doRoundTrip(t *testing.T, item interface{}) {
 		return
 	}
 
+	copiedNewUnstr := runtime.DeepCopyJSONValue(newUnstr)
+	if value, ok := copiedNewUnstr.(map[string]interface{}); ok {
+		newUnstr = value
+	} else {
+		t.Errorf("DeepCopyJSONValue return unexpected type %T", copiedNewUnstr)
+		return
+	}
+
 	newObj := reflect.New(reflect.TypeOf(item).Elem()).Interface()
 	err = runtime.NewTestUnstructuredConverter(simpleEquality).FromUnstructured(newUnstr, newObj)
 	if err != nil {
@@ -329,6 +338,12 @@ func TestRoundTrip(t *testing.T) {
 			// Test slice of interface{} with different values.
 			obj: &D{
 				A: []interface{}{float64(3.5), int64(4), "3.0", nil},
+			},
+		},
+		{
+			// Test uint values.
+			obj: &A{
+				D: 1,
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:

Fix in [62981](https://github.com/kubernetes/kubernetes/pull/62981/changes#diff-80c28e2dbc8a4a118cae3f4bb6b1252b0e098b0e4b463ed3d26e9b6d6ce85508R594) left structToUnstructured unchanged and it still can generate uint64. It might generate panic if Unstuctured is deep-copied after. For example in `sigs.k8s.io/controller-runtime/pkg/controller/controllerutil.CreateOrPatch`
```
panic({0x21bcf80?, 0x362352068490?})
	GOROOT/src/runtime/panic.go:860 +0x13a
k8s.io/apimachinery/pkg/runtime.DeepCopyJSONValue({0x20c9be0?, 0x362358935800?})
	external/gazelle++go_deps+io_k8s_apimachinery/pkg/runtime/converter.go:639 +0x26e
k8s.io/apimachinery/pkg/runtime.DeepCopyJSONValue({0x22762c0?, 0x3623627e4000})
	external/gazelle++go_deps+io_k8s_apimachinery/pkg/runtime/converter.go:623 +0x2e5
k8s.io/apimachinery/pkg/runtime.DeepCopyJSONValue({0x22762c0?, 0x3623634c6d80})
	external/gazelle++go_deps+io_k8s_apimachinery/pkg/runtime/converter.go:623 +0x2e5
k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.NestedFieldCopy(0x3e4ebe0?, {0x36236100ba60?, 0x3623548bcf08?, 0x8?})
	external/gazelle++go_deps+io_k8s_apimachinery/pkg/apis/meta/v1/unstructured/helpers.go:45 +0x2a
sigs.k8s.io/controller-runtime/pkg/controller/controllerutil.CreateOrPatch({0x2765bf8, 0x36235d108cf0}, {0x2779ec0, 0x362350dc6f60}, {0x278ab68, 0x362354a8c508}, 0x36236100bbd8)
	external/gazelle++go_deps+io_k8s_sigs_controller_runtime/pkg/controller/controllerutil/controllerutil.go:379 +0x425
```

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #62769 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
