### PR TITLE
Reduce numbers of conversions in CEL evaluation pipeline

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/conversion.go
@@ -18,8 +18,9 @@ package admission
 
 import (
 	"reflect"
-	"sync"
 
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -33,29 +34,31 @@ type VersionedAttributes struct {
 	// VersionedOldObject holds Attributes.OldObject (if non-nil), converted to VersionedKind.
 	// It must never be mutated.
 	VersionedOldObject runtime.Object
-	// unstructuredOldObject lazily caches Attributes.OldObject (if non-nil) as Unstructured. This helps in avoiding its repeated construction.
-	unstructuredOldObject *unstructured.Unstructured
+	// celOldObjectVal lazily caches Attributes.OldObject (if non-nil) as ref.Val representation. This helps in avoiding its repeated construction.
+	celOldObjectVal ref.Val
 	// VersionedObject holds Attributes.Object (if non-nil), converted to VersionedKind.
 	// If mutated, Dirty must be set to true by the mutator.
 	VersionedObject runtime.Object
-	// unstructuredObject lazily caches Attributes.Object (if non-nil) as Unstructured. This helps in avoiding its repeated construction.
-	unstructuredObject *unstructured.Unstructured
+	// celObjectVal lazily caches Attributes.Object (if non-nil) as ref.Val representation. This helps in avoiding its repeated construction.
+	celObjectVal ref.Val
 
 	// VersionedKind holds the fully qualified kind
 	VersionedKind schema.GroupVersionKind
 	// Dirty indicates VersionedObject has been modified since being converted from Attributes.Object
 	Dirty bool
-
-	// unstructuredCacheMutex protects the lazy initialization and cache clearing of the UnstructuredObject and UnstructuredOldObject fields.
-	unstructuredCacheMutex sync.Mutex
 }
 
-func (v *VersionedAttributes) updateOldObject(out runtime.Object) error {
-	v.unstructuredCacheMutex.Lock()
-	defer v.unstructuredCacheMutex.Unlock()
+// UpdateObject updates the VersionedObject and clears the cached CEL representation.
+func (v *VersionedAttributes) UpdateObject(obj runtime.Object) error {
+	v.VersionedObject = obj
+	v.celObjectVal = nil
+	return nil
+}
 
+// UpdateOldObject updates the VersionedOldObject and clears the cached CEL representation.
+func (v *VersionedAttributes) UpdateOldObject(out runtime.Object) error {
 	v.VersionedOldObject = out
-	v.unstructuredOldObject = nil
+	v.celOldObjectVal = nil
 	return nil
 }
 
@@ -112,52 +115,31 @@ func NewVersionedAttributes(attr Attributes, gvk schema.GroupVersionKind, o Obje
 	return versionedAttr, nil
 }
 
-// UpdateObject updates the VersionedObject and clears the cached UnstructuredObject.
-func (v *VersionedAttributes) UpdateObject(obj runtime.Object) error {
-	v.unstructuredCacheMutex.Lock()
-	defer v.unstructuredCacheMutex.Unlock()
 
-	v.VersionedObject = obj
-	v.unstructuredObject = nil
-	return nil
+// GetCELObjectVal lazily converts and returns the CEL representation of the object.
+func (v *VersionedAttributes) GetCELObjectVal() (ref.Val, error) {
+	return getCELVal(v.VersionedObject, &v.celObjectVal)
 }
 
-// GetUnstructuredObject lazily converts and returns the Unstructured representation of the object.
-func (v *VersionedAttributes) GetUnstructuredObject() (*unstructured.Unstructured, error) {
-	v.unstructuredCacheMutex.Lock()
-	defer v.unstructuredCacheMutex.Unlock()
+// GetCELOldObjectVal lazily converts and returns the CEL representation of the old object.
+func (v *VersionedAttributes) GetCELOldObjectVal() (ref.Val, error) {
+	return getCELVal(v.VersionedOldObject, &v.celOldObjectVal)
+}
 
-	if v.unstructuredObject != nil {
-		return v.unstructuredObject, nil
+func getCELVal(obj runtime.Object, cachedVal *ref.Val) (ref.Val, error) {
+	if *cachedVal != nil {
+		return *cachedVal, nil
 	}
-	if v.VersionedObject == nil {
+	if obj == nil {
 		return nil, nil
 	}
-	unstructuredObj, err := ConvertObjectToUnstructured(v.VersionedObject)
+	// TODO: Eventually use TypedToVal instead of unstructured object conversion.
+	unstructuredObj, err := ConvertObjectToUnstructured(obj)
 	if err != nil {
 		return nil, err
 	}
-	v.unstructuredObject = unstructuredObj
-	return v.unstructuredObject, nil
-}
-
-// GetUnstructuredOldObject lazily converts and returns the Unstructured representation of the old object.
-func (v *VersionedAttributes) GetUnstructuredOldObject() (*unstructured.Unstructured, error) {
-	v.unstructuredCacheMutex.Lock()
-	defer v.unstructuredCacheMutex.Unlock()
-
-	if v.unstructuredOldObject != nil {
-		return v.unstructuredOldObject, nil
-	}
-	if v.VersionedOldObject == nil {
-		return nil, nil
-	}
-	unstructuredObj, err := ConvertObjectToUnstructured(v.VersionedOldObject)
-	if err != nil {
-		return nil, err
-	}
-	v.unstructuredOldObject = unstructuredObj
-	return v.unstructuredOldObject, nil
+	*cachedVal = types.DefaultTypeAdapter.NativeToValue(unstructuredObj.Object)
+	return *cachedVal, nil
 }
 
 // ConvertVersionedAttributes converts VersionedObject and VersionedOldObject to the specified kind, if needed.
@@ -178,7 +160,7 @@ func ConvertVersionedAttributes(attr *VersionedAttributes, gvk schema.GroupVersi
 		if err != nil {
 			return err
 		}
-		if err := attr.updateOldObject(out); err != nil {
+		if err := attr.UpdateOldObject(out); err != nil {
 			return err
 		}
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/conversion.go
@@ -17,6 +17,10 @@ limitations under the License.
 package admission
 
 import (
+	"reflect"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -29,13 +33,30 @@ type VersionedAttributes struct {
 	// VersionedOldObject holds Attributes.OldObject (if non-nil), converted to VersionedKind.
 	// It must never be mutated.
 	VersionedOldObject runtime.Object
+	// unstructuredOldObject lazily caches Attributes.OldObject (if non-nil) as Unstructured. This helps in avoiding its repeated construction.
+	unstructuredOldObject *unstructured.Unstructured
 	// VersionedObject holds Attributes.Object (if non-nil), converted to VersionedKind.
 	// If mutated, Dirty must be set to true by the mutator.
 	VersionedObject runtime.Object
+	// unstructuredObject lazily caches Attributes.Object (if non-nil) as Unstructured. This helps in avoiding its repeated construction.
+	unstructuredObject *unstructured.Unstructured
+
 	// VersionedKind holds the fully qualified kind
 	VersionedKind schema.GroupVersionKind
 	// Dirty indicates VersionedObject has been modified since being converted from Attributes.Object
 	Dirty bool
+
+	// unstructuredCacheMutex protects the lazy initialization and cache clearing of the UnstructuredObject and UnstructuredOldObject fields.
+	unstructuredCacheMutex sync.Mutex
+}
+
+func (v *VersionedAttributes) updateOldObject(out runtime.Object) error {
+	v.unstructuredCacheMutex.Lock()
+	defer v.unstructuredCacheMutex.Unlock()
+
+	v.VersionedOldObject = out
+	v.unstructuredOldObject = nil
+	return nil
 }
 
 // GetObject overrides the Attributes.GetObject()
@@ -87,7 +108,56 @@ func NewVersionedAttributes(attr Attributes, gvk schema.GroupVersionKind, o Obje
 		}
 		versionedAttr.VersionedObject = out
 	}
+
 	return versionedAttr, nil
+}
+
+// UpdateObject updates the VersionedObject and clears the cached UnstructuredObject.
+func (v *VersionedAttributes) UpdateObject(obj runtime.Object) error {
+	v.unstructuredCacheMutex.Lock()
+	defer v.unstructuredCacheMutex.Unlock()
+
+	v.VersionedObject = obj
+	v.unstructuredObject = nil
+	return nil
+}
+
+// GetUnstructuredObject lazily converts and returns the Unstructured representation of the object.
+func (v *VersionedAttributes) GetUnstructuredObject() (*unstructured.Unstructured, error) {
+	v.unstructuredCacheMutex.Lock()
+	defer v.unstructuredCacheMutex.Unlock()
+
+	if v.unstructuredObject != nil {
+		return v.unstructuredObject, nil
+	}
+	if v.VersionedObject == nil {
+		return nil, nil
+	}
+	unstructuredObj, err := ConvertObjectToUnstructured(v.VersionedObject)
+	if err != nil {
+		return nil, err
+	}
+	v.unstructuredObject = unstructuredObj
+	return v.unstructuredObject, nil
+}
+
+// GetUnstructuredOldObject lazily converts and returns the Unstructured representation of the old object.
+func (v *VersionedAttributes) GetUnstructuredOldObject() (*unstructured.Unstructured, error) {
+	v.unstructuredCacheMutex.Lock()
+	defer v.unstructuredCacheMutex.Unlock()
+
+	if v.unstructuredOldObject != nil {
+		return v.unstructuredOldObject, nil
+	}
+	if v.VersionedOldObject == nil {
+		return nil, nil
+	}
+	unstructuredObj, err := ConvertObjectToUnstructured(v.VersionedOldObject)
+	if err != nil {
+		return nil, err
+	}
+	v.unstructuredOldObject = unstructuredObj
+	return v.unstructuredOldObject, nil
 }
 
 // ConvertVersionedAttributes converts VersionedObject and VersionedOldObject to the specified kind, if needed.
@@ -108,7 +178,9 @@ func ConvertVersionedAttributes(attr *VersionedAttributes, gvk schema.GroupVersi
 		if err != nil {
 			return err
 		}
-		attr.VersionedOldObject = out
+		if err := attr.updateOldObject(out); err != nil {
+			return err
+		}
 	}
 
 	if attr.VersionedObject != nil {
@@ -125,7 +197,9 @@ func ConvertVersionedAttributes(attr *VersionedAttributes, gvk schema.GroupVersi
 		if err != nil {
 			return err
 		}
-		attr.VersionedObject = out
+		if err := attr.UpdateObject(out); err != nil {
+			return err
+		}
 	}
 
 	// Remember we converted to this version
@@ -133,4 +207,16 @@ func ConvertVersionedAttributes(attr *VersionedAttributes, gvk schema.GroupVersi
 	attr.Dirty = false
 
 	return nil
+}
+
+// ConvertObjectToUnstructured converts an object to an unstructured representation.
+func ConvertObjectToUnstructured(obj interface{}) (*unstructured.Unstructured, error) {
+	if obj == nil || reflect.ValueOf(obj).IsNil() {
+		return &unstructured.Unstructured{Object: nil}, nil
+	}
+	ret, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	return &unstructured.Unstructured{Object: ret}, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/conversion.go
@@ -31,41 +31,29 @@ import (
 type VersionedAttributes struct {
 	// Attributes holds the original admission attributes
 	Attributes
-	// VersionedOldObject holds Attributes.OldObject (if non-nil), converted to VersionedKind.
+	// VersionedOldObject holds Attributes.OldObject (if non-nil), converted to VersionedKind and encapsulated in a LazyObject.
 	// It must never be mutated.
-	VersionedOldObject runtime.Object
-	// celOldObjectVal lazily caches Attributes.OldObject (if non-nil) as ref.Val representation. This helps in avoiding its repeated construction.
-	celOldObjectVal ref.Val
-	// VersionedObject holds Attributes.Object (if non-nil), converted to VersionedKind.
+	VersionedOldObject LazyObject
+	// VersionedObject holds Attributes.Object (if non-nil), converted to VersionedKind and encapsulated in a LazyObject.
 	// If mutated, Dirty must be set to true by the mutator.
-	VersionedObject runtime.Object
-	// celObjectVal lazily caches Attributes.Object (if non-nil) as ref.Val representation. This helps in avoiding its repeated construction.
-	celObjectVal ref.Val
+	VersionedObject LazyObject
 
 	// VersionedKind holds the fully qualified kind
 	VersionedKind schema.GroupVersionKind
-	// Dirty indicates VersionedObject has been modified since being converted from Attributes.Object
+	// Dirty indicates the inner object in VersionedObject has been modified since being converted from Attributes.Object
 	Dirty bool
 }
 
 // UpdateObject updates the VersionedObject and clears the cached CEL representation.
-func (v *VersionedAttributes) UpdateObject(obj runtime.Object) error {
-	v.VersionedObject = obj
-	v.celObjectVal = nil
-	return nil
-}
-
-// UpdateOldObject updates the VersionedOldObject and clears the cached CEL representation.
-func (v *VersionedAttributes) UpdateOldObject(out runtime.Object) error {
-	v.VersionedOldObject = out
-	v.celOldObjectVal = nil
-	return nil
+func (v *VersionedAttributes) UpdateObject(obj runtime.Object) {
+	v.Dirty = true
+	v.VersionedObject.Set(obj)
 }
 
 // GetObject overrides the Attributes.GetObject()
 func (v *VersionedAttributes) GetObject() runtime.Object {
-	if v.VersionedObject != nil {
-		return v.VersionedObject
+	if v.VersionedObject.object != nil {
+		return v.VersionedObject.object
 	}
 	return v.Attributes.GetObject()
 }
@@ -102,50 +90,60 @@ func NewVersionedAttributes(attr Attributes, gvk schema.GroupVersionKind, o Obje
 		if err != nil {
 			return nil, err
 		}
-		versionedAttr.VersionedOldObject = out
+		versionedAttr.VersionedOldObject.Set(out)
 	}
 	if obj := attr.GetObject(); obj != nil {
 		out, err := ConvertToGVK(obj, gvk, o)
 		if err != nil {
 			return nil, err
 		}
-		versionedAttr.VersionedObject = out
+		versionedAttr.VersionedObject.Set(out)
 	}
 
 	return versionedAttr, nil
 }
 
-
-// GetCELObjectVal lazily converts and returns the CEL representation of the object.
-func (v *VersionedAttributes) GetCELObjectVal() (ref.Val, error) {
-	return getCELVal(v.VersionedObject, &v.celObjectVal)
+// LazyObject encapsulates a versioned runtime.Object and its lazily-evaluated Common Expression Language (CEL) representation.
+type LazyObject struct {
+	object runtime.Object
+	celVal ref.Val
 }
 
-// GetCELOldObjectVal lazily converts and returns the CEL representation of the old object.
-func (v *VersionedAttributes) GetCELOldObjectVal() (ref.Val, error) {
-	return getCELVal(v.VersionedOldObject, &v.celOldObjectVal)
+// NewLazyObject returns a new LazyObject wrapping the provided runtime.Object.
+func NewLazyObject(obj runtime.Object) LazyObject {
+	return LazyObject{object: obj}
 }
 
-func getCELVal(obj runtime.Object, cachedVal *ref.Val) (ref.Val, error) {
-	if *cachedVal != nil {
-		return *cachedVal, nil
+// Object returns the underlying runtime.Object.
+func (l *LazyObject) Object() runtime.Object {
+	return l.object
+}
+
+func (l *LazyObject) Set(obj runtime.Object) {
+	l.object = obj
+	l.celVal = nil
+}
+
+func (l *LazyObject) CELValue() (ref.Val, error) {
+	if l.celVal != nil {
+		return l.celVal, nil
 	}
-	if obj == nil {
+	if l.object == nil {
 		return nil, nil
 	}
 	// TODO: Eventually use TypedToVal instead of unstructured object conversion.
-	unstructuredObj, err := ConvertObjectToUnstructured(obj)
+	unstructuredObj, err := ConvertObjectToUnstructured(l.object)
 	if err != nil {
 		return nil, err
 	}
-	*cachedVal = types.DefaultTypeAdapter.NativeToValue(unstructuredObj.Object)
-	return *cachedVal, nil
+	l.celVal = types.DefaultTypeAdapter.NativeToValue(unstructuredObj.Object)
+	return l.celVal, nil
 }
 
 // ConvertVersionedAttributes converts VersionedObject and VersionedOldObject to the specified kind, if needed.
 // If attr.VersionedKind already matches the requested kind, no conversion is performed.
 // If conversion is required:
-// * attr.VersionedObject is used as the source for the new object if Dirty=true (and is round-tripped through attr.Attributes.Object, clearing Dirty in the process)
+// * attr.VersionedObject.Object() is used as the source for the new object if Dirty=true (and is round-tripped through attr.Attributes.Object, clearing Dirty in the process)
 // * attr.Attributes.Object is used as the source for the new object if Dirty=false
 // * attr.Attributes.OldObject is used as the source for the old object
 func ConvertVersionedAttributes(attr *VersionedAttributes, gvk schema.GroupVersionKind, o ObjectInterfaces) error {
@@ -160,15 +158,13 @@ func ConvertVersionedAttributes(attr *VersionedAttributes, gvk schema.GroupVersi
 		if err != nil {
 			return err
 		}
-		if err := attr.UpdateOldObject(out); err != nil {
-			return err
-		}
+		attr.VersionedOldObject.Set(out)
 	}
 
-	if attr.VersionedObject != nil {
+	if attr.VersionedObject.object != nil {
 		// convert the existing versioned object to internal
 		if attr.Dirty {
-			err := o.GetObjectConvertor().Convert(attr.VersionedObject, attr.Attributes.GetObject(), nil)
+			err := o.GetObjectConvertor().Convert(attr.VersionedObject.object, attr.Attributes.GetObject(), nil)
 			if err != nil {
 				return err
 			}
@@ -179,9 +175,7 @@ func ConvertVersionedAttributes(attr *VersionedAttributes, gvk schema.GroupVersi
 		if err != nil {
 			return err
 		}
-		if err := attr.UpdateObject(out); err != nil {
-			return err
-		}
+		attr.VersionedObject.Set(out)
 	}
 
 	// Remember we converted to this version

--- a/staging/src/k8s.io/apiserver/pkg/admission/conversion_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/conversion_test.go
@@ -194,8 +194,8 @@ func TestConvertVersionedAttributes(t *testing.T) {
 					&example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "newpod"}},
 					&example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "oldpod"}},
 				),
-				VersionedObject:    &examplev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "newpodversioned"}},
-				VersionedOldObject: &examplev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "oldpodversioned"}},
+				VersionedObject:    NewLazyObject(&examplev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "newpodversioned"}}),
+				VersionedOldObject: NewLazyObject(&examplev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "oldpodversioned"}}),
 				VersionedKind:      examplev1.SchemeGroupVersion.WithKind("Pod"),
 				Dirty:              true,
 			},
@@ -205,8 +205,8 @@ func TestConvertVersionedAttributes(t *testing.T) {
 					&example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "newpod"}},
 					&example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "oldpod"}},
 				),
-				VersionedObject:    &examplev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "newpodversioned"}},
-				VersionedOldObject: &examplev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "oldpodversioned"}},
+				VersionedObject:    NewLazyObject(&examplev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "newpodversioned"}}),
+				VersionedOldObject: NewLazyObject(&examplev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "oldpodversioned"}}),
 				VersionedKind:      examplev1.SchemeGroupVersion.WithKind("Pod"),
 				Dirty:              true,
 			},
