### PR TITLE
Fix race condition in kubectl drain unit test

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package drain
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"reflect"
@@ -481,9 +481,8 @@ func TestDeleteOrEvictWithDryRunServer(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			var buf bytes.Buffer
 			h := &Helper{
-				Out:                &buf,
+				Out:                io.Discard,
 				GracePeriodSeconds: 10,
 				DisableEviction:    tc.disableEviction,
 				DryRunStrategy:     cmdutil.DryRunServer,


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
This PR https://github.com/kubernetes/kubernetes/pull/137543 introduces a new unit test. However, it fails with race condition https://github.com/kubernetes/kubectl/issues/1847. This PR fixes the race condition.

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes/kubectl/issues/1847

#### Does this PR introduce a user-facing change?
```release-note
None
```
