### PR TITLE
fix: pod status updating latency

### DIFF
--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -1142,6 +1142,19 @@ func (m *manager) syncBatch(ctx context.Context, all bool) int {
 	for _, update := range updatedStatuses {
 		logger.V(5).Info("Sync pod status", "podUID", update.podUID, "statusUID", update.statusUID, "version", update.status.version)
 		m.syncPod(ctx, update.podUID, update.status)
+		// Re-signal the channel so the sync goroutine picks up any versions
+		// that were not yet sent to the API server.
+		m.podStatusesLock.RLock()
+		latestStatus, exists := m.podStatuses[update.podUID]
+		m.podStatusesLock.RUnlock()
+		if exists &&
+			m.apiStatusVersions[update.statusUID] >= update.status.version &&
+			m.apiStatusVersions[update.statusUID] < latestStatus.version {
+			select {
+			case m.podStatusChannel <- struct{}{}:
+			default:
+			}
+		}
 	}
 
 	return len(updatedStatuses)

--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -3094,3 +3094,95 @@ func getPodStatus() v1.PodStatus {
 		Message: "Message",
 	}
 }
+
+// TestSyncBatchReSignalsAfterDroppedReadinessUpdates verifies that syncBatch
+// re-signals podStatusChannel when a newer status version has accumulated in
+// m.podStatuses while a syncPod API call was in flight
+func TestSyncBatchReSignalsAfterDroppedReadinessUpdates(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+
+	const numContainers = 2
+	pod := getTestPod()
+	pod.Spec.Containers = make([]v1.Container, numContainers)
+	containerIDs := make([]kubecontainer.ContainerID, numContainers)
+	containerStatuses := make([]v1.ContainerStatus, numContainers)
+	for i := 0; i < numContainers; i++ {
+		pod.Spec.Containers[i] = v1.Container{Name: fmt.Sprintf("c%d", i)}
+		containerIDs[i] = kubecontainer.ContainerID{Type: "test", ID: fmt.Sprintf("%d", i)}
+		containerStatuses[i] = v1.ContainerStatus{
+			Name:        fmt.Sprintf("c%d", i),
+			ContainerID: containerIDs[i].String(),
+			Ready:       true,
+		}
+	}
+	initialStatus := v1.PodStatus{
+		ContainerStatuses: containerStatuses,
+		Conditions: []v1.PodCondition{{
+			Type:   v1.PodReady,
+			Status: v1.ConditionTrue,
+		}},
+	}
+
+	client := fake.NewSimpleClientset(pod)
+	m := newTestManager(client)
+	m.podManager.(mutablePodManager).AddPod(pod)
+
+	// establish initial status so m.podStatuses and apiStatusVersions are in sync.
+	m.SetPodStatus(logger, pod, initialStatus)
+	_, ctx2 := ktesting.NewTestContext(t)
+	m.syncBatch(ctx2, true)
+
+	// drain the channel so it is empty.
+	for len(m.podStatusChannel) > 0 {
+		<-m.podStatusChannel
+	}
+
+	// pre-fill the channel with a sentinel so subsequent
+	// SetContainerReadiness calls cannot send their signal.
+	m.podStatusChannel <- struct{}{}
+
+	// mark both containers not-ready, signals are dropped (channel full).
+	for i := 0; i < numContainers; i++ {
+		m.SetContainerReadiness(logger, pod.UID, containerIDs[i], false)
+	}
+
+	// drain the sentinel, channel is now empty, but m.podStatuses is
+	// ahead of apiStatusVersions.
+	<-m.podStatusChannel
+	require.Equal(t, 0, len(m.podStatusChannel), "channel should be empty before syncBatch")
+
+	// snapshot the current latest version so we can verify the precondition.
+	m.podStatusesLock.RLock()
+	versionBeforeSync := m.podStatuses[pod.UID].version
+	m.podStatusesLock.RUnlock()
+
+	statusUID := kubetypes.MirrorPodUID(pod.UID)
+
+	// reactor that simulates a new update arriving while syncPod is
+	// blocked on the API call.
+	client.PrependReactor("patch", "pods", func(action core.Action) (bool, runtime.Object, error) {
+		m.podStatusesLock.Lock()
+		if s, ok := m.podStatuses[pod.UID]; ok {
+			s.version++
+			m.podStatuses[pod.UID] = s
+		}
+		m.podStatusesLock.Unlock()
+		return true, pod.DeepCopy(), nil
+	})
+
+	// also need a GET reactor so syncPod can retrieve the pod.
+	client.PrependReactor("get", "pods", func(action core.Action) (bool, runtime.Object, error) {
+		return true, pod.DeepCopy(), nil
+	})
+
+	// confirm precondition: apiStatusVersions < versionBeforeSync (dropped signals).
+	require.Less(t, m.apiStatusVersions[statusUID], versionBeforeSync,
+		"apiStatusVersions should be behind podStatuses before syncBatch")
+
+	// checks for a newer version and re-signals the channel.
+	m.syncBatch(ctx, false)
+
+	// assert that the channel received a re-signal.
+	require.Equal(t, 1, len(m.podStatusChannel),
+		"syncBatch should have re-signalled podStatusChannel for the version bumped inside syncPod")
+}

