### PR TITLE
Add retrying for Bind API calls

### DIFF
--- a/pkg/scheduler/framework/api_calls/pod_binding.go
+++ b/pkg/scheduler/framework/api_calls/pod_binding.go
@@ -25,6 +25,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/util"
 )
 
 // PodBindingCall is used to bind the pod using the binding details.
@@ -50,7 +51,7 @@ func (pbc *PodBindingCall) Execute(ctx context.Context, client clientset.Interfa
 	logger := klog.FromContext(ctx)
 	logger.V(3).Info("Attempting to bind pod to node", "pod", klog.KObj(&pbc.binding.ObjectMeta), "node", pbc.binding.Target.Name)
 
-	return client.CoreV1().Pods(pbc.binding.Namespace).Bind(ctx, pbc.binding, metav1.CreateOptions{})
+	return util.BindPod(ctx, client, pbc.binding)
 }
 
 func (pbc *PodBindingCall) Sync(obj metav1.Object) (metav1.Object, error) {

--- a/pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
+++ b/pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
+	"k8s.io/kubernetes/pkg/scheduler/util"
 )
 
 // Name of the plugin used in the plugin registry and configurations.
@@ -67,7 +68,7 @@ func (b DefaultBinder) Bind(ctx context.Context, state fwk.CycleState, p *v1.Pod
 		return nil
 	}
 	logger.V(3).Info("Attempting to bind pod to node", "pod", klog.KObj(p), "node", klog.KRef("", nodeName))
-	err := b.handle.ClientSet().CoreV1().Pods(binding.Namespace).Bind(ctx, binding, metav1.CreateOptions{})
+	err := util.BindPod(ctx, b.handle.ClientSet(), binding)
 	if err != nil {
 		return fwk.AsStatus(err)
 	}

--- a/pkg/scheduler/util/utils.go
+++ b/pkg/scheduler/util/utils.go
@@ -98,7 +98,21 @@ func MoreImportantPod(pod1, pod2 *v1.Pod) bool {
 // Retriable defines the retriable errors during a scheduling cycle.
 func Retriable(err error) bool {
 	return apierrors.IsInternalError(err) || apierrors.IsServiceUnavailable(err) ||
-		apierrors.IsConflict(err) || net.IsConnectionRefused(err)
+		net.IsConnectionRefused(err)
+}
+
+// RetriableWithConflict defines the retriable errors during a scheduling cycle, including conflicts.
+func RetriableWithConflict(err error) bool {
+	return Retriable(err) || apierrors.IsConflict(err)
+}
+
+// BindPod binds a pod to a node with retry.
+func BindPod(ctx context.Context, cs kubernetes.Interface, binding *v1.Binding) error {
+	bindFn := func() error {
+		return cs.CoreV1().Pods(binding.Namespace).Bind(ctx, binding, metav1.CreateOptions{})
+	}
+
+	return retry.OnError(retry.DefaultBackoff, Retriable, bindFn)
 }
 
 // PatchPodStatus calculates the delta bytes change from <old.Status> to <newStatus>,
@@ -135,7 +149,7 @@ func PatchPodStatus(ctx context.Context, cs kubernetes.Interface, name string, n
 		return err
 	}
 
-	return retry.OnError(retry.DefaultBackoff, Retriable, patchFn)
+	return retry.OnError(retry.DefaultBackoff, RetriableWithConflict, patchFn)
 }
 
 // PatchPodGroupStatus calculates the delta bytes change from <old.Status> to <newStatus>,
@@ -174,7 +188,7 @@ func PatchPodGroupStatus(ctx context.Context, cs kubernetes.Interface, name stri
 		return err
 	}
 
