### PR TITLE
Use contextual logging in system namespaces controller

### DIFF
--- a/pkg/controlplane/apiserver/server.go
+++ b/pkg/controlplane/apiserver/server.go
@@ -142,7 +142,7 @@ func (c completedConfig) New(name string, delegationTarget genericapiserver.Dele
 	}
 	if len(c.SystemNamespaces) > 0 {
 		s.GenericAPIServer.AddPostStartHookOrDie("start-system-namespaces-controller", func(hookContext genericapiserver.PostStartHookContext) error {
-			go systemnamespaces.NewController(c.SystemNamespaces, client, s.VersionedInformers.Core().V1().Namespaces()).Run(hookContext.Done())
+			go systemnamespaces.NewController(c.SystemNamespaces, client, s.VersionedInformers.Core().V1().Namespaces()).Run(hookContext)
 			return nil
 		})
 	}

--- a/pkg/controlplane/controller/systemnamespaces/system_namespaces_controller.go
+++ b/pkg/controlplane/controller/systemnamespaces/system_namespaces_controller.go
@@ -18,7 +18,6 @@ package systemnamespaces
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -30,7 +29,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
-
 	"k8s.io/klog/v2"
 )
 
@@ -59,32 +57,32 @@ func NewController(systemNamespaces []string, clientset kubernetes.Interface, na
 }
 
 // Run starts one worker.
-func (c *Controller) Run(stopCh <-chan struct{}) {
-	defer utilruntime.HandleCrash()
-	defer klog.Infof("Shutting down system namespaces controller")
+func (c *Controller) Run(ctx context.Context) {
+	defer utilruntime.HandleCrashWithContext(ctx)
+	logger := klog.FromContext(ctx)
+	defer logger.Info("Shutting down system namespaces controller")
 
-	klog.Infof("Starting system namespaces controller")
+	logger.Info("Starting system namespaces controller")
 
-	if !cache.WaitForCacheSync(stopCh, c.namespaceSynced) {
-		utilruntime.HandleError(fmt.Errorf("timed out waiting for caches to sync"))
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, c.namespaceSynced) {
 		return
 	}
 
-	go wait.Until(c.sync, c.interval, stopCh)
+	go wait.UntilWithContext(ctx, c.sync, c.interval)
 
-	<-stopCh
+	<-ctx.Done()
 }
 
-func (c *Controller) sync() {
+func (c *Controller) sync(ctx context.Context) {
 	// Loop the system namespace list, and create them if they do not exist
 	for _, ns := range c.systemNamespaces {
-		if err := c.createNamespaceIfNeeded(ns); err != nil {
-			utilruntime.HandleError(fmt.Errorf("unable to create required kubernetes system Namespace %s: %v", ns, err))
+		if err := c.createNamespaceIfNeeded(ctx, ns); err != nil {
+			utilruntime.HandleErrorWithContext(ctx, err, "Unable to create required kubernetes system namespace", "namespace", ns)
 		}
 	}
 }
 
-func (c *Controller) createNamespaceIfNeeded(ns string) error {
+func (c *Controller) createNamespaceIfNeeded(ctx context.Context, ns string) error {
 	if _, err := c.namespaceLister.Get(ns); err == nil {
 		// the namespace already exists
 		return nil
@@ -95,7 +93,7 @@ func (c *Controller) createNamespaceIfNeeded(ns string) error {
 			Namespace: "",
 		},
 	}
-	_, err := c.client.CoreV1().Namespaces().Create(context.TODO(), newNs, metav1.CreateOptions{})
+	_, err := c.client.CoreV1().Namespaces().Create(ctx, newNs, metav1.CreateOptions{})
 	if err != nil && errors.IsAlreadyExists(err) {
 		err = nil
 	}

--- a/pkg/controlplane/controller/systemnamespaces/system_namespaces_controller_test.go
+++ b/pkg/controlplane/controller/systemnamespaces/system_namespaces_controller_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 // Test_Controller validates the garbage collection logic for the apiserverleasegc controller.
@@ -87,6 +88,7 @@ func Test_Controller(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
 			objs := []runtime.Object{}
 			for _, ns := range test.namespaces {
 				objs = append(objs,
@@ -114,7 +116,7 @@ func Test_Controller(t *testing.T) {
 				return true, create.GetObject(), nil
 			})
 
-			controller.sync()
+			controller.sync(ctx)
 
 			expectAction(t, clientset.Actions(), test.actions)
 			namespaces, err := controller.namespaceLister.List(labels.Everything())


### PR DESCRIPTION
## Summary
- Migrates `pkg/controlplane/controller/systemnamespaces` to contextual logging
- Replaces legacy `klog.Infof` calls with `logger.Info` using `klog.FromContext(ctx)`
- Propagates `context.Context` through `Run`, `sync`, and `createNamespaceIfNeeded`
- Updates caller in `server.go` and tests accordingly

Related: #126379

## Details

This PR migrates the system namespaces controller to use contextual logging, as part of the umbrella issue #126379.

Changes:
- `Run(stopCh <-chan struct{})` → `Run(ctx context.Context)`
- `utilruntime.HandleCrash()` → `utilruntime.HandleCrashWithContext(ctx)`
- `klog.Infof(...)` → `logger.Info(...)` via `klog.FromContext(ctx)`
- `cache.WaitForCacheSync` → `cache.WaitForNamedCacheSyncWithContext`
- `utilruntime.HandleError(fmt.Errorf(...))` → `utilruntime.HandleErrorWithContext(ctx, err, msg, kv...)`
- `wait.Until` → `wait.UntilWithContext`
- `context.TODO()` replaced with propagated `ctx`
- Caller in `server.go` updated to pass `hookContext` (which embeds `context.Context`) instead of `hookContext.Done()`
- Tests updated to use `ktesting.NewTestContext(t)`

## Test plan
- [x] Package compiles successfully
- [x] All 6 existing test cases pass (`Test_Controller/*`)
- [x] `go build ./pkg/controlplane/apiserver/...` — caller site compiles