### PR TITLE
Fix: memorymanager clears stale podEntries when V2 restore falls back to V1

### DIFF
--- a/pkg/kubelet/cm/memorymanager/state/state_checkpoint.go
+++ b/pkg/kubelet/cm/memorymanager/state/state_checkpoint.go
@@ -150,6 +150,7 @@ func (sc *stateCheckpoint) loadAndMigrateCheckpointV2() (*MemoryManagerCheckpoin
 
 	// Loaded V1, now migrate to V2.
 	sc.logger.Info("migrating memory manager checkpoint from v1 to v2")
+	checkpointV2 = newMemoryManagerCheckpointV2()
 	sc.migrateV1CheckpointToV2Checkpoint(checkpointV1, checkpointV2)
 
 	return checkpointV2, nil

--- a/pkg/kubelet/cm/memorymanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/memorymanager/state/state_checkpoint_test.go
@@ -354,6 +354,76 @@ func TestCheckpointStateRestore(t *testing.T) {
 	}
 }
 
+func TestCheckpointStateRestoreClearsCorruptV2PodEntriesBeforeV1Migration(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResources, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResourceManagers, true)
+
+	testingDir, err := os.MkdirTemp("", "memorymanager_state_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(testingDir)
+
+	cpm, err := checkpointmanager.NewCheckpointManager(testingDir)
+	require.NoError(t, err)
+
+	checkpointV1 := &MemoryManagerCheckpointV1{
+		PolicyName: "static",
+		MachineState: NUMANodeMap{
+			0: &NUMANodeState{
+				MemoryMap: map[v1.ResourceName]*MemoryTable{
+					v1.ResourceMemory: {
+						Allocatable:    1536,
+						Free:           1024,
+						Reserved:       512,
+						SystemReserved: 512,
+						TotalMemSize:   2048,
+					},
+				},
+			},
+		},
+		Entries: ContainerMemoryAssignments{
+			"pod": map[string][]Block{
+				"container1": {
+					{
+						NUMAAffinity: []int{0},
+						Type:         v1.ResourceMemory,
+						Size:         512,
+					},
+				},
+			},
+		},
+	}
+	data, err := checkpointV1.MarshalCheckpoint()
+	require.NoError(t, err)
+
+	var content map[string]any
+	require.NoError(t, json.Unmarshal(data, &content))
+	content["podEntries"] = map[string]any{
+		"stale-pod": map[string]any{
+			"memoryBlocks": []any{
+				map[string]any{
+					"numaAffinity": []any{1},
+					"type":         string(v1.ResourceMemory),
+					"size":         1024,
+				},
+			},
+		},
+	}
+	data, err = json.Marshal(content)
+	require.NoError(t, err)
+
+	checkpoint := &testutil.MockCheckpoint{Content: string(data)}
+	require.NoError(t, cpm.CreateCheckpoint(testingCheckpoint, checkpoint))
+
+	restoredState, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "static")
+	require.NoError(t, err)
+
+	require.Len(t, restoredState.GetMachineState(), 1)
+	assert.Equal(t, checkpointV1.MachineState[0].MemoryMap, restoredState.GetMachineState()[0].MemoryMap)
+	assert.Equal(t, checkpointV1.Entries, restoredState.GetMemoryAssignments())
+	assert.Empty(t, restoredState.GetPodMemoryAssignments())
+}
+
 func TestCheckpointStateStore(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	expectedState := &stateMemory{


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Trigger scenario
  The bug is triggered when PodLevelResourceManagers is enabled and kubelet restores the memory manager checkpoint from a file that:
  - looks like a V2 checkpoint and can be unmarshaled into MemoryManagerCheckpointV2
  - contains invalid V2 checksum, so V2 restore fails
  - is still readable as V1, so the code falls back to V1 and migrates V1 data into V2

  A practical case is a partially corrupted or hand-edited V2 checkpoint file that still carries podEntries data.

  After fallback, kubelet restores a hybrid checkpoint:
  - PolicyName, MachineState, and Entries come from V1
  - stale PodEntries remain from the failed V2 load attempt

  As a result, sc.cache.SetPodMemoryAssignments(cp.PodEntries) receives corrupted leftover pod-level assignments that should not exist after V1 fallback.


  Root cause
  checkpointmanager.GetCheckpoint() first calls UnmarshalCheckpoint() and only then VerifyChecksum().
  That means a corrupt V2 file can already populate checkpointV2 before checksum verification fails.

  In loadAndMigrateCheckpointV2(), the old logic reused that same checkpointV2 object during V1 -> V2 migration.
  But migrateV1CheckpointToV2Checkpoint() only overwrites:
  - PolicyName
  - MachineState
  - Entries

  It does not clear or replace PodEntries, so stale V2 data survives the fallback path.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
