### PR TITLE
Remove redundant type assertions in CEL function bindings

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/library/authz.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/authz.go
@@ -368,15 +368,8 @@ func (*authzSelectors) ProgramOptions() []cel.ProgramOption {
 }
 
 func authorizerPath(arg1, arg2 ref.Val) ref.Val {
-	authz, ok := arg1.(authorizerVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
-	path, ok := arg2.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
+	authz := arg1.(authorizerVal)
+	path := arg2.Value().(string)
 
 	if len(strings.TrimSpace(path)) == 0 {
 		return types.NewErr("path must not be empty")
@@ -386,16 +379,8 @@ func authorizerPath(arg1, arg2 ref.Val) ref.Val {
 }
 
 func authorizerGroup(arg1, arg2 ref.Val) ref.Val {
-	authz, ok := arg1.(authorizerVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
-	group, ok := arg2.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
+	authz := arg1.(authorizerVal)
+	group := arg2.Value().(string)
 	return authz.groupCheck(group)
 }
 
@@ -405,20 +390,9 @@ func authorizerServiceAccount(args ...ref.Val) ref.Val {
 		return types.NoSuchOverloadErr()
 	}
 
-	authz, ok := args[0].(authorizerVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(args[0])
-	}
-
-	namespace, ok := args[1].Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(args[1])
-	}
-
-	name, ok := args[2].Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(args[2])
-	}
+	authz := args[0].(authorizerVal)
+	namespace := args[1].Value().(string)
+	name := args[2].Value().(string)
 
 	if errors := apimachineryvalidation.ValidateServiceAccountName(name, false); len(errors) > 0 {
 		return types.NewErr("Invalid service account name")
@@ -430,15 +404,8 @@ func authorizerServiceAccount(args ...ref.Val) ref.Val {
 }
 
 func groupCheckResource(arg1, arg2 ref.Val) ref.Val {
-	groupCheck, ok := arg1.(groupCheckVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
-	resource, ok := arg2.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
+	groupCheck := arg1.(groupCheckVal)
+	resource := arg2.Value().(string)
 
 	if len(strings.TrimSpace(resource)) == 0 {
 		return types.NewErr("resource must not be empty")
@@ -447,15 +414,8 @@ func groupCheckResource(arg1, arg2 ref.Val) ref.Val {
 }
 
 func resourceCheckSubresource(arg1, arg2 ref.Val) ref.Val {
-	resourceCheck, ok := arg1.(resourceCheckVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
-	subresource, ok := arg2.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
+	resourceCheck := arg1.(resourceCheckVal)
+	subresource := arg2.Value().(string)
 
 	result := resourceCheck
 	result.subresource = subresource
@@ -463,15 +423,8 @@ func resourceCheckSubresource(arg1, arg2 ref.Val) ref.Val {
 }
 
 func resourceCheckFieldSelector(arg1, arg2 ref.Val) ref.Val {
-	resourceCheck, ok := arg1.(resourceCheckVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
-	fieldSelector, ok := arg2.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
+	resourceCheck := arg1.(resourceCheckVal)
+	fieldSelector := arg2.Value().(string)
 
 	result := resourceCheck
 	result.fieldSelector = fieldSelector
@@ -479,15 +432,8 @@ func resourceCheckFieldSelector(arg1, arg2 ref.Val) ref.Val {
 }
 
 func resourceCheckLabelSelector(arg1, arg2 ref.Val) ref.Val {
-	resourceCheck, ok := arg1.(resourceCheckVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
-	labelSelector, ok := arg2.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
+	resourceCheck := arg1.(resourceCheckVal)
+	labelSelector := arg2.Value().(string)
 
 	result := resourceCheck
 	result.labelSelector = labelSelector
@@ -495,15 +441,8 @@ func resourceCheckLabelSelector(arg1, arg2 ref.Val) ref.Val {
 }
 
 func resourceCheckNamespace(arg1, arg2 ref.Val) ref.Val {
-	resourceCheck, ok := arg1.(resourceCheckVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
-	namespace, ok := arg2.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
+	resourceCheck := arg1.(resourceCheckVal)
+	namespace := arg2.Value().(string)
 
 	result := resourceCheck
 	result.namespace = namespace
@@ -511,15 +450,8 @@ func resourceCheckNamespace(arg1, arg2 ref.Val) ref.Val {
 }
 
 func resourceCheckName(arg1, arg2 ref.Val) ref.Val {
-	resourceCheck, ok := arg1.(resourceCheckVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
-	name, ok := arg2.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
+	resourceCheck := arg1.(resourceCheckVal)
+	name := arg2.Value().(string)
 
 	result := resourceCheck
 	result.name = name
@@ -527,48 +459,24 @@ func resourceCheckName(arg1, arg2 ref.Val) ref.Val {
 }
 
 func pathCheckCheck(arg1, arg2 ref.Val) ref.Val {
-	pathCheck, ok := arg1.(pathCheckVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
-	httpRequestVerb, ok := arg2.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
+	pathCheck := arg1.(pathCheckVal)
+	httpRequestVerb := arg2.Value().(string)
 	return pathCheck.Authorize(context.TODO(), httpRequestVerb)
 }
 
 func resourceCheckCheck(arg1, arg2 ref.Val) ref.Val {
-	resourceCheck, ok := arg1.(resourceCheckVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
-	apiVerb, ok := arg2.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
+	resourceCheck := arg1.(resourceCheckVal)
+	apiVerb := arg2.Value().(string)
 	return resourceCheck.Authorize(context.TODO(), apiVerb)
 }
 
 func decisionErrored(arg ref.Val) ref.Val {
-	decision, ok := arg.(decisionVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	decision := arg.(decisionVal)
 	return types.Bool(decision.err != nil)
 }
 
 func decisionError(arg ref.Val) ref.Val {
-	decision, ok := arg.(decisionVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	decision := arg.(decisionVal)
 	if decision.err == nil {
 		return types.String("")
 	}
@@ -576,20 +484,12 @@ func decisionError(arg ref.Val) ref.Val {
 }
 
 func decisionAllowed(arg ref.Val) ref.Val {
-	decision, ok := arg.(decisionVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	decision := arg.(decisionVal)
 	return types.Bool(decision.authDecision == authorizer.DecisionAllow)
 }
 
 func decisionReason(arg ref.Val) ref.Val {
-	decision, ok := arg.(decisionVal)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	decision := arg.(decisionVal)
 	return types.String(decision.reason)
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/cidr.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/cidr.go
@@ -172,10 +172,7 @@ func (*cidrs) ProgramOptions() []cel.ProgramOption {
 }
 
 func stringToCIDR(arg ref.Val) ref.Val {
-	s, ok := arg.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	s := arg.Value().(string)
 
 	net, err := parseCIDR(s)
 	if err != nil {
@@ -188,11 +185,7 @@ func stringToCIDR(arg ref.Val) ref.Val {
 }
 
 func cidrToString(arg ref.Val) ref.Val {
-	cidr, ok := arg.(apiservercel.CIDR)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	cidr := arg.(apiservercel.CIDR)
 	return types.String(cidr.Prefix.String())
 }
 
@@ -205,72 +198,39 @@ func cidrContainsCIDRString(arg ref.Val, other ref.Val) ref.Val {
 }
 
 func cidrContainsIP(arg ref.Val, other ref.Val) ref.Val {
-	cidr, ok := arg.(apiservercel.CIDR)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(other)
-	}
-
-	ip, ok := other.(apiservercel.IP)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	cidr := arg.(apiservercel.CIDR)
+	ip := other.(apiservercel.IP)
 	return types.Bool(cidr.Contains(ip.Addr))
 }
 
 func cidrContainsCIDR(arg ref.Val, other ref.Val) ref.Val {
-	cidr, ok := arg.(apiservercel.CIDR)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
-	containsCIDR, ok := other.(apiservercel.CIDR)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(other)
-	}
-
+	cidr := arg.(apiservercel.CIDR)
+	containsCIDR := other.(apiservercel.CIDR)
 	return types.Bool(cidr.Overlaps(containsCIDR.Prefix) && cidr.Prefix.Bits() <= containsCIDR.Prefix.Bits())
 }
 
 func prefixLength(arg ref.Val) ref.Val {
-	cidr, ok := arg.(apiservercel.CIDR)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	cidr := arg.(apiservercel.CIDR)
 	return types.Int(cidr.Prefix.Bits())
 }
 
 func isCIDR(arg ref.Val) ref.Val {
-	s, ok := arg.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	s := arg.Value().(string)
 	_, err := parseCIDR(s)
 	return types.Bool(err == nil)
 }
 
 func cidrToIP(arg ref.Val) ref.Val {
-	cidr, ok := arg.(apiservercel.CIDR)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	cidr := arg.(apiservercel.CIDR)
 	return apiservercel.IP{
 		Addr: cidr.Prefix.Addr(),
 	}
 }
 
 func masked(arg ref.Val) ref.Val {
-	cidr, ok := arg.(apiservercel.CIDR)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
-	maskedCIDR := cidr.Prefix.Masked()
+	cidr := arg.(apiservercel.CIDR)
 	return apiservercel.CIDR{
-		Prefix: maskedCIDR,
+		Prefix: cidr.Prefix.Masked(),
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/format.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/format.go
@@ -252,10 +252,7 @@ var formatLibraryDecls = map[string][]cel.FunctionOpt{
 	},
 	"format.named": {
 		cel.Overload("format-named", []*cel.Type{cel.StringType}, cel.OptionalType(apiservercel.FormatType), cel.UnaryBinding(func(name ref.Val) ref.Val {
-			nameString, ok := name.Value().(string)
-			if !ok {
-				return types.MaybeNoSuchOverloadErr(name)
-			}
+			nameString := name.Value().(string)
 
 			f, ok := ConstantFormats[nameString]
 			if !ok {
@@ -267,15 +264,8 @@ var formatLibraryDecls = map[string][]cel.FunctionOpt{
 }
 
 func formatValidate(arg1, arg2 ref.Val) ref.Val {
-	f, ok := arg1.Value().(apiservercel.Format)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg1)
-	}
-
-	str, ok := arg2.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg2)
-	}
+	f := arg1.Value().(apiservercel.Format)
+	str := arg2.Value().(string)
 
 	res := f.ValidateFunc(str)
 	if len(res) == 0 {

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/ip.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/ip.go
@@ -199,10 +199,7 @@ func (*ip) ProgramOptions() []cel.ProgramOption {
 }
 
 func stringToIP(arg ref.Val) ref.Val {
-	s, ok := arg.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	s := arg.Value().(string)
 
 	addr, err := parseIPAddr(s)
 	if err != nil {
@@ -216,19 +213,12 @@ func stringToIP(arg ref.Val) ref.Val {
 }
 
 func ipToString(arg ref.Val) ref.Val {
-	ip, ok := arg.(apiservercel.IP)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	ip := arg.(apiservercel.IP)
 	return types.String(ip.Addr.String())
 }
 
 func family(arg ref.Val) ref.Val {
-	ip, ok := arg.(apiservercel.IP)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	ip := arg.(apiservercel.IP)
 
 	switch {
 	case ip.Addr.Is4():
@@ -241,10 +231,7 @@ func family(arg ref.Val) ref.Val {
 }
 
 func ipIsCanonical(arg ref.Val) ref.Val {
-	s, ok := arg.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	s := arg.Value().(string)
 
 	addr, err := parseIPAddr(s)
 	if err != nil {
@@ -259,57 +246,33 @@ func ipIsCanonical(arg ref.Val) ref.Val {
 }
 
 func isIP(arg ref.Val) ref.Val {
-	s, ok := arg.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	s := arg.Value().(string)
 	_, err := parseIPAddr(s)
 	return types.Bool(err == nil)
 }
 
 func isUnspecified(arg ref.Val) ref.Val {
-	ip, ok := arg.(apiservercel.IP)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	ip := arg.(apiservercel.IP)
 	return types.Bool(ip.Addr.IsUnspecified())
 }
 
 func isLoopback(arg ref.Val) ref.Val {
-	ip, ok := arg.(apiservercel.IP)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	ip := arg.(apiservercel.IP)
 	return types.Bool(ip.Addr.IsLoopback())
 }
 
 func isLinkLocalMulticast(arg ref.Val) ref.Val {
-	ip, ok := arg.(apiservercel.IP)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	ip := arg.(apiservercel.IP)
 	return types.Bool(ip.Addr.IsLinkLocalMulticast())
 }
 
 func isLinkLocalUnicast(arg ref.Val) ref.Val {
-	ip, ok := arg.(apiservercel.IP)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	ip := arg.(apiservercel.IP)
 	return types.Bool(ip.Addr.IsLinkLocalUnicast())
 }
 
 func isGlobalUnicast(arg ref.Val) ref.Val {
-	ip, ok := arg.(apiservercel.IP)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	ip := arg.(apiservercel.IP)
 	return types.Bool(ip.Addr.IsGlobalUnicast())
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/jsonpatch.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/jsonpatch.go
@@ -80,10 +80,7 @@ func escapeKey(k string) string {
 }
 
 func escape(arg ref.Val) ref.Val {
-	s, ok := arg.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	s := arg.Value().(string)
 	escaped := escapeKey(s)
 	return types.String(escaped)
 }

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/lists.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/lists.go
@@ -189,16 +189,10 @@ func (*lists) ProgramOptions() []cel.ProgramOption {
 
 func isSorted(val ref.Val) ref.Val {
 	var prev traits.Comparer
-	iterable, ok := val.(traits.Iterable)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(val)
-	}
+	iterable := val.(traits.Iterable)
 	for it := iterable.Iterator(); it.HasNext() == types.True; {
 		next := it.Next()
-		nextCmp, ok := next.(traits.Comparer)
-		if !ok {
-			return types.MaybeNoSuchOverloadErr(next)
-		}
+		nextCmp := next.(traits.Comparer)
 		if prev != nil {
 			cmp := prev.Compare(next)
 			if cmp == types.IntOne {
@@ -212,31 +206,13 @@ func isSorted(val ref.Val) ref.Val {
 
 func sum(init func() ref.Val) functions.UnaryOp {
 	return func(val ref.Val) ref.Val {
-		i := init()
-		acc, ok := i.(traits.Adder)
-		if !ok {
-			// Should never happen since all passed in init values are valid
-			return types.MaybeNoSuchOverloadErr(i)
-		}
-		iterable, ok := val.(traits.Iterable)
-		if !ok {
-			return types.MaybeNoSuchOverloadErr(val)
-		}
+		acc := init().(traits.Adder)
+		iterable := val.(traits.Iterable)
 		for it := iterable.Iterator(); it.HasNext() == types.True; {
 			next := it.Next()
-			nextAdder, ok := next.(traits.Adder)
-			if !ok {
-				// Should never happen for type checked CEL programs
-				return types.MaybeNoSuchOverloadErr(next)
-			}
+			nextAdder := next.(traits.Adder)
 			if acc != nil {
-				s := acc.Add(next)
-				sum, ok := s.(traits.Adder)
-				if !ok {
-					// Should never happen for type checked CEL programs
-					return types.MaybeNoSuchOverloadErr(s)
-				}
-				acc = sum
+				acc = acc.Add(next).(traits.Adder)
 			} else {
 				acc = nextAdder
 			}
@@ -256,17 +232,10 @@ func max() functions.UnaryOp {
 func cmp(opName string, opPreferCmpResult ref.Val) functions.UnaryOp {
 	return func(val ref.Val) ref.Val {
 		var result traits.Comparer
-		iterable, ok := val.(traits.Iterable)
-		if !ok {
-			return types.MaybeNoSuchOverloadErr(val)
-		}
+		iterable := val.(traits.Iterable)
 		for it := iterable.Iterator(); it.HasNext() == types.True; {
 			next := it.Next()
-			nextCmp, ok := next.(traits.Comparer)
-			if !ok {
-				// Should never happen for type checked CEL programs
-				return types.MaybeNoSuchOverloadErr(next)
-			}
+			nextCmp := next.(traits.Comparer)
 			if result == nil {
 				result = nextCmp
 			} else {
@@ -284,10 +253,7 @@ func cmp(opName string, opPreferCmpResult ref.Val) functions.UnaryOp {
 }
 
 func indexOf(list ref.Val, item ref.Val) ref.Val {
-	lister, ok := list.(traits.Lister)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(list)
-	}
+	lister := list.(traits.Lister)
 	sz := lister.Size().(types.Int)
 	for i := types.Int(0); i < sz; i++ {
 		if lister.Get(types.Int(i)).Equal(item) == types.True {
@@ -298,10 +264,7 @@ func indexOf(list ref.Val, item ref.Val) ref.Val {
 }
 
 func lastIndexOf(list ref.Val, item ref.Val) ref.Val {
-	lister, ok := list.(traits.Lister)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(list)
-	}
+	lister := list.(traits.Lister)
 	sz := lister.Size().(types.Int)
 	for i := sz - 1; i >= 0; i-- {
 		if lister.Get(types.Int(i)).Equal(item) == types.True {

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/quantity.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/quantity.go
@@ -203,10 +203,7 @@ func (*quantity) ProgramOptions() []cel.ProgramOption {
 }
 
 func isQuantity(arg ref.Val) ref.Val {
-	str, ok := arg.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	str := arg.Value().(string)
 
 	_, err := resource.ParseQuantity(str)
 	if err != nil {
@@ -217,10 +214,7 @@ func isQuantity(arg ref.Val) ref.Val {
 }
 
 func stringToQuantity(arg ref.Val) ref.Val {
-	str, ok := arg.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	str := arg.Value().(string)
 
 	q, err := resource.ParseQuantity(str)
 	if err != nil {
@@ -231,27 +225,18 @@ func stringToQuantity(arg ref.Val) ref.Val {
 }
 
 func quantityGetApproximateFloat(arg ref.Val) ref.Val {
-	q, ok := arg.Value().(*resource.Quantity)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	q := arg.Value().(*resource.Quantity)
 	return types.Double(q.AsApproximateFloat64())
 }
 
 func quantityCanValue(arg ref.Val) ref.Val {
-	q, ok := arg.Value().(*resource.Quantity)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	q := arg.Value().(*resource.Quantity)
 	_, success := q.AsInt64()
 	return types.Bool(success)
 }
 
 func quantityGetValue(arg ref.Val) ref.Val {
-	q, ok := arg.Value().(*resource.Quantity)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	q := arg.Value().(*resource.Quantity)
 	v, success := q.AsInt64()
 	if !success {
 		return types.WrapErr(errors.New("cannot convert value to integer"))
@@ -260,65 +245,31 @@ func quantityGetValue(arg ref.Val) ref.Val {
 }
 
 func quantityGetSign(arg ref.Val) ref.Val {
-	q, ok := arg.Value().(*resource.Quantity)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	q := arg.Value().(*resource.Quantity)
 	return types.Int(q.Sign())
 }
 
 func quantityIsGreaterThan(arg ref.Val, other ref.Val) ref.Val {
-	q, ok := arg.Value().(*resource.Quantity)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
-	q2, ok := other.Value().(*resource.Quantity)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	q := arg.Value().(*resource.Quantity)
+	q2 := other.Value().(*resource.Quantity)
 	return types.Bool(q.Cmp(*q2) == 1)
 }
 
 func quantityIsLessThan(arg ref.Val, other ref.Val) ref.Val {
-	q, ok := arg.Value().(*resource.Quantity)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
-	q2, ok := other.Value().(*resource.Quantity)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	q := arg.Value().(*resource.Quantity)
+	q2 := other.Value().(*resource.Quantity)
 	return types.Bool(q.Cmp(*q2) == -1)
 }
 
 func quantityCompareTo(arg ref.Val, other ref.Val) ref.Val {
-	q, ok := arg.Value().(*resource.Quantity)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
-	q2, ok := other.Value().(*resource.Quantity)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	q := arg.Value().(*resource.Quantity)
+	q2 := other.Value().(*resource.Quantity)
 	return types.Int(q.Cmp(*q2))
 }
 
 func quantityAdd(arg ref.Val, other ref.Val) ref.Val {
-	q, ok := arg.Value().(*resource.Quantity)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
-	q2, ok := other.Value().(*resource.Quantity)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	q := arg.Value().(*resource.Quantity)
+	q2 := other.Value().(*resource.Quantity)
 
 	copy := *q
 	copy.Add(*q2)
@@ -328,15 +279,8 @@ func quantityAdd(arg ref.Val, other ref.Val) ref.Val {
 }
 
 func quantityAddInt(arg ref.Val, other ref.Val) ref.Val {
-	q, ok := arg.Value().(*resource.Quantity)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
-	q2, ok := other.Value().(int64)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	q := arg.Value().(*resource.Quantity)
+	q2 := other.Value().(int64)
 
 	q2Converted := *resource.NewQuantity(q2, resource.DecimalExponent)
 
@@ -348,15 +292,8 @@ func quantityAddInt(arg ref.Val, other ref.Val) ref.Val {
 }
 
 func quantitySub(arg ref.Val, other ref.Val) ref.Val {
-	q, ok := arg.Value().(*resource.Quantity)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
-	q2, ok := other.Value().(*resource.Quantity)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	q := arg.Value().(*resource.Quantity)
+	q2 := other.Value().(*resource.Quantity)
 
 	copy := *q
 	copy.Sub(*q2)
@@ -366,15 +303,8 @@ func quantitySub(arg ref.Val, other ref.Val) ref.Val {
 }
 
 func quantitySubInt(arg ref.Val, other ref.Val) ref.Val {
-	q, ok := arg.Value().(*resource.Quantity)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
-	q2, ok := other.Value().(int64)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	q := arg.Value().(*resource.Quantity)
+	q2 := other.Value().(int64)
 
 	q2Converted := *resource.NewQuantity(q2, resource.DecimalExponent)
 

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/regex.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/regex.go
@@ -95,14 +95,8 @@ func (*regex) ProgramOptions() []cel.ProgramOption {
 }
 
 func find(strVal ref.Val, regexVal ref.Val) ref.Val {
-	str, ok := strVal.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(strVal)
-	}
-	regex, ok := regexVal.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(regexVal)
-	}
+	str := strVal.Value().(string)
+	regex := regexVal.Value().(string)
 	re, err := regexp.Compile(regex)
 	if err != nil {
 		return types.NewErr("Illegal regex: %v", err.Error())
@@ -116,20 +110,11 @@ func findAll(args ...ref.Val) ref.Val {
 	if argn < 2 || argn > 3 {
 		return types.NoSuchOverloadErr()
 	}
-	str, ok := args[0].Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(args[0])
-	}
-	regex, ok := args[1].Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(args[1])
-	}
+	str := args[0].Value().(string)
+	regex := args[1].Value().(string)
 	n := int64(-1)
 	if argn == 3 {
-		n, ok = args[2].Value().(int64)
-		if !ok {
-			return types.MaybeNoSuchOverloadErr(args[2])
-		}
+		n = args[2].Value().(int64)
 	}
 
 	re, err := regexp.Compile(regex)
@@ -157,10 +142,7 @@ var FindRegexOptimization = &interpreter.RegexOptimization{
 			if len(args) != 2 {
 				return types.NoSuchOverloadErr()
 			}
-			in, ok := args[0].Value().(string)
-			if !ok {
-				return types.MaybeNoSuchOverloadErr(args[0])
-			}
+			in := args[0].Value().(string)
 			return types.String(compiledRegex.FindString(in))
 		}), nil
 	},
@@ -182,16 +164,10 @@ var FindAllRegexOptimization = &interpreter.RegexOptimization{
 			if argn < 2 || argn > 3 {
 				return types.NoSuchOverloadErr()
 			}
-			str, ok := args[0].Value().(string)
-			if !ok {
-				return types.MaybeNoSuchOverloadErr(args[0])
-			}
+			str := args[0].Value().(string)
 			n := int64(-1)
 			if argn == 3 {
-				n, ok = args[2].Value().(int64)
-				if !ok {
-					return types.MaybeNoSuchOverloadErr(args[2])
-				}
+				n = args[2].Value().(int64)
 			}
 
 			result := compiledRegex.FindAllString(str, int(n))

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/semverlib.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/semverlib.go
@@ -182,15 +182,8 @@ func isSemver(arg ref.Val) ref.Val {
 	return isSemverNormalize(arg, types.Bool(false))
 }
 func isSemverNormalize(arg ref.Val, normalizeArg ref.Val) ref.Val {
-	str, ok := arg.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
-	normalize, ok := normalizeArg.Value().(bool)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	str := arg.Value().(string)
+	normalize := normalizeArg.Value().(bool)
 
 	// Using semver/v4 here is okay because this function isn't
 	// used to validate the Kubernetes API. In the CEL base library
@@ -213,15 +206,8 @@ func stringToSemver(arg ref.Val) ref.Val {
 	return stringToSemverNormalize(arg, types.Bool(false))
 }
 func stringToSemverNormalize(arg ref.Val, normalizeArg ref.Val) ref.Val {
-	str, ok := arg.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
-	normalize, ok := normalizeArg.Value().(bool)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	str := arg.Value().(string)
+	normalize := normalizeArg.Value().(bool)
 
 	// Using semver/v4 here is okay because this function isn't
 	// used to validate the Kubernetes API. In the CEL base library
@@ -243,68 +229,35 @@ func stringToSemverNormalize(arg ref.Val, normalizeArg ref.Val) ref.Val {
 }
 
 func semverMajor(arg ref.Val) ref.Val {
-	v, ok := arg.Value().(semver.Version)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	v := arg.Value().(semver.Version)
 	return types.Int(v.Major)
 }
 
 func semverMinor(arg ref.Val) ref.Val {
-	v, ok := arg.Value().(semver.Version)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	v := arg.Value().(semver.Version)
 	return types.Int(v.Minor)
 }
 
 func semverPatch(arg ref.Val) ref.Val {
-	v, ok := arg.Value().(semver.Version)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	v := arg.Value().(semver.Version)
 	return types.Int(v.Patch)
 }
 
 func semverIsGreaterThan(arg ref.Val, other ref.Val) ref.Val {
-	v, ok := arg.Value().(semver.Version)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
-	v2, ok := other.Value().(semver.Version)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	v := arg.Value().(semver.Version)
+	v2 := other.Value().(semver.Version)
 	return types.Bool(v.Compare(v2) == 1)
 }
 
 func semverIsLessThan(arg ref.Val, other ref.Val) ref.Val {
-	v, ok := arg.Value().(semver.Version)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
-	v2, ok := other.Value().(semver.Version)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	v := arg.Value().(semver.Version)
+	v2 := other.Value().(semver.Version)
 	return types.Bool(v.Compare(v2) == -1)
 }
 
 func semverCompareTo(arg ref.Val, other ref.Val) ref.Val {
-	v, ok := arg.Value().(semver.Version)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
-	v2, ok := other.Value().(semver.Version)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
-
+	v := arg.Value().(semver.Version)
+	v2 := other.Value().(semver.Version)
 	return types.Int(v.Compare(v2))
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/urls.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/urls.go
@@ -165,10 +165,7 @@ func (*urls) ProgramOptions() []cel.ProgramOption {
 }
 
 func stringToUrl(arg ref.Val) ref.Val {
-	s, ok := arg.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	s := arg.Value().(string)
 	// Use ParseRequestURI to check the URL before conversion.
 	// ParseRequestURI requires absolute URLs and is used by the OpenAPIv3 'uri' format.
 	_, err := url.ParseRequestURI(s)
@@ -186,50 +183,32 @@ func stringToUrl(arg ref.Val) ref.Val {
 }
 
 func getScheme(arg ref.Val) ref.Val {
-	u, ok := arg.Value().(*url.URL)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	u := arg.Value().(*url.URL)
 	return types.String(u.Scheme)
 }
 
 func getHost(arg ref.Val) ref.Val {
-	u, ok := arg.Value().(*url.URL)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	u := arg.Value().(*url.URL)
 	return types.String(u.Host)
 }
 
 func getHostname(arg ref.Val) ref.Val {
-	u, ok := arg.Value().(*url.URL)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	u := arg.Value().(*url.URL)
 	return types.String(u.Hostname())
 }
 
 func getPort(arg ref.Val) ref.Val {
-	u, ok := arg.Value().(*url.URL)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	u := arg.Value().(*url.URL)
 	return types.String(u.Port())
 }
 
 func getEscapedPath(arg ref.Val) ref.Val {
-	u, ok := arg.Value().(*url.URL)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	u := arg.Value().(*url.URL)
 	return types.String(u.EscapedPath())
 }
 
 func getQuery(arg ref.Val) ref.Val {
-	u, ok := arg.Value().(*url.URL)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	u := arg.Value().(*url.URL)
 
 	result := map[ref.Val]ref.Val{}
 	for k, v := range u.Query() {
@@ -239,10 +218,7 @@ func getQuery(arg ref.Val) ref.Val {
 }
 
 func isURL(arg ref.Val) ref.Val {
-	s, ok := arg.Value().(string)
-	if !ok {
-		return types.MaybeNoSuchOverloadErr(arg)
-	}
+	s := arg.Value().(string)
 	_, err := url.ParseRequestURI(s)
 	return types.Bool(err == nil)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:

CEL validates argument types at compile time before dispatch, so the
`if !ok { return types.MaybeNoSuchOverloadErr(arg) }` fallbacks after the
type assertions in the CEL library function bindings are unreachable.
Drop them to simplify the implementations.

The few remaining `(Maybe)NoSuchOverloadErr` calls are kept on purpose:
- arity guards on variadic bindings (e.g. `authorizerServiceAccount`,
  `findAll`),
- defensive `Equal` overrides on custom `ref.Val` types where `other`
  can legitimately be of any type.

#### Which issue(s) this PR is related to:

Fixes #122239

#### Special notes for your reviewer:

This revives the cleanup originally attempted in #123420, scoped to the
straightforward removal of redundant type assertions. The pointer/value
refactor of `apiservercel.Quantity` from that PR is intentionally not
included here.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
