### PR TITLE
HPA: refactor replica_calculator_test GetResourceReplicas

### DIFF
--- a/pkg/controller/podautoscaler/replica_calculator_test.go
+++ b/pkg/controller/podautoscaler/replica_calculator_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta/testrestmapper"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -53,28 +54,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type resourceInfo struct {
-	name     v1.ResourceName
-	requests []resource.Quantity
-	levels   [][]int64
-	// only applies to pod names returned from "heapster"
-	podNames []string
-
-	targetUtilization   int32
-	expectedUtilization int32
-	expectedValue       int64
-}
-
-type metricType int
-
 const (
-	objectMetric metricType = iota
-	objectPerPodMetric
-	externalMetric
-	externalPerPodMetric
-	podMetric
+	testNamespace       = "test-namespace"
+	podNamePrefix       = "test-pod"
+	numContainersPerPod = 2
 )
 
+// TODO(omerap12): this will be removed for refactoring
 type metricInfo struct {
 	name         string
 	levels       []int64
@@ -87,6 +73,7 @@ type metricInfo struct {
 	expectedUsage     int64
 }
 
+// TODO(omerap12): this will be removed for refactoring
 type replicaCalcTestCase struct {
 	currentReplicas  int32
 	expectedReplicas int32
@@ -105,11 +92,788 @@ type replicaCalcTestCase struct {
 	podDeletionTimestamp []bool
 }
 
+// TODO(omerap12): this will be removed for refactoring
+type resourceInfo struct {
+	name     v1.ResourceName
+	requests []resource.Quantity
+	levels   [][]int64
+	// only applies to pod names returned from "heapster"
+	podNames []string
+
+	targetUtilization   int32
+	expectedUtilization int32
+	expectedValue       int64
+}
+
+// TODO(omerap12): this will be removed for refactoring
+type metricType int
+
+// TODO(omerap12): this will be removed for refactoring
 const (
-	testNamespace       = "test-namespace"
-	podNamePrefix       = "test-pod"
-	numContainersPerPod = 2
+	objectMetric metricType = iota
+	objectPerPodMetric
+	externalMetric
+	externalPerPodMetric
+	podMetric
 )
+
+// cpuResource describes the per-container CPU requests and the pod-level metric
+// levels that shape the fake pod/metrics clients for resource-based tests.
+type cpuResource struct {
+	// requests is the per-pod CPU request. len(requests) is the number of pods.
+	requests []resource.Quantity
+	// levels[i][j] is the usage of container j in pod i. Out-of-range values
+	// simulate pods with missing metrics.
+	levels [][]int64
+	// podNames, if non-empty, overrides the pod name returned by the fake
+	// metrics client for index i.
+	podNames []string
+}
+
+// customMetric describes how the fake custom - or external-metrics client should
+// respond in metric-based tests.
+type customMetric struct {
+	name string
+	// levels are the values returned by the metrics client, one per pod
+	// (or one per external-metric sample).
+	levels []int64
+	// singleObject is required for object and objectPerPod metric tests.
+	singleObject *autoscalingv2.CrossVersionObjectReference
+	// selector is required for external and externalPerPod metric tests.
+	selector *metav1.LabelSelector
+}
+
+// calcScenario is a pure input bundle: it describes what pods exist, what
+// metrics they report, and what readiness/phase they are in.
+type calcScenario struct {
+	currentReplicas int32
+
+	// Exactly one of resource or metric is set.
+	resource *cpuResource
+	metric   *customMetric
+
+	// container, if set, scopes GetResourceReplicas to a specific container.
+	container string
+
+	// timestamp used by the fake metrics clients for all returned samples.
+	timestamp time.Time
+
+	// Per-pod state. When non-nil, each slice must be at least currentReplicas
+	// long (or longer if the fixture is also describing failed/deleted pods
+	// that aren't counted in currentReplicas).
+	podReadiness         []v1.ConditionStatus
+	podStartTime         []metav1.Time
+	podPhase             []v1.PodPhase
+	podDeletionTimestamp []bool
+}
+
+// cpuRequests returns n identical CPU resource quantities parsed from val.
+func cpuRequests(n int, val string) []resource.Quantity {
+	requests := make([]resource.Quantity, n)
+	for i := range requests {
+		requests[i] = resource.MustParse(val)
+	}
+	return requests
+}
+
+// makePodMetricLevels returns a [pod][container]int64 where every container in
+// pod i reports the same usage containerMetric[i].
+func makePodMetricLevels(containerMetric ...int64) [][]int64 {
+	metrics := make([][]int64, len(containerMetric))
+	for i := range containerMetric {
+		metrics[i] = make([]int64, numContainersPerPod)
+		for j := range numContainersPerPod {
+			metrics[i][j] = containerMetric[i]
+		}
+	}
+	return metrics
+}
+
+// replicaCalcSetup holds a ReplicaCalculator and the fake clients it uses.
+// Tests call methods on .calc and check the result.
+type replicaCalcSetup struct {
+	calc       *ReplicaCalculator
+	ctx        context.Context
+	selector   labels.Selector
+	namespace  string
+	tolerances Tolerances
+}
+
+// resourceCase bundles a single input fixture with expected outputs for the resource-based replica tests.
+type resourceCase struct {
+	name    string
+	fixture calcScenario
+
+	targetUtilization   int32
+	expectedReplicas    int32
+	expectedUtilization int32
+	expectedRawValue    int64
+	expectedError       error
+
+	// tolerances, if non-nil, overrides the default setup tolerances.
+	tolerances *Tolerances
+}
+
+// newReplicaCalcSetup creates fake pod, metrics, custom-metrics, and
+// external-metrics clients and adds them to ReplicaCalculator within replicaCalcSetup.
+func newReplicaCalcSetup(t *testing.T, f *calcScenario) *replicaCalcSetup {
+	t.Helper()
+
+	tCtx := ktesting.Init(t)
+
+	podClient := newFakePodClient(f)
+	metricsClient := metricsclient.NewRESTMetricsClient(
+		newFakeResourceMetricsClient(f).MetricsV1beta1(),
+		newFakeCustomMetricsClient(t, f),
+		newFakeExternalMetricsClient(t, f),
+	)
+
+	informerFactory := informers.NewSharedInformerFactory(podClient, controller.NoResyncPeriodFunc())
+	informer := informerFactory.Core().V1().Pods()
+
+	calc := NewReplicaCalculator(metricsClient, informer.Lister(),
+		defaultTestingCPUInitializationPeriod, defaultTestingDelayOfInitialReadinessStatus)
+
+	informerFactory.Start(tCtx.Done())
+
+	syncCtx, cancel := context.WithTimeout(tCtx, 10*time.Second)
+	defer cancel()
+	if !cache.WaitForNamedCacheSyncWithContext(syncCtx, informer.Informer().HasSynced) {
+		tCtx.Fatal("Failed to sync informer cache within the 10s timeout")
+	}
+
+	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+		MatchLabels: map[string]string{"name": podNamePrefix},
+	})
+	require.NoError(t, err, "test pod label selector should parse")
+
+	return &replicaCalcSetup{
+		calc:       calc,
+		ctx:        tCtx,
+		selector:   selector,
+		namespace:  testNamespace,
+		tolerances: Tolerances{defaultTestingTolerance, defaultTestingTolerance},
+	}
+}
+
+// newFakePodClient returns a fake Kubernetes clientset that lists pods.
+func newFakePodClient(f *calcScenario) *fake.Clientset {
+	fakeClient := &fake.Clientset{}
+	fakeClient.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+		obj := &v1.PodList{}
+		podsCount := int(f.currentReplicas)
+		// Failed pods aren't included in currentReplicas.
+		if f.podPhase != nil && len(f.podPhase) > podsCount {
+			podsCount = len(f.podPhase)
+		}
+		for i := 0; i < podsCount; i++ {
+			obj.Items = append(obj.Items, buildFakePod(f, i))
+		}
+		return true, obj, nil
+	})
+	return fakeClient
+}
+
+// buildFakePod build a fake pod based on calcScenario's pod index.
+func buildFakePod(f *calcScenario, i int) v1.Pod {
+	podReadiness := v1.ConditionTrue
+	if f.podReadiness != nil && i < len(f.podReadiness) {
+		podReadiness = f.podReadiness[i]
+	}
+	var podStartTime metav1.Time
+	if f.podStartTime != nil {
+		podStartTime = f.podStartTime[i]
+	}
+	podPhase := v1.PodRunning
+	if f.podPhase != nil {
+		podPhase = f.podPhase[i]
+	}
+	deleted := f.podDeletionTimestamp != nil && f.podDeletionTimestamp[i]
+
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%d", podNamePrefix, i),
+			Namespace: testNamespace,
+			Labels:    map[string]string{"name": podNamePrefix},
+		},
+		Status: v1.PodStatus{
+			Phase:     podPhase,
+			StartTime: &podStartTime,
+			Conditions: []v1.PodCondition{
+				{Type: v1.PodReady, Status: podReadiness},
+			},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{Name: "container1"}, {Name: "container2"}},
+		},
+	}
+	if deleted {
+		pod.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	}
+	if f.resource != nil && i < len(f.resource.requests) {
+		req := v1.ResourceRequirements{
+			Requests: v1.ResourceList{v1.ResourceCPU: f.resource.requests[i]},
+		}
+		pod.Spec.Containers[0].Resources = req
+		pod.Spec.Containers[1].Resources = req
+	}
+	return pod
+}
+
+// newFakeResourceMetricsClient returns a fake metrics.k8s.io client.
+func newFakeResourceMetricsClient(f *calcScenario) *metricsfake.Clientset {
+	fakeMetricsClient := &metricsfake.Clientset{}
+	fakeMetricsClient.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+		if f.resource == nil {
+			return true, nil, fmt.Errorf("no pod resource metrics specified in test client")
+		}
+		metrics := &metricsapi.PodMetricsList{}
+		for i, resValue := range f.resource.levels {
+			podName := fmt.Sprintf("%s-%d", podNamePrefix, i)
+			if len(f.resource.podNames) > i {
+				podName = f.resource.podNames[i]
+			}
+			// The list reactor does label-selector filtering for us, so the
+			// returned pod metrics must match the selector.
+			podMetric := metricsapi.PodMetrics{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: testNamespace,
+					Labels:    map[string]string{"name": podNamePrefix},
+				},
+				Timestamp:  metav1.Time{Time: f.timestamp},
+				Window:     metav1.Duration{Duration: time.Minute},
+				Containers: make([]metricsapi.ContainerMetrics, numContainersPerPod),
+			}
+			for j, m := range resValue {
+				podMetric.Containers[j] = metricsapi.ContainerMetrics{
+					Name: fmt.Sprintf("container%v", j+1),
+					Usage: v1.ResourceList{
+						v1.ResourceCPU: *resource.NewMilliQuantity(m, resource.DecimalSI),
+					},
+				}
+			}
+			metrics.Items = append(metrics.Items, podMetric)
+		}
+		return true, metrics, nil
+	})
+	return fakeMetricsClient
+}
+
+// newFakeCustomMetricsClient returns a fake custom-metrics client.
+func newFakeCustomMetricsClient(t *testing.T, f *calcScenario) *cmfake.FakeCustomMetricsClient {
+	fakeCMClient := &cmfake.FakeCustomMetricsClient{}
+	fakeCMClient.AddReactor("get", "*", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+		getForAction, wasGetFor := action.(cmfake.GetForAction)
+		if !wasGetFor {
+			return true, nil, fmt.Errorf("expected a get-for action, got %v instead", action)
+		}
+		if f.metric == nil {
+			return true, nil, fmt.Errorf("no custom metrics specified in test client")
+		}
+		assert.Equal(t, f.metric.name, getForAction.GetMetricName(), "the metric requested should have matched the one specified")
+
+		if getForAction.GetName() == "*" {
+			// Multiple-pod query.
+			assert.Equal(t, "pods", getForAction.GetResource().Resource, "the type of object that we requested multiple metrics for should have been pods")
+			metrics := cmapi.MetricValueList{}
+			for i, level := range f.metric.levels {
+				metrics.Items = append(metrics.Items, cmapi.MetricValue{
+					DescribedObject: v1.ObjectReference{
+						Kind:      "Pod",
+						Name:      fmt.Sprintf("%s-%d", podNamePrefix, i),
+						Namespace: testNamespace,
+					},
+					Timestamp: metav1.Time{Time: f.timestamp},
+					Metric:    cmapi.MetricIdentifier{Name: f.metric.name},
+					Value:     *resource.NewMilliQuantity(level, resource.DecimalSI),
+				})
+			}
+			return true, &metrics, nil
+		}
+
+		// Single-object query.
+		name := getForAction.GetName()
+		assert.NotNil(t, f.metric.singleObject, "should have only requested a single-object metric when calling GetObjectMetricReplicas")
+		mapper := testrestmapper.TestOnlyStaticRESTMapper(legacyscheme.Scheme)
+		gk := schema.FromAPIVersionAndKind(f.metric.singleObject.APIVersion, f.metric.singleObject.Kind).GroupKind()
+		mapping, err := mapper.RESTMapping(gk)
+		if err != nil {
+			return true, nil, fmt.Errorf("unable to get mapping for %s: %w", gk.String(), err)
+		}
+		assert.Equal(t, mapping.Resource.GroupResource().String(), getForAction.GetResource().Resource, "should have requested metrics for the resource matching the GroupKind passed in")
+		assert.Equal(t, f.metric.singleObject.Name, name, "should have requested metrics for the object matching the name passed in")
+
+		return true, &cmapi.MetricValueList{
+			Items: []cmapi.MetricValue{{
+				DescribedObject: v1.ObjectReference{
+					Kind:       f.metric.singleObject.Kind,
+					APIVersion: f.metric.singleObject.APIVersion,
+					Name:       name,
+				},
+				Timestamp: metav1.Time{Time: f.timestamp},
+				Metric:    cmapi.MetricIdentifier{Name: f.metric.name},
+				Value:     *resource.NewMilliQuantity(f.metric.levels[0], resource.DecimalSI),
+			}},
+		}, nil
+	})
+	return fakeCMClient
+}
+
+// newFakeExternalMetricsClient returns a fake external-metrics client.
+func newFakeExternalMetricsClient(t *testing.T, f *calcScenario) *emfake.FakeExternalMetricsClient {
+	fakeEMClient := &emfake.FakeExternalMetricsClient{}
+	fakeEMClient.AddReactor("list", "*", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+		listAction, wasList := action.(core.ListAction)
+		if !wasList {
+			return true, nil, fmt.Errorf("expected a list-for action, got %v instead", action)
+		}
+		if f.metric == nil {
+			return true, nil, fmt.Errorf("no external metrics specified in test client")
+		}
+		assert.Equal(t, f.metric.name, listAction.GetResource().Resource, "the metric requested should have matched the one specified")
+
+		selector, err := metav1.LabelSelectorAsSelector(f.metric.selector)
+		if err != nil {
+			return true, nil, fmt.Errorf("failed to convert label selector specified in test client")
+		}
+		assert.Equal(t, selector, listAction.GetListRestrictions().Labels, "the metric selector should have matched the one specified")
+
+		metrics := emapi.ExternalMetricValueList{}
+		for _, level := range f.metric.levels {
+			metrics.Items = append(metrics.Items, emapi.ExternalMetricValue{
+				Timestamp:  metav1.Time{Time: f.timestamp},
+				MetricName: f.metric.name,
+				Value:      *resource.NewMilliQuantity(level, resource.DecimalSI),
+			})
+		}
+		return true, &metrics, nil
+	})
+	return fakeEMClient
+}
+
+// assertResourceReplicas checks the result of GetResourceReplicas against
+// expected values (or expected error) and verifies the metric timestamp.
+func assertResourceReplicas(t *testing.T, wantReplicas int32, wantUtilization int32, wantRawValue int64, wantTimestamp time.Time, wantErr error,
+	gotReplicas int32, gotUtilization int32, gotRawValue int64, gotTimestamp time.Time, gotErr error) {
+	t.Helper()
+	if wantErr != nil {
+		require.Error(t, gotErr, "there should be an error calculating the replica count")
+		assert.ErrorContains(t, gotErr, wantErr.Error(), "error message should contain expected text")
+		return
+	}
+	require.NoError(t, gotErr, "there should not have been an error calculating the replica count")
+	assert.Equal(t, wantReplicas, gotReplicas, "replicas should be as expected")
+	assert.Equal(t, wantUtilization, gotUtilization, "utilization should be as expected")
+	assert.Equal(t, wantRawValue, gotRawValue, "raw value should be as expected")
+	assert.True(t, wantTimestamp.Equal(gotTimestamp), "timestamp should be as expected")
+}
+
+// TestReplicaCalcResourceScale covers scale-up, scale-down, and no-scale scenarios for GetResourceReplicas.
+func TestReplicaCalcResourceScale(t *testing.T) {
+	testCases := []resourceCase{
+		{
+			name: "scale up",
+			fixture: calcScenario{
+				currentReplicas: 3,
+				resource: &cpuResource{
+					requests: cpuRequests(3, "1.0"),
+					levels:   makePodMetricLevels(300, 500, 700),
+				},
+			},
+			targetUtilization:   30,
+			expectedReplicas:    5,
+			expectedUtilization: 50,
+			expectedRawValue:    numContainersPerPod * 500,
+		},
+		{
+			name: "scale up: container metric",
+			fixture: calcScenario{
+				currentReplicas: 3,
+				container:       "container2",
+				resource: &cpuResource{
+					requests: cpuRequests(3, "1.0"),
+					levels:   [][]int64{{1000, 300}, {1000, 500}, {1000, 700}},
+				},
+			},
+			targetUtilization:   30,
+			expectedReplicas:    5,
+			expectedUtilization: 50,
+			expectedRawValue:    500,
+		},
+		{
+			name: "scale up: unready pod scales less",
+			fixture: calcScenario{
+				currentReplicas: 3,
+				podReadiness:    []v1.ConditionStatus{v1.ConditionFalse, v1.ConditionTrue, v1.ConditionTrue},
+				resource: &cpuResource{
+					requests: cpuRequests(3, "1.0"),
+					levels:   makePodMetricLevels(300, 500, 700),
+				},
+			},
+			targetUtilization:   30,
+			expectedReplicas:    4,
+			expectedUtilization: 60,
+			expectedRawValue:    numContainersPerPod * 600,
+		},
+		{
+			name: "scale up: hot-CPU container scales less",
+			fixture: calcScenario{
+				currentReplicas: 3,
+				podStartTime:    []metav1.Time{hotCPUCreationTime(), coolCPUCreationTime(), coolCPUCreationTime()},
+				container:       "container2",
+				resource: &cpuResource{
+					requests: cpuRequests(3, "1.0"),
+					levels:   [][]int64{{0, 300}, {0, 500}, {0, 700}},
+				},
+			},
+			targetUtilization:   30,
+			expectedReplicas:    4,
+			expectedUtilization: 60,
+			expectedRawValue:    600,
+		},
+		{
+			name: "scale up: hot-CPU pod scales less",
+			fixture: calcScenario{
+				currentReplicas: 3,
+				podStartTime:    []metav1.Time{hotCPUCreationTime(), coolCPUCreationTime(), coolCPUCreationTime()},
+				resource: &cpuResource{
+					requests: cpuRequests(3, "1.0"),
+					levels:   makePodMetricLevels(300, 500, 700),
+				},
+			},
+			targetUtilization:   30,
+			expectedReplicas:    4,
+			expectedUtilization: 60,
+			expectedRawValue:    numContainersPerPod * 600,
+		},
+		{
+			name: "no scale: unready pods ignored",
+			fixture: calcScenario{
+				currentReplicas: 3,
+				podReadiness:    []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
+				resource: &cpuResource{
+					requests: cpuRequests(3, "1.0"),
+					levels:   makePodMetricLevels(400, 500, 700),
+				},
+			},
+			targetUtilization:   30,
+			expectedReplicas:    3,
+			expectedUtilization: 40,
+			expectedRawValue:    numContainersPerPod * 400,
+		},
+		{
+			name: "no scale: hot-CPU pods ignored",
+			fixture: calcScenario{
+				currentReplicas: 3,
+				podReadiness:    []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
+				podStartTime:    []metav1.Time{coolCPUCreationTime(), hotCPUCreationTime(), hotCPUCreationTime()},
+				resource: &cpuResource{
+					requests: cpuRequests(3, "1.0"),
+					levels:   makePodMetricLevels(400, 500, 700),
+				},
+			},
+			targetUtilization:   30,
+			expectedReplicas:    3,
+			expectedUtilization: 40,
+			expectedRawValue:    numContainersPerPod * 400,
+		},
+		{
+			name: "scale up: failed pods ignored",
+			fixture: calcScenario{
+				currentReplicas: 2,
+				podReadiness:    []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
+				podPhase:        []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodFailed, v1.PodFailed},
+				resource: &cpuResource{
+					requests: cpuRequests(4, "1.0"),
+					levels:   makePodMetricLevels(500, 700),
+				},
+			},
+			targetUtilization:   30,
+			expectedReplicas:    4,
+			expectedUtilization: 60,
+			expectedRawValue:    numContainersPerPod * 600,
+		},
+		{
+			name: "scale up: failed pods ignored with missing container metric",
+			fixture: calcScenario{
+				currentReplicas: 2,
+				podReadiness:    []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
+				podPhase:        []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodFailed, v1.PodFailed},
+				container:       "container2",
+				resource: &cpuResource{
+					requests: cpuRequests(4, "1.0"),
+					levels:   [][]int64{{1000, 500}, {9000, 700}, {1000}, {9000}},
+				},
+			},
+			targetUtilization:   30,
+			expectedReplicas:    4,
+			expectedUtilization: 60,
+			expectedRawValue:    600,
+		},
+		{
+			name: "scale up: container metrics with failed pods ignored",
+			fixture: calcScenario{
+				currentReplicas: 2,
+				podReadiness:    []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
+				podPhase:        []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodFailed, v1.PodFailed},
+				container:       "container2",
+				resource: &cpuResource{
+					requests: cpuRequests(4, "1.0"),
+					levels:   [][]int64{{1000, 500}, {9000, 700}},
+				},
+			},
+			targetUtilization:   30,
+			expectedReplicas:    4,
+			expectedUtilization: 60,
+			expectedRawValue:    600,
+		},
+		{
+			name: "scale up: pods being deleted are ignored",
+			fixture: calcScenario{
+				currentReplicas:      2,
+				podReadiness:         []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
+				podPhase:             []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning},
+				podDeletionTimestamp: []bool{false, false, true, true},
+				resource: &cpuResource{
+					requests: cpuRequests(4, "1.0"),
+					levels:   makePodMetricLevels(500, 700),
+				},
+			},
+			targetUtilization:   30,
+			expectedReplicas:    4,
+			expectedUtilization: 60,
+			expectedRawValue:    numContainersPerPod * 600,
+		},
+		{
+			name: "scale up: container metrics with pods being deleted ignored",
+			fixture: calcScenario{
+				currentReplicas:      2,
+				podReadiness:         []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
+				podPhase:             []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning},
+				podDeletionTimestamp: []bool{false, false, true, true},
+				container:            "container1",
+				resource: &cpuResource{
+					requests: cpuRequests(4, "1.0"),
+					levels:   makePodMetricLevels(500, 700), // TODO: This test is broken and works only because of missing metrics.
+				},
+			},
+			targetUtilization:   30,
+			expectedReplicas:    4,
+			expectedUtilization: 60,
+			expectedRawValue:    600,
+		},
+		{
+			name: "scale down",
+			fixture: calcScenario{
+				currentReplicas: 5,
+				resource: &cpuResource{
+					requests: cpuRequests(5, "1.0"),
+					levels:   makePodMetricLevels(100, 300, 500, 250, 250),
+				},
+			},
+			targetUtilization:   50,
+			expectedReplicas:    3,
+			expectedUtilization: 28,
+			expectedRawValue:    numContainersPerPod * 280,
+		},
+		{
+			name: "scale down: container metric",
+			fixture: calcScenario{
+				currentReplicas: 5,
+				container:       "container2",
+				resource: &cpuResource{
+					requests: cpuRequests(5, "1.0"),
+					levels:   [][]int64{{1000, 100}, {1000, 300}, {1000, 500}, {1000, 250}, {1000, 250}},
+				},
+			},
+			targetUtilization:   50,
+			expectedReplicas:    3,
+			expectedUtilization: 28,
+			expectedRawValue:    280,
+		},
+		{
+			name: "scale down: exclude unready pods",
+			fixture: calcScenario{
+				currentReplicas: 5,
+				podReadiness:    []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
+				resource: &cpuResource{
+					requests: cpuRequests(5, "1.0"),
+					levels:   makePodMetricLevels(100, 300, 500, 250, 250),
+				},
+			},
+			targetUtilization:   50,
+			expectedReplicas:    2,
+			expectedUtilization: 30,
+			expectedRawValue:    numContainersPerPod * 300,
+		},
+		{
+			name: "scale down: container metric excludes unready pods",
+			fixture: calcScenario{
+				currentReplicas: 5,
+				podReadiness:    []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
+				container:       "container2",
+				resource: &cpuResource{
+					requests: cpuRequests(5, "1.0"),
+					levels:   [][]int64{{1000, 100}, {1000, 300}, {1000, 500}, {1000, 250}, {1000, 250}},
+				},
+			},
+			targetUtilization:   50,
+			expectedReplicas:    2,
+			expectedUtilization: 30,
+			expectedRawValue:    300,
+		},
+		{
+			name: "scale down: exclude unscheduled pods",
+			fixture: calcScenario{
+				currentReplicas: 5,
+				podReadiness:    []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse, v1.ConditionFalse, v1.ConditionFalse},
+				podPhase:        []v1.PodPhase{v1.PodRunning, v1.PodPending, v1.PodPending, v1.PodPending, v1.PodPending},
+				resource: &cpuResource{
+					requests: cpuRequests(5, "1.0"),
+					levels:   makePodMetricLevels(100),
+				},
+			},
+			targetUtilization:   50,
+			expectedReplicas:    1,
+			expectedUtilization: 10,
+			expectedRawValue:    numContainersPerPod * 100,
+		},
+		{
+			name: "scale down: container metric excludes unscheduled pods",
+			fixture: calcScenario{
+				currentReplicas: 5,
+				podReadiness:    []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse, v1.ConditionFalse, v1.ConditionFalse},
+				podPhase:        []v1.PodPhase{v1.PodRunning, v1.PodPending, v1.PodPending, v1.PodPending, v1.PodPending},
+				container:       "container2",
+				resource: &cpuResource{
+					requests: cpuRequests(5, "1.0"),
+					levels:   [][]int64{{1000, 100}, {1000, 300}, {1000, 500}, {1000, 250}, {1000, 250}},
+				},
+			},
+			targetUtilization:   50,
+			expectedReplicas:    1,
+			expectedUtilization: 10,
+			expectedRawValue:    100,
+		},
+		{
+			name: "scale down: ignore hot-CPU pods",
+			fixture: calcScenario{
+				currentReplicas: 5,
+				podStartTime:    []metav1.Time{coolCPUCreationTime(), coolCPUCreationTime(), coolCPUCreationTime(), hotCPUCreationTime(), hotCPUCreationTime()},
+				resource: &cpuResource{
+					requests: cpuRequests(5, "1.0"),
+					levels:   makePodMetricLevels(100, 300, 500, 250, 250),
+				},
+			},
+			targetUtilization:   50,
+			expectedReplicas:    2,
+			expectedUtilization: 30,
+			expectedRawValue:    numContainersPerPod * 300,
+		},
+		{
+			name: "scale down: container metric ignores hot-CPU pods",
+			fixture: calcScenario{
+				currentReplicas: 5,
+				podStartTime:    []metav1.Time{coolCPUCreationTime(), coolCPUCreationTime(), coolCPUCreationTime(), hotCPUCreationTime(), hotCPUCreationTime()},
+				container:       "container2",
+				resource: &cpuResource{
+					requests: cpuRequests(5, "1.0"),
+					levels:   [][]int64{{1000, 100}, {1000, 300}, {1000, 500}, {1000, 1000}, {1000, 1000}},
+				},
+			},
+			targetUtilization:   50,
+			expectedReplicas:    2,
+			expectedUtilization: 30,
+			expectedRawValue:    300,
+		},
+		{
+			name: "scale down: failed pods ignored",
+			fixture: calcScenario{
+				currentReplicas: 5,
+				podReadiness:    []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
+				podPhase:        []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodFailed, v1.PodFailed},
+				resource: &cpuResource{
+					requests: cpuRequests(7, "1.0"),
+					levels:   makePodMetricLevels(100, 300, 500, 250, 250),
+				},
+			},
+			targetUtilization:   50,
+			expectedReplicas:    3,
+			expectedUtilization: 28,
+			expectedRawValue:    numContainersPerPod * 280,
+		},
+		{
+			name: "scale down: container metric with failed pods ignored",
+			fixture: calcScenario{
+				currentReplicas: 5,
+				podReadiness:    []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
+				podPhase:        []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodFailed, v1.PodFailed},
+				container:       "container2",
+				resource: &cpuResource{
+					requests: cpuRequests(7, "1.0"),
+					levels:   [][]int64{{1000, 100}, {1000, 300}, {1000, 500}, {1000, 250}, {1000, 250}}, // TODO: Test is broken.
+				},
+			},
+			targetUtilization:   50,
+			expectedReplicas:    3,
+			expectedUtilization: 28,
+			expectedRawValue:    280,
+		},
+		{
+			name: "scale down: pods being deleted are ignored",
+			fixture: calcScenario{
+				currentReplicas:      5,
+				podReadiness:         []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
+				podPhase:             []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning},
+				podDeletionTimestamp: []bool{false, false, false, false, false, true, true},
+				resource: &cpuResource{
+					requests: cpuRequests(7, "1.0"),
+					levels:   makePodMetricLevels(100, 300, 500, 250, 250),
+				},
+			},
+			targetUtilization:   50,
+			expectedReplicas:    3,
+			expectedUtilization: 28,
+			expectedRawValue:    numContainersPerPod * 280,
+		},
+		{
+			// Regression test for https://github.com/kubernetes/kubernetes/issues/83561.
+			name: "scale down: still-running pods being deleted are ignored",
+			fixture: calcScenario{
+				currentReplicas:      5,
+				podReadiness:         []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
+				podPhase:             []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning},
+				podDeletionTimestamp: []bool{false, false, false, false, false, true, true},
+				container:            "container2",
+				resource: &cpuResource{
+					requests: cpuRequests(7, "1.0"),
+					levels:   [][]int64{{1000, 100}, {1000, 300}, {1000, 500}, {1000, 250}, {1000, 250}},
+				},
+			},
+			targetUtilization:   50,
+			expectedReplicas:    3,
+			expectedUtilization: 28,
+			expectedRawValue:    280,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newReplicaCalcSetup(t, &tc.fixture)
+			if tc.tolerances != nil {
+				h.tolerances = *tc.tolerances
+			}
+			replicas, util, raw, ts, err := h.calc.GetResourceReplicas(
+				h.ctx, tc.fixture.currentReplicas, tc.targetUtilization,
+				v1.ResourceCPU, h.tolerances, h.namespace, h.selector, tc.fixture.container,
+			)
+			assertResourceReplicas(t,
+				tc.expectedReplicas, tc.expectedUtilization, tc.expectedRawValue, tc.fixture.timestamp, tc.expectedError,
+				replicas, util, raw, ts, err,
+			)
+		})
+	}
+}
 
 func (tc *replicaCalcTestCase) prepareTestClientSet() *fake.Clientset {
 	fakeClient := &fake.Clientset{}
@@ -270,7 +1034,7 @@ func (tc *replicaCalcTestCase) prepareTestCMClient(t *testing.T) *cmfake.FakeCus
 		gk := schema.FromAPIVersionAndKind(tc.metric.singleObject.APIVersion, tc.metric.singleObject.Kind).GroupKind()
 		mapping, err := mapper.RESTMapping(gk)
 		if err != nil {
-			return true, nil, fmt.Errorf("unable to get mapping for %s: %v", gk.String(), err)
+			return true, nil, fmt.Errorf("unable to get mapping for %s: %w", gk.String(), err)
 		}
 		groupResource := mapping.Resource.GroupResource()
 
@@ -438,16 +1202,6 @@ func (tc *replicaCalcTestCase) runTest(t *testing.T) {
 	assert.Equal(t, tc.metric.expectedUsage, outUsage, "usage should be as expected")
 	assert.True(t, tc.timestamp.Equal(outTimestamp), "timestamp should be as expected")
 }
-func makePodMetricLevels(containerMetric ...int64) [][]int64 {
-	metrics := make([][]int64, len(containerMetric))
-	for i := 0; i < len(containerMetric); i++ {
-		metrics[i] = make([]int64, numContainersPerPod)
-		for j := 0; j < numContainersPerPod; j++ {
-			metrics[i][j] = containerMetric[i]
-		}
-	}
-	return metrics
-}
 func TestReplicaCalcDisjointResourcesMetrics(t *testing.T) {
 	tc := replicaCalcTestCase{
 		currentReplicas: 1,
@@ -459,59 +1213,6 @@ func TestReplicaCalcDisjointResourcesMetrics(t *testing.T) {
 			podNames: []string{"an-older-pod-name"},
 
 			targetUtilization: 100,
-		},
-	}
-	tc.runTest(t)
-}
-
-func TestReplicaCalcScaleUp(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:  3,
-		expectedReplicas: 5,
-		resource: &resourceInfo{
-			name:     v1.ResourceCPU,
-			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   makePodMetricLevels(300, 500, 700),
-
-			targetUtilization:   30,
-			expectedUtilization: 50,
-			expectedValue:       numContainersPerPod * 500,
-		},
-	}
-	tc.runTest(t)
-}
-
-func TestReplicaCalcContainerScaleUp(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:  3,
-		expectedReplicas: 5,
-		resource: &resourceInfo{
-			name:     v1.ResourceCPU,
-			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   [][]int64{{1000, 300}, {1000, 500}, {1000, 700}},
-
-			targetUtilization:   30,
-			expectedUtilization: 50,
-			expectedValue:       500,
-		},
-		container: "container2",
-	}
-	tc.runTest(t)
-}
-
-func TestReplicaCalcScaleUpUnreadyLessScale(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:  3,
-		expectedReplicas: 4,
-		podReadiness:     []v1.ConditionStatus{v1.ConditionFalse, v1.ConditionTrue, v1.ConditionTrue},
-		resource: &resourceInfo{
-			name:     v1.ResourceCPU,
-			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   makePodMetricLevels(300, 500, 700),
-
-			targetUtilization:   30,
-			expectedUtilization: 60,
-			expectedValue:       numContainersPerPod * 600,
 		},
 	}
 	tc.runTest(t)
