### PR TITLE
Fix pullmanager lock stripe normalization

### DIFF
--- a/pkg/kubelet/images/pullmanager/locks.go
+++ b/pkg/kubelet/images/pullmanager/locks.go
@@ -21,6 +21,11 @@ import (
 	"sync"
 )
 
+const (
+	minStripedLockSetSize int32 = 1
+	maxStripedLockSetSize int32 = 31
+)
+
 // StripedLockSet allows context locking based on string keys, where each key
 // is mapped to a an index in a size-limited slice of locks.
 type StripedLockSet struct {
@@ -32,10 +37,10 @@ type StripedLockSet struct {
 // used for locking context based on string keys.
 // The size will be normalized to stay in the <1, 31> interval.
 func NewStripedLockSet(size int32) *StripedLockSet {
-	size = max(size, 1) // make sure we're at least at size 1
+	size = min(maxStripedLockSetSize, max(minStripedLockSetSize, size))
 
 	return &StripedLockSet{
-		locks: make([]sync.Mutex, min(31, size)),
+		locks: make([]sync.Mutex, size),
 		size:  size,
 	}
 }

--- a/pkg/kubelet/images/pullmanager/locks_test.go
+++ b/pkg/kubelet/images/pullmanager/locks_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pullmanager
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestStripedLockSetNormalizesSize(t *testing.T) {
+	tests := []struct {
+		name string
+		size int32
+		want int32
+	}{
+		{
+			name: "negative",
+			size: -1,
+			want: 1,
+		},
+		{
+			name: "zero",
+			size: 0,
+			want: 1,
+		},
+		{
+			name: "below max",
+			size: 10,
+			want: 10,
+		},
+		{
+			name: "above max",
+			size: 500,
+			want: 31,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lockSet := NewStripedLockSet(tt.size)
+			if len(lockSet.locks) != int(tt.want) {
+				t.Fatalf("len(NewStripedLockSet(%d).locks) = %d, want %d", tt.size, len(lockSet.locks), tt.want)
+			}
+		})
+	}
+}
+
+func TestStripedLockSetLargeRequestedSizeDoesNotPanic(t *testing.T) {
+	const requestedSize int32 = 500
+	lockSet := NewStripedLockSet(requestedSize)
+	key := keyWithOriginalStripeOutsideAllocatedRange(t, requestedSize, len(lockSet.locks))
+
+	lockSet.Lock(key)
+	lockSet.Unlock(key)
+}
+
+func keyWithOriginalStripeOutsideAllocatedRange(t *testing.T, requestedSize int32, allocatedLocks int) string {
+	t.Helper()
+
+	for i := range 1000 {
+		key := fmt.Sprintf("image-ref-%d", i)
+		if keyToID(key, requestedSize) >= uint32(allocatedLocks) {
+			return key
+		}
+	}
+	t.Fatalf("failed to find key with stripe outside allocated range")
+	return ""
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node

#### What this PR does / why we need it:

`NewStripedLockSet` normalized the allocated lock slice to at most 31 entries, but kept the original requested size in `StripedLockSet.size`. `Lock` and `Unlock` then hashed keys modulo the original requested size, which could index beyond the allocated lock slice when `maxParallelImagePulls` was greater than 31.

This removes the separate stored size and uses the backing lock slice length as the stripe count, so the hash modulus always matches the indexable range.

The PR also adds regression coverage for a large requested stripe count such as `500`, matching the shape of the panic reported in #138935.

#### Which issue(s) this PR fixes:

Fixes #138935

#### Special notes for your reviewer:

The focused regression test intentionally chooses a key that would hash outside the allocated 31-lock range when using the original requested size.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a kubelet panic in image pull credential verification when maxParallelImagePulls is configured above 31.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
