### PR TITLE
apimachinery: add selector overlap helper

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
@@ -18,6 +18,7 @@ package labels
 
 import (
 	"fmt"
+	"math"
 	"slices"
 	"sort"
 	"strconv"
@@ -124,6 +125,153 @@ func Nothing() Selector {
 // Support for detecting such cases can be added in the future.
 func MatchesNothing(selector Selector) bool {
 	return selector == sharedNothingSelector
+}
+
+// SelectorsOverlap returns true if there is any label set that could match both selectors.
+func SelectorsOverlap(selector1, selector2 Selector) bool {
+	reqs1, selectable1 := selector1.Requirements()
+	reqs2, selectable2 := selector2.Requirements()
+	if !selectable1 || !selectable2 {
+		return false
+	}
+
+	requirementsByKey := map[string][]Requirement{}
+	for _, req := range reqs1 {
+		requirementsByKey[req.key] = append(requirementsByKey[req.key], req)
+	}
+	for _, req := range reqs2 {
+		requirementsByKey[req.key] = append(requirementsByKey[req.key], req)
+	}
+
+	for _, reqs := range requirementsByKey {
+		if !requirementsOverlap(reqs) {
+			return false
+		}
+	}
+	return true
+}
+
+func requirementsOverlap(reqs []Requirement) bool {
+	var (
+		mustExist    bool
+		mustNotExist bool
+		allowed      sets.String
+		forbidden    sets.String
+		hasLower     bool
+		lower        int64
+		hasUpper     bool
+		upper        int64
+	)
+
+	for _, req := range reqs {
+		switch req.operator {
+		case selection.In, selection.Equals, selection.DoubleEquals:
+			mustExist = true
+			values := sets.NewString(req.strValues...)
+			if allowed == nil {
+				allowed = values
+			} else {
+				allowed = allowed.Intersection(values)
+			}
+		case selection.NotIn, selection.NotEquals:
+			if forbidden == nil {
+				forbidden = sets.String{}
+			}
+			forbidden.Insert(req.strValues...)
+		case selection.Exists:
+			mustExist = true
+		case selection.DoesNotExist:
+			mustNotExist = true
+		case selection.GreaterThan, selection.LessThan:
+			mustExist = true
+			value, err := strconv.ParseInt(req.strValues[0], 10, 64)
+			if err != nil {
+				return false
+			}
+			switch req.operator {
+			case selection.GreaterThan:
+				if !hasLower || value > lower {
+					hasLower = true
+					lower = value
+				}
+			case selection.LessThan:
+				if !hasUpper || value < upper {
+					hasUpper = true
+					upper = value
+				}
+			}
+		default:
+			return false
+		}
+	}
+
+	if mustNotExist {
+		return !mustExist
+	}
+	if allowed != nil {
+		for value := range allowed {
+			if valueSatisfies(value, forbidden, hasLower, lower, hasUpper, upper) {
+				return true
+			}
+		}
+		return false
+	}
+	if hasLower || hasUpper {
+		return numericValueExists(forbidden, hasLower, lower, hasUpper, upper)
+	}
+	return true
+}
+
+func valueSatisfies(value string, forbidden sets.String, hasLower bool, lower int64, hasUpper bool, upper int64) bool {
+	if forbidden.Has(value) {
+		return false
+	}
+	if hasLower || hasUpper {
+		intValue, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return false
+		}
+		if hasLower && intValue <= lower {
+			return false
+		}
+		if hasUpper && intValue >= upper {
+			return false
+		}
+	}
+	return true
+}
+
+func numericValueExists(forbidden sets.String, hasLower bool, lower int64, hasUpper bool, upper int64) bool {
+	if hasLower && lower == math.MaxInt64 {
+		return false
+	}
+	if hasUpper && upper <= 0 {
+		return false
+	}
+	if hasLower && hasUpper && lower+1 >= upper {
+		return false
+	}
+
+	candidate := int64(0)
+	if hasLower && candidate <= lower {
+		candidate = lower + 1
+	}
+	if hasUpper && candidate >= upper {
+		candidate = upper - 1
+	}
+	if candidate < 0 {
+		candidate = 0
+	}
+	for forbidden.Has(strconv.FormatInt(candidate, 10)) {
+		if candidate == math.MaxInt64 {
+			return false
+		}
+		if hasUpper && candidate+1 >= upper {
+			return false
+		}
+		candidate++
+	}
+	return !hasLower || candidate > lower
 }
 
 // NewSelector returns a nil selector

--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
@@ -1220,8 +1220,152 @@ func TestMatchesNothing(t *testing.T) {
 	}
 }
 