@@ -532,61 +1233,6 @@ func TestReplicaCalcScaleUpOverflow(t *testing.T) {
 				APIVersion: "apps/v1",
 				Name:       "some-deployment",
 			},
-		},
-	}
-	tc.runTest(t)
-}
-
-func TestReplicaCalcScaleUpContainerHotCpuLessScale(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:  3,
-		expectedReplicas: 4,
-		podStartTime:     []metav1.Time{hotCPUCreationTime(), coolCPUCreationTime(), coolCPUCreationTime()},
-		resource: &resourceInfo{
-			name:     v1.ResourceCPU,
-			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   [][]int64{{0, 300}, {0, 500}, {0, 700}},
-
-			targetUtilization:   30,
-			expectedUtilization: 60,
-			expectedValue:       600,
-		},
-		container: "container2",
-	}
-	tc.runTest(t)
-}
-
-func TestReplicaCalcScaleUpHotCpuLessScale(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:  3,
-		expectedReplicas: 4,
-		podStartTime:     []metav1.Time{hotCPUCreationTime(), coolCPUCreationTime(), coolCPUCreationTime()},
-		resource: &resourceInfo{
-			name:     v1.ResourceCPU,
-			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   makePodMetricLevels(300, 500, 700),
-
-			targetUtilization:   30,
-			expectedUtilization: 60,
-			expectedValue:       numContainersPerPod * 600,
-		},
-	}
-	tc.runTest(t)
-}
-
-func TestReplicaCalcScaleUpUnreadyNoScale(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:  3,
-		expectedReplicas: 3,
-		podReadiness:     []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
-		resource: &resourceInfo{
-			name:     v1.ResourceCPU,
-			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   makePodMetricLevels(400, 500, 700),
-
-			targetUtilization:   30,
-			expectedUtilization: 40,
-			expectedValue:       numContainersPerPod * 400,
 		},
 	}
 	tc.runTest(t)
