### PR TITLE
Ensure replicaset annotations are up to date if spec replicas match

### DIFF
--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -71,6 +71,16 @@ func rs(name string, replicas int32, selector map[string]string, timestamp metav
 	}
 }
 
+func rsWithDesiredReplica(name string, replicas int32, selector map[string]string, timestamp metav1.Time, annReplicas, maxSurge int32) *apps.ReplicaSet {
+	r := rs(name, replicas, selector, timestamp)
+	if r.Annotations == nil {
+		r.Annotations = map[string]string{}
+	}
+	r.Annotations[util.DesiredReplicasAnnotation] = fmt.Sprintf("%d", annReplicas)
+	r.Annotations[util.MaxReplicasAnnotation] = fmt.Sprintf("%d", annReplicas+maxSurge)
+	return r
+}
+
 func newRSWithStatus(name string, specReplicas, statusReplicas int32, selector map[string]string) *apps.ReplicaSet {
 	rs := rs(name, specReplicas, selector, noTimestamp)
 	rs.Status = apps.ReplicaSetStatus{

--- a/pkg/controller/deployment/sync.go
+++ b/pkg/controller/deployment/sync.go
@@ -309,6 +309,12 @@ func (dc *DeploymentController) scale(ctx context.Context, deployment *apps.Depl
 	// deployment. If there is no active replica set, then we should scale up the newest replica set.
 	if activeOrLatest := deploymentutil.FindActiveOrLatest(newRS, oldRSs); activeOrLatest != nil {
 		if *(activeOrLatest.Spec.Replicas) == *(deployment.Spec.Replicas) {
+			// Ensure that we have up-to-date "desired-replicas" annotation on replicaset
+			if _, _, err := dc.scaleReplicaSet(
+				ctx, activeOrLatest, *(deployment.Spec.Replicas), deployment, true,
+			); err != nil {
+				return err
+			}
 			return nil
 		}
 		_, _, err := dc.scaleReplicaSet(ctx, activeOrLatest, *(deployment.Spec.Replicas), deployment, false)

--- a/pkg/controller/deployment/sync_test.go
+++ b/pkg/controller/deployment/sync_test.go
@@ -265,6 +265,16 @@ func TestScale(t *testing.T) {
 			expectedNew: rs("foo-v2", 2, nil, newTimestamp),
 			expectedOld: []*apps.ReplicaSet{rs("foo-v1", 1, nil, oldTimestamp)},
 		},
+		{
+			name:          "deployment and replicaset has the same replicas amount - but replicaset annotation differs",
+			deployment:    newDeployment("foo", 2, nil, ptr.To(intstr.FromInt32(1)), ptr.To(intstr.FromInt32(1)), nil),
+			oldDeployment: newDeployment("foo", 2, nil, ptr.To(intstr.FromInt32(1)), ptr.To(intstr.FromInt32(1)), nil),
+			newRS:         rsWithDesiredReplica("foo-v1", 2, nil, newTimestamp, 3, 1),
+			oldRSs:        []*apps.ReplicaSet{},
+
+			expectedNew: rsWithDesiredReplica("foo-v1", 2, nil, newTimestamp, 2, 1),
+			expectedOld: []*apps.ReplicaSet{},
+		},
 	}
 
 	for _, test := range tests {
@@ -282,7 +292,9 @@ func TestScale(t *testing.T) {
 				if desired, ok := test.desiredReplicasAnnotations[test.newRS.Name]; ok {
 					desiredReplicas = desired
 				}
-				deploymentutil.SetReplicasAnnotations(test.newRS, desiredReplicas, desiredReplicas+deploymentutil.MaxSurge(*test.oldDeployment))
+				if test.newRS.Annotations == nil {
+					deploymentutil.SetReplicasAnnotations(test.newRS, desiredReplicas, desiredReplicas+deploymentutil.MaxSurge(*test.oldDeployment))
+				}
 			}
 			for i := range test.oldRSs {
 				rs := test.oldRSs[i]
@@ -307,8 +319,10 @@ func TestScale(t *testing.T) {
 			// Skip updating the map if the replica set wasn't updated since there will be
 			// no update action for it.
 			nameToSize := make(map[string]int32)
+			nameToAnn := make(map[string]map[string]string)
 			if test.newRS != nil {
 				nameToSize[test.newRS.Name] = *(test.newRS.Spec.Replicas)
+				nameToAnn[test.newRS.Name] = test.newRS.Annotations
 			}
 			for i := range test.oldRSs {
 				rs := test.oldRSs[i]
@@ -319,12 +333,19 @@ func TestScale(t *testing.T) {
 				rs := action.(testclient.UpdateAction).GetObject().(*apps.ReplicaSet)
 				if !test.wasntUpdated[rs.Name] {
 					nameToSize[rs.Name] = *(rs.Spec.Replicas)
+					nameToAnn[rs.Name] = rs.Annotations
 				}
 			}
 
-			if test.expectedNew != nil && test.newRS != nil && *(test.expectedNew.Spec.Replicas) != nameToSize[test.newRS.Name] {
-				t.Errorf("%s: expected new replicas: %d, got: %d", test.name, *(test.expectedNew.Spec.Replicas), nameToSize[test.newRS.Name])
-				return
+			if test.expectedNew != nil && test.newRS != nil {
+				if *(test.expectedNew.Spec.Replicas) != nameToSize[test.newRS.Name] {
+					t.Errorf("%s: expected new replicas: %d, got: %d", test.name, *(test.expectedNew.Spec.Replicas), nameToSize[test.newRS.Name])
+					return
+				}
+				if test.expectedNew.Annotations[deploymentutil.DesiredReplicasAnnotation] != nameToAnn[test.newRS.Name][deploymentutil.DesiredReplicasAnnotation] ||
+					test.expectedNew.Annotations[deploymentutil.MaxReplicasAnnotation] != nameToAnn[test.newRS.Name][deploymentutil.MaxReplicasAnnotation] {
+					t.Errorf("%s: expected new annotations: %v, got: %v", test.name, test.expectedNew.Annotations, test.newRS.Annotations)
+				}
 			}
 			if len(test.expectedOld) != len(test.oldRSs) {
 				t.Errorf("%s: expected %d old replica sets, got %d", test.name, len(test.expectedOld), len(test.oldRSs))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind/bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

There's a chance of race condition in deployment controller, which leads to potential deadlock.

Normally, the deployment sync goes as follows (extremely simplified):
1. For a given deployment, deployment controller get its active replica set.
2. Next, it compares deployment spec.Replicas and that replicaset deployment.kubernetes.io/desired-replicas. If these numbers are not equal, it qualifies as "scaling event" - controller makes sure deployment and replicaset replicas are equal (either by scaling up or down), and then returns. **Subsequent steps will not be executed**.
3. If it's not a scaling event, controller proceeds to a regular rollout reconciliation (creating/deleting replicasets, etc).

The catch is - during step 3, controller bails out early if replicaset.Spec.Replicas == deployment.Spec.Replicas. And that's the problem.

Imagine that, for some race condition reason, we end up with deployment.Spec.Replicas == replicaset.Spec.Replicas == 2, and deployment.kubernetes.io/desired-replicas: 3. In this case, it's a "scaling event", so rollout reconciliation is skipped. But scaling is aborted early, because actual replicas amount are equal.

In fact, that imaginary scenario can be completely real - we've experienced it on our k8s clusters, which led to stuck deployments rollout. Not sure what exactly causes it though (maybe some HPA scale events during the rollout, stale watcher caches, etc) - but we've verified that it's a real race condition which can happen. 

In this PR, we add a simple reconciliation in `if replicaset.Spec.Replicas == deployment.Spec.Replicas` bailout case - basically we make sure that replicaset annotation is up to date by "scaling" deployment to its current amount of replicas. It shouldn't add unnecessary API calls, since that scaleReplicaSet bails out early if both annotation and replicas amount are up to date.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