@@ -218,8 +218,8 @@ func TestConvertVersionedAttributes(t *testing.T) {
 					&example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "newpod"}},
 					&example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "oldpod"}},
 				),
-				VersionedObject:    &examplev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "newpodversioned"}},
-				VersionedOldObject: &examplev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "oldpodversioned"}},
+				VersionedObject:    NewLazyObject(&examplev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "newpodversioned"}}),
+				VersionedOldObject: NewLazyObject(&examplev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "oldpodversioned"}}),
 				VersionedKind:      gvk("g", "v", "k"),
 			},
 			GVK: examplev1.SchemeGroupVersion.WithKind("Pod"),
@@ -229,8 +229,8 @@ func TestConvertVersionedAttributes(t *testing.T) {
 					&example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "oldpod"}},
 				),
 				// name gets overwritten from converted attributes, type gets set explicitly
-				VersionedObject:    &examplev1.Pod{TypeMeta: metav1.TypeMeta{APIVersion: "example.apiserver.k8s.io/v1", Kind: "Pod"}, ObjectMeta: metav1.ObjectMeta{Name: "newpod"}},
-				VersionedOldObject: &examplev1.Pod{TypeMeta: metav1.TypeMeta{APIVersion: "example.apiserver.k8s.io/v1", Kind: "Pod"}, ObjectMeta: metav1.ObjectMeta{Name: "oldpod"}},
+				VersionedObject:    NewLazyObject(&examplev1.Pod{TypeMeta: metav1.TypeMeta{APIVersion: "example.apiserver.k8s.io/v1", Kind: "Pod"}, ObjectMeta: metav1.ObjectMeta{Name: "newpod"}}),
+				VersionedOldObject: NewLazyObject(&examplev1.Pod{TypeMeta: metav1.TypeMeta{APIVersion: "example.apiserver.k8s.io/v1", Kind: "Pod"}, ObjectMeta: metav1.ObjectMeta{Name: "oldpod"}}),
 				VersionedKind:      examplev1.SchemeGroupVersion.WithKind("Pod"),
 			},
 		},
