### PR TITLE
scheduler: fix snapshot AssumePod/ForgetPod affinity and PVC indexes

### DIFF
--- a/pkg/scheduler/backend/cache/snapshot.go
+++ b/pkg/scheduler/backend/cache/snapshot.go
@@ -19,6 +19,7 @@ package cache
 import (
 	"fmt"
 	"maps"
+	"slices"
 
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
@@ -88,9 +89,15 @@ type Snapshot struct {
 	// keyed in the format "namespace/name".
 	usedPVCRefCounts map[string]int
 	generation       int64
-	// assumedPods maps a pod key to an assumed pod object during a single pod group scheduling cycle.
-	// This map should be emptied before the next cycle starts.
-	assumedPods map[string]*v1.Pod
+	// assumedPodStates maps a pod key to its assume-time state during a single pod
+	// group scheduling cycle. The state records exactly what AssumePod added
+	// to the snapshot-wide indexes so that ForgetPod can revert it without
+	// rescanning the snapshot. This map should be emptied before the next cycle starts.
+	assumedPodStates map[string]*assumedPodState
+	// assumedPodKeys records the keys of assumed pods in assume order. It lets
+	// forgetAllAssumedPods revert leftover pods in reverse assume order, which the
+	// LIFO contract documented on assumedPodState relies on.
+	assumedPodKeys []string
 	// podGroupStates maps a pod group key to a snapshot of its state, used during a pod group scheduling cycle.
 	podGroupStates map[podGroupKey]*podGroupStateSnapshot
 	// placementNodes stores nodes that are present in the current placement.
@@ -109,12 +116,38 @@ type Snapshot struct {
 var _ fwk.SharedLister = &Snapshot{}
 var _ fwk.MutableSnapshotSharedLister = &Snapshot{}
 
+// assumedPodState captures what an AssumePod call added to the snapshot's
+// shared affinity indexes (havePodsWithAffinityNodeInfoList,
+// havePodsWithRequiredAntiAffinityNodeInfoList). ForgetPod reads it to undo
+// exactly those additions in O(1) per index. The PVC index is reference
+// counted (usedPVCRefCounts) and reverted directly from the pod's volumes, so
+// it needs no per-pod bookkeeping here.
+//
+// This relies on the contract of snapshot-level Assume/Forget:
+//  1. ForgetPod is only called for a pod that was previously assumed.
+//  2. Pods are forgotten in reverse order of being assumed.
+//  3. No other snapshot mutations happen between AssumePod and ForgetPod
+//     of the same pod.
+type assumedPodState struct {
+	// pod is the assumed pod. It is retained so forgetAllAssumedPods can
+	// revert leftover pods without the caller re-supplying them.
+	pod *v1.Pod
+	// addedToAffinityList is true if AssumePod appended the pod's node to the
+	// snapshot's affinity list (the node had no pods with affinity terms
+	// before this pod was assumed).
+	addedToAffinityList bool
+	// addedToAntiAffinityList is true if AssumePod appended the pod's node to
+	// the snapshot's required anti-affinity list (the node had no pods with
+	// required anti-affinity terms before this pod was assumed).
+	addedToAntiAffinityList bool
+}
+
 // NewEmptySnapshot initializes a Snapshot struct and returns it.
 func NewEmptySnapshot() *Snapshot {
 	return &Snapshot{
 		nodeInfoMap:            make(map[string]*framework.NodeInfo),
 		usedPVCRefCounts:       make(map[string]int),
-		assumedPods:            make(map[string]*v1.Pod),
+		assumedPodStates:       make(map[string]*assumedPodState),
 		podGroupStates:         make(map[podGroupKey]*podGroupStateSnapshot),
 		genericWorkloadEnabled: utilfeature.DefaultFeatureGate.Enabled(features.GenericWorkload),
 	}
@@ -393,7 +426,13 @@ func (s *Snapshot) IsPVCUsedByPods(key string) bool {
 	return s.usedPVCRefCounts[key] > 0
 }
 
-// AssumePod assumes a given pod in the snapshot.
+// AssumePod assumes a given pod in the snapshot. In addition to adding the
+// pod to its node's NodeInfo, it keeps the snapshot-wide affinity, anti-affinity
+// and PVC indexes (havePodsWithAffinityNodeInfoList,
+// havePodsWithRequiredAntiAffinityNodeInfoList, usedPVCRefCounts) consistent so
+// that scheduling plugins observe up-to-date state during the pod group cycle.
+// The affinity additions are recorded in assumedPodState so ForgetPod can undo
+// them directly.
 // ForgetPod should be called on the snapshot before syncing it with the cache.
 // This function is not thread safe, so it should be executed when no other routines can write/read from the snapshot.
 func (s *Snapshot) AssumePod(podInfo *framework.PodInfo) error {
@@ -411,9 +450,27 @@ func (s *Snapshot) AssumePod(podInfo *framework.PodInfo) error {
 	// Since this operation only affects the snapshot,
 	// we should keep the old number to remain consistent with the cached value.
 	oldGeneration := nodeInfo.Generation
+	hadPodsWithAffinity := len(nodeInfo.PodsWithAffinity) > 0
+	hadPodsWithRequiredAntiAffinity := len(nodeInfo.PodsWithRequiredAntiAffinity) > 0
 	nodeInfo.AddPodInfo(podInfo)
 	nodeInfo.Generation = oldGeneration
-	s.assumedPods[key] = pod
+	// nodeInfo.AddPodInfo maintains the NodeInfo's affinity and PVC indexes;
+	// the snapshot-wide indexes must be updated to match, otherwise inter-pod
+	// (anti-)affinity and VolumeRestrictions plugins observe stale state.
+	state := &assumedPodState{pod: pod}
+	if !hadPodsWithAffinity && len(nodeInfo.PodsWithAffinity) > 0 {
+		s.havePodsWithAffinityNodeInfoList = append(s.havePodsWithAffinityNodeInfoList, nodeInfo)
+		state.addedToAffinityList = true
+	}
+	if !hadPodsWithRequiredAntiAffinity && len(nodeInfo.PodsWithRequiredAntiAffinity) > 0 {
+		s.havePodsWithRequiredAntiAffinityNodeInfoList = append(s.havePodsWithRequiredAntiAffinityNodeInfoList, nodeInfo)
+		state.addedToAntiAffinityList = true
+	}
+	for pvcKey := range framework.PodPVCKeys(pod) {
+		s.usedPVCRefCounts[pvcKey]++
+	}
+	s.assumedPodStates[key] = state
+	s.assumedPodKeys = append(s.assumedPodKeys, key)
 	// Update the pod group state in the snapshot if the pod belongs to a pod group.
 	if !s.genericWorkloadEnabled || pod.Spec.SchedulingGroup == nil {
 		return nil
@@ -425,18 +482,31 @@ func (s *Snapshot) AssumePod(podInfo *framework.PodInfo) error {
 	return nil
 }
 
-// ForgetPod forgets a given pod from the snapshot.
+// ForgetPod forgets a given pod from the snapshot. In addition to removing
+// the pod from its node's NodeInfo, it reverts the snapshot-wide index
+// additions recorded by AssumePod (havePodsWithAffinityNodeInfoList,
+// havePodsWithRequiredAntiAffinityNodeInfoList, usedPVCRefCounts). Reverting the
+// affinity lists relies on the LIFO Assume/Forget contract documented on
+// assumedPodState.
 // This function is not thread safe, so it should be executed when no other routines can write/read from the snapshot.
 func (s *Snapshot) ForgetPod(logger klog.Logger, pod *v1.Pod) error {
 	key, err := framework.GetPodKey(pod)
 	if err != nil {
 		return err
 	}
-	assumedPod, ok := s.assumedPods[key]
+	state, ok := s.assumedPodStates[key]
 	if !ok {
 		return fmt.Errorf("assumed pod %q not found in the snapshot", key)
 	}
-	delete(s.assumedPods, key)
+	delete(s.assumedPodStates, key)
+	// The LIFO Assume/Forget contract (see assumedPodState) guarantees the pod
+	// being forgotten is the last assumed one, so its key is popped from the end.
+	if n := len(s.assumedPodKeys); n > 0 && s.assumedPodKeys[n-1] == key {
+		s.assumedPodKeys = s.assumedPodKeys[:n-1]
+	} else {
+		utilruntime.HandleErrorWithLogger(logger, nil, "Cannot remove assumed pod key on ForgetPod: the pod is not the last assumed one", "pod", klog.KObj(pod))
+	}
+	assumedPod := state.pod
 	nodeName := assumedPod.Spec.NodeName
 	if nodeInfo, ok := s.nodeInfoMap[nodeName]; ok {
 		// Calling RemovePod increases the Generation number of the nodeInfo.
@@ -448,6 +518,20 @@ func (s *Snapshot) ForgetPod(logger klog.Logger, pod *v1.Pod) error {
 			return err
 		}
 		nodeInfo.Generation = oldGeneration
+		// Undo only what this pod's AssumePod added to the snapshot-wide
+		// indexes; the NodeInfo's own indexes are maintained by RemovePod.
+		if state.addedToAffinityList {
+			s.havePodsWithAffinityNodeInfoList = removeAssumedNodeInfo(logger, s.havePodsWithAffinityNodeInfoList, nodeInfo, "havePodsWithAffinityNodeInfoList", pod)
+		}
+		if state.addedToAntiAffinityList {
+			s.havePodsWithRequiredAntiAffinityNodeInfoList = removeAssumedNodeInfo(logger, s.havePodsWithRequiredAntiAffinityNodeInfoList, nodeInfo, "havePodsWithRequiredAntiAffinityNodeInfoList", pod)
+		}
+		for pvcKey := range framework.PodPVCKeys(pod) {
+			s.usedPVCRefCounts[pvcKey]--
+			if s.usedPVCRefCounts[pvcKey] <= 0 {
+				delete(s.usedPVCRefCounts, pvcKey)
+			}
+		}
 		if len(nodeInfo.Pods) == 0 && nodeInfo.Node() == nil {
 			delete(s.nodeInfoMap, nodeName)
 		}
@@ -466,16 +550,37 @@ func (s *Snapshot) ForgetPod(logger klog.Logger, pod *v1.Pod) error {
 // forgetAllAssumedPods forgets all assumed pods from the snapshot.
 // This function is not thread safe, so it should be executed when no other routines can write/read from the snapshot.
 func (s *Snapshot) forgetAllAssumedPods(logger klog.Logger) {
-	if len(s.assumedPods) == 0 {
+	if len(s.assumedPodStates) == 0 {
 		return
 	}
-	for _, pod := range s.assumedPods {
-		err := s.ForgetPod(logger, pod)
-		if err != nil {
+	logger.Error(nil, "Found assumed pods in the snapshot that were not forgotten", "assumedPodsCount", len(s.assumedPodStates))
+	// Forget in reverse assume order to honor the LIFO contract that ForgetPod
+	// relies on to revert the snapshot-wide indexes (see assumedPodState).
+	keys := slices.Clone(s.assumedPodKeys)
+	for i := len(keys) - 1; i >= 0; i-- {
+		state, ok := s.assumedPodStates[keys[i]]
+		if !ok {
+			utilruntime.HandleErrorWithLogger(logger, nil, "Assumed pod state not found for the recorded assumed pod key", "podKey", keys[i])
+			continue
+		}
+		if err := s.ForgetPod(logger, state.pod); err != nil {
 			utilruntime.HandleErrorWithLogger(logger, err, "Failed to forget assumed pod")
 		}
 	}
-	logger.Error(nil, "Found assumed pods in the snapshot that were not forgotten", "assumedPodsCount", len(s.assumedPods))
+}
+
+// removeAssumedNodeInfo removes nodeInfo from the end of list. AssumePod only
+// ever appends to these lists, and the LIFO Assume/Forget contract guarantees
+// the entry added for the pod now being forgotten is the last one. If the last
+// entry is not nodeInfo the contract was violated: the error is reported and
+// list is returned unchanged.
+func removeAssumedNodeInfo(logger klog.Logger, list []fwk.NodeInfo, nodeInfo fwk.NodeInfo, listName string, pod *v1.Pod) []fwk.NodeInfo {
+	if len(list) == 0 || list[len(list)-1] != nodeInfo {
+		utilruntime.HandleErrorWithLogger(logger, nil, "Cannot revert snapshot index on ForgetPod: list does not end with the assumed pod's node", "list", listName, "pod", klog.KObj(pod), "node", nodeInfo.Node().Name)
+		return list
+	}
+	list[len(list)-1] = nil
+	return list[:len(list)-1]
 }
 
 // AssumePlacement sets placement context in the snapshot.

--- a/pkg/scheduler/backend/cache/snapshot_test.go
+++ b/pkg/scheduler/backend/cache/snapshot_test.go
@@ -19,6 +19,7 @@ package cache
 import (
 	"fmt"
 	"maps"
+	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -496,8 +497,8 @@ func TestSnapshot_AssumeForget(t *testing.T) {
 
 			if tt.forgetAll {
 				snapshot.forgetAllAssumedPods(logger)
-				if len(snapshot.assumedPods) != 0 {
-					t.Errorf("Expected assumedPods to be empty, but has %d pods", len(snapshot.assumedPods))
+				if len(snapshot.assumedPodStates) != 0 {
+					t.Errorf("Expected assumedPodStates to be empty, but has %d pods", len(snapshot.assumedPodStates))
 				}
 			} else {
 				for _, p := range tt.podsToForget {
@@ -541,6 +542,269 @@ func TestSnapshot_AssumeForget(t *testing.T) {
 						}
 					}
 				}
+			}
+		})
+	}
+}
+
+func TestSnapshot_AssumeForgetAffinityAndPVC(t *testing.T) {
+	node1 := st.MakeNode().Name("node-1").Obj()
+	node2 := st.MakeNode().Name("node-2").Obj()
+
+	affinityPod := st.MakePod().Name("affinity-pod").UID("affinity-pod").Node("node-1").
+		PodAffinity("zone", &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}, st.PodAffinityWithRequiredReq).Obj()
+	affinityPod2 := st.MakePod().Name("affinity-pod-2").UID("affinity-pod-2").Node("node-1").
+		PodAffinity("zone", &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}, st.PodAffinityWithRequiredReq).Obj()
+	antiAffinityPod := st.MakePod().Name("anti-affinity-pod").UID("anti-affinity-pod").Node("node-1").
+		PodAntiAffinity("zone", &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}, st.PodAntiAffinityWithRequiredReq).Obj()
+	antiAffinityPod2 := st.MakePod().Name("anti-affinity-pod-2").UID("anti-affinity-pod-2").Node("node-1").
+		PodAntiAffinity("zone", &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}, st.PodAntiAffinityWithRequiredReq).Obj()
+	bothPod := st.MakePod().Name("both-pod").UID("both-pod").Node("node-2").
+		PodAffinity("zone", &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}, st.PodAffinityWithRequiredReq).
+		PodAntiAffinity("zone", &metav1.LabelSelector{MatchLabels: map[string]string{"baz": "qux"}}, st.PodAntiAffinityWithRequiredReq).Obj()
+	pvcPod := st.MakePod().Name("pvc-pod").UID("pvc-pod").Namespace("ns").Node("node-1").PVC("my-pvc").Obj()
+	// pvcPod2 references the same PVC as pvcPod on the same node, to exercise the
+	// shared-PVC reference-counting path.
+	pvcPod2 := st.MakePod().Name("pvc-pod-2").UID("pvc-pod-2").Namespace("ns").Node("node-1").PVC("my-pvc").Obj()
+	mixedVolumePod := st.MakePod().Name("mixed-pod").UID("mixed-pod").Namespace("ns").Node("node-1").
+		PVC("tracked-pvc").
+		Volume(v1.Volume{Name: "empty", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}}).
+		Volume(v1.Volume{Name: "cm", VolumeSource: v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{}}}).Obj()
+
+	// Pods that are already part of the snapshot (passed to NewSnapshot, not
+	// assumed). ForgetPod must never revert the indexes they contributed.
+	preexistingAffinityPod := st.MakePod().Name("pre-affinity-pod").UID("pre-affinity-pod").Node("node-2").
+		PodAffinity("zone", &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}, st.PodAffinityWithRequiredReq).Obj()
+	preexistingAntiAffinityPod := st.MakePod().Name("pre-anti-pod").UID("pre-anti-pod").Node("node-2").
+		PodAntiAffinity("zone", &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}, st.PodAntiAffinityWithRequiredReq).Obj()
+	preexistingPVCPod := st.MakePod().Name("pre-pvc-pod").UID("pre-pvc-pod").Namespace("ns").Node("node-2").PVC("pre-pvc").Obj()
+	// affinityPodNode2 is assumed onto node-2, which already hosts a pod with
+	// affinity terms, to exercise the "no double-append" path.
+	affinityPodNode2 := st.MakePod().Name("affinity-pod-n2").UID("affinity-pod-n2").Node("node-2").
+		PodAffinity("zone", &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}, st.PodAffinityWithRequiredReq).Obj()
+	// sharedPVCPod is assumed onto node-1 but references the same PVC as the
+	// pre-existing preexistingPVCPod.
+	sharedPVCPod := st.MakePod().Name("shared-pvc-pod").UID("shared-pvc-pod").Namespace("ns").Node("node-1").PVC("pre-pvc").Obj()
+
+	mustPodInfo := func(pod *v1.Pod) *framework.PodInfo {
+		podInfo, err := framework.NewPodInfo(pod)
+		if err != nil {
+			t.Fatalf("Failed to build PodInfo for %q: %v", pod.Name, err)
+		}
+		return podInfo
+	}
+
+	tests := []struct {
+		name string
+		// initialPods are part of the snapshot from the start (passed to
+		// NewSnapshot). They are not assumed and must survive ForgetPod.
+		initialPods  []*v1.Pod
+		podsToAssume []*v1.Pod
+		podsToForget []*v1.Pod
+		// forgetAll calls forgetAllAssumedPods instead of forgetting podsToForget
+		// one by one. It exercises the LIFO revert of all leftover assumed pods.
+		forgetAll                bool
+		expectedAffinity         sets.Set[string]
+		expectedAntiAffinity     sets.Set[string]
+		expectedUsedPVCRefCounts map[string]int
+	}{
+		{
+			name:             "assume pod with required affinity",
+			podsToAssume:     []*v1.Pod{affinityPod},
+			expectedAffinity: sets.New("node-1"),
+		},
+		{
+			name:         "assume pod with required anti-affinity",
+			podsToAssume: []*v1.Pod{antiAffinityPod},
+			// A pod declaring anti-affinity also counts as having affinity terms.
+			expectedAffinity:     sets.New("node-1"),
+			expectedAntiAffinity: sets.New("node-1"),
+		},
+		{
+			name:                     "assume pod with a PVC volume",
+			podsToAssume:             []*v1.Pod{pvcPod},
+			expectedUsedPVCRefCounts: map[string]int{"ns/my-pvc": 1},
+		},
+		{
+			name:         "forget pod with affinity returns to baseline",
+			podsToAssume: []*v1.Pod{affinityPod},
+			podsToForget: []*v1.Pod{affinityPod},
+		},
+		{
+			name:         "forget pod with anti-affinity returns to baseline",
+			podsToAssume: []*v1.Pod{antiAffinityPod},
+			podsToForget: []*v1.Pod{antiAffinityPod},
+		},
+		{
+			name:         "forget pod with PVC returns to baseline",
+			podsToAssume: []*v1.Pod{pvcPod},
+			podsToForget: []*v1.Pod{pvcPod},
+		},
+		{
+			// AssumePod/ForgetPod are documented as LIFO, so we forget the
+			// pod assumed last; node-1 must remain in the list because the
+			// first pod still has affinity terms.
+			name:             "two pods with affinity on the same node, forget the last assumed",
+			podsToAssume:     []*v1.Pod{affinityPod, affinityPod2},
+			podsToForget:     []*v1.Pod{affinityPod2},
+			expectedAffinity: sets.New("node-1"),
+		},
+		{
+			// Forgetting both assumed pods (in reverse order) must return the
+			// affinity list to its empty baseline.
+			name:         "two pods with affinity on the same node, forget both returns to baseline",
+			podsToAssume: []*v1.Pod{affinityPod, affinityPod2},
+			podsToForget: []*v1.Pod{affinityPod2, affinityPod},
+		},
+		{
+			// Same as the affinity case above, but for required anti-affinity:
+			// node-1 must remain in both lists because the first pod still has
+			// (anti-)affinity terms.
+			name:                 "two pods with anti-affinity on the same node, forget the last assumed",
+			podsToAssume:         []*v1.Pod{antiAffinityPod, antiAffinityPod2},
+			podsToForget:         []*v1.Pod{antiAffinityPod2},
+			expectedAffinity:     sets.New("node-1"),
+			expectedAntiAffinity: sets.New("node-1"),
+		},
+		{
+			name:         "two pods with anti-affinity on the same node, forget both returns to baseline",
+			podsToAssume: []*v1.Pod{antiAffinityPod, antiAffinityPod2},
+			podsToForget: []*v1.Pod{antiAffinityPod2, antiAffinityPod},
+		},
+		{
+			// Same as above, but for a PVC shared by two pods on the same node:
+			// the key must remain tracked until the last referencing pod is
+			// forgotten.
+			name:                     "two pods sharing a PVC on the same node, forget the last assumed",
+			podsToAssume:             []*v1.Pod{pvcPod, pvcPod2},
+			podsToForget:             []*v1.Pod{pvcPod2},
+			expectedUsedPVCRefCounts: map[string]int{"ns/my-pvc": 1},
+		},
+		{
+			name:         "two pods sharing a PVC on the same node, forget both returns to baseline",
+			podsToAssume: []*v1.Pod{pvcPod, pvcPod2},
+			podsToForget: []*v1.Pod{pvcPod2, pvcPod},
+		},
+		{
+			// forgetAllAssumedPods must revert every leftover assumed pod in
+			// reverse assume order. Several pods are assumed across two nodes with
+			// affinity, anti-affinity and a shared PVC; after forgetting them all
+			// the snapshot must return to its empty baseline.
+			name:         "forget all assumed pods returns to baseline",
+			podsToAssume: []*v1.Pod{affinityPod, bothPod, pvcPod, pvcPod2},
+			forgetAll:    true,
+		},
+		{
+			name:                 "pod with both affinity and anti-affinity terms",
+			podsToAssume:         []*v1.Pod{bothPod},
+			expectedAffinity:     sets.New("node-2"),
+			expectedAntiAffinity: sets.New("node-2"),
+		},
+		{
+			name:                     "pod with mixed volumes only tracks the PVC",
+			podsToAssume:             []*v1.Pod{mixedVolumePod},
+			expectedUsedPVCRefCounts: map[string]int{"ns/tracked-pvc": 1},
+		},
+		{
+			// node-2 already hosts a pod with affinity terms, so assuming
+			// another one must not append node-2 to the list a second time.
+			name:             "assume affinity pod on a node that already has affinity pods",
+			initialPods:      []*v1.Pod{preexistingAffinityPod},
+			podsToAssume:     []*v1.Pod{affinityPodNode2},
+			expectedAffinity: sets.New("node-2"),
+		},
+		{
+			// Forgetting the assumed pod must keep node-2 in the list because
+			// the pre-existing pod still declares affinity terms.
+			name:             "forget assumed pod keeps the pre-existing affinity entry",
+			initialPods:      []*v1.Pod{preexistingAffinityPod},
+			podsToAssume:     []*v1.Pod{affinityPodNode2},
+			podsToForget:     []*v1.Pod{affinityPodNode2},
+			expectedAffinity: sets.New("node-2"),
+		},
+		{
+			// The assumed pod shares a PVC with a pre-existing pod, so the key
+			// is already tracked; ForgetPod must not drop it.
+			name:                     "forget assumed pod keeps a PVC shared with a pre-existing pod",
+			initialPods:              []*v1.Pod{preexistingPVCPod},
+			podsToAssume:             []*v1.Pod{sharedPVCPod},
+			podsToForget:             []*v1.Pod{sharedPVCPod},
+			expectedUsedPVCRefCounts: map[string]int{"ns/pre-pvc": 1},
+		},
+		{
+			// Pre-existing affinity, anti-affinity and PVC state on node-2,
+			// plus several pods assumed onto node-1 and partially forgotten in
+			// reverse order. node-1 must appear in the affinity list exactly
+			// once even though two assumed pods declare affinity terms there.
+			name:                     "pre-existing state with multiple assume and partial forget",
+			initialPods:              []*v1.Pod{preexistingAffinityPod, preexistingAntiAffinityPod, preexistingPVCPod},
+			podsToAssume:             []*v1.Pod{affinityPod, pvcPod, antiAffinityPod},
+			podsToForget:             []*v1.Pod{antiAffinityPod, pvcPod},
+			expectedAffinity:         sets.New("node-1", "node-2"),
+			expectedAntiAffinity:     sets.New("node-2"),
+			expectedUsedPVCRefCounts: map[string]int{"ns/pre-pvc": 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
+			snapshot := NewSnapshot(tt.initialPods, []*v1.Node{node1, node2})
+
+			for _, p := range tt.podsToAssume {
+				if err := snapshot.AssumePod(mustPodInfo(p)); err != nil {
+					t.Fatalf("Failed to assume pod %q: %v", p.Name, err)
+				}
+			}
+			if tt.forgetAll {
+				snapshot.forgetAllAssumedPods(logger)
+				if len(snapshot.assumedPodStates) != 0 {
+					t.Errorf("Expected assumedPodStates to be empty after forgetAll, but has %d entries", len(snapshot.assumedPodStates))
+				}
+				if len(snapshot.assumedPodKeys) != 0 {
+					t.Errorf("Expected assumedPodKeys to be empty after forgetAll, but has %d entries", len(snapshot.assumedPodKeys))
+				}
+			} else {
+				for _, p := range tt.podsToForget {
+					if err := snapshot.ForgetPod(logger, p); err != nil {
+						t.Fatalf("Failed to forget pod %q: %v", p.Name, err)
+					}
+				}
+			}
+
+			affinityList, err := snapshot.HavePodsWithAffinityList()
+			if err != nil {
+				t.Fatalf("HavePodsWithAffinityList failed: %v", err)
+			}
+			gotAffinity := make([]string, 0, len(affinityList))
+			for _, n := range affinityList {
+				gotAffinity = append(gotAffinity, n.Node().Name)
+			}
+			slices.Sort(gotAffinity)
+			// Comparing sorted node name slices also catches duplicated entries.
+			if diff := cmp.Diff(sets.List(tt.expectedAffinity), gotAffinity); diff != "" {
+				t.Errorf("Unexpected affinity node list (-want +got):\n%s", diff)
+			}
+
+			antiAffinityList, err := snapshot.HavePodsWithRequiredAntiAffinityList()
+			if err != nil {
+				t.Fatalf("HavePodsWithRequiredAntiAffinityList failed: %v", err)
+			}
+			gotAntiAffinity := make([]string, 0, len(antiAffinityList))
+			for _, n := range antiAffinityList {
+				gotAntiAffinity = append(gotAntiAffinity, n.Node().Name)
+			}
+			slices.Sort(gotAntiAffinity)
+			if diff := cmp.Diff(sets.List(tt.expectedAntiAffinity), gotAntiAffinity); diff != "" {
+				t.Errorf("Unexpected anti-affinity node list (-want +got):\n%s", diff)
+			}
+
+			wantPVC := tt.expectedUsedPVCRefCounts
+			if wantPVC == nil {
+				wantPVC = map[string]int{}
+			}
+			if diff := cmp.Diff(wantPVC, snapshot.usedPVCRefCounts); diff != "" {
+				t.Errorf("Unexpected usedPVCRefCounts (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -19,6 +19,7 @@ package framework
 import (
 	"errors"
 	"fmt"
+	"iter"
 	"slices"
 	"sort"
 	"strings"
@@ -512,12 +513,7 @@ func (n *NodeInfo) updateUsedPorts(pod *v1.Pod, add bool) {
 
 // updatePVCRefCounts updates the PVCRefCounts of NodeInfo.
 func (n *NodeInfo) updatePVCRefCounts(pod *v1.Pod, add bool) {
-	for _, v := range pod.Spec.Volumes {
-		if v.PersistentVolumeClaim == nil {
-			continue
-		}
-
-		key := GetNamespacedName(pod.Namespace, v.PersistentVolumeClaim.ClaimName)
+	for key := range PodPVCKeys(pod) {
 		if add {
 			n.PVCRefCounts[key] += 1
 		} else {
@@ -1458,4 +1454,20 @@ func GetPodNamespacedName(pod *v1.Pod) string {
 // GetNamespacedName returns the string format of a namespaced resource name.
 func GetNamespacedName(namespace, name string) string {
 	return fmt.Sprintf("%s/%s", namespace, name)
+}
+
+// PodPVCKeys returns an iterator over the namespaced keys ("namespace/name") of
+// the PersistentVolumeClaims referenced by the pod's volumes. Volumes that are
+// not backed by a PVC are skipped.
+func PodPVCKeys(pod *v1.Pod) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		for _, v := range pod.Spec.Volumes {
+			if v.PersistentVolumeClaim == nil {
+				continue
+			}
+			if !yield(GetNamespacedName(pod.Namespace, v.PersistentVolumeClaim.ClaimName)) {
+				return
+			}
+		}
+	}
 }

--- a/test/integration/scheduler/podgroup/podgroup_affinity_test.go
+++ b/test/integration/scheduler/podgroup/podgroup_affinity_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podgroup
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	schedulingapi "k8s.io/api/scheduling/v1alpha3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/scheduler"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	stepsframework "k8s.io/kubernetes/test/integration/scheduler/podgroup/stepsframework"
+	testutils "k8s.io/kubernetes/test/integration/util"
+)
+
+const hostnameKey = "kubernetes.io/hostname"
+
+// TestPodGroupSchedulingWithPodAntiAffinity is a regression test for the snapshot
+// AssumePod/ForgetPod bug. During a PodGroup scheduling cycle the pods of a group
+// are assumed into the scheduler snapshot one by one, so the snapshot must keep
+// its havePodsWithRequiredAntiAffinityNodeInfoList consistent: otherwise the
+// InterPodAffinity plugin does not see the required anti-affinity terms of pods
+// assumed earlier in the same cycle and silently co-locates pods that should be
+// kept apart.
+//
+// The anti-affinity pod is created and enqueued first so the pod group cycle
+// (which orders pods of equal priority by enqueue time) always assumes it before
+// the plain pod, and it is pinned to node-1 so the assignment is deterministic.
+// The plain pod declares no anti-affinity of its own, so it can only be kept off
+// node-1 via the existing-pods anti-affinity term recorded in the snapshot when
+// the anti-affinity pod was assumed - exactly the path the fix repairs.
+//
+// The single-topology case is the deterministic regression signal: without the
+// fix the plain pod ignores the assumed anti-affinity pod, the group is silently
+// co-located on the only node and the "unschedulable" assertion fails. The
+// multi-topology case additionally checks that the plain pod lands on node-2.
+func TestPodGroupSchedulingWithPodAntiAffinity(t *testing.T) {
+	nodeCapacity := map[v1.ResourceName]string{v1.ResourceCPU: "2"}
+	podRequest := map[v1.ResourceName]string{v1.ResourceCPU: "1"}
+
+	// antiAffinityPod repels other pods labeled app=foo from its hostname. It is
+	// assumed first (created and enqueued before the plain pod) and pinned to
+	// node-1 for a deterministic assignment.
+	antiAffinityPod := st.MakePod().Name("anti-pod").Label("app", "foo").
+		Req(podRequest).Container("image").
+		NodeSelector(map[string]string{hostnameKey: "node-1"}).
+		PodAntiAffinity(hostnameKey, &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}}, st.PodAntiAffinityWithRequiredReq).
+		PodGroupName("pg").Priority(200).Obj()
+	// plainPod matches the anti-affinity pod's selector but declares no
+	// anti-affinity itself, so it can only be kept off node-1 via the existing-pods
+	// anti-affinity path that relies on the snapshot.
+	plainPod := st.MakePod().Name("plain-pod").Label("app", "foo").
+		Req(podRequest).Container("image").
+		PodGroupName("pg").Priority(200).Obj()
+
+	workload := st.MakeWorkload().Name("workload").
+		PodGroupTemplate(st.MakePodGroupTemplate().Name("t").MinCount(2).Obj()).Obj()
+	podGroup := st.MakePodGroup().Name("pg").WorkloadRef("t", "workload").Priority(200).MinCount(2).Obj()
+
+	tests := []struct {
+		name  string
+		nodes []*v1.Node
+		steps []stepsframework.Step
+	}{
+		{
+			name: "anti-affinity honored across the cycle on a multi-topology cluster",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node-1").Label(hostnameKey, "node-1").Capacity(nodeCapacity).Obj(),
+				st.MakeNode().Name("node-2").Label(hostnameKey, "node-2").Capacity(nodeCapacity).Obj(),
+			},
+			steps: []stepsframework.Step{
+				{
+					Name:           "Create the PodGroup object",
+					CreatePodGroup: podGroup,
+				},
+				{
+					Name:              "Create both pods belonging to the group",
+					CreatePodsInOrder: []*v1.Pod{antiAffinityPod, plainPod},
+				},
+				{
+					Name:                 "Verify both pods are scheduled",
+					WaitForPodsScheduled: []string{"anti-pod", "plain-pod"},
+				},
+				{
+					Name: "Verify the anti-affinity pod landed on node-1",
+					VerifyAssignments: &stepsframework.VerifyAssignments{
+						Pods:  []string{"anti-pod"},
+						Nodes: sets.New("node-1"),
+					},
+				},
+				{
+					Name: "Verify the plain pod was kept off node-1 and landed on node-2",
+					VerifyAssignments: &stepsframework.VerifyAssignments{
+						Pods:  []string{"plain-pod"},
+						Nodes: sets.New("node-2"),
+					},
+				},
+			},
+		},
+		{
+			name: "anti-affinity keeps the group unschedulable on a single-topology cluster",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node-1").Label(hostnameKey, "node-1").Capacity(nodeCapacity).Obj(),
+			},
+			steps: []stepsframework.Step{
+				{
+					Name:           "Create the PodGroup object",
+					CreatePodGroup: podGroup,
+				},
+				{
+					Name:              "Create both pods belonging to the group",
+					CreatePodsInOrder: []*v1.Pod{antiAffinityPod, plainPod},
+				},
+				{
+					Name:                     "Verify the group becomes unschedulable instead of co-locating",
+					WaitForPodsUnschedulable: []string{"anti-pod", "plain-pod"},
+				},
+				{
+					Name: "Verify PodGroup condition is set to Unschedulable",
+					WaitForPodGroupCondition: &stepsframework.PodGroupConditionCheck{
+						PodGroupName:    "pg",
+						ConditionStatus: metav1.ConditionFalse,
+						Reason:          schedulingapi.PodGroupReasonUnschedulable,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+				features.GenericWorkload: true,
+			})
+
+			testCtx := testutils.InitTestSchedulerWithNS(t, "podgroup-anti-affinity",
+				// disable backoff
+				scheduler.WithPodMaxBackoffSeconds(0),
+				scheduler.WithPodInitialBackoffSeconds(0))
+			ns := testCtx.NS.Name
+
+			commonSteps := []stepsframework.Step{
+				{
+					Name:        "Create Nodes",
+					CreateNodes: tt.nodes,
+				},
+				{
+					Name:            "Create workloads",
+					CreateWorkloads: []*schedulingapi.Workload{workload},
+				},
+			}
+
+			if err := stepsframework.RunSteps(testCtx, t, ns, append(commonSteps, tt.steps...)); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/test/integration/scheduler/podgroup/podgroup_pvc_test.go
+++ b/test/integration/scheduler/podgroup/podgroup_pvc_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podgroup
+
+import (
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	schedulingapi "k8s.io/api/scheduling/v1alpha3"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/kubernetes"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/component-helpers/storage/volume"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/scheduler"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	stepsframework "k8s.io/kubernetes/test/integration/scheduler/podgroup/stepsframework"
+	testutils "k8s.io/kubernetes/test/integration/util"
+)
+
+// createBoundRWOPPVC creates a HostPath PV and a PVC bound to it, both with the
+// ReadWriteOncePod access mode.
+func createBoundRWOPPVC(cs kubernetes.Interface, ns, name string) error {
+	storage := v1.VolumeResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Mi")}}
+	volType := v1.HostPathDirectoryOrCreate
+	pv, err := testutils.CreatePV(cs, st.MakePersistentVolume().
+		Name(fmt.Sprintf("pv-%s-%s", ns, name)).
+		AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
+		Capacity(storage.Requests).
+		HostPathVolumeSource(&v1.HostPathVolumeSource{Path: "/mnt", Type: &volType}).
+		Obj())
+	if err != nil {
+		return fmt.Errorf("cannot create pv: %w", err)
+	}
+	_, err = testutils.CreatePVC(cs, st.MakePersistentVolumeClaim().
+		Name(name).
+		Namespace(ns).
+		// Annotation and volume name required for PVC to be considered bound.
+		Annotation(volume.AnnBindCompleted, "true").
+		VolumeName(pv.Name).
+		AccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOncePod}).
+		Resources(storage).
+		Obj())
+	if err != nil {
+		return fmt.Errorf("cannot create pvc: %w", err)
+	}
+	return nil
+}
+
+// TestPodGroupSchedulingWithReadWriteOncePodPVC is a regression test for the
+// snapshot AssumePod/ForgetPod bug. During a PodGroup scheduling cycle the pods
+// of a group are assumed into the scheduler snapshot one by one, so AssumePod
+// must record the assumed pod's PVCs in the snapshot's usedPVCRefCounts:
+// otherwise the VolumeRestrictions plugin does not see that a ReadWriteOncePod
+// PVC is already used by a pod assumed earlier in the same cycle and silently
+// lets a second pod mount it.
+//
+// The first pod is created and enqueued first so the pod group cycle (which
+// orders pods of equal priority by enqueue time) always assumes it before the
+// second pod, although the conflict is symmetric: whichever pod is assumed
+// second must observe the PVC of the one assumed first. In the conflict case
+// both pods reference the same ReadWriteOncePod PVC, so the group must stay
+// unschedulable; without the fix both pods are scheduled and share the PVC in
+// violation of its access mode. The no-conflict case is the positive control:
+// with two distinct PVCs the same group schedules, proving the setup is
+// schedulable and the conflict case fails for the intended reason.
+func TestPodGroupSchedulingWithReadWriteOncePodPVC(t *testing.T) {
+	nodeCapacity := map[v1.ResourceName]string{v1.ResourceCPU: "2"}
+	podRequest := map[v1.ResourceName]string{v1.ResourceCPU: "1"}
+
+	workload := st.MakeWorkload().Name("workload").
+		PodGroupTemplate(st.MakePodGroupTemplate().Name("t").MinCount(2).Obj()).Obj()
+	podGroup := st.MakePodGroup().Name("pg").WorkloadRef("t", "workload").Priority(200).MinCount(2).Obj()
+
+	tests := []struct {
+		name string
+		// secondPodPVC is the PVC referenced by the pod assumed second in the
+		// cycle; the pod assumed first always references pvc-1.
+		secondPodPVC string
+		steps        []stepsframework.Step
+	}{
+		{
+			name:         "two pods sharing a ReadWriteOncePod PVC keep the group unschedulable",
+			secondPodPVC: "pvc-1",
+			steps: []stepsframework.Step{
+				{
+					Name:                     "Verify the group becomes unschedulable instead of sharing the PVC",
+					WaitForPodsUnschedulable: []string{"pvc-pod-1", "pvc-pod-2"},
+				},
+				{
+					Name: "Verify PodGroup condition is set to Unschedulable",
+					WaitForPodGroupCondition: &stepsframework.PodGroupConditionCheck{
+						PodGroupName:    "pg",
+						ConditionStatus: metav1.ConditionFalse,
+						Reason:          schedulingapi.PodGroupReasonUnschedulable,
+					},
+				},
+			},
+		},
+		{
+			name:         "two pods with distinct ReadWriteOncePod PVCs are scheduled",
+			secondPodPVC: "pvc-2",
+			steps: []stepsframework.Step{
+				{
+					Name:                 "Verify both pods are scheduled",
+					WaitForPodsScheduled: []string{"pvc-pod-1", "pvc-pod-2"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+				features.GenericWorkload: true,
+			})
+
+			testCtx := testutils.InitTestSchedulerWithNS(t, "podgroup-pvc",
+				// disable backoff
+				scheduler.WithPodMaxBackoffSeconds(0),
+				scheduler.WithPodInitialBackoffSeconds(0))
+			ns := testCtx.NS.Name
+
+			for _, pvcName := range sets.List(sets.New("pvc-1", tt.secondPodPVC)) {
+				if err := createBoundRWOPPVC(testCtx.ClientSet, ns, pvcName); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// firstPod is assumed first (created and enqueued before the second
+			// pod) and takes pvc-1.
+			firstPod := st.MakePod().Name("pvc-pod-1").
+				Req(podRequest).Container("image").
+				PVC("pvc-1").
+				PodGroupName("pg").Priority(200).Obj()
+			// secondPod is assumed second; whether its PVC conflicts with the
+			// first pod's depends on the test case.
+			secondPod := st.MakePod().Name("pvc-pod-2").
+				Req(podRequest).Container("image").
+				PVC(tt.secondPodPVC).
+				PodGroupName("pg").Priority(200).Obj()
+
+			commonSteps := []stepsframework.Step{
+				{
+					Name:        "Create Nodes",
+					CreateNodes: []*v1.Node{st.MakeNode().Name("node-1").Capacity(nodeCapacity).Obj()},
+				},
+				{
+					Name:            "Create workloads",
+					CreateWorkloads: []*schedulingapi.Workload{workload},
+				},
+				{
+					Name:           "Create the PodGroup object",
+					CreatePodGroup: podGroup,
+				},
+				{
+					Name:              "Create both pods belonging to the group",
+					CreatePodsInOrder: []*v1.Pod{firstPod, secondPod},
+				},
+			}
+
+			if err := stepsframework.RunSteps(testCtx, t, ns, append(commonSteps, tt.steps...)); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Snapshot.AssumePod and Snapshot.ForgetPod updated the per-node NodeInfo but did not maintain the snapshot-wide havePodsWithAffinityNodeInfoList, havePodsWithRequiredAntiAffinityNodeInfoList and usedPVCSet. As a result, inter-pod (anti-)affinity and VolumeRestrictions plugins observed stale state during the PodGroup scheduling cycle. This PR keeps those indexes consistent on assume and forget.

#### Which issue(s) this PR is related to:

Fixes #139028

#### Special notes for your reviewer:

- Affects only the PodGroup scheduling cycle (GenericWorkload, alpha).
- Mirrors existing logic in cacheImpl.addPod/removePod; cacheImpl itself is untouched.
- Unit tests added in snapshot_test.go covering affinity, anti-affinity, PVC tracking, symmetric forget, multiple affinity pods on one node, combined affinity/anti-affinity, and mixed volumes.

#### Does this PR introduce a user-facing change?

```release-note
kube-scheduler: fixed inter-pod (anti-)affinity and volume restriction evaluation during PodGroup scheduling cycles. The scheduler snapshot's AssumePod and ForgetPod now correctly maintain affinity node lists and PVC usage tracking.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: