### PR TITLE
Enable optional or required linter for networking api group 

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13914,8 +13914,7 @@
         }
       },
       "required": [
-        "pathType",
-        "backend"
+        "pathType"
       ],
       "type": "object"
     },
@@ -14104,6 +14103,9 @@
           "description": "spec is the desired state of the IngressClass. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
+      "required": [
+        "spec"
+      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -14190,6 +14192,9 @@
           "description": "parameters is a link to a custom resource containing additional configuration for the controller. This is optional if the controller does not require extra parameters."
         }
       },
+      "required": [
+        "controller"
+      ],
       "type": "object"
     },
     "io.k8s.api.networking.v1.IngressList": {
@@ -14280,10 +14285,6 @@
           "type": "string"
         }
       },
-      "required": [
-        "port",
-        "protocol"
-      ],
       "type": "object"
     },
     "io.k8s.api.networking.v1.IngressRule": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -14829,8 +14829,7 @@
         }
       },
       "required": [
-        "pathType",
-        "backend"
+        "pathType"
       ],
       "type": "object"
     },
@@ -15019,6 +15018,9 @@
           "description": "spec is the desired state of the IngressClass. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
         }
       },
+      "required": [
+        "spec"
+      ],
       "type": "object",
       "x-kubernetes-group-version-kind": [
         {
@@ -15105,6 +15107,9 @@
           "description": "parameters is a link to a custom resource containing additional configuration for the controller. This is optional if the controller does not require extra parameters."
         }
       },
+      "required": [
+        "controller"
+      ],
       "type": "object"
     },
     "io.k8s.api.networking.v1.IngressList": {
@@ -15195,10 +15200,6 @@
           "type": "string"
         }
       },
-      "required": [
-        "port",
-        "protocol"
-      ],
       "type": "object"
     },
     "io.k8s.api.networking.v1.IngressRule": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -14829,7 +14829,8 @@
         }
       },
       "required": [
-        "pathType"
+        "pathType",
+        "backend"
       ],
       "type": "object"
     },
@@ -15229,7 +15230,8 @@
         }
       },
       "required": [
-        "name"
+        "name",
+        "port"
       ],
       "type": "object"
     },

--- a/api/openapi-spec/v3/apis__networking.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__networking.k8s.io__v1_openapi.json
@@ -48,8 +48,7 @@
           }
         },
         "required": [
-          "pathType",
-          "backend"
+          "pathType"
         ],
         "type": "object"
       },
@@ -291,6 +290,9 @@
             "description": "spec is the desired state of the IngressClass. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status"
           }
         },
+        "required": [
+          "spec"
+        ],
         "type": "object",
         "x-kubernetes-group-version-kind": [
           {
@@ -388,6 +390,9 @@
             "description": "parameters is a link to a custom resource containing additional configuration for the controller. This is optional if the controller does not require extra parameters."
           }
         },
+        "required": [
+          "controller"
+        ],
         "type": "object"
       },
       "io.k8s.api.networking.v1.IngressList": {
@@ -485,10 +490,6 @@
             "type": "string"
           }
         },
-        "required": [
-          "port",
-          "protocol"
-        ],
         "type": "object"
       },
       "io.k8s.api.networking.v1.IngressRule": {

--- a/api/openapi-spec/v3/apis__networking.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__networking.k8s.io__v1_openapi.json
@@ -48,7 +48,8 @@
           }
         },
         "required": [
-          "pathType"
+          "pathType",
+          "backend"
         ],
         "type": "object"
       },
@@ -529,7 +530,8 @@
           }
         },
         "required": [
-          "name"
+          "name",
+          "port"
         ],
         "type": "object"
       },

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -231,7 +231,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -244,6 +244,11 @@ linters:
       
       # NonPointerStructs - Existing fields that are non-pointer structs but where the current rules are incorrect.
       
+      # IngressBackend and ServiceBackendPort are union-like structs, but nonpointerstructs does not understand unions today.
+      # Validation makes these require at least one of the fields within to be set.
+      - text: "nonpointerstructs: field (HTTPIngressPath\\.Backend|IngressServiceBackend\\.Port) is a non-pointer struct with no required fields\\..*"
+        path: "staging/src/k8s.io/api/networking/v1/types\\.go"
+      
       # The (PodGroupSpec|PodGroupTemplate|CompositePodGroupSpec|CompositePodGroupTemplate).SchedulingPolicy field is a union type, but nonpointerstructs does not understand unions today.
       # Validation makes this require at least one of the fields within to be set.
       - text: "nonpointerstructs: field (PodGroupSpec|PodGroupTemplate|CompositePodGroupSpec|CompositePodGroupTemplate)\\.SchedulingPolicy is a non-pointer struct with no required fields\\..*"

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -232,7 +232,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -246,7 +246,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -247,7 +247,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -259,6 +259,11 @@ linters:
       
       # NonPointerStructs - Existing fields that are non-pointer structs but where the current rules are incorrect.
       