@@ -241,8 +241,8 @@ func TestConvertVersionedAttributes(t *testing.T) {
 					u(`{"apiVersion": "mygroup.k8s.io/v1","kind": "Flunder","metadata":{"name":"newobj"}}`),
 					u(`{"apiVersion": "mygroup.k8s.io/v1","kind": "Flunder","metadata":{"name":"oldobj"}}`),
 				),
-				VersionedObject:    u(`{"apiVersion": "mygroup.k8s.io/v1","kind": "Flunder","metadata":{"name":"newobjversioned"}}`),
-				VersionedOldObject: u(`{"apiVersion": "mygroup.k8s.io/v1","kind": "Flunder","metadata":{"name":"oldobjversioned"}}`),
+				VersionedObject:    NewLazyObject(u(`{"apiVersion": "mygroup.k8s.io/v1","kind": "Flunder","metadata":{"name":"newobjversioned"}}`)),
+				VersionedOldObject: NewLazyObject(u(`{"apiVersion": "mygroup.k8s.io/v1","kind": "Flunder","metadata":{"name":"oldobjversioned"}}`)),
 				VersionedKind:      gvk("g", "v", "k"), // claim a different current version to trigger conversion
 			},
 			GVK: gvk("mygroup.k8s.io", "v1", "Flunder"),
@@ -251,8 +251,8 @@ func TestConvertVersionedAttributes(t *testing.T) {
 					u(`{"apiVersion": "mygroup.k8s.io/v1","kind": "Flunder","metadata":{"name":"newobj"}}`),
 					u(`{"apiVersion": "mygroup.k8s.io/v1","kind": "Flunder","metadata":{"name":"oldobj"}}`),
 				),
-				VersionedObject:    u(`{"apiVersion": "mygroup.k8s.io/v1","kind": "Flunder","metadata":{"name":"newobj"}}`),
-				VersionedOldObject: u(`{"apiVersion": "mygroup.k8s.io/v1","kind": "Flunder","metadata":{"name":"oldobj"}}`),
+				VersionedObject:    NewLazyObject(u(`{"apiVersion": "mygroup.k8s.io/v1","kind": "Flunder","metadata":{"name":"newobj"}}`)),
+				VersionedOldObject: NewLazyObject(u(`{"apiVersion": "mygroup.k8s.io/v1","kind": "Flunder","metadata":{"name":"oldobj"}}`)),
 				VersionedKind:      gvk("mygroup.k8s.io", "v1", "Flunder"),
 			},
 		},
@@ -263,8 +263,8 @@ func TestConvertVersionedAttributes(t *testing.T) {
 					&example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "newpod"}},
 					&example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "oldpod"}},
 				),
-				VersionedObject:    &examplev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "newpodversioned"}},
-				VersionedOldObject: &examplev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "oldpodversioned"}},
+				VersionedObject:    NewLazyObject(&examplev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "newpodversioned"}}),
+				VersionedOldObject: NewLazyObject(&examplev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "oldpodversioned"}}),
 				VersionedKind:      gvk("g", "v", "k"), // claim a different current version to trigger conversion
 				Dirty:              true,
 			},
@@ -275,9 +275,9 @@ func TestConvertVersionedAttributes(t *testing.T) {
 					&example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "oldpod"}},
 				),
 				// new name gets preserved from versioned object, type gets set explicitly
-				VersionedObject: &examplev1.Pod{TypeMeta: metav1.TypeMeta{APIVersion: "example.apiserver.k8s.io/v1", Kind: "Pod"}, ObjectMeta: metav1.ObjectMeta{Name: "newpodversioned"}},
+				VersionedObject: NewLazyObject(&examplev1.Pod{TypeMeta: metav1.TypeMeta{APIVersion: "example.apiserver.k8s.io/v1", Kind: "Pod"}, ObjectMeta: metav1.ObjectMeta{Name: "newpodversioned"}}),
 				// old name gets overwritten from converted attributes, type gets set explicitly
