### PR TITLE
Fix typo in kubectl autoscale example

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go
@@ -66,7 +66,7 @@ var (
 		kubectl autoscale deployment bar --min=3 --max=6 --cpu=500m --memory=200Mi
 		
 		# Auto scale a deployment "bar", with the number of pods between 2 and 8, target CPU utilization 60% and memory utilization 70%
-        kubectl autoscale deployment bar --min=3 --max=6 --cpu=60% --memory=70%`))
+        kubectl autoscale deployment bar --min=2 --max=8 --cpu=60% --memory=70%`))
 )
 
 // AutoscaleOptions declares the arguments accepted by the Autoscale command


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Fixes an inconsistency in the `kubectl autoscale` example where the comment says "between 2 and 8 pods" but the command uses `--min=3 --max=6`.

ref: https://github.com/kubernetes/kubernetes/blob/0775c6d795f92b6d91b84940346c479ac3e53f6f/staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go#L68-L69

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

Fixes: https://github.com/kubernetes/website/issues/55643

/sig cli