### PR TITLE
Decouple ShutdownAdmit handler from ShutdownManager

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1146,9 +1146,14 @@ func NewMainKubelet(ctx context.Context,
 		v1.NamespaceNodeLease,
 		util.SetNodeOwnerFunc(ctx, klet.heartbeatClient, string(klet.nodeName)))
 
+	// Create a standalone shutdown admit handler linked by a shared state.
+	shutdownState := nodeshutdown.NewShutdownState()
+	shutdownAdmitHandler := nodeshutdown.NewAdmitHandler(shutdownState)
+
 	// setup node shutdown manager
 	shutdownManager := nodeshutdown.NewManager(&nodeshutdown.Config{
 		Logger:                           logger,
+		State:                            shutdownState,
 		VolumeManager:                    klet.volumeManager,
 		Recorder:                         kubeDeps.Recorder,
 		NodeRef:                          nodeRef,
@@ -1161,7 +1166,7 @@ func NewMainKubelet(ctx context.Context,
 		StateDirectory:                   rootDirectory,
 	})
 	klet.shutdownManager = shutdownManager
-	handlers = append(handlers, shutdownManager)
+	handlers = append(handlers, shutdownAdmitHandler)
 
 	klet.allocationManager.AddPodAdmitHandlers(append([]lifecycle.PodAdmitHandler{resizeAdmitHandler}, handlers...))
 

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -407,8 +407,10 @@ func newTestKubeletWithImageList(
 	handlers = append(handlers, allocation.NewPodResizesAdmitHandler(kubelet.containerManager, fakeRuntime, kubelet.allocationManager, logger))
 
 	// setup shutdown manager
+	shutdownState := nodeshutdown.NewShutdownState()
 	shutdownManager := nodeshutdown.NewManager(&nodeshutdown.Config{
 		Logger:                          logger,
+		State:                           shutdownState,
 		Recorder:                        fakeRecorder,
 		NodeRef:                         nodeRef,
 		GetPodsFunc:                     kubelet.podManager.GetPods,
@@ -422,7 +424,7 @@ func newTestKubeletWithImageList(
 	if err != nil {
 		t.Fatalf("Failed to create UserNsManager: %v", err)
 	}
-	handlers = append(handlers, shutdownManager)
+	handlers = append(handlers, nodeshutdown.NewAdmitHandler(shutdownState))
 
 	// Add this as cleanup predicate pod admitter
 	handlers = append(handlers, lifecycle.NewPredicateAdmitHandler(kubelet.GetCachedNode, lifecycle.NewAdmissionFailureHandlerStub(), kubelet.containerManager.UpdatePluginResources))

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -39,9 +40,6 @@ import (
 
 // Manager interface provides methods for Kubelet to manage node shutdown.
 type Manager interface {
-	lifecycle.PodAdmitHandler
-
-	Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult
 	Start(ctx context.Context) error
 	ShutdownStatus() error
 }
@@ -49,6 +47,7 @@ type Manager interface {
 // Config represents Manager configuration
 type Config struct {
 	Logger                           klog.Logger
+	State                            *ShutdownState
 	VolumeManager                    volumemanager.VolumeManager
 	Recorder                         record.EventRecorder
 	NodeRef                          *v1.ObjectReference
@@ -64,11 +63,6 @@ type Config struct {
 
 // managerStub is a fake node shutdown managerImpl .
 type managerStub struct{}
-
-// Admit returns a fake Pod admission which always returns true
-func (managerStub) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult {
-	return lifecycle.PodAdmitResult{Admit: true}
-}
 
 // Start is a no-op always returning nil for non linux platforms.
 func (managerStub) Start(context.Context) error {
@@ -299,4 +293,36 @@ func groupByPriority(shutdownGracePeriodByPodPriority []kubeletconfig.ShutdownGr
 		groups[index].Pods = append(groups[index].Pods, pod)
 	}
 	return groups
+}
+
+// ShutdownState is a lightweight object that tracks if the node is shutting down.
+type ShutdownState struct {
+	ShuttingDown atomic.Bool
+}
+
+// NewShutdownState creates a new ShutdownState.
+func NewShutdownState() *ShutdownState {
+	return &ShutdownState{}
+}
+
+// AdmitHandler evaluates if pods can be admitted based on the node shutdown state.
+type AdmitHandler struct {
+	state *ShutdownState
+}
+
+// NewAdmitHandler returns a standalone PodAdmitHandler that uses ShutdownState.
+func NewAdmitHandler(state *ShutdownState) lifecycle.PodAdmitHandler {
+	return &AdmitHandler{state: state}
+}
+
+// Admit rejects pods if the node is actively shutting down.
+func (h *AdmitHandler) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult {
+	if h.state.ShuttingDown.Load() {
+		return lifecycle.PodAdmitResult{
+			Admit:   false,
+			Reason:  NodeShutdownNotAdmittedReason,
+			Message: nodeShutdownNotAdmittedMessage,
+		}
+	}
+	return lifecycle.PodAdmitResult{Admit: true}
 }

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -34,7 +33,6 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	kubeletevents "k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/eviction"
-	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/pkg/kubelet/nodeshutdown/systemd"
 )
@@ -68,9 +66,8 @@ type managerImpl struct {
 	dbusCon     dbusInhibiter
 	inhibitLock systemd.InhibitLock
 
-	nodeShuttingDownMutex sync.Mutex
-	nodeShuttingDownNow   bool
-	podManager            *podManager
+	state      *ShutdownState
+	podManager *podManager
 
 	enableMetrics bool
 	storage       storage
@@ -97,6 +94,7 @@ func NewManager(conf *Config) Manager {
 		nodeRef:        conf.NodeRef,
 		getPods:        conf.GetPodsFunc,
 		syncNodeStatus: conf.SyncNodeStatusFunc,
+		state:          conf.State,
 		podManager:     podManager,
 		enableMetrics:  utilfeature.DefaultFeatureGate.Enabled(features.GracefulNodeShutdownBasedOnPodPriority),
 		storage: localStorage{
@@ -109,20 +107,6 @@ func NewManager(conf *Config) Manager {
 		"shutdownGracePeriodByPodPriority", podManager.shutdownGracePeriodByPodPriority,
 	)
 	return manager
-}
-
-// Admit rejects all pods if node is shutting
-func (m *managerImpl) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult {
-	nodeShuttingDown := m.ShutdownStatus() != nil
-
-	if nodeShuttingDown {
-		return lifecycle.PodAdmitResult{
-			Admit:   false,
-			Reason:  NodeShutdownNotAdmittedReason,
-			Message: nodeShutdownNotAdmittedMessage,
-		}
-	}
-	return lifecycle.PodAdmitResult{Admit: true}
 }
 
 // setMetrics sets the metrics for the node shutdown manager.
@@ -282,9 +266,7 @@ func (m *managerImpl) start(ctx context.Context) (chan struct{}, error) {
 					m.recorder.Event(m.nodeRef, v1.EventTypeNormal, kubeletevents.NodeShutdown, "Shutdown manager detected shutdown cancellation")
 				}
 
-				m.nodeShuttingDownMutex.Lock()
-				m.nodeShuttingDownNow = isShuttingDown
-				m.nodeShuttingDownMutex.Unlock()
+				m.state.ShuttingDown.Store(isShuttingDown)
 
 				if isShuttingDown {
 					// Update node status and ready condition
@@ -317,10 +299,7 @@ func (m *managerImpl) acquireInhibitLock() error {
 
 // ShutdownStatus will return an error if the node is currently shutting down.
 func (m *managerImpl) ShutdownStatus() error {
-	m.nodeShuttingDownMutex.Lock()
-	defer m.nodeShuttingDownMutex.Unlock()
-
-	if m.nodeShuttingDownNow {
+	if m.state.ShuttingDown.Load() {
 		return fmt.Errorf("node is shutting down")
 	}
 	return nil

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux_test.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux_test.go
@@ -340,6 +340,7 @@ func TestManager(t *testing.T) {
 			nodeRef := &v1.ObjectReference{Kind: "Node", Name: "test", UID: types.UID("test"), Namespace: ""}
 			manager := NewManager(&Config{
 				Logger:                          logger,
+				State:                           NewShutdownState(),
 				VolumeManager:                   fakeVolumeManager,
 				Recorder:                        fakeRecorder,
 				NodeRef:                         nodeRef,
@@ -365,7 +366,6 @@ func TestManager(t *testing.T) {
 				assert.NoError(t, err, "expected manager.Start() to not return error")
 				assert.True(t, fakeDbus.didInhibitShutdown, "expected that manager inhibited shutdown")
 				assert.NoError(t, manager.ShutdownStatus(), "expected that manager does not return error since shutdown is not active")
-				assert.True(t, manager.Admit(nil).Admit)
 
 				// Send fake shutdown event
 				select {
@@ -387,7 +387,6 @@ func TestManager(t *testing.T) {
 				}
 
 				assert.Error(t, manager.ShutdownStatus(), "expected that manager returns error since shutdown is active")
-				assert.False(t, manager.Admit(nil).Admit)
 				assert.Equal(t, tc.expectedPodToGracePeriodOverride, killedPodsToGracePeriods)
 				assert.Equal(t, tc.expectedDidOverrideInhibitDelay, fakeDbus.didOverrideInhibitDelay, "override system inhibit delay differs")
 				if tc.expectedPodStatuses != nil {
@@ -445,6 +444,7 @@ func TestFeatureEnabled(t *testing.T) {
 
 			manager := NewManager(&Config{
 				Logger:                          logger,
+				State:                           NewShutdownState(),
 				VolumeManager:                   fakeVolumeManager,
 				Recorder:                        fakeRecorder,
 				NodeRef:                         nodeRef,
@@ -504,6 +504,7 @@ func TestRestart(t *testing.T) {
 	nodeRef := &v1.ObjectReference{Kind: "Node", Name: "test", UID: types.UID("test"), Namespace: ""}
 	manager := NewManager(&Config{
 		Logger:                          logger,
+		State:                           NewShutdownState(),
 		VolumeManager:                   fakeVolumeManager,
 		Recorder:                        fakeRecorder,
 		NodeRef:                         nodeRef,
@@ -565,6 +566,7 @@ func TestStartDoesNotReconnectAfterContextCancel(t *testing.T) {
 
 	manager := NewManager(&Config{
 		Logger:                          logger,
+		State:                           NewShutdownState(),
 		VolumeManager:                   volumemanager.NewFakeVolumeManager([]v1.UniqueVolumeName{}, 0, nil, false),
 		Recorder:                        &record.FakeRecorder{},
 		NodeRef:                         &v1.ObjectReference{Kind: "Node", Name: "test", UID: types.UID("test"), Namespace: ""},
@@ -618,7 +620,6 @@ func Test_managerImpl_processShutdownEvent(t *testing.T) {
 		syncNodeStatus                   func(context.Context)
 		dbusCon                          dbusInhibiter
 		inhibitLock                      systemd.InhibitLock
-		nodeShuttingDownNow              bool
 		clock                            clock.Clock
 	}
 	tests := []struct {
@@ -671,15 +672,14 @@ func Test_managerImpl_processShutdownEvent(t *testing.T) {
 				),
 			)
 			m := &managerImpl{
-				logger:                logger,
-				recorder:              tt.fields.recorder,
-				nodeRef:               tt.fields.nodeRef,
-				getPods:               tt.fields.getPods,
-				syncNodeStatus:        tt.fields.syncNodeStatus,
-				dbusCon:               tt.fields.dbusCon,
-				inhibitLock:           tt.fields.inhibitLock,
-				nodeShuttingDownMutex: sync.Mutex{},
-				nodeShuttingDownNow:   tt.fields.nodeShuttingDownNow,
+				logger:         logger,
+				recorder:       tt.fields.recorder,
+				nodeRef:        tt.fields.nodeRef,
+				getPods:        tt.fields.getPods,
+				syncNodeStatus: tt.fields.syncNodeStatus,
+				dbusCon:        tt.fields.dbusCon,
+				inhibitLock:    tt.fields.inhibitLock,
+				state:          &ShutdownState{},
 				podManager: &podManager{
 					logger:                           logger,
 					volumeManager:                    tt.fields.volumeManager,

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -34,7 +33,6 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	kubeletevents "k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/eviction"
-	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/pkg/windows/service"
 
@@ -58,9 +56,8 @@ type managerImpl struct {
 	getPods        eviction.ActivePodsFunc
 	syncNodeStatus func(context.Context)
 
-	nodeShuttingDownMutex sync.Mutex
-	nodeShuttingDownNow   bool
-	podManager            *podManager
+	state      *ShutdownState
+	podManager *podManager
 
 	enableMetrics bool
 	storage       storage
@@ -98,6 +95,7 @@ func NewManager(conf *Config) Manager {
 		nodeRef:        conf.NodeRef,
 		getPods:        conf.GetPodsFunc,
 		syncNodeStatus: conf.SyncNodeStatusFunc,
+		state:          conf.State,
 		podManager:     podManager,
 		enableMetrics:  utilfeature.DefaultFeatureGate.Enabled(features.GracefulNodeShutdownBasedOnPodPriority),
 		storage: localStorage{
@@ -110,20 +108,6 @@ func NewManager(conf *Config) Manager {
 		"shutdownGracePeriodByPodPriority", podManager.shutdownGracePeriodByPodPriority,
 	)
 	return manager
-}
-
-// Admit rejects all pods if node is shutting
-func (m *managerImpl) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult {
-	nodeShuttingDown := m.ShutdownStatus() != nil
-
-	if nodeShuttingDown {
-		return lifecycle.PodAdmitResult{
-			Admit:   false,
-			Reason:  NodeShutdownNotAdmittedReason,
-			Message: nodeShutdownNotAdmittedMessage,
-		}
-	}
-	return lifecycle.PodAdmitResult{Admit: true}
 }
 
 // setMetrics sets the metrics for the node shutdown manager.
@@ -238,10 +222,7 @@ func (m *managerImpl) start() (chan struct{}, error) {
 
 // ShutdownStatus will return an error if the node is currently shutting down.
 func (m *managerImpl) ShutdownStatus() error {
-	m.nodeShuttingDownMutex.Lock()
-	defer m.nodeShuttingDownMutex.Unlock()
-
-	if m.nodeShuttingDownNow {
+	if m.state.ShuttingDown.Load() {
 		return fmt.Errorf("node is shutting down")
 	}
 	return nil
@@ -252,9 +233,7 @@ func (m *managerImpl) ProcessShutdownEvent(ctx context.Context) error {
 
 	m.recorder.Event(m.nodeRef, v1.EventTypeNormal, kubeletevents.NodeShutdown, "Shutdown manager detected preshutdown event")
 
-	m.nodeShuttingDownMutex.Lock()
-	m.nodeShuttingDownNow = true
-	m.nodeShuttingDownMutex.Unlock()
+	m.state.ShuttingDown.Store(true)
 
 	nodeStatusCtx := klog.NewContext(ctx, m.logger)
 	go m.syncNodeStatus(nodeStatusCtx)

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows_test.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows_test.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -88,6 +87,7 @@ func TestFeatureEnabled(t *testing.T) {
 
 			manager := NewManager(&Config{
 				Logger:                          logger,
+				State:                           NewShutdownState(),
 				VolumeManager:                   fakeVolumeManager,
 				Recorder:                        fakeRecorder,
 				NodeRef:                         nodeRef,
@@ -120,7 +120,6 @@ func Test_managerImpl_ProcessShutdownEvent(t *testing.T) {
 		getPods                          eviction.ActivePodsFunc
 		killPodFunc                      eviction.KillPodFunc
 		syncNodeStatus                   func(context.Context)
-		nodeShuttingDownNow              bool
 		clock                            clock.Clock
 	}
 	tests := []struct {
@@ -239,13 +238,12 @@ func Test_managerImpl_ProcessShutdownEvent(t *testing.T) {
 				),
 			)
 			m := &managerImpl{
-				logger:                logger,
-				recorder:              tt.fields.recorder,
-				nodeRef:               tt.fields.nodeRef,
-				getPods:               tt.fields.getPods,
-				syncNodeStatus:        tt.fields.syncNodeStatus,
-				nodeShuttingDownMutex: sync.Mutex{},
-				nodeShuttingDownNow:   tt.fields.nodeShuttingDownNow,
+				logger:         logger,
+				recorder:       tt.fields.recorder,
+				nodeRef:        tt.fields.nodeRef,
+				getPods:        tt.fields.getPods,
+				syncNodeStatus: tt.fields.syncNodeStatus,
+				state:          NewShutdownState(),
 				podManager: &podManager{
 					logger:                           logger,
 					volumeManager:                    tt.fields.volumeManager,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Currently, Kubelet has a structural circular dependency during initialization involving the Allocation Manager, Pod Workers, Volume Manager, and Node Shutdown Manager.

The initialization cycle looks like this:

AllocationManager -> requires ShutdownManager (for its admit handler) -> requires VolumeManager (to wait for unmounts via WaitForAllPodsUnmount) -> requires PodWorkers -> requires AllocationManager.

The AllocationManager only needs the ShutdownManager (AdmitHandler) to check a simple boolean state (is the node shutting down?) so it can reject new pods. However, because these components are tightly coupled, it is forced to depend on the entire heavy teardown logic of the ShutdownManager.

This PR breaks the cycle using state segregation:
    1. Extracted the shutdown boolean into a lightweight, atomic ShutdownState object.
    2. Created a standalone ShutdownAdmitHandler that only depends on this state.
    3. The AllocationManager is now given this lightweight admit handler (breaking the dependency on VolumeManager).
    4. The heavy ShutdownManager is initialized later with the VolumeManager and the shared ShutdownState, which it updates when a shutdown event is intercepted.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Related to https://github.com/kubernetes/kubernetes/issues/132298

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
