### PR TITLE
kubeadm: avoid panic in TryLoadPrivatePublicKeyFromDisk for mismatched private/public key types

### DIFF
--- a/cmd/kubeadm/app/util/pkiutil/pki_helpers.go
+++ b/cmd/kubeadm/app/util/pkiutil/pki_helpers.go
@@ -340,11 +340,20 @@ func TryLoadPrivatePublicKeyFromDisk(pkiPath, name string) (crypto.PrivateKey, c
 	}
 
 	// Allow RSA and ECDSA formats only
+	mismatchErrFmt := "the private key file %[2]s is in %[1]s format but the public key file %[3]s is not in %[1]s format"
 	switch k := privKey.(type) {
 	case *rsa.PrivateKey:
-		return k, pubKeys[0].(*rsa.PublicKey), nil
+		pubKey, ok := pubKeys[0].(*rsa.PublicKey)
+		if !ok {
+			return nil, nil, errors.Errorf(mismatchErrFmt, "RSA", privateKeyPath, publicKeyPath)
+		}
+		return k, pubKey, nil
 	case *ecdsa.PrivateKey:
-		return k, pubKeys[0].(*ecdsa.PublicKey), nil
+		pubKey, ok := pubKeys[0].(*ecdsa.PublicKey)
+		if !ok {
+			return nil, nil, errors.Errorf(mismatchErrFmt, "ECDSA", privateKeyPath, publicKeyPath)
+		}
+		return k, pubKey, nil
 	default:
 		return nil, nil, errors.Errorf("the private key file %s is neither in RSA nor ECDSA format", privateKeyPath)
 	}

--- a/cmd/kubeadm/app/util/pkiutil/pki_helpers_test.go
+++ b/cmd/kubeadm/app/util/pkiutil/pki_helpers_test.go
@@ -566,6 +566,77 @@ func TestTryLoadKeyFromDisk(t *testing.T) {
 	}
 }
 
+func TestTryLoadPrivatePublicKeyFromDisk(t *testing.T) {
+	tests := []struct {
+		desc       string
+		privateKey crypto.Signer
+		publicKey  crypto.PublicKey
+		writePub   bool
+		wantErr    bool
+	}{
+		{
+			desc:       "RSA private key and RSA public key",
+			privateKey: rootCAKey,
+			publicKey:  rootCAKey.Public(),
+			writePub:   true,
+			wantErr:    false,
+		},
+		{
+			desc:       "ECDSA private key and ECDSA public key",
+			privateKey: ecdsaP256Key,
+			publicKey:  ecdsaP256Key.Public(),
+			writePub:   true,
+			wantErr:    false,
+		},
+		{
+			desc:       "RSA private key and ECDSA public key",
+			privateKey: rootCAKey,
+			publicKey:  ecdsaP256Key.Public(),
+			writePub:   true,
+			wantErr:    true,
+		},
+		{
+			desc:       "ECDSA private key and RSA public key",
+			privateKey: ecdsaP256Key,
+			publicKey:  rootCAKey.Public(),
+			writePub:   true,
+			wantErr:    true,
+		},
+		{
+			desc:       "missing public key file",
+			privateKey: rootCAKey,
+			writePub:   false,
+			wantErr:    true,
+		},
+	}
+
+	for _, rt := range tests {
+		t.Run(rt.desc, func(t *testing.T) {
+			tmpdir, err := os.MkdirTemp("", "")
+			if err != nil {
+				t.Fatalf("Couldn't create tmpdir")
+			}
+			defer func() { _ = os.RemoveAll(tmpdir) }()
+
+			err = WriteKey(tmpdir, "foo", rt.privateKey)
+			if err != nil {
+				t.Fatalf("failed to write private key: %v", err)
+			}
+			if rt.writePub {
+				err = WritePublicKey(tmpdir, "foo", rt.publicKey)
+				if err != nil {
+					t.Fatalf("failed to write public key: %v", err)
+				}
+			}
+
+			_, _, actual := TryLoadPrivatePublicKeyFromDisk(tmpdir, "foo")
+			if (actual != nil) != rt.wantErr {
+				t.Fatalf("TryLoadPrivatePublicKeyFromDisk() error = %v, wantErr %v", actual, rt.wantErr)
+			}
+		})
+	}
+}
+
 func TestPathsForCertAndKey(t *testing.T) {
 	crtPath, keyPath := PathsForCertAndKey("/foo", "bar")
 	expectedPath := filepath.FromSlash("/foo/bar.crt")


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind cleanup


<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

kubeadm: avoid panic in TryLoadPrivatePublicKeyFromDisk for mismatched private/public key types

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: fixed a panic in kubeadm PKI key loading when the private key type and public key type mismatch.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
