### PR TITLE
kubelet: handle nil volume specs in DSW

### DIFF
--- a/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/desired_state_of_world.go
@@ -271,9 +271,13 @@ func (dsw *desiredStateOfWorld) AddPodToVolume(
 
 	volumePlugin, err := dsw.volumePluginMgr.FindPluginBySpec(volumeSpec)
 	if err != nil || volumePlugin == nil {
+		volumeSpecName := ""
+		if volumeSpec != nil {
+			volumeSpecName = volumeSpec.Name()
+		}
 		return "", fmt.Errorf(
 			"failed to get Plugin from volumeSpec for volume %q err=%v",
-			volumeSpec.Name(),
+			volumeSpecName,
 			err)
 	}
 	volumePluginName := getVolumePluginNameWithDriver(logger, volumePlugin, volumeSpec)

--- a/pkg/kubelet/volumemanager/cache/desired_state_of_world_test.go
+++ b/pkg/kubelet/volumemanager/cache/desired_state_of_world_test.go
@@ -19,6 +19,7 @@ package cache
 import (
 	"maps"
 	"slices"
+	"strings"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -81,6 +82,38 @@ func Test_AddPodToVolume_Positive_NewPodNewVolume(t *testing.T) {
 		t, generatedVolumeName, []string{"volume-name"}, false /* expectReportedInUse */, dsw)
 	verifyPodExistsInVolumeDsw(t, podName, generatedVolumeName, "" /* SELinuxContext */, dsw)
 	verifyVolumeExistsWithSpecNameInVolumeDsw(t, podName, volumeSpec.Name(), dsw)
+}
+
+// Calls AddPodToVolume() with a nil volume spec.
+// Verifies it returns an error and leaves the desired state unchanged.
+func Test_AddPodToVolume_Negative_NilVolumeSpec(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	volumePluginMgr, _ := volumetesting.GetTestKubeletVolumePluginMgr(t)
+	seLinuxTranslator := util.NewFakeSELinuxLabelTranslator()
+	dsw := NewDesiredStateOfWorld(volumePluginMgr, seLinuxTranslator)
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod-nil-volume-spec",
+			UID:  "pod-nil-volume-spec-uid",
+		},
+	}
+	podName := util.GetUniquePodName(pod)
+
+	generatedVolumeName, err := dsw.AddPodToVolume(
+		logger, podName, pod, nil, "" /* outerVolumeSpecName */, "" /* volumeGIDValue */, nil /* seLinuxContainerContexts */)
+
+	if err == nil {
+		t.Fatal("AddPodToVolume did not fail. Expected error for nil volume spec, got nil")
+	}
+	if !strings.Contains(err.Error(), "volume spec is nil") {
+		t.Fatalf("AddPodToVolume returned unexpected error. Expected to contain %q, got %q", "volume spec is nil", err.Error())
+	}
+	if generatedVolumeName != "" {
+		t.Fatalf("AddPodToVolume returned unexpected volume name. Expected empty, got %q", generatedVolumeName)
+	}
+	if volumesToMount := dsw.GetVolumesToMount(); len(volumesToMount) != 0 {
+		t.Fatalf("AddPodToVolume mutated desired state. Expected no volumes, got %v", volumesToMount)
+	}
 }
 
 // Calls AddPodToVolume() twice to add the same pod to the same volume


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node

#### What changed

`AddPodToVolume` now handles a nil `volumeSpec` on the plugin lookup error path without dereferencing it.

#### Why

`AddPodToVolume` already receives an error from the volume plugin manager when the volume spec is nil, but it dereferenced that nil spec while formatting the error message. That could panic before returning the plugin-manager error, and the desired state should remain unchanged.

This updates the error path to return the plugin-manager error without mutating desired state, and adds a regression test for that edge case.

#### Which issue(s) this PR is related to:

Related to #109717

#### How tested

- `go test ./pkg/kubelet/volumemanager/cache -run Test_AddPodToVolume_Negative_NilVolumeSpec -count=1`

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```