### PR TITLE
apiserver: unify storage list metrics (watch cache and etcd)

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/routes/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/metrics.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apiserver/pkg/server/mux"
 	cachermetrics "k8s.io/apiserver/pkg/storage/cacher/metrics"
 	etcd3metrics "k8s.io/apiserver/pkg/storage/etcd3/metrics"
+	storagemetrics "k8s.io/apiserver/pkg/storage/metrics"
 	flowcontrolmetrics "k8s.io/apiserver/pkg/util/flowcontrol/metrics"
 	peerproxymetrics "k8s.io/apiserver/pkg/util/peerproxy/metrics"
 	proxymetrics "k8s.io/apiserver/pkg/util/proxy/metrics"
@@ -47,9 +48,10 @@ func (m MetricsWithReset) Install(c *mux.PathRecorderMux) {
 	c.Handle("/metrics", legacyregistry.HandlerWithReset())
 }
 
-// register apiserver and etcd metrics
+// register apiserver and storage metrics
 func register() {
 	apimetrics.Register()
+	storagemetrics.Register()
 	cachermetrics.Register()
 	etcd3metrics.Register()
 	flowcontrolmetrics.Register()

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -55,6 +55,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/cacher/store"
 	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
 	etcdfeature "k8s.io/apiserver/pkg/storage/feature"
+	storagemetrics "k8s.io/apiserver/pkg/storage/metrics"
 	storagetesting "k8s.io/apiserver/pkg/storage/testing"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientfeatures "k8s.io/client-go/features"
@@ -557,6 +558,69 @@ apiserver_watch_cache_consistent_read_total{fallback="skipped", group="", resour
 				t.Errorf("unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+func TestListMetrics(t *testing.T) {
+	registry := k8smetrics.NewKubeRegistry()
+	storagemetrics.ResetMetricsForTest()
+	defer storagemetrics.ResetMetricsForTest()
+	storagemetrics.RegisterMetricsForTest(registry)
+
+	backingStorage := &cachertesting.MockStorage{}
+	backingStorage.GetListFn = func(_ context.Context, _ string, _ storage.ListOptions, listObj runtime.Object) error {
+		podList := listObj.(*example.PodList)
+		podList.ListMeta = metav1.ListMeta{ResourceVersion: "100"}
+		return nil
+	}
+
+	cacher, v, err := newTestCacherWithoutSyncing(backingStorage, clock.RealClock{})
+	if err != nil {
+		t.Fatalf("Couldn't create cacher: %v", err)
+	}
+	defer cacher.Stop()
+
+	if err := cacher.ready.wait(context.Background()); err != nil {
+		t.Fatalf("unexpected error waiting for the cache to be ready: %v", err)
+	}
+
+	input := &example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "ns"}}
+	if err := v.UpdateObject(input, 100); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if err := cacher.watchCache.Add(input); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	result := &example.PodList{}
+	err = cacher.GetList(context.TODO(), "/pods/", storage.ListOptions{
+		ResourceVersion: "",
+		Predicate:       storage.Everything,
+		Recursive:       true,
+	}, result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedMetrics := `# HELP apiserver_storage_list_requests_total [ALPHA] Number of LIST requests served from storage partitioned by backend and index.
+# TYPE apiserver_storage_list_requests_total counter
+apiserver_storage_list_requests_total{group="",index="",resource="pods",storage="watchcache"} 1
+# HELP apiserver_storage_list_fetched_objects_total [ALPHA] Number of objects read from storage in the course of serving a LIST request partitioned by backend and index.
+# TYPE apiserver_storage_list_fetched_objects_total counter
+apiserver_storage_list_fetched_objects_total{group="",index="",resource="pods",storage="watchcache"} 1
+# HELP apiserver_storage_list_returned_objects_total [ALPHA] Number of objects returned for a LIST request from storage partitioned by backend.
+# TYPE apiserver_storage_list_returned_objects_total counter
+apiserver_storage_list_returned_objects_total{group="",resource="pods",storage="watchcache"} 1
+`
+
+	if err := testutil.GatherAndCompare(
+		registry,
+		strings.NewReader(expectedMetrics),
+		"apiserver_storage_list_requests_total",
+		"apiserver_storage_list_fetched_objects_total",
+		"apiserver_storage_list_returned_objects_total",
+	); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -602,9 +602,9 @@ func TestListMetrics(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedMetrics := `# HELP apiserver_storage_list_requests_total [ALPHA] Number of LIST requests served from storage partitioned by backend and index.
-# TYPE apiserver_storage_list_requests_total counter
-apiserver_storage_list_requests_total{group="",index="",resource="pods",storage="watchcache"} 1
+	expectedMetrics := `# HELP apiserver_storage_list_total [ALPHA] Number of LIST requests served from storage partitioned by backend and index.
+# TYPE apiserver_storage_list_total counter
+apiserver_storage_list_total{group="",index="",resource="pods",storage="watchcache"} 1
 # HELP apiserver_storage_list_fetched_objects_total [ALPHA] Number of objects read from storage in the course of serving a LIST request partitioned by backend and index.
 # TYPE apiserver_storage_list_fetched_objects_total counter
 apiserver_storage_list_fetched_objects_total{group="",index="",resource="pods",storage="watchcache"} 1
@@ -616,7 +616,7 @@ apiserver_storage_list_returned_objects_total{group="",resource="pods",storage="
 	if err := testutil.GatherAndCompare(
 		registry,
 		strings.NewReader(expectedMetrics),
-		"apiserver_storage_list_requests_total",
+		"apiserver_storage_list_total",
 		"apiserver_storage_list_fetched_objects_total",
 		"apiserver_storage_list_returned_objects_total",
 	); err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/features"
+	storagemetrics "k8s.io/apiserver/pkg/storage/metrics"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	compbasemetrics "k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
@@ -42,31 +43,35 @@ const (
 var (
 	listCacheCount = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
-			Namespace:      namespace,
-			Name:           "cache_list_total",
-			Help:           "Number of LIST requests served from watch cache",
-			StabilityLevel: compbasemetrics.ALPHA,
+			Namespace:         namespace,
+			Name:              "cache_list_total",
+			Help:              "Number of LIST requests served from watch cache",
+			StabilityLevel:    compbasemetrics.ALPHA,
+			DeprecatedVersion: "1.37.0",
 		},
 		[]string{"group", "resource", "index"},
 	)
 	listCacheNumFetched = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
-			Namespace:      namespace,
-			Name:           "cache_list_fetched_objects_total",
-			Help:           "Number of objects read from watch cache in the course of serving a LIST request",
-			StabilityLevel: compbasemetrics.ALPHA,
+			Namespace:         namespace,
+			Name:              "cache_list_fetched_objects_total",
+			Help:              "Number of objects read from watch cache in the course of serving a LIST request",
+			StabilityLevel:    compbasemetrics.ALPHA,
+			DeprecatedVersion: "1.37.0",
 		},
 		[]string{"group", "resource", "index"},
 	)
 	listCacheNumReturned = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
-			Namespace:      namespace,
-			Name:           "cache_list_returned_objects_total",
-			Help:           "Number of objects returned for a LIST request from watch cache",
-			StabilityLevel: compbasemetrics.ALPHA,
+			Namespace:         namespace,
+			Name:              "cache_list_returned_objects_total",
+			Help:              "Number of objects returned for a LIST request from watch cache",
+			StabilityLevel:    compbasemetrics.ALPHA,
+			DeprecatedVersion: "1.37.0",
 		},
 		[]string{"group", "resource"},
 	)
