### PR TITLE
[Do Not Merge] PoC scheduler: prototype OpportunisticBatching hint fallback for nominated pods

### DIFF
--- a/pkg/scheduler/framework/runtime/batch.go
+++ b/pkg/scheduler/framework/runtime/batch.go
@@ -178,12 +178,6 @@ func (b *OpportunisticBatch) batchStateCompatible(ctx context.Context, pod *v1.P
 		return false
 	}
 
-	// Pods with a nominated node should bypass opportunistic batching.
-	if pod.Status.NominatedNodeName != "" {
-		b.logUnusableState(logger, cycleCount, metrics.BatchFlushPodNominated)
-		return false
-	}
-
 	// If the new pod is incompatible with the current state, throw the state away.
 	if signature == nil || !bytes.Equal(signature, b.state.signature) {
 		b.logUnusableState(logger, cycleCount, metrics.BatchFlushPodIncompatible)

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -718,36 +718,39 @@ func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, schedFramework 
 }
 
 func (sched *Scheduler) evaluateNominatedNode(ctx context.Context, pod *v1.Pod, schedFramework framework.Framework, state fwk.CycleState, nodeHint string, diagnosis framework.Diagnosis) ([]fwk.NodeInfo, error) {
-	// In the future we could potentially use the hint if the nominated node failed.
-	// https://github.com/kubernetes/kubernetes/issues/135163
-	nnn := pod.Status.NominatedNodeName
-	if len(nnn) == 0 {
-		nnn = nodeHint
-	}
-
-	nodeInfo, err := sched.nodeInfoSnapshot.GetNodeInPlacement(nnn)
-	if err != nil {
-		if _, err := sched.nodeInfoSnapshot.Get(nnn); err != nil {
+	if nnn := pod.Status.NominatedNodeName; len(nnn) > 0 {
+		feasibleNodes, err := sched.tryEvaluateNominatedNode(ctx, pod, schedFramework, state, nnn, diagnosis)
+		if err != nil {
 			return nil, err
 		}
-		// It's not an error if NNN is in the cluster but not in the placement.
-		// This can happen during the pod group placement scheduling cycle, where we simulate multiple potential placements.
+		if len(feasibleNodes) != 0 {
+			return feasibleNodes, nil
+		}
+	}
+
+	if len(nodeHint) > 0 && nodeHint != pod.Status.NominatedNodeName {
+		return sched.tryEvaluateNominatedNode(ctx, pod, schedFramework, state, nodeHint, diagnosis)
+	}
+
+	return nil, nil
+}
+
+func (sched *Scheduler) tryEvaluateNominatedNode(ctx context.Context, pod *v1.Pod, schedFramework framework.Framework, state fwk.CycleState, nodeName string, diagnosis framework.Diagnosis) ([]fwk.NodeInfo, error) {
+	nodeInfo, err := sched.nodeInfoSnapshot.GetNodeInPlacement(nodeName)
+	if err != nil {
+		if _, err := sched.nodeInfoSnapshot.Get(nodeName); err != nil {
+			return nil, err
+		}
 		logger := klog.FromContext(ctx)
-		logger.V(4).Info("Pod's nominated node is present in the cluster but not available in the current placement", "pod", klog.KObj(pod), "node", pod.Status.NominatedNodeName)
+		logger.V(4).Info("Node not in placement, skipping", "pod", klog.KObj(pod), "node", nodeName)
 		return nil, nil
 	}
-	node := []fwk.NodeInfo{nodeInfo}
-	feasibleNodes, err := sched.findNodesThatPassFilters(ctx, schedFramework, state, pod, &diagnosis, node)
+	feasibleNodes, err := sched.findNodesThatPassFilters(ctx, schedFramework, state, pod, &diagnosis, []fwk.NodeInfo{nodeInfo})
 	if err != nil {
 		return nil, err
 	}
 
-	feasibleNodes, err = findNodesThatPassExtenders(ctx, sched.Extenders, pod, feasibleNodes, diagnosis.NodeToStatus)
-	if err != nil {
-		return nil, err
-	}
-
-	return feasibleNodes, nil
+	return findNodesThatPassExtenders(ctx, sched.Extenders, pod, feasibleNodes, diagnosis.NodeToStatus)
 }
 
 // hasScoring checks if scoring nodes is configured.

--- a/test/integration/scheduler_perf/executor.go
+++ b/test/integration/scheduler_perf/executor.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	cacheddiscovery "k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
@@ -208,6 +209,15 @@ func (e *WorkloadExecutor) runCreatePodsOp(tCtx ktesting.TContext, opIndex int, 
 		op.PodTemplatePath = e.testCase.DefaultPodTemplatePath
 	}
 
+	if op.NominatedNodeName != "" {
+		if err := createPodsRapidly(tCtx, namespace, op); err != nil {
+			return err
+		}
+		if err := patchNominatedNodeName(tCtx, namespace, op); err != nil {
+			return err
+		}
+	}
+
 	if op.CollectMetrics {
 		if e.collectorCancel != nil {
 			return fmt.Errorf("metrics collection is overlapping. Probably second collector was started before stopping a previous one")
@@ -218,8 +228,14 @@ func (e *WorkloadExecutor) runCreatePodsOp(tCtx ktesting.TContext, opIndex int, 
 			return err
 		}
 	}
-	if err := createPodsRapidly(tCtx, namespace, op); err != nil {
-		return err
+	if op.NominatedNodeName != "" {
+		if err := clearSchedulingGates(tCtx, namespace, op); err != nil {
+			return err
+		}
+	} else {
+		if err := createPodsRapidly(tCtx, namespace, op); err != nil {
+			return err
+		}
 	}
 	switch {
 	case op.SkipWaitToCompletion:
@@ -535,6 +551,41 @@ func createPodsRapidly(tCtx ktesting.TContext, namespace string, cpo *createPods
 	config.AddStrategy(namespace, cpo.Count, strategy)
 	podCreator := testutils.NewTestPodCreator(tCtx.Client(), config)
 	return podCreator.CreatePods(tCtx)
+}
+
+func patchNominatedNodeName(tCtx ktesting.TContext, namespace string, cpo *createPodsOp) error {
+	podClient := tCtx.Client().CoreV1().Pods(namespace)
+	pods, err := podClient.List(tCtx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("listing pods: %w", err)
+	}
+	if len(pods.Items) != cpo.Count {
+		return fmt.Errorf("expected %d pods in %q, got %d", cpo.Count, namespace, len(pods.Items))
+	}
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		patch := []byte(fmt.Sprintf(`{"status":{"nominatedNodeName":%q}}`, cpo.NominatedNodeName))
+		if _, err := podClient.Patch(tCtx, pod.Name, types.MergePatchType, patch, metav1.PatchOptions{}, "status"); err != nil {
+			return fmt.Errorf("patching status.nominatedNodeName for pod %s: %w", pod.Name, err)
+		}
+	}
+	return nil
+}
+
+func clearSchedulingGates(tCtx ktesting.TContext, namespace string, cpo *createPodsOp) error {
+	podClient := tCtx.Client().CoreV1().Pods(namespace)
+	pods, err := podClient.List(tCtx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("listing pods: %w", err)
+	}
+	patch := []byte(`{"spec":{"schedulingGates":null}}`)
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if _, err := podClient.Patch(tCtx, pod.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{}); err != nil {
+			return fmt.Errorf("clearing schedulingGates for pod %s: %w", pod.Name, err)
+		}
+	}
+	return nil
 }
 
 // createPodsSteadily implements the "create pods and delete pods" mode of [createPodsOp].

--- a/test/integration/scheduler_perf/nnn_hint_fallback/nnn_hint_fallback_test.go
+++ b/test/integration/scheduler_perf/nnn_hint_fallback/nnn_hint_fallback_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nnnhintfallback
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	_ "k8s.io/component-base/logs/json/register"
+	perf "k8s.io/kubernetes/test/integration/scheduler_perf"
+)
+
+func TestMain(m *testing.M) {
+	if err := perf.InitTests(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+
+	m.Run()
+}
+
+func TestSchedulerPerf(t *testing.T) {
+	perf.RunIntegrationPerfScheduling(t, "performance-config.yaml")
+}
+
+func BenchmarkPerfScheduling(b *testing.B) {
+	perf.RunBenchmarkPerfScheduling(b, "performance-config.yaml", "nnnhintfallback", nil)
+}

--- a/test/integration/scheduler_perf/nnn_hint_fallback/performance-config.yaml
+++ b/test/integration/scheduler_perf/nnn_hint_fallback/performance-config.yaml
@@ -1,0 +1,33 @@
+# The following labels are used in this file. (listed in ascending order of the number of covered test cases)
+#
+# - integration-test: test cases to run as the integration test.
+# - performance: test cases to run in the performance test.
+# - short: supplemental label for the above two labels (must not used alone), which literally means short execution time test cases.
+#
+# NNNMiss measures the NNN miss -> OB hint hit path.
+- name: NNNMiss
+  defaultPodTemplatePath: templates/gated-pod-default.yaml
+  schedulerConfigPath: scheduler-config.yaml
+  featureGates:
+    OpportunisticBatching: true
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $initNodes
+  - opcode: createNodes
+    count: 1
+    nodeTemplatePath: templates/blocked-node.yaml
+  - opcode: createPods
+    countParam: $measurePods
+    nominatedNodeName: scheduler-perf-blocked
+    collectMetrics: true
+  workloads:
+  - name: 500Nodes
+    labels: [integration-test, short]
+    params:
+      initNodes: 500
+      measurePods: 499
+  - name: 5000Nodes
+    labels: [performance]
+    params:
+      initNodes: 5000
+      measurePods: 4999

--- a/test/integration/scheduler_perf/nnn_hint_fallback/scheduler-config.yaml
+++ b/test/integration/scheduler_perf/nnn_hint_fallback/scheduler-config.yaml
@@ -1,0 +1,10 @@
+apiVersion: kubescheduler.config.k8s.io/v1
+kind: KubeSchedulerConfiguration
+profiles:
+- schedulerName: default-scheduler
+  pluginConfig:
+  # Keep PodTopologySpread from making OB signatures unavailable.
+  - name: PodTopologySpread
+    args:
+      defaultingType: List
+      defaultConstraints: []

--- a/test/integration/scheduler_perf/nnn_hint_fallback/templates/blocked-node.yaml
+++ b/test/integration/scheduler_perf/nnn_hint_fallback/templates/blocked-node.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Node
+metadata:
+  name: scheduler-perf-blocked
+  labels:
+    kubernetes.io/hostname: scheduler-perf-blocked
+spec:
+  taints:
+    - effect: NoSchedule
+      key: nnn-bench/blocked
+status:
+  capacity:
+    pods: "110"
+    cpu: "4"
+    memory: 32Gi
+  conditions:
+    - status: "True"
+      type: Ready
+  phase: Running

--- a/test/integration/scheduler_perf/nnn_hint_fallback/templates/gated-pod-default.yaml
+++ b/test/integration/scheduler_perf/nnn_hint_fallback/templates/gated-pod-default.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: gated-pod-
+spec:
+  schedulingGates:
+  - name: test.k8s.io/hold
+  containers:
+  - image: registry.k8s.io/pause:3.10.2
+    name: pause
+    resources:
+      limits:
+        cpu: "4"
+        memory: 16Gi
+      requests:
+        cpu: "4"
+        memory: 16Gi

--- a/test/integration/scheduler_perf/operations.go
+++ b/test/integration/scheduler_perf/operations.go
@@ -344,7 +344,8 @@ type createPodsOp struct {
 	PersistentVolumeClaimTemplatePath *string
 	// Params to be passed to the template.
 	// Values with `$` prefix will be resolved to the workload parameters.
-	TemplateParams map[string]any
+	TemplateParams    map[string]any
+	NominatedNodeName string
 }
 
 func (cpo *createPodsOp) isValid(allowParameterization bool) error {
@@ -362,6 +363,12 @@ func (cpo *createPodsOp) isValid(allowParameterization bool) error {
 	}
 	if cpo.SteadyState && !allowParameterization && cpo.Duration.Duration <= 0 {
 		return errors.New("when creating pods in a steady state, the test duration must be > 0")
+	}
+	if cpo.NominatedNodeName != "" && cpo.SteadyState {
+		return errors.New("nominatedNodeName and steadyState cannot be used together")
+	}
+	if cpo.NominatedNodeName != "" && cpo.SkipWaitToCompletion {
+		return errors.New("nominatedNodeName and skipWaitToCompletion cannot be used together")
 	}
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig scheduling


#### What this PR does / why we need it:

Draft for #138660 

#### Which issue(s) this PR is related to:

#138660

#### Special notes for your reviewer:

This is a draft PR to check the approach before polishing the implementation.

I added a scheduler_perf workload for the case this is meant to improve:

**Best-Case: NNN miss -> OB hint hit**

Local result, NNNMiss/5000Nodes, benchstat, count=10:

| metric | before | after | delta |
| --- | ---: | ---: | ---: |
| SchedulingDuration | 88.58 ±1% | 67.25 ±1% | -24.09% |
| SchedulingThroughput Average | 56.53 ±1% | 74.70 ±9% | +32.13% |
| SchedulingThroughput P99 | 208.8 ±17% | 432.5 ±36% | +107.14% |
| runtime_seconds | 160.6 ±1% | 139.0 ±1% | -13.48% |
| scheduling_attempt_duration Average | 27.91 ±1% | 25.04 ±7% | -10.28% |

**Worst-Case: NNN miss -> OB hint miss -> full scan**

With the current features of scheduler_perf, I attempted to reproduce the worst-case scenario, but it was difficult. OB hints come from previously feasible nodes, so making the hint fail reliably needs some dynamic node change between scheduling cycles.

From the code path, the extra work in that case is one more single-node filter attempt before the existing full scan. In the run above, the single-node-heavy Filter p50 was around 0.35-0.53ms. Compared with the base scheduling attempt average of 27.91ms, that is roughly 1-3% per affected attempt. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
