### PR TITLE
kube-proxy/ipvs: preallocate result slices in runner getters

### DIFF
--- a/pkg/proxy/ipvs/util/ipvs_linux.go
+++ b/pkg/proxy/ipvs/util/ipvs_linux.go
@@ -114,7 +114,7 @@ func (runner *runner) GetVirtualServers() ([]*VirtualServer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not get IPVS services: %w", err)
 	}
-	vss := make([]*VirtualServer, 0)
+	vss := make([]*VirtualServer, 0, len(ipvsSvcs))
 	for _, ipvsSvc := range ipvsSvcs {
 		vs, err := toVirtualServer(ipvsSvc)
 		if err != nil {
@@ -188,7 +188,7 @@ func (runner *runner) GetRealServers(vs *VirtualServer) ([]*RealServer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not get IPVS destination for service: %w", err)
 	}
-	rss := make([]*RealServer, 0)
+	rss := make([]*RealServer, 0, len(dsts))
 	for _, dst := range dsts {
 		dst, err := toRealServer(dst)
 		// TODO: aggregate errors?


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
In `pkg/proxy/ipvs/util/ipvs_linux.go`, both `GetVirtualServers` and `GetRealServers` build a result slice by appending one entry per source element. Pass the source length as the `make()` capacity so the slice does not need to be regrown during the loop.

```go
// before
vss := make([]*VirtualServer, 0)
for _, ipvsSvc := range ipvsSvcs { ... vss = append(vss, vs) }

// after
vss := make([]*VirtualServer, 0, len(ipvsSvcs))
```

These functions are called during proxy syncs and reach hundreds-to-thousands of services in larger clusters.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
No behavior change; matches the existing preallocation pattern used elsewhere in `pkg/proxy/`.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```