### PR TITLE
pkg/kubelet: migrate NewFileStore callers to NewFileStoreWithLogger

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -993,7 +993,7 @@ func buildKubeletClientConfig(ctx context.Context, s *options.KubeletServer, tp 
 
 		kubeClientConfigOverrides(s, clientConfig)
 
-		clientCertificateManager, err := buildClientCertificateManager(certConfig, clientConfig, s.CertDirectory, nodeName)
+		clientCertificateManager, err := buildClientCertificateManager(logger, certConfig, clientConfig, s.CertDirectory, nodeName)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1095,7 +1095,7 @@ func updateDialer(clientConfig *restclient.Config) (func(), error) {
 // buildClientCertificateManager creates a certificate manager that will use certConfig to request a client certificate
 // if no certificate is available, or the most recent clientConfig (which is assumed to point to the cert that the manager will
 // write out).
-func buildClientCertificateManager(certConfig, clientConfig *restclient.Config, certDir string, nodeName types.NodeName) (certificate.Manager, error) {
+func buildClientCertificateManager(logger klog.Logger, certConfig, clientConfig *restclient.Config, certDir string, nodeName types.NodeName) (certificate.Manager, error) {
 	newClientsetFn := func(current *tls.Certificate) (clientset.Interface, error) {
 		// If we have a valid certificate, use that to fetch CSRs. Otherwise use the bootstrap
 		// credentials. In the future it would be desirable to change the behavior of bootstrap
@@ -1109,6 +1109,7 @@ func buildClientCertificateManager(certConfig, clientConfig *restclient.Config, 
 	}
 
 	return kubeletcertificate.NewKubeletClientCertificateManager(
+		logger,
 		certDir,
 		nodeName,
 

--- a/cmd/kubelet/app/server_bootstrap_test.go
+++ b/cmd/kubelet/app/server_bootstrap_test.go
@@ -44,6 +44,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/component-base/featuregate"
+	"k8s.io/klog/v2/ktesting"
 	capihelper "k8s.io/kubernetes/pkg/apis/certificates/v1"
 	"k8s.io/kubernetes/pkg/controller/certificates/authority"
 )
@@ -88,7 +89,8 @@ func Test_buildClientCertificateManager(t *testing.T) {
 	}
 
 	nodeName := types.NodeName("test")
-	m, err := buildClientCertificateManager(config1, config2, testDir, nodeName)
+	logger, _ := ktesting.NewTestContext(t)
+	m, err := buildClientCertificateManager(logger, config1, config2, testDir, nodeName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +158,8 @@ func Test_buildClientCertificateManager_populateCertDir(t *testing.T) {
 		Host:      "http://localhost",
 	}
 	nodeName := types.NodeName("test")
-	if _, err := buildClientCertificateManager(config1, config2, testDir, nodeName); err != nil {
+	logger, _ := ktesting.NewTestContext(t)
+	if _, err := buildClientCertificateManager(logger, config1, config2, testDir, nodeName); err != nil {
 		t.Fatal(err)
 	}
 	fi := getFileInfo(testDir)
@@ -167,7 +170,7 @@ func Test_buildClientCertificateManager_populateCertDir(t *testing.T) {
 	// an invalid cert should be ignored
 	config2.CertData = []byte("invalid contents")
 	config2.KeyData = []byte("invalid contents")
-	if _, err := buildClientCertificateManager(config1, config2, testDir, nodeName); err == nil {
+	if _, err := buildClientCertificateManager(logger, config1, config2, testDir, nodeName); err == nil {
 		t.Fatal("unexpected non error")
 	}
 	fi = getFileInfo(testDir)
@@ -178,7 +181,7 @@ func Test_buildClientCertificateManager_populateCertDir(t *testing.T) {
 	// an expired client certificate should be written to disk, because the cert manager can
 	// use config1 to refresh it and the cert manager won't return it for clients.
 	config2.CertData, config2.KeyData = genClientCert(t, time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
-	if _, err := buildClientCertificateManager(config1, config2, testDir, nodeName); err != nil {
+	if _, err := buildClientCertificateManager(logger, config1, config2, testDir, nodeName); err != nil {
 		t.Fatal(err)
 	}
 	fi = getFileInfo(testDir)
@@ -188,7 +191,7 @@ func Test_buildClientCertificateManager_populateCertDir(t *testing.T) {
 
 	// a valid, non-expired client certificate should be written to disk
 	config2.CertData, config2.KeyData = genClientCert(t, time.Now().Add(-time.Hour), time.Now().Add(24*time.Hour))
-	if _, err := buildClientCertificateManager(config1, config2, testDir, nodeName); err != nil {
+	if _, err := buildClientCertificateManager(logger, config1, config2, testDir, nodeName); err != nil {
 		t.Fatal(err)
 	}
 	fi = getFileInfo(testDir)

--- a/pkg/kubelet/certificate/bootstrap/bootstrap.go
+++ b/pkg/kubelet/certificate/bootstrap/bootstrap.go
@@ -66,7 +66,7 @@ func LoadClientConfig(logger klog.Logger, kubeconfigPath, bootstrapPath, certDir
 		return clientConfig, restclient.CopyConfig(clientConfig), nil
 	}
 
-	store, err := certificate.NewFileStore("kubelet-client", certDir, certDir, "", "")
+	store, err := certificate.NewFileStoreWithLogger(logger, "kubelet-client", certDir, certDir, "", "")
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to build bootstrap cert store")
 	}
@@ -130,7 +130,7 @@ func LoadClientCert(ctx context.Context, kubeconfigPath, bootstrapPath, certDir 
 		return fmt.Errorf("unable to create certificates signing request client: %v", err)
 	}
 
-	store, err := certificate.NewFileStore("kubelet-client", certDir, certDir, "", "")
+	store, err := certificate.NewFileStoreWithLogger(logger, "kubelet-client", certDir, certDir, "", "")
 	if err != nil {
 		return fmt.Errorf("unable to build bootstrap cert store")
 	}

--- a/pkg/kubelet/certificate/kubelet.go
+++ b/pkg/kubelet/certificate/kubelet.go
@@ -72,14 +72,15 @@ func newGetTemplateFn(nodeName types.NodeName, getAddresses func() []v1.NodeAddr
 
 // NewKubeletServerCertificateManager creates a certificate manager for the kubelet when retrieving a server certificate
 // or returns an error.
-func NewKubeletServerCertificateManager(kubeClient clientset.Interface, kubeCfg *kubeletconfig.KubeletConfiguration, nodeName types.NodeName, getAddresses func() []v1.NodeAddress, certDirectory string) (certificate.Manager, error) {
+func NewKubeletServerCertificateManager(logger klog.Logger, kubeClient clientset.Interface, kubeCfg *kubeletconfig.KubeletConfiguration, nodeName types.NodeName, getAddresses func() []v1.NodeAddress, certDirectory string) (certificate.Manager, error) {
 	var clientsetFn certificate.ClientsetFunc
 	if kubeClient != nil {
 		clientsetFn = func(current *tls.Certificate) (clientset.Interface, error) {
 			return kubeClient, nil
 		}
 	}
-	certificateStore, err := certificate.NewFileStore(
+	certificateStore, err := certificate.NewFileStoreWithLogger(
+		logger,
 		"kubelet-server",
 		certDirectory,
 		certDirectory,
@@ -197,6 +198,7 @@ func addressesToHostnamesAndIPs(addresses []v1.NodeAddress) (dnsNames []string, 
 // client that can be used to sign new certificates (or rotate). If a CSR
 // client is set later, it may begin rotating/renewing the client cert.
 func NewKubeletClientCertificateManager(
+	logger klog.Logger,
 	certDirectory string,
 	nodeName types.NodeName,
 	bootstrapCertData []byte,
@@ -206,7 +208,8 @@ func NewKubeletClientCertificateManager(
 	clientsetFn certificate.ClientsetFunc,
 ) (certificate.Manager, error) {
 
-	certificateStore, err := certificate.NewFileStore(
+	certificateStore, err := certificate.NewFileStoreWithLogger(
+		logger,
 		"kubelet-client",
 		certDirectory,
 		certDirectory,

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -920,7 +920,7 @@ func NewMainKubelet(ctx context.Context,
 
 		// kubelet configuration that automatically rotates serving certs
 		if kubeCfg.ServerTLSBootstrap && utilfeature.DefaultFeatureGate.Enabled(features.RotateKubeletServerCertificate) {
-			klet.serverCertificateManager, err = kubeletcertificate.NewKubeletServerCertificateManager(klet.kubeClient, kubeCfg, klet.nodeName, func() []v1.NodeAddress {
+			klet.serverCertificateManager, err = kubeletcertificate.NewKubeletServerCertificateManager(logger, klet.kubeClient, kubeCfg, klet.nodeName, func() []v1.NodeAddress {
 				return klet.getLastObservedNodeAddresses(ctx)
 			}, certDirectory)
 			if err != nil {


### PR DESCRIPTION
Migrate all callers of certificate.NewFileStore to use the contextual
logging variant certificate.NewFileStoreWithLogger, passing a logger
from the calling context.

Changes:
- pkg/kubelet/certificate/kubelet.go: add logger param to
  NewKubeletServerCertificateManager and NewKubeletClientCertificateManager
- pkg/kubelet/certificate/bootstrap/bootstrap.go: use logger already
  available in LoadClientConfig and LoadClientCert
- pkg/kubelet/kubelet.go: pass logger to NewKubeletServerCertificateManager
- cmd/kubelet/app/server.go: add logger param to
  buildClientCertificateManager and pass through

Fixes part of #126379


```release-note
NONE
```