--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -1482,6 +1482,115 @@ done
 			return false, nil
 		}, 1*time.Minute, framework.Poll).ShouldNot(gomega.BeTrueBecause("should not see liveness probes"))
 	})
+
+	ginkgo.It("should mark all containers as not-ready when all readiness probes fail simultaneously", func(ctx context.Context) {
+		const (
+			containerCount   = 40
+			sharedVolumeName = "health-vol"
+			healthFile       = "/health/ready"
+			periodSeconds    = 2
+		)
+
+		podName := "multi-container-probe-" + string(uuid.NewUUID())
+		containers := make([]v1.Container, containerCount)
+		for i := 0; i < containerCount; i++ {
+			containers[i] = v1.Container{
+				Name:    fmt.Sprintf("container-%d", i),
+				Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+				Command: []string{"/bin/sh", "-c", fmt.Sprintf("touch %s && sleep 3600", healthFile)},
+				VolumeMounts: []v1.VolumeMount{
+					{Name: sharedVolumeName, MountPath: "/health"},
+				},
+				ReadinessProbe: &v1.Probe{
+					ProbeHandler: v1.ProbeHandler{
+						Exec: &v1.ExecAction{
+							Command: []string{"cat", healthFile},
+						},
+					},
+					InitialDelaySeconds: 1,
+					PeriodSeconds:       periodSeconds,
+					FailureThreshold:    1,
+				},
+			}
+		}
+
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podName,
+				Namespace: f.Namespace.Name,
+			},
+			Spec: v1.PodSpec{
+				Containers: containers,
+				Volumes: []v1.Volume{
+					{
+						Name: sharedVolumeName,
+						VolumeSource: v1.VolumeSource{
+							EmptyDir: &v1.EmptyDirVolumeSource{},
+						},
+					},
+				},
+			},
+		}
+
+		ginkgo.By("Creating a pod with 40 containers sharing a volume, each with a readiness probe")
+		podClient.Create(ctx, pod)
+
+		ginkgo.By("Waiting for all containers to become ready")
+		framework.ExpectNoError(e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, podName,
+			"all containers ready", 3*time.Minute, func(pod *v1.Pod) (bool, error) {
+				if len(pod.Status.ContainerStatuses) < containerCount {
+					return false, nil
+				}
+				for _, cs := range pod.Status.ContainerStatuses {
+					if !cs.Ready {
+						return false, nil
+					}
+				}
+				return true, nil
+			}))
+
+		ginkgo.By("Removing the shared health file to fail all 40 probes simultaneously")
+		_, _, err := e2epod.ExecWithOptions(f, e2epod.ExecOptions{
+			Command:       []string{"rm", "-f", healthFile},
+			Namespace:     f.Namespace.Name,
+			PodName:       podName,
+			ContainerName: "container-0",
+			CaptureStdout: true,
+			CaptureStderr: true,
+		})
+		framework.ExpectNoError(err, "failed to delete shared health file")
+
+		ginkgo.By("Waiting 30 seconds for all patches to settle")
+		time.Sleep(30 * time.Second)
+
+		ginkgo.By("Verifying the ContainersReady condition lists all 40 containers as unready")
+		currentPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, podName, metav1.GetOptions{})
+		framework.ExpectNoError(err, "failed to get pod after wait")
+
+		for _, cond := range currentPod.Status.Conditions {
+			if cond.Type != v1.ContainersReady {
+				continue
+			}
+			framework.Logf("ContainersReady condition: status=%s message=%q", cond.Status, cond.Message)
+			if cond.Status != v1.ConditionFalse {
+				framework.Failf("expected ContainersReady=False after all probes failed, got: %s", cond.Status)
+			}
+			for i := 0; i < containerCount; i++ {
+				containerName := fmt.Sprintf("container-%d", i)
+				if !strings.Contains(cond.Message, containerName) {
+					framework.Failf("expected ContainersReady message to mention %s after 30s, got: %q", containerName, cond.Message)
+				}
+			}
+			break
+		}
+
+		ginkgo.By("Verifying all container statuses are not-ready")
+		for _, cs := range currentPod.Status.ContainerStatuses {
+			if cs.Ready {
+				framework.Failf("container %s is still ready=true after 30s with failed probe", cs.Name)
+			}
+		}
+	})
 })
 
 // waitForPodStatusByInformer waits pod status change by informer


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Issue description: While syncPod is executing the patch to the API server, new SetContainerReadiness calls arrive and update m.podStatuses to a newer version. Each of those calls tries to signal podStatusChannel, but the channel is capacity-1 and already holds a token from a concurrent update. The signals are silently dropped till next reconcile. 
When syncPod returns, the API server has version N, but m.podStatuses has already moved to version N+K, and nobody has signalled the channel for those K updates. It caused the latency during update pod status to latest.     

