### PR TITLE
fix(kubelet): indicate threshold status in probe failure events

### DIFF
--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -80,7 +80,7 @@ func (pb *prober) recordContainerEvent(ctx context.Context, pod *v1.Pod, contain
 }
 
 // probe probes the container.
-func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (results.Result, error) {
+func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (results.Result, string, error) {
 	var probeSpec *v1.Probe
 	switch probeType {
 	case readiness:
@@ -90,46 +90,46 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 	case startup:
 		probeSpec = container.StartupProbe
 	default:
-		return results.Failure, fmt.Errorf("unknown probe type: %q", probeType)
+		return results.Failure, "", fmt.Errorf("unknown probe type: %q", probeType)
 	}
 
 	logger := klog.FromContext(ctx)
 	if probeSpec == nil {
 		logger.Info("Probe is nil", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name)
-		return results.Success, nil
+		return results.Success, "", nil
 	}
-
 	result, output, err := pb.runProbeWithRetries(ctx, probeType, probeSpec, pod, status, container, containerID, maxProbeRetries)
 
 	if err != nil {
 		// Handle probe error
 		logger.V(1).Info("Probe errored", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result, "err", err)
 		pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe errored and resulted in %s state: %s", probeType, result, err)
-		return results.Failure, err
+		return results.Failure, "", err
 	}
 
 	switch result {
 	case probe.Success:
 		logger.V(3).Info("Probe succeeded", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name)
-		return results.Success, nil
+		return results.Success, output, nil
 
 	case probe.Warning:
 		pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerProbeWarning, "%s probe warning: %s", probeType, output)
 		logger.V(3).Info("Probe succeeded with a warning", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "output", output)
-		return results.Success, nil
+		return results.Success, output, nil
 
 	case probe.Failure:
 		logger.V(1).Info("Probe failed", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result, "output", output)
-		pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed: %s", probeType, output)
-		return results.Failure, nil
+		// Event emission moved to worker.doProbe() where we have access to
+		// FailureThreshold and resultRun to indicate whether the failure was ignored.
+		return results.Failure, output, nil
 
 	case probe.Unknown:
 		logger.V(1).Info("Probe unknown without error", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result)
-		return results.Failure, nil
+		return results.Failure, output, nil
 
 	default:
 		logger.V(1).Info("Unsupported probe result", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result)
-		return results.Failure, nil
+		return results.Failure, output, nil
 	}
 }
 

--- a/pkg/kubelet/prober/prober_test.go
+++ b/pkg/kubelet/prober/prober_test.go
@@ -253,7 +253,7 @@ func TestProbe(t *testing.T) {
 				prober.exec = fakeExecProber{test.execResult, nil}
 			}
 
-			result, err := prober.probe(ctx, pType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
+			result, _, err := prober.probe(ctx, pType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
 
 			if test.expectError {
 				require.Error(t, err, "[%s] Expected probe error but no error was returned.", testID)
@@ -266,7 +266,7 @@ func TestProbe(t *testing.T) {
 			if len(test.expectCommand) > 0 {
 				prober.exec = execprobe.New()
 				prober.runner = &containertest.FakeContainerCommandRunner{}
-				_, err := prober.probe(ctx, pType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
+				_, _, err := prober.probe(ctx, pType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
 				require.NoError(t, err, "[%s] Didn't expect probe error ", testID)
 
 				if !reflect.DeepEqual(test.expectCommand, prober.runner.(*containertest.FakeContainerCommandRunner).Cmd) {

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/prober/results"
+	"k8s.io/kubernetes/pkg/kubelet/events"
 )
 
 // worker handles the periodic probing of its assigned container. Each worker has a go-routine
@@ -346,7 +347,7 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 	}
 
 	// Note, exec probe does NOT have access to pod environment variables or downward API
-	result, err := w.probeManager.prober.probe(ctx, w.probeType, w.pod, status, w.container, w.containerID)
+	result, output, err := w.probeManager.prober.probe(ctx, w.probeType, w.pod, status, w.container, w.containerID)
 	if err != nil {
 		// Prober error, throw away the result.
 		return true
@@ -373,10 +374,17 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 	if (result == results.Failure && w.resultRun < int(w.spec.FailureThreshold)) ||
 		(result == results.Success && w.resultRun < int(w.spec.SuccessThreshold)) {
 		// Success or failure is below threshold - leave the probe state unchanged.
+		if result == results.Failure {
+			w.probeManager.prober.recordContainerEvent(ctx, w.pod, &w.container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed (attempt %d/%d, below threshold): %s", w.probeType, w.resultRun, w.spec.FailureThreshold, output)
+		}
 		return true
 	}
 
 	w.resultsManager.Set(w.containerID, result, w.pod)
+
+	if result == results.Failure {
+		w.probeManager.prober.recordContainerEvent(ctx, w.pod, &w.container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed (threshold reached): %s", w.probeType, output)
+	}
 
 	if (w.probeType == liveness && result == results.Failure) || w.probeType == startup {
 		// The container fails a liveness/startup check, it will need to be restarted.


### PR DESCRIPTION
## Summary

Fixes #115823 - ContainerUnhealthy events from kubelet probes now indicate whether the failure was below the FailureThreshold (ignored) or reached it (action taken).

**Before**: Every probe failure emitted an identical `ContainerUnhealthy` event:
```
Liveness probe failed: HTTP probe failed with statuscode: 500
```
Users had no way to distinguish between transient failures (below threshold) and failures that actually triggered a container restart.

**After**: Events now include threshold context:
```
Liveness probe failed (attempt 1/3, below threshold): HTTP probe failed with statuscode: 500
Liveness probe failed (threshold reached): HTTP probe failed with statuscode: 500
```

## Changes

- Moved event emission from `prober.probe()` to `worker.doProbe()` where the `resultRun` and `FailureThreshold` values are available
- Modified `prober.probe()` signature to also return the probe output string, so the worker can include diagnostic info in events
- Updated `prober_test.go` callers for the new signature

## Which issue(s) this PR fixes

Fixes #115823

## Does this PR introduce a user-facing change?

```release-note
kubelet: ContainerUnhealthy events from probes now indicate whether the failure was below the FailureThreshold (and therefore ignored) or exceeded it (action taken). For example: "Liveness probe failed (attempt 1/3, below threshold): ..." vs "Liveness probe failed (threshold reached): ..."
```

## Test plan

- [x] All existing `pkg/kubelet/prober` tests pass
- [x] `go build ./pkg/kubelet/prober/` succeeds

/sig node