### PR TITLE
Enable WAP correctly in basic policy integration test

### DIFF
--- a/test/integration/scheduler/podgroup/podgroup_test.go
+++ b/test/integration/scheduler/podgroup/podgroup_test.go
@@ -60,7 +60,7 @@ func TestPodGroupScheduling(t *testing.T) {
 	otherGangPodGroup := st.MakePodGroup().Name("pg2").TemplateRef("t", "other-workload").
 		Priority(100).MinCount(3).Obj()
 
-	basicPodGroup := st.MakePodGroup().Name("pg1").TemplateRef("t2", "workload").BasicPolicy().Obj()
+	basicPodGroup := st.MakePodGroup().Name("pg1").TemplateRef("t2", "workload").Priority(100).BasicPolicy().Obj()
 
 	p1 := st.MakePod().Name("p1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").
 		PodGroupName("pg1").Priority(100).Obj()
@@ -109,10 +109,10 @@ func TestPodGroupScheduling(t *testing.T) {
 		PodGroupName("pg2").Priority(100).Obj()
 
 	tests := []struct {
-		name                          string
-		enableWorkloadAwarePreemption bool
-		requiresTAS                   bool
-		steps                         []stepsframework.Step
+		name                                  string
+		enableWorkloadAwarePreemption         bool
+		enableTopologyAwareWorkloadScheduling []bool
+		steps                                 []stepsframework.Step
 	}{
 		{
 			name: "gang schedules when pod group and resources are available",
@@ -437,7 +437,9 @@ func TestPodGroupScheduling(t *testing.T) {
 			},
 		},
 		{
-			name: "basic group schedules with workload-aware preemption",
+			name:                                  "basic group schedules with workload-aware preemption",
+			enableTopologyAwareWorkloadScheduling: []bool{false},
+			enableWorkloadAwarePreemption:         true,
 			steps: []stepsframework.Step{
 				{
 					Name:       "Create a low priority pod taking all resources",
@@ -526,8 +528,8 @@ func TestPodGroupScheduling(t *testing.T) {
 			},
 		},
 		{
-			name:        "tas gang with constraint does not use pod by pod preemption",
-			requiresTAS: true,
+			name:                                  "tas gang with constraint does not use pod by pod preemption",
+			enableTopologyAwareWorkloadScheduling: []bool{true},
 			steps: []stepsframework.Step{
 				{
 					Name:       "Create very low and low priority pods that take up all node resources",
@@ -552,9 +554,9 @@ func TestPodGroupScheduling(t *testing.T) {
 			},
 		},
 		{
-			name:                          "tas gang with constraint does not use workload preemption",
-			enableWorkloadAwarePreemption: true,
-			requiresTAS:                   true,
+			name:                                  "tas gang with constraint does not use workload preemption",
+			enableWorkloadAwarePreemption:         true,
+			enableTopologyAwareWorkloadScheduling: []bool{true},
 			steps: []stepsframework.Step{
 				{
 					Name:       "Create very low and low priority pods that take up all node resources",
@@ -581,11 +583,11 @@ func TestPodGroupScheduling(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		runWithTasFlagSettings := []bool{true, false}
-		for _, tasEnabled := range runWithTasFlagSettings {
-			if tt.requiresTAS && !tasEnabled {
-				continue
-			}
+		tasEnabledValues := tt.enableTopologyAwareWorkloadScheduling
+		if len(tasEnabledValues) == 0 {
+			tasEnabledValues = []bool{true, false}
+		}
+		for _, tasEnabled := range tasEnabledValues {
 			t.Run(fmt.Sprintf("%s (TopologyAwareWorkloadScheduling enabled: %v)", tt.name, tasEnabled), func(t *testing.T) {
 				featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
 					features.GenericWorkload:                 true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Test that was expected to work with workload-aware preemption enabled was configured without that gate. This PR fixes it by enabling the WorkloadAwarePreemption in this test case.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
