### PR TITLE
Do not allow to decrease the number of scheduled preemptor pods during the preemption reprieve process.

### DIFF
--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -161,6 +161,10 @@ type SortedScoredNodes interface {
 	Len() int
 }
 
+// PodGroupSchedulingFunc is a function that will be run to check feasibility of a pod group
+// scheduling during workload-aware preemption algorithm.
+type PodGroupSchedulingFunc func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status)
+
 // PodGroupPostFilterPlugin is an interface for plugins that are called
 // after a PodGroup cannot be scheduled.
 // It should not be used by any other plugin but DefaultPreemption.
@@ -168,7 +172,7 @@ type PodGroupPostFilterPlugin interface {
 	fwk.Plugin
 
 	// PodGroupPostFilter is called after a PodGroup cannot be scheduled.
-	PodGroupPostFilter(ctx context.Context, pg *v1alpha2.PodGroup, pods []*v1.Pod, pgSchedulingFunc func(ctx context.Context) *fwk.Status) *fwk.Status
+	PodGroupPostFilter(ctx context.Context, pg *v1alpha2.PodGroup, pods []*v1.Pod, pgSchedulingFunc PodGroupSchedulingFunc) *fwk.Status
 }
 
 // Framework manages the set of plugins in use by the scheduling framework.

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -35,6 +35,7 @@ import (
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 	"k8s.io/kubernetes/pkg/scheduler/framework/preemption"
@@ -465,6 +466,6 @@ func filterPodsWithPDBViolation(podInfos []fwk.PodInfo, pdbs []*policy.PodDisrup
 }
 
 // PodGroupPostFilter runs a default preemption for the pod group.
-func (pl *DefaultPreemption) PodGroupPostFilter(ctx context.Context, pg *schedulingapi.PodGroup, pods []*v1.Pod, pgSchedulingFunc func(ctx context.Context) *fwk.Status) *fwk.Status {
+func (pl *DefaultPreemption) PodGroupPostFilter(ctx context.Context, pg *schedulingapi.PodGroup, pods []*v1.Pod, pgSchedulingFunc framework.PodGroupSchedulingFunc) *fwk.Status {
 	return pl.podGroupEvaluator.Preempt(ctx, pg, pods, pgSchedulingFunc)
 }

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -2459,6 +2459,19 @@ type fakePodActivator struct {
 
 func (f *fakePodActivator) Activate(logger klog.Logger, pods map[string]*v1.Pod) {}
 
+type mockProposedAssignment struct {
+	nodeName string
+	pod      *v1.Pod
+}
+
+func (pa *mockProposedAssignment) GetNodeName() string {
+	return pa.nodeName
+}
+
+func (pa *mockProposedAssignment) GetPod() *v1.Pod {
+	return pa.pod
+}
+
 func TestPreEnqueue(t *testing.T) {
 	onePodRes := map[v1.ResourceName]string{v1.ResourcePods: "1"}
 	tests := []struct {
@@ -2624,12 +2637,23 @@ func TestPreEnqueue(t *testing.T) {
 					t.Fatalf("could not find pg: %v", err)
 				}
 				podsToPreempt := []*v1.Pod{tt.podToTriggerPreemption}
-				pgSchedulingFunc := func(ctx context.Context) *fwk.Status {
+				var pgSchedulingFunc framework.PodGroupSchedulingFunc = func(_ context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
 					nodeInfo, _ := f.SnapshotSharedLister().NodeInfos().Get("node1")
 					if len(nodeInfo.GetPods()) == 0 {
-						return fwk.NewStatus(fwk.Success)
+						return &fwk.PodGroupAssignments{
+							ProposedAssignments: []fwk.ProposedAssignment{
+								&mockProposedAssignment{
+									nodeName: "node1",
+									pod:      tt.podToTriggerPreemption,
+								},
+								&mockProposedAssignment{
+									nodeName: "node1",
+									pod:      tt.podToCheck,
+								},
+							},
+						}, fwk.NewStatus(fwk.Success)
 					}
-					return fwk.NewStatus(fwk.Unschedulable, "need to preempt")
+					return nil, fwk.NewStatus(fwk.Unschedulable, "need to preempt")
 				}
 				p.PodGroupPostFilter(ctx, pg, podsToPreempt, pgSchedulingFunc)
 			} else {

--- a/pkg/scheduler/framework/preemption/podgrouppreemption.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption.go
@@ -27,6 +27,7 @@ import (
 	schedulingapi "k8s.io/api/scheduling/v1alpha2"
 	policylisters "k8s.io/client-go/listers/policy/v1"
 	schedulinglisters "k8s.io/client-go/listers/scheduling/v1alpha2"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 
 	"k8s.io/klog/v2"
@@ -63,7 +64,7 @@ func NewPodGroupEvaluator(fh fwk.Handle, executor *Executor) *PodGroupEvaluator 
 // scheduling after modifying the node state.
 // The caller is expected to backup the NodeInfo before calling this function
 // And rollback the state to the backup after function is finished.
-func (ev *PodGroupEvaluator) Preempt(ctx context.Context, pg *schedulingapi.PodGroup, pods []*v1.Pod, podGroupSchedulingFunc func(context.Context) *fwk.Status) *fwk.Status {
+func (ev *PodGroupEvaluator) Preempt(ctx context.Context, pg *schedulingapi.PodGroup, pods []*v1.Pod, podGroupSchedulingFunc framework.PodGroupSchedulingFunc) *fwk.Status {
 	// In case of workload-aware preemption, the domain is whole cluster.
 	// We do not make a snapshot of node info. Those nodes will be shared
 	// with the PodGroup scheduling algorithm passed as podGroupSchedulingFunc.
@@ -93,7 +94,7 @@ func (ev *PodGroupEvaluator) selectVictimsOnDomain(
 	preemptor *podGroupPreemptor,
 	domain *domain,
 	pdbs []*policy.PodDisruptionBudget,
-	podGroupSchedulingFunc func(context.Context) *fwk.Status) (*extenderv1.Victims, *fwk.Status) {
+	podGroupSchedulingFunc framework.PodGroupSchedulingFunc) (*extenderv1.Victims, *fwk.Status) {
 	logger := klog.FromContext(ctx)
 
 	// Ensure the preemptor is eligible to preempt other pods.
@@ -158,9 +159,11 @@ func (ev *PodGroupEvaluator) selectVictimsOnDomain(
 	}
 
 	// If the scheduling failed after removing all potential victims, return the status.
-	if status := podGroupSchedulingFunc(ctx); !status.IsSuccess() {
+	assignments, status := podGroupSchedulingFunc(ctx)
+	if !status.IsSuccess() {
 		return nil, status
 	}
+	maxScheduledCount := len(assignments.ProposedAssignments)
 
 	sort.Slice(potentialVictims, func(i, j int) bool {
 		return moreImportantVictim(potentialVictims[i], potentialVictims[j])
@@ -174,8 +177,22 @@ func (ev *PodGroupEvaluator) selectVictimsOnDomain(
 			return false, err
 		}
 
-		status := podGroupSchedulingFunc(ctx)
+		assignments, status := podGroupSchedulingFunc(ctx)
 		fits := status.IsSuccess()
+		scheduledCount := 0
+		if assignments != nil {
+			scheduledCount = len(assignments.ProposedAssignments)
+		}
+
+		// For a PodGroup using default scheduling algorithm it's possible to schedule more pods after reprieving.
+		// More in: https://github.com/kubernetes/kubernetes/pull/138757#discussion_r3199360621
+		maxScheduledCount = max(maxScheduledCount, scheduledCount)
+
+		// Do not reprieve the victim if it reduces the number of scheduled Pods for a PodGroup.
+		if scheduledCount < maxScheduledCount {
+			fits = false
+		}
+
 		if !fits {
 			if err := removePods(v); err != nil {
 				return false, err

--- a/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
@@ -68,15 +68,16 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		nodeNames      []string
-		initPods       []*v1.Pod
-		initPodGroups  []*schedulingapi.PodGroup
-		preemptor      *podGroupPreemptor
-		pdbs           []*policy.PodDisruptionBudget
-		blockingRules  []blockingRule
-		expectedPods   []string
-		expectedStatus *fwk.Status
+		name                     string
+		nodeNames                []string
+		initPods                 []*v1.Pod
+		initPodGroups            []*schedulingapi.PodGroup
+		preemptor                *podGroupPreemptor
+		pdbs                     []*policy.PodDisruptionBudget
+		blockingRules            []blockingRule
+		customMockSchedulingFunc func(ctx context.Context, domainNodes []fwk.NodeInfo) (*fwk.PodGroupAssignments, *fwk.Status)
+		expectedPods             []string
+		expectedStatus           *fwk.Status
 	}{
 		{
 			name:      "Mix of no-group and single-pod-groups",
@@ -579,6 +580,325 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 			expectedPods:   []string{},
 			expectedStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
 		},
+		{
+			name:      "Gang scheduling: do not reprieve if it reduces scheduled pods below max possible",
+			nodeNames: []string{"node1", "node2", "node3"},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
+				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(midPriority).Obj(),
+				st.MakePod().Name("p3").UID("v3").Node("node3").Priority(midPriority).Obj(),
+			},
+			initPodGroups: []*schedulingapi.PodGroup{},
+			preemptor: newPodGroupPreemptor(
+				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).MinCount(2).Obj(),
+				[]*v1.Pod{
+					st.MakePod().Name("p-a").UID("p-a").Priority(highPriority).Obj(),
+					st.MakePod().Name("p-b").UID("p-b").Priority(highPriority).Obj(),
+					st.MakePod().Name("p-c").UID("p-c").Priority(highPriority).Obj(),
+				},
+			),
+			blockingRules: []blockingRule{
+				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
+				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("p2")},
+				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("p3")},
+			},
+			// maxScheduledCount will be 3 (all 3 preemptor pods can be scheduled if p1, p2, p3 are preempted).
+			// If any of p1, p2, p3 are reprieved, scheduledCount drops to 2.
+			// Even though 2 >= MinCount(2), we shouldn't reprieve because it reduces scheduledCount < maxScheduledCount(3).
+			// So, all 3 should be preempted.
+			expectedPods:   []string{"p1", "p2", "p3"},
+			expectedStatus: fwk.NewStatus(fwk.Success),
+		},
+		{
+			name:      "Gang scheduling: reprieve if it does not reduce scheduled pods below max possible",
+			nodeNames: []string{"node1", "node2", "node3", "node4"},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
+				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).Obj(),
+				st.MakePod().Name("p3").UID("v3").Node("node3").Priority(lowPriority).Obj(),
+				st.MakePod().Name("p4").UID("v4").Node("node4").Priority(midPriority).Obj(),
+			},
+			initPodGroups: []*schedulingapi.PodGroup{},
+			preemptor: newPodGroupPreemptor(
+				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).MinCount(2).Obj(),
+				[]*v1.Pod{
+					st.MakePod().Name("p-a").UID("p-a").Priority(highPriority).Obj(),
+					st.MakePod().Name("p-b").UID("p-b").Priority(highPriority).Obj(),
+					st.MakePod().Name("p-c").UID("p-c").Priority(highPriority).Obj(),
+				},
+			),
+			blockingRules: []blockingRule{
+				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
+				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("p2")},
+				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("p3")},
+				{nodeName: "node4", capacity: 1, blockingVictims: sets.New("p4")},
+			},
+			// Preemptor has 3 pods and minCount of 2, so maxScheduledCount will be 3.
+			// Pod p4 with highest priority of all victims could be reprieved and we will still be able to schedule all of pods.
+			expectedPods:   []string{"p1", "p2", "p3"},
+			expectedStatus: fwk.NewStatus(fwk.Success),
+		},
+		{
+			name:      "Gang scheduling: schedule as many pods as possible without preempting higher priority pods, but still more than minCount",
+			nodeNames: []string{"node1", "node2", "node3", "node4"},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
+				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).Obj(),
+				st.MakePod().Name("p3").UID("v3").Node("node3").Priority(highPriority).Obj(),
+				st.MakePod().Name("p4").UID("v4").Node("node4").Priority(highPriority).Obj(),
+			},
+			initPodGroups: []*schedulingapi.PodGroup{},
+			preemptor: newPodGroupPreemptor(
+				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).MinCount(1).Obj(),
+				[]*v1.Pod{
+					st.MakePod().Name("p-a").UID("p-a").Priority(highPriority).Obj(),
+					st.MakePod().Name("p-b").UID("p-b").Priority(highPriority).Obj(),
+					st.MakePod().Name("p-c").UID("p-c").Priority(highPriority).Obj(),
+				},
+			),
+			blockingRules: []blockingRule{
+				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
+				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("p2")},
+				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("p3")},
+				{nodeName: "node4", capacity: 1, blockingVictims: sets.New("p4")},
+			},
+			// Preemptor has 3 pods and minCount of 1, but maxScheduledCount will be 2, because there are higher priority pods p3, p4.
+			expectedPods:   []string{"p1", "p2"},
+			expectedStatus: fwk.NewStatus(fwk.Success),
+		},
+		{
+			name:      "Gang scheduling: do not reprieve victim pod group of lower priority",
+			nodeNames: []string{"node1", "node2", "node3"},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("v1").UID("v1").Node("node1").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg").Priority(midPriority).Obj(),
+				st.MakePod().Name("v2").UID("v2").Node("node2").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg").Priority(midPriority).Obj(),
+				st.MakePod().Name("v3").UID("v3").Node("node3").Namespace(v1.NamespaceDefault).Priority(lowPriority).Obj(),
+			},
+			initPodGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("victim-pg").UID("victim-pg").Namespace(v1.NamespaceDefault).Priority(midPriority).DisruptionMode(schedulingapi.DisruptionModePodGroup).MinCount(1).Obj(),
+			},
+			preemptor: newPodGroupPreemptor(
+				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).MinCount(1).Obj(),
+				[]*v1.Pod{
+					st.MakePod().Name("p-a").UID("p-a").Priority(highPriority).Obj(),
+					st.MakePod().Name("p-b").UID("p-b").Priority(highPriority).Obj(),
+					st.MakePod().Name("p-c").UID("p-c").Priority(highPriority).Obj(),
+				},
+			),
+			blockingRules: []blockingRule{
+				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("v1")},
+				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("v2")},
+				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("v3")},
+			},
+			expectedPods:   []string{"v1", "v2", "v3"},
+			expectedStatus: fwk.NewStatus(fwk.Success),
+		},
+		{
+			name:      "Gang scheduling: preempt a pod group victim but do not schedule full pod group",
+			nodeNames: []string{"node1", "node2", "node3", "node4"},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("v1").UID("v1").Node("node1").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg").Priority(midPriority).Obj(),
+				st.MakePod().Name("v2").UID("v2").Node("node2").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg").Priority(midPriority).Obj(),
+				st.MakePod().Name("v3").UID("v3").Node("node3").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg2").Priority(highPriority).Obj(),
+				st.MakePod().Name("v4").UID("v4").Node("node4").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg2").Priority(highPriority).Obj(),
+			},
+			initPodGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("victim-pg").UID("victim-pg").Namespace(v1.NamespaceDefault).Priority(midPriority).DisruptionMode(schedulingapi.DisruptionModePodGroup).MinCount(2).Obj(),
+				st.MakePodGroup().Name("victim-pg2").UID("victim-pg2").Namespace(v1.NamespaceDefault).Priority(highPriority).DisruptionMode(schedulingapi.DisruptionModePodGroup).MinCount(2).Obj(),
+			},
+			preemptor: newPodGroupPreemptor(
+				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).MinCount(1).DisruptionMode(schedulingapi.DisruptionModePodGroup).Obj(),
+				[]*v1.Pod{
+					st.MakePod().Name("p-a").UID("p-a").Priority(highPriority).Obj(),
+					st.MakePod().Name("p-b").UID("p-b").Priority(highPriority).Obj(),
+					st.MakePod().Name("p-c").UID("p-c").Priority(highPriority).Obj(),
+				},
+			),
+			blockingRules: []blockingRule{
+				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("v1")},
+				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("v2")},
+				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("v3")},
+				{nodeName: "node4", capacity: 1, blockingVictims: sets.New("v4")},
+			},
+			expectedPods:   []string{"v1", "v2"},
+			expectedStatus: fwk.NewStatus(fwk.Success),
+		},
+		{
+			name:      "Basic scheduling: do not reprieve if it reduces scheduled pods below max possible",
+			nodeNames: []string{"node1", "node2", "node3"},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
+				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(midPriority).Obj(),
+				st.MakePod().Name("p3").UID("v3").Node("node3").Priority(midPriority).Obj(),
+			},
+			initPodGroups: []*schedulingapi.PodGroup{},
+			preemptor: newPodGroupPreemptor(
+				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).BasicPolicy().Obj(),
+				[]*v1.Pod{
+					st.MakePod().Name("p-a").UID("p-a").Priority(highPriority).Obj(),
+					st.MakePod().Name("p-b").UID("p-b").Priority(highPriority).Obj(),
+					st.MakePod().Name("p-c").UID("p-c").Priority(highPriority).Obj(),
+				},
+			),
+			blockingRules: []blockingRule{
+				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
+				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("p2")},
+				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("p3")},
+			},
+			expectedPods:   []string{"p1", "p2", "p3"},
+			expectedStatus: fwk.NewStatus(fwk.Success),
+		},
+		{
+			name:      "Basic scheduling: reprieve if it does not reduce scheduled pods below max possible",
+			nodeNames: []string{"node1", "node2", "node3", "node4"},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
+				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).Obj(),
+				st.MakePod().Name("p3").UID("v3").Node("node3").Priority(lowPriority).Obj(),
+				st.MakePod().Name("p4").UID("v4").Node("node4").Priority(midPriority).Obj(),
+			},
+			initPodGroups: []*schedulingapi.PodGroup{},
+			preemptor: newPodGroupPreemptor(
+				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).BasicPolicy().Obj(),
+				[]*v1.Pod{
+					st.MakePod().Name("p-a").UID("p-a").Priority(highPriority).Obj(),
+					st.MakePod().Name("p-b").UID("p-b").Priority(highPriority).Obj(),
+					st.MakePod().Name("p-c").UID("p-c").Priority(highPriority).Obj(),
+				},
+			),
+			blockingRules: []blockingRule{
+				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
+				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("p2")},
+				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("p3")},
+				{nodeName: "node4", capacity: 1, blockingVictims: sets.New("p4")},
+			},
+			expectedPods:   []string{"p1", "p2", "p3"},
+			expectedStatus: fwk.NewStatus(fwk.Success),
+		},
+		{
+			name:      "Basic scheduling: schedule as many pods as possible without preempting higher priority pods",
+			nodeNames: []string{"node1", "node2", "node3", "node4"},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Obj(),
+				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).Obj(),
+				st.MakePod().Name("p3").UID("v3").Node("node3").Priority(highPriority).Obj(),
+				st.MakePod().Name("p4").UID("v4").Node("node4").Priority(highPriority).Obj(),
+			},
+			initPodGroups: []*schedulingapi.PodGroup{},
+			preemptor: newPodGroupPreemptor(
+				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).BasicPolicy().Obj(),
+				[]*v1.Pod{
+					st.MakePod().Name("p-a").UID("p-a").Priority(highPriority).Obj(),
+					st.MakePod().Name("p-b").UID("p-b").Priority(highPriority).Obj(),
+					st.MakePod().Name("p-c").UID("p-c").Priority(highPriority).Obj(),
+				},
+			),
+			blockingRules: []blockingRule{
+				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("p1")},
+				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("p2")},
+				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("p3")},
+				{nodeName: "node4", capacity: 1, blockingVictims: sets.New("p4")},
+			},
+			expectedPods:   []string{"p1", "p2"},
+			expectedStatus: fwk.NewStatus(fwk.Success),
+		},
+		{
+			name:      "Reprieval allows more pods to schedule than initial maxScheduledCount due to greedy placement",
+			nodeNames: []string{"nodeA", "nodeB"},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("v1").UID("v1").Node("nodeA").Priority(midPriority).Obj(),
+				st.MakePod().Name("v2").UID("v2").Node("nodeB").Priority(lowPriority).Obj(),
+			},
+			initPodGroups: []*schedulingapi.PodGroup{},
+			preemptor: newPodGroupPreemptor(
+				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).BasicPolicy().Obj(),
+				[]*v1.Pod{
+					st.MakePod().Name("p1").UID("p1").Priority(highPriority).Obj(),
+					st.MakePod().Name("p2").UID("p2").Priority(highPriority).Obj(),
+					st.MakePod().Name("p3").UID("p3").Priority(highPriority).Obj(),
+				},
+			),
+			customMockSchedulingFunc: func(ctx context.Context, domainNodes []fwk.NodeInfo) (*fwk.PodGroupAssignments, *fwk.Status) {
+				v1Present, v2Present := false, false
+				for _, n := range domainNodes {
+					for _, pod := range n.GetPods() {
+						if pod.GetPod().Name == "v1" {
+							v1Present = true
+						} else if pod.GetPod().Name == "v2" {
+							v2Present = true
+						}
+					}
+				}
+
+				scheduledCount := 2
+				if v1Present && !v2Present {
+					scheduledCount = 3 // v1 reprieved: this increases scheduledCount!
+				}
+
+				return &fwk.PodGroupAssignments{
+					ProposedAssignments: make([]fwk.ProposedAssignment, scheduledCount),
+				}, fwk.NewStatus(fwk.Success)
+			},
+			expectedPods:   []string{"v2"},
+			expectedStatus: fwk.NewStatus(fwk.Success),
+		},
+		{
+			name:      "Basic scheduling: do not reprieve victim pod group of lower priority",
+			nodeNames: []string{"node1", "node2", "node3"},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("v1").UID("v1").Node("node1").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg").Priority(midPriority).Obj(),
+				st.MakePod().Name("v2").UID("v2").Node("node2").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg").Priority(midPriority).Obj(),
+				st.MakePod().Name("v3").UID("v3").Node("node3").Namespace(v1.NamespaceDefault).Priority(lowPriority).Obj(),
+			},
+			initPodGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("victim-pg").UID("victim-pg").Namespace(v1.NamespaceDefault).Priority(midPriority).DisruptionMode(schedulingapi.DisruptionModePodGroup).MinCount(1).Obj(),
+			},
+			preemptor: newPodGroupPreemptor(
+				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).BasicPolicy().Obj(),
+				[]*v1.Pod{
+					st.MakePod().Name("p-a").UID("p-a").Priority(highPriority).Obj(),
+					st.MakePod().Name("p-b").UID("p-b").Priority(highPriority).Obj(),
+					st.MakePod().Name("p-c").UID("p-c").Priority(highPriority).Obj(),
+				},
+			),
+			blockingRules: []blockingRule{
+				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("v1")},
+				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("v2")},
+				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("v3")},
+			},
+			expectedPods:   []string{"v1", "v2", "v3"},
+			expectedStatus: fwk.NewStatus(fwk.Success),
+		},
+		{
+			name:      "Basic scheduling: preempt a pod group victim but do not schedule full pod group",
+			nodeNames: []string{"node1", "node2", "node3", "node4"},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("v1").UID("v1").Node("node1").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg").Priority(midPriority).Obj(),
+				st.MakePod().Name("v2").UID("v2").Node("node2").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg").Priority(midPriority).Obj(),
+				st.MakePod().Name("v3").UID("v3").Node("node3").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg2").Priority(highPriority).Obj(),
+				st.MakePod().Name("v4").UID("v4").Node("node4").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg2").Priority(highPriority).Obj(),
+			},
+			initPodGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("victim-pg").UID("victim-pg").Namespace(v1.NamespaceDefault).Priority(midPriority).DisruptionMode(schedulingapi.DisruptionModePodGroup).MinCount(2).Obj(),
+				st.MakePodGroup().Name("victim-pg2").UID("victim-pg2").Namespace(v1.NamespaceDefault).Priority(highPriority).DisruptionMode(schedulingapi.DisruptionModePodGroup).MinCount(2).Obj(),
+			},
+			preemptor: newPodGroupPreemptor(
+				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).BasicPolicy().DisruptionMode(schedulingapi.DisruptionModePodGroup).Obj(),
+				[]*v1.Pod{
+					st.MakePod().Name("p-a").UID("p-a").Priority(highPriority).Obj(),
+					st.MakePod().Name("p-b").UID("p-b").Priority(highPriority).Obj(),
+					st.MakePod().Name("p-c").UID("p-c").Priority(highPriority).Obj(),
+				},
+			),
+			blockingRules: []blockingRule{
+				{nodeName: "node1", capacity: 1, blockingVictims: sets.New("v1")},
+				{nodeName: "node2", capacity: 1, blockingVictims: sets.New("v2")},
+				{nodeName: "node3", capacity: 1, blockingVictims: sets.New("v3")},
+				{nodeName: "node4", capacity: 1, blockingVictims: sets.New("v4")},
+			},
+			expectedPods:   []string{"v1", "v2"},
+			expectedStatus: fwk.NewStatus(fwk.Success),
+		},
 	}
 
 	for _, tt := range tests {
@@ -615,8 +935,21 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 			// Create a mock podGroupSchedulingFunc.
 			// This simulates whether the preempting PodGroup can schedule given the current
 			// hypothetical state of the cluster (where some candidate victims might be removed).
-			mockSchedulingFunc := func(ctx context.Context) *fwk.Status {
+			var mockSchedulingFunc framework.PodGroupSchedulingFunc = func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
+				if tt.customMockSchedulingFunc != nil {
+					return tt.customMockSchedulingFunc(ctx, domainNodes)
+				}
 				neededSlots := len(tt.preemptor.Members())
+				if tt.preemptor.podGroup != nil {
+					if tt.preemptor.podGroup.Spec.SchedulingPolicy.Gang != nil {
+						neededSlots = int(tt.preemptor.podGroup.Spec.SchedulingPolicy.Gang.MinCount)
+					} else {
+						// For non-gang pod groups (e.g., BasicPolicy), scheduling even 1 pod is considered a success
+						// since there's no all-or-nothing constraint.
+						neededSlots = 1
+					}
+				}
+
 				availableSlots := 0
 				nodeMap := make(map[string]fwk.NodeInfo)
 				for _, n := range domainNodes {
@@ -645,9 +978,12 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				}
 
 				if availableSlots >= neededSlots {
-					return fwk.NewStatus(fwk.Success)
+					assignmentsCount := min(availableSlots, len(tt.preemptor.Members()))
+					return &fwk.PodGroupAssignments{
+						ProposedAssignments: make([]fwk.ProposedAssignment, assignmentsCount),
+					}, fwk.NewStatus(fwk.Success)
 				}
-				return fwk.NewStatus(fwk.Unschedulable)
+				return nil, fwk.NewStatus(fwk.Unschedulable)
 			}
 
 			pl := &PodGroupEvaluator{}

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -282,7 +282,7 @@ func (pl *TestPlugin) PlacementScoreExtensions() fwk.PlacementScoreExtensions {
 	return nil
 }
 
-func (pl *TestPlugin) PodGroupPostFilter(ctx context.Context, pg *v1alpha2.PodGroup, pods []*v1.Pod, pgSchedulingFunc func(ctx context.Context) *fwk.Status) *fwk.Status {
+func (pl *TestPlugin) PodGroupPostFilter(ctx context.Context, pg *v1alpha2.PodGroup, pods []*v1.Pod, pgSchedulingFunc framework.PodGroupSchedulingFunc) *fwk.Status {
 	return nil
 }
 

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -280,10 +280,14 @@ func (sched *Scheduler) runWorkloadAwarePreemption(ctx context.Context, schedFwk
 	}
 	defer restoreFn()
 
-	return plugins[0].PodGroupPostFilter(ctx, pg, podGroupInfo.UnscheduledPods, func(ctx context.Context) *fwk.Status {
+	var pgSchedulingFunc framework.PodGroupSchedulingFunc = func(_ context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
 		res := sched.podGroupSchedulingAlgorithm(ctx, schedFwk, podGroupCycleState, podGroupInfo, runWithoutPostFilters)
-		return res.status
-	})
+		return &fwk.PodGroupAssignments{
+			// We do not fill the Placement struct, because we do not need it.
+			ProposedAssignments: makeProposedAssignments(&res),
+		}, res.status
+	}
+	return plugins[0].PodGroupPostFilter(ctx, pg, podGroupInfo.UnscheduledPods, pgSchedulingFunc)
 }
 
 // algorithmResult stores the scheduling result and status for a scheduling attempt of a single pod.
@@ -752,18 +756,24 @@ func (sched *Scheduler) findBestPlacement(ctx context.Context, schedFwk framewor
 func makePodGroupAssignments(successfulResults map[*fwk.Placement]*podGroupAlgorithmResult) []*fwk.PodGroupAssignments {
 	placementPodGroupAssignments := make([]*fwk.PodGroupAssignments, 0, len(successfulResults))
 	for placement, result := range successfulResults {
-		proposedAssignments := make([]fwk.ProposedAssignment, 0)
-		for _, algorithmResult := range result.podResults {
-			if algorithmResult.GetNodeName() != "" {
-				proposedAssignments = append(proposedAssignments, &algorithmResult)
-			}
-		}
+		proposedAssignments := makeProposedAssignments(result)
 		placementPodGroupAssignments = append(placementPodGroupAssignments, &fwk.PodGroupAssignments{
 			Placement:           placement,
 			ProposedAssignments: proposedAssignments,
 		})
 	}
 	return placementPodGroupAssignments
+}
+
+// makeProposedAssignments builds a list of proposedAssignments from the result of a pod group scheduling attempt.
+func makeProposedAssignments(res *podGroupAlgorithmResult) []fwk.ProposedAssignment {
+	proposedAssignments := make([]fwk.ProposedAssignment, 0)
+	for _, podRes := range res.podResults {
+		if podRes.GetNodeName() != "" {
+			proposedAssignments = append(proposedAssignments, &podRes)
+		}
+	}
+	return proposedAssignments
 }
 
 // podGroupSchedulingAlgorithm attempts to schedule pods in the pod group according to the policy and constraints and returns the scheduling result for each pod in the pod group.

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -100,7 +100,7 @@ func (mp *fakePodGroupPlugin) Permit(ctx context.Context, state fwk.CycleState, 
 	return fwk.NewStatus(fwk.Unschedulable, "default fake permit failure"), 0
 }
 
-func (mp *fakePodGroupPlugin) PodGroupPostFilter(ctx context.Context, pg *schedulingv1alpha2.PodGroup, pods []*v1.Pod, pgSchedulingFunc func(ctx context.Context) *fwk.Status) *fwk.Status {
+func (mp *fakePodGroupPlugin) PodGroupPostFilter(ctx context.Context, pg *schedulingv1alpha2.PodGroup, pods []*v1.Pod, pgSchedulingFunc framework.PodGroupSchedulingFunc) *fwk.Status {
 	mp.podGroupPostFilterCalled = true
 	if mp.podGroupPostFilterStatus != nil {
 		return mp.podGroupPostFilterStatus

--- a/test/integration/scheduler/preemption/podgrouppreemption_test.go
+++ b/test/integration/scheduler/preemption/podgrouppreemption_test.go
@@ -356,6 +356,326 @@ func TestPodGroupPreemption(t *testing.T) {
 			expectedPreempted:          []string{"low-3"},
 			expectedPodsPreemptedByWAP: 0,
 		},
+		{
+			name: "Gang scheduling: do not reprieve if it reduces scheduled pods below max possible",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node3").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("preemptor-pg").Namespace("default").Priority(100).MinCount(2).Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("p1").Node("node1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
+				st.MakePod().Name("p2").Node("node2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(50).Obj(),
+				st.MakePod().Name("p3").Node("node3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(50).Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(102).Obj(),
+				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(101).Obj(),
+				st.MakePod().Name("p-c").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+			},
+			expectedScheduled:          []string{"p-a", "p-b", "p-c"},
+			expectedPreempted:          []string{"p1", "p2", "p3"},
+			expectedPodsPreemptedByWAP: 3,
+		},
+		{
+			name: "Gang scheduling: reprieve if it does not reduce scheduled pods below max possible",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node3").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node4").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("preemptor-pg").Namespace("default").Priority(100).MinCount(2).Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("p1").Node("node1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
+				st.MakePod().Name("p2").Node("node2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
+				st.MakePod().Name("p3").Node("node3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
+				st.MakePod().Name("p4").Node("node4").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(50).Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(102).Obj(),
+				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(101).Obj(),
+				st.MakePod().Name("p-c").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+			},
+			expectedScheduled:          []string{"p-a", "p-b", "p-c", "p4"},
+			expectedPreempted:          []string{"p1", "p2", "p3"},
+			expectedPodsPreemptedByWAP: 3,
+		},
+		{
+			name: "Gang scheduling: schedule as many pods as possible without preempting higher priority pods, but still more than minCount",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node3").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node4").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("preemptor-pg").Namespace("default").Priority(100).MinCount(1).Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("p1").Node("node1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
+				st.MakePod().Name("p2").Node("node2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
+				st.MakePod().Name("p3").Node("node3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(200).Obj(),
+				st.MakePod().Name("p4").Node("node4").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(200).Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(102).Obj(),
+				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(101).Obj(),
+				st.MakePod().Name("p-c").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+			},
+			expectedScheduled:          []string{"p-a", "p-b", "p3", "p4"},
+			expectedPreempted:          []string{"p1", "p2"},
+			expectedUnschedulable:      []string{"p-c"},
+			expectedPodsPreemptedByWAP: 2,
+		},
+		{
+			name: "Gang scheduling: do not reprieve victim pod group of lower priority",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node3").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("victim-pg").Namespace("default").Priority(50).DisruptionMode(schedulingapi.DisruptionModePodGroup).MinCount(1).Obj(),
+				st.MakePodGroup().Name("preemptor-pg").Namespace("default").Priority(100).MinCount(1).Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("v1").Node("node1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("victim-pg").ZeroTerminationGracePeriod().Priority(50).Obj(),
+				st.MakePod().Name("v2").Node("node2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("victim-pg").ZeroTerminationGracePeriod().Priority(50).Obj(),
+				st.MakePod().Name("v3").Node("node3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(102).Obj(),
+				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(101).Obj(),
+				st.MakePod().Name("p-c").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+			},
+			expectedScheduled:          []string{"p-a", "p-b", "p-c"},
+			expectedPreempted:          []string{"v1", "v2", "v3"},
+			expectedPodsPreemptedByWAP: 3,
+		},
+		{
+			name: "Gang scheduling: preempt a pod group victim but do not schedule full pod group",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node3").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node4").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("victim-pg").Namespace("default").Priority(50).DisruptionMode(schedulingapi.DisruptionModePodGroup).MinCount(2).Obj(),
+				st.MakePodGroup().Name("victim-pg2").Namespace("default").Priority(200).DisruptionMode(schedulingapi.DisruptionModePodGroup).MinCount(2).Obj(),
+				st.MakePodGroup().Name("preemptor-pg").Namespace("default").Priority(100).MinCount(1).DisruptionMode(schedulingapi.DisruptionModePodGroup).Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("v1").Node("node1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("victim-pg").ZeroTerminationGracePeriod().Priority(50).Obj(),
+				st.MakePod().Name("v2").Node("node2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("victim-pg").ZeroTerminationGracePeriod().Priority(50).Obj(),
+				st.MakePod().Name("v3").Node("node3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("victim-pg2").ZeroTerminationGracePeriod().Priority(200).Obj(),
+				st.MakePod().Name("v4").Node("node4").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("victim-pg2").ZeroTerminationGracePeriod().Priority(200).Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(102).Obj(),
+				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(101).Obj(),
+				st.MakePod().Name("p-c").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+			},
+			expectedScheduled:          []string{"p-a", "p-b", "v3", "v4"},
+			expectedPreempted:          []string{"v1", "v2"},
+			expectedUnschedulable:      []string{"p-c"},
+			expectedPodsPreemptedByWAP: 2,
+		},
+		{
+			name: "Basic scheduling: do not reprieve if it reduces scheduled pods below max possible",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node3").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("preemptor-pg").Namespace("default").Priority(100).BasicPolicy().Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("p1").Node("node1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
+				st.MakePod().Name("p2").Node("node2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(50).Obj(),
+				st.MakePod().Name("p3").Node("node3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(50).Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(102).Obj(),
+				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(101).Obj(),
+				st.MakePod().Name("p-c").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+			},
+			expectedScheduled:          []string{"p-a", "p-b", "p-c"},
+			expectedPreempted:          []string{"p1", "p2", "p3"},
+			expectedPodsPreemptedByWAP: 3,
+		},
+		{
+			name: "Basic scheduling: reprieve if it does not reduce scheduled pods below max possible",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node3").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node4").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("preemptor-pg").Namespace("default").Priority(100).BasicPolicy().Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("p1").Node("node1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
+				st.MakePod().Name("p2").Node("node2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
+				st.MakePod().Name("p3").Node("node3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
+				st.MakePod().Name("p4").Node("node4").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(50).Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(102).Obj(),
+				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(101).Obj(),
+				st.MakePod().Name("p-c").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+			},
+			expectedScheduled:          []string{"p-a", "p-b", "p-c", "p4"},
+			expectedPreempted:          []string{"p1", "p2", "p3"},
+			expectedPodsPreemptedByWAP: 3,
+		},
+		{
+			name: "Basic scheduling: schedule as many pods as possible without preempting higher priority pods",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node3").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node4").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("preemptor-pg").Namespace("default").Priority(100).BasicPolicy().Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("p1").Node("node1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
+				st.MakePod().Name("p2").Node("node2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
+				st.MakePod().Name("p3").Node("node3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(200).Obj(),
+				st.MakePod().Name("p4").Node("node4").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(200).Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(102).Obj(),
+				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(101).Obj(),
+				st.MakePod().Name("p-c").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+			},
+			expectedScheduled:          []string{"p-a", "p-b", "p3", "p4"},
+			expectedPreempted:          []string{"p1", "p2"},
+			expectedUnschedulable:      []string{"p-c"},
+			expectedPodsPreemptedByWAP: 2,
+		},
+		{
+			name: "Basic scheduling: do not reprieve victim pod group of lower priority",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node3").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("victim-pg").Namespace("default").Priority(50).DisruptionMode(schedulingapi.DisruptionModePodGroup).MinCount(1).Obj(),
+				st.MakePodGroup().Name("preemptor-pg").Namespace("default").Priority(100).BasicPolicy().Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("v1").Node("node1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("victim-pg").ZeroTerminationGracePeriod().Priority(50).Obj(),
+				st.MakePod().Name("v2").Node("node2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("victim-pg").ZeroTerminationGracePeriod().Priority(50).Obj(),
+				st.MakePod().Name("v3").Node("node3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(102).Obj(),
+				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(101).Obj(),
+				st.MakePod().Name("p-c").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+			},
+			expectedScheduled:          []string{"p-a", "p-b", "p-c"},
+			expectedPreempted:          []string{"v1", "v2", "v3"},
+			expectedPodsPreemptedByWAP: 3,
+		},
+		{
+			name: "Basic scheduling: preempt a pod group victim but do not schedule full pod group",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node3").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node4").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("victim-pg").Namespace("default").Priority(50).DisruptionMode(schedulingapi.DisruptionModePodGroup).MinCount(2).Obj(),
+				st.MakePodGroup().Name("victim-pg2").Namespace("default").Priority(200).DisruptionMode(schedulingapi.DisruptionModePodGroup).MinCount(2).Obj(),
+				st.MakePodGroup().Name("preemptor-pg").Namespace("default").Priority(100).BasicPolicy().DisruptionMode(schedulingapi.DisruptionModePodGroup).Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("v1").Node("node1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("victim-pg").ZeroTerminationGracePeriod().Priority(50).Obj(),
+				st.MakePod().Name("v2").Node("node2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("victim-pg").ZeroTerminationGracePeriod().Priority(50).Obj(),
+				st.MakePod().Name("v3").Node("node3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("victim-pg2").ZeroTerminationGracePeriod().Priority(200).Obj(),
+				st.MakePod().Name("v4").Node("node4").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("victim-pg2").ZeroTerminationGracePeriod().Priority(200).Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("p-a").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(102).Obj(),
+				st.MakePod().Name("p-b").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(101).Obj(),
+				st.MakePod().Name("p-c").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).Obj(),
+			},
+			expectedScheduled:          []string{"p-a", "p-b", "v3", "v4"},
+			expectedPreempted:          []string{"v1", "v2"},
+			expectedUnschedulable:      []string{"p-c"},
+			expectedPodsPreemptedByWAP: 2,
+		},
+		{
+			name: "Reprieval allows more pods to schedule than initial maxScheduledCount due to greedy placement",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("nodea").Label("topology.kubernetes.io/zone", "zoneA").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "2", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("nodeb").Label("topology.kubernetes.io/zone", "zoneB").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "3", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			podGroups: []*schedulingapi.PodGroup{
+				st.MakePodGroup().Name("preemptor-pg").Namespace("default").Priority(100).MinCount(3).TopologyKey("topology.kubernetes.io/zone").Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("va").Node("nodea").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").ZeroTerminationGracePeriod().Priority(50).NodeAffinityIn("topology.kubernetes.io/zone", []string{"zoneA"}, st.NodeSelectorTypeMatchExpressions).Obj(),
+				st.MakePod().Name("vb").Node("nodeb").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).NodeAffinityIn("topology.kubernetes.io/zone", []string{"zoneB"}, st.NodeSelectorTypeMatchExpressions).Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("p1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).
+					NodeAffinity(&v1.NodeAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
+							{
+								Weight: 100,
+								Preference: v1.NodeSelectorTerm{
+									MatchExpressions: []v1.NodeSelectorRequirement{
+										{Key: "topology.kubernetes.io/zone", Operator: v1.NodeSelectorOpIn, Values: []string{"zoneA"}},
+									},
+								},
+							},
+						},
+					}).Obj(),
+				st.MakePod().Name("p2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).
+					NodeAffinity(&v1.NodeAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
+							{
+								Weight: 100,
+								Preference: v1.NodeSelectorTerm{
+									MatchExpressions: []v1.NodeSelectorRequirement{
+										{Key: "topology.kubernetes.io/zone", Operator: v1.NodeSelectorOpIn, Values: []string{"zoneA"}},
+									},
+								},
+							},
+						},
+					}).Obj(),
+				st.MakePod().Name("p3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("preemptor-pg").ZeroTerminationGracePeriod().Priority(100).
+					NodeAffinity(&v1.NodeAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
+							{
+								Weight: 100,
+								Preference: v1.NodeSelectorTerm{
+									MatchExpressions: []v1.NodeSelectorRequirement{
+										{Key: "topology.kubernetes.io/zone", Operator: v1.NodeSelectorOpIn, Values: []string{"zoneA"}},
+									},
+								},
+							},
+						},
+					}).Obj(),
+			},
+			expectedScheduled:          []string{"p1", "p2", "p3", "va"},
+			expectedPreempted:          []string{"vb"},
+			expectedPodsPreemptedByWAP: 1,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Do not allow to decrease the number of scheduled preemptor pods during the preemption reprieve process.

Currently the reprieve process require PodGroup rescheduling, which may lead to picking smaller number of pods while still satisfying minCount limit. We promote placements with the biggest number of pods regardless of how much disruptive this placement is to other workloads (victims).

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/138709

Fixes #138709
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Workload-aware preemption now preempts victims so that as many as possible of the preemptor pods can be scheduled.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage
A mix of AI and human intervention was used to write tests
