### PR TITLE
e2e_dra: add DRAExtendedResource feature-gate on/off/on cycle test

### DIFF
--- a/test/e2e_dra/extendedresources_test.go
+++ b/test/e2e_dra/extendedresources_test.go
@@ -24,10 +24,10 @@ import (
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/dynamic-resource-allocation/resourceslice"
+	"k8s.io/kubernetes/test/e2e/dra/test-driver/app"
 	drautils "k8s.io/kubernetes/test/e2e/dra/utils"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -41,12 +41,6 @@ const (
 
 func extendedResourcesDriverResources(nodes *drautils.Nodes) map[string]resourceslice.DriverResources {
 	return drautils.DriverResourcesNow(nodes, 8)
-}
-
-func extendedResourceGateCycle(_ ktesting.TContext, _ *drautils.Builder) gateOffFunc {
-	return func(_ ktesting.TContext) gateOnAgainFunc {
-		return func(_ ktesting.TContext) {}
-	}
 }
 
 // extendedResourceUpgradeDowngrade tests the DRAExtendedResources feature during upgrade/downgrade scenarios
@@ -87,46 +81,141 @@ func testExtendedResource(tCtx ktesting.TContext, b *drautils.Builder, resourceT
 
 		return func(tCtx ktesting.TContext) {
 			// After downgrade: verify all pods still run correctly with their claims
-			podNames := []string{podBefore.Name, podAfter.Name}
-			claimNames := make([]string, 0, len(podNames))
-
-			for _, podName := range podNames {
-				pod, err := tCtx.Client().CoreV1().Pods(namespace).Get(tCtx, podName, metav1.GetOptions{})
-				tCtx.ExpectNoError(err, "get %s pod %s", resourceType, podName)
+			pods := []*v1.Pod{podBefore, podAfter}
+			for _, pod := range pods {
 				verifyPodRunningWithClaim(tCtx, b, pod, resourceName)
+			}
 
-				// Collect claim name before cleanup
-				if pod.Status.ExtendedResourceClaimStatus != nil {
-					claimNames = append(claimNames, pod.Status.ExtendedResourceClaimStatus.ResourceClaimName)
-				}
+			// Collect claim names before deleting pods so GC can be verified.
+			claimNames := make([]string, 0, len(pods))
+			for _, pod := range pods {
+				claimNames = append(claimNames, claimNameFromPod(tCtx, pod))
 			}
 
 			// Clean up pods
 			tCtx.Logf("Cleaning up %s resource pods after downgrade", resourceType)
-			for _, podName := range podNames {
-				tCtx.ExpectNoError(e2epod.DeletePodWithWaitByName(tCtx, tCtx.Client(), podName, namespace), "delete %s pod %s", resourceType, podName)
+			for _, pod := range pods {
+				tCtx.ExpectNoError(e2epod.DeletePodWithWaitByName(tCtx, tCtx.Client(), pod.Name, namespace))
 			}
 			tCtx.Logf("Successfully cleaned up %s resource pods", resourceType)
 
-			// Verify that ResourceClaims for our pods are cleaned up by garbage collector
-			remainingClaims := claimNames
-			tCtx.Eventually(func(tCtx ktesting.TContext) int {
-				stillExisting := make([]string, 0, len(remainingClaims))
-				for _, claimName := range remainingClaims {
-					_, err := tCtx.Client().ResourceV1().ResourceClaims(namespace).Get(tCtx, claimName, metav1.GetOptions{})
-					if err == nil {
-						stillExisting = append(stillExisting, claimName)
-					} else if !apierrors.IsNotFound(err) {
-						// If we get a real API error (not NotFound), fail immediately
-						tCtx.ExpectNoError(err, "unexpected error checking ResourceClaim %s", claimName)
-					}
-					// If IsNotFound, the claim has been deleted (expected behavior)
-				}
-				remainingClaims = stillExisting
-				return len(remainingClaims)
-			}).WithTimeout(3*time.Minute).Should(gomega.Equal(0), "ResourceClaims for %s pods should be garbage collected", resourceType)
+			eventuallyClaimsGone(tCtx, claimNames, 3*time.Minute)
+		}
+	}
+}
 
-			tCtx.Logf("Verified ResourceClaims for %s resource were garbage collected", resourceType)
+// extendedResourceGateCycle implements the DRAExtendedResource feature gate ON→OFF→ON cycle test:
+//
+//   - Phase 0 (gate ON): create a survivor pod and a to-delete pod with extended resource
+//     claims and verify they run and are allocated.
+//   - Phase 1 (gate OFF): assert survivor claims are preserved; verify that a new
+//     DeviceClass.ExtendedResourceName field is stripped by the apiserver; verify that a
+//     probe pod stays Pending without a special claim; delete to-delete pod and verify
+//     its claim is garbage collected.
+//   - Phase 2 (gate ON again): wait for kubelet's reconcile loop to unprepare the claim
+//     deleted in phase 1; verify the survivor still runs; allocate a fresh pod end-to-end;
+//     clean up.
+func extendedResourceGateCycle(tCtx ktesting.TContext, b *drautils.Builder) gateOffFunc {
+	var podSurvivor, podToDelete *v1.Pod
+	var resourceName v1.ResourceName
+	tCtx.Run("pods-with-extended-resource-running", func(tCtx ktesting.TContext) {
+		resourceName = createDeviceClassForExtendedResource(tCtx, b, resourceTypeExplicit)
+		podSurvivor = createPodWithExtendedResource(tCtx, b, "survivor", resourceName)
+		verifyPodRunningWithClaim(tCtx, b, podSurvivor, resourceName)
+		podToDelete = createPodWithExtendedResource(tCtx, b, "to-delete", resourceName)
+		verifyPodRunningWithClaim(tCtx, b, podToDelete, resourceName)
+	})
+
+	return func(tCtx ktesting.TContext) gateOnAgainFunc {
+		tCtx.Run("survivor-pods-still-running", func(tCtx ktesting.TContext) {
+			tCtx.ExpectNoError(e2epod.WaitForPodRunningInNamespace(tCtx, tCtx.Client(), podSurvivor))
+			tCtx.ExpectNoError(e2epod.WaitForPodRunningInNamespace(tCtx, tCtx.Client(), podToDelete))
+		})
+
+		// Verify that each pod's special ResourceClaim still exists and is allocated.
+		tCtx.Run("survivor-claim-preserved", func(tCtx ktesting.TContext) {
+			for _, pod := range []*v1.Pod{podSurvivor, podToDelete} {
+				claimName := claimNameFromPod(tCtx, pod)
+				claim, err := tCtx.Client().ResourceV1().ResourceClaims(pod.Namespace).Get(tCtx, claimName, metav1.GetOptions{})
+				tCtx.ExpectNoError(err, "get ResourceClaim %s", claimName)
+				tCtx.Expect(claim.Status.Allocation).ToNot(gomega.BeNil(),
+					"ResourceClaim %s must still be allocated", claimName)
+			}
+		})
+
+		tCtx.Run("new-deviceclass-field-stripped", func(tCtx ktesting.TContext) {
+			dc := b.ClassWithExtendedResource(string(resourceName))
+			dc.Name += "-post-off"
+			created := b.Create(tCtx, dc)[0].(*resourceapi.DeviceClass)
+			tCtx.Expect(created.Spec.ExtendedResourceName).To(gomega.BeNil(),
+				"DeviceClass.Spec.ExtendedResourceName must be stripped when gate is off")
+		})
+
+		// check that probe stays Pending and never gets a special claim.
+		tCtx.Run("probe-pod-pending-no-special-claim", func(tCtx ktesting.TContext) {
+			probePod := createPodWithExtendedResource(tCtx, b, "probe-off", resourceName)
+			tCtx.WithStep("probe pod stays Pending").
+				Consistently(func(tCtx ktesting.TContext) v1.PodPhase {
+					p, err := tCtx.Client().CoreV1().Pods(probePod.Namespace).Get(tCtx, probePod.Name, metav1.GetOptions{})
+					tCtx.ExpectNoError(err)
+					tCtx.Expect(p.Status.ExtendedResourceClaimStatus).To(gomega.BeNil(),
+						"probe pod must not get a special claim when gate is off")
+					return p.Status.Phase
+				}).WithTimeout(30 * time.Second).Should(gomega.Equal(v1.PodPending))
+
+			// Cleanup probe pod.
+			tCtx.ExpectNoError(e2epod.DeletePodWithWaitByName(tCtx, tCtx.Client(), probePod.Name, probePod.Namespace))
+		})
+
+		var toDeleteClaimName string
+		tCtx.Run("delete-pod-triggers-gc-with-gate-off", func(tCtx ktesting.TContext) {
+			// KEP-required: deleting a pod with gate OFF must let the GC (not
+			// the apiserver) remove the claim, and node accounting must release
+			// the device.
+			toDeleteClaimName = claimNameFromPod(tCtx, podToDelete)
+			tCtx.ExpectNoError(e2epod.DeletePodWithWaitByName(tCtx, tCtx.Client(), podToDelete.Name, podToDelete.Namespace))
+			eventuallyClaimsGone(tCtx, []string{toDeleteClaimName}, 3*time.Minute)
+			tCtx.ExpectNoError(e2epod.WaitForPodRunningInNamespace(tCtx, tCtx.Client(), podSurvivor))
+		})
+
+		return func(tCtx ktesting.TContext) {
+			// Wait for kubelet's reconcile loop (period: 60s) to call NodeUnprepareResources
+			// for to-delete, which was deleted while the gate was OFF. The reconcile loop
+			// only calls unprepare when the gate is ON, so this must happen after the flip.
+			tCtx.Run("wait-for-claim-unprepared", func(tCtx ktesting.TContext) {
+				for host, plugin := range b.Driver.Nodes {
+					tCtx.WithStep(fmt.Sprintf("wait for claim %s on %s to be unprepared", toDeleteClaimName, host)).
+						Eventually(func(ktesting.TContext) []app.ClaimID {
+							return plugin.GetPreparedResources()
+						}).WithTimeout(3*time.Minute).ShouldNot(gomega.ContainElement(gomega.HaveField("Name", gomega.HavePrefix(toDeleteClaimName))),
+						// HavePrefix because app.ClaimID.Name is "<claimName>/<device>", not the bare claim name.
+						"claim %s on host %s should be unprepared after gate re-enable", toDeleteClaimName, host)
+				}
+			})
+
+			tCtx.Run("survivor-pod-survives-reenable", func(tCtx ktesting.TContext) {
+				verifyPodRunningWithClaim(tCtx, b, podSurvivor, resourceName)
+			})
+
+			var freshPod *v1.Pod
+			tCtx.Run("fresh-pod-allocates-end-to-end", func(tCtx ktesting.TContext) {
+				freshPod = createPodWithExtendedResource(tCtx, b, "fresh", resourceName)
+				verifyPodRunningWithClaim(tCtx, b, freshPod, resourceName)
+			})
+
+			claimNames := []string{
+				claimNameFromPod(tCtx, podSurvivor),
+				claimNameFromPod(tCtx, freshPod),
+			}
+
+			tCtx.Run("cleanup-pods", func(tCtx ktesting.TContext) {
+				tCtx.ExpectNoError(e2epod.DeletePodWithWaitByName(tCtx, tCtx.Client(), podSurvivor.Name, podSurvivor.Namespace))
+				tCtx.ExpectNoError(e2epod.DeletePodWithWaitByName(tCtx, tCtx.Client(), freshPod.Name, freshPod.Namespace))
+			})
+
+			tCtx.Run("claims-GC", func(tCtx ktesting.TContext) {
+				eventuallyClaimsGone(tCtx, claimNames, 3*time.Minute)
+			})
 		}
 	}
 }
@@ -153,6 +242,17 @@ func createDeviceClassForExtendedResource(tCtx ktesting.TContext, b *drautils.Bu
 		tCtx.Fatalf("invalid resource type %q", resourceType)
 		return ""
 	}
+}
+
+// claimNameFromPod re-fetches the pod and returns the ResourceClaim name from
+// pod.Status.ExtendedResourceClaimStatus.
+func claimNameFromPod(tCtx ktesting.TContext, pod *v1.Pod) string {
+	tCtx.Helper()
+	p, err := tCtx.Client().CoreV1().Pods(pod.Namespace).Get(tCtx, pod.Name, metav1.GetOptions{})
+	tCtx.ExpectNoError(err, "get pod %s", pod.Name)
+	tCtx.Expect(p.Status.ExtendedResourceClaimStatus).ToNot(gomega.BeNil(),
+		"pod %s must have ExtendedResourceClaimStatus", pod.Name)
+	return p.Status.ExtendedResourceClaimStatus.ResourceClaimName
 }
 
 // createPodWithExtendedResource creates a pod with the given name requesting an extended resource.

--- a/test/e2e_dra/extendedresources_test.go
+++ b/test/e2e_dra/extendedresources_test.go
@@ -43,6 +43,12 @@ func extendedResourcesDriverResources(nodes *drautils.Nodes) map[string]resource
 	return drautils.DriverResourcesNow(nodes, 8)
 }
 
+func extendedResourceGateCycle(_ ktesting.TContext, _ *drautils.Builder) gateOffFunc {
+	return func(_ ktesting.TContext) gateOnAgainFunc {
+		return func(_ ktesting.TContext) {}
+	}
+}
+
 // extendedResourceUpgradeDowngrade tests the DRAExtendedResources feature during upgrade/downgrade scenarios
 // for a specific resource type (explicit or implicit).
 // This test verifies:

--- a/test/e2e_dra/featuregatecycle_test.go
+++ b/test/e2e_dra/featuregatecycle_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2edra
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/dynamic-resource-allocation/resourceslice"
+	drautils "k8s.io/kubernetes/test/e2e/dra/utils"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2etestfiles "k8s.io/kubernetes/test/e2e/framework/testfiles"
+	"k8s.io/kubernetes/test/utils/client-go/ktesting"
+	"k8s.io/kubernetes/test/utils/localupcluster"
+)
+
+// gateOnFunc runs while the feature gate is ON and returns the next phase.
+type gateOnFunc func(tCtx ktesting.TContext, b *drautils.Builder) gateOffFunc
+
+// gateOffFunc runs while the feature gate is OFF and returns the next phase.
+type gateOffFunc func(tCtx ktesting.TContext) gateOnAgainFunc
+
+// gateOnAgainFunc runs after the feature gate is re-enabled.
+type gateOnAgainFunc func(tCtx ktesting.TContext)
+
+type getResources func(nodes *drautils.Nodes) map[string]resourceslice.DriverResources
+
+func TestFeatureGateCycle(t *testing.T) { testFeatureGateCycle(ktesting.Init(t)) }
+
+func testFeatureGateCycle(tCtx ktesting.TContext) {
+	e2etestfiles.AddFileSource(e2etestfiles.RootFileSource{Root: repoRoot})
+
+	gomega.RegisterFailHandler(func(message string, callerSkip ...int) {
+		tCtx.Helper()
+		tCtx.Fatal(message)
+	})
+
+	envName, dir := currentBinDir()
+	if dir == "" {
+		tCtx.Fatalf("%s must be set", envName)
+	}
+
+	subTests := map[string]struct {
+		test                gateOnFunc
+		driverResourcesFunc getResources
+		// gates lists the feature gates to start ON in phase 0, toggle OFF in phase 1, and re-enable in phase 2.
+		gates []string
+		// emulatedVersion, if non-empty, is passed as EMULATED_VERSION to local-up-cluster.sh.
+		// Set this to the last version where the gates were still toggleable so the test
+		// keeps working once those gates become locked in a future release.
+		emulatedVersion string
+	}{
+		"extended-resource": {
+			test:                extendedResourceGateCycle,
+			driverResourcesFunc: extendedResourcesDriverResources,
+			gates:               []string{"DRAExtendedResource"},
+			// Emulate 1.36 so that gates which are locked in the current binary
+			// remain toggleable. DRAExtendedResource is toggleable in 1.36.
+			emulatedVersion: "1.36",
+		},
+	}
+
+	for name, def := range subTests {
+		tCtx.Run(name, func(tCtx ktesting.TContext) {
+			// ---- Phase 0: gate(s) ON ----
+			cluster := localupcluster.New()
+			tCtx.CleanupCtx(func(tCtx ktesting.TContext) {
+				tCtx.Step("cleanup", cluster.Stop)
+			})
+			localUpClusterEnv := map[string]string{
+				"RUNTIME_CONFIG": localUpClusterRuntimeConfig,
+			}
+			if def.emulatedVersion != "" {
+				localUpClusterEnv["EMULATED_VERSION"] = def.emulatedVersion
+			}
+			phase := "phase-0-gate-on"
+			cluster.Start(tCtx, phase, dir, localUpClusterEnv, turnFgOn(def.gates))
+
+			restConfig := cluster.LoadConfig(tCtx)
+			restConfig.UserAgent = restclient.DefaultKubernetesUserAgent() + " -- dra"
+			tCtx = tCtx.WithRESTConfig(restConfig).WithNamespace("default")
+
+			var nodes *drautils.Nodes
+			tCtx.Step("wait for node", func(tCtx ktesting.TContext) {
+				tCtx.ExpectNoError(e2enode.WaitForAllNodesSchedulable(tCtx, tCtx.Client(), 5*time.Minute))
+				nodes = drautils.NewNodesNow(tCtx, 1, 1)
+			})
+
+			// Create builder
+			driver := drautils.NewDriverInstance(tCtx)
+			driver.SetNameSuffix(tCtx, name)
+			driver.IsLocal = true
+			driver.Run(tCtx, "/var/lib/kubelet", nodes, def.driverResourcesFunc(nodes))
+			builder := drautils.NewBuilderNow(tCtx, driver)
+			builder.SkipCleanup = true
+
+			var gateOffFn gateOffFunc
+			tCtx.Run(phase, func(tCtx ktesting.TContext) {
+				gateOffFn = def.test(tCtx, builder)
+			})
+
+			// ---- Phase 1: gate(s) OFF ----
+			phase = "phase-1-gate-off"
+			cluster.ToggleFeatureGates(tCtx, phase, turnFgOff(def.gates))
+			waitForSlices(tCtx, name, builder, def.driverResourcesFunc(nodes))
+
+			var gateOnAgainFn gateOnAgainFunc
+			tCtx.Run(phase, func(tCtx ktesting.TContext) {
+				gateOnAgainFn = gateOffFn(tCtx)
+			})
+
+			// ---- Phase 2: gate(s) ON again ----
+			phase = "phase-2-gate-on-again"
+			cluster.ToggleFeatureGates(tCtx, phase, turnFgOn(def.gates))
+			waitForSlices(tCtx, name, builder, def.driverResourcesFunc(nodes))
+
+			tCtx.Run(phase, func(tCtx ktesting.TContext) {
+				gateOnAgainFn(tCtx)
+			})
+		})
+	}
+}
+
+// turnFgOn returns a string to turn the given feature gates on, e.g. "FeatureA=true,FeatureB=true".
+func turnFgOn(featureGates []string) string {
+	return turnFg(featureGates, "=true")
+}
+
+// turnFgOff returns a string to turn the given feature gates off, e.g. "FeatureA=false,FeatureB=false".
+func turnFgOff(featureGates []string) string {
+	return turnFg(featureGates, "=false")
+}
+
+// turnFg is a common part of turnFgOn and turnFgOff, returns a string to turn the given
+// feature gates on or off based on the suffix, e.g. "FeatureA=true,FeatureB=true" or "FeatureA=false,FeatureB=false".
+func turnFg(featureGates []string, suffix string) string {
+	if len(featureGates) == 0 {
+		return ""
+	}
+	return strings.Join(featureGates, suffix+",") + suffix
+}

