### PR TITLE
Clear stale MemoryQoS cgroup values at kubelet startup

### DIFF
--- a/pkg/kubelet/cm/node_container_manager_linux.go
+++ b/pkg/kubelet/cm/node_container_manager_linux.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"time"
 
+	libcontainercgroups "github.com/opencontainers/cgroups"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -80,6 +82,16 @@ func (cm *containerManagerImpl) enforceNodeAllocatableCgroups(logger klog.Logger
 	cgroupConfig := &CgroupConfig{
 		Name:               cm.cgroupRoot,
 		ResourceParameters: cm.getCgroupConfig(nodeAllocatable, false),
+	}
+
+	// Stale memory.min from a previously enabled MemoryQoS state can persist
+	// across kubelet restarts. Reset to 0 so rollback takes effect.
+	if !utilfeature.DefaultFeatureGate.Enabled(kubefeatures.MemoryQoS) && libcontainercgroups.IsCgroup2UnifiedMode() {
+		rp := cgroupConfig.ResourceParameters
+		if rp.Unified == nil {
+			rp.Unified = make(map[string]string)
+		}
+		rp.Unified[Cgroup2MemoryMin] = "0"
 	}
 
 	// Using ObjectReference for events as the node maybe not cached; refer to #42701 for detail.

--- a/pkg/kubelet/cm/qos_container_manager_linux.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux.go
@@ -110,6 +110,14 @@ func (m *qosContainerManagerImpl) Start(ctx context.Context, getNodeAllocatable 
 			resourceParameters.CPUShares = &minShares
 		}
 
+		// Stale memory.low from a previously enabled MemoryQoS state can persist
+		// across kubelet restarts. Reset to 0 so rollback takes effect.
+		if !utilfeature.DefaultFeatureGate.Enabled(kubefeatures.MemoryQoS) && libcontainercgroups.IsCgroup2UnifiedMode() {
+			if qosClass == v1.PodQOSBurstable {
+				resourceParameters.Unified = map[string]string{Cgroup2MemoryLow: "0"}
+			}
+		}
+
 		// containerConfig object stores the cgroup specifications
 		containerConfig := &CgroupConfig{
 			Name:               containerName,

--- a/test/e2e_node/memory_qos_test.go
+++ b/test/e2e_node/memory_qos_test.go
@@ -588,9 +588,6 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 		ginkgo.AfterEach(func(ctx context.Context) { restoreConfig(ctx) })
 
 		ginkgo.It("should reset memory protection to 0 when MemoryQoS is disabled", func(ctx context.Context) {
-			// See https://github.com/kubernetes/kubernetes/pull/138430 for details
-			ginkgo.Skip("skipping test until MemoryQoS rollback is resolved")
-
 			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.TieredReservationMemoryReservationPolicy)
 
 			pod := memqosMakePod("memqos-rollback", f.Namespace.Name,
@@ -617,8 +614,7 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 			restartKubelet(ctx, true)
 			waitForKubeletToStart(ctx, f)
 
-			// QoS-class cgroup memory.low is cleared by the periodic setMemoryQoS loop
-			// (periodicQOSCgroupUpdateInterval = 1 minute) plus kubelet startup time.
+			// Stale QoS-class cgroup memory.low is cleared at kubelet startup.
 			var burstableCgroupPath string
 			if cgroupDriver == "systemd" {
 				burstableCgroupPath = filepath.Join(cgroupRoot, "kubepods.slice", "kubepods-burstable.slice")
@@ -631,9 +627,73 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 			}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(gomega.Equal(int64(0)),
 				"burstable QoS memory.low should reset to 0 when MemoryQoS is disabled")
 
-			// NOTE: Pod-level and container-level memory.low values persist after rollback.
-			// Pod-level: clearing via systemd SetUnitProperties interferes with other cgroup settings.
-			// Container-level: requires CRI runtime support for Unified in UpdateContainerResources.
+			// Pod and container memory.low values persist but have no effect
+			// since cgroup v2 memory protection is hierarchical (parent=0 wins).
+		})
+
+		ginkgo.It("should not clobber other cgroup values when clearing stale memory protection at startup", func(ctx context.Context) {
+			configureMemoryQoSWithPolicy(ctx, 0.9, kubeletconfig.TieredReservationMemoryReservationPolicy)
+
+			e2epod.NewPodClient(f).CreateSync(ctx, memqosMakePod("memqos-clobber-check", f.Namespace.Name,
+				v1.ResourceList{v1.ResourceMemory: resource.MustParse("128Mi")},
+				v1.ResourceList{v1.ResourceMemory: resource.MustParse("256Mi")},
+			))
+
+			var burstableCgroupPath string
+			if cgroupDriver == "systemd" {
+				burstableCgroupPath = filepath.Join(cgroupRoot, "kubepods.slice", "kubepods-burstable.slice")
+			} else {
+				burstableCgroupPath = filepath.Join(cgroupRoot, "kubepods", "burstable")
+			}
+
+			ginkgo.By("Verifying memory.low is non-zero while MemoryQoS is enabled")
+			gomega.Eventually(ctx, func() int64 {
+				val, _ := memqosReadCgroupInt64(burstableCgroupPath, cgroupMemoryLow)
+				return val
+			}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(
+				gomega.BeNumerically(">", int64(0)),
+				"memory.low should be non-zero when MemoryQoS is enabled with burstable pods")
+
+			ginkgo.By("Recording baseline cgroup values before rollback")
+			cgroupFiles := []string{"cpu.max", "memory.max"}
+			baselines := make(map[string]string)
+			for _, cgFile := range cgroupFiles {
+				filePath := filepath.Join(burstableCgroupPath, cgFile)
+				if _, statErr := os.Stat(filePath); os.IsNotExist(statErr) {
+					continue
+				}
+				val, err := memqosReadCgroupFile(burstableCgroupPath, cgFile)
+				framework.ExpectNoError(err, "reading baseline %s", cgFile)
+				baselines[cgFile] = val
+				framework.Logf("baseline %s: %s", cgFile, val)
+			}
+
+			ginkgo.By("Disabling MemoryQoS and restarting kubelet")
+			newCfg := oldCfg.DeepCopy()
+			if newCfg.FeatureGates == nil {
+				newCfg.FeatureGates = make(map[string]bool)
+			}
+			newCfg.FeatureGates["MemoryQoS"] = false
+			newCfg.MemoryReservationPolicy = kubeletconfig.NoneMemoryReservationPolicy
+			framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(newCfg))
+			restartKubelet(ctx, true)
+			waitForKubeletToStart(ctx, f)
+
+			ginkgo.By("Verifying memory.low was cleared to 0 at startup")
+			gomega.Eventually(ctx, func() int64 {
+				val, _ := memqosReadCgroupInt64(burstableCgroupPath, cgroupMemoryLow)
+				return val
+			}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(gomega.Equal(int64(0)),
+				"memory.low should be cleared at startup when MemoryQoS is disabled")
+
+			ginkgo.By("Verifying other cgroup values were not clobbered by the rollback")
+			for cgFile, baseline := range baselines {
+				post, err := memqosReadCgroupFile(burstableCgroupPath, cgFile)
+				framework.ExpectNoError(err, "reading post-rollback %s", cgFile)
+				framework.Logf("post-rollback %s: got=%s, baseline=%s", cgFile, post, baseline)
+				gomega.Expect(post).To(gomega.Equal(baseline),
+					fmt.Sprintf("%s changed after rollback", cgFile))
+			}
 		})
 	})
 


### PR DESCRIPTION
When MemoryQoS is disabled after being previously enabled, stale memory.min and memory.low values persist on QoS-class cgroups because systemd re-applies stored properties on every SetUnitProperties call.

Fix this by including memory.min=0 and memory.low=0 in the existing startup dbus calls (enforceNodeAllocatableCgroups for the root cgroup, qosContainerManager.Start for the burstable cgroup). This overwrites systemd's stored stale values so subsequent realizations re-apply 0.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind regression

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes https://github.com/kubernetes/kubernetes/issues/138436

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a regression where kubelet did not clear stale cgroup v2 memory.min and memory.low values when the MemoryQoS feature gate was disabled after being previously enabled.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/issues/2570
```
