### PR TITLE
Set microseconds eventTime in events

### DIFF
--- a/staging/src/k8s.io/client-go/tools/record/event.go
+++ b/staging/src/k8s.io/client-go/tools/record/event.go
@@ -502,6 +502,7 @@ func (recorder *recorderImpl) makeEvent(ref *v1.ObjectReference, annotations map
 			Namespace:   namespace,
 			Annotations: annotations,
 		},
+		EventTime:      metav1.MicroTime{Time: time.Now()},
 		InvolvedObject: *ref,
 		Reason:         reason,
 		Message:        message,


### PR DESCRIPTION
Copy of https://github.com/kubernetes/kubernetes/pull/135276

**What type of PR is this?**

/kind feature
/kind api-change

**What this PR does / why we need it:**

The record events API is used by many components and controllers, setting the event time can be useful for applications consuming events emitted by this package.