--- a/test/e2e_dra/upgradedowngrade_test.go
+++ b/test/e2e_dra/upgradedowngrade_test.go
@@ -34,6 +34,8 @@ import (
 
 	"github.com/onsi/gomega"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/version"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/dynamic-resource-allocation/resourceslice"
@@ -440,4 +442,27 @@ func serverDownloadURL(tCtx ktesting.TContext, prefix string, major, minor uint)
 		return "", "", fmt.Errorf("reading response body for %s failed: %w", url, err)
 	}
 	return fmt.Sprintf("https://dl.k8s.io/release/%s/kubernetes-server-%s-%s.tar.gz", string(version), runtime.GOOS, runtime.GOARCH), string(version), nil
+}
+
+// eventuallyClaimsGone polls until all named ResourceClaims are gone (404).
+func eventuallyClaimsGone(tCtx ktesting.TContext, claimNames []string, timeout time.Duration) {
+	tCtx.Helper()
+	ns := tCtx.Namespace()
+	remaining := make([]string, len(claimNames))
+	copy(remaining, claimNames)
+	tCtx.WithStep("wait for ResourceClaims GC").
+		Eventually(func(tCtx ktesting.TContext) int {
+			still := remaining[:0]
+			for _, name := range remaining {
+				_, err := tCtx.Client().ResourceV1().ResourceClaims(ns).Get(tCtx, name, metav1.GetOptions{})
+				if err == nil {
+					still = append(still, name)
+				} else if !apierrors.IsNotFound(err) {
+					tCtx.ExpectNoError(err, "check ResourceClaim %s", name)
+				}
+			}
+			remaining = still
+			return len(remaining)
+		}).WithTimeout(timeout).Should(gomega.Equal(0), "ResourceClaims should be GC'd")
+	tCtx.Logf("Verified ResourceClaims %s were garbage collected", claimNames)
 }

