### PR TITLE
[WIP] apiserver: streaming version conversion for LIST

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections.go
@@ -32,6 +32,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+type itemVisitor = func(runtime.Object) error
+type itemIterator = func(itemVisitor) error
+
 func streamEncodeCollections(obj runtime.Object, w io.Writer) (bool, error) {
 	list, ok := obj.(*unstructured.UnstructuredList)
 	if ok {
@@ -90,6 +93,20 @@ func getListMeta(list runtime.Object) (metav1.TypeMeta, metav1.ListMeta, []runti
 }
 
 func streamingEncodeList(w io.Writer, typeMeta metav1.TypeMeta, listMeta metav1.ListMeta, items []runtime.Object) error {
+	if items == nil {
+		return streamingEncodeListWithIterator(w, typeMeta, listMeta, nil)
+	}
+	return streamingEncodeListWithIterator(w, typeMeta, listMeta, func(visit itemVisitor) error {
+		for _, item := range items {
+			if err := visit(item); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func streamingEncodeListWithIterator(w io.Writer, typeMeta metav1.TypeMeta, listMeta metav1.ListMeta, iter itemIterator) error {
 	// Start
 	if _, err := w.Write([]byte(`{`)); err != nil {
 		return err
@@ -113,7 +130,7 @@ func streamingEncodeList(w io.Writer, typeMeta metav1.TypeMeta, listMeta metav1.
 	}
 
 	// Items
-	if err := encodeItemsObjectSlice(w, items); err != nil {
+	if err := encodeItemsObjectIterator(w, iter); err != nil {
 		return err
 	}
 
@@ -122,30 +139,43 @@ func streamingEncodeList(w io.Writer, typeMeta metav1.TypeMeta, listMeta metav1.
 	return err
 }
 
-func encodeItemsObjectSlice(w io.Writer, items []runtime.Object) (err error) {
-	if items == nil {
-		err := encodeKeyValuePair(w, "items", nil, nil)
-		return err
+func encodeItemsObjectIterator(w io.Writer, iter itemIterator) (err error) {
+	if iter == nil {
+		return encodeKeyValuePair(w, "items", nil, nil)
 	}
 	_, err = w.Write([]byte(`"items":[`))
 	if err != nil {
 		return err
 	}
-	suffix := []byte(",")
-	for i, item := range items {
-		if i == len(items)-1 {
-			suffix = nil
+	first := true
+	err = iter(func(item runtime.Object) error {
+		if !first {
+			if _, err := w.Write([]byte(",")); err != nil {
+				return err
+			}
 		}
-		err := encodeValue(w, item, suffix)
-		if err != nil {
-			return err
-		}
-	}
-	_, err = w.Write([]byte("]"))
+		first = false
+		return encodeValue(w, item, nil)
+	})
 	if err != nil {
 		return err
 	}
+	_, err = w.Write([]byte("]"))
 	return err
+}
+
+func (s *Serializer) EncodeListWithIterator(list runtime.Object, w io.Writer, iter itemIterator) (bool, error) {
+	if s.options.Yaml || s.options.Pretty || !s.options.StreamingCollectionsEncoding {
+		return false, nil
+	}
+	if _, ok := list.(*unstructured.UnstructuredList); ok {
+		return false, nil
+	}
+	typeMeta, listMeta, _, err := getListMeta(list)
+	if err != nil {
+		return false, nil
+	}
+	return true, streamingEncodeListWithIterator(w, typeMeta, listMeta, iter)
 }
 
 func streamingEncodeUnstructuredList(w io.Writer, list *unstructured.UnstructuredList) error {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
@@ -108,6 +108,10 @@ type Serializer struct {
 	identifier runtime.Identifier
 }
 
+func (*Serializer) OmitStreamedItemObjectKind() bool {
+	return true
+}
+
 // Serializer implements Serializer
 var _ runtime.Serializer = &Serializer{}
 var _ recognizer.RecognizingDecoder = &Serializer{}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
@@ -18,10 +18,12 @@ package versioning
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"reflect"
 	"sync"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -87,6 +89,14 @@ type codec struct {
 
 	// originalSchemeName is optional, but when filled in it holds the name of the scheme from which this codec originates
 	originalSchemeName string
+}
+
+type itemVisitor = func(runtime.Object) error
+type itemIterator = func(itemVisitor) error
+
+type streamingListEncoder interface {
+	runtime.Encoder
+	EncodeListWithIterator(list runtime.Object, w io.Writer, iter itemIterator) (handled bool, err error)
 }
 
 var _ runtime.EncoderWithAllocator = &codec{}
@@ -268,6 +278,16 @@ func (c *codec) doEncode(obj runtime.Object, w io.Writer, memAlloc runtime.Memor
 		return encodeFn(obj, w)
 	}
 
+	if streamingListEncoder, ok := c.encoder.(streamingListEncoder); ok {
+		handled, err := c.encodeStreamingList(obj, w, streamingListEncoder)
+		if err != nil {
+			return err
+		}
+		if handled {
+			return nil
+		}
+	}
+
 	// Perform a conversion if necessary
 	out, err := c.convertor.ConvertToVersion(obj, c.encodeVersion)
 	if err != nil {
@@ -282,6 +302,81 @@ func (c *codec) doEncode(obj runtime.Object, w io.Writer, memAlloc runtime.Memor
 
 	// Conversion is responsible for setting the proper group, version, and kind onto the outgoing object
 	return encodeFn(out, w)
+}
+
+func (c *codec) encodeStreamingList(list runtime.Object, w io.Writer, streamingListEncoder streamingListEncoder) (bool, error) {
+	if !meta.IsListType(list) {
+		return false, nil
+	}
+	if _, ok := list.(*unstructured.UnstructuredList); ok {
+		return false, nil
+	}
+
+	versionedListHeader, err := c.convertListHeaderToVersion(list)
+	if err != nil {
+		return false, err
+	}
+
+	return streamingListEncoder.EncodeListWithIterator(versionedListHeader, w, func(visit itemVisitor) error {
+		return meta.EachListItemWithAlloc(list, func(item runtime.Object) error {
+			versionedItem, err := c.convertor.ConvertToVersion(item, c.encodeVersion)
+			if err != nil {
+				return err
+			}
+			if e, ok := versionedItem.(runtime.NestedObjectEncoder); ok {
+				if err := e.EncodeNestedObjects(runtime.WithVersionEncoder{Version: c.encodeVersion, Encoder: c.encoder, ObjectTyper: c.typer}); err != nil {
+					return err
+				}
+			}
+			return visit(versionedItem)
+		})
+	})
+}
+
+func (c *codec) convertListHeaderToVersion(list runtime.Object) (runtime.Object, error) {
+	emptyList, err := newEmptyListWithListMeta(list)
+	if err != nil {
+		return nil, err
+	}
+	return c.convertor.ConvertToVersion(emptyList, c.encodeVersion)
+}
+
+func newEmptyListWithListMeta(list runtime.Object) (runtime.Object, error) {
+	listType := reflect.TypeOf(list)
+	if listType.Kind() != reflect.Pointer || listType.Elem().Kind() != reflect.Struct {
+		return nil, fmt.Errorf("expected pointer to list struct, got %T", list)
+	}
+
+	emptyList, ok := reflect.New(listType.Elem()).Interface().(runtime.Object)
+	if !ok {
+		return nil, fmt.Errorf("expected runtime.Object list, got %T", list)
+	}
+
+	src, err := meta.ListAccessor(list)
+	if err != nil {
+		return nil, err
+	}
+	dst, err := meta.ListAccessor(emptyList)
+	if err != nil {
+		return nil, err
+	}
+	copyListMeta(dst, src)
+	return emptyList, nil
+}
+
+func copyListMeta(dst, src meta.List) {
+	dst.SetSelfLink(src.GetSelfLink())
+	dst.SetResourceVersion(src.GetResourceVersion())
+	dst.SetContinue(src.GetContinue())
+	dst.SetRemainingItemCount(copyInt64Ptr(src.GetRemainingItemCount()))
+}
+
+func copyInt64Ptr(in *int64) *int64 {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
 }
 
 // Identifier implements runtime.Encoder interface.

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
@@ -317,20 +317,17 @@ func (c *codec) encodeStreamingList(list runtime.Object, w io.Writer, streamingL
 		return false, err
 	}
 
-	return streamingListEncoder.EncodeListWithIterator(versionedListHeader, w, func(visit itemVisitor) error {
+	produceVersionedItems := func(visit itemVisitor) error {
 		return meta.EachListItemWithAlloc(list, func(item runtime.Object) error {
-			versionedItem, err := c.convertor.ConvertToVersion(item, c.encodeVersion)
+			versionedItem, err := c.convertListItemToVersion(item)
 			if err != nil {
 				return err
 			}
-			if e, ok := versionedItem.(runtime.NestedObjectEncoder); ok {
-				if err := e.EncodeNestedObjects(runtime.WithVersionEncoder{Version: c.encodeVersion, Encoder: c.encoder, ObjectTyper: c.typer}); err != nil {
-					return err
-				}
-			}
 			return visit(versionedItem)
 		})
-	})
+	}
+
+	return streamingListEncoder.EncodeListWithIterator(versionedListHeader, w, produceVersionedItems)
 }
 
 func (c *codec) convertListHeaderToVersion(list runtime.Object) (runtime.Object, error) {
@@ -339,6 +336,19 @@ func (c *codec) convertListHeaderToVersion(list runtime.Object) (runtime.Object,
 		return nil, err
 	}
 	return c.convertor.ConvertToVersion(emptyList, c.encodeVersion)
+}
+
+func (c *codec) convertListItemToVersion(item runtime.Object) (runtime.Object, error) {
+	versionedItem, err := c.convertor.ConvertToVersion(item, c.encodeVersion)
+	if err != nil {
+		return nil, err
+	}
+	if e, ok := versionedItem.(runtime.NestedObjectEncoder); ok {
+		if err := e.EncodeNestedObjects(runtime.WithVersionEncoder{Version: c.encodeVersion, Encoder: c.encoder, ObjectTyper: c.typer}); err != nil {
+			return nil, err
+		}
+	}
+	return versionedItem, nil
 }
 
 func newEmptyListWithListMeta(list runtime.Object) (runtime.Object, error) {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
@@ -99,6 +99,24 @@ type streamingListEncoder interface {
 	EncodeListWithIterator(list runtime.Object, w io.Writer, iter itemIterator) (handled bool, err error)
 }
 
+type streamedItemObjectKindOmittingEncoder interface {
+	OmitStreamedItemObjectKind() bool
+}
+
+type streamedItemObjectKindOmitter struct {
+	runtime.Object
+}
+
+func (o streamedItemObjectKindOmitter) MarshalJSON() ([]byte, error) {
+	objectKind := o.Object.GetObjectKind()
+	oldGVK := objectKind.GroupVersionKind()
+	if oldGVK != (schema.GroupVersionKind{}) {
+		objectKind.SetGroupVersionKind(schema.GroupVersionKind{})
+		defer objectKind.SetGroupVersionKind(oldGVK)
+	}
+	return json.Marshal(o.Object)
+}
+
 var _ runtime.EncoderWithAllocator = &codec{}
 
 var identifiersMap sync.Map
@@ -350,6 +368,9 @@ func (c *codec) convertListItemToVersion(item runtime.Object) (runtime.Object, e
 		if err := e.EncodeNestedObjects(runtime.WithVersionEncoder{Version: c.encodeVersion, Encoder: c.encoder, ObjectTyper: c.typer}); err != nil {
 			return nil, err
 		}
+	}
+	if encoder, ok := c.encoder.(streamedItemObjectKindOmittingEncoder); ok && encoder.OmitStreamedItemObjectKind() {
+		versionedItem = streamedItemObjectKindOmitter{Object: versionedItem}
 	}
 	return versionedItem, nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
@@ -311,6 +311,9 @@ func (c *codec) encodeStreamingList(list runtime.Object, w io.Writer, streamingL
 	if _, ok := list.(*unstructured.UnstructuredList); ok {
 		return false, nil
 	}
+	if _, err := meta.ListAccessor(list); err != nil {
+		return false, nil
+	}
 
 	versionedListHeader, err := c.convertListHeaderToVersion(list)
 	if err != nil {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_test.go
@@ -17,14 +17,18 @@ limitations under the License.
 package versioning
 
 import (
+	"bytes"
+	stdjson "encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"reflect"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	runtimetesting "k8s.io/apimachinery/pkg/runtime/testing"
 	"k8s.io/apimachinery/pkg/util/diff"
 )
@@ -391,6 +395,151 @@ func TestCacheableObject(t *testing.T) {
 	runtimetesting.CacheableObjectTest(t, encoder)
 }
 
+func TestEncodeStreamingListConvertsItemsIndividually(t *testing.T) {
+	var remainingItemCount int64 = 7
+	internalList := &testInternalList{
+		ListMeta: metav1.ListMeta{
+			ResourceVersion:    "123",
+			Continue:           "next-token",
+			RemainingItemCount: &remainingItemCount,
+		},
+		Items: []testInternalItem{
+			{Name: "pod-a"},
+			{Name: "pod-b"},
+		},
+	}
+	serializer := &mockStreamingListSerializer{handled: true}
+	convertor := &countingListConvertor{}
+	typer := &mockTyper{gvks: []schema.GroupVersionKind{{Version: runtime.APIVersionInternal, Kind: "TestItemList"}}}
+
+	codec := NewCodec(serializer, nil, convertor, nil, typer, nil, schema.GroupVersion{Version: "v1"}, nil, "TestEncodeStreamingListConvertsItemsIndividually")
+	if err := codec.Encode(internalList, ioutil.Discard); err != nil {
+		t.Fatalf("unexpected encode error: %v", err)
+	}
+
+	if convertor.listWithItemsConversions != 0 {
+		t.Fatalf("unexpected full-list conversions with items: %d", convertor.listWithItemsConversions)
+	}
+	if convertor.emptyListConversions != 1 {
+		t.Fatalf("expected one empty-list conversion, got %d", convertor.emptyListConversions)
+	}
+	if convertor.itemConversions != len(internalList.Items) {
+		t.Fatalf("expected %d item conversions, got %d", len(internalList.Items), convertor.itemConversions)
+	}
+	if serializer.encodeCalled {
+		t.Fatalf("expected streaming list path, fallback encoder was used")
+	}
+	if serializer.versionedList == nil {
+		t.Fatalf("expected versioned list header to be passed to streaming serializer")
+	}
+	if got := serializer.versionedList.GetObjectKind().GroupVersionKind(); got != (schema.GroupVersionKind{Version: "v1", Kind: "TestItemList"}) {
+		t.Fatalf("unexpected versioned list GVK: %#v", got)
+	}
+	if len(serializer.items) != len(internalList.Items) {
+		t.Fatalf("expected %d streamed items, got %d", len(internalList.Items), len(serializer.items))
+	}
+	for i, item := range serializer.items {
+		gvk := item.GetObjectKind().GroupVersionKind()
+		if gvk != (schema.GroupVersionKind{Version: "v1", Kind: "TestItem"}) {
+			t.Fatalf("unexpected item %d GVK: %#v", i, gvk)
+		}
+	}
+}
+
+func TestEncodeStreamingListFallsBackToFullListConversion(t *testing.T) {
+	internalList := &testInternalList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "123"},
+		Items: []testInternalItem{
+			{Name: "pod-a"},
+			{Name: "pod-b"},
+		},
+	}
+	serializer := &mockStreamingListSerializer{handled: false}
+	convertor := &countingListConvertor{}
+	typer := &mockTyper{gvks: []schema.GroupVersionKind{{Version: runtime.APIVersionInternal, Kind: "TestItemList"}}}
+
+	codec := NewCodec(serializer, nil, convertor, nil, typer, nil, schema.GroupVersion{Version: "v1"}, nil, "TestEncodeStreamingListFallsBackToFullListConversion")
+	if err := codec.Encode(internalList, ioutil.Discard); err != nil {
+		t.Fatalf("unexpected encode error: %v", err)
+	}
+
+	if convertor.listWithItemsConversions != 1 {
+		t.Fatalf("expected one full-list conversion fallback, got %d", convertor.listWithItemsConversions)
+	}
+	if !serializer.encodeCalled {
+		t.Fatalf("expected fallback encoder to be used")
+	}
+}
+
+func TestEncodeStreamingListMatchesFullListConversionJSON(t *testing.T) {
+	var remainingItemCount int64 = 7
+	internalList := &testInternalList{
+		ListMeta: metav1.ListMeta{
+			ResourceVersion:    "123",
+			Continue:           "next-token",
+			RemainingItemCount: &remainingItemCount,
+		},
+		Items: []testInternalItem{
+			{Name: "pod-a"},
+			{Name: "pod-b"},
+		},
+	}
+
+	convertor := &countingListConvertor{}
+	typer := &mockTyper{gvks: []schema.GroupVersionKind{{Version: runtime.APIVersionInternal, Kind: "TestItemList"}}}
+
+	jsonEncoder := jsonserializer.NewSerializerWithOptions(
+		jsonserializer.DefaultMetaFactory,
+		nil,
+		nil,
+		jsonserializer.SerializerOptions{StreamingCollectionsEncoding: true},
+	)
+
+	codecOld := NewCodec(
+		encoderWithoutStreamingList{Encoder: jsonEncoder},
+		nil,
+		convertor,
+		nil,
+		typer,
+		nil,
+		schema.GroupVersion{Version: "v1"},
+		nil,
+		"TestEncodeStreamingListMatchesFullListConversionJSON",
+	)
+	codecNew := NewCodec(
+		jsonEncoder,
+		nil,
+		convertor,
+		nil,
+		typer,
+		nil,
+		schema.GroupVersion{Version: "v1"},
+		nil,
+		"TestEncodeStreamingListMatchesFullListConversionJSON",
+	)
+
+	var oldBuf, newBuf bytes.Buffer
+	if err := codecOld.Encode(internalList, &oldBuf); err != nil {
+		t.Fatalf("unexpected old-path encode error: %v", err)
+	}
+	if err := codecNew.Encode(internalList, &newBuf); err != nil {
+		t.Fatalf("unexpected new-path encode error: %v", err)
+	}
+
+	var oldDecoded any
+	var newDecoded any
+	if err := stdjson.Unmarshal(oldBuf.Bytes(), &oldDecoded); err != nil {
+		t.Fatalf("failed to decode old-path JSON: %v", err)
+	}
+	if err := stdjson.Unmarshal(newBuf.Bytes(), &newDecoded); err != nil {
+		t.Fatalf("failed to decode new-path JSON: %v", err)
+	}
+
+	if !reflect.DeepEqual(oldDecoded, newDecoded) {
+		t.Fatalf("decoded JSON differs between old and new paths:\n%s", diff.Diff(oldDecoded, newDecoded))
+	}
+}
+
 func BenchmarkIdentifier(b *testing.B) {
 	encoder := &mockSerializer{}
 	gv := schema.GroupVersion{Group: "group", Version: "version"}
@@ -402,4 +551,134 @@ func BenchmarkIdentifier(b *testing.B) {
 			b.Errorf("unexpected identifier: %s", id)
 		}
 	}
+}
+
+type testInternalItem struct {
+	metav1.TypeMeta `json:",inline"`
+	Name            string `json:"name,omitempty"`
+}
+
+func (i *testInternalItem) DeepCopyObject() runtime.Object {
+	copy := *i
+	return &copy
+}
+
+type testExternalItem struct {
+	metav1.TypeMeta `json:",inline"`
+	Name            string `json:"name,omitempty"`
+}
+
+func (i *testExternalItem) DeepCopyObject() runtime.Object {
+	copy := *i
+	return &copy
+}
+
+type testInternalList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []testInternalItem `json:"items"`
+}
+
+func (l *testInternalList) DeepCopyObject() runtime.Object {
+	copy := *l
+	if l.Items != nil {
+		copy.Items = append([]testInternalItem(nil), l.Items...)
+	}
+	return &copy
+}
+
+type testExternalList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []testExternalItem `json:"items"`
+}
+
+func (l *testExternalList) DeepCopyObject() runtime.Object {
+	copy := *l
+	if l.Items != nil {
+		copy.Items = append([]testExternalItem(nil), l.Items...)
+	}
+	return &copy
+}
+
+type countingListConvertor struct {
+	itemConversions          int
+	emptyListConversions     int
+	listWithItemsConversions int
+}
+
+func (c *countingListConvertor) Convert(in, out, context interface{}) error {
+	return fmt.Errorf("Convert is not implemented")
+}
+
+func (c *countingListConvertor) ConvertToVersion(in runtime.Object, gv runtime.GroupVersioner) (runtime.Object, error) {
+	switch obj := in.(type) {
+	case *testInternalItem:
+		c.itemConversions++
+		out := &testExternalItem{
+			TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "TestItem"},
+			Name:     obj.Name,
+		}
+		out.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: "TestItem"})
+		return out, nil
+	case *testInternalList:
+		out := &testExternalList{
+			TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "TestItemList"},
+			ListMeta: obj.ListMeta,
+		}
+		out.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: "TestItemList"})
+		if len(obj.Items) == 0 {
+			c.emptyListConversions++
+			return out, nil
+		}
+		c.listWithItemsConversions++
+		out.Items = make([]testExternalItem, len(obj.Items))
+		for i := range obj.Items {
+			out.Items[i] = testExternalItem{
+				TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "TestItem"},
+				Name:     obj.Items[i].Name,
+			}
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("unexpected object type %T", in)
+	}
+}
+
+func (c *countingListConvertor) ConvertFieldLabel(gvk schema.GroupVersionKind, label, value string) (string, string, error) {
+	return label, value, nil
+}
+
+type encoderWithoutStreamingList struct {
+	runtime.Encoder
+}
+
+type mockStreamingListSerializer struct {
+	handled       bool
+	encodeCalled  bool
+	versionedList runtime.Object
+	items         []runtime.Object
+	obj           runtime.Object
+}
+
+func (s *mockStreamingListSerializer) Encode(obj runtime.Object, w io.Writer) error {
+	s.encodeCalled = true
+	s.obj = obj
+	return nil
+}
+
+func (s *mockStreamingListSerializer) EncodeListWithIterator(list runtime.Object, w io.Writer, iter itemIterator) (bool, error) {
+	s.versionedList = list
+	if !s.handled {
+		return false, nil
+	}
+	s.items = s.items[:0]
+	return true, iter(func(obj runtime.Object) error {
+		s.items = append(s.items, obj)
+		return nil
+	})
+}
+
+func (s *mockStreamingListSerializer) Identifier() runtime.Identifier {
+	return runtime.Identifier("mock-streaming-list")
 }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_test.go
@@ -534,6 +534,24 @@ func TestEncodeStreamingListMatchesFullListConversionJSON(t *testing.T) {
 	if err := stdjson.Unmarshal(newBuf.Bytes(), &newDecoded); err != nil {
 		t.Fatalf("failed to decode new-path JSON: %v", err)
 	}
+	oldRoot, ok := oldDecoded.(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected old-path decoded type %T", oldDecoded)
+	}
+	oldItems, ok := oldRoot["items"].([]any)
+	if !ok || len(oldItems) == 0 {
+		t.Fatalf("unexpected old-path decoded items %#v", oldRoot["items"])
+	}
+	firstItem, ok := oldItems[0].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected old-path decoded first item %#v", oldItems[0])
+	}
+	if _, found := firstItem["kind"]; found {
+		t.Fatalf("expected old-path list item JSON to omit kind, got %#v", firstItem)
+	}
+	if _, found := firstItem["apiVersion"]; found {
+		t.Fatalf("expected old-path list item JSON to omit apiVersion, got %#v", firstItem)
+	}
 
 	if !reflect.DeepEqual(oldDecoded, newDecoded) {
 		t.Fatalf("decoded JSON differs between old and new paths:\n%s", diff.Diff(oldDecoded, newDecoded))
@@ -635,8 +653,7 @@ func (c *countingListConvertor) ConvertToVersion(in runtime.Object, gv runtime.G
 		out.Items = make([]testExternalItem, len(obj.Items))
 		for i := range obj.Items {
 			out.Items[i] = testExternalItem{
-				TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "TestItem"},
-				Name:     obj.Items[i].Name,
+				Name: obj.Items[i].Name,
 			}
 		}
 		return out, nil


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This WIP PR pushes streamed handling for JSON typed LIST objects one layer earlier, from the JSON encoder into the versioning codec.

The implementation keeps the existing streamed JSON assembly, but changes how version conversion is performed for typed list objects:


The key architectural split is:

- **versioning layer**
  - decides whether the streamed typed-LIST path can be used
  - converts the list header once
  - walks internal list items
  - converts each item individually with `ConvertToVersion(item, targetGV)`
  - passes each converted item to the serializer through an iterator/callback

- **JSON serializer layer**
  - owns JSON formatting
  - writes the list envelope (`kind`, `apiVersion`, `metadata`, `items`)
  - consumes converted items through the iterator
  - writes each item into the JSON `items` array in order

In other words, the serializer still controls JSON assembly, while the versioning codec controls how versioned items are produced.

Previous model:

```text
internal typed list
  -> ConvertToVersion(full list)
  -> external typed list with full Items []T materialized
  -> streamed JSON encoding
```

New model:

```text
internal typed list
  -> ConvertToVersion(empty list header)
  -> for each internal item:
       ConvertToVersion(item)
       pass item to JSON serializer callback
  -> streamed JSON encoding
```

Callback flow:

```text
versioning codec
  -> EncodeListWithIterator(versionedListHeader, writer, iter)

JSON serializer
  -> writes list envelope
  -> starts "items":[
  -> calls iter(visit)

iter (implemented by versioning)
  -> walks internal list items
  -> converts each item to target version
  -> calls visit(versionedItem)

visit (implemented by serializer)
  -> writes comma if needed
  -> encodes one item into the JSON array
```

This callback model is used to preserve layering.

There are two callbacks involved:

- `iter(...)` is the callback provided by the versioning codec
  - it describes how versioned items are produced from the internal list
- `visit(...)` is the callback provided by the serializer
  - it describes what should happen once one versioned item is ready to be written
  - in practice, this is the callback that performs the per-item JSON encode/write step



- **versioning does not need to know JSON formatting details**
  - versioning passes its `iter(...)` callback into `EncodeListWithIterator(...)`
  - inside `iter(...)`, versioning only:
    - walks the internal list
    - converts each item with `ConvertToVersion(item, targetGV)`
    - calls `visit(versionedItem)`
  - here, `visit(...)` is the serializer-provided callback, i.e. the callback that performs the actual per-item encode/write step
  - concretely, this happens here:
    https://github.com/kubernetes/kubernetes/blob/c27335aa44b8d0af1d578a133b7ca40e5ac73da3/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go#L320-L331

- **the serializer does not need to know how list traversal or version conversion works**
  - the serializer only knows that it has an `iter(...)` callback that can supply items while it is writing the JSON `items` array
  - here, `iter(...)` is the callback returned from the previous step by the versioning codec
  - the serializer writes `"items":[`, calls `iter(...)`, and for each callback invocation:
    - writes a comma if needed
    - encodes the item into JSON
  - concretely, the serializer consumes `iter(...)` here:
    https://github.com/kubernetes/kubernetes/blob/c27335aa44b8d0af1d578a133b7ca40e5ac73da3/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections.go#L151-L159
  - and the surrounding JSON list assembly is here:
    https://github.com/kubernetes/kubernetes/blob/c27335aa44b8d0af1d578a133b7ca40e5ac73da3/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections.go#L109-L165

- **no intermediate full external typed list needs to be materialized**
  - the list header is converted once, separately from items
  - then each item is converted and immediately handed to the serializer callback

#### Which issue(s) this PR is related to:

Fixes #139026

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [Issue]: https://github.com/kubernetes/kubernetes/issues/139026
- [Related KEP]: https://github.com/kubernetes/enhancements/issues/5116
```