+      # IngressBackend and ServiceBackendPort are union-like structs, but nonpointerstructs does not understand unions today.
+      # Validation makes these require at least one of the fields within to be set.
+      - text: "nonpointerstructs: field (HTTPIngressPath\\.Backend|IngressServiceBackend\\.Port) is a non-pointer struct with no required fields\\..*"
+        path: "staging/src/k8s.io/api/networking/v1/types\\.go"
+      
       # The (PodGroupSpec|PodGroupTemplate|CompositePodGroupSpec|CompositePodGroupTemplate).SchedulingPolicy field is a union type, but nonpointerstructs does not understand unions today.
       # Validation makes this require at least one of the fields within to be set.
       - text: "nonpointerstructs: field (PodGroupSpec|PodGroupTemplate|CompositePodGroupSpec|CompositePodGroupTemplate)\\.SchedulingPolicy is a non-pointer struct with no required fields\\..*"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -107,7 +107,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|networking|storage)"
+  path: "staging/src/k8s.io/api/(admissionregistration|apidiscovery|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|flowcontrol|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -120,6 +120,11 @@
 
 # NonPointerStructs - Existing fields that are non-pointer structs but where the current rules are incorrect.
 
+# IngressBackend and ServiceBackendPort are union-like structs, but nonpointerstructs does not understand unions today.
+# Validation makes these require at least one of the fields within to be set.
+- text: "nonpointerstructs: field (HTTPIngressPath\\.Backend|IngressServiceBackend\\.Port) is a non-pointer struct with no required fields\\..*"
+  path: "staging/src/k8s.io/api/networking/v1/types\\.go"
+
 # The (PodGroupSpec|PodGroupTemplate|CompositePodGroupSpec|CompositePodGroupTemplate).SchedulingPolicy field is a union type, but nonpointerstructs does not understand unions today.
 # Validation makes this require at least one of the fields within to be set.
 - text: "nonpointerstructs: field (PodGroupSpec|PodGroupTemplate|CompositePodGroupSpec|CompositePodGroupTemplate)\\.SchedulingPolicy is a non-pointer struct with no required fields\\..*"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -108,7 +108,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
+  path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -40682,7 +40682,7 @@ func schema_k8sio_api_networking_v1_HTTPIngressPath(ref common.ReferenceCallback
 						},
 					},
 				},
-				Required: []string{"pathType", "backend"},
+				Required: []string{"pathType"},
 			},
 		},
 		Dependencies: []string{
@@ -40994,6 +40994,7 @@ func schema_k8sio_api_networking_v1_IngressClass(ref common.ReferenceCallback) c
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -41123,6 +41124,7 @@ func schema_k8sio_api_networking_v1_IngressClassSpec(ref common.ReferenceCallbac
 						},
 					},
 				},
+				Required: []string{"controller"},
 			},
 		},
 		Dependencies: []string{
@@ -41292,7 +41294,6 @@ func schema_k8sio_api_networking_v1_IngressPortStatus(ref common.ReferenceCallba
 						},
 					},
 				},
-				Required: []string{"port", "protocol"},
 			},
 		},
 	}
@@ -42116,7 +42117,6 @@ func schema_k8sio_api_networking_v1beta1_HTTPIngressPath(ref common.ReferenceCal
 						},
 					},
 				},
-				Required: []string{"backend"},
 			},
 		},
 		Dependencies: []string{
@@ -42692,7 +42692,6 @@ func schema_k8sio_api_networking_v1beta1_IngressPortStatus(ref common.ReferenceC
 						},
 					},
 				},
-				Required: []string{"port", "protocol"},
 			},
 		},
 	}

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -42448,7 +42448,7 @@ func schema_k8sio_api_networking_v1_HTTPIngressPath(ref common.ReferenceCallback
 						},
 					},
 				},
-				Required: []string{"pathType"},
+				Required: []string{"pathType", "backend"},
 			},
 		},
 		Dependencies: []string{
@@ -43137,7 +43137,7 @@ func schema_k8sio_api_networking_v1_IngressServiceBackend(ref common.ReferenceCa
 						},
 					},
 				},
-				Required: []string{"name"},
+				Required: []string{"name", "port"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -42448,7 +42448,7 @@ func schema_k8sio_api_networking_v1_HTTPIngressPath(ref common.ReferenceCallback
 						},
 					},
 				},
-				Required: []string{"pathType", "backend"},
+				Required: []string{"pathType"},
 			},
 		},
 		Dependencies: []string{
@@ -42760,6 +42760,7 @@ func schema_k8sio_api_networking_v1_IngressClass(ref common.ReferenceCallback) c
 						},
 					},
 				},
+				Required: []string{"spec"},
 			},
 		},
 		Dependencies: []string{
@@ -42889,6 +42890,7 @@ func schema_k8sio_api_networking_v1_IngressClassSpec(ref common.ReferenceCallbac
 						},
 					},
 				},
+				Required: []string{"controller"},
 			},
 		},
 		Dependencies: []string{
@@ -43058,7 +43060,6 @@ func schema_k8sio_api_networking_v1_IngressPortStatus(ref common.ReferenceCallba
 						},
 					},
 				},
-				Required: []string{"port", "protocol"},
 			},
 		},
 	}
