### PR TITLE
Drop declarative minimum that is redundant with field type

### DIFF
--- a/pkg/apis/scheduling/v1alpha2/zz_generated.validations.go
+++ b/pkg/apis/scheduling/v1alpha2/zz_generated.validations.go
@@ -761,12 +761,6 @@ func Validate_PodGroupSpec(
 				}); len(e) != 0 {
 				errs = append(errs, e...)
 			}
-			if e := validate.IfOption(ctx, op, fldPath, obj, oldObj, "WorkloadAwarePreemption", true,
-				func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
-					return validate.Minimum(ctx, op, fldPath, obj, oldObj, -2147483648)
-				}); len(e) != 0 {
-				errs = append(errs, e...)
-			}
 			return
 		}
 		oldVal := safe.Field(oldObj,
@@ -1087,12 +1081,6 @@ func Validate_PodGroupTemplate(
 			if e := validate.IfOption(ctx, op, fldPath, obj, oldObj, "WorkloadAwarePreemption", true,
 				func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
 					return validate.Maximum(ctx, op, fldPath, obj, oldObj, 1000000000)
-				}); len(e) != 0 {
-				errs = append(errs, e...)
-			}
-			if e := validate.IfOption(ctx, op, fldPath, obj, oldObj, "WorkloadAwarePreemption", true,
-				func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *int32) field.ErrorList {
-					return validate.Minimum(ctx, op, fldPath, obj, oldObj, -2147483648)
 				}); len(e) != 0 {
 				errs = append(errs, e...)
 			}

--- a/staging/src/k8s.io/api/scheduling/v1alpha2/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1alpha2/generated.proto
@@ -288,7 +288,6 @@ message PodGroupSpec {
   // +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:optional
   // +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:immutable
   // +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:maximum=1000000000 # HighestUserDefinablePriority
-  // +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:minimum=-2147483648
   optional int32 priority = 7;
 }
 
@@ -418,7 +417,6 @@ message PodGroupTemplate {
   // +k8s:ifDisabled("WorkloadAwarePreemption")=+k8s:forbidden
   // +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:optional
   // +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:maximum=1000000000 # HighestUserDefinablePriority
-  // +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:minimum=-2147483648
   optional int32 priority = 7;
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1alpha2/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha2/types.go
@@ -201,7 +201,6 @@ type PodGroupTemplate struct {
 	// +k8s:ifDisabled("WorkloadAwarePreemption")=+k8s:forbidden
 	// +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:optional
 	// +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:maximum=1000000000 # HighestUserDefinablePriority
-	// +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:minimum=-2147483648
 	Priority *int32 `json:"priority,omitempty" protobuf:"varint,7,opt,name=priority"`
 }
 
@@ -456,7 +455,6 @@ type PodGroupSpec struct {
 	// +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:optional
 	// +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:immutable
 	// +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:maximum=1000000000 # HighestUserDefinablePriority
-	// +k8s:ifEnabled("WorkloadAwarePreemption")=+k8s:minimum=-2147483648
 	Priority *int32 `json:"priority,omitempty" protobuf:"varint,7,opt,name=priority"`
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Drops a declarative validation minimum that is redundant with the field type ... it is impossible for a value in this field to be smaller than int32min.

With strengthened test coverage in https://github.com/kubernetes/kubernetes/pull/138872, every declarative validation rule must have a test case that exercises the failure condition.

This minimum is impossible to make fail with a validation error, since a value smaller than it won't even decode into the field successfully.

Removing it since it is essentially untestable dead code.

/sig scheduling api-machinery
/cc @yongruilin 

```release-note
NONE
```