### PR TITLE
Skip conversion for empty expression groups

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/condition.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/condition.go
@@ -90,6 +90,10 @@ func objectToResolveVal(r runtime.Object) (interface{}, error) {
 func (c *condition) ForInput(ctx context.Context, versionedAttr *admission.VersionedAttributes, request *admissionv1.AdmissionRequest, inputs OptionalVariableBindings, namespace *v1.Namespace, runtimeCELCostBudget int64) ([]EvaluationResult, int64, error) {
 	// TODO: replace unstructured with ref.Val for CEL variables when native type support is available
 	evaluations := make([]EvaluationResult, len(c.compilationResults))
+	if len(c.compilationResults) == 0 {
+		return evaluations, runtimeCELCostBudget, nil
+	}
+
 	var err error
 
 	// if this activation supports composition, we will need the compositionCtx. It may be nil.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

VAP/MAP have validations, validation messages, and audit annotations.  We call `ForInput` for each.  If there are no expressions, we perform useless conversions.  This it a quick mitigation to avoid conversions.

Some quick benchmarks suggest this can reduce VAP/MAP latency be ~50% for typical use cases.

Deeper optimizations to minimize conversions across `ForInput` calls should be considered as a follow up.

```release-note
NONE
```

/sig api-machinery