### PR TITLE
Update scheduler_perf thresholds according to recent results

### DIFF
--- a/test/integration/scheduler_perf/misc/performance-config.yaml
+++ b/test/integration/scheduler_perf/misc/performance-config.yaml
@@ -65,7 +65,7 @@
     featureGates:
       SchedulerAsyncAPICalls: false
     labels: [performance]
-    threshold: 810
+    threshold: 790
     params:
       initNodes: 5000
       initPods: 5000
@@ -74,14 +74,14 @@
     featureGates:
       SchedulerAsyncAPICalls: true
     labels: [performance]
-    threshold: 810
+    threshold: 790
     params:
       initNodes: 5000
       initPods: 5000
       measurePods: 50000
   - name: 5000Nodes_50000Pods_NodeDeclaredFeaturesDisabled
     labels: [performance]
-    threshold: 810
+    threshold: 790
     featureGates:
       NodeDeclaredFeatures: false
     params:

--- a/test/integration/scheduler_perf/topology_spreading/performance-config.yaml
+++ b/test/integration/scheduler_perf/topology_spreading/performance-config.yaml
@@ -52,7 +52,7 @@
       measurePods: 2000
   - name: 5000Nodes_5000Pods
     labels: [performance]
-    threshold: 480
+    threshold: 460
     params:
       initNodes: 5000
       initPods: 5000


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
/kind flake

#### What this PR does / why we need it:

Recently we got an alert due to missed thresholds. The thresholds were set in #136321.

The tests occasionally dip under the threshold. Since the alerts are based on the aggregated (rather than per-test) results, we need to update the thresholds to avoid those, even if they're infrequent.

<img width="2037" height="1110" alt="image" src="https://github.com/user-attachments/assets/7252cad5-790a-479e-b9f2-46197df435ea" />

<img width="2037" height="1110" alt="image" src="https://github.com/user-attachments/assets/0a9fb716-6cd5-40bc-a7f5-df83c2ae7bf9" />

See the results in https://testgrid.k8s.io/sig-scalability-benchmarks#scheduler-perf and https://perf-dash.k8s.io/#/?jobname=scheduler-perf-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkPerfResults&Metric=SchedulingThroughput&Name=SchedulingBasic%2F5000Nodes%2Fnamespace-2&extension_point=not%20applicable&result=not%20applicable

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
