### PR TITLE
node: future proof graph populator fast-path to check ExtendedResourceClaimStatus

### DIFF
--- a/plugin/pkg/auth/authorizer/node/graph_populator.go
+++ b/plugin/pkg/auth/authorizer/node/graph_populator.go
@@ -111,7 +111,8 @@ func (g *graphPopulator) updatePod(oldObj, obj interface{}) {
 		hasNewEphemeralContainers := len(pod.Spec.EphemeralContainers) > len(oldPod.Spec.EphemeralContainers)
 		if (pod.Spec.NodeName == oldPod.Spec.NodeName) && (pod.UID == oldPod.UID) &&
 			!hasNewEphemeralContainers &&
-			resourceclaim.PodStatusEqual(oldPod.Status.ResourceClaimStatuses, pod.Status.ResourceClaimStatuses) {
+			resourceclaim.PodStatusEqual(oldPod.Status.ResourceClaimStatuses, pod.Status.ResourceClaimStatuses) &&
+			resourceclaim.PodExtendedStatusEqual(oldPod.Status.ExtendedResourceClaimStatus, pod.Status.ExtendedResourceClaimStatus) {
 			// Node and uid are unchanged, all object references in the pod spec are immutable respectively unmodified (claim statuses).
 			klog.V(5).Infof("updatePod %s/%s, node unchanged", pod.Namespace, pod.Name)
 			return

--- a/plugin/pkg/auth/authorizer/node/node_authorizer_test.go
+++ b/plugin/pkg/auth/authorizer/node/node_authorizer_test.go
@@ -1068,8 +1068,10 @@ func TestNodeAuthorizerAddEphemeralContainers(t *testing.T) {
 // ResourceClaimStatuses are all unchanged. For pods that use the
 // DRAExtendedResource path (e.g. a plain nvidia.com/gpu request),
 // ResourceClaimStatuses is nil both before and after the scheduler writes
-// the synthesized claim name, so the fast-path would fire prematurely and
-// the claim→pod→node edge would never be added to the authorization graph.
+// the synthesized claim name, and ExtendedResourceClaimStatus may change
+// under rare condition after a pod is bound to a node, so the fast-path
+// would fire prematurely and the claim→pod→node edge would never be added
+// to the authorization graph.
 func TestNodeAuthorizerUpdateExtendedResourceClaim(t *testing.T) {
 	g := NewGraph()
 	identifier := nodeidentifier.NewDefaultNodeIdentifier()
@@ -1077,9 +1079,10 @@ func TestNodeAuthorizerUpdateExtendedResourceClaim(t *testing.T) {
 
 	node1 := &user.DefaultInfo{Name: "system:node:node1", Groups: []string{"system:nodes"}}
 
-	// The pod has been bound to node1, but the scheduler has not yet written
-	// ExtendedResourceClaimStatus. There are no standard Spec.ResourceClaims,
-	// so ResourceClaimStatuses stays nil throughout.
+	// The pod has been bound to node1, but the scheduler has written
+	// extended-claim-0, not extended-claim-1, to ExtendedResourceClaimStatus.
+	// There are no standard Spec.ResourceClaims, so ResourceClaimStatuses
+	// stays nil throughout.
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pod1",
@@ -1089,14 +1092,26 @@ func TestNodeAuthorizerUpdateExtendedResourceClaim(t *testing.T) {
 		Spec: corev1.PodSpec{
 			NodeName: "node1",
 		},
+		Status: corev1.PodStatus{
+			ExtendedResourceClaimStatus: &corev1.PodExtendedResourceClaimStatus{
+				ResourceClaimName: "extended-claim-0",
+				RequestMappings: []corev1.ContainerExtendedResourceRequest{
+					{
+						ContainerName: "container0",
+						ResourceName:  "example.com/gpu",
+						RequestName:   "request",
+					},
+				},
+			},
+		},
 	}
 
 	p := &graphPopulator{}
 	p.graph = g
 	p.addPod(pod)
 
-	// Before the scheduler writes ExtendedResourceClaimStatus, the synthesized
-	// claim is not in the graph and node1 should have no opinion on it.
+	// Before the scheduler swaps the synthesized claim name, extended-claim-1
+	// is not in the graph and node1 should have no opinion on it.
 	decision, _, err := authz.Authorize(context.Background(), authorizer.AttributesRecord{
 		User:            node1,
 		ResourceRequest: true,
@@ -1110,16 +1125,15 @@ func TestNodeAuthorizerUpdateExtendedResourceClaim(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if decision != authorizer.DecisionNoOpinion {
-		t.Errorf("before ExtendedResourceClaimStatus is populated: want NoOpinion, got %v", decision)
+		t.Errorf("before ExtendedResourceClaimStatus is updated to extended-claim-1: want NoOpinion, got %v", decision)
 	}
 
-	// The scheduler creates the ResourceClaim and records its name in the pod
-	// status. updatePod must recognize that ExtendedResourceClaimStatus changed
-	// and rebuild the graph edge rather than taking the fast-path early exit.
+	// The scheduler swaps the synthesized ResourceClaim from extended-claim-0
+	// to extended-claim-1. updatePod must recognize that ExtendedResourceClaimStatus
+	// changed and rebuild the graph edge rather than taking the fast-path early
+	// exit.
 	updatedPod := pod.DeepCopy()
-	updatedPod.Status.ExtendedResourceClaimStatus = &corev1.PodExtendedResourceClaimStatus{
-		ResourceClaimName: "extended-claim-1",
-	}
+	updatedPod.Status.ExtendedResourceClaimStatus.ResourceClaimName = "extended-claim-1"
 	p.updatePod(pod, updatedPod)
 
 	// The node that hosts the pod should now be permitted to read the claim.
@@ -1136,7 +1150,7 @@ func TestNodeAuthorizerUpdateExtendedResourceClaim(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if decision != authorizer.DecisionAllow {
-		t.Errorf("after ExtendedResourceClaimStatus is populated: want Allow, got %v", decision)
+		t.Errorf("after ExtendedResourceClaimStatus is updated to extended-claim-1: want Allow, got %v", decision)
 	}
 
 	// A node that does not host the pod must not gain access to the claim.

--- a/plugin/pkg/auth/authorizer/node/node_authorizer_test.go
+++ b/plugin/pkg/auth/authorizer/node/node_authorizer_test.go
@@ -1058,6 +1058,106 @@ func TestNodeAuthorizerAddEphemeralContainers(t *testing.T) {
 	}
 }
 
+// TestNodeAuthorizerUpdateExtendedResourceClaim checks that a node gains
+// authorization to read its pod's synthesized ResourceClaim once the scheduler
+// writes ExtendedResourceClaimStatus into the pod — even when the pod carries
+// no standard Spec.ResourceClaims entries.
+//
+// Background: the graph populator's updatePod has a fast-path that skips
+// AddPod when the pod's node assignment, UID, ephemeral containers, and
+// ResourceClaimStatuses are all unchanged. For pods that use the
+// DRAExtendedResource path (e.g. a plain nvidia.com/gpu request),
+// ResourceClaimStatuses is nil both before and after the scheduler writes
+// the synthesized claim name, so the fast-path would fire prematurely and
+// the claim→pod→node edge would never be added to the authorization graph.
+func TestNodeAuthorizerUpdateExtendedResourceClaim(t *testing.T) {
+	g := NewGraph()
+	identifier := nodeidentifier.NewDefaultNodeIdentifier()
+	authz := NewAuthorizer(g, identifier, bootstrappolicy.NodeRules())
+
+	node1 := &user.DefaultInfo{Name: "system:node:node1", Groups: []string{"system:nodes"}}
+
+	// The pod has been bound to node1, but the scheduler has not yet written
+	// ExtendedResourceClaimStatus. There are no standard Spec.ResourceClaims,
+	// so ResourceClaimStatuses stays nil throughout.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod1",
+			Namespace: "ns1",
+			UID:       "pod1uid",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node1",
+		},
+	}
+
+	p := &graphPopulator{}
+	p.graph = g
+	p.addPod(pod)
+
+	// Before the scheduler writes ExtendedResourceClaimStatus, the synthesized
+	// claim is not in the graph and node1 should have no opinion on it.
+	decision, _, err := authz.Authorize(context.Background(), authorizer.AttributesRecord{
+		User:            node1,
+		ResourceRequest: true,
+		Verb:            "get",
+		Resource:        "resourceclaims",
+		APIGroup:        "resource.k8s.io",
+		Namespace:       "ns1",
+		Name:            "extended-claim-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if decision != authorizer.DecisionNoOpinion {
+		t.Errorf("before ExtendedResourceClaimStatus is populated: want NoOpinion, got %v", decision)
+	}
+
+	// The scheduler creates the ResourceClaim and records its name in the pod
+	// status. updatePod must recognize that ExtendedResourceClaimStatus changed
+	// and rebuild the graph edge rather than taking the fast-path early exit.
+	updatedPod := pod.DeepCopy()
+	updatedPod.Status.ExtendedResourceClaimStatus = &corev1.PodExtendedResourceClaimStatus{
+		ResourceClaimName: "extended-claim-1",
+	}
+	p.updatePod(pod, updatedPod)
+
+	// The node that hosts the pod should now be permitted to read the claim.
+	decision, _, err = authz.Authorize(context.Background(), authorizer.AttributesRecord{
+		User:            node1,
+		ResourceRequest: true,
+		Verb:            "get",
+		Resource:        "resourceclaims",
+		APIGroup:        "resource.k8s.io",
+		Namespace:       "ns1",
+		Name:            "extended-claim-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if decision != authorizer.DecisionAllow {
+		t.Errorf("after ExtendedResourceClaimStatus is populated: want Allow, got %v", decision)
+	}
+
+	// A node that does not host the pod must not gain access to the claim.
+	node2 := &user.DefaultInfo{Name: "system:node:node2", Groups: []string{"system:nodes"}}
+	decision, _, err = authz.Authorize(context.Background(), authorizer.AttributesRecord{
+		User:            node2,
+		ResourceRequest: true,
+		Verb:            "get",
+		Resource:        "resourceclaims",
+		APIGroup:        "resource.k8s.io",
+		Namespace:       "ns1",
+		Name:            "extended-claim-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if decision != authorizer.DecisionNoOpinion {
+		t.Errorf("node2 should not access a claim belonging to node1's pod: want NoOpinion, got %v", decision)
+	}
+}
+
 type sampleDataOpts struct {
 	nodes       int
 	namespaces  int


### PR DESCRIPTION
Pods using DRAExtendedResource (e.g. nvidia.com/gpu) have no Spec.ResourceClaims, so ResourceClaimStatuses stays nil. The updatePod fast-path skipped AddPod when only ExtendedResourceClaimStatus changed, leaving the synthesized claim→pod→node edge out of the authorization graph.

Add PodExtendedStatusEqual to the fast-path guard, matching what the scheduler event handler already does in events.go.

This PR adds safeguards to prevent some edge conditions.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a theoretic issue where nodes might have been denied access to synthesized ResourceClaims for pods using extended resources (e.g. nvidia.com/gpu), causing containers to get stuck in ContainerCreating. Not observed in practice.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