-				VersionedOldObject: &examplev1.Pod{TypeMeta: metav1.TypeMeta{APIVersion: "example.apiserver.k8s.io/v1", Kind: "Pod"}, ObjectMeta: metav1.ObjectMeta{Name: "oldpod"}},
+				VersionedOldObject: NewLazyObject(&examplev1.Pod{TypeMeta: metav1.TypeMeta{APIVersion: "example.apiserver.k8s.io/v1", Kind: "Pod"}, ObjectMeta: metav1.ObjectMeta{Name: "oldpod"}}),
 				VersionedKind:      examplev1.SchemeGroupVersion.WithKind("Pod"),
 				Dirty:              false,
 			},
@@ -289,8 +289,8 @@ func TestConvertVersionedAttributes(t *testing.T) {
 					u(`{"apiVersion": "mygroup.k8s.io/v1","kind": "Flunder","metadata":{"name":"newobj"}}`),
 					u(`{"apiVersion": "mygroup.k8s.io/v1","kind": "Flunder","metadata":{"name":"oldobj"}}`),
 				),
-				VersionedObject:    u(`{"apiVersion": "mygroup.k8s.io/v1","kind": "Flunder","metadata":{"name":"newobjversioned"}}`),
-				VersionedOldObject: u(`{"apiVersion": "mygroup.k8s.io/v1","kind": "Flunder","metadata":{"name":"oldobjversioned"}}`),
+				VersionedObject:    NewLazyObject(u(`{"apiVersion": "mygroup.k8s.io/v1","kind": "Flunder","metadata":{"name":"newobjversioned"}}`)),
+				VersionedOldObject: NewLazyObject(u(`{"apiVersion": "mygroup.k8s.io/v1","kind": "Flunder","metadata":{"name":"oldobjversioned"}}`)),
 				VersionedKind:      gvk("g", "v", "k"), // claim a different current version to trigger conversion
 				Dirty:              true,
 			},
@@ -301,9 +301,9 @@ func TestConvertVersionedAttributes(t *testing.T) {
 					u(`{"apiVersion": "mygroup.k8s.io/v1","kind": "Flunder","metadata":{"name":"oldobj"}}`),
 				),
 				// new name gets preserved from versioned object, type gets set explicitly
-				VersionedObject: u(`{"apiVersion": "mygroup.k8s.io/v1","kind": "Flunder","metadata":{"name":"newobjversioned"}}`),
+				VersionedObject: NewLazyObject(u(`{"apiVersion": "mygroup.k8s.io/v1","kind": "Flunder","metadata":{"name":"newobjversioned"}}`)),
 				// old name gets overwritten from converted attributes, type gets set explicitly
-				VersionedOldObject: u(`{"apiVersion": "mygroup.k8s.io/v1","kind": "Flunder","metadata":{"name":"oldobj"}}`),
+				VersionedOldObject: NewLazyObject(u(`{"apiVersion": "mygroup.k8s.io/v1","kind": "Flunder","metadata":{"name":"oldobj"}}`)),
 				VersionedKind:      gvk("mygroup.k8s.io", "v1", "Flunder"),
 				Dirty:              false,
 			},
@@ -315,8 +315,8 @@ func TestConvertVersionedAttributes(t *testing.T) {
 					&example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "newpod"}},
 					nil,
 				),
-				VersionedObject:    &examplev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "newpodversioned"}},
-				VersionedOldObject: nil,
+				VersionedObject:    NewLazyObject(&examplev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "newpodversioned"}}),
+				VersionedOldObject: NewLazyObject(nil),
 				VersionedKind:      gvk("g", "v", "k"), // claim a different current version to trigger conversion
 				Dirty:              true,
 			},
@@ -327,8 +327,8 @@ func TestConvertVersionedAttributes(t *testing.T) {
 					nil,
 				),
 				// new name gets preserved from versioned object, type gets set explicitly
-				VersionedObject:    &examplev1.Pod{TypeMeta: metav1.TypeMeta{APIVersion: "example.apiserver.k8s.io/v1", Kind: "Pod"}, ObjectMeta: metav1.ObjectMeta{Name: "newpodversioned"}},
-				VersionedOldObject: nil,
+				VersionedObject:    NewLazyObject(&examplev1.Pod{TypeMeta: metav1.TypeMeta{APIVersion: "example.apiserver.k8s.io/v1", Kind: "Pod"}, ObjectMeta: metav1.ObjectMeta{Name: "newpodversioned"}}),
+				VersionedOldObject: NewLazyObject(nil),
 				VersionedKind:      examplev1.SchemeGroupVersion.WithKind("Pod"),
 				Dirty:              false,
 			},
@@ -359,12 +359,6 @@ func TestConvertVersionedAttributes(t *testing.T) {
 			if e, a := tc.ExpectedAttrs.Dirty, tc.Attrs.Dirty; !reflect.DeepEqual(e, a) {
 				t.Errorf("unexpected diff:\n%s", cmp.Diff(e, a))
 			}
-			if e, a := tc.ExpectedAttrs.celObjectVal, tc.Attrs.celObjectVal; !reflect.DeepEqual(e, a) {
-				t.Errorf("unexpected diff:\n%s", cmp.Diff(e, a))
-			}
-			if e, a := tc.ExpectedAttrs.celOldObjectVal, tc.Attrs.celOldObjectVal; !reflect.DeepEqual(e, a) {
-				t.Errorf("unexpected diff:\n%s", cmp.Diff(e, a))
-			}
 		})
 	}
 }
