### PR TITLE
[WIP] Update verify.sh to improve codegen output on failure

### DIFF
--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -236,13 +236,31 @@ ret=0
 # to ensure that modules that aren't part of the workspace and/or are
 # not dependencies are checked too.
 # . and staging are listed explicitly here to avoid _output
-for module in ./go.mod ./staging/**/go.mod; do
-  module="${module%/go.mod}"
-  if [ -d "$module/hack" ]; then
-    kube::util::run-in "$module" run-checks "hack/verify-*.sh" bash
-    kube::util::run-in "$module" run-checks "hack/verify-*.py" python3
+# Wrap each script in a single juLog testcase across all modules.
+function run-across-modules {
+  local script
+  script="$(basename "$1")"
+  local runner
+  if [[ "$script" == *.py ]]; then
+    runner=python3
+  else
+    runner=bash
   fi
-done
+  local rc=0
+  for module in ./go.mod ./staging/**/go.mod; do
+    module="${module%/go.mod}"
+    if [[ ! -f "$module/hack/$script" ]]; then
+      continue
+    fi
+    echo "=== ${module#./} ==="
+    if ! kube::util::run-in "$module" "$runner" "hack/$script"; then
+      rc=1
+    fi
+  done
+  return "$rc"
+}
+run-checks "hack/verify-*.sh" run-across-modules
+run-checks "hack/verify-*.py" run-across-modules
 missing-target-checks
 
 if [[ ${ret} -eq 1 ]]; then


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`hack/make-rules/verify.sh` previously emitted one junit testcase per (script, module) pair, so a multi-module check like `verify-codegen` produced 7 testcases all named `codegen`.

When a PR's changes only affect some staging modules, the mixed pass/fail across those 7 testcases gets misreported as flake (see https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/138895/pull-kubernetes-verify/2053140712085524480). It shows codegen as flaky but in reality it should be considered failure as it failed for 6 staging modules and passed for one module.

This wraps each script in a single juLog testcase across all modules instead.

Failure preview: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/138980/pull-kubernetes-verify/2054012734411902976

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
