### PR TITLE
Have kubectl edit include kubernetes in file extension

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
@@ -294,7 +294,7 @@ func (o *EditOptions) Run() error {
 
 			// launch the editor
 			editedDiff := edited
-			edited, file, err = edit.LaunchTempFile(fmt.Sprintf("%s-edit-", filepath.Base(os.Args[0])), o.editPrinterOptions.ext, buf)
+			edited, file, err = edit.LaunchTempFile(fmt.Sprintf("%s-edit-", filepath.Base(os.Args[0])), fmt.Sprintf(".kubernetes%s", o.editPrinterOptions.ext), buf)
 			if err != nil {
 				return preservedFile(err, results.file, o.ErrOut)
 			}


### PR DESCRIPTION
This will allow editors and editor plugins to detect when yaml (or json) files are kubernetes and spin up integrations: for example inline suggestions and hover documentaion.

I verified this with a text editor here: https://github.com/helix-editor/helix/issues/15705
https://github.com/kubernetes/kubectl/issues/1846

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind feature

/sig cli



#### What this PR does / why we need it:

Along with other ecosystem changes this will allow users of `kubectl edit` to get better integration, improving their experience.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubectl/issues/1846

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
`kubectl edit` now uses the double barralled file extensions `.kubernetes.yaml` and `.kubernetes.json` to allow for better text editor integration.
```


