### PR TITLE
Allow freezing feature gates

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -88,6 +88,9 @@ cluster's shared state through which all other components interact.`,
 			// silence client-go warnings.
 			// kube-apiserver loopback clients should not log self-issued warnings.
 			rest.SetDefaultWarningHandler(rest.NoWarnings{})
+			if err := utilfeature.DefaultMutableFeatureGate.Freeze(); err != nil {
+				return err
+			}
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -363,7 +363,7 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 	if !fs.Changed("advertise-address") && !fs.Changed("endpoint-reconciler-type") {
 		s.EndpointReconcilerType = "none"
 	}
-	if utilfeature.DefaultFeatureGate.Enabled(zpagesfeatures.ComponentFlagz) {
+	if featureGate.Enabled(zpagesfeatures.ComponentFlagz) {
 		s.Flagz = flagz.NamedFlagSetsReader{FlagSets: namedFlagSets}
 	}
 
@@ -394,15 +394,18 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 		featuregatetesting.SetFeatureGateVersionsDuringTest(t, utilfeature.DefaultMutableFeatureGate, effectiveVersion.EmulationVersion(), effectiveVersion.MinCompatibilityVersion())
 	}
 	featureOverrides := map[featuregate.Feature]bool{}
-	for f := range utilfeature.DefaultMutableFeatureGate.GetAll() {
-		if featureGate.Enabled(f) != utilfeature.DefaultFeatureGate.Enabled(f) {
-			featureOverrides[f] = featureGate.Enabled(f)
+	{
+		// compare to Enabled() state in a copy of DefaultFeatureGate to avoid tripping pre-Freeze() Enabled() check detection
+		defaultFeatureGateCopy := utilfeature.DefaultFeatureGate.DeepCopy()
+		for f := range utilfeature.DefaultMutableFeatureGate.GetAll() {
+			if featureGate.Enabled(f) != defaultFeatureGateCopy.Enabled(f) {
+				featureOverrides[f] = featureGate.Enabled(f)
+			}
 		}
 	}
 	if len(featureOverrides) > 0 {
 		featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featureOverrides)
 	}
-	utilfeature.DefaultMutableFeatureGate.AddMetrics()
 
 	if instanceOptions.EnableCertAuth {
 		if featureGate.Enabled(genericfeatures.UnknownVersionInteroperabilityProxy) {

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -129,7 +129,13 @@ controller, and serviceaccounts controller.`,
 			// and CI ensures it works properly against matching kube-apiserver versions.
 			restclient.SetDefaultWarningHandler(restclient.NoWarnings{})
 			// makes sure feature gates are set before RunE.
-			return s.ComponentGlobalsRegistry.Set()
+			if err := s.ComponentGlobalsRegistry.Set(); err != nil {
+				return err
+			}
+			if err := utilfeature.DefaultMutableFeatureGate.Freeze(); err != nil {
+				return err
+			}
+			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			verflag.PrintAndExitIfRequested()

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -105,7 +105,13 @@ See [scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/)
 for more information about scheduling and the kube-scheduler component.`,
 		PersistentPreRunE: func(*cobra.Command, []string) error {
 			// makes sure feature gates are set before RunE.
-			return opts.ComponentGlobalsRegistry.Set()
+			if err := opts.ComponentGlobalsRegistry.Set(); err != nil {
+				return err
+			}
+			if err := utilfeature.DefaultMutableFeatureGate.Freeze(); err != nil {
+				return err
+			}
+			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCommand(cmd, opts, registryOptions...)

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -242,6 +242,10 @@ is checked every 20 seconds (also configurable with a flag).`,
 				}
 			}
 
+			if err := utilfeature.DefaultMutableFeatureGate.Freeze(); err != nil {
+				return err
+			}
+
 			// Config and flags parsed, now we can initialize logging.
 			logs.InitLogs()
 			// Retrieve the logger again to reflect the updated log settings
@@ -631,11 +635,6 @@ func run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Depend
 	}
 	kubeDeps.HealthChecker = healthChecker
 	healthChecker.Start(ctx)
-	// Set global feature gates based on the value on the initial KubeletServer
-	err = utilfeature.DefaultMutableFeatureGate.SetFromMap(s.KubeletConfiguration.FeatureGates)
-	if err != nil {
-		return err
-	}
 	// Propagate feature gate state to the metrics subsystem. This must be called
 	// after feature gates are set and before any histogram metrics are registered.
 	metricsfeatures.ApplyFeatureGates(featureGate)

--- a/pkg/controlplane/apiserver/config.go
+++ b/pkg/controlplane/apiserver/config.go
@@ -169,6 +169,11 @@ func BuildGenericConfig(
 	if lastErr = s.Traces.ApplyTo(genericConfig.EgressSelector, genericConfig); lastErr != nil {
 		return
 	}
+	// after applying features, before using APIServerID
+	if len(genericConfig.APIServerID) == 0 {
+		genericConfig.APIServerID = genericapiserver.DefaultAPIServerID(genericConfig.FeatureGate)
+	}
+
 	// wrap the definitions to revert any changes from disabled features
 	getOpenAPIDefinitions = openapi.GetOpenAPIDefinitionsWithoutDisabledFeatures(getOpenAPIDefinitions)
 	namer := openapinamer.NewDefinitionNamer(schemes...)

--- a/pkg/controlplane/apiserver/samples/generic/server/server.go
+++ b/pkg/controlplane/apiserver/samples/generic/server/server.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -67,6 +68,9 @@ APIs.`,
 		// stop printing usage when the command errors
 		SilenceUsage: true,
 		PersistentPreRunE: func(*cobra.Command, []string) error {
+			if err := utilfeature.DefaultMutableFeatureGate.Freeze(); err != nil {
+				return err
+			}
 			// silence client-go warnings.
 			// kube-apiserver loopback clients should not log self-issued warnings.
 			rest.SetDefaultWarningHandler(rest.NoWarnings{})

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/server.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/server.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/apiextensions-apiserver/pkg/cmd/server/options"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
 func NewServerCommand(ctx context.Context, out, errOut io.Writer) *cobra.Command {
@@ -33,7 +34,13 @@ func NewServerCommand(ctx context.Context, out, errOut io.Writer) *cobra.Command
 		Short: "Launch an API extensions API server",
 		Long:  "Launch an API extensions API server",
 		PersistentPreRunE: func(*cobra.Command, []string) error {
-			return o.ServerRunOptions.ComponentGlobalsRegistry.Set()
+			if err := o.ServerRunOptions.ComponentGlobalsRegistry.Set(); err != nil {
+				return err
+			}
+			if err := utilfeature.DefaultMutableFeatureGate.Freeze(); err != nil {
+				return err
+			}
+			return nil
 		},
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := o.Complete(); err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -403,33 +403,9 @@ func init() {
 
 // NewConfig returns a Config struct with the default values
 func NewConfig(codecs serializer.CodecFactory) *Config {
+
 	defaultHealthChecks := []healthz.HealthChecker{healthz.PingHealthz, healthz.LogHealthz}
-	var id string
-	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.APIServerIdentity) {
-		hostname, err := hostnameFunc()
-		if err != nil {
-			klog.Fatalf("error getting hostname for apiserver identity: %v", err)
-		}
 
-		// Since the hash needs to be unique across each kube-apiserver and aggregated apiservers,
-		// the hash used for the identity should include both the hostname and the identity value.
-		// TODO: receive the identity value as a parameter once the apiserver identity lease controller
-		// post start hook is moved to generic apiserver.
-		b := cryptobyte.NewBuilder(nil)
-		b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
-			b.AddBytes([]byte(hostname))
-		})
-		b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
-			b.AddBytes([]byte("kube-apiserver"))
-		})
-		hashData, err := b.Bytes()
-		if err != nil {
-			klog.Fatalf("error building hash data for apiserver identity: %v", err)
-		}
-
-		hash := sha256.Sum256(hashData)
-		id = "apiserver-" + strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(hash[:16]))
-	}
 	lifecycleSignals := newLifecycleSignals()
 
 	return &Config{
@@ -480,7 +456,6 @@ func NewConfig(codecs serializer.CodecFactory) *Config {
 		StorageObjectCountTracker:           flowcontrolrequest.NewStorageObjectCountTracker(),
 		ShutdownWatchTerminationGracePeriod: time.Duration(0),
 
-		APIServerID:           id,
 		StorageVersionManager: storageversion.NewDefaultManager(),
 		TracerProvider:        tracing.NewNoopTracerProvider(),
 	}
@@ -725,6 +700,11 @@ func (c *Config) Complete(informers informers.SharedInformerFactory) CompletedCo
 	}
 	if len(c.ExternalAddress) == 0 && c.PublicAddress != nil {
 		c.ExternalAddress = c.PublicAddress.String()
+	}
+
+	// After setting feature gates
+	if len(c.APIServerID) == 0 {
+		c.APIServerID = DefaultAPIServerID(c.FeatureGate)
 	}
 
 	// if there is no port, and we listen on one securely, use that one
@@ -1031,6 +1011,35 @@ func BuildHandlerChainWithStorageVersionPrecondition(apiHandler http.Handler, c 
 	// WithStorageVersionPrecondition needs the WithRequestInfo to run first
 	handler := genericapifilters.WithStorageVersionPrecondition(apiHandler, c.StorageVersionManager, c.Serializer)
 	return DefaultBuildHandlerChain(handler, c)
+}
+
+func DefaultAPIServerID(features featuregate.FeatureGate) string {
+	if !features.Enabled(genericfeatures.APIServerIdentity) {
+		return ""
+	}
+	hostname, err := hostnameFunc()
+	if err != nil {
+		klog.Fatalf("error getting hostname for apiserver identity: %v", err)
+	}
+
+	// Since the hash needs to be unique across each kube-apiserver and aggregated apiservers,
+	// the hash used for the identity should include both the hostname and the identity value.
+	// TODO: receive the identity value as a parameter once the apiserver identity lease controller
+	// post start hook is moved to generic apiserver.
+	b := cryptobyte.NewBuilder(nil)
+	b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
+		b.AddBytes([]byte(hostname))
+	})
+	b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
+		b.AddBytes([]byte("kube-apiserver"))
+	})
+	hashData, err := b.Bytes()
+	if err != nil {
+		klog.Fatalf("error building hash data for apiserver identity: %v", err)
+	}
+
+	hash := sha256.Sum256(hashData)
+	return "apiserver-" + strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(hash[:16]))
 }
 
 func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {

--- a/staging/src/k8s.io/component-base/featuregate/feature_gate.go
+++ b/staging/src/k8s.io/component-base/featuregate/feature_gate.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"maps"
 	"reflect"
+	"runtime/debug"
 	"slices"
 	"sort"
 	"strconv"
@@ -165,6 +166,9 @@ type MutableFeatureGate interface {
 	AddFlag(fs *pflag.FlagSet)
 	// Close sets closed to true, and prevents subsequent calls to Add
 	Close()
+	// Freeze sets frozen to true and prevents subsequent mutation of gate values.
+	// An error is returned if gates were read prior to freezing.
+	Freeze() error
 	// Set parses and stores flag gates for known features
 	// from a string like feature1=true,feature2=false,...
 	Set(value string) error
@@ -281,6 +285,12 @@ type featureGate struct {
 	queriedFeatures         atomic.Value
 	emulationVersion        atomic.Pointer[version.Version]
 	minCompatibilityVersion atomic.Pointer[version.Version]
+
+	// frozen is true once all gate changes have been completed, disables all mutation
+	frozen bool
+	// firstRead records the stack of the first caller to Enabled()
+	firstRead      sync.Once
+	firstReadStack string
 }
 
 var _ MutableVersionedFeatureGateWithLogger = &featureGate{}
@@ -485,6 +495,10 @@ func (f *featureGate) SetFromMapWithLogger(logger klog.Logger, m map[string]bool
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
+	if f.frozen {
+		return fmt.Errorf("cannot set %#v, gate is frozen", m)
+	}
+
 	// Copy existing state
 	enabled := map[Feature]bool{}
 	for k, v := range f.enabled.Load().(map[Feature]bool) {
@@ -544,6 +558,9 @@ func (f *featureGate) AddVersioned(features map[Feature]VersionedSpecs) error {
 
 	if f.closed {
 		return fmt.Errorf("cannot add a feature gate after adding it to the flag set")
+	}
+	if f.frozen {
+		return fmt.Errorf("cannot add features %#v, gate is frozen", features)
 	}
 	// Copy existing state
 	known := f.GetAllVersioned()
@@ -653,6 +670,10 @@ func (f *featureGate) AddDependencies(dependencies map[Feature][]Feature) error 
 	if f.closed {
 		return fmt.Errorf("cannot add a feature gate dependency after adding it to the flag set")
 	}
+	if f.frozen {
+		return fmt.Errorf("cannot add a feature gate dependency after frozen")
+	}
+
 	// Copy existing state
 	known := f.GetAllVersioned()
 
@@ -788,6 +809,9 @@ func (f *featureGate) overrideDefaultAtEmulationAndMinCompatVersion(logger klog.
 	if f.closed {
 		return fmt.Errorf("cannot override default for feature %q: gates already added to a flag set", name)
 	}
+	if f.frozen {
+		return fmt.Errorf("cannot override default for feature %q: gates are frozen", name)
+	}
 
 	// Copy existing state
 	known := f.GetAllVersioned()
@@ -865,11 +889,16 @@ func (f *featureGate) SetEmulationVersionAndMinCompatibilityVersionWithLogger(lo
 	helper, logger := logger.WithCallStackHelper()
 	helper()
 
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	if f.frozen {
+		return fmt.Errorf("cannot set emulation version, gate is frozen")
+	}
+
 	if emulationVersion.EqualTo(f.EmulationVersion()) && minCompatibilityVersion.EqualTo(f.MinCompatibilityVersion()) {
 		return nil
 	}
-	f.lock.Lock()
-	defer f.lock.Unlock()
 	logger.V(1).Info("Set feature gate emulation", "emulationVersion", emulationVersion, "minCompatibilityVersion", minCompatibilityVersion)
 
 	// Copy existing state
@@ -945,6 +974,11 @@ func featureEnabled(key Feature, enabled map[Feature]bool, known map[Feature]Ver
 
 // Enabled returns true if the key is enabled.  If the key is not known, this call will panic.
 func (f *featureGate) Enabled(key Feature) bool {
+	f.firstRead.Do(func() {
+		f.lock.Lock()
+		defer f.lock.Unlock()
+		f.firstReadStack = string(debug.Stack())
+	})
 	// TODO: ideally we should lock the feature gate in this call to be safe, need to evaluate how much performance impact locking would have.
 	v := featureEnabled(key, f.enabled.Load().(map[Feature]bool), f.known.Load().(map[Feature]VersionedSpecs), f.EmulationVersion(), f.MinCompatibilityVersion())
 	f.unsafeRecordQueried(key)
@@ -982,6 +1016,21 @@ func (f *featureGate) Close() {
 	f.lock.Lock()
 	f.closed = true
 	f.lock.Unlock()
+}
+
+// Freeze sets frozen to true and prevents subsequent mutation.
+// An error is returned if gates were read prior to freezing.
+func (f *featureGate) Freeze() error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	if f.frozen {
+		return nil
+	}
+	f.frozen = true
+	if f.firstReadStack != "" {
+		return fmt.Errorf("already read from\n%s\nbefore Freeze() was called from\n%s", f.firstReadStack, string(debug.Stack()))
+	}
+	return nil
 }
 
 // AddFlag adds a flag for setting global feature gates to the specified FlagSet.
@@ -1098,6 +1147,11 @@ func (f *featureGate) ExplicitlySet(name Feature) bool {
 func (f *featureGate) ResetFeatureValueToDefault(name Feature) error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
+
+	if f.frozen {
+		return fmt.Errorf("cannot reset to defaults, gate is frozen")
+	}
+
 	enabled := map[Feature]bool{}
 	for k, v := range f.enabled.Load().(map[Feature]bool) {
 		enabled[k] = v

--- a/staging/src/k8s.io/component-base/featuregate/feature_gate.go
+++ b/staging/src/k8s.io/component-base/featuregate/feature_gate.go
@@ -1033,6 +1033,15 @@ func (f *featureGate) Freeze() error {
 	return nil
 }
 
+// ThawForTest.
+func (f *featureGate) ThawForTest() {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.frozen = false
+	f.firstReadStack = ""
+	f.firstRead = sync.Once{}
+}
+
 // AddFlag adds a flag for setting global feature gates to the specified FlagSet.
 func (f *featureGate) AddFlag(fs *pflag.FlagSet) {
 	// TODO(mtaufen): Shouldn't we just close it on the first Set/SetFromMap instead?

--- a/staging/src/k8s.io/component-base/featuregate/testing/feature_gate.go
+++ b/staging/src/k8s.io/component-base/featuregate/testing/feature_gate.go
@@ -38,6 +38,10 @@ func init() {
 	featureFlagOverride = map[featuregate.Feature]string{}
 }
 
+type ThawableFeatureGate interface {
+	ThawForTest()
+}
+
 type FeatureOverrides = map[featuregate.Feature]bool
 
 // SetFeatureGateDuringTest sets the specified gate to the specified value for duration of the test.

--- a/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
 	openapinamer "k8s.io/apiserver/pkg/endpoints/openapi"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -31,6 +32,7 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/filters"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 	"k8s.io/kube-aggregator/pkg/apiserver"
 	aggregatorscheme "k8s.io/kube-aggregator/pkg/apiserver/scheme"
@@ -62,7 +64,13 @@ func NewCommandStartAggregator(ctx context.Context, defaults *AggregatorOptions)
 		Short: "Launch a API aggregator and proxy server",
 		Long:  "Launch a API aggregator and proxy server",
 		PersistentPreRunE: func(*cobra.Command, []string) error {
-			return o.ServerRunOptions.ComponentGlobalsRegistry.Set()
+			if err := o.ServerRunOptions.ComponentGlobalsRegistry.Set(); err != nil {
+				return err
+			}
+			if err := utilfeature.DefaultMutableFeatureGate.Freeze(); err != nil {
+				return err
+			}
+			return nil
 		},
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := o.Complete(); err != nil {

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -104,7 +104,13 @@ func NewCommandStartWardleServer(ctx context.Context, defaults *WardleServerOpti
 			if skipDefaultComponentGlobalsRegistrySet {
 				return nil
 			}
-			return defaults.ComponentGlobalsRegistry.Set()
+			if err := defaults.ComponentGlobalsRegistry.Set(); err != nil {
+				return err
+			}
+			if err := utilfeature.DefaultMutableFeatureGate.Freeze(); err != nil {
+				return err
+			}
+			return nil
 		},
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := o.Complete(); err != nil {

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -45,7 +45,6 @@ import (
 	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	"k8s.io/apiserver/pkg/authentication/user"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
-	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
 	genericapiserveroptions "k8s.io/apiserver/pkg/server/options"
 	utilcompatibility "k8s.io/apiserver/pkg/util/compatibility"
@@ -264,8 +263,6 @@ func TestFrontProxyConfig(t *testing.T) {
 		testFrontProxyConfig(t, false)
 	})
 	t.Run("WithUID", func(t *testing.T) {
-		featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MajorMinor(1, 33))
-		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RemoteRequestHeaderUID, true)
 		testFrontProxyConfig(t, true)
 	})
 }
@@ -792,6 +789,14 @@ func runPreparedWardleServer(
 		if flunderBanningFeatureGate {
 			args = append(args, "--feature-gates", fmt.Sprintf("wardle:BanFlunder=%v", banFlunder))
 		}
+
+		// thaw before calling into the sample-apiserver which will freeze
+		utilfeature.DefaultMutableFeatureGate.(featuregatetesting.ThawableFeatureGate).ThawForTest()
+		t.Cleanup(func() {
+			// thaw when we're done so that other tests that set feature gates during testing can run
+			utilfeature.DefaultMutableFeatureGate.(featuregatetesting.ThawableFeatureGate).ThawForTest()
+		})
+
 		// TODO figure out how to actually make BinaryVersion/EmulationVersion work with Wardle and KAS at the same time when Alpha FG are being set
 		wardleCmd := sampleserver.NewCommandStartWardleServer(ctx, wardleOptions, withUID)
 		wardleCmd.SetArgs(args)


### PR DESCRIPTION
xref:
* https://github.com/kubernetes/kubernetes/issues/134009
* https://github.com/kubernetes/kubernetes/pull/134149
* https://github.com/kubernetes/kubernetes/pull/134112
* https://github.com/kubernetes/kubernetes/pull/138453/changes#r3209944397

Looks like this immediately reveals very incorrect things we're doing checking feature gate .Enabled from init() funcs 🤦 

/sig api-machinery
/hold

cc @jpbetz @pohly @richabanker @siyuanfoundation 

```release-note
NONE
```