### PR TITLE
kubectl describe: include container Waiting.Message in pod output

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -2101,6 +2101,9 @@ func describeStatus(stateName string, state corev1.ContainerState, w PrefixWrite
 		if state.Waiting.Reason != "" {
 			w.Write(LEVEL_3, "Reason:\t%s\n", state.Waiting.Reason)
 		}
+		if state.Waiting.Message != "" {
+			w.Write(LEVEL_3, "Message:\t%s\n", state.Waiting.Message)
+		}
 	case state.Terminated != nil:
 		w.Write(LEVEL_2, "%s:\tTerminated\n", stateName)
 		if state.Terminated.Reason != "" {

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -1617,6 +1617,22 @@ func TestDescribeContainers(t *testing.T) {
 			},
 			expectedElements: []string{"test", "State", "Waiting", "Ready", "True", "Restart Count", "7", "Image", "image", "Reason", "potato"},
 		},
+		// Waiting state with Message.
+		{
+			container: corev1.Container{Name: "test", Image: "image"},
+			status: corev1.ContainerStatus{
+				Name: "test",
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason:  "ImagePullBackOff",
+						Message: `Back-off pulling image "nginx:nope"`,
+					},
+				},
+				Ready:        false,
+				RestartCount: 7,
+			},
+			expectedElements: []string{"test", "State", "Waiting", "Ready", "False", "Restart Count", "7", "Image", "image", "Reason", "ImagePullBackOff", "Message", "nginx:nope"},
+		},
 		// Terminated state.
 		{
 			container: corev1.Container{Name: "test", Image: "image"},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`kubectl describe pod` printed the container Waiting state's `Reason`
but silently dropped the `Message` field, even though the Terminated
branch in the same `describeStatus` function prints both. The kubelet
sets `containerStatuses[].state.waiting.message` for ImagePullBackOff,
ErrImagePull, CreateContainerConfigError, CreateContainerError,
CrashLoopBackOff, and similar failures, so the most actionable detail
was invisible to `kubectl describe` and users had to fall back to
`kubectl get events` or `-o yaml`.

This PR mirrors the Terminated branch and prints `Waiting.Message`
when non-empty.

**Before:**
```
Containers:
  broken:
    Image:	docker.io/library/nginx:nope-12345
    State:	Waiting
      Reason:	ImagePullBackOff
    Ready:	False
```

**After:**
```
Containers:
  broken:
    Image:	docker.io/library/nginx:nope-12345
    State:	Waiting
      Reason:	ImagePullBackOff
      Message:	Back-off pulling image "docker.io/library/nginx:nope-12345": failed to resolve reference "docker.io/library/nginx:nope-12345": docker.io/library/nginx:nope-12345: not found
    Ready:	False
```

#### Which issue(s) this PR fixes:

None tracked.

#### Special notes for your reviewer:

- 3-line change in `describeStatus`, mirroring the existing Terminated
  arm at the same indentation level.
- `describeStatus` is the only describe path that handles Waiting state
  (called from both the State and Last State sites in `DescribePod`),
  so the fix covers all describe paths uniformly.
- The asymmetry has been in place since at least the 2018 describer
  reorganization ([`da9387131e64`](https://github.com/kubernetes/kubernetes/commit/da9387131e64)).
- New unit test sub-case in `TestDescribeContainers` exercises a
  populated Waiting.Message; the existing simple Waiting case (empty
  Message) is unchanged because of the `if Message != ""` guard.

#### Does this PR introduce a user-facing change?

```release-note
`kubectl describe pod` now displays the container Waiting state's
Message field, matching the existing Terminated state output. This
surfaces the kubelet's detail for ImagePullBackOff, ErrImagePull,
CreateContainerConfigError, and similar transient failures inline,
without needing `kubectl get events` or `-o yaml`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
