### PR TITLE
Avoid unnecessary locking in NominatedPodsForNode

### DIFF
--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -1369,7 +1369,9 @@ func (p *PriorityQueue) NominatedPodsForNode(nodeName string) []fwk.PodInfo {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 	nominatedPods := p.nominator.nominatedPodsForNode(nodeName)
-
+	if len(nominatedPods) == 0 {
+		return []fwk.PodInfo{}
+	}
 	pods := make([]fwk.PodInfo, len(nominatedPods))
 	p.activeQ.underRLock(func(unlockedActiveQ unlockedActiveQueueReader) {
 		for i, np := range nominatedPods {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR avoids taking a read lock on activeQ in NominatedPodsForNode when there are no nominated pods on this node.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This optimization cannot be performed by the compiler as it cannot guarantee that skipping the whole underRLock  lock when nominatedPods is empty will have zero impact on the rest of the program. 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

Results of SchedulingThroughput in SchedulingBasic/5000Nodes_50000Pods benchmark run on my machine with and without this (5 runs for each version):

| Data Item | Without Improvement | With Improvement  |
| :--- | :--- | :---  |
| Average | 785.7366676235331 | 809.5821830529862 |
| Perc50 | 828.3727787047475 | 857.6487852857269 |
| Perc90 | 949.2894488320479 | 974.0118854287510 |
| Perc95 | 957.0998439104506 | 980.3917290562785 |
| Perc99 | 974.3773843806541 | 1005.2207988641843 | 