### PR TITLE
kubelet: hoist restartCountLogFileRegex to package level

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -76,6 +76,12 @@ var (
 	ErrPostStartHook = errors.New("PostStartHookError")
 )
 
+// restartCountLogFileRegex matches container log file names of the form
+// "<restartCount>.log" or "<restartCount>.log.<rotation-suffix>". Compiled
+// once at package init since calcRestartCountByLogDir is called for every
+// container restart-count check.
+var restartCountLogFileRegex = regexp.MustCompile(`^(\d+)\.log(\..*)?`)
+
 // recordContainerEvent should be used by the runtime manager for all container related events.
 // it has sanity checks to ensure that we do not write events that can abuse our masters.
 // in particular, it ensures that a containerID never appears in an event message as that
@@ -150,7 +156,6 @@ func calcRestartCountByLogDir(path string) (int, error) {
 		return 0, nil
 	}
 	restartCount := 0
-	restartCountLogFileRegex := regexp.MustCompile(`^(\d+)\.log(\..*)?`)
 	for _, file := range files {
 		if file.IsDir() {
 			continue


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
`calcRestartCountByLogDir` in `pkg/kubelet/kuberuntime/kuberuntime_container.go` recompiled the same regex on every invocation:

```go
restartCountLogFileRegex := regexp.MustCompile(\`^(\d+)\.log(\..*)?\`)
```

This function runs whenever the kubelet needs to recover a container's restart count from the log directory (typically when a container's status is missing). Move the regex to a package-level `var` so it is compiled once at init.

No behavior change.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
The regex literal is unchanged.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```