### PR TITLE
[DRAFT] Adding parallelization for PVC ref count tracking

### DIFF
--- a/pkg/scheduler/backend/cache/cache.go
+++ b/pkg/scheduler/backend/cache/cache.go
@@ -242,18 +242,6 @@ func (cache *cacheImpl) UpdateSnapshot(logger klog.Logger, nodeSnapshot *Snapsho
 			if (len(existing.PodsWithRequiredAntiAffinity) > 0) != (len(clone.PodsWithRequiredAntiAffinity) > 0) {
 				updateNodesHavePodsWithRequiredAntiAffinity = true
 			}
-			if !updateUsedPVCSet {
-				if len(existing.PVCRefCounts) != len(clone.PVCRefCounts) {
-					updateUsedPVCSet = true
-				} else {
-					for pvcKey := range clone.PVCRefCounts {
-						if _, found := existing.PVCRefCounts[pvcKey]; !found {
-							updateUsedPVCSet = true
-							break
-						}
-					}
-				}
-			}
 			// We need to preserve the original pointer of the NodeInfo struct since it
 			// is used in the NodeInfoList, which we may not update.
 			*existing = *clone
@@ -335,9 +323,6 @@ func (cache *cacheImpl) updateNodeInfoSnapshotList(logger klog.Logger, snapshot 
 				if len(nodeInfo.PodsWithRequiredAntiAffinity) > 0 {
 					snapshot.havePodsWithRequiredAntiAffinityNodeInfoList = append(snapshot.havePodsWithRequiredAntiAffinityNodeInfoList, nodeInfo)
 				}
-				for key := range nodeInfo.PVCRefCounts {
-					snapshot.usedPVCSet.Insert(key)
-				}
 			} else {
 				utilruntime.HandleErrorWithLogger(logger, nil, "Node exists in nodeTree but not in NodeInfoMap, this should not happen", "node", klog.KRef("", nodeName))
 			}
@@ -349,9 +334,6 @@ func (cache *cacheImpl) updateNodeInfoSnapshotList(logger klog.Logger, snapshot 
 			}
 			if len(nodeInfo.GetPodsWithRequiredAntiAffinity()) > 0 {
 				snapshot.havePodsWithRequiredAntiAffinityNodeInfoList = append(snapshot.havePodsWithRequiredAntiAffinityNodeInfoList, nodeInfo)
-			}
-			for key := range nodeInfo.GetPVCRefCounts() {
-				snapshot.usedPVCSet.Insert(key)
 			}
 		}
 	}