@@ -380,15 +374,15 @@ func TestVersionedAttributesCELObjectsCaching(t *testing.T) {
 	t.Run("lazy evaluation and cache clear on update", func(t *testing.T) {
 		vAttrs, err := NewVersionedAttributes(attrs, example2v1.SchemeGroupVersion.WithKind("ReplicaSet"), o)
 		require.NoError(t, err)
-		require.Nil(t, vAttrs.celObjectVal)
-		require.Nil(t, vAttrs.celOldObjectVal)
+		require.Nil(t, vAttrs.VersionedObject.celVal)
+		require.Nil(t, vAttrs.VersionedOldObject.celVal)
 
-		uObj, err := vAttrs.GetCELObjectVal()
+		uObj, err := vAttrs.VersionedObject.CELValue()
 		require.NoError(t, err)
 		require.NotNil(t, uObj)
 		require.Equal(t, "new-rs", getMetaName(uObj))
 
-		uOldObj, err := vAttrs.GetCELOldObjectVal()
+		uOldObj, err := vAttrs.VersionedOldObject.CELValue()
 		require.NoError(t, err)
 		require.NotNil(t, uOldObj)
 		require.Equal(t, "old-rs", getMetaName(uOldObj))
@@ -398,13 +392,11 @@ func TestVersionedAttributesCELObjectsCaching(t *testing.T) {
 			TypeMeta:   metav1.TypeMeta{APIVersion: "example2.apiserver.k8s.io/v1", Kind: "ReplicaSet"},
 			ObjectMeta: metav1.ObjectMeta{Name: "updated-rs"},
 		}
-		vAttrs.Dirty = true
-		err = vAttrs.UpdateObject(updateRS)
-		require.NoError(t, err)
+		vAttrs.UpdateObject(updateRS)
 		// Cache is cleared on update
-		require.Nil(t, vAttrs.celObjectVal)
+		require.Nil(t, vAttrs.VersionedObject.celVal)
 
-		uObj, err = vAttrs.GetCELObjectVal()
+		uObj, err = vAttrs.VersionedObject.CELValue()
 		require.NoError(t, err)
 		require.Equal(t, "updated-rs", getMetaName(uObj))
 
@@ -414,9 +406,9 @@ func TestVersionedAttributesCELObjectsCaching(t *testing.T) {
 		err = ConvertVersionedAttributes(vAttrs, targetGVK, o)
 		require.NoError(t, err)
 
-		uObj, err = vAttrs.GetCELObjectVal()
+		uObj, err = vAttrs.VersionedObject.CELValue()
 		require.NoError(t, err)
-		uOldObj, err = vAttrs.GetCELOldObjectVal()
+		uOldObj, err = vAttrs.VersionedOldObject.CELValue()
 		require.NoError(t, err)
 
 		require.Equal(t, "updated-rs", getMetaName(uObj))

--- a/staging/src/k8s.io/apiserver/pkg/admission/conversion_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/conversion_test.go
@@ -358,6 +358,69 @@ func TestConvertVersionedAttributes(t *testing.T) {
 			if e, a := tc.ExpectedAttrs.Dirty, tc.Attrs.Dirty; !reflect.DeepEqual(e, a) {
 				t.Errorf("unexpected diff:\n%s", cmp.Diff(e, a))
 			}
+			if e, a := tc.ExpectedAttrs.unstructuredObject, tc.Attrs.unstructuredObject; !reflect.DeepEqual(e, a) {
+				t.Errorf("unexpected diff:\n%s", cmp.Diff(e, a))
+			}
+			if e, a := tc.ExpectedAttrs.unstructuredOldObject, tc.Attrs.unstructuredOldObject; !reflect.DeepEqual(e, a) {
+				t.Errorf("unexpected diff:\n%s", cmp.Diff(e, a))
+			}
 		})
 	}
+}
+
+func TestVersionedAttributesUnstructuredObjectCaching(t *testing.T) {
+	scheme := initiateScheme(t)
+	o := NewObjectInterfacesFromScheme(scheme)
+
+	oldRS := &example.ReplicaSet{ObjectMeta: metav1.ObjectMeta{Name: "old-rs"}}
+	newRS := &example.ReplicaSet{ObjectMeta: metav1.ObjectMeta{Name: "new-rs"}}
+	attrs := NewAttributesRecord(newRS, oldRS, schema.GroupVersionKind{}, "", "", schema.GroupVersionResource{}, "", "", nil, false, nil)
+
+	t.Run("lazy evaluation and cache clear on update", func(t *testing.T) {
+		vAttrs, err := NewVersionedAttributes(attrs, example2v1.SchemeGroupVersion.WithKind("ReplicaSet"), o)
+		require.NoError(t, err)
+		require.Nil(t, vAttrs.unstructuredObject)
+		require.Nil(t, vAttrs.unstructuredOldObject)
+
+		uObj, err := vAttrs.GetUnstructuredObject()
+		require.NoError(t, err)
+		require.NotNil(t, uObj)
+		require.Equal(t, "new-rs", uObj.GetName())
+
+		uOldObj, err := vAttrs.GetUnstructuredOldObject()
+		require.NoError(t, err)
+		require.NotNil(t, uOldObj)
+		require.Equal(t, "old-rs", uOldObj.GetName())
+
+		// 1. Update object
+		updateRS := &example2v1.ReplicaSet{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "example2.apiserver.k8s.io/v1", Kind: "ReplicaSet"},
+			ObjectMeta: metav1.ObjectMeta{Name: "updated-rs"},
+		}
+		vAttrs.Dirty = true
+		err = vAttrs.UpdateObject(updateRS)
+		require.NoError(t, err)
+		// Cache is cleared on update
+		require.Nil(t, vAttrs.unstructuredObject)
+
+		uObj, err = vAttrs.GetUnstructuredObject()
+		require.NoError(t, err)
+		require.Equal(t, "updated-rs", uObj.GetName())
+
+		// 2. Convert GVK
+		targetGVK := example2v1.SchemeGroupVersion.WithKind("ReplicaSet")
+		vAttrs.VersionedKind = schema.GroupVersionKind{Group: "dummy", Version: "v1", Kind: "ReplicaSet"}
+		err = ConvertVersionedAttributes(vAttrs, targetGVK, o)
+		require.NoError(t, err)
+
+		uObj, err = vAttrs.GetUnstructuredObject()
+		require.NoError(t, err)
+		uOldObj, err = vAttrs.GetUnstructuredOldObject()
+		require.NoError(t, err)
+
+		require.Equal(t, "updated-rs", uObj.GetName())
+		require.Equal(t, "example2.apiserver.k8s.io/v1", uObj.GetAPIVersion())
+		require.Equal(t, "old-rs", uOldObj.GetName())
+		require.Equal(t, "example2.apiserver.k8s.io/v1", uOldObj.GetAPIVersion())
+	})
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/conversion_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/conversion_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
@@ -358,17 +359,17 @@ func TestConvertVersionedAttributes(t *testing.T) {
 			if e, a := tc.ExpectedAttrs.Dirty, tc.Attrs.Dirty; !reflect.DeepEqual(e, a) {
 				t.Errorf("unexpected diff:\n%s", cmp.Diff(e, a))
 			}
-			if e, a := tc.ExpectedAttrs.unstructuredObject, tc.Attrs.unstructuredObject; !reflect.DeepEqual(e, a) {
+			if e, a := tc.ExpectedAttrs.celObjectVal, tc.Attrs.celObjectVal; !reflect.DeepEqual(e, a) {
 				t.Errorf("unexpected diff:\n%s", cmp.Diff(e, a))
 			}
-			if e, a := tc.ExpectedAttrs.unstructuredOldObject, tc.Attrs.unstructuredOldObject; !reflect.DeepEqual(e, a) {
+			if e, a := tc.ExpectedAttrs.celOldObjectVal, tc.Attrs.celOldObjectVal; !reflect.DeepEqual(e, a) {
 				t.Errorf("unexpected diff:\n%s", cmp.Diff(e, a))
 			}
 		})
 	}
 }
 
