### PR TITLE
Fix flaky TestSchedulerRestartWithNominatedNode

### DIFF
--- a/test/integration/scheduler/nominated_node_name/nominated_node_name_test.go
+++ b/test/integration/scheduler/nominated_node_name/nominated_node_name_test.go
@@ -828,17 +828,23 @@ func TestSchedulerRestartWithNominatedNode(t *testing.T) {
 		pls = append(pls, mockQueueSort, mockPreBind)
 		pls = append(pls, additionalPlugins...)
 		registry, prof := schedulerutils.InitRegistryAndConfig(t, nil, pls...)
-		return schedulerutils.InitTestSchedulerForFrameworkTest(t, testContext, 0,
+		testCtx, teardown := schedulerutils.InitTestSchedulerForFrameworkTest(t, testContext, 0,
 			false, /* do not run scheduler immediately after init */
 			scheduler.WithProfiles(prof),
 			scheduler.WithFrameworkOutOfTreeRegistry(registry),
 		)
+		// Ensure both nodes are in the cache before proceeding
+		if err := testutils.WaitForNodesInCache(testCtx.Ctx, testCtx.Scheduler, 2); err != nil {
+			t.Fatalf("Failed to wait for nodes in cache: %v", err)
+		}
+		return testCtx, teardown
 	}
 
 	// To allow triggering scheduler restart in binding phase, we need to initialize the scheduler
 	// and pass the testCtx.SchedulerCloseFn to the bind plugin before calling Scheduler.Run.
 	mockBind := &mockBindPlugin{}
 	testCtx, _ := initSched(mockBind)
+
 	// This will fail the binding cycle and stop the scheduler
 	// Scheduler should set NNN for podA before this step.
 	mockBind.bindFn = func() *fwk.Status {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
/kind flake

#### What this PR does / why we need it:

The test introduced in https://github.com/kubernetes/kubernetes/pull/138443 is flaky, e.g. https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/138643/pull-kubernetes-integration/2051307330707918848.

> Unexpected NominatedNodeName after scheduler abort for pod pod-a, got node-other, want node-preferred

It looks like sometimes the preferred node is not seen by the scheduler. I couldn't repro it normally, but it reproduces if I create the node in a delayed goroutine. To make the test more robust, I added `WaitForNodesInCache` to wait for both nodes to be present in scheduler's cache.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #138784

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