--- a/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go
+++ b/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go
@@ -19,6 +19,7 @@ package volumerestrictions
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -29,6 +30,7 @@ import (
 	fwk "k8s.io/kube-scheduler/framework"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 	"k8s.io/kubernetes/pkg/scheduler/util"
@@ -38,6 +40,7 @@ import (
 type VolumeRestrictions struct {
 	pvcLister    corelisters.PersistentVolumeClaimLister
 	sharedLister fwk.SharedLister
+	parallelizer parallelize.Parallelizer
 }
 
 var _ fwk.PreFilterPlugin = &VolumeRestrictions{}
@@ -187,7 +190,7 @@ func (pl *VolumeRestrictions) PreFilter(ctx context.Context, cycleState fwk.Cycl
 		return nil, fwk.AsStatus(err)
 	}
 
-	s, err := pl.calPreFilterState(ctx, pod, pvcs)
+	s, err := pl.calPreFilterState(ctx, pod, nodes, pvcs)
 	if err != nil {
 		return nil, fwk.AsStatus(err)
 	}
@@ -235,15 +238,23 @@ func getPreFilterState(cycleState fwk.CycleState) (*preFilterState, error) {
 
 // calPreFilterState computes preFilterState describing which PVCs use ReadWriteOncePod
 // and which pods in the cluster are in conflict.
-func (pl *VolumeRestrictions) calPreFilterState(ctx context.Context, pod *v1.Pod, pvcs sets.Set[string]) (*preFilterState, error) {
+func (pl *VolumeRestrictions) calPreFilterState(ctx context.Context, pod *v1.Pod, nodes []fwk.NodeInfo, pvcs sets.Set[string]) (*preFilterState, error) {
 	conflictingPVCRefCount := 0
-	for pvc := range pvcs {
-		key := framework.GetNamespacedName(pod.Namespace, pvc)
-		if pl.sharedLister.StorageInfos().IsPVCUsedByPods(key) {
-			// There can only be at most one pod using the ReadWriteOncePod PVC.
-			conflictingPVCRefCount += 1
-		}
+	refCount := &atomic.Int32{}
+	// list iteration is faster than map
+	pvcList := pvcs.UnsortedList()
+	if len(pvcList) > 0 {
+		pl.parallelizer.Until(ctx, len(nodes), func(n int) {
+			for _, pvc := range pvcList {
+				key := framework.GetNamespacedName(pod.Namespace, pvc)
+				_, ok := nodes[n].GetPVCRefCounts()[key]
+				if ok {
+					refCount.Add(1)
+				}
+			}
+		}, pl.Name())
 	}
+	conflictingPVCRefCount = int(refCount.Load())
 	return &preFilterState{
 		readWriteOncePodPVCs:   pvcs,
 		conflictingPVCRefCount: conflictingPVCRefCount,
@@ -419,5 +430,6 @@ func New(_ context.Context, _ runtime.Object, handle fwk.Handle, fts feature.Fea
 	return &VolumeRestrictions{
 		pvcLister:    pvcLister,
 		sharedLister: sharedLister,
+		parallelizer: handle.Parallelizer().(parallelize.Parallelizer),
 	}, nil
 }

--- a/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions_test.go
+++ b/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions_test.go
@@ -25,13 +25,16 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2/ktesting"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	plugintesting "k8s.io/kubernetes/pkg/scheduler/framework/plugins/testing"
+	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 )
 
@@ -104,6 +107,7 @@ func TestGCEDiskConflicts(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
+			metrics.InitMetrics()
 			p := newPlugin(ctx, t)
 			cycleState := framework.NewCycleState()
 			_, preFilterGotStatus := p.(fwk.PreFilterPlugin).PreFilter(ctx, cycleState, test.pod, nil)
@@ -466,6 +470,7 @@ func TestAccessModeConflicts(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			metrics.InitMetrics()
 			_, ctx := ktesting.NewTestContext(t)
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
@@ -779,6 +784,105 @@ func Test_isSchedulableAfterPersistentVolumeClaimChange(t *testing.T) {
 
 			if diff := cmp.Diff(tc.expectedHint, actualHint); diff != "" {
 				t.Errorf("Unexpected QueueingHint (-want, +got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestLazyPVCRefCountPreFilter(t *testing.T) {
+	testCases := []struct {
+		name                     string
+		nodes                    []*framework.NodeInfo
+		pvcs                     sets.Set[string]
+		pod                      *v1.Pod
+		expectedConflictingCount int
+	}{
+		{
+			name: "normal pre-filtering should work - single pvcs",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns-1"},
+			},
+			nodes: []*framework.NodeInfo{
+				{
+					PVCRefCounts: map[string]int{
+						"ns-1/pvc-1": 1,
+					},
+				},
+			},
+			pvcs:                     sets.New("pvc-1"),
+			expectedConflictingCount: 1,
+		},
+		{
+			name: "normal pre-filtering should work - two pvcs",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns-1"},
+			},
+			nodes: []*framework.NodeInfo{
+				{
+					PVCRefCounts: map[string]int{
+						"ns-1/pvc-1": 1,
+						"ns-1/pvc-2": 1,
+					},
+				},
+			},
+			pvcs:                     sets.New("pvc-1", "pvc-2"),
+			expectedConflictingCount: 2,
+		},
+		{
+			name: "normal pre-filtering should work - two nodes",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns-1"},
+			},
+			nodes: []*framework.NodeInfo{
+				{
+					PVCRefCounts: map[string]int{
+						"ns-1/pvc-1": 1,
+					},
+				},
+				{
+					PVCRefCounts: map[string]int{
+						"ns-1/pvc-1": 1,
+					},
+				},
+			},
+			pvcs:                     sets.New("pvc-1"),
+			expectedConflictingCount: 2,
+		},
+		{
+			name: "normal pre-filtering should work - not overlapping",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns-1"},
+			},
+			nodes: []*framework.NodeInfo{
+				{
+					PVCRefCounts: map[string]int{
+						"ns-1/pvc-1": 1,
+						"ns-1/pvc-2": 1,
+					},
+				},
+			},
+			pvcs:                     sets.New("pvc-3"),
+			expectedConflictingCount: 0,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			metrics.InitMetrics()
+			ctx, cancel := context.WithCancel(context.TODO())
+			defer cancel()
+			vp := &VolumeRestrictions{
+				parallelizer: parallelize.NewParallelizer(10),
+			}
+			fwkNodes := make([]fwk.NodeInfo, len(tc.nodes))
+			for i, node := range tc.nodes {
+				fwkNodes[i] = node
+			}
+			state, err := vp.calPreFilterState(ctx, tc.pod, fwkNodes, tc.pvcs)
+			if err != nil {
+				t.Fail()
+			}
+			if s := cmp.Diff(state.conflictingPVCRefCount, tc.expectedConflictingCount); len(s) > 0 {
+				t.Errorf("Unexpected value: %v", s)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Fixes: https://github.com/kubernetes/kubernetes/issues/138426

This PR moves the calculation of PVC ref count from cache snapshotting phase to pre-score phase of VolumeRestriction plugin given that the data struct was only used by the VolumeRestriction plugin. Additionaly it added parallelization for aggregation the PVC refcount.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
