### PR TITLE
pkg/util/coverage: add ModulePath() to fakeTestDeps

### DIFF
--- a/pkg/util/coverage/fake_test_deps.go
+++ b/pkg/util/coverage/fake_test_deps.go
@@ -47,6 +47,11 @@ func (fakeTestDeps) ImportPath() string {
 }
 
 //nolint:unused // U1000 see comment above, we know it's unused normally.
+func (fakeTestDeps) ModulePath() string {
+	return ""
+}
+
+//nolint:unused // U1000 see comment above, we know it's unused normally.
 func (fakeTestDeps) MatchString(pat, str string) (bool, error) {
 	return false, nil
 }


### PR DESCRIPTION
Go 1.26's testing.testDeps interface added a ModulePath() string method. Without it, fakeTestDeps no longer satisfies the interface and any build with -tags=coverage (KUBE_BUILD_WITH_COVERAGE=true) fails to compile at pkg/util/coverage/coverage.go:84 (testing.MainStart):

    pkg/util/coverage/coverage.go:84:32: cannot use deps (variable of
    struct type fakeTestDeps) as testing.testDeps value in argument to
    testing.MainStart: fakeTestDeps does not implement testing.testDeps
    (missing method ModulePath)

This restores the two coverage jobs that have been failing for ~65 days:

  ci-kubernetes-coverage-conformance
    history:  https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-kubernetes-coverage-conformance
    sample:   https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-coverage-conformance/2053245547074031616

  ci-kubernetes-coverage-e2e-gci-gce
    history:  https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-kubernetes-coverage-e2e-gci-gce
    sample:   https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-coverage-e2e-gci-gce/2053247811943665664

The build image kube-cross:v1.36.0-go1.26.2-bullseye.0 is what surfaced this once kube-cross moved to Go 1.26.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
