### PR TITLE
KEP-4222: Cbor encoder supports streaming for collection objects

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/cbor.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/cbor.go
@@ -68,8 +68,9 @@ type Serializer interface {
 var _ Serializer = &serializer{}
 
 type options struct {
-	strict    bool
-	transcode bool
+	strict                       bool
+	transcode                    bool
+	streamingCollectionsEncoding bool
 }
 
 type Option func(*options)
@@ -89,6 +90,13 @@ func Strict(s bool) Option {
 func Transcode(s bool) Option {
 	return func(opts *options) {
 		opts.transcode = s
+	}
+}
+
+// StreamingCollectionsEncoding is used for testing purposes only.
+func StreamingCollectionsEncoding(s bool) Option {
+	return func(opts *options) {
+		opts.streamingCollectionsEncoding = s
 	}
 }
 
@@ -114,6 +122,7 @@ func newSerializer(metaFactory metaFactory, creater runtime.ObjectCreater, typer
 		typer:       typer,
 	}
 	s.options.transcode = true
+	s.options.streamingCollectionsEncoding = true
 	for _, o := range options {
 		o(&s.options)
 	}
@@ -147,13 +156,23 @@ func (s *serializer) EncodeNondeterministic(obj runtime.Object, w io.Writer) err
 }
 
 func (s *serializer) encode(mode modes.EncMode, obj runtime.Object, w io.Writer) error {
+	if _, err := w.Write(selfDescribedCBOR); err != nil {
+		return err
+	}
+
+	if s.options.streamingCollectionsEncoding {
+		ok, err := streamEncodeCollections(obj, w, mode)
+		if err != nil {
+			return err
+		}
+		if ok {
+			return nil
+		}
+	}
+
 	var v interface{} = obj
 	if u, ok := obj.(runtime.Unstructured); ok {
 		v = u.UnstructuredContent()
-	}
-
-	if _, err := w.Write(selfDescribedCBOR); err != nil {
-		return err
 	}
 
 	return mode.MarshalTo(v, w)

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/collections.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/collections.go
@@ -64,6 +64,18 @@ func getListMeta(list runtime.Object) (metav1.TypeMeta, metav1.ListMeta, []inter
 	if listType.NumField() != 3 {
 		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf("expected ListType to have 3 fields")
 	}
+	// The streaming encoder reproduces the field names and layout implied by the
+	// json struct tags (kind, apiVersion, metadata, items). The CBOR encoder,
+	// however, gives a "cbor" struct tag precedence over "json", so a cbor tag on
+	// any of these fields could rename a key, change its options (e.g. keyasint),
+	// or un-inline the embedded TypeMeta -- diverging from the streamed output.
+	// Refuse to stream such a type and fall back to the general encoder, which
+	// honors the cbor tag correctly.
+	for i := 0; i < listType.NumField(); i++ {
+		if _, ok := listType.Field(i).Tag.Lookup("cbor"); ok {
+			return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf("expected list field %d to have no cbor tag", i)
+		}
+	}
 	// TypeMeta
 	typeMeta, ok := listValue.Field(0).Interface().(metav1.TypeMeta)
 	if !ok {
@@ -251,23 +263,28 @@ func encodeKeyValuePair(w io.Writer, key string, value interface{}, mode modes.E
 	return nil
 }
 
+// CBOR major type prefix bytes (the type in the high 3 bits, additional info
+// zeroed), following RFC 8949 Section 3.1.
+const (
+	cborTypeArray byte = 0x80 // major type 4
+	cborTypeMap   byte = 0xa0 // major type 5
+)
+
 // writeMapHead writes a CBOR map header for a map with n entries.
-// Uses major type 5 (0xa0 base), following RFC 8949 Section 3.1.
 func writeMapHead(w io.Writer, n int) error {
-	return writeCollectionHead(w, 0xa0, int64(n))
+	return writeCollectionHead(w, cborTypeMap, int64(n))
 }
 
 // writeArrayHead writes a CBOR array header for an array with n elements.
-// Uses major type 4 (0x80 base), following RFC 8949 Section 3.1.
 func writeArrayHead(w io.Writer, n int) error {
-	return writeCollectionHead(w, 0x80, int64(n))
+	return writeCollectionHead(w, cborTypeArray, int64(n))
 }
 
 // writeCollectionHead writes a CBOR collection (array or map) header encoding
 // the number of elements n, following RFC 8949 Section 3 additional info rules:
 //
 //   - base: the prefix byte for the collection type.
-//     For maps: 0xa0 (major type 5), for arrays: 0x80 (major type 4).
+//     For maps: cborTypeMap (0xa0), for arrays: cborTypeArray (0x80).
 //
 // The extended form prefixes are derived from base using bitwise OR:
 //   - base|24: 1-byte length follows (additional info 24)

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/collections.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/collections.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/klog/v2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -51,6 +52,7 @@ func streamEncodeCollections(obj runtime.Object, w io.Writer, mode modes.EncMode
 	if err == nil {
 		return true, streamingEncodeList(w, typeMeta, listMeta, items, mode)
 	}
+	klog.ErrorS(err, "getListMeta err", "obj", obj)
 	return false, nil
 }
 
@@ -69,8 +71,13 @@ func getListMeta(list runtime.Object) (metav1.TypeMeta, metav1.ListMeta, []runti
 	if !ok {
 		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf("expected TypeMeta field to have TypeMeta type")
 	}
-	if listType.Field(0).Tag.Get("json") != ",inline" {
-		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf(`expected TypeMeta json field tag to be ",inline"`)
+	if !listType.Field(0).Anonymous {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf(`expected TypeMeta json field tag to be embedded`)
+	}
+	if jsonTag, jsonTagExists := listType.Field(0).Tag.Lookup("json"); !jsonTagExists {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf(`expected TypeMeta json field tag`)
+	} else if jsonTag != "" && jsonTag != ",inline" {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf(`expected TypeMeta json field tag to be "" or ",inline"`)
 	}
 	// ListMeta
 	listMeta, ok := listValue.Field(1).Interface().(metav1.ListMeta)
@@ -222,13 +229,13 @@ func encodeKeyValuePair(w io.Writer, key string, value interface{}, mode modes.E
 // writeMapHead writes a CBOR map header for a map with n entries.
 // Uses major type 5 (0xa0 base), following RFC 8949 Section 3.1.
 func writeMapHead(w io.Writer, n int) error {
-	return writeCollectionHead(w, 0xa0, n)
+	return writeCollectionHead(w, 0xa0, int64(n))
 }
 
 // writeArrayHead writes a CBOR array header for an array with n elements.
 // Uses major type 4 (0x80 base), following RFC 8949 Section 3.1.
 func writeArrayHead(w io.Writer, n int) error {
-	return writeCollectionHead(w, 0x80, n)
+	return writeCollectionHead(w, 0x80, int64(n))
 }
 
 // writeCollectionHead writes a CBOR collection (array or map) header encoding
@@ -250,7 +257,7 @@ func writeArrayHead(w io.Writer, n int) error {
 //	n <= 0xFFFF:      3 bytes — 0xb9 (0xa0|25), n>>8, n
 //	n <= 0xFFFFFFFF:  5 bytes — 0xba (0xa0|26), n>>24..n
 //	n > 0xFFFFFFFF:   9 bytes — 0xbb (0xa0|27), n>>56..n
-func writeCollectionHead(w io.Writer, base byte, n int) error {
+func writeCollectionHead(w io.Writer, base byte, n int64) error {
 	switch {
 	case n <= 23:
 		// Additional info 0–23: length is encoded directly in the low 5 bits.

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/collections.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/collections.go
@@ -22,12 +22,11 @@ import (
 	"io"
 	"maps"
 	"math/rand"
+	"reflect"
 	"slices"
 	"sort"
 
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/conversion"
-	"k8s.io/klog/v2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -52,12 +51,11 @@ func streamEncodeCollections(obj runtime.Object, w io.Writer, mode modes.EncMode
 	if err == nil {
 		return true, streamingEncodeList(w, typeMeta, listMeta, items, mode)
 	}
-	klog.ErrorS(err, "getListMeta err", "obj", obj)
 	return false, nil
 }
 
 // getListMeta implements list extraction logic for cbor stream serialization.
-func getListMeta(list runtime.Object) (metav1.TypeMeta, metav1.ListMeta, []runtime.Object, error) {
+func getListMeta(list runtime.Object) (metav1.TypeMeta, metav1.ListMeta, []interface{}, error) {
 	listValue, err := conversion.EnforcePtr(list)
 	if err != nil {
 		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, err
@@ -88,14 +86,38 @@ func getListMeta(list runtime.Object) (metav1.TypeMeta, metav1.ListMeta, []runti
 		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf(`expected ListMeta json field tag to be "metadata,omitempty"`)
 	}
 	// Items
-	items, err := meta.ExtractList(list)
-	if err != nil {
-		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, err
-	}
 	if listType.Field(2).Tag.Get("json") != "items" {
 		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf(`expected Items json field tag to be "items"`)
 	}
+	items, err := getListItems(listValue.Field(2))
+	if err != nil {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, err
+	}
 	return typeMeta, listMeta, items, nil
+}
+
+// getListItems returns the elements of a list's Items field as addressable
+// values. Marshaling each element directly (rather than routing through
+// meta.ExtractList) preserves the element's own type and custom marshaler, so
+// that e.g. a metav1.List whose Items are runtime.RawExtension holding CBOR
+// bytes are encoded verbatim by runtime.RawExtension.MarshalCBOR instead of
+// being flattened into a runtime.Unknown (which has no MarshalCBOR and would be
+// misencoded as a struct or fail JSON transcoding).
+//
+// A nil Items slice returns a nil result, distinct from an empty non-nil slice,
+// so the encoder can emit CBOR null rather than an empty array.
+func getListItems(itemsValue reflect.Value) ([]interface{}, error) {
+	if itemsValue.Kind() != reflect.Slice {
+		return nil, fmt.Errorf("expected Items field to be a slice, got %s", itemsValue.Kind())
+	}
+	if itemsValue.IsNil() {
+		return nil, nil
+	}
+	items := make([]interface{}, itemsValue.Len())
+	for i := range items {
+		items[i] = itemsValue.Index(i).Addr().Interface()
+	}
+	return items, nil
 }
 
 type cborMapEntry struct {
@@ -103,7 +125,7 @@ type cborMapEntry struct {
 	write func() error
 }
 
-func streamingEncodeList(w io.Writer, typeMeta metav1.TypeMeta, listMeta metav1.ListMeta, items []runtime.Object, mode modes.EncMode) error {
+func streamingEncodeList(w io.Writer, typeMeta metav1.TypeMeta, listMeta metav1.ListMeta, items []interface{}, mode modes.EncMode) error {
 	var entries []cborMapEntry
 
 	if typeMeta.Kind != "" {
@@ -150,8 +172,11 @@ func streamingEncodeList(w io.Writer, typeMeta metav1.TypeMeta, listMeta metav1.
 		})
 	}
 
-	// For nondeterministic modes (SortFastShuffle), randomize the initial offset
-	// of the encoding for-loop.
+	// entries is built in a fixed order (kind, items, metadata, apiVersion).
+	// Unlike streamingEncodeUnstructuredList, whose keys come in Go's randomized
+	// map-iteration order, there is no inherent randomness here, so for
+	// nondeterministic modes (SortFastShuffle) we rotate the encoding for-loop
+	// by a random initial offset.
 	start := 0
 	if !mode.IsDeterministic() && len(entries) > 0 {
 		start = rand.Intn(len(entries))
@@ -175,11 +200,12 @@ func streamingEncodeUnstructuredList(w io.Writer, list *unstructured.Unstructure
 	if _, exists := list.Object["items"]; !exists {
 		keys = append(keys, "items")
 	}
-	// Sort keys only for deterministic modes (SortBytewiseLexical):
-	// shorter lengths come first, then lexicographic by content.
-	// For nondeterministic modes (SortFastShuffle), randomize the initial offset
-	// of the encoding for-loop (essentially what SortFastShuffle does for structs).
-	start := 0
+	// keys starts in Go's randomized map-iteration order. For deterministic
+	// modes (SortBytewiseLexical) we sort it: shorter lengths come first, then
+	// lexicographic by content. For nondeterministic modes (SortFastShuffle) we
+	// leave the map-iteration order as-is, which already varies from call to
+	// call (analogous to what SortFastShuffle does for structs), so no explicit
+	// shuffling is needed.
 	if mode.IsDeterministic() {
 		sort.Slice(keys, func(i, j int) bool {
 			if len(keys[i]) != len(keys[j]) {
@@ -193,8 +219,7 @@ func streamingEncodeUnstructuredList(w io.Writer, list *unstructured.Unstructure
 		return err
 	}
 
-	for i := 0; i < len(keys); i++ {
-		key := keys[(start+i)%len(keys)]
+	for _, key := range keys {
 		if err := mode.MarshalTo(key, w); err != nil {
 			return err
 		}
@@ -284,3 +309,4 @@ func writeCollectionHead(w io.Writer, base byte, n int64) error {
 		return err
 	}
 }
+

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/collections.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/collections.go
@@ -117,7 +117,7 @@ func streamingEncodeList(w io.Writer, typeMeta metav1.TypeMeta, listMeta metav1.
 				_, err := w.Write([]byte{0xf6}) // CBOR null
 				return err
 			}
-			if err := writeArrayHeader(w, len(items)); err != nil {
+			if err := writeArrayHead(w, len(items)); err != nil {
 				return err
 			}
 			for _, item := range items {
@@ -180,8 +180,6 @@ func streamingEncodeUnstructuredList(w io.Writer, list *unstructured.Unstructure
 			}
 			return keys[i] < keys[j]
 		})
-	} else if len(keys) > 0 {
-		start = rand.Intn(len(keys)) //nolint:gosec // Don't need a CSPRNG for deck cutting.
 	}
 
 	if err := writeMapHead(w, len(keys)); err != nil {
@@ -194,7 +192,7 @@ func streamingEncodeUnstructuredList(w io.Writer, list *unstructured.Unstructure
 			return err
 		}
 		if key == "items" {
-			if err := writeArrayHeader(w, len(list.Items)); err != nil {
+			if err := writeArrayHead(w, len(list.Items)); err != nil {
 				return err
 			}
 			for _, item := range list.Items {
@@ -221,35 +219,38 @@ func encodeKeyValuePair(w io.Writer, key string, value interface{}, mode modes.E
 	return nil
 }
 
-// writeMapHeader writes a CBOR map header for a map with n entries.
+// writeMapHead writes a CBOR map header for a map with n entries.
 // Uses major type 5 (0xa0 base), following RFC 8949 Section 3.1.
 func writeMapHead(w io.Writer, n int) error {
-	return writeCollectionHead(w, 0xa0, 0xb8, n)
+	return writeCollectionHead(w, 0xa0, n)
 }
 
-// writeArrayHeader writes a CBOR array header for an array with n elements.
+// writeArrayHead writes a CBOR array header for an array with n elements.
 // Uses major type 4 (0x80 base), following RFC 8949 Section 3.1.
-func writeArrayHeader(w io.Writer, n int) error {
-	return writeCollectionHead(w, 0x80, 0x98, n)
+func writeArrayHead(w io.Writer, n int) error {
+	return writeCollectionHead(w, 0x80, n)
 }
 
-// writeCollectionHeader writes a CBOR collection (array or map) header encoding
+// writeCollectionHead writes a CBOR collection (array or map) header encoding
 // the number of elements n, following RFC 8949 Section 3 additional info rules:
 //
-//   - base: the single-byte prefix when n fits in the low 5 bits (n <= 23),
-//     e.g. 0xa0 for map, 0x80 for array.
-//   - ext: the prefix byte when n requires additional bytes (n > 23),
-//     e.g. 0xb8 for map, 0x98 for array. ext+0 means 1-byte length follows,
-//     ext+1 means 2-byte, ext+2 means 4-byte, ext+3 means 8-byte.
+//   - base: the prefix byte for the collection type.
+//     For maps: 0xa0 (major type 5), for arrays: 0x80 (major type 4).
 //
-// Encoding table (map example, base=0xa0, ext=0xb8):
+// The extended form prefixes are derived from base using bitwise OR:
+//   - base|24: 1-byte length follows (additional info 24)
+//   - base|25: 2-byte length follows (additional info 25)
+//   - base|26: 4-byte length follows (additional info 26)
+//   - base|27: 8-byte length follows (additional info 27)
+//
+// Encoding table (map example, base=0xa0):
 //
 //	n <= 23:         1 byte  — 0xa0|n
-//	n <= 0xFF:        2 bytes — 0xb8, n
-//	n <= 0xFFFF:      3 bytes — 0xb9, n>>8, n
-//	n <= 0xFFFFFFFF:  5 bytes — 0xba, n>>24..n
-//	n > 0xFFFFFFFF:   9 bytes — 0xbb, n>>56..n
-func writeCollectionHead(w io.Writer, base, ext byte, n int) error {
+//	n <= 0xFF:        2 bytes — 0xb8 (0xa0|24), n
+//	n <= 0xFFFF:      3 bytes — 0xb9 (0xa0|25), n>>8, n
+//	n <= 0xFFFFFFFF:  5 bytes — 0xba (0xa0|26), n>>24..n
+//	n > 0xFFFFFFFF:   9 bytes — 0xbb (0xa0|27), n>>56..n
+func writeCollectionHead(w io.Writer, base byte, n int) error {
 	switch {
 	case n <= 23:
 		// Additional info 0–23: length is encoded directly in the low 5 bits.
@@ -257,20 +258,20 @@ func writeCollectionHead(w io.Writer, base, ext byte, n int) error {
 		return err
 	case n <= 0xFF:
 		// Additional info 24: one additional byte carries the length.
-		_, err := w.Write([]byte{ext, byte(n)})
+		_, err := w.Write([]byte{base | 24, byte(n)})
 		return err
 	case n <= 0xFFFF:
 		// Additional info 25: two additional bytes carry the length (big-endian).
-		_, err := w.Write([]byte{ext + 1, byte(n >> 8), byte(n)})
+		_, err := w.Write([]byte{base | 25, byte(n >> 8), byte(n)})
 		return err
 	case n <= 0xFFFFFFFF:
 		// Additional info 26: four additional bytes carry the length (big-endian).
-		_, err := w.Write([]byte{ext + 2, byte(n >> 24), byte(n >> 16), byte(n >> 8), byte(n)})
+		_, err := w.Write([]byte{base | 26, byte(n >> 24), byte(n >> 16), byte(n >> 8), byte(n)})
 		return err
 	default:
 		// Additional info 27: eight additional bytes carry the length (big-endian).
 		_, err := w.Write([]byte{
-			ext + 3, byte(n >> 56), byte(n >> 48), byte(n >> 40), byte(n >> 32), byte(n >> 24), byte(n >> 16),
+			base | 27, byte(n >> 56), byte(n >> 48), byte(n >> 40), byte(n >> 32), byte(n >> 24), byte(n >> 16),
 			byte(n >> 8), byte(n),
 		})
 		return err

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/collections.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/collections.go
@@ -1,0 +1,278 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cbor
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"math/rand"
+	"slices"
+	"sort"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/conversion"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes"
+
+	"github.com/fxamacker/cbor/v2"
+)
+
+func streamEncodeCollections(obj runtime.Object, w io.Writer, mode modes.EncMode) (bool, error) {
+	list, ok := obj.(*unstructured.UnstructuredList)
+	if ok {
+		return true, streamingEncodeUnstructuredList(w, list, mode)
+	}
+	if _, ok := obj.(cbor.Marshaler); ok {
+		return false, nil
+	}
+	if _, ok := obj.(json.Marshaler); ok {
+		return false, nil
+	}
+	typeMeta, listMeta, items, err := getListMeta(obj)
+	if err == nil {
+		return true, streamingEncodeList(w, typeMeta, listMeta, items, mode)
+	}
+	return false, nil
+}
+
+// getListMeta implements list extraction logic for cbor stream serialization.
+func getListMeta(list runtime.Object) (metav1.TypeMeta, metav1.ListMeta, []runtime.Object, error) {
+	listValue, err := conversion.EnforcePtr(list)
+	if err != nil {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, err
+	}
+	listType := listValue.Type()
+	if listType.NumField() != 3 {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf("expected ListType to have 3 fields")
+	}
+	// TypeMeta
+	typeMeta, ok := listValue.Field(0).Interface().(metav1.TypeMeta)
+	if !ok {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf("expected TypeMeta field to have TypeMeta type")
+	}
+	if listType.Field(0).Tag.Get("json") != ",inline" {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf(`expected TypeMeta json field tag to be ",inline"`)
+	}
+	// ListMeta
+	listMeta, ok := listValue.Field(1).Interface().(metav1.ListMeta)
+	if !ok {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf("expected ListMeta field to have ListMeta type")
+	}
+	if listType.Field(1).Tag.Get("json") != "metadata,omitempty" {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf(`expected ListMeta json field tag to be "metadata,omitempty"`)
+	}
+	// Items
+	items, err := meta.ExtractList(list)
+	if err != nil {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, err
+	}
+	if listType.Field(2).Tag.Get("json") != "items" {
+		return metav1.TypeMeta{}, metav1.ListMeta{}, nil, fmt.Errorf(`expected Items json field tag to be "items"`)
+	}
+	return typeMeta, listMeta, items, nil
+}
+
+type cborMapEntry struct {
+	key   string
+	write func() error
+}
+
+func streamingEncodeList(w io.Writer, typeMeta metav1.TypeMeta, listMeta metav1.ListMeta, items []runtime.Object, mode modes.EncMode) error {
+	var entries []cborMapEntry
+
+	if typeMeta.Kind != "" {
+		entries = append(entries, cborMapEntry{
+			key: "kind",
+			write: func() error {
+				return encodeKeyValuePair(w, "kind", typeMeta.Kind, mode)
+			},
+		})
+	}
+	entries = append(entries, cborMapEntry{
+		key: "items",
+		write: func() error {
+			if err := mode.MarshalTo("items", w); err != nil {
+				return err
+			}
+			if items == nil {
+				_, err := w.Write([]byte{0xf6}) // CBOR null
+				return err
+			}
+			if err := writeArrayHeader(w, len(items)); err != nil {
+				return err
+			}
+			for _, item := range items {
+				if err := mode.MarshalTo(item, w); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	})
+	entries = append(entries, cborMapEntry{
+		key: "metadata",
+		write: func() error {
+			return encodeKeyValuePair(w, "metadata", listMeta, mode)
+		},
+	})
+	if typeMeta.APIVersion != "" {
+		entries = append(entries, cborMapEntry{
+			key: "apiVersion",
+			write: func() error {
+				return encodeKeyValuePair(w, "apiVersion", typeMeta.APIVersion, mode)
+			},
+		})
+	}
+
+	// For nondeterministic modes (SortFastShuffle), randomize the initial offset
+	// of the encoding for-loop.
+	start := 0
+	if !mode.IsDeterministic() && len(entries) > 0 {
+		start = rand.Intn(len(entries))
+	}
+
+	if err := writeMapHead(w, len(entries)); err != nil {
+		return err
+	}
+
+	for i := 0; i < len(entries); i++ {
+		entry := entries[(start+i)%len(entries)]
+		if err := entry.write(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func streamingEncodeUnstructuredList(w io.Writer, list *unstructured.UnstructuredList, mode modes.EncMode) error {
+	keys := slices.Collect(maps.Keys(list.Object))
+	if _, exists := list.Object["items"]; !exists {
+		keys = append(keys, "items")
+	}
+	// Sort keys only for deterministic modes (SortBytewiseLexical):
+	// shorter lengths come first, then lexicographic by content.
+	// For nondeterministic modes (SortFastShuffle), randomize the initial offset
+	// of the encoding for-loop (essentially what SortFastShuffle does for structs).
+	start := 0
+	if mode.IsDeterministic() {
+		sort.Slice(keys, func(i, j int) bool {
+			if len(keys[i]) != len(keys[j]) {
+				return len(keys[i]) < len(keys[j])
+			}
+			return keys[i] < keys[j]
+		})
+	} else if len(keys) > 0 {
+		start = rand.Intn(len(keys)) //nolint:gosec // Don't need a CSPRNG for deck cutting.
+	}
+
+	if err := writeMapHead(w, len(keys)); err != nil {
+		return err
+	}
+
+	for i := 0; i < len(keys); i++ {
+		key := keys[(start+i)%len(keys)]
+		if err := mode.MarshalTo(key, w); err != nil {
+			return err
+		}
+		if key == "items" {
+			if err := writeArrayHeader(w, len(list.Items)); err != nil {
+				return err
+			}
+			for _, item := range list.Items {
+				if err := mode.MarshalTo(item.Object, w); err != nil {
+					return err
+				}
+			}
+		} else {
+			if err := mode.MarshalTo(list.Object[key], w); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func encodeKeyValuePair(w io.Writer, key string, value interface{}, mode modes.EncMode) error {
+	if err := mode.MarshalTo(key, w); err != nil {
+		return err
+	}
+	if err := mode.MarshalTo(value, w); err != nil {
+		return err
+	}
+	return nil
+}
+
+// writeMapHeader writes a CBOR map header for a map with n entries.
+// Uses major type 5 (0xa0 base), following RFC 8949 Section 3.1.
+func writeMapHead(w io.Writer, n int) error {
+	return writeCollectionHead(w, 0xa0, 0xb8, n)
+}
+
+// writeArrayHeader writes a CBOR array header for an array with n elements.
+// Uses major type 4 (0x80 base), following RFC 8949 Section 3.1.
+func writeArrayHeader(w io.Writer, n int) error {
+	return writeCollectionHead(w, 0x80, 0x98, n)
+}
+
+// writeCollectionHeader writes a CBOR collection (array or map) header encoding
+// the number of elements n, following RFC 8949 Section 3 additional info rules:
+//
+//   - base: the single-byte prefix when n fits in the low 5 bits (n <= 23),
+//     e.g. 0xa0 for map, 0x80 for array.
+//   - ext: the prefix byte when n requires additional bytes (n > 23),
+//     e.g. 0xb8 for map, 0x98 for array. ext+0 means 1-byte length follows,
+//     ext+1 means 2-byte, ext+2 means 4-byte, ext+3 means 8-byte.
+//
+// Encoding table (map example, base=0xa0, ext=0xb8):
+//
+//	n <= 23:         1 byte  — 0xa0|n
+//	n <= 0xFF:        2 bytes — 0xb8, n
+//	n <= 0xFFFF:      3 bytes — 0xb9, n>>8, n
+//	n <= 0xFFFFFFFF:  5 bytes — 0xba, n>>24..n
+//	n > 0xFFFFFFFF:   9 bytes — 0xbb, n>>56..n
+func writeCollectionHead(w io.Writer, base, ext byte, n int) error {
+	switch {
+	case n <= 23:
+		// Additional info 0–23: length is encoded directly in the low 5 bits.
+		_, err := w.Write([]byte{base + byte(n)})
+		return err
+	case n <= 0xFF:
+		// Additional info 24: one additional byte carries the length.
+		_, err := w.Write([]byte{ext, byte(n)})
+		return err
+	case n <= 0xFFFF:
+		// Additional info 25: two additional bytes carry the length (big-endian).
+		_, err := w.Write([]byte{ext + 1, byte(n >> 8), byte(n)})
+		return err
+	case n <= 0xFFFFFFFF:
+		// Additional info 26: four additional bytes carry the length (big-endian).
+		_, err := w.Write([]byte{ext + 2, byte(n >> 24), byte(n >> 16), byte(n >> 8), byte(n)})
+		return err
+	default:
+		// Additional info 27: eight additional bytes carry the length (big-endian).
+		_, err := w.Write([]byte{
+			ext + 3, byte(n >> 56), byte(n >> 48), byte(n >> 40), byte(n >> 32), byte(n >> 24), byte(n >> 16),
+			byte(n >> 8), byte(n),
+		})
+		return err
+	}
+}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/collections.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/collections.go
@@ -326,4 +326,3 @@ func writeCollectionHead(w io.Writer, base byte, n int64) error {
 		return err
 	}
 }
-

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/collections_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/collections_test.go
@@ -894,6 +894,117 @@ func TestFuzzCollectionsEncoding(t *testing.T) {
 	}
 }
 
+// mustCBORSelfDescribed encodes v to CBOR and prepends the self-described CBOR
+// tag (0xd9d9f7), matching how runtime.RawExtension stores CBOR-content bytes.
+func mustCBORSelfDescribed(t *testing.T, v interface{}) []byte {
+	t.Helper()
+	data, err := modes.Encode.Marshal(v)
+	if err != nil {
+		t.Fatalf("failed to marshal %#v to CBOR: %v", v, err)
+	}
+	return append([]byte{0xd9, 0xd9, 0xf7}, data...)
+}
+
+// TestStreamEncodeListRawExtension is a regression test for streaming encoding of
+// a metav1.List whose Items are runtime.RawExtension. Streaming encoding must be
+// byte-identical to non-streaming encoding, and must round-trip.
+//
+// Previously the streaming path routed items through meta.ExtractList, which
+// flattens a RawExtension holding raw bytes into a runtime.Unknown (dropping its
+// content type). runtime.Unknown implements MarshalJSON but not MarshalCBOR, so
+// CBOR-content bytes were either misencoded as a struct or, worse, failed while
+// the encoder attempted to transcode them from JSON. The streaming path now
+// marshals each RawExtension directly, honoring runtime.RawExtension.MarshalCBOR.
+func TestStreamEncodeListRawExtension(t *testing.T) {
+	streamingSerializer := NewSerializer(nil, nil)
+	normalSerializer := NewSerializer(nil, nil, StreamingCollectionsEncoding(false))
+
+	for _, tc := range []struct {
+		name string
+		// nonEmpty indicates Items encodes as a non-empty array (should stream).
+		nonEmpty bool
+		// roundTrips indicates decoding the output reproduces the input exactly.
+		// Only holds for CBOR-content RawExtension: decoding normalizes JSON bytes
+		// and populated Objects into CBOR Raw bytes.
+		roundTrips bool
+		items      []runtime.RawExtension
+	}{
+		{
+			name:       "RawExtension with CBOR bytes",
+			nonEmpty:   true,
+			roundTrips: true,
+			items: []runtime.RawExtension{
+				{Raw: mustCBORSelfDescribed(t, map[string]interface{}{"foo": "bar"})},
+				{Raw: mustCBORSelfDescribed(t, map[string]interface{}{"baz": int64(1)})},
+			},
+		},
+		{
+			name:     "RawExtension with JSON bytes",
+			nonEmpty: true,
+			items: []runtime.RawExtension{
+				{Raw: []byte(`{"foo":"bar"}`)},
+			},
+		},
+		{
+			name:     "RawExtension with Object",
+			nonEmpty: true,
+			items: []runtime.RawExtension{
+				{Object: &testapigroupv1.Carp{ObjectMeta: metav1.ObjectMeta{Name: "carp"}}},
+			},
+		},
+		{
+			name:  "RawExtension items empty",
+			items: []runtime.RawExtension{},
+		},
+		{
+			name:  "RawExtension items nil",
+			items: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			in := &metav1.List{
+				TypeMeta: metav1.TypeMeta{Kind: "List", APIVersion: "v1"},
+				ListMeta: metav1.ListMeta{ResourceVersion: "42"},
+				Items:    tc.items,
+			}
+
+			var streamingBuf writeCountingBuffer
+			if err := streamingSerializer.Encode(in, &streamingBuf); err != nil {
+				t.Fatalf("streaming encode error: %v", err)
+			}
+
+			var normalBuf bytes.Buffer
+			if err := normalSerializer.Encode(in, &normalBuf); err != nil {
+				t.Fatalf("normal encode error: %v", err)
+			}
+
+			if diff := cmp.Diff(normalBuf.Bytes(), streamingBuf.Bytes()); diff != "" {
+				t.Logf("normal:    %x", normalBuf.Bytes())
+				t.Logf("streaming: %x", streamingBuf.Bytes())
+				t.Errorf("streaming output differs from normal encoding:\n%s", diff)
+			}
+
+			// Non-empty lists should exercise the streaming path (more than the
+			// map-head + items-key writes).
+			if tc.nonEmpty && streamingBuf.writeCount <= 2 {
+				t.Errorf("expected streaming encoding to use more than 2 writes, got %d", streamingBuf.writeCount)
+			}
+
+			// Round-trip: decoding the streamed bytes must reproduce the input
+			// for CBOR-content items (see roundTrips doc above).
+			if tc.roundTrips {
+				out := &metav1.List{}
+				if err := modes.Decode.Unmarshal(streamingBuf.Bytes(), out); err != nil {
+					t.Fatalf("decode error: %v", err)
+				}
+				if !apiequality.Semantic.DeepEqual(in, out) {
+					t.Errorf("round-trip mismatch:\n%s", cmp.Diff(in, out))
+				}
+			}
+		})
+	}
+}
+
 // TestStreamEncodeCollectionsDeterministic verifies that the streaming serializer
 // produces output identical to the normal non-streaming serializer.
 func TestStreamEncodeCollectionsDeterministic(t *testing.T) {
@@ -1073,3 +1184,4 @@ func TestStreamEncodeCollectionsNondeterministic(t *testing.T) {
 		})
 	}
 }
+

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/collections_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/collections_test.go
@@ -1215,3 +1215,102 @@ func TestStreamEncodeCollectionsNondeterministic(t *testing.T) {
 	}
 }
 
+// TestCollectionHeadMatchesLibrary verifies that writeArrayHead and writeMapHead
+// produce byte-identical output to the fxamacker/cbor library's own head encoding
+// at every length-encoding width boundary (and its neighbors) reachable by
+// allocating a real collection. The library encodes an n-element array/map with a
+// leading definite-length head, so our streamed head must equal that prefix.
+//
+// The reachable sizes exercise the 1-, 2-, 3-, and 5-byte argument forms (the last
+// at n=65536). The 8-byte form (n > 2^32) cannot be produced by allocation and is
+// covered against explicit RFC 8949 bytes by TestWriteCollectionHeadBoundaries.
+func TestCollectionHeadMatchesLibrary(t *testing.T) {
+	// Width-class boundaries and neighbors:
+	//   n <= 23           -> 1-byte head
+	//   24    <= n <= 255 -> 2-byte head
+	//   256   <= n <= 65535 -> 3-byte head
+	//   65536 <= n        -> 5-byte head
+	sizes := []int{0, 1, 23, 24, 25, 255, 256, 257, 65535, 65536, 65537}
+
+	assertPrefix := func(t *testing.T, kind string, n int, head, lib []byte) {
+		t.Helper()
+		end := min(len(head), len(lib))
+		if !bytes.Equal(head, lib[:end]) {
+			t.Errorf("%s head mismatch for n=%d:\n  ours:    % x\n  library: % x", kind, n, head, lib[:min(len(lib), len(head)+4)])
+		}
+	}
+
+	for _, n := range sizes {
+		t.Run(fmt.Sprintf("array/%d", n), func(t *testing.T) {
+			var head bytes.Buffer
+			if err := writeArrayHead(&head, n); err != nil {
+				t.Fatalf("writeArrayHead(%d): %v", n, err)
+			}
+			lib, err := modes.Encode.Marshal(make([]bool, n))
+			if err != nil {
+				t.Fatalf("library marshal []bool len %d: %v", n, err)
+			}
+			assertPrefix(t, "array", n, head.Bytes(), lib)
+		})
+		t.Run(fmt.Sprintf("map/%d", n), func(t *testing.T) {
+			var head bytes.Buffer
+			if err := writeMapHead(&head, n); err != nil {
+				t.Fatalf("writeMapHead(%d): %v", n, err)
+			}
+			m := make(map[int64]bool, n)
+			for i := range n {
+				m[int64(i)] = false
+			}
+			lib, err := modes.Encode.Marshal(m)
+			if err != nil {
+				t.Fatalf("library marshal map len %d: %v", n, err)
+			}
+			assertPrefix(t, "map", n, head.Bytes(), lib)
+		})
+	}
+}
+
+// TestWriteCollectionHeadBoundaries checks writeCollectionHead against explicit
+// RFC 8949 Section 3 expected bytes at every additional-information width boundary
+// and its neighbors, for both the array (0x80) and map (0xa0) major types. Unlike
+// TestCollectionHeadMatchesLibrary, this calls writeCollectionHead directly, so it
+// can cover the 8-byte argument form (n > 2^32) that no allocatable collection can
+// reach.
+func TestWriteCollectionHeadBoundaries(t *testing.T) {
+	for _, tc := range []struct {
+		n     int64
+		array []byte
+		mp    []byte
+	}{
+		{n: 0, array: []byte{0x80}, mp: []byte{0xa0}},
+		{n: 1, array: []byte{0x81}, mp: []byte{0xa1}},
+		{n: 23, array: []byte{0x97}, mp: []byte{0xb7}},                                                                                                            // max 1-byte
+		{n: 24, array: []byte{0x98, 0x18}, mp: []byte{0xb8, 0x18}},                                                                                                // min 2-byte
+		{n: 255, array: []byte{0x98, 0xff}, mp: []byte{0xb8, 0xff}},                                                                                               // max 2-byte
+		{n: 256, array: []byte{0x99, 0x01, 0x00}, mp: []byte{0xb9, 0x01, 0x00}},                                                                                   // min 3-byte
+		{n: 65535, array: []byte{0x99, 0xff, 0xff}, mp: []byte{0xb9, 0xff, 0xff}},                                                                                 // max 3-byte
+		{n: 65536, array: []byte{0x9a, 0x00, 0x01, 0x00, 0x00}, mp: []byte{0xba, 0x00, 0x01, 0x00, 0x00}},                                                         // min 5-byte
+		{n: 4294967295, array: []byte{0x9a, 0xff, 0xff, 0xff, 0xff}, mp: []byte{0xba, 0xff, 0xff, 0xff, 0xff}},                                                    // max 5-byte (2^32-1)
+		{n: 4294967296, array: []byte{0x9b, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00}, mp: []byte{0xbb, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00}},    // min 9-byte (2^32)
+		{n: 1099511627775, array: []byte{0x9b, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff}, mp: []byte{0xbb, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff}}, // 0xFFFFFFFFFF
+	} {
+		t.Run(fmt.Sprintf("array/%d", tc.n), func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := writeCollectionHead(&buf, cborTypeArray, tc.n); err != nil {
+				t.Fatalf("writeCollectionHead: %v", err)
+			}
+			if !bytes.Equal(buf.Bytes(), tc.array) {
+				t.Errorf("n=%d: got % x, want % x", tc.n, buf.Bytes(), tc.array)
+			}
+		})
+		t.Run(fmt.Sprintf("map/%d", tc.n), func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := writeCollectionHead(&buf, cborTypeMap, tc.n); err != nil {
+				t.Fatalf("writeCollectionHead: %v", err)
+			}
+			if !bytes.Equal(buf.Bytes(), tc.mp) {
+				t.Errorf("n=%d: got % x, want % x", tc.n, buf.Bytes(), tc.mp)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/collections_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/collections_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,13 +19,14 @@ package cbor
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 	"testing"
 
-	"github.com/fxamacker/cbor/v2"
 	"github.com/google/go-cmp/cmp"
 
 	"sigs.k8s.io/randfill"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	testapigroupv1 "k8s.io/apimachinery/pkg/apis/testapigroup/v1"
@@ -33,16 +34,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes"
 )
 
-func TestCollectionsEncoding(t *testing.T) {
-	t.Run("Normal", func(t *testing.T) {
-		testCollectionsEncoding(t, false)
-	})
-	t.Run("Streaming", func(t *testing.T) {
-		testCollectionsEncoding(t, true)
-	})
-}
-
-func testCollectionsEncoding(t *testing.T, streamingEnabled bool) {
+// TestStreamingCollectionsEncoding verifies that streaming encoding produces
+// output identical to normal non-streaming encoding, and that the streaming
+// encoder actually uses multiple Write calls (not just buffering everything).
+func TestStreamingCollectionsEncoding(t *testing.T) {
 	var buf writeCountingBuffer
 	var remainingItems int64 = 1
 	for _, tc := range []struct {
@@ -299,16 +294,30 @@ func testCollectionsEncoding(t *testing.T, streamingEnabled bool) {
 				},
 			},
 		},
-		// Handling structs implementing json.Marshaler but NOT cbor.Marshaler
+		// Handling structs implementing cbor.Marshaler but NOT json.Marshaler
 		{
-			name:         "List with json.Marshaler but no cbor.Marshaler cannot be streamed",
-			in:           &ListWithMarshalJSONNoCBORList{},
+			name:         "List with cbor.Marshaler cannot be streamed",
+			in:           &ListWithMarshalCBORList{},
 			cannotStream: true,
 		},
 		{
-			name: "Struct with json.Marshaler but no cbor.Marshaler",
-			in: &StructWithMarshalJSONNoCBORList{
-				Items: []StructWithMarshalJSONNoCBOR{
+			name: "Struct with cbor.Marshaler",
+			in: &StructWithMarshalCBORList{
+				Items: []StructWithMarshalCBOR{
+					{},
+				},
+			},
+		},
+		// Handling structs implementing both json.Marshaler and cbor.Marshaler
+		{
+			name:         "List with json.Marshaler and cbor.Marshaler cannot be streamed",
+			in:           &ListWithBothMarshalersList{},
+			cannotStream: true,
+		},
+		{
+			name: "Struct with json.Marshaler and cbor.Marshaler",
+			in: &StructWithBothMarshalersList{
+				Items: []StructWithBothMarshalers{
 					{},
 				},
 			},
@@ -390,10 +399,12 @@ func testCollectionsEncoding(t *testing.T, streamingEnabled bool) {
 					RemainingItemCount: &remainingItems,
 				},
 				Items: []testapigroupv1.Carp{
-					{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Carp"}, ObjectMeta: metav1.ObjectMeta{
-						Name:      "pod",
-						Namespace: "default",
-					}},
+					{
+						TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Carp"}, ObjectMeta: metav1.ObjectMeta{
+							Name:      "pod",
+							Namespace: "default",
+						},
+					},
 				},
 			},
 		},
@@ -408,14 +419,18 @@ func testCollectionsEncoding(t *testing.T, streamingEnabled bool) {
 					ResourceVersion: "2345",
 				},
 				Items: []testapigroupv1.Carp{
-					{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Carp"}, ObjectMeta: metav1.ObjectMeta{
-						Name:      "pod",
-						Namespace: "default",
-					}},
-					{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Carp"}, ObjectMeta: metav1.ObjectMeta{
-						Name:      "pod2",
-						Namespace: "default2",
-					}},
+					{
+						TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Carp"}, ObjectMeta: metav1.ObjectMeta{
+							Name:      "pod",
+							Namespace: "default",
+						},
+					},
+					{
+						TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Carp"}, ObjectMeta: metav1.ObjectMeta{
+							Name:      "pod2",
+							Namespace: "default2",
+						},
+					},
 				},
 			},
 		},
@@ -462,18 +477,22 @@ func testCollectionsEncoding(t *testing.T, streamingEnabled bool) {
 		{
 			name: "UnstructuredList no elements",
 			in: &unstructured.UnstructuredList{
-				Object: map[string]interface{}{"kind": "List", "apiVersion": "v1", "metadata": map[string]interface{}{"resourceVersion": "2345"}},
-				Items:  []unstructured.Unstructured{},
+				Object: map[string]interface{}{
+					"kind": "List", "apiVersion": "v1", "metadata": map[string]interface{}{"resourceVersion": "2345"},
+				},
+				Items: []unstructured.Unstructured{},
 			},
 		},
 		{
 			name: "UnstructuredList one element with continue",
 			in: &unstructured.UnstructuredList{
-				Object: map[string]interface{}{"kind": "List", "apiVersion": "v1", "metadata": map[string]interface{}{
-					"resourceVersion":    "2345",
-					"continue":           "abc",
-					"remainingItemCount": "1",
-				}},
+				Object: map[string]interface{}{
+					"kind": "List", "apiVersion": "v1", "metadata": map[string]interface{}{
+						"resourceVersion":    "2345",
+						"continue":           "abc",
+						"remainingItemCount": "1",
+					},
+				},
 				Items: []unstructured.Unstructured{
 					{
 						Object: map[string]interface{}{
@@ -491,9 +510,11 @@ func testCollectionsEncoding(t *testing.T, streamingEnabled bool) {
 		{
 			name: "UnstructuredList two elements",
 			in: &unstructured.UnstructuredList{
-				Object: map[string]interface{}{"kind": "List", "apiVersion": "v1", "metadata": map[string]interface{}{
-					"resourceVersion": "2345",
-				}},
+				Object: map[string]interface{}{
+					"kind": "List", "apiVersion": "v1", "metadata": map[string]interface{}{
+						"resourceVersion": "2345",
+					},
+				},
 				Items: []unstructured.Unstructured{
 					{
 						Object: map[string]interface{}{
@@ -521,13 +542,15 @@ func testCollectionsEncoding(t *testing.T, streamingEnabled bool) {
 		{
 			name: "UnstructuredList conflict on items",
 			in: &unstructured.UnstructuredList{
-				Object: map[string]interface{}{"items": []unstructured.Unstructured{
-					{
-						Object: map[string]interface{}{
-							"name": "pod",
+				Object: map[string]interface{}{
+					"items": []unstructured.Unstructured{
+						{
+							Object: map[string]interface{}{
+								"name": "pod",
+							},
 						},
 					},
-				}},
+				},
 				Items: []unstructured.Unstructured{
 					{
 						Object: map[string]interface{}{
@@ -540,7 +563,7 @@ func testCollectionsEncoding(t *testing.T, streamingEnabled bool) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			buf.Reset()
-			s := NewSerializer(nil, nil, StreamingCollectionsEncoding(streamingEnabled))
+			s := NewSerializer(nil, nil, StreamingCollectionsEncoding(true))
 			if err := s.Encode(tc.in, &buf); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -555,7 +578,7 @@ func testCollectionsEncoding(t *testing.T, streamingEnabled bool) {
 				t.Errorf("streaming and normal encoding differ:\n%s", diff)
 			}
 
-			expectStreaming := !tc.cannotStream && streamingEnabled
+			expectStreaming := !tc.cannotStream
 			if expectStreaming && buf.writeCount <= 2 {
 				t.Errorf("expected streaming but Write was called only: %d", buf.writeCount)
 			}
@@ -648,41 +671,86 @@ func (l *StructWithMarshalJSON) MarshalJSON() ([]byte, error) {
 	return []byte(`"marshallJSON"`), nil
 }
 
-type ListWithMarshalJSONNoCBORList struct {
+type ListWithMarshalCBORList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-	Items           []StructWithMarshalJSONNoCBOR `json:"items" protobuf:"bytes,2,rep,name=items"`
+	Items           []string `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-func (l *ListWithMarshalJSONNoCBORList) DeepCopyObject() runtime.Object {
+func (l *ListWithMarshalCBORList) DeepCopyObject() runtime.Object {
 	return nil
 }
 
-func (l *ListWithMarshalJSONNoCBORList) MarshalJSON() ([]byte, error) {
-	return []byte(`"marshalJSONNoCBOR"`), nil
+func (l *ListWithMarshalCBORList) MarshalCBOR() ([]byte, error) {
+	return []byte("\x6bmarshalCBOR"), nil
 }
 
-type StructWithMarshalJSONNoCBORList struct {
+type StructWithMarshalCBORList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-	Items           []StructWithMarshalJSONNoCBOR `json:"items" protobuf:"bytes,2,rep,name=items"`
+	Items           []StructWithMarshalCBOR `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-func (s *StructWithMarshalJSONNoCBORList) DeepCopyObject() runtime.Object {
+func (s *StructWithMarshalCBORList) DeepCopyObject() runtime.Object {
 	return nil
 }
 
-type StructWithMarshalJSONNoCBOR struct {
+type StructWithMarshalCBOR struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 }
 
-func (l *StructWithMarshalJSONNoCBOR) DeepCopyObject() runtime.Object {
+func (l *StructWithMarshalCBOR) DeepCopyObject() runtime.Object {
 	return nil
 }
 
-func (l *StructWithMarshalJSONNoCBOR) MarshalJSON() ([]byte, error) {
-	return []byte(`"marshalJSONNoCBOR"`), nil
+func (l *StructWithMarshalCBOR) MarshalCBOR() ([]byte, error) {
+	return []byte("\x6bmarshalCBOR"), nil
+}
+
+type ListWithBothMarshalersList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items           []string `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+func (l *ListWithBothMarshalersList) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+func (l *ListWithBothMarshalersList) MarshalJSON() ([]byte, error) {
+	return []byte(`"marshalJSON"`), nil
+}
+
+func (l *ListWithBothMarshalersList) MarshalCBOR() ([]byte, error) {
+	return []byte("\x6bmarshalCBOR"), nil
+}
+
+type StructWithBothMarshalersList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items           []StructWithBothMarshalers `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+func (s *StructWithBothMarshalersList) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+type StructWithBothMarshalers struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+}
+
+func (l *StructWithBothMarshalers) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+func (l *StructWithBothMarshalers) MarshalJSON() ([]byte, error) {
+	return []byte(`"marshalJSON"`), nil
+}
+
+func (l *StructWithBothMarshalers) MarshalCBOR() ([]byte, error) {
+	return []byte("\x6bmarshalCBOR"), nil
 }
 
 type StructWithRawBytesList struct {
@@ -739,196 +807,98 @@ func TestFuzzCollectionsEncoding(t *testing.T) {
 			"kind":       "List",
 			"apiVersion": "v1",
 			c.String(0):  c.String(0),
-			c.String(0):  c.Uint64(),
+			c.String(0):  int64(c.Intn(1000000)), // Limit to int64 range
 			c.String(0):  c.Bool(),
 			"metadata": map[string]interface{}{
-				"resourceVersion":    fmt.Sprintf("%d", c.Uint64()),
+				"resourceVersion":    fmt.Sprintf("%d", c.Intn(1000000)), // String format
 				"continue":           c.String(0),
-				"remainingItemCount": fmt.Sprintf("%d", c.Uint64()),
+				"remainingItemCount": fmt.Sprintf("%d", c.Intn(1000000)), // String format
 				c.String(0):          c.String(0),
-			}}
+			},
+		}
 		c.Fill(&list.Items)
 	}
 	fuzzMap := func(kvs map[string]interface{}, c randfill.Continue) {
 		kvs[c.String(0)] = c.Bool()
-		kvs[c.String(0)] = c.Uint64()
+		kvs[c.String(0)] = int64(c.Intn(1000000)) // Limit to int64 range
 		kvs[c.String(0)] = c.String(0)
 	}
 	f := randfill.New().Funcs(disableFuzzFieldsV1, fuzzUnstructuredList, fuzzMap)
-	streamingBuffer := &bytes.Buffer{}
-	normalSerializer := NewSerializer(nil, nil)
-	normalBuffer := &bytes.Buffer{}
-	t.Run("CarpList", func(t *testing.T) {
-		for i := 0; i < 1000; i++ {
-			list := &testapigroupv1.CarpList{}
-			f.Fill(list)
-			streamingBuffer.Reset()
-			normalBuffer.Reset()
-			if _, err := streamingBuffer.Write(selfDescribedCBOR); err != nil {
-				t.Fatalf("unexpected error: %v", err)
+	streamingSerializer := NewSerializer(nil, nil)
+	normalSerializer := NewSerializer(nil, nil, StreamingCollectionsEncoding(false))
+
+	for _, tc := range []struct {
+		name   string
+		newObj func() runtime.Object
+	}{
+		{name: "CarpList", newObj: func() runtime.Object { return &testapigroupv1.CarpList{} }},
+		{name: "UnstructuredList", newObj: func() runtime.Object { return &unstructured.UnstructuredList{} }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var streamingBuf writeCountingBuffer
+			var normalBuf, ndetBuf bytes.Buffer
+			for i := range 1000 {
+				obj := tc.newObj()
+				f.Fill(obj)
+
+				// Non-streaming, deterministic encode as the reference for all comparisons.
+				normalBuf.Reset()
+				if err := normalSerializer.Encode(obj, &normalBuf); err != nil {
+					t.Fatalf("trial %d: normal encode error: %v", i, err)
+				}
+
+				// Streaming deterministic encode must match the reference byte-for-byte.
+				streamingBuf.Reset()
+				if err := streamingSerializer.Encode(obj, &streamingBuf); err != nil {
+					t.Fatalf("trial %d: streaming encode error: %v", i, err)
+				}
+				if diff := cmp.Diff(normalBuf.Bytes(), streamingBuf.Bytes()); diff != "" {
+					t.Logf("normal:    %x", normalBuf.Bytes())
+					t.Logf("streaming: %x", streamingBuf.Bytes())
+					t.Fatalf("trial %d: streaming and non-streaming differ:\n%s", i, diff)
+				}
+				if streamingBuf.writeCount <= 2 {
+					t.Errorf("trial %d: expected streaming encoding to use more than 2 writes, got %d", i, streamingBuf.writeCount)
+				}
+
+				// Streaming nondeterministic encode must decode to the same value.
+				ndetBuf.Reset()
+				if err := streamingSerializer.EncodeNondeterministic(obj, &ndetBuf); err != nil {
+					t.Fatalf("trial %d: nondeterministic encode error: %v", i, err)
+				}
+
+				var detObj, ndetObj interface{}
+				if err := modes.Decode.Unmarshal(normalBuf.Bytes(), &detObj); err != nil {
+					t.Fatalf("trial %d: decode deterministic: %v", i, err)
+				}
+				if err := modes.Decode.Unmarshal(ndetBuf.Bytes(), &ndetObj); err != nil {
+					t.Fatalf("trial %d: decode nondeterministic: %v", i, err)
+				}
+				if diff := cmp.Diff(detObj, ndetObj); diff != "" {
+					t.Errorf("trial %d: semantic mismatch between deterministic and nondeterministic:\n%s", i, diff)
+				}
+
+				detTyped := reflect.New(reflect.TypeOf(obj).Elem()).Interface()
+				ndetTyped := reflect.New(reflect.TypeOf(obj).Elem()).Interface()
+				if err := modes.Decode.Unmarshal(normalBuf.Bytes(), detTyped); err != nil {
+					t.Fatalf("trial %d: decode deterministic into %T: %v", i, obj, err)
+				}
+				if err := modes.Decode.Unmarshal(ndetBuf.Bytes(), ndetTyped); err != nil {
+					t.Fatalf("trial %d: decode nondeterministic into %T: %v", i, obj, err)
+				}
+				if !apiequality.Semantic.DeepEqual(detTyped, ndetTyped) {
+					t.Errorf("trial %d: typed %T mismatch between deterministic and nondeterministic encodings", i, obj)
+				}
 			}
-			ok, err := streamEncodeCollections(list, streamingBuffer, modes.Encode)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if !ok {
-				t.Fatalf("expected streaming encoder to encode %T", list)
-			}
-			if err := normalSerializer.Encode(list, normalBuffer); err != nil {
-				t.Fatal(err)
-			}
-			if diff := cmp.Diff(normalBuffer.Bytes(), streamingBuffer.Bytes()); diff != "" {
-				t.Logf("normal: %x", normalBuffer.Bytes())
-				t.Logf("streaming: %x", streamingBuffer.Bytes())
-				t.Errorf("not matching:\n%s", diff)
-			}
-		}
-	})
-	t.Run("UnstructuredList", func(t *testing.T) {
-		for i := 0; i < 1000; i++ {
-			list := &unstructured.UnstructuredList{}
-			f.Fill(list)
-			streamingBuffer.Reset()
-			normalBuffer.Reset()
-			if _, err := streamingBuffer.Write(selfDescribedCBOR); err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			ok, err := streamEncodeCollections(list, streamingBuffer, modes.Encode)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if !ok {
-				t.Fatalf("expected streaming encoder to encode %T", list)
-			}
-			if err := normalSerializer.Encode(list, normalBuffer); err != nil {
-				t.Fatal(err)
-			}
-			if diff := cmp.Diff(normalBuffer.Bytes(), streamingBuffer.Bytes()); diff != "" {
-				t.Logf("normal: %x", normalBuffer.Bytes())
-				t.Logf("streaming: %x", streamingBuffer.Bytes())
-				t.Errorf("not matching:\n%s", diff)
-			}
-		}
-	})
-	// Test EncodeNondeterministic: key order may differ from Encode, so we only
-	// verify the output is structurally valid CBOR (has selfDescribedCBOR prefix).
-	t.Run("CarpList/Nondeterministic", func(t *testing.T) {
-		for i := 0; i < 100; i++ {
-			list := &testapigroupv1.CarpList{}
-			f.Fill(list)
-			streamingBuffer.Reset()
-			if _, err := streamingBuffer.Write(selfDescribedCBOR); err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			ok, err := streamEncodeCollections(list, streamingBuffer, modes.EncodeNondeterministic)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if !ok {
-				t.Fatalf("expected streaming encoder to encode %T", list)
-			}
-			if !bytes.HasPrefix(streamingBuffer.Bytes(), selfDescribedCBOR) {
-				t.Errorf("streaming output missing selfDescribedCBOR prefix")
-			}
-		}
-	})
-	t.Run("UnstructuredList/Nondeterministic", func(t *testing.T) {
-		for i := 0; i < 100; i++ {
-			list := &unstructured.UnstructuredList{}
-			f.Fill(list)
-			streamingBuffer.Reset()
-			if _, err := streamingBuffer.Write(selfDescribedCBOR); err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			ok, err := streamEncodeCollections(list, streamingBuffer, modes.EncodeNondeterministic)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if !ok {
-				t.Fatalf("expected streaming encoder to encode %T", list)
-			}
-			if !bytes.HasPrefix(streamingBuffer.Bytes(), selfDescribedCBOR) {
-				t.Errorf("streaming output missing selfDescribedCBOR prefix")
-			}
-		}
-	})
+		})
+	}
 }
 
-// extractCBORMapKeys decodes the top-level CBOR map keys (as strings) from data in
-// insertion order, skipping the selfDescribedCBOR tag prefix (0xd9d9f7) if present.
-// Only the immediate keys of the outermost map are returned; values are skipped via
-// cbor streaming decoder. Keys must be CBOR byte strings (major type 2) or text
-// strings (major type 3) with a short length (≤23 bytes).
-func extractCBORMapKeys(t *testing.T, data []byte) []string {
-	t.Helper()
-	// Skip selfDescribedCBOR tag prefix if present.
-	if bytes.HasPrefix(data, selfDescribedCBOR) {
-		data = data[len(selfDescribedCBOR):]
-	}
-	if len(data) == 0 {
-		return nil
-	}
-	// Parse map header manually to get the number of entries and
-	// advance pos past the header byte(s).
-	pos := 0
-	mapByte := data[pos]
-	pos++
-	if mapByte>>5 != 5 {
-		t.Fatalf("extractCBORMapKeys: expected major type 5 (map), got byte 0x%02x", mapByte)
-	}
-	addInfo := mapByte & 0x1f
-	var mapSize int
-	switch {
-	case addInfo <= 23:
-		mapSize = int(addInfo)
-	case addInfo == 24:
-		mapSize = int(data[pos])
-		pos++
-	case addInfo == 25:
-		mapSize = int(data[pos])<<8 | int(data[pos+1])
-		pos += 2
-	default:
-		t.Fatalf("extractCBORMapKeys: unsupported map size additional info %d", addInfo)
-	}
-	// Use a streaming decoder to read key+value pairs one at a time.
-	// This correctly handles each value's variable byte length.
-	dec := cbor.NewDecoder(bytes.NewReader(data[pos:]))
-	keys := make([]string, 0, mapSize)
-	for i := 0; i < mapSize; i++ {
-		// Decode the key as a RawMessage, then extract the string from the raw bytes.
-		var rawKey cbor.RawMessage
-		if err := dec.Decode(&rawKey); err != nil {
-			t.Fatalf("extractCBORMapKeys: decode key %d: %v", i, err)
-		}
-		if len(rawKey) == 0 {
-			t.Fatalf("extractCBORMapKeys: empty raw key at index %d", i)
-		}
-		keyMajor := rawKey[0] >> 5
-		if keyMajor != 2 && keyMajor != 3 {
-			t.Fatalf("extractCBORMapKeys: key %d has unexpected major type %d (byte 0x%02x)", i, keyMajor, rawKey[0])
-		}
-		// Extract the string content: skip the header byte(s).
-		keyHdrLen := 1
-		if rawKey[0]&0x1f == 24 {
-			keyHdrLen = 2 // 1 type byte + 1 length byte
-		}
-		keys = append(keys, string(rawKey[keyHdrLen:]))
-		// Skip the value.
-		var rawVal cbor.RawMessage
-		if err := dec.Decode(&rawVal); err != nil {
-			t.Fatalf("extractCBORMapKeys: decode value for key %q: %v", keys[len(keys)-1], err)
-		}
-	}
-	return keys
-}
-
-// TestStreamEncodeCollectionsDeterministic verifies that streamEncodeCollections
-// with modes.Encode (SortBytewiseLexical) produces:
-//  1. Idempotent output: the same input always encodes to identical bytes.
-//  2. Correct key order: top-level map keys follow SortBytewiseLexical
-//     (shorter length first, then lexicographic within same length).
+// TestStreamEncodeCollectionsDeterministic verifies that the streaming serializer
+// produces output identical to the normal non-streaming serializer.
 func TestStreamEncodeCollectionsDeterministic(t *testing.T) {
-	wantKeyOrder := []string{"kind", "items", "metadata", "apiVersion"}
+	streamingSerializer := NewSerializer(nil, nil)
+	normalSerializer := NewSerializer(nil, nil, StreamingCollectionsEncoding(false))
 
 	for _, tc := range []struct {
 		name string
@@ -946,6 +916,8 @@ func TestStreamEncodeCollectionsDeterministic(t *testing.T) {
 				},
 				Items: []testapigroupv1.Carp{
 					{ObjectMeta: metav1.ObjectMeta{Name: "a"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "b"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "c"}},
 				},
 			},
 		},
@@ -959,46 +931,48 @@ func TestStreamEncodeCollectionsDeterministic(t *testing.T) {
 				},
 				Items: []unstructured.Unstructured{
 					{Object: map[string]interface{}{"name": "a"}},
+					{Object: map[string]interface{}{"name": "b"}},
+					{Object: map[string]interface{}{"name": "b"}},
 				},
 			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			// 1. Idempotence: encode twice, bytes must match.
-			var buf1, buf2 bytes.Buffer
-			for _, buf := range []*bytes.Buffer{&buf1, &buf2} {
-				if _, err := buf.Write(selfDescribedCBOR); err != nil {
-					t.Fatal(err)
-				}
-				ok, err := streamEncodeCollections(tc.in, buf, modes.Encode)
-				if err != nil {
-					t.Fatalf("streamEncodeCollections error: %v", err)
-				}
-				if !ok {
-					t.Fatalf("expected streaming encoder to handle %T", tc.in)
-				}
-			}
-			if diff := cmp.Diff(buf1.Bytes(), buf2.Bytes()); diff != "" {
-				t.Errorf("deterministic encoding is not idempotent:\n%s", diff)
+			// Encode with streaming enabled.
+			var streamingBuf writeCountingBuffer
+			if err := streamingSerializer.Encode(tc.in, &streamingBuf); err != nil {
+				t.Fatalf("streaming encode error: %v", err)
 			}
 
-			// 2. Key order follows SortBytewiseLexical.
-			// Expected order for {kind(4), items(5), metadata(8), apiVersion(10)}:
-			// shorter length first → kind < items < metadata < apiVersion
-			gotKeys := extractCBORMapKeys(t, buf1.Bytes())
-			if diff := cmp.Diff(wantKeyOrder, gotKeys); diff != "" {
-				t.Errorf("top-level key order does not follow SortBytewiseLexical:\n%s", diff)
+			// Encode with normal non-streaming encoder.
+			var normalBuf bytes.Buffer
+			if err := normalSerializer.Encode(tc.in, &normalBuf); err != nil {
+				t.Fatalf("normal encode error: %v", err)
+			}
+
+			// Output must be identical.
+			if diff := cmp.Diff(normalBuf.Bytes(), streamingBuf.Bytes()); diff != "" {
+				t.Logf("normal: %x", normalBuf.Bytes())
+				t.Logf("streaming: %x", streamingBuf.Bytes())
+				t.Errorf("streaming output differs from normal encoding:\n%s", diff)
+			}
+
+			if streamingBuf.writeCount <= 2 {
+				t.Errorf("expected streaming encoding to use more than 2 writes, got %d", streamingBuf.writeCount)
 			}
 		})
 	}
 }
 
-// TestStreamEncodeCollectionsNondeterministic verifies that streamEncodeCollections
-// with modes.EncodeNondeterministic (SortFastShuffle):
+// TestStreamEncodeCollectionsNondeterministic verifies that the streaming serializer's
+// EncodeNondeterministic method:
 //  1. Semantic correctness: the output decodes to the same object as deterministic encoding.
 //  2. Non-idempotence: across multiple trials the key order is observed to vary
 //     (probabilistic; uses a multi-key object to make the probability of flake negligible).
 func TestStreamEncodeCollectionsNondeterministic(t *testing.T) {
+	streamingSerializer := NewSerializer(nil, nil)
+	normalSerializer := NewSerializer(nil, nil, StreamingCollectionsEncoding(false))
+
 	// A list with kind+apiVersion+metadata+items = 4 keys.
 	// With SortFastShuffle the number of possible orderings is 4! = 24.
 	// Over 200 trials the probability of seeing only 1 unique ordering is (1/24)^199 ≈ 0.
@@ -1020,6 +994,8 @@ func TestStreamEncodeCollectionsNondeterministic(t *testing.T) {
 				},
 				Items: []testapigroupv1.Carp{
 					{ObjectMeta: metav1.ObjectMeta{Name: "a"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "b"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "c"}},
 				},
 			},
 		},
@@ -1033,43 +1009,36 @@ func TestStreamEncodeCollectionsNondeterministic(t *testing.T) {
 				},
 				Items: []unstructured.Unstructured{
 					{Object: map[string]interface{}{"name": "a"}},
+					{Object: map[string]interface{}{"name": "b"}},
+					{Object: map[string]interface{}{"name": "c"}},
 				},
 			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			// Encode once with deterministic mode as reference for semantic equality.
+			// Encode once with non-streaming, deterministic mode as reference for semantic equality.
 			var detBuf bytes.Buffer
-			if _, err := detBuf.Write(selfDescribedCBOR); err != nil {
-				t.Fatal(err)
-			}
-			ok, err := streamEncodeCollections(tc.in, &detBuf, modes.Encode)
-			if err != nil {
+			if err := normalSerializer.Encode(tc.in, &detBuf); err != nil {
 				t.Fatalf("deterministic encode error: %v", err)
 			}
-			if !ok {
-				t.Fatalf("expected streaming encoder to handle %T", tc.in)
-			}
 			var detObj map[string]interface{}
-			if err := modes.Decode.Unmarshal(detBuf.Bytes()[len(selfDescribedCBOR):], &detObj); err != nil {
+			if err := modes.Decode.Unmarshal(detBuf.Bytes(), &detObj); err != nil {
 				t.Fatalf("decode deterministic output: %v", err)
 			}
+			detTyped := reflect.New(reflect.TypeOf(tc.in).Elem()).Interface()
+			if err := modes.Decode.Unmarshal(detBuf.Bytes(), detTyped); err != nil {
+				t.Fatalf("decode deterministic output into %T: %v", tc.in, err)
+			}
 
-			// Run nTrials of nondeterministic encoding.
-			uniqueOutputs := make(map[string]struct{})
-			for i := 0; i < nTrials; i++ {
-				var buf bytes.Buffer
-				if _, err := buf.Write(selfDescribedCBOR); err != nil {
-					t.Fatal(err)
-				}
-				ok, err := streamEncodeCollections(tc.in, &buf, modes.EncodeNondeterministic)
-				if err != nil {
+			// Run nTrials of nondeterministic encoding, stopping early once we
+			// observe a second distinct byte sequence.
+			var firstEncoding string
+			for i := range nTrials {
+				var buf writeCountingBuffer
+				if err := streamingSerializer.EncodeNondeterministic(tc.in, &buf); err != nil {
 					t.Fatalf("trial %d: nondeterministic encode error: %v", i, err)
 				}
-				if !ok {
-					t.Fatalf("trial %d: expected streaming encoder to handle %T", i, tc.in)
-				}
-				payload := buf.Bytes()[len(selfDescribedCBOR):]
+				payload := buf.Bytes()
 
 				// Semantic correctness: decoded value must equal the deterministic reference.
 				var ndetObj map[string]interface{}
@@ -1080,14 +1049,27 @@ func TestStreamEncodeCollectionsNondeterministic(t *testing.T) {
 					t.Errorf("trial %d: semantic mismatch between deterministic and nondeterministic:\n%s", i, diff)
 				}
 
-				uniqueOutputs[string(payload)] = struct{}{}
+				ndetTyped := reflect.New(reflect.TypeOf(tc.in).Elem()).Interface()
+				if err := modes.Decode.Unmarshal(payload, ndetTyped); err != nil {
+					t.Fatalf("trial %d: decode nondeterministic output into %T: %v", i, tc.in, err)
+				}
+				if !apiequality.Semantic.DeepEqual(detTyped, ndetTyped) {
+					t.Errorf("trial %d: typed %T mismatch between deterministic and nondeterministic encodings", i, tc.in)
+				}
+
+				if buf.writeCount <= 2 {
+					t.Errorf("trial %d: expected streaming encoding to use more than 2 writes, got %d", i, buf.writeCount)
+				}
+
+				enc := string(payload)
+				if i == 0 {
+					firstEncoding = enc
+				} else if enc != firstEncoding {
+					return
+				}
 			}
 
-			// Non-idempotence: must have observed at least 2 distinct byte sequences.
-			if len(uniqueOutputs) < 2 {
-				t.Errorf("nondeterministic encoding produced only %d unique byte sequence(s) over %d trials; expected varied output", len(uniqueOutputs), nTrials)
-			}
-			t.Logf("%s: observed %d unique encodings over %d trials", tc.name, len(uniqueOutputs), nTrials)
+			t.Errorf("nondeterministic encoding produced only 1 unique byte sequence over %d trials; expected varied output", nTrials)
 		})
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/collections_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/collections_test.go
@@ -1,0 +1,1093 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cbor
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/google/go-cmp/cmp"
+
+	"sigs.k8s.io/randfill"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	testapigroupv1 "k8s.io/apimachinery/pkg/apis/testapigroup/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes"
+)
+
+func TestCollectionsEncoding(t *testing.T) {
+	t.Run("Normal", func(t *testing.T) {
+		testCollectionsEncoding(t, false)
+	})
+	t.Run("Streaming", func(t *testing.T) {
+		testCollectionsEncoding(t, true)
+	})
+}
+
+func testCollectionsEncoding(t *testing.T, streamingEnabled bool) {
+	var buf writeCountingBuffer
+	var remainingItems int64 = 1
+	for _, tc := range []struct {
+		name         string
+		in           runtime.Object
+		cannotStream bool
+	}{
+		// Preserving the distinction between integers and floating-point numbers
+		{
+			name: "Struct with floats",
+			in: &StructWithFloatsList{
+				Items: []StructWithFloats{
+					{
+						Int:     1,
+						Float32: float32(1),
+						Float64: 1.1,
+					},
+				},
+			},
+		},
+		{
+			name: "Unstructured object float",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"int":     1,
+					"float32": float32(1),
+					"float64": 1.1,
+				},
+			},
+		},
+		{
+			name: "Unstructured items float",
+			in: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"int":     1,
+							"float32": float32(1),
+							"float64": 1.1,
+						},
+					},
+				},
+			},
+		},
+		// Handling structs with duplicate field names (JSON tag names) without producing duplicate keys in the encoded output
+		{
+			name: "StructWithDuplicatedTags",
+			in: &StructWithDuplicatedTagsList{
+				Items: []StructWithDuplicatedTags{
+					{
+						Key1: "key1",
+						Key2: "key2",
+					},
+				},
+			},
+		},
+		// Encoding Go strings containing invalid UTF-8 sequences without error
+		{
+			name: "UnstructuredList object invalid UTF-8",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"key": "\x80", // first byte is a continuation byte
+				},
+			},
+		},
+		{
+			name: "UnstructuredList items invalid UTF-8",
+			in: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"key": "\x80",
+						},
+					},
+				},
+			},
+		},
+		// Preserving the distinction between absent, present-but-null, and present-and-empty states for slices and maps
+		{
+			name: "CarpList items nil",
+			in: &testapigroupv1.CarpList{
+				Items: nil,
+			},
+		},
+		{
+			name: "CarpList slice nil",
+			in: &testapigroupv1.CarpList{
+				Items: []testapigroupv1.Carp{
+					{
+						Status: testapigroupv1.CarpStatus{
+							Conditions: nil,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "CarpList map nil",
+			in: &testapigroupv1.CarpList{
+				Items: []testapigroupv1.Carp{
+					{
+						Spec: testapigroupv1.CarpSpec{
+							NodeSelector: nil,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "UnstructuredList items nil",
+			in: &unstructured.UnstructuredList{
+				Items: nil,
+			},
+		},
+		{
+			name: "UnstructuredList items slice nil",
+			in: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"slice": ([]string)(nil),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "UnstructuredList items map nil",
+			in: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"map": (map[string]string)(nil),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "UnstructuredList object nil",
+			in: &unstructured.UnstructuredList{
+				Object: nil,
+			},
+		},
+		{
+			name: "UnstructuredList object slice nil",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"slice": ([]string)(nil),
+				},
+			},
+		},
+		{
+			name: "UnstructuredList object map nil",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"map": (map[string]string)(nil),
+				},
+			},
+		},
+		{
+			name: "CarpList items empty",
+			in: &testapigroupv1.CarpList{
+				Items: []testapigroupv1.Carp{},
+			},
+		},
+		{
+			name: "CarpList slice empty",
+			in: &testapigroupv1.CarpList{
+				Items: []testapigroupv1.Carp{
+					{
+						Status: testapigroupv1.CarpStatus{
+							Conditions: []testapigroupv1.CarpCondition{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "CarpList map empty",
+			in: &testapigroupv1.CarpList{
+				Items: []testapigroupv1.Carp{
+					{
+						Spec: testapigroupv1.CarpSpec{
+							NodeSelector: map[string]string{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "UnstructuredList items empty",
+			in: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{},
+			},
+		},
+		{
+			name: "UnstructuredList items slice empty",
+			in: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"slice": []string{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "UnstructuredList items map empty",
+			in: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"map": map[string]string{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "UnstructuredList object empty",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{},
+			},
+		},
+		{
+			name: "UnstructuredList object slice empty",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"slice": []string{},
+				},
+			},
+		},
+		{
+			name: "UnstructuredList object map empty",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"map": map[string]string{},
+				},
+			},
+		},
+		// Handling structs implementing json.Marshaler method
+		{
+			name:         "List with json.Marshaler cannot be streamed",
+			in:           &ListWithMarshalJSONList{},
+			cannotStream: true,
+		},
+		{
+			name: "Struct with json.Marshaler",
+			in: &StructWithMarshalJSONList{
+				Items: []StructWithMarshalJSON{
+					{},
+				},
+			},
+		},
+		// Handling structs implementing json.Marshaler but NOT cbor.Marshaler
+		{
+			name:         "List with json.Marshaler but no cbor.Marshaler cannot be streamed",
+			in:           &ListWithMarshalJSONNoCBORList{},
+			cannotStream: true,
+		},
+		{
+			name: "Struct with json.Marshaler but no cbor.Marshaler",
+			in: &StructWithMarshalJSONNoCBORList{
+				Items: []StructWithMarshalJSONNoCBOR{
+					{},
+				},
+			},
+		},
+		// Handling raw bytes.
+		{
+			name: "Struct with raw bytes",
+			in: &StructWithRawBytesList{
+				Items: []StructWithRawBytes{
+					{
+						Slice: []byte{0x01, 0x02, 0x03},
+						Array: [3]byte{0x01, 0x02, 0x03},
+					},
+				},
+			},
+		},
+		{
+			name: "UnstructuredList object raw bytes",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"slice": []byte{0x01, 0x02, 0x03},
+					"array": [3]byte{0x01, 0x02, 0x03},
+				},
+			},
+		},
+		{
+			name: "UnstructuredList items raw bytes",
+			in: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"slice": []byte{0x01, 0x02, 0x03},
+							"array": [3]byte{0x01, 0x02, 0x03},
+						},
+					},
+				},
+			},
+		},
+		// Other scenarios:
+		{
+			name: "List just kind",
+			in: &testapigroupv1.CarpList{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "List",
+				},
+			},
+		},
+		{
+			name: "List just apiVersion",
+			in: &testapigroupv1.CarpList{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+			},
+		},
+		{
+			name: "List no elements",
+			in: &testapigroupv1.CarpList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "List",
+					APIVersion: "v1",
+				},
+				ListMeta: metav1.ListMeta{
+					ResourceVersion: "2345",
+				},
+				Items: []testapigroupv1.Carp{},
+			},
+		},
+		{
+			name: "List one element with continue",
+			in: &testapigroupv1.CarpList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "List",
+					APIVersion: "v1",
+				},
+				ListMeta: metav1.ListMeta{
+					ResourceVersion:    "2345",
+					Continue:           "abc",
+					RemainingItemCount: &remainingItems,
+				},
+				Items: []testapigroupv1.Carp{
+					{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Carp"}, ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod",
+						Namespace: "default",
+					}},
+				},
+			},
+		},
+		{
+			name: "List two elements",
+			in: &testapigroupv1.CarpList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "List",
+					APIVersion: "v1",
+				},
+				ListMeta: metav1.ListMeta{
+					ResourceVersion: "2345",
+				},
+				Items: []testapigroupv1.Carp{
+					{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Carp"}, ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod",
+						Namespace: "default",
+					}},
+					{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Carp"}, ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod2",
+						Namespace: "default2",
+					}},
+				},
+			},
+		},
+		{
+			name: "List with extra field cannot be streamed",
+			in: &ListWithAdditionalFields{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "List",
+					APIVersion: "v1",
+				},
+				ListMeta: metav1.ListMeta{
+					ResourceVersion: "2345",
+				},
+				Items: []testapigroupv1.Carp{},
+			},
+			cannotStream: true,
+		},
+		{
+			name: "Not a collection cannot be streamed",
+			in: &testapigroupv1.Carp{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "List",
+					APIVersion: "v1",
+				},
+			},
+			cannotStream: true,
+		},
+		{
+			name: "UnstructuredList empty",
+			in:   &unstructured.UnstructuredList{},
+		},
+		{
+			name: "UnstructuredList just kind",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{"kind": "List"},
+			},
+		},
+		{
+			name: "UnstructuredList just apiVersion",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{"apiVersion": "v1"},
+			},
+		},
+		{
+			name: "UnstructuredList no elements",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{"kind": "List", "apiVersion": "v1", "metadata": map[string]interface{}{"resourceVersion": "2345"}},
+				Items:  []unstructured.Unstructured{},
+			},
+		},
+		{
+			name: "UnstructuredList one element with continue",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{"kind": "List", "apiVersion": "v1", "metadata": map[string]interface{}{
+					"resourceVersion":    "2345",
+					"continue":           "abc",
+					"remainingItemCount": "1",
+				}},
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "Carp",
+							"metadata": map[string]interface{}{
+								"name":      "pod",
+								"namespace": "default",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "UnstructuredList two elements",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{"kind": "List", "apiVersion": "v1", "metadata": map[string]interface{}{
+					"resourceVersion": "2345",
+				}},
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "Carp",
+							"metadata": map[string]interface{}{
+								"name":      "pod",
+								"namespace": "default",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"apiVersion": "v1",
+							"kind":       "Carp",
+							"metadata": map[string]interface{}{
+								"name":      "pod2",
+								"namespace": "default",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "UnstructuredList conflict on items",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{"items": []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"name": "pod",
+						},
+					},
+				}},
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"name": "pod2",
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			buf.Reset()
+			s := NewSerializer(nil, nil, StreamingCollectionsEncoding(streamingEnabled))
+			if err := s.Encode(tc.in, &buf); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var normalBuf bytes.Buffer
+			normalS := NewSerializer(nil, nil, StreamingCollectionsEncoding(false))
+			if err := normalS.Encode(tc.in, &normalBuf); err != nil {
+				t.Fatalf("normal encode error: %v", err)
+			}
+
+			if diff := cmp.Diff(buf.Bytes(), normalBuf.Bytes()); diff != "" {
+				t.Errorf("streaming and normal encoding differ:\n%s", diff)
+			}
+
+			expectStreaming := !tc.cannotStream && streamingEnabled
+			if expectStreaming && buf.writeCount <= 2 {
+				t.Errorf("expected streaming but Write was called only: %d", buf.writeCount)
+			}
+			if !expectStreaming && buf.writeCount > 2 {
+				t.Errorf("expected non-streaming but Write was called more than once: %d", buf.writeCount)
+			}
+		})
+	}
+}
+
+type StructWithFloatsList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items           []StructWithFloats `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+func (l *StructWithFloatsList) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+type StructWithFloats struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	Int     int
+	Float32 float32
+	Float64 float64
+}
+
+func (s *StructWithFloats) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+type StructWithDuplicatedTagsList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items           []StructWithDuplicatedTags `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+func (l *StructWithDuplicatedTagsList) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+type StructWithDuplicatedTags struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	Key1 string `json:"key"`
+	Key2 string `json:"key"` //nolint:govet
+}
+
+func (s *StructWithDuplicatedTags) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+type ListWithMarshalJSONList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items           []string `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+func (l *ListWithMarshalJSONList) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+func (l *ListWithMarshalJSONList) MarshalJSON() ([]byte, error) {
+	return []byte(`"marshallJSON"`), nil
+}
+
+type StructWithMarshalJSONList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items           []StructWithMarshalJSON `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+func (s *StructWithMarshalJSONList) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+type StructWithMarshalJSON struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+}
+
+func (l *StructWithMarshalJSON) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+func (l *StructWithMarshalJSON) MarshalJSON() ([]byte, error) {
+	return []byte(`"marshallJSON"`), nil
+}
+
+type ListWithMarshalJSONNoCBORList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items           []StructWithMarshalJSONNoCBOR `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+func (l *ListWithMarshalJSONNoCBORList) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+func (l *ListWithMarshalJSONNoCBORList) MarshalJSON() ([]byte, error) {
+	return []byte(`"marshalJSONNoCBOR"`), nil
+}
+
+type StructWithMarshalJSONNoCBORList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items           []StructWithMarshalJSONNoCBOR `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+func (s *StructWithMarshalJSONNoCBORList) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+type StructWithMarshalJSONNoCBOR struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+}
+
+func (l *StructWithMarshalJSONNoCBOR) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+func (l *StructWithMarshalJSONNoCBOR) MarshalJSON() ([]byte, error) {
+	return []byte(`"marshalJSONNoCBOR"`), nil
+}
+
+type StructWithRawBytesList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items           []StructWithRawBytes `json:"items" protobuf:"bytes,2,rep,name=items"`
+}
+
+func (s *StructWithRawBytesList) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+type StructWithRawBytes struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Slice             []byte
+	Array             [3]byte
+}
+
+func (s *StructWithRawBytes) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+type ListWithAdditionalFields struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items           []testapigroupv1.Carp `json:"items" protobuf:"bytes,2,rep,name=items"`
+	AdditionalField int
+}
+
+func (s *ListWithAdditionalFields) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+type writeCountingBuffer struct {
+	writeCount int
+	bytes.Buffer
+}
+
+func (b *writeCountingBuffer) Write(data []byte) (int, error) {
+	b.writeCount++
+	return b.Buffer.Write(data)
+}
+
+func (b *writeCountingBuffer) Reset() {
+	b.writeCount = 0
+	b.Buffer.Reset()
+}
+
+func TestFuzzCollectionsEncoding(t *testing.T) {
+	disableFuzzFieldsV1 := func(field *metav1.FieldsV1, c randfill.Continue) {}
+	fuzzUnstructuredList := func(list *unstructured.UnstructuredList, c randfill.Continue) {
+		list.Object = map[string]interface{}{
+			"kind":       "List",
+			"apiVersion": "v1",
+			c.String(0):  c.String(0),
+			c.String(0):  c.Uint64(),
+			c.String(0):  c.Bool(),
+			"metadata": map[string]interface{}{
+				"resourceVersion":    fmt.Sprintf("%d", c.Uint64()),
+				"continue":           c.String(0),
+				"remainingItemCount": fmt.Sprintf("%d", c.Uint64()),
+				c.String(0):          c.String(0),
+			}}
+		c.Fill(&list.Items)
+	}
+	fuzzMap := func(kvs map[string]interface{}, c randfill.Continue) {
+		kvs[c.String(0)] = c.Bool()
+		kvs[c.String(0)] = c.Uint64()
+		kvs[c.String(0)] = c.String(0)
+	}
+	f := randfill.New().Funcs(disableFuzzFieldsV1, fuzzUnstructuredList, fuzzMap)
+	streamingBuffer := &bytes.Buffer{}
+	normalSerializer := NewSerializer(nil, nil)
+	normalBuffer := &bytes.Buffer{}
+	t.Run("CarpList", func(t *testing.T) {
+		for i := 0; i < 1000; i++ {
+			list := &testapigroupv1.CarpList{}
+			f.Fill(list)
+			streamingBuffer.Reset()
+			normalBuffer.Reset()
+			if _, err := streamingBuffer.Write(selfDescribedCBOR); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			ok, err := streamEncodeCollections(list, streamingBuffer, modes.Encode)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !ok {
+				t.Fatalf("expected streaming encoder to encode %T", list)
+			}
+			if err := normalSerializer.Encode(list, normalBuffer); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(normalBuffer.Bytes(), streamingBuffer.Bytes()); diff != "" {
+				t.Logf("normal: %x", normalBuffer.Bytes())
+				t.Logf("streaming: %x", streamingBuffer.Bytes())
+				t.Errorf("not matching:\n%s", diff)
+			}
+		}
+	})
+	t.Run("UnstructuredList", func(t *testing.T) {
+		for i := 0; i < 1000; i++ {
+			list := &unstructured.UnstructuredList{}
+			f.Fill(list)
+			streamingBuffer.Reset()
+			normalBuffer.Reset()
+			if _, err := streamingBuffer.Write(selfDescribedCBOR); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			ok, err := streamEncodeCollections(list, streamingBuffer, modes.Encode)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !ok {
+				t.Fatalf("expected streaming encoder to encode %T", list)
+			}
+			if err := normalSerializer.Encode(list, normalBuffer); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(normalBuffer.Bytes(), streamingBuffer.Bytes()); diff != "" {
+				t.Logf("normal: %x", normalBuffer.Bytes())
+				t.Logf("streaming: %x", streamingBuffer.Bytes())
+				t.Errorf("not matching:\n%s", diff)
+			}
+		}
+	})
+	// Test EncodeNondeterministic: key order may differ from Encode, so we only
+	// verify the output is structurally valid CBOR (has selfDescribedCBOR prefix).
+	t.Run("CarpList/Nondeterministic", func(t *testing.T) {
+		for i := 0; i < 100; i++ {
+			list := &testapigroupv1.CarpList{}
+			f.Fill(list)
+			streamingBuffer.Reset()
+			if _, err := streamingBuffer.Write(selfDescribedCBOR); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			ok, err := streamEncodeCollections(list, streamingBuffer, modes.EncodeNondeterministic)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !ok {
+				t.Fatalf("expected streaming encoder to encode %T", list)
+			}
+			if !bytes.HasPrefix(streamingBuffer.Bytes(), selfDescribedCBOR) {
+				t.Errorf("streaming output missing selfDescribedCBOR prefix")
+			}
+		}
+	})
+	t.Run("UnstructuredList/Nondeterministic", func(t *testing.T) {
+		for i := 0; i < 100; i++ {
+			list := &unstructured.UnstructuredList{}
+			f.Fill(list)
+			streamingBuffer.Reset()
+			if _, err := streamingBuffer.Write(selfDescribedCBOR); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			ok, err := streamEncodeCollections(list, streamingBuffer, modes.EncodeNondeterministic)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !ok {
+				t.Fatalf("expected streaming encoder to encode %T", list)
+			}
+			if !bytes.HasPrefix(streamingBuffer.Bytes(), selfDescribedCBOR) {
+				t.Errorf("streaming output missing selfDescribedCBOR prefix")
+			}
+		}
+	})
+}
+
+// extractCBORMapKeys decodes the top-level CBOR map keys (as strings) from data in
+// insertion order, skipping the selfDescribedCBOR tag prefix (0xd9d9f7) if present.
+// Only the immediate keys of the outermost map are returned; values are skipped via
+// cbor streaming decoder. Keys must be CBOR byte strings (major type 2) or text
+// strings (major type 3) with a short length (≤23 bytes).
+func extractCBORMapKeys(t *testing.T, data []byte) []string {
+	t.Helper()
+	// Skip selfDescribedCBOR tag prefix if present.
+	if bytes.HasPrefix(data, selfDescribedCBOR) {
+		data = data[len(selfDescribedCBOR):]
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	// Parse map header manually to get the number of entries and
+	// advance pos past the header byte(s).
+	pos := 0
+	mapByte := data[pos]
+	pos++
+	if mapByte>>5 != 5 {
+		t.Fatalf("extractCBORMapKeys: expected major type 5 (map), got byte 0x%02x", mapByte)
+	}
+	addInfo := mapByte & 0x1f
+	var mapSize int
+	switch {
+	case addInfo <= 23:
+		mapSize = int(addInfo)
+	case addInfo == 24:
+		mapSize = int(data[pos])
+		pos++
+	case addInfo == 25:
+		mapSize = int(data[pos])<<8 | int(data[pos+1])
+		pos += 2
+	default:
+		t.Fatalf("extractCBORMapKeys: unsupported map size additional info %d", addInfo)
+	}
+	// Use a streaming decoder to read key+value pairs one at a time.
+	// This correctly handles each value's variable byte length.
+	dec := cbor.NewDecoder(bytes.NewReader(data[pos:]))
+	keys := make([]string, 0, mapSize)
+	for i := 0; i < mapSize; i++ {
+		// Decode the key as a RawMessage, then extract the string from the raw bytes.
+		var rawKey cbor.RawMessage
+		if err := dec.Decode(&rawKey); err != nil {
+			t.Fatalf("extractCBORMapKeys: decode key %d: %v", i, err)
+		}
+		if len(rawKey) == 0 {
+			t.Fatalf("extractCBORMapKeys: empty raw key at index %d", i)
+		}
+		keyMajor := rawKey[0] >> 5
+		if keyMajor != 2 && keyMajor != 3 {
+			t.Fatalf("extractCBORMapKeys: key %d has unexpected major type %d (byte 0x%02x)", i, keyMajor, rawKey[0])
+		}
+		// Extract the string content: skip the header byte(s).
+		keyHdrLen := 1
+		if rawKey[0]&0x1f == 24 {
+			keyHdrLen = 2 // 1 type byte + 1 length byte
+		}
+		keys = append(keys, string(rawKey[keyHdrLen:]))
+		// Skip the value.
+		var rawVal cbor.RawMessage
+		if err := dec.Decode(&rawVal); err != nil {
+			t.Fatalf("extractCBORMapKeys: decode value for key %q: %v", keys[len(keys)-1], err)
+		}
+	}
+	return keys
+}
+
+// TestStreamEncodeCollectionsDeterministic verifies that streamEncodeCollections
+// with modes.Encode (SortBytewiseLexical) produces:
+//  1. Idempotent output: the same input always encodes to identical bytes.
+//  2. Correct key order: top-level map keys follow SortBytewiseLexical
+//     (shorter length first, then lexicographic within same length).
+func TestStreamEncodeCollectionsDeterministic(t *testing.T) {
+	wantKeyOrder := []string{"kind", "items", "metadata", "apiVersion"}
+
+	for _, tc := range []struct {
+		name string
+		in   runtime.Object
+	}{
+		{
+			name: "CarpList with all top-level fields",
+			in: &testapigroupv1.CarpList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "CarpList",
+					APIVersion: "v1",
+				},
+				ListMeta: metav1.ListMeta{
+					ResourceVersion: "42",
+				},
+				Items: []testapigroupv1.Carp{
+					{ObjectMeta: metav1.ObjectMeta{Name: "a"}},
+				},
+			},
+		},
+		{
+			name: "UnstructuredList with all top-level fields",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"kind":       "List",
+					"apiVersion": "v1",
+					"metadata":   map[string]interface{}{"resourceVersion": "42"},
+				},
+				Items: []unstructured.Unstructured{
+					{Object: map[string]interface{}{"name": "a"}},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// 1. Idempotence: encode twice, bytes must match.
+			var buf1, buf2 bytes.Buffer
+			for _, buf := range []*bytes.Buffer{&buf1, &buf2} {
+				if _, err := buf.Write(selfDescribedCBOR); err != nil {
+					t.Fatal(err)
+				}
+				ok, err := streamEncodeCollections(tc.in, buf, modes.Encode)
+				if err != nil {
+					t.Fatalf("streamEncodeCollections error: %v", err)
+				}
+				if !ok {
+					t.Fatalf("expected streaming encoder to handle %T", tc.in)
+				}
+			}
+			if diff := cmp.Diff(buf1.Bytes(), buf2.Bytes()); diff != "" {
+				t.Errorf("deterministic encoding is not idempotent:\n%s", diff)
+			}
+
+			// 2. Key order follows SortBytewiseLexical.
+			// Expected order for {kind(4), items(5), metadata(8), apiVersion(10)}:
+			// shorter length first → kind < items < metadata < apiVersion
+			gotKeys := extractCBORMapKeys(t, buf1.Bytes())
+			if diff := cmp.Diff(wantKeyOrder, gotKeys); diff != "" {
+				t.Errorf("top-level key order does not follow SortBytewiseLexical:\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestStreamEncodeCollectionsNondeterministic verifies that streamEncodeCollections
+// with modes.EncodeNondeterministic (SortFastShuffle):
+//  1. Semantic correctness: the output decodes to the same object as deterministic encoding.
+//  2. Non-idempotence: across multiple trials the key order is observed to vary
+//     (probabilistic; uses a multi-key object to make the probability of flake negligible).
+func TestStreamEncodeCollectionsNondeterministic(t *testing.T) {
+	// A list with kind+apiVersion+metadata+items = 4 keys.
+	// With SortFastShuffle the number of possible orderings is 4! = 24.
+	// Over 200 trials the probability of seeing only 1 unique ordering is (1/24)^199 ≈ 0.
+	const nTrials = 200
+
+	for _, tc := range []struct {
+		name string
+		in   runtime.Object
+	}{
+		{
+			name: "CarpList",
+			in: &testapigroupv1.CarpList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "CarpList",
+					APIVersion: "v1",
+				},
+				ListMeta: metav1.ListMeta{
+					ResourceVersion: "42",
+				},
+				Items: []testapigroupv1.Carp{
+					{ObjectMeta: metav1.ObjectMeta{Name: "a"}},
+				},
+			},
+		},
+		{
+			name: "UnstructuredList",
+			in: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"kind":       "List",
+					"apiVersion": "v1",
+					"metadata":   map[string]interface{}{"resourceVersion": "42"},
+				},
+				Items: []unstructured.Unstructured{
+					{Object: map[string]interface{}{"name": "a"}},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Encode once with deterministic mode as reference for semantic equality.
+			var detBuf bytes.Buffer
+			if _, err := detBuf.Write(selfDescribedCBOR); err != nil {
+				t.Fatal(err)
+			}
+			ok, err := streamEncodeCollections(tc.in, &detBuf, modes.Encode)
+			if err != nil {
+				t.Fatalf("deterministic encode error: %v", err)
+			}
+			if !ok {
+				t.Fatalf("expected streaming encoder to handle %T", tc.in)
+			}
+			var detObj map[string]interface{}
+			if err := modes.Decode.Unmarshal(detBuf.Bytes()[len(selfDescribedCBOR):], &detObj); err != nil {
+				t.Fatalf("decode deterministic output: %v", err)
+			}
+
+			// Run nTrials of nondeterministic encoding.
+			uniqueOutputs := make(map[string]struct{})
+			for i := 0; i < nTrials; i++ {
+				var buf bytes.Buffer
+				if _, err := buf.Write(selfDescribedCBOR); err != nil {
+					t.Fatal(err)
+				}
+				ok, err := streamEncodeCollections(tc.in, &buf, modes.EncodeNondeterministic)
+				if err != nil {
+					t.Fatalf("trial %d: nondeterministic encode error: %v", i, err)
+				}
+				if !ok {
+					t.Fatalf("trial %d: expected streaming encoder to handle %T", i, tc.in)
+				}
+				payload := buf.Bytes()[len(selfDescribedCBOR):]
+
+				// Semantic correctness: decoded value must equal the deterministic reference.
+				var ndetObj map[string]interface{}
+				if err := modes.Decode.Unmarshal(payload, &ndetObj); err != nil {
+					t.Fatalf("trial %d: decode nondeterministic output: %v", i, err)
+				}
+				if diff := cmp.Diff(detObj, ndetObj); diff != "" {
+					t.Errorf("trial %d: semantic mismatch between deterministic and nondeterministic:\n%s", i, diff)
+				}
+
+				uniqueOutputs[string(payload)] = struct{}{}
+			}
+
+			// Non-idempotence: must have observed at least 2 distinct byte sequences.
+			if len(uniqueOutputs) < 2 {
+				t.Errorf("nondeterministic encoding produced only %d unique byte sequence(s) over %d trials; expected varied output", len(uniqueOutputs), nTrials)
+			}
+			t.Logf("%s: observed %d unique encodings over %d trials", tc.name, len(uniqueOutputs), nTrials)
+		})
+	}
+}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/collections_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/collections_test.go
@@ -449,6 +449,23 @@ func TestStreamingCollectionsEncoding(t *testing.T) {
 			cannotStream: true,
 		},
 		{
+			// A cbor struct tag takes precedence over json in the CBOR encoder, so
+			// the streaming encoder (which follows the json tags) must not claim
+			// this type; it falls back to the general encoder, which renames the
+			// items key to "elements".
+			name: "List with cbor tag cannot be streamed",
+			in: &ListWithCBORTagList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "List",
+					APIVersion: "v1",
+				},
+				Items: []testapigroupv1.Carp{
+					{ObjectMeta: metav1.ObjectMeta{Name: "pod"}},
+				},
+			},
+			cannotStream: true,
+		},
+		{
 			name: "Not a collection cannot be streamed",
 			in: &testapigroupv1.Carp{
 				TypeMeta: metav1.TypeMeta{
@@ -782,6 +799,19 @@ type ListWithAdditionalFields struct {
 }
 
 func (s *ListWithAdditionalFields) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+// ListWithCBORTagList has a valid json-tagged shape but a cbor struct tag on
+// Items that renames its key. Because the CBOR encoder prefers the cbor tag over
+// json, getListMeta must refuse to stream this type.
+type ListWithCBORTagList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Items           []testapigroupv1.Carp `json:"items" cbor:"elements" protobuf:"bytes,2,rep,name=items"`
+}
+
+func (s *ListWithCBORTagList) DeepCopyObject() runtime.Object {
 	return nil
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/encode.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/encode.go
@@ -107,6 +107,7 @@ var encode = EncMode{
 		}
 		return encode
 	}(),
+	deterministic: true,
 }
 
 var Encode = EncMode{
@@ -122,6 +123,7 @@ var Encode = EncMode{
 		}
 		return em
 	}(),
+	deterministic: true,
 }
 
 var EncodeNondeterministic = EncMode{
@@ -134,14 +136,20 @@ var EncodeNondeterministic = EncMode{
 		}
 		return em
 	}(),
+	deterministic: false,
 }
 
 type EncMode struct {
-	delegate cbor.UserBufferEncMode
+	delegate      cbor.UserBufferEncMode
+	deterministic bool
 }
 
 func (em EncMode) options() cbor.EncOptions {
 	return em.delegate.EncOptions()
+}
+
+func (em EncMode) IsDeterministic() bool {
+	return em.deterministic
 }
 
 func (em EncMode) MarshalTo(v interface{}, w io.Writer) error {


### PR DESCRIPTION
Add StreamingCollectionEncodingToCbor feature gate to control whether CBOR serializer encodes collections item by item. Support deterministic and nondeterministic.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

The APIserver's CBOR encoder supports true streaming for collection objects (e.g., Lists).

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Allow API server CBOR encoder to encode collections item by item, instead of all at once.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/4222
```
