### PR TITLE
kubelet: stop status manager from flooding apiserver with 404 GETs for deleted pods

### DIFF
--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -1141,14 +1141,14 @@ func (m *manager) syncBatch(ctx context.Context, all bool) int {
 
 	for _, update := range updatedStatuses {
 		logger.V(5).Info("Sync pod status", "podUID", update.podUID, "statusUID", update.statusUID, "version", update.status.version)
-		m.syncPod(ctx, update.podUID, update.status)
+		m.syncPod(ctx, update.podUID, update.statusUID, update.status)
 	}
 
 	return len(updatedStatuses)
 }
 
 // syncPod syncs the given status with the API server. The caller must not hold the status lock.
-func (m *manager) syncPod(ctx context.Context, uid types.UID, status versionedPodStatus) {
+func (m *manager) syncPod(ctx context.Context, uid types.UID, statusUID kubetypes.MirrorPodUID, status versionedPodStatus) {
 	logger := klog.FromContext(ctx)
 	// TODO: make me easier to express from client code
 	pod, err := m.kubeClient.CoreV1().Pods(status.podNamespace).Get(ctx, status.podName, metav1.GetOptions{})
@@ -1158,6 +1158,11 @@ func (m *manager) syncPod(ctx context.Context, uid types.UID, status versionedPo
 			"pod", klog.KRef(status.podNamespace, status.podName))
 		// If the Pod is deleted the status will be cleared in
 		// RemoveOrphanedStatuses, so we just ignore the update here.
+		// Mark this version as synced to avoid retrying on every sync cycle,
+		// which would cause unnecessary API server load in degraded situations
+		// (e.g., when the local filesystem have some hardware issues (like changed to read-only) and pod cleanup cannot
+		// complete). A new status update (version bump) will still trigger a retry.
+		m.apiStatusVersions[statusUID] = status.version
 		return
 	}
 	if err != nil {
@@ -1175,6 +1180,9 @@ func (m *manager) syncPod(ctx context.Context, uid types.UID, status versionedPo
 			"oldPodUID", uid,
 			"podUID", translatedUID)
 		m.deletePodStatus(uid)
+		// Clean up the old version tracking so that if the pod is re-added
+		// (e.g., via SetPodStatus), the new status will be synced.
+		delete(m.apiStatusVersions, statusUID)
 		return
 	}
 

--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -334,6 +334,35 @@ func TestSyncPodIgnoresNotFound(t *testing.T) {
 	verifyActions(t, syncer, []core.Action{getAction()})
 }
 
+func TestSyncPodNotFoundStopsRetrying(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	client := fake.Clientset{}
+	syncer := newTestManager(&client)
+	client.AddReactor("get", "pods", func(action core.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.NewNotFound(api.Resource("pods"), "test-pod")
+	})
+	pod := getTestPod()
+	syncer.SetPodStatus(logger, pod, getRandomPodStatus())
+	// First sync: should issue one GET that returns 404.
+	verifyActions(t, syncer, []core.Action{getAction()})
+
+	// Subsequent syncBatch(true) should NOT issue another GET because the
+	// version was marked as synced after the 404 response.
+	syncer.testSyncBatch(ctx)
+	actions := syncer.kubeClient.(*fake.Clientset).Actions()
+	assert.Empty(t, actions, "Expected no API calls after 404 was already handled")
+
+	// A new status update should trigger one more GET (and 404 again).
+	syncer.SetPodStatus(logger, pod, getRandomPodStatus())
+	verifyActions(t, syncer, []core.Action{getAction()})
+
+	// And again, no retries after that.
+	syncer.kubeClient.(*fake.Clientset).ClearActions()
+	syncer.testSyncBatch(ctx)
+	actions = syncer.kubeClient.(*fake.Clientset).Actions()
+	assert.Empty(t, actions, "Expected no API calls on second retry suppression")
+}
+
 func TestSyncPod(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	syncer := newTestManager(&fake.Clientset{})

--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -363,6 +363,45 @@ func TestSyncPodNotFoundStopsRetrying(t *testing.T) {
 	assert.Empty(t, actions, "Expected no API calls on second retry suppression")
 }
 
+func TestSyncPodMismatchedUIDClearsVersionAndResyncs(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	client := fake.Clientset{}
+	syncer := newTestManager(&client)
+
+	pod := getTestPod()
+	pod.UID = "first"
+	syncer.podManager.(mutablePodManager).AddPod(pod)
+
+	// A different pod exists on the API server with the same name but different UID,
+	// simulating a pod that was deleted and recreated.
+	recreatedPod := getTestPod()
+	recreatedPod.UID = "second"
+	syncer.kubeClient = fake.NewSimpleClientset(recreatedPod)
+	syncer.podManager.(mutablePodManager).AddPod(recreatedPod)
+
+	// Sync the old pod's status. syncPod will GET the recreated pod from the API server,
+	// TranslatePodUID("second") returns "second" which != "first" → UID mismatch.
+	// This should delete the old status and clean up apiStatusVersions.
+	syncer.SetPodStatus(logger, pod, getRandomPodStatus())
+	verifyActions(t, syncer, []core.Action{getAction()})
+
+	// The apiStatusVersions entry for the old pod should be cleaned up.
+	oldMirrorUID := kubetypes.MirrorPodUID(pod.UID)
+	_, exists := syncer.apiStatusVersions[oldMirrorUID]
+	assert.False(t, exists, "apiStatusVersions for old UID should be deleted after mismatch")
+
+	// Now set status for the recreated pod. It should sync normally (GET + PATCH)
+	// because the stale version entry was cleaned up and won't suppress the sync.
+	syncer.SetPodStatus(logger, recreatedPod, getRandomPodStatus())
+	verifyActions(t, syncer, []core.Action{getAction(), patchAction()})
+
+	// Subsequent syncBatch should not re-sync (version already recorded).
+	syncer.kubeClient.(*fake.Clientset).ClearActions()
+	syncer.testSyncBatch(ctx)
+	actions := syncer.kubeClient.(*fake.Clientset).Actions()
+	assert.Empty(t, actions, "Expected no API calls after recreated pod status was already synced")
+}
+
 func TestSyncPod(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	syncer := newTestManager(&fake.Clientset{})


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
it will stop kubelet to send repeated meaningless request to apiserver when pod worker failed cleanup due to some underlying node issue, see https://github.com/kubernetes/kubernetes/issues/139020
#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/139020
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
N/A
```

/sig node

