### PR TITLE
test/utils/ktesting: make CleanupGracePeriod configurable in TContext

### DIFF
--- a/test/utils/ktesting/initoption/initoption.go
+++ b/test/utils/ktesting/initoption/initoption.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package initoption
 
-import "k8s.io/kubernetes/test/utils/ktesting/internal"
+import (
+	"time"
+
+	"k8s.io/kubernetes/test/utils/ktesting/internal"
+)
 
 // InitOption is a functional option for Init and InitCtx.
 type InitOption func(c *internal.InitConfig)
@@ -36,5 +40,20 @@ func PerTestOutput(enabled bool) InitOption {
 func BufferLogs(enabled bool) InitOption {
 	return func(c *internal.InitConfig) {
 		c.BufferLogs = enabled
+	}
+}
+
+// WithCleanupGracePeriod overrides the default cleanup grace period used by
+// [Init]. The cleanup grace period is the time reserved before the test-suite
+// deadline so that cleanup callbacks can complete before the test binary is
+// killed.
+//
+// A non-positive value is ignored and the default is used instead.
+//
+// When using Ginkgo to manage the test suite this option has no effect because
+// Ginkgo itself manages timeouts.
+func WithCleanupGracePeriod(d time.Duration) InitOption {
+	return func(c *internal.InitConfig) {
+		c.CleanupGracePeriod = d
 	}
 }

--- a/test/utils/ktesting/internal/config.go
+++ b/test/utils/ktesting/internal/config.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package internal
 
+import "time"
+
 type InitConfig struct {
-	PerTestOutput bool
-	BufferLogs    bool
+	PerTestOutput      bool
+	BufferLogs         bool
+	CleanupGracePeriod time.Duration // Zero means use the package default (DefaultCleanupGracePeriod).
 }

--- a/test/utils/ktesting/tcontext.go
+++ b/test/utils/ktesting/tcontext.go
@@ -40,18 +40,20 @@ import (
 // used to capture log output in memory to check it in tests.
 type Underlier = ktesting.Underlier
 
-// CleanupGracePeriod is the time that a [TContext] gets canceled before the
-// deadline of its underlying test suite (usually determined via "go test
+// DefaultCleanupGracePeriod is the time that a [TContext] gets canceled before
+// the deadline of its underlying test suite (usually determined via "go test
 // -timeout"). This gives the running test(s) time to fail with an informative
 // timeout error. After that, all cleanup callbacks then have the remaining
 // time to complete before the test binary is killed.
 //
-// For this to work, each blocking calls in a test must respect the
+// For this to work, each blocking call in a test must respect the
 // cancellation of the [TContext].
 //
 // When using Ginkgo to manage the test suite and running tests, the
-// CleanupGracePeriod is ignored because Ginkgo itself manages timeouts.
-const CleanupGracePeriod = 5 * time.Second
+// cleanup grace period is ignored because Ginkgo itself manages timeouts.
+//
+// This value can be overridden per-[TContext] via [initoption.WithCleanupGracePeriod].
+const DefaultCleanupGracePeriod = 5 * time.Second
 
 // TB is the interface common to [testing.T], [testing.B], [testing.F] and
 // [github.com/onsi/ginkgo/v2] which ktesting relies upon itself or
@@ -172,15 +174,23 @@ func Init(tb TB, opts ...InitOption) TContext {
 		header = klogHeader
 	}
 
+	// Resolve the effective cleanup grace period: use the caller-supplied value
+	// if positive, otherwise fall back to DefaultCleanupGracePeriod.
+	gracePeriod := c.CleanupGracePeriod
+	if gracePeriod <= 0 {
+		gracePeriod = DefaultCleanupGracePeriod
+	}
+
 	var cancelTimeout func(cause string)
 	if deadline != nil {
 		timeLeft := time.Until(*deadline)
-		timeLeft -= CleanupGracePeriod
-		ctx, cancelTimeout = withTimeout(ctx, tb, timeLeft, fmt.Sprintf("test suite deadline (%s) is close, need to clean up before the %s cleanup grace period", deadline.Truncate(time.Second), CleanupGracePeriod))
+		timeLeft -= gracePeriod
+		ctx, cancelTimeout = withTimeout(ctx, tb, timeLeft, fmt.Sprintf("test suite deadline (%s) is close, need to clean up before the %s cleanup grace period", deadline.Truncate(time.Second), gracePeriod))
 	}
 
 	// Construct new TContext with context and settings as determined above.
 	tCtx := InitCtx(ctx, tb)
+	tCtx.cleanupGracePeriod = gracePeriod
 	tCtx.isSyncTest = isSyncTest
 	if cancelTimeout != nil {
 		tCtx.cancel = cancelTimeout
@@ -240,12 +250,19 @@ type InitOption = initoption.InitOption
 
 // InitCtx is a variant of [Init] which uses an already existing context and
 // whatever logger and timeouts are stored there.
-// Functional options are part of the API, but currently
-// there are none which have an effect.
-func InitCtx(ctx context.Context, tb TB, _ ...InitOption) TContext {
+func InitCtx(ctx context.Context, tb TB, opts ...InitOption) TContext {
+	c := internal.InitConfig{}
+	for _, opt := range opts {
+		opt(&c)
+	}
+	gracePeriod := c.CleanupGracePeriod
+	if gracePeriod <= 0 {
+		gracePeriod = DefaultCleanupGracePeriod
+	}
 	return TContext{
-		Context:   ctx,
-		testingTB: testingTB{TB: tb},
+		Context:            ctx,
+		testingTB:          testingTB{TB: tb},
+		cleanupGracePeriod: gracePeriod,
 	}
 }
 
@@ -414,6 +431,11 @@ type TContext struct {
 	//
 	// Used by WithError.
 	capture *capture
+
+	// cleanupGracePeriod is the effective cleanup grace period for this context.
+	// It is always non-zero: both Init and InitCtx resolve it from the supplied
+	// options or fall back to DefaultCleanupGracePeriod.
+	cleanupGracePeriod time.Duration
 }
 
 type capture struct {

--- a/test/utils/ktesting/tcontext_internal_test.go
+++ b/test/utils/ktesting/tcontext_internal_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is in package ktesting (not ktesting_test) so that it can access
+// unexported fields of TContext.
+package ktesting
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/onsi/gomega"
+
+	"k8s.io/kubernetes/test/utils/ktesting/initoption"
+)
+
+// deadlineT2 mirrors the deadlineT helper in ktesting_test.
+type deadlineT2 struct {
+	TB
+	deadline *time.Time
+}
+
+func (t *deadlineT2) Deadline() (time.Time, bool) {
+	if t.deadline == nil {
+		return time.Time{}, false
+	}
+	return *t.deadline, true
+}
+
+// TestDefaultCleanupGracePeriod verifies that cleanupGracePeriod is set to
+// DefaultCleanupGracePeriod when no override is given.
+func TestDefaultCleanupGracePeriod(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		mockDeadline := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+		mockT := &deadlineT2{TB: t, deadline: &mockDeadline}
+		tCtx := Init(mockT)
+		if tCtx.cleanupGracePeriod != DefaultCleanupGracePeriod {
+			t.Errorf("expected cleanupGracePeriod %v, got %v", DefaultCleanupGracePeriod, tCtx.cleanupGracePeriod)
+		}
+	})
+}
+
+// TestCustomCleanupGracePeriod verifies that WithCleanupGracePeriod stores the
+// override in cleanupGracePeriod and shifts the effective deadline accordingly.
+func TestCustomCleanupGracePeriod(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		mockDeadline := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+		mockT := &deadlineT2{TB: t, deadline: &mockDeadline}
+		custom := 30 * time.Second
+		tCtx := Init(mockT, initoption.WithCleanupGracePeriod(custom))
+
+		if tCtx.cleanupGracePeriod != custom {
+			t.Errorf("expected cleanupGracePeriod %v, got %v", custom, tCtx.cleanupGracePeriod)
+		}
+
+		actualDeadline, ok := tCtx.Deadline()
+		if !ok {
+			t.Fatal("expected a deadline but got none")
+		}
+		expect := mockDeadline.Add(-custom)
+		tCtx.Expect(actualDeadline).To(
+			gomega.BeTemporally("==", expect),
+			"context deadline should be shifted by the custom grace period")
+	})
+}
+
+// TestInitCtxCleanupGracePeriod verifies that InitCtx applies
+// WithCleanupGracePeriod via the previously ignored opts parameter.
+func TestInitCtxCleanupGracePeriod(t *testing.T) {
+	custom := 42 * time.Second
+	tCtx := InitCtx(context.Background(), t, initoption.WithCleanupGracePeriod(custom))
+	if tCtx.cleanupGracePeriod != custom {
+		t.Errorf("expected cleanupGracePeriod %v, got %v", custom, tCtx.cleanupGracePeriod)
+	}
+}
+
+// TestInitCtxDefaultCleanupGracePeriod verifies that InitCtx falls back to
+// DefaultCleanupGracePeriod when no option is given.
+func TestInitCtxDefaultCleanupGracePeriod(t *testing.T) {
+	tCtx := InitCtx(context.Background(), t)
+	if tCtx.cleanupGracePeriod != DefaultCleanupGracePeriod {
+		t.Errorf("expected cleanupGracePeriod %v, got %v", DefaultCleanupGracePeriod, tCtx.cleanupGracePeriod)
+	}
+}

