### PR TITLE
fix: pod-level cgroup was not updated when the OOMKilled container restarts

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -1049,6 +1049,21 @@ func HasAnyRegularContainerCreated(pod *v1.Pod, podStatus *kubecontainer.PodStat
 	return false
 }
 
+// markInitContainerForRestart appends the init container at index to
+// InitContainersToStart and, when the container has a pending in-place resize,
+// calls computePodResizeAction so the pod-level cgroup is updated before the
+// container is restarted.
+// markInitContainerForRestart returns the keepContainer value from computePodResizeAction,
+// or true when the resize call is skipped.
+func (m *kubeGenericRuntimeManager) markInitContainerForRestart(ctx context.Context, pod *v1.Pod, index int, container *v1.Container, status *kubecontainer.Status, changes *podActions) bool {
+	changes.InitContainersToStart = append(changes.InitContainersToStart, index)
+	if podutil.IsRestartableInitContainer(container) ||
+		utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingInitContainers) {
+		return m.computePodResizeAction(ctx, pod, index, true, status, changes)
+	}
+	return true
+}
+
 // computeInitContainerActions sets the actions on the given changes that need
 // to be taken for the init containers. This includes actions to initialize the
 // init containers and actions to keep restartable init containers running.
@@ -1137,10 +1152,7 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(ctx context.Cont
 			// it is likely that the container runtime failed to start it. To
 			// prevent the container from getting stuck in the 'created' state,
 			// restart it.
-			changes.InitContainersToStart = append(changes.InitContainersToStart, i)
-			if podutil.IsRestartableInitContainer(container) || utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingInitContainers) {
-				m.computePodResizeAction(ctx, pod, i, true, status, changes)
-			}
+			m.markInitContainerForRestart(ctx, pod, i, container, status, changes)
 
 		case kubecontainer.ContainerStateRunning:
 			if !podutil.IsRestartableInitContainer(container) {
@@ -1166,8 +1178,7 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(ctx context.Cont
 								message:   fmt.Sprintf("Init container %s failed startup probe", container.Name),
 								reason:    reasonStartupProbe,
 							}
-							changes.InitContainersToStart = append(changes.InitContainersToStart, i)
-							m.computePodResizeAction(ctx, pod, i, true, status, changes)
+							m.markInitContainerForRestart(ctx, pod, i, container, status, changes)
 						}
 						break
 					}
@@ -1226,8 +1237,7 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(ctx context.Cont
 		// Otherwise, restart the init container.
 		case kubecontainer.ContainerStateExited:
 			if podutil.IsRestartableInitContainer(container) {
-				changes.InitContainersToStart = append(changes.InitContainersToStart, i)
-				m.computePodResizeAction(ctx, pod, i, true, status, changes)
+				m.markInitContainerForRestart(ctx, pod, i, container, status, changes)
 			} else { // init container
 				if isInitContainerFailed(status) {
 					restartOnFailure := restartOnFailure
@@ -1239,10 +1249,7 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(ctx context.Cont
 						changes.InitContainersToStart = nil
 						return false
 					}
-					changes.InitContainersToStart = append(changes.InitContainersToStart, i)
-					if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingInitContainers) {
-						m.computePodResizeAction(ctx, pod, i, true, status, changes)
-					}
+					m.markInitContainerForRestart(ctx, pod, i, container, status, changes)
 					break
 				}
 
@@ -1265,8 +1272,7 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(ctx context.Cont
 						status.State),
 					reason: reasonUnknown,
 				}
-				changes.InitContainersToStart = append(changes.InitContainersToStart, i)
-				m.computePodResizeAction(ctx, pod, i, true, status, changes)
+				m.markInitContainerForRestart(ctx, pod, i, container, status, changes)
 			} else { // init container
 				if !isInitContainerFailed(status) {
 					logger.V(4).Info("This should not happen, init container is in unknown state but not failed", "pod", klog.KObj(pod), "containerStatus", status)
@@ -1295,10 +1301,7 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(ctx context.Cont
 						status.State),
 					reason: reasonUnknown,
 				}
-				changes.InitContainersToStart = append(changes.InitContainersToStart, i)
-				if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingInitContainers) {
-					m.computePodResizeAction(ctx, pod, i, true, status, changes)
-				}
+				m.markInitContainerForRestart(ctx, pod, i, container, status, changes)
 			}
 		}
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -1057,8 +1057,9 @@ func HasAnyRegularContainerCreated(pod *v1.Pod, podStatus *kubecontainer.PodStat
 // or true when the resize call is skipped.
 func (m *kubeGenericRuntimeManager) markInitContainerForRestart(ctx context.Context, pod *v1.Pod, index int, container *v1.Container, status *kubecontainer.Status, changes *podActions) bool {
 	changes.InitContainersToStart = append(changes.InitContainersToStart, index)
-	if podutil.IsRestartableInitContainer(container) ||
-		utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingInitContainers) {
+	if !changes.UpdatePodResources &&
+		(podutil.IsRestartableInitContainer(container) ||
+			utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingInitContainers)) {
 		return m.computePodResizeAction(ctx, pod, index, true, status, changes)
 	}
 	return true

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -1179,7 +1179,6 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(ctx context.Cont
 								message:   fmt.Sprintf("Init container %s failed startup probe", container.Name),
 								reason:    reasonStartupProbe,
 							}
-							m.markInitContainerForRestart(ctx, pod, i, container, status, changes)
 						}
 						break
 					}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -1138,6 +1138,9 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(ctx context.Cont
 			// prevent the container from getting stuck in the 'created' state,
 			// restart it.
 			changes.InitContainersToStart = append(changes.InitContainersToStart, i)
+			if podutil.IsRestartableInitContainer(container) || utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingInitContainers) {
+				m.computePodResizeAction(ctx, pod, i, true, status, changes)
+			}
 
 		case kubecontainer.ContainerStateRunning:
 			if !podutil.IsRestartableInitContainer(container) {
@@ -1164,6 +1167,7 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(ctx context.Cont
 								reason:    reasonStartupProbe,
 							}
 							changes.InitContainersToStart = append(changes.InitContainersToStart, i)
+							m.computePodResizeAction(ctx, pod, i, true, status, changes)
 						}
 						break
 					}
@@ -1223,6 +1227,7 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(ctx context.Cont
 		case kubecontainer.ContainerStateExited:
 			if podutil.IsRestartableInitContainer(container) {
 				changes.InitContainersToStart = append(changes.InitContainersToStart, i)
+				m.computePodResizeAction(ctx, pod, i, true, status, changes)
 			} else { // init container
 				if isInitContainerFailed(status) {
 					restartOnFailure := restartOnFailure
@@ -1235,6 +1240,9 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(ctx context.Cont
 						return false
 					}
 					changes.InitContainersToStart = append(changes.InitContainersToStart, i)
+					if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingInitContainers) {
+						m.computePodResizeAction(ctx, pod, i, true, status, changes)
+					}
 					break
 				}
 
@@ -1258,6 +1266,7 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(ctx context.Cont
 					reason: reasonUnknown,
 				}
 				changes.InitContainersToStart = append(changes.InitContainersToStart, i)
+				m.computePodResizeAction(ctx, pod, i, true, status, changes)
 			} else { // init container
 				if !isInitContainerFailed(status) {
 					logger.V(4).Info("This should not happen, init container is in unknown state but not failed", "pod", klog.KObj(pod), "containerStatus", status)
@@ -1287,6 +1296,9 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(ctx context.Cont
 					reason: reasonUnknown,
 				}
 				changes.InitContainersToStart = append(changes.InitContainersToStart, i)
+				if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingInitContainers) {
+					m.computePodResizeAction(ctx, pod, i, true, status, changes)
+				}
 			}
 		}
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1273,7 +1273,8 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 		}
 	}
 
