### PR TITLE
Replace openssl speed CPU burner in summary_test.go

### DIFF
--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -99,10 +99,10 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 					"CPU": ptrMatchAllFields(gstruct.Fields{
 						"Time": recent(maxStatsAge),
 						// CRI stats provider tries to estimate the value of UsageNanoCores. This value can be
-						// either 0 or between 10000 and 2e10.
+						// either 0 or between 10000 and 2e9.
 						// Please refer, https://github.com/kubernetes/kubernetes/pull/95345#discussion_r501630942
 						// for more information.
-						"UsageNanoCores":       gomega.SatisfyAny(gstruct.PointTo(gomega.BeZero()), bounded(10000, 2e10)),
+						"UsageNanoCores":       gomega.SatisfyAny(gstruct.PointTo(gomega.BeZero()), bounded(10000, 2e9)),
 						"UsageCoreNanoSeconds": bounded(10000000, 1e15),
 						"PSI":                  psiExpectation(),
 					}),
@@ -181,8 +181,8 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 						"StartTime": recent(maxStartAge),
 						"CPU": ptrMatchAllFields(gstruct.Fields{
 							"Time":                 recent(maxStatsAge),
-							"UsageNanoCores":       bounded(10000, 2e10),
-							"UsageCoreNanoSeconds": bounded(10000000, 1e15),
+							"UsageNanoCores":       bounded(10000, 1e9),
+							"UsageCoreNanoSeconds": bounded(10000000, 1e11),
 							"PSI":                  psiExpectation(),
 						}),
 						"Memory": ptrMatchAllFields(gstruct.Fields{
@@ -232,8 +232,8 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 				}),
 				"CPU": ptrMatchAllFields(gstruct.Fields{
 					"Time":                 recent(maxStatsAge),
-					"UsageNanoCores":       bounded(10000, 2e10),
-					"UsageCoreNanoSeconds": bounded(10000000, 1e15),
+					"UsageNanoCores":       bounded(10000, 1e9),
+					"UsageCoreNanoSeconds": bounded(10000000, 1e11),
 					"PSI":                  psiExpectation(),
 				}),
 				"Memory": ptrMatchAllFields(gstruct.Fields{
@@ -285,7 +285,7 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 					"SystemContainers": gstruct.MatchAllElements(summaryObjectID, systemContainers),
 					"CPU": ptrMatchAllFields(gstruct.Fields{
 						"Time":                 recent(maxStatsAge),
-						"UsageNanoCores":       bounded(100e3, 2e10),
+						"UsageNanoCores":       bounded(100e3, 2e9),
 						"UsageCoreNanoSeconds": bounded(1e9, 1e15),
 						"PSI":                  psiExpectation(),
 					}),
@@ -510,7 +510,7 @@ func getSummaryTestPods(f *framework.Framework, numRestarts int32, names ...stri
 								Add: []v1.Capability{"NET_RAW"},
 							},
 						},
-						Command: getRestartingContainerCommand("/test-empty-dir-mnt", 0, numRestarts, "echo 'some bytes' >/outside_the_volume.txt; ping -c 10 -s 100 -v google.com; echo 'hello world' >> /test-empty-dir-mnt/file; echo 720;openssl speed -multi $(grep -ci processor /proc/cpuinfo)"),
+						Command: getRestartingContainerCommand("/test-empty-dir-mnt", 0, numRestarts, "echo 'some bytes' >/outside_the_volume.txt; ping -c 1 google.com; echo 'hello world' >> /test-empty-dir-mnt/file; dd if=/dev/zero of=/dev/null bs=1 count=10000000;"),
 						Resources: v1.ResourceRequirements{
 							Limits: v1.ResourceList{
 								// Must set memory limit to get MemoryStats.AvailableBytes


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

The `openssl speed -multi $(nproc)` command added in #138423 causes the `ContainerMetrics` cadvisor test to fail on CRI-O conformance (ci-node-crio-conformance) by exceeding upper bounds for `container_fs_writes_total`, `container_blkio_device_usage_total` and `container_memory_failures_total`.

This PR replaces it with a lightweight `dd`-based CPU burner (`dd if=/dev/zero of=/dev/null bs=1 count=10000000`) that generates CPU load via syscall overhead without filesystem I/O or memory side effects, and reverts the bound changes to pre-#138423 values.

#### Which issue(s) this PR is related to:

#138753
#138402

#### Special notes for your reviewer:

The underlying `UsageNanoCores` issue is better addressed at the kubelet level by #138687.

#### Does this PR introduce a user-facing change?

```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
None
```