### PR TITLE
PoC: Add aggregated streaming span events for streamed responses

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/trace_writer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/trace_writer.go
@@ -1,0 +1,211 @@
+package responsewriters
+
+import (
+	"io"
+	"net/http"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"k8s.io/component-base/tracing"
+	"k8s.io/utils/clock"
+)
+
+// layer tracks metrics for a specific tracing layer (e.g., "Serialize", "Compress").
+type layer struct {
+	name          string
+	duration      time.Duration
+	childDuration time.Duration
+	bytes         int64
+	count         int64
+	child         *layer
+}
+
+// TraceWriterManager manages layers of traced writers and reports their metrics
+// to both OpenTelemetry and legacy traces via tracing.Span.AddEvent.
+type TraceWriterManager struct {
+	span   *tracing.Span
+	layers []*layer
+	clock  clock.PassiveClock
+}
+
+// NewTraceWriterManager creates a new manager associated with the given span.
+func NewTraceWriterManager(span *tracing.Span) *TraceWriterManager {
+	return &TraceWriterManager{
+		span:  span,
+		clock: clock.RealClock{},
+	}
+}
+
+// SetClock allows injecting a custom clock for testing.
+func (m *TraceWriterManager) SetClock(c clock.PassiveClock) {
+	m.clock = c
+}
+
+// WrapWriter wraps the given writer to track writes as a named layer.
+func (m *TraceWriterManager) WrapWriter(w io.Writer, name string) WriterFlusher {
+	l := &layer{name: name}
+	tw := &tracedWriter{
+		next:  w,
+		layer: l,
+		m:     m,
+	}
+
+	// Find child layer if the writer is a tracedWriter or wraps one.
+	if unwrapper, ok := w.(interface{ Unwrap() io.Writer }); ok {
+		if childTw, ok := w.(*tracedWriter); ok {
+			l.child = childTw.layer
+		} else if childTw, ok := unwrapper.Unwrap().(*tracedWriter); ok {
+			l.child = childTw.layer
+		}
+	} else if childTw, ok := w.(*tracedWriter); ok {
+		l.child = childTw.layer
+	}
+
+	m.layers = append(m.layers, l)
+	return tw
+}
+
+// WithWriter creates a new WriterSpan for tracking a logical step in writing.
+// It wraps the provided writer to track IO time separately from processing time.
+func (m *TraceWriterManager) WithWriter(name string, w io.Writer) (io.Writer, *WriterSpan) {
+	var childLayer *layer
+	for current := w; current != nil; {
+		if tw, ok := current.(*tracedWriter); ok {
+			childLayer = tw.layer
+			break
+		}
+		if unwrapper, ok := current.(interface{ Unwrap() io.Writer }); ok {
+			current = unwrapper.Unwrap()
+		} else {
+			break
+		}
+	}
+
+	if childLayer != nil {
+		l := &layer{name: name, child: childLayer}
+		m.layers = append(m.layers, l)
+		return w, &WriterSpan{
+			m:     m,
+			layer: l,
+			start: m.clock.Now(),
+		}
+	}
+
+	ioLayer := &layer{name: "Writer"}
+	m.layers = append(m.layers, ioLayer)
+
+	tw := &tracedWriter{
+		next:  w,
+		layer: ioLayer,
+		m:     m,
+	}
+
+	l := &layer{name: name, child: ioLayer}
+	m.layers = append(m.layers, l)
+
+	return tw, &WriterSpan{
+		m:     m,
+		layer: l,
+		start: m.clock.Now(),
+	}
+}
+
+// ReportLayers calculates exclusive durations and reports metrics for all layers.
+func (m *TraceWriterManager) ReportLayers() {
+	var layers []string
+	for _, l := range m.layers {
+		layers = append(layers, l.name)
+		
+		var exclusive time.Duration
+		if l.childDuration > 0 {
+			exclusive = l.duration - l.childDuration
+		} else if l.child != nil {
+			exclusive = l.duration - l.child.duration
+		} else {
+			exclusive = l.duration
+		}
+		
+		if exclusive < 0 {
+			exclusive = 0
+		}
+
+		reportBytes := l.bytes
+		reportCount := l.count
+
+		var attrs []attribute.KeyValue
+		if reportBytes > 0 || reportCount > 0 {
+			attrs = append(attrs, attribute.Int64("size", reportBytes), attribute.Int64("count", reportCount))
+		}
+
+		// Report duration and parallel flag as fields via AddEvent
+		attrs = append(attrs, attribute.String("duration", exclusive.String()), attribute.Bool("parallel", true))
+		
+		m.span.AddEvent(l.name, attrs...)
+	}
+	if len(layers) > 0 {
+		m.span.SetAttributes(attribute.StringSlice("writer.layers", layers))
+	}
+}
+
+// WriterFlusher combines io.Writer and http.Flusher.
+type WriterFlusher interface {
+	io.Writer
+	http.Flusher
+}
+
+// tracedWriter wraps an io.Writer to accumulate duration and byte counts.
+type tracedWriter struct {
+	next  io.Writer
+	layer *layer
+	m     *TraceWriterManager
+}
+
+var _ io.Writer = (*tracedWriter)(nil)
+var _ http.Flusher = (*tracedWriter)(nil)
+
+func (w *tracedWriter) Write(p []byte) (n int, err error) {
+	start := w.m.clock.Now()
+	n, err = w.next.Write(p)
+	duration := w.m.clock.Since(start)
+	w.layer.duration += duration
+	w.layer.bytes += int64(n)
+	w.layer.count++
+	return n, err
+}
+
+func (w *tracedWriter) Flush() {
+	flusher, ok := w.next.(http.Flusher)
+	if !ok {
+		return
+	}
+	start := w.m.clock.Now()
+	flusher.Flush()
+	duration := w.m.clock.Since(start)
+	w.layer.duration += duration
+	w.layer.count++
+}
+
+func (w *tracedWriter) Unwrap() io.Writer {
+	return w.next
+}
+
+// WriterSpan represents a timed logical step in writing.
+type WriterSpan struct {
+	m     *TraceWriterManager
+	layer *layer
+	start time.Time
+}
+
+// End completes the span and records its duration.
+func (s *WriterSpan) End() {
+	duration := s.m.clock.Since(s.start)
+	s.layer.duration = duration
+	if s.layer.child != nil {
+		s.layer.childDuration = s.layer.child.duration
+	}
+}
+
+// Done is a convenience alias for End.
+func (s *WriterSpan) Done() {
+	s.End()
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/trace_writer_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/trace_writer_test.go
@@ -1,0 +1,111 @@
+package responsewriters
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+
+	"k8s.io/component-base/tracing"
+	testingclock "k8s.io/utils/clock/testing"
+	utiltrace "k8s.io/utils/trace"
+	"k8s.io/klog/v2"
+	"k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+)
+
+type clockSteppingWriter struct {
+	clock *testingclock.FakeClock
+	step  time.Duration
+}
+
+func (w *clockSteppingWriter) Write(p []byte) (int, error) {
+	w.clock.Step(w.step)
+	return len(p), nil
+}
+
+func TestTraceWriterManager(t *testing.T) {
+	ctx := context.Background()
+	ctx, span := tracing.Start(ctx, "TestSpan")
+
+	traceMgr := NewTraceWriterManager(span)
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	traceMgr.SetClock(fakeClock)
+
+	steppingWriter := &clockSteppingWriter{clock: fakeClock, step: 15 * time.Millisecond}
+	networkW := traceMgr.WrapWriter(steppingWriter, "Network")
+
+	// Perform a write, which should accumulate bytes, count, and duration
+	networkW.Write([]byte("data"))
+
+	if len(traceMgr.layers) != 1 {
+		t.Fatalf("Expected 1 layer, got %d", len(traceMgr.layers))
+	}
+
+	l := traceMgr.layers[0]
+	if l.name != "Network" {
+		t.Errorf("Expected layer name 'Network', got %q", l.name)
+	}
+	if l.bytes != 4 {
+		t.Errorf("Expected 4 bytes, got %d", l.bytes)
+	}
+	if l.count != 1 {
+		t.Errorf("Expected count 1, got %d", l.count)
+	}
+	if l.duration != 15*time.Millisecond {
+		t.Errorf("Expected duration 15ms, got %v", l.duration)
+	}
+}
+
+func TestSerializeObjectTracing(t *testing.T) {
+	// Initialize klog flags for testing
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	klog.InitFlags(fs)
+	fs.Set("v", "4") // Force verbose logging to see trace steps
+
+	var buf bytes.Buffer
+	klog.SetOutput(&buf)
+
+	// Enable feature gate for compression to test Compress layer
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.APIResponseCompression, true)
+
+	ctx := context.Background()
+	
+	// Create a legacy trace
+	legacyTrace := utiltrace.New("ParentTrace")
+	ctx = utiltrace.ContextWithTrace(ctx, legacyTrace)
+	
+	req := httptest.NewRequest("GET", "/path", nil)
+	req = req.WithContext(ctx)
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	largePayload := bytes.Repeat([]byte("0123456789abcdef"), defaultGzipThresholdBytes/16+1)
+	encoder := &fakeEncoder{
+		buf: largePayload,
+	}
+	recorder := httptest.NewRecorder()
+
+	SerializeObject("application/json", encoder, recorder, req, http.StatusOK, nil /* object */)
+
+	// Force logging of parent trace
+	legacyTrace.LogIfLong(1 * time.Millisecond)
+
+	output := buf.String()
+	t.Logf("Captured Trace Output:\n%s", output)
+
+	// Verify that the output contains the expected layers
+	if !bytes.Contains([]byte(output), []byte(`"Serialize"`)) {
+		t.Errorf("Expected output to contain 'Serialize'. Output:\n%s", output)
+	}
+	if !bytes.Contains([]byte(output), []byte(`"Compress"`)) {
+		t.Errorf("Expected output to contain 'Compress'. Output:\n%s", output)
+	}
+	if !bytes.Contains([]byte(output), []byte(`"Network"`)) {
+		t.Errorf("Expected output to contain 'Network'. Output:\n%s", output)
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -101,15 +101,20 @@ func SerializeObject(mediaType string, encoder runtime.Encoder, hw http.Response
 	req = req.WithContext(ctx)
 	defer span.End(5 * time.Second)
 
+	traceMgr := NewTraceWriterManager(span)
+	defer traceMgr.ReportLayers()
+
 	w := &deferredResponseWriter{
 		mediaType:       mediaType,
 		statusCode:      statusCode,
 		contentEncoding: negotiateContentEncoding(req),
 		hw:              hw,
 		ctx:             ctx,
+		traceMgr:        traceMgr,
 	}
 
-	err := encoder.Encode(object, w)
+	traceW := traceMgr.WrapWriter(w, "Serialize")
+	err := encoder.Encode(object, traceW)
 	if err == nil {
 		err = w.Close()
 		if err != nil {
@@ -200,6 +205,8 @@ type deferredResponseWriter struct {
 	hasWritten  bool
 	hw          http.ResponseWriter
 	w           io.Writer
+	gzipWriter  *gzip.Writer
+	traceMgr    *TraceWriterManager
 	// totalBytes is the number of bytes written to `w` and does not include buffered bytes
 	totalBytes int
 	// lastWriteErr holds the error result (if any) of the last write attempt to `w`
@@ -257,6 +264,8 @@ func (w *deferredResponseWriter) unbufferedWrite(p []byte) (n int, err error) {
 	w.hasWritten = true
 
 	hw := w.hw
+	networkW := w.traceMgr.WrapWriter(hw, "Network")
+
 	header := hw.Header()
 	switch {
 	case w.contentEncoding == "gzip" && len(p) > defaultGzipThresholdBytes:
@@ -264,18 +273,12 @@ func (w *deferredResponseWriter) unbufferedWrite(p []byte) (n int, err error) {
 		header.Add("Vary", "Accept-Encoding")
 
 		gw := gzipPool.Get().(*gzip.Writer)
-		gw.Reset(hw)
-
-		w.w = gw
+		gw.Reset(networkW)
+		w.gzipWriter = gw
+		w.w = w.traceMgr.WrapWriter(gw, "Compress")
 	default:
-		w.w = hw
+		w.w = networkW
 	}
-
-	span := tracing.SpanFromContext(w.ctx)
-	span.AddEvent("About to start writing response",
-		attribute.String("writer", fmt.Sprintf("%T", w.w)),
-		attribute.Int("size", len(p)),
-	)
 
 	header.Set("Content-Type", w.mediaType)
 	hw.WriteHeader(w.statusCode)
@@ -310,11 +313,11 @@ func (w *deferredResponseWriter) Close() (err error) {
 		return err
 	}
 
-	switch t := w.w.(type) {
-	case *gzip.Writer:
-		err = t.Close()
-		t.Reset(nil)
-		gzipPool.Put(t)
+	if w.gzipWriter != nil {
+		err = w.gzipWriter.Close()
+		w.gzipWriter.Reset(nil)
+		gzipPool.Put(w.gzipWriter)
+		w.gzipWriter = nil
 	}
 	return err
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/endpoints/handlers/negotiation"
+	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
 	"k8s.io/apiserver/pkg/endpoints/metrics"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/features"
@@ -248,13 +249,16 @@ func (s *WatchServer) HandleHTTP(w http.ResponseWriter, req *http.Request) {
 		attribute.String("mediaType", s.MediaType),
 		attribute.String("encoder", string(s.Encoder.Identifier())))
 	req = req.WithContext(ctx)
+	traceMgr := responsewriters.NewTraceWriterManager(span)
+	defer traceMgr.ReportLayers()
+
 	defer func() {
 		if s.MemoryAllocator != nil {
 			runtime.AllocatorPool.Put(s.MemoryAllocator)
 		}
 	}()
 
-	flusher, ok := w.(http.Flusher)
+	_, ok := w.(http.Flusher)
 	if !ok {
 		err := fmt.Errorf("unable to start watch - can't get http.Flusher: %#v", w)
 		utilruntime.HandleErrorWithContext(req.Context(), err, "Unable to start watch")
@@ -262,7 +266,8 @@ func (s *WatchServer) HandleHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	framer := s.Framer.NewFrameWriter(w)
+	tracedNetwork := traceMgr.WrapWriter(w, "Network")
+	framer := s.Framer.NewFrameWriter(tracedNetwork)
 	if framer == nil {
 		// programmer error
 		err := fmt.Errorf("no stream framing support is available for media type %q", s.MediaType)
@@ -270,6 +275,7 @@ func (s *WatchServer) HandleHTTP(w http.ResponseWriter, req *http.Request) {
 		s.Scope.err(errors.NewBadRequest(err.Error()), w, req)
 		return
 	}
+	tracedFramer := traceMgr.WrapWriter(framer, "Framer")
 
 	// ensure the connection times out
 	timeoutCh, cleanup := s.TimeoutFactory.TimeoutCh()
@@ -279,12 +285,12 @@ func (s *WatchServer) HandleHTTP(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Content-Type", s.MediaType)
 	w.Header().Set("Transfer-Encoding", "chunked")
 	w.WriteHeader(http.StatusOK)
-	flusher.Flush()
+	tracedNetwork.Flush()
 
 	gvr := s.Scope.Resource
 
 	recorder := &watchEventMetricsRecorder{
-		writer:      framer,
+		writer:      tracedFramer,
 		countMetric: metrics.WatchEvents.WithContext(req.Context()).WithLabelValues(gvr.Group, gvr.Version, gvr.Resource),
 		sizeMetric:  metrics.WatchEventsSizes.WithContext(req.Context()).WithLabelValues(gvr.Group, gvr.Version, gvr.Resource),
 	}
@@ -324,7 +330,7 @@ func (s *WatchServer) HandleHTTP(w http.ResponseWriter, req *http.Request) {
 			recorder.RecordEvent()
 
 			if len(ch) == 0 {
-				flusher.Flush()
+				tracedNetwork.Flush()
 			}
 			if isWatchListLatencyRecordingRequired {
 				// Record completion of initial listing phase for WatchList

--- a/staging/src/k8s.io/component-base/tracing/tracing.go
+++ b/staging/src/k8s.io/component-base/tracing/tracing.go
@@ -60,6 +60,11 @@ func (s *Span) AddEvent(name string, attributes ...attribute.KeyValue) {
 	}
 }
 
+// SetAttributes sets attributes on the OpenTelemetry span.
+func (s *Span) SetAttributes(attributes ...attribute.KeyValue) {
+	s.otelSpan.SetAttributes(attributes...)
+}
+
 // End ends the span, and logs if the span duration is greater than the logThreshold.
 func (s *Span) End(logThreshold time.Duration) {
 	s.otelSpan.End()


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds span events to spans with aggregated details about the streamed response.

Before (copied from the issue):

```
Trace[1461829279]: ["SerializeObject" audit-id:e2ed459c-4f3c-47e4-abb3-099e8a4ad38d,method:GET,url:/api/v1/namespaces/0/pods,protocol:HTTP/2.0,mediaType:application/vnd.kubernetes.protobuf,encoder:{"encodeGV":"v1","encoder":"protobuf","name":"versioning"}] 9230ms (12:49:16.965)
Trace[1461829279]:  ---"About to start writing response" writer:*gzip.Writer,size:201240 227ms (12:49:17.192)
Trace[1461829279]:  ---"Write call succeeded" size:1006056694 9003ms (12:49:26.196)]
Trace[1461829279]: ---"Writing http response done" count:10000 0ms (12:49:26.196)
Trace[1461829279]: [9.244573577s] [9.244573577s] END
```

After (trace logged by unit test):

```
I0507 20:36:57.082377 2980167 trace.go:236] Trace[195300817]: "ParentTrace" (07-May-2026 20:36:57.078) (total time: 3ms):
Trace[195300817]: ["SerializeObject" audit-id:,method:GET,url:/path,protocol:HTTP/1.1,mediaType:application/json,encoder:fake 3ms (20:36:57.078)
Trace[195300817]:  ---"Write call succeeded" size:131088 3ms (20:36:57.082)
Trace[195300817]:  ---"Serialize" size:131088,count:1,duration:3.559531ms,parallel:true 0ms (20:36:57.082)
Trace[195300817]:  ---"Network" size:863,count:10,duration:10.358µs,parallel:true 0ms (20:36:57.082)
Trace[195300817]:  ---"Compress" size:131088,count:1,duration:3.5321ms,parallel:true 0ms (20:36:57.082)]
Trace[195300817]: [3.69947ms] [3.69947ms] END
```

#### Which issue(s) this PR is related to:

PoC for https://github.com/kubernetes/kubernetes/issues/136002

#### Special notes for your reviewer:

Alternatives:

* https://github.com/kubernetes/utils/pull/348
* https://github.com/kubernetes/kubernetes/pull/137181
* https://github.com/kubernetes/kubernetes/pull/136001

Pros of this approach:

No required api changes to component-base/tracing or utils/trace (I added SetAttributes to get the same behavior on otel spans that the other PoC had, but it isn't strictly neccessary).  Writer is contained within the responsewriter package.

#### Does this PR introduce a user-facing change?

```release-note
APIServer tracing spans for streamed responses include more details in span events
```

@serathius @richabanker 

Gemini helped write most of this.