### PR TITLE
apiserver: pass context with ReqInfo to AllowUnconditionalUpdate and AllowCreateOnUpdate

### DIFF
--- a/pkg/registry/admissionregistration/mutatingadmissionpolicy/strategy.go
+++ b/pkg/registry/admissionregistration/mutatingadmissionpolicy/strategy.go
@@ -105,7 +105,7 @@ func (v *mutatingAdmissionPolicyStrategy) Canonicalize(obj runtime.Object) {
 }
 
 // AllowCreateOnUpdate is false for MutatingAdmissionPolicy; this means you may not create one with a PUT request.
-func (v *mutatingAdmissionPolicyStrategy) AllowCreateOnUpdate() bool {
+func (v *mutatingAdmissionPolicyStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -131,6 +131,6 @@ func (v *mutatingAdmissionPolicyStrategy) WarningsOnUpdate(ctx context.Context, 
 
 // AllowUnconditionalUpdate is the default update policy for MutatingAdmissionPolicy objects. Status update should
 // only be allowed if version match.
-func (v *mutatingAdmissionPolicyStrategy) AllowUnconditionalUpdate() bool {
+func (v *mutatingAdmissionPolicyStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }

--- a/pkg/registry/admissionregistration/mutatingadmissionpolicy/strategy_test.go
+++ b/pkg/registry/admissionregistration/mutatingadmissionpolicy/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mutatingadmissionpolicy
 
 import (
+	"context"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +36,7 @@ func TestMutatingAdmissionPolicyStrategy(t *testing.T) {
 	if strategy.NamespaceScoped() {
 		t.Error("MutatingAdmissionPolicy strategy must be cluster scoped")
 	}
-	if strategy.AllowCreateOnUpdate() {
+	if strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("MutatingAdmissionPolicy should not allow create on update")
 	}
 

--- a/pkg/registry/admissionregistration/mutatingadmissionpolicybinding/strategy.go
+++ b/pkg/registry/admissionregistration/mutatingadmissionpolicybinding/strategy.go
@@ -113,7 +113,7 @@ func (v *mutatingAdmissionPolicyBindingStrategy) Canonicalize(obj runtime.Object
 }
 
 // AllowCreateOnUpdate is false for MutatingAdmissionPolicyBinding; this means you may not create one with a PUT request.
-func (v *mutatingAdmissionPolicyBindingStrategy) AllowCreateOnUpdate() bool {
+func (v *mutatingAdmissionPolicyBindingStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -139,6 +139,6 @@ func (v *mutatingAdmissionPolicyBindingStrategy) WarningsOnUpdate(ctx context.Co
 
 // AllowUnconditionalUpdate is the default update policy for MutatingAdmissionPolicyBinding objects. Status update should
 // only be allowed if version match.
-func (v *mutatingAdmissionPolicyBindingStrategy) AllowUnconditionalUpdate() bool {
+func (v *mutatingAdmissionPolicyBindingStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }

--- a/pkg/registry/admissionregistration/mutatingadmissionpolicybinding/strategy_test.go
+++ b/pkg/registry/admissionregistration/mutatingadmissionpolicybinding/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mutatingadmissionpolicybinding
 
 import (
+	"context"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,7 +37,7 @@ func TestPolicyBindingStrategy(t *testing.T) {
 	if strategy.NamespaceScoped() {
 		t.Error("PolicyBinding strategy must be cluster scoped")
 	}
-	if strategy.AllowCreateOnUpdate() {
+	if strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("PolicyBinding should not allow create on update")
 	}
 

--- a/pkg/registry/admissionregistration/mutatingwebhookconfiguration/strategy.go
+++ b/pkg/registry/admissionregistration/mutatingwebhookconfiguration/strategy.go
@@ -88,7 +88,7 @@ func (mutatingWebhookConfigurationStrategy) Canonicalize(obj runtime.Object) {
 }
 
 // AllowCreateOnUpdate is false for mutatingWebhookConfiguration; this means you may not create one with a PUT request.
-func (mutatingWebhookConfigurationStrategy) AllowCreateOnUpdate() bool {
+func (mutatingWebhookConfigurationStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -108,6 +108,6 @@ func (mutatingWebhookConfigurationStrategy) WarningsOnUpdate(ctx context.Context
 
 // AllowUnconditionalUpdate is the default update policy for mutatingWebhookConfiguration objects. Status update should
 // only be allowed if version match.
-func (mutatingWebhookConfigurationStrategy) AllowUnconditionalUpdate() bool {
+func (mutatingWebhookConfigurationStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }

--- a/pkg/registry/admissionregistration/validatingadmissionpolicy/strategy.go
+++ b/pkg/registry/admissionregistration/validatingadmissionpolicy/strategy.go
@@ -112,7 +112,7 @@ func (v *validatingAdmissionPolicyStrategy) Canonicalize(obj runtime.Object) {
 }
 
 // AllowCreateOnUpdate is false for validatingAdmissionPolicy; this means you may not create one with a PUT request.
-func (v *validatingAdmissionPolicyStrategy) AllowCreateOnUpdate() bool {
+func (v *validatingAdmissionPolicyStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -138,7 +138,7 @@ func (v *validatingAdmissionPolicyStrategy) WarningsOnUpdate(ctx context.Context
 
 // AllowUnconditionalUpdate is the default update policy for validatingAdmissionPolicy objects. Status update should
 // only be allowed if version match.
-func (v *validatingAdmissionPolicyStrategy) AllowUnconditionalUpdate() bool {
+func (v *validatingAdmissionPolicyStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }
 

--- a/pkg/registry/admissionregistration/validatingadmissionpolicy/strategy_test.go
+++ b/pkg/registry/admissionregistration/validatingadmissionpolicy/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validatingadmissionpolicy
 
 import (
+	"context"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +36,7 @@ func TestValidatingAdmissionPolicyStrategy(t *testing.T) {
 	if strategy.NamespaceScoped() {
 		t.Error("ValidatingAdmissionPolicy strategy must be cluster scoped")
 	}
-	if strategy.AllowCreateOnUpdate() {
+	if strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("ValidatingAdmissionPolicy should not allow create on update")
 	}
 

--- a/pkg/registry/admissionregistration/validatingadmissionpolicybinding/strategy.go
+++ b/pkg/registry/admissionregistration/validatingadmissionpolicybinding/strategy.go
@@ -117,7 +117,7 @@ func (v *validatingAdmissionPolicyBindingStrategy) Canonicalize(obj runtime.Obje
 }
 
 // AllowCreateOnUpdate is false for ValidatingAdmissionPolicyBinding; this means you may not create one with a PUT request.
-func (v *validatingAdmissionPolicyBindingStrategy) AllowCreateOnUpdate() bool {
+func (v *validatingAdmissionPolicyBindingStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -143,6 +143,6 @@ func (v *validatingAdmissionPolicyBindingStrategy) WarningsOnUpdate(ctx context.
 
 // AllowUnconditionalUpdate is the default update policy for ValidatingAdmissionPolicyBinding objects. Status update should
 // only be allowed if version match.
-func (v *validatingAdmissionPolicyBindingStrategy) AllowUnconditionalUpdate() bool {
+func (v *validatingAdmissionPolicyBindingStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }

--- a/pkg/registry/admissionregistration/validatingadmissionpolicybinding/strategy_test.go
+++ b/pkg/registry/admissionregistration/validatingadmissionpolicybinding/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validatingadmissionpolicybinding
 
 import (
+	"context"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,7 +37,7 @@ func TestPolicyBindingStrategy(t *testing.T) {
 	if strategy.NamespaceScoped() {
 		t.Error("PolicyBinding strategy must be cluster scoped")
 	}
-	if strategy.AllowCreateOnUpdate() {
+	if strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("PolicyBinding should not allow create on update")
 	}
 

--- a/pkg/registry/admissionregistration/validatingwebhookconfiguration/strategy.go
+++ b/pkg/registry/admissionregistration/validatingwebhookconfiguration/strategy.go
@@ -88,7 +88,7 @@ func (validatingWebhookConfigurationStrategy) Canonicalize(obj runtime.Object) {
 }
 
 // AllowCreateOnUpdate is false for validatingWebhookConfiguration; this means you may not create one with a PUT request.
-func (validatingWebhookConfigurationStrategy) AllowCreateOnUpdate() bool {
+func (validatingWebhookConfigurationStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -108,6 +108,6 @@ func (validatingWebhookConfigurationStrategy) WarningsOnUpdate(ctx context.Conte
 
 // AllowUnconditionalUpdate is the default update policy for validatingWebhookConfiguration objects. Status update should
 // only be allowed if version match.
-func (validatingWebhookConfigurationStrategy) AllowUnconditionalUpdate() bool {
+func (validatingWebhookConfigurationStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }

--- a/pkg/registry/admissionregistration/validatingwebhookconfiguration/strategy_test.go
+++ b/pkg/registry/admissionregistration/validatingwebhookconfiguration/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validatingwebhookconfiguration
 
 import (
+	"context"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,7 +33,7 @@ func TestValidatingWebhookConfigurationStrategy(t *testing.T) {
 	if Strategy.NamespaceScoped() {
 		t.Error("ValidatingWebhookConfiguration strategy must be cluster scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("ValidatingWebhookConfiguration should not allow create on update")
 	}
 

--- a/pkg/registry/apiserverinternal/storageversion/strategy.go
+++ b/pkg/registry/apiserverinternal/storageversion/strategy.go
@@ -84,7 +84,7 @@ func (storageVersionStrategy) Canonicalize(obj runtime.Object) {
 }
 
 // Does not allow creating a StorageVersion object with a PUT request.
-func (storageVersionStrategy) AllowCreateOnUpdate() bool {
+func (storageVersionStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -103,7 +103,7 @@ func (storageVersionStrategy) WarningsOnUpdate(ctx context.Context, obj, old run
 
 // AllowUnconditionalUpdate is the default update policy for storageVersion objects. Status update should
 // only be allowed if version match.
-func (storageVersionStrategy) AllowUnconditionalUpdate() bool {
+func (storageVersionStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }
 

--- a/pkg/registry/apiserverinternal/storageversion/strategy_test.go
+++ b/pkg/registry/apiserverinternal/storageversion/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package storageversion
 
 import (
+	"context"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +30,7 @@ func TestStorageVersionStrategy(t *testing.T) {
 	if Strategy.NamespaceScoped() {
 		t.Error("StorageVersion strategy must be cluster scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("StorageVersion should not allow create on update")
 	}
 

--- a/pkg/registry/apps/controllerrevision/strategy.go
+++ b/pkg/registry/apps/controllerrevision/strategy.go
@@ -51,7 +51,7 @@ func (strategy) NamespaceScoped() bool {
 func (strategy) Canonicalize(obj runtime.Object) {
 }
 
-func (strategy) AllowCreateOnUpdate() bool {
+func (strategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -73,7 +73,7 @@ func (strategy) PrepareForUpdate(ctx context.Context, newObj, oldObj runtime.Obj
 	_ = newObj.(*apps.ControllerRevision)
 }
 
-func (strategy) AllowUnconditionalUpdate() bool {
+func (strategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/apps/controllerrevision/strategy_test.go
+++ b/pkg/registry/apps/controllerrevision/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllerrevision
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -34,7 +35,7 @@ func TestStrategy_NamespaceScoped(t *testing.T) {
 }
 
 func TestStrategy_AllowCreateOnUpdate(t *testing.T) {
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Error("ControllerRevision should not be created on update")
 	}
 }

--- a/pkg/registry/apps/daemonset/strategy.go
+++ b/pkg/registry/apps/daemonset/strategy.go
@@ -132,7 +132,7 @@ func (daemonSetStrategy) Canonicalize(obj runtime.Object) {
 
 // AllowCreateOnUpdate is false for daemon set; this means a POST is
 // needed to create one
-func (daemonSetStrategy) AllowCreateOnUpdate() bool {
+func (daemonSetStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -159,7 +159,7 @@ func (daemonSetStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.
 }
 
 // AllowUnconditionalUpdate is the default update policy for daemon set objects.
-func (daemonSetStrategy) AllowUnconditionalUpdate() bool {
+func (daemonSetStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/apps/deployment/strategy.go
+++ b/pkg/registry/apps/deployment/strategy.go
@@ -102,7 +102,7 @@ func (deploymentStrategy) Canonicalize(obj runtime.Object) {
 }
 
 // AllowCreateOnUpdate is false for deployments.
-func (deploymentStrategy) AllowCreateOnUpdate() bool {
+func (deploymentStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -145,7 +145,7 @@ func (deploymentStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime
 	return warnings
 }
 
-func (deploymentStrategy) AllowUnconditionalUpdate() bool {
+func (deploymentStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/apps/replicaset/strategy.go
+++ b/pkg/registry/apps/replicaset/strategy.go
@@ -132,7 +132,7 @@ func (rsStrategy) Canonicalize(obj runtime.Object) {
 
 // AllowCreateOnUpdate is false for ReplicaSets; this means a POST is
 // needed to create one.
-func (rsStrategy) AllowCreateOnUpdate() bool {
+func (rsStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -156,7 +156,7 @@ func (rsStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object)
 	return warnings
 }
 
-func (rsStrategy) AllowUnconditionalUpdate() bool {
+func (rsStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/apps/replicaset/strategy_test.go
+++ b/pkg/registry/apps/replicaset/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package replicaset
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -45,7 +46,7 @@ func TestReplicaSetStrategy(t *testing.T) {
 	if !Strategy.NamespaceScoped() {
 		t.Errorf("ReplicaSet must be namespace scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("ReplicaSet should not allow create on update")
 	}
 
@@ -100,7 +101,7 @@ func TestReplicaSetStatusStrategy(t *testing.T) {
 	if !StatusStrategy.NamespaceScoped() {
 		t.Errorf("ReplicaSet must be namespace scoped")
 	}
-	if StatusStrategy.AllowCreateOnUpdate() {
+	if StatusStrategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("ReplicaSet should not allow create on update")
 	}
 	validSelector := map[string]string{"a": "b"}

--- a/pkg/registry/apps/statefulset/strategy.go
+++ b/pkg/registry/apps/statefulset/strategy.go
@@ -151,7 +151,7 @@ func (statefulSetStrategy) Canonicalize(obj runtime.Object) {
 }
 
 // AllowCreateOnUpdate is false for StatefulSet; this means POST is needed to create one.
-func (statefulSetStrategy) AllowCreateOnUpdate() bool {
+func (statefulSetStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -183,7 +183,7 @@ func (statefulSetStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtim
 }
 
 // AllowUnconditionalUpdate is the default update policy for StatefulSet objects.
-func (statefulSetStrategy) AllowUnconditionalUpdate() bool {
+func (statefulSetStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/apps/statefulset/strategy_test.go
+++ b/pkg/registry/apps/statefulset/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package statefulset
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -37,7 +38,7 @@ func TestStatefulSetStrategy(t *testing.T) {
 	if !Strategy.NamespaceScoped() {
 		t.Errorf("StatefulSet must be namespace scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("StatefulSet should not allow create on update")
 	}
 
@@ -276,7 +277,7 @@ func TestStatefulSetStatusStrategy(t *testing.T) {
 	if !StatusStrategy.NamespaceScoped() {
 		t.Errorf("StatefulSet must be namespace scoped")
 	}
-	if StatusStrategy.AllowCreateOnUpdate() {
+	if StatusStrategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("StatefulSet should not allow create on update")
 	}
 	validSelector := map[string]string{"a": "b"}

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/strategy.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/strategy.go
@@ -114,7 +114,7 @@ func (autoscalerStrategy) Canonicalize(obj runtime.Object) {
 }
 
 // AllowCreateOnUpdate is false for autoscalers.
-func (autoscalerStrategy) AllowCreateOnUpdate() bool {
+func (autoscalerStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -147,7 +147,7 @@ func (autoscalerStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime
 	return nil
 }
 
-func (autoscalerStrategy) AllowUnconditionalUpdate() bool {
+func (autoscalerStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/batch/cronjob/strategy.go
+++ b/pkg/registry/batch/cronjob/strategy.go
@@ -130,12 +130,12 @@ func (cronJobStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object)
 func (cronJobStrategy) Canonicalize(obj runtime.Object) {
 }
 
-func (cronJobStrategy) AllowUnconditionalUpdate() bool {
+func (cronJobStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 
 // AllowCreateOnUpdate is false for scheduled jobs; this means a POST is needed to create one.
-func (cronJobStrategy) AllowCreateOnUpdate() bool {
+func (cronJobStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 

--- a/pkg/registry/batch/cronjob/strategy_test.go
+++ b/pkg/registry/batch/cronjob/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cronjob
 
 import (
+	"context"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,7 +67,7 @@ func TestCronJobStrategy(t *testing.T) {
 	if !Strategy.NamespaceScoped() {
 		t.Errorf("CronJob must be namespace scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("CronJob should not allow create on update")
 	}
 
@@ -155,7 +156,7 @@ func TestCronJobStatusStrategy(t *testing.T) {
 	if !StatusStrategy.NamespaceScoped() {
 		t.Errorf("CronJob must be namespace scoped")
 	}
-	if StatusStrategy.AllowCreateOnUpdate() {
+	if StatusStrategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("CronJob should not allow create on update")
 	}
 	validPodTemplateSpec := api.PodTemplateSpec{

--- a/pkg/registry/batch/job/strategy.go
+++ b/pkg/registry/batch/job/strategy.go
@@ -284,12 +284,12 @@ func generateSelector(obj *batch.Job) {
 func (jobStrategy) Canonicalize(obj runtime.Object) {
 }
 
-func (jobStrategy) AllowUnconditionalUpdate() bool {
+func (jobStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 
 // AllowCreateOnUpdate is false for jobs; this means a POST is needed to create one.
-func (jobStrategy) AllowCreateOnUpdate() bool {
+func (jobStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 

--- a/pkg/registry/certificates/certificates/strategy.go
+++ b/pkg/registry/certificates/certificates/strategy.go
@@ -68,7 +68,7 @@ func (csrStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 }
 
 // AllowCreateOnUpdate is false for CSRs.
-func (csrStrategy) AllowCreateOnUpdate() bool {
+func (csrStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -139,7 +139,7 @@ func (csrStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object
 // populates it with the latest version. Else, it checks that the
 // version specified by the user matches the version of latest etcd
 // object.
-func (csrStrategy) AllowUnconditionalUpdate() bool {
+func (csrStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/certificates/clustertrustbundle/strategy.go
+++ b/pkg/registry/certificates/clustertrustbundle/strategy.go
@@ -60,7 +60,7 @@ func (strategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []stri
 
 func (strategy) Canonicalize(obj runtime.Object) {}
 
-func (strategy) AllowCreateOnUpdate() bool {
+func (strategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -76,6 +76,6 @@ func (strategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) [
 	return nil
 }
 
-func (strategy) AllowUnconditionalUpdate() bool {
+func (strategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }

--- a/pkg/registry/certificates/clustertrustbundle/strategy_test.go
+++ b/pkg/registry/certificates/clustertrustbundle/strategy_test.go
@@ -30,7 +30,7 @@ func TestWarningsOnCreate(t *testing.T) {
 }
 
 func TestAllowCreateOnUpdate(t *testing.T) {
-	if Strategy.AllowCreateOnUpdate() != false {
+	if Strategy.AllowCreateOnUpdate(context.Background()) != false {
 		t.Errorf("Got true, want false")
 	}
 }
@@ -42,7 +42,7 @@ func TestWarningsOnUpdate(t *testing.T) {
 }
 
 func TestAllowUnconditionalUpdate(t *testing.T) {
-	if Strategy.AllowUnconditionalUpdate() != false {
+	if Strategy.AllowUnconditionalUpdate(context.Background()) != false {
 		t.Errorf("Got true, want false")
 	}
 }

--- a/pkg/registry/certificates/podcertificaterequest/strategy.go
+++ b/pkg/registry/certificates/podcertificaterequest/strategy.go
@@ -76,7 +76,7 @@ func (s *Strategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []s
 
 func (s *Strategy) Canonicalize(obj runtime.Object) {}
 
-func (s *Strategy) AllowCreateOnUpdate() bool {
+func (s *Strategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -96,7 +96,7 @@ func (s *Strategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object
 	return nil
 }
 
-func (s *Strategy) AllowUnconditionalUpdate() bool {
+func (s *Strategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }
 

--- a/pkg/registry/certificates/podcertificaterequest/strategy_test.go
+++ b/pkg/registry/certificates/podcertificaterequest/strategy_test.go
@@ -48,7 +48,7 @@ func TestWarningsOnCreate(t *testing.T) {
 
 func TestAllowCreateOnUpdate(t *testing.T) {
 	strategy := NewStrategy()
-	if strategy.AllowCreateOnUpdate() != false {
+	if strategy.AllowCreateOnUpdate(context.Background()) != false {
 		t.Errorf("Got true, want false")
 	}
 }
@@ -64,7 +64,7 @@ func TestWarningsOnUpdate(t *testing.T) {
 
 func TestAllowUnconditionalUpdate(t *testing.T) {
 	strategy := NewStrategy()
-	if strategy.AllowUnconditionalUpdate() != false {
+	if strategy.AllowUnconditionalUpdate(context.Background()) != false {
 		t.Errorf("Got true, want false")
 	}
 }

--- a/pkg/registry/coordination/lease/strategy.go
+++ b/pkg/registry/coordination/lease/strategy.go
@@ -82,7 +82,7 @@ func (leaseStrategy) Canonicalize(obj runtime.Object) {
 }
 
 // AllowCreateOnUpdate is true for Lease; this means you may create one with a PUT request.
-func (leaseStrategy) AllowCreateOnUpdate() bool {
+func (leaseStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return true
 }
 
@@ -97,6 +97,6 @@ func (leaseStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Obje
 }
 
 // AllowUnconditionalUpdate is the default update policy for Lease objects.
-func (leaseStrategy) AllowUnconditionalUpdate() bool {
+func (leaseStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }

--- a/pkg/registry/coordination/leasecandidate/strategy.go
+++ b/pkg/registry/coordination/leasecandidate/strategy.go
@@ -71,7 +71,7 @@ func (LeaseCandidateStrategy) Canonicalize(obj runtime.Object) {
 }
 
 // AllowCreateOnUpdate is true for leasecandidate; this means you may create one with a PUT request.
-func (LeaseCandidateStrategy) AllowCreateOnUpdate() bool {
+func (LeaseCandidateStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return true
 }
 
@@ -86,7 +86,7 @@ func (LeaseCandidateStrategy) WarningsOnUpdate(ctx context.Context, obj, old run
 }
 
 // AllowUnconditionalUpdate is the default update policy for leasecandidate objects.
-func (LeaseCandidateStrategy) AllowUnconditionalUpdate() bool {
+func (LeaseCandidateStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }
 

--- a/pkg/registry/core/configmap/strategy.go
+++ b/pkg/registry/core/configmap/strategy.go
@@ -71,7 +71,7 @@ func (strategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []stri
 func (strategy) Canonicalize(obj runtime.Object) {
 }
 
-func (strategy) AllowCreateOnUpdate() bool {
+func (strategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -93,7 +93,7 @@ func (strategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) [
 func dropDisabledFields(configMap *api.ConfigMap, oldConfigMap *api.ConfigMap) {
 }
 
-func (strategy) AllowUnconditionalUpdate() bool {
+func (strategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/core/configmap/strategy_test.go
+++ b/pkg/registry/core/configmap/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package configmap
 
 import (
+	"context"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +30,7 @@ func TestConfigMapStrategy(t *testing.T) {
 	if !Strategy.NamespaceScoped() {
 		t.Errorf("ConfigMap must be namespace scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("ConfigMap should not allow create on update")
 	}
 

--- a/pkg/registry/core/endpoint/strategy.go
+++ b/pkg/registry/core/endpoint/strategy.go
@@ -68,7 +68,7 @@ func (endpointsStrategy) Canonicalize(obj runtime.Object) {
 }
 
 // AllowCreateOnUpdate is true for endpoints.
-func (endpointsStrategy) AllowCreateOnUpdate() bool {
+func (endpointsStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return true
 }
 
@@ -82,7 +82,7 @@ func (endpointsStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.
 	return endpointsWarnings(obj.(*api.Endpoints))
 }
 
-func (endpointsStrategy) AllowUnconditionalUpdate() bool {
+func (endpointsStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/core/event/strategy.go
+++ b/pkg/registry/core/event/strategy.go
@@ -71,7 +71,7 @@ func (eventStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) [
 func (eventStrategy) Canonicalize(obj runtime.Object) {
 }
 
-func (eventStrategy) AllowCreateOnUpdate() bool {
+func (eventStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return true
 }
 
@@ -87,7 +87,7 @@ func (eventStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Obje
 	return nil
 }
 
-func (eventStrategy) AllowUnconditionalUpdate() bool {
+func (eventStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/core/limitrange/strategy.go
+++ b/pkg/registry/core/limitrange/strategy.go
@@ -66,7 +66,7 @@ func (limitrangeStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Obje
 func (limitrangeStrategy) Canonicalize(obj runtime.Object) {
 }
 
-func (limitrangeStrategy) AllowCreateOnUpdate() bool {
+func (limitrangeStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return true
 }
 
@@ -80,6 +80,6 @@ func (limitrangeStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime
 	return nil
 }
 
-func (limitrangeStrategy) AllowUnconditionalUpdate() bool {
+func (limitrangeStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }

--- a/pkg/registry/core/namespace/strategy.go
+++ b/pkg/registry/core/namespace/strategy.go
@@ -131,7 +131,7 @@ func (namespaceStrategy) Canonicalize(obj runtime.Object) {
 }
 
 // AllowCreateOnUpdate is false for namespaces.
-func (namespaceStrategy) AllowCreateOnUpdate() bool {
+func (namespaceStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -146,7 +146,7 @@ func (namespaceStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.
 	return nil
 }
 
-func (namespaceStrategy) AllowUnconditionalUpdate() bool {
+func (namespaceStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/core/namespace/strategy_test.go
+++ b/pkg/registry/core/namespace/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package namespace
 
 import (
+	"context"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -34,7 +35,7 @@ func TestNamespaceStrategy(t *testing.T) {
 	if Strategy.NamespaceScoped() {
 		t.Errorf("Namespaces should not be namespace scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("Namespaces should not allow create on update")
 	}
 	namespace := &api.Namespace{
@@ -85,7 +86,7 @@ func TestNamespaceStatusStrategy(t *testing.T) {
 	if StatusStrategy.NamespaceScoped() {
 		t.Errorf("Namespaces should not be namespace scoped")
 	}
-	if StatusStrategy.AllowCreateOnUpdate() {
+	if StatusStrategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("Namespaces should not allow create on update")
 	}
 	now := metav1.Now()
@@ -121,7 +122,7 @@ func TestNamespaceFinalizeStrategy(t *testing.T) {
 	if FinalizeStrategy.NamespaceScoped() {
 		t.Errorf("Namespaces should not be namespace scoped")
 	}
-	if FinalizeStrategy.AllowCreateOnUpdate() {
+	if FinalizeStrategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("Namespaces should not allow create on update")
 	}
 	oldNamespace := &api.Namespace{

--- a/pkg/registry/core/node/strategy.go
+++ b/pkg/registry/core/node/strategy.go
@@ -73,7 +73,7 @@ func (nodeStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 }
 
 // AllowCreateOnUpdate is false for nodes.
-func (nodeStrategy) AllowCreateOnUpdate() bool {
+func (nodeStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -155,7 +155,7 @@ func (nodeStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Objec
 	return nodeWarnings(obj)
 }
 
-func (nodeStrategy) AllowUnconditionalUpdate() bool {
+func (nodeStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/core/persistentvolume/strategy.go
+++ b/pkg/registry/core/persistentvolume/strategy.go
@@ -90,7 +90,7 @@ func (persistentvolumeStrategy) WarningsOnCreate(ctx context.Context, obj runtim
 func (persistentvolumeStrategy) Canonicalize(obj runtime.Object) {
 }
 
-func (persistentvolumeStrategy) AllowCreateOnUpdate() bool {
+func (persistentvolumeStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -116,7 +116,7 @@ func (persistentvolumeStrategy) WarningsOnUpdate(ctx context.Context, obj, old r
 	return pvutil.GetWarningsForPersistentVolume(obj.(*api.PersistentVolume))
 }
 
-func (persistentvolumeStrategy) AllowUnconditionalUpdate() bool {
+func (persistentvolumeStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/core/persistentvolumeclaim/strategy.go
+++ b/pkg/registry/core/persistentvolumeclaim/strategy.go
@@ -94,7 +94,7 @@ func (persistentvolumeclaimStrategy) WarningsOnCreate(ctx context.Context, obj r
 func (persistentvolumeclaimStrategy) Canonicalize(obj runtime.Object) {
 }
 
-func (persistentvolumeclaimStrategy) AllowCreateOnUpdate() bool {
+func (persistentvolumeclaimStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -131,7 +131,7 @@ func (persistentvolumeclaimStrategy) WarningsOnUpdate(ctx context.Context, obj, 
 	return pvcutil.GetWarningsForPersistentVolumeClaim(obj.(*api.PersistentVolumeClaim))
 }
 
-func (persistentvolumeclaimStrategy) AllowUnconditionalUpdate() bool {
+func (persistentvolumeclaimStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -134,7 +134,7 @@ func (podStrategy) Canonicalize(obj runtime.Object) {
 }
 
 // AllowCreateOnUpdate is false for pods.
-func (podStrategy) AllowCreateOnUpdate() bool {
+func (podStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -156,7 +156,7 @@ func (podStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object
 }
 
 // AllowUnconditionalUpdate allows pods to be overwritten
-func (podStrategy) AllowUnconditionalUpdate() bool {
+func (podStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/core/podtemplate/strategy.go
+++ b/pkg/registry/core/podtemplate/strategy.go
@@ -70,7 +70,7 @@ func (podTemplateStrategy) Canonicalize(obj runtime.Object) {
 }
 
 // AllowCreateOnUpdate is false for pod templates.
-func (podTemplateStrategy) AllowCreateOnUpdate() bool {
+func (podTemplateStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -110,6 +110,6 @@ func (podTemplateStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtim
 	return warnings
 }
 
-func (podTemplateStrategy) AllowUnconditionalUpdate() bool {
+func (podTemplateStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }

--- a/pkg/registry/core/podtemplate/strategy_test.go
+++ b/pkg/registry/core/podtemplate/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package podtemplate
 
 import (
+	"context"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,7 +31,7 @@ func TestStrategy(t *testing.T) {
 	if !Strategy.NamespaceScoped() {
 		t.Errorf("must be namespace scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("should not allow create on update")
 	}
 

--- a/pkg/registry/core/replicationcontroller/strategy.go
+++ b/pkg/registry/core/replicationcontroller/strategy.go
@@ -146,7 +146,7 @@ func (rcStrategy) Canonicalize(obj runtime.Object) {
 
 // AllowCreateOnUpdate is false for replication controllers; this means a POST is
 // needed to create one.
-func (rcStrategy) AllowCreateOnUpdate() bool {
+func (rcStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -189,7 +189,7 @@ func (rcStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object)
 	return warnings
 }
 
-func (rcStrategy) AllowUnconditionalUpdate() bool {
+func (rcStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/core/replicationcontroller/strategy_test.go
+++ b/pkg/registry/core/replicationcontroller/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package replicationcontroller
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -36,7 +37,7 @@ func TestControllerStrategy(t *testing.T) {
 	if !Strategy.NamespaceScoped() {
 		t.Errorf("ReplicationController must be namespace scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("ReplicationController should not allow create on update")
 	}
 
@@ -93,7 +94,7 @@ func TestControllerStatusStrategy(t *testing.T) {
 	if !StatusStrategy.NamespaceScoped() {
 		t.Errorf("ReplicationController must be namespace scoped")
 	}
-	if StatusStrategy.AllowCreateOnUpdate() {
+	if StatusStrategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("ReplicationController should not allow create on update")
 	}
 	validSelector := map[string]string{"a": "b"}

--- a/pkg/registry/core/resourcequota/strategy.go
+++ b/pkg/registry/core/resourcequota/strategy.go
@@ -113,7 +113,7 @@ func (resourcequotaStrategy) Canonicalize(obj runtime.Object) {
 }
 
 // AllowCreateOnUpdate is false for resourcequotas.
-func (resourcequotaStrategy) AllowCreateOnUpdate() bool {
+func (resourcequotaStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -128,7 +128,7 @@ func (resourcequotaStrategy) WarningsOnUpdate(ctx context.Context, obj, old runt
 	return nil
 }
 
-func (resourcequotaStrategy) AllowUnconditionalUpdate() bool {
+func (resourcequotaStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/core/resourcequota/strategy_test.go
+++ b/pkg/registry/core/resourcequota/strategy_test.go
@@ -31,7 +31,7 @@ func TestResourceQuotaStrategy(t *testing.T) {
 	if !Strategy.NamespaceScoped() {
 		t.Errorf("ResourceQuota should be namespace scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("ResourceQuota should not allow create on update")
 	}
 	resourceQuota := &api.ResourceQuota{

--- a/pkg/registry/core/secret/strategy.go
+++ b/pkg/registry/core/secret/strategy.go
@@ -69,7 +69,7 @@ func (strategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []stri
 func (strategy) Canonicalize(obj runtime.Object) {
 }
 
-func (strategy) AllowCreateOnUpdate() bool {
+func (strategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -97,7 +97,7 @@ func (strategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) [
 func dropDisabledFields(secret *api.Secret, oldSecret *api.Secret) {
 }
 
-func (strategy) AllowUnconditionalUpdate() bool {
+func (strategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/core/service/strategy.go
+++ b/pkg/registry/core/service/strategy.go
@@ -100,7 +100,7 @@ func (svcStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []s
 func (svcStrategy) Canonicalize(obj runtime.Object) {
 }
 
-func (svcStrategy) AllowCreateOnUpdate() bool {
+func (svcStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return true
 }
 
@@ -114,7 +114,7 @@ func (svcStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object
 	return serviceapi.GetWarningsForService(obj.(*api.Service), old.(*api.Service))
 }
 
-func (svcStrategy) AllowUnconditionalUpdate() bool {
+func (svcStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/core/serviceaccount/strategy.go
+++ b/pkg/registry/core/serviceaccount/strategy.go
@@ -61,7 +61,7 @@ func (strategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []stri
 func (strategy) Canonicalize(obj runtime.Object) {
 }
 
-func (strategy) AllowCreateOnUpdate() bool {
+func (strategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -84,7 +84,7 @@ func (strategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) [
 	return warnIfHasEnforceMountableSecretsAnnotation(obj.(*api.ServiceAccount), old.(*api.ServiceAccount))
 }
 
-func (strategy) AllowUnconditionalUpdate() bool {
+func (strategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/discovery/endpointslice/strategy.go
+++ b/pkg/registry/discovery/endpointslice/strategy.go
@@ -112,7 +112,7 @@ func (endpointSliceStrategy) Canonicalize(obj runtime.Object) {
 }
 
 // AllowCreateOnUpdate is false for EndpointSlice; this means POST is needed to create one.
-func (endpointSliceStrategy) AllowCreateOnUpdate() bool {
+func (endpointSliceStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -135,7 +135,7 @@ func (endpointSliceStrategy) WarningsOnUpdate(ctx context.Context, obj, old runt
 }
 
 // AllowUnconditionalUpdate is the default update policy for EndpointSlice objects.
-func (endpointSliceStrategy) AllowUnconditionalUpdate() bool {
+func (endpointSliceStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/flowcontrol/flowschema/strategy.go
+++ b/pkg/registry/flowcontrol/flowschema/strategy.go
@@ -98,12 +98,12 @@ func (flowSchemaStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Obje
 func (flowSchemaStrategy) Canonicalize(obj runtime.Object) {
 }
 
-func (flowSchemaStrategy) AllowUnconditionalUpdate() bool {
+func (flowSchemaStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 
 // AllowCreateOnUpdate is false for flow-schemas; this means a POST is needed to create one.
-func (flowSchemaStrategy) AllowCreateOnUpdate() bool {
+func (flowSchemaStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 

--- a/pkg/registry/flowcontrol/prioritylevelconfiguration/strategy.go
+++ b/pkg/registry/flowcontrol/prioritylevelconfiguration/strategy.go
@@ -109,12 +109,12 @@ func (priorityLevelConfigurationStrategy) WarningsOnCreate(ctx context.Context, 
 func (priorityLevelConfigurationStrategy) Canonicalize(obj runtime.Object) {
 }
 
-func (priorityLevelConfigurationStrategy) AllowUnconditionalUpdate() bool {
+func (priorityLevelConfigurationStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 
 // AllowCreateOnUpdate is false for priority-level-configurations; this means a POST is needed to create one.
-func (priorityLevelConfigurationStrategy) AllowCreateOnUpdate() bool {
+func (priorityLevelConfigurationStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 

--- a/pkg/registry/networking/ingress/strategy.go
+++ b/pkg/registry/networking/ingress/strategy.go
@@ -115,7 +115,7 @@ func (ingressStrategy) Canonicalize(obj runtime.Object) {
 }
 
 // AllowCreateOnUpdate is false for Ingress; this means POST is needed to create one.
-func (ingressStrategy) AllowCreateOnUpdate() bool {
+func (ingressStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -130,7 +130,7 @@ func (ingressStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Ob
 }
 
 // AllowUnconditionalUpdate is the default update policy for Ingress objects.
-func (ingressStrategy) AllowUnconditionalUpdate() bool {
+func (ingressStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/networking/ingress/strategy_test.go
+++ b/pkg/registry/networking/ingress/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ingress
 
 import (
+	"context"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -80,7 +81,7 @@ func TestIngressStrategy(t *testing.T) {
 	if !Strategy.NamespaceScoped() {
 		t.Errorf("Ingress must be namespace scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("Ingress should not allow create on update")
 	}
 
@@ -111,7 +112,7 @@ func TestIngressStatusStrategy(t *testing.T) {
 	if !StatusStrategy.NamespaceScoped() {
 		t.Errorf("Ingress must be namespace scoped")
 	}
-	if StatusStrategy.AllowCreateOnUpdate() {
+	if StatusStrategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("Ingress should not allow create on update")
 	}
 	oldIngress := newIngress()

--- a/pkg/registry/networking/ingressclass/strategy.go
+++ b/pkg/registry/networking/ingressclass/strategy.go
@@ -83,7 +83,7 @@ func (ingressClassStrategy) Canonicalize(obj runtime.Object) {
 
 // AllowCreateOnUpdate is false for IngressClass; this means POST is needed to
 // create one.
-func (ingressClassStrategy) AllowCreateOnUpdate() bool {
+func (ingressClassStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -102,6 +102,6 @@ func (ingressClassStrategy) WarningsOnUpdate(ctx context.Context, obj, old runti
 
 // AllowUnconditionalUpdate is the default update policy for IngressClass
 // objects.
-func (ingressClassStrategy) AllowUnconditionalUpdate() bool {
+func (ingressClassStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }

--- a/pkg/registry/networking/ingressclass/strategy_test.go
+++ b/pkg/registry/networking/ingressclass/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ingressclass
 
 import (
+	"context"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +30,7 @@ func TestIngressClassStrategy(t *testing.T) {
 	if Strategy.NamespaceScoped() {
 		t.Errorf("IngressClass must not be namespace scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("IngressClass should not allow create on update")
 	}
 

--- a/pkg/registry/networking/ipaddress/strategy.go
+++ b/pkg/registry/networking/ipaddress/strategy.go
@@ -80,7 +80,7 @@ func (ipAddressStrategy) Canonicalize(obj runtime.Object) {
 }
 
 // AllowCreateOnUpdate is false for IPAddress; this means POST is needed to create one.
-func (ipAddressStrategy) AllowCreateOnUpdate() bool {
+func (ipAddressStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -94,7 +94,7 @@ func (ipAddressStrategy) ValidateUpdate(ctx context.Context, new, old runtime.Ob
 }
 
 // AllowUnconditionalUpdate is the default update policy for IPAddress objects.
-func (ipAddressStrategy) AllowUnconditionalUpdate() bool {
+func (ipAddressStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/networking/ipaddress/strategy_test.go
+++ b/pkg/registry/networking/ipaddress/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ipaddress
 
 import (
+	"context"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,7 +57,7 @@ func TestIPAddressStrategy(t *testing.T) {
 	if Strategy.NamespaceScoped() {
 		t.Errorf("ipAddress must not be namespace scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("ipAddress should not allow create on update")
 	}
 

--- a/pkg/registry/networking/networkpolicy/strategy.go
+++ b/pkg/registry/networking/networkpolicy/strategy.go
@@ -79,7 +79,7 @@ func (networkPolicyStrategy) WarningsOnCreate(ctx context.Context, obj runtime.O
 func (networkPolicyStrategy) Canonicalize(obj runtime.Object) {}
 
 // AllowCreateOnUpdate is false for NetworkPolicy; this means POST is needed to create one.
-func (networkPolicyStrategy) AllowCreateOnUpdate() bool {
+func (networkPolicyStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -95,7 +95,7 @@ func (networkPolicyStrategy) WarningsOnUpdate(ctx context.Context, obj, old runt
 }
 
 // AllowUnconditionalUpdate is the default update policy for NetworkPolicy objects.
-func (networkPolicyStrategy) AllowUnconditionalUpdate() bool {
+func (networkPolicyStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/networking/servicecidr/strategy.go
+++ b/pkg/registry/networking/servicecidr/strategy.go
@@ -97,7 +97,7 @@ func (serviceCIDRStrategy) Canonicalize(obj runtime.Object) {
 }
 
 // AllowCreateOnUpdate is false for ServiceCIDR; this means POST is needed to create one.
-func (serviceCIDRStrategy) AllowCreateOnUpdate() bool {
+func (serviceCIDRStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -115,7 +115,7 @@ func (serviceCIDRStrategy) ValidateUpdate(ctx context.Context, new, old runtime.
 }
 
 // AllowUnconditionalUpdate is the default update policy for ServiceCIDR objects.
-func (serviceCIDRStrategy) AllowUnconditionalUpdate() bool {
+func (serviceCIDRStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/node/runtimeclass/strategy.go
+++ b/pkg/registry/node/runtimeclass/strategy.go
@@ -50,7 +50,7 @@ func (strategy) NamespaceScoped() bool {
 }
 
 // AllowCreateOnUpdate is true for RuntimeClasses.
-func (strategy) AllowCreateOnUpdate() bool {
+func (strategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return true
 }
 
@@ -107,6 +107,6 @@ func (strategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) [
 // populates it with the latest version. Else, it checks that the
 // version specified by the user matches the version of latest etcd
 // object.
-func (strategy) AllowUnconditionalUpdate() bool {
+func (strategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }

--- a/pkg/registry/policy/poddisruptionbudget/strategy.go
+++ b/pkg/registry/policy/poddisruptionbudget/strategy.go
@@ -105,7 +105,7 @@ func (podDisruptionBudgetStrategy) Canonicalize(obj runtime.Object) {
 }
 
 // AllowCreateOnUpdate is true for PodDisruptionBudget; this means you may create one with a PUT request.
-func (podDisruptionBudgetStrategy) AllowCreateOnUpdate() bool {
+func (podDisruptionBudgetStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -124,7 +124,7 @@ func (podDisruptionBudgetStrategy) WarningsOnUpdate(ctx context.Context, obj, ol
 
 // AllowUnconditionalUpdate is the default update policy for PodDisruptionBudget objects. Status update should
 // only be allowed if version match.
-func (podDisruptionBudgetStrategy) AllowUnconditionalUpdate() bool {
+func (podDisruptionBudgetStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }
 

--- a/pkg/registry/policy/poddisruptionbudget/strategy_test.go
+++ b/pkg/registry/policy/poddisruptionbudget/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package poddisruptionbudget
 
 import (
+	"context"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,7 +32,7 @@ func TestPodDisruptionBudgetStrategy(t *testing.T) {
 	if !Strategy.NamespaceScoped() {
 		t.Errorf("PodDisruptionBudget must be namespace scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("PodDisruptionBudget should not allow create on update")
 	}
 
@@ -123,7 +124,7 @@ func TestPodDisruptionBudgetStatusStrategy(t *testing.T) {
 	if !StatusStrategy.NamespaceScoped() {
 		t.Errorf("PodDisruptionBudgetStatus must be namespace scoped")
 	}
-	if StatusStrategy.AllowCreateOnUpdate() {
+	if StatusStrategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("PodDisruptionBudgetStatus should not allow create on update")
 	}
 

--- a/pkg/registry/rbac/clusterrole/strategy.go
+++ b/pkg/registry/rbac/clusterrole/strategy.go
@@ -51,7 +51,7 @@ func (strategy) NamespaceScoped() bool {
 }
 
 // AllowCreateOnUpdate is true for ClusterRoles.
-func (strategy) AllowCreateOnUpdate() bool {
+func (strategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return true
 }
 
@@ -106,7 +106,7 @@ func (strategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) [
 // populates it with the latest version. Else, it checks that the
 // version specified by the user matches the version of latest etcd
 // object.
-func (strategy) AllowUnconditionalUpdate() bool {
+func (strategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/rbac/clusterrolebinding/strategy.go
+++ b/pkg/registry/rbac/clusterrolebinding/strategy.go
@@ -50,7 +50,7 @@ func (strategy) NamespaceScoped() bool {
 }
 
 // AllowCreateOnUpdate is true for ClusterRoleBindings.
-func (strategy) AllowCreateOnUpdate() bool {
+func (strategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return true
 }
 
@@ -97,6 +97,6 @@ func (strategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) [
 // populates it with the latest version. Else, it checks that the
 // version specified by the user matches the version of latest etcd
 // object.
-func (strategy) AllowUnconditionalUpdate() bool {
+func (strategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }

--- a/pkg/registry/rbac/role/strategy.go
+++ b/pkg/registry/rbac/role/strategy.go
@@ -50,7 +50,7 @@ func (strategy) NamespaceScoped() bool {
 }
 
 // AllowCreateOnUpdate is true for Roles.
-func (strategy) AllowCreateOnUpdate() bool {
+func (strategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return true
 }
 
@@ -99,6 +99,6 @@ func (strategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) [
 // populates it with the latest version. Else, it checks that the
 // version specified by the user matches the version of latest etcd
 // object.
-func (strategy) AllowUnconditionalUpdate() bool {
+func (strategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }

--- a/pkg/registry/rbac/rolebinding/strategy.go
+++ b/pkg/registry/rbac/rolebinding/strategy.go
@@ -50,7 +50,7 @@ func (strategy) NamespaceScoped() bool {
 }
 
 // AllowCreateOnUpdate is true for RoleBindings.
-func (strategy) AllowCreateOnUpdate() bool {
+func (strategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return true
 }
 
@@ -109,6 +109,6 @@ func (strategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) [
 // populates it with the latest version. Else, it checks that the
 // version specified by the user matches the version of latest etcd
 // object.
-func (strategy) AllowUnconditionalUpdate() bool {
+func (strategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }

--- a/pkg/registry/resource/deviceclass/strategy.go
+++ b/pkg/registry/resource/deviceclass/strategy.go
@@ -61,7 +61,7 @@ func (deviceClassStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Obj
 func (deviceClassStrategy) Canonicalize(obj runtime.Object) {
 }
 
-func (deviceClassStrategy) AllowCreateOnUpdate() bool {
+func (deviceClassStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -87,7 +87,7 @@ func (deviceClassStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtim
 	return nil
 }
 
-func (deviceClassStrategy) AllowUnconditionalUpdate() bool {
+func (deviceClassStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/resource/deviceclass/strategy_test.go
+++ b/pkg/registry/resource/deviceclass/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package deviceclass
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,7 +52,7 @@ func TestStrategy(t *testing.T) {
 	if Strategy.NamespaceScoped() {
 		t.Errorf("DeviceClass must not be namespace scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("DeviceClass should not allow create on update")
 	}
 }

--- a/pkg/registry/resource/devicetaintrule/strategy.go
+++ b/pkg/registry/resource/devicetaintrule/strategy.go
@@ -82,7 +82,7 @@ func (*deviceTaintRuleStrategy) WarningsOnCreate(ctx context.Context, obj runtim
 func (*deviceTaintRuleStrategy) Canonicalize(obj runtime.Object) {
 }
 
-func (*deviceTaintRuleStrategy) AllowCreateOnUpdate() bool {
+func (*deviceTaintRuleStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -122,7 +122,7 @@ func (*deviceTaintRuleStrategy) WarningsOnUpdate(ctx context.Context, obj, old r
 	return nil
 }
 
-func (*deviceTaintRuleStrategy) AllowUnconditionalUpdate() bool {
+func (*deviceTaintRuleStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/resource/devicetaintrule/strategy_test.go
+++ b/pkg/registry/resource/devicetaintrule/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package devicetaintrule
 
 import (
+	"context"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -78,7 +79,7 @@ func TestDeviceTaintRuleStrategy(t *testing.T) {
 	if Strategy.NamespaceScoped() {
 		t.Errorf("DeviceTaintRule must not be namespace scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("DeviceTaintRule should not allow create on update")
 	}
 }

--- a/pkg/registry/resource/resourceclaim/strategy.go
+++ b/pkg/registry/resource/resourceclaim/strategy.go
@@ -129,7 +129,7 @@ func (*resourceclaimStrategy) WarningsOnCreate(ctx context.Context, obj runtime.
 func (*resourceclaimStrategy) Canonicalize(obj runtime.Object) {
 }
 
-func (*resourceclaimStrategy) AllowCreateOnUpdate() bool {
+func (*resourceclaimStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -152,7 +152,7 @@ func (*resourceclaimStrategy) WarningsOnUpdate(ctx context.Context, obj, old run
 	return nil
 }
 
-func (*resourceclaimStrategy) AllowUnconditionalUpdate() bool {
+func (*resourceclaimStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/resource/resourceclaim/strategy_test.go
+++ b/pkg/registry/resource/resourceclaim/strategy_test.go
@@ -409,7 +409,7 @@ func TestStrategy(t *testing.T) {
 	if !strategy.NamespaceScoped() {
 		t.Errorf("ResourceClaim must be namespace scoped")
 	}
-	if strategy.AllowCreateOnUpdate() {
+	if strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("ResourceClaim should not allow create on update")
 	}
 }

--- a/pkg/registry/resource/resourceclaimtemplate/strategy.go
+++ b/pkg/registry/resource/resourceclaimtemplate/strategy.go
@@ -81,7 +81,7 @@ func (*resourceClaimTemplateStrategy) WarningsOnCreate(ctx context.Context, obj 
 func (*resourceClaimTemplateStrategy) Canonicalize(obj runtime.Object) {
 }
 
-func (*resourceClaimTemplateStrategy) AllowCreateOnUpdate() bool {
+func (*resourceClaimTemplateStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -100,7 +100,7 @@ func (*resourceClaimTemplateStrategy) WarningsOnUpdate(ctx context.Context, obj,
 	return nil
 }
 
-func (*resourceClaimTemplateStrategy) AllowUnconditionalUpdate() bool {
+func (*resourceClaimTemplateStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/resource/resourceclaimtemplate/strategy_test.go
+++ b/pkg/registry/resource/resourceclaimtemplate/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resourceclaimtemplate
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -270,7 +271,7 @@ func TestClaimTemplateStrategy(t *testing.T) {
 	if !strategy.NamespaceScoped() {
 		t.Errorf("ResourceClaimTemplate must be namespace scoped")
 	}
-	if strategy.AllowCreateOnUpdate() {
+	if strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("ResourceClaimTemplate should not allow create on update")
 	}
 }

--- a/pkg/registry/resource/resourcepoolstatusrequest/strategy.go
+++ b/pkg/registry/resource/resourcepoolstatusrequest/strategy.go
@@ -82,7 +82,7 @@ func (*resourcePoolStatusRequestStrategy) WarningsOnCreate(ctx context.Context, 
 func (*resourcePoolStatusRequestStrategy) Canonicalize(obj runtime.Object) {
 }
 
-func (*resourcePoolStatusRequestStrategy) AllowCreateOnUpdate() bool {
+func (*resourcePoolStatusRequestStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -101,7 +101,7 @@ func (*resourcePoolStatusRequestStrategy) WarningsOnUpdate(ctx context.Context, 
 	return nil
 }
 
-func (*resourcePoolStatusRequestStrategy) AllowUnconditionalUpdate() bool {
+func (*resourcePoolStatusRequestStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }
 

--- a/pkg/registry/resource/resourceslice/strategy.go
+++ b/pkg/registry/resource/resourceslice/strategy.go
@@ -84,7 +84,7 @@ func (resourceSliceStrategy) WarningsOnCreate(ctx context.Context, obj runtime.O
 func (resourceSliceStrategy) Canonicalize(obj runtime.Object) {
 }
 
-func (resourceSliceStrategy) AllowCreateOnUpdate() bool {
+func (resourceSliceStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -117,7 +117,7 @@ func (resourceSliceStrategy) WarningsOnUpdate(ctx context.Context, obj, old runt
 	return warnings
 }
 
-func (resourceSliceStrategy) AllowUnconditionalUpdate() bool {
+func (resourceSliceStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/resource/resourceslice/strategy_test.go
+++ b/pkg/registry/resource/resourceslice/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resourceslice
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -213,7 +214,7 @@ func TestResourceSliceStrategy(t *testing.T) {
 	if Strategy.NamespaceScoped() {
 		t.Errorf("ResourceSlice must not be namespace scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("ResourceSlice should not allow create on update")
 	}
 }

--- a/pkg/registry/scheduling/podgroup/strategy.go
+++ b/pkg/registry/scheduling/podgroup/strategy.go
@@ -95,7 +95,7 @@ func (*podGroupStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Objec
 
 func (*podGroupStrategy) Canonicalize(obj runtime.Object) {}
 
-func (*podGroupStrategy) AllowCreateOnUpdate() bool {
+func (*podGroupStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -116,7 +116,7 @@ func (*podGroupStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.
 	return nil
 }
 
-func (*podGroupStrategy) AllowUnconditionalUpdate() bool {
+func (*podGroupStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/scheduling/podgroup/strategy_test.go
+++ b/pkg/registry/scheduling/podgroup/strategy_test.go
@@ -86,7 +86,7 @@ func TestStrategy(t *testing.T) {
 	if !strategy.NamespaceScoped() {
 		t.Errorf("PodGroup must be namespace scoped")
 	}
-	if strategy.AllowCreateOnUpdate() {
+	if strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("PodGroup should not allow create on update")
 	}
 }

--- a/pkg/registry/scheduling/priorityclass/strategy.go
+++ b/pkg/registry/scheduling/priorityclass/strategy.go
@@ -66,7 +66,7 @@ func (priorityClassStrategy) WarningsOnCreate(ctx context.Context, obj runtime.O
 func (priorityClassStrategy) Canonicalize(obj runtime.Object) {}
 
 // AllowCreateOnUpdate is false for PriorityClass; this means POST is needed to create one.
-func (priorityClassStrategy) AllowCreateOnUpdate() bool {
+func (priorityClassStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -81,6 +81,6 @@ func (priorityClassStrategy) WarningsOnUpdate(ctx context.Context, obj, old runt
 }
 
 // AllowUnconditionalUpdate is the default update policy for PriorityClass objects.
-func (priorityClassStrategy) AllowUnconditionalUpdate() bool {
+func (priorityClassStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }

--- a/pkg/registry/scheduling/priorityclass/strategy_test.go
+++ b/pkg/registry/scheduling/priorityclass/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package priorityclass
 
 import (
+	"context"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +30,7 @@ func TestPriorityClassStrategy(t *testing.T) {
 	if Strategy.NamespaceScoped() {
 		t.Errorf("PriorityClass must not be namespace scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("PriorityClass should not allow create on update")
 	}
 

--- a/pkg/registry/scheduling/workload/strategy.go
+++ b/pkg/registry/scheduling/workload/strategy.go
@@ -74,7 +74,7 @@ func (workloadStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object
 
 func (workloadStrategy) Canonicalize(obj runtime.Object) {}
 
-func (workloadStrategy) AllowCreateOnUpdate() bool {
+func (workloadStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -90,7 +90,7 @@ func (workloadStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.O
 	return nil
 }
 
-func (workloadStrategy) AllowUnconditionalUpdate() bool {
+func (workloadStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/pkg/registry/scheduling/workload/strategy_test.go
+++ b/pkg/registry/scheduling/workload/strategy_test.go
@@ -67,7 +67,7 @@ func TestWorkloadStrategy(t *testing.T) {
 	if !Strategy.NamespaceScoped() {
 		t.Errorf("Workload must be namespace scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("Workload should not allow create on update")
 	}
 }

--- a/pkg/registry/storage/csidriver/strategy.go
+++ b/pkg/registry/storage/csidriver/strategy.go
@@ -91,7 +91,7 @@ func (csiDriverStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Objec
 func (csiDriverStrategy) Canonicalize(obj runtime.Object) {
 }
 
-func (csiDriverStrategy) AllowCreateOnUpdate() bool {
+func (csiDriverStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -152,6 +152,6 @@ func (csiDriverStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.
 	return warnings
 }
 
-func (csiDriverStrategy) AllowUnconditionalUpdate() bool {
+func (csiDriverStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }

--- a/pkg/registry/storage/csidriver/strategy_test.go
+++ b/pkg/registry/storage/csidriver/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package csidriver
 
 import (
+	"context"
 	"slices"
 	"testing"
 
@@ -58,7 +59,7 @@ func TestCSIDriverStrategy(t *testing.T) {
 	if Strategy.NamespaceScoped() {
 		t.Errorf("CSIDriver must not be namespace scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("CSIDriver should not allow create on update")
 	}
 

--- a/pkg/registry/storage/csinode/strategy.go
+++ b/pkg/registry/storage/csinode/strategy.go
@@ -58,7 +58,7 @@ func (csiNodeStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object)
 func (csiNodeStrategy) Canonicalize(obj runtime.Object) {
 }
 
-func (csiNodeStrategy) AllowCreateOnUpdate() bool {
+func (csiNodeStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -77,6 +77,6 @@ func (csiNodeStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Ob
 	return nil
 }
 
-func (csiNodeStrategy) AllowUnconditionalUpdate() bool {
+func (csiNodeStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }

--- a/pkg/registry/storage/csinode/strategy_test.go
+++ b/pkg/registry/storage/csinode/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package csinode
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -166,7 +167,7 @@ func TestCSINodeStrategy(t *testing.T) {
 	if Strategy.NamespaceScoped() {
 		t.Errorf("CSINode must not be namespace scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("CSINode should not allow create on update")
 	}
 

--- a/pkg/registry/storage/csistoragecapacity/strategy.go
+++ b/pkg/registry/storage/csistoragecapacity/strategy.go
@@ -66,7 +66,7 @@ func (csiStorageCapacityStrategy) WarningsOnCreate(ctx context.Context, obj runt
 func (csiStorageCapacityStrategy) Canonicalize(obj runtime.Object) {
 }
 
-func (csiStorageCapacityStrategy) AllowCreateOnUpdate() bool {
+func (csiStorageCapacityStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -89,7 +89,7 @@ func (csiStorageCapacityStrategy) WarningsOnUpdate(ctx context.Context, obj, old
 	return storageutil.GetWarningsForCSIStorageCapacity(obj.(*storage.CSIStorageCapacity))
 }
 
-func (csiStorageCapacityStrategy) AllowUnconditionalUpdate() bool {
+func (csiStorageCapacityStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }
 

--- a/pkg/registry/storage/csistoragecapacity/strategy_test.go
+++ b/pkg/registry/storage/csistoragecapacity/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package csistoragecapacity
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -66,7 +67,7 @@ func TestCSIStorageCapacityStrategy(t *testing.T) {
 	if !Strategy.NamespaceScoped() {
 		t.Errorf("CSIStorageCapacity must be namespace scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("CSIStorageCapacity should not allow create on update")
 	}
 

--- a/pkg/registry/storage/storageclass/strategy.go
+++ b/pkg/registry/storage/storageclass/strategy.go
@@ -62,7 +62,7 @@ func (storageClassStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Ob
 func (storageClassStrategy) Canonicalize(obj runtime.Object) {
 }
 
-func (storageClassStrategy) AllowCreateOnUpdate() bool {
+func (storageClassStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -81,6 +81,6 @@ func (storageClassStrategy) WarningsOnUpdate(ctx context.Context, obj, old runti
 	return storageutil.GetWarningsForStorageClass(obj.(*storage.StorageClass))
 }
 
-func (storageClassStrategy) AllowUnconditionalUpdate() bool {
+func (storageClassStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }

--- a/pkg/registry/storage/storageclass/strategy_test.go
+++ b/pkg/registry/storage/storageclass/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package storageclass
 
 import (
+	"context"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,7 +31,7 @@ func TestStorageClassStrategy(t *testing.T) {
 	if Strategy.NamespaceScoped() {
 		t.Errorf("StorageClass must not be namespace scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("StorageClass should not allow create on update")
 	}
 

--- a/pkg/registry/storage/volumeattachment/strategy.go
+++ b/pkg/registry/storage/volumeattachment/strategy.go
@@ -79,7 +79,7 @@ func (volumeAttachmentStrategy) WarningsOnCreate(ctx context.Context, obj runtim
 func (volumeAttachmentStrategy) Canonicalize(obj runtime.Object) {
 }
 
-func (volumeAttachmentStrategy) AllowCreateOnUpdate() bool {
+func (volumeAttachmentStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -104,7 +104,7 @@ func (volumeAttachmentStrategy) WarningsOnUpdate(ctx context.Context, obj, old r
 	return nil
 }
 
-func (volumeAttachmentStrategy) AllowUnconditionalUpdate() bool {
+func (volumeAttachmentStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }
 

--- a/pkg/registry/storage/volumeattachment/strategy_test.go
+++ b/pkg/registry/storage/volumeattachment/strategy_test.go
@@ -76,7 +76,7 @@ func TestVolumeAttachmentStrategy(t *testing.T) {
 	if Strategy.NamespaceScoped() {
 		t.Errorf("VolumeAttachment must not be namespace scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("VolumeAttachment should not allow create on update")
 	}
 

--- a/pkg/registry/storage/volumeattributesclass/strategy.go
+++ b/pkg/registry/storage/volumeattributesclass/strategy.go
@@ -60,7 +60,7 @@ func (volumeAttributesClassStrategy) WarningsOnCreate(ctx context.Context, obj r
 func (volumeAttributesClassStrategy) Canonicalize(obj runtime.Object) {
 }
 
-func (volumeAttributesClassStrategy) AllowCreateOnUpdate() bool {
+func (volumeAttributesClassStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -77,6 +77,6 @@ func (volumeAttributesClassStrategy) WarningsOnUpdate(ctx context.Context, obj, 
 	return nil
 }
 
-func (volumeAttributesClassStrategy) AllowUnconditionalUpdate() bool {
+func (volumeAttributesClassStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }

--- a/pkg/registry/storage/volumeattributesclass/strategy_test.go
+++ b/pkg/registry/storage/volumeattributesclass/strategy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package volumeattributesclass
 
 import (
+	"context"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +30,7 @@ func TestVolumeAttributesClassStrategy(t *testing.T) {
 	if Strategy.NamespaceScoped() {
 		t.Errorf("VolumeAttributesClassStrategy must not be namespace scoped")
 	}
-	if Strategy.AllowCreateOnUpdate() {
+	if Strategy.AllowCreateOnUpdate(context.Background()) {
 		t.Errorf("VolumeAttributesClassStrategy should not allow create on update")
 	}
 

--- a/pkg/registry/storagemigration/storagemigration/strategy.go
+++ b/pkg/registry/storagemigration/storagemigration/strategy.go
@@ -85,7 +85,7 @@ func (strategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []stri
 
 func (strategy) Canonicalize(obj runtime.Object) {}
 
-func (strategy) AllowCreateOnUpdate() bool {
+func (strategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -99,7 +99,7 @@ func (strategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) [
 	return nil
 }
 
-func (strategy) AllowUnconditionalUpdate() bool {
+func (strategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }
 

--- a/pkg/registry/testapigroup/carp/strategy.go
+++ b/pkg/registry/testapigroup/carp/strategy.go
@@ -85,7 +85,7 @@ func (*carpStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) [
 func (*carpStrategy) Canonicalize(obj runtime.Object) {
 }
 
-func (*carpStrategy) AllowCreateOnUpdate() bool {
+func (*carpStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -103,7 +103,7 @@ func (*carpStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Obje
 	return nil
 }
 
-func (*carpStrategy) AllowUnconditionalUpdate() bool {
+func (*carpStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return true
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go
@@ -261,12 +261,12 @@ func (customResourceStrategy) Canonicalize(obj runtime.Object) {
 
 // AllowCreateOnUpdate is false for CustomResources; this means a POST is
 // needed to create one.
-func (customResourceStrategy) AllowCreateOnUpdate() bool {
+func (customResourceStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
 // AllowUnconditionalUpdate is the default update policy for CustomResource objects.
-func (customResourceStrategy) AllowUnconditionalUpdate() bool {
+func (customResourceStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/strategy.go
@@ -143,12 +143,12 @@ func (strategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []stri
 
 // AllowCreateOnUpdate is false for CustomResourceDefinition; this means a POST is
 // needed to create one.
-func (strategy) AllowCreateOnUpdate() bool {
+func (strategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
 // AllowUnconditionalUpdate is the default update policy for CustomResourceDefinition objects.
-func (strategy) AllowUnconditionalUpdate() bool {
+func (strategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -279,11 +279,11 @@ func (statusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Obj
 	metav1.ResetObjectMetaForStatus(&newObj.ObjectMeta, &newObj.ObjectMeta)
 }
 
-func (statusStrategy) AllowCreateOnUpdate() bool {
+func (statusStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
-func (statusStrategy) AllowUnconditionalUpdate() bool {
+func (statusStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -643,7 +643,7 @@ func (e *Store) Update(ctx context.Context, name string, objInfo rest.UpdatedObj
 	out := e.NewFunc()
 
 	// only ignore a not found error if this type allows creating on update, or we're forcing allowing create (like for server-side-apply)
-	ignoreNotFound := e.UpdateStrategy.AllowCreateOnUpdate() || forceAllowCreate
+	ignoreNotFound := e.UpdateStrategy.AllowCreateOnUpdate(ctx) || forceAllowCreate
 	// deleteObj is only used in case a deletion is carried out
 	var deleteObj runtime.Object
 	err = e.Storage.GuaranteedUpdate(ctx, key, out, ignoreNotFound, storagePreconditions, func(existing runtime.Object, res storage.ResponseMeta) (runtime.Object, *uint64, error) {
@@ -652,7 +652,7 @@ func (e *Store) Update(ctx context.Context, name string, objInfo rest.UpdatedObj
 			return nil, nil, err
 		}
 		if existingResourceVersion == 0 {
-			if !e.UpdateStrategy.AllowCreateOnUpdate() && !forceAllowCreate {
+			if !e.UpdateStrategy.AllowCreateOnUpdate(ctx) && !forceAllowCreate {
 				return nil, nil, apierrors.NewNotFound(qualifiedResource, name)
 			}
 		}
@@ -671,7 +671,7 @@ func (e *Store) Update(ctx context.Context, name string, objInfo rest.UpdatedObj
 		if err != nil {
 			return nil, nil, err
 		}
-		doUnconditionalUpdate := newResourceVersion == 0 && e.UpdateStrategy.AllowUnconditionalUpdate()
+		doUnconditionalUpdate := newResourceVersion == 0 && e.UpdateStrategy.AllowUnconditionalUpdate(ctx)
 
 		if existingResourceVersion == 0 {
 			// Init metadata as early as possible.

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -109,9 +109,13 @@ type testRESTStrategy struct {
 	allowUnconditionalUpdate bool
 }
 
-func (t *testRESTStrategy) NamespaceScoped() bool          { return t.namespaceScoped }
-func (t *testRESTStrategy) AllowCreateOnUpdate() bool      { return t.allowCreateOnUpdate }
-func (t *testRESTStrategy) AllowUnconditionalUpdate() bool { return t.allowUnconditionalUpdate }
+func (t *testRESTStrategy) NamespaceScoped() bool { return t.namespaceScoped }
+func (t *testRESTStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
+	return t.allowCreateOnUpdate
+}
+func (t *testRESTStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
+	return t.allowUnconditionalUpdate
+}
 
 func (t *testRESTStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 	metaObj, err := meta.Accessor(obj)

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/create_update.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/create_update.go
@@ -26,10 +26,15 @@ import (
 // RESTCreateUpdateStrategy is a union of RESTUpdateStrategy and RESTCreateStrategy,
 // and it defines the minimum validation, accepted input, and name generation
 // behavior to create and update an object that follows Kubernetes API conventions.
+//
+// The context that is passed to these methods can be used to retrieve
+// information about the request with request.RequestInfoFrom(ctx) and
+// to return different responses depending on the APIVersion in the
+// request.
 type RESTCreateUpdateStrategy interface {
 	RESTCreateStrategy
 	// AllowCreateOnUpdate returns true if the object can be created by a PUT.
-	AllowCreateOnUpdate() bool
+	AllowCreateOnUpdate(ctx context.Context) bool
 	// PrepareForUpdate is invoked on update before validation to normalize
 	// the object.  For example: remove fields that are not to be persisted,
 	// sort order-insensitive list fields, etc.  This should not remove fields
@@ -62,7 +67,7 @@ type RESTCreateUpdateStrategy interface {
 	// AllowUnconditionalUpdate returns true if the object can be updated
 	// unconditionally (irrespective of the latest resource version), when
 	// there is no resource version specified in the object.
-	AllowUnconditionalUpdate() bool
+	AllowUnconditionalUpdate(ctx context.Context) bool
 }
 
 // Ensure that RESTCreateUpdateStrategy extends RESTCreateStrategy

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
@@ -36,12 +36,17 @@ import (
 // name generation behavior to update an object that follows Kubernetes
 // API conventions. A resource may have many UpdateStrategies, depending on
 // the call pattern in use.
+//
+// The context that is passed to these methods can be used to retrieve
+// information about the request with request.RequestInfoFrom(ctx) and
+// to return different responses depending on the APIVersion in the
+// request.
 type RESTUpdateStrategy interface {
 	runtime.ObjectTyper
 	// NamespaceScoped returns true if the object must be within a namespace.
 	NamespaceScoped() bool
 	// AllowCreateOnUpdate returns true if the object can be created by a PUT.
-	AllowCreateOnUpdate() bool
+	AllowCreateOnUpdate(ctx context.Context) bool
 	// PrepareForUpdate is invoked on update before validation to normalize
 	// the object.  For example: remove fields that are not to be persisted,
 	// sort order-insensitive list fields, etc.  This should not remove fields
@@ -80,7 +85,7 @@ type RESTUpdateStrategy interface {
 	// AllowUnconditionalUpdate returns true if the object can be updated
 	// unconditionally (irrespective of the latest resource version), when
 	// there is no resource version specified in the object.
-	AllowUnconditionalUpdate() bool
+	AllowUnconditionalUpdate(ctx context.Context) bool
 }
 
 // TODO: add other common fields that require global validation.

--- a/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/strategy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/strategy.go
@@ -90,11 +90,11 @@ func (apiServerStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Objec
 	return nil
 }
 
-func (apiServerStrategy) AllowCreateOnUpdate() bool {
+func (apiServerStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
-func (apiServerStrategy) AllowUnconditionalUpdate() bool {
+func (apiServerStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }
 
@@ -149,11 +149,11 @@ func (apiServerStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old ru
 	newAPIService.OwnerReferences = oldAPIService.OwnerReferences
 }
 
-func (apiServerStatusStrategy) AllowCreateOnUpdate() bool {
+func (apiServerStatusStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
-func (apiServerStatusStrategy) AllowUnconditionalUpdate() bool {
+func (apiServerStatusStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/fischer/strategy.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/fischer/strategy.go
@@ -82,11 +82,11 @@ func (fischerStrategy) Validate(ctx context.Context, obj runtime.Object) field.E
 // WarningsOnCreate returns warnings for the creation of the given object.
 func (fischerStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string { return nil }
 
-func (fischerStrategy) AllowCreateOnUpdate() bool {
+func (fischerStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
-func (fischerStrategy) AllowUnconditionalUpdate() bool {
+func (fischerStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/flunder/strategy.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/flunder/strategy.go
@@ -84,11 +84,11 @@ func (flunderStrategy) Validate(ctx context.Context, obj runtime.Object) field.E
 // WarningsOnCreate returns warnings for the creation of the given object.
 func (flunderStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string { return nil }
 
-func (flunderStrategy) AllowCreateOnUpdate() bool {
+func (flunderStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
 	return false
 }
 
-func (flunderStrategy) AllowUnconditionalUpdate() bool {
+func (flunderStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
 	return false
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This enables implementing different behavior for AllowUnconditionalUpdate and AllowCreateOnUpdate depending on the API version, which can be found in ReqInfo.APIVersion. The specific need for this is to switch from AllowUnconditionalUpdate=true (not recommended!) to false in v1 of resource.k8s.io DeviceTaintRule.

This is done by adding the missing context parameter to the existing methods instead of adding a new optional interface because a) the resulting implementation is simpler and gets checked by the compiler and b) the Go API guarantees of k8s.io/apiserver are more relaxed than in other modules because it's less used downstream.

Example implementation:

    func (*deviceTaintRuleStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
           reqInfo, _ := request.RequestInfoFrom(ctx)
           if reqInfo != nil && reqInfo.APIVersion == "v1" {
                   // Should have done that already earlier. Better late than never...
                   return false
           }
           // Historic behavior for v1beta2 and older, cannot change that anymore.
           return true
    }


#### Which issue(s) this PR is related to:

Required for https://github.com/kubernetes/kubernetes/pull/138676.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @liggitt 