### PR TITLE
scheduler: Eliminate map lookups from heap comparison path

### DIFF
--- a/pkg/scheduler/backend/heap/heap.go
+++ b/pkg/scheduler/backend/heap/heap.go
@@ -14,9 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Below is the implementation of the a heap. The logic is pretty much the same
-// as cache.heap, however, this heap does not perform synchronization. It leaves
-// synchronization to the SchedulingQueue.
+// Below is the implementation of a generic heap. It does not perform
+// synchronization. It leaves synchronization to the SchedulingQueue.
 
 package heap
 
@@ -31,25 +30,19 @@ import (
 type KeyFunc[T any] func(obj T) string
 
 type heapItem[T any] struct {
-	obj   T   // The object which is stored in the heap.
-	index int // The index of the object's key in the Heap.queue.
-}
-
-type itemKeyValue[T any] struct {
-	key string
+	// obj is the object which is stored in the heap.
 	obj T
+	// key is the key of the object for identity/lookup.
+	key string
 }
 
 // data is an internal struct that implements the standard heap interface
 // and keeps the data stored in the heap.
 type data[T any] struct {
-	// items is a map from key of the objects to the objects and their index.
-	// We depend on the property that items in the map are in the queue and vice versa.
-	items map[string]*heapItem[T]
-	// queue implements a heap data structure and keeps the order of elements
-	// according to the heap invariant. The queue keeps the keys of objects stored
-	// in "items".
-	queue []string
+	// queue is a heap-ordered slice of item pointers.
+	queue []*heapItem[T]
+	// keyIndex maps object keys to their index in queue for O(1) lookups.
+	keyIndex map[string]int
 
 	// keyFunc is used to make the key used for queued item insertion and retrieval, and
 	// should be deterministic.
@@ -65,18 +58,7 @@ var (
 // Less compares two objects and returns true if the first one should go
 // in front of the second one in the heap.
 func (h *data[T]) Less(i, j int) bool {
-	if i > len(h.queue) || j > len(h.queue) {
-		return false
-	}
-	itemi, ok := h.items[h.queue[i]]
-	if !ok {
-		return false
-	}
-	itemj, ok := h.items[h.queue[j]]
-	if !ok {
-		return false
-	}
-	return h.lessFunc(itemi.obj, itemj.obj)
+	return h.lessFunc(h.queue[i].obj, h.queue[j].obj)
 }
 
 // Len returns the number of items in the Heap.
@@ -85,47 +67,37 @@ func (h *data[T]) Len() int { return len(h.queue) }
 // Swap implements swapping of two elements in the heap. This is a part of standard
 // heap interface and should never be called directly.
 func (h *data[T]) Swap(i, j int) {
-	if i < 0 || j < 0 {
-		return
-	}
 	h.queue[i], h.queue[j] = h.queue[j], h.queue[i]
-	item := h.items[h.queue[i]]
-	item.index = i
-	item = h.items[h.queue[j]]
-	item.index = j
+	h.keyIndex[h.queue[i].key] = i
+	h.keyIndex[h.queue[j].key] = j
 }
 
 // Push is supposed to be called by container/heap.Push only.
-func (h *data[T]) Push(kv interface{}) {
-	keyValue := kv.(*itemKeyValue[T])
-	n := len(h.queue)
-	h.items[keyValue.key] = &heapItem[T]{keyValue.obj, n}
-	h.queue = append(h.queue, keyValue.key)
+func (h *data[T]) Push(x interface{}) {
+	item := x.(*heapItem[T])
+	h.keyIndex[item.key] = len(h.queue)
+	h.queue = append(h.queue, item)
 }
 
 // Pop is supposed to be called by container/heap.Pop only.
 func (h *data[T]) Pop() interface{} {
-	if len(h.queue) == 0 {
+	n := len(h.queue)
+	if n == 0 {
 		return nil
 	}
-	key := h.queue[len(h.queue)-1]
-	h.queue = h.queue[0 : len(h.queue)-1]
-	item, ok := h.items[key]
-	if !ok {
-		// This is an error
-		return nil
-	}
-	delete(h.items, key)
+	item := h.queue[n-1]
+	h.queue[n-1] = nil // avoid memory leak
+	h.queue = h.queue[:n-1]
+	delete(h.keyIndex, item.key)
 	return item.obj
 }
 
 // Peek returns the head of the heap without removing it.
 func (h *data[T]) Peek() (T, bool) {
 	if len(h.queue) > 0 {
-		return h.items[h.queue[0]].obj, true
+		return h.queue[0].obj, true
 	}
-	var zero T
-	return zero, false
+	return *new(T), false
 }
 
 // Heap is a producer/consumer queue that implements a heap data structure.
@@ -143,11 +115,11 @@ type Heap[T any] struct {
 // already exists.
 func (h *Heap[T]) AddOrUpdate(obj T) {
 	key := h.data.keyFunc(obj)
-	if _, exists := h.data.items[key]; exists {
-		h.data.items[key].obj = obj
-		heap.Fix(h.data, h.data.items[key].index)
+	if idx, exists := h.data.keyIndex[key]; exists {
+		h.data.queue[idx].obj = obj
+		heap.Fix(h.data, idx)
 	} else {
-		heap.Push(h.data, &itemKeyValue[T]{key, obj})
+		heap.Push(h.data, &heapItem[T]{obj: obj, key: key})
 		if h.metricRecorder != nil {
 			h.metricRecorder.Inc()
 		}
@@ -157,13 +129,12 @@ func (h *Heap[T]) AddOrUpdate(obj T) {
 // Delete removes an item and returns the deleted obj.
 func (h *Heap[T]) Delete(obj T) T {
 	key := h.data.keyFunc(obj)
-	if item, ok := h.data.items[key]; ok {
-		obj := item.obj
-		heap.Remove(h.data, item.index)
+	if idx, ok := h.data.keyIndex[key]; ok {
+		removed := heap.Remove(h.data, idx).(T)
 		if h.metricRecorder != nil {
 			h.metricRecorder.Dec()
 		}
-		return obj
+		return removed
 	}
 	var zero T
 	return zero
@@ -176,15 +147,14 @@ func (h *Heap[T]) Peek() (T, bool) {
 
 // Pop returns the head of the heap and removes it.
 func (h *Heap[T]) Pop() (T, error) {
-	obj := heap.Pop(h.data)
-	if obj != nil {
-		if h.metricRecorder != nil {
-			h.metricRecorder.Dec()
-		}
-		return obj.(T), nil
+	if h.data.Len() == 0 {
+		return *new(T), fmt.Errorf("heap is empty")
 	}
-	var zero T
-	return zero, fmt.Errorf("heap is empty")
+	obj := heap.Pop(h.data)
+	if h.metricRecorder != nil {
+		h.metricRecorder.Dec()
+	}
+	return obj.(T), nil
 }
 
 // Get returns the requested item, or sets exists=false.
@@ -195,24 +165,23 @@ func (h *Heap[T]) Get(obj T) (T, bool) {
 
 // GetByKey returns the requested item, or sets exists=false.
 func (h *Heap[T]) GetByKey(key string) (T, bool) {
-	item, exists := h.data.items[key]
+	idx, exists := h.data.keyIndex[key]
 	if !exists {
-		var zero T
-		return zero, false
+		return *new(T), false
 	}
-	return item.obj, true
+	return h.data.queue[idx].obj, true
 }
 
 func (h *Heap[T]) Has(obj T) bool {
 	key := h.data.keyFunc(obj)
-	_, ok := h.GetByKey(key)
+	_, ok := h.data.keyIndex[key]
 	return ok
 }
 
 // List returns a list of all the items.
 func (h *Heap[T]) List() []T {
-	list := make([]T, 0, len(h.data.items))
-	for _, item := range h.data.items {
+	list := make([]T, 0, len(h.data.queue))
+	for _, item := range h.data.queue {
 		list = append(list, item.obj)
 	}
 	return list
@@ -232,8 +201,8 @@ func New[T any](keyFn KeyFunc[T], lessFn LessFunc[T]) *Heap[T] {
 func NewWithRecorder[T any](keyFn KeyFunc[T], lessFn LessFunc[T], metricRecorder metrics.MetricRecorder) *Heap[T] {
 	return &Heap[T]{
 		data: &data[T]{
-			items:    map[string]*heapItem[T]{},
-			queue:    []string{},
+			queue:    []*heapItem[T]{},
+			keyIndex: map[string]int{},
 			keyFunc:  keyFn,
 			lessFunc: lessFn,
 		},

--- a/pkg/scheduler/backend/heap/heap_test.go
+++ b/pkg/scheduler/backend/heap/heap_test.go
@@ -21,6 +21,8 @@ package heap
 
 import (
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func testHeapObjectKeyFunc(obj testHeapObject) string {
@@ -62,74 +64,37 @@ func compareInts(val1 testHeapObject, val2 testHeapObject) bool {
 	return first < second
 }
 
-// TestHeapBasic tests Heap invariant
-func TestHeapBasic(t *testing.T) {
+func expectPopOrder(t *testing.T, h *Heap[testHeapObject], want []int) {
+	t.Helper()
+	var got []int
+	for h.Len() > 0 {
+		item, err := h.Pop()
+		if err != nil {
+			t.Fatalf("unexpected pop error: %v", err)
+		}
+		got = append(got, item.val.(int))
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("unexpected pop order (-want, +got):\n%s", diff)
+	}
+}
+
+// TestHeap_Peek tests that Peek returns the minimum element after each insertion.
+func TestHeap_Peek(t *testing.T) {
 	h := New(testHeapObjectKeyFunc, compareInts)
 	const amount = 500
-	var i int
 	var zero testHeapObject
 
-	// empty queue
 	if item, ok := h.Peek(); ok || item != zero {
 		t.Errorf("expected nil object but got %v", item)
 	}
 
-	for i = amount; i > 0; i-- {
+	for i := amount; i > 0; i-- {
 		h.AddOrUpdate(mkHeapObj(string([]rune{'a', rune(i)}), i))
-		// Retrieve head without removing it
 		head, ok := h.Peek()
 		if e, a := i, head.val; !ok || a != e {
 			t.Errorf("expected %d, got %d", e, a)
 		}
-	}
-
-	// Make sure that the numbers are popped in ascending order.
-	prevNum := 0
-	for i := 0; i < amount; i++ {
-		item, err := h.Pop()
-		num := item.val.(int)
-		// All the items must be sorted.
-		if err != nil || prevNum > num {
-			t.Errorf("got %v out of order, last was %v", item, prevNum)
-		}
-		prevNum = num
-	}
-
-	_, err := h.Pop()
-	if err == nil {
-		t.Errorf("expected Pop() to error on empty heap")
-	}
-}
-
-// TestHeap_AddOrUpdate_Add tests add capabilities of Heap.AddOrUpdate
-// and ensures that heap invariant is preserved after adding items.
-func TestHeap_AddOrUpdate_Add(t *testing.T) {
-	h := New(testHeapObjectKeyFunc, compareInts)
-	h.AddOrUpdate(mkHeapObj("foo", 10))
-	h.AddOrUpdate(mkHeapObj("bar", 1))
-	h.AddOrUpdate(mkHeapObj("baz", 11))
-	h.AddOrUpdate(mkHeapObj("zab", 30))
-	h.AddOrUpdate(mkHeapObj("foo", 13)) // This updates "foo".
-
-	item, err := h.Pop()
-	if e, a := 1, item.val; err != nil || a != e {
-		t.Fatalf("expected %d, got %d", e, a)
-	}
-	item, err = h.Pop()
-	if e, a := 11, item.val; err != nil || a != e {
-		t.Fatalf("expected %d, got %d", e, a)
-	}
-	if obj := h.Delete(mkHeapObj("baz", 11)); obj.name != "" { // Nothing is deleted.
-		t.Fatalf("nothing should be deleted from the heap")
-	}
-	h.AddOrUpdate(mkHeapObj("foo", 14)) // foo is updated.
-	item, err = h.Pop()
-	if e, a := 14, item.val; err != nil || a != e {
-		t.Fatalf("expected %d, got %d", e, a)
-	}
-	item, err = h.Pop()
-	if e, a := 30, item.val; err != nil || a != e {
-		t.Fatalf("expected %d, got %d", e, a)
 	}
 }
 
@@ -189,7 +154,7 @@ func TestHeap_AddOrUpdate_Update(t *testing.T) {
 
 	// Update an item to a value that should push it to the head.
 	h.AddOrUpdate(mkHeapObj("baz", 0))
-	if h.data.queue[0] != "baz" || h.data.items["baz"].index != 0 {
+	if h.data.queue[0].key != "baz" || h.data.keyIndex["baz"] != 0 {
 		t.Fatalf("expected baz to be at the head")
 	}
 	item, err := h.Pop()
@@ -198,7 +163,7 @@ func TestHeap_AddOrUpdate_Update(t *testing.T) {
 	}
 	// Update bar to push it farther back in the queue.
 	h.AddOrUpdate(mkHeapObj("bar", 100))
-	if h.data.queue[0] != "foo" || h.data.items["foo"].index != 0 {
+	if h.data.queue[0].key != "foo" || h.data.keyIndex["foo"] != 0 {
 		t.Fatalf("expected foo to be at the head")
 	}
 }
@@ -269,6 +234,480 @@ func TestHeap_List(t *testing.T) {
 		if !ok || v != heapObj.val {
 			t.Errorf("unexpected item in the list: %v", heapObj)
 		}
+	}
+}
+
+func TestHeapHas(t *testing.T) {
+	t.Run("empty heap", func(t *testing.T) {
+		h := New(testHeapObjectKeyFunc, compareInts)
+		if got := h.Has(mkHeapObj("foo", 0)); got != false {
+			t.Errorf("Has(%q) = %v, want %v", "foo", got, false)
+		}
+	})
+
+	t.Run("non-existing item in populated heap", func(t *testing.T) {
+		h := New(testHeapObjectKeyFunc, compareInts)
+		h.AddOrUpdate(mkHeapObj("bar", 1))
+		if got := h.Has(mkHeapObj("foo", 0)); got != false {
+			t.Errorf("Has(%q) = %v, want %v", "foo", got, false)
+		}
+	})
+
+	t.Run("existing item (single element)", func(t *testing.T) {
+		h := New(testHeapObjectKeyFunc, compareInts)
+		h.AddOrUpdate(mkHeapObj("foo", 10))
+		if got := h.Has(mkHeapObj("foo", 0)); got != true {
+			t.Errorf("Has(%q) = %v, want %v", "foo", got, true)
+		}
+	})
+
+	t.Run("existing item (multiple elements)", func(t *testing.T) {
+		h := New(testHeapObjectKeyFunc, compareInts)
+		h.AddOrUpdate(mkHeapObj("bar", 1))
+		h.AddOrUpdate(mkHeapObj("foo", 10))
+		h.AddOrUpdate(mkHeapObj("baz", 11))
+		if got := h.Has(mkHeapObj("foo", 0)); got != true {
+			t.Errorf("Has(%q) = %v, want %v", "foo", got, true)
+		}
+	})
+
+	t.Run("item missing after deletion", func(t *testing.T) {
+		h := New(testHeapObjectKeyFunc, compareInts)
+		h.AddOrUpdate(mkHeapObj("foo", 10))
+		h.Delete(mkHeapObj("foo", 0))
+		if got := h.Has(mkHeapObj("foo", 0)); got != false {
+			t.Errorf("Has(%q) = %v, want %v", "foo", got, false)
+		}
+	})
+}
+
+func TestHeapZeroAndOneElement(t *testing.T) {
+	t.Run("pop single element", func(t *testing.T) {
+		h := New(testHeapObjectKeyFunc, compareInts)
+		h.AddOrUpdate(mkHeapObj("foo", 42))
+		item, err := h.Pop()
+		if e, a := 42, item.val; err != nil || a != e {
+			t.Fatalf("expected %d, got %d", e, a)
+		}
+		if e, a := 0, h.Len(); a != e {
+			t.Fatalf("expected %d, got %d", e, a)
+		}
+	})
+
+	t.Run("pop empty heap errors", func(t *testing.T) {
+		h := New(testHeapObjectKeyFunc, compareInts)
+		_, err := h.Pop()
+		if err == nil {
+			t.Fatalf("expected error popping empty heap")
+		}
+	})
+
+	t.Run("delete single element", func(t *testing.T) {
+		h := New(testHeapObjectKeyFunc, compareInts)
+		h.AddOrUpdate(mkHeapObj("bar", 7))
+		h.Delete(mkHeapObj("bar", 0))
+		if e, a := 0, h.Len(); a != e {
+			t.Fatalf("expected %d, got %d", e, a)
+		}
+	})
+
+	t.Run("peek single element", func(t *testing.T) {
+		h := New(testHeapObjectKeyFunc, compareInts)
+		h.AddOrUpdate(mkHeapObj("baz", 99))
+		item, ok := h.Peek()
+		if e, a := 99, item.val; !ok || a != e {
+			t.Fatalf("expected %d, got %d", e, a)
+		}
+	})
+}
+
+func TestHeapPopOrder(t *testing.T) {
+	tests := []struct {
+		name     string
+		inserts  []testHeapObject
+		expected []int
+	}{
+		{
+			name: "ascending insertion",
+			inserts: []testHeapObject{
+				mkHeapObj("foo", 1),
+				mkHeapObj("bar", 2),
+				mkHeapObj("baz", 3),
+			},
+			expected: []int{1, 2, 3},
+		},
+		{
+			name: "descending insertion",
+			inserts: []testHeapObject{
+				mkHeapObj("foo", 30),
+				mkHeapObj("bar", 20),
+				mkHeapObj("baz", 10),
+			},
+			expected: []int{10, 20, 30},
+		},
+		{
+			name: "random insertion",
+			inserts: []testHeapObject{
+				mkHeapObj("foo", 15),
+				mkHeapObj("bar", 3),
+				mkHeapObj("baz", 42),
+				mkHeapObj("zab", 1),
+				mkHeapObj("faz", 27),
+			},
+			expected: []int{1, 3, 15, 27, 42},
+		},
+		{
+			name: "duplicate values",
+			inserts: []testHeapObject{
+				mkHeapObj("foo", 5),
+				mkHeapObj("bar", 5),
+				mkHeapObj("baz", 5),
+			},
+			expected: []int{5, 5, 5},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := New(testHeapObjectKeyFunc, compareInts)
+			for _, obj := range tt.inserts {
+				h.AddOrUpdate(obj)
+			}
+
+			expectPopOrder(t, h, tt.expected)
+		})
+	}
+}
+
+func TestHeapDeleteMiddle(t *testing.T) {
+	tests := []struct {
+		name         string
+		inserts      []testHeapObject
+		deletes      []string
+		expectedPops []int
+	}{
+		{
+			name: "delete middle items",
+			inserts: []testHeapObject{
+				mkHeapObj("foo", 10),
+				mkHeapObj("bar", 1),
+				mkHeapObj("bal", 20),
+				mkHeapObj("baz", 15),
+				mkHeapObj("zab", 25),
+				mkHeapObj("faz", 5),
+			},
+			deletes:      []string{"foo", "baz"},
+			expectedPops: []int{1, 5, 20, 25},
+		},
+		{
+			name: "delete head",
+			inserts: []testHeapObject{
+				mkHeapObj("foo", 1),
+				mkHeapObj("bar", 10),
+				mkHeapObj("baz", 20),
+			},
+			deletes:      []string{"foo"},
+			expectedPops: []int{10, 20},
+		},
+		{
+			name: "delete all but one",
+			inserts: []testHeapObject{
+				mkHeapObj("foo", 10),
+				mkHeapObj("bar", 1),
+				mkHeapObj("baz", 20),
+			},
+			deletes:      []string{"foo", "baz"},
+			expectedPops: []int{1},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := New(testHeapObjectKeyFunc, compareInts)
+			for _, obj := range tt.inserts {
+				h.AddOrUpdate(obj)
+			}
+			for _, key := range tt.deletes {
+				h.Delete(mkHeapObj(key, 0))
+			}
+
+			expectPopOrder(t, h, tt.expectedPops)
+		})
+	}
+}
+
+func TestHeapUpdatePriority(t *testing.T) {
+	tests := []struct {
+		name         string
+		inserts      []testHeapObject
+		updates      []testHeapObject
+		expectedPops []int
+	}{
+		{
+			name: "update to same value",
+			inserts: []testHeapObject{
+				mkHeapObj("foo", 10),
+				mkHeapObj("bar", 1),
+				mkHeapObj("baz", 11),
+			},
+			updates:      []testHeapObject{mkHeapObj("foo", 10)},
+			expectedPops: []int{1, 10, 11},
+		},
+		{
+			name: "update to lower value (move to head)",
+			inserts: []testHeapObject{
+				mkHeapObj("foo", 10),
+				mkHeapObj("bar", 1),
+				mkHeapObj("baz", 11),
+			},
+			updates:      []testHeapObject{mkHeapObj("baz", 0)},
+			expectedPops: []int{0, 1, 10},
+		},
+		{
+			name: "update to higher value (move to tail)",
+			inserts: []testHeapObject{
+				mkHeapObj("foo", 10),
+				mkHeapObj("bar", 1),
+				mkHeapObj("baz", 11),
+			},
+			updates:      []testHeapObject{mkHeapObj("bar", 100)},
+			expectedPops: []int{10, 11, 100},
+		},
+		{
+			name: "full order inversion",
+			inserts: []testHeapObject{
+				mkHeapObj("foo", 1),
+				mkHeapObj("bar", 2),
+				mkHeapObj("baz", 3),
+				mkHeapObj("zab", 4),
+				mkHeapObj("faz", 5),
+			},
+			updates: []testHeapObject{
+				mkHeapObj("faz", 0),
+				mkHeapObj("foo", 100),
+			},
+			expectedPops: []int{0, 2, 3, 4, 100},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := New(testHeapObjectKeyFunc, compareInts)
+			for _, obj := range tt.inserts {
+				h.AddOrUpdate(obj)
+			}
+			for _, obj := range tt.updates {
+				h.AddOrUpdate(obj)
+			}
+
+			expectPopOrder(t, h, tt.expectedPops)
+		})
+	}
+}
+
+func TestHeapLen(t *testing.T) {
+	tests := []struct {
+		name        string
+		action      func(h *Heap[testHeapObject])
+		expectedLen int
+	}{
+		{
+			name:        "empty heap",
+			action:      func(h *Heap[testHeapObject]) {},
+			expectedLen: 0,
+		},
+		{
+			name: "after one add",
+			action: func(h *Heap[testHeapObject]) {
+				h.AddOrUpdate(mkHeapObj("foo", 10))
+			},
+			expectedLen: 1,
+		},
+		{
+			name: "after three adds",
+			action: func(h *Heap[testHeapObject]) {
+				h.AddOrUpdate(mkHeapObj("foo", 10))
+				h.AddOrUpdate(mkHeapObj("bar", 1))
+				h.AddOrUpdate(mkHeapObj("baz", 11))
+			},
+			expectedLen: 3,
+		},
+		{
+			name: "update does not change len",
+			action: func(h *Heap[testHeapObject]) {
+				h.AddOrUpdate(mkHeapObj("foo", 10))
+				h.AddOrUpdate(mkHeapObj("bar", 1))
+				h.AddOrUpdate(mkHeapObj("foo", 20))
+			},
+			expectedLen: 2,
+		},
+		{
+			name: "after add and delete",
+			action: func(h *Heap[testHeapObject]) {
+				h.AddOrUpdate(mkHeapObj("foo", 10))
+				h.AddOrUpdate(mkHeapObj("bar", 1))
+				h.Delete(mkHeapObj("bar", 0))
+			},
+			expectedLen: 1,
+		},
+		{
+			name: "after add and pop",
+			action: func(h *Heap[testHeapObject]) {
+				h.AddOrUpdate(mkHeapObj("foo", 10))
+				h.AddOrUpdate(mkHeapObj("bar", 1))
+				_, _ = h.Pop()
+			},
+			expectedLen: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := New(testHeapObjectKeyFunc, compareInts)
+			tt.action(h)
+			if e, a := tt.expectedLen, h.Len(); a != e {
+				t.Fatalf("expected %d, got %d", e, a)
+			}
+		})
+	}
+}
+
+func TestHeapPopAllAndReuse(t *testing.T) {
+	tests := []struct {
+		name         string
+		firstRound   []testHeapObject
+		secondRound  []testHeapObject
+		expectedPops []int
+	}{
+		{
+			name: "reuse with different keys",
+			firstRound: []testHeapObject{
+				mkHeapObj("foo", 3),
+				mkHeapObj("bar", 1),
+				mkHeapObj("baz", 2),
+			},
+			secondRound: []testHeapObject{
+				mkHeapObj("x", 20),
+				mkHeapObj("y", 10),
+				mkHeapObj("z", 15),
+			},
+			expectedPops: []int{10, 15, 20},
+		},
+		{
+			name: "reuse with same keys",
+			firstRound: []testHeapObject{
+				mkHeapObj("foo", 100),
+				mkHeapObj("bar", 200),
+			},
+			secondRound: []testHeapObject{
+				mkHeapObj("foo", 5),
+				mkHeapObj("bar", 3),
+			},
+			expectedPops: []int{3, 5},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := New(testHeapObjectKeyFunc, compareInts)
+			for _, obj := range tt.firstRound {
+				h.AddOrUpdate(obj)
+			}
+			for h.Len() > 0 {
+				_, _ = h.Pop()
+			}
+			for _, obj := range tt.secondRound {
+				h.AddOrUpdate(obj)
+			}
+			expectPopOrder(t, h, tt.expectedPops)
+		})
+	}
+}
+
+func TestHeapDeleteAll(t *testing.T) {
+	tests := []struct {
+		name        string
+		inserts     []testHeapObject
+		deleteOrder []string
+	}{
+		{
+			name: "delete in random order",
+			inserts: []testHeapObject{
+				mkHeapObj("foo", 10),
+				mkHeapObj("bar", 1),
+				mkHeapObj("bal", 31),
+				mkHeapObj("baz", 11),
+				mkHeapObj("zab", 30),
+			},
+			deleteOrder: []string{"baz", "foo", "zab", "bar", "bal"},
+		},
+		{
+			name: "delete head first",
+			inserts: []testHeapObject{
+				mkHeapObj("foo", 1),
+				mkHeapObj("bar", 10),
+				mkHeapObj("baz", 20),
+			},
+			deleteOrder: []string{"foo", "bar", "baz"},
+		},
+		{
+			name: "delete tail first",
+			inserts: []testHeapObject{
+				mkHeapObj("foo", 1),
+				mkHeapObj("bar", 10),
+				mkHeapObj("baz", 20),
+			},
+			deleteOrder: []string{"baz", "bar", "foo"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := New(testHeapObjectKeyFunc, compareInts)
+			for _, obj := range tt.inserts {
+				h.AddOrUpdate(obj)
+			}
+			for _, key := range tt.deleteOrder {
+				h.Delete(mkHeapObj(key, 0))
+			}
+			if e, a := 0, h.Len(); a != e {
+				t.Fatalf("expected %d, got %d", e, a)
+			}
+			// Heap should still be usable.
+			h.AddOrUpdate(mkHeapObj("new", 5))
+			item, err := h.Pop()
+			if e, a := 5, item.val; err != nil || a != e {
+				t.Fatalf("expected %d, got %d", e, a)
+			}
+		})
+	}
+}
+
+func TestHeapLargeScale(t *testing.T) {
+	h := New(testHeapObjectKeyFunc, compareInts)
+	const amount = 1000
+
+	// Insert items in descending order.
+	for i := amount; i > 0; i-- {
+		h.AddOrUpdate(mkHeapObj(string([]rune{'a', rune(i)}), i))
+	}
+
+	// Update a subset to new priorities.
+	for i := 1; i <= amount; i += 10 {
+		h.AddOrUpdate(mkHeapObj(string([]rune{'a', rune(i)}), amount+i))
+	}
+
+	// Delete a subset.
+	for i := 5; i <= amount; i += 10 {
+		h.Delete(mkHeapObj(string([]rune{'a', rune(i)}), 0))
+	}
+
+	// Pop all remaining and verify sorted order.
+	prevNum := 0
+	for h.Len() > 0 {
+		item, err := h.Pop()
+		if err != nil {
+			t.Fatalf("unexpected pop error: %v", err)
+		}
+		num := item.val.(int)
+		if prevNum > num {
+			t.Fatalf("got %d out of order, last was %d", num, prevNum)
+		}
+		prevNum = num
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig scheduling

#### What this PR does / why we need it:
Replace the `queue []string` + `items map[string]*heapItem` double-map indirection in the scheduler heap with a pointer-based `queue []*heapItem` slice and a separate `keyIndex map[string]int` for key lookups. This will eliminate the separate heapItem map entries so items are now stored directly in the slice.

Previously, every `Less(i, j)` and `Swap(i, j)` call required hash-map lookups that costs O(log n) comparisons per Push/Pop/Fix. Now `Less` and `Swap` use direct pointer dereferences where the map is only consulted for key-based operations (AddOrUpdate, Delete, Get) which happen once per call.

I ran the benchmark locally with sizes (100, 1000, 5000) and the result was as follow:

Operation | Before | After | Change
-- | -- | -- | --
Pop | 16.7ms | 9.6ms | -43%
AddOrUpdate (Fix) | 2.7ms | 1.5ms | -45%
Push | 6.6ms | 5.0ms | -24%
Mixed | 15.1ms | 8.2ms | -46%

Allocations per Push/Mixed dropped ~50%. And also, triggered the [kubernetes-e2e-gce-100-performance](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/136355/pull-kubernetes-e2e-gce-100-performance/2034335783338381312) pipeline.

#### Which issue(s) this PR is related to:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No. Internal data structure change only.

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
