### PR TITLE
Fix memory leak in HPA stabilization and scale event tracking

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -1060,29 +1060,27 @@ func (a *HorizontalController) reconcileAutoscaler(ctx context.Context, hpaShare
 }
 
 // stabilizeRecommendation:
-// - replaces old recommendation with the newest recommendation,
+// - removes all outdated recommendations and appends the newest one,
 // - returns max of recommendations that are not older than downscaleStabilisationWindow.
 func (a *HorizontalController) stabilizeRecommendation(key string, prenormalizedDesiredReplicas int32) int32 {
 	maxRecommendation := prenormalizedDesiredReplicas
-	foundOldSample := false
-	oldSampleIndex := 0
 	cutoff := time.Now().Add(-a.downscaleStabilisationWindow)
 
 	a.recommendationsLock.Lock()
 	defer a.recommendationsLock.Unlock()
-	for i, rec := range a.recommendations[key] {
+	// Remove all outdated recommendations and find the max of the remaining ones.
+	kept := a.recommendations[key][:0]
+	for _, rec := range a.recommendations[key] {
 		if rec.timestamp.Before(cutoff) {
-			foundOldSample = true
-			oldSampleIndex = i
-		} else if rec.recommendation > maxRecommendation {
+			continue
+		}
+		if rec.recommendation > maxRecommendation {
 			maxRecommendation = rec.recommendation
 		}
+		kept = append(kept, rec)
 	}
-	if foundOldSample {
-		a.recommendations[key][oldSampleIndex] = timestampedRecommendation{prenormalizedDesiredReplicas, time.Now()}
-	} else {
-		a.recommendations[key] = append(a.recommendations[key], timestampedRecommendation{prenormalizedDesiredReplicas, time.Now()})
-	}
+	kept = append(kept, timestampedRecommendation{prenormalizedDesiredReplicas, time.Now()})
+	a.recommendations[key] = kept
 	return maxRecommendation
 }
 
@@ -1183,64 +1181,47 @@ func (a *HorizontalController) getUnableComputeReplicaCountCondition(hpa runtime
 	}
 }
 
-// storeScaleEvent stores (adds or replaces outdated) scale event.
-// outdated events to be replaced were marked as outdated in the `markScaleEventsOutdated` function
+// storeScaleEvent stores the new scale event and removes all outdated events.
+// Outdated events are identified by the `markScaleEventsOutdated` function.
 func (a *HorizontalController) storeScaleEvent(behavior *autoscalingv2.HorizontalPodAutoscalerBehavior, key string, prevReplicas, newReplicas int32) {
 	if behavior == nil {
 		return // we should not store any event as they will not be used
 	}
-	var oldSampleIndex int
-	var longestPolicyPeriod int32
-	foundOldSample := false
 	if newReplicas > prevReplicas {
-		longestPolicyPeriod = getLongestPolicyPeriod(behavior.ScaleUp)
+		longestPolicyPeriod := getLongestPolicyPeriod(behavior.ScaleUp)
 
 		a.scaleUpEventsLock.Lock()
 		defer a.scaleUpEventsLock.Unlock()
 		markScaleEventsOutdated(a.scaleUpEvents[key], longestPolicyPeriod)
-		replicaChange := newReplicas - prevReplicas
-		for i, event := range a.scaleUpEvents[key] {
-			if event.outdated {
-				foundOldSample = true
-				oldSampleIndex = i
-			}
-		}
-		newEvent := timestampedScaleEvent{replicaChange, time.Now(), false}
-		if foundOldSample {
-			a.scaleUpEvents[key][oldSampleIndex] = newEvent
-		} else {
-			a.scaleUpEvents[key] = append(a.scaleUpEvents[key], newEvent)
-		}
+		a.scaleUpEvents[key] = compactScaleEvents(a.scaleUpEvents[key])
+		a.scaleUpEvents[key] = append(a.scaleUpEvents[key], timestampedScaleEvent{newReplicas - prevReplicas, time.Now(), false})
 	} else {
-		longestPolicyPeriod = getLongestPolicyPeriod(behavior.ScaleDown)
+		longestPolicyPeriod := getLongestPolicyPeriod(behavior.ScaleDown)
 
 		a.scaleDownEventsLock.Lock()
 		defer a.scaleDownEventsLock.Unlock()
 		markScaleEventsOutdated(a.scaleDownEvents[key], longestPolicyPeriod)
-		replicaChange := prevReplicas - newReplicas
-		for i, event := range a.scaleDownEvents[key] {
-			if event.outdated {
-				foundOldSample = true
-				oldSampleIndex = i
-			}
-		}
-		newEvent := timestampedScaleEvent{replicaChange, time.Now(), false}
-		if foundOldSample {
-			a.scaleDownEvents[key][oldSampleIndex] = newEvent
-		} else {
-			a.scaleDownEvents[key] = append(a.scaleDownEvents[key], newEvent)
-		}
+		a.scaleDownEvents[key] = compactScaleEvents(a.scaleDownEvents[key])
+		a.scaleDownEvents[key] = append(a.scaleDownEvents[key], timestampedScaleEvent{prevReplicas - newReplicas, time.Now(), false})
 	}
 }
 