-	if resizable, _, _ := allocation.IsInPlacePodVerticalScalingAllowed(pod); resizable {
+	resizable, _, _ := allocation.IsInPlacePodVerticalScalingAllowed(pod)
+	if resizable {
 		changes.ContainersToUpdate = make(map[v1.ResourceName][]containerToUpdateInfo)
 	}
 
@@ -1309,6 +1310,18 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 			if kubecontainer.ShouldContainerBeRestarted(logger, &container, pod, podStatus) {
 				logger.V(3).Info("Container of pod is not in the desired state and shall be started", "containerName", container.Name, "pod", klog.KObj(pod))
 				changes.ContainersToStart = append(changes.ContainersToStart, idx)
+				// for non-running containers with a pending in-place resize,
+				// we cannot call UpdateContainerResources via CRI. set UpdatePodResources as true so
+				// that doPodResizeAction updates the pod-level cgroup before the container restarts.
+				if containerStatus != nil && resizable {
+					actuatedPodResources, _ := m.actuatedState.GetPodLevelResources(pod.UID)
+					actuatedContainerResources, _ := m.actuatedState.GetContainerResources(pod.UID, container.Name)
+					desiredResources := containerResourcesFromRequirements(pod.Spec.Resources, &container.Resources)
+					currentResources := containerResourcesFromRequirements(actuatedPodResources, &actuatedContainerResources)
+					if currentResources != desiredResources {
+						changes.UpdatePodResources = true
+					}
+				}
 				if containerStatus != nil && containerStatus.State == kubecontainer.ContainerStateUnknown {
 					// If container is in unknown state, we don't know whether it
 					// is actually running or not, always try killing it before

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1310,11 +1310,14 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 			if kubecontainer.ShouldContainerBeRestarted(logger, &container, pod, podStatus) {
 				logger.V(3).Info("Container of pod is not in the desired state and shall be started", "containerName", container.Name, "pod", klog.KObj(pod))
 				changes.ContainersToStart = append(changes.ContainersToStart, idx)
-				// for non-running containers with a pending in-place resize,
-				// we cannot call UpdateContainerResources via CRI. set UpdatePodResources as true so
-				// that doPodResizeAction updates the pod-level cgroup before the container restarts.
+				// kubelet manages the pod cgroups while CRI manages the container-level cgroups,
+				// so kubelet must explicitly adjust the pod cgroups first
+				// before making the CRI call to start the container
 				if containerStatus != nil && resizable {
-					actuatedPodResources, _ := m.actuatedState.GetPodLevelResources(pod.UID)
+					var actuatedPodResources *v1.ResourceRequirements
+					if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodLevelResourcesVerticalScaling) {
+						actuatedPodResources, _ = m.actuatedState.GetPodLevelResources(pod.UID)
+					}
 					actuatedContainerResources, _ := m.actuatedState.GetContainerResources(pod.UID, container.Name)
 					desiredResources := containerResourcesFromRequirements(pod.Spec.Resources, &container.Resources)
 					currentResources := containerResourcesFromRequirements(actuatedPodResources, &actuatedContainerResources)

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -729,6 +729,17 @@ func (m *kubeGenericRuntimeManager) computePodResizeAction(ctx context.Context, 
 	// Proceed only when kubelet has accepted the resize a.k.a v1.Spec.Resources.Requests == v1.Status.AllocatedResources.
 	// Skip if runtime containerID doesn't match pod.Status containerID (container is restarting)
 	if kubeContainerStatus.State != kubecontainer.ContainerStateRunning {
+		// Non-running container being restarted
+		actuatedContainerResources, _ := m.actuatedState.GetContainerResources(pod.UID, container.Name)
+		var actuatedPodResources *v1.ResourceRequirements
+		if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodLevelResourcesVerticalScaling) {
+			actuatedPodResources, _ = m.actuatedState.GetPodLevelResources(pod.UID)
+		}
+		desiredResources := containerResourcesFromRequirements(pod.Spec.Resources, &container.Resources)
+		currentResources := containerResourcesFromRequirements(actuatedPodResources, &actuatedContainerResources)
+		if currentResources != desiredResources {
+			changes.UpdatePodResources = true
+		}
 		return true
 	}
 
@@ -1273,8 +1284,7 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 		}
 	}
 
-	resizable, _, _ := allocation.IsInPlacePodVerticalScalingAllowed(pod)
-	if resizable {
+	if resizable, _, _ := allocation.IsInPlacePodVerticalScalingAllowed(pod); resizable {
 		changes.ContainersToUpdate = make(map[v1.ResourceName][]containerToUpdateInfo)
 	}
 
@@ -1313,17 +1323,8 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 				// kubelet manages the pod cgroups while CRI manages the container-level cgroups,
 				// so kubelet must explicitly adjust the pod cgroups first
 				// before making the CRI call to start the container
-				if containerStatus != nil && resizable {
-					var actuatedPodResources *v1.ResourceRequirements
-					if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodLevelResourcesVerticalScaling) {
-						actuatedPodResources, _ = m.actuatedState.GetPodLevelResources(pod.UID)
-					}
-					actuatedContainerResources, _ := m.actuatedState.GetContainerResources(pod.UID, container.Name)
-					desiredResources := containerResourcesFromRequirements(pod.Spec.Resources, &container.Resources)
-					currentResources := containerResourcesFromRequirements(actuatedPodResources, &actuatedContainerResources)
-					if currentResources != desiredResources {
-						changes.UpdatePodResources = true
-					}
+				if containerStatus != nil {
+					m.computePodResizeAction(ctx, pod, idx, false, containerStatus, &changes)
 				}
 				if containerStatus != nil && containerStatus.State == kubecontainer.ContainerStateUnknown {
 					// If container is in unknown state, we don't know whether it

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -724,27 +724,8 @@ func (m *kubeGenericRuntimeManager) computePodResizeAction(ctx context.Context, 
 		container = pod.Spec.Containers[containerIdx]
 	}
 
-	// Determine if the *running* container needs resource update by comparing v1.Spec.Resources (desired)
-	// with v1.Status.Resources / runtime.Status.Resources (last known actual).
-	// Proceed only when kubelet has accepted the resize a.k.a v1.Spec.Resources.Requests == v1.Status.AllocatedResources.
-	// Skip if runtime containerID doesn't match pod.Status containerID (container is restarting)
-	if kubeContainerStatus.State != kubecontainer.ContainerStateRunning {
-		// Non-running container being restarted
-		actuatedContainerResources, _ := m.actuatedState.GetContainerResources(pod.UID, container.Name)
-		var actuatedPodResources *v1.ResourceRequirements
-		if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodLevelResourcesVerticalScaling) {
-			actuatedPodResources, _ = m.actuatedState.GetPodLevelResources(pod.UID)
-		}
-		desiredResources := containerResourcesFromRequirements(pod.Spec.Resources, &container.Resources)
-		currentResources := containerResourcesFromRequirements(actuatedPodResources, &actuatedContainerResources)
-		if currentResources != desiredResources {
-			changes.UpdatePodResources = true
-		}
-		return true
-	}
-
 	actuatedContainerResources, found := m.actuatedState.GetContainerResources(pod.UID, container.Name)
-	if !found {
+	if !found && kubeContainerStatus.State == kubecontainer.ContainerStateRunning {
 		logger.Error(nil, "Missing actuated resource record", "pod", klog.KObj(pod), "container", container.Name)
 		// Proceed with the zero-value actuated resources. For restart NotRequired, this may
 		// result in an extra call to UpdateContainerResources, but that call should be idempotent.
@@ -761,6 +742,15 @@ func (m *kubeGenericRuntimeManager) computePodResizeAction(ctx context.Context, 
 
 	if currentResources == desiredResources {
 		// No resize required.
+		return true
+	}
+
+	// Determine if the *running* container needs resource update by comparing v1.Spec.Resources (desired)
+	// with v1.Status.Resources / runtime.Status.Resources (last known actual).
+	// Proceed only when kubelet has accepted the resize a.k.a v1.Spec.Resources.Requests == v1.Status.AllocatedResources.
+	// Skip if runtime containerID doesn't match pod.Status containerID (container is restarting)
+	if kubeContainerStatus.State != kubecontainer.ContainerStateRunning {
+		changes.UpdatePodResources = true
 		return true
 	}
 
@@ -1323,7 +1313,7 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 				// kubelet manages the pod cgroups while CRI manages the container-level cgroups,
 				// so kubelet must explicitly adjust the pod cgroups first
 				// before making the CRI call to start the container
-				if containerStatus != nil {
+				if containerStatus != nil && !changes.UpdatePodResources {
 					m.computePodResizeAction(ctx, pod, idx, false, containerStatus, &changes)
 				}
 				if containerStatus != nil && containerStatus.State == kubecontainer.ContainerStateUnknown {

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -3947,6 +3947,52 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 	}
 }
 
+func TestComputePodResizeActionForOOMKilledContainer(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("in-place resize is only supported on Linux")
+	}
+	tCtx := ktesting.Init(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
+	_, _, m, err := createTestRuntimeManager(tCtx)
+	m.machineInfo.MemoryCapacity = 17179860387 // 16GB
+	require.NoError(t, err)
+
+	mem100M := resource.MustParse("100Mi")
+	mem200M := resource.MustParse("200Mi")
+	cpu100m := resource.MustParse("100m")
+
+	pod, status := makeBasePodAndStatus()
+	pod.Spec.Containers = pod.Spec.Containers[:1]
+	status.ContainerStatuses = status.ContainerStatuses[:1]
+
+	pod.Spec.Containers[0].Resources = v1.ResourceRequirements{
+		Limits:   v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem200M},
+		Requests: v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem200M},
+	}
+	pod.Spec.Containers[0].ResizePolicy = []v1.ContainerResizePolicy{
+		{ResourceName: v1.ResourceCPU, RestartPolicy: v1.NotRequired},
+		{ResourceName: v1.ResourceMemory, RestartPolicy: v1.NotRequired},
+	}
+	// record the pre-resize resource limits as what was last actuated.
+	require.NoError(t, m.actuatedState.SetContainerResources(pod.UID, pod.Spec.Containers[0].Name, v1.ResourceRequirements{
+		Limits:   v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
+		Requests: v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
+	}))
+
+	// simulate OOMKilled
+	status.ContainerStatuses[0].State = kubecontainer.ContainerStateExited
+	status.ContainerStatuses[0].Hash = kubecontainer.HashContainer(&pod.Spec.Containers[0])
+
+	t.Cleanup(func() { _ = m.actuatedState.RemovePod(pod.UID) })
+
+	actions := m.computePodActions(tCtx, pod, status, false)
+
+	// the container is OOMKilled and must not be added to ContainersToUpdate (no live CRI call).
+	assert.Empty(t, actions.ContainersToUpdate, "OOMKilled container must not be in ContainersToUpdate")
+	// UpdatePodResources must be true so doPodResizeAction updates the pod-level cgroup.
+	assert.True(t, actions.UpdatePodResources, "UpdatePodResources must be true for OOMKilled container with pending resize")
+}
+
 func TestUpdatePodContainerResources(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -3993,6 +3993,137 @@ func TestComputePodResizeActionForOOMKilledContainer(t *testing.T) {
 	assert.True(t, actions.UpdatePodResources, "UpdatePodResources must be true for OOMKilled container with pending resize")
 }
 
+func TestComputePodResizeActionForOOMKilledInitContainer(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("in-place resize is only supported on Linux")
+	}
+	tCtx := ktesting.Init(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingInitContainers, true)
+	_, _, m, err := createTestRuntimeManager(tCtx)
+	m.machineInfo.MemoryCapacity = 17179860387 // 16GB
+	require.NoError(t, err)
+
+	mem100M := resource.MustParse("100Mi")
+	mem200M := resource.MustParse("200Mi")
+	cpu100m := resource.MustParse("100m")
+
+	pod, status := makeBasePodAndStatus()
+	// a single init container.
+	pod.Spec.InitContainers = []v1.Container{
+		{
+			Name:  "init1",
+			Image: "bar-image",
+			Resources: v1.ResourceRequirements{
+				Limits:   v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem200M},
+				Requests: v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem200M},
+			},
+			ResizePolicy: []v1.ContainerResizePolicy{
+				{ResourceName: v1.ResourceCPU, RestartPolicy: v1.NotRequired},
+				{ResourceName: v1.ResourceMemory, RestartPolicy: v1.NotRequired},
+			},
+		},
+	}
+	// no regular containers running so pod is not yet initialized.
+	status.ContainerStatuses = []*kubecontainer.Status{
+		{
+			ID:       kubecontainer.ContainerID{ID: "initid1"},
+			Name:     "init1",
+			State:    kubecontainer.ContainerStateExited,
+			Reason:   "OOMKilled",
+			ExitCode: 137,
+			Hash:     kubecontainer.HashContainer(&pod.Spec.InitContainers[0]),
+		},
+	}
+	pod.Spec.Containers = nil
+	pod.Status.ContainerStatuses = nil
+
+	// record pre-resize resource limits as what was last actuated.
+	require.NoError(t, m.actuatedState.SetContainerResources(pod.UID, pod.Spec.InitContainers[0].Name, v1.ResourceRequirements{
+		Limits:   v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
+		Requests: v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
+	}))
+	t.Cleanup(func() { _ = m.actuatedState.RemovePod(pod.UID) })
+
+	actions := m.computePodActions(tCtx, pod, status, false)
+
+	// the init container is OOMKilled and must not be in ContainersToUpdate.
+	assert.Empty(t, actions.ContainersToUpdate, "OOMKilled init container must not be in ContainersToUpdate")
+	// UpdatePodResources must be true so doPodResizeAction updates the pod-level cgroup.
+	assert.True(t, actions.UpdatePodResources, "UpdatePodResources must be true for OOMKilled init container with pending resize")
+}
+
+func TestComputePodResizeActionForOOMKilledSidecarContainer(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("in-place resize is only supported on Linux")
+	}
+	tCtx := ktesting.Init(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
+	_, _, m, err := createTestRuntimeManager(tCtx)
+	m.machineInfo.MemoryCapacity = 17179860387 // 16GB
+	require.NoError(t, err)
+
+	mem100M := resource.MustParse("100Mi")
+	mem200M := resource.MustParse("200Mi")
+	cpu100m := resource.MustParse("100m")
+
+	pod, status := makeBasePodAndStatus()
+	pod.Spec.Containers = nil
+	pod.Status.ContainerStatuses = nil
+	status.ContainerStatuses = nil
+
+	// one running regular container so the pod is considered initialized.
+	regularContainer := v1.Container{
+		Name:  "app",
+		Image: "busybox",
+	}
+	pod.Spec.Containers = []v1.Container{regularContainer}
+	status.ContainerStatuses = append(status.ContainerStatuses, &kubecontainer.Status{
+		ID:    kubecontainer.ContainerID{ID: "appid"},
+		Name:  "app",
+		State: kubecontainer.ContainerStateRunning,
+		Hash:  kubecontainer.HashContainer(&pod.Spec.Containers[0]),
+	})
+
+	// one sidecar that has been OOMKilled.
+	sidecar := v1.Container{
+		Name:          "sidecar",
+		Image:         "bar-image",
+		RestartPolicy: &containerRestartPolicyAlways,
+		Resources: v1.ResourceRequirements{
+			Limits:   v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem200M},
+			Requests: v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem200M},
+		},
+		ResizePolicy: []v1.ContainerResizePolicy{
+			{ResourceName: v1.ResourceCPU, RestartPolicy: v1.NotRequired},
+			{ResourceName: v1.ResourceMemory, RestartPolicy: v1.NotRequired},
+		},
+	}
+	pod.Spec.InitContainers = []v1.Container{sidecar}
+	status.ContainerStatuses = append(status.ContainerStatuses, &kubecontainer.Status{
+		ID:       kubecontainer.ContainerID{ID: "sidecarid"},
+		Name:     "sidecar",
+		State:    kubecontainer.ContainerStateExited,
+		Reason:   "OOMKilled",
+		ExitCode: 137,
+		Hash:     kubecontainer.HashContainer(&pod.Spec.InitContainers[0]),
+	})
+
+	// record pre-resize resource limits as what was last actuated.
+	require.NoError(t, m.actuatedState.SetContainerResources(pod.UID, sidecar.Name, v1.ResourceRequirements{
+		Limits:   v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
+		Requests: v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
+	}))
+	t.Cleanup(func() { _ = m.actuatedState.RemovePod(pod.UID) })
+
+	actions := m.computePodActions(tCtx, pod, status, false)
+
+	// the sidecar is OOMKilled and must not be in ContainersToUpdate.
+	assert.Empty(t, actions.ContainersToUpdate, "OOMKilled sidecar must not be in ContainersToUpdate")
+	// UpdatePodResources must be true so doPodResizeAction updates the pod-level cgroup.
+	assert.True(t, actions.UpdatePodResources, "UpdatePodResources must be true for OOMKilled sidecar with pending resize")
+}
+
 func TestUpdatePodContainerResources(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -3974,7 +3974,7 @@ func TestComputePodResizeActionForOOMKilledContainer(t *testing.T) {
 		{ResourceName: v1.ResourceMemory, RestartPolicy: v1.NotRequired},
 	}
 	// record the pre-resize resource limits as what was last actuated.
-	require.NoError(t, m.actuatedState.SetContainerResources(pod.UID, pod.Spec.Containers[0].Name, v1.ResourceRequirements{
+	require.NoError(t, m.actuatedState.SetContainerResources(klog.FromContext(tCtx), pod.UID, pod.Spec.Containers[0].Name, v1.ResourceRequirements{
 		Limits:   v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
 		Requests: v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
 	}))
@@ -3983,7 +3983,7 @@ func TestComputePodResizeActionForOOMKilledContainer(t *testing.T) {
 	status.ContainerStatuses[0].State = kubecontainer.ContainerStateExited
 	status.ContainerStatuses[0].Hash = kubecontainer.HashContainer(&pod.Spec.Containers[0])
 
-	t.Cleanup(func() { _ = m.actuatedState.RemovePod(pod.UID) })
+	t.Cleanup(func() { _ = m.actuatedState.RemovePod(klog.FromContext(tCtx), pod.UID) })
 
 	actions := m.computePodActions(tCtx, pod, status, false)
 
@@ -4039,11 +4039,11 @@ func TestComputePodResizeActionForOOMKilledInitContainer(t *testing.T) {
 	pod.Status.ContainerStatuses = nil
 
 	// record pre-resize resource limits as what was last actuated.
-	require.NoError(t, m.actuatedState.SetContainerResources(pod.UID, pod.Spec.InitContainers[0].Name, v1.ResourceRequirements{
+	require.NoError(t, m.actuatedState.SetContainerResources(klog.FromContext(tCtx), pod.UID, pod.Spec.InitContainers[0].Name, v1.ResourceRequirements{
 		Limits:   v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
 		Requests: v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
 	}))
-	t.Cleanup(func() { _ = m.actuatedState.RemovePod(pod.UID) })
+	t.Cleanup(func() { _ = m.actuatedState.RemovePod(klog.FromContext(tCtx), pod.UID) })
 
 	actions := m.computePodActions(tCtx, pod, status, false)
 
@@ -4110,11 +4110,11 @@ func TestComputePodResizeActionForOOMKilledSidecarContainer(t *testing.T) {
 	})
 
 	// record pre-resize resource limits as what was last actuated.
-	require.NoError(t, m.actuatedState.SetContainerResources(pod.UID, sidecar.Name, v1.ResourceRequirements{
+	require.NoError(t, m.actuatedState.SetContainerResources(klog.FromContext(tCtx), pod.UID, sidecar.Name, v1.ResourceRequirements{
 		Limits:   v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
 		Requests: v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
 	}))
-	t.Cleanup(func() { _ = m.actuatedState.RemovePod(pod.UID) })
+	t.Cleanup(func() { _ = m.actuatedState.RemovePod(klog.FromContext(tCtx), pod.UID) })
 
 	actions := m.computePodActions(tCtx, pod, status, false)
 

--- a/test/e2e/common/node/container_restart_policy.go
+++ b/test/e2e/common/node/container_restart_policy.go
@@ -507,11 +507,11 @@ func validateAllContainersRestarted(ctx context.Context, f *framework.Framework,
 			}
 			if cStatus.RestartCount > 0 {
 				restartedCount++
+				if cStatus.LastTerminationState.Terminated == nil {
+					return false, fmt.Errorf("container %s does not have lastTerminationState after restart", cName)
+				}
 			} else {
-				framework.Logf("container %s did not restart", cName)
-			}
-			if cStatus.LastTerminationState.Terminated == nil {
-				return false, fmt.Errorf("container %s do not have lastTerminationState", cName)
+				framework.Logf("container %s did not restart yet", cName)
 			}
 		}
 		framework.Logf("%d out of %d containers restarted", restartedCount, len(containers))

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -1060,14 +1060,14 @@ func verifyInitContainerResources(ctx context.Context, f *framework.Framework, p
 
 func doPodResizeOOMKilledTest(f *framework.Framework) {
 	// doPodResizeOOMKilledTest verifies that an in-place memory resize applied while a container
-	// is in OOMKilled state correctly updates both the container-level and pod-level cgroups, so
-	// that the restarted container is no longer OOM-killed. Steps below:
-	// 1. Pod created with 128Mi memory limit.
-	// 2. watching for OOMKilled state.
-	// 3. OOMKill detected after ~15s, restarts=1.
-	// 4. apply resize: 128Mi to 256Mi while container is OOMKilled.
+	// is in CrashLoopBackOff correctly updates both the container-level and pod-level cgroups.
+	// Steps below:
+	// 1. pod created with 128Mi memory limit.
+	// 2. container OOMKills immediately, kubelet restarts it.
+	// 3. wait until RestartCount >= 2 so the container is sitting in a >=20s backoff window.
+	// 4. apply resize 128Mi to 256Mi while container is in CrashLoopBackOff.
 	// 5. patch accepted, old actuated value still in status as expected.
-	// 6. test waits for pod to become Ready with new limits actuated.
+	// 6. test waits for pod to become ready with new limits actuated.
 	const (
 		initialMemLimit = "128Mi"
 		allocateMem     = "200M"
@@ -1084,8 +1084,6 @@ func doPodResizeOOMKilledTest(f *framework.Framework) {
 			initialResources := &cgroups.ContainerResources{
 				MemReq: initialMemLimit,
 				MemLim: initialMemLimit,
-				CPUReq: "100m",
-				CPULim: "200m",
 			}
 			containerInfo := podresize.ResizableContainerInfo{
 				Name:      containerName,
@@ -1155,8 +1153,6 @@ func doPodResizeOOMKilledTest(f *framework.Framework) {
 			resizedResources := &cgroups.ContainerResources{
 				MemReq: resizedMemLimit,
 				MemLim: resizedMemLimit,
-				CPUReq: "100m",
-				CPULim: "200m",
 			}
 			resizedContainerInfo := podresize.ResizableContainerInfo{
 				Name:      containerName,
@@ -1173,9 +1169,6 @@ func doPodResizeOOMKilledTest(f *framework.Framework) {
 				ctx, oomPod.Name,
 				types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "resize")
 			framework.ExpectNoError(pErr, "failed to patch pod for resize while OOMKilled")
-			if patchedCS := e2epod.FindContainerStatusInPod(patchedPod, containerName); patchedCS != nil {
-				framework.Logf("Resize patch applied; allocatedResources.memory=%s", patchedCS.AllocatedResources.Memory())
-			}
 
 			// the container restarts successfully with new 256Mi limit and the pod becomes Ready.
 			ginkgo.By("Waiting for pod to become Ready after resize (verifies pod-level cgroup was updated)")

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -1105,7 +1105,7 @@ func doPodResizeOOMKilledTest(f *framework.Framework) {
 					testPod.Spec.Containers[i].Command = []string{"/bin/sh"}
 					testPod.Spec.Containers[i].Args = []string{
 						"-c",
-						fmt.Sprintf("dd if=/dev/zero of=/dev/null bs=%s count=1", allocateMem),
+						fmt.Sprintf("dd if=/dev/zero of=/dev/shm/oom bs=%s count=1 && sleep 600 ", allocateMem),
 					}
 					break
 				}

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -37,6 +37,7 @@ import (
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/ginkgo/v2"
@@ -1055,3 +1056,175 @@ func verifyInitContainerResources(ctx context.Context, f *framework.Framework, p
 		})),
 	)
 }
+
+func doPodResizeOOMKilledTest(f *framework.Framework) {
+	// doPodResizeOOMKilledTest verifies that an in-place memory resize applied while a container
+	// is in OOMKilled state correctly updates both the container-level and pod-level cgroups, so
+	// that the restarted container is no longer OOM-killed. Steps below:
+	// 1. Pod created with 128Mi memory limit.
+	// 2. watching for OOMKilled state.
+	// 3. OOMKill detected after ~15s, restarts=1.
+	// 4. apply resize: 128Mi to 256Mi while container is OOMKilled.
+	// 5. patch accepted, old actuated value still in status as expected.
+	// 6. test waits for pod to become Ready with new limits actuated.
+	const (
+		initialMemLimit = "128Mi"
+		allocateMem     = "200M"
+		resizedMemLimit = "256Mi"
+		containerName   = "oom-container"
+	)
+
+	ginkgo.It("should update pod-level cgroup after resizing an OOMKilled container",
+		feature.InPlacePodVerticalScaling, func(ctx context.Context) {
+
+			podClient := e2epod.NewPodClient(f)
+
+			restartPolicy := v1.RestartContainer
+			initialResources := &cgroups.ContainerResources{
+				MemReq: initialMemLimit,
+				MemLim: initialMemLimit,
+				CPUReq: "100m",
+				CPULim: "200m",
+			}
+			containerInfo := podresize.ResizableContainerInfo{
+				Name:      containerName,
+				Resources: initialResources,
+				MemPolicy: &restartPolicy,
+			}
+
+			tStamp := strconv.Itoa(time.Now().Nanosecond())
+			testPod := podresize.MakePodWithResizableContainers(
+				f.Namespace.Name, "resize-oomkilled", tStamp,
+				[]podresize.ResizableContainerInfo{containerInfo}, nil)
+			testPod = e2epod.MustMixinRestrictedPodSecurity(testPod)
+
+			for i := range testPod.Spec.Containers {
+				if testPod.Spec.Containers[i].Name == containerName {
+					testPod.Spec.Containers[i].Image = imageutils.GetE2EImage(imageutils.BusyBox)
+					testPod.Spec.Containers[i].Command = []string{"/bin/sh"}
+					testPod.Spec.Containers[i].Args = []string{
+						"-c",
+						fmt.Sprintf("dd if=/dev/zero of=/dev/null bs=%s count=1", allocateMem),
+					}
+					break
+				}
+			}
+
+			// use RestartPolicyAlways so the container restarts after OOM
+			testPod.Spec.RestartPolicy = v1.RestartPolicyAlways
+
+			ginkgo.By("Creating pod with low memory limit to trigger OOMKill")
+			newPod := podClient.Create(ctx, testPod)
+
+			ginkgo.By("Waiting for container to be OOMKilled")
+			framework.ExpectNoError(
+				framework.Gomega().
+					Eventually(ctx, framework.RetryNotFound(
+						framework.GetObject(f.ClientSet.CoreV1().Pods(newPod.Namespace).Get, newPod.Name, metav1.GetOptions{}))).
+					WithTimeout(f.Timeouts.PodStart).
+					Should(framework.MakeMatcher(func(pod *v1.Pod) (func() string, error) {
+						for _, cs := range pod.Status.ContainerStatuses {
+							if cs.Name != containerName {
+								continue
+							}
+							// accept either currently terminated which caught it right after OOM
+							// or already restarted with OOM recorded in lastTerminationState.
+							if cs.State.Terminated != nil && cs.State.Terminated.Reason == "OOMKilled" {
+								return nil, nil
+							}
+							if cs.LastTerminationState.Terminated != nil && cs.LastTerminationState.Terminated.Reason == "OOMKilled" {
+								return nil, nil
+							}
+						}
+						return func() string { return "waiting for OOMKilled state" }, nil
+					})),
+			)
+
+			// fetch the pod at OOMKilled time so we can build the resize patch.
+			oomPod, err := f.ClientSet.CoreV1().Pods(newPod.Namespace).Get(ctx, newPod.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err, "failed to get pod after OOMKill")
+			oomCS := e2epod.FindContainerStatusInPod(oomPod, containerName)
+			gomega.Expect(oomCS).NotTo(gomega.BeNil(), "container status not found for %q after OOMKill", containerName)
+			restartCountAtResize := oomCS.RestartCount
+			framework.Logf("Pod %s is OOMKilled (restarts=%d), applying resize to %s",
+				oomPod.Name, restartCountAtResize, resizedMemLimit)
+
+			// build the resize patch: increase memory limit from initialMemLimit to resizedMemLimit.
+			resizedResources := &cgroups.ContainerResources{
+				MemReq: resizedMemLimit,
+				MemLim: resizedMemLimit,
+				CPUReq: "100m",
+				CPULim: "200m",
+			}
+			resizedContainerInfo := podresize.ResizableContainerInfo{
+				Name:      containerName,
+				Resources: resizedResources,
+				MemPolicy: &restartPolicy,
+			}
+			patch := podresize.MakeResizePatch(
+				[]podresize.ResizableContainerInfo{containerInfo},
+				[]podresize.ResizableContainerInfo{resizedContainerInfo},
+				nil, nil)
+
+			ginkgo.By("Applying in-place resize while container is OOMKilled")
+			patchedPod, pErr := f.ClientSet.CoreV1().Pods(oomPod.Namespace).Patch(
+				ctx, oomPod.Name,
+				types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "resize")
+			framework.ExpectNoError(pErr, "failed to patch pod for resize while OOMKilled")
+			if patchedCS := e2epod.FindContainerStatusInPod(patchedPod, containerName); patchedCS != nil {
+				framework.Logf("Resize patch applied; allocatedResources.memory=%s", patchedCS.AllocatedResources.Memory())
+			}
+
+			// the container restarts successfully with new 256Mi limit and the pod becomes Ready.
+			ginkgo.By("Waiting for pod to become Ready after resize (verifies pod-level cgroup was updated)")
+			expectedContainers := []podresize.ResizableContainerInfo{resizedContainerInfo}
+			resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, patchedPod, expectedContainers)
+
+			// Verify that dd successfully allocated 200M after the resize.
+			ginkgo.By("Verifying dd allocated 200M successfully after resize (container exits cleanly, not OOMKilled)")
+			framework.ExpectNoError(
+				framework.Gomega().
+					Eventually(ctx, framework.RetryNotFound(
+						framework.GetObject(f.ClientSet.CoreV1().Pods(resizedPod.Namespace).Get, resizedPod.Name, metav1.GetOptions{}))).
+					WithTimeout(f.Timeouts.PodStart).
+					Should(framework.MakeMatcher(func(pod *v1.Pod) (func() string, error) {
+						for _, cs := range pod.Status.ContainerStatuses {
+							if cs.Name != containerName {
+								continue
+							}
+							lt := cs.LastTerminationState.Terminated
+							if lt == nil {
+								return func() string { return "waiting for container to complete a post-resize cycle" }, nil
+							}
+							if lt.ExitCode != 0 {
+								if lt.Reason == "OOMKilled" && cs.RestartCount > restartCountAtResize {
+									return nil, gomega.StopTrying("container was OOMKilled after resize; pod-level cgroup was not updated")
+								}
+								return func() string {
+									return fmt.Sprintf("waiting for clean exit after resize-restart (last exit code=%d reason=%q)", lt.ExitCode, lt.Reason)
+								}, nil
+							}
+							return nil, nil
+						}
+						return func() string { return "waiting for container status" }, nil
+					})),
+			)
+
+			ginkgo.By("Deleting pod")
+			podClient.DeleteSync(ctx, resizedPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
+		})
+}
+
+var _ = SIGDescribe("Pod InPlace Resize OOMKilled Container", func() {
+	f := framework.NewDefaultFramework("pod-resize-oomkill-tests")
+
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		_, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
+		framework.ExpectNoError(err)
+		if framework.NodeOSDistroIs("windows") {
+			e2eskipper.Skipf("runtime does not support InPlacePodVerticalScaling -- skipping")
+		}
+	})
+
+	doPodResizeOOMKilledTest(f)
+})

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -878,6 +878,7 @@ var _ = SIGDescribe("Pod InPlace Resize Container", func() {
 	doPodResizeReadAndReplaceTests(f)
 	doPodResizePatchErrorTests(f)
 	doPodResizeMemoryLimitDecreaseTest(f)
+	doPodResizeOOMKilledTest(f)
 })
 
 var _ = SIGDescribe("Pod InPlace Resize Init Container", framework.WithFeatureGate(features.InPlacePodVerticalScalingInitContainers), func() {
@@ -1214,17 +1215,3 @@ func doPodResizeOOMKilledTest(f *framework.Framework) {
 			podClient.DeleteSync(ctx, resizedPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
 		})
 }
-
-var _ = SIGDescribe("Pod InPlace Resize OOMKilled Container", func() {
-	f := framework.NewDefaultFramework("pod-resize-oomkill-tests")
-
-	ginkgo.BeforeEach(func(ctx context.Context) {
-		_, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
-		framework.ExpectNoError(err)
-		if framework.NodeOSDistroIs("windows") {
-			e2eskipper.Skipf("runtime does not support InPlacePodVerticalScaling -- skipping")
-		}
-	})
-
-	doPodResizeOOMKilledTest(f)
-})

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -1117,7 +1117,7 @@ func doPodResizeOOMKilledTest(f *framework.Framework) {
 			ginkgo.By("Creating pod with low memory limit to trigger OOMKill")
 			newPod := podClient.Create(ctx, testPod)
 
-			ginkgo.By("Waiting for container to be OOMKilled")
+			ginkgo.By("Waiting for container to enter CrashLoopBackOff after OOMKill (RestartCount >= 2)")
 			framework.ExpectNoError(
 				framework.Gomega().
 					Eventually(ctx, framework.RetryNotFound(
@@ -1128,26 +1128,27 @@ func doPodResizeOOMKilledTest(f *framework.Framework) {
 							if cs.Name != containerName {
 								continue
 							}
-							// accept either currently terminated which caught it right after OOM
-							// or already restarted with OOM recorded in lastTerminationState.
-							if cs.State.Terminated != nil && cs.State.Terminated.Reason == "OOMKilled" {
-								return nil, nil
+							if cs.LastTerminationState.Terminated == nil ||
+								cs.LastTerminationState.Terminated.Reason != "OOMKilled" {
+								return func() string { return "waiting for OOMKilled in lastTerminationState" }, nil
 							}
-							if cs.LastTerminationState.Terminated != nil && cs.LastTerminationState.Terminated.Reason == "OOMKilled" {
-								return nil, nil
+							if cs.RestartCount < 2 {
+								return func() string {
+									return fmt.Sprintf("waiting for RestartCount >= 2 to ensure backoff window (currently %d)", cs.RestartCount)
+								}, nil
 							}
 						}
-						return func() string { return "waiting for OOMKilled state" }, nil
+						return nil, nil
 					})),
 			)
 
-			// fetch the pod at OOMKilled time so we can build the resize patch.
+			// fetch the pod now that it is in backoff so we can build the resize patch.
 			oomPod, err := f.ClientSet.CoreV1().Pods(newPod.Namespace).Get(ctx, newPod.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err, "failed to get pod after OOMKill")
 			oomCS := e2epod.FindContainerStatusInPod(oomPod, containerName)
 			gomega.Expect(oomCS).NotTo(gomega.BeNil(), "container status not found for %q after OOMKill", containerName)
 			restartCountAtResize := oomCS.RestartCount
-			framework.Logf("Pod %s is OOMKilled (restarts=%d), applying resize to %s",
+			framework.Logf("Pod %s is in CrashLoopBackOff after OOMKill (restarts=%d), applying resize to %s",
 				oomPod.Name, restartCountAtResize, resizedMemLimit)
 
 			// build the resize patch: increase memory limit from initialMemLimit to resizedMemLimit.
@@ -1181,7 +1182,6 @@ func doPodResizeOOMKilledTest(f *framework.Framework) {
 			expectedContainers := []podresize.ResizableContainerInfo{resizedContainerInfo}
 			resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, patchedPod, expectedContainers)
 
-			// Verify that dd successfully allocated 200M after the resize.
 			ginkgo.By("Verifying dd allocated 200M successfully after resize (container exits cleanly, not OOMKilled)")
 			framework.ExpectNoError(
 				framework.Gomega().
@@ -1193,16 +1193,22 @@ func doPodResizeOOMKilledTest(f *framework.Framework) {
 							if cs.Name != containerName {
 								continue
 							}
+							if cs.RestartCount < restartCountAtResize+2 {
+								return func() string {
+									return fmt.Sprintf("waiting for RestartCount >= %d to confirm post-resize cycle (currently %d)",
+										restartCountAtResize+2, cs.RestartCount)
+								}, nil
+							}
 							lt := cs.LastTerminationState.Terminated
 							if lt == nil {
-								return func() string { return "waiting for container to complete a post-resize cycle" }, nil
+								return func() string { return "waiting for post-resize LastTerminationState" }, nil
 							}
 							if lt.ExitCode != 0 {
-								if lt.Reason == "OOMKilled" && cs.RestartCount > restartCountAtResize {
+								if lt.Reason == "OOMKilled" {
 									return nil, gomega.StopTrying("container was OOMKilled after resize; pod-level cgroup was not updated")
 								}
 								return func() string {
-									return fmt.Sprintf("waiting for clean exit after resize-restart (last exit code=%d reason=%q)", lt.ExitCode, lt.Reason)
+									return fmt.Sprintf("waiting for clean exit after resize (last exit code=%d reason=%q)", lt.ExitCode, lt.Reason)
 								}, nil
 							}
 							return nil, nil

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -893,6 +893,8 @@ var _ = SIGDescribe("Pod InPlace Resize Init Container", framework.WithFeatureGa
 	})
 
 	doPodResizeInitContainerResizeTest(f)
+	doPodResizeOOMKilledInitContainerTest(f)
+	doPodResizeOOMKilledSidecarTest(f)
 })
 
 func doPatchAndRollback(ctx context.Context, f *framework.Framework, originalContainers, expectedContainers []podresize.ResizableContainerInfo, originalPodResources, expectedPodResources *v1.ResourceRequirements, doRollback bool, mountPodCgroup bool) {
@@ -1056,6 +1058,307 @@ func verifyInitContainerResources(ctx context.Context, f *framework.Framework, p
 			return nil, nil
 		})),
 	)
+}
+
+func doPodResizeOOMKilledInitContainerTest(f *framework.Framework) {
+	// doPodResizeOOMKilledInitContainerTest verifies that an in-place memory resize applied while
+	// a sidecar (restartable init container) is OOMKilling correctly updates both the
+	// container-level and pod-level cgroups.
+	// Steps:
+	// 1. Pod created with a sidecar at 128Mi memory limit and a long-running main container.
+	// 2. Wait for RestartCount>=1 with LastTerminationState.Reason=="OOMKilled" and
+	//    State.Waiting.Reason=="CrashLoopBackOff". container in 10s backoff, not running.
+	// 3. Apply resize 128Mi to 256Mi while container is in backoff with actuatedState==128Mi guaranteed.
+	// 4. Wait for pod to become Ready with new limits actuated.
+	// 5. Verify container exits cleanly (dd succeeds) after the resize.
+	const (
+		initialMemLimit   = "128Mi"
+		allocateMem       = "150M"
+		resizedMemLimit   = "256Mi"
+		initContainerName = "oom-init-container"
+		mainContainerName = "main-container"
+	)
+
+	ginkgo.It("should update pod-level cgroup after resizing an OOMKilled init container",
+		feature.InPlacePodVerticalScaling, func(ctx context.Context) {
+
+			podClient := e2epod.NewPodClient(f)
+
+			initialResources := &cgroups.ContainerResources{
+				MemReq: initialMemLimit,
+				MemLim: initialMemLimit,
+			}
+			initContainerInfo := podresize.ResizableContainerInfo{
+				Name:          initContainerName,
+				Resources:     initialResources,
+				InitCtr:       true,
+				RestartPolicy: v1.ContainerRestartPolicyAlways,
+			}
+			mainContainerInfo := podresize.ResizableContainerInfo{
+				Name:      mainContainerName,
+				Resources: &cgroups.ContainerResources{MemReq: "64Mi", MemLim: "64Mi"},
+			}
+
+			tStamp := strconv.Itoa(time.Now().Nanosecond())
+			testPod := podresize.MakePodWithResizableContainers(
+				f.Namespace.Name, "resize-oomkilled-init", tStamp,
+				[]podresize.ResizableContainerInfo{initContainerInfo, mainContainerInfo}, nil)
+			testPod = e2epod.MustMixinRestrictedPodSecurity(testPod)
+
+			for i := range testPod.Spec.InitContainers {
+				if testPod.Spec.InitContainers[i].Name == initContainerName {
+					testPod.Spec.InitContainers[i].Image = imageutils.GetE2EImage(imageutils.BusyBox)
+					testPod.Spec.InitContainers[i].Command = []string{"/bin/sh"}
+					testPod.Spec.InitContainers[i].Args = []string{
+						"-c",
+						fmt.Sprintf("dd if=/dev/zero of=/tmp/oom bs=%s count=1", allocateMem),
+					}
+					break
+				}
+			}
+
+			testPod.Spec.RestartPolicy = v1.RestartPolicyAlways
+
+			ginkgo.By("Creating pod with low memory limit on init container to trigger OOMKill")
+			newPod := podClient.Create(ctx, testPod)
+
+			// Wait for RestartCount>=1 with an OOMKill in LastTerminationState and the container
+			// in CrashLoopBackOff.
+			ginkgo.By("Waiting for first CrashLoopBackOff after OOMKill (RestartCount>=1)")
+			framework.ExpectNoError(
+				framework.Gomega().
+					Eventually(ctx, framework.RetryNotFound(
+						framework.GetObject(f.ClientSet.CoreV1().Pods(newPod.Namespace).Get, newPod.Name, metav1.GetOptions{}))).
+					WithTimeout(f.Timeouts.PodStart).
+					Should(framework.MakeMatcher(func(pod *v1.Pod) (func() string, error) {
+						for _, cs := range pod.Status.InitContainerStatuses {
+							if cs.Name != initContainerName {
+								continue
+							}
+							if cs.RestartCount >= 1 &&
+								cs.LastTerminationState.Terminated != nil &&
+								cs.LastTerminationState.Terminated.Reason == "OOMKilled" &&
+								cs.State.Waiting != nil &&
+								cs.State.Waiting.Reason == "CrashLoopBackOff" {
+								return nil, nil
+							}
+						}
+						return func() string {
+							return "waiting for RestartCount>=1 with OOMKill in LastTerminationState and CrashLoopBackOff"
+						}, nil
+					})),
+			)
+
+			resizedResources := &cgroups.ContainerResources{
+				MemReq: resizedMemLimit,
+				MemLim: resizedMemLimit,
+			}
+			resizedInitContainerInfo := podresize.ResizableContainerInfo{
+				Name:          initContainerName,
+				Resources:     resizedResources,
+				InitCtr:       true,
+				RestartPolicy: v1.ContainerRestartPolicyAlways,
+			}
+			patch := podresize.MakeResizePatch(
+				[]podresize.ResizableContainerInfo{initContainerInfo, mainContainerInfo},
+				[]podresize.ResizableContainerInfo{resizedInitContainerInfo, mainContainerInfo},
+				nil, nil)
+
+			ginkgo.By("Applying in-place resize while init container is in CrashLoopBackOff with actuatedState==128Mi guaranteed")
+			patchedPod, pErr := f.ClientSet.CoreV1().Pods(newPod.Namespace).Patch(
+				ctx, newPod.Name,
+				types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "resize")
+			framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+			ginkgo.By("Waiting for pod to become Ready after resize. verifies pod-level cgroup was updated")
+			expectedContainers := []podresize.ResizableContainerInfo{resizedInitContainerInfo, mainContainerInfo}
+			resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, patchedPod, expectedContainers)
+
+			ginkgo.By("Verifying init container allocated 200M successfully after resize. exits cleanly, not OOMKilled")
+			framework.ExpectNoError(
+				framework.Gomega().
+					Eventually(ctx, framework.RetryNotFound(
+						framework.GetObject(f.ClientSet.CoreV1().Pods(resizedPod.Namespace).Get, resizedPod.Name, metav1.GetOptions{}))).
+					WithTimeout(f.Timeouts.PodStart).
+					Should(framework.MakeMatcher(func(pod *v1.Pod) (func() string, error) {
+						for _, cs := range pod.Status.InitContainerStatuses {
+							if cs.Name != initContainerName {
+								continue
+							}
+							lt := cs.LastTerminationState.Terminated
+							if lt == nil {
+								return func() string { return "waiting for post-resize LastTerminationState" }, nil
+							}
+							if lt.ExitCode == 0 {
+								return nil, nil
+							}
+							if lt.Reason == "OOMKilled" {
+								return func() string {
+									return fmt.Sprintf("init container still OOMKilling after resize (restartCount=%d); waiting for clean exit", cs.RestartCount)
+								}, nil
+							}
+							return func() string {
+								return fmt.Sprintf("waiting for clean exit (last exit code=%d reason=%q)", lt.ExitCode, lt.Reason)
+							}, nil
+						}
+						return func() string { return "waiting for init container status" }, nil
+					})),
+			)
+
+			ginkgo.By("Deleting pod")
+			podClient.DeleteSync(ctx, resizedPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
+		})
+}
+
+func doPodResizeOOMKilledSidecarTest(f *framework.Framework) {
+	// doPodResizeOOMKilledSidecarTest verifies that an in-place memory resize applied while a
+	// sidecar is OOMKilling correctly updates both the
+	// container-level and pod-level cgroups.
+	// Steps:
+	// 1. Pod created with a sidecar at 128Mi memory limit and a long-running main container.
+	// 2. Wait for RestartCount>=1 with OOMKill in LastTerminationState and CrashLoopBackOff.
+	// 3. Apply resize 128Mi to 256Mi while sidecar is in backoff with actuatedState==128Mi guaranteed.
+	// 4. Wait for pod to become Ready with new limits actuated.
+	// 5. Verify sidecar exits cleanly (dd succeeds) after the resize.
+	const (
+		initialMemLimit   = "128Mi"
+		allocateMem       = "150M"
+		resizedMemLimit   = "256Mi"
+		sidecarName       = "oom-sidecar"
+		mainContainerName = "main-container"
+	)
+
+	ginkgo.It("should update pod-level cgroup after resizing an OOMKilled sidecar",
+		feature.InPlacePodVerticalScaling, func(ctx context.Context) {
+
+			podClient := e2epod.NewPodClient(f)
+
+			restartPolicy := v1.RestartContainer
+			initialResources := &cgroups.ContainerResources{
+				MemReq: initialMemLimit,
+				MemLim: initialMemLimit,
+			}
+			sidecarInfo := podresize.ResizableContainerInfo{
+				Name:          sidecarName,
+				Resources:     initialResources,
+				MemPolicy:     &restartPolicy,
+				InitCtr:       true,
+				RestartPolicy: v1.ContainerRestartPolicyAlways,
+			}
+			mainContainerInfo := podresize.ResizableContainerInfo{
+				Name:      mainContainerName,
+				Resources: &cgroups.ContainerResources{MemReq: "64Mi", MemLim: "64Mi"},
+			}
+
+			tStamp := strconv.Itoa(time.Now().Nanosecond())
+			testPod := podresize.MakePodWithResizableContainers(
+				f.Namespace.Name, "resize-oomkilled-sidecar", tStamp,
+				[]podresize.ResizableContainerInfo{sidecarInfo, mainContainerInfo}, nil)
+			testPod = e2epod.MustMixinRestrictedPodSecurity(testPod)
+
+			for i := range testPod.Spec.InitContainers {
+				if testPod.Spec.InitContainers[i].Name == sidecarName {
+					testPod.Spec.InitContainers[i].Image = imageutils.GetE2EImage(imageutils.BusyBox)
+					testPod.Spec.InitContainers[i].Command = []string{"/bin/sh"}
+					testPod.Spec.InitContainers[i].Args = []string{
+						"-c",
+						fmt.Sprintf("dd if=/dev/zero of=/tmp/oom bs=%s count=1", allocateMem),
+					}
+					break
+				}
+			}
+
+			testPod.Spec.RestartPolicy = v1.RestartPolicyAlways
+
+			ginkgo.By("Creating pod with low memory limit on sidecar to trigger OOMKill")
+			newPod := podClient.Create(ctx, testPod)
+
+			// Wait for RestartCount>=1 with OOMKill in LastTerminationState and CrashLoopBackOff.
+			ginkgo.By("Waiting for first CrashLoopBackOff after OOMKill (RestartCount>=1)")
+			framework.ExpectNoError(
+				framework.Gomega().
+					Eventually(ctx, framework.RetryNotFound(
+						framework.GetObject(f.ClientSet.CoreV1().Pods(newPod.Namespace).Get, newPod.Name, metav1.GetOptions{}))).
+					WithTimeout(f.Timeouts.PodStart).
+					Should(framework.MakeMatcher(func(pod *v1.Pod) (func() string, error) {
+						for _, cs := range pod.Status.InitContainerStatuses {
+							if cs.Name != sidecarName {
+								continue
+							}
+							if cs.RestartCount >= 1 &&
+								cs.LastTerminationState.Terminated != nil &&
+								cs.LastTerminationState.Terminated.Reason == "OOMKilled" &&
+								cs.State.Waiting != nil &&
+								cs.State.Waiting.Reason == "CrashLoopBackOff" {
+								return nil, nil
+							}
+						}
+						return func() string {
+							return "waiting for RestartCount>=1 with OOMKill in LastTerminationState and CrashLoopBackOff"
+						}, nil
+					})),
+			)
+
+			resizedResources := &cgroups.ContainerResources{
+				MemReq: resizedMemLimit,
+				MemLim: resizedMemLimit,
+			}
+			resizedSidecarInfo := podresize.ResizableContainerInfo{
+				Name:          sidecarName,
+				Resources:     resizedResources,
+				MemPolicy:     &restartPolicy,
+				InitCtr:       true,
+				RestartPolicy: v1.ContainerRestartPolicyAlways,
+			}
+			patch := podresize.MakeResizePatch(
+				[]podresize.ResizableContainerInfo{sidecarInfo, mainContainerInfo},
+				[]podresize.ResizableContainerInfo{resizedSidecarInfo, mainContainerInfo},
+				nil, nil)
+
+			ginkgo.By("Applying in-place resize while sidecar is in CrashLoopBackOff (actuatedState==128Mi guaranteed)")
+			patchedPod, pErr := f.ClientSet.CoreV1().Pods(newPod.Namespace).Patch(
+				ctx, newPod.Name,
+				types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "resize")
+			framework.ExpectNoError(pErr, "failed to patch pod for resize")
+
+			ginkgo.By("Waiting for pod to become Ready after resize (verifies pod-level cgroup was updated)")
+			expectedContainers := []podresize.ResizableContainerInfo{resizedSidecarInfo, mainContainerInfo}
+			resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, patchedPod, expectedContainers)
+
+			ginkgo.By("Verifying sidecar allocated 200M successfully after resize (exits cleanly, not OOMKilled)")
+			framework.ExpectNoError(
+				framework.Gomega().
+					Eventually(ctx, framework.RetryNotFound(
+						framework.GetObject(f.ClientSet.CoreV1().Pods(resizedPod.Namespace).Get, resizedPod.Name, metav1.GetOptions{}))).
+					WithTimeout(f.Timeouts.PodStart).
+					Should(framework.MakeMatcher(func(pod *v1.Pod) (func() string, error) {
+						for _, cs := range pod.Status.InitContainerStatuses {
+							if cs.Name != sidecarName {
+								continue
+							}
+							lt := cs.LastTerminationState.Terminated
+							if lt == nil {
+								return func() string { return "waiting for post-resize LastTerminationState" }, nil
+							}
+							if lt.ExitCode == 0 {
+								return nil, nil
+							}
+							if lt.Reason == "OOMKilled" {
+								return func() string {
+									return fmt.Sprintf("sidecar still OOMKilling after resize (restartCount=%d); waiting for clean exit", cs.RestartCount)
+								}, nil
+							}
+							return func() string {
+								return fmt.Sprintf("waiting for clean exit (last exit code=%d reason=%q)", lt.ExitCode, lt.Reason)
+							}, nil
+						}
+						return func() string { return "waiting for sidecar status" }, nil
+					})),
+			)
+
+			ginkgo.By("Deleting pod")
+			podClient.DeleteSync(ctx, resizedPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
+		})
 }
 
 func doPodResizeOOMKilledTest(f *framework.Framework) {


### PR DESCRIPTION

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Issue description:
when the OOMKilled container restarts, the kubelet calls startContainer. the new container is launched by the CRI runtime using the resource spec from the last known actuatedState, which was never updated. 
so the container starts with the old (too-low) memory limit, hits the old cgroup constraint, and OOMs again.

Fix method:
we cannot call UpdateContainerResources via CRI for non-running container. set UpdatePodResources as true so that doPodResizeAction updates the pod-level cgroup before the container restarts.

#### Which issue(s) this PR is related to:
Fix issue: #138760

#### Special notes for your reviewer:
**_Unit Test_**

> go test ./pkg/kubelet/kuberuntime/... -run "TestComputePodResizeActionForOOMKilledContainer" -count=1 -timeout 60s -v 2>&1 | tail -10
> === RUN   TestComputePodResizeActionForOOMKilledContainer
>     kuberuntime_manager_test.go:3839: in-place resize is only supported on Linux
> --- SKIP: TestComputePodResizeActionForOOMKilledContainer (0.00s)
> PASS
> ok      k8s.io/kubernetes/pkg/kubelet/kuberuntime       2.051s
> testing: warning: no tests to run
> PASS
> ok      k8s.io/kubernetes/pkg/kubelet/kuberuntime/util  1.213s [no tests to run]
> 

**_E2e-node test bash command_**

> 	FOCUS="${FOCUS:-Pod InPlace Resize OOMKilled}"
> 	SYSTEM_SPEC_FILE=/container.yaml
> 			# container.yaml
> 			os: Linux
> 			kernelSpec:
> 			  versions:
> 			  - '5\..*'
> 			  - '6\..*'
> 			runtimeSpec:
> 			  cgroups:
> 			  - 'cpu'
> 			  - 'memory'
> 			  - 'pids'
> 	CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock FOCUS="${FOCUS}" \
> 	TEST_ARGS="${TEST_ARGS:---system-spec-file=${SYSTEM_SPEC_FILE} --kubelet-flags=--runtime-cgroups=}" \
> 	  make test-e2e-node 2>&1

	
**_E2e-node test output without fix_**
	

> 
> 		+++ [0507 09:36:08] Building go targets for linux/arm64
> 		    github.com/onsi/ginkgo/v2/ginkgo (non-static)
> 		Creating artifacts directory at /tmp/_artifacts/260507T093610
> 		Test artifacts will be written to /tmp/_artifacts/260507T093610
> 		No need to refresh sudo credentials
> 		I0507 09:36:14.603249  843461 build.go:59] Building k8s binaries...
> 		+++ [0507 09:36:37] Building go targets for linux/arm64
> 		    k8s.io/kubernetes/cmd/kubelet (non-static)
> 		I0507 09:37:00.679704  843461 build.go:59] Building k8s binaries...
> 		+++ [0507 09:37:25] Building go targets for linux/arm64
> 		    github.com/onsi/ginkgo/v2/ginkgo (non-static)
> 		    k8s.io/kubernetes/cluster/gce/gci/mounter (static)
> 		    k8s.io/kubernetes/test/e2e_node/e2e_node.test (test)
> 		    k8s.io/kubernetes/test/e2e_node/plugins/gcp-credential-provider (non-static)
> 		I0507 09:38:40.052052  843461 run_local.go:60] Got build output dir: /kubernetes/_output/local/go/bin
> 		I0507 09:38:40.053001  843461 run_local.go:121] Running command: /kubernetes/_output/local/go/bin/ginkgo -timeout=24h -nodes=8  -focus="Pod InPlace Resize OOMKilled"  -skip="\[Flaky\]|\[Slow\]|\[Serial\]"  /kubernetes/_output/local/go/bin/e2e_node.test -- --v 4 --report-dir=/tmp/_artifacts/260507T093610 --node-name colima --kubelet-flags="--cluster-domain=cluster.local" --dns-domain="cluster.local" --prepull-images=false  --container-runtime-endpoint=unix:///run/containerd/containerd.sock --system-spec-file=/container.yaml --kubelet-flags=--runtime-cgroups= --runtime-config= --kubelet-config-file="test/e2e_node/jenkins/default-kubelet-config.yaml"
> 		Running Suite: E2eNode Suite - /kubernetes/_output/local/go/bin
> 		===============================================================
> 		Random Seed: 1778146720 - will randomize all specs
> 		
> 		Will run 1 of 1207 specs
> 		Running in parallel across 8 processes
> 		  I0507 09:38:41.297022  844751 mount_linux.go:323] Detected umount with safe 'not mounted' behavior
> 		  I0507 09:38:41.297710  844751 mount_linux.go:323] Detected umount with safe 'not mounted' behavior
> 		  I0507 09:38:41.298264  844751 mount_linux.go:323] Detected umount with safe 'not mounted' behavior
> 		  W0507 09:38:41.336578  844751 test_context.go:505] Unable to find in-cluster config, using default host : https://127.0.0.1:6443/
> 		  I0507 09:38:41.336607  844751 test_context.go:520] Tolerating taints "node-role.kubernetes.io/control-plane" when considering if nodes are ready
> 		  I0507 09:38:41.336611  844751 test_context.go:528] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
> 		  I0507 09:38:41.337090  844751 feature_gate.go:477] "Updated" featureGates={}
> 		  I0507 09:38:41.337144  844751 feature_gate.go:477] "Updated" featureGates={}
> 		Validating os...
> 		OS: Linux
> 		Validating kernel...
> 		KERNEL_VERSION: 6.8.0-100-generic
> 		Validating cgroups...
> 		Validating package...
> 		PASS
> 		------------------------------
> 		[SynchronizedBeforeSuite] PASSED [4.505 seconds]
> 		[SynchronizedBeforeSuite] 
> 		k8s.io/kubernetes/test/e2e_node/e2e_node_suite_test.go:234
> 		
> 		  Captured StdOut/StdErr Output >>
> 		    I0507 09:38:41.297022  844751 mount_linux.go:323] Detected umount with safe 'not mounted' behavior
> 		    I0507 09:38:41.297710  844751 mount_linux.go:323] Detected umount with safe 'not mounted' behavior
> 		    I0507 09:38:41.298264  844751 mount_linux.go:323] Detected umount with safe 'not mounted' behavior
> 		    W0507 09:38:41.336578  844751 test_context.go:505] Unable to find in-cluster config, using default host : https://127.0.0.1:6443/
> 		    I0507 09:38:41.336607  844751 test_context.go:520] Tolerating taints "node-role.kubernetes.io/control-plane" when considering if nodes are ready
> 		    I0507 09:38:41.336611  844751 test_context.go:528] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
> 		    I0507 09:38:41.337090  844751 feature_gate.go:477] "Updated" featureGates={}
> 		    I0507 09:38:41.337144  844751 feature_gate.go:477] "Updated" featureGates={}
> 		  Validating os...
> 		  OS: Linux
> 		  Validating kernel...
> 		  KERNEL_VERSION: 6.8.0-100-generic
> 		  Validating cgroups...
> 		  Validating package...
> 		  PASS
> 		  << Captured StdOut/StdErr Output
> 		------------------------------
> 		SS…
> 		------------------------------
> 		• [FAILED] [16.245 seconds]
> 		[sig-node] Pod InPlace Resize OOMKilled Container [It] should update pod-level cgroup after resizing an OOMKilled container [Feature:InPlacePodVerticalScaling] [sig-node, Feature:InPlacePodVerticalScaling]
> 		k8s.io/kubernetes/test/e2e/common/node/pod_resize.go:1077
> 		
> 		  Timeline >>
> 		  STEP: Creating a kubernetes client @ 05/07/26 09:38:45.581
> 		  STEP: Building a namespace api object, basename pod-resize-oomkill-tests @ 05/07/26 09:38:45.583
> 		  I0507 09:38:45.617760  844614 framework.go:384] Skipping waiting for service account
> 		  STEP: Creating pod with low memory limit to trigger OOMKill @ 05/07/26 09:38:45.634
> 		  STEP: Waiting for container to be OOMKilled @ 05/07/26 09:38:45.646
> 		  I0507 09:38:49.674369  844614 pod_resize.go:1149] Pod resize-oomkilled is OOMKilled (restarts=1), applying resize to 256Mi
> 		  STEP: Applying in-place resize while container is OOMKilled @ 05/07/26 09:38:49.688
> 		  I0507 09:38:49.697841  844614 pod_resize.go:1175] Resize patch applied; allocatedResources.memory=128Mi
> 		  STEP: Waiting for pod to become Ready after resize (verifies pod-level cgroup was updated) @ 05/07/26 09:38:49.697
> 		  STEP: Verifying dd allocated 200M successfully after resize (container exits cleanly, not OOMKilled) @ 05/07/26 09:39:01.75
> 		  I0507 09:39:01.759322  844614 pod_resize.go:1185] Failed inside E2E framework:
> 		      k8s.io/kubernetes/test/e2e/common/node.init.func32.doPodResizeOOMKilledTest.2({0x41f62d8, 0x1ce3a967e600})
> 		        k8s.io/kubernetes/test/e2e/common/node/pod_resize.go:1190 +0xb6c
> 		  [FAILED] in [It] - k8s.io/kubernetes/test/e2e/common/node/pod_resize.go:1185 @ 05/07/26 09:39:01.76
> 		  I0507 09:39:01.763512  844614 helper.go:125] Waiting up to 7m0s for all (but 0) nodes to be ready
> 		  STEP: dump namespace information after failure @ 05/07/26 09:39:01.772
> 		  STEP: Collecting events from namespace "pod-resize-oomkill-tests-7995". @ 05/07/26 09:39:01.772
> 		  STEP: Found 8 events. @ 05/07/26 09:39:01.776
> 		  I0507 09:39:01.776268  844614 dump.go:53] At 2026-05-07 09:38:46 +0000 UTC - event for resize-oomkilled: {kubelet colima} Pulling: Pulling image "registry.k8s.io/e2e-test-images/busybox:1.37.0-1"
> 		  I0507 09:39:01.776288  844614 dump.go:53] At 2026-05-07 09:38:47 +0000 UTC - event for resize-oomkilled: {kubelet colima} Pulled: Successfully pulled image "registry.k8s.io/e2e-test-images/busybox:1.37.0-1" in 1.068s (1.068s including waiting). Image size: 1848198 bytes.
> 		  I0507 09:39:01.776316  844614 dump.go:53] At 2026-05-07 09:38:47 +0000 UTC - event for resize-oomkilled: {kubelet colima} Created: Container created
> 		  I0507 09:39:01.776323  844614 dump.go:53] At 2026-05-07 09:38:47 +0000 UTC - event for resize-oomkilled: {kubelet colima} Started: Container started
> 		  I0507 09:39:01.776343  844614 dump.go:53] At 2026-05-07 09:38:48 +0000 UTC - event for resize-oomkilled: {kubelet colima} Pulled: Container image "registry.k8s.io/e2e-test-images/busybox:1.37.0-1" already present on machine and can be accessed by the pod
> 		  I0507 09:39:01.776352  844614 dump.go:53] At 2026-05-07 09:38:49 +0000 UTC - event for resize-oomkilled: {kubelet colima} ResizeStarted: Pod resize started: {"containers":[{"name":"oom-container","resources":{"limits":{"cpu":"200m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}}],"generation":2}
> 		  I0507 09:39:01.776358  844614 dump.go:53] At 2026-05-07 09:38:49 +0000 UTC - event for resize-oomkilled: {kubelet colima} ResizeCompleted: Pod resize completed: {"containers":[{"name":"oom-container","resources":{"limits":{"cpu":"200m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}}],"generation":2}
> 		  I0507 09:39:01.776383  844614 dump.go:53] At 2026-05-07 09:38:49 +0000 UTC - event for resize-oomkilled: {kubelet colima} BackOff: Back-off restarting failed container oom-container in pod resize-oomkilled_pod-resize-oomkill-tests-7995(34c97307-23b4-4767-8718-9cc40471a54e)
> 		  I0507 09:39:01.779160  844614 resource.go:151] POD               NODE    PHASE    GRACE  CONDITIONS
> 		  I0507 09:39:01.779355  844614 resource.go:158] resize-oomkilled  colima  Running         [{PodReadyToStartContainers 2 True 0001-01-01 00:00:00 +0000 UTC 2026-05-07 09:38:46 +0000 UTC  } {Initialized 2 True 0001-01-01 00:00:00 +0000 UTC 2026-05-07 09:38:45 +0000 UTC  } {Ready 2 True 0001-01-01 00:00:00 +0000 UTC 2026-05-07 09:39:00 +0000 UTC  } {ContainersReady 2 True 0001-01-01 00:00:00 +0000 UTC 2026-05-07 09:39:00 +0000 UTC  } {PodScheduled 2 True 0001-01-01 00:00:00 +0000 UTC 2026-05-07 09:38:45 +0000 UTC  }]
> 		  I0507 09:39:01.779367  844614 resource.go:161] 
> 		  I0507 09:39:01.791431  844614 dump.go:109] 
> 		  Logging node info for node colima
> 		  I0507 09:39:01.792560  844614 dump.go:114] Node Info: … 
> 		  I0507 09:39:01.793534  844614 dump.go:121] 
> 		  Logging pods the kubelet thinks are on node colima
> 		  I0507 09:39:01.799075  844614 dump.go:128] pod-resize-oomkill-tests-7995/resize-oomkilled started at 2026-05-07 09:38:45 +0000 UTC (0+1 container statuses recorded)
> 		  I0507 09:39:01.799088  844614 dump.go:134]    Container oom-container ready: true, restart count 3
> 		  W0507 09:39:01.800148  844614 metrics_grabber.go:115] Can't find any pods in namespace kube-system to grab metrics from
> 		  I0507 09:39:01.822324  844614 kubelet_metrics.go:205] 
> 		  Latency metrics for node colima
> 		  STEP: Destroying namespace "pod-resize-oomkill-tests-7995" for this suite. @ 05/07/26 09:39:01.822
> 		  << Timeline
> 		
> 		  [FAILED] Told to stop trying after 0.002s.
> 		  container was OOMKilled after resize; pod-level cgroup was not updated
> 		  In [It] at: k8s.io/kubernetes/test/e2e/common/node/pod_resize.go:1185 @ 05/07/26 09:39:01.76
> 		------------------------------
> 		SSSSS…
> 		
> 		Summarizing 1 Failure:
> 		  [FAIL] [sig-node] Pod InPlace Resize OOMKilled Container [It] should update pod-level cgroup after resizing an OOMKilled container [Feature:InPlacePodVerticalScaling] [sig-node, Feature:InPlacePodVerticalScaling]
> 		  k8s.io/kubernetes/test/e2e/common/node/pod_resize.go:1185
> 		
> 		Ran 1 of 1207 Specs in 28.016 seconds
> 		FAIL! -- 0 Passed | 1 Failed | 0 Pending | 1206 Skipped
> 		
> 		Ginkgo ran 1 suite in 28.907048156s
> 		
> 		Test Suite Failed
> 		F0507 09:39:09.023292  843461 run_local.go:101] Test failed: exit status 1
> 		exit status 1
> 		make: *** [Makefile:292: test-e2e-node] Error 1
> 