-	return retry.OnError(retry.DefaultBackoff, Retriable, patchFn)
+	return retry.OnError(retry.DefaultBackoff, RetriableWithConflict, patchFn)
 }
 
 // DeletePod deletes the given <pod> from API server

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/net"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
@@ -613,6 +614,123 @@ func TestPatchPodGroupStatus(t *testing.T) {
 			}
 			if diff := cmp.Diff(wantStatus, retrievedPG.Status); diff != "" {
 				t.Errorf("unexpected podgroup status (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestBindPod(t *testing.T) {
+	binding := &v1.Binding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod",
+			Namespace: "ns",
+		},
+		Target: v1.ObjectReference{
+			Name: "node",
+		},
+	}
+
+	validateNoErr := func(err error) bool { return err == nil }
+
+	tests := []struct {
+		name          string
+		errFunc       func() error
+		failCalls     int
+		expectedCalls int
+		validateErr   func(error) bool
+	}{
+		{
+			name:          "successful",
+			failCalls:     0,
+			expectedCalls: 1,
+			validateErr:   validateNoErr,
+		},
+		{
+			name: "no retry on conflict",
+			errFunc: func() error {
+				return apierrors.NewConflict(v1.Resource("pods"), "pod", errors.New("conflict"))
+			},
+			failCalls:     1,
+			expectedCalls: 1,
+			validateErr:   apierrors.IsConflict,
+		},
+		{
+			name: "retry on internal error and succeed",
+			errFunc: func() error {
+				return apierrors.NewInternalError(errors.New("internal"))
+			},
+			failCalls:     1,
+			expectedCalls: 2,
+			validateErr:   validateNoErr,
+		},
+		{
+			name: "retry on service unavailable and succeed",
+			errFunc: func() error {
+				return apierrors.NewServiceUnavailable("service unavailable")
+			},
+			failCalls:     1,
+			expectedCalls: 2,
+			validateErr:   validateNoErr,
+		},
+		{
+			name: "retry on connection refused and succeed",
+			errFunc: func() error {
+				return fmt.Errorf("connection refused: %w", syscall.ECONNREFUSED)
+			},
+			failCalls:     1,
+			expectedCalls: 2,
+			validateErr:   validateNoErr,
+		},
+		{
+			name: "no retry on not found",
+			errFunc: func() error {
+				return apierrors.NewNotFound(v1.Resource("pods"), "pod")
+			},
+			failCalls:     1,
+			expectedCalls: 1,
+			validateErr:   apierrors.IsNotFound,
+		},
+		{
+			name: "persistent internal error fails after retries",
+			errFunc: func() error {
+				return apierrors.NewInternalError(errors.New("internal"))
+			},
+			failCalls:     retry.DefaultBackoff.Steps,
+			expectedCalls: retry.DefaultBackoff.Steps,
+			validateErr:   apierrors.IsInternalError,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			client := clientsetfake.NewClientset()
+			calls := 0
+			client.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+				createAction := action.(clienttesting.CreateActionImpl)
+				if createAction.Subresource != "binding" {
+					return false, nil, nil
+				}
+				calls++
+
+				if calls <= tc.failCalls {
+					return true, nil, tc.errFunc()
+				}
+
+				return true, nil, nil
+			})
+
+			err := BindPod(ctx, client, binding)
+
+			if !tc.validateErr(err) {
+				t.Errorf("BindPod() returned unexpected error: %v", err)
+			}
+
+			if calls != tc.expectedCalls {
+				t.Errorf("Expected %d calls to binding API, got %d", tc.expectedCalls, calls)
 			}
 		})
 	}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds retrying of binding API calls. With group pod scheduling if one pod will not bind successfully all group will not bind. This may cause problems with binding big groups of pods. With retries on transient errors we are increasing chances of group to be bind. Also it adds retry for pod-by-pod binding, because in the future all binding will be handled by group scheduling.
  
#### Which issue(s) this PR is related to:
Fixes #138255
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
Bind calls are not versioned so retrying on ```apierrors.IsConflict(err)``` will work without rebasing

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Binding API calls in kube-scheduler are now retried when a transient error occurs.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
