### PR TITLE
Skip redundant sort in newCacheIntervalFromStore for OrderedLister stores

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval.go
@@ -168,7 +168,9 @@ func newCacheIntervalFromStore(resourceVersion uint64, indexer store.Indexer, ke
 		}
 		buffer.endIndex++
 	}
-	sort.Sort(sortableWatchCacheEvents(buffer.buffer))
+	if _, ordered := indexer.(store.OrderedLister); !ordered {
+		sort.Sort(sortableWatchCacheEvents(buffer.buffer))
+	}
 	ci := &watchCacheInterval{
 		startIndex: 0,
 		// Simulate that we already have all the events we're looking for.

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval_test.go
@@ -460,7 +460,7 @@ func TestCacheIntervalFromStoreSorted(t *testing.T) {
 			}
 
 			got := make([]string, 0, n)
-			for i := 0; i < n; i++ {
+			for range n {
 				ev, err := wci.Next()
 				if err != nil {
 					t.Fatal(err)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"sync"
 	"testing"
 
@@ -426,5 +427,49 @@ func TestCacheIntervalNextFromStore(t *testing.T) {
 	// The interval's buffer should now be empty.
 	if !wci.buffer.isEmpty() {
 		t.Error("expected cache interval's buffer to be empty")
+	}
+}
+
+// TestCacheIntervalFromStoreSorted verifies newCacheIntervalFromStore returns
+// events sorted by Key for both indexer backends.
+func TestCacheIntervalFromStoreSorted(t *testing.T) {
+	cases := []struct {
+		name    string
+		indexer store.Indexer
+	}{
+		{"legacy", cache.NewIndexer(store.ElementKey, store.ElementIndexers(nil))},
+		{"btree", store.NewIndexer(nil)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			const n = 50
+			// Insert in reverse-key order so any code path that returns
+			// items in insertion order trivially fails the sorted check below.
+			for i := n - 1; i >= 0; i-- {
+				key := fmt.Sprintf("pod-%08d", i)
+				elem := makeTestStoreElement(makeTestPod(key, uint64(i)))
+				err := tc.indexer.Add(elem)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			wci, err := newCacheIntervalFromStore(n, tc.indexer, "", false)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got := make([]string, 0, n)
+			for i := 0; i < n; i++ {
+				ev, err := wci.Next()
+				if err != nil {
+					t.Fatal(err)
+				}
+				got = append(got, ev.Key)
+			}
+			if !sort.StringsAreSorted(got) {
+				t.Errorf("events not sorted by key: %v", got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`newCacheIntervalFromStore` sorts events from `indexer.List()` under the watch cache RLock. For btree-backed stores (`OrderedLister`), `List()` already returns items sorted by Key, so skip the redundant sort.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