@@ -43884,7 +43885,6 @@ func schema_k8sio_api_networking_v1beta1_HTTPIngressPath(ref common.ReferenceCal
 						},
 					},
 				},
-				Required: []string{"backend"},
 			},
 		},
 		Dependencies: []string{
@@ -44460,7 +44460,6 @@ func schema_k8sio_api_networking_v1beta1_IngressPortStatus(ref common.ReferenceC
 						},
 					},
 				},
-				Required: []string{"port", "protocol"},
 			},
 		},
 	}

--- a/staging/src/k8s.io/api/networking/v1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1/generated.proto
@@ -285,12 +285,12 @@ message IngressLoadBalancerStatus {
 // IngressPortStatus represents the error condition of a service port
 message IngressPortStatus {
   // port is the port number of the ingress port.
-  // +required
+  // +optional
   optional int32 port = 1;
 
   // protocol is the protocol of the ingress port.
   // The supported values are: "TCP", "UDP", "SCTP"
-  // +required
+  // +optional
   optional string protocol = 2;
 
   // error is to record the problem with the service port
@@ -689,4 +689,3 @@ message ServiceCIDRStatus {
   // +listMapKey=type
   repeated .k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 1;
 }
-

--- a/staging/src/k8s.io/api/networking/v1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1/generated.proto
@@ -54,10 +54,12 @@ message HTTPIngressPath {
   //   the IngressClass. Implementations can treat this as a separate PathType
   //   or treat it identically to Prefix or Exact path types.
   // Implementations are required to support all path types.
+  // +required
   optional string pathType = 3;
 
   // backend defines the referenced service endpoint to which the traffic
   // will be forwarded to.
+  // +optional
   optional IngressBackend backend = 2;
 }
 
@@ -69,6 +71,7 @@ message HTTPIngressPath {
 message HTTPIngressRuleValue {
   // paths is a collection of paths that map requests to backends.
   // +listType=atomic
+  // +required
   repeated HTTPIngressPath paths = 1;
 }
 
@@ -233,6 +236,7 @@ message IngressClassSpec {
   // same implementing controller. This should be specified as a
   // domain-prefixed path no more than 250 characters in length, e.g.
   // "acme.io/ingress-controller". This field is immutable.
+  // +optional
   optional string controller = 1;
 
   // parameters is a link to a custom resource containing additional
@@ -281,10 +285,12 @@ message IngressLoadBalancerStatus {
 // IngressPortStatus represents the error condition of a service port
 message IngressPortStatus {
   // port is the port number of the ingress port.
+  // +required
   optional int32 port = 1;
 
   // protocol is the protocol of the ingress port.
   // The supported values are: "TCP", "UDP", "SCTP"
+  // +required
   optional string protocol = 2;
 
   // error is to record the problem with the service port
@@ -353,10 +359,12 @@ message IngressRuleValue {
 message IngressServiceBackend {
   // name is the referenced service. The service must exist in
   // the same namespace as the Ingress object.
+  // +required
   optional string name = 1;
 
   // port of the referenced service. A port name or port number
   // is required for a IngressServiceBackend.
+  // +optional
   optional ServiceBackendPort port = 2;
 }
 

--- a/staging/src/k8s.io/api/networking/v1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1/generated.proto
@@ -183,7 +183,7 @@ message IngressClass {
 
   // spec is the desired state of the IngressClass.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  // +optional
+  // +required
   optional IngressClassSpec spec = 2;
 }
 
@@ -236,7 +236,7 @@ message IngressClassSpec {
   // same implementing controller. This should be specified as a
   // domain-prefixed path no more than 250 characters in length, e.g.
   // "acme.io/ingress-controller". This field is immutable.
-  // +optional
+  // +required
   optional string controller = 1;
 
   // parameters is a link to a custom resource containing additional
@@ -689,3 +689,4 @@ message ServiceCIDRStatus {
   // +listMapKey=type
   repeated .k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 1;
 }
+

--- a/staging/src/k8s.io/api/networking/v1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1/generated.proto
@@ -59,7 +59,7 @@ message HTTPIngressPath {
 
   // backend defines the referenced service endpoint to which the traffic
   // will be forwarded to.
-  // +optional
+  // +required
   optional IngressBackend backend = 2;
 }
 
@@ -365,7 +365,7 @@ message IngressServiceBackend {
 
   // port of the referenced service. A port name or port number
   // is required for a IngressServiceBackend.
-  // +optional
+  // +required
   optional ServiceBackendPort port = 2;
 }
 

--- a/staging/src/k8s.io/api/networking/v1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1/generated.proto
@@ -183,7 +183,7 @@ message IngressClass {
 
   // spec is the desired state of the IngressClass.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  // +optional
+  // +required
   optional IngressClassSpec spec = 2;
 }
 
@@ -236,7 +236,7 @@ message IngressClassSpec {
   // same implementing controller. This should be specified as a
   // domain-prefixed path no more than 250 characters in length, e.g.
   // "acme.io/ingress-controller". This field is immutable.
-  // +optional
+  // +required
   optional string controller = 1;
 
   // parameters is a link to a custom resource containing additional
@@ -691,3 +691,4 @@ message ServiceCIDRStatus {
   // +k8s:alpha(since: "1.37")=+k8s:eachVal=+k8s:opaqueType
   repeated .k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 1;
 }
+

--- a/staging/src/k8s.io/api/networking/v1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1/generated.proto
@@ -285,12 +285,12 @@ message IngressLoadBalancerStatus {
 // IngressPortStatus represents the error condition of a service port
 message IngressPortStatus {
   // port is the port number of the ingress port.
-  // +required
+  // +optional
   optional int32 port = 1;
 
   // protocol is the protocol of the ingress port.
   // The supported values are: "TCP", "UDP", "SCTP"
-  // +required
+  // +optional
   optional string protocol = 2;
 
   // error is to record the problem with the service port
@@ -691,4 +691,3 @@ message ServiceCIDRStatus {
   // +k8s:alpha(since: "1.37")=+k8s:eachVal=+k8s:opaqueType
   repeated .k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 1;
 }
-

--- a/staging/src/k8s.io/api/networking/v1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1/generated.proto
@@ -54,10 +54,12 @@ message HTTPIngressPath {
   //   the IngressClass. Implementations can treat this as a separate PathType
   //   or treat it identically to Prefix or Exact path types.
   // Implementations are required to support all path types.
+  // +required
   optional string pathType = 3;
 
   // backend defines the referenced service endpoint to which the traffic
   // will be forwarded to.
+  // +optional
   optional IngressBackend backend = 2;
 }
 
@@ -69,6 +71,7 @@ message HTTPIngressPath {
 message HTTPIngressRuleValue {
   // paths is a collection of paths that map requests to backends.
   // +listType=atomic
+  // +required
   repeated HTTPIngressPath paths = 1;
 }
 
@@ -233,6 +236,7 @@ message IngressClassSpec {
   // same implementing controller. This should be specified as a
   // domain-prefixed path no more than 250 characters in length, e.g.
   // "acme.io/ingress-controller". This field is immutable.
+  // +optional
   optional string controller = 1;
 
   // parameters is a link to a custom resource containing additional
@@ -281,10 +285,12 @@ message IngressLoadBalancerStatus {
 // IngressPortStatus represents the error condition of a service port
 message IngressPortStatus {
   // port is the port number of the ingress port.
+  // +required
   optional int32 port = 1;
 
   // protocol is the protocol of the ingress port.
   // The supported values are: "TCP", "UDP", "SCTP"
+  // +required
   optional string protocol = 2;
 
   // error is to record the problem with the service port
@@ -354,10 +360,12 @@ message IngressRuleValue {
 message IngressServiceBackend {
   // name is the referenced service. The service must exist in
   // the same namespace as the Ingress object.
+  // +required
   optional string name = 1;
 
   // port of the referenced service. A port name or port number
   // is required for a IngressServiceBackend.
+  // +optional
   optional ServiceBackendPort port = 2;
 }
 

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -514,7 +514,7 @@ type HTTPIngressPath struct {
 
 	// backend defines the referenced service endpoint to which the traffic
 	// will be forwarded to.
-	// +required
+	// +optional
 	Backend IngressBackend `json:"backend" protobuf:"bytes,2,opt,name=backend"`
 }
 
@@ -542,7 +542,7 @@ type IngressServiceBackend struct {
 
 	// port of the referenced service. A port name or port number
 	// is required for a IngressServiceBackend.
-	// +required
+	// +optional
 	Port ServiceBackendPort `json:"port,omitempty" protobuf:"bytes,2,opt,name=port"`
 }
 
@@ -580,7 +580,7 @@ type IngressClass struct {
 
 	// spec is the desired state of the IngressClass.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
+	// +required
 	Spec IngressClassSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -373,10 +373,12 @@ type IngressLoadBalancerIngress struct {
 // IngressPortStatus represents the error condition of a service port
 type IngressPortStatus struct {
 	// port is the port number of the ingress port.
+	// +required
 	Port int32 `json:"port" protobuf:"varint,1,opt,name=port"`
 
 	// protocol is the protocol of the ingress port.
 	// The supported values are: "TCP", "UDP", "SCTP"
+	// +required
 	Protocol v1.Protocol `json:"protocol" protobuf:"bytes,2,opt,name=protocol,casttype=Protocol"`
 
 	// error is to record the problem with the service port
@@ -448,6 +450,7 @@ type IngressRuleValue struct {
 type HTTPIngressRuleValue struct {
 	// paths is a collection of paths that map requests to backends.
 	// +listType=atomic
+	// +required
 	Paths []HTTPIngressPath `json:"paths" protobuf:"bytes,1,rep,name=paths"`
 }
 
@@ -506,10 +509,12 @@ type HTTPIngressPath struct {
 	//   the IngressClass. Implementations can treat this as a separate PathType
 	//   or treat it identically to Prefix or Exact path types.
 	// Implementations are required to support all path types.
+	// +required
 	PathType *PathType `json:"pathType" protobuf:"bytes,3,opt,name=pathType"`
 
 	// backend defines the referenced service endpoint to which the traffic
 	// will be forwarded to.
+	// +optional
 	Backend IngressBackend `json:"backend" protobuf:"bytes,2,opt,name=backend"`
 }
 
@@ -532,10 +537,12 @@ type IngressBackend struct {
 type IngressServiceBackend struct {
 	// name is the referenced service. The service must exist in
 	// the same namespace as the Ingress object.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 
 	// port of the referenced service. A port name or port number
 	// is required for a IngressServiceBackend.
+	// +optional
 	Port ServiceBackendPort `json:"port,omitempty" protobuf:"bytes,2,opt,name=port"`
 }
 
@@ -585,6 +592,7 @@ type IngressClassSpec struct {
 	// same implementing controller. This should be specified as a
 	// domain-prefixed path no more than 250 characters in length, e.g.
 	// "acme.io/ingress-controller". This field is immutable.
+	// +optional
 	Controller string `json:"controller,omitempty" protobuf:"bytes,1,opt,name=controller"`
 
 	// parameters is a link to a custom resource containing additional

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -514,7 +514,7 @@ type HTTPIngressPath struct {
 
 	// backend defines the referenced service endpoint to which the traffic
 	// will be forwarded to.
-	// +optional
+	// +required
 	Backend IngressBackend `json:"backend" protobuf:"bytes,2,opt,name=backend"`
 }
 
@@ -542,7 +542,7 @@ type IngressServiceBackend struct {
 
 	// port of the referenced service. A port name or port number
 	// is required for a IngressServiceBackend.
-	// +optional
+	// +required
 	Port ServiceBackendPort `json:"port,omitempty" protobuf:"bytes,2,opt,name=port"`
 }
 
@@ -592,7 +592,7 @@ type IngressClassSpec struct {
 	// same implementing controller. This should be specified as a
 	// domain-prefixed path no more than 250 characters in length, e.g.
 	// "acme.io/ingress-controller". This field is immutable.
-	// +optional
+	// +required
 	Controller string `json:"controller,omitempty" protobuf:"bytes,1,opt,name=controller"`
 
 	// parameters is a link to a custom resource containing additional

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -373,12 +373,12 @@ type IngressLoadBalancerIngress struct {
 // IngressPortStatus represents the error condition of a service port
 type IngressPortStatus struct {
 	// port is the port number of the ingress port.
-	// +required
+	// +optional
 	Port int32 `json:"port" protobuf:"varint,1,opt,name=port"`
 
 	// protocol is the protocol of the ingress port.
 	// The supported values are: "TCP", "UDP", "SCTP"
-	// +required
+	// +optional
 	Protocol v1.Protocol `json:"protocol" protobuf:"bytes,2,opt,name=protocol,casttype=Protocol"`
 
 	// error is to record the problem with the service port

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -515,7 +515,7 @@ type HTTPIngressPath struct {
 
 	// backend defines the referenced service endpoint to which the traffic
 	// will be forwarded to.
-	// +optional
+	// +required
 	Backend IngressBackend `json:"backend" protobuf:"bytes,2,opt,name=backend"`
 }
 
@@ -543,7 +543,7 @@ type IngressServiceBackend struct {
 
 	// port of the referenced service. A port name or port number
 	// is required for a IngressServiceBackend.
-	// +optional
+	// +required
 	Port ServiceBackendPort `json:"port,omitempty" protobuf:"bytes,2,opt,name=port"`
 }
 
@@ -593,7 +593,7 @@ type IngressClassSpec struct {
 	// same implementing controller. This should be specified as a
 	// domain-prefixed path no more than 250 characters in length, e.g.
 	// "acme.io/ingress-controller". This field is immutable.
-	// +optional
+	// +required
 	Controller string `json:"controller,omitempty" protobuf:"bytes,1,opt,name=controller"`
 
 	// parameters is a link to a custom resource containing additional

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -373,10 +373,12 @@ type IngressLoadBalancerIngress struct {
 // IngressPortStatus represents the error condition of a service port
 type IngressPortStatus struct {
 	// port is the port number of the ingress port.
+	// +required
 	Port int32 `json:"port" protobuf:"varint,1,opt,name=port"`
 
 	// protocol is the protocol of the ingress port.
 	// The supported values are: "TCP", "UDP", "SCTP"
+	// +required
 	Protocol v1.Protocol `json:"protocol" protobuf:"bytes,2,opt,name=protocol,casttype=Protocol"`
 
 	// error is to record the problem with the service port
@@ -449,6 +451,7 @@ type IngressRuleValue struct {
 type HTTPIngressRuleValue struct {
 	// paths is a collection of paths that map requests to backends.
 	// +listType=atomic
+	// +required
 	Paths []HTTPIngressPath `json:"paths" protobuf:"bytes,1,rep,name=paths"`
 }
 
@@ -507,10 +510,12 @@ type HTTPIngressPath struct {
 	//   the IngressClass. Implementations can treat this as a separate PathType
 	//   or treat it identically to Prefix or Exact path types.
 	// Implementations are required to support all path types.
+	// +required
 	PathType *PathType `json:"pathType" protobuf:"bytes,3,opt,name=pathType"`
 
 	// backend defines the referenced service endpoint to which the traffic
 	// will be forwarded to.
+	// +optional
 	Backend IngressBackend `json:"backend" protobuf:"bytes,2,opt,name=backend"`
 }
 
@@ -533,10 +538,12 @@ type IngressBackend struct {
 type IngressServiceBackend struct {
 	// name is the referenced service. The service must exist in
 	// the same namespace as the Ingress object.
+	// +required
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 
 	// port of the referenced service. A port name or port number
 	// is required for a IngressServiceBackend.
+	// +optional
 	Port ServiceBackendPort `json:"port,omitempty" protobuf:"bytes,2,opt,name=port"`
 }
 
@@ -586,6 +593,7 @@ type IngressClassSpec struct {
 	// same implementing controller. This should be specified as a
 	// domain-prefixed path no more than 250 characters in length, e.g.
 	// "acme.io/ingress-controller". This field is immutable.
+	// +optional
 	Controller string `json:"controller,omitempty" protobuf:"bytes,1,opt,name=controller"`
 
 	// parameters is a link to a custom resource containing additional

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -515,7 +515,7 @@ type HTTPIngressPath struct {
 
 	// backend defines the referenced service endpoint to which the traffic
 	// will be forwarded to.
-	// +required
+	// +optional
 	Backend IngressBackend `json:"backend" protobuf:"bytes,2,opt,name=backend"`
 }
 
@@ -543,7 +543,7 @@ type IngressServiceBackend struct {
 
 	// port of the referenced service. A port name or port number
 	// is required for a IngressServiceBackend.
-	// +required
+	// +optional
 	Port ServiceBackendPort `json:"port,omitempty" protobuf:"bytes,2,opt,name=port"`
 }
 
@@ -581,7 +581,7 @@ type IngressClass struct {
 
 	// spec is the desired state of the IngressClass.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +optional
+	// +required
 	Spec IngressClassSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -515,7 +515,7 @@ type HTTPIngressPath struct {
 
 	// backend defines the referenced service endpoint to which the traffic
 	// will be forwarded to.
-	// +optional
+	// +required
 	Backend IngressBackend `json:"backend" protobuf:"bytes,2,opt,name=backend"`
 }
 
@@ -543,7 +543,7 @@ type IngressServiceBackend struct {
 
 	// port of the referenced service. A port name or port number
 	// is required for a IngressServiceBackend.
-	// +optional
+	// +required
 	Port ServiceBackendPort `json:"port,omitempty" protobuf:"bytes,2,opt,name=port"`
 }
 

--- a/staging/src/k8s.io/api/networking/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1beta1/generated.proto
@@ -270,12 +270,12 @@ message IngressLoadBalancerStatus {
 // IngressPortStatus represents the error condition of a service port
 message IngressPortStatus {
   // port is the port number of the ingress port.
-  // +required
+  // +optional
   optional int32 port = 1;
 
   // protocol is the protocol of the ingress port.
   // The supported values are: "TCP", "UDP", "SCTP"
-  // +required
+  // +optional
   optional string protocol = 2;
 
   // error is to record the problem with the service port
@@ -477,4 +477,3 @@ message ServiceCIDRStatus {
   // +listMapKey=type
   repeated .k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 1;
 }
-

--- a/staging/src/k8s.io/api/networking/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1beta1/generated.proto
@@ -203,7 +203,7 @@ message IngressClassParametersReference {
 
   // scope represents if this refers to a cluster or namespace scoped resource.
   // This may be set to "Cluster" (default) or "Namespace".
-  // +optional
+  // +required
   optional string scope = 4;
 
   // namespace is the namespace of the resource being referenced. This field is
@@ -477,3 +477,4 @@ message ServiceCIDRStatus {
   // +listMapKey=type
   repeated .k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 1;
 }
+

--- a/staging/src/k8s.io/api/networking/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1beta1/generated.proto
@@ -55,10 +55,12 @@ message HTTPIngressPath {
   //   or treat it identically to Prefix or Exact path types.
   // Implementations are required to support all path types.
   // Defaults to ImplementationSpecific.
+  // +optional
   optional string pathType = 3;
 
   // backend defines the referenced service endpoint to which the traffic
   // will be forwarded to.
+  // +optional
   optional IngressBackend backend = 2;
 }
 
@@ -70,6 +72,7 @@ message HTTPIngressPath {
 message HTTPIngressRuleValue {
   // paths is a collection of paths that map requests to backends.
   // +listType=atomic
+  // +required
   repeated HTTPIngressPath paths = 1;
 }
 
@@ -200,6 +203,7 @@ message IngressClassParametersReference {
 
   // scope represents if this refers to a cluster or namespace scoped resource.
   // This may be set to "Cluster" (default) or "Namespace".
+  // +optional
   optional string scope = 4;
 
   // namespace is the namespace of the resource being referenced. This field is
@@ -217,6 +221,7 @@ message IngressClassSpec {
   // same implementing controller. This should be specified as a
   // domain-prefixed path no more than 250 characters in length, e.g.
   // "acme.io/ingress-controller". This field is immutable.
+  // +optional
   optional string controller = 1;
 
   // parameters is a link to a custom resource containing additional
@@ -265,10 +270,12 @@ message IngressLoadBalancerStatus {
 // IngressPortStatus represents the error condition of a service port
 message IngressPortStatus {
   // port is the port number of the ingress port.
+  // +required
   optional int32 port = 1;
 
   // protocol is the protocol of the ingress port.
   // The supported values are: "TCP", "UDP", "SCTP"
+  // +required
   optional string protocol = 2;
 
   // error is to record the problem with the service port

--- a/staging/src/k8s.io/api/networking/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1beta1/generated.proto
@@ -270,12 +270,12 @@ message IngressLoadBalancerStatus {
 // IngressPortStatus represents the error condition of a service port
 message IngressPortStatus {
   // port is the port number of the ingress port.
-  // +required
+  // +optional
   optional int32 port = 1;
 
   // protocol is the protocol of the ingress port.
   // The supported values are: "TCP", "UDP", "SCTP"
-  // +required
+  // +optional
   optional string protocol = 2;
 
   // error is to record the problem with the service port
@@ -479,4 +479,3 @@ message ServiceCIDRStatus {
   // +k8s:alpha(since: "1.37")=+k8s:eachVal=+k8s:opaqueType
   repeated .k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 1;
 }
-

--- a/staging/src/k8s.io/api/networking/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1beta1/generated.proto
@@ -203,7 +203,7 @@ message IngressClassParametersReference {
 
   // scope represents if this refers to a cluster or namespace scoped resource.
   // This may be set to "Cluster" (default) or "Namespace".
-  // +optional
+  // +required
   optional string scope = 4;
 
   // namespace is the namespace of the resource being referenced. This field is
@@ -479,3 +479,4 @@ message ServiceCIDRStatus {
   // +k8s:alpha(since: "1.37")=+k8s:eachVal=+k8s:opaqueType
   repeated .k8s.io.apimachinery.pkg.apis.meta.v1.Condition conditions = 1;
 }
+

--- a/staging/src/k8s.io/api/networking/v1beta1/types.go
+++ b/staging/src/k8s.io/api/networking/v1beta1/types.go
@@ -163,12 +163,12 @@ type IngressLoadBalancerIngress struct {
 // IngressPortStatus represents the error condition of a service port
 type IngressPortStatus struct {
 	// port is the port number of the ingress port.
-	// +required
+	// +optional
 	Port int32 `json:"port" protobuf:"varint,1,opt,name=port"`
 
 	// protocol is the protocol of the ingress port.
 	// The supported values are: "TCP", "UDP", "SCTP"
-	// +required
+	// +optional
 	Protocol v1.Protocol `json:"protocol" protobuf:"bytes,2,opt,name=protocol,casttype=Protocol"`
 
 	// error is to record the problem with the service port

--- a/staging/src/k8s.io/api/networking/v1beta1/types.go
+++ b/staging/src/k8s.io/api/networking/v1beta1/types.go
@@ -409,7 +409,7 @@ type IngressClassParametersReference struct {
 
 	// scope represents if this refers to a cluster or namespace scoped resource.
 	// This may be set to "Cluster" (default) or "Namespace".
-	// +optional
+	// +required
 	Scope *string `json:"scope" protobuf:"bytes,4,opt,name=scope"`
 
 	// namespace is the namespace of the resource being referenced. This field is

--- a/staging/src/k8s.io/api/networking/v1beta1/types.go
+++ b/staging/src/k8s.io/api/networking/v1beta1/types.go
@@ -163,10 +163,12 @@ type IngressLoadBalancerIngress struct {
 // IngressPortStatus represents the error condition of a service port
 type IngressPortStatus struct {
 	// port is the port number of the ingress port.
+	// +required
 	Port int32 `json:"port" protobuf:"varint,1,opt,name=port"`
 
 	// protocol is the protocol of the ingress port.
 	// The supported values are: "TCP", "UDP", "SCTP"
+	// +required
 	Protocol v1.Protocol `json:"protocol" protobuf:"bytes,2,opt,name=protocol,casttype=Protocol"`
 
 	// error is to record the problem with the service port
@@ -245,6 +247,7 @@ type IngressRuleValue struct {
 type HTTPIngressRuleValue struct {
 	// paths is a collection of paths that map requests to backends.
 	// +listType=atomic
+	// +required
 	Paths []HTTPIngressPath `json:"paths" protobuf:"bytes,1,rep,name=paths"`
 	// TODO: Consider adding fields for ingress-type specific global
 	// options usable by a loadbalancer, like http keep-alive.
@@ -305,10 +308,12 @@ type HTTPIngressPath struct {
 	//   or treat it identically to Prefix or Exact path types.
 	// Implementations are required to support all path types.
 	// Defaults to ImplementationSpecific.
+	// +optional
 	PathType *PathType `json:"pathType,omitempty" protobuf:"bytes,3,opt,name=pathType"`
 
 	// backend defines the referenced service endpoint to which the traffic
 	// will be forwarded to.
+	// +optional
 	Backend IngressBackend `json:"backend" protobuf:"bytes,2,opt,name=backend"`
 }
 
@@ -363,6 +368,7 @@ type IngressClassSpec struct {
 	// same implementing controller. This should be specified as a
 	// domain-prefixed path no more than 250 characters in length, e.g.
 	// "acme.io/ingress-controller". This field is immutable.
+	// +optional
 	Controller string `json:"controller,omitempty" protobuf:"bytes,1,opt,name=controller"`
 
 	// parameters is a link to a custom resource containing additional
@@ -403,6 +409,7 @@ type IngressClassParametersReference struct {
 
 	// scope represents if this refers to a cluster or namespace scoped resource.
 	// This may be set to "Cluster" (default) or "Namespace".
+	// +optional
 	Scope *string `json:"scope" protobuf:"bytes,4,opt,name=scope"`
 
 	// namespace is the namespace of the resource being referenced. This field is

--- a/staging/src/k8s.io/api/networking/v1beta1/types.go
+++ b/staging/src/k8s.io/api/networking/v1beta1/types.go
@@ -410,7 +410,7 @@ type IngressClassParametersReference struct {
 
 	// scope represents if this refers to a cluster or namespace scoped resource.
 	// This may be set to "Cluster" (default) or "Namespace".
-	// +optional
+	// +required
 	Scope *string `json:"scope" protobuf:"bytes,4,opt,name=scope"`
 
 	// namespace is the namespace of the resource being referenced. This field is

--- a/staging/src/k8s.io/api/networking/v1beta1/types.go
+++ b/staging/src/k8s.io/api/networking/v1beta1/types.go
@@ -163,10 +163,12 @@ type IngressLoadBalancerIngress struct {
 // IngressPortStatus represents the error condition of a service port
 type IngressPortStatus struct {
 	// port is the port number of the ingress port.
+	// +required
 	Port int32 `json:"port" protobuf:"varint,1,opt,name=port"`
 
 	// protocol is the protocol of the ingress port.
 	// The supported values are: "TCP", "UDP", "SCTP"
+	// +required
 	Protocol v1.Protocol `json:"protocol" protobuf:"bytes,2,opt,name=protocol,casttype=Protocol"`
 
 	// error is to record the problem with the service port
@@ -246,6 +248,7 @@ type IngressRuleValue struct {
 type HTTPIngressRuleValue struct {
 	// paths is a collection of paths that map requests to backends.
 	// +listType=atomic
+	// +required
 	Paths []HTTPIngressPath `json:"paths" protobuf:"bytes,1,rep,name=paths"`
 	// TODO: Consider adding fields for ingress-type specific global
 	// options usable by a loadbalancer, like http keep-alive.
@@ -306,10 +309,12 @@ type HTTPIngressPath struct {
 	//   or treat it identically to Prefix or Exact path types.
 	// Implementations are required to support all path types.
 	// Defaults to ImplementationSpecific.
+	// +optional
 	PathType *PathType `json:"pathType,omitempty" protobuf:"bytes,3,opt,name=pathType"`
 
 	// backend defines the referenced service endpoint to which the traffic
 	// will be forwarded to.
+	// +optional
 	Backend IngressBackend `json:"backend" protobuf:"bytes,2,opt,name=backend"`
 }
 
@@ -364,6 +369,7 @@ type IngressClassSpec struct {
 	// same implementing controller. This should be specified as a
 	// domain-prefixed path no more than 250 characters in length, e.g.
 	// "acme.io/ingress-controller". This field is immutable.
+	// +optional
 	Controller string `json:"controller,omitempty" protobuf:"bytes,1,opt,name=controller"`
 
 	// parameters is a link to a custom resource containing additional
@@ -404,6 +410,7 @@ type IngressClassParametersReference struct {
 
 	// scope represents if this refers to a cluster or namespace scoped resource.
 	// This may be set to "Cluster" (default) or "Namespace".
+	// +optional
 	Scope *string `json:"scope" protobuf:"bytes,4,opt,name=scope"`
 
 	// namespace is the namespace of the resource being referenced. This field is


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR enables the `optionalorrequired` kube-api-linter check for the `networking.k8s.io` API group.

The `optionalorrequired` linter requires API fields to be explicitly marked as either `+optional` or `+required`. The networking API group was previously excluded from this check because existing fields were missing those markers. This PR addresses those existing violations and removes `networking` from the broad exception list so new missing markers in this API group will be caught by linting.

Specifically, this PR:

- Adds missing `+optional` and `+required` markers to networking API fields in `networking/v1` and `networking/v1beta1`.
- Keeps compatibility with existing JSON behavior by matching markers to the current API field tags and behavior.
- Regenerates affected protobuf output after updating API comments.
- Updates kube-api-linter exceptions so `optionalorrequired` is now enforced for the networking API group.

This helps continue the broader effort to enable existing kube-api-linter rules across Kubernetes API groups.

#### Which issue(s) this PR is related to:

Fixes #136871

#### Special notes for your reviewer:

I verified the networking API group with:

```bash
./hack/verify-golangci-lint.sh staging/src/k8s.io/api/networking/...
