### PR TITLE
Add Operation to run selective CPU profiling in scheduler benchmark

### DIFF
--- a/test/integration/scheduler_perf/executor.go
+++ b/test/integration/scheduler_perf/executor.go
@@ -23,7 +23,9 @@ import (
 	"maps"
 	"math"
 	"os"
+	"path/filepath"
 	"runtime"
+	"runtime/pprof"
 	"strings"
 	"sync"
 	"testing"
@@ -69,6 +71,7 @@ type WorkloadExecutor struct {
 	topicName                    string
 	nextNodeIndex                int
 	opts                         *schedulerPerfOptions
+	cpuProfileFile               *os.File
 }
 
 func (e *WorkloadExecutor) wait() {
@@ -98,6 +101,10 @@ func (e *WorkloadExecutor) runOp(tCtx ktesting.TContext, op realOp, opIndex int)
 		return e.runStartCollectingMetricsOp(tCtx, opIndex, concreteOp)
 	case *stopCollectingMetricsOp:
 		return e.runStopCollectingMetrics(tCtx, opIndex)
+	case *startCollectingProfileOp:
+		return e.runStartCollectingProfileOp(tCtx, opIndex, concreteOp)
+	case *stopCollectingProfileOp:
+		return e.runStopCollectingProfileOp(tCtx, opIndex, concreteOp)
 	case *createResourceDriverOp:
 		concreteOp.run(tCtx, e.scheduler.Profiles["default-scheduler"].SharedDRAManager())
 		return nil
@@ -459,6 +466,58 @@ func (e *WorkloadExecutor) runStartCollectingMetricsOp(tCtx ktesting.TContext, o
 		return err
 	}
 	return nil
+}
+
+// runStartCollectingProfileOp starts profile collection.
+// The output file is created relative to dataItemsDir if it is set.
+func (e *WorkloadExecutor) runStartCollectingProfileOp(tCtx ktesting.TContext, _ int, op *startCollectingProfileOp) error {
+	switch strings.ToUpper(op.Type) {
+	case "CPU":
+		if e.cpuProfileFile != nil {
+			return fmt.Errorf("cpu profile collection is already ongoing")
+		}
+		filePath := op.FilePath
+		if dataItemsDir != nil && *dataItemsDir != "" {
+			filePath = filepath.Join(*dataItemsDir, filePath)
+		}
+		if err := os.MkdirAll(filepath.Dir(filePath), 0750); err != nil {
+			return fmt.Errorf("failed to create directory for cpu profile: %w", err)
+		}
+		f, err := os.Create(filePath)
+		if err != nil {
+			return fmt.Errorf("failed to create file %q for cpu profile: %w", filePath, err)
+		}
+		if err := pprof.StartCPUProfile(f); err != nil {
+			if closeErr := f.Close(); closeErr != nil {
+				err = errors.Join(err, closeErr)
+			}
+			return fmt.Errorf("failed to start cpu profile: %w", err)
+		}
+		e.cpuProfileFile = f
+		tCtx.Logf("Started CPU profile collection into %q", filePath)
+		return nil
+	default:
+		return fmt.Errorf("unsupported profile type %q", op.Type)
+	}
+}
+
+func (e *WorkloadExecutor) runStopCollectingProfileOp(tCtx ktesting.TContext, _ int, op *stopCollectingProfileOp) error {
+	switch strings.ToUpper(op.Type) {
+	case "CPU":
+		if e.cpuProfileFile == nil {
+			return fmt.Errorf("missing startCollectingProfile operation before stopping")
+		}
+		pprof.StopCPUProfile()
+		err := e.cpuProfileFile.Close()
+		e.cpuProfileFile = nil
+		if err != nil {
+			return fmt.Errorf("failed to close cpu profile file: %w", err)
+		}
+		tCtx.Log("Stopped CPU profile collection")
+		return nil
+	default:
+		return fmt.Errorf("unsupported profile type %q", op.Type)
+	}
 }
 
 func startCollectingMetrics(tCtx ktesting.TContext, collectorWG *sync.WaitGroup, podInformer coreinformers.PodInformer, mcc *metricsCollectorConfig, throughputErrorMargin float64, opIndex int, name string, namespaces []string, labelSelector map[string]string) ([]testDataCollector, func(string), error) {

--- a/test/integration/scheduler_perf/executor_test.go
+++ b/test/integration/scheduler_perf/executor_test.go
@@ -996,3 +996,139 @@ func verifyNamespaceCreated(expectedNamespace string) verifyFunc {
 		return nil
 	}
 }
+
+func TestProfileCollection(t *testing.T) {
+	t.Run("successful collection", func(t *testing.T) {
+		tCtx := ktesting.Init(t)
+		tempDir := t.TempDir()
+		profilePath := filepath.Join(tempDir, "cpu-profile.out")
+
+		exec := &WorkloadExecutor{}
+		startOp := &startCollectingProfileOp{
+			Opcode:   startCollectingProfileOpcode,
+			Type:     "CPU",
+			FilePath: profilePath,
+		}
+
+		if err := exec.runOp(tCtx, startOp, 0); err != nil {
+			t.Fatalf("Failed to start CPU profile collection: %v", err)
+		}
+		if exec.cpuProfileFile == nil {
+			t.Fatalf("Expected cpuProfileFile to be set, got nil")
+		}
+
+		stopOp := &stopCollectingProfileOp{
+			Opcode: stopCollectingProfileOpcode,
+			Type:   "CPU",
+		}
+		if err := exec.runOp(tCtx, stopOp, 0); err != nil {
+			t.Fatalf("Failed to stop CPU profile collection: %v", err)
+		}
+		if exec.cpuProfileFile != nil {
+			t.Fatalf("Expected cpuProfileFile to be nil after stop, got %v", exec.cpuProfileFile)
+		}
+		if _, err := os.Stat(profilePath); err != nil {
+			t.Fatalf("Expected profile file %q to exist, got error: %v", profilePath, err)
+		}
+	})
+
+	t.Run("start while already ongoing", func(t *testing.T) {
+		tCtx := ktesting.Init(t)
+		tempDir := t.TempDir()
+		profilePath := filepath.Join(tempDir, "cpu-profile.out")
+
+		exec := &WorkloadExecutor{}
+		startOp := &startCollectingProfileOp{
+			Opcode:   startCollectingProfileOpcode,
+			Type:     "CPU",
+			FilePath: profilePath,
+		}
+
+		if err := exec.runOp(tCtx, startOp, 0); err != nil {
+			t.Fatalf("Failed to start CPU profile collection: %v", err)
+		}
+		if err := exec.runOp(tCtx, startOp, 0); err == nil {
+			t.Fatalf("Expected error starting profile collection while already ongoing, got nil")
+		}
+
+		if err := exec.runOp(tCtx, &stopCollectingProfileOp{
+			Opcode: stopCollectingProfileOpcode,
+			Type:   "CPU",
+		}, 0); err != nil {
+			t.Fatalf("Failed to stop CPU profile collection: %v", err)
+		}
+	})
+
+	t.Run("stop without starting", func(t *testing.T) {
+		tCtx := ktesting.Init(t)
+		exec := &WorkloadExecutor{}
+		stopOp := &stopCollectingProfileOp{
+			Opcode: stopCollectingProfileOpcode,
+			Type:   "CPU",
+		}
+
+		if err := exec.runOp(tCtx, stopOp, 0); err == nil {
+			t.Fatalf("Expected error stopping profile collection without starting, got nil")
+		}
+	})
+
+	t.Run("invalid profile for start", func(t *testing.T) {
+		startOp := &startCollectingProfileOp{
+			Opcode:   startCollectingProfileOpcode,
+			Type:     "MEMORY",
+			FilePath: "some-path.out",
+		}
+		if err := startOp.isValid(true); err == nil {
+			t.Fatalf("Expected error for invalid profile type, got nil")
+		}
+	})
+
+	t.Run("invalid profile for stop", func(t *testing.T) {
+		stopOp := &stopCollectingProfileOp{
+			Opcode: stopCollectingProfileOpcode,
+			Type:   "MEMORY",
+		}
+		if err := stopOp.isValid(true); err == nil {
+			t.Fatalf("Expected error for invalid profile type, got nil")
+		}
+	})
+
+	t.Run("successful collection with dataItemsDir", func(t *testing.T) {
+		tCtx := ktesting.Init(t)
+		tempDir := t.TempDir()
+		oldDataItemsDir := dataItemsDir
+		dataItemsDir = ptr.To(tempDir)
+		defer func() { dataItemsDir = oldDataItemsDir }()
+
+		profileName := "cpu-profile.out"
+		expectedPath := filepath.Join(tempDir, profileName)
+
+		exec := &WorkloadExecutor{}
+		startOp := &startCollectingProfileOp{
+			Opcode:   startCollectingProfileOpcode,
+			Type:     "CPU",
+			FilePath: profileName,
+		}
+
+		if err := exec.runOp(tCtx, startOp, 0); err != nil {
+			t.Fatalf("Failed to start CPU profile collection: %v", err)
+		}
+		if exec.cpuProfileFile == nil {
+			t.Fatalf("Expected cpuProfileFile to be set, got nil")
+		}
+
+		stopOp := &stopCollectingProfileOp{
+			Opcode: stopCollectingProfileOpcode,
+			Type:   "CPU",
+		}
+		if err := exec.runOp(tCtx, stopOp, 0); err != nil {
+			t.Fatalf("Failed to stop CPU profile collection: %v", err)
+		}
+		if exec.cpuProfileFile != nil {
+			t.Fatalf("Expected cpuProfileFile to be nil after stop, got %v", exec.cpuProfileFile)
+		}
+		if _, err := os.Stat(expectedPath); err != nil {
+			t.Fatalf("Expected profile file %q to exist, got error: %v", expectedPath, err)
+		}
+	})
+}

--- a/test/integration/scheduler_perf/operations.go
+++ b/test/integration/scheduler_perf/operations.go
@@ -700,6 +700,59 @@ func (scm stopCollectingMetricsOp) patchParams(_ *Workload) (realOp, error) {
 	return &scm, nil
 }
 
+// startCollectingProfileOp defines an op that starts profile collection.
+// stopCollectingProfileOp has to be used after this op to finish collecting.
+type startCollectingProfileOp struct {
+	// Must be "startCollectingProfile".
+	Opcode operationCode
+	// Type is the profile type to collect (currently only "CPU" is supported).
+	Type string
+	// FilePath is the path to the output profile file. If dataItemsDir is set,
+	// the file will be created relative to dataItemsDir.
+	FilePath string
+}
+
+func (scp *startCollectingProfileOp) isValid(_ bool) error {
+	if scp.FilePath == "" {
+		return fmt.Errorf("filePath cannot be empty")
+	}
+	if strings.ToUpper(scp.Type) != "CPU" {
+		return fmt.Errorf("only CPU profile type is supported, got %q", scp.Type)
+	}
+	return nil
+}
+
+func (*startCollectingProfileOp) collectsMetrics() bool {
+	return false
+}
+
+func (scp startCollectingProfileOp) patchParams(_ *Workload) (realOp, error) {
+	return &scp, nil
+}
+
+// stopCollectingProfileOp defines an op that stops profile collection.
+type stopCollectingProfileOp struct {
+	// Must be "stopCollectingProfile".
+	Opcode operationCode
+	// Type is the profile type to stop (currently only "CPU" is supported).
+	Type string
+}
+
+func (scp *stopCollectingProfileOp) isValid(_ bool) error {
+	if strings.ToUpper(scp.Type) != "CPU" {
+		return fmt.Errorf("only CPU profile type is supported, got %q", scp.Type)
+	}
+	return nil
+}
+
+func (*stopCollectingProfileOp) collectsMetrics() bool {
+	return false
+}
+
+func (scp stopCollectingProfileOp) patchParams(_ *Workload) (realOp, error) {
+	return &scp, nil
+}
+
 // resolveTemplateParams resolves the template parameters using the workload parameters.
 func resolveTemplateParams(templateParams map[string]any, w *Workload) (map[string]any, error) {
 	if len(templateParams) == 0 {

--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -77,6 +77,8 @@ const (
 	startCollectingMetricsOpcode operationCode = "startCollectingMetrics"
 	stopCollectingMetricsOpcode  operationCode = "stopCollectingMetrics"
 	waitForPodGroupsOpcode       operationCode = "waitForPodGroups"
+	startCollectingProfileOpcode operationCode = "startCollectingProfile"
+	stopCollectingProfileOpcode  operationCode = "stopCollectingProfile"
 )
 
 const (
@@ -515,6 +517,8 @@ func (op *op) UnmarshalJSON(b []byte) error {
 		startCollectingMetricsOpcode: &startCollectingMetricsOp{},
 		stopCollectingMetricsOpcode:  &stopCollectingMetricsOp{},
 		waitForPodGroupsOpcode:       &waitForPodGroups{},
+		startCollectingProfileOpcode: &startCollectingProfileOp{},
+		stopCollectingProfileOpcode:  &stopCollectingProfileOp{},
 		// TODO(#94601): add a delete nodes op to simulate scaling behaviour?
 	}
 	// First determine the opcode using lenient decoding (= ignore extra fields).


### PR DESCRIPTION
/sig scheduling

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR defines a new collector for collecting profiles in the selected part of the test. For now it supports only collecting CPU profiles. The idea behind is to avoid collection of profiles for steps of benchmark test that set up the cluster. For example in preemption tests we do not want to have in profile data, the scheduling of low priority pods as it can pollute the profile when trying to understand behavior of preemption.   

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

Sample use:

```
- name: SchedulingBasic
  defaultPodTemplatePath: ../templates/pod-default.yaml
  workloadTemplate:
  - opcode: createNodes
    countParam: $initNodes
  - opcode: createPods
    countParam: $initPods
  - opcode: startCollectingProfile
    type: cpu
    filepath: cpu-profile.out
  - opcode: createPods
    countParam: $measurePods
    collectMetrics: true
  - opcode: stopCollectingProfile
    type: cpu
...
```
 
