### PR TITLE
TestNodeDeclaredFeatureAdmission: retry transient node "not found" errors

### DIFF
--- a/test/integration/pods/pods_test.go
+++ b/test/integration/pods/pods_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -33,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
 	typedv1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -1624,18 +1626,31 @@ func TestNodeDeclaredFeatureAdmission(t *testing.T) {
 			podToUpdate := createdPod.DeepCopy()
 			tc.podUpdateFn(podToUpdate)
 
-			_, err = client.CoreV1().Pods(ns.Name).UpdateResize(context.TODO(), podToUpdate.Name, podToUpdate, metav1.UpdateOptions{})
-
-			if tc.expectError == "" {
-				if err != nil {
-					t.Errorf("Expected no error, but got: %v", err)
+			pollErr := wait.PollUntilContextTimeout(context.TODO(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+				_, err = client.CoreV1().Pods(ns.Name).UpdateResize(ctx, podToUpdate.Name, podToUpdate, metav1.UpdateOptions{})
+				if tc.expectError == "" {
+					if err == nil {
+						return true, nil
+					}
+					if strings.Contains(err.Error(), "not found") {
+						return false, nil
+					}
+					return false, err
+				} else {
+					if err != nil {
+						if strings.Contains(err.Error(), tc.expectError) {
+							return true, nil
+						}
+						if strings.Contains(err.Error(), "not found") {
+							return false, nil
+						}
+						return false, err
+					}
+					return false, fmt.Errorf("expected error containing %q, but got no error", tc.expectError)
 				}
-			} else {
-				if err == nil {
-					t.Errorf("Expected error containing %q, but got no error", tc.expectError)
-				} else if !strings.Contains(err.Error(), tc.expectError) {
-					t.Errorf("Expected error containing %q, but got: %v", tc.expectError, err)
-				}
+			})
+			if pollErr != nil {
+				t.Errorf("Unexpected error: %v (last error during update: %v)", pollErr, err)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind flake

#### What this PR does / why we need it:

Fixes a flaky integration test.

The `NodeDeclaredFeatureValidator` admission plugin validates updates to pods by matching their requirement against the capabilities of their assigned Node. To do this, the admission plugin retrieves Node information from the nodeLister (informer cache) of the APIServer. In integration tests, when a node is created via the client, it is written synchronously to etcd, but the informer cache gets updated asynchronously. If the test sends a pod update too quickly, the admission plugin fails with a transient node "test-node" not found error.

We fix this with `wait.PollUntilContextTimeout` with retry on "not found" errors.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

This PR was assisted by gemini.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig node
/cc pravk03 tallclair

Flakes:
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/138880/pull-kubernetes-integration/2052807113943552000
- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/138657/pull-kubernetes-integration/2049238300845150208