+
 	InitCounter = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
 			Namespace:      namespace,
@@ -242,6 +247,7 @@ func RecordListCacheMetrics(groupResource schema.GroupResource, indexName string
 	listCacheCount.WithLabelValues(groupResource.Group, groupResource.Resource, indexName).Inc()
 	listCacheNumFetched.WithLabelValues(groupResource.Group, groupResource.Resource, indexName).Add(float64(numFetched))
 	listCacheNumReturned.WithLabelValues(groupResource.Group, groupResource.Resource).Add(float64(numReturned))
+	storagemetrics.RecordListMetrics(groupResource, storagemetrics.StorageBackendWatchCache, indexName, numFetched, numReturned)
 }
 
 // RecordResourceVersion sets the current resource version for a given resource type.

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage"
+	storagemetrics "k8s.io/apiserver/pkg/storage/metrics"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	compbasemetrics "k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
@@ -144,33 +145,37 @@ var (
 	)
 	listStorageCount = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
-			Name:           "apiserver_storage_list_total",
-			Help:           "Number of LIST requests served from storage",
-			StabilityLevel: compbasemetrics.ALPHA,
+			Name:              "apiserver_storage_list_total",
+			Help:              "Number of LIST requests served from storage",
+			StabilityLevel:    compbasemetrics.ALPHA,
+			DeprecatedVersion: "1.37.0",
 		},
 		[]string{"group", "resource"},
 	)
 	listStorageNumFetched = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
-			Name:           "apiserver_storage_list_fetched_objects_total",
-			Help:           "Number of objects read from storage in the course of serving a LIST request",
-			StabilityLevel: compbasemetrics.ALPHA,
+			Name:              "apiserver_storage_list_fetched_objects_total",
+			Help:              "Number of objects read from storage in the course of serving a LIST request",
+			StabilityLevel:    compbasemetrics.ALPHA,
+			DeprecatedVersion: "1.37.0",
 		},
 		[]string{"group", "resource"},
 	)
 	listStorageNumSelectorEvals = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
