### PR TITLE
test/e2e: fix "Cillium" typo in netpol test comment

### DIFF
--- a/test/e2e/network/netpol/network_policy.go
+++ b/test/e2e/network/netpol/network_policy.go
@@ -46,7 +46,7 @@ const (
 	// See https://github.com/kubernetes/kubernetes/issues/95879
 	// The semantics of the effect of network policies on loopback calls may be undefined: should
 	//   they always be ALLOWED; how do Services affect this?
-	//   Calico, Cillium, Antrea seem to do different things.
+	//   Calico, Cilium, Antrea seem to do different things.
 	// Since different CNIs have different results, that causes tests including loopback to fail
 	//   on some CNIs.  So let's just ignore loopback calls for the purposes of deciding test pass/fail.
 	ignoreLoopback    = true


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Fixes a small typo (`Cillium` -> `Cilium`) in a Go code comment in
`test/e2e/network/netpol/network_policy.go`. This is a comment-only
change and does not affect any behavior.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Comment-only single-character fix; no behavior change.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```