-func TestVersionedAttributesUnstructuredObjectCaching(t *testing.T) {
+func TestVersionedAttributesCELObjectsCaching(t *testing.T) {
 	scheme := initiateScheme(t)
 	o := NewObjectInterfacesFromScheme(scheme)
 
@@ -379,18 +380,18 @@ func TestVersionedAttributesUnstructuredObjectCaching(t *testing.T) {
 	t.Run("lazy evaluation and cache clear on update", func(t *testing.T) {
 		vAttrs, err := NewVersionedAttributes(attrs, example2v1.SchemeGroupVersion.WithKind("ReplicaSet"), o)
 		require.NoError(t, err)
-		require.Nil(t, vAttrs.unstructuredObject)
-		require.Nil(t, vAttrs.unstructuredOldObject)
+		require.Nil(t, vAttrs.celObjectVal)
+		require.Nil(t, vAttrs.celOldObjectVal)
 
-		uObj, err := vAttrs.GetUnstructuredObject()
+		uObj, err := vAttrs.GetCELObjectVal()
 		require.NoError(t, err)
 		require.NotNil(t, uObj)
-		require.Equal(t, "new-rs", uObj.GetName())
+		require.Equal(t, "new-rs", getMetaName(uObj))
 
-		uOldObj, err := vAttrs.GetUnstructuredOldObject()
+		uOldObj, err := vAttrs.GetCELOldObjectVal()
 		require.NoError(t, err)
 		require.NotNil(t, uOldObj)
-		require.Equal(t, "old-rs", uOldObj.GetName())
+		require.Equal(t, "old-rs", getMetaName(uOldObj))
 
 		// 1. Update object
 		updateRS := &example2v1.ReplicaSet{
@@ -401,11 +402,11 @@ func TestVersionedAttributesUnstructuredObjectCaching(t *testing.T) {
 		err = vAttrs.UpdateObject(updateRS)
 		require.NoError(t, err)
 		// Cache is cleared on update
-		require.Nil(t, vAttrs.unstructuredObject)
+		require.Nil(t, vAttrs.celObjectVal)
 
-		uObj, err = vAttrs.GetUnstructuredObject()
+		uObj, err = vAttrs.GetCELObjectVal()
 		require.NoError(t, err)
-		require.Equal(t, "updated-rs", uObj.GetName())
+		require.Equal(t, "updated-rs", getMetaName(uObj))
 
 		// 2. Convert GVK
 		targetGVK := example2v1.SchemeGroupVersion.WithKind("ReplicaSet")
@@ -413,14 +414,44 @@ func TestVersionedAttributesUnstructuredObjectCaching(t *testing.T) {
 		err = ConvertVersionedAttributes(vAttrs, targetGVK, o)
 		require.NoError(t, err)
 
-		uObj, err = vAttrs.GetUnstructuredObject()
+		uObj, err = vAttrs.GetCELObjectVal()
 		require.NoError(t, err)
-		uOldObj, err = vAttrs.GetUnstructuredOldObject()
+		uOldObj, err = vAttrs.GetCELOldObjectVal()
 		require.NoError(t, err)
 
-		require.Equal(t, "updated-rs", uObj.GetName())
-		require.Equal(t, "example2.apiserver.k8s.io/v1", uObj.GetAPIVersion())
-		require.Equal(t, "old-rs", uOldObj.GetName())
-		require.Equal(t, "example2.apiserver.k8s.io/v1", uOldObj.GetAPIVersion())
+		require.Equal(t, "updated-rs", getMetaName(uObj))
+		require.Equal(t, "example2.apiserver.k8s.io/v1", getAPIVersion(uObj))
+		require.Equal(t, "old-rs", getMetaName(uOldObj))
+		require.Equal(t, "example2.apiserver.k8s.io/v1", getAPIVersion(uOldObj))
 	})
+}
+
+func getMetaName(val ref.Val) string {
+	if val == nil {
+		return ""
+	}
+	m, ok := val.Value().(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	metadata, ok := m["metadata"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	return metadata["name"].(string)
+}
+
+func getAPIVersion(val ref.Val) string {
+	if val == nil {
+		return ""
+	}
+	m, ok := val.Value().(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	apiVersion, ok := m["apiVersion"].(string)
+	if !ok {
+		return ""
+	}
+	return apiVersion
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/activation.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/activation.go
@@ -34,12 +34,12 @@ import (
 // newActivation creates an activation for CEL admission plugins from the given request, admission chain and
 // variable binding information.
 func newActivation(compositionCtx CompositionContext, versionedAttr *admission.VersionedAttributes, request *admissionv1.AdmissionRequest, inputs OptionalVariableBindings, namespace *v1.Namespace) (*evaluationActivation, error) {
-	celOldObjVal, err := versionedAttr.GetCELOldObjectVal()
+	celOldObjVal, err := versionedAttr.VersionedOldObject.CELValue()
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare oldObject variable for evaluation: %w", err)
 	}
 
-	celObjVal, err := versionedAttr.GetCELObjectVal()
+	celObjVal, err := versionedAttr.VersionedObject.CELValue()
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare object variable for evaluation: %w", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/activation.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/activation.go
@@ -19,9 +19,10 @@ package cel
 import (
 	"context"
 	"fmt"
-	"github.com/google/cel-go/interpreter"
 	"math"
 	"time"
+
+	"github.com/google/cel-go/interpreter"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	v1 "k8s.io/api/core/v1"
@@ -33,25 +34,14 @@ import (
 // newActivation creates an activation for CEL admission plugins from the given request, admission chain and
 // variable binding information.
 func newActivation(compositionCtx CompositionContext, versionedAttr *admission.VersionedAttributes, request *admissionv1.AdmissionRequest, inputs OptionalVariableBindings, namespace *v1.Namespace) (*evaluationActivation, error) {
-
-	var oldObjectVal any
-	var err error
-
-	unstructuredOldObj, err := versionedAttr.GetUnstructuredOldObject()
+	celOldObjVal, err := versionedAttr.GetCELOldObjectVal()
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare oldObject variable for evaluation: %w", err)
 	}
-	if unstructuredOldObj != nil {
-		oldObjectVal = unstructuredOldObj.Object
-	}
 
-	var objectVal any
-	unstructuredObj, err := versionedAttr.GetUnstructuredObject()
+	celObjVal, err := versionedAttr.GetCELObjectVal()
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare object variable for evaluation: %w", err)
-	}
-	if unstructuredObj != nil {
-		objectVal = unstructuredObj.Object
 	}
 
 	var paramsVal, authorizerVal, requestResourceAuthorizerVal any
@@ -67,7 +57,7 @@ func newActivation(compositionCtx CompositionContext, versionedAttr *admission.V
 		requestResourceAuthorizerVal = library.NewResourceAuthorizerVal(versionedAttr.GetUserInfo(), inputs.Authorizer, versionedAttr)
 	}
 
-	requestVal, err := convertObjectToUnstructured(request)
+	requestVal, err := admission.ConvertObjectToUnstructured(request)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare request variable for evaluation: %w", err)
 	}
@@ -76,8 +66,8 @@ func newActivation(compositionCtx CompositionContext, versionedAttr *admission.V
 		return nil, fmt.Errorf("failed to prepare namespace variable for evaluation: %w", err)
 	}
 	va := &evaluationActivation{
-		object:                    objectVal,
-		oldObject:                 oldObjectVal,
+		object:                    celObjVal,
+		oldObject:                 celOldObjVal,
 		params:                    paramsVal,
 		request:                   requestVal.Object,
 		namespace:                 namespaceVal,

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/activation.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/activation.go
@@ -33,14 +33,27 @@ import (
 // newActivation creates an activation for CEL admission plugins from the given request, admission chain and
 // variable binding information.
 func newActivation(compositionCtx CompositionContext, versionedAttr *admission.VersionedAttributes, request *admissionv1.AdmissionRequest, inputs OptionalVariableBindings, namespace *v1.Namespace) (*evaluationActivation, error) {
-	oldObjectVal, err := objectToResolveVal(versionedAttr.VersionedOldObject)
+
+	var oldObjectVal any
+	var err error
+
+	unstructuredOldObj, err := versionedAttr.GetUnstructuredOldObject()
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare oldObject variable for evaluation: %w", err)
 	}
-	objectVal, err := objectToResolveVal(versionedAttr.VersionedObject)
+	if unstructuredOldObj != nil {
+		oldObjectVal = unstructuredOldObj.Object
+	}
+
+	var objectVal any
+	unstructuredObj, err := versionedAttr.GetUnstructuredObject()
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare object variable for evaluation: %w", err)
 	}
+	if unstructuredObj != nil {
+		objectVal = unstructuredObj.Object
+	}
+
 	var paramsVal, authorizerVal, requestResourceAuthorizerVal any
 	if inputs.VersionedParams != nil {
 		paramsVal, err = objectToResolveVal(inputs.VersionedParams)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/condition.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/condition.go
@@ -24,7 +24,6 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/cel/environment"
@@ -62,22 +61,11 @@ func NewCondition(compilationResults []CompilationResult) ConditionEvaluator {
 	}
 }
 
-func convertObjectToUnstructured(obj interface{}) (*unstructured.Unstructured, error) {
-	if obj == nil || reflect.ValueOf(obj).IsNil() {
-		return &unstructured.Unstructured{Object: nil}, nil
-	}
-	ret, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
-	if err != nil {
-		return nil, err
-	}
-	return &unstructured.Unstructured{Object: ret}, nil
-}
-
 func objectToResolveVal(r runtime.Object) (interface{}, error) {
 	if r == nil || reflect.ValueOf(r).IsNil() {
 		return nil, nil
 	}
-	v, err := convertObjectToUnstructured(r)
+	v, err := admission.ConvertObjectToUnstructured(r)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/compilation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/compilation_test.go
@@ -352,8 +352,8 @@ func TestCompilation(t *testing.T) {
 				vAttrs := &admission.VersionedAttributes{
 					Attributes:         attrs,
 					VersionedKind:      gvk,
-					VersionedObject:    obj,
-					VersionedOldObject: tc.oldObject,
+					VersionedObject:    admission.NewLazyObject(obj),
+					VersionedOldObject: admission.NewLazyObject(tc.oldObject),
 				}
 				r := patch.Request{
 					MatchedResource:     tc.gvr,

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/dispatcher.go
@@ -272,10 +272,8 @@ func (d *dispatcher) dispatchOne(
 		}
 	}
 	o.GetObjectDefaulter().Default(newVersionedObject)
-
 	versionedAttributes.Dirty = true
-	versionedAttributes.VersionedObject = newVersionedObject
-	return nil
+	return versionedAttributes.UpdateObject(newVersionedObject)
 }
 
 func keyFor(invocation generic.PolicyInvocation[*Policy, *PolicyBinding, PolicyEvaluator]) (key, error) {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/dispatcher.go
@@ -177,12 +177,12 @@ func (d *dispatcher) dispatchInvocations(
 			continue
 		}
 
-		objectBeforeMutations := versionedAttr.VersionedObject
+		objectBeforeMutations := versionedAttr.VersionedObject.Object()
 		// Mutations for a single invocation of a MutatingAdmissionPolicy are evaluated
 		// in order.
 		for mutationIndex := range invocation.Policy.Spec.Mutations {
 			lastVersionedAttr = versionedAttr
-			if versionedAttr.VersionedObject == nil { // Do not call patchers if there is no object to patch.
+			if versionedAttr.VersionedObject.Object() == nil { // Do not call patchers if there is no object to patch.
 				continue
 			}
 
@@ -205,7 +205,7 @@ func (d *dispatcher) dispatchInvocations(
 				celmetrics.Metrics.ObserveAdmission(ctx, elapsed, invocation.Policy.Name, invocation.Binding.Name, celmetrics.MutationNoError)
 			}
 		}
-		if !apiequality.Semantic.DeepEqual(objectBeforeMutations, versionedAttr.VersionedObject) {
+		if !apiequality.Semantic.DeepEqual(objectBeforeMutations, versionedAttr.VersionedObject.Object()) {
 			// The mutation has changed the object. Prepare to reinvoke all previous mutations that are eligible for re-invocation.
 			policyReinvokeCtx.RequireReinvokingPreviouslyInvokedPlugins()
 			reinvokeCtx.SetShouldReinvoke()
@@ -215,10 +215,10 @@ func (d *dispatcher) dispatchInvocations(
 		}
 	}
 
-	if lastVersionedAttr != nil && lastVersionedAttr.VersionedObject != nil && lastVersionedAttr.Dirty {
+	if lastVersionedAttr != nil && lastVersionedAttr.VersionedObject.Object() != nil && lastVersionedAttr.Dirty {
 		policyReinvokeCtx.RequireReinvokingPreviouslyInvokedPlugins()
 		reinvokeCtx.SetShouldReinvoke()
-		if err := o.GetObjectConvertor().Convert(lastVersionedAttr.VersionedObject, lastVersionedAttr.Attributes.GetObject(), nil); err != nil {
+		if err := o.GetObjectConvertor().Convert(lastVersionedAttr.VersionedObject.Object(), lastVersionedAttr.Attributes.GetObject(), nil); err != nil {
 			return nil, k8serrors.NewInternalError(fmt.Errorf("failed to convert object: %w", err))
 		}
 	}
@@ -261,7 +261,7 @@ func (d *dispatcher) dispatchOne(
 		return err
 	}
 
-	switch versionedAttributes.VersionedObject.(type) {
+	switch versionedAttributes.VersionedObject.Object().(type) {
 	case *unstructured.Unstructured:
 		// No conversion needed before defaulting for the patch object if the admitted object is unstructured.
 	default:
@@ -272,8 +272,8 @@ func (d *dispatcher) dispatchOne(
 		}
 	}
 	o.GetObjectDefaulter().Default(newVersionedObject)
-	versionedAttributes.Dirty = true
-	return versionedAttributes.UpdateObject(newVersionedObject)
+	versionedAttributes.UpdateObject(newVersionedObject)
+	return nil
 }
 
 func keyFor(invocation generic.PolicyInvocation[*Policy, *PolicyBinding, PolicyEvaluator]) (key, error) {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/dispatcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/dispatcher_test.go
@@ -679,8 +679,8 @@ func TestDispatcher(t *testing.T) {
 			vAttrs := &admission.VersionedAttributes{
 				Attributes:         attrs,
 				VersionedKind:      tc.gvk,
-				VersionedObject:    tc.object,
-				VersionedOldObject: tc.oldObject,
+				VersionedObject:    admission.NewLazyObject(tc.object),
+				VersionedOldObject: admission.NewLazyObject(tc.oldObject),
 			}
 
 			err = dispatcher.Dispatch(ctx, vAttrs, objectInterfaces, tc.policyHooks)
@@ -688,7 +688,7 @@ func TestDispatcher(t *testing.T) {
 				t.Fatalf("error dispatching policy hooks: %v", err)
 			}
 
-			obj := vAttrs.VersionedObject
+			obj := vAttrs.VersionedObject.Object()
 			if !equality.Semantic.DeepEqual(obj, tc.expect) {
 				t.Errorf("unexpected result, got diff:\n%s\n", cmp.Diff(tc.expect, obj))
 			}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch/json_patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch/json_patch.go
@@ -85,7 +85,7 @@ func (e *jsonPatcher) Patch(ctx context.Context, r Request, runtimeCELCostBudget
 	}
 	o := r.ObjectInterfaces
 	jsonSerializer := json.NewSerializerWithOptions(json.DefaultMetaFactory, o.GetObjectCreater(), o.GetObjectTyper(), json.SerializerOptions{Pretty: false, Strict: true})
-	objJS, err := runtime.Encode(jsonSerializer, r.VersionedAttributes.VersionedObject)
+	objJS, err := runtime.Encode(jsonSerializer, r.VersionedAttributes.VersionedObject.Object())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create JSON patch: %w", err)
 	}
@@ -93,13 +93,13 @@ func (e *jsonPatcher) Patch(ctx context.Context, r Request, runtimeCELCostBudget
 	if err != nil {
 		if errors.Is(err, jsonpatch.ErrTestFailed) {
 			// If a json patch fails a test operation, the patch must not be applied
-			return r.VersionedAttributes.VersionedObject, nil
+			return r.VersionedAttributes.VersionedObject.Object(), nil
 		}
 		return nil, fmt.Errorf("JSON Patch: %w", err)
 	}
 
 	var newVersionedObject runtime.Object
-	if _, ok := r.VersionedAttributes.VersionedObject.(*unstructured.Unstructured); ok {
+	if _, ok := r.VersionedAttributes.VersionedObject.Object().(*unstructured.Unstructured); ok {
 		newVersionedObject = &unstructured.Unstructured{}
 	} else {
 		newVersionedObject, err = o.GetObjectCreater().New(r.VersionedAttributes.VersionedKind)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch/json_patch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch/json_patch_test.go
@@ -444,8 +444,8 @@ func TestJSONPatch(t *testing.T) {
 			vAttrs := &admission.VersionedAttributes{
 				Attributes:         attrs,
 				VersionedKind:      gvk,
-				VersionedObject:    tc.object,
-				VersionedOldObject: tc.oldObject,
+				VersionedObject:    admission.NewLazyObject(tc.object),
+				VersionedOldObject: admission.NewLazyObject(tc.oldObject),
 			}
 
 			r := Request{

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch/smd.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch/smd.go
@@ -107,8 +107,8 @@ func (e *applyConfigPatcher) Patch(ctx context.Context, r Request, runtimeCELCos
 	}
 
 	patchObject := unstructured.Unstructured{Object: value}
-	patchObject.SetGroupVersionKind(r.VersionedAttributes.VersionedObject.GetObjectKind().GroupVersionKind())
-	patched, err := ApplyStructuredMergeDiff(r.TypeConverter, r.VersionedAttributes.VersionedObject, &patchObject)
+	patchObject.SetGroupVersionKind(r.VersionedAttributes.VersionedObject.Object().GetObjectKind().GroupVersionKind())
+	patched, err := ApplyStructuredMergeDiff(r.TypeConverter, r.VersionedAttributes.VersionedObject.Object(), &patchObject)
 	if err != nil {
 		return nil, fmt.Errorf("error applying patch: %w", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch/smd_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch/smd_test.go
@@ -396,8 +396,8 @@ func TestApplyConfiguration(t *testing.T) {
 			vAttrs := &admission.VersionedAttributes{
 				Attributes:         attrs,
 				VersionedKind:      gvk,
-				VersionedObject:    tc.object,
-				VersionedOldObject: tc.oldObject,
+				VersionedObject:    admission.NewLazyObject(tc.object),
+				VersionedOldObject: admission.NewLazyObject(tc.oldObject),
 			}
 
 			r := Request{

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/plugin_test.go
@@ -337,7 +337,7 @@ type annotationPatcher struct {
 }
 
 func (ap annotationPatcher) Patch(ctx context.Context, request patch.Request, runtimeCELCostBudget int64) (runtime.Object, error) {
-	obj := request.VersionedAttributes.VersionedObject.DeepCopyObject()
+	obj := request.VersionedAttributes.VersionedObject.Object().DeepCopyObject()
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
 		return nil, err
@@ -351,5 +351,5 @@ type smdPatcher struct {
 }
 
 func (sp smdPatcher) Patch(ctx context.Context, request patch.Request, runtimeCELCostBudget int64) (runtime.Object, error) {
-	return patch.ApplyStructuredMergeDiff(request.TypeConverter, request.VersionedAttributes.VersionedObject, sp.patch)
+	return patch.ApplyStructuredMergeDiff(request.TypeConverter, request.VersionedAttributes.VersionedObject.Object(), sp.patch)
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/dispatcher.go
@@ -115,14 +115,9 @@ func (c *dispatcher) Dispatch(ctx context.Context, a admission.Attributes, o adm
 	}
 
 	authz := admissionauthorizer.NewCachingAuthorizer(c.authz)
+	versionedAttrs := map[schema.GroupVersionKind]*admission.VersionedAttributes{}
 
 	for _, hook := range hooks {
-		// versionedAttributes will be set to non-nil inside of the loop, but
-		// is scoped outside of the param loop so we only convert once. We defer
-		// conversion so that it is only performed when we know a policy matches,
-		// saving the cost of converting non-matching requests.
-		var versionedAttr *admission.VersionedAttributes
-
 		definition := hook.Policy
 		matches, matchResource, matchKind, err := c.matcher.DefinitionMatches(a, o, NewValidatingAdmissionPolicyAccessor(definition))
 		if err != nil {
@@ -164,7 +159,10 @@ func (c *dispatcher) Dispatch(ctx context.Context, a admission.Attributes, o adm
 			if err != nil {
 				addConfigError(err, definition, binding)
 				continue
-			} else if versionedAttr == nil && len(params) > 0 {
+			}
+
+			versionedAttr := versionedAttrs[matchKind]
+			if versionedAttr == nil && len(params) > 0 {
 				// As optimization versionedAttr creation is deferred until
 				// first use. Since > 0 params, we will validate
 				va, err := admission.NewVersionedAttributes(a, matchKind, o)
@@ -174,6 +172,7 @@ func (c *dispatcher) Dispatch(ctx context.Context, a admission.Attributes, o adm
 					continue
 				}
 				versionedAttr = va
+				versionedAttrs[matchKind] = va
 			}
 
 			var validationResults []ValidateResult

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
@@ -232,8 +232,8 @@ func (a *mutatingDispatcher) Dispatch(ctx context.Context, attr admission.Attrib
 	}
 
 	// convert versionedAttr.VersionedObject to the internal version in the underlying admission.Attributes
-	if v.versionedAttr != nil && v.versionedAttr.VersionedObject != nil && v.versionedAttr.Dirty {
-		return o.GetObjectConvertor().Convert(v.versionedAttr.VersionedObject, v.versionedAttr.Attributes.GetObject(), nil)
+	if v.versionedAttr != nil && v.versionedAttr.VersionedObject.Object() != nil && v.versionedAttr.Dirty {
+		return o.GetObjectConvertor().Convert(v.versionedAttr.VersionedObject.Object(), v.versionedAttr.Attributes.GetObject(), nil)
 	}
 
 	return nil
@@ -343,7 +343,7 @@ func (a *mutatingDispatcher) callAttrMutatingHook(ctx context.Context, h *admiss
 	}
 
 	// if a non-empty patch was provided, and we have no object we can apply it to (e.g. a DELETE admission operation), error
-	if attr.VersionedObject == nil {
+	if attr.VersionedObject.Object() == nil {
 		return false, apierrors.NewInternalError(fmt.Errorf("admission webhook %q attempted to modify the object, which is not supported for this operation", h.Name))
 	}
 
@@ -352,7 +352,7 @@ func (a *mutatingDispatcher) callAttrMutatingHook(ctx context.Context, h *admiss
 	switch result.PatchType {
 	// VerifyAdmissionResponse normalizes to v1 patch types, regardless of the AdmissionReview version used
 	case admissionv1.PatchTypeJSONPatch:
-		objJS, err := runtime.Encode(jsonSerializer, attr.VersionedObject)
+		objJS, err := runtime.Encode(jsonSerializer, attr.VersionedObject.Object())
 		if err != nil {
 			return false, apierrors.NewInternalError(err)
 		}
@@ -365,7 +365,7 @@ func (a *mutatingDispatcher) callAttrMutatingHook(ctx context.Context, h *admiss
 	}
 
 	var newVersionedObject runtime.Object
-	if _, ok := attr.VersionedObject.(*unstructured.Unstructured); ok {
+	if _, ok := attr.VersionedObject.Object().(*unstructured.Unstructured); ok {
 		// Custom Resources don't have corresponding Go struct's.
 		// They are represented as Unstructured.
 		newVersionedObject = &unstructured.Unstructured{}
@@ -382,12 +382,11 @@ func (a *mutatingDispatcher) callAttrMutatingHook(ctx context.Context, h *admiss
 		return false, apierrors.NewInternalError(err)
 	}
 
-	changed = !apiequality.Semantic.DeepEqual(attr.VersionedObject, newVersionedObject)
+	changed = !apiequality.Semantic.DeepEqual(attr.VersionedObject.Object(), newVersionedObject)
 	span.AddEvent("Patch applied")
 	annotator.addPatchAnnotation(patchObj, result.PatchType)
-	attr.Dirty = true
-	attr.VersionedObject = newVersionedObject
-	o.GetObjectDefaulter().Default(attr.VersionedObject)
+	attr.UpdateObject(newVersionedObject)
+	o.GetObjectDefaulter().Default(attr.VersionedObject.Object())
 	return changed, nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/request/admissionreview.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/request/admissionreview.go
@@ -204,10 +204,10 @@ func CreateV1AdmissionReview(uid types.UID, versionedAttributes *admission.Versi
 			Operation:          admissionv1.Operation(attr.GetOperation()),
 			UserInfo:           userInfo,
 			Object: runtime.RawExtension{
-				Object: versionedAttributes.VersionedObject,
+				Object: versionedAttributes.VersionedObject.Object(),
 			},
 			OldObject: runtime.RawExtension{
-				Object: versionedAttributes.VersionedOldObject,
+				Object: versionedAttributes.VersionedOldObject.Object(),
 			},
 			DryRun: &dryRun,
 			Options: runtime.RawExtension{
@@ -270,10 +270,10 @@ func CreateV1beta1AdmissionReview(uid types.UID, versionedAttributes *admission.
 			Operation:          admissionv1beta1.Operation(attr.GetOperation()),
 			UserInfo:           userInfo,
 			Object: runtime.RawExtension{
-				Object: versionedAttributes.VersionedObject,
+				Object: versionedAttributes.VersionedObject.Object(),
 			},
 			OldObject: runtime.RawExtension{
-				Object: versionedAttributes.VersionedOldObject,
+				Object: versionedAttributes.VersionedOldObject.Object(),
 			},
 			DryRun: &dryRun,
 			Options: runtime.RawExtension{

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/request/admissionreview_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/request/admissionreview_test.go
@@ -502,8 +502,8 @@ func TestCreateAdmissionObjects(t *testing.T) {
 		{
 			name: "v1",
 			attrs: &admission.VersionedAttributes{
-				VersionedObject:    versionedObj.DeepCopyObject(),
-				VersionedOldObject: versionedObjOld.DeepCopyObject(),
+				VersionedObject:    admission.NewLazyObject(versionedObj.DeepCopyObject()),
+				VersionedOldObject: admission.NewLazyObject(versionedObjOld.DeepCopyObject()),
 				Attributes:         attrs,
 			},
 			invocation: &generic.WebhookInvocation{
@@ -545,8 +545,8 @@ func TestCreateAdmissionObjects(t *testing.T) {
 		{
 			name: "v1beta1",
 			attrs: &admission.VersionedAttributes{
-				VersionedObject:    versionedObj.DeepCopyObject(),
-				VersionedOldObject: versionedObjOld.DeepCopyObject(),
+				VersionedObject:    admission.NewLazyObject(versionedObj.DeepCopyObject()),
+				VersionedOldObject: admission.NewLazyObject(versionedObjOld.DeepCopyObject()),
 				Attributes:         attrs,
 			},
 			invocation: &generic.WebhookInvocation{


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind cleanup

#### What this PR does / why we need it:

The Common Expression Language (CEL) admission plugin frequently converts `runtime.Object` to an unstructured representation (`map[string]interface{}`) for policy evaluations. When multiple policy rules or webhooks are executed in sequence, converting the same object repeatedly becomes a significant CPU bottleneck.

This PR optimizes the CEL evaluation pipeline by introducing a thread-safe, lazy-loaded caching mechanism for unstructured object representations and a high-performance manual construction path for `AdmissionRequest`.

**Key Optimizations:**

1.  **Lazy-Loaded Unstructured Caching:** Introduces unexported `celObjectVal` and `celOldObjectVal` fields in `VersionedAttributes`. These are populated lazily via `GetCelObjectVal()` and `GetCelOldObjectVal()` only when a CEL evaluation actually requires them. This ensures that we only pay the conversion cost once per request and avoid it entirely if CEL evaluation is skipped (e.g., for empty expression groups).


#### Performance Benchmarks (200 QPS Load Test):

| Scenario | Kubernetes 1.35 | Master Branch | This PR (HEAD) | Improvement (vs Master) |
| :--- | :--- | :--- | :--- | :--- |
| **5 VAPs (Heavy Load)** | 1.25 Cores | 1.10 Cores | **0.93 Cores** | **~15% reduction** |
| **1 VAP (Light Load)** | 0.82 Cores | 0.81 Cores | **0.84 Cores** | **Functionally identical** |



#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

*   The `FillUnstructuredFields` option from earlier iterations has been removed in favor of strict lazy loading.
*   The `TestVersionedAttributesUnstructuredObjectCaching` test suite has been updated to verify the lazy initialization and cache-clearing behavior.
*   Full reproduction steps and profiling data can be found in this [Gist](https://gist.github.com/lalitc375/d7746f0d916c4f542e994cc4b996f611).

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
