### PR TITLE
validation-gen:Support symbolic MIN/MAX values in maximum/minimum tags

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/doc.go
@@ -122,3 +122,17 @@ type NegativeMinimumStruct struct {
 
 // +k8s:minimum=1
 type IntType int
+
+type SymbolicStruct struct {
+	TypeMeta int
+
+	// +k8s:minimum=MIN
+	Int32MinField int32 `json:"int32MinField"`
+	// +k8s:minimum=MAX
+	Int32MaxField int32 `json:"int32MaxField"`
+
+	// +k8s:minimum=MIN
+	Uint32MinField uint32 `json:"uint32MinField"`
+	// +k8s:minimum=MAX
+	Uint32MaxField uint32 `json:"uint32MaxField"`
+}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/doc_test.go
@@ -338,3 +338,35 @@ func TestNegativeMinimumStruct(t *testing.T) {
 		field.Invalid(field.NewPath("requiredNegativeMinimumPtrField"), nil, "").WithOrigin("minimum"),
 	})
 }
+
+func TestSymbolicStruct(t *testing.T) {
+	st := localSchemeBuilder.Test(t)
+
+	// Int32MinField has minimum=MIN (-2147483648). All values in int32 range are valid.
+	st.Value(&SymbolicStruct{
+		Int32MinField:  -2147483648,
+		Int32MaxField:  2147483647,
+		Uint32MinField: 0,
+		Uint32MaxField: 4294967295,
+	}).ExpectValid()
+
+	// Int32MaxField has minimum=MAX (2147483647). Value 2147483646 is below minimum.
+	st.Value(&SymbolicStruct{
+		Int32MinField:  -2147483648,
+		Int32MaxField:  2147483646,
+		Uint32MinField: 0,
+		Uint32MaxField: 4294967295,
+	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
+		field.Invalid(field.NewPath("int32MaxField"), nil, "").WithOrigin("minimum"),
+	})
+
+	// Uint32MaxField has minimum=MAX (4294967295). Value 4294967294 is below minimum.
+	st.Value(&SymbolicStruct{
+		Int32MinField:  -2147483648,
+		Int32MaxField:  2147483647,
+		Uint32MinField: 0,
+		Uint32MaxField: 4294967294,
+	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
+		field.Invalid(field.NewPath("uint32MaxField"), nil, "").WithOrigin("minimum"),
+	})
+}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/zz_generated.validations.go
@@ -97,6 +97,21 @@ func RegisterValidations(scheme *testscheme.Scheme) error {
 				field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath())),
 			}
 		})
+	// type SymbolicStruct
+	scheme.AddValidationFunc(
+		(*SymbolicStruct)(nil),
+		func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+			switch op.Request.SubresourcePath() {
+			case "/":
+				return Validate_SymbolicStruct(
+					ctx, op, nil, /* fldPath */
+					obj.(*SymbolicStruct),
+					safe.Cast[*SymbolicStruct](oldObj))
+			}
+			return field.ErrorList{
+				field.InternalError(nil, fmt.Errorf("no validation found for %T, subresource: %v", obj, op.Request.SubresourcePath())),
+			}
+		})
 	return nil
 }
 
@@ -858,6 +873,113 @@ func Validate_RequiredStruct(
 				return oldObj.RequiredTypedefPtrField
 			})
 		errs = append(errs, fn(fldPath.Child("requiredTypedefPtrField"), obj.RequiredTypedefPtrField, oldVal, oldObj != nil)...)