+func TestSelectorsOverlap(t *testing.T) {
+	tests := []struct {
+		name      string
+		selector1 Selector
+		selector2 Selector
+		want      bool
+	}{
+		{
+			name:      "everything overlaps everything",
+			selector1: Everything(),
+			selector2: Everything(),
+			want:      true,
+		},
+		{
+			name:      "nothing does not overlap everything",
+			selector1: Nothing(),
+			selector2: Everything(),
+			want:      false,
+		},
+		{
+			name:      "empty selector overlaps equality",
+			selector1: mustParseSelector(t, ""),
+			selector2: mustParseSelector(t, "env=prod"),
+			want:      true,
+		},
+		{
+			name:      "same equality overlaps",
+			selector1: mustParseSelector(t, "env=prod"),
+			selector2: mustParseSelector(t, "env=prod"),
+			want:      true,
+		},
+		{
+			name:      "different equality does not overlap",
+			selector1: mustParseSelector(t, "env=prod"),
+			selector2: mustParseSelector(t, "env=dev"),
+			want:      false,
+		},
+		{
+			name:      "subset match labels overlap",
+			selector1: mustParseSelector(t, "env=prod"),
+			selector2: mustParseSelector(t, "env=prod,tier=frontend"),
+			want:      true,
+		},
+		{
+			name:      "intersecting in requirements overlap",
+			selector1: mustParseSelector(t, "env in (prod,stage)"),
+			selector2: mustParseSelector(t, "env in (stage,dev)"),
+			want:      true,
+		},
+		{
+			name:      "disjoint in requirements do not overlap",
+			selector1: mustParseSelector(t, "env in (prod,stage)"),
+			selector2: mustParseSelector(t, "env in (dev,test)"),
+			want:      false,
+		},
+		{
+			name:      "in and notin overlap when an allowed value remains",
+			selector1: mustParseSelector(t, "env in (prod,stage)"),
+			selector2: mustParseSelector(t, "env notin (prod)"),
+			want:      true,
+		},
+		{
+			name:      "in and notin do not overlap when all allowed values are forbidden",
+			selector1: mustParseSelector(t, "env in (prod,stage)"),
+			selector2: mustParseSelector(t, "env notin (prod,stage)"),
+			want:      false,
+		},
+		{
+			name:      "exists and does not exist do not overlap",
+			selector1: mustParseSelector(t, "env"),
+			selector2: mustParseSelector(t, "!env"),
+			want:      false,
+		},
+		{
+			name:      "does not exist overlaps notin because missing label satisfies both",
+			selector1: mustParseSelector(t, "!env"),
+			selector2: mustParseSelector(t, "env notin (prod)"),
+			want:      true,
+		},
+		{
+			name:      "greater than and less than overlap",
+			selector1: mustParseSelector(t, "version>1"),
+			selector2: mustParseSelector(t, "version<3"),
+			want:      true,
+		},
+		{
+			name:      "greater than and less than do not overlap",
+			selector1: mustParseSelector(t, "version>3"),
+			selector2: mustParseSelector(t, "version<3"),
+			want:      false,
+		},
+		{
+			name:      "numeric equality overlaps range",
+			selector1: mustParseSelector(t, "version=2"),
+			selector2: mustParseSelector(t, "version>1,version<3"),
+			want:      true,
+		},
+		{
+			name:      "upper bounded range overlaps not equals",
+			selector1: mustParseSelector(t, "version<2"),
+			selector2: mustParseSelector(t, "version!=1"),
+			want:      true,
+		},
+		{
+			name:      "upper bounded range overlaps when zero is forbidden but another value remains",
+			selector1: mustParseSelector(t, "version<3"),
+			selector2: mustParseSelector(t, "version!=0"),
+			want:      true,
+		},
+		{
+			name:      "upper bounded range does not overlap when all values are forbidden",
+			selector1: mustParseSelector(t, "version<3"),
+			selector2: mustParseSelector(t, "version notin (0,1,2)"),
+			want:      false,
+		},
+		{
+			name:      "non numeric equality does not overlap range",
+			selector1: mustParseSelector(t, "version=stable"),
+			selector2: mustParseSelector(t, "version>1"),
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SelectorsOverlap(tt.selector1, tt.selector2); got != tt.want {
+				t.Errorf("SelectorsOverlap(%q, %q) = %v, want %v", tt.selector1, tt.selector2, got, tt.want)
+			}
+			if got := SelectorsOverlap(tt.selector2, tt.selector1); got != tt.want {
+				t.Errorf("SelectorsOverlap(%q, %q) = %v, want %v", tt.selector2, tt.selector1, got, tt.want)
+			}
+		})
+	}
+}
+
 func expectMatchNothing(t *testing.T, selector Selector, want bool) {
 	if MatchesNothing(selector) != want {
 		t.Errorf("Wanted %s to MatchNothing '%t', but it did not.\n", selector, want)
 	}
+}
+
+func mustParseSelector(t *testing.T, selector string) Selector {
+	t.Helper()
+	parsed, err := Parse(selector)
+	if err != nil {
+		t.Fatalf("Parse(%q) failed: %v", selector, err)
+	}
+	return parsed
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds `labels.SelectorsOverlap`, a helper that reports whether there is at least one label set that can match two selectors.

This is useful for admission and validation paths that need to reject overlapping selector scopes. A recent example is `kubernetes-sigs/node-readiness-controller`, where selector overlap detection currently needs to handle both `matchLabels` and `matchExpressions`:

- Motivation PR: https://github.com/kubernetes-sigs/node-readiness-controller/pull/212
- Reviewer discussion asking about an apimachinery helper for matchExpressions: https://github.com/kubernetes-sigs/node-readiness-controller/pull/212#discussion_r3199883763

The helper handles equality, set membership, existence, non-existence, and numeric comparison requirements, with unit coverage for subset, disjoint, expression-based, and numeric selector cases.

#### Which issue(s) this PR is related to:

Related to https://github.com/kubernetes-sigs/node-readiness-controller/issues/211
Related to https://github.com/kubernetes-sigs/node-readiness-controller/pull/212

#### Special notes for your reviewer:

This does not change Kubernetes component behavior directly. It adds a reusable apimachinery primitive that downstream projects can adopt after updating their `k8s.io/apimachinery` dependency.

AI tooling disclosure: I used Codex to help draft tests and some parts of the selector-overlap logic. I reviewed and validated the final patch, and I am responsible for it.

Checks run:

- `go test ./staging/src/k8s.io/apimachinery/pkg/labels`
- `hack/verify-gofmt.sh`
- `git diff --check`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```
