### PR TITLE
kube-proxy/ipvs/ipset: preallocate ListEntries result with bound capacity

### DIFF
--- a/pkg/proxy/ipvs/ipset/ipset.go
+++ b/pkg/proxy/ipvs/ipset/ipset.go
@@ -401,7 +401,7 @@ func (runner *runner) ListEntries(set string) ([]string, error) {
 	memberMatcher := regexp.MustCompile(EntryMemberPattern)
 	list := memberMatcher.ReplaceAllString(string(out[:]), "")
 	strs := strings.Split(list, "\n")
-	results := make([]string, 0)
+	results := make([]string, 0, len(strs))
 	for i := range strs {
 		if len(strs[i]) > 0 {
 			results = append(results, strs[i])


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
In `pkg/proxy/ipvs/ipset/ipset.go`, the `ListEntries` result slice is bounded by the number of lines parsed from the ipset output (`len(strs)`). Pass that as the `make()` capacity so the slice doesn't need to be regrown as entries are appended.

```go
// before
results := make([]string, 0)
for i := range strs { if len(strs[i]) > 0 { results = append(results, strs[i]) } }

// after
results := make([]string, 0, len(strs))
```

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
No behavior change.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```