### PR TITLE
Prevent ReplicaSet controller from deleting pods that have been orphaned

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -473,7 +473,7 @@ type PodControlInterface interface {
 	// CreatePodsWithGenerateName creates new pods according to the spec, sets object as the pod's controller and sets pod's generateName.
 	CreatePodsWithGenerateName(ctx context.Context, namespace string, template *v1.PodTemplateSpec, object runtime.Object, controllerRef *metav1.OwnerReference, generateName string) error
 	// DeletePod deletes the pod identified by podID.
-	DeletePod(ctx context.Context, namespace string, podID string, object runtime.Object) error
+	DeletePod(ctx context.Context, namespace string, podID string, object runtime.Object, opts metav1.DeleteOptions) error
 	// PatchPod patches the pod.
 	PatchPod(ctx context.Context, namespace, name string, data []byte) error
 }
@@ -616,14 +616,14 @@ func (r RealPodControl) createPods(ctx context.Context, namespace string, pod *v
 	return nil
 }
 
-func (r RealPodControl) DeletePod(ctx context.Context, namespace string, podID string, object runtime.Object) error {
+func (r RealPodControl) DeletePod(ctx context.Context, namespace string, podID string, object runtime.Object, opts metav1.DeleteOptions) error {
 	accessor, err := meta.Accessor(object)
 	if err != nil {
 		return fmt.Errorf("object does not have ObjectMeta, %v", err)
 	}
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("Deleting pod", "controller", accessor.GetName(), "pod", klog.KRef(namespace, podID))
-	if err := r.KubeClient.CoreV1().Pods(namespace).Delete(ctx, podID, metav1.DeleteOptions{}); err != nil {
+	if err := r.KubeClient.CoreV1().Pods(namespace).Delete(ctx, podID, opts); err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.V(4).Info("Pod has already been deleted.", "pod", klog.KRef(namespace, podID))
 			return err
@@ -679,7 +679,7 @@ func (f *FakePodControl) CreatePodsWithGenerateName(ctx context.Context, namespa
 	return nil
 }
 
-func (f *FakePodControl) DeletePod(ctx context.Context, namespace string, podID string, object runtime.Object) error {
+func (f *FakePodControl) DeletePod(ctx context.Context, namespace string, podID string, object runtime.Object, opts metav1.DeleteOptions) error {
 	f.Lock()
 	defer f.Unlock()
 	f.DeletePodName = append(f.DeletePodName, podID)

--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -436,7 +436,7 @@ func TestDeletePodsAllowsMissing(t *testing.T) {
 
 	controllerSpec := newReplicationController(1)
 
-	err := podControl.DeletePod(context.TODO(), "namespace-name", "podName", controllerSpec)
+	err := podControl.DeletePod(context.TODO(), "namespace-name", "podName", controllerSpec, metav1.DeleteOptions{})
 	assert.True(t, apierrors.IsNotFound(err))
 }
 

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -1119,7 +1119,7 @@ func (dsc *DaemonSetsController) syncNodes(ctx context.Context, ds *apps.DaemonS
 	for i := 0; i < deleteDiff; i++ {
 		go func(ix int) {
 			defer deleteWait.Done()
-			if err := dsc.podControl.DeletePod(ctx, ds.Namespace, podsToDelete[ix], ds); err != nil {
+			if err := dsc.podControl.DeletePod(ctx, ds.Namespace, podsToDelete[ix], ds, metav1.DeleteOptions{}); err != nil {
 				// We are cleaning up an expectation that this delete will be observed,
 				// since any failure to delete the pod means that we will never observe
 				// the delete.

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -1119,6 +1119,8 @@ func (dsc *DaemonSetsController) syncNodes(ctx context.Context, ds *apps.DaemonS
 	for i := 0; i < deleteDiff; i++ {
 		go func(ix int) {
 			defer deleteWait.Done()
+			// TODO: Consider using ResourceVersion preconditions to ensure we don't delete a pod that has
+			// been modified since our last cached read.
 			if err := dsc.podControl.DeletePod(ctx, ds.Namespace, podsToDelete[ix], ds, metav1.DeleteOptions{}); err != nil {
 				// We are cleaning up an expectation that this delete will be observed,
 				// since any failure to delete the pod means that we will never observe

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -281,10 +281,10 @@ func (f *fakePodControl) CreatePods(ctx context.Context, namespace string, templ
 	return nil
 }
 
-func (f *fakePodControl) DeletePod(ctx context.Context, namespace string, podID string, object runtime.Object) error {
+func (f *fakePodControl) DeletePod(ctx context.Context, namespace string, podID string, object runtime.Object, opts metav1.DeleteOptions) error {
 	f.Lock()
 	defer f.Unlock()
-	if err := f.FakePodControl.DeletePod(ctx, namespace, podID, object); err != nil {
+	if err := f.FakePodControl.DeletePod(ctx, namespace, podID, object, opts); err != nil {
 		return fmt.Errorf("failed to delete pod %q", podID)
 	}
 	pod, ok := f.podIDMap[podID]

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -1250,7 +1250,7 @@ func (jm *Controller) deleteActivePods(ctx context.Context, job *batch.Job, pods
 	for i := range pods {
 		go func(pod *v1.Pod) {
 			defer wg.Done()
-			if err := jm.podControl.DeletePod(ctx, job.Namespace, pod.Name, job); err != nil && !apierrors.IsNotFound(err) {
+			if err := jm.podControl.DeletePod(ctx, job.Namespace, pod.Name, job, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 				atomic.AddInt32(&successfulDeletes, -1)
 				errCh <- err
 				utilruntime.HandleError(err)
@@ -1307,7 +1307,7 @@ func (jm *Controller) deleteJobPods(ctx context.Context, job *batch.Job, jobKey 
 					return
 				}
 			}
-			if err := jm.podControl.DeletePod(ctx, job.Namespace, pod.Name, job); err != nil {
+			if err := jm.podControl.DeletePod(ctx, job.Namespace, pod.Name, job, metav1.DeleteOptions{}); err != nil {
 				failDelete(pod, err)
 			}
 			if podutil.IsPodReady(pod) {

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -1250,6 +1250,8 @@ func (jm *Controller) deleteActivePods(ctx context.Context, job *batch.Job, pods
 	for i := range pods {
 		go func(pod *v1.Pod) {
 			defer wg.Done()
+			// TODO: Consider using ResourceVersion preconditions to ensure we don't delete a pod that has
+			// been modified since our last cached read.
 			if err := jm.podControl.DeletePod(ctx, job.Namespace, pod.Name, job, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 				atomic.AddInt32(&successfulDeletes, -1)
 				errCh <- err
@@ -1307,6 +1309,8 @@ func (jm *Controller) deleteJobPods(ctx context.Context, job *batch.Job, jobKey 
 					return
 				}
 			}
+			// TODO: Consider using ResourceVersion preconditions to ensure we don't delete a pod that has
+			// been modified since our last cached read.
 			if err := jm.podControl.DeletePod(ctx, job.Namespace, pod.Name, job, metav1.DeleteOptions{}); err != nil {
 				failDelete(pod, err)
 			}

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -723,7 +723,12 @@ func (rsc *ReplicaSetController) manageReplicas(ctx context.Context, activePods 
 		for _, pod := range podsToDelete {
 			go func(targetPod *v1.Pod) {
 				defer wg.Done()
-				if err := rsc.podControl.DeletePod(ctx, rs.Namespace, targetPod.Name, rs); err != nil {
+				opts := metav1.DeleteOptions{
+					Preconditions: &metav1.Preconditions{
+						ResourceVersion: &targetPod.ResourceVersion,
+					},
+				}
+				if err := rsc.podControl.DeletePod(ctx, rs.Namespace, targetPod.Name, rs, opts); err != nil {
 					// Decrement the expected number of deletes because the informer won't observe this deletion
 					podKey := controller.PodKey(targetPod)
 					rsc.expectations.DeletionObserved(logger, rsKey, podKey)

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -732,7 +732,10 @@ func (rsc *ReplicaSetController) manageReplicas(ctx context.Context, activePods 
 					// Decrement the expected number of deletes because the informer won't observe this deletion
 					podKey := controller.PodKey(targetPod)
 					rsc.expectations.DeletionObserved(logger, rsKey, podKey)
-					if !apierrors.IsNotFound(err) {
+					if apierrors.IsConflict(err) {
+						logger.V(4).Info("Conflict deleting pod, decremented expectations", "pod", podKey, "kind", rsc.Kind, "replicaSet", klog.KObj(rs))
+						errCh <- err
+					} else if !apierrors.IsNotFound(err) {
 						logger.V(2).Info("Failed to delete pod, decremented expectations", "pod", podKey, "kind", rsc.Kind, "replicaSet", klog.KObj(rs))
 						errCh <- err
 					}

--- a/pkg/controller/replicaset/replica_set_test.go
+++ b/pkg/controller/replicaset/replica_set_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/onsi/gomega"
 	"math/rand"
 	"net/http/httptest"
 	"net/url"
@@ -31,9 +30,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/onsi/gomega"
+
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -1363,6 +1365,67 @@ func shuffle(controllers []*apps.ReplicaSet) []*apps.ReplicaSet {
 		shuffled[i] = controllers[randIndexes[i]]
 	}
 	return shuffled
+}
+
+type preconditionPodControl struct {
+	*controller.FakePodControl
+	opts metav1.DeleteOptions
+}
+
+func (p *preconditionPodControl) DeletePod(ctx context.Context, namespace string, podID string, object runtime.Object, opts metav1.DeleteOptions) error {
+	p.opts = opts
+	return p.FakePodControl.DeletePod(ctx, namespace, podID, object, opts)
+}
+
+func TestSyncReplicaSetDeletePreconditions(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	labelMap := map[string]string{"foo": "bar"}
+	rs := newReplicaSet(1, labelMap)
+
+	client := fake.NewSimpleClientset(rs)
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	manager, informers := testNewReplicaSetControllerFromClient(t, client, stopCh, BurstReplicas)
+
+	// Add a running pod that belongs to the ReplicaSet
+	podList := newPodList(informers.Core().V1().Pods().Informer().GetIndexer(), 1, v1.PodRunning, labelMap, rs, "pod")
+	pod := &podList.Items[0]
+
+	// Set up scale-down to 0 so the next sync attempts deletion
+	*(rs.Spec.Replicas) = 0
+	if err := informers.Apps().V1().ReplicaSets().Informer().GetIndexer().Add(rs); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set pod's initial RV to "1" for the test setup
+	pod.ResourceVersion = "1"
+	if err := informers.Core().V1().Pods().Informer().GetIndexer().Update(pod); err != nil {
+		t.Fatal(err)
+	}
+
+	fakePodControl := &controller.FakePodControl{}
+	fakePodControl.Err = apierrors.NewConflict(schema.GroupResource{Resource: "pods"}, pod.Name, fmt.Errorf("Precondition failed: ResourceVersion does not match"))
+	podControl := &preconditionPodControl{FakePodControl: fakePodControl}
+	manager.podControl = podControl
+
+	// Run sync.
+	_ = manager.syncReplicaSet(ctx, GetKey(rs, t))
+
+	// Verify that deletion was attempted
+	if len(podControl.DeletePodName) != 1 || podControl.DeletePodName[0] != pod.Name {
+		t.Errorf("Deletion was not attempted correctly, expected %s, got %v", pod.Name, podControl.DeletePodName)
+	}
+	if podControl.opts.Preconditions == nil || podControl.opts.Preconditions.ResourceVersion == nil || *podControl.opts.Preconditions.ResourceVersion != "1" {
+		t.Errorf("Precondition ResourceVersion not set correctly, expected '1', got %v", podControl.opts.Preconditions)
+	}
+
+	// Verify that expectations are satisfied after failure (they are decremented on error)
+	rsKey, _ := controller.KeyFunc(rs)
+	satisfied := manager.expectations.SatisfiedExpectations(klog.FromContext(ctx), rsKey)
+	if !satisfied {
+		t.Errorf("Expectations should be satisfied after failure")
+	}
 }
 
 func TestOverlappingRSs(t *testing.T) {

--- a/pkg/controller/replication/conversion.go
+++ b/pkg/controller/replication/conversion.go
@@ -345,10 +345,10 @@ func (pc podControlAdapter) CreatePods(ctx context.Context, namespace string, te
 	return pc.PodControlInterface.CreatePods(ctx, namespace, template, rc, controllerRef)
 }
 
-func (pc podControlAdapter) DeletePod(ctx context.Context, namespace string, podID string, object runtime.Object) error {
+func (pc podControlAdapter) DeletePod(ctx context.Context, namespace string, podID string, object runtime.Object, opts metav1.DeleteOptions) error {
 	rc, err := convertRStoRC(object.(*apps.ReplicaSet))
 	if err != nil {
 		return err
 	}
-	return pc.PodControlInterface.DeletePod(ctx, namespace, podID, rc)
+	return pc.PodControlInterface.DeletePod(ctx, namespace, podID, rc, opts)
 }

--- a/pkg/controller/statefulset/stateful_pod_control.go
+++ b/pkg/controller/statefulset/stateful_pod_control.go
@@ -236,6 +236,8 @@ func (spc *StatefulPodControl) UpdateStatefulPod(ctx context.Context, set *apps.
 // DeleteStatefulPod deletes a Pod. A NotFound is considered a successful response, since the
 // end result is the same: the pod is deleted.
 func (spc *StatefulPodControl) DeleteStatefulPod(set *apps.StatefulSet, pod *v1.Pod) error {
+	// TODO: Consider using ResourceVersion preconditions to ensure we don't delete a pod that
+	// has been modified since our last cached read.
 	if err := spc.objectMgr.DeletePod(pod); err != nil {
 		if !apierrors.IsNotFound(err) {
 			spc.recordPodEvent("delete", set, pod, err)

--- a/test/integration/replicaset/replicaset_test.go
+++ b/test/integration/replicaset/replicaset_test.go
@@ -1138,3 +1138,100 @@ func TestTerminatingReplicas(t *testing.T) {
 		t.Fatalf("len(pods) = %d, want 7", len(pods.Items))
 	}
 }
+
+func TestReplicaSetScaleDownWithOrphanedPod(t *testing.T) {
+	tCtx, closeFn, rm, informers, clientSet := rmSetup(t)
+	defer closeFn()
+
+	ns := framework.CreateNamespaceOrDie(clientSet, "test-rs-scale-down-orphaned", t)
+	defer framework.DeleteNamespaceOrDie(clientSet, ns, t)
+	stopControllers := runControllerAndInformers(t, rm, informers, 0)
+	defer stopControllers()
+
+	rs := newRS("rs", ns.Name, 1)
+
+	// Create ReplicaSet
+	createdRSs, _ := createRSsPods(t, clientSet, []*apps.ReplicaSet{rs}, []*v1.Pod{})
+	rs = createdRSs[0]
+
+	waitRSStable(t, clientSet, rs)
+
+	podClient := clientSet.CoreV1().Pods(ns.Name)
+	pods := getPods(t, podClient, labelMap())
+	if len(pods.Items) != 1 {
+		t.Fatalf("len(pods) = %d, want 1", len(pods.Items))
+	}
+	pod := &pods.Items[0]
+
+	// Orphan pod by updating labels.
+	newLabelMap := map[string]string{"foo": "baz"}
+	pod = updatePod(t, podClient, pod.Name, func(p *v1.Pod) {
+		p.Labels = newLabelMap
+	})
+
+	// Wait for the ReplicaSet controller to observe the label change and orphan the pod.
+	// Note: This test should pass even without this polling loop because the ReplicaSet controller
+	// sets a ResourceVersion precondition when deleting pods. If the controller tried to delete the pod
+	// before its cache saw the label update, the API server would reject it due to precondition failure.
+	// We wait here to make the test deterministic and ensure it exercises the orphaning logic.
+	if err := wait.PollUntilContextTimeout(tCtx, interval, timeout, true, func(c context.Context) (bool, error) {
+		newPod, err := podClient.Get(c, pod.Name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, err
+			}
+			return false, nil
+		}
+		return metav1.GetControllerOf(newPod) == nil, nil
+	}); err != nil {
+		t.Fatalf("Failed to verify ControllerRef for the pod %s is nil: %v", pod.Name, err)
+	}
+
+	// Wait for the ReplicaSet controller to create a replacement pod.
+	var replacementPod *v1.Pod
+	if err := wait.PollUntilContextTimeout(tCtx, interval, timeout, true, func(c context.Context) (bool, error) {
+		pods := getPods(t, podClient, labelMap())
+		if len(pods.Items) == 1 {
+			replacementPod = pods.Items[0].DeepCopy()
+			return true, nil
+		}
+		return false, nil
+	}); err != nil {
+		t.Fatalf("Failed to wait for replacement pod to be created: %v", err)
+	}
+
+	// Give the ReplicaSet controller time to stabilize after creating the replacement Pod.
+	waitRSStable(t, clientSet, rs)
+
+	// Scale down to 0
+	scaleRS(t, clientSet, rs, 0)
+
+	// Verify that the replacement pod is deleted or has a deletion timestamp
+	if err := wait.PollUntilContextTimeout(tCtx, interval, timeout, true, func(c context.Context) (bool, error) {
+		p, err := podClient.Get(c, replacementPod.Name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, nil
+		}
+		return p.DeletionTimestamp != nil, nil
+	}); err != nil {
+		t.Fatalf("Failed to verify replacement pod is deleted: %v", err)
+	}
+
+	// Verify that the orphaned Pod has not been deleted and is still orphaned.
+	orphanedPod, err := podClient.Get(tCtx, pod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Pod should still exist because it was orphaned and is no longer managed by the ReplicaSet: %v", err)
+	}
+	if orphanedPod.DeletionTimestamp != nil {
+		t.Errorf("Pod should not be deleted, but it has a DeletionTimestamp")
+	}
+	if metav1.GetControllerOf(orphanedPod) != nil {
+		t.Errorf("Pod should still be orphaned, but it has a ControllerRef")
+	}
+	if orphanedPod.Labels["foo"] != "baz" {
+		t.Errorf("Pod labels should still be the new ones, got %v", orphanedPod.Labels)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When the ReplicaSet controller deletes Pods during a scale-down, it does so without making sure it has observed the latest changes to the ReplicaSet. The consequence is that if a Pod has been orphaned and is no longer owned by the ReplicaSet controller, it will still go ahead and delete the Pod.

This PR updates the ReplicaSet controller so that it sets a precondition on the delete call so that it will fail if there has been another update. This makes sure that orphaned pods are not deleted by the controller.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This PR was created with assistance from Gemini

#### Does this PR introduce a user-facing change?

```release-note
Prevent the ReplicaSet controller from deleting orphaned pods
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