+	}
+
+	return errs
+}
+
+// Validate_SymbolicStruct validates an instance of SymbolicStruct according
+// to declarative validation rules in the API schema.
+func Validate_SymbolicStruct(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *SymbolicStruct) (errs field.ErrorList) {
+
+	// field SymbolicStruct.TypeMeta has no validation
+
+	{ // field SymbolicStruct.Int32MinField
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int32,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, -2147483648); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *SymbolicStruct) *int32 {
+				return &oldObj.Int32MinField
+			})
+		errs = append(errs, fn(fldPath.Child("int32MinField"), &obj.Int32MinField, oldVal, oldObj != nil)...)
+	}
+
+	{ // field SymbolicStruct.Int32MaxField
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int32,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 2147483647); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *SymbolicStruct) *int32 {
+				return &oldObj.Int32MaxField
+			})
+		errs = append(errs, fn(fldPath.Child("int32MaxField"), &obj.Int32MaxField, oldVal, oldObj != nil)...)
+	}
+
+	{ // field SymbolicStruct.Uint32MinField
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *uint32,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *SymbolicStruct) *uint32 {
+				return &oldObj.Uint32MinField
+			})
+		errs = append(errs, fn(fldPath.Child("uint32MinField"), &obj.Uint32MinField, oldVal, oldObj != nil)...)
+	}
+
+	{ // field SymbolicStruct.Uint32MaxField
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *uint32,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 4294967295); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *SymbolicStruct) *uint32 {
+				return &oldObj.Uint32MaxField
+			})
+		errs = append(errs, fn(fldPath.Child("uint32MaxField"), &obj.Uint32MaxField, oldVal, oldObj != nil)...)
 	}
 
 	return errs

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/util/util.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/util/util.go
@@ -142,20 +142,9 @@ func ParseInt(val string) (int, error) {
 // validates that the result fits within the specified bit size. The bitSize
 // parameter should be 8, 16, 32, or 64, corresponding to the target Go type.
 // Values outside the representable range for the target type are rejected at
-// parse time with a descriptive error.
+// parse time with a descriptive error. The symbolic values "MIN" and "MAX"
+// are also supported, resolving to the type-appropriate bound.
 func ParseSignedInt(val string, bitSize int) (int64, error) {
-	intVal, err := strconv.ParseInt(val, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("parsing %q as int: %w", val, err)
-	}
-
-	// Verify canonical form: reject leading zeros, unary plus, etc.
-	strVal := strconv.FormatInt(intVal, 10)
-	if strVal != val {
-		return 0, fmt.Errorf("%q is not a valid int value", val)
-	}
-
-	// Validate the parsed value fits in the target type's range.
 	var minVal, maxVal int64
 	switch bitSize {
 	case 8:
@@ -169,6 +158,26 @@ func ParseSignedInt(val string, bitSize int) (int64, error) {
 	default:
 		return 0, fmt.Errorf("unsupported bitSize %d; must be 8, 16, 32, or 64", bitSize)
 	}
+
+	if val == "MIN" {
+		return minVal, nil
+	}
+	if val == "MAX" {
+		return maxVal, nil
+	}
+
+	intVal, err := strconv.ParseInt(val, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parsing %q as int: %w", val, err)
+	}
+
+	// Verify canonical form: reject leading zeros, unary plus, etc.
+	strVal := strconv.FormatInt(intVal, 10)
+	if strVal != val {
+		return 0, fmt.Errorf("%q is not a valid int value", val)
+	}
+
+	// Validate the parsed value fits in the target type's range.
 	if intVal < minVal || intVal > maxVal {
 		return 0, fmt.Errorf("value %d does not fit in int%d (range [%d, %d])", intVal, bitSize, minVal, maxVal)
 	}
@@ -179,19 +188,9 @@ func ParseSignedInt(val string, bitSize int) (int64, error) {
 // ParseUnsignedInt strictly parses an unsigned integer from a string input and
 // validates that the result fits within the specified bit size. The bitSize
 // parameter should be 8, 16, 32, or 64, corresponding to the target Go type.
+// The symbolic values "MIN" and "MAX" are also supported, resolving to 0 and
+// the maximum representable value for the specified bit size respectively.
 func ParseUnsignedInt(val string, bitSize int) (uint64, error) {
-	uintVal, err := strconv.ParseUint(val, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("parsing %q as uint: %w", val, err)
-	}
-
-	// Verify canonical form: reject leading zeros, unary plus, etc.
-	strVal := strconv.FormatUint(uintVal, 10)
-	if strVal != val {
-		return 0, fmt.Errorf("%q is not a valid uint value", val)
-	}
-
-	// Validate the parsed value fits in the target type's range.
 	var maxVal uint64
 	switch bitSize {
 	case 8:
@@ -205,6 +204,26 @@ func ParseUnsignedInt(val string, bitSize int) (uint64, error) {
 	default:
 		return 0, fmt.Errorf("unsupported bitSize %d; must be 8, 16, 32, or 64", bitSize)
 	}
+
+	if val == "MIN" {
+		return 0, nil
+	}
+	if val == "MAX" {
+		return maxVal, nil
+	}
+
+	uintVal, err := strconv.ParseUint(val, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parsing %q as uint: %w", val, err)
+	}
+
+	// Verify canonical form: reject leading zeros, unary plus, etc.
+	strVal := strconv.FormatUint(uintVal, 10)
+	if strVal != val {
+		return 0, fmt.Errorf("%q is not a valid uint value", val)
+	}
+
+	// Validate the parsed value fits in the target type's range.
 	if uintVal > maxVal {
 		return 0, fmt.Errorf("value %d does not fit in uint%d (range [0, %d])", uintVal, bitSize, maxVal)
 	}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/util/util_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/util/util_test.go
@@ -652,6 +652,55 @@ func TestParseSignedInt(t *testing.T) {
 			bitSize:       8,
 			expectedError: true,
 		},
+		// --- symbolic values ---
+		{
+			name:        "int32 symbolic MIN",
+			in:          "MIN",
+			bitSize:     32,
+			expectedOut: -2147483648,
+		},
+		{
+			name:        "int32 symbolic MAX",
+			in:          "MAX",
+			bitSize:     32,
+			expectedOut: 2147483647,
+		},
+		{
+			name:        "int64 symbolic MIN",
+			in:          "MIN",
+			bitSize:     64,
+			expectedOut: -9223372036854775808,
+		},
+		{
+			name:        "int64 symbolic MAX",
+			in:          "MAX",
+			bitSize:     64,
+			expectedOut: 9223372036854775807,
+		},
+		{
+			name:        "int16 symbolic MIN",
+			in:          "MIN",
+			bitSize:     16,
+			expectedOut: -32768,
+		},
+		{
+			name:        "int16 symbolic MAX",
+			in:          "MAX",
+			bitSize:     16,
+			expectedOut: 32767,
+		},
+		{
+			name:        "int8 symbolic MIN",
+			in:          "MIN",
+			bitSize:     8,
+			expectedOut: -128,
+		},
+		{
+			name:        "int8 symbolic MAX",
+			in:          "MAX",
+			bitSize:     8,
+			expectedOut: 127,
+		},
 		// --- canonical form rejection ---
 		{
 			name:          "leading zeros rejected",
@@ -819,6 +868,55 @@ func TestParseUnsignedInt(t *testing.T) {
 			in:          "4294967296",
 			bitSize:     64,
 			expectedOut: 4294967296,
+		},
+		// --- symbolic values ---
+		{
+			name:        "uint64 symbolic MIN",
+			in:          "MIN",
+			bitSize:     64,
+			expectedOut: 0,
+		},
+		{
+			name:        "uint64 symbolic MAX",
+			in:          "MAX",
+			bitSize:     64,
+			expectedOut: 18446744073709551615,
+		},
+		{
+			name:        "uint32 symbolic MIN",
+			in:          "MIN",
+			bitSize:     32,
+			expectedOut: 0,
+		},
+		{
+			name:        "uint32 symbolic MAX",
+			in:          "MAX",
+			bitSize:     32,
+			expectedOut: 4294967295,
+		},
+		{
+			name:        "uint16 symbolic MIN",
+			in:          "MIN",
+			bitSize:     16,
+			expectedOut: 0,
+		},
+		{
+			name:        "uint16 symbolic MAX",
+			in:          "MAX",
+			bitSize:     16,
+			expectedOut: 65535,
+		},
+		{
+			name:        "uint8 symbolic MIN",
+			in:          "MIN",
+			bitSize:     8,
+			expectedOut: 0,
+		},
+		{
+			name:        "uint8 symbolic MAX",
+			in:          "MAX",
+			bitSize:     8,
+			expectedOut: 255,
 		},
 		// --- canonical form rejection ---
 		{

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/limits.go
@@ -454,7 +454,7 @@ func (mtv minimumTagValidator) Docs() TagDoc {
 			Description: "<integer>",
 			Docs:        "This field must be greater than or equal to X.",
 		}},
-		PayloadsType:     codetags.ValueTypeInt,
+		PayloadsType:     codetags.ValueTypeRaw,
 		PayloadsRequired: true,
 	}
 }
@@ -517,7 +517,7 @@ func (mtv maximumTagValidator) Docs() TagDoc {
 			Description: "<integer>",
 			Docs:        "This field must be less than or equal to X.",
 		}},
-		PayloadsType:     codetags.ValueTypeInt,
+		PayloadsType:     codetags.ValueTypeRaw,
 		PayloadsRequired: true,
 	}
 }


### PR DESCRIPTION


#### What type of PR is this?

/kind feature
/sig-api-machinery

#### What this PR does / why we need it:

This PR allows `MIN` and `MAX` as symbolic values for `k8s:minimum` and `k8s:maximum` validation markers in validation-gen. The values natively resolve based on the field's concrete type.

Key changes:
- `ParseSignedInt` and `ParseUnsignedInt` now intercept "MIN" and "MAX" resolving them to correct limit depending on the `bitSize` argument. 
- Test coverage for both symbolic parsers has been implemented across all supported bit sizes.
- Changes the payloadsType of `k8s:minimum` and `k8s:maximum` tags to `ValueTypeRaw`.

#### Which issue(s) this PR is related to:
Fixes  #137966

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`validation-gen` now supports symbolic `MIN` and `MAX` values inside `k8s:minimum` and `k8s:maximum` DV markers.
```