-			Name:           "apiserver_storage_list_evaluated_objects_total",
-			Help:           "Number of objects tested in the course of serving a LIST request from storage",
-			StabilityLevel: compbasemetrics.ALPHA,
+			Name:              "apiserver_storage_list_evaluated_objects_total",
+			Help:              "Number of objects tested in the course of serving a LIST request from storage",
+			StabilityLevel:    compbasemetrics.ALPHA,
+			DeprecatedVersion: "1.37.0",
 		},
 		[]string{"group", "resource"},
 	)
 	listStorageNumReturned = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
-			Name:           "apiserver_storage_list_returned_objects_total",
-			Help:           "Number of objects returned for a LIST request from storage",
-			StabilityLevel: compbasemetrics.ALPHA,
+			Name:              "apiserver_storage_list_returned_objects_total",
+			Help:              "Number of objects returned for a LIST request from storage",
+			StabilityLevel:    compbasemetrics.ALPHA,
+			DeprecatedVersion: "1.37.0",
 		},
 		[]string{"group", "resource"},
 	)
@@ -303,6 +308,8 @@ func RecordStorageListMetrics(groupResource schema.GroupResource, numFetched, nu
 	listStorageNumFetched.WithLabelValues(groupResource.Group, groupResource.Resource).Add(float64(numFetched))
 	listStorageNumSelectorEvals.WithLabelValues(groupResource.Group, groupResource.Resource).Add(float64(numEvald))
 	listStorageNumReturned.WithLabelValues(groupResource.Group, groupResource.Resource).Add(float64(numReturned))
+	storagemetrics.RecordListMetrics(groupResource, storagemetrics.StorageBackendEtcd, "", numFetched, numReturned)
+	storagemetrics.RecordListEvaluatedObjects(groupResource, storagemetrics.StorageBackendEtcd, numEvald)
 }
 
 type Monitor interface {

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -143,42 +143,6 @@ var (
 		},
 		[]string{},
 	)
-	listStorageCount = compbasemetrics.NewCounterVec(
-		&compbasemetrics.CounterOpts{
-			Name:              "apiserver_storage_list_total",
-			Help:              "Number of LIST requests served from storage",
-			StabilityLevel:    compbasemetrics.ALPHA,
-			DeprecatedVersion: "1.37.0",
-		},
-		[]string{"group", "resource"},
-	)
-	listStorageNumFetched = compbasemetrics.NewCounterVec(
-		&compbasemetrics.CounterOpts{
-			Name:              "apiserver_storage_list_fetched_objects_total",
-			Help:              "Number of objects read from storage in the course of serving a LIST request",
-			StabilityLevel:    compbasemetrics.ALPHA,
-			DeprecatedVersion: "1.37.0",
-		},
-		[]string{"group", "resource"},
-	)
-	listStorageNumSelectorEvals = compbasemetrics.NewCounterVec(
-		&compbasemetrics.CounterOpts{
-			Name:              "apiserver_storage_list_evaluated_objects_total",
-			Help:              "Number of objects tested in the course of serving a LIST request from storage",
-			StabilityLevel:    compbasemetrics.ALPHA,
-			DeprecatedVersion: "1.37.0",
-		},
-		[]string{"group", "resource"},
-	)
-	listStorageNumReturned = compbasemetrics.NewCounterVec(
-		&compbasemetrics.CounterOpts{
-			Name:              "apiserver_storage_list_returned_objects_total",
-			Help:              "Number of objects returned for a LIST request from storage",
-			StabilityLevel:    compbasemetrics.ALPHA,
-			DeprecatedVersion: "1.37.0",
-		},
-		[]string{"group", "resource"},
-	)
 	decodeErrorCounts = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
 			Namespace:      "apiserver",
@@ -208,10 +172,6 @@ func Register() {
 		legacyregistry.MustRegister(etcdBookmarkCounts)
 		legacyregistry.MustRegister(etcdBookmarkTotal)
 		legacyregistry.MustRegister(etcdLeaseObjectCounts)
-		legacyregistry.MustRegister(listStorageCount)
-		legacyregistry.MustRegister(listStorageNumFetched)
-		legacyregistry.MustRegister(listStorageNumSelectorEvals)
-		legacyregistry.MustRegister(listStorageNumReturned)
 		legacyregistry.MustRegister(decodeErrorCounts)
 	})
 }
