### PR TITLE
kube-aggregator: add request count and latency metrics for extension API servers

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
@@ -19,13 +19,16 @@ package apiserver
 import (
 	"net/http"
 	"net/url"
+	"strings"
 	"sync/atomic"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/proxy"
 	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
 	endpointmetrics "k8s.io/apiserver/pkg/endpoints/metrics"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/endpoints/responsewriter"
 	genericfeatures "k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	utilflowcontrol "k8s.io/apiserver/pkg/util/flowcontrol"
@@ -120,6 +123,22 @@ func (r *proxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// Wrap the response writer so we can observe the actual HTTP status code
+	// emitted by the upgrade-aware proxy handler (or the proxyError calls
+	// below) and report it as a kube-aggregator request metric.
+	delegate := &endpointmetrics.ResponseWriterDelegator{ResponseWriter: w}
+	w = responsewriter.WrapForHTTP1Or2(delegate)
+	start := time.Now()
+	defer func() {
+		status := delegate.Status()
+		if status == 0 {
+			// No header was explicitly written; net/http defaults to 200 OK.
+			status = http.StatusOK
+		}
+		group, version := apiServiceGroupVersion(req, handlingInfo.name)
+		recordAggregatorRequest(endpointmetrics.NormalizedVerb(req), group, version, status, time.Since(start))
+	}()
+
 	if !handlingInfo.serviceAvailable {
 		proxyError(w, req, "service unavailable", http.StatusServiceUnavailable)
 		return
@@ -185,6 +204,21 @@ func (r *proxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 	utilflowcontrol.RequestDelegated(req.Context())
 	handler.ServeHTTP(w, newReq)
+}
+
+// apiServiceGroupVersion returns the (group, version) labels to record for a
+// proxied request. It prefers RequestInfo (which is the value the rest of the
+// apiserver metrics report) and falls back to splitting the APIService name,
+// which is always of the form "<version>.<group>" (or just "<version>." for
+// the core group).
+func apiServiceGroupVersion(req *http.Request, apiServiceName string) (group, version string) {
+	if info, ok := genericapirequest.RequestInfoFrom(req.Context()); ok && info.IsResourceRequest {
+		return info.APIGroup, info.APIVersion
+	}
+	if version, group, ok := strings.Cut(apiServiceName, "."); ok {
+		return group, version
+	}
+	return "", apiServiceName
 }
 
 // responder implements rest.Responder for assisting a connector in writing objects or errors.

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics.go
@@ -17,6 +17,9 @@ limitations under the License.
 package apiserver
 
 import (
+	"strconv"
+	"time"
+
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 )
@@ -46,7 +49,41 @@ var x509InsecureSHA1Counter = metrics.NewCounter(
 	},
 )
 
+var aggregatorRequestCounter = metrics.NewCounterVec(
+	&metrics.CounterOpts{
+		Subsystem:      "kube_aggregator",
+		Namespace:      "apiserver",
+		Name:           "request_total",
+		Help:           "Counter of requests proxied by the kube-aggregator to extension API servers, broken down by verb, group, version, and HTTP response code.",
+		StabilityLevel: metrics.ALPHA,
+	},
+	[]string{"verb", "group", "version", "code"},
+)
+
+var aggregatorRequestDuration = metrics.NewHistogramVec(
+	&metrics.HistogramOpts{
+		Subsystem:      "kube_aggregator",
+		Namespace:      "apiserver",
+		Name:           "request_duration_seconds",
+		Help:           "Request duration in seconds for requests proxied by the kube-aggregator to extension API servers, broken down by verb, group, version, and HTTP response code.",
+		Buckets:        []float64{0.005, 0.025, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 25, 60},
+		StabilityLevel: metrics.ALPHA,
+	},
+	[]string{"verb", "group", "version", "code"},
+)
+
 func init() {
 	legacyregistry.MustRegister(x509MissingSANCounter)
 	legacyregistry.MustRegister(x509InsecureSHA1Counter)
+	legacyregistry.MustRegister(aggregatorRequestCounter)
+	legacyregistry.MustRegister(aggregatorRequestDuration)
+}
+
+// recordAggregatorRequest reports a request proxied to an extension API server.
+// status is the response status code observed at the kube-aggregator boundary;
+// callers must pass a non-zero status (200 by convention if no header was written).
+func recordAggregatorRequest(verb, group, version string, status int, latency time.Duration) {
+	code := strconv.Itoa(status)
+	aggregatorRequestCounter.WithLabelValues(verb, group, version, code).Inc()
+	aggregatorRequestDuration.WithLabelValues(verb, group, version, code).Observe(latency.Seconds())
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/metrics_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
+)
+
+func TestRecordAggregatorRequest(t *testing.T) {
+	aggregatorRequestCounter.Reset()
+	aggregatorRequestDuration.Reset()
+	t.Cleanup(func() {
+		aggregatorRequestCounter.Reset()
+		aggregatorRequestDuration.Reset()
+	})
+
+	recordAggregatorRequest("get", "metrics.k8s.io", "v1beta1", http.StatusOK, 50*time.Millisecond)
+	recordAggregatorRequest("get", "metrics.k8s.io", "v1beta1", http.StatusOK, 30*time.Millisecond)
+	recordAggregatorRequest("list", "metrics.k8s.io", "v1beta1", http.StatusServiceUnavailable, 5*time.Millisecond)
+	recordAggregatorRequest("create", "", "v1", http.StatusCreated, 7*time.Millisecond)
+
+	wantCounter := `
+# HELP apiserver_kube_aggregator_request_total [ALPHA] Counter of requests proxied by the kube-aggregator to extension API servers, broken down by verb, group, version, and HTTP response code.
+# TYPE apiserver_kube_aggregator_request_total counter
+apiserver_kube_aggregator_request_total{code="200",group="metrics.k8s.io",verb="get",version="v1beta1"} 2
+apiserver_kube_aggregator_request_total{code="201",group="",verb="create",version="v1"} 1
+apiserver_kube_aggregator_request_total{code="503",group="metrics.k8s.io",verb="list",version="v1beta1"} 1
+`
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(wantCounter), "apiserver_kube_aggregator_request_total"); err != nil {
+		t.Errorf("unexpected counter state:\n%v", err)
+	}
+
+	// We don't pin every histogram bucket, but the total sample count
+	// must equal the number of recordAggregatorRequest calls above.
+	histVec, err := testutil.GetHistogramVecFromGatherer(legacyregistry.DefaultGatherer, "apiserver_kube_aggregator_request_duration_seconds", nil)
+	if err != nil {
+		t.Fatalf("get histogram vec: %v", err)
+	}
+	if got, want := histVec.GetAggregatedSampleCount(), uint64(4); got != want {
+		t.Errorf("apiserver_kube_aggregator_request_duration_seconds total samples: got %d, want %d", got, want)
+	}
+}
+
+func TestAPIServiceGroupVersion(t *testing.T) {
+	tests := []struct {
+		name           string
+		apiServiceName string
+		requestInfo    *request.RequestInfo
+		wantGroup      string
+		wantVersion    string
+	}{
+		{
+			name:           "request info present, resource request, named group",
+			apiServiceName: "v1beta1.metrics.k8s.io",
+			requestInfo:    &request.RequestInfo{IsResourceRequest: true, APIGroup: "metrics.k8s.io", APIVersion: "v1beta1"},
+			wantGroup:      "metrics.k8s.io",
+			wantVersion:    "v1beta1",
+		},
+		{
+			name:           "request info present, core group",
+			apiServiceName: "v1.",
+			requestInfo:    &request.RequestInfo{IsResourceRequest: true, APIGroup: "", APIVersion: "v1"},
+			wantGroup:      "",
+			wantVersion:    "v1",
+		},
+		{
+			name:           "request info absent, fall back to apiservice name (named group)",
+			apiServiceName: "v1beta1.metrics.k8s.io",
+			wantGroup:      "metrics.k8s.io",
+			wantVersion:    "v1beta1",
+		},
+		{
+			name:           "request info absent, fall back to apiservice name (core group)",
+			apiServiceName: "v1.",
+			wantGroup:      "",
+			wantVersion:    "v1",
+		},
+		{
+			name:           "non-resource request falls back to apiservice name",
+			apiServiceName: "v1beta1.metrics.k8s.io",
+			requestInfo:    &request.RequestInfo{IsResourceRequest: false},
+			wantGroup:      "metrics.k8s.io",
+			wantVersion:    "v1beta1",
+		},
+		{
+			name:           "malformed apiservice name with no separator",
+			apiServiceName: "garbage",
+			wantGroup:      "",
+			wantVersion:    "garbage",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tc.requestInfo != nil {
+				req = req.WithContext(request.WithRequestInfo(req.Context(), tc.requestInfo))
+			}
+			gotGroup, gotVersion := apiServiceGroupVersion(req, tc.apiServiceName)
+			if gotGroup != tc.wantGroup || gotVersion != tc.wantVersion {
+				t.Errorf("apiServiceGroupVersion(%q) = (%q, %q), want (%q, %q)",
+					tc.apiServiceName, gotGroup, gotVersion, tc.wantGroup, tc.wantVersion)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig api-machinery
/sig instrumentation

#### What this PR does / why we need it:

Adds request count and latency metrics for the last hop the apiserver
makes that did not previously have its own per-request observability:
the kube-aggregator proxy to extension API servers (aggregated apiservices).

Two new ALPHA metrics are emitted from
`kube-aggregator/pkg/apiserver/handler_proxy.go`:

- `apiserver_kube_aggregator_request_total`
- `apiserver_kube_aggregator_request_duration_seconds`

Both are labeled by `verb` (normalized like `apiserver_request_total`),
`group`, `version`, and HTTP `code`, so operators can correlate them
with `apiserver_request_total{component="aggregator"}` and tell which
backend APIService is contributing latency or errors.

Status is captured by wrapping the response writer with the same
`ResponseWriterDelegator` the rest of the apiserver metrics use, so the
upstream's actual response code lands in the metric (not just 200).

#### Which issue(s) this PR is related to:

Refs #117167 (last unchecked item: "Extension apiserver" request/error
counts and request latencies).

#### Special notes for your reviewer:

This revives the work in #118636 — closed by the rotten-bot — and
addresses the open review comments from @benluddy and @dgrisonnet:

- The earlier PR called the metric handler before the upstream had
  written a status, so every `apiserver_request_total` sample was
  effectively `code="200"`. This version wraps the response writer
  with `endpointmetrics.ResponseWriterDelegator` and reads the status
  in a `defer`, so error paths and proxied-through statuses are both
  reflected.
- Switched the `resource` label to `(group, version)` so the metrics
  align with what the rest of the apiserver request metrics report
  about a request, per the discussion at
  https://github.com/kubernetes/kubernetes/pull/118636#discussion_r1251215059
- Used the existing `kube_aggregator` Subsystem (matching the x509
  counters already in `metrics.go`) and tighter histogram buckets
  (12 vs. 23) per https://github.com/kubernetes/kubernetes/pull/118636#discussion_r1251211826

`apiServiceGroupVersion` prefers `RequestInfo` from the context (so
labels match `apiserver_request_total`) and falls back to splitting
the APIService name (`<version>.<group>`) for non-resource requests.

The metrics are added at ALPHA. Once they have soaked, graduating to
beta can ride on the existing graduation effort in #136107 / #136196.

#### Does this PR introduce a user-facing change?

```release-note
kube-aggregator now exports two ALPHA metrics — `apiserver_kube_aggregator_request_total` and `apiserver_kube_aggregator_request_duration_seconds` — covering requests proxied to extension API servers, labeled by verb, group, version, and HTTP code.
```
