### PR TITLE
kubelet: improve systemd watchdog

### DIFF
--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -217,7 +217,7 @@ func Run(ctx context.Context, cc *schedulerserverconfig.CompletedConfig, sched *
 	}
 
 	handlerSyncReadyCh := make(chan struct{})
-	handlerSyncCheck := healthz.NamedCheck("sched-handler-sync", func(_ *http.Request) error {
+	handlerSyncCheck := healthz.NamedCheck("sched-handler-sync", func(_ context.Context) error {
 		select {
 		case <-handlerSyncReadyCh:
 			return nil

--- a/pkg/controlplane/apiserver/aggregator.go
+++ b/pkg/controlplane/apiserver/aggregator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apiserver
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -290,7 +291,7 @@ func makeAPIServiceAvailableHealthCheck(name string, apiServices []*v1.APIServic
 	})
 
 	// Don't return healthy until the pending list is empty
-	return healthz.NamedCheck(name, func(r *http.Request) error {
+	return healthz.NamedCheck(name, func(ctx context.Context) error {
 		pendingServiceNamesLock.RLock()
 		defer pendingServiceNamesLock.RUnlock()
 		if pendingServiceNames.Len() > 0 {

--- a/pkg/kubelet/cm/devicemanager/plugin/v1beta1/server.go
+++ b/pkg/kubelet/cm/devicemanager/plugin/v1beta1/server.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/http"
 	"os"
 	"path/filepath"
 	"sync"
@@ -212,7 +211,7 @@ func (s *server) Name() string {
 	return "device-plugin"
 }
 
-func (s *server) Check(_ *http.Request) error {
+func (s *server) Check(_ context.Context) error {
 	return s.lastError
 }
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -3228,7 +3228,7 @@ func (kl *Kubelet) LatestLoopEntryTime() time.Time {
 }
 
 // SyncLoopHealthCheck checks if kubelet's sync loop that updates containers is working.
-func (kl *Kubelet) SyncLoopHealthCheck(req *http.Request) error {
+func (kl *Kubelet) SyncLoopHealthCheck(ctx context.Context) error {
 	duration := kl.resyncInterval * 2
 	minDuration := time.Minute * 5
 	if duration < minDuration {

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -317,7 +317,7 @@ type HostInterface interface {
 	CheckpointContainer(ctx context.Context, podUID types.UID, podFullName, containerName string, options *runtimeapi.CheckpointContainerRequest) error
 	GetKubeletContainerLogs(ctx context.Context, podFullName, containerName string, logOptions *v1.PodLogOptions, stdout, stderr io.Writer) error
 	ServeLogs(w http.ResponseWriter, req *http.Request)
-	SyncLoopHealthCheck(req *http.Request) error
+	SyncLoopHealthCheck(ctx context.Context) error
 	GetExec(ctx context.Context, podFullName string, podUID types.UID, containerName string, cmd []string, streamOpts remotecommandserver.Options) (*url.URL, error)
 	GetAttach(ctx context.Context, podFullName string, podUID types.UID, containerName string, streamOpts remotecommandserver.Options) (*url.URL, error)
 	GetPortForward(ctx context.Context, podName, podNamespace string, podUID types.UID, portForwardOpts portforward.V4Options) (*url.URL, error)

--- a/pkg/kubelet/watchdog/types.go
+++ b/pkg/kubelet/watchdog/types.go
@@ -18,7 +18,6 @@ package watchdog
 
 import (
 	"context"
-	"net/http"
 
 	"k8s.io/apiserver/pkg/server/healthz"
 )
@@ -31,5 +30,5 @@ type HealthChecker interface {
 
 // syncLoopHealthChecker contains the health check method for syncLoop.
 type syncLoopHealthChecker interface {
-	SyncLoopHealthCheck(req *http.Request) error
+	SyncLoopHealthCheck(ctx context.Context) error
 }

--- a/pkg/kubelet/watchdog/watchdog_linux.go
+++ b/pkg/kubelet/watchdog/watchdog_linux.go
@@ -148,7 +148,7 @@ func (hc *healthChecker) Start(ctx context.Context) {
 		err := wait.ExponentialBackoffWithContext(ctx, hc.retryBackoff, func(_ context.Context) (bool, error) {
 			ack, err := hc.watchdog.SdNotify(false)
 			if err != nil {
-				logger.V(5).Info("Failed to notify systemd watchdog, retrying", "error", err)
+				logger.Error(err, "Failed to notify systemd watchdog, retrying")
 				return false, nil
 			}
 			if !ack {

--- a/pkg/kubelet/watchdog/watchdog_linux.go
+++ b/pkg/kubelet/watchdog/watchdog_linux.go
@@ -166,7 +166,7 @@ func (hc *healthChecker) Start(ctx context.Context) {
 
 func (hc *healthChecker) doCheck() error {
 	for _, hc := range hc.getHealthCheckers() {
-		if err := hc.Check(nil); err != nil {
+		if err := hc.Check(context.TODO()); err != nil {
 			return fmt.Errorf("checker %s failed: %w", hc.Name(), err)
 		}
 	}

--- a/pkg/kubelet/watchdog/watchdog_linux.go
+++ b/pkg/kubelet/watchdog/watchdog_linux.go
@@ -131,6 +131,17 @@ func (hc *healthChecker) getHealthCheckers() []healthz.HealthChecker {
 	return []healthz.HealthChecker{}
 }
 
+func (hc *healthChecker) getTimeout() time.Duration {
+	timeout := hc.interval / 2
+	if timeout > 5*time.Second {
+		return 5 * time.Second
+	}
+	if timeout < time.Second {
+		return time.Second
+	}
+	return timeout
+}
+
 func (hc *healthChecker) Start(ctx context.Context) {
 	logger := klog.FromContext(ctx)
 	if hc.interval <= 0 {
@@ -140,23 +151,43 @@ func (hc *healthChecker) Start(ctx context.Context) {
 	logger.Info("Starting systemd watchdog with interval", "interval", hc.interval)
 
 	go wait.UntilWithContext(ctx, func(ctx context.Context) {
-		if err := hc.doCheck(); err != nil {
+		if err := hc.doCheck(ctx); err != nil {
 			logger.Error(err, "Do not notify watchdog this iteration as the kubelet is reportedly not healthy")
 			return
 		}
 
-		err := wait.ExponentialBackoffWithContext(ctx, hc.retryBackoff, func(_ context.Context) (bool, error) {
-			ack, err := hc.watchdog.SdNotify(false)
-			if err != nil {
-				logger.Error(err, "Failed to notify systemd watchdog, retrying")
-				return false, nil
-			}
-			if !ack {
-				return false, fmt.Errorf("failed to notify systemd watchdog, notification not supported - (i.e. NOTIFY_SOCKET is unset)")
-			}
+		timeout := hc.getTimeout()
 
-			logger.V(5).Info("Watchdog plugin notified", "acknowledgment", ack, "state", daemon.SdNotifyWatchdog)
-			return true, nil
+		err := wait.ExponentialBackoffWithContext(ctx, hc.retryBackoff, func(ctx context.Context) (bool, error) {
+			type result struct {
+				ack bool
+				err error
+			}
+			resCh := make(chan result, 1)
+
+			go func() {
+				ack, err := hc.watchdog.SdNotify(false)
+				resCh <- result{ack, err}
+			}()
+
+			select {
+			case res := <-resCh:
+				if res.err != nil {
+					logger.Error(res.err, "Failed to notify systemd watchdog, retrying")
+					return false, nil
+				}
+				if !res.ack {
+					return false, fmt.Errorf("failed to notify systemd watchdog, notification not supported - (i.e. NOTIFY_SOCKET is unset)")
+				}
+
+				logger.V(5).Info("Watchdog plugin notified", "acknowledgment", res.ack, "state", daemon.SdNotifyWatchdog)
+				return true, nil
+			case <-time.After(timeout):
+				logger.Error(nil, "Systemd watchdog notification timed out", "timeout", timeout)
+				return false, nil // retry
+			case <-ctx.Done():
+				return false, ctx.Err()
+			}
 		})
 		if err != nil {
 			logger.Error(err, "Failed to notify watchdog")
@@ -164,11 +195,29 @@ func (hc *healthChecker) Start(ctx context.Context) {
 	}, hc.interval)
 }
 
-func (hc *healthChecker) doCheck() error {
-	for _, hc := range hc.getHealthCheckers() {
-		if err := hc.Check(context.TODO()); err != nil {
-			return fmt.Errorf("checker %s failed: %w", hc.Name(), err)
+func (hc *healthChecker) doCheck(ctx context.Context) error {
+	timeout := hc.getTimeout()
+	for _, checker := range hc.getHealthCheckers() {
+		if err := hc.runCheckerWithTimeout(ctx, checker, timeout); err != nil {
+			return fmt.Errorf("checker %s failed: %w", checker.Name(), err)
 		}
 	}
 	return nil
+}
+
+func (hc *healthChecker) runCheckerWithTimeout(ctx context.Context, checker healthz.HealthChecker, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- checker.Check(ctx)
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }

--- a/pkg/kubelet/watchdog/watchdog_linux_test.go
+++ b/pkg/kubelet/watchdog/watchdog_linux_test.go
@@ -36,19 +36,28 @@ func init() {
 
 // Mock syncLoopHealthChecker
 type mockSyncLoopHealthChecker struct {
-	healthCheckErr error
+	healthCheckErr   error
+	healthCheckDelay time.Duration
 }
 
 func (m *mockSyncLoopHealthChecker) SyncLoopHealthCheck(ctx context.Context) error {
+	if m.healthCheckDelay > 0 {
+		select {
+		case <-time.After(m.healthCheckDelay):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 	return m.healthCheckErr
 }
 
 // Mock WatchdogClient
 type mockWatchdogClient struct {
-	enabledVal time.Duration
-	enabledErr error
-	notifyAck  bool
-	notifyErr  error
+	enabledVal  time.Duration
+	enabledErr  error
+	notifyAck   bool
+	notifyErr   error
+	notifyDelay time.Duration
 }
 
 func (m *mockWatchdogClient) SdWatchdogEnabled(unsetEnvironment bool) (time.Duration, error) {
@@ -56,6 +65,9 @@ func (m *mockWatchdogClient) SdWatchdogEnabled(unsetEnvironment bool) (time.Dura
 }
 
 func (m *mockWatchdogClient) SdNotify(unsetEnvironment bool) (bool, error) {
+	if m.notifyDelay > 0 {
+		time.Sleep(m.notifyDelay)
+	}
 	return m.notifyAck, m.notifyErr
 }
 
@@ -98,13 +110,15 @@ func TestNewHealthChecker(t *testing.T) {
 func TestHealthCheckerStart(t *testing.T) {
 	// Test cases
 	tests := []struct {
-		name           string
-		enabledVal     time.Duration
-		noCheckers     bool
-		healthCheckErr error
-		notifyAck      bool
-		notifyErr      error
-		expectedLogs   []string
+		name             string
+		enabledVal       time.Duration
+		noCheckers       bool
+		healthCheckErr   error
+		healthCheckDelay time.Duration
+		notifyAck        bool
+		notifyErr        error
+		notifyDelay      time.Duration
+		expectedLogs     []string
 	}{
 		{
 			name:           "Watchdog enabled and notify succeeds",
@@ -147,6 +161,27 @@ func TestHealthCheckerStart(t *testing.T) {
 			expectedLogs: []string{
 				"Starting systemd watchdog with interval", "Watchdog plugin notified"},
 		},
+		{
+			name:             "Watchdog enabled and health check times out",
+			enabledVal:       interval,
+			healthCheckErr:   nil,
+			healthCheckDelay: 2 * time.Second, // hc.interval/2 is 1s, so this will time out
+			notifyAck:        true,
+			notifyErr:        nil,
+			expectedLogs:     []string{"Starting systemd watchdog with interval", "Do not notify watchdog this iteration as the kubelet is reportedly not healthy", "context deadline exceeded"},
+		},
+		{
+			name:        "Watchdog enabled and SdNotify times out",
+			enabledVal:  interval,
+			notifyAck:   true,
+			notifyErr:   nil,
+			notifyDelay: 2 * time.Second, // hc.interval/2 is 1s, so this will time out
+			expectedLogs: []string{
+				"Starting systemd watchdog with interval",
+				"Systemd watchdog notification timed out",
+				"Failed to notify watchdog",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -159,9 +194,10 @@ func TestHealthCheckerStart(t *testing.T) {
 
 			// Mock SdWatchdogEnabled to return a valid value
 			mockClient := &mockWatchdogClient{
-				enabledVal: tt.enabledVal,
-				notifyAck:  tt.notifyAck,
-				notifyErr:  tt.notifyErr,
+				enabledVal:  tt.enabledVal,
+				notifyAck:   tt.notifyAck,
+				notifyErr:   tt.notifyErr,
+				notifyDelay: tt.notifyDelay,
 			}
 
 			// Create a healthChecker
@@ -170,7 +206,10 @@ func TestHealthCheckerStart(t *testing.T) {
 				t.Fatalf("NewHealthChecker() failed: %v", err)
 			}
 			if !tt.noCheckers {
-				hc.SetHealthCheckers(&mockSyncLoopHealthChecker{healthCheckErr: tt.healthCheckErr}, nil)
+				hc.SetHealthCheckers(&mockSyncLoopHealthChecker{
+					healthCheckErr:   tt.healthCheckErr,
+					healthCheckDelay: tt.healthCheckDelay,
+				}, nil)
 			}
 
 			// Start the health checker

--- a/pkg/kubelet/watchdog/watchdog_linux_test.go
+++ b/pkg/kubelet/watchdog/watchdog_linux_test.go
@@ -19,8 +19,8 @@ limitations under the License.
 package watchdog
 
 import (
+	"context"
 	"errors"
-	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -39,7 +39,7 @@ type mockSyncLoopHealthChecker struct {
 	healthCheckErr error
 }
 
-func (m *mockSyncLoopHealthChecker) SyncLoopHealthCheck(req *http.Request) error {
+func (m *mockSyncLoopHealthChecker) SyncLoopHealthCheck(ctx context.Context) error {
 	return m.healthCheckErr
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"sync"
@@ -159,9 +160,9 @@ func (c delayedLivezCheck) Name() string {
 	return c.check.Name()
 }
 
-func (c delayedLivezCheck) Check(req *http.Request) error {
+func (c delayedLivezCheck) Check(ctx context.Context) error {
 	if c.clock.Now().After(c.startCheck) {
-		return c.check.Check(req)
+		return c.check.Check(ctx)
 	}
 	return nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
@@ -40,7 +40,7 @@ const DefaultHealthzPath = "/healthz"
 // HealthChecker is a named healthz checker.
 type HealthChecker interface {
 	Name() string
-	Check(req *http.Request) error
+	Check(ctx context.Context) error
 }
 
 type GroupedHealthChecker interface {
@@ -59,7 +59,7 @@ func (ping) Name() string {
 }
 
 // PingHealthz is a health check that returns true.
-func (ping) Check(_ *http.Request) error {
+func (ping) Check(_ context.Context) error {
 	return nil
 }
 
@@ -75,7 +75,7 @@ func (l *log) Name() string {
 	return "log"
 }
 
-func (l *log) Check(_ *http.Request) error {
+func (l *log) Check(_ context.Context) error {
 	l.startOnce.Do(func() {
 		l.lastVerified.Store(time.Now())
 		go wait.Forever(func() {
@@ -126,7 +126,7 @@ func (s *shutdown) Name() string {
 	return "shutdown"
 }
 
-func (s *shutdown) Check(req *http.Request) error {
+func (s *shutdown) Check(_ context.Context) error {
 	select {
 	case <-s.stopCh:
 		return fmt.Errorf("process is shutting down")
@@ -135,7 +135,7 @@ func (s *shutdown) Check(req *http.Request) error {
 	return nil
 }
 
-func (i *informerSync) Check(_ *http.Request) error {
+func (i *informerSync) Check(_ context.Context) error {
 	stopCh := make(chan struct{})
 	// Close stopCh to force checking if informers are synced now.
 	close(stopCh)
@@ -152,12 +152,12 @@ func (i *informerSync) Check(_ *http.Request) error {
 }
 
 // NamedCheck returns a healthz checker for the given name and function.
-func NamedCheck(name string, check func(r *http.Request) error) HealthChecker {
+func NamedCheck(name string, check func(ctx context.Context) error) HealthChecker {
 	return &healthzCheck{name, check}
 }
 
 // NamedGroupedCheck returns a healthz checker for the given name and function.
-func NamedGroupedCheck(name string, groupName string, check func(r *http.Request) error) HealthChecker {
+func NamedGroupedCheck(name string, groupName string, check func(ctx context.Context) error) HealthChecker {
 	return &groupedHealthzCheck{
 		groupName:     groupName,
 		HealthChecker: &healthzCheck{name, check},
@@ -232,7 +232,7 @@ type mux interface {
 // healthzCheck implements HealthChecker on an arbitrary name and check function.
 type healthzCheck struct {
 	name  string
-	check func(r *http.Request) error
+	check func(ctx context.Context) error
 }
 
 var _ HealthChecker = &healthzCheck{}
@@ -241,8 +241,8 @@ func (c *healthzCheck) Name() string {
 	return c.name
 }
 
-func (c *healthzCheck) Check(r *http.Request) error {
-	return c.check(r)
+func (c *healthzCheck) Check(ctx context.Context) error {
+	return c.check(ctx)
 }
 
 type groupedHealthzCheck struct {
@@ -288,7 +288,7 @@ func handleRootHealth(name string, firstTimeHealthy func(), checks ...HealthChec
 				fmt.Fprintf(&individualCheckOutput, "[+]%s excluded with %s: ok\n", check.Name(), check.GroupName())
 				continue
 			}
-			if err := check.Check(r); err != nil {
+			if err := check.Check(r.Context()); err != nil {
 				slis.ObserveHealthcheck(context.Background(), check.Name(), name, slis.Error)
 				// don't include the error since this endpoint is public.  If someone wants more detail
 				// they should have explicit permission to the detailed checks.
@@ -332,9 +332,9 @@ func handleRootHealth(name string, firstTimeHealthy func(), checks ...HealthChec
 }
 
 // adaptCheckToHandler returns an http.HandlerFunc that serves the provided checks.
-func adaptCheckToHandler(c func(r *http.Request) error) http.HandlerFunc {
+func adaptCheckToHandler(c func(ctx context.Context) error) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := c(r)
+		err := c(r.Context())
 		if err != nil {
 			http.Error(w, fmt.Sprintf("internal server error: %v", err), http.StatusInternalServerError)
 		} else {

--- a/staging/src/k8s.io/apiserver/pkg/server/hooks.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/hooks.go
@@ -235,7 +235,7 @@ func (h postStartHookHealthz) Name() string {
 
 var errHookNotFinished = errors.New("not finished")
 
-func (h postStartHookHealthz) Check(req *http.Request) error {
+func (h postStartHookHealthz) Check(ctx context.Context) error {
 	select {
 	case <-h.done:
 		return nil

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
@@ -178,12 +178,12 @@ func (k kmsHealthChecker) Name() string {
 	return kmsReloadHealthCheckName
 }
 
-func (k kmsHealthChecker) Check(req *http.Request) error {
+func (k kmsHealthChecker) Check(ctx context.Context) error {
 	var errs []error
 
 	for i := range k {
 		checker := k[i]
-		if err := checker.Check(req); err != nil {
+		if err := checker.Check(ctx); err != nil {
 			errs = append(errs, fmt.Errorf("%s: %w", checker.Name(), err))
 		}
 	}
@@ -192,14 +192,14 @@ func (k kmsHealthChecker) Check(req *http.Request) error {
 }
 
 func (h *kmsPluginProbe) toHealthzCheck(idx int) healthz.HealthChecker {
-	return healthz.NamedCheck(fmt.Sprintf("kms-provider-%d", idx), func(r *http.Request) error {
+	return healthz.NamedCheck(fmt.Sprintf("kms-provider-%d", idx), func(ctx context.Context) error {
 		return h.check()
 	})
 }
 
 func (h *kmsv2PluginProbe) toHealthzCheck(idx int) healthz.HealthChecker {
-	return healthz.NamedCheck(fmt.Sprintf("kms-provider-%d", idx), func(r *http.Request) error {
-		return h.check(r.Context())
+	return healthz.NamedCheck(fmt.Sprintf("kms-provider-%d", idx), func(ctx context.Context) error {
+		return h.check(ctx)
 	})
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -423,7 +423,7 @@ func (s *EtcdOptions) addEtcdHealthEndpoint(c *server.Config) error {
 	if err != nil {
 		return err
 	}
-	c.AddHealthChecks(healthz.NamedGroupedCheck("etcd", "etcd", func(r *http.Request) error {
+	c.AddHealthChecks(healthz.NamedGroupedCheck("etcd", "etcd", func(_ context.Context) error {
 		return healthCheck()
 	}))
 
@@ -431,7 +431,7 @@ func (s *EtcdOptions) addEtcdHealthEndpoint(c *server.Config) error {
 	if err != nil {
 		return err
 	}
-	c.AddReadyzChecks(healthz.NamedGroupedCheck("etcd-readiness", "etcd-readiness", func(r *http.Request) error {
+	c.AddReadyzChecks(healthz.NamedGroupedCheck("etcd-readiness", "etcd-readiness", func(_ context.Context) error {
 		return readyCheck()
 	}))
 
@@ -463,7 +463,7 @@ func (s *EtcdOptions) addEtcdHealthEndpoint(c *server.Config) error {
 			if err != nil {
 				return err
 			}
-			c.AddHealthChecks(healthz.NamedGroupedCheck(fmt.Sprintf("etcd-override-%d", len(serversSets)-1), "etcd", func(r *http.Request) error {
+			c.AddHealthChecks(healthz.NamedGroupedCheck(fmt.Sprintf("etcd-override-%d", len(serversSets)-1), "etcd", func(_ context.Context) error {
 				return healthCheck()
 			}))
 
@@ -471,7 +471,7 @@ func (s *EtcdOptions) addEtcdHealthEndpoint(c *server.Config) error {
 			if err != nil {
 				return err
 			}
-			c.AddReadyzChecks(healthz.NamedGroupedCheck(fmt.Sprintf("etcd-override-readiness-%d", len(serversSets)-1), "etcd-readiness", func(r *http.Request) error {
+			c.AddReadyzChecks(healthz.NamedGroupedCheck(fmt.Sprintf("etcd-override-readiness-%d", len(serversSets)-1), "etcd-readiness", func(_ context.Context) error {
 				return readyCheck()
 			}))
 		}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving_with_loopback.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving_with_loopback.go
@@ -17,8 +17,8 @@ limitations under the License.
 package options
 
 import (
+	"context"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/google/uuid"
@@ -118,7 +118,7 @@ func (s *SecureServingOptionsWithLoopback) ApplyToConfig(cfg *server.Config) err
 // liveness probes to be used to automatically restart the apiserver.
 func (s *SecureServingOptionsWithLoopback) addLoopbackServingCertificateHealthCheck(healthCheckAdder HealthzLivezHealthChecksAdder) {
 	expirationDate := s.clock.Now().Add(maxAge)
-	check := healthz.NamedCheck("loopback-serving-certificate", func(r *http.Request) error {
+	check := healthz.NamedCheck("loopback-serving-certificate", func(_ context.Context) error {
 		if s.clock.Now().After(expirationDate) {
 			return LoopbackCertificateExpiredError{}
 		}

--- a/staging/src/k8s.io/client-go/tools/leaderelection/healthzadaptor.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/healthzadaptor.go
@@ -17,7 +17,7 @@ limitations under the License.
 package leaderelection
 
 import (
-	"net/http"
+	"context"
 	"sync"
 	"time"
 )
@@ -42,7 +42,7 @@ func (l *HealthzAdaptor) Name() string {
 
 // Check is called by the healthz endpoint handler.
 // It fails (returns an error) if we own the lease but had not been able to renew it.
-func (l *HealthzAdaptor) Check(req *http.Request) error {
+func (l *HealthzAdaptor) Check(ctx context.Context) error {
 	l.pointerLock.Lock()
 	defer l.pointerLock.Unlock()
 	if l.le == nil {

--- a/staging/src/k8s.io/controller-manager/pkg/healthz/handler_test.go
+++ b/staging/src/k8s.io/controller-manager/pkg/healthz/handler_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package healthz
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -28,7 +29,7 @@ import (
 )
 
 func TestMutableHealthzHandler(t *testing.T) {
-	badChecker := healthz.NamedCheck("bad", func(r *http.Request) error {
+	badChecker := healthz.NamedCheck("bad", func(_ context.Context) error {
 		return fmt.Errorf("bad")
 	})
 	for _, tc := range []struct {
@@ -141,7 +142,7 @@ func TestConcurrentChecks(t *testing.T) {
 	defer close(stopChan) // always close no matter passing or not
 	concurrentChan := make(chan interface{}, N)
 	var concurrentCount int32
-	pausingCheck := healthz.NamedCheck("pausing", func(r *http.Request) error {
+	pausingCheck := healthz.NamedCheck("pausing", func(_ context.Context) error {
 		atomic.AddInt32(&concurrentCount, 1)
 		concurrentChan <- nil
 		<-stopChan

--- a/staging/src/k8s.io/controller-manager/pkg/healthz/healthz.go
+++ b/staging/src/k8s.io/controller-manager/pkg/healthz/healthz.go
@@ -17,7 +17,7 @@ limitations under the License.
 package healthz
 
 import (
-	"net/http"
+	"context"
 
 	"k8s.io/apiserver/pkg/server/healthz"
 )
@@ -37,7 +37,7 @@ func NamedHealthChecker(name string, check UnnamedHealthChecker) healthz.HealthC
 // UnnamedHealthChecker is an unnamed healthz checker.
 // The name of the check can be set by the controller manager.
 type UnnamedHealthChecker interface {
-	Check(req *http.Request) error
+	Check(ctx context.Context) error
 }
 
 var _ UnnamedHealthChecker = (healthz.HealthChecker)(nil)

--- a/staging/src/k8s.io/controller-manager/pkg/healthz/healthz_test.go
+++ b/staging/src/k8s.io/controller-manager/pkg/healthz/healthz_test.go
@@ -17,8 +17,8 @@ limitations under the License.
 package healthz
 
 import (
+	"context"
 	"fmt"
-	"net/http"
 	"testing"
 )
 
@@ -26,7 +26,7 @@ type checkWithMessage struct {
 	message string
 }
 
-func (c *checkWithMessage) Check(_ *http.Request) error {
+func (c *checkWithMessage) Check(_ context.Context) error {
 	return fmt.Errorf("%s", c.message)
 }
 
@@ -35,7 +35,7 @@ func TestNamedHealthChecker(t *testing.T) {
 	if named.Name() != "foo" {
 		t.Errorf("expected: %v, got: %v", "foo", named.Name())
 	}
-	if err := named.Check(nil); err.Error() != "hello" {
+	if err := named.Check(context.Background()); err.Error() != "hello" {
 		t.Errorf("expected: %v, got: %v", "hello", err.Error())
 	}
 }


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Currently, when the systemd watchdog restarts the kubelet via SIGABRT due to a missed heartbeat, the logs fail to specify which health check timed out. To fix this visibility gap, this commit updates the kubelet health checks to use context timeouts. This allows specific health check failures to be correctly identified and logged before a restart occurs.

#### Which issue(s) this PR is related to:

Fixes #135449

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
