### PR TITLE
Fix grammar in resourcequota package doc: it's -> its

### DIFF
--- a/pkg/registry/core/resourcequota/doc.go
+++ b/pkg/registry/core/resourcequota/doc.go
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package resourcequota provides Registry interface and it's REST
+// Package resourcequota provides Registry interface and its REST
 // implementation for storing ResourceQuota api objects.
 package resourcequota


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Fixes a grammar error in the package doc comment for `pkg/registry/core/resourcequota/doc.go`. The contraction `it's` (it is) is replaced with the possessive `its`.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
Comment-only change, no behavior impact.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```