### PR TITLE
cacher: switch test codec default from JSON to protobuf

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -381,7 +381,7 @@ func TestStats(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SizeBasedListCostEstimate, sizeBasedListCostEstimate)
 			ctx, cacher, terminate := testSetup(t)
 			t.Cleanup(terminate)
-			storagetesting.RunTestStats(ctx, t, cacher, codecs.LegacyCodec(examplev1.SchemeGroupVersion), identity.NewEncryptCheckTransformer(), sizeBasedListCostEstimate)
+			storagetesting.RunTestStats(ctx, t, cacher, examplev1ProtoCodec, identity.NewEncryptCheckTransformer(), sizeBasedListCostEstimate)
 		})
 	}
 }
@@ -492,6 +492,7 @@ type setupOptions struct {
 	indexerFuncs   map[string]storage.IndexerFunc
 	indexers       cache.Indexers
 	clock          clock.WithTicker
+	codec          runtime.Codec
 }
 
 type setupOption func(*setupOptions)
@@ -502,6 +503,7 @@ func withDefaults(options *setupOptions) {
 	options.resourcePrefix = prefix
 	options.keyFunc = func(obj runtime.Object) (string, error) { return storage.NamespaceKeyFunc(prefix, obj) }
 	options.clock = clock.RealClock{}
+	options.codec = examplev1ProtoCodec
 }
 
 func withClusterScopedKeyFunc(options *setupOptions) {
@@ -545,7 +547,7 @@ func testSetupWithEtcdServer(t testing.TB, opts ...setupOption) (context.Context
 		opt(&setupOpts)
 	}
 
-	server, etcdStorage := newEtcdTestStorage(t, etcd3testing.PathPrefix())
+	server, etcdStorage := newEtcdTestStorageWithCodec(t, etcd3testing.PathPrefix(), setupOpts.codec)
 	// Inject one list error to make sure we test the relist case.
 	listErrors := 1
 	if clientfeatures.FeatureGates().Enabled(clientfeatures.WatchListClient) {
@@ -570,7 +572,7 @@ func testSetupWithEtcdServer(t testing.TB, opts ...setupOption) (context.Context
 		NewListFunc:         newPodList,
 		IndexerFuncs:        setupOpts.indexerFuncs,
 		Indexers:            &setupOpts.indexers,
-		Codec:               codecs.LegacyCodec(examplev1.SchemeGroupVersion),
+		Codec:               setupOpts.codec,
 		Clock:               setupOpts.clock,
 	}
 	cacher, err := NewCacherFromConfig(config)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_testing_utils_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_testing_utils_test.go
@@ -25,7 +25,6 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/apitesting"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -62,17 +61,24 @@ func init() {
 	scheme.AddUnversionedTypes(corev1.SchemeGroupVersion, &metav1.Status{})
 	pb := protobuf.NewSerializer(scheme, scheme)
 	corev1ProtoCodec = codecs.CodecForVersions(pb, pb, schema.GroupVersions{corev1.SchemeGroupVersion}, nil)
+	examplev1ProtoCodec = codecs.CodecForVersions(pb, pb, schema.GroupVersions{examplev1.SchemeGroupVersion}, nil)
 }
 
-var corev1ProtoCodec runtime.Codec
+var (
+	corev1ProtoCodec    runtime.Codec
+	examplev1ProtoCodec runtime.Codec
+)
 
 func newPod() runtime.Object     { return &example.Pod{} }
 func newPodList() runtime.Object { return &example.PodList{} }
 
 func newEtcdTestStorage(t testing.TB, prefix string) (*etcd3testing.EtcdTestServer, storage.Interface) {
+	return newEtcdTestStorageWithCodec(t, prefix, examplev1ProtoCodec)
+}
+
+func newEtcdTestStorageWithCodec(t testing.TB, prefix string, codec runtime.Codec) (*etcd3testing.EtcdTestServer, storage.Interface) {
 	server, _ := etcd3testing.NewUnsecuredEtcd3TestClientServer(t)
 	versioner := storage.APIObjectVersioner{}
-	codec := apitesting.TestCodec(codecs, examplev1.SchemeGroupVersion)
 	compactor := etcd3.NewCompactor(server.V3Client.Client, 0, clock.RealClock{}, nil)
 	t.Cleanup(compactor.Stop)
 	storage, err := etcd3.New(


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The cacher unit tests and benchmarks all use `example.Pod` but was defaulting to JSON encoding. apiserver uses proto for core types by default and this changes the tests to align with that.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
