### PR TITLE
apiserver: add watch_cache_initialization_duration_seconds metric

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -501,6 +501,7 @@ func (c *Cacher) startCaching(stopChannel <-chan struct{}) {
 	err = c.reflector.ListAndWatch(stopChannel)
 	if err != nil {
 		klog.Errorf("cacher (%v): unexpected ListAndWatch error: %v; reinitializing...", c.groupResource.String(), err)
+		metrics.WatchCacheInitializationErrors.WithLabelValues(c.groupResource.Group, c.groupResource.Resource).Inc()
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -484,10 +484,13 @@ func NewCacherFromConfig(config Config) (*Cacher, error) {
 }
 
 func (c *Cacher) startCaching(stopChannel <-chan struct{}) {
+	startTime := time.Now()
 	c.watchCache.SetOnReplace(func() {
 		c.ready.setReady()
-		klog.V(1).InfoS("cacher initialized", "group", c.groupResource.Group, "resource", c.groupResource.Resource)
+		duration := time.Since(startTime)
+		klog.V(1).InfoS("cacher initialized", "group", c.groupResource.Group, "resource", c.groupResource.Resource, "duration", duration)
 		metrics.WatchCacheInitializations.WithLabelValues(c.groupResource.Group, c.groupResource.Resource).Inc()
+		metrics.WatchCacheInitializationDuration.WithLabelValues(c.groupResource.Group, c.groupResource.Resource).Observe(duration.Seconds())
 	})
 	var err error
 	defer func() {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -161,6 +161,18 @@ var (
 		[]string{"group", "resource"},
 	)
 
+	WatchCacheInitializationDuration = compbasemetrics.NewHistogramVec(
+		&compbasemetrics.HistogramOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "initialization_duration_seconds",
+			Help:           "Histogram of watch cache initialization duration in seconds, broken by resource type.",
+			StabilityLevel: compbasemetrics.ALPHA,
+			Buckets:        []float64{0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 180, 600},
+		},
+		[]string{"group", "resource"},
+	)
+
 	WatchCacheReadWait = compbasemetrics.NewHistogramVec(
 		&compbasemetrics.HistogramOpts{
 			Namespace:      namespace,
@@ -227,6 +239,7 @@ func Register() {
 		legacyregistry.MustRegister(watchCacheCapacityDecreaseTotal)
 		legacyregistry.MustRegister(WatchCacheCapacity)
 		legacyregistry.MustRegister(WatchCacheInitializations)
+		legacyregistry.MustRegister(WatchCacheInitializationDuration)
 		legacyregistry.MustRegister(WatchCacheReadWait)
 		legacyregistry.MustRegister(ConsistentReadTotal)
 		legacyregistry.MustRegister(StorageConsistencyCheckTotal)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -161,6 +161,17 @@ var (
 		[]string{"group", "resource"},
 	)
 
+	WatchCacheInitializationErrors = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "initialization_errors_total",
+			Help:           "Counter of watch cache initialization errors broken by resource type.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"group", "resource"},
+	)
+
 	WatchCacheInitializationDuration = compbasemetrics.NewHistogramVec(
 		&compbasemetrics.HistogramOpts{
 			Namespace:      namespace,
@@ -239,6 +250,7 @@ func Register() {
 		legacyregistry.MustRegister(watchCacheCapacityDecreaseTotal)
 		legacyregistry.MustRegister(WatchCacheCapacity)
 		legacyregistry.MustRegister(WatchCacheInitializations)
+		legacyregistry.MustRegister(WatchCacheInitializationErrors)
 		legacyregistry.MustRegister(WatchCacheInitializationDuration)
 		legacyregistry.MustRegister(WatchCacheReadWait)
 		legacyregistry.MustRegister(ConsistentReadTotal)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds gauge `apiserver_watch_cache_initialization_duration_seconds` (alpha, labeled by group/resource) holding the duration of the most recent watch cache initialization. Set in the existing `onReplace` callback alongside `WatchCacheInitializations`.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

/sig api-machinery

#### Does this PR introduce a user-facing change?

```release-note
Added metric `apiserver_watch_cache_initialization_duration_seconds` recording the duration of the most recent watch cache initialization, labeled by group and resource.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```