### PR TITLE
Automating etcd installation needed for tests

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -72,8 +72,6 @@ dependencies:
       match: ETCD_IMAGE|ETCD_VERSION
     - path: cmd/kubeadm/app/constants/constants.go
       match: DefaultEtcdVersion =
-    - path: hack/lib/etcd.sh
-      match: ETCD_VERSION=
     - path: staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
       match: registry.k8s.io/etcd
     - path: test/utils/image/manifest.go

--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -16,7 +16,7 @@
 
 # A set of helpers for starting/running etcd for tests
 
-ETCD_VERSION=${ETCD_VERSION:-3.7.0-rc.0}
+ETCD_VERSION=${ETCD_VERSION:-$(grep -oP "etcd_version',\s*'\K[0-9.]+" "${KUBE_ROOT}/cluster/gce/manifests/etcd.manifest" 2>/dev/null || echo "3.6.11")}
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 ETCD_PORT=${ETCD_PORT:-2379}
 # This is intentionally not called ETCD_LOG_LEVEL:
@@ -28,9 +28,13 @@ export KUBE_INTEGRATION_ETCD_URL="http://${ETCD_HOST}:${ETCD_PORT}"
 kube::etcd::validate() {
   # validate if in path
   command -v etcd >/dev/null || {
-    kube::log::usage "etcd must be in your PATH"
-    kube::log::info "You can use 'hack/install-etcd.sh' to install a copy in third_party/."
-    exit 1
+    if [[ -f "${KUBE_ROOT}/third_party/etcd/etcd" ]]; then
+      export PATH="${KUBE_ROOT}/third_party/etcd:${PATH}"
+      hash etcd
+    else
+      kube::log::usage "etcd must be in your PATH"
+      exit 1
+    fi
   }
 
   # validate etcd port is free
@@ -168,17 +172,20 @@ kube::etcd::install() {
       return 0 # already installed
     fi
 
+    local github_base_url="https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}"
+    local gcs_base_url="https://storage.googleapis.com/etcd/v${ETCD_VERSION}"
+
     if [[ ${os} == "darwin" ]]; then
       download_file="etcd-v${ETCD_VERSION}-${os}-${arch}.zip"
-      url="https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}/${download_file}"
-      kube::util::download_file "${url}" "${download_file}"
+      kube::util::download_file "${github_base_url}/${download_file}" "${download_file}" || \
+        kube::util::download_file "${gcs_base_url}/${download_file}" "${download_file}"
       unzip -o "${download_file}"
       ln -fns "etcd-v${ETCD_VERSION}-${os}-${arch}" etcd
       rm "${download_file}"
     elif [[ ${os} == "linux" ]]; then
-      url="https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-${os}-${arch}.tar.gz"
       download_file="etcd-v${ETCD_VERSION}-${os}-${arch}.tar.gz"
-      kube::util::download_file "${url}" "${download_file}"
+      kube::util::download_file "${github_base_url}/${download_file}" "${download_file}" || \
+        kube::util::download_file "${gcs_base_url}/${download_file}" "${download_file}"
       tar xzf "${download_file}"
       ln -fns "etcd-v${ETCD_VERSION}-${os}-${arch}" etcd
       rm "${download_file}"

--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -16,7 +16,7 @@
 
 # A set of helpers for starting/running etcd for tests
 
-ETCD_VERSION=${ETCD_VERSION:-$(grep -oP "etcd_version',\s*'\K[0-9.]+" "${KUBE_ROOT}/cluster/gce/manifests/etcd.manifest" 2>/dev/null || echo "3.6.11")}
+ETCD_VERSION=${ETCD_VERSION:-$(v=$(grep -oP "etcd_version',\s*'\K[^']+" "${KUBE_ROOT}/cluster/gce/manifests/etcd.manifest" 2>/dev/null | sed 's/-[0-9][0-9]*$//'); echo "${v:-3.6.11}")}
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 ETCD_PORT=${ETCD_PORT:-2379}
 # This is intentionally not called ETCD_LOG_LEVEL:
@@ -175,24 +175,26 @@ kube::etcd::install() {
     local github_base_url="https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}"
     local gcs_base_url="https://storage.googleapis.com/etcd/v${ETCD_VERSION}"
 
+    local download_file
     if [[ ${os} == "darwin" ]]; then
       download_file="etcd-v${ETCD_VERSION}-${os}-${arch}.zip"
-      kube::util::download_file "${github_base_url}/${download_file}" "${download_file}" || \
-        kube::util::download_file "${gcs_base_url}/${download_file}" "${download_file}"
-      unzip -o "${download_file}"
-      ln -fns "etcd-v${ETCD_VERSION}-${os}-${arch}" etcd
-      rm "${download_file}"
     elif [[ ${os} == "linux" ]]; then
       download_file="etcd-v${ETCD_VERSION}-${os}-${arch}.tar.gz"
-      kube::util::download_file "${github_base_url}/${download_file}" "${download_file}" || \
-        kube::util::download_file "${gcs_base_url}/${download_file}" "${download_file}"
-      tar xzf "${download_file}"
-      ln -fns "etcd-v${ETCD_VERSION}-${os}-${arch}" etcd
-      rm "${download_file}"
     else
       kube::log::info "${os} is NOT supported."
       return 1
     fi
+
+    kube::util::download_file "${github_base_url}/${download_file}" "${download_file}" || \
+      kube::util::download_file "${gcs_base_url}/${download_file}" "${download_file}"
+
+    if [[ ${download_file} == *.zip ]]; then
+      unzip -o "${download_file}"
+    else
+      tar xzf "${download_file}"
+    fi
+    ln -fns "etcd-v${ETCD_VERSION}-${os}-${arch}" etcd
+    rm "${download_file}"
     V=4 kube::log::info "installed etcd v${ETCD_VERSION}"
     return 0 # newly installed
   )

--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -106,16 +106,40 @@ runTests() {
   cleanup
 }
 
-checkEtcdOnPath() {
-  kube::log::status "Checking etcd is on PATH"
-  which etcd && return
-  kube::log::status "Cannot find etcd, cannot run integration tests."
-  kube::log::status "Please see https://git.k8s.io/community/contributors/devel/sig-testing/integration-tests.md#install-etcd-dependency for instructions."
-  kube::log::usage "You can use 'hack/install-etcd.sh' to install a copy in third_party/."
-  return 1
+checkOrInstallEtcd() {
+  local third_party_etcd="${KUBE_ROOT}/third_party/etcd/etcd"
+  local install_docs="Please see https://git.k8s.io/community/contributors/devel/sig-testing/integration-tests.md#install-etcd-dependency for instructions."
+  local required_version
+  required_version=$(grep -oP "etcd_version',\s*'\K[0-9.]+" "${KUBE_ROOT}/cluster/gce/manifests/etcd.manifest" 2>/dev/null || echo "")
+
+  if [[ ! -f "${third_party_etcd}" ]]; then
+    kube::log::status "etcd not found in third_party, installing"
+    kube::etcd::install || {
+      kube::log::status "Failed to install etcd. ${install_docs}"
+      return 1
+    }
+    return 0
+  fi
+
+  if [[ -n "${required_version}" ]]; then
+    local installed_version
+    installed_version=$("${third_party_etcd}" --version 2>/dev/null | grep Version | head -n 1 | cut -d " " -f 3)
+    if [[ "${installed_version}" != "${required_version}" ]]; then
+      kube::log::status "etcd version ${installed_version} differs from required ${required_version}, installing"
+      kube::etcd::install || {
+        kube::log::status "Failed to install etcd ${required_version}. ${install_docs}"
+        return 1
+      }
+      return 0
+    fi
+  fi
+
+  export PATH="${KUBE_ROOT}/third_party/etcd:${PATH}"
+  hash etcd
+  kube::log::status "etcd ${required_version} is ready"
 }
 
-checkEtcdOnPath
+checkOrInstallEtcd
 
 # Run cleanup to stop etcd on interrupt or other kill signal.
 trap cleanup EXIT


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

In few places ETCD locally installed is needed, for example to run integration tests. This PR adds automating ETCD installation in third_party directory when issuing integration tests as well as adding alternative download URL in case primary is not available or reachable.
The ETCD version is pulled from cluster/gce/manifests/etcd.manifest file so it will not have to be maintained separately in script itself.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
