### PR TITLE
kubectl explain: add --max-depth flag

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain.go
@@ -51,6 +51,9 @@ var (
 		# Get all the fields in the resource
 		kubectl explain pods --recursive
 
+		# Get fields in the resource up to a specific recursive depth
+		kubectl explain pods --recursive --max-depth=2
+
 		# Get the explanation for deployment in supported api versions
 		kubectl explain deployments --api-version=apps/v1
 
@@ -73,6 +76,7 @@ type ExplainFlags struct {
 	APIVersion   string
 	OutputFormat string
 	Recursive    bool
+	MaxDepth     int
 
 	genericiooptions.IOStreams
 }
@@ -87,9 +91,10 @@ func NewExplainFlags(streams genericiooptions.IOStreams) *ExplainFlags {
 
 // AddFlags registers flags for a cli
 func (flags *ExplainFlags) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().BoolVarP(&flags.Recursive, "recursive", "R", flags.Recursive, "Print the fields of fields (Currently only 1 level deep)")
+	cmd.Flags().BoolVarP(&flags.Recursive, "recursive", "R", flags.Recursive, "Print the fields of fields. Use --max-depth to cap the recursion depth.")
 	cmd.Flags().StringVar(&flags.APIVersion, "api-version", flags.APIVersion, "Get different explanations for particular API version (API group/version)")
 	cmd.Flags().StringVarP(&flags.OutputFormat, "output", "o", plaintextTemplateName, "Format in which to render the schema (plaintext, plaintext-openapiv2)")
+	cmd.Flags().IntVar(&flags.MaxDepth, "max-depth", flags.MaxDepth, "Maximum recursion depth when printing nested fields with --recursive. 0 means no limit. Requires --recursive when greater than 0.")
 }
 
 // ToOptions converts from CLI inputs to runtime input
@@ -111,6 +116,7 @@ func (flags *ExplainFlags) ToOptions(f cmdutil.Factory, parent string, args []st
 		Recursive:    flags.Recursive,
 		APIVersion:   flags.APIVersion,
 		OutputFormat: flags.OutputFormat,
+		MaxDepth:     flags.MaxDepth,
 
 		CmdParent: parent,
 		args:      args,
@@ -154,6 +160,7 @@ type ExplainOptions struct {
 	APIVersion string
 	// Name of the template to use with the openapiv3 template renderer.
 	OutputFormat string
+	MaxDepth     int
 
 	CmdParent string
 	args      []string
@@ -171,6 +178,12 @@ func (o *ExplainOptions) Validate() error {
 	}
 	if len(o.args) > 1 {
 		return fmt.Errorf("We accept only this format: explain RESOURCE\n")
+	}
+	if o.MaxDepth > 0 && !o.Recursive {
+		return fmt.Errorf("--max-depth requires --recursive")
+	}
+	if o.MaxDepth < 0 {
+		return fmt.Errorf("--max-depth must be non-negative")
 	}
 
 	return nil
@@ -224,6 +237,7 @@ func (o *ExplainOptions) Run() error {
 			o.OpenAPIV3Client,
 			fullySpecifiedGVR,
 			o.Recursive,
+			o.MaxDepth,
 			o.OutputFormat,
 		)
 	}
@@ -260,5 +274,5 @@ func (o *ExplainOptions) renderOpenAPIV2(
 		return fmt.Errorf("couldn't find resource for %q", gvk)
 	}
 
-	return explain.PrintModelDescription(fieldsPath, o.Out, schema, gvk, o.Recursive)
+	return explain.PrintModelDescription(fieldsPath, o.Out, schema, gvk, o.Recursive, o.MaxDepth)
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain_test.go
@@ -80,6 +80,61 @@ func TestExplainInvalidArgs(t *testing.T) {
 	}
 }
 
+func TestExplainMaxDepth(t *testing.T) {
+	tf := cmdtesting.NewTestFactory()
+	defer tf.Cleanup()
+
+	testCases := []struct {
+		name          string
+		recursive     bool
+		maxDepth      int
+		expectedError string
+	}{
+		{
+			name:          "negative max-depth fails validation",
+			maxDepth:      -1,
+			expectedError: "--max-depth must be non-negative",
+		},
+		{
+			name:          "max-depth without recursive fails validation",
+			maxDepth:      2,
+			expectedError: "--max-depth requires --recursive",
+		},
+		{
+			name:      "max-depth with recursive passes validation",
+			recursive: true,
+			maxDepth:  2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			flags := explain.NewExplainFlags(genericiooptions.NewTestIOStreamsDiscard())
+			flags.Recursive = tc.recursive
+			flags.MaxDepth = tc.maxDepth
+
+			opts, err := flags.ToOptions(tf, "kubectl", []string{"pods"})
+			if err != nil {
+				t.Fatalf("unexpected error %v", err)
+			}
+
+			err = opts.Validate()
+			if len(tc.expectedError) > 0 {
+				if err == nil || err.Error() != tc.expectedError {
+					t.Errorf("expected validation error %q, got: %v", tc.expectedError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected validation error: %v", err)
+			}
+			if opts.MaxDepth != tc.maxDepth {
+				t.Errorf("expected MaxDepth=%d, got %d", tc.maxDepth, opts.MaxDepth)
+			}
+		})
+	}
+}
+
 func TestExplainNotExistResource(t *testing.T) {
 	tf := cmdtesting.NewTestFactory()
 	defer tf.Cleanup()

--- a/staging/src/k8s.io/kubectl/pkg/explain/explain.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/explain.go
@@ -151,7 +151,7 @@ func SplitAndParseResourceRequestWithMatchingPrefix(inResource string, mapper me
 // PrintModelDescription prints the description of a specific model or dot path.
 // If recursive, all components nested within the fields of the schema will be
 // printed.
-func PrintModelDescription(fieldsPath []string, w io.Writer, schema proto.Schema, gvk schema.GroupVersionKind, recursive bool) error {
+func PrintModelDescription(fieldsPath []string, w io.Writer, schema proto.Schema, gvk schema.GroupVersionKind, recursive bool, maxDepth int) error {
 	fieldName := ""
 	if len(fieldsPath) != 0 {
 		fieldName = fieldsPath[len(fieldsPath)-1]
@@ -162,7 +162,7 @@ func PrintModelDescription(fieldsPath []string, w io.Writer, schema proto.Schema
 	if err != nil {
 		return err
 	}
-	b := fieldsPrinterBuilder{Recursive: recursive}
+	b := fieldsPrinterBuilder{Recursive: recursive, MaxDepth: maxDepth}
 	f := &Formatter{Writer: w, Wrap: 80}
 	return PrintModel(fieldName, f, b, schema, gvk)
 }

--- a/staging/src/k8s.io/kubectl/pkg/explain/fields_printer_builder.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/fields_printer_builder.go
@@ -20,13 +20,16 @@ package explain
 // recursiveFieldsPrinter based on the argument.
 type fieldsPrinterBuilder struct {
 	Recursive bool
+	MaxDepth  int
 }
 
 // BuildFieldsPrinter builds the appropriate fieldsPrinter.
 func (f fieldsPrinterBuilder) BuildFieldsPrinter(writer *Formatter) fieldsPrinter {
 	if f.Recursive {
 		return &recursiveFieldsPrinter{
-			Writer: writer,
+			Writer:   writer,
+			MaxDepth: f.MaxDepth,
+			Depth:    1,
 		}
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/explain/model_printer_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/model_printer_test.go
@@ -150,7 +150,7 @@ FIELDS:
 			t.Fatalf("Couldn't find schema %v", test.gvk)
 		}
 		buf := bytes.Buffer{}
-		if err := PrintModelDescription(test.path, &buf, schema, test.gvk, false); err != nil {
+		if err := PrintModelDescription(test.path, &buf, schema, test.gvk, false, 0); err != nil {
 			t.Fatalf("Failed to PrintModelDescription for path %v: %v", test.path, err)
 		}
 		got := buf.String()
@@ -159,6 +159,86 @@ FIELDS:
 		}
 	}
 }
+
+// TestModelMaxDepth is an integration-style test for the v1 (OpenAPIv2) render
+// path. It exercises PrintModelDescription end-to-end with exact expected
+// outputs across the boundary values of --max-depth.
+func TestModelMaxDepth(t *testing.T) {
+	gvk := schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "OneKind",
+	}
+	schemaForKind := resources.LookupResource(gvk)
+	if schemaForKind == nil {
+		t.Fatalf("Couldn't find schema %v", gvk)
+	}
+
+	unlimitedWant := `KIND:     OneKind
+VERSION:  v1
+
+DESCRIPTION:
+     OneKind has a short description
+
+FIELDS:
+   field1	<Object>
+      array	<[]integer>
+      int	<integer>
+      object	<map[string]string>
+      primitive	<string>
+      string	<string>
+   field2	<[]map[string]string>
+`
+
+	tests := []struct {
+		name     string
+		maxDepth int
+		want     string
+	}{
+		{
+			name:     "depth 0 means unlimited",
+			maxDepth: 0,
+			want:     unlimitedWant,
+		},
+		{
+			name:     "depth 1 prints only top-level fields",
+			maxDepth: 1,
+			want: `KIND:     OneKind
+VERSION:  v1
+
+DESCRIPTION:
+     OneKind has a short description
+
+FIELDS:
+   field1	<Object>
+   field2	<[]map[string]string>
+`,
+		},
+		{
+			name:     "depth 2 reaches the leaves",
+			maxDepth: 2,
+			want:     unlimitedWant,
+		},
+		{
+			name:     "depth larger than schema equals unlimited",
+			maxDepth: 100,
+			want:     unlimitedWant,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := PrintModelDescription(nil, &buf, schemaForKind, gvk, true, tt.maxDepth); err != nil {
+				t.Fatalf("PrintModelDescription: %v", err)
+			}
+			if got := buf.String(); got != tt.want {
+				t.Errorf("Got:\n%v\nWant:\n%v\n", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCRDModel(t *testing.T) {
 	gvk := schema.GroupVersionKind{
 		Group:   "",
@@ -187,7 +267,7 @@ DESCRIPTION:
 
 	for _, test := range tests {
 		buf := bytes.Buffer{}
-		if err := PrintModelDescription(test.path, &buf, schema, gvk, false); err != nil {
+		if err := PrintModelDescription(test.path, &buf, schema, gvk, false, 0); err != nil {
 			t.Fatalf("Failed to PrintModelDescription for path %v: %v", test.path, err)
 		}
 		got := buf.String()

--- a/staging/src/k8s.io/kubectl/pkg/explain/recursive_fields_printer.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/recursive_fields_printer.go
@@ -24,8 +24,10 @@ const indentPerLevel = 3
 // recursiveFieldsPrinter recursively prints all the fields for a given
 // schema.
 type recursiveFieldsPrinter struct {
-	Writer *Formatter
-	Error  error
+	Writer   *Formatter
+	Error    error
+	MaxDepth int
+	Depth    int
 }
 
 var _ proto.SchemaVisitor = &recursiveFieldsPrinter{}
@@ -43,8 +45,13 @@ func (f *recursiveFieldsPrinter) VisitKind(k *proto.Kind) {
 	for _, key := range k.Keys() {
 		v := k.Fields[key]
 		f.Writer.Write("%s\t<%s>", key, GetTypeName(v))
+		if f.MaxDepth > 0 && f.Depth >= f.MaxDepth {
+			continue
+		}
 		subFields := &recursiveFieldsPrinter{
-			Writer: f.Writer.Indent(indentPerLevel),
+			Writer:   f.Writer.Indent(indentPerLevel),
+			MaxDepth: f.MaxDepth,
+			Depth:    f.Depth + 1,
 		}
 		if err := subFields.PrintFields(v); err != nil {
 			f.Error = err

--- a/staging/src/k8s.io/kubectl/pkg/explain/recursive_fields_printer_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/recursive_fields_printer_test.go
@@ -99,3 +99,140 @@ field2	<Object>
 		t.Errorf("Got:\n%v\nWant:\n%v\n", buf.String(), want)
 	}
 }
+
+func TestRecursiveFieldsMaxDepth(t *testing.T) {
+	resources := tst.NewFakeResources("test-recursive-swagger.json")
+	s := resources.LookupResource(schema.GroupVersionKind{
+		Group:   "",
+		Version: "v2",
+		Kind:    "OneKind",
+	})
+	if s == nil {
+		t.Fatal("Couldn't find schema v2.OneKind")
+	}
+
+	unlimitedWant := `field1	<Object>
+   referencefield	<Object>
+   referencesarray	<[]Object>
+field2	<Object>
+   reference	<Object>
+      referencefield	<Object>
+      referencesarray	<[]Object>
+   string	<string>
+`
+
+	tests := []struct {
+		name     string
+		maxDepth int
+		want     string
+	}{
+		{
+			name:     "depth 0 means unlimited",
+			maxDepth: 0,
+			want:     unlimitedWant,
+		},
+		{
+			name:     "depth 1 prints only top-level fields",
+			maxDepth: 1,
+			want: `field1	<Object>
+field2	<Object>
+`,
+		},
+		{
+			name:     "depth 2 prints two levels of nesting",
+			maxDepth: 2,
+			want: `field1	<Object>
+   referencefield	<Object>
+   referencesarray	<[]Object>
+field2	<Object>
+   reference	<Object>
+   string	<string>
+`,
+		},
+		{
+			name:     "depth 3 reaches the cycle-detection bound",
+			maxDepth: 3,
+			want:     unlimitedWant,
+		},
+		{
+			name:     "depth larger than schema is bounded by cycle detection",
+			maxDepth: 100,
+			want:     unlimitedWant,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schemaForField, err := LookupSchemaForField(s, []string{})
+			if err != nil {
+				t.Fatalf("Invalid path %v: %v", []string{}, err)
+			}
+
+			var buf bytes.Buffer
+			f := Formatter{Writer: &buf, Wrap: 80}
+			builder := fieldsPrinterBuilder{Recursive: true, MaxDepth: tt.maxDepth}
+			if err := builder.BuildFieldsPrinter(&f).PrintFields(schemaForField); err != nil {
+				t.Fatalf("Failed to print fields: %v", err)
+			}
+			if got := buf.String(); got != tt.want {
+				t.Errorf("Got:\n%v\nWant:\n%v\n", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRecursiveFieldsMaxDepthNonRecursiveSchema(t *testing.T) {
+	s := resources.LookupResource(schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "OneKind",
+	})
+	if s == nil {
+		t.Fatal("Couldn't find schema v1.OneKind")
+	}
+
+	tests := []struct {
+		name     string
+		maxDepth int
+		want     string
+	}{
+		{
+			name:     "depth 1 stops before object children",
+			maxDepth: 1,
+			want: `field1	<Object>
+field2	<[]map[string]string>
+`,
+		},
+		{
+			name:     "depth 2 reaches the leaves",
+			maxDepth: 2,
+			want: `field1	<Object>
+   array	<[]integer>
+   int	<integer>
+   object	<map[string]string>
+   primitive	<string>
+   string	<string>
+field2	<[]map[string]string>
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schemaForField, err := LookupSchemaForField(s, []string{})
+			if err != nil {
+				t.Fatalf("Invalid path %v: %v", []string{}, err)
+			}
+
+			var buf bytes.Buffer
+			f := Formatter{Writer: &buf, Wrap: 80}
+			builder := fieldsPrinterBuilder{Recursive: true, MaxDepth: tt.maxDepth}
+			if err := builder.BuildFieldsPrinter(&f).PrintFields(schemaForField); err != nil {
+				t.Fatalf("Failed to print fields: %v", err)
+			}
+			if got := buf.String(); got != tt.want {
+				t.Errorf("Got:\n%v\nWant:\n%v\n", got, tt.want)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/explain.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/explain.go
@@ -36,6 +36,7 @@ func PrintModelDescription(
 	client openapi.Client,
 	gvr schema.GroupVersionResource,
 	recursive bool,
+	maxDepth int,
 	outputFormat string,
 ) error {
 	generator := NewGenerator()
@@ -44,7 +45,7 @@ func PrintModelDescription(
 	}
 
 	return printModelDescriptionWithGenerator(
-		generator, fieldsPath, w, client, gvr, recursive, outputFormat)
+		generator, fieldsPath, w, client, gvr, recursive, maxDepth, outputFormat)
 }
 
 // Factored out for testability
@@ -55,6 +56,7 @@ func printModelDescriptionWithGenerator(
 	client openapi.Client,
 	gvr schema.GroupVersionResource,
 	recursive bool,
+	maxDepth int,
 	outputFormat string,
 ) error {
 	paths, err := client.Paths()
@@ -86,7 +88,7 @@ func printModelDescriptionWithGenerator(
 		return fmt.Errorf("failed to parse openapi schema for %s: %w", resourcePath, err)
 	}
 
-	err = generator.Render(outputFormat, parsedV3Schema, gvr, fieldsPath, recursive, w)
+	err = generator.Render(outputFormat, parsedV3Schema, gvr, fieldsPath, recursive, maxDepth, w)
 
 	explainErr := explainError("")
 	if errors.As(err, &explainErr) {

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/explain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/explain_test.go
@@ -44,12 +44,12 @@ func TestExplainErrors(t *testing.T) {
 		Group:    "test0.example.com",
 		Version:  "v1",
 		Resource: "doesntmatter",
-	}, false, "unknown-format")
+	}, false, 0, "unknown-format")
 	require.ErrorContains(t, err, "couldn't find resource for \"test0.example.com/v1, Resource=doesntmatter\"")
 
 	// Validate error when openapi client returns error.
 	fakeClient.ForcedErr = fmt.Errorf("Always fails")
-	err = PrintModelDescription(nil, &buf, fakeClient, apiGroupsGVR, false, "unknown-format")
+	err = PrintModelDescription(nil, &buf, fakeClient, apiGroupsGVR, false, 0, "unknown-format")
 	require.ErrorContains(t, err, "failed to fetch list of groupVersions")
 
 	// Validate error when GroupVersion "Schema()" call returns error.
@@ -60,7 +60,7 @@ func TestExplainErrors(t *testing.T) {
 		Group:    "test1.example.com",
 		Version:  "v1",
 		Resource: "doesntmatter",
-	}, false, "unknown-format")
+	}, false, 0, "unknown-format")
 	require.ErrorContains(t, err, "failed to fetch openapi schema ")
 
 	// Validate error when returned bytes from GroupVersion "Schema" are invalid.
@@ -70,12 +70,12 @@ func TestExplainErrors(t *testing.T) {
 		Group:    "test2.example.com",
 		Version:  "v1",
 		Resource: "doesntmatter",
-	}, false, "unknown-format")
+	}, false, 0, "unknown-format")
 	require.ErrorContains(t, err, "failed to parse openapi schema")
 
 	// Validate error when render template is not recognized.
 	client := openapitest.NewEmbeddedFileClient()
-	err = PrintModelDescription(nil, &buf, client, apiGroupsGVR, false, "unknown-format")
+	err = PrintModelDescription(nil, &buf, client, apiGroupsGVR, false, 0, "unknown-format")
 	require.ErrorContains(t, err, "unrecognized format: unknown-format")
 }
 
@@ -107,7 +107,7 @@ func TestExplainOpenAPIClient(t *testing.T) {
 		FieldPath: nil,
 	}
 
-	err = printModelDescriptionWithGenerator(gen, nil, &buf, fileClient, apiGroupsGVR, false, "Context")
+	err = printModelDescriptionWithGenerator(gen, nil, &buf, fileClient, apiGroupsGVR, false, 0, "Context")
 	require.NoError(t, err)
 
 	var actualContext TemplateContext

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/generator.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/generator.go
@@ -39,6 +39,8 @@ type Generator interface {
 		fieldSelector []string,
 		// Boolean indicating whether the fields should be rendered recursively/deeply
 		recursive bool,
+		// Maximum recursion depth when recursive is true. 0 means no limit.
+		maxDepth int,
 		// Output writer
 		writer io.Writer,
 	) error
@@ -48,6 +50,7 @@ type TemplateContext struct {
 	GVR       schema.GroupVersionResource
 	Document  map[string]interface{}
 	Recursive bool
+	MaxDepth  int
 	FieldPath []string
 }
 
@@ -84,6 +87,8 @@ func (g *generator) Render(
 	fieldSelector []string,
 	// Boolean indicating whether the fields should be rendered recursively/deeply
 	recursive bool,
+	// Maximum recursion depth when recursive is true. 0 means no limit.
+	maxDepth int,
 	// Output writer
 	writer io.Writer,
 ) error {
@@ -95,6 +100,7 @@ func (g *generator) Render(
 	err := compiledTemplate.Execute(writer, TemplateContext{
 		Document:  document,
 		Recursive: recursive,
+		MaxDepth:  maxDepth,
 		FieldPath: fieldSelector,
 		GVR:       gvr,
 	})

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/generator_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/generator_test.go
@@ -46,7 +46,7 @@ func TestGeneratorMissingOutput(t *testing.T) {
 
 	gen := NewGenerator()
 	badTemplateName := "bad-template"
-	err = gen.Render(badTemplateName, doc, appsDeploymentGVR, nil, false, &buf)
+	err = gen.Render(badTemplateName, doc, appsDeploymentGVR, nil, false, 0, &buf)
 
 	require.ErrorContains(t, err, "unrecognized format: "+badTemplateName)
 	require.Zero(t, buf.Len())
@@ -54,7 +54,7 @@ func TestGeneratorMissingOutput(t *testing.T) {
 	err = gen.AddTemplate(badTemplateName, "ok")
 	require.NoError(t, err)
 
-	err = gen.Render(badTemplateName, doc, appsDeploymentGVR, nil, false, &buf)
+	err = gen.Render(badTemplateName, doc, appsDeploymentGVR, nil, false, 0, &buf)
 	require.NoError(t, err)
 	require.Equal(t, "ok", buf.String())
 }
@@ -84,6 +84,7 @@ func TestGeneratorContext(t *testing.T) {
 		expectedContext.GVR,
 		expectedContext.FieldPath,
 		expectedContext.Recursive,
+		expectedContext.MaxDepth,
 		&buf)
 	require.NoError(t, err)
 

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext.tmpl
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext.tmpl
@@ -36,7 +36,7 @@
     VERSION:    {{ $gvk.version }}{{"\n" -}}
     {{- "\n" -}}
 
-    {{- with include "schema" (dict "gvk" $gvk "Document" $.Document "FieldPath" $.FieldPath "Recursive" $.Recursive) -}}
+    {{- with include "schema" (dict "gvk" $gvk "Document" $.Document "FieldPath" $.FieldPath "Recursive" $.Recursive "MaxDepth" $.MaxDepth) -}}
         {{- . -}}
     {{- else -}}
         {{- throw "error: GVK %v not found in OpenAPI schema" $gvk -}}
@@ -101,7 +101,7 @@ Takes dictionary as argument with keys:
         {{- with include "externalDocs" (dict "schema" $resolved) -}}
             {{- "\n" -}}{{- . -}}
         {{- end -}}
-        {{- with include "fieldList" (dict "schema" $resolved "level" 1 "Document" $.Document "Recursive" $.Recursive) -}}
+        {{- with include "fieldList" (dict "schema" $resolved "level" 1 "Document" $.Document "Recursive" $.Recursive "MaxDepth" $.MaxDepth) -}}
             FIELDS:{{- "\n" -}}
             {{- . -}}
         {{- end -}}
@@ -176,7 +176,7 @@ Takes dictionary as argument with keys:
         {{- $resolved := or (resolveRef $refString $.Document) $.schema -}}
         {{- range $k, $v := $resolved.properties -}}
             {{- template "fieldDetail" (dict "name" $k "schema" $resolved "short" $.Recursive "level" $.level "Document" $.Document) -}}
-            {{- if $.Recursive -}}
+            {{- if and $.Recursive (or (eq $.MaxDepth 0) (lt $.level $.MaxDepth)) -}}
                 {{- /* Check if we already know about this element */}}
                 {{- template "fieldList" (set $nextContext "schema" $v "level" (add $.level 1)) -}}
             {{- end -}}

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/templates/plaintext_test.go
@@ -81,6 +81,51 @@ var (
 		delete(paths, "/apis/batch/v1/namespaces/{namespace}/cronjobs/{name}")
 		return res
 	}()
+
+	nestedWidgetGVR = schema.GroupVersionResource{
+		Group:    "example.com",
+		Version:  "v1",
+		Resource: "widgets",
+	}
+
+	nestedWidgetOpenAPI map[string]interface{} = map[string]interface{}{
+		"paths": map[string]interface{}{
+			"/apis/example.com/v1/widgets": map[string]interface{}{
+				"get": map[string]interface{}{
+					"x-kubernetes-group-version-kind": map[string]interface{}{
+						"group":   "example.com",
+						"version": "v1",
+						"kind":    "Widget",
+					},
+				},
+			},
+		},
+		"components": map[string]interface{}{
+			"schemas": map[string]interface{}{
+				"com.example.v1.Widget": map[string]interface{}{
+					"type": "object",
+					"x-kubernetes-group-version-kind": []map[string]interface{}{
+						{"group": "example.com", "version": "v1", "kind": "Widget"},
+					},
+					"properties": map[string]interface{}{
+						"name": map[string]interface{}{"type": "string"},
+						"meta": map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"id": map[string]interface{}{"type": "string"},
+								"tags": map[string]interface{}{
+									"type": "object",
+									"properties": map[string]interface{}{
+										"key": map[string]interface{}{"type": "string"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 )
 
 type testCase struct {
@@ -636,7 +681,10 @@ func TestPlaintext(t *testing.T) {
 				"short": false,
 			},
 			Checks: []check{
-				checkEquals("thefield\t<string> -required-\n  a description that should be printed\n\n"),
+				checkEquals(`thefield	<string> -required-
+  a description that should be printed
+
+`),
 			},
 		},
 		{
@@ -745,7 +793,11 @@ func TestPlaintext(t *testing.T) {
 				"isLongView": true,
 			},
 			Checks: []check{
-				checkEquals("ENUM:\n    0\n    1\n    2\n    3"),
+				checkEquals(`ENUM:
+    0
+    1
+    2
+    3`),
 			},
 		},
 		{
@@ -762,7 +814,8 @@ func TestPlaintext(t *testing.T) {
 				"indentAmount": 2,
 			},
 			Checks: []check{
-				checkEquals("\n  enum: 0, 1, 2, 3"),
+				checkEquals(`
+  enum: 0, 1, 2, 3`),
 			},
 		},
 		{
@@ -780,7 +833,8 @@ func TestPlaintext(t *testing.T) {
 				"indentAmount": 2,
 			},
 			Checks: []check{
-				checkEquals("\n  enum: 0, 1, ...."),
+				checkEquals(`
+  enum: 0, 1, ....`),
 			},
 		},
 		{
@@ -798,7 +852,9 @@ func TestPlaintext(t *testing.T) {
 				"indentAmount": 2,
 			},
 			Checks: []check{
-				checkEquals("ENUM:\n    0\n    1, ...."),
+				checkEquals(`ENUM:
+    0
+    1, ....`),
 			},
 		},
 		{
@@ -985,6 +1041,135 @@ func TestPlaintext(t *testing.T) {
 				checkContains("Widget naming conventions"),
 				checkContains("URL: https://example.com/docs/naming"),
 				checkContains("size of the widget"),
+			},
+		},
+		{
+			Name: "MaxDepthZeroIsUnlimited",
+			Context: v2.TemplateContext{
+				Document:  nestedWidgetOpenAPI,
+				GVR:       nestedWidgetGVR,
+				FieldPath: nil,
+				Recursive: true,
+				MaxDepth:  0,
+			},
+			Checks: []check{
+				// Non-recursive field details separate descriptions with a blank line,
+				// and the root template emits the final trailing newline.
+				checkEquals(`GROUP:      example.com
+KIND:       Widget
+VERSION:    v1
+
+DESCRIPTION:
+    <empty>
+FIELDS:
+  meta	<Object>
+    id	<string>
+    tags	<Object>
+      key	<string>
+  name	<string>
+
+`),
+			},
+		},
+		{
+			Name: "MaxDepthOneStopsAtTopLevelFields",
+			Context: v2.TemplateContext{
+				Document:  nestedWidgetOpenAPI,
+				GVR:       nestedWidgetGVR,
+				FieldPath: nil,
+				Recursive: true,
+				MaxDepth:  1,
+			},
+			Checks: []check{
+				checkEquals(`GROUP:      example.com
+KIND:       Widget
+VERSION:    v1
+
+DESCRIPTION:
+    <empty>
+FIELDS:
+  meta	<Object>
+  name	<string>
+
+`),
+			},
+		},
+		{
+			Name: "MaxDepthTwoExpandsOneLevelDeeper",
+			Context: v2.TemplateContext{
+				Document:  nestedWidgetOpenAPI,
+				GVR:       nestedWidgetGVR,
+				FieldPath: nil,
+				Recursive: true,
+				MaxDepth:  2,
+			},
+			Checks: []check{
+				checkEquals(`GROUP:      example.com
+KIND:       Widget
+VERSION:    v1
+
+DESCRIPTION:
+    <empty>
+FIELDS:
+  meta	<Object>
+    id	<string>
+    tags	<Object>
+  name	<string>
+
+`),
+			},
+		},
+		{
+			Name: "MaxDepthLargerThanSchemaEqualsUnlimited",
+			Context: v2.TemplateContext{
+				Document:  nestedWidgetOpenAPI,
+				GVR:       nestedWidgetGVR,
+				FieldPath: nil,
+				Recursive: true,
+				MaxDepth:  100,
+			},
+			Checks: []check{
+				checkEquals(`GROUP:      example.com
+KIND:       Widget
+VERSION:    v1
+
+DESCRIPTION:
+    <empty>
+FIELDS:
+  meta	<Object>
+    id	<string>
+    tags	<Object>
+      key	<string>
+  name	<string>
+
+`),
+			},
+		},
+		{
+			Name: "MaxDepthIgnoredWhenRecursiveFalse",
+			Context: v2.TemplateContext{
+				Document:  nestedWidgetOpenAPI,
+				GVR:       nestedWidgetGVR,
+				FieldPath: nil,
+				Recursive: false,
+				MaxDepth:  5,
+			},
+			Checks: []check{
+				checkEquals(`GROUP:      example.com
+KIND:       Widget
+VERSION:    v1
+
+DESCRIPTION:
+    <empty>
+FIELDS:
+  meta	<Object>
+    <no description>
+
+  name	<string>
+    <no description>
+
+
+`),
 			},
 		},
 	}

--- a/test/cmd/discovery.sh
+++ b/test/cmd/discovery.sh
@@ -465,11 +465,29 @@ __EOF__
 
   set -o errexit
 
-  output_message=$(kubectl explain mock-resource)
-  kube::test::if_has_string "${output_message}" 'FIELDS:'
+  output_message=$(kubectl explain mock-resource --recursive --max-depth=1)
+  kube::test::if_has_string "${output_message}" 'spec'
+  kube::test::if_has_not_string "${output_message}" 'annotations'
+
+  output_message=$(kubectl explain mock-resource --recursive --max-depth=2)
+  kube::test::if_has_string "${output_message}" 'annotations'
+  kube::test::if_has_not_string "${output_message}" 'subresource'
 
   output_message=$(kubectl explain mock-resource --recursive)
-  kube::test::if_has_string "${output_message}" 'FIELDS:'
+  kube::test::if_has_string "${output_message}" 'subresource'
+  kube::test::if_has_string "${output_message}" 'map\[string\]\[\]string'
+
+  output_message=$(kubectl explain mock-resource --recursive --max-depth=1 -o plaintext-openapiv2)
+  kube::test::if_has_string "${output_message}" 'spec'
+  kube::test::if_has_not_string "${output_message}" 'annotations'
+
+  output_message=$(kubectl explain mock-resource --recursive --max-depth=2 -o plaintext-openapiv2)
+  kube::test::if_has_string "${output_message}" 'annotations'
+  kube::test::if_has_not_string "${output_message}" 'subresource'
+
+  output_message=$(kubectl explain mock-resource --recursive -o plaintext-openapiv2)
+  kube::test::if_has_string "${output_message}" 'subresource'
+  kube::test::if_has_string "${output_message}" 'map\[string\]\[\]string'
 
   # Cleanup
   kubectl delete crd mock-resources.test.com


### PR DESCRIPTION
#### What type of PR is this?

`/kind feature
`

#### What this PR does / why we need it:

`kubectl explain --recursive` prints the full schema tree for a resource. For large resources (Pod, Deployment, CRDs with deeply nested specs), the output is hundreds of lines and there is no way to ask for a shallower overview short of navigating field-by-field with dotted paths.

This PR adds a new `--max-depth=N` flag to `kubectl explain` that caps recursion depth when printing nested fields:
- `--max-depth=0` (default) preserves the existing unlimited behavior.
- `--max-depth=N` (N > 0) prints fields up to N levels and implies `--recursive`.
- Negative values are rejected at validation time.

The cap is threaded through both render paths so behavior is consistent regardless of which one runs:
- v1 (OpenAPIv2): `recursiveFieldsPrinter` carries a depth counter and skips child recursion at the limit.
- v2 (OpenAPIv3, default): the plaintext template guards `fieldList` recursion on `lt $.level $.MaxDepth`.

When recursion stops at the limit, the field name and type marker (e.g., `spec\t<PodSpec>`) are still printed, so users see what exists and can drill down with a field path or a deeper `--max-depth`.

#### Which issue(s) this PR is related to:
Fixes kubernetes/kubectl#1659

#### Special notes:

The flag is purely additive and backward compatible: the default `MaxDepth=0` is treated as unlimited, so existing `--recursive` invocations are unchanged. Tests cover validation, the v1 printer, the v2 template, and the CLI wiring; `test/cmd/discovery.sh` also exercises the flag end-to-end against a CRD.

Does this PR introduce a user-facing change?

```release-note
Added a `--max-depth` flag to `kubectl explain --recursive` to limit the depth of nested fields displayed in the output.
```
