### PR TITLE
aggregator: use original req.Host for X-Forwarded-Host in proxy handler

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
@@ -77,6 +77,12 @@ type UpgradeAwareHandler struct {
 	// specifies the Host header value to send in the HTTP request. If this is false, the incoming req.Host header will
 	// just be forwarded to the backend server.
 	UseLocationHost bool
+	// OriginalHost, if set, is used as the value of the X-Forwarded-Host header
+	// sent to the backend when WrapTransport is true. It should be the host as
+	// received by the proxy from the client (i.e. req.Host before the request
+	// URL is rewritten to the backend address). When empty, the backend URL host
+	// is used, which is the legacy behavior.
+	OriginalHost string
 	// FlushInterval controls how often the standard HTTP proxy will flush content from the upstream.
 	FlushInterval time.Duration
 	// MaxBytesPerSec controls the maximum rate for an upstream connection. No rate is imposed if the value is zero.
@@ -511,6 +517,9 @@ func dial(req *http.Request, transport http.RoundTripper) (net.Conn, error) {
 func (h *UpgradeAwareHandler) defaultProxyTransport(url *url.URL, internalTransport http.RoundTripper) http.RoundTripper {
 	scheme := url.Scheme
 	host := url.Host
+	if h.OriginalHost != "" {
+		host = h.OriginalHost
+	}
 	suffix := h.Location.Path
 	if strings.HasSuffix(url.Path, "/") && !strings.HasSuffix(suffix, "/") {
 		suffix += "/"

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware_test.go
@@ -385,6 +385,35 @@ func TestServeHTTP(t *testing.T) {
 	}
 }
 
+func TestOriginalHostForwarding(t *testing.T) {
+	var gotForwardedHost string
+	backendHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotForwardedHost = r.Header.Get("X-Forwarded-Host")
+		w.WriteHeader(http.StatusOK)
+	})
+	backendServer := httptest.NewServer(backendHandler)
+	defer backendServer.Close()
+
+	backendURL, _ := url.Parse(backendServer.URL)
+	responder := &fakeResponder{t: t}
+
+	proxyHandler := NewUpgradeAwareHandler(backendURL, nil, true, false, responder)
+	proxyHandler.OriginalHost = "foo.com:6443"
+
+	proxyServer := httptest.NewServer(proxyHandler)
+	defer proxyServer.Close()
+
+	resp, err := http.Get(proxyServer.URL + "/some/path")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+
+	if gotForwardedHost != "foo.com:6443" {
+		t.Errorf("X-Forwarded-Host = %q, want %q", gotForwardedHost, "foo.com:6443")
+	}
+}
+
 type RoundTripperFunc func(req *http.Request) (*http.Response, error)
 
 func (fn RoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
@@ -149,6 +149,8 @@ func (r *proxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	location.Path = req.URL.Path
 	location.RawQuery = req.URL.Query().Encode()
 
+	originalHost := req.Host
+
 	newReq, cancelFn := apiserverproxyutil.NewRequestForProxy(location, req)
 	defer cancelFn()
 
@@ -180,6 +182,7 @@ func (r *proxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	handler := proxy.NewUpgradeAwareHandler(location, proxyRoundTripper, true, upgrade, &responder{w: w})
+	handler.OriginalHost = originalHost
 	if r.rejectForwardingRedirects {
 		handler.RejectForwardingRedirects = true
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
@@ -459,7 +459,9 @@ func TestProxyHandler(t *testing.T) {
 				t.Errorf("expected %v, got %v", e, a)
 				return
 			}
-			// this varies every test
+			if e, a := []string{server.Listener.Addr().String()}, target.headers["X-Forwarded-Host"]; tc.expectedCalled && !reflect.DeepEqual(e, a) {
+				t.Errorf("expected %v, got %v", e, a)
+			}
 			delete(target.headers, "X-Forwarded-Host")
 			if e, a := tc.expectedHeaders, target.headers; !reflect.DeepEqual(e, a) {
 				t.Errorf("expected != got %v", cmp.Diff(e, a))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
/sig api-machinery
#### What this PR does / why we need it:
The aggregation layer currently passes the backend's internal IP instead of the client's original host in the X-Forwarded-Host header because the original host gets overwritten too early during the proxy request setup. To fix this, we now capture and stash the client's original host right before that overwrite occurs, allowing the proxy transport to explicitly use this saved value when forwarding the request to the backend.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #107435 
#### Special notes for your reviewer:
The fix doesn't affect WebSocket/SPDY upgrade paths

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
use original req.Host for X-Forwarded-Host in proxy handler
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
-
```
