### PR TITLE
Automated cherry pick of #138584: [chore] test/compatibility_lifecycle: resolve feature names from variables

### DIFF
--- a/test/compatibility_lifecycle/cmd/feature_gates.go
+++ b/test/compatibility_lifecycle/cmd/feature_gates.go
@@ -60,7 +60,10 @@ type featureSpec struct {
 }
 
 type featureInfo struct {
-	Name           string        `yaml:"name" json:"name"`
+	Name string `yaml:"name" json:"name"`
+	// FullName is the full name of the feature, including the package name,
+	// used for ensuring that features are grouped by their package prefix first,
+	// and then sorted alphabetically within that group.
 	FullName       string        `yaml:"-" json:"-"`
 	VersionedSpecs []featureSpec `yaml:"versionedSpecs" json:"versionedSpecs"`
 }
@@ -435,9 +438,20 @@ func isFeatureSpecType(v ast.Expr, aliasMap map[string]string) bool {
 }
 
 func parseFeatureInfo(variables map[string]ast.Expr, kv *ast.KeyValueExpr) (featureInfo, error) {
+	name := identifierName(kv.Key, true)
+	fullName := identifierName(kv.Key, false)
+
+	if id, ok := kv.Key.(*ast.Ident); ok {
+		if varVal, ok := variables[id.Name]; ok {
+			if strVal, err := basicStringLiteral(varVal); err == nil {
+				name = strVal
+			}
+		}
+	}
+
 	info := featureInfo{
-		Name:           identifierName(kv.Key, true),
-		FullName:       identifierName(kv.Key, false),
+		Name:           name,
+		FullName:       fullName,
 		VersionedSpecs: []featureSpec{},
 	}
 	specExps := []ast.Expr{}

--- a/test/compatibility_lifecycle/cmd/feature_gates_test.go
+++ b/test/compatibility_lifecycle/cmd/feature_gates_test.go
@@ -108,7 +108,7 @@ func TestVerifyOrUpdateFeatureListVersioned(t *testing.T) {
     lockToDefault: false
     preRelease: Beta
     version: "1.30"
-- name: CPUCFSQuotaPeriod
+- name: CustomCPUCFSQuotaPeriod
   versionedSpecs:
   - default: false
     lockToDefault: false
@@ -136,6 +136,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/component-base/featuregate"
 )
+
+const CPUCFSQuotaPeriod featuregate.Feature = "CustomCPUCFSQuotaPeriod"
+
 var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
 	AppArmorFields: {
 		{Version: version.MajorMinor(1, 30), Default: true, PreRelease: featuregate.Beta},
@@ -166,6 +169,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/component-base/featuregate"
 )
+
+const CPUCFSQuotaPeriod featuregate.Feature = "CustomCPUCFSQuotaPeriod"
+
 var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
 	AppArmorFields: {
 		{Version: version.MajorMinor(1, 30), Default: true, PreRelease: featuregate.Beta},
@@ -196,7 +202,7 @@ var otherFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
     lockToDefault: false
     preRelease: Beta
     version: "1.30"
-- name: CPUCFSQuotaPeriod
+- name: CustomCPUCFSQuotaPeriod
   versionedSpecs:
   - default: false
     lockToDefault: false
@@ -276,6 +282,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/component-base/featuregate"
 )
+
+const CPUCFSQuotaPeriod featuregate.Feature = "CustomCPUCFSQuotaPeriod"
+
 var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
 	AppArmorFields: {
 		{Version: version.MajorMinor(1, 30), Default: true, PreRelease: featuregate.Beta},
@@ -312,7 +321,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
     lockToDefault: false
     preRelease: Beta
     version: "1.30"
-- name: CPUCFSQuotaPeriod
+- name: CustomCPUCFSQuotaPeriod
   versionedSpecs:
   - default: false
     lockToDefault: false
@@ -333,6 +342,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/component-base/featuregate"
 )
+
+const CPUCFSQuotaPeriod featuregate.Feature = "CustomCPUCFSQuotaPeriod"
+
 var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
 	CPUCFSQuotaPeriod: {
 		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
@@ -373,6 +385,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/component-base/featuregate"
 )
+
+const CPUCFSQuotaPeriod featuregate.Feature = "CustomCPUCFSQuotaPeriod"
+
 var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
 	AppArmorFields: {
 		{Version: version.MajorMinor(1, 30), Default: true, PreRelease: featuregate.Beta},
@@ -401,7 +416,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
     lockToDefault: false
     preRelease: Beta
     version: "1.30"
-- name: CPUCFSQuotaPeriod
+- name: CustomCPUCFSQuotaPeriod
   versionedSpecs:
   - default: false
     lockToDefault: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -299,12 +299,6 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.33"
-- name: CPUCFSQuotaPeriod
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: "1.12"
 - name: CPUManagerPolicyAlphaOptions
   versionedSpecs:
   - default: false
@@ -385,6 +379,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "1.21"
+- name: CustomCPUCFSQuotaPeriod
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "1.12"
 - name: CustomResourceFieldSelectors
   versionedSpecs:
   - default: false
@@ -1409,7 +1409,7 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.12"
-- name: RuntimeClassInImageCriAPI
+- name: RuntimeClassInImageCriApi
   versionedSpecs:
   - default: false
     lockToDefault: false


### PR DESCRIPTION
Cherry pick of #138584 on release-1.34.

#138584: [chore] test/compatibility_lifecycle: resolve feature names from variables

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind failing-test


```release-note

```