### PR TITLE
test/e2e_dra improvements

### DIFF
--- a/test/e2e_dra/run.sh
+++ b/test/e2e_dra/run.sh
@@ -18,10 +18,8 @@ set -ex
 
 killall etcd || true
 sudo rm -rf /tmp/ginkgo* /tmp/*.log /var/run/kubernetes /var/run/cdi /var/lib/kubelet/plugins_registry /var/lib/kubelet/plugins /var/lib/kubelet/*_state /var/lib/kubelet/checkpoints /tmp/artifacts
-sudo mkdir /var/lib/kubelet/plugins_registry
-sudo mkdir /var/lib/kubelet/plugins
-sudo mkdir /var/run/cdi
-sudo chown "$(id -u)" /var/lib/kubelet/plugins_registry /var/lib/kubelet/plugins /var/run/cdi
+sudo mkdir /var/run/kubernetes /var/lib/kubelet/plugins_registry /var/lib/kubelet/plugins /var/run/cdi
+sudo chown "$(id -u)" /var/run/kubernetes /var/lib/kubelet/plugins_registry /var/lib/kubelet/plugins /var/run/cdi
 ARTIFACTS=/tmp/artifacts
 TMP_DIR=${ARTIFACTS}/tmp
 LOG_DIR=${ARTIFACTS}/logs

--- a/test/e2e_dra/run.sh
+++ b/test/e2e_dra/run.sh
@@ -17,7 +17,7 @@
 set -ex
 
 killall etcd || true
-sudo rm -rf /tmp/ginkgo* /var/run/kubernetes /var/run/cdi /var/lib/kubelet/plugins_registry /var/lib/kubelet/plugins /var/lib/kubelet/*_state /var/lib/kubelet/checkpoints /tmp/artifacts
+sudo rm -rf /var/run/kubernetes /var/run/cdi /var/lib/kubelet/plugins_registry /var/lib/kubelet/plugins /var/lib/kubelet/*_state /var/lib/kubelet/checkpoints /tmp/artifacts
 sudo mkdir /var/run/kubernetes /var/lib/kubelet/plugins_registry /var/lib/kubelet/plugins /var/run/cdi
 sudo chown "$(id -u)" /var/run/kubernetes /var/lib/kubelet/plugins_registry /var/lib/kubelet/plugins /var/run/cdi
 ARTIFACTS=/tmp/artifacts

--- a/test/e2e_dra/run.sh
+++ b/test/e2e_dra/run.sh
@@ -16,7 +16,6 @@
 
 set -ex
 
-killall etcd || true
 sudo rm -rf /var/run/kubernetes /var/run/cdi /var/lib/kubelet/plugins_registry /var/lib/kubelet/plugins /var/lib/kubelet/*_state /var/lib/kubelet/checkpoints /tmp/artifacts
 sudo mkdir /var/run/kubernetes /var/lib/kubelet/plugins_registry /var/lib/kubelet/plugins /var/run/cdi
 sudo chown "$(id -u)" /var/run/kubernetes /var/lib/kubelet/plugins_registry /var/lib/kubelet/plugins /var/run/cdi

--- a/test/e2e_dra/run.sh
+++ b/test/e2e_dra/run.sh
@@ -17,7 +17,7 @@
 set -ex
 
 killall etcd || true
-sudo rm -rf /tmp/ginkgo* /tmp/*.log /var/run/kubernetes /var/run/cdi /var/lib/kubelet/plugins_registry /var/lib/kubelet/plugins /var/lib/kubelet/*_state /var/lib/kubelet/checkpoints /tmp/artifacts
+sudo rm -rf /tmp/ginkgo* /var/run/kubernetes /var/run/cdi /var/lib/kubelet/plugins_registry /var/lib/kubelet/plugins /var/lib/kubelet/*_state /var/lib/kubelet/checkpoints /tmp/artifacts
 sudo mkdir /var/run/kubernetes /var/lib/kubelet/plugins_registry /var/lib/kubelet/plugins /var/run/cdi
 sudo chown "$(id -u)" /var/run/kubernetes /var/lib/kubelet/plugins_registry /var/lib/kubelet/plugins /var/run/cdi
 ARTIFACTS=/tmp/artifacts


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- Create /var/run/kubernetes with user ownership so control plane components (apiserver, controller-manager, scheduler) run without sudo.
- Remove killall etcd — etcd is now stopped cleanly by Cluster.Stop.
- Remove overly broad /tmp/\*.log and /tmp/ginkgo* cleanup globs that could accidentally delete unrelated files.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
