### PR TITLE
kubeadm: validate HTTP status when fetching cluster-info over HTTPS

### DIFF
--- a/cmd/kubeadm/app/discovery/https/https.go
+++ b/cmd/kubeadm/app/discovery/https/https.go
@@ -26,11 +26,16 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"k8s.io/kubernetes/cmd/kubeadm/app/discovery/file"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/errors"
 )
 
-// RetrieveValidatedConfigInfo connects to the API Server and makes sure it can talk
-// securely to the API Server using the provided CA cert and
-// optionally refreshes the cluster-info information from the cluster-info ConfigMap
+// RetrieveValidatedConfigInfo downloads a discovery kubeconfig from the given
+// HTTPS URL and hands it to file.ValidateConfigInfo for the cluster-info
+// ConfigMap validation that completes discovery. The HTTPS connection itself
+// is verified only against the host's default TLS trust store; kubeadm does
+// not pin to a caller-supplied CA at this stage, so the kubeconfig payload is
+// retrieved from an effectively arbitrary location and only becomes trusted
+// after file.ValidateConfigInfo succeeds.
 func RetrieveValidatedConfigInfo(httpsURL string, discoveryTimeout time.Duration) (*clientcmdapi.Config, error) {
 	client := &http.Client{Transport: netutil.SetOldTransportDefaults(&http.Transport{})}
 	response, err := client.Get(httpsURL)
@@ -38,6 +43,10 @@ func RetrieveValidatedConfigInfo(httpsURL string, discoveryTimeout time.Duration
 		return nil, err
 	}
 	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("error trying to fetch discovery kubeconfig over HTTPS from %s, received status %d", httpsURL, response.StatusCode)
+	}
 
 	kubeconfig, err := io.ReadAll(response.Body)
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`RetrieveValidatedConfigInfo` in `cmd/kubeadm/app/discovery/https/https.go` previously read the response body of the cluster-info HTTP GET unconditionally and then tried to parse it as a kubeconfig:

```go
response, err := client.Get(httpsURL)
if err != nil {
    return nil, err
}
defer response.Body.Close()

kubeconfig, err := io.ReadAll(response.Body)   // <-- no status code check
```

A non-200 response (404, 5xx, or an HTML error page from a misconfigured server) would silently flow into `clientcmd.Load()` and produce a confusing parse error far from the actual cause. This PR adds an explicit status check, matching the pattern already used in `cmd/kubeadm/app/util/version.go`.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
The error message follows the format used by `version.go`:

```go
if response.StatusCode != http.StatusOK {
    return nil, errors.Errorf("unable to fetch cluster-info. URL: %q, status: %v", httpsURL, response.Status)
}
```

#### Does this PR introduce a user-facing change?
```release-note
kubeadm: when fetching cluster-info over HTTPS during discovery, the HTTP response status code is now checked, so a non-200 response produces a clear error instead of a confusing kubeconfig parse failure.
```