### PR TITLE
test/e2e/common/node: poll for eventually-consistent state to reduce flakiness

### DIFF
--- a/test/e2e/common/node/ephemeral_containers.go
+++ b/test/e2e/common/node/ephemeral_containers.go
@@ -88,9 +88,13 @@ var _ = SIGDescribe("Ephemeral Containers", framework.WithNodeConformance(), fun
 		// Can't use anything depending on kubectl here because it's not available in the node test environment
 		output := e2epod.ExecCommandInContainer(f, pod.Name, ecName, "/bin/echo", "marco")
 		gomega.Expect(output).To(gomega.ContainSubstring("marco"))
-		log, err := e2epod.GetPodLogs(ctx, f.ClientSet, pod.Namespace, pod.Name, ecName)
-		framework.ExpectNoError(err, "Failed to get logs for pod %q ephemeral container %q", e2epod.FormatPod(pod), ecName)
-		gomega.Expect(log).To(gomega.ContainSubstring("polo"))
+		// Poll for the expected log output. The ephemeral container may report Running before
+		// it has actually executed the command and produced "polo" stdout, especially on
+		// runtimes with slower container startup (e.g. VM-isolated containers).
+		gomega.Eventually(ctx, func() (string, error) {
+			return e2epod.GetPodLogs(ctx, f.ClientSet, pod.Namespace, pod.Name, ecName)
+		}, f.Timeouts.PodStartShort, framework.PollInterval()).Should(gomega.ContainSubstring("polo"),
+			"Failed to get expected log output for pod %q ephemeral container %q", e2epod.FormatPod(pod), ecName)
 	})
 
 	/*
@@ -141,9 +145,13 @@ var _ = SIGDescribe("Ephemeral Containers", framework.WithNodeConformance(), fun
 		// Can't use anything depending on kubectl here because it's not available in the node test environment
 		output := e2epod.ExecCommandInContainer(f, pod.Name, ecName, "/bin/echo", "marco")
 		gomega.Expect(output).To(gomega.ContainSubstring("marco"))
-		log, err := e2epod.GetPodLogs(ctx, f.ClientSet, pod.Namespace, pod.Name, ecName)
-		framework.ExpectNoError(err, "Failed to get logs for pod %q ephemeral container %q", e2epod.FormatPod(pod), ecName)
-		gomega.Expect(log).To(gomega.ContainSubstring("polo"))
+		// Poll for the expected log output. The ephemeral container may report Running before
+		// it has actually executed the command and produced "polo" stdout, especially on
+		// runtimes with slower container startup (e.g. VM-isolated containers).
+		gomega.Eventually(ctx, func() (string, error) {
+			return e2epod.GetPodLogs(ctx, f.ClientSet, pod.Namespace, pod.Name, ecName)
+		}, f.Timeouts.PodStartShort, framework.PollInterval()).Should(gomega.ContainSubstring("polo"),
+			"Failed to get expected log output for pod %q ephemeral container %q", e2epod.FormatPod(pod), ecName)
 
 		ginkgo.By(fmt.Sprintf("checking pod %q has only one ephemeralcontainer", pod.Name))
 		podResource := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}

--- a/test/e2e/common/node/lifecycle_hook.go
+++ b/test/e2e/common/node/lifecycle_hook.go
@@ -714,7 +714,12 @@ var _ = SIGDescribe("Lifecycle Sleep Hook", framework.WithNodeConformance(), fun
 			ginkgo.By("create the pod with lifecycle hook using sleep action")
 			p := podClient.Create(ctx, podWithHook)
 			defer podClient.DeleteSync(ctx, podWithHook.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
-			framework.ExpectNoError(e2epod.WaitForContainerTerminated(ctx, f.ClientSet, f.Namespace.Name, p.Name, name, gracePeriod*time.Second))
+			// Use the framework PodDelete timeout instead of gracePeriod*time.Second so
+			// we have headroom for slower runtimes (e.g. VM-isolated containers) to
+			// transition through Terminated. The actual correctness check below uses
+			// the container's intrinsic StartedAt/FinishedAt timestamps and is unaffected
+			// by how long we waited here.
+			framework.ExpectNoError(e2epod.WaitForContainerTerminated(ctx, f.ClientSet, f.Namespace.Name, p.Name, name, f.Timeouts.PodDelete))
 
 			p, err := podClient.Get(ctx, p.Name, metav1.GetOptions{})
 			if err != nil {

--- a/test/e2e/common/node/pods.go
+++ b/test/e2e/common/node/pods.go
@@ -656,28 +656,34 @@ var _ = SIGDescribe("Pods", func() {
 
 		url := req.URL()
 
-		ws, err := e2ewebsocket.OpenWebSocketForURL(url, config, []string{"binary.k8s.io"})
-		if err != nil {
-			framework.Failf("Failed to open websocket to %s: %v", url.String(), err)
-		}
-		defer ws.Close()
-		buf := &bytes.Buffer{}
-		for {
-			var msg []byte
-			if err := websocket.Message.Receive(ws, &msg); err != nil {
-				if err == io.EOF {
-					break
+		// Poll for the expected log content. The container may report Running before
+		// its first stdout line ("container is alive") has been flushed, especially on
+		// runtimes with slower container startup (e.g. VM-isolated containers). Retry
+		// the websocket read until we observe the expected output or the timeout
+		// elapses.
+		gomega.Eventually(ctx, func() (string, error) {
+			ws, err := e2ewebsocket.OpenWebSocketForURL(url, config, []string{"binary.k8s.io"})
+			if err != nil {
+				return "", fmt.Errorf("failed to open websocket to %s: %w", url.String(), err)
+			}
+			defer ws.Close()
+			buf := &bytes.Buffer{}
+			for {
+				var msg []byte
+				if err := websocket.Message.Receive(ws, &msg); err != nil {
+					if err == io.EOF {
+						break
+					}
+					return "", fmt.Errorf("failed to read completely from websocket %s: %w", url.String(), err)
 				}
-				framework.Failf("Failed to read completely from websocket %s: %v", url.String(), err)
+				if len(strings.TrimSpace(string(msg))) == 0 {
+					continue
+				}
+				buf.Write(msg)
 			}
-			if len(strings.TrimSpace(string(msg))) == 0 {
-				continue
-			}
-			buf.Write(msg)
-		}
-		if buf.String() != "container is alive\n" {
-			framework.Failf("Unexpected websocket logs:\n%s", buf.String())
-		}
+			return buf.String(), nil
+		}, f.Timeouts.PodStartShort, framework.PollInterval()).Should(gomega.Equal("container is alive\n"),
+			"Unexpected websocket logs from pod %q", pod.Name)
 	})
 
 	// Slow (~7 mins)


### PR DESCRIPTION
## What type of PR is this?
/kind cleanup
/kind flake

## What this PR does / why we need it

These tests have race conditions where they assume immediate state visibility after a pod transitions to `Running`. The current code works on fast runtimes but is fundamentally racy: kubelet log streaming, log file flushing, and container status updates are eventually consistent, not synchronous.

Switching to `gomega.Eventually` polling makes the tests deterministic. The success path on fast runtimes is unchanged (polling succeeds on first attempt), but the tests now correctly handle scenarios where state takes a moment to propagate. This benefits any environment where containers may take longer to start (VM-isolated runtimes such as Kata, gVisor, and Windows Hyper-V; overloaded CI VMs; shared multi-tenant clusters).

### Changes

- **`ephemeral_containers.go`** (both `should be added` and `should update` tests): the `polo` log-content check is polled via `gomega.Eventually` with `f.Timeouts.PodStartShort`. The container may report Running before its first stdout has been flushed.

- **`lifecycle_hook.go`** (`ignore terminated container`): use `f.Timeouts.PodDelete` instead of `gracePeriod*time.Second` for the termination wait. The actual correctness check (container's intrinsic `StartedAt`/`FinishedAt` < `sleepSeconds`) is unchanged and unaffected by how long we waited.

- **`pods.go`** (`retrieving logs from the container over websockets`): poll the websocket open and read via `gomega.Eventually`. The container can be reported Running before its first stdout line has been flushed, so opening the websocket immediately may return an empty or partial buffer.

## Which issue(s) this PR fixes

None — observed as recurring flakes in capz-windows-master-hyperv CI but the underlying races affect any sufficiently slow environment.

## Special notes for your reviewer

These are pure robustness improvements:
- No test semantics change — same things are validated
- No happy-path slowdown — polling succeeds on first attempt when state is already there
- No new dependencies, no new test infrastructure

## Does this PR introduce a user-facing change?

```
elease-note
NONE
```
