### PR TITLE
test: enhance integration tests for pod update in scheduler

### DIFF
--- a/test/integration/scheduler/queueing/queue.go
+++ b/test/integration/scheduler/queueing/queue.go
@@ -102,6 +102,8 @@ type CoreResourceEnqueueTestCase struct {
 	TriggerFn func(testCtx *testutils.TestContext) (map[fwk.ClusterEvent]uint64, error)
 	// WantRequeuedPods is the map of Pods that are expected to be requeued after triggerFn.
 	WantRequeuedPods sets.Set[string]
+	// WantScheduledPods is the set of Pods that are expected to be successfully scheduled after triggerFn and requeueing.
+	WantScheduledPods sets.Set[string]
 	// EnablePlugins is a list of plugins to enable.
 	// PrioritySort and DefaultPreemption are enabled by default because they are required by the framework.
 	// If empty, all plugins are enabled.
@@ -298,7 +300,8 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			}
 			return map[fwk.ClusterEvent]uint64{{Resource: fwk.UnscheduledPod, ActionType: fwk.UpdatePodScaleDown}: 1}, nil
 		},
-		WantRequeuedPods: sets.New("pod1"),
+		WantRequeuedPods:  sets.New("pod1"),
+		WantScheduledPods: sets.New("pod1"),
 	},
 	{
 		Name:          "Pod rejected by the NodeResourcesFit plugin is requeued when a Pod is deleted",
@@ -319,7 +322,8 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			}
 			return map[fwk.ClusterEvent]uint64{framework.EventAssignedPodDelete: 1}, nil
 		},
-		WantRequeuedPods: sets.New("pod2"),
+		WantRequeuedPods:  sets.New("pod2"),
+		WantScheduledPods: sets.New("pod2"),
 	},
 	{
 		Name:          "Pod rejected by the NodeResourcesFit plugin is requeued when a Node is created",
@@ -340,7 +344,8 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			}
 			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.Add}: 1}, nil
 		},
-		WantRequeuedPods: sets.New("pod1"),
+		WantRequeuedPods:  sets.New("pod1"),
+		WantScheduledPods: sets.New("pod1"),
 	},
 	{
 		Name:          "Pod rejected by the NodeResourcesFit plugin is requeued when a Node is updated",
@@ -360,7 +365,8 @@ var CoreResourceEnqueueTestCases = []*CoreResourceEnqueueTestCase{
 			}
 			return map[fwk.ClusterEvent]uint64{{Resource: fwk.Node, ActionType: fwk.UpdateNodeAllocatable}: 1}, nil
 		},
-		WantRequeuedPods: sets.New("pod1"),
+		WantRequeuedPods:  sets.New("pod1"),
+		WantScheduledPods: sets.New("pod1"),
 	},
 	{
 		Name:          "Pod rejected by the NodeResourcesFit plugin isn't requeued when a Node has the extended resource, and DRAExtendedResource is disabled",
@@ -2598,7 +2604,11 @@ func RunTestCoreResourceEnqueue(t *testing.T, tt *CoreResourceEnqueueTestCase) {
 	}
 	logger, _ := ktesting.NewTestContext(t)
 
-	opts := []scheduler.Option{scheduler.WithPodInitialBackoffSeconds(0), scheduler.WithPodMaxBackoffSeconds(0)}
+	opts := []scheduler.Option{
+		scheduler.WithPodInitialBackoffSeconds(0),
+		scheduler.WithPodMaxBackoffSeconds(0),
+		scheduler.WithPodMaxInUnschedulablePodsDuration(24 * time.Hour),
+	}
 	if tt.EnablePlugins != nil {
 		enablePlugins := []configv1.Plugin{
 			// These are required plugins to start the scheduler.
@@ -2798,5 +2808,28 @@ func RunTestCoreResourceEnqueue(t *testing.T, tt *CoreResourceEnqueueTestCase) {
 		return requeuedPods.Equal(tt.WantRequeuedPods), nil
 	}); err != nil {
 		t.Fatalf("Expect Pods %v to be requeued, but %v are requeued actually", tt.WantRequeuedPods, requeuedPods)
+	}
+	if tt.WantScheduledPods.Len() > 0 {
+		t.Log("Waiting for pods to be scheduled")
+		for i := 0; i < tt.WantRequeuedPods.Len(); i++ {
+			testCtx.Scheduler.ScheduleOne(testCtx.Ctx)
+		}
+		// Verify that the scheduled status of every Pod in tt.Pods matches tt.WantScheduledPods
+		var scheduledPods sets.Set[string]
+		if err := wait.PollUntilContextTimeout(ctx, time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+			scheduledPods = sets.Set[string]{} // reset
+			for _, podInfo := range tt.Pods {
+				pod, err := testCtx.ClientSet.CoreV1().Pods(testCtx.NS.Name).Get(testCtx.Ctx, podInfo.Name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				if pod.Spec.NodeName != "" {
+					scheduledPods.Insert(podInfo.Name)
+				}
+			}
+			return scheduledPods.Equal(tt.WantScheduledPods), nil
+		}); err != nil {
+			t.Fatalf("Failed to wait for pods to match scheduled expectations: want scheduled=%v, got scheduled=%v", tt.WantScheduledPods, scheduledPods)
+		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/sig scheduling
/kind cleanup

#### What this PR does / why we need it:
This PR enhances the integration test framework in `test/integration/scheduler/queueing/queue.go` to verify that pods are successfully scheduled after an update event.

• Added `WantScheduledPods` field to `CoreResourceEnqueueTestCase` struct.
• Updated `RunTestCoreResourceEnqueue` to attempt scheduling pods in `WantScheduledPods` and verify they are bound to a node.
• Updated 4 test cases to use `WantScheduledPods` to verify full scheduling functionality.

This PR tests fixes introduced in #138847 (PodInfo refactoring).

#### Testing Done:
• Added integration tests in `test/integration/scheduler/queueing/queue.go`.
• Ran `go test -v ./test/integration/scheduler/queueing -run TestCoreResourceEnqueue` and all tests passed.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