--- a/test/utils/ktesting/tcontext_test.go
+++ b/test/utils/ktesting/tcontext_test.go
@@ -75,7 +75,7 @@ func TestNormalInit(t *testing.T) {
 	// The outcome depends on how the unit test was started.
 	// See below for deterministic deadline/no deadline testing.
 	expectDeadline, expectOK := t.Deadline()
-	expectDeadline = expectDeadline.Add(-ktesting.CleanupGracePeriod)
+	expectDeadline = expectDeadline.Add(-ktesting.DefaultCleanupGracePeriod)
 	tCtx := ktesting.Init(t)
 	actualDeadline, actualOK := tCtx.Deadline()
 	tCtx.Expect(actualOK).To(gomega.Equal(expectOK), "have deadline")
@@ -104,7 +104,7 @@ func TestDeadline(t *testing.T) {
 		tCtx := ktesting.Init(mockT)
 		actualDeadline, ok := tCtx.Deadline()
 		if ok {
-			expectDeadline := mockDeadline.Add(-ktesting.CleanupGracePeriod)
+			expectDeadline := mockDeadline.Add(-ktesting.DefaultCleanupGracePeriod)
 			tCtx.Expect(actualDeadline).To(gomega.BeTemporally("==", expectDeadline), "deadline")
 		} else {
 			tCtx.Error("Expected a deadline, got none")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/kind deprecation

#### What this PR does / why we need it:

`TContext` previously hardcoded `CleanupGracePeriod = 5s`, which is insufficient for heavyweight tests like `e2e_dra` that require more time to shut down external processes, DaemonSets, or other resources properly.

This PR makes the cleanup grace period configurable by:
- Adding a `WithCleanupGracePeriod(time.Duration)` functional option to `initoption`.
- Renaming the package-level `CleanupGracePeriod` constant to `DefaultCleanupGracePeriod` and providing a deprecated alias for backward compatibility.
- Adding a `CleanupGracePeriod()` getter to `TContext` to retrieve the effective grace period.
- Updating `Init` and `InitCtx` to respect the configured override while falling back to the 5s default.

#### Which issue(s) this PR is related to:

Fixes #138884.

#### Special notes for your reviewer:

The `CleanupGracePeriod` constant was renamed to `DefaultCleanupGracePeriod` to avoid shadowing with the new `TContext.CleanupGracePeriod()` method. A deprecated alias has been introduced to ensure no breaking changes for external callers during the transition.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
