### PR TITLE
scheduling: close declarative-validation test gaps for PodGroup and Workload

### DIFF
--- a/pkg/apis/scheduling/v1alpha2/zz_generated.validations.go
+++ b/pkg/apis/scheduling/v1alpha2/zz_generated.validations.go
@@ -946,10 +946,6 @@ func Validate_PodGroupTemplate(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true

--- a/pkg/registry/scheduling/podgroup/declarative_validation_test.go
+++ b/pkg/registry/scheduling/podgroup/declarative_validation_test.go
@@ -331,6 +331,12 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				field.TooMany(field.NewPath("spec", "resourceClaims"), scheduling.MaxPodGroupResourceClaims+1, scheduling.MaxPodGroupResourceClaims).WithOrigin("maxItems"),
 			},
 		},
+		"empty claim name": {
+			input: mkValidPodGroup(addResourceClaims(scheduling.PodGroupResourceClaim{Name: "", ResourceClaimName: new("resource-claim")})),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "resourceClaims").Index(0).Child("name"), ""),
+			},
+		},
 	}
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
@@ -685,6 +691,18 @@ func testDeclarativeValidateStatusUpdate(t *testing.T, apiVersion string) {
 				field.Duplicate(field.NewPath("status", "resourceClaimStatuses").Index(2), nil),
 			},
 		},
+		"too many resource claim statuses": {
+			oldObj: mkValidPodGroup(setResourceVersion("1"),
+				addManyResourceClaims(scheduling.MaxPodGroupResourceClaims+1),
+			),
+			updateObj: mkValidPodGroup(setResourceVersion("1"),
+				addManyResourceClaims(scheduling.MaxPodGroupResourceClaims+1),
+				addManyResourceClaimStatuses(scheduling.MaxPodGroupResourceClaims+1),
+			),
+			expectedErrs: field.ErrorList{
+				field.TooMany(field.NewPath("status", "resourceClaimStatuses"), scheduling.MaxPodGroupResourceClaims+1, scheduling.MaxPodGroupResourceClaims).WithOrigin("maxItems"),
+			},
+		},
 	}
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
@@ -786,6 +804,28 @@ func addResourceClaimStatuses(statuses ...scheduling.PodGroupResourceClaimStatus
 	return func(obj *scheduling.PodGroup) {
 		obj.Status.ResourceClaimStatuses = append(obj.Status.ResourceClaimStatuses, statuses...)
 	}
+}
+
+func addManyResourceClaims(n int) func(obj *scheduling.PodGroup) {
+	claims := make([]scheduling.PodGroupResourceClaim, n)
+	for i := range n {
+		claims[i] = scheduling.PodGroupResourceClaim{
+			Name:              "c" + strconv.Itoa(i),
+			ResourceClaimName: new("r" + strconv.Itoa(i)),
+		}
+	}
+	return addResourceClaims(claims...)
+}
+
+func addManyResourceClaimStatuses(n int) func(obj *scheduling.PodGroup) {
+	statuses := make([]scheduling.PodGroupResourceClaimStatus, n)
+	for i := range n {
+		statuses[i] = scheduling.PodGroupResourceClaimStatus{
+			Name:              "c" + strconv.Itoa(i),
+			ResourceClaimName: new("r" + strconv.Itoa(i)),
+		}
+	}
+	return addResourceClaimStatuses(statuses...)
 }
 
 func addCondition(conditionType string) func(obj *scheduling.PodGroup) {

--- a/pkg/registry/scheduling/workload/declarative_validation_test.go
+++ b/pkg/registry/scheduling/workload/declarative_validation_test.go
@@ -349,6 +349,16 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				field.TooMany(field.NewPath("spec", "podGroupTemplates").Index(0).Child("resourceClaims"), scheduling.MaxPodGroupResourceClaims+1, scheduling.MaxPodGroupResourceClaims).WithOrigin("maxItems"),
 			},
 		},
+		"empty claim name": {
+			input: mkValidWorkload(addResourceClaims(scheduling.PodGroupResourceClaim{Name: "", ResourceClaimName: new("resource-claim")})),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "podGroupTemplates").Index(0).Child("resourceClaims").Index(0).Child("name"), ""),
+			},
+		},
+		"schedulingConstraints set with TAS disabled": {
+			input:        mkValidWorkload(setSchedulingConstraints(0)),
+			expectedErrs: field.ErrorList{field.Forbidden(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingConstraints"), "")},
+		},
 	}
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {

--- a/staging/src/k8s.io/api/scheduling/v1alpha2/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1alpha2/generated.proto
@@ -376,7 +376,6 @@ message PodGroupTemplate {
   // +k8s:listType=map
   // +k8s:listMapKey=name
   // +k8s:maxItems=4
-  // +k8s:immutable
   // +featureGate=DRAWorkloadResourceClaims
   repeated PodGroupResourceClaim resourceClaims = 4;
 

--- a/staging/src/k8s.io/api/scheduling/v1alpha2/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha2/types.go
@@ -159,7 +159,6 @@ type PodGroupTemplate struct {
 	// +k8s:listType=map
 	// +k8s:listMapKey=name
 	// +k8s:maxItems=4
-	// +k8s:immutable
 	// +featureGate=DRAWorkloadResourceClaims
 	ResourceClaims []PodGroupResourceClaim `json:"resourceClaims,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name" protobuf:"bytes,4,rep,name=resourceClaims"`
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
 Closes the PodGroup and Workload (scheduling.k8s.io/v1alpha2) gaps from the declarative-validation coverage guardrail.

  - **PodGroup**: add equivalence tests for `spec.resourceClaims[].name` Required and `status.resourceClaimStatuses` TooMany.
  - **Workload**: add equivalence tests for `spec.podGroupTemplates[].resourceClaims[].name` Required and
  spec.podGroupTemplates[].schedulingConstraints Forbidden (TopologyAwareWorkloadScheduling disabled).
  - Drop the redundant `+k8s:immutable` on `PodGroupTemplate.ResourceClaims`. The outer `+k8s:immutable` on WorkloadSpec.PodGroupTemplates short-circuits on any change to a podGroupTemplate (including its resourceClaims), so the inner one never fires.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
 Part of 
- #138697

#### Special notes for your reviewer:
Two "minimum" rules (PodGroup and Workload) remain as uncovered. Both are `+k8s:minimum=-2147483648` on *int32, which is unreachable; they are intentionally left as-is and would be included in the allowlist.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
