### PR TITLE
strategicpatch: fix nil return in LookupPatchMetadataForSlice

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/meta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/meta.go
@@ -264,7 +264,7 @@ func (s PatchMetaFromOpenAPI) LookupPatchMetadataForStruct(key string) (LookupPa
 
 func (s PatchMetaFromOpenAPI) LookupPatchMetadataForSlice(key string) (LookupPatchMeta, PatchMeta, error) {
 	if s.Schema == nil {
-		return nil, PatchMeta{}, nil
+		return &PatchMetaFromOpenAPI{}, PatchMeta{}, nil
 	}
 	sliceItem := NewSliceItem(key, s.Schema.GetPath())
 	s.Schema.Accept(sliceItem)


### PR DESCRIPTION
## What this PR does / why we need it

Commit 5af28702540 ("fix nested map segmentation fault", #134107) changed `PatchMetaFromOpenAPI.LookupPatchMetadataForStruct` to return `&PatchMetaFromOpenAPI{}` instead of bare `nil` when `s.Schema == nil`, so that recursive lookups that bottom out in a schemaless region (e.g. inside a JSON-typed field) don't return a nil `LookupPatchMeta` interface that downstream callers will dereference.

The sister method `LookupPatchMetadataForSlice` was missed and still returns `nil` in that case. The five callers in `patch.go` (lines 306, 1165, 1417, 1723, 1975) treat the returned value as a non-nil `LookupPatchMeta` and call methods on it, which panics.

This applies the symmetric fix.

## Special notes for your reviewer

@kostis-codefresh for awareness — this mirrors your earlier fix.

```release-note
NONE
```

/kind bug
/sig api-machinery