**_E2e-node test output with fix_**

> 
> 		+++ [0507 03:15:37] Building go targets for linux/arm64
> 		    github.com/onsi/ginkgo/v2/ginkgo (non-static)
> 		Creating artifacts directory at /tmp/_artifacts/260507T031539
> 		Test artifacts will be written to /tmp/_artifacts/260507T031539
> 		No need to refresh sudo credentials
> 		I0507 03:15:43.420824  715118 build.go:59] Building k8s binaries...
> 		+++ [0507 03:16:03] Building go targets for linux/arm64
> 		    k8s.io/kubernetes/cmd/kubelet (non-static)
> 		I0507 03:16:26.195049  715118 build.go:59] Building k8s binaries...
> 		+++ [0507 03:16:49] Building go targets for linux/arm64
> 		    github.com/onsi/ginkgo/v2/ginkgo (non-static)
> 		    k8s.io/kubernetes/cluster/gce/gci/mounter (static)
> 		    k8s.io/kubernetes/test/e2e_node/e2e_node.test (test)
> 		    k8s.io/kubernetes/test/e2e_node/plugins/gcp-credential-provider (non-static)
> 		I0507 03:18:16.598323  715118 run_local.go:60] Got build output dir: /kubernetes/_output/local/go/bin
> 		I0507 03:18:16.599212  715118 run_local.go:121] Running command: /kubernetes/_output/local/go/bin/ginkgo -timeout=24h -nodes=8  -focus="Pod InPlace Resize OOMKilled"  -skip="\[Flaky\]|\[Slow\]|\[Serial\]"  /kubernetes/_output/local/go/bin/e2e_node.test -- --v 4 --report-dir=/tmp/_artifacts/260507T031539 --node-name colima --kubelet-flags="--cluster-domain=cluster.local" --dns-domain="cluster.local" --prepull-images=false  --container-runtime-endpoint=unix:///run/containerd/containerd.sock --system-spec-file=/kubernetes/test/e2e_node/system/specs/container.yaml --kubelet-flags=--runtime-cgroups= --runtime-config= --kubelet-config-file="test/e2e_node/jenkins/default-kubelet-config.yaml"
> 		Running Suite: E2eNode Suite - /kubernetes/_output/local/go/bin
> 		===============================================================
> 		Random Seed: 1778123896 - will randomize all specs
> 		
> 		Will run 1 of 1207 specs
> 		Running in parallel across 8 processes
> 		  I0507 03:18:17.684314  716753 mount_linux.go:323] Detected umount with safe 'not mounted' behavior
> 		  I0507 03:18:17.684987  716753 mount_linux.go:323] Detected umount with safe 'not mounted' behavior
> 		  I0507 03:18:17.685526  716753 mount_linux.go:323] Detected umount with safe 'not mounted' behavior
> 		  W0507 03:18:17.709121  716753 test_context.go:505] Unable to find in-cluster config, using default host : https://127.0.0.1:6443/
> 		  I0507 03:18:17.709141  716753 test_context.go:520] Tolerating taints "node-role.kubernetes.io/control-plane" when considering if nodes are ready
> 		  I0507 03:18:17.709144  716753 test_context.go:528] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
> 		  I0507 03:18:17.709517  716753 feature_gate.go:477] "Updated" featureGates={}
> 		  I0507 03:18:17.709605  716753 feature_gate.go:477] "Updated" featureGates={}
> 		Validating os...
> 		OS: Linux
> 		Validating kernel...
> 		KERNEL_VERSION: 6.8.0-100-generic
> 		Validating cgroups...
> 		Validating package...
> 		PASS
> 		------------------------------
> 		[SynchronizedBeforeSuite] PASSED [3.634 seconds]
> 		[SynchronizedBeforeSuite] 
> 		k8s.io/kubernetes/test/e2e_node/e2e_node_suite_test.go:234
> 		
> 		  Captured StdOut/StdErr Output >>
> 		    I0507 03:18:17.684314  716753 mount_linux.go:323] Detected umount with safe 'not mounted' behavior
> 		    I0507 03:18:17.684987  716753 mount_linux.go:323] Detected umount with safe 'not mounted' behavior
> 		    I0507 03:18:17.685526  716753 mount_linux.go:323] Detected umount with safe 'not mounted' behavior
> 		    W0507 03:18:17.709121  716753 test_context.go:505] Unable to find in-cluster config, using default host : https://127.0.0.1:6443/
> 		    I0507 03:18:17.709141  716753 test_context.go:520] Tolerating taints "node-role.kubernetes.io/control-plane" when considering if nodes are ready
> 		    I0507 03:18:17.709144  716753 test_context.go:528] The --provider flag is not set. Continuing as if --provider=skeleton had been used.
> 		    I0507 03:18:17.709517  716753 feature_gate.go:477] "Updated" featureGates={}
> 		    I0507 03:18:17.709605  716753 feature_gate.go:477] "Updated" featureGates={}
> 		  Validating os...
> 		  OS: Linux
> 		  Validating kernel...
> 		  KERNEL_VERSION: 6.8.0-100-generic
> 		  Validating cgroups...
> 		  Validating package...
> 		  PASS
> 		  << Captured StdOut/StdErr Output
> 		------------------------------
> 		SSSSS…
> 		
> 		Ran 1 of 1207 Specs in 29.370 seconds
> 		SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 1206 Skipped
> 		
> 		Ginkgo ran 1 suite in 30.230796124s
> 		Test Suite Passed
> 		
> 		=== Test finished (exit=0) ===

#### Does this PR introduce a user-facing change?
```release-note
Fixed a bug in the `InPlacePodVerticalScaling` feature where applying an in-place memory resize while a container was OOMKilled caused the container to keep being OOMKilled on every restart, because the pod-level cgroup `memory.max` was not updated before the container restarted. 
```
