### PR TITLE
cluster/addons/addon-manager: fix stale registry reference in README

### DIFF
--- a/cluster/addons/addon-manager/README.md
+++ b/cluster/addons/addon-manager/README.md
@@ -40,20 +40,20 @@ The `addon-manager` is built for multiple architectures.
 ```console
 # Build for linux/amd64 (default)
 $ make push ARCH=amd64
-# ---> staging-k8s.gcr.io/addon-manager/kube-addon-manager-amd64:VERSION
-# ---> staging-k8s.gcr.io/addon-manager/kube-addon-manager:VERSION (image with backwards-compatible naming)
+# ---> gcr.io/k8s-staging-addon-manager/kube-addon-manager-amd64:VERSION
+# ---> gcr.io/k8s-staging-addon-manager/kube-addon-manager:VERSION (image with backwards-compatible naming)
 
 $ make push ARCH=arm
-# ---> staging-k8s.gcr.io/addon-manager/kube-addon-manager-arm:VERSION
+# ---> gcr.io/k8s-staging-addon-manager/kube-addon-manager-arm:VERSION
 
 $ make push ARCH=arm64
-# ---> staging-k8s.gcr.io/addon-manager/kube-addon-manager-arm64:VERSION
+# ---> gcr.io/k8s-staging-addon-manager/kube-addon-manager-arm64:VERSION
 
 $ make push ARCH=ppc64le
-# ---> staging-k8s.gcr.io/addon-manager/kube-addon-manager-ppc64le:VERSION
+# ---> gcr.io/k8s-staging-addon-manager/kube-addon-manager-ppc64le:VERSION
 
 $ make push ARCH=s390x
-# ---> staging-k8s.gcr.io/addon-manager/kube-addon-manager-s390x:VERSION
+# ---> gcr.io/k8s-staging-addon-manager/kube-addon-manager-s390x:VERSION
 ```
 
 If you don't want to push the images, run `make` or `make build` instead


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Updates stale `staging-k8s.gcr.io` references in the build output comments of `cluster/addons/addon-manager/README.md` to `gcr.io/k8s-staging-addon-manager`, which matches the actual `IMAGE` variable in the Makefile.

`staging-k8s.gcr.io` was the old staging registry format that no longer exists. The correct staging push target is `gcr.io/k8s-staging-addon-manager`, from which images are promoted to `registry.k8s.io` for end users.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Documentation only — no logic changes. The `# --->` comments in the build example now correctly reflect where `make push` sends images, consistent with the `IMAGE=gcr.io/k8s-staging-addon-manager/kube-addon-manager` variable in the Makefile.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```