### PR TITLE
refactor: separate New and Update PodInfo and add unit tests

### DIFF
--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -785,53 +785,22 @@ func (pi *PodInfo) DeepCopy() *PodInfo {
 	}
 }
 
-// Update creates a full new PodInfo by default. And only updates the pod when the PodInfo
-// has been instantiated and the passed pod is the exact same one as the original pod.
+// Update updates the pod pointer in PodInfo if the passed pod has the same UID.
+// It returns an error if the UIDs mismatch.
 func (pi *PodInfo) Update(pod *v1.Pod) error {
-	if pod != nil && pi.Pod != nil && pi.Pod.UID == pod.UID {
-		// PodInfo includes immutable information, and so it is safe to update the pod in place if it is
-		// the exact same pod
-		pi.Pod = pod
-		return nil
+	if pod == nil {
+		return fmt.Errorf("cannot update with nil pod")
 	}
-	var preferredAffinityTerms []v1.WeightedPodAffinityTerm
-	var preferredAntiAffinityTerms []v1.WeightedPodAffinityTerm
-	if affinity := pod.Spec.Affinity; affinity != nil {
-		if a := affinity.PodAffinity; a != nil {
-			preferredAffinityTerms = a.PreferredDuringSchedulingIgnoredDuringExecution
-		}
-		if a := affinity.PodAntiAffinity; a != nil {
-			preferredAntiAffinityTerms = a.PreferredDuringSchedulingIgnoredDuringExecution
-		}
+	if pi.Pod == nil {
+		return fmt.Errorf("cannot update PodInfo - its Pod is nil")
 	}
-
-	// Attempt to parse the affinity terms
-	var parseErrs []error
-	requiredAffinityTerms, err := fwk.GetAffinityTerms(pod, fwk.GetPodAffinityTerms(pod.Spec.Affinity))
-	if err != nil {
-		parseErrs = append(parseErrs, fmt.Errorf("requiredAffinityTerms: %w", err))
+	if pi.Pod.UID != pod.UID {
+		return fmt.Errorf("pod UID mismatch, expected %v, got %v", pi.Pod.UID, pod.UID)
 	}
-	requiredAntiAffinityTerms, err := fwk.GetAffinityTerms(pod,
-		fwk.GetPodAntiAffinityTerms(pod.Spec.Affinity))
-	if err != nil {
-		parseErrs = append(parseErrs, fmt.Errorf("requiredAntiAffinityTerms: %w", err))
-	}
-	weightedAffinityTerms, err := fwk.GetWeightedAffinityTerms(pod, preferredAffinityTerms)
-	if err != nil {
-		parseErrs = append(parseErrs, fmt.Errorf("preferredAffinityTerms: %w", err))
-	}
-	weightedAntiAffinityTerms, err := fwk.GetWeightedAffinityTerms(pod, preferredAntiAffinityTerms)
-	if err != nil {
-		parseErrs = append(parseErrs, fmt.Errorf("preferredAntiAffinityTerms: %w", err))
-	}
-
 	pi.Pod = pod
-	pi.RequiredAffinityTerms = requiredAffinityTerms
-	pi.RequiredAntiAffinityTerms = requiredAntiAffinityTerms
-	pi.PreferredAffinityTerms = weightedAffinityTerms
-	pi.PreferredAntiAffinityTerms = weightedAntiAffinityTerms
+	// Reset cached resource to force recomputation on next CalculateResource call.
 	pi.cachedResource = nil
-	return utilerrors.NewAggregate(parseErrs)
+	return nil
 }
 
 func (pi *PodInfo) CalculateResource() fwk.PodResource {
@@ -983,9 +952,48 @@ func (f *FitError) Error() string {
 
 // NewPodInfo returns a new PodInfo.
 func NewPodInfo(pod *v1.Pod) (*PodInfo, error) {
-	pInfo := &PodInfo{}
-	err := pInfo.Update(pod)
-	return pInfo, err
+	if pod == nil {
+		return nil, fmt.Errorf("pod cannot be nil")
+	}
+	pInfo := &PodInfo{Pod: pod}
+
+	var preferredAffinityTerms []v1.WeightedPodAffinityTerm
+	var preferredAntiAffinityTerms []v1.WeightedPodAffinityTerm
+	if affinity := pod.Spec.Affinity; affinity != nil {
+		if a := affinity.PodAffinity; a != nil {
+			preferredAffinityTerms = a.PreferredDuringSchedulingIgnoredDuringExecution
+		}
+		if a := affinity.PodAntiAffinity; a != nil {
+			preferredAntiAffinityTerms = a.PreferredDuringSchedulingIgnoredDuringExecution
+		}
+	}
+
+	// Attempt to parse the affinity terms
+	var parseErrs []error
+	requiredAffinityTerms, err := fwk.GetAffinityTerms(pod, fwk.GetPodAffinityTerms(pod.Spec.Affinity))
+	if err != nil {
+		parseErrs = append(parseErrs, fmt.Errorf("requiredAffinityTerms: %w", err))
+	}
+	requiredAntiAffinityTerms, err := fwk.GetAffinityTerms(pod,
+		fwk.GetPodAntiAffinityTerms(pod.Spec.Affinity))
+	if err != nil {
+		parseErrs = append(parseErrs, fmt.Errorf("requiredAntiAffinityTerms: %w", err))
+	}
+	weightedAffinityTerms, err := fwk.GetWeightedAffinityTerms(pod, preferredAffinityTerms)
+	if err != nil {
+		parseErrs = append(parseErrs, fmt.Errorf("preferredAffinityTerms: %w", err))
+	}
+	weightedAntiAffinityTerms, err := fwk.GetWeightedAffinityTerms(pod, preferredAntiAffinityTerms)
+	if err != nil {
+		parseErrs = append(parseErrs, fmt.Errorf("preferredAntiAffinityTerms: %w", err))
+	}
+
+	pInfo.RequiredAffinityTerms = requiredAffinityTerms
+	pInfo.RequiredAntiAffinityTerms = requiredAntiAffinityTerms
+	pInfo.PreferredAffinityTerms = weightedAffinityTerms
+	pInfo.PreferredAntiAffinityTerms = weightedAntiAffinityTerms
+
+	return pInfo, utilerrors.NewAggregate(parseErrs)
 }
 
 // Resource is a collection of compute resource.

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -2923,6 +2923,150 @@ func TestQueuedPodInfo_UpdateInvalidatesSignature(t *testing.T) {
 	}
 }
 
+func TestPodInfo_Update(t *testing.T) {
+	pod1 := st.MakePod().Name("pod1").UID("uid1").Obj()
+	pod2 := pod1.DeepCopy()
+	pod2.Labels = map[string]string{"foo": "bar"}
+	pod3 := st.MakePod().Name("pod2").UID("uid2").Obj()
+
+	tests := []struct {
+		name        string
+		podInfo     *PodInfo
+		pod         *v1.Pod
+		expectedErr string
+		verify      func(t *testing.T, pi *PodInfo)
+	}{
+		{
+			name:    "successful update (same UID)",
+			podInfo: func() *PodInfo { pi, _ := NewPodInfo(pod1); return pi }(),
+			pod:     pod2,
+			verify: func(t *testing.T, pi *PodInfo) {
+				if pi.Pod.Labels["foo"] != "bar" {
+					t.Errorf("Expected updated labels, got %v", pi.Pod.Labels)
+				}
+			},
+		},
+		{
+			name: "successful update (same UID) - clears cachedResource",
+			podInfo: func() *PodInfo {
+				pi, _ := NewPodInfo(pod1)
+				pi.cachedResource = &fwk.PodResource{}
+				return pi
+			}(),
+			pod: pod2,
+			verify: func(t *testing.T, pi *PodInfo) {
+				if pi.cachedResource != nil {
+					t.Errorf("Expected cachedResource to be nil after Update, got %v", pi.cachedResource)
+				}
+			},
+		},
+		{
+			name:        "failed update (different UID)",
+			podInfo:     func() *PodInfo { pi, _ := NewPodInfo(pod1); return pi }(),
+			pod:         pod3,
+			expectedErr: "pod UID mismatch",
+		},
+		{
+			name:        "failed update (nil pod)",
+			podInfo:     func() *PodInfo { pi, _ := NewPodInfo(pod1); return pi }(),
+			pod:         nil,
+			expectedErr: "cannot update with nil pod",
+		},
+		{
+			name:        "failed update (nil PodInfo.Pod)",
+			podInfo:     &PodInfo{},
+			pod:         pod1,
+			expectedErr: "cannot update PodInfo - its Pod is nil",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.podInfo.Update(tc.pod)
+			if tc.expectedErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.expectedErr) {
+					t.Errorf("Expected error containing '%s', got %v", tc.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error, got %v", err)
+				}
+				if tc.verify != nil {
+					tc.verify(t, tc.podInfo)
+				}
+			}
+		})
+	}
+}
+
+func TestNewPodInfo(t *testing.T) {
+	affinity := &v1.Affinity{
+		PodAffinity: &v1.PodAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"foo": "bar"},
+					},
+					TopologyKey: "kubernetes.io/hostname",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		pod         *v1.Pod
+		expectedErr string
+		verify      func(t *testing.T, pi *PodInfo)
+	}{
+		{
+			name:        "nil pod",
+			pod:         nil,
+			expectedErr: "pod cannot be nil",
+		},
+		{
+			name: "pod without affinity",
+			pod:  st.MakePod().Name("pod1").Obj(),
+			verify: func(t *testing.T, pi *PodInfo) {
+				if pi.Pod.Name != "pod1" {
+					t.Errorf("Expected pod name 'pod1', got %v", pi.Pod.Name)
+				}
+			},
+		},
+		{
+			name: "pod with affinity",
+			pod: func() *v1.Pod {
+				p := st.MakePod().Name("pod2").Obj()
+				p.Spec.Affinity = affinity
+				return p
+			}(),
+			verify: func(t *testing.T, pi *PodInfo) {
+				if len(pi.RequiredAffinityTerms) != 1 {
+					t.Errorf("Expected 1 required affinity term, got %v", len(pi.RequiredAffinityTerms))
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pi, err := NewPodInfo(tc.pod)
+			if tc.expectedErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.expectedErr) {
+					t.Errorf("Expected error containing '%s', got %v", tc.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error, got %v", err)
+				}
+				if tc.verify != nil {
+					tc.verify(t, pi)
+				}
+			}
+		})
+	}
+}
+
 func TestUpdateNodeAllocatableDRAClaimState(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DRANodeAllocatableResources, true)
 	claim1NamespacedName := types.NamespacedName{


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig scheduling

#### What this PR does / why we need it:

This PR refactors `PodInfo` in `pkg/scheduler/framework/types.go` to separate initialization from updates.
- The `Update` method now only updates the pod pointer if the UID matches, avoiding redundant parsing of affinity terms.
- The parsing of affinity terms is now done exclusively in `NewPodInfo` during creation.
- Unit tests have been added for both `Update` and `NewPodInfo` to ensure correctness.

**Testing Done**:
- Added unit tests in `pkg/scheduler/framework/types_test.go`.
- Ran `go test ./pkg/scheduler/framework/...` and all tests passed.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
