### PR TITLE
Added RawScores and refactored RunScorePlugins

### DIFF
--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -235,6 +235,14 @@ type Framework interface {
 	// StoreScheduleResults stores the results after we have sorted and filtered nodes.
 	StoreScheduleResults(ctx context.Context, signature fwk.PodSignature, hintedNode, chosenNode string, otherNodes SortedScoredNodes, cycleCount int64)
 
+	// RunRawScorePlugins runs only the Score() phase of each active scoring plugin for a single node,
+	// without NormalizeScore or weighting and returns pre-NormalizeScore values.
+	RunRawScorePlugins(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) ([]fwk.PluginScore, *fwk.Status)
+
+	// NormalizeScores runs NormalizeScore() and applies weights for the given nodes, using
+	// their RawScores as input. It updates Scores and TotalScore in-place on each NodePluginScores.
+	NormalizeScores(ctx context.Context, state fwk.CycleState, pod *v1.Pod, scores []fwk.NodePluginScores) *fwk.Status
+
 	// RunPlacementGeneratePlugins runs the set of configured PlacementGenerate plugins.
 	// It returns the combined list of generated Placements.
 	RunPlacementGeneratePlugins(ctx context.Context, state fwk.PodGroupCycleState, podGroup fwk.PodGroupInfo, nodes []fwk.NodeInfo) ([]*fwk.Placement, *fwk.Status)

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -1408,55 +1408,133 @@ func (f *frameworkImpl) RunScorePlugins(ctx context.Context, state fwk.CycleStat
 		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Score, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
 	}()
 	allNodePluginScores := make([]fwk.NodePluginScores, len(nodes))
-	numPlugins := len(f.scorePlugins)
-	plugins := make([]fwk.ScorePlugin, 0, numPlugins)
-	pluginToNodeScores := make(map[string]fwk.NodeScoreList, numPlugins)
-	for _, pl := range f.scorePlugins {
-		if state.GetSkipScorePlugins().Has(pl.Name()) {
-			continue
+	plugins := f.filterScorePlugins(state)
+	if len(plugins) == 0 {
+		for i, nodeInfo := range nodes {
+			allNodePluginScores[i] = fwk.NodePluginScores{
+				Name:      nodeInfo.Node().Name,
+				RawScores: make([]fwk.PluginScore, 0),
+				Scores:    make([]fwk.PluginScore, 0),
+			}
 		}
-		plugins = append(plugins, pl)
+		return allNodePluginScores, nil
+	}
+
+	pluginToNodeScores := make(map[string]fwk.NodeScoreList, len(plugins))
+	for _, pl := range plugins {
 		pluginToNodeScores[pl.Name()] = make(fwk.NodeScoreList, len(nodes))
 	}
+
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	errCh := parallelize.NewResultChannel[error]()
 
-	if len(plugins) > 0 {
-		logger := klog.FromContext(ctx)
-		verboseLogs := logger.V(4).Enabled()
-		if verboseLogs {
-			logger = klog.LoggerWithName(logger, "Score")
+	if l := klog.FromContext(ctx); l.V(4).Enabled() {
+		ctx = klog.NewContext(ctx, klog.LoggerWithName(l, "Score"))
+	}
+	// Run Score method for each node in parallel.
+	f.Parallelizer().Until(ctx, len(nodes), func(index int) {
+		nodeInfo := nodes[index]
+		nodeName := nodeInfo.Node().Name
+		nodeCtx := ctx
+		if l := klog.FromContext(nodeCtx); l.V(4).Enabled() {
+			nodeCtx = klog.NewContext(nodeCtx,
+				klog.LoggerWithValues(l, "node", klog.ObjectRef{Name: nodeName}),
+			)
 		}
-		// Run Score method for each node in parallel.
-		f.Parallelizer().Until(ctx, len(nodes), func(index int) {
-			nodeInfo := nodes[index]
-			nodeName := nodeInfo.Node().Name
-			logger := logger
-			if verboseLogs {
-				logger = klog.LoggerWithValues(logger, "node", klog.ObjectRef{Name: nodeName})
-			}
-			for _, pl := range plugins {
-				ctx := ctx
-				if verboseLogs {
-					logger := klog.LoggerWithName(logger, pl.Name())
-					ctx = klog.NewContext(ctx, logger)
-				}
-				s, status := f.runScorePlugin(ctx, pl, state, pod, nodeInfo)
-				if !status.IsSuccess() {
-					err := fmt.Errorf("plugin %q failed with: %w", pl.Name(), status.AsError())
-					errCh.SendWithCancel(err, cancel)
-					return
-				}
-				pluginToNodeScores[pl.Name()][index] = fwk.NodeScore{
-					Name:  nodeName,
-					Score: s,
-				}
-			}
-		}, metrics.Score)
-		if err := errCh.Receive(); err != nil {
-			return nil, fwk.AsStatus(fmt.Errorf("running Score plugins: %w", err))
+		rawScores, status := f.runRawScorePlugins(nodeCtx, state, pod, nodeInfo, plugins)
+		if !status.IsSuccess() {
+			errCh.SendWithCancel(status.AsError(), cancel)
+			return
 		}
+		allNodePluginScores[index] = fwk.NodePluginScores{
+			Name:      nodeName,
+			RawScores: rawScores,
+		}
+		for _, rawScore := range rawScores {
+			pluginToNodeScores[rawScore.Name][index] = fwk.NodeScore{
+				Name:  nodeName,
+				Score: rawScore.Score,
+			}
+		}
+	}, metrics.Score)
+	if err := errCh.Receive(); err != nil {
+		return nil, fwk.AsStatus(fmt.Errorf("running Score plugins: %w", err))
+	}
+
+	status = f.normalizeScores(ctx, state, pod, plugins, allNodePluginScores, pluginToNodeScores)
+	if !status.IsSuccess() {
+		return nil, status
+	}
+	return allNodePluginScores, nil
+}
+
+func (f *frameworkImpl) RunRawScorePlugins(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) ([]fwk.PluginScore, *fwk.Status) {
+	plugins := f.filterScorePlugins(state)
+	if len(plugins) == 0 {
+		return nil, nil
+	}
+	return f.runRawScorePlugins(ctx, state, pod, nodeInfo, plugins)
+}
+
+func (f *frameworkImpl) runRawScorePlugins(ctx context.Context, state fwk.CycleState, pod *v1.Pod,
+	nodeInfo fwk.NodeInfo, plugins []fwk.ScorePlugin) ([]fwk.PluginScore, *fwk.Status) {
+	scores := make([]fwk.PluginScore, 0, len(plugins))
+	for _, pl := range plugins {
+		plCtx := ctx
+		if l := klog.FromContext(ctx); l.V(4).Enabled() {
+			plCtx = klog.NewContext(ctx, klog.LoggerWithName(l, pl.Name()))
+		}
+		score, status := f.runScorePlugin(plCtx, pl, state, pod, nodeInfo)
+		if !status.IsSuccess() {
+			return nil, fwk.AsStatus(fmt.Errorf("plugin %q failed with: %w", pl.Name(), status.AsError()))
+		}
+		scores = append(scores, fwk.PluginScore{Name: pl.Name(), Score: score})
+	}
+	return scores, nil
+}
+
+func (f *frameworkImpl) NormalizeScores(ctx context.Context, state fwk.CycleState, pod *v1.Pod,
+	scores []fwk.NodePluginScores) *fwk.Status {
+	plugins := f.filterScorePlugins(state)
+	if len(plugins) == 0 {
+		for i := range scores {
+			scores[i].Scores = make([]fwk.PluginScore, 0)
+			scores[i].TotalScore = 0
+		}
+		return nil
+	}
+	pluginToNodeScores := make(map[string]fwk.NodeScoreList, len(plugins))
+	for _, pl := range plugins {
+		pluginToNodeScores[pl.Name()] = make(fwk.NodeScoreList, len(scores))
+	}
+
+	for i, nodeScore := range scores {
+		for _, rawScore := range nodeScore.RawScores {
+			if nodeScoreList, ok := pluginToNodeScores[rawScore.Name]; ok {
+				nodeScoreList[i] = fwk.NodeScore{
+					Name:  nodeScore.Name,
+					Score: rawScore.Score,
+				}
+			}
+		}
+	}
+
+	return f.normalizeScores(ctx, state, pod, plugins, scores, pluginToNodeScores)
+}
+
+func (f *frameworkImpl) normalizeScores(ctx context.Context, state fwk.CycleState, pod *v1.Pod,
+	plugins []fwk.ScorePlugin, scores []fwk.NodePluginScores, pluginToNodeScores map[string]fwk.NodeScoreList) *fwk.Status {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	errCh := parallelize.NewResultChannel[error]()
+
+	// Pre-resolve per-plugin data into slices to avoid map lookups.
+	nodeScoreLists := make([]fwk.NodeScoreList, len(plugins))
+	weights := make([]int, len(plugins))
+	for i, pl := range plugins {
+		nodeScoreLists[i] = pluginToNodeScores[pl.Name()]
+		weights[i] = f.scorePluginWeight[pl.Name()]
 	}
 
 	// Run NormalizeScore method for each ScorePlugin in parallel.
@@ -1465,8 +1543,7 @@ func (f *frameworkImpl) RunScorePlugins(ctx context.Context, state fwk.CycleStat
 		if pl.ScoreExtensions() == nil {
 			return
 		}
-		nodeScoreList := pluginToNodeScores[pl.Name()]
-		status := f.runScoreExtension(ctx, pl, state, pod, nodeScoreList)
+		status := f.runScoreExtension(ctx, pl, state, pod, nodeScoreLists[index])
 		if !status.IsSuccess() {
 			err := fmt.Errorf("plugin %q failed with: %w", pl.Name(), status.AsError())
 			errCh.SendWithCancel(err, cancel)
@@ -1474,41 +1551,44 @@ func (f *frameworkImpl) RunScorePlugins(ctx context.Context, state fwk.CycleStat
 		}
 	}, metrics.Score)
 	if err := errCh.Receive(); err != nil {
-		return nil, fwk.AsStatus(fmt.Errorf("running Normalize on Score plugins: %w", err))
+		return fwk.AsStatus(fmt.Errorf("running Normalize on Score plugins: %w", err))
 	}
 
-	// Apply score weight for each ScorePlugin in parallel,
-	// and then, build allNodePluginScores.
-	f.Parallelizer().Until(ctx, len(nodes), func(index int) {
-		nodePluginScores := fwk.NodePluginScores{
-			Name:   nodes[index].Node().Name,
-			Scores: make([]fwk.PluginScore, len(plugins)),
-		}
-
+	// Apply score weight for each ScorePlugin in parallel.
+	f.Parallelizer().Until(ctx, len(scores), func(index int) {
+		nodePluginScores := make([]fwk.PluginScore, len(plugins))
+		var totalScore int64
 		for i, pl := range plugins {
-			weight := f.scorePluginWeight[pl.Name()]
-			nodeScoreList := pluginToNodeScores[pl.Name()]
-			score := nodeScoreList[index].Score
+			score := nodeScoreLists[i][index].Score
 
 			if score > fwk.MaxNodeScore || score < fwk.MinNodeScore {
-				err := fmt.Errorf("plugin %q returns an invalid score %v, it should in the range of [%v, %v] after normalizing", pl.Name(), score, fwk.MinNodeScore, fwk.MaxNodeScore)
+				err := fmt.Errorf("plugin %q returns an invalid score %v, it should in the range of [%v, %v] after normalizing",
+					pl.Name(), score, fwk.MinNodeScore, fwk.MaxNodeScore)
 				errCh.SendWithCancel(err, cancel)
 				return
 			}
-			weightedScore := score * int64(weight)
-			nodePluginScores.Scores[i] = fwk.PluginScore{
-				Name:  pl.Name(),
-				Score: weightedScore,
-			}
-			nodePluginScores.TotalScore += weightedScore
+			weightedScore := score * int64(weights[i])
+			nodePluginScores[i] = fwk.PluginScore{Name: pl.Name(), Score: weightedScore}
+			totalScore += weightedScore
 		}
-		allNodePluginScores[index] = nodePluginScores
+		scores[index].Scores = nodePluginScores
+		scores[index].TotalScore = totalScore
 	}, metrics.Score)
 	if err := errCh.Receive(); err != nil {
-		return nil, fwk.AsStatus(fmt.Errorf("applying score defaultWeights on Score plugins: %w", err))
+		return fwk.AsStatus(fmt.Errorf("applying score defaultWeights on Score plugins: %w", err))
 	}
 
-	return allNodePluginScores, nil
+	return nil
+}
+
+func (f *frameworkImpl) filterScorePlugins(state fwk.CycleState) []fwk.ScorePlugin {
+	plugins := make([]fwk.ScorePlugin, 0, len(f.scorePlugins))
+	for _, pl := range f.scorePlugins {
+		if !state.GetSkipScorePlugins().Has(pl.Name()) {
+			plugins = append(plugins, pl)
+		}
+	}
+	return plugins
 }
 
 func (f *frameworkImpl) runScorePlugin(ctx context.Context, pl fwk.ScorePlugin, state fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) (int64, *fwk.Status) {

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -1408,7 +1408,7 @@ func (f *frameworkImpl) RunScorePlugins(ctx context.Context, state fwk.CycleStat
 		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Score, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
 	}()
 	allNodePluginScores := make([]fwk.NodePluginScores, len(nodes))
-	plugins := f.filterScorePlugins(state)
+	plugins := f.nonSkippedScorePlugins(state)
 	if len(plugins) == 0 {
 		for i, nodeInfo := range nodes {
 			allNodePluginScores[i] = fwk.NodePluginScores{
@@ -1470,7 +1470,7 @@ func (f *frameworkImpl) RunScorePlugins(ctx context.Context, state fwk.CycleStat
 }
 
 func (f *frameworkImpl) RunRawScorePlugins(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) ([]fwk.PluginScore, *fwk.Status) {
-	plugins := f.filterScorePlugins(state)
+	plugins := f.nonSkippedScorePlugins(state)
 	if len(plugins) == 0 {
 		return nil, nil
 	}
@@ -1496,7 +1496,7 @@ func (f *frameworkImpl) runRawScorePlugins(ctx context.Context, state fwk.CycleS
 
 func (f *frameworkImpl) NormalizeScores(ctx context.Context, state fwk.CycleState, pod *v1.Pod,
 	scores []fwk.NodePluginScores) *fwk.Status {
-	plugins := f.filterScorePlugins(state)
+	plugins := f.nonSkippedScorePlugins(state)
 	if len(plugins) == 0 {
 		for i := range scores {
 			scores[i].Scores = make([]fwk.PluginScore, 0)
@@ -1581,7 +1581,8 @@ func (f *frameworkImpl) normalizeScores(ctx context.Context, state fwk.CycleStat
 	return nil
 }
 
-func (f *frameworkImpl) filterScorePlugins(state fwk.CycleState) []fwk.ScorePlugin {
+// nonSkippedScorePlugins returns score plugins that have not been marked for skipping in the cycle state.
+func (f *frameworkImpl) nonSkippedScorePlugins(state fwk.CycleState) []fwk.ScorePlugin {
 	plugins := make([]fwk.ScorePlugin, 0, len(f.scorePlugins))
 	for _, pl := range f.scorePlugins {
 		if !state.GetSkipScorePlugins().Has(pl.Name()) {

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -1429,7 +1429,7 @@ func (f *frameworkImpl) RunScorePlugins(ctx context.Context, state fwk.CycleStat
 	defer cancel()
 	errCh := parallelize.NewResultChannel[error]()
 
-	if l := klog.FromContext(ctx); l.V(4).Enabled() {
+	if l := klog.FromContext(ctx).V(4); l.Enabled() {
 		ctx = klog.NewContext(ctx, klog.LoggerWithName(l, "Score"))
 	}
 	// Run Score method for each node in parallel.
@@ -1437,7 +1437,7 @@ func (f *frameworkImpl) RunScorePlugins(ctx context.Context, state fwk.CycleStat
 		nodeInfo := nodes[index]
 		nodeName := nodeInfo.Node().Name
 		nodeCtx := ctx
-		if l := klog.FromContext(nodeCtx); l.V(4).Enabled() {
+		if l := klog.FromContext(nodeCtx).V(4); l.Enabled() {
 			nodeCtx = klog.NewContext(nodeCtx,
 				klog.LoggerWithValues(l, "node", klog.ObjectRef{Name: nodeName}),
 			)
@@ -1482,7 +1482,7 @@ func (f *frameworkImpl) runRawScorePlugins(ctx context.Context, state fwk.CycleS
 	scores := make([]fwk.PluginScore, 0, len(plugins))
 	for _, pl := range plugins {
 		plCtx := ctx
-		if l := klog.FromContext(ctx); l.V(4).Enabled() {
+		if l := klog.FromContext(ctx).V(4); l.Enabled() {
 			plCtx = klog.NewContext(ctx, klog.LoggerWithName(l, pl.Name()))
 		}
 		score, status := f.runScorePlugin(plCtx, pl, state, pod, nodeInfo)
@@ -1561,9 +1561,9 @@ func (f *frameworkImpl) normalizeScores(ctx context.Context, state fwk.CycleStat
 		for i, pl := range plugins {
 			score := nodeScoreLists[i][index].Score
 
-			if score > fwk.MaxNodeScore || score < fwk.MinNodeScore {
+			if score > fwk.MaxScore || score < fwk.MinScore {
 				err := fmt.Errorf("plugin %q returns an invalid score %v, it should in the range of [%v, %v] after normalizing",
-					pl.Name(), score, fwk.MinNodeScore, fwk.MaxNodeScore)
+					pl.Name(), score, fwk.MinScore, fwk.MaxScore)
 				errCh.SendWithCancel(err, cancel)
 				return
 			}

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -1876,12 +1876,14 @@ func TestRunScorePlugins(t *testing.T) {
 			plugins: buildScoreConfigDefaultWeights(),
 			want: []fwk.NodePluginScores{
 				{
-					Name:   "node1",
-					Scores: []fwk.PluginScore{},
+					Name:      "node1",
+					RawScores: []fwk.PluginScore{},
+					Scores:    []fwk.PluginScore{},
 				},
 				{
-					Name:   "node2",
-					Scores: []fwk.PluginScore{},
+					Name:      "node2",
+					RawScores: []fwk.PluginScore{},
+					Scores:    []fwk.PluginScore{},
 				},
 			},
 		},
@@ -1900,6 +1902,12 @@ func TestRunScorePlugins(t *testing.T) {
 			want: []fwk.NodePluginScores{
 				{
 					Name: "node1",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scorePlugin1,
+							Score: 1,
+						},
+					},
 					Scores: []fwk.PluginScore{
 						{
 							Name:  scorePlugin1,
@@ -1910,6 +1918,12 @@ func TestRunScorePlugins(t *testing.T) {
 				},
 				{
 					Name: "node2",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scorePlugin1,
+							Score: 1,
+						},
+					},
 					Scores: []fwk.PluginScore{
 						{
 							Name:  scorePlugin1,
@@ -1932,10 +1946,17 @@ func TestRunScorePlugins(t *testing.T) {
 					},
 				},
 			},
-			// scoreWithNormalizePlugin1 Score returns 10, but NormalizeScore overrides to 5, weight=1, so want=5
+			// scoreWithNormalizePlugin1 Score returns 10, NormalizeScore overrides to 5, weight=1.
+			// RawScores captures pre-NormalizeScore (10), Scores captures post-normalize post-weighting (5*1=5).
 			want: []fwk.NodePluginScores{
 				{
 					Name: "node1",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scoreWithNormalizePlugin1,
+							Score: 10,
+						},
+					},
 					Scores: []fwk.PluginScore{
 						{
 							Name:  scoreWithNormalizePlugin1,
@@ -1946,6 +1967,12 @@ func TestRunScorePlugins(t *testing.T) {
 				},
 				{
 					Name: "node2",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scoreWithNormalizePlugin1,
+							Score: 10,
+						},
+					},
 					Scores: []fwk.PluginScore{
 						{
 							Name:  scoreWithNormalizePlugin1,
@@ -1979,12 +2006,26 @@ func TestRunScorePlugins(t *testing.T) {
 					},
 				},
 			},
-			// scorePlugin1 Score returns 1, weight =1, so want=1.
-			// scoreWithNormalizePlugin1 Score returns 3, but NormalizeScore overrides to 4, weight=1, so want=4.
-			// scoreWithNormalizePlugin2 Score returns 4, but NormalizeScore overrides to 5, weight=2, so want=10.
+			// scorePlugin1: Score=1, weight=1 → RawScores=1, Scores=1.
+			// scoreWithNormalizePlugin1: Score=3, NormalizeScore→4, weight=1 → RawScores=3, Scores=4.
+			// scoreWithNormalizePlugin2: Score=4, NormalizeScore→5, weight=2 → RawScores=4, Scores=10.
 			want: []fwk.NodePluginScores{
 				{
 					Name: "node1",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scorePlugin1,
+							Score: 1,
+						},
+						{
+							Name:  scoreWithNormalizePlugin1,
+							Score: 3,
+						},
+						{
+							Name:  scoreWithNormalizePlugin2,
+							Score: 4,
+						},
+					},
 					Scores: []fwk.PluginScore{
 						{
 							Name:  scorePlugin1,
@@ -2003,6 +2044,20 @@ func TestRunScorePlugins(t *testing.T) {
 				},
 				{
 					Name: "node2",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scorePlugin1,
+							Score: 1,
+						},
+						{
+							Name:  scoreWithNormalizePlugin1,
+							Score: 3,
+						},
+						{
+							Name:  scoreWithNormalizePlugin2,
+							Score: 4,
+						},
+					},
 					Scores: []fwk.PluginScore{
 						{
 							Name:  scorePlugin1,
@@ -2121,10 +2176,16 @@ func TestRunScorePlugins(t *testing.T) {
 					},
 				},
 			},
-			// scorePlugin1 Score returns 1, weight=3, so want=3.
+			// scorePlugin1 Score returns 1, weight=3, so Scores=3, RawScores=1.
 			want: []fwk.NodePluginScores{
 				{
 					Name: "node1",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scorePlugin1,
+							Score: 1,
+						},
+					},
 					Scores: []fwk.PluginScore{
 						{
 							Name:  scorePlugin1,
@@ -2135,6 +2196,12 @@ func TestRunScorePlugins(t *testing.T) {
 				},
 				{
 					Name: "node2",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scorePlugin1,
+							Score: 1,
+						},
+					},
 					Scores: []fwk.PluginScore{
 						{
 							Name:  scorePlugin1,
@@ -2166,6 +2233,12 @@ func TestRunScorePlugins(t *testing.T) {
 			want: []fwk.NodePluginScores{
 				{
 					Name: "node1",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scorePlugin1,
+							Score: 1,
+						},
+					},
 					Scores: []fwk.PluginScore{
 						{
 							Name:  scorePlugin1,
@@ -2176,6 +2249,12 @@ func TestRunScorePlugins(t *testing.T) {
 				},
 				{
 					Name: "node2",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scorePlugin1,
+							Score: 1,
+						},
+					},
 					Scores: []fwk.PluginScore{
 						{
 							Name:  scorePlugin1,
@@ -2200,12 +2279,14 @@ func TestRunScorePlugins(t *testing.T) {
 			skippedPlugins: sets.New(scorePlugin1),
 			want: []fwk.NodePluginScores{
 				{
-					Name:   "node1",
-					Scores: []fwk.PluginScore{},
+					Name:      "node1",
+					RawScores: []fwk.PluginScore{},
+					Scores:    []fwk.PluginScore{},
 				},
 				{
-					Name:   "node2",
-					Scores: []fwk.PluginScore{},
+					Name:      "node2",
+					RawScores: []fwk.PluginScore{},
+					Scores:    []fwk.PluginScore{},
 				},
 			},
 		},
@@ -2216,12 +2297,14 @@ func TestRunScorePlugins(t *testing.T) {
 			skippedPlugins: sets.New(scorePlugin1, "score-plugin-unknown"),
 			want: []fwk.NodePluginScores{
 				{
-					Name:   "node1",
-					Scores: []fwk.PluginScore{},
+					Name:      "node1",
+					RawScores: []fwk.PluginScore{},
+					Scores:    []fwk.PluginScore{},
 				},
 				{
-					Name:   "node2",
-					Scores: []fwk.PluginScore{},
+					Name:      "node2",
+					RawScores: []fwk.PluginScore{},
+					Scores:    []fwk.PluginScore{},
 				},
 			},
 		},
@@ -2261,6 +2344,491 @@ func TestRunScorePlugins(t *testing.T) {
 			}
 			if diff := cmp.Diff(tt.want, res); diff != "" {
 				t.Errorf("Score map after RunScorePlugin (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRunRawScorePlugins(t *testing.T) {
+	tests := []struct {
+		name          string
+		plugins       *config.Plugins
+		pluginConfigs []config.PluginConfig
+		skippedPlugin string
+		want          []fwk.PluginScore
+		err           bool
+	}{
+		{
+			name:    "no score plugins",
+			plugins: buildScoreConfigDefaultWeights(),
+			want:    nil,
+		},
+		{
+			name:    "single plugin returns raw score without weighting",
+			plugins: buildScoreConfigDefaultWeights(scorePlugin1),
+			pluginConfigs: []config.PluginConfig{
+				{
+					Name: scorePlugin1,
+					Args: &runtime.Unknown{Raw: []byte(`{ "scoreRes": 5 }`)}},
+			},
+			want: []fwk.PluginScore{
+				{
+					Name:  scorePlugin1,
+					Score: 5,
+				},
+			},
+		},
+		{
+			name:    "NormalizeScore is not run, only raw Score is returned",
+			plugins: buildScoreConfigDefaultWeights(scoreWithNormalizePlugin1),
+			pluginConfigs: []config.PluginConfig{
+				{
+					Name: scoreWithNormalizePlugin1,
+					Args: &runtime.Unknown{Raw: []byte(`{ "scoreRes": 7, "normalizeRes": 99 }`)},
+				},
+			},
+			want: []fwk.PluginScore{{Name: scoreWithNormalizePlugin1, Score: 7}},
+		},
+		{
+			name:    "multiple plugins, scores are not weighted",
+			plugins: buildScoreConfigDefaultWeights(scorePlugin1, scoreWithNormalizePlugin1),
+			pluginConfigs: []config.PluginConfig{
+				{
+					Name: scorePlugin1,
+					Args: &runtime.Unknown{Raw: []byte(`{ "scoreRes": 3 }`)},
+				},
+				{
+					Name: scoreWithNormalizePlugin1,
+					Args: &runtime.Unknown{Raw: []byte(`{ "scoreRes": 4, "normalizeRes": 99 }`)},
+				},
+			},
+			want: []fwk.PluginScore{
+				{
+					Name:  scorePlugin1,
+					Score: 3,
+				},
+				{
+					Name:  scoreWithNormalizePlugin1,
+					Score: 4,
+				},
+			},
+		},
+		{
+			name:    "score fails",
+			plugins: buildScoreConfigDefaultWeights(scorePlugin1),
+			pluginConfigs: []config.PluginConfig{
+				{
+					Name: scorePlugin1,
+					Args: &runtime.Unknown{Raw: []byte(`{ "scoreStatus": 1 }`)},
+				},
+			},
+			err: true,
+		},
+		{
+			name:    "skipped plugin is excluded from results",
+			plugins: buildScoreConfigDefaultWeights(scorePlugin1, scoreWithNormalizePlugin1),
+			pluginConfigs: []config.PluginConfig{
+				{
+					Name: scorePlugin1,
+					Args: &runtime.Unknown{Raw: []byte(`{ "scoreRes": 2 }`)},
+				},
+				{
+					Name: scoreWithNormalizePlugin1,
+					Args: &runtime.Unknown{Raw: []byte(`{ "scoreStatus": 1 }`)},
+				},
+			},
+			skippedPlugin: scoreWithNormalizePlugin1,
+			want: []fwk.PluginScore{
+				{
+					Name:  scorePlugin1,
+					Score: 2,
+				},
+			},
+		},
+		{
+			name:          "all plugins skipped",
+			plugins:       buildScoreConfigDefaultWeights(scorePlugin1),
+			skippedPlugin: scorePlugin1,
+			want:          nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile := config.KubeSchedulerProfile{
+				Plugins:      tt.plugins,
+				PluginConfig: tt.pluginConfigs,
+			}
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			f, err := newFrameworkWithQueueSortAndBind(ctx, registry, profile)
+			if err != nil {
+				t.Fatalf("Failed to create framework for testing: %v", err)
+			}
+			defer func() { _ = f.Close() }()
+
+			state := framework.NewCycleState()
+			if tt.skippedPlugin != "" {
+				state.SetSkipScorePlugins(sets.New(tt.skippedPlugin))
+			}
+			got, status := f.RunRawScorePlugins(ctx, state, pod, BuildNodeInfos([]*v1.Node{node})[0])
+
+			if tt.err {
+				if status.IsSuccess() {
+					t.Errorf("expected error status, got success")
+				}
+				return
+			}
+			if !status.IsSuccess() {
+				t.Errorf("unexpected error: %v", status)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("RunRawScorePlugins (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNormalizeScores(t *testing.T) {
+	tests := []struct {
+		name          string
+		plugins       *config.Plugins
+		pluginConfigs []config.PluginConfig
+		skippedPlugin string
+		inputScores   []fwk.NodePluginScores
+		want          []fwk.NodePluginScores
+		err           bool
+	}{
+		{
+			name:    "single plugin without NormalizeScore",
+			plugins: buildScoreConfigDefaultWeights(scorePlugin1),
+			inputScores: []fwk.NodePluginScores{
+				{
+					Name: nodeName,
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scorePlugin1,
+							Score: 5,
+						},
+					},
+				},
+			},
+			want: []fwk.NodePluginScores{
+				{
+					Name: nodeName,
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scorePlugin1,
+							Score: 5,
+						},
+					},
+					Scores: []fwk.PluginScore{
+						{
+							Name:  scorePlugin1,
+							Score: 5,
+						},
+					},
+					TotalScore: 5,
+				},
+			},
+		},
+		{
+			name:    "NormalizeScore overrides raw score",
+			plugins: buildScoreConfigDefaultWeights(scoreWithNormalizePlugin1),
+			pluginConfigs: []config.PluginConfig{
+				{
+					Name: scoreWithNormalizePlugin1,
+					Args: &runtime.Unknown{Raw: []byte(`{ "scoreRes": 7, "normalizeRes": 20 }`)},
+				},
+			},
+			inputScores: []fwk.NodePluginScores{
+				{
+					Name: nodeName,
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scoreWithNormalizePlugin1,
+							Score: 7,
+						},
+					},
+				},
+			},
+			want: []fwk.NodePluginScores{
+				{
+					Name: nodeName,
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scoreWithNormalizePlugin1,
+							Score: 7,
+						},
+					},
+					Scores: []fwk.PluginScore{
+						{
+							Name:  scoreWithNormalizePlugin1,
+							Score: 20,
+						},
+					},
+					TotalScore: 20,
+				},
+			},
+		},
+		{
+			name:    "weight is applied to normalized score",
+			plugins: buildScoreConfigDefaultWeights(scoreWithNormalizePlugin2),
+			pluginConfigs: []config.PluginConfig{
+				{
+					Name: scoreWithNormalizePlugin2,
+					Args: &runtime.Unknown{Raw: []byte(`{ "normalizeRes": 10 }`)},
+				},
+			},
+			inputScores: []fwk.NodePluginScores{
+				{
+					Name: nodeName,
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scoreWithNormalizePlugin2,
+							Score: 5,
+						},
+					},
+				},
+			},
+			// scoreWithNormalizePlugin2 has weight=2, normalizeRes=10 → weighted score=20.
+			want: []fwk.NodePluginScores{
+				{
+					Name: nodeName,
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scoreWithNormalizePlugin2,
+							Score: 5,
+						},
+					},
+					Scores: []fwk.PluginScore{
+						{
+							Name:  scoreWithNormalizePlugin2,
+							Score: 20,
+						},
+					},
+					TotalScore: 20,
+				},
+			},
+		},
+		{
+			name:    "multiple plugins across multiple nodes",
+			plugins: buildScoreConfigDefaultWeights(scorePlugin1, scoreWithNormalizePlugin1),
+			pluginConfigs: []config.PluginConfig{
+				{
+					Name: scoreWithNormalizePlugin1,
+					Args: &runtime.Unknown{Raw: []byte(`{ "normalizeRes": 8 }`)},
+				},
+			},
+			inputScores: []fwk.NodePluginScores{
+				{
+					Name: "node1",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scorePlugin1,
+							Score: 3,
+						},
+						{
+							Name:  scoreWithNormalizePlugin1,
+							Score: 7,
+						},
+					},
+				},
+				{
+					Name: "node2",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scorePlugin1,
+							Score: 5,
+						},
+						{
+							Name:  scoreWithNormalizePlugin1,
+							Score: 2,
+						},
+					},
+				},
+			},
+			// scorePlugin1: no NormalizeScore, raw scores preserved per node.
+			// scoreWithNormalizePlugin1: NormalizeScore sets all nodes to 8.
+			want: []fwk.NodePluginScores{
+				{
+					Name: "node1",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scorePlugin1,
+							Score: 3,
+						},
+						{
+							Name:  scoreWithNormalizePlugin1,
+							Score: 7,
+						},
+					},
+					Scores: []fwk.PluginScore{
+						{
+							Name:  scorePlugin1,
+							Score: 3,
+						},
+						{
+							Name:  scoreWithNormalizePlugin1,
+							Score: 8,
+						},
+					},
+					TotalScore: 11,
+				},
+				{
+					Name: "node2",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scorePlugin1,
+							Score: 5,
+						},
+						{
+							Name:  scoreWithNormalizePlugin1,
+							Score: 2,
+						},
+					},
+					Scores: []fwk.PluginScore{
+						{
+							Name:  scorePlugin1,
+							Score: 5,
+						},
+						{
+							Name:  scoreWithNormalizePlugin1,
+							Score: 8,
+						},
+					},
+					TotalScore: 13,
+				},
+			},
+		},
+		{
+			name:          "no active plugins zeroes scores and TotalScore",
+			plugins:       buildScoreConfigDefaultWeights(scorePlugin1),
+			skippedPlugin: scorePlugin1,
+			inputScores: []fwk.NodePluginScores{
+				{
+					Name: nodeName,
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scorePlugin1,
+							Score: 5,
+						},
+					},
+				},
+			},
+			want: []fwk.NodePluginScores{
+				{
+					Name: nodeName,
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scorePlugin1,
+							Score: 5,
+						},
+					},
+					Scores: []fwk.PluginScore{},
+				},
+			},
+		},
+		{
+			name:    "unknown plugin name in RawScores is ignored",
+			plugins: buildScoreConfigDefaultWeights(scorePlugin1),
+			inputScores: []fwk.NodePluginScores{
+				{
+					Name: nodeName,
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scorePlugin1,
+							Score: 5,
+						},
+						{
+							Name:  "unknown-plugin",
+							Score: 99,
+						},
+					},
+				},
+			},
+			want: []fwk.NodePluginScores{
+				{
+					Name: nodeName,
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scorePlugin1,
+							Score: 5,
+						},
+						{
+							Name:  "unknown-plugin",
+							Score: 99,
+						},
+					},
+					Scores: []fwk.PluginScore{
+						{
+							Name:  scorePlugin1,
+							Score: 5,
+						},
+					},
+					TotalScore: 5,
+				},
+			},
+		},
+		{
+			name:    "normalize fails",
+			plugins: buildScoreConfigDefaultWeights(scoreWithNormalizePlugin1),
+			pluginConfigs: []config.PluginConfig{
+				{
+					Name: scoreWithNormalizePlugin1,
+					Args: &runtime.Unknown{Raw: []byte(`{ "normalizeStatus": 1 }`)},
+				},
+			},
+			inputScores: []fwk.NodePluginScores{
+				{
+					Name: nodeName,
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  scoreWithNormalizePlugin1,
+							Score: 3,
+						},
+					},
+				},
+			},
+			err: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile := config.KubeSchedulerProfile{
+				Plugins:      tt.plugins,
+				PluginConfig: tt.pluginConfigs,
+			}
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			f, err := newFrameworkWithQueueSortAndBind(ctx, registry, profile)
+			if err != nil {
+				t.Fatalf("Failed to create framework for testing: %v", err)
+			}
+			defer func() { _ = f.Close() }()
+
+			state := framework.NewCycleState()
+			if tt.skippedPlugin != "" {
+				state.SetSkipScorePlugins(sets.New(tt.skippedPlugin))
+			}
+
+			scores := tt.inputScores
+			status := f.NormalizeScores(ctx, state, pod, scores)
+
+			if tt.err {
+				if status.IsSuccess() {
+					t.Errorf("expected error status, got success")
+				}
+				return
+			}
+			if !status.IsSuccess() {
+				t.Errorf("unexpected error: %v", status)
+			}
+			if diff := cmp.Diff(tt.want, scores); diff != "" {
+				t.Errorf("NormalizeScores (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -4035,6 +4035,16 @@ func Test_prioritizeNodes(t *testing.T) {
 			want: []fwk.NodePluginScores{
 				{
 					Name: "node1",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  "NodeResourcesBalancedAllocation",
+							Score: 0,
+						},
+						{
+							Name:  "Node2Prioritizer",
+							Score: 10,
+						},
+					},
 					Scores: []fwk.PluginScore{
 						{
 							Name:  "Node2Prioritizer",
@@ -4049,6 +4059,16 @@ func Test_prioritizeNodes(t *testing.T) {
 				},
 				{
 					Name: "node2",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  "NodeResourcesBalancedAllocation",
+							Score: 0,
+						},
+						{
+							Name:  "Node2Prioritizer",
+							Score: 100,
+						},
+					},
 					Scores: []fwk.PluginScore{
 						{
 							Name:  "Node2Prioritizer",
@@ -4097,8 +4117,13 @@ func Test_prioritizeNodes(t *testing.T) {
 			want: []fwk.NodePluginScores{
 				{
 					Name: "node1",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  "NodeResourcesBalancedAllocation",
+							Score: 0,
+						},
+					},
 					Scores: []fwk.PluginScore{
-
 						{
 							Name:  "FakeExtender1",
 							Score: 300,
@@ -4116,6 +4141,12 @@ func Test_prioritizeNodes(t *testing.T) {
 				},
 				{
 					Name: "node2",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  "NodeResourcesBalancedAllocation",
+							Score: 0,
+						},
+					},
 					Scores: []fwk.PluginScore{
 						{
 							Name:  "FakeExtender1",
@@ -4152,6 +4183,16 @@ func Test_prioritizeNodes(t *testing.T) {
 			want: []fwk.NodePluginScores{
 				{
 					Name: "node1",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  "NodeResourcesBalancedAllocation",
+							Score: 0,
+						},
+						{
+							Name:  "Node2Prioritizer",
+							Score: 10,
+						},
+					},
 					Scores: []fwk.PluginScore{
 						{
 							Name:  "Node2Prioritizer",
@@ -4166,6 +4207,16 @@ func Test_prioritizeNodes(t *testing.T) {
 				},
 				{
 					Name: "node2",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  "NodeResourcesBalancedAllocation",
+							Score: 0,
+						},
+						{
+							Name:  "Node2Prioritizer",
+							Score: 100,
+						},
+					},
 					Scores: []fwk.PluginScore{
 						{
 							Name:  "Node2Prioritizer",
@@ -4194,8 +4245,8 @@ func Test_prioritizeNodes(t *testing.T) {
 			},
 			extenders: nil,
 			want: []fwk.NodePluginScores{
-				{Name: "node1", Scores: []fwk.PluginScore{}},
-				{Name: "node2", Scores: []fwk.PluginScore{}},
+				{Name: "node1", RawScores: []fwk.PluginScore{}, Scores: []fwk.PluginScore{}},
+				{Name: "node2", RawScores: []fwk.PluginScore{}, Scores: []fwk.PluginScore{}},
 			},
 		},
 		{
@@ -4223,6 +4274,12 @@ func Test_prioritizeNodes(t *testing.T) {
 			want: []fwk.NodePluginScores{
 				{
 					Name: "node1",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  "ImageLocality",
+							Score: 5,
+						},
+					},
 					Scores: []fwk.PluginScore{
 						{
 							Name:  "ImageLocality",
@@ -4233,6 +4290,12 @@ func Test_prioritizeNodes(t *testing.T) {
 				},
 				{
 					Name: "node2",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  "ImageLocality",
+							Score: 5,
+						},
+					},
 					Scores: []fwk.PluginScore{
 						{
 							Name:  "ImageLocality",
@@ -4243,6 +4306,12 @@ func Test_prioritizeNodes(t *testing.T) {
 				},
 				{
 					Name: "node3",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  "ImageLocality",
+							Score: 5,
+						},
+					},
 					Scores: []fwk.PluginScore{
 						{
 							Name:  "ImageLocality",
@@ -4277,6 +4346,12 @@ func Test_prioritizeNodes(t *testing.T) {
 			want: []fwk.NodePluginScores{
 				{
 					Name: "node1",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  "ImageLocality",
+							Score: 18,
+						},
+					},
 					Scores: []fwk.PluginScore{
 						{
 							Name:  "ImageLocality",
@@ -4287,6 +4362,12 @@ func Test_prioritizeNodes(t *testing.T) {
 				},
 				{
 					Name: "node2",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  "ImageLocality",
+							Score: 18,
+						},
+					},
 					Scores: []fwk.PluginScore{
 						{
 							Name:  "ImageLocality",
@@ -4297,6 +4378,12 @@ func Test_prioritizeNodes(t *testing.T) {
 				},
 				{
 					Name: "node3",
+					RawScores: []fwk.PluginScore{
+						{
+							Name:  "ImageLocality",
+							Score: 0,
+						},
+					},
 					Scores: []fwk.PluginScore{
 						{
 							Name:  "ImageLocality",

--- a/staging/src/k8s.io/kube-scheduler/framework/interface.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/interface.go
@@ -285,7 +285,9 @@ type NodeScore struct {
 type NodePluginScores struct {
 	// Name is node name.
 	Name string
-	// Scores is scores from plugins and extenders.
+	// RawScores holds Score() output for each active scoring plugin, before normalization is applied.
+	RawScores []PluginScore
+	// Scores is normalized weighted scores from plugins and extenders.
 	Scores []PluginScore
 	// TotalScore is the total score in Scores.
 	TotalScore int64


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

Added `RawScores` to `NodePluginScores` struct and introduced `RunRawScorePlugins` and `NormalizeScores` functions to the framework, splitting the scoring pipeline into raw-score and normalize phases. In a future PR these changes will be integrated with opportunistic batch rescoring feature, which needs to rescore a single node and re-normalize it against a set of cached nodes.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

https://github.com/kubernetes/kubernetes/issues/137707

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
- [KEP-5598: Opportunistic Batching](https://git.k8s.io/enhancements/keps/sig-scheduling/5598-opportunistic-batching/README.md)
- [KEP Rescore PR](https://github.com/kubernetes/enhancements/pull/6039)

#### Other comments:
AI tooling was used to assist in preparing this PR. All changes have been reviewed and verified by the author.