### PR TITLE
kubelet: cap node log query pattern length

### DIFF
--- a/pkg/kubelet/kubelet_server_journal.go
+++ b/pkg/kubelet/kubelet_server_journal.go
@@ -42,6 +42,7 @@ const (
 	dateLayout       = "2006-1-2 15:4:5"
 	maxTailLines     = 100000
 	maxServiceLength = 256
+	maxPatternLength = 256
 	maxServices      = 4
 	nodeLogDir       = "/var/log/"
 )
@@ -263,8 +264,13 @@ func (n *nodeLogQuery) validate() field.ErrorList {
 		}
 	}
 
-	if _, err := syntax.Parse(n.Pattern, syntax.Perl); err != nil {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("pattern"), n.Pattern, err.Error()))
+	if n.Pattern != "" {
+		if len(n.Pattern) > maxPatternLength {
+			allErrs = append(allErrs, field.TooLong(field.NewPath("pattern"), "", maxPatternLength))
+		}
+		if _, err := syntax.Parse(n.Pattern, syntax.Perl); err != nil {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("pattern"), n.Pattern, err.Error()))
+		}
 	}
 
 	return allErrs

--- a/pkg/kubelet/kubelet_server_journal_test.go
+++ b/pkg/kubelet/kubelet_server_journal_test.go
@@ -275,6 +275,12 @@ func Test_nodeLogQuery_validate(t *testing.T) {
 		{name: "two files", Files: []string{file1, file2}, wantErr: true},
 		{name: "one file options", Files: []string{file1}, options: options{Pattern: pattern}, wantErr: true},
 		{name: "invalid pattern", Services: []string{service1}, options: options{Pattern: invalid}, wantErr: true},
+		{
+			name:     "pattern length exceeds cap",
+			Services: []string{service1},
+			options:  options{Pattern: strings.Repeat("a", maxPatternLength+1)},
+			wantErr:  true,
+		},
 		{name: "since", Services: []string{service1}, options: options{SinceTime: &since}},
 		{name: "until", Services: []string{service1}, options: options{UntilTime: &until}},
 		{name: "since until", Services: []string{service1}, options: options{SinceTime: &until, UntilTime: &since},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig node

#### What this PR does / why we need it:

This PR adds a length cap for the kubelet node log query `pattern` option before it is passed to the platform log backend.

Node log queries already bound related inputs such as service names and `tailLines`. This applies a similar explicit bound to the regex pattern input used for filtering service logs, and adds regression coverage for overlong patterns.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This is a defensive input-hardening change for kubelet node log query validation.

Tests run:

```text
go test ./pkg/kubelet -run 'Test_nodeLogQuery_validate/pattern_length_exceeds_cap' -count=1
go test ./pkg/kubelet -run 'Test_nodeLogQuery_validate|Test_getLoggingCmd' -count=1
go test ./pkg/kubelet -count=1
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
