### PR TITLE
feat(scheduler): add gated_pods ALPHA metric

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -6313,6 +6313,20 @@
   componentEndpoints:
   - component: kube-scheduler
     endpoint: /metrics
+- name: gated_pods
+  subsystem: scheduler
+  help: Number of pods in the gated queue broken down by scheduling gate name from
+    spec.schedulingGates. A pod declaring multiple scheduling gates is counted once
+    per gate, so the sum across gates is greater than or equal to scheduler_pending_pods{queue=\"gated\"}.
+    Pods gated by plugins that do not correspond to a spec.schedulingGates entry are
+    not included.
+  type: Gauge
+  stabilityLevel: ALPHA
+  labels:
+  - gate
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: get_node_hint_duration_seconds
   subsystem: scheduler
   help: Latency for getting a node hint.

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -377,7 +377,7 @@ func NewPriorityQueue(
 		stop:                              make(chan struct{}),
 		podMaxInUnschedulablePodsDuration: options.podMaxInUnschedulablePodsDuration,
 		backoffQ:                          backoffQ,
-		unschedulablePods:                 newUnschedulablePods(metrics.NewUnschedulablePodsRecorder(), metrics.NewGatedPodsRecorder()),
+		unschedulablePods:                 newUnschedulablePods(metrics.NewUnschedulablePodsRecorder(), metrics.NewGatedPodsRecorder(), metrics.NewGatedPodsByGateRecorder()),
 		preEnqueuePluginMap:               options.preEnqueuePluginMap,
 		queueingHintMap:                   options.queueingHintMap,
 		pluginToEventsMap:                 buildEventMap(options.queueingHintMap),

--- a/pkg/scheduler/backend/queue/unschedulable_pods.go
+++ b/pkg/scheduler/backend/queue/unschedulable_pods.go
@@ -18,6 +18,7 @@ package queue
 
 import (
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	"k8s.io/kubernetes/pkg/scheduler/util"
@@ -33,20 +34,35 @@ type unschedulablePods struct {
 	// that are specifically blocked by scheduling gates. These recorders handle
 	// increments, decrements, and transitions (Gated <-> Ungated).
 	unschedulableRecorder, gatedRecorder metrics.MetricRecorder
+	// gatedByGateRecorder tracks per-gate counts of pods currently sitting in the
+	// gated state, broken down by their spec.SchedulingGates names. Pods gated by
+	// plugins without a corresponding spec entry contribute to gatedRecorder but
+	// not here.
+	gatedByGateRecorder metrics.GatedPodsByGateRecorder
+	// countedGates records, for each pod currently counted on gatedByGateRecorder,
+	// the gate names that were incremented. We track this independently of
+	// pod.Spec.SchedulingGates because the spec can change (gates can only be
+	// removed) between the time a pod is added to the gated state and the time
+	// we need to decrement its counters.
+	countedGates map[string]sets.Set[string]
 }
 
 // newUnschedulablePods initializes a new object of unschedulablePods.
-func newUnschedulablePods(unschedulableRecorder, gatedRecorder metrics.MetricRecorder) *unschedulablePods {
+func newUnschedulablePods(unschedulableRecorder, gatedRecorder metrics.MetricRecorder, gatedByGateRecorder metrics.GatedPodsByGateRecorder) *unschedulablePods {
 	return &unschedulablePods{
 		podInfoMap:            make(map[string]*framework.QueuedPodInfo),
 		keyFunc:               util.GetPodFullName,
 		unschedulableRecorder: unschedulableRecorder,
 		gatedRecorder:         gatedRecorder,
+		gatedByGateRecorder:   gatedByGateRecorder,
+		countedGates:          make(map[string]sets.Set[string]),
 	}
 }
 
 // updateMetricsOnStateChange handles the metric accounting when a pod changes
-// between Gated and Unschedulable states.
+// between Gated and Unschedulable states. Per-gate accounting (gatedByGateRecorder)
+// is reconciled separately in addOrUpdate so that gate set changes are picked up
+// even when the gated/ungated state does not flip.
 func (u *unschedulablePods) updateMetricsOnStateChange(gatedBefore, isGated bool) {
 	if gatedBefore == isGated {
 		return
@@ -77,6 +93,11 @@ func (u *unschedulablePods) addOrUpdate(pInfo *framework.QueuedPodInfo, gatedBef
 		}
 		metrics.SchedulerQueueIncomingPods.WithLabelValues("unschedulable", event).Inc()
 	}
+	if pInfo.Gated() {
+		u.reconcileCountedGates(podID, pInfo.Pod)
+	} else {
+		u.releaseCountedGates(podID)
+	}
 	u.podInfoMap[podID] = pInfo
 }
 
@@ -91,6 +112,7 @@ func (u *unschedulablePods) delete(pod *v1.Pod, gated bool) {
 			u.unschedulableRecorder.Dec()
 		}
 	}
+	u.releaseCountedGates(podID)
 	delete(u.podInfoMap, podID)
 }
 
@@ -109,4 +131,53 @@ func (u *unschedulablePods) clear() {
 	u.podInfoMap = make(map[string]*framework.QueuedPodInfo)
 	u.unschedulableRecorder.Clear()
 	u.gatedRecorder.Clear()
+	u.gatedByGateRecorder.Clear()
+	u.countedGates = make(map[string]sets.Set[string])
+}
+
+// reconcileCountedGates incs/decs gatedByGateRecorder so that the per-gate
+// counters reflect the pod's current spec.SchedulingGates. Called whenever a
+// pod is added or updated while in the Gated state.
+func (u *unschedulablePods) reconcileCountedGates(podID string, pod *v1.Pod) {
+	prev := u.countedGates[podID]
+	curr := podSchedulingGateNameSet(pod)
+
+	for g := range prev.Difference(curr) {
+		u.gatedByGateRecorder.Dec(g)
+	}
+	for g := range curr.Difference(prev) {
+		u.gatedByGateRecorder.Inc(g)
+	}
+
+	if curr.Len() == 0 {
+		delete(u.countedGates, podID)
+	} else {
+		u.countedGates[podID] = curr
+	}
+}
+
+// releaseCountedGates decrements gatedByGateRecorder for the gate set
+// previously counted for this pod (if any) and clears the bookkeeping entry.
+func (u *unschedulablePods) releaseCountedGates(podID string) {
+	prev, ok := u.countedGates[podID]
+	if !ok {
+		return
+	}
+	for g := range prev {
+		u.gatedByGateRecorder.Dec(g)
+	}
+	delete(u.countedGates, podID)
+}
+
+// podSchedulingGateNameSet returns the set of gate names declared on the pod's
+// spec.SchedulingGates.
+func podSchedulingGateNameSet(pod *v1.Pod) sets.Set[string] {
+	if len(pod.Spec.SchedulingGates) == 0 {
+		return sets.New[string]()
+	}
+	out := sets.New[string]()
+	for _, g := range pod.Spec.SchedulingGates {
+		out.Insert(g.Name)
+	}
+	return out
 }

--- a/pkg/scheduler/backend/queue/unschedulable_pods_test.go
+++ b/pkg/scheduler/backend/queue/unschedulable_pods_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package queue
 
 import (
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -50,6 +51,47 @@ func (m *mockMetricRecorder) Clear() {
 
 func (m *mockMetricRecorder) value() int64 {
 	return m.val.Load()
+}
+
+var _ metrics.GatedPodsByGateRecorder = &mockGatedPodsByGateRecorder{}
+
+type mockGatedPodsByGateRecorder struct {
+	mu     sync.Mutex
+	counts map[string]int64
+}
+
+func newMockGatedPodsByGateRecorder() *mockGatedPodsByGateRecorder {
+	return &mockGatedPodsByGateRecorder{counts: map[string]int64{}}
+}
+
+func (m *mockGatedPodsByGateRecorder) Inc(gate string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.counts[gate]++
+}
+
+func (m *mockGatedPodsByGateRecorder) Dec(gate string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.counts[gate]--
+}
+
+func (m *mockGatedPodsByGateRecorder) Clear() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.counts = map[string]int64{}
+}
+
+func (m *mockGatedPodsByGateRecorder) snapshot() map[string]int64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make(map[string]int64, len(m.counts))
+	for k, v := range m.counts {
+		if v != 0 {
+			out[k] = v
+		}
+	}
+	return out
 }
 
 func TestUnschedulablePods(t *testing.T) {
@@ -370,7 +412,8 @@ func TestUnschedulablePods(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			unschedulableRecorder := &mockMetricRecorder{}
 			gatedRecorder := &mockMetricRecorder{}
-			upm := newUnschedulablePods(unschedulableRecorder, gatedRecorder)
+			gatedByGateRecorder := newMockGatedPodsByGateRecorder()
+			upm := newUnschedulablePods(unschedulableRecorder, gatedRecorder, gatedByGateRecorder)
 			assertMetrics := func(expectedPods []*framework.QueuedPodInfo, action string) {
 				t.Helper()
 
@@ -410,4 +453,125 @@ func TestUnschedulablePods(t *testing.T) {
 			assertMetrics([]*framework.QueuedPodInfo{}, string(clear))
 		})
 	}
+}
+
+func TestUnschedulablePods_GatedByGateRecorder(t *testing.T) {
+	const (
+		gateFoo = "example.com/foo"
+		gateBar = "example.com/bar"
+		gateBaz = "example.com/baz"
+	)
+
+	makeGatedPodInfo := func(name string, gates ...string) *framework.QueuedPodInfo {
+		pod := st.MakePod().Name(name).Namespace("ns").SchedulingGates(gates).Obj()
+		info := &framework.QueuedPodInfo{
+			PodInfo:              mustNewTestPodInfo(t, pod),
+			GatingPlugin:         "test",
+			UnschedulablePlugins: sets.New[string]("test"),
+		}
+		return info
+	}
+
+	ungated := func(info *framework.QueuedPodInfo) *framework.QueuedPodInfo {
+		clone := *info
+		clone.GatingPlugin = ""
+		clone.UnschedulablePlugins = sets.New[string]()
+		clone.PodInfo = mustNewTestPodInfo(t, info.Pod.DeepCopy())
+		clone.Pod.Spec.SchedulingGates = nil
+		return &clone
+	}
+
+	dropGate := func(info *framework.QueuedPodInfo, gate string) *framework.QueuedPodInfo {
+		pod := info.Pod.DeepCopy()
+		filtered := pod.Spec.SchedulingGates[:0]
+		for _, g := range pod.Spec.SchedulingGates {
+			if g.Name != gate {
+				filtered = append(filtered, g)
+			}
+		}
+		pod.Spec.SchedulingGates = filtered
+		clone := *info
+		clone.PodInfo = mustNewTestPodInfo(t, pod)
+		return &clone
+	}
+
+	assertCounts := func(t *testing.T, rec *mockGatedPodsByGateRecorder, want map[string]int64, msg string) {
+		t.Helper()
+		if diff := cmp.Diff(want, rec.snapshot()); diff != "" {
+			t.Errorf("Unexpected gatedByGateRecorder counts after %s (-want, +got):\n%s", msg, diff)
+		}
+	}
+
+	t.Run("adds and decrements per-gate counters across gated pods", func(t *testing.T) {
+		rec := newMockGatedPodsByGateRecorder()
+		upm := newUnschedulablePods(&mockMetricRecorder{}, &mockMetricRecorder{}, rec)
+
+		p1 := makeGatedPodInfo("p1", gateFoo, gateBar)
+		p2 := makeGatedPodInfo("p2", gateFoo)
+
+		upm.addOrUpdate(p1, false, framework.EventUnscheduledPodAdd.Label())
+		assertCounts(t, rec, map[string]int64{gateFoo: 1, gateBar: 1}, "adding p1")
+
+		upm.addOrUpdate(p2, false, framework.EventUnscheduledPodAdd.Label())
+		assertCounts(t, rec, map[string]int64{gateFoo: 2, gateBar: 1}, "adding p2")
+
+		upm.delete(p1.Pod, true)
+		assertCounts(t, rec, map[string]int64{gateFoo: 1}, "deleting p1")
+
+		upm.delete(p2.Pod, true)
+		assertCounts(t, rec, map[string]int64{}, "deleting p2")
+	})
+
+	t.Run("reconciles when a gate is removed while pod stays gated", func(t *testing.T) {
+		rec := newMockGatedPodsByGateRecorder()
+		upm := newUnschedulablePods(&mockMetricRecorder{}, &mockMetricRecorder{}, rec)
+
+		p := makeGatedPodInfo("p", gateFoo, gateBar)
+		upm.addOrUpdate(p, false, framework.EventUnscheduledPodAdd.Label())
+		assertCounts(t, rec, map[string]int64{gateFoo: 1, gateBar: 1}, "initial add")
+
+		updated := dropGate(p, gateBar)
+		upm.addOrUpdate(updated, true, framework.EventUnscheduledPodUpdate.Label())
+		assertCounts(t, rec, map[string]int64{gateFoo: 1}, "dropping gateBar")
+	})
+
+	t.Run("releases per-gate counters when pod transitions to ungated", func(t *testing.T) {
+		rec := newMockGatedPodsByGateRecorder()
+		upm := newUnschedulablePods(&mockMetricRecorder{}, &mockMetricRecorder{}, rec)
+
+		p := makeGatedPodInfo("p", gateFoo, gateBaz)
+		upm.addOrUpdate(p, false, framework.EventUnscheduledPodAdd.Label())
+		assertCounts(t, rec, map[string]int64{gateFoo: 1, gateBaz: 1}, "initial add")
+
+		upm.addOrUpdate(ungated(p), true, framework.EventUnscheduledPodUpdate.Label())
+		assertCounts(t, rec, map[string]int64{}, "transition to ungated")
+	})
+
+	t.Run("ignores pods that are gated without spec.schedulingGates", func(t *testing.T) {
+		rec := newMockGatedPodsByGateRecorder()
+		upm := newUnschedulablePods(&mockMetricRecorder{}, &mockMetricRecorder{}, rec)
+
+		// Pod is Gated() because a plugin set GatingPlugin, but has no spec gates.
+		p := makeGatedPodInfo("p")
+		upm.addOrUpdate(p, false, framework.EventUnscheduledPodAdd.Label())
+		assertCounts(t, rec, map[string]int64{}, "plugin-only gating")
+
+		upm.delete(p.Pod, true)
+		assertCounts(t, rec, map[string]int64{}, "delete plugin-only gated pod")
+	})
+
+	t.Run("clear() resets the recorder", func(t *testing.T) {
+		rec := newMockGatedPodsByGateRecorder()
+		upm := newUnschedulablePods(&mockMetricRecorder{}, &mockMetricRecorder{}, rec)
+
+		upm.addOrUpdate(makeGatedPodInfo("p1", gateFoo), false, framework.EventUnscheduledPodAdd.Label())
+		upm.addOrUpdate(makeGatedPodInfo("p2", gateBar), false, framework.EventUnscheduledPodAdd.Label())
+		assertCounts(t, rec, map[string]int64{gateFoo: 1, gateBar: 1}, "two gated pods")
+
+		upm.clear()
+		assertCounts(t, rec, map[string]int64{}, "clear")
+		if len(upm.countedGates) != 0 {
+			t.Errorf("expected countedGates to be empty after clear, got %d entries", len(upm.countedGates))
+		}
+	})
 }

--- a/pkg/scheduler/metrics/metric_recorder.go
+++ b/pkg/scheduler/metrics/metric_recorder.go
@@ -80,6 +80,37 @@ func (r *PendingPodsRecorder) Clear() {
 	r.recorder.Set(float64(0))
 }
 
+// GatedPodsByGateRecorder records the per-gate count of pods sitting in the
+// gated queue. Unlike MetricRecorder it is parameterised by a gate name so
+// that one gauge series is emitted per scheduling gate.
+type GatedPodsByGateRecorder interface {
+	Inc(gate string)
+	Dec(gate string)
+	Clear()
+}
+
+var _ GatedPodsByGateRecorder = &gatedPodsByGateRecorder{}
+
+type gatedPodsByGateRecorder struct{}
+
+// NewGatedPodsByGateRecorder returns a recorder that updates the scheduler
+// gated_pods gauge.
+func NewGatedPodsByGateRecorder() GatedPodsByGateRecorder {
+	return &gatedPodsByGateRecorder{}
+}
+
+func (r *gatedPodsByGateRecorder) Inc(gate string) {
+	GatedPodsByGate(gate).Inc()
+}
+
+func (r *gatedPodsByGateRecorder) Dec(gate string) {
+	GatedPodsByGate(gate).Dec()
+}
+
+func (r *gatedPodsByGateRecorder) Clear() {
+	ResetGatedPodsByGate()
+}
+
 // histogramVecMetric is the data structure passed in the buffer channel between the main framework thread
 // and the metricsRecorder goroutine.
 type histogramVecMetric struct {

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -136,6 +136,7 @@ var (
 	PreemptionVictims            *metrics.Histogram
 	PreemptionAttempts           *metrics.Counter
 	pendingPods                  *metrics.GaugeVec
+	gatedPods                    *metrics.GaugeVec
 	InFlightEvents               *metrics.GaugeVec
 	Goroutines                   *metrics.GaugeVec
 	BatchAttemptStats            *metrics.CounterVec
@@ -279,6 +280,13 @@ func InitMetrics() {
 			Help:           "Number of pending pods, by the queue type. 'active' means number of pods in activeQ; 'backoff' means number of pods in backoffQ; 'unschedulable' means number of pods in unschedulablePods that the scheduler attempted to schedule and failed; 'gated' is the number of unschedulable pods that the scheduler never attempted to schedule because they are gated.",
 			StabilityLevel: metrics.STABLE,
 		}, []string{"queue"})
+	gatedPods = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Subsystem:      SchedulerSubsystem,
+			Name:           "gated_pods",
+			Help:           "Number of pods in the gated queue broken down by scheduling gate name from spec.schedulingGates. A pod declaring multiple scheduling gates is counted once per gate, so the sum across gates is greater than or equal to scheduler_pending_pods{queue=\"gated\"}. Pods gated by plugins that do not correspond to a spec.schedulingGates entry are not included.",
+			StabilityLevel: metrics.ALPHA,
+		}, []string{"gate"})
 	InFlightEvents = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
 			Subsystem:      SchedulerSubsystem,
@@ -537,6 +545,7 @@ func InitMetrics() {
 		PreemptionVictims,
 		PreemptionAttempts,
 		pendingPods,
+		gatedPods,
 		PodSchedulingSLIDuration,
 		PodSchedulingAttempts,
 		PodScheduledAfterFlush,
@@ -588,6 +597,17 @@ func UnschedulablePods() metrics.GaugeMetric {
 // GatedPods returns the pending pods metrics with the label gated
 func GatedPods() metrics.GaugeMetric {
 	return pendingPods.With(metrics.Labels{"queue": "gated"})
+}
+
+// GatedPodsByGate returns the gated_pods metric scoped to the given
+// scheduling gate name.
+func GatedPodsByGate(gate string) metrics.GaugeMetric {
+	return gatedPods.With(metrics.Labels{"gate": gate})
+}
+
+// ResetGatedPodsByGate clears all series of the gated_pods metric.
+func ResetGatedPodsByGate() {
+	gatedPods.Reset()
 }
 
 // SinceInSeconds gets the time since the specified start in seconds.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When pods are blocked in the scheduler's gated queue, the existing STABLE `scheduler_pending_pods{queue="gated"}` gauge tells operators how many pods are stuck but not which gate is responsible. Listing pods to discover which `spec.SchedulingGates` are held by which controller is awkward when multiple gates coexist on the same cluster (cluster autoscaler / Karpenter integrations, custom admission flows, deployment-snapshot gates, spot-placement policies, etc.).

This PR adds a new ALPHA gauge:

```
# HELP scheduler_gated_pods [ALPHA] Number of pods in the gated queue broken down by scheduling gate name from spec.schedulingGates. A pod declaring multiple scheduling gates is counted once per gate, so the sum across gates is greater than or equal to scheduler_pending_pods{queue="gated"}. Pods gated by plugins that do not correspond to a spec.schedulingGates entry are not included.
# TYPE scheduler_gated_pods gauge
scheduler_gated_pods{gate="example.com/foo"} 3
scheduler_gated_pods{gate="example.com/bar"} 1
```

Properties:

- Cardinality is bounded by the (typically small) number of distinct gate names in use on a cluster.
- A pod declaring multiple gates is counted once per gate, so `sum(scheduler_gated_pods)` is greater than or equal to `scheduler_pending_pods{queue="gated"}`.
- Pods that the scheduler gates via a plugin without a matching `spec.schedulingGates` entry continue to contribute to `scheduler_pending_pods{queue="gated"}` but do not appear in the new metric. This is documented in the metric help text.

Per-gate accounting is wired through `unschedulablePods`, which now remembers the gate set it incremented for each pod so it can decrement correctly when the gate set shrinks (gates can only be removed, not added), when the pod transitions out of the gated state, when the pod is deleted, or when the queue is cleared. Unit tests cover each of those transitions.

Existing `scheduler_pending_pods` is unchanged.

#### Which issue(s) this PR is related to:

Fixes #139035

#### Special notes for your reviewer:

The new metric is registered unconditionally (no feature gate) because it is ALPHA and has bounded cardinality, matching the convention used by sibling ALPHA scheduler metrics. Happy to put it behind a feature gate if sig-scheduling / sig-instrumentation prefer.

#### Does this PR introduce a user-facing change?

```release-note
kube-scheduler: added a new ALPHA metric `scheduler_gated_pods` that breaks the gated-queue pod count down by `spec.schedulingGates` name. A pod declaring multiple gates is counted once per gate. Pods gated by plugins without a matching `spec.schedulingGates` entry are not included.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

/sig scheduling
/sig instrumentation