Fix: After each syncPod completes, check whether m.podStatuses has moved ahead of what was just synced. If so, send a signal to podStatusChannel to wake up the sync goroutine immediately for another syncBatch, rather than waiting for the next reconciliation.     

#### Which issue(s) this PR is related to:
Issue #138889 might related

#### Special notes for your reviewer:
The e2e test PASS. the #138889 looks like a persist issue. This PR is mainly to reduce the latency of updating the pod status. 

> 	/tmp/e2e-local.test --kubeconfig="${KUBECONFIG}" \
> 	--ginkgo.focus="should mark all containers as not-ready when all readiness probes fail simultaneously" --ginkgo.v --provider=skeleton
> 	        I0513 17:04:03.063880   52054 e2e.go:109] Starting e2e run "9aa8892a-3e59-4699-a17d-d0fa40c7de78" on Ginkgo node 1
> 		Running Suite: Kubernetes e2e suite - /Users/xxxxxx/projects/xxxxxx
> 		
> 		Random Seed: 1778663042 - will randomize all specs
> 		
> 		Will run 1 of 7583 specs
> 		…….
> 		------------------------------
> 		SSSSSSS
> 		------------------------------
> 		[SynchronizedAfterSuite] 
> 		/Users/xxxxx/projects/kubernetes-readiness-probe-fail/test/e2e/e2e.go:80
> 		  I0513 17:04:56.830230   52054 suites.go:34] Running AfterSuite actions on node 1
> 		[SynchronizedAfterSuite] PASSED [0.000 seconds]
> 		------------------------------
> 		[ReportAfterSuite] Invariant Metrics
> 		/Users/xxxx/projects/kubernetes-readiness-probe-fail/test/e2e/invariants/metrics.go:44
> 		[ReportAfterSuite] PASSED [0.000 seconds]
> 		------------------------------
> 		[ReportAfterSuite] [sig-testing] Log Check
> 		/Users/xxxxx/projects/kubernetes-readiness-probe-fail/test/e2e/invariants/logcheck/logcheck.go:179
> 		[ReportAfterSuite] PASSED [0.000 seconds]
> 		------------------------------
> 		[ReportAfterSuite] Kubernetes e2e suite report
> 		/Users/xxxxx/projects/kubernetes-readiness-probe-fail/test/e2e/e2e_test.go:160
> 		[ReportAfterSuite] PASSED [0.000 seconds]
> 		------------------------------
> 		
> 		Ran 1 of 7583 Specs in 53.636 seconds
> 		SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 7582 Skipped
> 		PASS

Unit test pass:

> go test ./pkg/kubelet/status/... -run "TestSyncBatchReSignalsAfterDroppedReadinessUpdates" -v -timeout 60s 2>&1 | tail -5
>     status_manager.go:1206: I0513 17:58:41.197525] Status for pod updated successfully pod="new/foo" statusVersion=3 status={"conditions":[{"type":"Ready","status":"False","lastProbeTime":null,"lastTransitionTime":"2026-05-13T09:58:41Z","reason":"ContainersNotReady","message":"containers with unready status: [c0 c1]"},{"type":"ContainersReady","status":"False","lastProbeTime":null,"lastTransitionTime":"2026-05-13T09:58:41Z","reason":"ContainersNotReady","message":"containers with unready status: [c0 c1]"}],"startTime":"2026-05-13T09:58:41Z","containerStatuses":[{"name":"c0","state":{},"lastState":{},"ready":false,"restartCount":0,"image":"","imageID":"","containerID":"test://0"},{"name":"c1","state":{},"lastState":{},"ready":false,"restartCount":0,"image":"","imageID":"","containerID":"test://1"}]}
> --- PASS: TestSyncBatchReSignalsAfterDroppedReadinessUpdates (0.00s)
> PASS
> ok      k8s.io/kubernetes/pkg/kubelet/status    (cached)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

