### PR TITLE
Migrate TTL controllers to contextual logging

### DIFF
--- a/pkg/controller/ttl/ttl_controller.go
+++ b/pkg/controller/ttl/ttl_controller.go
@@ -94,7 +94,9 @@ func NewTTLController(ctx context.Context, nodeInformer informers.NodeInformer, 
 		UpdateFunc: func(old, newObj interface{}) {
 			ttlc.updateNode(logger, old, newObj)
 		},
-		DeleteFunc: ttlc.deleteNode,
+		DeleteFunc: func(obj interface{}) {
+			ttlc.deleteNode(logger, obj)
+		},
 	})
 
 	ttlc.nodeStore = listers.NewNodeLister(nodeInformer.Informer().GetIndexer())
@@ -148,7 +150,7 @@ func (ttlc *Controller) Run(ctx context.Context, workers int) {
 func (ttlc *Controller) addNode(logger klog.Logger, obj interface{}) {
 	node, ok := obj.(*v1.Node)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", obj))
+		utilruntime.HandleErrorWithLogger(logger, nil, "Unexpected object type passed to addNode", "type", fmt.Sprintf("%T", obj))
 		return
 	}
 
@@ -167,7 +169,7 @@ func (ttlc *Controller) addNode(logger klog.Logger, obj interface{}) {
 func (ttlc *Controller) updateNode(logger klog.Logger, _, newObj interface{}) {
 	node, ok := newObj.(*v1.Node)
 	if !ok {
-		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", newObj))
+		utilruntime.HandleErrorWithLogger(logger, nil, "Unexpected object type passed to updateNode", "type", fmt.Sprintf("%T", newObj))
 		return
 	}
 	// Processing all updates of nodes guarantees that we will update
@@ -178,17 +180,17 @@ func (ttlc *Controller) updateNode(logger klog.Logger, _, newObj interface{}) {
 	ttlc.enqueueNode(logger, node)
 }
 
-func (ttlc *Controller) deleteNode(obj interface{}) {
+func (ttlc *Controller) deleteNode(logger klog.Logger, obj interface{}) {
 	_, ok := obj.(*v1.Node)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", obj))
+			utilruntime.HandleErrorWithLogger(logger, nil, "Unexpected object type passed to deleteNode", "type", fmt.Sprintf("%T", obj))
 			return
 		}
 		_, ok = tombstone.Obj.(*v1.Node)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("unexpected object types: %v", obj))
+			utilruntime.HandleErrorWithLogger(logger, nil, "Unexpected object type in tombstone", "type", fmt.Sprintf("%T", tombstone.Obj))
 			return
 		}
 	}
@@ -233,7 +235,7 @@ func (ttlc *Controller) processItem(ctx context.Context) bool {
 	}
 
 	ttlc.queue.AddRateLimited(key)
-	utilruntime.HandleError(err)
+	utilruntime.HandleErrorWithContext(ctx, err, "Failed to process node TTL", "key", key)
 	return true
 }
 

--- a/pkg/controller/ttl/ttl_controller_test.go
+++ b/pkg/controller/ttl/ttl_controller_test.go
@@ -229,6 +229,7 @@ func TestDesiredTTL(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
+		logger, _ := ktesting.NewTestContext(t)
 		ttlController := &Controller{
 			queue:             workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
 			nodeCount:         testCase.nodeCount,
@@ -236,11 +237,10 @@ func TestDesiredTTL(t *testing.T) {
 			boundaryStep:      testCase.boundaryStep,
 		}
 		if testCase.addNode {
-			logger, _ := ktesting.NewTestContext(t)
 			ttlController.addNode(logger, &v1.Node{})
 		}
 		if testCase.deleteNode {
-			ttlController.deleteNode(&v1.Node{})
+			ttlController.deleteNode(logger, &v1.Node{})
 		}
 		assert.Equal(t, testCase.expectedTTL, ttlController.getDesiredTTLSeconds(),
 			"%d: unexpected ttl: %d", i, ttlController.getDesiredTTLSeconds())

--- a/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
+++ b/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
@@ -153,17 +153,17 @@ func (tc *Controller) enqueue(logger klog.Logger, job *batch.Job) {
 	logger.V(4).Info("Add job to cleanup", "job", klog.KObj(job))
 	key, err := controller.KeyFunc(job)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", job, err))
+		utilruntime.HandleErrorWithLogger(logger, err, "Failed to get key for job", "job", klog.KObj(job))
 		return
 	}
 
 	tc.queue.Add(key)
 }
 
-func (tc *Controller) enqueueAfter(job *batch.Job, after time.Duration) {
+func (tc *Controller) enqueueAfter(logger klog.Logger, job *batch.Job, after time.Duration) {
 	key, err := controller.KeyFunc(job)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", job, err))
+		utilruntime.HandleErrorWithLogger(logger, err, "Failed to get key for job", "job", klog.KObj(job))
 		return
 	}
 
@@ -183,18 +183,18 @@ func (tc *Controller) processNextWorkItem(ctx context.Context) bool {
 	defer tc.queue.Done(key)
 
 	err := tc.processJob(ctx, key)
-	tc.handleErr(err, key)
+	tc.handleErr(ctx, err, key)
 
 	return true
 }
 
-func (tc *Controller) handleErr(err error, key string) {
+func (tc *Controller) handleErr(ctx context.Context, err error, key string) {
 	if err == nil {
 		tc.queue.Forget(key)
 		return
 	}
 
-	utilruntime.HandleError(fmt.Errorf("error cleaning up Job %v, will retry: %v", key, err))
+	utilruntime.HandleErrorWithContext(ctx, err, "Failed to clean up job, will retry", "key", key)
 	tc.queue.AddRateLimited(key)
 }
 
@@ -280,7 +280,7 @@ func (tc *Controller) processTTL(logger klog.Logger, job *batch.Job) (expiredAt 
 		return e, nil
 	}
 
-	tc.enqueueAfter(job, *t)
+	tc.enqueueAfter(logger, job, *t)
 	return nil, nil
 }
 


### PR DESCRIPTION
## What type of PR is this?
/kind cleanup

## What this PR does / why we need it:
This PR migrates the TTL and TTLAfterFinished controllers from traditional 
error handling to contextual logging APIs, improving observability through 
structured logging.

**Changes:**
- Migrated 5 `HandleError` calls in `ttl_controller.go` to `HandleErrorWithLogger/HandleErrorWithContext`
- Migrated 3 `HandleError` calls in `ttlafterfinished_controller.go` to contextual logging
- Added `logger klog.Logger` and `ctx context.Context` parameters to helper functions
- Updated test to pass logger parameter

## Which issue(s) this PR fixes:
Contributes to #126379

## Special notes for reviewer:
- All existing tests pass
- No functional changes, only logging improvements
- Follows the contextual logging migration pattern from KEP-3077

## Does this PR introduce a user-facing change?
```release-note
NONE
```  