### PR TITLE
KEP-6075: Allow FQDN with trailing dot in HostAliases

### DIFF
--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -432,6 +432,7 @@ func GetValidationOptionsFromPodSpecAndMeta(podSpec, oldPodSpec *api.PodSpec, po
 		// This also allows restart rules on sidecar containers.
 		AllowRestartAllContainers:                               utilfeature.DefaultFeatureGate.Enabled(features.RestartAllContainersOnContainerExits),
 		AllowImageVolumeWithDigest:                              utilfeature.DefaultFeatureGate.Enabled(features.ImageVolumeWithDigest),
+		AllowHostAliasesFQDN:                                    utilfeature.DefaultFeatureGate.Enabled(features.HostAliasesAllowFQDN),
 		AllowExistingRestartContainerForNonSidecarInitContainer: hasRestartContainerForNonSidecarInitContainer(oldPodSpec),
 	}
 

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -4352,7 +4352,7 @@ func ValidateHostAliases(hostAliases []core.HostAlias, fldPath *field.Path) fiel
 	for i, hostAlias := range hostAliases {
 		allErrs = append(allErrs, IsValidIPForLegacyField(fldPath.Index(i).Child("ip"), hostAlias.IP, nil)...)
 		for j, hostname := range hostAlias.Hostnames {
-			allErrs = append(allErrs, ValidateDNS1123Subdomain(hostname, fldPath.Index(i).Child("hostnames").Index(j))...)
+			allErrs = append(allErrs, ValidateDNS1123Subdomain(strings.TrimSuffix(hostname, "."), fldPath.Index(i).Child("hostnames").Index(j))...)
 		}
 	}
 	return allErrs
@@ -4501,6 +4501,8 @@ type PodValidationOptions struct {
 	AllowImageVolumeWithDigest bool
 	// Allow empty image volume reference for backward compatibility
 	AllowEmptyImageVolumeReference bool
+	// Allow FQDN with trailing dot in HostAliases
+	AllowHostAliasesFQDN bool
 }
 
 // validatePodMetadataAndSpec tests if required fields in the pod.metadata and pod.spec are set,
@@ -5620,6 +5622,17 @@ func ValidatePodCreate(pod *core.Pod, opts PodValidationOptions) field.ErrorList
 	}
 	allErrs = append(allErrs, validateSeccompAnnotationsAndFields(pod.ObjectMeta, &pod.Spec, fldPath)...)
 	allErrs = append(allErrs, validateAppArmorAnnotationsAndFieldsMatchOnCreate(pod.ObjectMeta, &pod.Spec, fldPath)...)