--- a/test/e2e_dra/upgradedowngrade_test.go
+++ b/test/e2e_dra/upgradedowngrade_test.go
@@ -218,7 +218,7 @@ func testUpgradeDowngrade(tCtx ktesting.TContext) {
 			"FEATURE_GATES":  "DynamicResourceAllocation=true,DRADeviceTaintRules=true,DRADeviceTaints=true,DRAExtendedResource=true,DRAPartitionableDevices=true",
 			// *not* needed because driver will run in "local filesystem" mode (= driver.IsLocal): "ALLOW_PRIVILEGED": "1",
 		}
-		cluster.Start(tCtx, fmt.Sprintf("0-initial-%d.%d", major, previousMinor), binDir, localUpClusterEnv)
+		cluster.Start(tCtx, fmt.Sprintf("0-initial-%d.%d", major, previousMinor), binDir, localUpClusterEnv, "")
 	})
 
 	restConfig := cluster.LoadConfig(tCtx)

--- a/test/e2e_dra/upgradedowngrade_test.go
+++ b/test/e2e_dra/upgradedowngrade_test.go
@@ -86,6 +86,10 @@ func waitForSlices(tCtx ktesting.TContext, name string, b *drautils.Builder, dri
 
 var repoRoot = repoRootDefault()
 
+const (
+	localUpClusterRuntimeConfig = "resource.k8s.io/v1beta1,resource.k8s.io/v1beta2,resource.k8s.io/v1alpha3"
+)
+
 func currentBinDir() (envName, content string) {
 	envName = "KUBERNETES_SERVER_BIN_DIR"
 	content, _ = os.LookupEnv(envName)
@@ -214,7 +218,7 @@ func testUpgradeDowngrade(tCtx ktesting.TContext) {
 	})
 	tCtx.Step(fmt.Sprintf("bring up v%d.%d", major, previousMinor), func(tCtx ktesting.TContext) {
 		localUpClusterEnv := map[string]string{
-			"RUNTIME_CONFIG": "resource.k8s.io/v1beta1,resource.k8s.io/v1beta2,resource.k8s.io/v1alpha3",
+			"RUNTIME_CONFIG": localUpClusterRuntimeConfig,
 			"FEATURE_GATES":  "DynamicResourceAllocation=true,DRADeviceTaintRules=true,DRADeviceTaints=true,DRAExtendedResource=true,DRAPartitionableDevices=true",
 			// *not* needed because driver will run in "local filesystem" mode (= driver.IsLocal): "ALLOW_PRIVILEGED": "1",
 		}

--- a/test/utils/localupcluster/localupcluster.go
+++ b/test/utils/localupcluster/localupcluster.go
@@ -51,6 +51,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/kubernetes/test/utils/client-go/ktesting"
 )
 
@@ -71,6 +72,9 @@ const (
 
 // Kubernetes components running in the cluster, in the order in which they need to be started and upgraded.
 var KubeClusterComponents = []ClusterComponentName{KubeAPIServer, KubeControllerManager, KubeScheduler, Kubelet, KubeProxy}
+
+// featureGatedComponents lists the components that accept --feature-gates on their command line.
+var featureGatedComponents = []ClusterComponentName{KubeAPIServer, KubeControllerManager, KubeScheduler, Kubelet}
 
 // All components, including etcd.
 var components = append([]ClusterComponentName{Etcd}, KubeClusterComponents...)
@@ -125,7 +129,7 @@ type Cluster struct {
 // Kubernetes release. They will be invoked with parameters  as defined in the
 // *current* local-up-cluster.sh. This works as long as local-up-cluster.sh in its
 // default configuration doesn't depend on something which was added only recently.
-func (c *Cluster) Start(tCtx ktesting.TContext, state string, bindir string, localUpClusterEnv map[string]string) {
+func (c *Cluster) Start(tCtx ktesting.TContext, state string, bindir string, localUpClusterEnv map[string]string, featureGates string) {
 	tCtx.Helper()
 	c.Stop(tCtx)
 
@@ -192,7 +196,7 @@ processLocalUpClusterOutput:
 			if !ok {
 				break processLocalUpClusterOutput
 			}
-			c.processLocalUpClusterOutput(tCtx, state, line)
+			c.processLocalUpClusterOutput(tCtx, state, line, featureGates)
 		}
 	}
 	// Usually it has stopped by now already because we saw the end of its output stream,
@@ -205,7 +209,7 @@ processLocalUpClusterOutput:
 // Matches e.g. "+ API_SECURE_PORT=6443".
 var varAssignment = regexp.MustCompile(`^\+ ([A-Z0-9_]+)=(.*)$`)
 
-func (c *Cluster) processLocalUpClusterOutput(tCtx ktesting.TContext, state string, line string) {
+func (c *Cluster) processLocalUpClusterOutput(tCtx ktesting.TContext, state string, line string, featureGates string) {
 	tCtx.Logf("local-up-cluster: %s", line)
 
 	if strings.HasPrefix(line, localUpClusterRunPrefix) {
@@ -219,6 +223,12 @@ func (c *Cluster) processLocalUpClusterOutput(tCtx ktesting.TContext, state stri
 
 		// Cluster components and etcd are kept running.
 		if slices.Contains(components, ClusterComponentName(name)) {
+			if featureGates != "" && slices.Contains(featureGatedComponents, ClusterComponentName(name)) {
+				splitCmdLine := strings.Split(cmdLine, " ")
+				merged, err := mergeFeatureGatesFlags(splitCmdLine, featureGates)
+				tCtx.ExpectNoError(err, "merge feature gates %s into %s command line", featureGates, name)
+				cmdLine = strings.Join(merged, " ")
+			}
 			c.runComponent(tCtx, state, ClusterComponentName(name), cmdLine)
 			return
 		}
@@ -336,6 +346,9 @@ type ModifyOptions struct {
 
 	// FileByComponent overrides BinDir for those components which are specified here.
 	FileByComponent map[ClusterComponentName]string
+
+	// FeatureGatesByComponent specifies feature gates to apply to component command line.
+	FeatureGatesByComponent map[ClusterComponentName]string
 }
 
 func (m ModifyOptions) GetComponentFile(component ClusterComponentName) string {
@@ -363,8 +376,6 @@ func (c *Cluster) Modify(tCtx ktesting.TContext, state string, options ModifyOpt
 		FileByComponent: make(map[ClusterComponentName]string),
 	}
 
-	// We could also do things like turning feature gates on or off.
-	// For now we only support replacing the file.
 	updated := make(map[ClusterComponentName]*Cmd)
 
 	// Phase 1: stop all components that need modification in reverse order
@@ -372,7 +383,7 @@ func (c *Cluster) Modify(tCtx ktesting.TContext, state string, options ModifyOpt
 	// apiserver they depend on.
 	for _, component := range slices.Backward(KubeClusterComponents) {
 		fileName := options.GetComponentFile(component)
-		if fileName == "" {
+		if fileName == "" && options.FeatureGatesByComponent[component] == "" {
 			continue
 		}
 		tCtx := tCtx.WithStep(fmt.Sprintf("stop %s", component))
@@ -388,17 +399,21 @@ func (c *Cluster) Modify(tCtx ktesting.TContext, state string, options ModifyOpt
 
 		// Find the command (might be wrapped by sudo!).
 		cmdLine := slices.Clone(cmd.CommandLine)
-		found := false
-		for i := range cmdLine {
-			if path.Base(cmdLine[i]) == string(component) {
-				found = true
-				restore.FileByComponent[component] = cmdLine[i]
-				cmdLine[i] = fileName
-				break
+
+		// Replace binary if requested.
+		if fileName != "" {
+			found := false
+			for i := range cmdLine {
+				if path.Base(cmdLine[i]) == string(component) {
+					found = true
+					restore.FileByComponent[component] = cmdLine[i]
+					cmdLine[i] = fileName
+					break
+				}
 			}
-		}
-		if !found {
-			tCtx.Fatal("binary filename not found")
+			if !found {
+				tCtx.Fatal("binary filename not found")
+			}
 		}
 		cmd.Name = string(component) + "-" + state
 		cmd.CommandLine = cmdLine
@@ -411,6 +426,12 @@ func (c *Cluster) Modify(tCtx ktesting.TContext, state string, options ModifyOpt
 	// apiserver.
 	for _, component := range KubeClusterComponents {
 		if cmd, ok := updated[component]; ok {
+			// Apply feature gates.
+			if featureGates, ok := options.FeatureGatesByComponent[component]; ok {
+				merged, err := mergeFeatureGatesFlags(cmd.CommandLine, featureGates)
+				tCtx.ExpectNoError(err, "merge feature gates %s into %s command line", featureGates, component)
+				cmd.CommandLine = merged
+			}
 			c.runComponentWithRetry(tCtx, component, cmd)
 		}
 	}
@@ -546,4 +567,70 @@ func dumpProcesses(tCtx ktesting.TContext) {
 	// cmd.Start(tCtx)
 	// processes := cmd.Wait(tCtx)
 	// tCtx.Log(processes)
+}
+
+// ToggleFeatureGates restarts the feature gated components with the specified feature gates.
+// The returned ModifyOptions can be passed to Modify to restore the original state.
+func (c *Cluster) ToggleFeatureGates(tCtx ktesting.TContext, state string, featureGates string) ModifyOptions {
+	tCtx.Helper()
+
+	opts := ModifyOptions{
+		FileByComponent:         make(map[ClusterComponentName]string),
+		FeatureGatesByComponent: make(map[ClusterComponentName]string),
+	}
+
+	for _, component := range featureGatedComponents {
+		opts.FeatureGatesByComponent[component] = featureGates
+	}
+
+	return c.Modify(tCtx, state, opts)
+}
+
+// mergeFeatureGatesFlags merges the given feature gates (in "fg1=true,fg2=false" format)
+// into the command line. Any existing --feature-gates flags are merged together and
+// overridden by the new gates. The result contains exactly one --feature-gates flag at
+// the position of the first one previously found, or appended at the end if none was
+// present. If no gates result, the command line is returned unchanged.
+//
+// An error is returned if any --feature-gates flag in cmdLine or the featureGates
+// argument itself is malformed.
+func mergeFeatureGatesFlags(cmdLine []string, featureGates string) ([]string, error) {
+	gates := map[string]bool{}
+	gatesValue := cliflag.NewMapStringBool(&gates)
+
+	// Strip all --feature-gates tokens from the command line, accumulating
+	// their values into gatesValue. Remember where the first one was so the
+	// merged flag lands at the same position.
+	insertIdx := -1
+	out := make([]string, 0, len(cmdLine))
+	for _, tok := range cmdLine {
+		value, ok := strings.CutPrefix(tok, "--feature-gates=")
+		if !ok {
+			out = append(out, tok)
+			continue
+		}
+		if err := gatesValue.Set(value); err != nil {
+			return nil, fmt.Errorf("invalid --feature-gates in command line %q: %w", tok, err)
+		}
+		if insertIdx == -1 {
+			insertIdx = len(out)
+		}
+	}
+
+	// Apply the new gates on top (new values win over existing ones).
+	if featureGates != "" {
+		if err := gatesValue.Set(featureGates); err != nil {
+			return nil, fmt.Errorf("invalid feature gates %q: %w", featureGates, err)
+		}
+	}
+
+	// If no existing parseable flag was found and no gates resulted, nothing to do.
+	if insertIdx == -1 && len(gates) == 0 {
+		return out, nil
+	}
+	flag := "--feature-gates=" + gatesValue.String()
+	if insertIdx != -1 {
+		return slices.Insert(out, insertIdx, flag), nil
+	}
+	return append(out, flag), nil
 }

--- a/test/utils/localupcluster/localupcluster_test.go
+++ b/test/utils/localupcluster/localupcluster_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package localupcluster
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeFeatureGatesFlags(t *testing.T) {
+	for name, tc := range map[string]struct {
+		cmdLine      []string
+		featureGates string
+		want         []string
+		wantErr      bool
+	}{
+		"nop": {
+			// --feature-gates= (empty value) with no new gates: output must be unchanged.
+			cmdLine:      []string{"--feature-gates="},
+			featureGates: "",
+			want:         []string{"--feature-gates="},
+		},
+		"append-when-no-existing-flag": {
+			cmdLine:      []string{"--some-other-option=bla", "--some-option"},
+			featureGates: "fg1=true,fg2=false",
+			want:         []string{"--some-other-option=bla", "--some-option", "--feature-gates=fg1=true,fg2=false"},
+		},
+		"replace-existing-flag": {
+			cmdLine:      []string{"--some-other-option=bla", "--feature-gates=fg1=false", "--some-option"},
+			featureGates: "fg1=true",
+			want:         []string{"--some-other-option=bla", "--feature-gates=fg1=true", "--some-option"},
+		},
+		"merge-with-existing-flag": {
+			cmdLine:      []string{"--feature-gates=fg1=false,fg2=true", "--some-option"},
+			featureGates: "fg3=true",
+			want:         []string{"--feature-gates=fg1=false,fg2=true,fg3=true", "--some-option"},
+		},
+		"new-gates-override-existing": {
+			cmdLine:      []string{"--feature-gates=fg1=false,fg2=true"},
+			featureGates: "fg1=true",
+			want:         []string{"--feature-gates=fg1=true,fg2=true"},
+		},
+		"collapse-multiple-flags": {
+			cmdLine: []string{
+				"--feature-gates=fg1=false",
+				"--some-option",
+				"--feature-gates=fg2=true",
+				"--other=val",
+				"--feature-gates=fg3=false",
+			},
+			featureGates: "fg4=true",
+			want: []string{
+				"--feature-gates=fg1=false,fg2=true,fg3=false,fg4=true",
+				"--some-option",
+				"--other=val",
+			},
+		},
+		"collapse-multiple-flags-later-wins": {
+			cmdLine:      []string{"--feature-gates=fg1=false", "--feature-gates=fg1=true"},
+			featureGates: "",
+			want:         []string{"--feature-gates=fg1=true"},
+		},
+		"empty-feature-gates-no-existing": {
+			cmdLine:      []string{"--some-option"},
+			featureGates: "",
+			want:         []string{"--some-option"},
+		},
+		"empty-feature-gates-with-existing": {
+			cmdLine:      []string{"--feature-gates=fg1=true", "--some-option"},
+			featureGates: "",
+			want:         []string{"--feature-gates=fg1=true", "--some-option"},
+		},
+		"nil-cmdline": {
+			cmdLine:      nil,
+			featureGates: "fg1=true",
+			want:         []string{"--feature-gates=fg1=true"},
+		},
+		"output-keys-are-sorted": {
+			cmdLine:      nil,
+			featureGates: "zeta=true,alpha=false,mike=true",
+			want:         []string{"--feature-gates=alpha=false,mike=true,zeta=true"},
+		},
+		"unparseable-existing-flag-returns-error": {
+			cmdLine:      []string{"--feature-gates=not-a-pair"},
+			featureGates: "fg1=true",
+			wantErr:      true,
+		},
+		"unparseable-input-returns-error": {
+			cmdLine:      nil,
+			featureGates: "not-a-pair",
+			wantErr:      true,
+		},
+		"existing-empty-flag-no-new-gates": {
+			// --feature-gates= (empty value) is parseable but yields no gates;
+			// featureGates is also empty. The placeholder must not be left as "".
+			cmdLine:      []string{"--feature-gates=", "--some-option"},
+			featureGates: "",
+			want:         []string{"--feature-gates=", "--some-option"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			// Snapshot input to detect accidental mutation.
+			cmdLineCopy := append([]string(nil), tc.cmdLine...)
+
+			got, err := mergeFeatureGatesFlags(tc.cmdLine, tc.featureGates)
+			switch {
+			case tc.wantErr && err == nil:
+				t.Fatalf("expected error, got nil; result=%q", got)
+			case !tc.wantErr && err != nil:
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !tc.wantErr && !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("mergeFeatureGatesFlags() mismatch:\n got:  %q\n want: %q", got, tc.want)
+			}
+			if !reflect.DeepEqual(tc.cmdLine, cmdLineCopy) {
+				t.Errorf("input slice was mutated:\n got:  %q\n want: %q", tc.cmdLine, cmdLineCopy)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- localupcluster: added feature gate toggle and ON-OFF-ON framework.
- e2e_dra: added the on/off/on cycle tests for extended resources.

Here is how the e2e_dra test run looks like now:

```
$ ./test/e2e_dra/run.sh go test -v -count=1 -timeout=1h ./test/e2e_dra/... > console.log 2>&1
$ grep PASS console.log 
--- PASS: TestFeatureGateCycle (228.23s)
    --- PASS: TestFeatureGateCycle/extended-resource (228.23s)
        --- PASS: TestFeatureGateCycle/extended-resource/phase-0-gate-on (4.29s)
            --- PASS: TestFeatureGateCycle/extended-resource/phase-0-gate-on/pods-with-extended-resource-running (4.29s)
        --- PASS: TestFeatureGateCycle/extended-resource/phase-1-gate-off (79.92s)
            --- PASS: TestFeatureGateCycle/extended-resource/phase-1-gate-off/survivor-pods-still-running (0.01s)
            --- PASS: TestFeatureGateCycle/extended-resource/phase-1-gate-off/survivor-claim-preserved (0.39s)
            --- PASS: TestFeatureGateCycle/extended-resource/phase-1-gate-off/new-deviceclass-field-stripped (0.20s)
            --- PASS: TestFeatureGateCycle/extended-resource/phase-1-gate-off/probe-pod-pending-no-special-claim (30.60s)
            --- PASS: TestFeatureGateCycle/extended-resource/phase-1-gate-off/delete-pod-triggers-gc-with-gate-off (48.72s)
        --- PASS: TestFeatureGateCycle/extended-resource/phase-2-gate-on-again (6.39s)
            --- PASS: TestFeatureGateCycle/extended-resource/phase-2-gate-on-again/wait-for-claim-unprepared (0.00s)
            --- PASS: TestFeatureGateCycle/extended-resource/phase-2-gate-on-again/survivor-pod-survives-reenable (0.20s)
            --- PASS: TestFeatureGateCycle/extended-resource/phase-2-gate-on-again/fresh-pod-allocates-end-to-end (2.14s)
            --- PASS: TestFeatureGateCycle/extended-resource/phase-2-gate-on-again/cleanup-pods (4.03s)
            --- PASS: TestFeatureGateCycle/extended-resource/phase-2-gate-on-again/claims-GC (0.01s)
--- PASS: TestUpgradeDowngrade (329.22s)
    --- PASS: TestUpgradeDowngrade/after-cluster-creation (21.17s)
        --- PASS: TestUpgradeDowngrade/after-cluster-creation/core-dra (2.15s)
        --- PASS: TestUpgradeDowngrade/after-cluster-creation/resource-claim-device-status (0.06s)
        --- PASS: TestUpgradeDowngrade/after-cluster-creation/device-taints (4.17s)
        --- PASS: TestUpgradeDowngrade/after-cluster-creation/partitionable-devices (10.51s)
        --- PASS: TestUpgradeDowngrade/after-cluster-creation/extended-resource-explicit (2.14s)
        --- PASS: TestUpgradeDowngrade/after-cluster-creation/extended-resource-implicit (2.14s)
    --- PASS: TestUpgradeDowngrade/after-cluster-upgrade (47.37s)
        --- PASS: TestUpgradeDowngrade/after-cluster-upgrade/resource-claim-device-status (0.23s)
        --- PASS: TestUpgradeDowngrade/after-cluster-upgrade/device-taints (32.02s)
        --- PASS: TestUpgradeDowngrade/after-cluster-upgrade/partitionable-devices (6.45s)
        --- PASS: TestUpgradeDowngrade/after-cluster-upgrade/extended-resource-explicit (2.25s)
        --- PASS: TestUpgradeDowngrade/after-cluster-upgrade/extended-resource-implicit (2.26s)
        --- PASS: TestUpgradeDowngrade/after-cluster-upgrade/core-dra (4.15s)
    --- PASS: TestUpgradeDowngrade/after-cluster-downgrade (24.18s)
        --- PASS: TestUpgradeDowngrade/after-cluster-downgrade/device-taints (2.03s)
        --- PASS: TestUpgradeDowngrade/after-cluster-downgrade/partitionable-devices (12.51s)
        --- PASS: TestUpgradeDowngrade/after-cluster-downgrade/extended-resource-explicit (4.30s)
        --- PASS: TestUpgradeDowngrade/after-cluster-downgrade/extended-resource-implicit (4.29s)
        --- PASS: TestUpgradeDowngrade/after-cluster-downgrade/core-dra (0.99s)
        --- PASS: TestUpgradeDowngrade/after-cluster-downgrade/resource-claim-device-status (0.05s)
PASS
```



#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/138447

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

