### PR TITLE
client-go: name informer reflectors from identifiers

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/factory.go
@@ -92,7 +92,7 @@ func WithTransform(transform cache.TransformFunc) SharedInformerOption {
 	}
 }
 
-// WithInformerName sets the InformerName for informer identity used in metrics.
+// WithInformerName sets the InformerName for informer identity used in metrics and logging.
 // The InformerName must be created via cache.NewInformerName() at startup,
 // which validates global uniqueness. Each informer type will register its
 // GVR under this name.

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -49,8 +49,9 @@ type InformerOptions struct {
 	// Indexers are the indexers for this informer.
 	Indexers cache.Indexers
 
-	// InformerName is used to uniquely identify this informer for metrics.
-	// If not set, metrics will not be published for this informer.
+	// InformerName is used to uniquely identify this informer for metrics and logging.
+	// If not set, metrics will not be published for this informer and its
+	// reflector uses the default name.
 	// Use cache.NewInformerName() to create an InformerName at startup.
 	InformerName *cache.InformerName
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
@@ -92,7 +92,7 @@ func WithTransform(transform cache.TransformFunc) SharedInformerOption {
 	}
 }
 
-// WithInformerName sets the InformerName for informer identity used in metrics.
+// WithInformerName sets the InformerName for informer identity used in metrics and logging.
 // The InformerName must be created via cache.NewInformerName() at startup,
 // which validates global uniqueness. Each informer type will register its
 // GVR under this name.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -49,8 +49,9 @@ type InformerOptions struct {
 	// Indexers are the indexers for this informer.
 	Indexers cache.Indexers
 
-	// InformerName is used to uniquely identify this informer for metrics.
-	// If not set, metrics will not be published for this informer.
+	// InformerName is used to uniquely identify this informer for metrics and logging.
+	// If not set, metrics will not be published for this informer and its
+	// reflector uses the default name.
 	// Use cache.NewInformerName() to create an InformerName at startup.
 	InformerName *cache.InformerName
 

--- a/staging/src/k8s.io/client-go/informers/factory.go
+++ b/staging/src/k8s.io/client-go/informers/factory.go
@@ -111,7 +111,7 @@ func WithTransform(transform cache.TransformFunc) SharedInformerOption {
 	}
 }
 
-// WithInformerName sets the InformerName for informer identity used in metrics.
+// WithInformerName sets the InformerName for informer identity used in metrics and logging.
 // The InformerName must be created via cache.NewInformerName() at startup,
 // which validates global uniqueness. Each informer type will register its
 // GVR under this name.

