### PR TITLE
fix(kubelet): prevent StripedLockSet panic on high core nodes

### DIFF
--- a/pkg/kubelet/images/pullmanager/locks.go
+++ b/pkg/kubelet/images/pullmanager/locks.go
@@ -33,10 +33,11 @@ type StripedLockSet struct {
 // The size will be normalized to stay in the <1, 31> interval.
 func NewStripedLockSet(size int32) *StripedLockSet {
 	size = max(size, 1) // make sure we're at least at size 1
+	actualSize := min(31, size)
 
 	return &StripedLockSet{
-		locks: make([]sync.Mutex, min(31, size)),
-		size:  size,
+		locks: make([]sync.Mutex, actualSize),
+		size:  actualSize,
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR resolves a catastrophic "index out of range" panic in the Kubelet introduced by the `KubeletEnsureSecretPulledImages` feature gate. 

When the `StripedLockSet` is initialized on machines with more than 31 CPU cores, the underlying `locks` slice allocation is capped at 31, but the mathematical `size` property of the struct was left uncapped. This caused the `keyToID` hashing modulo to generate indexes up to the total core count, which triggered a panic when attempting to access indices > 31.

This patch binds the `size` property to the actual slice length limit (`actualSize`), mathematically guaranteeing that the modulo arithmetic stays within the bounds of the array.

#### Which issue(s) this PR is related to:

Fixes #138935

#### Special notes for your reviewer:

/sig node

#### Does this PR introduce a user-facing change?

```release-note
Fixed a panic in the Kubelet image pull manager when running on nodes with more than 31 CPUs and the KubeletEnsureSecretPulledImages feature gate enabled. 
```
