### PR TITLE
[PodLevelResourceManagers] Metrics stability level & skip allocation for zero-memory containers

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -4430,6 +4430,39 @@
   componentEndpoints:
   - component: kubelet
     endpoint: /metrics
+- name: resource_manager_allocation_errors_total
+  subsystem: kubelet
+  help: Number of errors encountered during exclusive resource allocation.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - resource_name
+  - source
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
+- name: resource_manager_allocations_total
+  subsystem: kubelet
+  help: Number of exclusive resource allocations performed by a resource manager.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - resource_name
+  - source
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
+- name: resource_manager_container_assignments_total
+  subsystem: kubelet
+  help: Number of containers with a specific type of resource assignment.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - assignment_type
+  - resource_name
+  componentEndpoints:
+  - component: kubelet
+    endpoint: /metrics
 - name: restarted_pods_total
   subsystem: kubelet
   help: Number of pods that have been restarted because they were deleted and recreated
@@ -5617,36 +5650,6 @@
   - resource
   componentEndpoints:
   - component: kube-controller-manager
-    endpoint: /metrics
-- name: resource_manager_allocation_errors_total
-  help: Number of errors encountered during exclusive resource allocation.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - resource_name
-  - source
-  componentEndpoints:
-  - component: kubelet
-    endpoint: /metrics
-- name: resource_manager_allocations_total
-  help: Number of exclusive resource allocations performed by a resource manager.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - resource_name
-  - source
-  componentEndpoints:
-  - component: kubelet
-    endpoint: /metrics
-- name: resource_manager_container_assignments
-  help: Number of containers with a specific type of resource assignment.
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - assignment_type
-  - resource_name
-  componentEndpoints:
-  - component: kubelet
     endpoint: /metrics
 - name: request_processing_duration_seconds
   subsystem: resourcepoolstatusrequest_controller

--- a/hack/tools/instrumentation/documentation/documentation.md
+++ b/hack/tools/instrumentation/documentation/documentation.md
@@ -8,7 +8,7 @@ description: >-
 
 ## Metrics (v1.37)
 
-<!-- (auto-generated 2026 May 23) -->
+<!-- (auto-generated 2026 Jul 15) -->
 <!-- (auto-generated v1.37) -->
 This page details the metrics that different Kubernetes components export. You can query the metrics endpoint for these 
 components using an HTTP scrape, and fetch the current metrics data in Prometheus format.
