### PR TITLE
test(dynamicresources): assert in-flight claim is not replaced on second signal

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dra_manager_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dra_manager_test.go
@@ -60,6 +60,16 @@ func testSignalClaimPendingAllocation(tCtx ktesting.TContext) {
 				otherClaimUID: {claim: allocatedClaim2, sharers: 10},
 			},
 		},
+		"already-exists-ignores-different-claim-argument": {
+			inFlightAllocations: map[types.UID]inFlightAllocation{
+				claimUID: {claim: allocatedClaim, sharers: 1},
+			},
+			claimUID:       claimUID,
+			allocatedClaim: allocatedClaim2,
+			expectedInFlightAllocations: map[types.UID]inFlightAllocation{
+				claimUID: {claim: allocatedClaim, sharers: 2},
+			},
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds a focused unit test for `claimTracker.SignalClaimPendingAllocation` when a claim UID is already present in `inFlightAllocations`.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### What this PR changes
- Extends `TestSignalClaimPendingAllocation` with `already-exists-ignores-different-claim-argument`:
  - Precondition: UID maps to `{ claim: allocatedClaim, sharers: 1 }`.
  - Action: `SignalClaimPendingAllocation(uid, allocatedClaim2)` (different pointer than stored).
  - Expectation: map entry is `{ claim: allocatedClaim, sharers: 2 }` same stored claim, incremented sharers only.

#### Special notes for your reviewer:
This PR adds a unit test that documents and locks in the current behavior explicitly. The test covers the case where duplicate signals are issued for the same UID using a different claim pointer and verifies that:

- the original stored claim remains unchanged
- only the `sharers` count is incremented

This makes the current behavior explicit and protects it against unintended changes during future refactoring.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
