### PR TITLE
Fix ContainerMetrics cadvisor test flake for block I/O metrics

### DIFF
--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -182,7 +182,7 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 						"CPU": ptrMatchAllFields(gstruct.Fields{
 							"Time":                 recent(maxStatsAge),
 							"UsageNanoCores":       bounded(10000, 1e9),
-							"UsageCoreNanoSeconds": bounded(10000000, 1e11),
+							"UsageCoreNanoSeconds": bounded(10000000, 1e12),
 							"PSI":                  psiExpectation(),
 						}),
 						"Memory": ptrMatchAllFields(gstruct.Fields{
@@ -233,7 +233,7 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 				"CPU": ptrMatchAllFields(gstruct.Fields{
 					"Time":                 recent(maxStatsAge),
 					"UsageNanoCores":       bounded(10000, 1e9),
-					"UsageCoreNanoSeconds": bounded(10000000, 1e11),
+					"UsageCoreNanoSeconds": bounded(10000000, 1e12),
 					"PSI":                  psiExpectation(),
 				}),
 				"Memory": ptrMatchAllFields(gstruct.Fields{
@@ -510,7 +510,7 @@ func getSummaryTestPods(f *framework.Framework, numRestarts int32, names ...stri
 								Add: []v1.Capability{"NET_RAW"},
 							},
 						},
-						Command: getRestartingContainerCommand("/test-empty-dir-mnt", 0, numRestarts, "echo 'some bytes' >/outside_the_volume.txt; ping -c 1 google.com; echo 'hello world' >> /test-empty-dir-mnt/file; dd if=/dev/zero of=/dev/null bs=1 count=10000000;"),
+						Command: getRestartingContainerCommand("/test-empty-dir-mnt", 0, numRestarts, "dd if=/dev/zero of=/outside_the_volume.txt bs=4096 count=2 conv=fsync 2>/dev/null; ping -c 1 google.com; echo 'hello world' >> /test-empty-dir-mnt/file; dd if=/dev/zero of=/dev/null bs=1 count=10000000;"),
 						Resources: v1.ResourceRequirements{
 							Limits: v1.ResourceList{
 								// Must set memory limit to get MemoryStats.AvailableBytes


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
The test pod's `echo` writes (~11 bytes) stay in page cache and never reach the block device within the 60-second test window. This leaves the cgroup `io.stat` empty, so cadvisor does not emit `container_blkio_device_usage_total`, `container_fs_reads_bytes_total`, or `container_fs_writes_bytes_total`.
This PR replaces the `echo` with `dd conv=fsync` to force data through the block layer. Once `io.stat` has a device entry, all fields are present (even zeros), so all metrics pass.

Also increases the `UsageCoreNanoSeconds` upper bound from `1e11` to `1e12` for the container and pod-level CPU checks. The cumulative CPU time can exceed 100s on slower architectures like ppc64le where the `dd` CPU burner loop accumulates faster than expected.

#### Which issue(s) this PR is related to:
Fixes #138843
Refers to #138753

#### Special notes for your reviewer:
The flake started after #138755 replaced `openssl speed` with `dd if=/dev/zero of=/dev/null`.

#### Does this PR introduce a user-facing change?
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
None
```