--- a/staging/src/k8s.io/client-go/informers/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/client-go/informers/internalinterfaces/factory_interfaces.go
@@ -49,8 +49,9 @@ type InformerOptions struct {
 	// Indexers are the indexers for this informer.
 	Indexers cache.Indexers
 
-	// InformerName is used to uniquely identify this informer for metrics.
-	// If not set, metrics will not be published for this informer.
+	// InformerName is used to uniquely identify this informer for metrics and logging.
+	// If not set, metrics will not be published for this informer and its
+	// reflector uses the default name.
 	// Use cache.NewInformerName() to create an InformerName at startup.
 	InformerName *cache.InformerName
 

--- a/staging/src/k8s.io/client-go/tools/cache/controller.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller.go
@@ -42,6 +42,11 @@ import (
 
 // Config contains all the settings for one of these low-level controllers.
 type Config struct {
+	// Name is the name of this controller's reflector. If unset, the reflector
+	// defaults to the closest source_file.go:line in the call stack that is
+	// outside this package.
+	Name string
+
 	// The queue for your objects - has to be a DeltaFIFO due to
 	// assumptions in the implementation. Your Process() function
 	// should accept the output of this Queue's Pop() method.
@@ -179,6 +184,7 @@ func (c *controller) RunWithContext(ctx context.Context) {
 		c.config.ObjectType,
 		c.config.Queue,
 		ReflectorOptions{
+			Name:            c.config.Name,
 			Logger:          &logger,
 			ResyncPeriod:    c.config.FullResyncPeriod,
 			MinWatchTimeout: c.config.MinWatchTimeout,
@@ -448,8 +454,8 @@ type InformerOptions struct {
 	// Optional - if unset no additional transforming is happening.
 	Transform TransformFunc
 
-	// Identifier is used to identify the FIFO for metrics and logging purposes.
-	// If not set, metrics will not be published.
+	// Identifier is used to identify the informer for metrics and logging purposes.
+	// If not set, metrics will not be published and the reflector uses its default name.
 	Identifier InformerNameAndResource
 
 	// InformerMetricsProvider is the metrics provider for the informer.
@@ -817,6 +823,7 @@ func newInformer(clientState Store, options InformerOptions, keyFunc KeyFunc) Co
 	logger, fifo := newQueueFIFO(logger, options.ObjectType, clientState, options.Transform, options.Identifier, options.InformerMetricsProvider)
 
 	cfg := &Config{
+		Name:             options.Identifier.Name(),
 		Queue:            fifo,
 		ListerWatcher:    options.ListerWatcher,
 		ObjectType:       options.ObjectType,

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -352,8 +352,8 @@ type SharedIndexInformerOptions struct {
 	// underlying Reflector's type description.
 	ObjectDescription string
 
-	// Identifier is used to identify the FIFO for metrics and logging purposes.
-	// If not set, metrics will not be published.
+	// Identifier is used to identify the informer for metrics and logging purposes.
+	// If not set, metrics will not be published and the reflector uses its default name.
 	Identifier InformerNameAndResource
 
 	// InformerMetricsProvider is the metrics provider for the FIFO queue.
@@ -732,6 +732,7 @@ func (s *sharedIndexInformer) RunWithContext(ctx context.Context) {
 		logger, fifo := newQueueFIFO(logger, s.objectType, s.indexer, s.transform, s.identifier, s.informerMetricsProvider)
 
 		cfg := &Config{
+			Name:              s.identifier.Name(),
 			Queue:             fifo,
 			ListerWatcher:     s.listerWatcher,
 			ObjectType:        s.objectType,

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
@@ -36,6 +36,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -541,6 +542,65 @@ func TestSharedInformerErrorHandling(t *testing.T) {
 	case err := <-errCh:
 		if !strings.Contains(err.Error(), "Access Denied") {
 			t.Errorf("Expected 'Access Denied' error. Actual: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Errorf("Timeout waiting for error handler call")
+	}
+}
+
+func TestSharedInformerReflectorNameFromIdentifier(t *testing.T) {
+	source := newFakeControllerSource(t)
+	source.ListError = fmt.Errorf("Access Denied")
+
+	informerName, err := NewInformerName("shared-informer-reflector-name")
+	if err != nil {
+		t.Fatalf("NewInformerName() error = %v", err)
+	}
+	t.Cleanup(informerName.Release)
+
+	informer := NewSharedIndexInformerWithOptions(
+		source,
+		&v1.Pod{},
+		SharedIndexInformerOptions{
+			ResyncPeriod: time.Second,
+			Identifier: informerName.WithResource(schema.GroupVersionResource{
+				Group:    "",
+				Version:  "v1",
+				Resource: "pods",
+			}),
+		},
+	)
+
+	type watchError struct {
+		reflectorName string
+		err           error
+	}
+	errCh := make(chan watchError, 1)
+	_ = informer.SetWatchErrorHandler(func(r *Reflector, err error) {
+		select {
+		case errCh <- watchError{
+			reflectorName: r.Name(),
+			err:           err,
+		}:
+		default:
+		}
+	})
+
+	var wg wait.Group
+	stop := make(chan struct{})
+	wg.StartWithChannel(stop, informer.Run)
+	defer func() {
+		close(stop)
+		wg.Wait()
+	}()
+
+	select {
+	case got := <-errCh:
+		if !strings.Contains(got.err.Error(), "Access Denied") {
+			t.Errorf("Expected 'Access Denied' error. Actual: %v", got.err)
+		}
+		if got.reflectorName != "shared-informer-reflector-name" {
+			t.Errorf("Expected reflector name %q. Actual: %q", "shared-informer-reflector-name", got.reflectorName)
 		}
 	case <-time.After(time.Second):
 		t.Errorf("Timeout waiting for error handler call")

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factory.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factory.go
@@ -167,7 +167,7 @@ func WithTransform(transform {{.cacheTransformFunc|raw}}) SharedInformerOption {
 	}
 }
 
-// WithInformerName sets the InformerName for informer identity used in metrics.
+// WithInformerName sets the InformerName for informer identity used in metrics and logging.
 // The InformerName must be created via cache.NewInformerName() at startup,
 // which validates global uniqueness. Each informer type will register its
 // GVR under this name.

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factoryinterface.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factoryinterface.go
@@ -100,8 +100,9 @@ type InformerOptions struct {
 	// Indexers are the indexers for this informer.
 	Indexers {{.cacheIndexers|raw}}
 
-	// InformerName is used to uniquely identify this informer for metrics.
-	// If not set, metrics will not be published for this informer.
+	// InformerName is used to uniquely identify this informer for metrics and logging.
+	// If not set, metrics will not be published for this informer and its
+	// reflector uses the default name.
 	// Use cache.NewInformerName() to create an InformerName at startup.
 	InformerName *{{.cacheInformerName|raw}}
 

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/factory.go
@@ -92,7 +92,7 @@ func WithTransform(transform cache.TransformFunc) SharedInformerOption {
 	}
 }
 
-// WithInformerName sets the InformerName for informer identity used in metrics.
+// WithInformerName sets the InformerName for informer identity used in metrics and logging.
 // The InformerName must be created via cache.NewInformerName() at startup,
 // which validates global uniqueness. Each informer type will register its
 // GVR under this name.

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -49,8 +49,9 @@ type InformerOptions struct {
 	// Indexers are the indexers for this informer.
 	Indexers cache.Indexers
 
-	// InformerName is used to uniquely identify this informer for metrics.
-	// If not set, metrics will not be published for this informer.
+	// InformerName is used to uniquely identify this informer for metrics and logging.
+	// If not set, metrics will not be published for this informer and its
+	// reflector uses the default name.
 	// Use cache.NewInformerName() to create an InformerName at startup.
 	InformerName *cache.InformerName
 

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/factory.go
@@ -92,7 +92,7 @@ func WithTransform(transform cache.TransformFunc) SharedInformerOption {
 	}
 }
 
-// WithInformerName sets the InformerName for informer identity used in metrics.
+// WithInformerName sets the InformerName for informer identity used in metrics and logging.
 // The InformerName must be created via cache.NewInformerName() at startup,
 // which validates global uniqueness. Each informer type will register its
 // GVR under this name.

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -49,8 +49,9 @@ type InformerOptions struct {
 	// Indexers are the indexers for this informer.
 	Indexers cache.Indexers
 
-	// InformerName is used to uniquely identify this informer for metrics.
-	// If not set, metrics will not be published for this informer.
+	// InformerName is used to uniquely identify this informer for metrics and logging.
+	// If not set, metrics will not be published for this informer and its
+	// reflector uses the default name.
 	// Use cache.NewInformerName() to create an InformerName at startup.
 	InformerName *cache.InformerName
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/factory.go
@@ -95,7 +95,7 @@ func WithTransform(transform cache.TransformFunc) SharedInformerOption {
 	}
 }
 
-// WithInformerName sets the InformerName for informer identity used in metrics.
+// WithInformerName sets the InformerName for informer identity used in metrics and logging.
 // The InformerName must be created via cache.NewInformerName() at startup,
 // which validates global uniqueness. Each informer type will register its
 // GVR under this name.

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -49,8 +49,9 @@ type InformerOptions struct {
 	// Indexers are the indexers for this informer.
 	Indexers cache.Indexers
 
-	// InformerName is used to uniquely identify this informer for metrics.
-	// If not set, metrics will not be published for this informer.
+	// InformerName is used to uniquely identify this informer for metrics and logging.
+	// If not set, metrics will not be published for this informer and its
+	// reflector uses the default name.
 	// Use cache.NewInformerName() to create an InformerName at startup.
 	InformerName *cache.InformerName
 

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/factory.go
@@ -95,7 +95,7 @@ func WithTransform(transform cache.TransformFunc) SharedInformerOption {
 	}
 }
 
-// WithInformerName sets the InformerName for informer identity used in metrics.
+// WithInformerName sets the InformerName for informer identity used in metrics and logging.
 // The InformerName must be created via cache.NewInformerName() at startup,
 // which validates global uniqueness. Each informer type will register its
 // GVR under this name.

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -49,8 +49,9 @@ type InformerOptions struct {
 	// Indexers are the indexers for this informer.
 	Indexers cache.Indexers
 
-	// InformerName is used to uniquely identify this informer for metrics.
-	// If not set, metrics will not be published for this informer.
+	// InformerName is used to uniquely identify this informer for metrics and logging.
+	// If not set, metrics will not be published for this informer and its
+	// reflector uses the default name.
 	// Use cache.NewInformerName() to create an InformerName at startup.
 	InformerName *cache.InformerName
 

--- a/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/factory.go
@@ -92,7 +92,7 @@ func WithTransform(transform cache.TransformFunc) SharedInformerOption {
 	}
 }
 
-// WithInformerName sets the InformerName for informer identity used in metrics.
+// WithInformerName sets the InformerName for informer identity used in metrics and logging.
 // The InformerName must be created via cache.NewInformerName() at startup,
 // which validates global uniqueness. Each informer type will register its
 // GVR under this name.

--- a/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -49,8 +49,9 @@ type InformerOptions struct {
 	// Indexers are the indexers for this informer.
 	Indexers cache.Indexers
 
-	// InformerName is used to uniquely identify this informer for metrics.
-	// If not set, metrics will not be published for this informer.
+	// InformerName is used to uniquely identify this informer for metrics and logging.
+	// If not set, metrics will not be published for this informer and its
+	// reflector uses the default name.
 	// Use cache.NewInformerName() to create an InformerName at startup.
 	InformerName *cache.InformerName
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
@@ -92,7 +92,7 @@ func WithTransform(transform cache.TransformFunc) SharedInformerOption {
 	}
 }
 
-// WithInformerName sets the InformerName for informer identity used in metrics.
+// WithInformerName sets the InformerName for informer identity used in metrics and logging.
 // The InformerName must be created via cache.NewInformerName() at startup,
 // which validates global uniqueness. Each informer type will register its
 // GVR under this name.

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -49,8 +49,9 @@ type InformerOptions struct {
 	// Indexers are the indexers for this informer.
 	Indexers cache.Indexers
 
-	// InformerName is used to uniquely identify this informer for metrics.
-	// If not set, metrics will not be published for this informer.
+	// InformerName is used to uniquely identify this informer for metrics and logging.
+	// If not set, metrics will not be published for this informer and its
+	// reflector uses the default name.
 	// Use cache.NewInformerName() to create an InformerName at startup.
 	InformerName *cache.InformerName
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/factory.go
@@ -92,7 +92,7 @@ func WithTransform(transform cache.TransformFunc) SharedInformerOption {
 	}
 }
 
-// WithInformerName sets the InformerName for informer identity used in metrics.
+// WithInformerName sets the InformerName for informer identity used in metrics and logging.
 // The InformerName must be created via cache.NewInformerName() at startup,
 // which validates global uniqueness. Each informer type will register its
 // GVR under this name.

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -49,8 +49,9 @@ type InformerOptions struct {
 	// Indexers are the indexers for this informer.
 	Indexers cache.Indexers
 
-	// InformerName is used to uniquely identify this informer for metrics.
-	// If not set, metrics will not be published for this informer.
+	// InformerName is used to uniquely identify this informer for metrics and logging.
+	// If not set, metrics will not be published for this informer and its
+	// reflector uses the default name.
 	// Use cache.NewInformerName() to create an InformerName at startup.
 	InformerName *cache.InformerName
 

--- a/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/factory.go
@@ -92,7 +92,7 @@ func WithTransform(transform cache.TransformFunc) SharedInformerOption {
 	}
 }
 
-// WithInformerName sets the InformerName for informer identity used in metrics.
+// WithInformerName sets the InformerName for informer identity used in metrics and logging.
 // The InformerName must be created via cache.NewInformerName() at startup,
 // which validates global uniqueness. Each informer type will register its
 // GVR under this name.

--- a/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -49,8 +49,9 @@ type InformerOptions struct {
 	// Indexers are the indexers for this informer.
 	Indexers cache.Indexers
 
-	// InformerName is used to uniquely identify this informer for metrics.
-	// If not set, metrics will not be published for this informer.
+	// InformerName is used to uniquely identify this informer for metrics and logging.
+	// If not set, metrics will not be published for this informer and its
+	// reflector uses the default name.
 	// Use cache.NewInformerName() to create an InformerName at startup.
 	InformerName *cache.InformerName
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig api-machinery

#### What this PR does / why we need it:

Informer identifiers are documented as being used for metrics and logging, but shared and non-shared informer construction did not pass the identifier name to the underlying reflector. As a result, reflector log fields still used the default callsite-derived name, which makes multiple same-type informers hard to distinguish.

This PR passes the existing informer identifier name into the reflector and adds a regression test that verifies the reflector observed by the watch error handler is named from the informer identifier.

#### Which issue(s) this PR is related to:

Fixes #111790

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```
