### PR TITLE
apiserver: reject non-queued APF requests at zero concurrency

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
@@ -750,6 +750,8 @@ func (qs *queueSet) canAccommodateSeatsLocked(seats int) bool {
 	case qs.qCfg.DesiredNumQueues < 0:
 		// This is code for exemption from limitation
 		return true
+	case qs.dCfg.ConcurrencyLimit == 0:
+		return false
 	case seats > qs.dCfg.ConcurrencyLimit:
 		// we have picked the queue with the minimum virtual finish time, but
 		// the number of seats this request asks for exceeds the concurrency limit.

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
@@ -1056,6 +1056,30 @@ func TestDifferentFlowsWithoutQueuing(t *testing.T) {
 	}.exercise(t)
 }
 
+func TestZeroConcurrencyLimitWithoutQueuingRejects(t *testing.T) {
+	now := time.Now()
+	clk, counter := testeventclock.NewFake(now, 0, nil)
+	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter))
+	qCfg := fq.QueuingConfig{
+		Name:             "TestZeroConcurrencyLimitWithoutQueuingRejects",
+		DesiredNumQueues: 0,
+	}
+	seatDemandIntegratorSubject := fq.NewNamedIntegrator(clk, "seatDemandSubject")
+	qsc, err := qsf.BeginConstruction(qCfg, newGaugePair(clk), newExecSeatsGauge(clk), seatDemandIntegratorSubject)
+	if err != nil {
+		t.Fatal(err)
+	}
+	qs := qsComplete(qsc, 0)
+
+	req, idle := qs.StartRequest(context.Background(), &fcrequest.WorkEstimate{InitialSeats: 1}, 0, "", "fs", "test", "request", nil)
+	if req != nil {
+		t.Fatal("expected request to be rejected, got a Request object")
+	}
+	if !idle {
+		t.Fatal("expected queue set to remain idle after rejecting request")
+	}
+}
+
 // TestContextCancel tests cancellation of a request's context.
 // The outline is:
 //  1. Use a concurrency limit of 1.


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Priority levels with `limitResponse: Reject` use a non-queued QueueSet. When APF computed a concurrency limit of zero for that QueueSet, the oversized-request exception in `canAccommodateSeatsLocked` still admitted a request if nothing else was executing.

This changes non-exempt QueueSets with `ConcurrencyLimit == 0` to reject immediately, preserving the existing exemption path and the oversized-request allowance for positive concurrency limits.

#### Which issue(s) this PR fixes:
Fixes #134196

#### Special notes for your reviewer:
The regression test exercises the QueueSet behavior directly because the bug is in the no-queue admission predicate used by reject-style limited priority levels.

#### Does this PR introduce a user-facing change?
```release-note
Fixed API Priority and Fairness priority levels with zero computed concurrency and `limitResponse: Reject` so matching requests are rejected instead of admitted.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
None

#### Tests:
- `go test ./staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset -run TestZeroConcurrencyLimitWithoutQueuingRejects -count=1`
- `go test ./staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset -count=1`
- `go test ./staging/src/k8s.io/apiserver/pkg/util/flowcontrol -count=1`
- `git diff --check`
