### PR TITLE
Handle corrupted subpath mount points during container restart

### DIFF
--- a/pkg/volume/util/subpath/subpath_linux.go
+++ b/pkg/volume/util/subpath/subpath_linux.go
@@ -96,11 +96,19 @@ func prepareSubpathTarget(mounter mount.Interface, subpath Subpath) (bool, strin
 	bindPathTarget := getSubpathBindTarget(subpath)
 	isMount, err := mounter.IsMountPoint(bindPathTarget)
 	if err != nil {
-		if !os.IsNotExist(err) {
-			return false, "", fmt.Errorf("error checking path %s for mount: %s", bindPathTarget, err)
+		if os.IsNotExist(err) {
+			// Ignore ErrorNotExist: the file/directory will be created below if it does not exist yet.
+			isMount = false
+		} else if mount.IsCorruptedMnt(err) {
+			// The mount point is corrupted, attempt to recover by re-creating it.
+			klog.Warningf("Detected corrupted mount at %s (error: %v), unmounting", bindPathTarget, err)
+			if unmountErr := mounter.Unmount(bindPathTarget); unmountErr != nil {
+				return false, "", fmt.Errorf("error unmounting corrupted mount %s: %w", bindPathTarget, unmountErr)
+			}
+			isMount = false
+		} else {
+			return false, "", fmt.Errorf("error checking path %s for mount: %w", bindPathTarget, err)
 		}
-		// Ignore ErrorNotExist: the file/directory will be created below if it does not exist yet.
-		isMount = false
 	}
 	if isMount {
 		// It's already mounted, so check if it's bind-mounted to the same path

--- a/pkg/volume/util/subpath/subpath_linux.go
+++ b/pkg/volume/util/subpath/subpath_linux.go
@@ -94,15 +94,15 @@ func safeOpenSubPath(mounter mount.Interface, subpath Subpath) (int, error) {
 func prepareSubpathTarget(mounter mount.Interface, subpath Subpath) (bool, string, error) {
 	// Early check for already bind-mounted subpath.
 	bindPathTarget := getSubpathBindTarget(subpath)
-	notMount, err := mount.IsNotMountPoint(mounter, bindPathTarget)
+	isMount, err := mounter.IsMountPoint(bindPathTarget)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return false, "", fmt.Errorf("error checking path %s for mount: %s", bindPathTarget, err)
 		}
 		// Ignore ErrorNotExist: the file/directory will be created below if it does not exist yet.
-		notMount = true
+		isMount = false
 	}
-	if !notMount {
+	if isMount {
 		// It's already mounted, so check if it's bind-mounted to the same path
 		samePath, err := checkSubPathFileEqual(subpath, bindPathTarget)
 		if err != nil {

--- a/pkg/volume/util/subpath/subpath_linux_test.go
+++ b/pkg/volume/util/subpath/subpath_linux_test.go
@@ -928,10 +928,12 @@ func TestSubpath_PrepareSafeSubpath(t *testing.T) {
 		name string
 		// Function that prepares directory structure for the test under given
 		// base.
-		prepare      func(base string) ([]string, string, string, error)
-		expectError  bool
-		expectAction []mount.FakeAction
-		mountExists  bool
+		prepare        func(base string) ([]string, string, string, error)
+		modifyMounter  func(fm *mount.FakeMounter, bindPathTarget string)
+		expectError    bool
+		expectAction   []mount.FakeAction
+		mountExists    bool
+		expectDirExist bool
 	}{
 		{
 			name: "subpath-mount-already-exists-with-mismatching-mount",
@@ -980,6 +982,50 @@ func TestSubpath_PrepareSafeSubpath(t *testing.T) {
 			expectAction: []mount.FakeAction{},
 			mountExists:  true,
 		},
+		{
+			name: "subpath-mount-corrupted-recovered",
+			prepare: func(base string) ([]string, string, string, error) {
+				volpath, subpathMount := getTestPaths(base)
+				mounts := []string{subpathMount}
+				if err := os.MkdirAll(subpathMount, defaultPerm); err != nil {
+					return nil, "", "", err
+				}
+
+				subpath := filepath.Join(volpath, "dir0")
+				return mounts, volpath, subpath, os.MkdirAll(subpath, defaultPerm)
+			},
+			modifyMounter: func(fm *mount.FakeMounter, bindPathTarget string) {
+				fm.MountCheckErrors = map[string]error{
+					bindPathTarget: os.NewSyscallError("fake", syscall.ESTALE),
+				}
+			},
+			expectError:  false,
+			expectAction: []mount.FakeAction{{Action: "unmount"}},
+			mountExists:  false,
+		},
+		{
+			name: "subpath-mount-corrupted-unmount-fails",
+			prepare: func(base string) ([]string, string, string, error) {
+				volpath, subpathMount := getTestPaths(base)
+				mounts := []string{subpathMount}
+				if err := os.MkdirAll(subpathMount, defaultPerm); err != nil {
+					return nil, "", "", err
+				}
+
+				subpath := filepath.Join(volpath, "dir0")
+				return mounts, volpath, subpath, os.MkdirAll(subpath, defaultPerm)
+			},
+			modifyMounter: func(fm *mount.FakeMounter, bindPathTarget string) {
+				fm.MountCheckErrors = map[string]error{
+					bindPathTarget: os.NewSyscallError("fake", syscall.ESTALE),
+				}
+				fm.UnmountFunc = func(path string) error {
+					return fmt.Errorf("unmount failed")
+				}
+			},
+			expectError:    true,
+			expectDirExist: true,
+		},
 	}
 	for _, test := range tests {
 		klog.V(4).Infof("test %q", test.name)
@@ -1007,6 +1053,9 @@ func TestSubpath_PrepareSafeSubpath(t *testing.T) {
 		}
 
 		_, subpathMount := getTestPaths(base)
+		if test.modifyMounter != nil {
+			test.modifyMounter(fm, subpathMount)
+		}
 		bindMountExists, bindPathTarget, err := prepareSubpathTarget(fm, subpath)
 
 		if bindMountExists != test.mountExists {
@@ -1039,8 +1088,10 @@ func TestSubpath_PrepareSafeSubpath(t *testing.T) {
 			if bindPathTarget != "" {
 				t.Errorf("test %q failed: expected empty bindPathTarget, got %v", test.name, bindPathTarget)
 			}
-			if err = validateDirNotExists(subpathMount); err != nil {
-				t.Errorf("test %q failed: %v", test.name, err)
+			if !test.expectDirExist {
+				if err = validateDirNotExists(subpathMount); err != nil {
+					t.Errorf("test %q failed: %v", test.name, err)
+				}
 			}
 		}
 		if !test.expectError {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When a subpath mount point is corrupted (e.g. stale NFS file handle), kubelet cannot recover from it during container restart and the pod gets stuck in `CreateContainerConfigError`. Instead, we can try to recover by unmounting the corrupted mount and remounting when kubelet is preparing the subpath.

#### Which issue(s) this PR is related to:

[kubernetes/kubernetes#614](https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/614)

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

I've verified the patch and compared old and new versions:

## Setup

Pod `nfs-stale-test` mounts an NFS PVC with `subPathExpr: $(DIAGNOSTICS_SUBPATH)`.  
Pod `nfs-helper` mounts the same PVC at `/mnt/nfs` (raw, no subPath).  
Marker data written: `CRITICAL_DATA` to `/var/app/diagnostics/marker.txt`.

**Inode replacement** (from helper pod) invalidates the test pod's NFS4 file handle while preserving the directory and data:

```bash
kubectl exec nfs-helper -- sh -c '
  mv /mnt/nfs/nfs-stale-test /mnt/nfs/nfs-stale-test.bak;
  mkdir /mnt/nfs/nfs-stale-test;
  cp -a /mnt/nfs/nfs-stale-test.bak/* /mnt/nfs/nfs-stale-test/;
  rm -rf /mnt/nfs/nfs-stale-test.bak'
```

After this, the test pod returns `Stale file handle` but the helper pod can still read all data. Then the container is killed via `crictl stop`.

---

## BEFORE FIX

```
$ kubectl get pod nfs-stale-test
NAME             READY   STATUS                       RESTARTS   AGE
nfs-stale-test   0/1     CreateContainerConfigError   0          67s
```

```json
{"waiting":{"message":"failed to prepare subPath for volumeMount \"data\" of container \"main\"","reason":"CreateContainerConfigError"}}
```

**Kubelet log:**
```
E0507 kubelet_pods.go:371] "Failed to prepare subPath for volumeMount of the container"
  containerName="main" volumeMountName="data"
E0507 pod_workers.go:1324] "Error syncing pod, skipping"
  err="failed to \"StartContainer\" for \"main\" with CreateContainerConfigError"
```

Pod is **permanently stuck**. Restart count stays at 0. Requires manual intervention (pod deletion or host-level `umount`).

---

## AFTER FIX

```
$ kubectl get pod nfs-stale-test
NAME             READY   STATUS    RESTARTS      AGE
nfs-stale-test   1/1     Running   1 (15s ago)   46s
```

**Kubelet log:**
```
W0507 subpath_linux.go:104] Detected corrupted mount at /var/lib/kubelet/pods/53369a11-5f1e-412e-9d32-bd229039d133/volume-subpaths/nfs-test-pv/main/0 (error: lstat /var/lib/kubelet/pods/53369a11-5f1e-412e-9d32-bd229039d133/volume-subpaths/nfs-test-pv/main/0: stale file handle), unmounting
```

Pod **self-recovers**. Container restarts with all data intact:

```
$ kubectl exec nfs-stale-test -- cat /var/app/diagnostics/marker.txt
CRITICAL_DATA_PATCHED_TEST
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kubelet now recovers from corrupted subpath mount points (e.g. stale NFS file handle) during container restart instead of leaving the pod stuck in CreateContainerConfigError.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
