### PR TITLE
ccm: Link the leader election release on exit feature gate

### DIFF
--- a/staging/src/k8s.io/cloud-provider/app/controllermanager.go
+++ b/staging/src/k8s.io/cloud-provider/app/controllermanager.go
@@ -225,8 +225,9 @@ func Run(c *cloudcontrollerconfig.CompletedConfig, cloud cloudprovider.Interface
 		}
 	}
 
+	ctx := wait.ContextForChannel(stopCh)
+
 	if !c.ComponentConfig.Generic.LeaderElection.LeaderElect {
-		ctx := wait.ContextForChannel(stopCh)
 		run(ctx, controllerInitializers)
 		<-stopCh
 		return nil
@@ -254,7 +255,7 @@ func Run(c *cloudcontrollerconfig.CompletedConfig, cloud cloudprovider.Interface
 	}
 
 	// Start the main lock
-	go leaderElectAndRun(c, id, electionChecker,
+	go leaderElectAndRun(ctx, c, id, electionChecker,
 		c.ComponentConfig.Generic.LeaderElection.ResourceLock,
 		c.ComponentConfig.Generic.LeaderElection.ResourceName,
 		leaderelection.LeaderCallbacks{
@@ -272,7 +273,9 @@ func Run(c *cloudcontrollerconfig.CompletedConfig, cloud cloudprovider.Interface
 			},
 			OnStoppedLeading: func() {
 				klog.ErrorS(nil, "leaderelection lost")
-				klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+				if !utilfeature.DefaultFeatureGate.Enabled(cmfeatures.ControllerManagerReleaseLeaderElectionLockOnExit) {
+					klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+				}
 			},
 		})
 
@@ -282,7 +285,7 @@ func Run(c *cloudcontrollerconfig.CompletedConfig, cloud cloudprovider.Interface
 		<-leaderMigrator.MigrationReady
 
 		// Start the migration lock.
-		go leaderElectAndRun(c, id, electionChecker,
+		go leaderElectAndRun(ctx, c, id, electionChecker,
 			c.ComponentConfig.Generic.LeaderMigration.ResourceLock,
 			c.ComponentConfig.Generic.LeaderMigration.LeaderName,
 			leaderelection.LeaderCallbacks{
@@ -292,7 +295,9 @@ func Run(c *cloudcontrollerconfig.CompletedConfig, cloud cloudprovider.Interface
 				},
 				OnStoppedLeading: func() {
 					klog.ErrorS(nil, "migration leaderelection lost")
-					klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+					if !utilfeature.DefaultFeatureGate.Enabled(cmfeatures.ControllerManagerReleaseLeaderElectionLockOnExit) {
+						klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+					}
 				},
 			})
 	}
@@ -518,7 +523,7 @@ func ResyncPeriod(c *cloudcontrollerconfig.CompletedConfig) func() time.Duration
 
 // leaderElectAndRun runs the leader election, and runs the callbacks once the leader lease is acquired.
 // TODO: extract this function into staging/controller-manager
-func leaderElectAndRun(c *cloudcontrollerconfig.CompletedConfig, lockIdentity string, electionChecker *leaderelection.HealthzAdaptor, resourceLock string, leaseName string, callbacks leaderelection.LeaderCallbacks) {
+func leaderElectAndRun(ctx context.Context, c *cloudcontrollerconfig.CompletedConfig, lockIdentity string, electionChecker *leaderelection.HealthzAdaptor, resourceLock string, leaseName string, callbacks leaderelection.LeaderCallbacks) {
 	rl, err := resourcelock.NewFromKubeconfig(resourceLock,
 		c.ComponentConfig.Generic.LeaderElection.ResourceNamespace,
 		leaseName,
@@ -532,17 +537,29 @@ func leaderElectAndRun(c *cloudcontrollerconfig.CompletedConfig, lockIdentity st
 		klog.Fatalf("error creating lock: %v", err)
 	}
 
-	leaderelection.RunOrDie(context.TODO(), leaderelection.LeaderElectionConfig{
-		Lock:          rl,
-		LeaseDuration: c.ComponentConfig.Generic.LeaderElection.LeaseDuration.Duration,
-		RenewDeadline: c.ComponentConfig.Generic.LeaderElection.RenewDeadline.Duration,
-		RetryPeriod:   c.ComponentConfig.Generic.LeaderElection.RetryPeriod.Duration,
-		Callbacks:     callbacks,
-		WatchDog:      electionChecker,
-		Name:          leaseName,
-	})
+	leaderelection.RunOrDie(ctx, newLeaderElectionConfig(rl,
+		c.ComponentConfig.Generic.LeaderElection.LeaseDuration.Duration,
+		c.ComponentConfig.Generic.LeaderElection.RenewDeadline.Duration,
+		c.ComponentConfig.Generic.LeaderElection.RetryPeriod.Duration,
+		callbacks, electionChecker, leaseName))
 
 	panic("unreachable")
+}
+
+// newLeaderElectionConfig builds the LeaderElectionConfig used by the cloud-controller-manager.
+// ReleaseOnCancel is gated on the ControllerManagerReleaseLeaderElectionLockOnExit feature gate
+// so the lease is released on context cancellation (see KEP-5366).
+func newLeaderElectionConfig(lock resourcelock.Interface, leaseDuration, renewDeadline, retryPeriod time.Duration, callbacks leaderelection.LeaderCallbacks, electionChecker *leaderelection.HealthzAdaptor, leaseName string) leaderelection.LeaderElectionConfig {
+	return leaderelection.LeaderElectionConfig{
+		Lock:            lock,
+		LeaseDuration:   leaseDuration,
+		RenewDeadline:   renewDeadline,
+		RetryPeriod:     retryPeriod,
+		Callbacks:       callbacks,
+		WatchDog:        electionChecker,
+		ReleaseOnCancel: utilfeature.DefaultFeatureGate.Enabled(cmfeatures.ControllerManagerReleaseLeaderElectionLockOnExit),
+		Name:            leaseName,
+	}
 }
 
 // filterInitializers returns initializers that has filterFunc(name) == expected.

--- a/staging/src/k8s.io/cloud-provider/app/leader_election_test.go
+++ b/staging/src/k8s.io/cloud-provider/app/leader_election_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"testing"
+	"time"
+
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/tools/leaderelection"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	cmfeatures "k8s.io/controller-manager/pkg/features"
+	_ "k8s.io/controller-manager/pkg/features/register"
+)
+
+func TestNewLeaderElectionConfig(t *testing.T) {
+	const (
+		leaseDuration = 15 * time.Second
+		renewDeadline = 10 * time.Second
+		retryPeriod   = 2 * time.Second
+		leaseName     = "cloud-controller-manager"
+	)
+	callbacks := leaderelection.LeaderCallbacks{}
+
+	for _, tc := range []struct {
+		name                string
+		featureEnabled      bool
+		wantReleaseOnCancel bool
+	}{
+		{name: "feature gate disabled (default)", featureEnabled: false, wantReleaseOnCancel: false},
+		{name: "feature gate enabled", featureEnabled: true, wantReleaseOnCancel: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, cmfeatures.ControllerManagerReleaseLeaderElectionLockOnExit, tc.featureEnabled)
+
+			got := newLeaderElectionConfig(nil, leaseDuration, renewDeadline, retryPeriod, callbacks, nil, leaseName)
+
+			if got.ReleaseOnCancel != tc.wantReleaseOnCancel {
+				t.Errorf("ReleaseOnCancel = %v, want %v", got.ReleaseOnCancel, tc.wantReleaseOnCancel)
+			}
+			if got.Name != leaseName {
+				t.Errorf("Name = %q, want %q", got.Name, leaseName)
+			}
+			if got.LeaseDuration != leaseDuration {
+				t.Errorf("LeaseDuration = %v, want %v", got.LeaseDuration, leaseDuration)
+			}
+			if got.RenewDeadline != renewDeadline {
+				t.Errorf("RenewDeadline = %v, want %v", got.RenewDeadline, renewDeadline)
+			}
+			if got.RetryPeriod != retryPeriod {
+				t.Errorf("RetryPeriod = %v, want %v", got.RetryPeriod, retryPeriod)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/controller-manager/pkg/features/kube_features.go
@@ -43,7 +43,7 @@ const (
 
 	// owner: @jefftree, @tchap
 	//
-	// Make kube-controller-manager release leader election lock on exit.
+	// Make kube-controller-manager and cloud-controller-manager release leader election lock on exit.
 	ControllerManagerReleaseLeaderElectionLockOnExit featuregate.Feature = "ControllerManagerReleaseLeaderElectionLockOnExit"
 )
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Mirrors #137708 for cloud-controller-manager: plumbs the run context into `leaderelection.RunOrDie` and wires `ReleaseOnCancel` to the `ControllerManagerReleaseLeaderElectionLockOnExit` feature gate. When the gate is enabled, the lease is released on context cancellation so a new leader can take over without waiting for the lease to expire.

#### Which issue(s) this PR is related to:

Fixes #119905

Followup to:
- https://github.com/kubernetes/kubernetes/pull/132620
- https://github.com/kubernetes/kubernetes/pull/136279
- https://github.com/kubernetes/kubernetes/pull/137708

#### Special notes for your reviewer:

Unlike #137708, this PR extracts a `newLeaderElectionConfig` helper to make the gate wiring unit-testable, since cloud-controller-manager has no integration test infrastructure equivalent to `cmd/kube-controller-manager/app/testing`.

#### Does this PR introduce a user-facing change?

```release-note
The `ControllerManagerReleaseLeaderElectionLockOnExit` feature gate now also applies to `cloud-controller-manager`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- [KEP-5366: Graceful Leader Transition: Phase 2](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5366-graceful-leader-transition#phase-2-fast-lease-release)