### PR TITLE
Moved SortedScoredNodes to framework package

### DIFF
--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -158,8 +158,8 @@ func NewPodsToActivate() *PodsToActivate {
 type SortedScoredNodes interface {
 	Pop() fwk.NodePluginScores
 	Len() int
-	// List returns all nodes in heap-internal order (not sorted by score).
-	List() []fwk.NodePluginScores
+	// UnorderedList returns all nodes in heap-internal order (not sorted by score).
+	UnorderedList() []fwk.NodePluginScores
 }
 
 // PodGroupSchedulingFunc is a function that will be run to check feasibility of a pod group

--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -156,8 +156,10 @@ func NewPodsToActivate() *PodsToActivate {
 
 // SortedScoredNodes is a list of scored nodes, returned from scheduling.
 type SortedScoredNodes interface {
-	Pop() string
+	Pop() fwk.NodePluginScores
 	Len() int
+	// List returns all nodes in heap-internal order (not sorted by score).
+	List() []fwk.NodePluginScores
 }
 
 // PodGroupSchedulingFunc is a function that will be run to check feasibility of a pod group

--- a/pkg/scheduler/framework/runtime/batch.go
+++ b/pkg/scheduler/framework/runtime/batch.go
@@ -87,7 +87,7 @@ func (b *OpportunisticBatch) GetNodeHint(ctx context.Context, pod *v1.Pod, signa
 
 	// Otherwise, pop the head of the list in our state and return it as
 	// a hint. Also record it in our data to compare on storage.
-	hint = b.state.sortedNodes.Pop()
+	hint = b.state.sortedNodes.Pop().Name
 	logger.V(3).Info("OpportunisticBatch provided node hint",
 		"profile", b.handle.ProfileName(), "pod", klog.KObj(pod), "cycleCount", cycleCount, "hint", hint,
 		"remainingNodes", b.state.sortedNodes.Len())

--- a/pkg/scheduler/framework/runtime/batch_test.go
+++ b/pkg/scheduler/framework/runtime/batch_test.go
@@ -184,7 +184,7 @@ func (t *testSortedScoredNodes) Len() int {
 	return len(t.Nodes)
 }
 
-func (t *testSortedScoredNodes) List() []fwk.NodePluginScores {
+func (t *testSortedScoredNodes) UnorderedList() []fwk.NodePluginScores {
 	result := make([]fwk.NodePluginScores, len(t.Nodes))
 	for i, name := range t.Nodes {
 		result[i] = fwk.NodePluginScores{Name: name}

--- a/pkg/scheduler/framework/runtime/batch_test.go
+++ b/pkg/scheduler/framework/runtime/batch_test.go
@@ -174,14 +174,22 @@ type testSortedScoredNodes struct {
 
 var _ framework.SortedScoredNodes = &testSortedScoredNodes{}
 
-func (t *testSortedScoredNodes) Pop() string {
-	ret := t.Nodes[0]
+func (t *testSortedScoredNodes) Pop() fwk.NodePluginScores {
+	ret := fwk.NodePluginScores{Name: t.Nodes[0]}
 	t.Nodes = t.Nodes[1:]
 	return ret
 }
 
 func (t *testSortedScoredNodes) Len() int {
 	return len(t.Nodes)
+}
+
+func (t *testSortedScoredNodes) List() []fwk.NodePluginScores {
+	result := make([]fwk.NodePluginScores, len(t.Nodes))
+	for i, name := range t.Nodes {
+		result[i] = fwk.NodePluginScores{Name: name}
+	}
+	return result
 }
 
 func newTestNodes(n []string) *testSortedScoredNodes {

--- a/pkg/scheduler/framework/sorted_nodes.go
+++ b/pkg/scheduler/framework/sorted_nodes.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -43,8 +43,8 @@ func (s *sortedNodeScores) Len() int {
 	return s.nodes.Len()
 }
 
-// List returns a snapshot of all nodes. The ordering is heap-internal and not sorted.
-func (s *sortedNodeScores) List() []fwk.NodePluginScores {
+// UnorderedList returns all nodes in heap-internal order (not sorted by score).
+func (s *sortedNodeScores) UnorderedList() []fwk.NodePluginScores {
 	result := make([]fwk.NodePluginScores, len(s.nodes))
 	copy(result, s.nodes)
 	return result

--- a/pkg/scheduler/framework/sorted_nodes.go
+++ b/pkg/scheduler/framework/sorted_nodes.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"container/heap"
+
+	fwk "k8s.io/kube-scheduler/framework"
+)
+
+var _ SortedScoredNodes = (*sortedNodeScores)(nil)
+
+type sortedNodeScores struct {
+	nodes nodeScoreHeap
+}
+
+// NewSortedScoredNodes creates a SortedScoredNodes backed by a max-heap keyed on TotalScore.
+func NewSortedScoredNodes(nodeScoreList []fwk.NodePluginScores) SortedScoredNodes {
+	var h nodeScoreHeap = nodeScoreList
+	heap.Init(&h)
+	return &sortedNodeScores{nodes: h}
+}
+
+func (s *sortedNodeScores) Pop() fwk.NodePluginScores {
+	return heap.Pop(&s.nodes).(fwk.NodePluginScores)
+}
+
+func (s *sortedNodeScores) Len() int {
+	return s.nodes.Len()
+}
+
+// List returns a snapshot of all nodes. The ordering is heap-internal and not sorted.
+func (s *sortedNodeScores) List() []fwk.NodePluginScores {
+	result := make([]fwk.NodePluginScores, len(s.nodes))
+	copy(result, s.nodes)
+	return result
+}
+
+// nodeScoreHeap is a heap of fwk.NodePluginScores.
+type nodeScoreHeap []fwk.NodePluginScores
+
+var _ heap.Interface = &nodeScoreHeap{}
+
+func (h nodeScoreHeap) Len() int { return len(h) }
+func (h nodeScoreHeap) Less(i, j int) bool {
+	return (h[i].TotalScore > h[j].TotalScore ||
+		(h[i].TotalScore == h[j].TotalScore && h[i].Randomizer > h[j].Randomizer))
+}
+func (h nodeScoreHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+
+func (h *nodeScoreHeap) Push(x interface{}) {
+	*h = append(*h, x.(fwk.NodePluginScores))
+}
+
+func (h *nodeScoreHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}

--- a/pkg/scheduler/framework/sorted_nodes.go
+++ b/pkg/scheduler/framework/sorted_nodes.go
@@ -44,6 +44,8 @@ func (s *sortedNodeScores) Len() int {
 }
 
 // UnorderedList returns all nodes in heap-internal order (not sorted by score).
+// Only the outer slice is copied. Each NodePluginScores.Scores slice is still
+// shared with the heap. Callers must not mutate the returned elements.
 func (s *sortedNodeScores) UnorderedList() []fwk.NodePluginScores {
 	result := make([]fwk.NodePluginScores, len(s.nodes))
 	copy(result, s.nodes)

--- a/pkg/scheduler/framework/sorted_nodes_test.go
+++ b/pkg/scheduler/framework/sorted_nodes_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	fwk "k8s.io/kube-scheduler/framework"
+)
+
+func TestSortedScoredNodes_Pop(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []fwk.NodePluginScores
+		expected []fwk.NodePluginScores
+	}{
+		{
+			name:     "empty",
+			input:    []fwk.NodePluginScores{},
+			expected: []fwk.NodePluginScores{},
+		},
+		{
+			name: "single node",
+			input: []fwk.NodePluginScores{
+				{Name: "node1", TotalScore: 5},
+			},
+			expected: []fwk.NodePluginScores{
+				{Name: "node1", TotalScore: 5},
+			},
+		},
+		{
+			name: "descending by TotalScore",
+			input: []fwk.NodePluginScores{
+				{Name: "node1", TotalScore: 1},
+				{Name: "node3", TotalScore: 3},
+				{Name: "node2", TotalScore: 2},
+			},
+			expected: []fwk.NodePluginScores{
+				{Name: "node3", TotalScore: 3},
+				{Name: "node2", TotalScore: 2},
+				{Name: "node1", TotalScore: 1},
+			},
+		},
+		{
+			name: "tie-break by Randomizer",
+			input: []fwk.NodePluginScores{
+				{Name: "nodeA", TotalScore: 5, Randomizer: 1},
+				{Name: "nodeB", TotalScore: 5, Randomizer: 3},
+				{Name: "nodeC", TotalScore: 5, Randomizer: 2},
+			},
+			expected: []fwk.NodePluginScores{
+				{Name: "nodeB", TotalScore: 5, Randomizer: 3},
+				{Name: "nodeC", TotalScore: 5, Randomizer: 2},
+				{Name: "nodeA", TotalScore: 5, Randomizer: 1},
+			},
+		},
+		{
+			name: "mixed scores and tie-breaks",
+			input: []fwk.NodePluginScores{
+				{Name: "node3.1", TotalScore: 3, Randomizer: 1},
+				{Name: "node2", TotalScore: 2},
+				{Name: "node1", TotalScore: 1},
+				{Name: "node3.2", TotalScore: 3, Randomizer: 2},
+			},
+			expected: []fwk.NodePluginScores{
+				{Name: "node3.2", TotalScore: 3, Randomizer: 2},
+				{Name: "node3.1", TotalScore: 3, Randomizer: 1},
+				{Name: "node2", TotalScore: 2},
+				{Name: "node1", TotalScore: 1},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewSortedScoredNodes(tc.input)
+			var got []fwk.NodePluginScores
+			for s.Len() > 0 {
+				got = append(got, s.Pop())
+			}
+			if diff := cmp.Diff(tc.expected, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("pop order mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSortedScoredNodes_Len(t *testing.T) {
+	nodes := []fwk.NodePluginScores{
+		{Name: "node1", TotalScore: 10},
+		{Name: "node2", TotalScore: 20},
+		{Name: "node3", TotalScore: 30},
+	}
+	s := NewSortedScoredNodes(nodes)
+	for want := len(nodes); want > 0; want-- {
+		if got := s.Len(); got != want {
+			t.Fatalf("Len() = %d, want %d", got, want)
+		}
+		s.Pop()
+	}
+	if got := s.Len(); got != 0 {
+		t.Errorf("Len() after all pops = %d, want 0", got)
+	}
+}
+
+func TestSortedScoredNodes_List(t *testing.T) {
+	sortByName := cmpopts.SortSlices(func(a, b fwk.NodePluginScores) bool {
+		return a.Name < b.Name
+	})
+	tests := []struct {
+		name     string
+		input    []fwk.NodePluginScores
+		popCount int
+		expected []fwk.NodePluginScores
+	}{
+		{
+			name:     "empty",
+			input:    []fwk.NodePluginScores{},
+			expected: []fwk.NodePluginScores{},
+		},
+		{
+			name: "all nodes before any pops",
+			input: []fwk.NodePluginScores{
+				{Name: "node1", TotalScore: 1},
+				{Name: "node2", TotalScore: 2},
+				{Name: "node3", TotalScore: 3},
+			},
+			expected: []fwk.NodePluginScores{
+				{Name: "node1", TotalScore: 1},
+				{Name: "node2", TotalScore: 2},
+				{Name: "node3", TotalScore: 3},
+			},
+		},
+		{
+			name: "remaining nodes after a pop",
+			input: []fwk.NodePluginScores{
+				{Name: "node1", TotalScore: 1},
+				{Name: "node2", TotalScore: 2},
+				{Name: "node3", TotalScore: 3},
+			},
+			popCount: 1,
+			expected: []fwk.NodePluginScores{
+				{Name: "node1", TotalScore: 1},
+				{Name: "node2", TotalScore: 2},
+			},
+		},
+		{
+			name: "empty after all pops",
+			input: []fwk.NodePluginScores{
+				{Name: "node1", TotalScore: 1},
+				{Name: "node2", TotalScore: 2},
+			},
+			popCount: 2,
+			expected: []fwk.NodePluginScores{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewSortedScoredNodes(tc.input)
+			for range tc.popCount {
+				s.Pop()
+			}
+			got := s.List()
+			if diff := cmp.Diff(tc.expected, got, sortByName, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("List() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/framework/sorted_nodes_test.go
+++ b/pkg/scheduler/framework/sorted_nodes_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -177,7 +177,7 @@ func TestSortedScoredNodes_List(t *testing.T) {
 			for range tc.popCount {
 				s.Pop()
 			}
-			got := s.List()
+			got := s.UnorderedList()
 			if diff := cmp.Diff(tc.expected, got, sortByName, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("List() mismatch (-want +got):\n%s", diff)
 			}

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -17,7 +17,6 @@ limitations under the License.
 package scheduler
 
 import (
-	"container/heap"
 	"context"
 	"errors"
 	"fmt"
@@ -602,8 +601,8 @@ func (sched *Scheduler) schedulePod(ctx context.Context, fwk framework.Framework
 		return result, err
 	}
 
-	sortedPrioritizedNodes := newSortedNodeScores(priorityList)
-	node := sortedPrioritizedNodes.Pop()
+	sortedPrioritizedNodes := framework.NewSortedScoredNodes(priorityList)
+	node := sortedPrioritizedNodes.Pop().Name
 	trace.Step("Prioritizing done")
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.OpportunisticBatching) {
@@ -1045,56 +1044,6 @@ func prioritizeNodes(
 		}
 	}
 	return nodesScores, nil
-}
-
-type sortedNodeScores struct {
-	nodes nodeScoreHeap
-}
-
-func newSortedNodeScores(nodeScoreList []fwk.NodePluginScores) *sortedNodeScores {
-	var h nodeScoreHeap = nodeScoreList
-	heap.Init(&h)
-	return &sortedNodeScores{nodes: h}
-}
-
-func (s *sortedNodeScores) Pop() string {
-	ent := heap.Pop(&s.nodes).(fwk.NodePluginScores)
-	return ent.Name
-}
-
-// Used only for unit tests.
-func (s *sortedNodeScores) PopScore() fwk.NodePluginScores {
-	ent := heap.Pop(&s.nodes).(fwk.NodePluginScores)
-	return ent
-}
-
-func (s *sortedNodeScores) Len() int {
-	return s.nodes.Len()
-}
-
-// nodeScoreHeap is a heap of fwk.NodePluginScores.
-type nodeScoreHeap []fwk.NodePluginScores
-
-// nodeScoreHeap implements heap.Interface.
-var _ heap.Interface = &nodeScoreHeap{}
-
-func (h nodeScoreHeap) Len() int { return len(h) }
-func (h nodeScoreHeap) Less(i, j int) bool {
-	return (h[i].TotalScore > h[j].TotalScore ||
-		(h[i].TotalScore == h[j].TotalScore && h[i].Randomizer > h[j].Randomizer))
-}
-func (h nodeScoreHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
-
-func (h *nodeScoreHeap) Push(x interface{}) {
-	*h = append(*h, x.(fwk.NodePluginScores))
-}
-
-func (h *nodeScoreHeap) Pop() interface{} {
-	old := *h
-	n := len(old)
-	x := old[n-1]
-	*h = old[0 : n-1]
-	return x
 }
 
 // assume signals to the cache that a pod is already in the cache, so that binding can be asynchronous.

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -2725,11 +2725,10 @@ func Test_SelectHost(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var err error
-			var scoreList = []fwk.NodePluginScores{}
-			h := newSortedNodeScores(test.list)
+			var scoreList []fwk.NodePluginScores
+			h := framework.NewSortedScoredNodes(test.list)
 			for range len(test.list) {
-				gotNode := h.PopScore()
-				scoreList = append(scoreList, gotNode)
+				scoreList = append(scoreList, h.Pop())
 			}
 			if !errors.Is(err, test.wantError) {
 				t.Fatalf("unexpected error is returned from selectHost: got: %v want: %v", err, test.wantError)

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -2679,7 +2679,6 @@ func Test_SelectHost(t *testing.T) {
 		name             string
 		list             []fwk.NodePluginScores
 		expectedNodeList []fwk.NodePluginScores
-		wantError        error
 	}{
 		{
 			name: "unique properly ordered scores",
@@ -2724,14 +2723,10 @@ func Test_SelectHost(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			var err error
 			var scoreList []fwk.NodePluginScores
 			h := framework.NewSortedScoredNodes(test.list)
 			for range len(test.list) {
 				scoreList = append(scoreList, h.Pop())
-			}
-			if !errors.Is(err, test.wantError) {
-				t.Fatalf("unexpected error is returned from selectHost: got: %v want: %v", err, test.wantError)
 			}
 			if !cmp.Equal(test.expectedNodeList, scoreList) {
 				t.Errorf("Unexpected scoreList: %v", scoreList)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Moved `sortedNodeScores` and `nodeScoreHeap` from `schedule_one.go` into `pkg/scheduler/framework/sorted_nodes.go`.

  Two interface changes were done in `SortedScoredNodes`:
  1. `Pop()` returns `NodePluginScores` instead of string, useful for callers that need the full struct, callers that only need the name can use `.Pop().Name`.
  2. `List()` was added, returning all remaining nodes. The rescoring path will need this in a future PR when cached nodes scores will need to be normalized.

Added unit tests for `SortedScoredNodes` interface.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

https://github.com/kubernetes/kubernetes/issues/137707

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
- [KEP-5598: Opportunistic Batching](https://git.k8s.io/enhancements/keps/sig-scheduling/5598-opportunistic-batching/README.md)
- [KEP Rescore PR](https://github.com/kubernetes/enhancements/pull/6039)

#### Other comments:
AI tooling was used to assist in preparing this PR. All changes have been reviewed and verified by the author.