### PR TITLE
Fix incoherent doc comment on validatePayload

### DIFF
--- a/pkg/volume/util/atomic_writer.go
+++ b/pkg/volume/util/atomic_writer.go
@@ -267,7 +267,7 @@ func (w *AtomicWriter) Write(payload map[string]FileProjection, setPerms func(su
 	return nil
 }
 
-// validatePayload returns an error if any path in the payload returns a copy of the payload with the paths cleaned.
+// validatePayload returns a copy of the payload with the paths cleaned, or an error if any path is invalid.
 func validatePayload(payload map[string]FileProjection) (map[string]FileProjection, error) {
 	cleanPayload := make(map[string]FileProjection)
 	for k, content := range payload {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Fixes the doc comment on `validatePayload` in `pkg/volume/util/atomic_writer.go`. The original sentence was incoherent ("returns an error if any path in the payload returns a copy of the payload..."). The replacement accurately describes the function's behavior: it returns a cleaned copy of the payload, or an error if any path is invalid.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
Comment-only change, no behavior impact.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```