### PR TITLE
Fix MAP JSONPatch panic when value is a list of Object literals

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch/json_patch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch/json_patch_test.go
@@ -341,6 +341,20 @@ func TestJSONPatch(t *testing.T) {
 			}}},
 		},
 		{
+			name: "jsonPatch add list of CEL initializers as value",
+			expression: `[
+					JSONPatch{op: "add", path: "/spec/template/spec/containers", value: [
+						Object.spec.template.spec.containers{name: "a"},
+						Object.spec.template.spec.containers{name: "b"},
+					]},
+				]`,
+			gvr:    deploymentGVR,
+			object: &appsv1.Deployment{Spec: appsv1.DeploymentSpec{}},
+			expectedResult: &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "a"}, {Name: "b"}},
+			}}}},
+		},
+		{
 			name: "jsonPatch with CEL initializer",
 			expression: `[
 					JSONPatch{op: "add", path: "/spec/template/spec/containers/-", value: Object.spec.template.spec.containers{

--- a/staging/src/k8s.io/apiserver/pkg/cel/mutation/dynamic/objects.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/mutation/dynamic/objects.go
@@ -128,7 +128,11 @@ func (v *ObjectVal) ConvertToNative(typeDesc reflect.Type) (any, error) {
 	// an arbitrary JSON value, such as our MutatingAdmissionPolicy JSON Patch valueExpression
 	// field, so we support the conversion here, for Object data literals, as well.
 	if typeDesc == reflect.TypeOf(&structpb.Value{}) {
-		return structpb.NewStruct(result)
+		s, err := structpb.NewStruct(result)
+		if err != nil {
+			return nil, err
+		}
+		return structpb.NewStructValue(s), nil
 	}
 	return nil, fmt.Errorf("unable to convert to %v", typeDesc)
 }

--- a/staging/src/k8s.io/apiserver/pkg/cel/mutation/dynamic/objects_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/mutation/dynamic/objects_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestOptional(t *testing.T) {
@@ -62,6 +63,28 @@ func TestOptional(t *testing.T) {
 				t.Errorf("wrong result, expected %v but got %v", tc.expected, converted)
 			}
 		})
+	}
+}
+
+func TestConvertToNativeStructpbValue(t *testing.T) {
+	v := &ObjectVal{
+		objectType: types.NewObjectType("Object.spec.volumes"),
+		fields: map[string]ref.Val{
+			"name": types.String("x"),
+		},
+	}
+	got, err := v.ConvertToNative(reflect.TypeFor[*structpb.Value]())
+	if err != nil {
+		t.Fatalf("ConvertToNative: %v", err)
+	}
+	pbVal, ok := got.(*structpb.Value)
+	if !ok {
+		t.Fatalf("ConvertToNative returned %T, want *structpb.Value", got)
+	}
+	gotMap := pbVal.GetStructValue().AsMap()
+	want := map[string]any{"name": "x"}
+	if !reflect.DeepEqual(gotMap, want) {
+		t.Errorf("ConvertToNative = %v, want %v", gotMap, want)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig api-machinery

#### What this PR does / why we need it:

`ObjectVal.ConvertToNative`, when asked for `*structpb.Value`, returns a `*structpb.Struct`. The direct caller in `json_patch.go` tolerates this because it immediately JSON-marshals the result, and a `*structpb.Struct` and a `*structpb.Value` wrapping it serialize identically.

When a MutatingAdmissionPolicy JSONPatch `value` is a list of `Object{}` literals, however, the conversion goes through cel-go's `baseList.ConvertToNative`, which builds a `[]*structpb.Value` via `reflect.Set` on each element. Assigning the `*structpb.Struct` into a `*structpb.Value` slice slot panics, and the panic propagates through the admission chain to the request handler, so the client sees `stream error: INTERNAL_ERROR; received from peer` rather than a policy error. `failurePolicy: Ignore` does not suppress it because the panic unwinds past the dispatcher's error collection.

Apiserver log signature:

```
"APIServer panic'd: reflect.Set: value of type *structpb.Struct is not assignable to type *structpb.Value"
```

This PR wraps the struct in `structpb.NewStructValue` so the declared return type is honored. A unit test asserts the returned type, and a `TestJSONPatch` table case covers the list-of-initializers shape that triggered the panic; that case panics with the trace above on an unpatched tree.

#### Which issue(s) this PR is related to:

N/A

KEP: https://github.com/kubernetes/enhancements/issues/3962

#### Special notes for your reviewer:

The bug has existed since the `ObjectVal` introduction in 9ee1ea9d37c2 and is present in 1.32 through current master. A separate hardening change to have the mutating dispatcher recover from CEL evaluation panics and route them through `failurePolicy` would be worthwhile but is not included here.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a kube-apiserver panic when a MutatingAdmissionPolicy JSONPatch expression sets `value` to a list of `Object{}` literals.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