@@ -620,125 +1266,6 @@ func TestExternalPerPodMetricUsageOverflow(t *testing.T) {
 			expectedUsage:     math.MaxInt64,
 			selector:          &metav1.LabelSelector{MatchLabels: map[string]string{"label": "value"}},
 		},
-	}
-	tc.runTest(t)
-}
-
-func TestReplicaCalcScaleHotCpuNoScale(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:  3,
-		expectedReplicas: 3,
-		podReadiness:     []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
-		podStartTime:     []metav1.Time{coolCPUCreationTime(), hotCPUCreationTime(), hotCPUCreationTime()},
-		resource: &resourceInfo{
-			name:     v1.ResourceCPU,
-			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   makePodMetricLevels(400, 500, 700),
-
-			targetUtilization:   30,
-			expectedUtilization: 40,
-			expectedValue:       numContainersPerPod * 400,
-		},
-	}
-	tc.runTest(t)
-}
-
-func TestReplicaCalcScaleUpIgnoresFailedPods(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:  2,
-		expectedReplicas: 4,
-		podReadiness:     []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
-		podPhase:         []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodFailed, v1.PodFailed},
-		resource: &resourceInfo{
-			name:     v1.ResourceCPU,
-			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   makePodMetricLevels(500, 700),
-
-			targetUtilization:   30,
-			expectedUtilization: 60,
-			expectedValue:       numContainersPerPod * 600,
-		},
-	}
-	tc.runTest(t)
-}
-
-func TestReplicaCalcMissingContainerMetricScaleUpIgnoresFailedPods(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:  2,
-		expectedReplicas: 4,
-		podReadiness:     []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
-		podPhase:         []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodFailed, v1.PodFailed},
-		resource: &resourceInfo{
-			name:     v1.ResourceCPU,
-			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   [][]int64{{1000, 500}, {9000, 700}, {1000}, {9000}},
-
-			targetUtilization:   30,
-			expectedUtilization: 60,
-			expectedValue:       600,
-		},
-		container: "container2",
-	}
-	tc.runTest(t)
-}
-
-func TestReplicaCalcScaleUpContainerIgnoresFailedPods(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:  2,
-		expectedReplicas: 4,
-		podReadiness:     []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
-		podPhase:         []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodFailed, v1.PodFailed},
-		resource: &resourceInfo{
-			name:     v1.ResourceCPU,
-			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   [][]int64{{1000, 500}, {9000, 700}},
-
-			targetUtilization:   30,
-			expectedUtilization: 60,
-			expectedValue:       600,
-		},
-		container: "container2",
-	}
-	tc.runTest(t)
-}
-
-func TestReplicaCalcScaleUpIgnoresDeletionPods(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:      2,
-		expectedReplicas:     4,
-		podReadiness:         []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
-		podPhase:             []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning},
-		podDeletionTimestamp: []bool{false, false, true, true},
-		resource: &resourceInfo{
-			name:     v1.ResourceCPU,
-			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   makePodMetricLevels(500, 700),
-
-			targetUtilization:   30,
-			expectedUtilization: 60,
-			expectedValue:       numContainersPerPod * 600,
-		},
-	}
-	tc.runTest(t)
-}
-
-func TestReplicaCalcScaleUpContainerIgnoresDeletionPods(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:      2,
-		expectedReplicas:     4,
-		podReadiness:         []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
-		podPhase:             []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning},
-		podDeletionTimestamp: []bool{false, false, true, true},
-		resource: &resourceInfo{
-			name:     v1.ResourceCPU,
-			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   makePodMetricLevels(500, 700), // TODO: This test is broken and works only because of missing metrics
-
-			targetUtilization:   30,
-			expectedUtilization: 60,
-			expectedValue:       600,
-		},
-		container: "container1",
 	}
 	tc.runTest(t)
 }
