### PR TITLE
Fix error formatting and use proper error wrapping in HPA controller

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -262,7 +262,7 @@ func (a *HorizontalController) enqueueRateLimited(obj interface{}) {
 func (a *HorizontalController) enqueueHPA(obj interface{}) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %w", obj, err))
 		return
 	}
 
@@ -288,7 +288,7 @@ func (a *HorizontalController) enqueueHPA(obj interface{}) {
 func (a *HorizontalController) deleteHPA(obj interface{}) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %w", obj, err))
 		return
 	}
 
@@ -378,7 +378,7 @@ func (a *HorizontalController) computeReplicasForMetrics(ctx context.Context, hp
 	}
 
 	if invalidMetricError != nil {
-		invalidMetricError = fmt.Errorf("invalid metrics (%v invalid out of %v), first error is: %v", invalidMetricsCount, len(metricSpecs), invalidMetricError)
+		invalidMetricError = fmt.Errorf("invalid metrics (%v invalid out of %v), first error is: %w", invalidMetricsCount, len(metricSpecs), invalidMetricError)
 	}
 
 	// If all metrics are invalid or some are invalid and we would scale down,
@@ -501,36 +501,36 @@ func (a *HorizontalController) computeReplicasForMetric(ctx context.Context, hpa
 		metricSelector, err := metav1.LabelSelectorAsSelector(spec.Object.Metric.Selector)
 		if err != nil {
 			condition := a.getUnableComputeReplicaCountCondition(hpa, "FailedGetObjectMetric", err)
-			return 0, "", time.Time{}, condition, fmt.Errorf("failed to get object metric value: %v", err)
+			return 0, "", time.Time{}, condition, fmt.Errorf("failed to get object metric value: %w", err)
 		}
 		replicaCountProposal, timestampProposal, metricNameProposal, condition, err = a.computeStatusForObjectMetric(specReplicas, statusReplicas, spec, hpa, selector, status, metricSelector)
 		if err != nil {
-			return 0, "", time.Time{}, condition, fmt.Errorf("failed to get object metric value: %v", err)
+			return 0, "", time.Time{}, condition, fmt.Errorf("failed to get object metric value: %w", err)
 		}
 	case autoscalingv2.PodsMetricSourceType:
 		metricSelector, err := metav1.LabelSelectorAsSelector(spec.Pods.Metric.Selector)
 		if err != nil {
 			condition := a.getUnableComputeReplicaCountCondition(hpa, "FailedGetPodsMetric", err)
-			return 0, "", time.Time{}, condition, fmt.Errorf("failed to get pods metric value: %v", err)
+			return 0, "", time.Time{}, condition, fmt.Errorf("failed to get pods metric value: %w", err)
 		}
 		replicaCountProposal, timestampProposal, metricNameProposal, condition, err = a.computeStatusForPodsMetric(specReplicas, spec, hpa, selector, status, metricSelector)
 		if err != nil {
-			return 0, "", time.Time{}, condition, fmt.Errorf("failed to get pods metric value: %v", err)
+			return 0, "", time.Time{}, condition, fmt.Errorf("failed to get pods metric value: %w", err)
 		}
 	case autoscalingv2.ResourceMetricSourceType:
 		replicaCountProposal, timestampProposal, metricNameProposal, condition, err = a.computeStatusForResourceMetric(ctx, specReplicas, spec, hpa, selector, status)
 		if err != nil {
-			return 0, "", time.Time{}, condition, fmt.Errorf("failed to get %s resource metric value: %v", spec.Resource.Name, err)
+			return 0, "", time.Time{}, condition, fmt.Errorf("failed to get %s resource metric value: %w", spec.Resource.Name, err)
 		}
 	case autoscalingv2.ContainerResourceMetricSourceType:
 		replicaCountProposal, timestampProposal, metricNameProposal, condition, err = a.computeStatusForContainerResourceMetric(ctx, specReplicas, spec, hpa, selector, status)
 		if err != nil {
-			return 0, "", time.Time{}, condition, fmt.Errorf("failed to get %s container metric value: %v", spec.ContainerResource.Container, err)
+			return 0, "", time.Time{}, condition, fmt.Errorf("failed to get %s container metric value: %w", spec.ContainerResource.Container, err)
 		}
 	case autoscalingv2.ExternalMetricSourceType:
 		replicaCountProposal, timestampProposal, metricNameProposal, condition, err = a.computeStatusForExternalMetric(specReplicas, statusReplicas, spec, hpa, selector, status)
 		if err != nil {
-			return 0, "", time.Time{}, condition, fmt.Errorf("failed to get %s external metric value: %v", spec.External.Metric.Name, err)
+			return 0, "", time.Time{}, condition, fmt.Errorf("failed to get %s external metric value: %w", spec.External.Metric.Name, err)
 		}
 	default:
 		// It shouldn't reach here as invalid metric source type is filtered out in the api-server's validation.
@@ -600,7 +600,7 @@ func (a *HorizontalController) computeStatusForObjectMetric(specReplicas, status
 		replicaCountProposal, usageProposal, timestampProposal, err := a.replicaCalc.GetObjectPerPodMetricReplicas(statusReplicas, metricSpec.Object.Target.AverageValue.MilliValue(), metricSpec.Object.Metric.Name, tolerances, hpa.Namespace, &metricSpec.Object.DescribedObject, metricSelector)
 		if err != nil {
 			condition := a.getUnableComputeReplicaCountCondition(hpa, "FailedGetObjectMetric", err)
-			return 0, time.Time{}, "", condition, fmt.Errorf("failed to get %s object metric: %v", metricSpec.Object.Metric.Name, err)
+			return 0, time.Time{}, "", condition, fmt.Errorf("failed to get %s object metric: %w", metricSpec.Object.Metric.Name, err)
 		}
 		metricStatus.Object.Current.AverageValue = resource.NewMilliQuantity(usageProposal, resource.DecimalSI)
 		*status = metricStatus
@@ -646,7 +646,7 @@ func (a *HorizontalController) computeStatusForResourceMetricGeneric(ctx context
 		var rawProposal int64
 		replicaCountProposal, rawProposal, timestampProposal, err := a.replicaCalc.GetRawResourceReplicas(ctx, currentReplicas, target.AverageValue.MilliValue(), resourceName, tolerances, namespace, selector, container)
 		if err != nil {
-			return 0, nil, time.Time{}, "", condition, fmt.Errorf("failed to get %s usage: %v", resourceName, err)
+			return 0, nil, time.Time{}, "", condition, fmt.Errorf("failed to get %s usage: %w", resourceName, err)
 		}
 		metricNameProposal = fmt.Sprintf("%s resource", resourceName.String())
 		quantity := buildQuantity(resourceName, rawProposal)
@@ -664,7 +664,7 @@ func (a *HorizontalController) computeStatusForResourceMetricGeneric(ctx context
 	targetUtilization := *target.AverageUtilization
 	replicaCountProposal, percentageProposal, rawProposal, timestampProposal, err := a.replicaCalc.GetResourceReplicas(ctx, currentReplicas, targetUtilization, resourceName, tolerances, namespace, selector, container)
 	if err != nil {
-		return 0, nil, time.Time{}, "", condition, fmt.Errorf("failed to get %s utilization: %v", resourceName, err)
+		return 0, nil, time.Time{}, "", condition, fmt.Errorf("failed to get %s utilization: %w", resourceName, err)
 	}
 
 	metricNameProposal = fmt.Sprintf("%s resource utilization (percentage of request)", resourceName)
@@ -739,7 +739,7 @@ func (a *HorizontalController) computeStatusForExternalMetric(specReplicas, stat
 		replicaCountProposal, usageProposal, timestampProposal, err := a.replicaCalc.GetExternalPerPodMetricReplicas(statusReplicas, metricSpec.External.Target.AverageValue.MilliValue(), metricSpec.External.Metric.Name, tolerances, hpa.Namespace, metricSpec.External.Metric.Selector)
 		if err != nil {
 			condition = a.getUnableComputeReplicaCountCondition(hpa, "FailedGetExternalMetric", err)
-			return 0, time.Time{}, "", condition, fmt.Errorf("failed to get %s external metric: %v", metricSpec.External.Metric.Name, err)
+			return 0, time.Time{}, "", condition, fmt.Errorf("failed to get %s external metric: %w", metricSpec.External.Metric.Name, err)
 		}
 		*status = autoscalingv2.MetricStatus{
 			Type: autoscalingv2.ExternalMetricSourceType,
@@ -759,7 +759,7 @@ func (a *HorizontalController) computeStatusForExternalMetric(specReplicas, stat
 		replicaCountProposal, usageProposal, timestampProposal, err := a.replicaCalc.GetExternalMetricReplicas(specReplicas, metricSpec.External.Target.Value.MilliValue(), metricSpec.External.Metric.Name, tolerances, hpa.Namespace, metricSpec.External.Metric.Selector, selector)
 		if err != nil {
 			condition = a.getUnableComputeReplicaCountCondition(hpa, "FailedGetExternalMetric", err)
-			return 0, time.Time{}, "", condition, fmt.Errorf("failed to get external metric %s: %v", metricSpec.External.Metric.Name, err)
+			return 0, time.Time{}, "", condition, fmt.Errorf("failed to get external metric %s: %w", metricSpec.External.Metric.Name, err)
 		}
 		*status = autoscalingv2.MetricStatus{
 			Type: autoscalingv2.ExternalMetricSourceType,
@@ -848,7 +848,7 @@ func (a *HorizontalController) reconcileAutoscaler(ctx context.Context, hpaShare
 		if err := a.updateStatusIfNeeded(ctx, hpaStatusOriginal, hpa); err != nil {
 			utilruntime.HandleError(err)
 		}
-		return fmt.Errorf("unable to determine resource for scale target reference: %v", err)
+		return fmt.Errorf("unable to determine resource for scale target reference: %w", err)
 	}
 
 	scale, targetGR, err := a.scaleForResourceMappings(ctx, hpa.Namespace, hpa.Spec.ScaleTargetRef.Name, mappings)
@@ -858,7 +858,7 @@ func (a *HorizontalController) reconcileAutoscaler(ctx context.Context, hpaShare
 		if err := a.updateStatusIfNeeded(ctx, hpaStatusOriginal, hpa); err != nil {
 			utilruntime.HandleError(err)
 		}
-		return fmt.Errorf("failed to query scale subresource for %s: %v", reference, err)
+		return fmt.Errorf("failed to query scale subresource for %s: %w", reference, err)
 	}
 	setCondition(hpa, autoscalingv2.AbleToScale, v1.ConditionTrue, "SucceededGetScale", "the HPA controller was able to get the target's current scale")
 	currentReplicas := scale.Spec.Replicas
@@ -926,7 +926,7 @@ func (a *HorizontalController) reconcileAutoscaler(ctx context.Context, hpaShare
 				utilruntime.HandleError(err)
 			}
 			a.eventRecorder.Event(hpa, v1.EventTypeWarning, "FailedComputeMetricsReplicas", err.Error())
-			return fmt.Errorf("failed to compute desired number of replicas based on listed metrics for %s: %v", reference, err)
+			return fmt.Errorf("failed to compute desired number of replicas based on listed metrics for %s: %w", reference, err)
 		}
 		if err != nil {
 			// We proceed to scaling, but return this error from reconcileAutoscaler() finally.
@@ -1004,7 +1004,7 @@ func (a *HorizontalController) reconcileAutoscaler(ctx context.Context, hpaShare
 			if err := a.updateStatusIfNeeded(ctx, hpaStatusOriginal, hpa); err != nil {
 				utilruntime.HandleError(err)
 			}
-			return fmt.Errorf("failed to rescale %s: %v", reference, err)
+			return fmt.Errorf("failed to rescale %s: %w", reference, err)
 		}
 
 		// This block executes only on a successful rescale.
@@ -1538,7 +1538,7 @@ func (a *HorizontalController) updateStatus(ctx context.Context, hpa *autoscalin
 	_, err := a.hpaNamespacer.HorizontalPodAutoscalers(hpa.Namespace).UpdateStatus(ctx, hpa, metav1.UpdateOptions{})
 	if err != nil {
 		a.eventRecorder.Event(hpa, v1.EventTypeWarning, "FailedUpdateStatus", err.Error())
-		return fmt.Errorf("failed to update status for %s: %v", hpa.Name, err)
+		return fmt.Errorf("failed to update status for %s: %w", hpa.Name, err)
 	}
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("Successfully updated status", "HPA", klog.KObj(hpa))

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -1726,7 +1726,7 @@ func TestScaleUpOneMetricInvalid(t *testing.T) {
 		reportedLevels:      []uint64{300, 400, 500},
 		reportedCPURequests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
 		expectedReportedReconciliationActionLabel: monitor.ActionLabelScaleUp,
-		expectedReportedReconciliationErrorLabel:  monitor.ErrorLabelInternal,
+		expectedReportedReconciliationErrorLabel:  monitor.ErrorLabelSpec,
 		expectedReportedMetricComputationActionLabels: map[autoscalingv2.MetricSourceType]monitor.ActionLabel{
 			autoscalingv2.ResourceMetricSourceType: monitor.ActionLabelScaleUp,
 			// Actually, such an invalid type should be validated in the kube-apiserver and invalid metric type shouldn't be recorded.
@@ -3593,7 +3593,7 @@ func TestConditionInvalidSourceType(t *testing.T) {
 			},
 		},
 		expectedReportedReconciliationActionLabel: monitor.ActionLabelNone,
-		expectedReportedReconciliationErrorLabel:  monitor.ErrorLabelInternal,
+		expectedReportedReconciliationErrorLabel:  monitor.ErrorLabelSpec,
 		expectedReportedMetricComputationActionLabels: map[autoscalingv2.MetricSourceType]monitor.ActionLabel{
 			// Actually, such an invalid type should be validated in the kube-apiserver and invalid metric type shouldn't be recorded.
 			"CheddarCheese": monitor.ActionLabelNone,
@@ -5289,7 +5289,7 @@ func TestNoScaleDownOneMetricInvalid(t *testing.T) {
 			{Type: autoscalingv2.ScalingActive, Status: v1.ConditionFalse, Reason: "InvalidMetricSourceType"},
 		},
 		expectedReportedReconciliationActionLabel: monitor.ActionLabelNone,
-		expectedReportedReconciliationErrorLabel:  monitor.ErrorLabelInternal,
+		expectedReportedReconciliationErrorLabel:  monitor.ErrorLabelSpec,
 		expectedReportedMetricComputationActionLabels: map[autoscalingv2.MetricSourceType]monitor.ActionLabel{
 			autoscalingv2.ResourceMetricSourceType: monitor.ActionLabelScaleDown,
 			"CheddarCheese":                        monitor.ActionLabelNone,

--- a/pkg/controller/podautoscaler/metrics/client.go
+++ b/pkg/controller/podautoscaler/metrics/client.go
@@ -67,7 +67,7 @@ type resourceMetricsClient struct {
 func (c *resourceMetricsClient) GetResourceMetric(ctx context.Context, resource v1.ResourceName, namespace string, selector labels.Selector, container string) (PodMetricsInfo, time.Time, error) {
 	metrics, err := c.client.PodMetricses(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
 	if err != nil {
-		return nil, time.Time{}, fmt.Errorf("unable to fetch metrics from resource metrics API: %v", err)
+		return nil, time.Time{}, fmt.Errorf("unable to fetch metrics from resource metrics API: %w", err)
 	}
 
 	if len(metrics.Items) == 0 {
@@ -143,7 +143,7 @@ type customMetricsClient struct {
 func (c *customMetricsClient) GetRawMetric(metricName string, namespace string, selector labels.Selector, metricSelector labels.Selector) (PodMetricsInfo, time.Time, error) {
 	metrics, err := c.client.NamespacedMetrics(namespace).GetForObjects(schema.GroupKind{Kind: "Pod"}, selector, metricName, metricSelector)
 	if err != nil {
-		return nil, time.Time{}, fmt.Errorf("unable to fetch metrics from custom metrics API: %v", err)
+		return nil, time.Time{}, fmt.Errorf("unable to fetch metrics from custom metrics API: %w", err)
 	}
 
 	if len(metrics.Items) == 0 {
@@ -184,7 +184,7 @@ func (c *customMetricsClient) GetObjectMetric(metricName string, namespace strin
 	}
 
 	if err != nil {
-		return 0, time.Time{}, fmt.Errorf("unable to fetch metrics from custom metrics API: %v", err)
+		return 0, time.Time{}, fmt.Errorf("unable to fetch metrics from custom metrics API: %w", err)
 	}
 
 	return metricValue.Value.MilliValue(), metricValue.Timestamp.Time, nil
@@ -201,7 +201,7 @@ type externalMetricsClient struct {
 func (c *externalMetricsClient) GetExternalMetric(metricName, namespace string, selector labels.Selector) ([]int64, time.Time, error) {
 	metrics, err := c.client.NamespacedMetrics(namespace).List(metricName, selector)
 	if err != nil {
-		return []int64{}, time.Time{}, fmt.Errorf("unable to fetch metrics from external metrics API: %v", err)
+		return []int64{}, time.Time{}, fmt.Errorf("unable to fetch metrics from external metrics API: %w", err)
 	}
 
 	if len(metrics.Items) == 0 {

--- a/pkg/controller/podautoscaler/replica_calculator.go
+++ b/pkg/controller/podautoscaler/replica_calculator.go
@@ -80,11 +80,11 @@ func NewReplicaCalculator(metricsClient metricsclient.MetricsClient, podLister c
 func (c *ReplicaCalculator) GetResourceReplicas(ctx context.Context, currentReplicas int32, targetUtilization int32, resource v1.ResourceName, tolerances Tolerances, namespace string, selector labels.Selector, container string) (replicaCount int32, utilization int32, rawUtilization int64, timestamp time.Time, err error) {
 	metrics, timestamp, err := c.metricsClient.GetResourceMetric(ctx, resource, namespace, selector, container)
 	if err != nil {
-		return 0, 0, 0, time.Time{}, fmt.Errorf("unable to get metrics for resource %s: %v", resource, err)
+		return 0, 0, 0, time.Time{}, fmt.Errorf("unable to get metrics for resource %s: %w", resource, err)
 	}
 	podList, err := c.podLister.Pods(namespace).List(selector)
 	if err != nil {
-		return 0, 0, 0, time.Time{}, fmt.Errorf("unable to get pods while calculating replica count: %v", err)
+		return 0, 0, 0, time.Time{}, fmt.Errorf("unable to get pods while calculating replica count: %w", err)
 	}
 	if len(podList) == 0 {
 		return 0, 0, 0, time.Time{}, fmt.Errorf("no pods returned by selector while calculating replica count")
@@ -169,7 +169,7 @@ func (c *ReplicaCalculator) GetResourceReplicas(ctx context.Context, currentRepl
 func (c *ReplicaCalculator) GetRawResourceReplicas(ctx context.Context, currentReplicas int32, targetUsage int64, resource v1.ResourceName, tolerances Tolerances, namespace string, selector labels.Selector, container string) (replicaCount int32, usage int64, timestamp time.Time, err error) {
 	metrics, timestamp, err := c.metricsClient.GetResourceMetric(ctx, resource, namespace, selector, container)
 	if err != nil {
-		return 0, 0, time.Time{}, fmt.Errorf("unable to get metrics for resource %s: %v", resource, err)
+		return 0, 0, time.Time{}, fmt.Errorf("unable to get metrics for resource %s: %w", resource, err)
 	}
 
 	replicaCount, usage, err = c.calcPlainMetricReplicas(metrics, currentReplicas, targetUsage, tolerances, namespace, selector, resource)
@@ -182,7 +182,7 @@ func (c *ReplicaCalculator) GetRawResourceReplicas(ctx context.Context, currentR
 func (c *ReplicaCalculator) GetMetricReplicas(currentReplicas int32, targetUsage int64, metricName string, tolerances Tolerances, namespace string, selector labels.Selector, metricSelector labels.Selector) (replicaCount int32, usage int64, timestamp time.Time, err error) {
 	metrics, timestamp, err := c.metricsClient.GetRawMetric(metricName, namespace, selector, metricSelector)
 	if err != nil {
-		return 0, 0, time.Time{}, fmt.Errorf("unable to get metric %s: %v", metricName, err)
+		return 0, 0, time.Time{}, fmt.Errorf("unable to get metric %s: %w", metricName, err)
 	}
 
 	replicaCount, usage, err = c.calcPlainMetricReplicas(metrics, currentReplicas, targetUsage, tolerances, namespace, selector, "")
@@ -194,7 +194,7 @@ func (c *ReplicaCalculator) calcPlainMetricReplicas(metrics metricsclient.PodMet
 
 	podList, err := c.podLister.Pods(namespace).List(selector)
 	if err != nil {
-		return 0, 0, fmt.Errorf("unable to get pods while calculating replica count: %v", err)
+		return 0, 0, fmt.Errorf("unable to get pods while calculating replica count: %w", err)
 	}
 
 	if len(podList) == 0 {
@@ -330,7 +330,7 @@ func (c *ReplicaCalculator) GetObjectPerPodMetricReplicas(statusReplicas int32, 
 func (c *ReplicaCalculator) getReadyPodsCount(namespace string, selector labels.Selector) (int64, error) {
 	podList, err := c.podLister.Pods(namespace).List(selector)
 	if err != nil {
-		return 0, fmt.Errorf("unable to get pods while calculating replica count: %v", err)
+		return 0, fmt.Errorf("unable to get pods while calculating replica count: %w", err)
 	}
 
 	if len(podList) == 0 {

--- a/pkg/controller/podautoscaler/replica_calculator.go
+++ b/pkg/controller/podautoscaler/replica_calculator.go
@@ -269,7 +269,7 @@ func (c *ReplicaCalculator) calcPlainMetricReplicas(metrics metricsclient.PodMet
 func (c *ReplicaCalculator) GetObjectMetricReplicas(currentReplicas int32, targetUsage int64, metricName string, tolerances Tolerances, namespace string, objectRef *autoscaling.CrossVersionObjectReference, selector labels.Selector, metricSelector labels.Selector) (replicaCount int32, usage int64, timestamp time.Time, err error) {
 	usage, _, err = c.metricsClient.GetObjectMetric(metricName, namespace, objectRef, metricSelector)
 	if err != nil {
-		return 0, 0, time.Time{}, fmt.Errorf("unable to get metric %s: %v on %s %s/%s", metricName, objectRef.Kind, namespace, objectRef.Name, err)
+		return 0, 0, time.Time{}, fmt.Errorf("unable to get metric %s on %s %s/%s: %w", metricName, objectRef.Kind, namespace, objectRef.Name, err)
 	}
 
 	usageRatio := float64(usage) / float64(targetUsage)
@@ -311,7 +311,7 @@ func (c *ReplicaCalculator) getUsageRatioReplicaCount(currentReplicas int32, usa
 func (c *ReplicaCalculator) GetObjectPerPodMetricReplicas(statusReplicas int32, targetAverageUsage int64, metricName string, tolerances Tolerances, namespace string, objectRef *autoscaling.CrossVersionObjectReference, metricSelector labels.Selector) (replicaCount int32, usage int64, timestamp time.Time, err error) {
 	usage, timestamp, err = c.metricsClient.GetObjectMetric(metricName, namespace, objectRef, metricSelector)
 	if err != nil {
-		return 0, 0, time.Time{}, fmt.Errorf("unable to get metric %s: %v on %s %s/%s", metricName, objectRef.Kind, namespace, objectRef.Name, err)
+		return 0, 0, time.Time{}, fmt.Errorf("unable to get metric %s on %s %s/%s: %w", metricName, objectRef.Kind, namespace, objectRef.Name, err)
 	}
 
 	replicaCount = statusReplicas


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

This PR makes two improvements to error handling in the HPA controller:

**1. Fix format-string argument order in object metric error messages**

The error format strings in `GetObjectMetricReplicas` and `GetObjectPerPodMetricReplicas` in the HPA replica calculator had the `fmt.Errorf` arguments in the wrong order relative to the format verbs.

The format string was:
```
"unable to get metric %s: %v on %s %s/%s", metricName, objectRef.Kind, namespace, objectRef.Name, err
```

This caused `objectRef.Kind` to be printed where the error (`%v`) should appear, and `err` to be formatted by the final `%s` meant for `objectRef.Name`. The resulting error messages were misleading and made debugging object metric failures harder.

Fixed by reordering the format string to the idiomatic Go pattern (context first, error last):
```
"unable to get metric %s on %s %s/%s: %w", metricName, objectRef.Kind, namespace, objectRef.Name, err
```

**2. Use `%w` for proper error wrapping across the package**

Replaced `%v` with `%w` for error arguments in all `fmt.Errorf` calls throughout the HPA controller (`horizontal.go`), replica calculator (`replica_calculator.go`), and metrics client (`metrics/client.go`). This enables proper error wrapping so that callers can use `errors.Is` and `errors.As` to inspect underlying errors.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- The first commit fixes the argument ordering bug in `GetObjectMetricReplicas` and `GetObjectPerPodMetricReplicas`.
- The second commit is a broader cleanup that replaces `%v` → `%w` for all error arguments in `fmt.Errorf` across the `pkg/controller/podautoscaler` package (30 occurrences across 3 files).
- Two `%v` usages were intentionally left unchanged: integer format arguments in `computeReplicasForMetrics`, and the sentinel error pattern on line 836 of `horizontal.go` where `%v` is used for `err` alongside a deliberate `%w` for `errSpec`.

#### Does this PR introduce a user-facing change?

```release-note
Fixed incorrect error message formatting in the HPA controller when object metric retrieval fails. Error messages now correctly display the metric name, object kind, namespace, object name, and the underlying error. Also improved error wrapping across the HPA controller to use %w instead of %v, enabling proper error chain inspection.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```