+
+	if !opts.AllowHostAliasesFQDN {
+		for i, hostAlias := range pod.Spec.HostAliases {
+			for j, hostname := range hostAlias.Hostnames {
+				if strings.HasSuffix(hostname, ".") && hostname != "." {
+					allErrs = append(allErrs, field.Forbidden(fldPath.Child("hostAliases").Index(i).Child("hostnames").Index(j),
+						"trailing dot requires feature gate HostAliasesAllowFQDN"))
+				}
+			}
+		}
+	}
 
 	return allErrs
 }

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -10478,6 +10478,9 @@ func TestValidatePodSpec(t *testing.T) {
 		"populate HostAliases with `foo.bar` hostnames": podtest.MakePod("",
 			podtest.SetHostAliases(core.HostAlias{IP: "12.34.56.78", Hostnames: []string{"host1.foo", "host2.bar"}}),
 		),
+		"populate HostAliases with fqdn hostname": podtest.MakePod("",
+			podtest.SetHostAliases(core.HostAlias{IP: "10.10.10.10", Hostnames: []string{"example.com.", "localhost.", "my-server."}}),
+		),
 		"populate HostAliases with HostNetwork": podtest.MakePod("",
 			podtest.SetHostAliases(core.HostAlias{IP: "12.34.56.78", Hostnames: []string{"host1.foo", "host2.bar"}}),
 			podtest.SetSecurityContext(&core.PodSecurityContext{
@@ -10613,6 +10616,24 @@ func TestValidatePodSpec(t *testing.T) {
 				HostNetwork: false,
 			}),
 			podtest.SetHostAliases(core.HostAlias{IP: "12.34.56.78", Hostnames: []string{"@#$^#@#$"}}),
+		)},
+		"with hostAliases with bare dot": {pod: *podtest.MakePod("",
+			podtest.SetSecurityContext(&core.PodSecurityContext{
+				HostNetwork: false,
+			}),
+			podtest.SetHostAliases(core.HostAlias{IP: "12.34.56.78", Hostnames: []string{"."}}),
+		)},
+		"with hostAliases with double dot": {pod: *podtest.MakePod("",
+			podtest.SetSecurityContext(&core.PodSecurityContext{
+				HostNetwork: false,
+			}),
+			podtest.SetHostAliases(core.HostAlias{IP: "12.34.56.78", Hostnames: []string{".."}}),
+		)},
+		"with hostAliases with double fqdn dot": {pod: *podtest.MakePod("",
+			podtest.SetSecurityContext(&core.PodSecurityContext{
+				HostNetwork: false,
+			}),
+			podtest.SetHostAliases(core.HostAlias{IP: "12.34.56.78", Hostnames: []string{"example.com.."}}),
 		)},
 		"bad supplementalGroups large than math.MaxInt32": {pod: *podtest.MakePod("",
 			podtest.SetSecurityContext(&core.PodSecurityContext{
@@ -13083,6 +13104,24 @@ func TestValidatePod(t *testing.T) {
 				)),
 			),
 		},
+		"with hostAliases with trailing dot (gate disabled)": {
+			expectedError: "trailing dot requires feature gate HostAliasesAllowFQDN",
+			spec: *podtest.MakePod("test-pod",
+				podtest.SetHostAliases(core.HostAlias{IP: "10.10.10.10", Hostnames: []string{"example.com."}}),
+			),
+		},
+		"with hostAliases with bare dot (gate disabled)": {
+			expectedError: "a lowercase RFC 1123 subdomain must consist of",
+			spec: *podtest.MakePod("test-pod",
+				podtest.SetHostAliases(core.HostAlias{IP: "10.10.10.10", Hostnames: []string{"."}}),
+			),
+		},
+		"with hostAliases with double dot (gate disabled)": {
+			expectedError: "a lowercase RFC 1123 subdomain must consist of",
+			spec: *podtest.MakePod("test-pod",
+				podtest.SetHostAliases(core.HostAlias{IP: "10.10.10.10", Hostnames: []string{".."}}),
+			),
+		},
 	}
 
 	for k, v := range errorCases {
@@ -13093,6 +13132,58 @@ func TestValidatePod(t *testing.T) {
 				t.Errorf("missing expectedError, got %q", errs.ToAggregate().Error())
 			} else if actualError := errs.ToAggregate().Error(); !strings.Contains(actualError, v.expectedError) {
 				t.Errorf("expected error to contain %q, got %q", v.expectedError, actualError)
+			}
+		})
+	}
+}
+
+func TestValidatePodCreateHostAliasesFQDN(t *testing.T) {
+	fldPath := field.NewPath("spec")
+
+	tests := []struct {
+		name            string
+		pod             *core.Pod
+		opts            PodValidationOptions
+		wantFieldErrors field.ErrorList
+	}{
+		{
+			name: "fqdn hostname with gate enabled",
+			pod: podtest.MakePod("test-pod",
+				podtest.SetHostAliases(core.HostAlias{IP: "10.10.10.10", Hostnames: []string{"example.com.", "localhost.", "my-server."}}),
+			),
+			opts: PodValidationOptions{AllowHostAliasesFQDN: true, ResourceIsPod: true},
+		},
+		{
+			name: "fqdn hostname with gate disabled",
+			pod: podtest.MakePod("test-pod",
+				podtest.SetHostAliases(core.HostAlias{IP: "10.10.10.10", Hostnames: []string{"example.com."}}),
+			),
+			opts: PodValidationOptions{ResourceIsPod: true},
+			wantFieldErrors: []*field.Error{
+				field.Forbidden(fldPath.Child("hostAliases").Index(0).Child("hostnames").Index(0), "trailing dot requires feature gate HostAliasesAllowFQDN"),
+			},
+		},
+		{
+			name: "regular hostname works regardless of gate",
+			pod: podtest.MakePod("test-pod",
+				podtest.SetHostAliases(core.HostAlias{IP: "10.10.10.10", Hostnames: []string{"example.com"}}),
+			),
+			opts: PodValidationOptions{ResourceIsPod: true},
+		},
+		{
+			name: "single-label fqdn with gate enabled",
+			pod: podtest.MakePod("test-pod",
+				podtest.SetHostAliases(core.HostAlias{IP: "10.10.10.10", Hostnames: []string{"my-server."}}),
+			),
+			opts: PodValidationOptions{AllowHostAliasesFQDN: true, ResourceIsPod: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := ValidatePodCreate(tt.pod, tt.opts)
+			if diff := cmp.Diff(tt.wantFieldErrors, errs); diff != "" {
+				t.Errorf("unexpected field errors (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -410,6 +410,12 @@ const (
 	// Enables support of HPA scaling to zero pods when an object or custom metric is configured.
 	HPAScaleToZero featuregate.Feature = "HPAScaleToZero"
 
+	// owner: @aleoli
+	// kep: https://kep.k8s.io/6075
+	//
+	// Allow FQDN with trailing dot in HostAliases
+	HostAliasesAllowFQDN featuregate.Feature = "HostAliasesAllowFQDN"
+
 	// owner: @HirazawaUi
 	// kep: https://kep.k8s.io/4762
 	//
@@ -1440,6 +1446,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.16"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
+	HostAliasesAllowFQDN: {
+		{Version: version.MustParse("1.37"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
 	HostnameOverride: {
 		{Version: version.MustParse("1.34"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.35"), Default: true, PreRelease: featuregate.Beta},
@@ -2337,6 +2347,8 @@ var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]feature
 	HPAGeneration: {},
 
 	HPAScaleToZero: {},
+
+	HostAliasesAllowFQDN: {},
 
 	HostnameOverride: {},
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

Add a new alpha feature gate HostAliasesAllowFQDN that allows a trailing dot in hostnames under spec.hostAliases[].hostnames. The trailing dot denotes a Fully Qualified Domain Name (FQDN) as defined in RFC 1034, preventing DNS resolvers from appending the search path.

ValidateHostAliases unconditionally strips a single trailing dot using strings.TrimSuffix before calling ValidateDNS1123Subdomain, so the validation always succeeds for valid subdomains regardless of gate state. The feature gate is enforced via a check in ValidatePodCreate that rejects trailing dots when the gate is disabled, with automatic ratcheting on update. The trailing dot is stored verbatim in etcd so that the kubelet writes it into /etc/hosts as required for FQDN resolution.

#### Which issue(s) this PR is related to:

Fixes #135273

KEP: https://github.com/kubernetes/enhancements/issues/6075

#### Special notes for your reviewer:

```NONE```

#### Does this PR introduce a user-facing change?

```release-note
Introduce alpha feature gate `HostAliasesAllowFQDN` to allow a trailing
dot in `spec.hostAliases[].hostnames` for FQDN entries.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

[KEP-6075](https://github.com/kubernetes/enhancements/issues/6075)

/hold
