### PR TITLE
util/taints: preallocate existing taints list with bound capacity

### DIFF
--- a/pkg/util/taints/taints.go
+++ b/pkg/util/taints/taints.go
@@ -126,7 +126,7 @@ func ParseTaints(spec []string) ([]v1.Taint, []v1.Taint, error) {
 
 // CheckIfTaintsAlreadyExists checks if the node already has taints that we want to add and returns a string with taint keys.
 func CheckIfTaintsAlreadyExists(oldTaints []v1.Taint, taints []v1.Taint) string {
-	var existingTaintList = make([]string, 0)
+	var existingTaintList = make([]string, 0, len(taints))
 	for _, taint := range taints {
 		for _, oldTaint := range oldTaints {
 			if taint.Key == oldTaint.Key && taint.Effect == oldTaint.Effect {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
`CheckIfTaintsAlreadyExists` in `pkg/util/taints/taints.go` builds a list of taint keys, with at most one entry per element of the input `taints` slice. Pass `len(taints)` as the `make()` capacity so the slice doesn't need to be regrown when many taints overlap with the existing set.

```go
// before
var existingTaintList = make([]string, 0)

// after
var existingTaintList = make([]string, 0, len(taints))
```

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
No behavior change.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```