### PR TITLE
[DRA] Partitionable Device Performance Optimization

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -6728,6 +6728,49 @@ func TestAllocator(t *testing.T,
 				deviceAllocationResult(req0SubReq1, driverA, pool1, device2, false),
 			)},
 		},
+		"partitionable-devices-devices-consume-counter-set-in-different-nodes": {
+			features: Features{
+				PartitionableDevices: true,
+			},
+			claimsToAllocate: objects(
+				claimWithRequests(claim0, nil, request(req0, classA, 1)),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithCounterSets(slice1, node1, resourcePool(pool1, 3), driverA,
+					counterSet(counterSet1, map[string]resource.Quantity{
+						"memory": resource.MustParse("8Gi"),
+					}),
+				),
+				sliceWithDevices(slice2, node1, resourcePool(pool1, 3), driverA,
+					device(device1, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1, map[string]resource.Quantity{
+							"memory": resource.MustParse("6Gi"),
+						}),
+					),
+				),
+				sliceWithDevices(slice3, node2, resourcePool(pool1, 3), driverA,
+					device(device2, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1, map[string]resource.Quantity{
+							"memory": resource.MustParse("6Gi"),
+						}),
+					),
+					device(device3, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1, map[string]resource.Quantity{
+							"memory": resource.MustParse("2Gi"),
+						}),
+					),
+				),
+			),
+			allocatedDevices: []DeviceID{
+				MakeDeviceID(driverA, pool1, device1),
+			},
+			node: node(node2, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node2),
+				deviceAllocationResult(req0, driverA, pool1, device3, false),
+			)},
+		},
 		"partitionable-devices-validation-error-on-non-targeting-slice": {
 			features: Features{
 				PartitionableDevices: true,

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -127,7 +127,7 @@ func NewAllocator(ctx context.Context,
 	slicesShared := make([]*resourceapi.ResourceSlice, 0)
 	for _, slice := range slices {
 		nodeName := ptr.Deref(slice.Spec.NodeName, "")
-		if nodeName == "" || len(slice.Spec.SharedCounters) > 0 {
+		if nodeName == "" {
 			slicesShared = append(slicesShared, slice)
 		} else {
 			slicesOnNode[nodeName] = append(slicesOnNode[nodeName], slice)

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/pools_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/pools_experimental.go
@@ -66,12 +66,12 @@ func GatherPools(ctx context.Context, slicesForNode []*resourceapi.ResourceSlice
 
 		// Determine if the slice is relevant for the node.
 		relevant := false
-
-		// Always include slices with SharedCounters since they are needed to use a pool
-		// regardless of their node selector.
-		if len(slice.Spec.SharedCounters) > 0 {
-			relevant = true
-		} else if nodeName, allNodes := ptr.Deref(slice.Spec.NodeName, ""), ptr.Deref(slice.Spec.AllNodes, false); nodeName != "" || allNodes || slice.Spec.NodeSelector != nil {
+		// Slices containing SharedCounters might be excluded here if they do not target the current node.
+		// This is safe: if a device on this node references a shared counter from an excluded slice,
+		// the initial isComplete check below will fail due to the missing slice. Consequently,
+		// checkSlicesInPool will be called to fetch all slices in the pool, ensuring that the required
+		// shared counter slice is collected and included during pool construction.
+		if nodeName, allNodes := ptr.Deref(slice.Spec.NodeName, ""), ptr.Deref(slice.Spec.AllNodes, false); nodeName != "" || allNodes || slice.Spec.NodeSelector != nil {
 			match, err := NodeMatches(node, nodeName, allNodes, slice.Spec.NodeSelector)
 			if err != nil {
 				return nil, fmt.Errorf("failed to perform node selection for slice %s: %w", slice.Name, err)
@@ -240,17 +240,40 @@ func buildPool(id PoolID, slices []*draapi.ResourceSlice, features Features, all
 
 	var deviceSlices []*draapi.ResourceSlice
 	var counterSetSlices []*draapi.ResourceSlice
-	if features.PartitionableDevices {
+	var slicesNotTargetingNode []*draapi.ResourceSlice
+
+	for _, slice := range slices {
+		if features.PartitionableDevices && len(slice.Spec.SharedCounters) > 0 {
+			counterSetSlices = append(counterSetSlices, slice)
+		} else {
+			deviceSlices = append(deviceSlices, slice)
+		}
+	}
+
+	// Process and convert any slices that were excluded because they didn't target the current node.
+	if len(slices) < len(allSlicesForPool) {
+		// We only want to convert the slices we haven't already converted, so make it easy to
+		// look up the names of converted slices.
+		slicesTargetingNodeNames := sets.New[string]()
 		for _, slice := range slices {
-			if len(slice.Spec.SharedCounters) > 0 {
-				counterSetSlices = append(counterSetSlices, slice)
+			slicesTargetingNodeNames.Insert(slice.Name)
+		}
+		for _, slice := range allSlicesForPool {
+			if slicesTargetingNodeNames.Has(slice.Name) {
+				continue
+			}
+			var convertedSlice draapi.ResourceSlice
+			if err := draapi.Convert_v1_ResourceSlice_To_api_ResourceSlice(slice, &convertedSlice, nil); err != nil {
+				return nil, fmt.Errorf("convert ResourceSlice: %w", err)
+			}
+			if features.PartitionableDevices && len(convertedSlice.Spec.SharedCounters) > 0 {
+				counterSetSlices = append(counterSetSlices, &convertedSlice)
 			} else {
-				deviceSlices = append(deviceSlices, slice)
+				slicesNotTargetingNode = append(slicesNotTargetingNode, &convertedSlice)
 			}
 		}
-	} else {
-		deviceSlices = slices
 	}
+
 	if err := validateDeviceNames(deviceSlices); err != nil {
 		return &Pool{
 			PoolID:        id,
@@ -258,6 +281,7 @@ func buildPool(id PoolID, slices []*draapi.ResourceSlice, features Features, all
 			InvalidReason: err.Error(),
 		}, nil
 	}
+
 	// If the partitionable devices feature is not enabled, we don't need to
 	// validate counter sets and consumed counters, so we are done.
 	if !features.PartitionableDevices {
@@ -276,49 +300,16 @@ func buildPool(id PoolID, slices []*draapi.ResourceSlice, features Features, all
 		}, nil
 	}
 
-	if err := validateDeviceCounterConsumption(counterSets, slices); err != nil {
+	// Validate device counter consumption for devices targeting the node.
+	if err := validateDeviceCounterConsumption(counterSets, deviceSlices); err != nil {
 		return &Pool{
 			PoolID:        id,
 			IsInvalid:     true,
 			InvalidReason: err.Error(),
 		}, nil
 	}
-	// If we have already seen all slices (both with counter sets and devices),
-	// we don't need to do any more validation.
-	if allSlicesForPool == nil || len(slices) == len(allSlicesForPool) {
-		return &Pool{
-			PoolID:                    id,
-			DeviceSlicesTargetingNode: deviceSlices,
-			CounterSets:               counterSets,
-		}, nil
-	}
 
-	// If we have slices that were discarded earlier because they didn't target the current node
-	// we need to check them now. They might include devices that consume counters in the pool and
-	// the allocator needs to know about them to correctly determine available counters.
-	//
-	// We only want to convert the slices we haven't already converted, so make it easy to
-	// look up the names of converted slices.
-	slicesTargetingNodeNames := sets.New[string]()
-	for _, slice := range slices {
-		slicesTargetingNodeNames.Insert(slice.Name)
-	}
-	var slicesNotTargetingNode []*draapi.ResourceSlice
-	for _, slice := range allSlicesForPool {
-		if slicesTargetingNodeNames.Has(slice.Name) {
-			continue
-		}
-		var convertedSlice draapi.ResourceSlice
-		if err := draapi.Convert_v1_ResourceSlice_To_api_ResourceSlice(slice, &convertedSlice, nil); err != nil {
-			return nil, fmt.Errorf("convert ResourceSlice: %w", err)
-		}
-		slicesNotTargetingNode = append(slicesNotTargetingNode, &convertedSlice)
-	}
-	// We need to make sure the devices here are correctly consuming counters and counter
-	// sets. Otherwise the allocator might make incorrect decisions.
-	// We don't validate the device names here. It might be that we should do that, but
-	// this is consistent with existing behavior where we don't validate slices that
-	// we don't allocate from.
+	// Validate device counter consumption for devices not targeting the node.
 	if err := validateDeviceCounterConsumption(counterSets, slicesNotTargetingNode); err != nil {
 		return &Pool{
 			PoolID:        id,
@@ -326,6 +317,7 @@ func buildPool(id PoolID, slices []*draapi.ResourceSlice, features Features, all
 			InvalidReason: err.Error(),
 		}, nil
 	}
+
 	return &Pool{
 		PoolID:                       id,
 		DeviceSlicesTargetingNode:    deviceSlices,

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
@@ -126,7 +126,7 @@ func NewAllocator(ctx context.Context,
 	slicesShared := make([]*resourceapi.ResourceSlice, 0)
 	for _, slice := range slices {
 		nodeName := ptr.Deref(slice.Spec.NodeName, "")
-		if nodeName == "" || len(slice.Spec.SharedCounters) > 0 {
+		if nodeName == "" {
 			slicesShared = append(slicesShared, slice)
 		} else {
 			slicesOnNode[nodeName] = append(slicesOnNode[nodeName], slice)

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/pools_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/pools_incubating.go
@@ -66,12 +66,12 @@ func GatherPools(ctx context.Context, slicesForNode []*resourceapi.ResourceSlice
 
 		// Determine if the slice is relevant for the node.
 		relevant := false
-
-		// Always include slices with SharedCounters since they are needed to use a pool
-		// regardless of their node selector.
-		if len(slice.Spec.SharedCounters) > 0 {
-			relevant = true
-		} else if nodeName, allNodes := ptr.Deref(slice.Spec.NodeName, ""), ptr.Deref(slice.Spec.AllNodes, false); nodeName != "" || allNodes || slice.Spec.NodeSelector != nil {
+		// Slices containing SharedCounters might be excluded here if they do not target the current node.
+		// This is safe: if a device on this node references a shared counter from an excluded slice,
+		// the initial isComplete check below will fail due to the missing slice. Consequently,
+		// checkSlicesInPool will be called to fetch all slices in the pool, ensuring that the required
+		// shared counter slice is collected and included during pool construction.
+		if nodeName, allNodes := ptr.Deref(slice.Spec.NodeName, ""), ptr.Deref(slice.Spec.AllNodes, false); nodeName != "" || allNodes || slice.Spec.NodeSelector != nil {
 			match, err := NodeMatches(node, nodeName, allNodes, slice.Spec.NodeSelector)
 			if err != nil {
 				return nil, fmt.Errorf("failed to perform node selection for slice %s: %w", slice.Name, err)
@@ -240,17 +240,40 @@ func buildPool(id PoolID, slices []*draapi.ResourceSlice, features Features, all
 
 	var deviceSlices []*draapi.ResourceSlice
 	var counterSetSlices []*draapi.ResourceSlice
-	if features.PartitionableDevices {
+	var slicesNotTargetingNode []*draapi.ResourceSlice
+
+	for _, slice := range slices {
+		if features.PartitionableDevices && len(slice.Spec.SharedCounters) > 0 {
+			counterSetSlices = append(counterSetSlices, slice)
+		} else {
+			deviceSlices = append(deviceSlices, slice)
+		}
+	}
+
+	// Process and convert any slices that were excluded because they didn't target the current node.
+	if len(slices) < len(allSlicesForPool) {
+		// We only want to convert the slices we haven't already converted, so make it easy to
+		// look up the names of converted slices.
+		slicesTargetingNodeNames := sets.New[string]()
 		for _, slice := range slices {
-			if len(slice.Spec.SharedCounters) > 0 {
-				counterSetSlices = append(counterSetSlices, slice)
+			slicesTargetingNodeNames.Insert(slice.Name)
+		}
+		for _, slice := range allSlicesForPool {
+			if slicesTargetingNodeNames.Has(slice.Name) {
+				continue
+			}
+			var convertedSlice draapi.ResourceSlice
+			if err := draapi.Convert_v1_ResourceSlice_To_api_ResourceSlice(slice, &convertedSlice, nil); err != nil {
+				return nil, fmt.Errorf("convert ResourceSlice: %w", err)
+			}
+			if features.PartitionableDevices && len(convertedSlice.Spec.SharedCounters) > 0 {
+				counterSetSlices = append(counterSetSlices, &convertedSlice)
 			} else {
-				deviceSlices = append(deviceSlices, slice)
+				slicesNotTargetingNode = append(slicesNotTargetingNode, &convertedSlice)
 			}
 		}
-	} else {
-		deviceSlices = slices
 	}
+
 	if err := validateDeviceNames(deviceSlices); err != nil {
 		return &Pool{
 			PoolID:        id,
@@ -258,6 +281,7 @@ func buildPool(id PoolID, slices []*draapi.ResourceSlice, features Features, all
 			InvalidReason: err.Error(),
 		}, nil
 	}
+
 	// If the partitionable devices feature is not enabled, we don't need to
 	// validate counter sets and consumed counters, so we are done.
 	if !features.PartitionableDevices {
@@ -276,49 +300,16 @@ func buildPool(id PoolID, slices []*draapi.ResourceSlice, features Features, all
 		}, nil
 	}
 
-	if err := validateDeviceCounterConsumption(counterSets, slices); err != nil {
+	// Validate device counter consumption for devices targeting the node.
+	if err := validateDeviceCounterConsumption(counterSets, deviceSlices); err != nil {
 		return &Pool{
 			PoolID:        id,
 			IsInvalid:     true,
 			InvalidReason: err.Error(),
 		}, nil
 	}
-	// If we have already seen all slices (both with counter sets and devices),
-	// we don't need to do any more validation.
-	if allSlicesForPool == nil || len(slices) == len(allSlicesForPool) {
-		return &Pool{
-			PoolID:                    id,
-			DeviceSlicesTargetingNode: deviceSlices,
-			CounterSets:               counterSets,
-		}, nil
-	}
 
-	// If we have slices that were discarded earlier because they didn't target the current node
-	// we need to check them now. They might include devices that consume counters in the pool and
-	// the allocator needs to know about them to correctly determine available counters.
-	//
-	// We only want to convert the slices we haven't already converted, so make it easy to
-	// look up the names of converted slices.
-	slicesTargetingNodeNames := sets.New[string]()
-	for _, slice := range slices {
-		slicesTargetingNodeNames.Insert(slice.Name)
-	}
-	var slicesNotTargetingNode []*draapi.ResourceSlice
-	for _, slice := range allSlicesForPool {
-		if slicesTargetingNodeNames.Has(slice.Name) {
-			continue
-		}
-		var convertedSlice draapi.ResourceSlice
-		if err := draapi.Convert_v1_ResourceSlice_To_api_ResourceSlice(slice, &convertedSlice, nil); err != nil {
-			return nil, fmt.Errorf("convert ResourceSlice: %w", err)
-		}
-		slicesNotTargetingNode = append(slicesNotTargetingNode, &convertedSlice)
-	}
-	// We need to make sure the devices here are correctly consuming counters and counter
-	// sets. Otherwise the allocator might make incorrect decisions.
-	// We don't validate the device names here. It might be that we should do that, but
-	// this is consistent with existing behavior where we don't validate slices that
-	// we don't allocate from.
+	// Validate device counter consumption for devices not targeting the node.
 	if err := validateDeviceCounterConsumption(counterSets, slicesNotTargetingNode); err != nil {
 		return &Pool{
 			PoolID:        id,
@@ -326,6 +317,7 @@ func buildPool(id PoolID, slices []*draapi.ResourceSlice, features Features, all
 			InvalidReason: err.Error(),
 		}, nil
 	}
+
 	return &Pool{
 		PoolID:                       id,
 		DeviceSlicesTargetingNode:    deviceSlices,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
During scale testing for Partitionable Devices, we observed a severe performance regression where the scheduling throughput was **~3 pods/second** for partitionable devices, comparing to **~100 pods/second** for non-partitionable devices. Profiling identified `GatherPools` as the primary CPU bottleneck.

### The Problem
To support cross-node counter pools, the allocator put all counter slices to `slicesShared` and `GatherPools` marked all counter slices as unconditionally "relevant" to the target scheduling node, regardless of its actual node affinity or node name.

In a multi-node cluster with node-local partitionable device pools, this eager relevance check led to a cascading performance overhead:
1. For every scheduling cycle on target node `A`, `GatherPools` would eagerly pull the counter slices for all other nodes (e.g., node `B`, node `C`).
2. Because the corresponding device slices for node `B` and `C` are node-local and filtered out as irrelevant, the scheduler constructed "partial" pools for node `B` and `C`.
3. Since these foreign pools were incomplete on node `A`, they failed the `isComplete` check.
4. This repeatedly triggered the expensive fallback scan (`checkSlicesInPool`) for **every single irrelevant pool** on **every node**.

### The Fix
This PR removes the `len(slice.Spec.SharedCounters) > 0` check, which puts all counter slices to slicesShared. Counter slices are now filtered using standard relevance rules (matching `NodeName`, `AllNodes`, or `NodeSelector`).

This is safe and preserves complete functionality:
*   **Node-Local Pools**: Both the counter slice and device slice match the target node, allowing `GatherPools` to assemble a complete pool in the first pass.
*   **Cross-Node Shared Pools**: If a shared counter slice is published on a different node, the target node's gathered slices will be incomplete. The existing completeness check will catch this and call the fallback `checkSlicesInPool` to correctly fetch the missing counter slice from the cluster cache.

### Performance Results
Verified with the scale tests
*   Without this PR: ~3 pods/second
*   With this PR: **~100 pods/second**


### Notes
The scale tests are achieve by modifying https://github.com/kubernetes/kubernetes/blob/master/test/integration/scheduler_perf/dra.go#L173 to create device slices and counter slices instead and reuse SteadyStateClusterResourceClaimTemplate test suite. I didn’t use https://github.com/kubernetes/kubernetes/blob/master/test/integration/scheduler_perf/dra/partitionabledevices/performance-config.yaml because the slices created from this test suite use node selectors.

Ideally, I am thinking if we can run GatherPools only once for scheduling a Pod. For example, we run GatherPools in PreFilter and reuse this information in Filter. However, that's out of the scope of this PR.

cc @mortent @johnbelamaric  @pohly 
#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/issues/137828
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