@@ -884,41 +1411,6 @@ func TestReplicaCalcScaleUpPerPodCMExternal(t *testing.T) {
 	tc.runTest(t)
 }
 
-func TestReplicaCalcScaleDown(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:  5,
-		expectedReplicas: 3,
-		resource: &resourceInfo{
-			name:     v1.ResourceCPU,
-			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   makePodMetricLevels(100, 300, 500, 250, 250),
-
-			targetUtilization:   50,
-			expectedUtilization: 28,
-			expectedValue:       numContainersPerPod * 280,
-		},
-	}
-	tc.runTest(t)
-}
-
-func TestReplicaCalcContainerScaleDown(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:  5,
-		expectedReplicas: 3,
-		resource: &resourceInfo{
-			name:     v1.ResourceCPU,
-			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   [][]int64{{1000, 100}, {1000, 300}, {1000, 500}, {1000, 250}, {1000, 250}},
-
-			targetUtilization:   50,
-			expectedUtilization: 28,
-			expectedValue:       280,
-		},
-		container: "container2",
-	}
-	tc.runTest(t)
-}
-
 func TestReplicaCalcScaleDownCM(t *testing.T) {
 	tc := replicaCalcTestCase{
 		currentReplicas:  5,
@@ -1001,200 +1493,6 @@ func TestReplicaCalcScaleDownPerPodCMExternal(t *testing.T) {
 			selector:          &metav1.LabelSelector{MatchLabels: map[string]string{"label": "value"}},
 			metricType:        externalPerPodMetric,
 		},
-	}
-	tc.runTest(t)
-}
-
-func TestReplicaCalcScaleDownExcludeUnreadyPods(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:  5,
-		expectedReplicas: 2,
-		podReadiness:     []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
-		resource: &resourceInfo{
-			name:     v1.ResourceCPU,
-			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   makePodMetricLevels(100, 300, 500, 250, 250),
-
-			targetUtilization:   50,
-			expectedUtilization: 30,
-			expectedValue:       numContainersPerPod * 300,
-		},
-	}
-	tc.runTest(t)
-}
-
-func TestReplicaCalcScaleDownContainerExcludeUnreadyPods(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:  5,
-		expectedReplicas: 2,
-		podReadiness:     []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
-		resource: &resourceInfo{
-			name:     v1.ResourceCPU,
-			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   [][]int64{{1000, 100}, {1000, 300}, {1000, 500}, {1000, 250}, {1000, 250}},
-
-			targetUtilization:   50,
-			expectedUtilization: 30,
-			expectedValue:       300,
-		},
-		container: "container2",
-	}
-	tc.runTest(t)
-}
-
-func TestReplicaCalcScaleDownExcludeUnscheduledPods(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:  5,
-		expectedReplicas: 1,
-		podReadiness:     []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse, v1.ConditionFalse, v1.ConditionFalse},
-		podPhase:         []v1.PodPhase{v1.PodRunning, v1.PodPending, v1.PodPending, v1.PodPending, v1.PodPending},
-		resource: &resourceInfo{
-			name:     v1.ResourceCPU,
-			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   makePodMetricLevels(100),
-
-			targetUtilization:   50,
-			expectedUtilization: 10,
-			expectedValue:       numContainersPerPod * 100,
-		},
-	}
-	tc.runTest(t)
-}
-
-func TestReplicaCalcScaleDownContainerExcludeUnscheduledPods(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:  5,
-		expectedReplicas: 1,
-		podReadiness:     []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse, v1.ConditionFalse, v1.ConditionFalse},
-		podPhase:         []v1.PodPhase{v1.PodRunning, v1.PodPending, v1.PodPending, v1.PodPending, v1.PodPending},
-		resource: &resourceInfo{
-			name:     v1.ResourceCPU,
-			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   [][]int64{{1000, 100}, {1000, 300}, {1000, 500}, {1000, 250}, {1000, 250}},
-
-			targetUtilization:   50,
-			expectedUtilization: 10,
-			expectedValue:       100,
-		},
-		container: "container2",
-	}
-	tc.runTest(t)
-}
-
-func TestReplicaCalcScaleDownIgnoreHotCpuPods(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:  5,
-		expectedReplicas: 2,
-		podStartTime:     []metav1.Time{coolCPUCreationTime(), coolCPUCreationTime(), coolCPUCreationTime(), hotCPUCreationTime(), hotCPUCreationTime()},
-		resource: &resourceInfo{
-			name:     v1.ResourceCPU,
-			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   makePodMetricLevels(100, 300, 500, 250, 250),
-
-			targetUtilization:   50,
-			expectedUtilization: 30,
-			expectedValue:       numContainersPerPod * 300,
-		},
-	}
-	tc.runTest(t)
-}
-
-func TestReplicaCalcScaleDownContainerIgnoreHotCpuPods(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:  5,
-		expectedReplicas: 2,
-		podStartTime:     []metav1.Time{coolCPUCreationTime(), coolCPUCreationTime(), coolCPUCreationTime(), hotCPUCreationTime(), hotCPUCreationTime()},
-		resource: &resourceInfo{
-			name:     v1.ResourceCPU,
-			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   [][]int64{{1000, 100}, {1000, 300}, {1000, 500}, {1000, 1000}, {1000, 1000}},
-
-			targetUtilization:   50,
-			expectedUtilization: 30,
-			expectedValue:       300,
-		},
-		container: "container2",
-	}
-	tc.runTest(t)
-}
-
-func TestReplicaCalcScaleDownIgnoresFailedPods(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:  5,
-		expectedReplicas: 3,
-		podReadiness:     []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
-		podPhase:         []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodFailed, v1.PodFailed},
-		resource: &resourceInfo{
-			name:     v1.ResourceCPU,
-			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   makePodMetricLevels(100, 300, 500, 250, 250),
-
-			targetUtilization:   50,
-			expectedUtilization: 28,
-			expectedValue:       numContainersPerPod * 280,
-		},
-	}
-	tc.runTest(t)
-}
-
-func TestReplicaCalcScaleDownContainerIgnoresFailedPods(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:  5,
-		expectedReplicas: 3,
-		podReadiness:     []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
-		podPhase:         []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodFailed, v1.PodFailed},
-		resource: &resourceInfo{
-			name:     v1.ResourceCPU,
-			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   [][]int64{{1000, 100}, {1000, 300}, {1000, 500}, {1000, 250}, {1000, 250}}, //TODO: Test is broken
-
-			targetUtilization:   50,
-			expectedUtilization: 28,
-			expectedValue:       280,
-		},
-		container: "container2",
-	}
-	tc.runTest(t)
-}
-
-func TestReplicaCalcScaleDownIgnoresDeletionPods(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:      5,
-		expectedReplicas:     3,
-		podReadiness:         []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
-		podPhase:             []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning},
-		podDeletionTimestamp: []bool{false, false, false, false, false, true, true},
-		resource: &resourceInfo{
-			name:     v1.ResourceCPU,
-			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   makePodMetricLevels(100, 300, 500, 250, 250),
-
-			targetUtilization:   50,
-			expectedUtilization: 28,
-			expectedValue:       numContainersPerPod * 280,
-		},
-	}
-	tc.runTest(t)
-}
-
-// Regression test for https://github.com/kubernetes/kubernetes/issues/83561
-func TestReplicaCalcScaleDownIgnoresDeletionPods_StillRunning(t *testing.T) {
-	tc := replicaCalcTestCase{
-		currentReplicas:      5,
-		expectedReplicas:     3,
-		podReadiness:         []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
-		podPhase:             []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning},
-		podDeletionTimestamp: []bool{false, false, false, false, false, true, true},
-		resource: &resourceInfo{
-			name:     v1.ResourceCPU,
-			requests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
-			levels:   [][]int64{{1000, 100}, {1000, 300}, {1000, 500}, {1000, 250}, {1000, 250}},
-
-			targetUtilization:   50,
-			expectedUtilization: 28,
-			expectedValue:       280,
-		},
-		container: "container2",
 	}
 	tc.runTest(t)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This is part of an ongoing refactor of the HPA unit tests that we discussed at KubeCon.
Since a full refactor of `replica_calculator_test.go` would be difficult to review in a single PR, I’m splitting the work into multiple smaller PRs.
This PR includes two changes:
1. Adds the Go structs and variables that will be used throughout the file
2. Covers `GetResourceReplicas` scale-up, scale-down, and no-scale scenarios

The balance is currently positive, but it will become negative once the refactor is completed.
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
