### PR TITLE
Replace remote executor code with the DefaultExecutor from kubectl

### DIFF
--- a/test/e2e/auth/per_node_update.go
+++ b/test/e2e/auth/per_node_update.go
@@ -134,7 +134,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy", func() {
 		framework.ExpectNoError(err)
 
 		// get the actual projected token from the pod.
-		nodeScopedSAToken, stderr, err := e2epod.ExecWithOptionsContext(ctx, f, e2epod.ExecOptions{
+		nodeScopedSAToken, stderr, err := e2epod.Exec(f.TContext(ctx), e2epod.ExecOptions{
 			Command:            []string{"cat", "/var/run/secrets/kubernetes.io/serviceaccount/token"},
 			Namespace:          actualPod.Namespace,
 			PodName:            actualPod.Name,

--- a/test/e2e/dra/utils/builder.go
+++ b/test/e2e/dra/utils/builder.go
@@ -549,7 +549,7 @@ var envLineRE = regexp.MustCompile(`^(?:admin|user|claim)_[a-zA-Z0-9_]*=.*$`)
 
 func TestContainerEnv(tCtx ktesting.TContext, pod *v1.Pod, containerName string, fullMatch bool, env ...string) {
 	tCtx.Helper()
-	stdout, stderr, err := e2epod.ExecWithOptionsTCtx(tCtx, e2epod.ExecOptions{
+	stdout, stderr, err := e2epod.Exec(tCtx, e2epod.ExecOptions{
 		Command:       []string{"env"},
 		Namespace:     pod.Namespace,
 		PodName:       pod.Name,

--- a/test/e2e/framework/pod/exec_util.go
+++ b/test/e2e/framework/pod/exec_util.go
@@ -37,7 +37,8 @@ import (
 	"github.com/onsi/gomega"
 )
 
-// ExecOptions passed to ExecWithOptions
+// ExecOptions controls how [Exec] runs a command inside a pod container.
+// At minimum, Command, Namespace, and PodName must be set.
 type ExecOptions struct {
 	Command       []string
 	Namespace     string
@@ -51,25 +52,16 @@ type ExecOptions struct {
 	Quiet              bool
 }
 
-// ExecWithOptions executes a command in the specified container,
+// Exec executes a command in the specified container,
 // returning stdout, stderr and error. `options` allowed for
 // additional parameters to be passed.
-func ExecWithOptions(f *framework.Framework, options ExecOptions) (string, string, error) {
-	return ExecWithOptionsContext(context.Background(), f, options)
-}
-
-func ExecWithOptionsContext(ctx context.Context, f *framework.Framework, options ExecOptions) (string, string, error) {
-	return ExecWithOptionsTCtx(f.TContext(ctx), options)
-}
-
-func ExecWithOptionsTCtx(tCtx ktesting.TContext, options ExecOptions) (string, string, error) {
+func Exec(tCtx ktesting.TContext, options ExecOptions) (string, string, error) {
 	if !options.Quiet {
-		tCtx.Logf("ExecWithOptions %+v", options)
+		tCtx.Logf("Exec %+v", options)
 	}
 
 	const tty = false
-
-	tCtx.Logf("ExecWithOptions: Clientset creation")
+	tCtx.Logf("Exec: Clientset creation")
 	req := tCtx.Client().CoreV1().RESTClient().Post().
 		Resource("pods").
 		Name(options.PodName).
@@ -85,7 +77,7 @@ func ExecWithOptionsTCtx(tCtx ktesting.TContext, options ExecOptions) (string, s
 	}, scheme.ParameterCodec)
 
 	var stdout, stderr bytes.Buffer
-	tCtx.Logf("ExecWithOptions: execute(%s)", req.URL())
+	tCtx.Logf("Exec: execute(%s)", req.URL())
 	err := execute(tCtx, req.URL(), options.Stdin, &stdout, &stderr, tty)
 
 	if options.PreserveWhitespace {
@@ -98,7 +90,7 @@ func ExecWithOptionsTCtx(tCtx ktesting.TContext, options ExecOptions) (string, s
 // specified container and return stdout, stderr and error
 func ExecCommandInContainerWithFullOutput(f *framework.Framework, podName, containerName string, cmd ...string) (string, string, error) {
 	// TODO (pohly): add context support
-	return ExecWithOptions(f, ExecOptions{
+	return Exec(f.TContext(context.Background()), ExecOptions{
 		Command:            cmd,
 		Namespace:          f.Namespace.Name,
 		PodName:            podName,
@@ -125,28 +117,20 @@ func ExecShellInContainer(f *framework.Framework, podName, containerName string,
 	return ExecCommandInContainer(f, podName, containerName, "/bin/sh", "-c", cmd)
 }
 
-func execCommandInPod(ctx context.Context, f *framework.Framework, podName string, cmd ...string) string {
-	pod, err := NewPodClient(f).Get(ctx, podName, metav1.GetOptions{})
-	framework.ExpectNoError(err, "failed to get pod %v", podName)
-	gomega.Expect(pod.Spec.Containers).NotTo(gomega.BeEmpty())
-	return ExecCommandInContainer(f, podName, pod.Spec.Containers[0].Name, cmd...)
-}
-
-func execCommandInPodWithFullOutput(ctx context.Context, f *framework.Framework, podName string, cmd ...string) (string, string, error) {
-	pod, err := NewPodClient(f).Get(ctx, podName, metav1.GetOptions{})
-	framework.ExpectNoError(err, "failed to get pod %v", podName)
-	gomega.Expect(pod.Spec.Containers).NotTo(gomega.BeEmpty())
-	return ExecCommandInContainerWithFullOutput(f, podName, pod.Spec.Containers[0].Name, cmd...)
-}
-
 // ExecShellInPod executes the specified command on the pod.
 func ExecShellInPod(ctx context.Context, f *framework.Framework, podName string, cmd string) string {
-	return execCommandInPod(ctx, f, podName, "/bin/sh", "-c", cmd)
+	pod, err := NewPodClient(f).Get(ctx, podName, metav1.GetOptions{})
+	framework.ExpectNoError(err, "failed to get pod %v", podName)
+	gomega.Expect(pod.Spec.Containers).NotTo(gomega.BeEmpty())
+	return ExecCommandInContainer(f, podName, pod.Spec.Containers[0].Name, "/bin/sh", "-c", cmd)
 }
 
 // ExecShellInPodWithFullOutput executes the specified command on the Pod and returns stdout, stderr and error.
 func ExecShellInPodWithFullOutput(ctx context.Context, f *framework.Framework, podName string, cmd string) (string, string, error) {
-	return execCommandInPodWithFullOutput(ctx, f, podName, "/bin/sh", "-c", cmd)
+	pod, err := NewPodClient(f).Get(ctx, podName, metav1.GetOptions{})
+	framework.ExpectNoError(err, "failed to get pod %v", podName)
+	gomega.Expect(pod.Spec.Containers).NotTo(gomega.BeEmpty())
+	return ExecCommandInContainerWithFullOutput(f, podName, pod.Spec.Containers[0].Name, "/bin/sh", "-c", cmd)
 }
 
 // VerifyExecInPodSucceed verifies shell cmd in target pod succeed

--- a/test/e2e/framework/pod/exec_util.go
+++ b/test/e2e/framework/pod/exec_util.go
@@ -22,19 +22,17 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"strings"
+
+	"github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/remotecommand"
 	clientexec "k8s.io/client-go/util/exec"
+	"k8s.io/kubectl/pkg/cmd/exec"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/utils/client-go/ktesting"
-	"k8s.io/streaming/pkg/httpstream"
-
-	"github.com/onsi/gomega"
 )
 
 // ExecOptions controls how [Exec] runs a command inside a pod container.
@@ -78,7 +76,8 @@ func Exec(tCtx ktesting.TContext, options ExecOptions) (string, string, error) {
 
 	var stdout, stderr bytes.Buffer
 	tCtx.Logf("Exec: execute(%s)", req.URL())
-	err := execute(tCtx, req.URL(), options.Stdin, &stdout, &stderr, tty)
+	executor := exec.DefaultRemoteExecutor{}
+	err := executor.ExecuteWithContext(tCtx, req.URL(), tCtx.RESTConfig(), options.Stdin, &stdout, &stderr, tty, nil)
 
 	if options.PreserveWhitespace {
 		return stdout.String(), stderr.String(), err
@@ -168,36 +167,4 @@ func VerifyExecInPodFail(ctx context.Context, f *framework.Framework, pod *v1.Po
 		}
 	}
 	return fmt.Errorf("%q should fail with exit code %d, but exit without error", shExec, exitCode)
-}
-
-func execute(tCtx ktesting.TContext, url *url.URL, stdin io.Reader, stdout, stderr io.Writer, tty bool) error {
-	config := tCtx.RESTConfig()
-	// WebSocketExecutor executor is default
-	// WebSocketExecutor must be "GET" method as described in RFC 6455 Sec. 4.1 (page 17).
-	websocketExec, err := remotecommand.NewWebSocketExecutor(config, "GET", url.String())
-	if err != nil {
-		return err
-	}
-	spdyExec, err := remotecommand.NewSPDYExecutor(config, "POST", url)
-	if err != nil {
-		return err
-	}
-	exec, err := remotecommand.NewFallbackExecutor(websocketExec, spdyExec, func(err error) bool {
-		if httpstream.IsUpgradeFailure(err) || httpstream.IsHTTPSProxyError(err) {
-			framework.Logf("fallback to secondary dialer from primary dialer err: %v", err)
-			return true
-		}
-		framework.Logf("unexpected error trying to use websockets for pod exec: %v", err)
-		return false
-	})
-	if err != nil {
-		return err
-	}
-
-	return exec.StreamWithContext(tCtx, remotecommand.StreamOptions{
-		Stdin:  stdin,
-		Stdout: stdout,
-		Stderr: stderr,
-		Tty:    tty,
-	})
 }

--- a/test/e2e/kubectl/exec.go
+++ b/test/e2e/kubectl/exec.go
@@ -35,7 +35,7 @@ func worker(f *framework.Framework, pod *v1.Pod, id int, jobs <-chan int, result
 		func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
-			stdout, stderr, err := e2epod.ExecWithOptionsContext(ctx, f, e2epod.ExecOptions{
+			stdout, stderr, err := e2epod.Exec(f.TContext(ctx), e2epod.ExecOptions{
 				Command:            []string{"date"},
 				Namespace:          f.Namespace.Name,
 				PodName:            pod.Name,

--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -497,7 +497,7 @@ var _ = common.SIGDescribe("DNS", func() {
 
 		runCommand := func(arg string) string {
 			cmd := []string{"/agnhost", arg}
-			stdout, stderr, err := e2epod.ExecWithOptions(f, e2epod.ExecOptions{
+			stdout, stderr, err := e2epod.Exec(f.TContext(ctx), e2epod.ExecOptions{
 				Command:       cmd,
 				Namespace:     f.Namespace.Name,
 				PodName:       testAgnhostPod.Name,
@@ -571,7 +571,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		ginkgo.By("Verifying customized DNS option is configured on pod...")
 		// TODO: Figure out a better way other than checking the actual resolv,conf file.
 		cmd := []string{"cat", "/etc/resolv.conf"}
-		stdout, stderr, err := e2epod.ExecWithOptions(f, e2epod.ExecOptions{
+		stdout, stderr, err := e2epod.Exec(f.TContext(ctx), e2epod.ExecOptions{
 			Command:       cmd,
 			Namespace:     f.Namespace.Name,
 			PodName:       testUtilsPod.Name,
@@ -591,7 +591,7 @@ var _ = common.SIGDescribe("DNS", func() {
 		// - DNS query is sent to the specified server.
 		cmd = []string{"dig", "+short", "+search", testDNSNameShort}
 		digFunc := func() (bool, error) {
-			stdout, stderr, err := e2epod.ExecWithOptions(f, e2epod.ExecOptions{
+			stdout, stderr, err := e2epod.Exec(f.TContext(ctx), e2epod.ExecOptions{
 				Command:       cmd,
 				Namespace:     f.Namespace.Name,
 				PodName:       testUtilsPod.Name,

--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -128,7 +128,7 @@ func (t *dnsTestCommon) runDig(dnsName, target string) []string {
 	}
 	cmd = append(cmd, dnsName)
 
-	stdout, stderr, err := e2epod.ExecWithOptions(t.f, e2epod.ExecOptions{
+	stdout, stderr, err := e2epod.Exec(t.f.TContext(context.Background()), e2epod.ExecOptions{
 		Command:       cmd,
 		Namespace:     t.f.Namespace.Name,
 		PodName:       t.utilPod.Name,

--- a/test/e2e/network/netpol/kubemanager.go
+++ b/test/e2e/network/netpol/kubemanager.go
@@ -236,7 +236,7 @@ func (k *kubeManager) probeConnectivity(args *probeConnectivityArgs) (bool, stri
 
 // executeRemoteCommand executes a remote shell command on the given pod.
 func (k *kubeManager) executeRemoteCommand(namespace string, pod string, command []string) (string, string, error) {
-	return e2epod.ExecWithOptions(k.framework, e2epod.ExecOptions{
+	return e2epod.Exec(k.framework.TContext(context.Background()), e2epod.ExecOptions{
 		Command:            command,
 		Namespace:          namespace,
 		PodName:            pod,

--- a/test/e2e/storage/drivers/proxy/io.go
+++ b/test/e2e/storage/drivers/proxy/io.go
@@ -69,8 +69,7 @@ func (p PodDirIO) Mkdir(path string) error {
 func (p PodDirIO) CreateFile(path string, content io.Reader) error {
 	// Piping the content into dd via stdin turned out to be unreliable.
 	// Sometimes dd would stop after writing zero bytes, without an error
-	// from ExecWithOptions (reported as
-	// https://github.com/kubernetes/kubernetes/issues/112834).
+	// from Exec (reported as https://github.com/kubernetes/kubernetes/issues/112834).
 	//
 	// Therefore the content is now encoded inside the command itself.
 	data, err := io.ReadAll(content)
@@ -105,7 +104,7 @@ func (p PodDirIO) RemoveAll(path string) error {
 }
 
 func (p PodDirIO) execute(command []string, stdin io.Reader) (string, string, error) {
-	stdout, stderr, err := e2epod.ExecWithOptionsTCtx(p.TCtx, e2epod.ExecOptions{
+	stdout, stderr, err := e2epod.Exec(p.TCtx, e2epod.ExecOptions{
 		Command:       command,
 		Namespace:     p.Namespace,
 		PodName:       p.PodName,

--- a/test/e2e/storage/utils/host_exec.go
+++ b/test/e2e/storage/utils/host_exec.go
@@ -156,7 +156,7 @@ func (h *hostExecutor) exec(ctx context.Context, cmd string, node *v1.Node) (Res
 	}
 	containerName := pod.Spec.Containers[0].Name
 	var err error
-	result.Stdout, result.Stderr, err = e2epod.ExecWithOptions(h.Framework, e2epod.ExecOptions{
+	result.Stdout, result.Stderr, err = e2epod.Exec(h.Framework.TContext(ctx), e2epod.ExecOptions{
 		Command:            args,
 		Namespace:          pod.Namespace,
 		PodName:            pod.Name,

--- a/test/e2e/windows/dns.go
+++ b/test/e2e/windows/dns.go
@@ -80,7 +80,7 @@ var _ = sigDescribe(feature.Windows, "DNS", skipUnlessWindows(func() {
 		// This isn't the best 'test' but it is a great diagnostic, see later test for the 'real' test.
 		ginkgo.By("Calling ipconfig to get debugging info for this pod's DNS and confirm that a dns server 1.1.1.1 can be injected, along with ")
 		cmd := []string{"ipconfig", "/all"}
-		stdout, _, err := e2epod.ExecWithOptions(f, e2epod.ExecOptions{
+		stdout, _, err := e2epod.Exec(f.TContext(ctx), e2epod.ExecOptions{
 			Command:       cmd,
 			Namespace:     f.Namespace.Name,
 			PodName:       testPod.Name,
@@ -105,7 +105,7 @@ var _ = sigDescribe(feature.Windows, "DNS", skipUnlessWindows(func() {
 		// TODO @jayunit100 add ResolveHost to agn images
 
 		cmd = []string{"curl.exe", "-k", "https://kubernetezzzzzzzz:443"}
-		stdout, _, err = e2epod.ExecWithOptions(f, e2epod.ExecOptions{
+		stdout, _, err = e2epod.Exec(f.TContext(ctx), e2epod.ExecOptions{
 			Command:       cmd,
 			Namespace:     f.Namespace.Name,
 			PodName:       testPod.Name,
@@ -120,7 +120,7 @@ var _ = sigDescribe(feature.Windows, "DNS", skipUnlessWindows(func() {
 
 		ginkgo.By("Verifying that injected dns records for 'kubernetes' resolve to the valid ip address")
 		cmd = []string{"curl.exe", "-k", "https://kubernetes:443"}
-		stdout, _, err = e2epod.ExecWithOptions(f, e2epod.ExecOptions{
+		stdout, _, err = e2epod.Exec(f.TContext(ctx), e2epod.ExecOptions{
 			Command:       cmd,
 			Namespace:     f.Namespace.Name,
 			PodName:       testPod.Name,


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig testing
/sig cli

#### What this PR does / why we need it:
This PR does two things:
1. Cleans up several exec helpers and squashes into smaller API surface.
2. Replaces the implementation of the remote executor with the one from kubectl, to eliminate code duplication.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
/assign @ardaguclu 
for sig-cli visibility
/assign @pohly 
for sig-testing visibility

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
