### PR TITLE
Add dir and owner file for windows node level e2e test

### DIFF
--- a/test/e2e_node_windows/OWNERS
+++ b/test/e2e_node_windows/OWNERS
@@ -1,0 +1,23 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+options:
+  # make root approval non-recursive
+  no_parent_owners: true
+approvers:
+  # from sig-testing, make tree-wide changes to test code
+  - aojea
+  - bentheelder
+  - pohly
+  # from sig-node, as a backup for kubelet changes that require minor updates in this folder
+  - sig-node-approvers
+  # from sig-windows
+  - marosset
+  - claudiubelu
+  - aravindhp
+  - zylxjtu
+reviewers:
+  - marosset
+  - claudiubelu
+  - aravindhp
+  - zylxjtu
+labels:
+  - sig/windows


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:
  Adds an empty `test/e2e_node_windows/` directory with a dedicated `OWNERS`
  file, in preparation for the Windows node-level e2e test framework that is
  being split out of #138235.

  This PR is intentionally minimal — it does **not** add any Go code, any
  test, or any build wiring. It only establishes the directory and the
  ownership boundary so that subsequent PRs which fill in the framework can
  land under the agreed-upon governance model.

 In review of #138235, SIG-Testing leads (@pohly, @BenTheElder) and
  SIG-Node (@SergeyKanzhelev) requested that SIG-Testing reviewers
  are not auto-pinged on routine Windows-only changes while still retaining
  approval rights for tree-wide refactors. SIG-Node likewise asked to be
  listed as approvers for cases where refactors break the Windows build. 

#### Which issue(s) this PR is related to:

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

No
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
