### PR TITLE
Use direct I/O for ContainerMetrics cadvisor test

### DIFF
--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -510,7 +510,7 @@ func getSummaryTestPods(f *framework.Framework, numRestarts int32, names ...stri
 								Add: []v1.Capability{"NET_RAW"},
 							},
 						},
-						Command: getRestartingContainerCommand("/test-empty-dir-mnt", 0, numRestarts, "dd if=/dev/zero of=/outside_the_volume.txt bs=4096 count=2 conv=fsync 2>/dev/null; ping -c 1 google.com; echo 'hello world' >> /test-empty-dir-mnt/file; dd if=/dev/zero of=/dev/null bs=1 count=10000000;"),
+						Command: getRestartingContainerCommand("/test-empty-dir-mnt", 0, numRestarts, "dd if=/dev/zero of=/outside_the_volume.txt oflag=direct bs=4096 count=2 2>/dev/null; dd if=/outside_the_volume.txt of=/dev/null iflag=direct bs=4096 count=2 2>/dev/null; ping -c 1 google.com; echo 'hello world' >> /test-empty-dir-mnt/file; dd if=/dev/zero of=/dev/null bs=1 count=10000000;"),
 						Resources: v1.ResourceRequirements{
 							Limits: v1.ResourceList{
 								// Must set memory limit to get MemoryStats.AvailableBytes


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
Overlayfs does not support cgroupv2 writeback accounting. Buffered writes (even with `conv=fsync`) get attributed to the root cgroup instead of the container's cgroup. This causes cadvisor to see an empty `io.stat`, making `container_blkio_device_usage_total`, `container_fs_reads_bytes_total`, and `container_fs_writes_bytes_total` permanently absent.

Switches to `oflag=direct` for writes and adds `iflag=direct` reads to bypass the page cache entirely. Direct I/O is always attributed to the issuing process's cgroup regardless of filesystem type.

#### Which issue(s) this PR is related to:
#138843

#### Special notes for your reviewer:
This is a follow-up to #138851 which used `conv=fsync` but did not fix the flake because overlayfs writeback accounting attributes I/O to the root cgroup on cgroupv2.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```