### PR TITLE
[wontfix] Increase HTTP/2 MaxReadFrameSize to mitigate watchlist latency

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
@@ -190,6 +190,7 @@ func configureHTTP2Transport(t *http.Transport) error {
 	// https://github.com/kubernetes/kubernetes/issues/87615.
 	t2.ReadIdleTimeout = time.Duration(readIdleTimeoutSeconds()) * time.Second
 	t2.PingTimeout = time.Duration(pingTimeoutSeconds()) * time.Second
+	t2.MaxReadFrameSize = 16777215
 	return nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:
This PR increases the `MaxReadFrameSize` in HTTP/2 clients to the maximum value (`16777215`) to mitigate severe WatchList latency spikes at scale.
During scale up (e.g., 5000 nodes, 165K pods), the API Server experiences huge contention in the Go scheduler and runtime mutexes due to the high volume of uncompressed WatchList HTTP/2 data being fragmented over the network stack. By increasing `MaxReadFrameSize`, we drastically reduce the number of network frames, thereby reducing goroutine preemption and scheduler overhead.

#### Which issue(s) this PR is related to:
Fixes #138670

#### Special notes for your reviewer:
This is a mitigation for the Go runtime scheduler bottleneck identified in #138670.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
