### PR TITLE
kubelet/devicemanager: honor --root-dir for device-plugin socket (with legacy fallback)

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -308,7 +308,7 @@ func NewContainerManager(ctx context.Context, mountUtil mount.Interface, cadviso
 	}
 
 	logger.Info("Creating device plugin manager")
-	cm.deviceManager, err = devicemanager.NewManagerImpl(logger, machineInfo.Topology, cm.topologyManager)
+	cm.deviceManager, err = devicemanager.NewManagerImpl(logger, nodeConfig.KubeletRootDir, machineInfo.Topology, cm.topologyManager)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -188,7 +188,7 @@ func NewContainerManager(ctx context.Context, mountUtil mount.Interface, cadviso
 	}
 
 	logger.Info("Creating device plugin manager")
-	cm.deviceManager, err = devicemanager.NewManagerImpl(logger, nil, cm.topologyManager)
+	cm.deviceManager, err = devicemanager.NewManagerImpl(logger, nodeConfig.KubeletRootDir, nil, cm.topologyManager)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -67,7 +67,10 @@ type ManagerImpl struct {
 	endpoints map[string]endpointInfo // Key is ResourceName
 	mutex     sync.Mutex
 
-	server plugin.Server
+	// servers are the device plugin registration listeners. servers[0] is
+	// the primary listener (rooted under --root-dir). Additional entries are
+	// back-compat listeners (e.g. the hardcoded /var/lib/kubelet path).
+	servers []plugin.Server
 
 	// activePods is a method for listing active pods on the node
 	// so the amount of pluginResources requested by existing pods
@@ -130,17 +133,42 @@ type PodReusableDevices map[string]map[string]sets.Set[string]
 func (s *sourcesReadyStub) AddSource(source string) {}
 func (s *sourcesReadyStub) AllReady() bool          { return true }
 
-// NewManagerImpl creates a new manager.
-func NewManagerImpl(logger klog.Logger, topology []cadvisorapi.Node, topologyAffinityStore topologymanager.Store) (*ManagerImpl, error) {
-	socketPath := pluginapi.KubeletSocket
-	if runtime.GOOS == "windows" {
-		socketPath = os.Getenv("SYSTEMDRIVE") + pluginapi.KubeletSocketWindows
-	}
-	return newManagerImpl(logger, socketPath, topology, topologyAffinityStore)
+// NewManagerImpl creates a new manager. rootDir is the kubelet root directory
+// (the value of --root-dir). When rootDir is empty, the legacy hardcoded path
+// is used as the only listener.
+func NewManagerImpl(logger klog.Logger, rootDir string, topology []cadvisorapi.Node, topologyAffinityStore topologymanager.Store) (*ManagerImpl, error) {
+	return newManagerImpl(logger, devicePluginSocketPaths(rootDir), topology, topologyAffinityStore)
 }
 
-func newManagerImpl(logger klog.Logger, socketPath string, topology []cadvisorapi.Node, topologyAffinityStore topologymanager.Store) (*ManagerImpl, error) {
-	logger.V(2).Info("Creating Device Plugin manager", "path", socketPath)
+// devicePluginSocketPaths returns the listen socket paths for the device
+// plugin registration server. The primary path lives under rootDir; when
+// rootDir differs from the legacy hardcoded location, the legacy path is also
+// returned so that plugins compiled against pluginapi.KubeletSocket continue
+// to work without modification.
+func devicePluginSocketPaths(rootDir string) []string {
+	legacy := pluginapi.KubeletSocket
+	if runtime.GOOS == "windows" {
+		legacy = os.Getenv("SYSTEMDRIVE") + pluginapi.KubeletSocketWindows
+	}
+	if rootDir == "" {
+		return []string{legacy}
+	}
+	// Clean rootDir before deriving the primary path so equality with the
+	// legacy hardcoded path is robust against trailing slashes and . segments;
+	// a stale mismatch here would cause both listeners to target the same
+	// socket and fail to bind.
+	primary := filepath.Join(filepath.Clean(rootDir), "device-plugins", "kubelet.sock")
+	if primary == legacy {
+		return []string{primary}
+	}
+	return []string{primary, legacy}
+}
+
+func newManagerImpl(logger klog.Logger, socketPaths []string, topology []cadvisorapi.Node, topologyAffinityStore topologymanager.Store) (*ManagerImpl, error) {
+	if len(socketPaths) == 0 {
+		return nil, fmt.Errorf("at least one device plugin socket path is required")
+	}
+	logger.V(2).Info("Creating Device Plugin manager", "primary", socketPaths[0], "extras", socketPaths[1:])
 
 	var numaNodes []int
 	for _, node := range topology {
@@ -161,13 +189,14 @@ func newManagerImpl(logger klog.Logger, socketPath string, topology []cadvisorap
 		update:                make(chan resourceupdates.Update, 100),
 	}
 
-	server, err := plugin.NewServer(logger, socketPath, manager, manager)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create plugin server: %v", err)
+	for _, sp := range socketPaths {
+		server, err := plugin.NewServer(logger, sp, manager, manager)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create plugin server for %q: %v", sp, err)
+		}
+		manager.servers = append(manager.servers, server)
 	}
-
-	manager.server = server
-	manager.checkpointdir, _ = filepath.Split(server.SocketPath())
+	manager.checkpointdir, _ = filepath.Split(manager.servers[0].SocketPath())
 
 	// The following structures are populated with real implementations in manager.Start()
 	// Before that, initializes them to perform no-op operations.
@@ -345,14 +374,18 @@ func (m *ManagerImpl) genericDeviceUpdateCallback(logger klog.Logger, resourceNa
 	logger.V(2).Info("Processed device updates for resource", "resourceName", resourceName, "totalCount", len(devices), "healthyCount", healthyCount)
 }
 
-// GetWatcherHandler returns the plugin handler
+// GetWatcherHandler returns the plugin handler. The primary (rootdir-relative)
+// server is returned because the kubelet plugin-watcher only watches the
+// rootdir-relative plugins_registry directory.
 func (m *ManagerImpl) GetWatcherHandler() cache.PluginHandler {
-	return m.server
+	return m.servers[0]
 }
 
-// GetHealthChecker returns the plugin handler
+// GetHealthChecker returns the plugin handler health checker for the primary
+// server. Back-compat listener failures are surfaced via Start errors rather
+// than ongoing healthz reporting.
 func (m *ManagerImpl) GetHealthChecker() healthz.HealthChecker {
-	return m.server
+	return m.servers[0]
 }
 
 // checkpointFile returns device plugin checkpoint file path.
@@ -377,14 +410,25 @@ func (m *ManagerImpl) Start(logger klog.Logger, activePods ActivePodsFunc, sourc
 		logger.Error(err, "Continue after failing to read checkpoint file. Device allocation info may NOT be up-to-date")
 	}
 
-	return m.server.Start(logger)
+	for _, srv := range m.servers {
+		if err := srv.Start(logger); err != nil {
+			return fmt.Errorf("failed to start device plugin server at %q: %v", srv.SocketPath(), err)
+		}
+	}
+	return nil
 }
 
-// Stop is the function that can stop the plugin server.
+// Stop is the function that can stop the plugin servers.
 // Can be called concurrently, more than once, and is safe to call
 // without a prior Start.
 func (m *ManagerImpl) Stop(logger klog.Logger) error {
-	return m.server.Stop(logger)
+	var errs []error
+	for _, srv := range m.servers {
+		if err := srv.Stop(logger); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errorsutil.NewAggregate(errs)
 }
 
 // Allocate is the call that you can use to allocate a set of devices

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -192,7 +192,7 @@ func newManagerImpl(logger klog.Logger, socketPaths []string, topology []cadviso
 	for _, sp := range socketPaths {
 		server, err := plugin.NewServer(logger, sp, manager, manager)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create plugin server for %q: %v", sp, err)
+			return nil, fmt.Errorf("failed to create plugin server for %q: %w", sp, err)
 		}
 		manager.servers = append(manager.servers, server)
 	}
@@ -410,9 +410,18 @@ func (m *ManagerImpl) Start(logger klog.Logger, activePods ActivePodsFunc, sourc
 		logger.Error(err, "Continue after failing to read checkpoint file. Device allocation info may NOT be up-to-date")
 	}
 
-	for _, srv := range m.servers {
+	for i, srv := range m.servers {
 		if err := srv.Start(logger); err != nil {
-			return fmt.Errorf("failed to start device plugin server at %q: %v", srv.SocketPath(), err)
+			// Roll back the servers we already started. Callers typically
+			// `defer Stop()` only after Start returns successfully, so a
+			// partially started manager would otherwise leak the running
+			// listeners.
+			for _, started := range m.servers[:i] {
+				if stopErr := started.Stop(logger); stopErr != nil {
+					logger.Error(stopErr, "Failed to stop device plugin server while rolling back partial start", "socket", started.SocketPath())
+				}
+			}
+			return fmt.Errorf("failed to start device plugin server at %q: %w", srv.SocketPath(), err)
 		}
 	}
 	return nil

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -19,6 +19,7 @@ package devicemanager
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -163,12 +164,8 @@ func TestNewManagerImplDualSockets(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	topologyStore := topologymanager.NewFakeManager(logger)
 
-	primaryDir, err := os.MkdirTemp("", "device_plugin_primary")
-	require.NoError(t, err)
-	defer os.RemoveAll(primaryDir)
-	compatDir, err := os.MkdirTemp("", "device_plugin_compat")
-	require.NoError(t, err)
-	defer os.RemoveAll(compatDir)
+	primaryDir := t.TempDir()
+	compatDir := t.TempDir()
 
 	primarySocket := filepath.Join(primaryDir, "kubelet.sock")
 	compatSocket := filepath.Join(compatDir, "kubelet.sock")
@@ -180,6 +177,70 @@ func TestNewManagerImplDualSockets(t *testing.T) {
 	require.Equal(t, compatSocket, m.servers[1].SocketPath())
 	// Checkpoint must live under the primary (rootdir-relative) directory.
 	require.Equal(t, primaryDir+string(filepath.Separator), m.checkpointdir)
+}
+
+// fakeServer is a plugin.Server stub that records Start/Stop calls and can be
+// configured to fail on Start. It is used to exercise Manager.Start rollback
+// behaviour without binding real unix sockets.
+type fakeServer struct {
+	socket     string
+	startErr   error
+	startCalls int
+	stopCalls  int
+}
+
+func (s *fakeServer) Start(klog.Logger) error {
+	s.startCalls++
+	return s.startErr
+}
+func (s *fakeServer) Stop(klog.Logger) error {
+	s.stopCalls++
+	return nil
+}
+func (s *fakeServer) SocketPath() string { return s.socket }
+func (s *fakeServer) Name() string       { return "fake" }
+func (s *fakeServer) Check(*http.Request) error {
+	return nil
+}
+func (s *fakeServer) ValidatePlugin(context.Context, string, string, []string) error {
+	return nil
+}
+func (s *fakeServer) RegisterPlugin(context.Context, string, string, []string, *time.Duration) error {
+	return nil
+}
+func (s *fakeServer) DeRegisterPlugin(context.Context, string, string) {}
+
+// TestManagerStartRollsBackOnPartialFailure ensures that when one of the
+// dual-socket servers fails to start, the servers that already started are
+// stopped so the manager does not leak running listeners. Callers typically
+// `defer Stop()` only after Start returns successfully, so Start must clean up
+// after itself on partial failure.
+func TestManagerStartRollsBackOnPartialFailure(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
+	primary := &fakeServer{socket: "/primary.sock"}
+	compat := &fakeServer{socket: "/compat.sock", startErr: fmt.Errorf("bind failed")}
+
+	checkpointDir := t.TempDir()
+	checkpointManager, err := checkpointmanager.NewCheckpointManager(checkpointDir)
+	require.NoError(t, err)
+
+	m := &ManagerImpl{
+		servers:               []plugin.Server{primary, compat},
+		activePods:            func() []*v1.Pod { return nil },
+		sourcesReady:          &sourcesReadyStub{},
+		checkpointManager:     checkpointManager,
+		topologyAffinityStore: topologymanager.NewFakeManager(logger),
+	}
+
+	err = m.Start(logger, m.activePods, m.sourcesReady, containermap.ContainerMap{}, sets.New[string]())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), compat.SocketPath())
+
+	require.Equal(t, 1, primary.startCalls, "primary server should have been started")
+	require.Equal(t, 1, compat.startCalls, "compat server should have been attempted")
+	require.Equal(t, 1, primary.stopCalls, "already-started primary server should be rolled back")
+	require.Equal(t, 0, compat.stopCalls, "failed server should not be stopped")
 }
 
 func TestNewManagerImplStart(t *testing.T) {

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -73,7 +73,8 @@ func newWrappedManagerImpl(logger klog.Logger, socketPath string, manager *Manag
 		callback:    manager.genericDeviceUpdateCallback,
 	}
 	w.socketdir, _ = filepath.Split(socketPath)
-	w.server, _ = plugin.NewServer(logger, socketPath, w, w)
+	srv, _ := plugin.NewServer(logger, socketPath, w, w)
+	w.servers = []plugin.Server{srv}
 	return w
 }
 
@@ -106,9 +107,79 @@ func TestNewManagerImpl(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoErrorf(t, os.RemoveAll(socketDir), "unable to remove dir %s", socketDir)
 	})
-	_, err = newManagerImpl(logger, socketName, nil, topologyStore)
+	_, err = newManagerImpl(logger, []string{socketName}, nil, topologyStore)
 	require.NoError(t, err)
 	os.RemoveAll(socketDir)
+}
+
+func TestDevicePluginSocketPaths(t *testing.T) {
+	legacy := pluginapi.KubeletSocket
+	if goruntime.GOOS == "windows" {
+		legacy = os.Getenv("SYSTEMDRIVE") + pluginapi.KubeletSocketWindows
+	}
+
+	for _, tc := range []struct {
+		name    string
+		rootDir string
+		want    []string
+	}{
+		{
+			name:    "empty root dir falls back to legacy only",
+			rootDir: "",
+			want:    []string{legacy},
+		},
+		{
+			name:    "default root dir collapses to single legacy listener",
+			rootDir: filepath.Dir(filepath.Dir(legacy)),
+			want:    []string{legacy},
+		},
+		{
+			name:    "custom root dir exposes primary and legacy",
+			rootDir: filepath.Join(string(filepath.Separator), "var", "lib", "ci", "kubelet"),
+			want: []string{
+				filepath.Join(string(filepath.Separator), "var", "lib", "ci", "kubelet", "device-plugins", "kubelet.sock"),
+				legacy,
+			},
+		},
+		{
+			name:    "default root dir with trailing slash collapses",
+			rootDir: filepath.Dir(filepath.Dir(legacy)) + string(filepath.Separator),
+			want:    []string{legacy},
+		},
+		{
+			name:    "default root dir with dot segment collapses",
+			rootDir: filepath.Join(filepath.Dir(filepath.Dir(legacy)), ".", "."),
+			want:    []string{legacy},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := devicePluginSocketPaths(tc.rootDir)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestNewManagerImplDualSockets(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	topologyStore := topologymanager.NewFakeManager(logger)
+
+	primaryDir, err := os.MkdirTemp("", "device_plugin_primary")
+	require.NoError(t, err)
+	defer os.RemoveAll(primaryDir)
+	compatDir, err := os.MkdirTemp("", "device_plugin_compat")
+	require.NoError(t, err)
+	defer os.RemoveAll(compatDir)
+
+	primarySocket := filepath.Join(primaryDir, "kubelet.sock")
+	compatSocket := filepath.Join(compatDir, "kubelet.sock")
+
+	m, err := newManagerImpl(logger, []string{primarySocket, compatSocket}, nil, topologyStore)
+	require.NoError(t, err)
+	require.Len(t, m.servers, 2)
+	require.Equal(t, primarySocket, m.servers[0].SocketPath())
+	require.Equal(t, compatSocket, m.servers[1].SocketPath())
+	// Checkpoint must live under the primary (rootdir-relative) directory.
+	require.Equal(t, primaryDir+string(filepath.Separator), m.checkpointdir)
 }
 
 func TestNewManagerImplStart(t *testing.T) {
@@ -301,7 +372,7 @@ func TestDevicePluginReRegistrationProbeMode(t *testing.T) {
 func setupDeviceManager(t *testing.T, devs []*pluginapi.Device, callback monitorCallback, socketName string,
 	topology []cadvisorapi.Node, logger klog.Logger) (Manager, <-chan interface{}) {
 	topologyStore := topologymanager.NewFakeManager(logger)
-	m, err := newManagerImpl(logger, socketName, topology, topologyStore)
+	m, err := newManagerImpl(logger, []string{socketName}, topology, topologyStore)
 	require.NoError(t, err)
 	updateChan := make(chan interface{})
 
@@ -382,7 +453,7 @@ func TestUpdateCapacityAllocatable(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoErrorf(t, os.RemoveAll(socketDir), "unable to remove dir %s", socketDir)
 	})
-	testManager, err := newManagerImpl(logger, socketName, nil, topologyStore)
+	testManager, err := newManagerImpl(logger, []string{socketName}, nil, topologyStore)
 	as := assert.New(t)
 	as.NotNil(testManager)
 	as.NoError(err)
@@ -530,7 +601,7 @@ func TestGetAllocatableDevicesMultipleResources(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoErrorf(t, os.RemoveAll(socketDir), "unable to remove dir %s", socketDir)
 	})
-	testManager, err := newManagerImpl(logger, socketName, nil, topologyStore)
+	testManager, err := newManagerImpl(logger, []string{socketName}, nil, topologyStore)
 	as := assert.New(t)
 	as.NotNil(testManager)
 	as.NoError(err)
@@ -574,7 +645,7 @@ func TestGetAllocatableDevicesHealthTransition(t *testing.T) {
 	t.Cleanup(func() {
 		require.NoErrorf(t, os.RemoveAll(socketDir), "unable to remove dir %s", socketDir)
 	})
-	testManager, err := newManagerImpl(logger, socketName, nil, topologyStore)
+	testManager, err := newManagerImpl(logger, []string{socketName}, nil, topologyStore)
 	as := assert.New(t)
 	as.NotNil(testManager)
 	as.NoError(err)
@@ -2274,7 +2345,7 @@ func TestEndpointSyncOnDisconnect(t *testing.T) {
 		}
 	}()
 
-	manager, err := newManagerImpl(logger, socketName, nil, nil)
+	manager, err := newManagerImpl(logger, []string{socketName}, nil, nil)
 	require.NoError(t, err)
 
 	resourceName := "domain1.com/resource1"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Related to https://github.com/kubernetes/kubernetes/issues/120626#issuecomment-4315365667

The device plugin registration server has historically listened at the hardcoded path /var/lib/kubelet/device-plugins/kubelet.sock, regardless of the kubelet --root-dir flag. Operators who relocate kubelet state (e.g. --root-dir=/var/lib/ci/kubelet) cannot mount a single root directory into a pod and reach the device plugin socket from there, breaking topology-updater and similar workloads.

NewManagerImpl now accepts a rootDir argument and starts a listener at <rootDir>/device-plugins/kubelet.sock. When rootDir differs from the legacy default, an additional listener is started at the hardcoded pluginapi.KubeletSocket so that device plugins built against the unchanged staging API constant keep working without modification. The checkpoint file follows the primary (rootdir-relative) directory.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #120626 
Fixes https://github.com/k0sproject/k0s/issues/7585 

#### Special notes for your reviewer:

I haven't change the constants, so `DevicePluginPath` and `KubeletSocket` constants are still hardcoded, which helps existing plugins continue to work unmodified.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Device Manager now honors --root-dir for device-plugin socket
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
