### PR TITLE
fix(apiserver): unwrap CacheableObject in decoratedWatcher

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/decorated_watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/decorated_watcher.go
@@ -58,6 +58,12 @@ func (d *decoratedWatcher) run(ctx context.Context) {
 			}
 			switch recv.Type {
 			case watch.Added, watch.Modified, watch.Deleted, watch.Bookmark:
+				// The watch cache may wrap objects in a CacheableObject for
+				// serialization efficiency. Unwrap to the underlying object
+				// so the decorator's type assertions work correctly.
+				if co, ok := recv.Object.(runtime.CacheableObject); ok {
+					recv.Object = co.GetObject()
+				}
 				d.decorator(recv.Object)
 				send = recv
 			case watch.Error:

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/decorated_watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/decorated_watcher_test.go
@@ -18,11 +18,13 @@ package registry
 
 import (
 	"context"
+	"io"
 	"testing"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/apis/example"
@@ -104,5 +106,52 @@ func expectErrorEvent(t *testing.T, dw *decoratedWatcher) {
 		}
 	case <-time.After(wait.ForeverTestTimeout):
 		t.Fatalf("timeout after %v", wait.ForeverTestTimeout)
+	}
+}
+
+// wrappedObject simulates the cachingObject wrapper used by the watch cache.
+// It implements runtime.CacheableObject so the decoratedWatcher can extract
+// the underlying object for decoration.
+type wrappedObject struct {
+	inner runtime.Object
+}
+
+func (w *wrappedObject) GetObjectKind() schema.ObjectKind { return w.inner.GetObjectKind() }
+func (w *wrappedObject) DeepCopyObject() runtime.Object   { return &wrappedObject{inner: w.inner.DeepCopyObject()} }
+func (w *wrappedObject) GetObject() runtime.Object        { return w.inner.DeepCopyObject() }
+func (w *wrappedObject) CacheEncode(_ runtime.Identifier, _ func(runtime.Object, io.Writer) error, _ io.Writer) error {
+	return nil
+}
+
+func TestDecoratedWatcherUnwrapsCachingObject(t *testing.T) {
+	w := watch.NewFake()
+	decorator := func(obj runtime.Object) {
+		if pod, ok := obj.(*example.Pod); ok {
+			pod.Annotations = map[string]string{"decorated": "true"}
+		}
+	}
+	ctx := context.Background()
+	dw := newDecoratedWatcher(ctx, w, decorator)
+	defer dw.Stop()
+
+	// Send a wrapped object (simulating cachingObject from the watch cache).
+	go w.Action(watch.Modified, &wrappedObject{
+		inner: &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "wrapped-pod"}},
+	})
+
+	select {
+	case e := <-dw.ResultChan():
+		pod, ok := e.Object.(*example.Pod)
+		if !ok {
+			t.Fatalf("expected *example.Pod after unwrapping, got %T", e.Object)
+		}
+		if pod.Annotations["decorated"] != "true" {
+			t.Fatalf("decorator did not run on unwrapped object: annotations=%v", pod.Annotations)
+		}
+		if pod.Name != "wrapped-pod" {
+			t.Fatalf("expected name wrapped-pod, got %s", pod.Name)
+		}
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatalf("timeout waiting for event")
 	}
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The watch cache wraps objects in a `CacheableObject` for serialization efficiency. The Store's [Decorator](https://github.com/kubernetes/kubernetes/blob/v1.33.0/pkg/registry/core/service/storage/storage.go#L129) uses type assertions that fail against the wrapper, silently skipping read-time [defaulting](https://github.com/kubernetes/kubernetes/blob/v1.33.0/pkg/registry/core/service/storage/storage.go#L232) on watch events. Unwrap via GetObject() before decorating so fields like Service IPFamilies are correctly populated for watch clients.

#### Which issue(s) this PR is related to:
Fixes: https://github.com/kubernetes/kubernetes/issues/138735
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.


Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
#138736 is a parallel defensive fix at KCM and this addresses the root cause at the apiserver layer. Affected code paths:  defaultOnRead for [services](https://github.com/kubernetes/kubernetes/blob/v1.33.0/pkg/registry/core/service/storage/storage.go#L232) and [PVCs](https://github.com/kubernetes/kubernetes/blob/v1.33.0/pkg/registry/core/persistentvolumeclaim/storage/storage.go#L86). 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed watch events for Services and PersistentVolumeClaims to correctly apply read-time field defaulting (e.g., spec.ipFamilies) that was previously skipped due to CacheableObject wrapping.

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