@@ -1873,6 +1873,20 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">cloud_node_lifecycle_controller_cloud_provider_calls_total</div>
+	<div class="metric_help">The total number of cloud provider API calls, labeled by operation and result.</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">operation</span><span class="metric_label">result</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">cloud_node_lifecycle_controller_monitor_nodes_duration_seconds</div>
+	<div class="metric_help">A metric measuring the duration in seconds of a single MonitorNodes loop execution.</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>
+	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>cloud-controller-manager (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">cloud_provider_webhook_request_duration_seconds</div>
 	<div class="metric_help">Request latency in seconds. Broken down by status code.</div>
 	<ul>
@@ -2299,20 +2313,6 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">usage</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li></ul>
-	</div><div class="metric" data-stability="alpha">
-	<div class="metric_name">kube_apiserver_pod_logs_pods_logs_backend_tls_failure_total</div>
-	<div class="metric_help">Total number of requests for pods/logs that failed due to kubelet server TLS verification</div>
-	<ul>
-	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
-	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.27.0</span></li></ul>
-	</div><div class="metric" data-stability="alpha">
-	<div class="metric_name">kube_apiserver_pod_logs_pods_logs_insecure_backend_total</div>
-	<div class="metric_help">Total number of requests for pods/logs sliced by usage type: enforce_tls, skip_tls_allowed, skip_tls_denied</div>
-	<ul>
-	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
-	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">usage</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-apiserver (/metrics)</li></ul></li><li class="metric_deprecated_version"><label class="metric_detail">Deprecated Versions:</label><span>1.27.0</span></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_active_pods</div>
 	<div class="metric_help">The number of pods the kubelet considers active and which are being considered when admitting new pods. static is true if the pod is not from the apiserver.</div>
@@ -2916,6 +2916,27 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">preemption_signal</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">kubelet_resource_manager_allocation_errors_total</div>
+	<div class="metric_help">Number of errors encountered during exclusive resource allocation.</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">resource_name</span><span class="metric_label">source</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">kubelet_resource_manager_allocations_total</div>
+	<div class="metric_help">Number of exclusive resource allocations performed by a resource manager.</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">resource_name</span><span class="metric_label">source</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">kubelet_resource_manager_container_assignments_total</div>
+	<div class="metric_help">Number of containers with a specific type of resource assignment.</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">assignment_type</span><span class="metric_label">resource_name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">kubelet_restarted_pods_total</div>
 	<div class="metric_help">Number of pods that have been restarted because they were deleted and recreated with the same UID while the kubelet was watching them (common for static pods, extremely uncommon for API pods)</div>
 	<ul>
@@ -3301,6 +3322,27 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
 	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">kubeproxy_sync_proxy_rules_winkernel_lb_create_failures_total</div>
+	<div class="metric_help">Cumulative proxy winkernel lb create failures</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">error</span><span class="metric_label">ip_family</span><span class="metric_label">lb_type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">kubeproxy_sync_proxy_rules_winkernel_lb_delete_failures_total</div>
+	<div class="metric_help">Cumulative proxy winkernel lb delete failures</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">error</span><span class="metric_label">ip_family</span><span class="metric_label">lb_type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
+	<div class="metric_name">kubeproxy_sync_proxy_rules_winkernel_lb_update_failures_total</div>
+	<div class="metric_help">Cumulative proxy winkernel lb update failures</div>
+	<ul>
+	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
+	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
+	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">error</span><span class="metric_label">ip_family</span><span class="metric_label">lb_type</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-proxy (/metrics)</li></ul></li></ul>
+	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">leader_election_master_status</div>
 	<div class="metric_help">Gauge of if the reporting system is master of the relevant lease, 0 indicates backup, 1 indicates master. 'name' is the string used to identify the lease. Please make sure to group by name.</div>
 	<ul>
@@ -3531,27 +3573,6 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
 	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">group</span><span class="metric_label">resource</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-controller-manager (/metrics)</li></ul></li></ul>
-	</div><div class="metric" data-stability="alpha">
-	<div class="metric_name">resource_manager_allocation_errors_total</div>
-	<div class="metric_help">Number of errors encountered during exclusive resource allocation.</div>
-	<ul>
-	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
-	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">resource_name</span><span class="metric_label">source</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
-	</div><div class="metric" data-stability="alpha">
-	<div class="metric_name">resource_manager_allocations_total</div>
-	<div class="metric_help">Number of exclusive resource allocations performed by a resource manager.</div>
-	<ul>
-	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
-	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">resource_name</span><span class="metric_label">source</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
-	</div><div class="metric" data-stability="alpha">
-	<div class="metric_name">resource_manager_container_assignments</div>
-	<div class="metric_help">Number of containers with a specific type of resource assignment.</div>
-	<ul>
-	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
-	<li data-type="counter"><label class="metric_detail">Type:</label> <span class="metric_type">Counter</span></li>
-	<li class="metric_labels_varying"><label class="metric_detail">Labels:</label><span class="metric_label">assignment_type</span><span class="metric_label">resource_name</span></li><li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kubelet (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">resourcepoolstatusrequest_controller_request_processing_duration_seconds</div>
 	<div class="metric_help">Time taken to process a ResourcePoolStatusRequest</div>
@@ -3827,7 +3848,7 @@ Alpha metrics do not have any API guarantees. These metrics must be used at your
 	<li class="metric_component_endpoints"><label class="metric_detail">Components:</label><ul><li>kube-scheduler (/metrics)</li></ul></li></ul>
 	</div><div class="metric" data-stability="alpha">
 	<div class="metric_name">scheduler_podgroup_scheduling_attempt_duration_seconds</div>
-	<div class="metric_help">Pod group scheduling attempt latency in seconds (scheduling algorithm + binding)</div>
+	<div class="metric_help">Pod group scheduling attempt latency in seconds</div>
 	<ul>
 	<li><label class="metric_detail">Stability Level:</label><span class="metric_stability_level">ALPHA</span></li>
 	<li data-type="histogram"><label class="metric_detail">Type:</label> <span class="metric_type">Histogram</span></li>

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -2532,6 +2532,60 @@ func TestStaticPolicyAllocatePod(t *testing.T) {
 				expTotalErrors: 0,
 			},
 		},
+		{
+			description: "scope: pod, should reject a pod due to SMT alignment error when FullPhysicalCPUsOnly is enabled",
+			topo:        topoDualSocketHT,
+			options: map[string]string{
+				FullPCPUsOnlyOption: "true",
+			},
+			numReservedCPUs: 2,
+			reservedCPUs:    cpuset.New(0, 1),
+			stAssignments:   state.ContainerCPUAssignments{},
+			stDefaultCPUSet: cpuset.New(2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			pod: makePodWithContainersAndPodLevelResources("pod-smt-error", "3", "3", []containerSpec{}, []containerSpec{
+				{name: "gu-container", request: "3", limit: "3"},
+			}),
+			topologyHint:                    topologymanager.TopologyHint{NUMANodeAffinity: newNUMAAffinity(0), Preferred: true},
+			expErr:                          SMTAlignmentError{RequestedCPUs: 3, CpusPerCore: 2},
+			expPodAssignments:               state.ContainerCPUAssignments{},
+			expDefaultCPUSet:                cpuset.New(2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			podLevelResourcesEnabled:        true,
+			podLevelResourceManagersEnabled: true,
+			requiredMetrics: requiredMetrics{
+				expTotalErrors: 1,
+			},
+		},
+		{
+			description: "scope: pod, should successfully allocate CPUs for a pod when FullPhysicalCPUsOnly is enabled and CPU request is a multiple of SMT level",
+			topo:        topoDualSocketHT,
+			options: map[string]string{
+				FullPCPUsOnlyOption: "true",
+			},
+			numReservedCPUs: 2,
+			reservedCPUs:    cpuset.New(0, 1),
+			stAssignments:   state.ContainerCPUAssignments{},
+			stDefaultCPUSet: cpuset.New(2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			pod: makePodWithContainersAndPodLevelResources("pod-smt-success", "4", "4", []containerSpec{}, []containerSpec{
+				{name: "gu-container-1", request: "2", limit: "2"},
+				{name: "gu-container-2", request: "2", limit: "2"},
+			}),
+			topologyHint: topologymanager.TopologyHint{NUMANodeAffinity: newNUMAAffinity(0), Preferred: true},
+			expErr:       nil,
+			expPodAssignments: state.ContainerCPUAssignments{
+				"pod-smt-success": map[string]cpuset.CPUSet{
+					"gu-container-1": cpuset.New(2, 8),
+					"gu-container-2": cpuset.New(4, 10),
+				},
+			},
+			expDefaultCPUSet:                cpuset.New(3, 5, 6, 7, 9, 11),
+			podLevelResourcesEnabled:        true,
+			podLevelResourceManagersEnabled: true,
+			requiredMetrics: requiredMetrics{
+				expTotalAllocs:              2,
+				expExclusiveAssignments:     2,
+				expPodSharedPoolAssignments: 0,
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -447,6 +447,15 @@ func (p *staticPolicy) Allocate(ctx context.Context, s state.State, pod *v1.Pod,
 		return nil
 	}
 
+	requestedResources, err := getContainerRequestedResources(logger, pod, container)
+	if err != nil {
+		return err
+	}
+	if len(requestedResources) == 0 {
+		logger.V(5).Info("Exclusive memory allocation skipped, container requests no memory resources", "podUID", podUID, "containerName", container.Name)
+		return nil
+	}
+
 	logger.Info("Allocate")
 	// Container belongs in an exclusively allocated pool
 	metrics.MemoryManagerPinningRequestTotal.Inc()
@@ -466,11 +475,6 @@ func (p *staticPolicy) Allocate(ctx context.Context, s state.State, pod *v1.Pod,
 	// Call Topology Manager to get the aligned affinity across all hint providers.
 	hint := p.affinity.GetAffinity(logger, podUID, container.Name)
 	logger.Info("Got topology affinity", "hint", hint)
-
-	requestedResources, err := getContainerRequestedResources(logger, pod, container)
-	if err != nil {
-		return err
-	}
 
 	machineState := s.GetMachineState()
 	bestHint := &hint
@@ -856,6 +860,9 @@ func (p *staticPolicy) GetTopologyHints(logger klog.Logger, s state.State, pod *
 	requestedResources, err := getContainerRequestedResources(logger, pod, container)
 	if err != nil {
 		logger.Error(err, "Failed to get container requested resources", "podUID", pod.UID, "containerName", container.Name)
+		return nil
+	}
+	if len(requestedResources) == 0 {
 		return nil
 	}
 

--- a/pkg/kubelet/cm/topologymanager/topology_manager_test.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager_test.go
@@ -23,11 +23,15 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2"
 
 	cadvisorapi "github.com/google/cadvisor/lib/model"
 
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/test/utils/ktesting"
@@ -596,5 +600,169 @@ func TestAdmit(t *testing.T) {
 		if !ctnActual.Admit && ctnActual.Reason != ErrorTopologyAffinity {
 			t.Errorf("Error occurred, expected Reason in result to be %v got %v", ErrorTopologyAffinity, ctnActual.Reason)
 		}
+	}
+}
+
+type trackingHintProvider struct {
+	podHintsCalled          bool
+	containerHintsCalled    bool
+	allocatePodCalled       bool
+	allocateContainerCalled bool
+	hints                   map[string][]TopologyHint
+}
+
+func (m *trackingHintProvider) GetTopologyHints(logger klog.Logger, pod *v1.Pod, container *v1.Container, operation lifecycle.Operation) map[string][]TopologyHint {
+	m.containerHintsCalled = true
+	return m.hints
+}
+
+func (m *trackingHintProvider) GetPodTopologyHints(logger klog.Logger, pod *v1.Pod, operation lifecycle.Operation) map[string][]TopologyHint {
+	m.podHintsCalled = true
+	return m.hints
+}
+
+func (m *trackingHintProvider) AllocatePod(logger klog.Logger, pod *v1.Pod, operation lifecycle.Operation) error {
+	m.allocatePodCalled = true
+	return nil
+}
+
+func (m *trackingHintProvider) Allocate(ctx context.Context, pod *v1.Pod, container *v1.Container, operation lifecycle.Operation) error {
+	m.allocateContainerCalled = true
+	return nil
+}
+
+func TestAdmitWithPodLevelResources(t *testing.T) {
+	numaInfo := &NUMAInfo{
+		Nodes: []int{0, 1},
+		NUMADistances: NUMADistances{
+			0: {10, 11},
+			1: {11, 10},
+		},
+	}
+	opts := PolicyOptions{}
+	restrictedPolicy := NewRestrictedPolicy(numaInfo, opts)
+
+	tcases := []struct {
+		name                            string
+		podLevelResourcesEnabled        bool
+		podLevelResourceManagersEnabled bool
+		pod                             *v1.Pod
+		expectedAdmit                   bool
+		expectedPodHintsCalled          bool
+		expectedContainerHintsCalled    bool
+		expectedAllocatePodCalled       bool
+		expectedAllocateContainerCalled bool
+		scope                           Scope
+	}{
+		{
+			name:                            "pod scope, feature disabled, falls back to container level flow",
+			podLevelResourcesEnabled:        true,
+			podLevelResourceManagersEnabled: false,
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Resources:  &v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")}},
+					Containers: []v1.Container{{Name: "c1", Resources: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")}}}},
+				},
+				Status: v1.PodStatus{QOSClass: v1.PodQOSGuaranteed},
+			},
+			expectedAdmit:                   true,
+			expectedPodHintsCalled:          true,
+			expectedContainerHintsCalled:    false,
+			expectedAllocatePodCalled:       false,
+			expectedAllocateContainerCalled: true,
+			scope:                           NewPodScope(restrictedPolicy),
+		},
+		{
+			name:                            "pod scope, feature enabled, uses pod-level flow",
+			podLevelResourcesEnabled:        true,
+			podLevelResourceManagersEnabled: true,
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Resources:  &v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")}},
+					Containers: []v1.Container{{Name: "c1", Resources: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")}}}},
+				},
+				Status: v1.PodStatus{QOSClass: v1.PodQOSGuaranteed},
+			},
+			expectedAdmit:                   true,
+			expectedPodHintsCalled:          true,
+			expectedContainerHintsCalled:    false,
+			expectedAllocatePodCalled:       true,
+			expectedAllocateContainerCalled: false,
+			scope:                           NewPodScope(restrictedPolicy),
+		},
+		{
+			name:                            "container scope, feature enabled, uses container-level flow",
+			podLevelResourcesEnabled:        true,
+			podLevelResourceManagersEnabled: true,
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Resources:  &v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")}},
+					Containers: []v1.Container{{Name: "c1", Resources: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")}}}},
+				},
+				Status: v1.PodStatus{QOSClass: v1.PodQOSGuaranteed},
+			},
+			expectedAdmit:                   true,
+			expectedPodHintsCalled:          false,
+			expectedContainerHintsCalled:    true,
+			expectedAllocatePodCalled:       false,
+			expectedAllocateContainerCalled: true,
+			scope:                           NewContainerScope(restrictedPolicy),
+		},
+		{
+			name:                            "container scope, feature disabled, uses container-level flow",
+			podLevelResourcesEnabled:        true,
+			podLevelResourceManagersEnabled: false,
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Resources:  &v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")}},
+					Containers: []v1.Container{{Name: "c1", Resources: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")}}}},
+				},
+				Status: v1.PodStatus{QOSClass: v1.PodQOSGuaranteed},
+			},
+			expectedAdmit:                   true,
+			expectedPodHintsCalled:          false,
+			expectedContainerHintsCalled:    true,
+			expectedAllocatePodCalled:       false,
+			expectedAllocateContainerCalled: true,
+			scope:                           NewContainerScope(restrictedPolicy),
+		},
+	}
+
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResources, tc.podLevelResourcesEnabled)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResourceManagers, tc.podLevelResourceManagersEnabled)
+
+			tracker := &trackingHintProvider{
+				hints: map[string][]TopologyHint{
+					"resource": {
+						{NUMANodeAffinity: NewTestBitMask(0), Preferred: true},
+					},
+				},
+			}
+
+			m := manager{scope: tc.scope}
+			tc.scope.AddHintProvider(tCtx.Logger(), tracker)
+
+			podAttr := lifecycle.PodAdmitAttributes{Pod: tc.pod}
+			actual := m.Admit(tCtx, &podAttr)
+
+			if actual.Admit != tc.expectedAdmit {
+				t.Errorf("Expected Admit to be %v got %v", tc.expectedAdmit, actual.Admit)
+			}
+			if tracker.podHintsCalled != tc.expectedPodHintsCalled {
+				t.Errorf("Expected podHintsCalled to be %v got %v", tc.expectedPodHintsCalled, tracker.podHintsCalled)
+			}
+			if tracker.containerHintsCalled != tc.expectedContainerHintsCalled {
+				t.Errorf("Expected containerHintsCalled to be %v got %v", tc.expectedContainerHintsCalled, tracker.containerHintsCalled)
+			}
+			if tracker.allocatePodCalled != tc.expectedAllocatePodCalled {
+				t.Errorf("Expected allocatePodCalled to be %v got %v", tc.expectedAllocatePodCalled, tracker.allocatePodCalled)
+			}
+			if tracker.allocateContainerCalled != tc.expectedAllocateContainerCalled {
+				t.Errorf("Expected allocateContainerCalled to be %v got %v", tc.expectedAllocateContainerCalled, tracker.allocateContainerCalled)
+			}
+		})
 	}
 }

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -120,7 +120,7 @@ const (
 
 	ResourceManagerAllocationErrorsTotalKey = "resource_manager_allocation_errors_total"
 
-	ResourceManagerContainerAssignmentsKey = "resource_manager_container_assignments"
+	ResourceManagerContainerAssignmentsTotalKey = "resource_manager_container_assignments_total"
 
 	ResourceManagerPod  = "pod"
 	ResourceManagerNode = "node"
@@ -1266,8 +1266,10 @@ var (
 	// allocations drawn from the node-level pool versus a pre-allocated pod-level pool.
 	ResourceManagerAllocationsTotal = metrics.NewCounterVec(
 		&metrics.CounterOpts{
-			Name: ResourceManagerAllocationTotalKey,
-			Help: "Number of exclusive resource allocations performed by a resource manager.",
+			Subsystem:      KubeletSubsystem,
+			Name:           ResourceManagerAllocationTotalKey,
+			Help:           "Number of exclusive resource allocations performed by a resource manager.",
+			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"resource_name", "source"},
 	)
@@ -1276,8 +1278,10 @@ var (
 	// resource allocation, distinguished by the intended allocation source.
 	ResourceManagerAllocationErrorsTotal = metrics.NewCounterVec(
 		&metrics.CounterOpts{
-			Name: ResourceManagerAllocationErrorsTotalKey,
-			Help: "Number of errors encountered during exclusive resource allocation.",
+			Subsystem:      KubeletSubsystem,
+			Name:           ResourceManagerAllocationErrorsTotalKey,
+			Help:           "Number of errors encountered during exclusive resource allocation.",
+			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"resource_name", "source"},
 	)
@@ -1288,8 +1292,10 @@ var (
 	// versus the pod-level shared pool.
 	ResourceManagerContainerAssignments = metrics.NewCounterVec(
 		&metrics.CounterOpts{
-			Name: ResourceManagerContainerAssignmentsKey,
-			Help: "Number of containers with a specific type of resource assignment.",
+			Subsystem:      KubeletSubsystem,
+			Name:           ResourceManagerContainerAssignmentsTotalKey,
+			Help:           "Number of containers with a specific type of resource assignment.",
+			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"resource_name", "assignment_type"},
 	)

--- a/staging/src/k8s.io/component-base/metrics/testutil/promlint.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/promlint.go
@@ -80,7 +80,6 @@ var exceptionMetrics = []string{
 	"kubelet_topology_manager_admission_duration_ms",             // metric names should not contain abbreviated units
 	"kubelet_certificate_manager_client_expiration_renew_errors", // counter metrics should have "_total" suffix
 	"kubelet_pod_resize_duration_milliseconds",                   // use base unit "seconds" instead of "milliseconds"
-	"resource_manager_container_assignments",                     // counter metrics should have "_total" suffix
 
 	// kube-proxy
 	"kubeproxy_sync_proxy_rules_iptables_total",           // non-counter metrics should not have "_total" suffix

--- a/test/e2e_node/cpu_manager_metrics_test.go
+++ b/test/e2e_node/cpu_manager_metrics_test.go
@@ -18,6 +18,7 @@ package e2enode
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -31,14 +32,15 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeletpodresourcesv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
+	"k8s.io/kubernetes/pkg/features"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/apis/podresources"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/pkg/kubelet/util"
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2emetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -509,11 +511,6 @@ var _ = SIGDescribe("CPU Manager Metrics", framework.WithSerial(), feature.CPUMa
 	})
 })
 
-func getKubeletMetrics(ctx context.Context) (e2emetrics.KubeletMetrics, error) {
-	ginkgo.By("Getting Kubelet metrics from the metrics API")
-	return e2emetrics.GrabKubeletMetricsWithoutProxy(ctx, nodeNameOrIP()+":10255", "/metrics")
-}
-
 func makeGuaranteedCPUExclusiveSleeperPod(name string, cpus int) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -551,3 +548,247 @@ func timelessSample(value interface{}) types.GomegaMatcher {
 		"Histogram": gstruct.Ignore(),
 	}))
 }
+
+var _ = SIGDescribe("CPU Manager Metrics Pod Level Resources", ginkgo.Ordered, ginkgo.ContinueOnFailure, framework.WithSerial(), feature.CPUManager, feature.PodLevelResources, feature.PodLevelResourceManagers, framework.WithFeatureGate(features.PodLevelResources), framework.WithFeatureGate(features.PodLevelResourceManagers), func() {
+	f := framework.NewDefaultFramework("cpu-manager-metrics-pod-level-resources")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	var oldCfg *kubeletconfig.KubeletConfiguration
+	var testPod *v1.Pod
+
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		var err error
+		if oldCfg == nil {
+			oldCfg, err = getCurrentKubeletConfig(ctx)
+			framework.ExpectNoError(err)
+		}
+		_, cpuAlloc, _ := getLocalNodeCPUDetails(ctx, f)
+		if cpuAlloc < 3 {
+			e2eskipper.Skipf("Skipping CPU Manager Metrics Pod Level Resources tests since the CPU capacity %d < 3", cpuAlloc)
+		}
+	})
+
+	ginkgo.AfterEach(func(ctx context.Context) {
+		if testPod != nil {
+			deletePodSyncByName(ctx, f, testPod.Name)
+			waitForContainerRemoval(ctx, testPod.Spec.Containers[0].Name, testPod.Name, testPod.Namespace)
+		}
+		updateKubeletConfig(ctx, f, oldCfg, true)
+	})
+
+	ginkgo.It("should increment allocation and container assignment metrics in pod scope", func(ctx context.Context) {
+		newCfg := configureCPUManagerInKubelet(oldCfg,
+			&cpuManagerKubeletArguments{
+				policyName:                     string(cpumanager.PolicyStatic),
+				topologyManagerPolicy:          string(topologymanager.PolicyRestricted),
+				topologyManagerScope:           string(topologymanager.PodTopologyScope),
+				enablePodLevelResources:        true,
+				enablePodLevelResourceManagers: true,
+				reservedSystemCPUs:             cpuset.New(0),
+			},
+		)
+		updateKubeletConfig(ctx, f, newCfg, true)
+
+		ginkgo.By("Getting baseline metrics")
+		baselineMetrics, err := getKubeletMetrics(ctx)
+		framework.ExpectNoError(err)
+
+		baseAllocations, err := getCounterMetricValue(baselineMetrics, "kubelet_resource_manager_allocations_total", map[string]string{"resource_name": "cpu", "source": "pod"})
+		if !errors.Is(err, ErrMetricNotFound) {
+			framework.ExpectNoError(err)
+		}
+
+		baseExclusiveAssignments, err := getCounterMetricValue(baselineMetrics, "kubelet_resource_manager_container_assignments_total", map[string]string{"resource_name": "cpu", "assignment_type": "pod_exclusive"})
+		if !errors.Is(err, ErrMetricNotFound) {
+			framework.ExpectNoError(err)
+		}
+
+		baseSharedAssignments, err := getCounterMetricValue(baselineMetrics, "kubelet_resource_manager_container_assignments_total", map[string]string{"resource_name": "cpu", "assignment_type": "pod_shared"})
+		if !errors.Is(err, ErrMetricNotFound) {
+			framework.ExpectNoError(err)
+		}
+
+		ginkgo.By("Creating a Guaranteed pod with pod-level resources and a mix of guaranteed and non-guaranteed containers")
+		testPod = &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "plrm-metrics-pod",
+			},
+			Spec: v1.PodSpec{
+				RestartPolicy: v1.RestartPolicyNever,
+				Containers: []v1.Container{
+					{
+						Name:  "exclusive-container",
+						Image: busyboxImage,
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("2"),
+								v1.ResourceMemory: resource.MustParse("64Mi"),
+							},
+							Limits: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("2"),
+								v1.ResourceMemory: resource.MustParse("64Mi"),
+							},
+						},
+						Command: []string{"sh", "-c", "sleep 1d"},
+					},
+					{
+						Name:    "shared-container",
+						Image:   busyboxImage,
+						Command: []string{"sh", "-c", "sleep 1d"},
+					},
+				},
+			},
+		}
+		testPod.Spec.Resources = &v1.ResourceRequirements{
+			Requests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("3"),
+				v1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+			Limits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("3"),
+				v1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+		}
+
+		testPod = e2epod.NewPodClient(f).CreateSync(ctx, testPod)
+
+		ginkgo.By("Verifying metrics show correct updates")
+		gomega.Eventually(ctx, func(ctx context.Context) error {
+			currentMetrics, err := getKubeletMetrics(ctx)
+			if err != nil {
+				return err
+			}
+
+			allocations, err := getCounterMetricValue(currentMetrics, "kubelet_resource_manager_allocations_total", map[string]string{"resource_name": "cpu", "source": "pod"})
+			if err != nil {
+				return err
+			}
+
+			exclusiveAssignments, err := getCounterMetricValue(currentMetrics, "kubelet_resource_manager_container_assignments_total", map[string]string{"resource_name": "cpu", "assignment_type": "pod_exclusive"})
+			if err != nil {
+				return err
+			}
+
+			sharedAssignments, err := getCounterMetricValue(currentMetrics, "kubelet_resource_manager_container_assignments_total", map[string]string{"resource_name": "cpu", "assignment_type": "pod_shared"})
+			if err != nil {
+				return err
+			}
+
+			// Expected metric deltas for pod scope with 2 containers (1 exclusive, 1 shared):
+			// - 2 allocations: processed for each container during pod-level resource manager allocation.
+			// - 1 pod_exclusive assignment: assigned to the container requesting exclusive CPUs.
+			// - 1 pod_shared assignment: assigned to the container using the shared pod pool.
+			if allocations-baseAllocations != 2 {
+				return fmt.Errorf("expected 2 new allocations, got %v", allocations-baseAllocations)
+			}
+			if exclusiveAssignments-baseExclusiveAssignments != 1 {
+				return fmt.Errorf("expected 1 new exclusive assignment, got %v", exclusiveAssignments-baseExclusiveAssignments)
+			}
+			if sharedAssignments-baseSharedAssignments != 1 {
+				return fmt.Errorf("expected 1 new shared assignment, got %v", sharedAssignments-baseSharedAssignments)
+			}
+			return nil
+		}).WithTimeout(2 * time.Minute).WithPolling(10 * time.Second).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("should increment allocation and container assignment metrics in container scope", func(ctx context.Context) {
+		newCfg := configureCPUManagerInKubelet(oldCfg,
+			&cpuManagerKubeletArguments{
+				policyName:                     string(cpumanager.PolicyStatic),
+				topologyManagerPolicy:          string(topologymanager.PolicyRestricted),
+				topologyManagerScope:           string(topologymanager.ContainerTopologyScope),
+				enablePodLevelResources:        true,
+				enablePodLevelResourceManagers: true,
+				reservedSystemCPUs:             cpuset.New(0),
+			},
+		)
+		updateKubeletConfig(ctx, f, newCfg, true)
+
+		ginkgo.By("Getting baseline metrics")
+		baselineMetrics, err := getKubeletMetrics(ctx)
+		framework.ExpectNoError(err)
+
+		baseAllocations, err := getCounterMetricValue(baselineMetrics, "kubelet_resource_manager_allocations_total", map[string]string{"resource_name": "cpu", "source": "node"})
+		if !errors.Is(err, ErrMetricNotFound) {
+			framework.ExpectNoError(err)
+		}
+
+		baseExclusiveAssignments, err := getCounterMetricValue(baselineMetrics, "kubelet_resource_manager_container_assignments_total", map[string]string{"resource_name": "cpu", "assignment_type": "node_exclusive"})
+		if !errors.Is(err, ErrMetricNotFound) {
+			framework.ExpectNoError(err)
+		}
+
+		ginkgo.By("Creating a Guaranteed pod with pod-level resources and a mix of guaranteed and non-guaranteed containers")
+		testPod = &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "plrm-metrics-pod-container-scope",
+			},
+			Spec: v1.PodSpec{
+				RestartPolicy: v1.RestartPolicyNever,
+				Containers: []v1.Container{
+					{
+						Name:  "exclusive-container",
+						Image: busyboxImage,
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("2"),
+								v1.ResourceMemory: resource.MustParse("64Mi"),
+							},
+							Limits: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("2"),
+								v1.ResourceMemory: resource.MustParse("64Mi"),
+							},
+						},
+						Command: []string{"sh", "-c", "sleep 1d"},
+					},
+					{
+						Name:    "shared-container",
+						Image:   busyboxImage,
+						Command: []string{"sh", "-c", "sleep 1d"},
+					},
+				},
+			},
+		}
+		testPod.Spec.Resources = &v1.ResourceRequirements{
+			Requests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("3"),
+				v1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+			Limits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("3"),
+				v1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+		}
+
+		testPod = e2epod.NewPodClient(f).CreateSync(ctx, testPod)
+
+		ginkgo.By("Verifying metrics show correct updates in container scope")
+		gomega.Eventually(ctx, func(ctx context.Context) error {
+			currentMetrics, err := getKubeletMetrics(ctx)
+			if err != nil {
+				return err
+			}
+
+			allocations, err := getCounterMetricValue(currentMetrics, "kubelet_resource_manager_allocations_total", map[string]string{"resource_name": "cpu", "source": "node"})
+			if err != nil {
+				return err
+			}
+
+			exclusiveAssignments, err := getCounterMetricValue(currentMetrics, "kubelet_resource_manager_container_assignments_total", map[string]string{"resource_name": "cpu", "assignment_type": "node_exclusive"})
+			if err != nil {
+				return err
+			}
+
+			// Expected metric deltas for container scope with 2 containers (1 exclusive, 1 without requests):
+			// - 1 allocation: containers requesting no resources skip allocation in container scope.
+			// - 1 node_exclusive assignment: assigned to the container requesting exclusive CPUs.
+			if allocations-baseAllocations != 1 {
+				return fmt.Errorf("expected 1 new allocation, got %v", allocations-baseAllocations)
+			}
+			if exclusiveAssignments-baseExclusiveAssignments != 1 {
+				return fmt.Errorf("expected 1 new node_exclusive assignment, got %v", exclusiveAssignments-baseExclusiveAssignments)
+			}
+			return nil
+		}).WithTimeout(2 * time.Minute).WithPolling(10 * time.Second).Should(gomega.Succeed())
+	})
+})

