### PR TITLE
scheudler: Fix flakey eventhandler integration test

### DIFF
--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -519,8 +519,9 @@ func addAllEventHandlers(
 
 	for gvk, at := range gvkMap {
 		switch gvk {
-		case fwk.Node, fwk.Pod:
-			// Do nothing.
+		case fwk.Node, fwk.Pod, fwk.AssignedPod, fwk.UnscheduledPod, fwk.TargetPod:
+			// Do nothing. Pod sub-types (AssignedPod, UnscheduledPod, TargetPod)
+			// share the Pod informer registered separately and don't need their own handler.
 		case fwk.CSINode:
 			if handlerRegistration, err = informerFactory.Storage().V1().CSINodes().Informer().AddEventHandler(
 				buildEvtResHandler(at, fwk.CSINode),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake
/sig scheduling

#### What this PR does / why we need it:

##### Root cause

Commit [7a54834917a](https://github.com/kubernetes/kubernetes/commit/7a54834917aba685ae7975dda77e1c8d207212d4) introduced `UnrollPodEvent()` in `buildQueueingHintMap`, which expands `fwk.Pod` events into three sub-type events: TargetPod, AssignedPod, and UnscheduledPod. 
These sub-types now appear in the `gvkMap` passed to `addAllEventHandlers()`. However, that same commit forgot to add them to the switch statement, so they fall through to the default case which tries to parse them as CRD-style GVK strings and logs "Incorrect event registration" errors.

#### Fix 
Adds `fwk.AssignedPod`, `fwk.UnscheduledPod`, and `fwk.TargetPod` to the existing no-op case, since these sub-types share the Pod informer and don't need their own event handler registration.

#### Which issue(s) this PR is related to:
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No.
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