+// compactScaleEvents removes all outdated events from the slice, reusing the backing array.
+func compactScaleEvents(events []timestampedScaleEvent) []timestampedScaleEvent {
+	kept := events[:0]
+	for _, e := range events {
+		if !e.outdated {
+			kept = append(kept, e)
+		}
+	}
+	return kept
+}
+
 // stabilizeRecommendationWithBehaviors:
-// - replaces old recommendation with the newest recommendation,
+// - removes all outdated recommendations and appends the newest one,
 // - returns {max,min} of recommendations that are not older than constraints.Scale{Up,Down}.DelaySeconds
 func (a *HorizontalController) stabilizeRecommendationWithBehaviors(args NormalizationArg) (int32, string, string) {
 	now := time.Now()
-
-	foundOldSample := false
-	oldSampleIndex := 0
 
 	upRecommendation := args.DesiredReplicas
 	upDelaySeconds := *args.ScaleUpBehavior.StabilizationWindowSeconds
@@ -1250,20 +1231,22 @@ func (a *HorizontalController) stabilizeRecommendationWithBehaviors(args Normali
 	downDelaySeconds := *args.ScaleDownBehavior.StabilizationWindowSeconds
 	downCutoff := now.Add(-time.Second * time.Duration(downDelaySeconds))
 
-	// Calculate the upper and lower stabilization limits.
+	// Calculate the upper and lower stabilization limits,
+	// removing recommendations that are outdated for both windows.
 	a.recommendationsLock.Lock()
 	defer a.recommendationsLock.Unlock()
-	for i, rec := range a.recommendations[args.Key] {
+	kept := a.recommendations[args.Key][:0]
+	for _, rec := range a.recommendations[args.Key] {
+		if rec.timestamp.Before(upCutoff) && rec.timestamp.Before(downCutoff) {
+			continue
+		}
 		if rec.timestamp.After(upCutoff) {
 			upRecommendation = min(rec.recommendation, upRecommendation)
 		}
 		if rec.timestamp.After(downCutoff) {
 			downRecommendation = max(rec.recommendation, downRecommendation)
 		}
-		if rec.timestamp.Before(upCutoff) && rec.timestamp.Before(downCutoff) {
-			foundOldSample = true
-			oldSampleIndex = i
-		}
+		kept = append(kept, rec)
 	}
 
 	// Bring the recommendation to within the upper and lower limits (stabilize).
@@ -1276,11 +1259,8 @@ func (a *HorizontalController) stabilizeRecommendationWithBehaviors(args Normali
 	}
 
 	// Record the unstabilized recommendation.
-	if foundOldSample {
-		a.recommendations[args.Key][oldSampleIndex] = timestampedRecommendation{args.DesiredReplicas, time.Now()}
-	} else {
-		a.recommendations[args.Key] = append(a.recommendations[args.Key], timestampedRecommendation{args.DesiredReplicas, time.Now()})
-	}
+	kept = append(kept, timestampedRecommendation{args.DesiredReplicas, time.Now()})
+	a.recommendations[args.Key] = kept
 
 	// Determine a human-friendly message.
 	var reason, message string

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -4335,7 +4335,7 @@ func TestNormalizeDesiredReplicas(t *testing.T) {
 			},
 			3,
 			3,
-			2,
+			1,
 		},
 		{
 			"stabilize - old recommendations",
@@ -4348,7 +4348,7 @@ func TestNormalizeDesiredReplicas(t *testing.T) {
 			},
 			3,
 			5,
-			4,
+			3,
 		},
 	}
 	for _, tc := range tests {
@@ -4365,6 +4365,35 @@ func TestNormalizeDesiredReplicas(t *testing.T) {
 		if len(hc.recommendations[tc.key]) != tc.expectedLogLength {
 			t.Errorf("[%s] after  stabilization recommendations log has %d entries, expected %d", tc.name, len(hc.recommendations[tc.key]), tc.expectedLogLength)
 		}
+	}
+}
+
+func TestStabilizeRecommendationRemovesAllOutdated(t *testing.T) {
+	hc := HorizontalController{
+		downscaleStabilisationWindow: 5 * time.Minute,
+		recommendations:              map[string][]timestampedRecommendation{},
+	}
+	key := "test-ns/test-hpa"
+
+	// Simulate many reconciliations producing recommendations that later age out.
+	// All entries are older than the 5-minute stabilization window.
+	outdatedCount := 100
+	oldRecs := make([]timestampedRecommendation, outdatedCount)
+	for i := range oldRecs {
+		oldRecs[i] = timestampedRecommendation{
+			recommendation: int32(10 + i),
+			timestamp:      time.Now().Add(-time.Duration(10+i) * time.Minute),
+		}
+	}
+	hc.recommendations[key] = oldRecs
+
+	// A single call should remove all outdated entries and keep only the new one.
+	r := hc.stabilizeRecommendation(key, 5)
+	if r != 5 {
+		t.Errorf("expected stabilized replicas 5, got %d", r)
+	}
+	if got := len(hc.recommendations[key]); got != 1 {
+		t.Errorf("expected 1 recommendation after cleanup, got %d (outdated entries leaked)", got)
 	}
 }
 
@@ -4906,32 +4935,31 @@ func TestStoreScaleEvents(t *testing.T) {
 			expectedReplicasChange: 7,
 		},
 		{
-			name:          "two entries, one of them to be replaced",
+			name:          "two entries, one of them outdated and removed",
 			replicaChange: 5,
 			prevScaleEvents: []timestampedScaleEvent{
-				{7, time.Now().Add(-time.Second * time.Duration(61)), false}, // outdated event, should be replaced
+				{7, time.Now().Add(-time.Second * time.Duration(61)), false}, // outdated event, should be removed
 				{6, time.Now().Add(-time.Second * time.Duration(59)), false},
 			},
 			newScaleEvents: []timestampedScaleEvent{
-				{5, time.Now(), false},
 				{6, time.Now(), false},
+				{5, time.Now(), false},
 			},
 			scalingRules:           generateScalingRules(10, 60, 0, 0, 0),
 			expectedReplicasChange: 6,
 		},
 		{
-			name:          "replace one entry, use policies with different periods",
+			name:          "remove outdated entries, use policies with different periods",
 			replicaChange: 5,
 			prevScaleEvents: []timestampedScaleEvent{
 				{8, time.Now().Add(-time.Second * time.Duration(29)), false},
 				{6, time.Now().Add(-time.Second * time.Duration(59)), false},
-				{7, time.Now().Add(-time.Second * time.Duration(61)), false}, // outdated event, should be marked as outdated
-				{9, time.Now().Add(-time.Second * time.Duration(61)), false}, // outdated event, should be replaced
+				{7, time.Now().Add(-time.Second * time.Duration(61)), false}, // outdated event, should be removed
+				{9, time.Now().Add(-time.Second * time.Duration(61)), false}, // outdated event, should be removed
 			},
 			newScaleEvents: []timestampedScaleEvent{
 				{8, time.Now(), false},
 				{6, time.Now(), false},
-				{7, time.Now(), true},
 				{5, time.Now(), false},
 			},
 			scalingRules:           generateScalingRules(10, 60, 100, 30, 0),
@@ -5096,7 +5124,7 @@ func TestNormalizeDesiredReplicasWithBehavior(t *testing.T) {
 			scaleDownStabilizationWindowSeconds: 60 * 5,
 		},
 		{
-			name: "no scale down stabilization, reuse recommendation element",
+			name: "no scale down stabilization, remove obsolete recommendations",
 			key:  "",
 			recommendations: []timestampedRecommendation{
 				{10, now.Add(-10 * time.Minute)},
@@ -5105,12 +5133,11 @@ func TestNormalizeDesiredReplicasWithBehavior(t *testing.T) {
 			prenormalizedDesiredReplicas: 3,
 			expectedStabilizedReplicas:   3,
 			expectedRecommendations: []timestampedRecommendation{
-				{10, now},
 				{3, now},
 			},
 		},
 		{
-			name: "no scale up stabilization, reuse recommendation element",
+			name: "no scale up stabilization, remove obsolete recommendations",
 			key:  "",
 			recommendations: []timestampedRecommendation{
 				{10, now.Add(-10 * time.Minute)},
@@ -5119,12 +5146,11 @@ func TestNormalizeDesiredReplicasWithBehavior(t *testing.T) {
 			prenormalizedDesiredReplicas: 100,
 			expectedStabilizedReplicas:   100,
 			expectedRecommendations: []timestampedRecommendation{
-				{10, now},
 				{100, now},
 			},
 		},
 		{
-			name: "scale down stabilization, reuse one of obsolete recommendation element",
+			name: "scale down stabilization, remove obsolete recommendations",
 			key:  "",
 			recommendations: []timestampedRecommendation{
 				{10, now.Add(-10 * time.Minute)},
@@ -5135,7 +5161,6 @@ func TestNormalizeDesiredReplicasWithBehavior(t *testing.T) {
 			prenormalizedDesiredReplicas: 3,
 			expectedStabilizedReplicas:   5,
 			expectedRecommendations: []timestampedRecommendation{
-				{10, now},
 				{4, now},
 				{5, now},
 				{3, now},
@@ -5143,10 +5168,7 @@ func TestNormalizeDesiredReplicasWithBehavior(t *testing.T) {
 			scaleDownStabilizationWindowSeconds: 3 * 60,
 		},
 		{
-			// we can reuse only the first recommendation element
-			// as the scale up delay = 150 (set in test), scale down delay = 300 (by default)
-			// hence, only the first recommendation is obsolete for both scale up and scale down
-			name: "scale up stabilization, reuse one of obsolete recommendation element",
+			name: "scale up stabilization, remove obsolete recommendations",
 			key:  "",
 			recommendations: []timestampedRecommendation{
 				{10, now.Add(-100 * time.Minute)},
@@ -5157,10 +5179,10 @@ func TestNormalizeDesiredReplicasWithBehavior(t *testing.T) {
 			prenormalizedDesiredReplicas: 100,
 			expectedStabilizedReplicas:   5,
 			expectedRecommendations: []timestampedRecommendation{
-				{100, now},
 				{6, now},
 				{5, now},
 				{9, now},
+				{100, now},
 			},
 			scaleUpStabilizationWindowSeconds: 300,
 		}, {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

The `stabilizeRecommendation`, `stabilizeRecommendationWithBehaviors`, and `storeScaleEvent` functions in the HPA controller store timestamped entries in slices and attempt to reclaim expired slots by replacing **one** outdated entry per call. If multiple entries age out between consecutive reconciliations, only one gets replaced — the rest persist indefinitely, causing the slices to grow monotonically over the lifetime of long-lived HPAs.

This PR fixes the issue by compacting the slices on each call: all outdated entries are removed, and only the new entry is appended. This bounds slice length to the number of reconciliations within the active stabilization window plus one.

**Severity context:**

With the current default 15-second sync period, the leak is difficult to trigger under normal conditions — it requires a processing gap of >30 seconds (e.g., API server latency, leader re-election, GC pause) for multiple entries to age out simultaneously. The per-entry cost is small (~16 bytes), so the practical impact at 15s intervals is minimal.

This fix ensures the HPA controller's memory behavior is correct by construction, regardless of sync frequency.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The fix applies to three functions that shared the same "find one outdated slot to reuse" pattern:
- `stabilizeRecommendation` — legacy downscale stabilization
- `stabilizeRecommendationWithBehaviors` — behavior-based stabilization
- `storeScaleEvent` — scale event tracking (extracted a `compactScaleEvents` helper)

All three now compact by removing all outdated entries instead of replacing one. Test expectations were updated to reflect the new behavior, and a new `TestStabilizeRecommendationRemovesAllOutdated` test was added that creates 100 outdated entries and verifies they are all cleaned up in a single call.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a memory leak in the HPA controller where outdated stabilization recommendations and scale events could accumulate in long-lived HPAs, particularly with short sync periods.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```