### PR TITLE
Handle opportunistic batching correctly during PodGroup scheduling cycle

### DIFF
--- a/pkg/scheduler/framework/runtime/batch.go
+++ b/pkg/scheduler/framework/runtime/batch.go
@@ -38,6 +38,8 @@ type OpportunisticBatch struct {
 	// Used primarily for tests, count the total pods we
 	// have successfully batched.
 	batchedPods int64
+
+	genericWorkloadEnabled bool
 }
 
 type batchState struct {
@@ -168,8 +170,12 @@ func (b *OpportunisticBatch) batchStateCompatible(ctx context.Context, pod *v1.P
 
 	// In this case, a previous pod was scheduled by another profile, meaning we can't use the state anymore.
 	if cycleCount != b.lastCycle.cycleCount+1 {
-		b.logUnusableState(logger, cycleCount, metrics.BatchFlushPodSkipped)
-		return false
+		// In case of PodGroup scheduling cycle, multiple pods can share the same cycle count.
+		// The batch state can be reused in that case.
+		if !b.genericWorkloadEnabled || cycleCount != b.lastCycle.cycleCount {
+			b.logUnusableState(logger, cycleCount, metrics.BatchFlushPodSkipped)
+			return false
+		}
 	}
 
 	// If our last pod failed we can't use the state.
@@ -228,8 +234,9 @@ func (b *OpportunisticBatch) stateEmpty() bool {
 	return b.state == nil || b.state.sortedNodes == nil || b.state.sortedNodes.Len() == 0
 }
 
-func newOpportunisticBatch(h fwk.Handle) *OpportunisticBatch {
+func newOpportunisticBatch(h fwk.Handle, genericWorkloadEnabled bool) *OpportunisticBatch {
 	return &OpportunisticBatch{
-		handle: h,
+		handle:                 h,
+		genericWorkloadEnabled: genericWorkloadEnabled,
 	}
 }

--- a/pkg/scheduler/framework/runtime/batch_test.go
+++ b/pkg/scheduler/framework/runtime/batch_test.go
@@ -195,6 +195,8 @@ func TestBatchBasic(t *testing.T) {
 		firstChosenNode string
 		// firstOtherNodes is supposed to set only if firstPodScheduledSuccessfully is true.
 		firstOtherNodes framework.SortedScoredNodes
+		// if it's true, the test case behaves as if the pods are processed during the same PodGroup scheduling cycle.
+		sameCycle bool
 		// if it's true, the test case behaves as if there is another pod handled by another profile between the first and second pod.
 		skipPod                    bool
 		secondPodID                string
@@ -202,6 +204,7 @@ func TestBatchBasic(t *testing.T) {
 		secondSig                  string
 		secondChosenNode           string
 		secondOtherNodes           framework.SortedScoredNodes
+		genericWorkloadEnabled     bool
 		expectedHint               string
 		expectedState              *batchState
 	}{
@@ -291,6 +294,34 @@ func TestBatchBasic(t *testing.T) {
 			expectedHint:                  "",
 		},
 		{
+			name:                          "pod doesn't use batch from preceding pod when they are from the same cycle state, but GenericWorkload is disabled",
+			firstPodID:                    blockingPodID("1"),
+			firstSig:                      "sig",
+			firstChosenNode:               "n3",
+			firstOtherNodes:               newTestNodes([]string{"n1"}),
+			firstPodScheduledSuccessfully: true,
+			sameCycle:                     true,
+			secondPodID:                   blockingPodID("2"),
+			secondSig:                     "sig",
+			secondChosenNode:              "n1",
+			genericWorkloadEnabled:        false,
+			expectedHint:                  "",
+		},
+		{
+			name:                          "pod uses batch from preceding pod when they are from the same cycle state and GenericWorkload is enabled",
+			firstPodID:                    blockingPodID("1"),
+			firstSig:                      "sig",
+			firstChosenNode:               "n3",
+			firstOtherNodes:               newTestNodes([]string{"n1"}),
+			firstPodScheduledSuccessfully: true,
+			sameCycle:                     true,
+			secondPodID:                   blockingPodID("2"),
+			secondSig:                     "sig",
+			secondChosenNode:              "n1",
+			genericWorkloadEnabled:        true,
+			expectedHint:                  "n1",
+		},
+		{
 			name:                          "pod uses batch from preceding pod and leaves remaining batch to next pod",
 			firstPodID:                    blockingPodID("1"),
 			firstSig:                      "sig",
@@ -339,7 +370,7 @@ func TestBatchBasic(t *testing.T) {
 			}
 
 			signature := fwk.PodSignature(tt.firstSig)
-			batch := newOpportunisticBatch(testFwk)
+			batch := newOpportunisticBatch(testFwk, tt.genericWorkloadEnabled)
 			state := framework.NewCycleState()
 
 			// Run the first "pod" through
@@ -354,6 +385,8 @@ func TestBatchBasic(t *testing.T) {
 			var cycleCount int64 = 2
 			if tt.skipPod {
 				cycleCount = 3
+			} else if tt.sameCycle {
+				cycleCount = 1
 			}
 
 			// Run the second pod

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -356,7 +356,7 @@ func NewFramework(ctx context.Context, r Registry, profile *config.KubeScheduler
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.OpportunisticBatching) {
-		f.batch = newOpportunisticBatch(f)
+		f.batch = newOpportunisticBatch(f, utilfeature.DefaultFeatureGate.Enabled(features.GenericWorkload))
 	}
 
 	if len(f.extenders) > 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This PR allows the batch result to be reused for pods from the same pod group during the pod group scheduling cycle. All pods during that cycle share the same cycle count. Before, such behavior made the batch state incompatible.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed the inconsistency between opportunistic batching and PodGroups that made the batching hints always infeasible during PodGroup scheduling cycle.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