@@ -304,10 +264,6 @@ func UpdateLeaseObjectCount(count int64) {
 
 // RecordStorageListMetrics notes various metrics of the cost to serve a LIST request
 func RecordStorageListMetrics(groupResource schema.GroupResource, numFetched, numEvald, numReturned int) {
-	listStorageCount.WithLabelValues(groupResource.Group, groupResource.Resource).Inc()
-	listStorageNumFetched.WithLabelValues(groupResource.Group, groupResource.Resource).Add(float64(numFetched))
-	listStorageNumSelectorEvals.WithLabelValues(groupResource.Group, groupResource.Resource).Add(float64(numEvald))
-	listStorageNumReturned.WithLabelValues(groupResource.Group, groupResource.Resource).Add(float64(numReturned))
 	storagemetrics.RecordListMetrics(groupResource, storagemetrics.StorageBackendEtcd, "", numFetched, numReturned)
 	storagemetrics.RecordListEvaluatedObjects(groupResource, storagemetrics.StorageBackendEtcd, numEvald)
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics_test.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/storage"
+	storagemetrics "k8s.io/apiserver/pkg/storage/metrics"
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/testutil"
 )
@@ -125,46 +126,24 @@ etcd_bookmark_total{group="apps",resource="deployments"} 1
 
 func TestRecordStorageListMetrics(t *testing.T) {
 	registry := metrics.NewKubeRegistry()
-	for _, metric := range []interface {
-		metrics.Registerable
-		Reset()
-	}{
-		listStorageCount,
-		listStorageNumFetched,
-		listStorageNumSelectorEvals,
-		listStorageNumReturned,
-	} {
-		metric.Reset()
-		registry.MustRegister(metric)
-	}
-	defer func() {
-		for _, metric := range []interface {
-			metrics.Registerable
-			Reset()
-		}{
-			listStorageCount,
-			listStorageNumFetched,
-			listStorageNumSelectorEvals,
-			listStorageNumReturned,
-		} {
-			metric.Reset()
-		}
-	}()
+	storagemetrics.ResetMetricsForTest()
+	storagemetrics.RegisterMetricsForTest(registry)
+	defer storagemetrics.ResetMetricsForTest()
 
 	RecordStorageListMetrics(schema.GroupResource{Group: "apps", Resource: "deployments"}, 4, 2, 1)
 
-	expectedMetrics := `# HELP apiserver_storage_list_total [ALPHA] Number of LIST requests served from storage
+	expectedMetrics := `# HELP apiserver_storage_list_total [ALPHA] Number of LIST requests served from storage partitioned by backend and index.
 # TYPE apiserver_storage_list_total counter
-apiserver_storage_list_total{group="apps",resource="deployments"} 1
-# HELP apiserver_storage_list_fetched_objects_total [ALPHA] Number of objects read from storage in the course of serving a LIST request
+apiserver_storage_list_total{group="apps",index="",resource="deployments",storage="etcd"} 1
+# HELP apiserver_storage_list_fetched_objects_total [ALPHA] Number of objects read from storage in the course of serving a LIST request partitioned by backend and index.
 # TYPE apiserver_storage_list_fetched_objects_total counter
-apiserver_storage_list_fetched_objects_total{group="apps",resource="deployments"} 4
-# HELP apiserver_storage_list_evaluated_objects_total [ALPHA] Number of objects tested in the course of serving a LIST request from storage
+apiserver_storage_list_fetched_objects_total{group="apps",index="",resource="deployments",storage="etcd"} 4
+# HELP apiserver_storage_list_evaluated_objects_total [ALPHA] Number of objects tested in the course of serving a LIST request from storage partitioned by backend.
 # TYPE apiserver_storage_list_evaluated_objects_total counter
-apiserver_storage_list_evaluated_objects_total{group="apps",resource="deployments"} 2
-# HELP apiserver_storage_list_returned_objects_total [ALPHA] Number of objects returned for a LIST request from storage
+apiserver_storage_list_evaluated_objects_total{group="apps",resource="deployments",storage="etcd"} 2
+# HELP apiserver_storage_list_returned_objects_total [ALPHA] Number of objects returned for a LIST request from storage partitioned by backend.
 # TYPE apiserver_storage_list_returned_objects_total counter
-apiserver_storage_list_returned_objects_total{group="apps",resource="deployments"} 1
+apiserver_storage_list_returned_objects_total{group="apps",resource="deployments",storage="etcd"} 1
 `
 
 	if err := testutil.GatherAndCompare(

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics_test.go
@@ -123,6 +123,62 @@ etcd_bookmark_total{group="apps",resource="deployments"} 1
 	}
 }
 
+func TestRecordStorageListMetrics(t *testing.T) {
+	registry := metrics.NewKubeRegistry()
+	for _, metric := range []interface {
+		metrics.Registerable
+		Reset()
+	}{
+		listStorageCount,
+		listStorageNumFetched,
+		listStorageNumSelectorEvals,
+		listStorageNumReturned,
+	} {
+		metric.Reset()
+		registry.MustRegister(metric)
+	}
+	defer func() {
+		for _, metric := range []interface {
+			metrics.Registerable
+			Reset()
+		}{
+			listStorageCount,
+			listStorageNumFetched,
+			listStorageNumSelectorEvals,
+			listStorageNumReturned,
+		} {
+			metric.Reset()
+		}
+	}()
+
+	RecordStorageListMetrics(schema.GroupResource{Group: "apps", Resource: "deployments"}, 4, 2, 1)
+
+	expectedMetrics := `# HELP apiserver_storage_list_total [ALPHA] Number of LIST requests served from storage
+# TYPE apiserver_storage_list_total counter
+apiserver_storage_list_total{group="apps",resource="deployments"} 1
+# HELP apiserver_storage_list_fetched_objects_total [ALPHA] Number of objects read from storage in the course of serving a LIST request
+# TYPE apiserver_storage_list_fetched_objects_total counter
+apiserver_storage_list_fetched_objects_total{group="apps",resource="deployments"} 4
+# HELP apiserver_storage_list_evaluated_objects_total [ALPHA] Number of objects tested in the course of serving a LIST request from storage
+# TYPE apiserver_storage_list_evaluated_objects_total counter
+apiserver_storage_list_evaluated_objects_total{group="apps",resource="deployments"} 2
+# HELP apiserver_storage_list_returned_objects_total [ALPHA] Number of objects returned for a LIST request from storage
+# TYPE apiserver_storage_list_returned_objects_total counter
+apiserver_storage_list_returned_objects_total{group="apps",resource="deployments"} 1
+`
+
+	if err := testutil.GatherAndCompare(
+		registry,
+		strings.NewReader(expectedMetrics),
+		"apiserver_storage_list_total",
+		"apiserver_storage_list_fetched_objects_total",
+		"apiserver_storage_list_evaluated_objects_total",
+		"apiserver_storage_list_returned_objects_total",
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRecordEtcdRequest(t *testing.T) {
 	registry := metrics.NewKubeRegistry()
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -284,9 +284,9 @@ func TestListMetrics(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedMetrics := `# HELP apiserver_storage_list_requests_total [ALPHA] Number of LIST requests served from storage partitioned by backend and index.
-# TYPE apiserver_storage_list_requests_total counter
-apiserver_storage_list_requests_total{group="",index="",resource="pods",storage="etcd"} 1
+	expectedMetrics := `# HELP apiserver_storage_list_total [ALPHA] Number of LIST requests served from storage partitioned by backend and index.
+# TYPE apiserver_storage_list_total counter
+apiserver_storage_list_total{group="",index="",resource="pods",storage="etcd"} 1
 # HELP apiserver_storage_list_fetched_objects_total [ALPHA] Number of objects read from storage in the course of serving a LIST request partitioned by backend and index.
 # TYPE apiserver_storage_list_fetched_objects_total counter
 apiserver_storage_list_fetched_objects_total{group="",index="",resource="pods",storage="etcd"} 1
@@ -301,7 +301,7 @@ apiserver_storage_list_returned_objects_total{group="",resource="pods",storage="
 	if err := testutil.GatherAndCompare(
 		registry,
 		strings.NewReader(expectedMetrics),
-		"apiserver_storage_list_requests_total",
+		"apiserver_storage_list_total",
 		"apiserver_storage_list_fetched_objects_total",
 		"apiserver_storage_list_evaluated_objects_total",
 		"apiserver_storage_list_returned_objects_total",

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -48,10 +48,13 @@ import (
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/etcd3/testserver"
+	storagemetrics "k8s.io/apiserver/pkg/storage/metrics"
 	storagetesting "k8s.io/apiserver/pkg/storage/testing"
 	"k8s.io/apiserver/pkg/storage/value"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	k8smetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 )
@@ -260,6 +263,51 @@ func TestTransformationFailure(t *testing.T) {
 func TestList(t *testing.T) {
 	ctx, store, client := testSetup(t)
 	storagetesting.RunTestList(ctx, t, store, compactStorage(store, client.Client), false, client.Kubernetes.(*storagetesting.KubernetesRecorder))
+}
+
+func TestListMetrics(t *testing.T) {
+	ctx, store, _ := testSetup(t)
+
+	registry := k8smetrics.NewKubeRegistry()
+	storagemetrics.ResetMetricsForTest()
+	defer storagemetrics.ResetMetricsForTest()
+	storagemetrics.RegisterMetricsForTest(registry)
+
+	pod := &example.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "pod-1"}}
+	out := &example.Pod{}
+	if err := store.Create(ctx, computePodKey(pod), pod, out, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	listOut := &example.PodList{}
+	if err := store.GetList(ctx, "/pods/", storage.ListOptions{Recursive: true, Predicate: storage.Everything}, listOut); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedMetrics := `# HELP apiserver_storage_list_requests_total [ALPHA] Number of LIST requests served from storage partitioned by backend and index.
+# TYPE apiserver_storage_list_requests_total counter
+apiserver_storage_list_requests_total{group="",index="",resource="pods",storage="etcd"} 1
+# HELP apiserver_storage_list_fetched_objects_total [ALPHA] Number of objects read from storage in the course of serving a LIST request partitioned by backend and index.
+# TYPE apiserver_storage_list_fetched_objects_total counter
+apiserver_storage_list_fetched_objects_total{group="",index="",resource="pods",storage="etcd"} 1
+# HELP apiserver_storage_list_evaluated_objects_total [ALPHA] Number of objects tested in the course of serving a LIST request from storage partitioned by backend.
+# TYPE apiserver_storage_list_evaluated_objects_total counter
+apiserver_storage_list_evaluated_objects_total{group="",resource="pods",storage="etcd"} 1
+# HELP apiserver_storage_list_returned_objects_total [ALPHA] Number of objects returned for a LIST request from storage partitioned by backend.
+# TYPE apiserver_storage_list_returned_objects_total counter
+apiserver_storage_list_returned_objects_total{group="",resource="pods",storage="etcd"} 1
+`
+
+	if err := testutil.GatherAndCompare(
+		registry,
+		strings.NewReader(expectedMetrics),
+		"apiserver_storage_list_requests_total",
+		"apiserver_storage_list_fetched_objects_total",
+		"apiserver_storage_list_evaluated_objects_total",
+		"apiserver_storage_list_returned_objects_total",
+	); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestConsistentList(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/metrics/metrics.go
@@ -1,0 +1,109 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	compbasemetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const (
+	subsystem                = "apiserver"
+	StorageBackendEtcd       = "etcd"
+	StorageBackendWatchCache = "watchcache"
+)
+
+var (
+	listTotal = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Subsystem:      subsystem,
+			Name:           "storage_list_requests_total",
+			Help:           "Number of LIST requests served from storage partitioned by backend and index.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"group", "resource", "storage", "index"},
+	)
+	listFetchedObjectsTotal = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Subsystem:      subsystem,
+			Name:           "storage_list_fetched_objects_total",
+			Help:           "Number of objects read from storage in the course of serving a LIST request partitioned by backend and index.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"group", "resource", "storage", "index"},
+	)
+	listEvaluatedObjectsTotal = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Subsystem:      subsystem,
+			Name:           "storage_list_evaluated_objects_total",
+			Help:           "Number of objects tested in the course of serving a LIST request from storage partitioned by backend.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"group", "resource", "storage"},
+	)
+	listReturnedObjectsTotal = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Subsystem:      subsystem,
+			Name:           "storage_list_returned_objects_total",
+			Help:           "Number of objects returned for a LIST request from storage partitioned by backend.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"group", "resource", "storage"},
+	)
+	registerMetrics sync.Once
+)
+
+// Register registers shared storage LIST metrics.
+func Register() {
+	registerMetrics.Do(func() {
+		legacyregistry.MustRegister(listTotal)
+		legacyregistry.MustRegister(listFetchedObjectsTotal)
+		legacyregistry.MustRegister(listEvaluatedObjectsTotal)
+		legacyregistry.MustRegister(listReturnedObjectsTotal)
+	})
+}
+
+// RegisterMetricsForTest registers shared storage LIST metrics on a test registry.
+func RegisterMetricsForTest(registry compbasemetrics.KubeRegistry) {
+	registry.MustRegister(listTotal)
+	registry.MustRegister(listFetchedObjectsTotal)
+	registry.MustRegister(listEvaluatedObjectsTotal)
+	registry.MustRegister(listReturnedObjectsTotal)
+}
+
+// ResetMetricsForTest resets shared storage LIST metrics between tests.
+func ResetMetricsForTest() {
+	listTotal.Reset()
+	listFetchedObjectsTotal.Reset()
+	listEvaluatedObjectsTotal.Reset()
+	listReturnedObjectsTotal.Reset()
+}
+
+// RecordListMetrics records LIST request count, fetched objects, and returned objects.
+func RecordListMetrics(groupResource schema.GroupResource, storageBackend, index string, numFetched, numReturned int) {
+	listTotal.WithLabelValues(groupResource.Group, groupResource.Resource, storageBackend, index).Inc()
+	listFetchedObjectsTotal.WithLabelValues(groupResource.Group, groupResource.Resource, storageBackend, index).Add(float64(numFetched))
+	listReturnedObjectsTotal.WithLabelValues(groupResource.Group, groupResource.Resource, storageBackend).Add(float64(numReturned))
+}
+
+// RecordListEvaluatedObjects records the number of objects evaluated while serving a LIST request.
+func RecordListEvaluatedObjects(groupResource schema.GroupResource, storageBackend string, numEvaluated int) {
+	listEvaluatedObjectsTotal.WithLabelValues(groupResource.Group, groupResource.Resource, storageBackend).Add(float64(numEvaluated))
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/metrics/metrics.go
@@ -34,7 +34,7 @@ var (
 	listTotal = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
 			Subsystem:      subsystem,
-			Name:           "storage_list_requests_total",
+			Name:           "storage_list_total",
 			Help:           "Number of LIST requests served from storage partitioned by backend and index.",
 			StabilityLevel: compbasemetrics.ALPHA,
 		},

--- a/staging/src/k8s.io/apiserver/pkg/storage/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/metrics/metrics_test.go
@@ -52,10 +52,10 @@ func TestRecordListMetrics(t *testing.T) {
 	RecordListEvaluatedObjects(groupResource, StorageBackendEtcd, 2)
 	RecordListMetrics(groupResource, StorageBackendWatchCache, "l:app", 3, 1)
 
-	expectedMetrics := `# HELP apiserver_storage_list_requests_total [ALPHA] Number of LIST requests served from storage partitioned by backend and index.
-# TYPE apiserver_storage_list_requests_total counter
-apiserver_storage_list_requests_total{group="apps",index="",resource="deployments",storage="etcd"} 1
-apiserver_storage_list_requests_total{group="apps",index="l:app",resource="deployments",storage="watchcache"} 1
+	expectedMetrics := `# HELP apiserver_storage_list_total [ALPHA] Number of LIST requests served from storage partitioned by backend and index.
+# TYPE apiserver_storage_list_total counter
+apiserver_storage_list_total{group="apps",index="",resource="deployments",storage="etcd"} 1
+apiserver_storage_list_total{group="apps",index="l:app",resource="deployments",storage="watchcache"} 1
 # HELP apiserver_storage_list_fetched_objects_total [ALPHA] Number of objects read from storage in the course of serving a LIST request partitioned by backend and index.
 # TYPE apiserver_storage_list_fetched_objects_total counter
 apiserver_storage_list_fetched_objects_total{group="apps",index="",resource="deployments",storage="etcd"} 4
@@ -72,7 +72,7 @@ apiserver_storage_list_returned_objects_total{group="apps",resource="deployments
 	if err := testutil.GatherAndCompare(
 		registry,
 		strings.NewReader(expectedMetrics),
-		"apiserver_storage_list_requests_total",
+		"apiserver_storage_list_total",
 		"apiserver_storage_list_fetched_objects_total",
 		"apiserver_storage_list_evaluated_objects_total",
 		"apiserver_storage_list_returned_objects_total",

--- a/staging/src/k8s.io/apiserver/pkg/storage/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/metrics/metrics_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8smetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/testutil"
+)
+
+func resetListMetrics() {
+	listTotal.Reset()
+	listFetchedObjectsTotal.Reset()
+	listEvaluatedObjectsTotal.Reset()
+	listReturnedObjectsTotal.Reset()
+}
+
+func TestRecordListMetrics(t *testing.T) {
+	registry := k8smetrics.NewKubeRegistry()
+	resetListMetrics()
+	defer registry.Reset()
+	defer resetListMetrics()
+
+	for _, metric := range []k8smetrics.Registerable{
+		listTotal,
+		listFetchedObjectsTotal,
+		listEvaluatedObjectsTotal,
+		listReturnedObjectsTotal,
+	} {
+		registry.MustRegister(metric)
+	}
+
+	groupResource := schema.GroupResource{Group: "apps", Resource: "deployments"}
+	RecordListMetrics(groupResource, StorageBackendEtcd, "", 4, 1)
+	RecordListEvaluatedObjects(groupResource, StorageBackendEtcd, 2)
+	RecordListMetrics(groupResource, StorageBackendWatchCache, "l:app", 3, 1)
+
+	expectedMetrics := `# HELP apiserver_storage_list_requests_total [ALPHA] Number of LIST requests served from storage partitioned by backend and index.
+# TYPE apiserver_storage_list_requests_total counter
+apiserver_storage_list_requests_total{group="apps",index="",resource="deployments",storage="etcd"} 1
+apiserver_storage_list_requests_total{group="apps",index="l:app",resource="deployments",storage="watchcache"} 1
+# HELP apiserver_storage_list_fetched_objects_total [ALPHA] Number of objects read from storage in the course of serving a LIST request partitioned by backend and index.
+# TYPE apiserver_storage_list_fetched_objects_total counter
+apiserver_storage_list_fetched_objects_total{group="apps",index="",resource="deployments",storage="etcd"} 4
+apiserver_storage_list_fetched_objects_total{group="apps",index="l:app",resource="deployments",storage="watchcache"} 3
+# HELP apiserver_storage_list_evaluated_objects_total [ALPHA] Number of objects tested in the course of serving a LIST request from storage partitioned by backend.
+# TYPE apiserver_storage_list_evaluated_objects_total counter
+apiserver_storage_list_evaluated_objects_total{group="apps",resource="deployments",storage="etcd"} 2
+# HELP apiserver_storage_list_returned_objects_total [ALPHA] Number of objects returned for a LIST request from storage partitioned by backend.
+# TYPE apiserver_storage_list_returned_objects_total counter
+apiserver_storage_list_returned_objects_total{group="apps",resource="deployments",storage="etcd"} 1
+apiserver_storage_list_returned_objects_total{group="apps",resource="deployments",storage="watchcache"} 1
+`
+
+	if err := testutil.GatherAndCompare(
+		registry,
+		strings.NewReader(expectedMetrics),
+		"apiserver_storage_list_requests_total",
+		"apiserver_storage_list_fetched_objects_total",
+		"apiserver_storage_list_evaluated_objects_total",
+		"apiserver_storage_list_returned_objects_total",
+	); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR unifies LIST cost metrics emitted by the apiserver storage layer across `etcd3` and `watch cache`.

Before this change, `etcd3` and `watch cache` exposed separate metric families for logically equivalent LIST operations. This made it harder to compare LIST serving behavior across storage backends or aggregate them consistently.

This change introduces a shared storage LIST metrics implementation and records both backends into the `apiserver_storage_list_*` metric family, using a `storage` label to distinguish the backend.

For metrics that already had an `index` dimension on the watch cache side, the etcd path now records an empty index (`index=""`), following the issue discussion that an empty index is equivalent to no index used.

#### Which issue(s) this PR is related to:

Fixes #138264

#### Special notes for your reviewer:


Metric changes in this PR are summarized below.

### Metric comparison

| Previous backend | Previous metric name | Previous labels | New metric name | New labels |
| --- | --- | --- | --- | --- |
| etcd | `apiserver_storage_list_total` | `group`, `resource` | `apiserver_storage_list_total` | `group`, `resource`, `storage`, `index` |
| etcd | `apiserver_storage_list_fetched_objects_total` | `group`, `resource` | `apiserver_storage_list_fetched_objects_total` | `group`, `resource`, `storage`, `index` |
| etcd | `apiserver_storage_list_evaluated_objects_total` | `group`, `resource` | `apiserver_storage_list_evaluated_objects_total` | `group`, `resource`, `storage` |
| etcd | `apiserver_storage_list_returned_objects_total` | `group`, `resource` | `apiserver_storage_list_returned_objects_total` | `group`, `resource`, `storage` |
| watch cache | `apiserver_cache_list_total` | `group`, `resource`, `index` | `apiserver_storage_list_total` | `group`, `resource`, `storage`, `index` |
| watch cache | `apiserver_cache_list_fetched_objects_total` | `group`, `resource`, `index` | `apiserver_storage_list_fetched_objects_total` | `group`, `resource`, `storage`, `index` |
| watch cache | `apiserver_cache_list_returned_objects_total` | `group`, `resource` | `apiserver_storage_list_returned_objects_total` | `group`, `resource`, `storage` |

### Example mapping

| Old series | New series |
| --- | --- |
| `apiserver_storage_list_total{group="apps",resource="deployments"}` | `apiserver_storage_list_total{group="apps",resource="deployments",storage="etcd",index=""}` |
| `apiserver_storage_list_fetched_objects_total{group="apps",resource="deployments"}` | `apiserver_storage_list_fetched_objects_total{group="apps",resource="deployments",storage="etcd",index=""}` |
| `apiserver_storage_list_evaluated_objects_total{group="apps",resource="deployments"}` | `apiserver_storage_list_evaluated_objects_total{group="apps",resource="deployments",storage="etcd"}` |
| `apiserver_storage_list_returned_objects_total{group="apps",resource="deployments"}` | `apiserver_storage_list_returned_objects_total{group="apps",resource="deployments",storage="etcd"}` |
| `apiserver_cache_list_total{group="apps",resource="deployments",index="l:app"}` | `apiserver_storage_list_total{group="apps",resource="deployments",storage="watchcache",index="l:app"}` |
| `apiserver_cache_list_fetched_objects_total{group="apps",resource="deployments",index="l:app"}` | `apiserver_storage_list_fetched_objects_total{group="apps",resource="deployments",storage="watchcache",index="l:app"}` |
| `apiserver_cache_list_returned_objects_total{group="apps",resource="deployments"}` | `apiserver_storage_list_returned_objects_total{group="apps",resource="deployments",storage="watchcache"}` |

### Compatibility note

This PR unifies the metrics by:
- moving watch cache LIST metrics into the `apiserver_storage_list_*` family
- adding `storage` and `index` labels to the unified storage metrics

As a result:
- the old `apiserver_cache_list_*` metric names are no longer emitted
- the etcd `apiserver_storage_list_*` metrics change label shape from `{group,resource}` to include backend labels


#### Does this PR introduce a user-facing change?

```release-note
Unified apiserver LIST storage metrics across etcd and watch cache under the `apiserver_storage_list_*` metric family by adding a `storage` label and using an empty `index` label for etcd-backed LIST metrics where no index is used.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
