### PR TITLE
Fix kubelet startup failure when restoring legacy V3 CPU manager checkpoints

### DIFF
--- a/pkg/kubelet/cm/cpumanager/state/checkpoint.go
+++ b/pkg/kubelet/cm/cpumanager/state/checkpoint.go
@@ -267,8 +267,25 @@ func (cp *CPUManagerCheckpointV3) VerifyChecksum() error {
 	ck := cp.Checksum
 	cp.Checksum = 0
 	err := ck.Verify(cp)
+	if err == nil {
+		cp.Checksum = ck
+		return nil
+	}
+
+	object := dump.ForHash(cp)
+	object = strings.Replace(object, "CPUManagerCheckpointV3", "CPUManagerCheckpoint", 1)
 	cp.Checksum = ck
-	return err
+
+	hash := fnv.New32a()
+	_, _ = fmt.Fprintf(hash, "%v", object)
+	actualCS := checksum.Checksum(hash.Sum32())
+	if cp.Checksum != actualCS {
+		return &errors.CorruptCheckpointError{
+			ActualCS:   uint64(actualCS),
+			ExpectedCS: uint64(cp.Checksum),
+		}
+	}
+	return nil
 }
 
 // VerifyChecksum verifies that current checksum of checkpoint is valid in v4 format

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -322,7 +322,7 @@ func TestCheckpointStateRestore(t *testing.T) {
 						"cpuSet":"7-9"
 					}
 				},
-				"checksum": 2284712151
+				"checksum": 766259872
 			}`,
 			"static",
 			containermap.ContainerMap{},
@@ -354,7 +354,7 @@ func TestCheckpointStateRestore(t *testing.T) {
 						"cpuSet":"7-9"
 					}
 				},
-				"checksum": 2284712151
+				"checksum": 766259872
 			}`,
 			"static",
 			containermap.ContainerMap{},
@@ -771,6 +771,43 @@ func TestCPUManagerCheckpoint_MarshalCheckpoint_HashCompatibility(t *testing.T) 
 			if writtenChecksum != expectedLegacyChecksum {
 				t.Errorf("Written Checksum %d does not match legacy calculation %d. Forward compatibility broken.", writtenChecksum, expectedLegacyChecksum)
 			}
+		})
+	}
+}
+
+func TestCPUManagerCheckpointV3_VerifyChecksum_Compatibility(t *testing.T) {
+	testCases := []struct {
+		name     string
+		checksum checksum.Checksum
+	}{
+		{
+			name:     "accepts legacy v3 checksum",
+			checksum: 766259872,
+		},
+		{
+			name:     "accepts current v3 checksum",
+			checksum: 2284712151,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cp := &CPUManagerCheckpointV3{
+				PolicyName:    "static",
+				DefaultCPUSet: "1-2",
+				Entries: map[string]map[string]string{
+					"pod1": {
+						"container1": "5-6",
+						"container2": "3-4",
+					},
+				},
+				PodEntries: PodCPUAssignments{
+					"pod2": {CPUSet: cpuset.New(7, 8, 9)},
+				},
+				Checksum: tc.checksum,
+			}
+
+			require.NoError(t, cp.VerifyChecksum())
 		})
 	}
 }

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -812,6 +812,68 @@ func TestCPUManagerCheckpointV3_VerifyChecksum_Compatibility(t *testing.T) {
 	}
 }
 
+func TestCPUManagerCheckpoint_RoundTrip(t *testing.T) {
+	testCases := []struct {
+		name     string
+		original checkpointmanager.Checkpoint
+		restored checkpointmanager.Checkpoint
+		verify   func(t *testing.T, original, restored checkpointmanager.Checkpoint)
+	}{
+		{
+			name: "V2 checkpoint",
+			original: &CPUManagerCheckpointV2{
+				PolicyName:    "static",
+				DefaultCPUSet: "0-3",
+				Entries: map[string]map[string]string{
+					"pod1": {"container1": "4-5"},
+				},
+			},
+			restored: newCPUManagerCheckpointV2(),
+			verify: func(t *testing.T, original, restored checkpointmanager.Checkpoint) {
+				o := original.(*CPUManagerCheckpointV2)
+				r := restored.(*CPUManagerCheckpointV2)
+				require.Equal(t, o.PolicyName, r.PolicyName)
+				require.Equal(t, o.DefaultCPUSet, r.DefaultCPUSet)
+				require.Equal(t, o.Entries, r.Entries)
+			},
+		},
+		{
+			name: "V3 checkpoint",
+			original: &CPUManagerCheckpointV3{
+				PolicyName:    "static",
+				DefaultCPUSet: "0-3",
+				Entries: map[string]map[string]string{
+					"pod1": {"container1": "4-5"},
+				},
+				PodEntries: PodCPUAssignments{
+					"pod2": {CPUSet: cpuset.New(6, 7)},
+				},
+			},
+			restored: newCPUManagerCheckpointV3(),
+			verify: func(t *testing.T, original, restored checkpointmanager.Checkpoint) {
+				o := original.(*CPUManagerCheckpointV3)
+				r := restored.(*CPUManagerCheckpointV3)
+				require.Equal(t, o.PolicyName, r.PolicyName)
+				require.Equal(t, o.DefaultCPUSet, r.DefaultCPUSet)
+				require.Equal(t, o.Entries, r.Entries)
+				require.Equal(t, o.PodEntries, r.PodEntries)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := tc.original.MarshalCheckpoint()
+			require.NoError(t, err)
+
+			require.NoError(t, tc.restored.UnmarshalCheckpoint(data))
+			require.NoError(t, tc.restored.VerifyChecksum())
+
+			tc.verify(t, tc.original, tc.restored)
+		})
+	}
+}
+
 func removeAll(dir string, t *testing.T) {
 	t.Helper()
 	if err := os.RemoveAll(dir); err != nil {


### PR DESCRIPTION
 
#### What type of PR is this?

/kind bug
 
#### What this PR does / why we need it:

Trigger scenario
    A node previously ran a version that wrote a V3 CPU manager checkpoint to disk.  That checkpoint’s checksum was computed using the legacy type identity CPUManagerCheckpoint.  The node is then upgraded to the current code, which first tries to read the file as V4, fails, and falls back to V3.   During V3 restore, checksum verification is performed against the new concrete type name CPUManagerCheckpointV3.

this leads to:
  - Kubelet fails to restore CPU manager state during startup.
  - The V3 checkpoint is incorrectly reported as corrupted.
  - Restore then falls through V2 and V1 parsing paths, which also fail.
  - Startup ends with a fatal restore error, and kubelet does not come up unless the checkpoint is removed manually.


  Root cause
In PR #137820,   CPUManagerCheckpointV3 was changed from a type alias to a distinct struct.
 Checksum generation and verification became asymmetric:
      - MarshalCheckpoint() already rewrites CPUManagerCheckpointV3 to CPUManagerCheckpoint before hashing, to preserve compatibility.
      - VerifyChecksum() used only ck.Verify(cp), which hashes the real current type name CPUManagerCheckpointV3.
  - Same logical data, different type name in the hash input, different checksum.

#### Which issue(s) this PR is related to:

PR #137820,

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