--- a/test/e2e_node/memory_manager_metrics_test.go
+++ b/test/e2e_node/memory_manager_metrics_test.go
@@ -20,6 +20,7 @@ package e2enode
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -31,7 +32,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/features"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2emetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
@@ -253,3 +256,264 @@ func printAllPodsOnNode(ctx context.Context, c clientset.Interface, nodeName str
 	framework.Logf("end listing pods: %d found", len(podList.Items))
 	return count, nil
 }
+
+var _ = SIGDescribe("Memory Manager Metrics Pod Level Resources", ginkgo.Ordered, ginkgo.ContinueOnFailure, framework.WithSerial(), feature.MemoryManager, feature.PodLevelResources, feature.PodLevelResourceManagers, framework.WithFeatureGate(features.PodLevelResources), framework.WithFeatureGate(features.PodLevelResourceManagers), func() {
+	f := framework.NewDefaultFramework("memory-manager-metrics-pod-level-resources")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	var (
+		oldCfg  *kubeletconfig.KubeletConfiguration
+		testPod *v1.Pod
+	)
+
+	memoryQuantity := resource.MustParse("1100Mi")
+	defaultKubeParams := &memoryManagerKubeletParams{
+		systemReservedMemory: []kubeletconfig.MemoryReservation{
+			{
+				NumaNode: 0,
+				Limits: v1.ResourceList{
+					resourceMemory: memoryQuantity,
+				},
+			},
+		},
+		systemReserved: map[string]string{resourceMemory: "500Mi"},
+		kubeReserved:   map[string]string{resourceMemory: "500Mi"},
+		evictionHard:   map[string]string{evictionHardMemory: "100Mi"},
+	}
+
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		var err error
+		if oldCfg == nil {
+			oldCfg, err = getCurrentKubeletConfig(ctx)
+			framework.ExpectNoError(err)
+		}
+	})
+
+	ginkgo.AfterEach(func(ctx context.Context) {
+		if testPod != nil {
+			deletePodSyncByName(ctx, f, testPod.Name)
+			waitForContainerRemoval(ctx, testPod.Spec.Containers[0].Name, testPod.Name, testPod.Namespace)
+		}
+		updateKubeletConfig(ctx, f, oldCfg, true)
+	})
+
+	ginkgo.It("should increment allocation and container assignment metrics in pod scope", func(ctx context.Context) {
+		newCfg := oldCfg.DeepCopy()
+		kubeParams := *defaultKubeParams
+		kubeParams.policy = staticPolicy
+		updateKubeletConfigWithMemoryManagerParams(newCfg, &kubeParams)
+
+		newCfg = configureMemoryManagerInKubelet(newCfg, &memoryManagerKubeletArguments{
+			policyName:                     string(staticPolicy),
+			topologyManagerPolicy:          topologymanager.PolicyRestricted,
+			topologyManagerScope:           topologymanager.PodTopologyScope,
+			enablePodLevelResources:        true,
+			enablePodLevelResourceManagers: true,
+		})
+		updateKubeletConfig(ctx, f, newCfg, true)
+
+		ginkgo.By("Getting baseline metrics")
+		baselineMetrics, err := getKubeletMetrics(ctx)
+		framework.ExpectNoError(err)
+
+		baseAllocations, err := getCounterMetricValue(baselineMetrics, "kubelet_resource_manager_allocations_total", map[string]string{"resource_name": "memory", "source": "pod"})
+		if !errors.Is(err, ErrMetricNotFound) {
+			framework.ExpectNoError(err)
+		}
+
+		baseExclusiveAssignments, err := getCounterMetricValue(baselineMetrics, "kubelet_resource_manager_container_assignments_total", map[string]string{"resource_name": "memory", "assignment_type": "pod_exclusive"})
+		if !errors.Is(err, ErrMetricNotFound) {
+			framework.ExpectNoError(err)
+		}
+
+		baseSharedAssignments, err := getCounterMetricValue(baselineMetrics, "kubelet_resource_manager_container_assignments_total", map[string]string{"resource_name": "memory", "assignment_type": "pod_shared"})
+		if !errors.Is(err, ErrMetricNotFound) {
+			framework.ExpectNoError(err)
+		}
+
+		ginkgo.By("Creating a Guaranteed pod with pod-level resources and a mix of guaranteed and non-guaranteed containers")
+		testPod = &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "plrm-memory-metrics-pod",
+			},
+			Spec: v1.PodSpec{
+				RestartPolicy: v1.RestartPolicyNever,
+				Containers: []v1.Container{
+					{
+						Name:  "exclusive-container",
+						Image: busyboxImage,
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("100m"),
+								v1.ResourceMemory: resource.MustParse("64Mi"),
+							},
+							Limits: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("100m"),
+								v1.ResourceMemory: resource.MustParse("64Mi"),
+							},
+						},
+						Command: []string{"sh", "-c", "sleep 1d"},
+					},
+					{
+						Name:    "shared-container",
+						Image:   busyboxImage,
+						Command: []string{"sh", "-c", "sleep 1d"},
+					},
+				},
+			},
+		}
+		testPod.Spec.Resources = &v1.ResourceRequirements{
+			Requests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("200m"),
+				v1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+			Limits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("200m"),
+				v1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+		}
+
+		testPod = e2epod.NewPodClient(f).CreateSync(ctx, testPod)
+
+		ginkgo.By("Verifying metrics show correct updates")
+		gomega.Eventually(ctx, func(ctx context.Context) error {
+			currentMetrics, err := getKubeletMetrics(ctx)
+			if err != nil {
+				return err
+			}
+
+			allocations, err := getCounterMetricValue(currentMetrics, "kubelet_resource_manager_allocations_total", map[string]string{"resource_name": "memory", "source": "pod"})
+			if err != nil {
+				return err
+			}
+
+			exclusiveAssignments, err := getCounterMetricValue(currentMetrics, "kubelet_resource_manager_container_assignments_total", map[string]string{"resource_name": "memory", "assignment_type": "pod_exclusive"})
+			if err != nil {
+				return err
+			}
+
+			sharedAssignments, err := getCounterMetricValue(currentMetrics, "kubelet_resource_manager_container_assignments_total", map[string]string{"resource_name": "memory", "assignment_type": "pod_shared"})
+			if err != nil {
+				return err
+			}
+
+			// Expected metric deltas for pod scope with 2 containers (1 exclusive, 1 shared):
+			// - 2 allocations: processed for each container during pod-level resource manager allocation.
+			// - 1 pod_exclusive assignment: assigned to the container requesting exclusive memory.
+			// - 1 pod_shared assignment: assigned to the container using the shared pod pool.
+			if allocations-baseAllocations != 2 {
+				return fmt.Errorf("expected 2 new allocations, got %v", allocations-baseAllocations)
+			}
+			if exclusiveAssignments-baseExclusiveAssignments != 1 {
+				return fmt.Errorf("expected 1 new exclusive assignment, got %v", exclusiveAssignments-baseExclusiveAssignments)
+			}
+			if sharedAssignments-baseSharedAssignments != 1 {
+				return fmt.Errorf("expected 1 new shared assignment, got %v", sharedAssignments-baseSharedAssignments)
+			}
+			return nil
+		}).WithTimeout(2 * time.Minute).WithPolling(10 * time.Second).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("should increment allocation and container assignment metrics in container scope", func(ctx context.Context) {
+		newCfg := oldCfg.DeepCopy()
+		kubeParams := *defaultKubeParams
+		kubeParams.policy = staticPolicy
+		updateKubeletConfigWithMemoryManagerParams(newCfg, &kubeParams)
+
+		newCfg = configureMemoryManagerInKubelet(newCfg, &memoryManagerKubeletArguments{
+			policyName:                     string(staticPolicy),
+			topologyManagerPolicy:          topologymanager.PolicyRestricted,
+			topologyManagerScope:           topologymanager.ContainerTopologyScope,
+			enablePodLevelResources:        true,
+			enablePodLevelResourceManagers: true,
+		})
+		updateKubeletConfig(ctx, f, newCfg, true)
+
+		ginkgo.By("Getting baseline metrics")
+		baselineMetrics, err := getKubeletMetrics(ctx)
+		framework.ExpectNoError(err)
+
+		baseAllocations, err := getCounterMetricValue(baselineMetrics, "kubelet_resource_manager_allocations_total", map[string]string{"resource_name": "memory", "source": "node"})
+		if !errors.Is(err, ErrMetricNotFound) {
+			framework.ExpectNoError(err)
+		}
+
+		baseExclusiveAssignments, err := getCounterMetricValue(baselineMetrics, "kubelet_resource_manager_container_assignments_total", map[string]string{"resource_name": "memory", "assignment_type": "node_exclusive"})
+		if !errors.Is(err, ErrMetricNotFound) {
+			framework.ExpectNoError(err)
+		}
+
+		ginkgo.By("Creating a Guaranteed pod with pod-level resources and a mix of guaranteed and non-guaranteed containers")
+		testPod = &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "plrm-memory-metrics-pod-container-scope",
+			},
+			Spec: v1.PodSpec{
+				RestartPolicy: v1.RestartPolicyNever,
+				Containers: []v1.Container{
+					{
+						Name:  "exclusive-container",
+						Image: busyboxImage,
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("100m"),
+								v1.ResourceMemory: resource.MustParse("64Mi"),
+							},
+							Limits: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("100m"),
+								v1.ResourceMemory: resource.MustParse("64Mi"),
+							},
+						},
+						Command: []string{"sh", "-c", "sleep 1d"},
+					},
+					{
+						Name:    "shared-container",
+						Image:   busyboxImage,
+						Command: []string{"sh", "-c", "sleep 1d"},
+					},
+				},
+			},
+		}
+		testPod.Spec.Resources = &v1.ResourceRequirements{
+			Requests: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("200m"),
+				v1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+			Limits: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("200m"),
+				v1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+		}
+
+		testPod = e2epod.NewPodClient(f).CreateSync(ctx, testPod)
+
+		ginkgo.By("Verifying metrics show correct updates in container scope")
+		gomega.Eventually(ctx, func(ctx context.Context) error {
+			currentMetrics, err := getKubeletMetrics(ctx)
+			if err != nil {
+				return err
+			}
+
+			allocations, err := getCounterMetricValue(currentMetrics, "kubelet_resource_manager_allocations_total", map[string]string{"resource_name": "memory", "source": "node"})
+			if err != nil {
+				return err
+			}
+
+			exclusiveAssignments, err := getCounterMetricValue(currentMetrics, "kubelet_resource_manager_container_assignments_total", map[string]string{"resource_name": "memory", "assignment_type": "node_exclusive"})
+			if err != nil {
+				return err
+			}
+
+			// Expected metric deltas for container scope with 2 containers (1 exclusive, 1 without requests):
+			// - 1 allocation: containers requesting no resources skip allocation in container scope.
+			// - 1 node_exclusive assignment: assigned to the container requesting exclusive memory.
+			if allocations-baseAllocations != 1 {
+				return fmt.Errorf("expected 1 new allocation, got %v", allocations-baseAllocations)
+			}
+			if exclusiveAssignments-baseExclusiveAssignments != 1 {
+				return fmt.Errorf("expected 1 new node_exclusive assignment, got %v", exclusiveAssignments-baseExclusiveAssignments)
+			}
+			return nil
+		}).WithTimeout(2 * time.Minute).WithPolling(10 * time.Second).Should(gomega.Succeed())
+	})
+})

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -19,6 +19,7 @@ package e2enode
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -42,6 +43,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/component-base/featuregate"
+	"k8s.io/component-base/metrics/testutil"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	remote "k8s.io/cri-client/pkg"
@@ -646,4 +648,34 @@ func deletePodSyncAndWait(ctx context.Context, f *framework.Framework, podNS, po
 	deletePodSyncByName(ctx, f, podName)
 	waitForAllContainerRemoval(ctx, podName, podNS)
 	framework.Logf("deleted pod: %s/%s", podNS, podName)
+}
+
+func getKubeletMetrics(ctx context.Context) (e2emetrics.KubeletMetrics, error) {
+	ginkgo.By("Getting Kubelet metrics from the metrics API")
+	return e2emetrics.GrabKubeletMetricsWithoutProxy(ctx, nodeNameOrIP()+":10255", "/metrics")
+}
+
+// ErrMetricNotFound indicates that a metric family or matching sample was not found in scraped metrics.
+var ErrMetricNotFound = errors.New("metric or sample not found in kubelet metrics")
+
+// getCounterMetricValue extracts the counter metric value matching metricName and labels.
+// It returns ErrMetricNotFound if metricName or the matching label sample is not found in metrics.
+func getCounterMetricValue(metrics e2emetrics.KubeletMetrics, metricName string, labels map[string]string) (float64, error) {
+	samples, ok := metrics[metricName]
+	if !ok {
+		return 0, fmt.Errorf("%w: metric %q not found in kubelet metrics", ErrMetricNotFound, metricName)
+	}
+	for _, sample := range samples {
+		match := true
+		for k, v := range labels {
+			if val, ok := sample.Metric[testutil.LabelName(k)]; !ok || string(val) != v {
+				match = false
+				break
+			}
+		}
+		if match {
+			return float64(sample.Value), nil
+		}
+	}
+	return 0, fmt.Errorf("%w: metric %q with labels %v not found in kubelet metrics", ErrMetricNotFound, metricName, labels)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

* Configure subsystem `kubelet` and stability level `BETA` for the introduced metrics.
* Fix Memory manager container-scope behavior under `PodLevelResources` to skip memory allocation and hint generation for containers that request no exclusive memory resources (`non-guaranteed` containers). This prevents incorrect metric increments and state pollution.
* Add missing unit and e2e tests for `PodLevelResourceManagers` and e2e tests for new metrics (unit tests implemented for Alpha https://github.com/kubernetes/kubernetes/pull/134768).

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

- Issue: https://github.com/kubernetes/enhancements/issues/5526
- KEP: [KEP-5526: Pod Level Resource Managers](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/5526-pod-level-resource-managers/README.md)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
N/A
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/5526-pod-level-resource-managers/README.md
```
