### PR TITLE
DRA: account for shared devices when rebuilding counters

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/allocator.go
@@ -260,32 +260,7 @@ func NodeMatches(features Features, node *v1.Node, nodeNameToMatch string, allNo
 	return false, fmt.Errorf("internal error: no NodeMatches implementation available for feature set %v", features)
 }
 
-// IsDeviceAllocated checks if a device is allocated, considering both fully allocated devices
-// and partially consumed devices when consumable capacity is enabled.
+// IsDeviceAllocated checks if a device has committed allocation state.
 func IsDeviceAllocated(deviceID DeviceID, allocatedState *AllocatedState) bool {
-	// Check if device is fully allocated (traditional case)
-	if allocatedState.AllocatedDevices.Has(deviceID) {
-		return true
-	}
-
-	// Check if device is partially consumed via shared allocations (consumable capacity case).
-	// We need to check if any shared device ID corresponds to our device.
-	for sharedDeviceID := range allocatedState.AllocatedSharedDeviceIDs {
-		// Extract the base device ID from the shared device ID by recreating it
-		baseDeviceID := MakeDeviceID(
-			sharedDeviceID.Driver.String(),
-			sharedDeviceID.Pool.String(),
-			sharedDeviceID.Device.String(),
-		)
-		if baseDeviceID == deviceID {
-			return true
-		}
-	}
-
-	// Check if device has consumed capacity tracked (consumable capacity case)
-	if _, hasConsumedCapacity := allocatedState.AggregatedCapacity[deviceID]; hasConsumedCapacity {
-		return true
-	}
-
-	return false
+	return internal.IsDeviceAllocated(deviceID, allocatedState)
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatedstate.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatedstate.go
@@ -58,6 +58,32 @@ func NewDeviceConsumedCapacity(deviceID DeviceID, consumedCapacity map[resourcea
 	return schedulerapi.NewDeviceConsumedCapacity(deviceID, consumedCapacity)
 }
 
+// IsDeviceAllocated checks if a device is allocated, considering both fully allocated devices
+// and partially consumed devices when consumable capacity is enabled.
+func IsDeviceAllocated(deviceID DeviceID, allocatedState *AllocatedState) bool {
+	// Check if device is fully allocated (traditional case).
+	if allocatedState.AllocatedDevices.Has(deviceID) {
+		return true
+	}
+
+	// Check if device is partially consumed via shared allocations (consumable capacity case).
+	// We need to check if any shared device ID corresponds to our device.
+	for sharedDeviceID := range allocatedState.AllocatedSharedDeviceIDs {
+		if sharedDeviceID.GetDeviceID() == deviceID {
+			return true
+		}
+	}
+
+	// For scheduler-generated state, consumed capacity is recorded together with
+	// a shared device ID. Keep this check to preserve IsDeviceAllocated semantics
+	// and handle manually constructed or future AllocatedState producers.
+	if _, hasConsumedCapacity := allocatedState.AggregatedCapacity[deviceID]; hasConsumedCapacity {
+		return true
+	}
+
+	return false
+}
+
 // GenerateShareID is a helper function that generates a new share ID.
 // This remains in the internal package as it's a utility function.
 func GenerateShareID() *types.UID {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -5425,6 +5425,57 @@ func TestAllocator(t *testing.T,
 				deviceRequestAllocationResult(req1SubReq1, driverA, pool1, device3).withConsumedCapacity(&fixedShareID, map[resourceapi.QualifiedName]resource.Quantity{"memory": resource.MustParse("4Gi")}),
 			)},
 		},
+		"allow-multiple-allocations-with-shared-device-counter-cross-cycle": {
+			features: Features{
+				PartitionableDevices: true,
+				ConsumableCapacity:   true,
+			},
+			claimsToAllocate: objects(
+				claim(claim0).withRequests(
+					deviceRequest(req0, classA, 1).
+						withCapacityRequest(ptr.To(one)).
+						withSelectors(resourceapi.DeviceSelector{
+							CEL: &resourceapi.CELDeviceSelector{
+								Expression: fmt.Sprintf(`device.attributes["%s"].mode == "b"`, driverA),
+							},
+						}),
+				),
+			),
+			allocatedSharedDeviceIDs: sets.New(
+				internal.MakeSharedDeviceID(MakeDeviceID(driverA, pool1, device1), &fixedShareID),
+			),
+			allocatedCapacityDevices: ConsumedCapacityCollection{
+				MakeDeviceID(driverA, pool1, device1): ConsumedCapacity{
+					capacity0: ptr.To(one),
+				},
+			},
+			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device1, fromCounters, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"mode": {StringValue: ptr.To("a")},
+					}).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1, map[string]resource.Quantity{
+							capacity0: one,
+						}),
+					).withAllowMultipleAllocations(),
+					device(device2, fromCounters, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"mode": {StringValue: ptr.To("b")},
+					}).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1, map[string]resource.Quantity{
+							capacity0: one,
+						}),
+					).withAllowMultipleAllocations(),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1, map[string]resource.Quantity{
+						capacity0: one,
+					}),
+				),
+			),
+			node:          node(node1, region1),
+			expectResults: []any{},
+		},
 		"consumable-capacity-with-partitionable-device-multiple-capacity-pools": {
 			// This test case combines integration of PrioritizedList, PartitionableDevices, and ConsumableCapacity features.
 			features: Features{

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -1650,7 +1650,7 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 					}
 					// Devices that aren't allocated doesn't consume any counters, so we don't
 					// need to consider them.
-					if !alloc.allocatedState.AllocatedDevices.Has(deviceID) {
+					if !internal.IsDeviceAllocated(deviceID, &alloc.allocatedState) {
 						continue
 					}
 					for _, deviceCounterConsumption := range device.ConsumesCounters {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
@@ -1522,7 +1522,7 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 					}
 					// Devices that aren't allocated doesn't consume any counters, so we don't
 					// need to consider them.
-					if !alloc.allocatedState.AllocatedDevices.Has(deviceID) {
+					if !internal.IsDeviceAllocated(deviceID, &alloc.allocatedState) {
 						continue
 					}
 					for _, deviceCounterConsumption := range device.ConsumesCounters {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When DRAConsumableCapacity is enabled, multi-allocatable device allocations are tracked via AllocatedSharedDeviceIDs and AggregatedCapacity instead of AllocatedDevices. The incubating and experimental allocators only checked AllocatedDevices when rebuilding available SharedCounters, so committed shared allocations could be missed across scheduling cycles.

Add an internal IsDeviceAllocated helper that checks all committed allocation-state sources and use it when reconstructing consumed counters. Add a regression test for a fresh allocator seeing committed shared-device counter consumption.

#### Which issue(s) this PR is related to:
Fixes #139034
KEPs: [4815](https://github.com/kubernetes/enhancements/issues/4815), [5075](https://github.com/kubernetes/enhancements/issues/5075)

#### Special notes for your reviewer:
- The behavior change is intentionally limited to the counter-reconstruction path in the incubating and experimental allocators. Stable has similar-looking code, but does not support `DRAConsumableCapacity`, so this specific feature composition is not reachable there.
 - `internal.IsDeviceAllocated` mirrors the existing exported `structured.IsDeviceAllocated` logic so sub-allocators can reuse it without importing the parent `structured` package and creating an import cycle.
 - The regression test is intentionally cross-cycle: it constructs a fresh allocator with committed shared allocation state in `AllocatedSharedDeviceIDs` and `AggregatedCapacity`. With the old `AllocatedDevices.Has(deviceID)` predicate, the test incorrectly allocates the second counter-consuming shared device; with this fix, it rejects it

#### Does this PR introduce a user-facing change?
```release-note
Fixed a Dynamic Resource Allocation scheduler bug that could assign mutually exclusive
device partitions to multiple Pods. This affected DRA drivers using `SharedCounters`
(`DRAPartitionableDevices`) together with multi-allocatable devices (`DRAConsumableCapacity`).
Depending on the device and driver, the incorrect double-allocation could cause workload failures,
device conflicts, crashes, or data loss.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE
