### PR TITLE
Introduce PercentageOfPlacementsToScore limit for TAS

### DIFF
--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -460,6 +460,7 @@ func Setup(ctx context.Context, opts *options.Options, outOfTreeRegistryOptions 
 		scheduler.WithKubeConfig(cc.KubeConfig),
 		scheduler.WithProfiles(cc.ComponentConfig.Profiles...),
 		scheduler.WithPercentageOfNodesToScore(cc.ComponentConfig.PercentageOfNodesToScore),
+		scheduler.WithPercentageOfPlacementsToScore(cc.ComponentConfig.PercentageOfPlacementsToScore),
 		scheduler.WithFrameworkOutOfTreeRegistry(outOfTreeRegistry),
 		scheduler.WithPodMaxBackoffSeconds(cc.ComponentConfig.PodMaxBackoffSeconds),
 		scheduler.WithPodInitialBackoffSeconds(cc.ComponentConfig.PodInitialBackoffSeconds),

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -68634,6 +68634,13 @@ func schema_k8sio_kube_scheduler_config_v1_KubeSchedulerConfiguration(ref common
 							Format:      "int32",
 						},
 					},
+					"percentageOfPlacementsToScore": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PercentageOfPlacementsToScore is the percentage of all placements that once found feasible for running a pod group, the scheduler stops its search for more feasible placements in the cluster. This helps improve scheduler's performance. Scheduler always tries to find at least \"minFeasiblePlacementsToFind\" feasible placements no matter what the value of this flag is. Example: if the cluster size is 500 placements and the value of this flag is 30, then scheduler stops finding further feasible placements once it finds 150 feasible ones. When the value is 0, default percentage (5%--100% based on the generated placements) of the placements will be scored. It is overridden by profile level PercentageOfPlacementsToScore.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"podInitialBackoffSeconds": {
 						SchemaProps: spec.SchemaProps{
 							Description: "PodInitialBackoffSeconds is the initial backoff for unschedulable pods. If specified, it must be greater than 0. If this value is null, the default value (1s) will be used.",
@@ -68720,6 +68727,13 @@ func schema_k8sio_kube_scheduler_config_v1_KubeSchedulerProfile(ref common.Refer
 					"percentageOfNodesToScore": {
 						SchemaProps: spec.SchemaProps{
 							Description: "PercentageOfNodesToScore is the percentage of all nodes that once found feasible for running a pod, the scheduler stops its search for more feasible nodes in the cluster. This helps improve scheduler's performance. Scheduler always tries to find at least \"minFeasibleNodesToFind\" feasible nodes no matter what the value of this flag is. Example: if the cluster size is 500 nodes and the value of this flag is 30, then scheduler stops finding further feasible nodes once it finds 150 feasible ones. When the value is 0, default percentage (5%--50% based on the size of the cluster) of the nodes will be scored. It will override global PercentageOfNodesToScore. If it is empty, global PercentageOfNodesToScore will be used.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"percentageOfPlacementsToScore": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PercentageOfPlacementsToScore is the percentage of all placements that once found feasible for running a pod group, the scheduler stops its search for more feasible placements in the cluster. This helps improve scheduler's performance. Scheduler always tries to find at least \"minFeasiblePlacementsToFind\" feasible placements no matter what the value of this flag is. Example: if the cluster size is 500 placements and the value of this flag is 30, then scheduler stops finding further feasible placements once it finds 150 feasible ones. When the value is 0, default percentage (5%--100% based on the generated placements) of the placements will be scored. It will override global PercentageOfPlacementsToScore. If it is empty, global PercentageOfPlacementsToScore will be used.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},

--- a/pkg/scheduler/apis/config/scheme/scheme_test.go
+++ b/pkg/scheduler/apis/config/scheme/scheme_test.go
@@ -216,6 +216,40 @@ profiles:
 			},
 		},
 		{
+			name: "v1 with non-default global percentageOfPlacementsToScore",
+			data: []byte(`
+apiVersion: kubescheduler.config.k8s.io/v1
+kind: KubeSchedulerConfiguration
+percentageOfPlacementsToScore: 10
+`),
+			wantProfiles: []config.KubeSchedulerProfile{
+				{
+					SchedulerName:                 "default-scheduler",
+					PercentageOfPlacementsToScore: nil,
+					Plugins:                       defaults.PluginsV1,
+					PluginConfig:                  defaults.PluginConfigsV1,
+				},
+			},
+		},
+		{
+			name: "v1 with non-default global and profile percentageOfPlacementsToScore",
+			data: []byte(`
+apiVersion: kubescheduler.config.k8s.io/v1
+kind: KubeSchedulerConfiguration
+percentageOfPlacementsToScore: 10
+profiles:
+- percentageOfPlacementsToScore: 20
+`),
+			wantProfiles: []config.KubeSchedulerProfile{
+				{
+					SchedulerName:                 "default-scheduler",
+					PercentageOfPlacementsToScore: ptr.To[int32](20),
+					Plugins:                       defaults.PluginsV1,
+					PluginConfig:                  defaults.PluginConfigsV1,
+				},
+			},
+		},
+		{
 			name: "v1 plugins can include version and kind",
 			data: []byte(`
 apiVersion: kubescheduler.config.k8s.io/v1

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -69,6 +69,16 @@ type KubeSchedulerConfiguration struct {
 	// nodes will be scored. It is overridden by profile level PercentageOfNodesToScore.
 	PercentageOfNodesToScore *int32
 
+	// PercentageOfPlacementsToScore is the percentage of all placements that once found feasible
+	// for running a pod group, the scheduler stops its search for more feasible placements in
+	// the cluster. This helps improve scheduler's performance. Scheduler always tries to find
+	// at least "minFeasiblePlacementsToFind" feasible placements no matter what the value of this flag is.
+	// Example: if the cluster size is 500 placements and the value of this flag is 30,
+	// then scheduler stops finding further feasible placements once it finds 150 feasible ones.
+	// When the value is 0, default percentage (5%--100% based on the generated placements) of the
+	// placements will be scored. It is overridden by profile level PercentageOfPlacementsToScore.
+	PercentageOfPlacementsToScore *int32
+
 	// PodInitialBackoffSeconds is the initial backoff for unschedulable pods.
 	// If specified, it must be greater than 0. If this value is null, the default value (1s)
 	// will be used.
@@ -113,6 +123,17 @@ type KubeSchedulerProfile struct {
 	// nodes will be scored. It will override global PercentageOfNodesToScore. If it is empty,
 	// global PercentageOfNodesToScore will be used.
 	PercentageOfNodesToScore *int32
+
+	// PercentageOfPlacementsToScore is the percentage of all placements that once found feasible
+	// for running a pod group, the scheduler stops its search for more feasible placements in
+	// the cluster. This helps improve scheduler's performance. Scheduler always tries to find
+	// at least "minFeasiblePlacementsToFind" feasible placements no matter what the value of this flag is.
+	// Example: if the cluster size is 500 placements and the value of this flag is 30,
+	// then scheduler stops finding further feasible placements once it finds 150 feasible ones.
+	// When the value is 0, default percentage (5%--100% based on the generated placements) of the
+	// placements will be scored. It will override global PercentageOfPlacementsToScore. If it is empty,
+	// global PercentageOfPlacementsToScore will be used.
+	PercentageOfPlacementsToScore *int32
 
 	// Plugins specify the set of plugins that should be enabled or disabled.
 	// Enabled plugins are the ones that should be enabled in addition to the
@@ -221,6 +242,11 @@ const (
 	// that once found feasible, the scheduler stops looking for more nodes.
 	// A value of 0 means adaptive, meaning the scheduler figures out a proper default.
 	DefaultPercentageOfNodesToScore = 0
+
+	// DefaultPercentageOfPlacementsToScore defines the percentage of placements of all placements
+	// that once found feasible, the scheduler stops looking for more placements.
+	// A value of 0 means adaptive, meaning the scheduler figures out a proper default.
+	DefaultPercentageOfPlacementsToScore = 0
 
 	// MaxCustomPriorityScore is the max score UtilizationShapePoint expects.
 	MaxCustomPriorityScore int64 = 10

--- a/pkg/scheduler/apis/config/v1/defaults.go
+++ b/pkg/scheduler/apis/config/v1/defaults.go
@@ -130,6 +130,10 @@ func SetDefaults_KubeSchedulerConfiguration(obj *configv1.KubeSchedulerConfigura
 		obj.PercentageOfNodesToScore = ptr.To[int32](config.DefaultPercentageOfNodesToScore)
 	}
 
+	if obj.PercentageOfPlacementsToScore == nil && feature.DefaultFeatureGate.Enabled(features.TopologyAwareWorkloadScheduling) {
+		obj.PercentageOfPlacementsToScore = ptr.To[int32](config.DefaultPercentageOfPlacementsToScore)
+	}
+
 	if len(obj.LeaderElection.ResourceLock) == 0 {
 		// Use lease-based leader election to reduce cost.
 		// We migrated for EndpointsLease lock in 1.17 and starting in 1.20 we

--- a/pkg/scheduler/apis/config/v1/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1/defaults_test.go
@@ -701,11 +701,51 @@ func TestSchedulerDefaults(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "default TopologyAwareWorkloadScheduling",
+			features: map[featuregate.Feature]bool{features.GenericWorkload: true, features.TopologyAwareWorkloadScheduling: true},
+			config:   &configv1.KubeSchedulerConfiguration{},
+			expected: &configv1.KubeSchedulerConfiguration{
+				Parallelism: ptr.To[int32](16),
+				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
+					EnableProfiling:           &enable,
+					EnableContentionProfiling: &enable,
+				},
+				LeaderElection: componentbaseconfig.LeaderElectionConfiguration{
+					LeaderElect:       ptr.To(true),
+					LeaseDuration:     metav1.Duration{Duration: 15 * time.Second},
+					RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
+					RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
+					ResourceLock:      "leases",
+					ResourceNamespace: "kube-system",
+					ResourceName:      "kube-scheduler",
+				},
+				ClientConnection: componentbaseconfig.ClientConnectionConfiguration{
+					QPS:         50,
+					Burst:       100,
+					ContentType: "application/vnd.kubernetes.protobuf",
+				},
+				PercentageOfNodesToScore:      ptr.To[int32](config.DefaultPercentageOfNodesToScore),
+				PercentageOfPlacementsToScore: ptr.To[int32](config.DefaultPercentageOfPlacementsToScore),
+				PodInitialBackoffSeconds:      ptr.To[int64](1),
+				PodMaxBackoffSeconds:          ptr.To[int64](10),
+				Profiles: []configv1.KubeSchedulerProfile{
+					{
+						Plugins:       getDefaultPlugins(),
+						PluginConfig:  pluginConfigs,
+						SchedulerName: ptr.To("default-scheduler"),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGatesDuringTest(t, feature.DefaultFeatureGate, tc.features)
+			if len(tc.features) > 0 && len(tc.expected.Profiles) > 0 {
+				tc.expected.Profiles[0].Plugins = getDefaultPlugins()
+			}
 			SetDefaults_KubeSchedulerConfiguration(tc.config)
 			if diff := cmp.Diff(tc.expected, tc.config); diff != "" {
 				t.Errorf("Got unexpected defaults (-want, +got):\n%s", diff)

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -443,6 +443,7 @@ func autoConvert_v1_KubeSchedulerConfiguration_To_config_KubeSchedulerConfigurat
 		return err
 	}
 	out.PercentageOfNodesToScore = (*int32)(unsafe.Pointer(in.PercentageOfNodesToScore))
+	out.PercentageOfPlacementsToScore = (*int32)(unsafe.Pointer(in.PercentageOfPlacementsToScore))
 	if err := metav1.Convert_Pointer_int64_To_int64(&in.PodInitialBackoffSeconds, &out.PodInitialBackoffSeconds, s); err != nil {
 		return err
 	}
@@ -479,6 +480,7 @@ func autoConvert_config_KubeSchedulerConfiguration_To_v1_KubeSchedulerConfigurat
 		return err
 	}
 	out.PercentageOfNodesToScore = (*int32)(unsafe.Pointer(in.PercentageOfNodesToScore))
+	out.PercentageOfPlacementsToScore = (*int32)(unsafe.Pointer(in.PercentageOfPlacementsToScore))
 	if err := metav1.Convert_int64_To_Pointer_int64(&in.PodInitialBackoffSeconds, &out.PodInitialBackoffSeconds, s); err != nil {
 		return err
 	}
@@ -506,6 +508,7 @@ func autoConvert_v1_KubeSchedulerProfile_To_config_KubeSchedulerProfile(in *conf
 		return err
 	}
 	out.PercentageOfNodesToScore = (*int32)(unsafe.Pointer(in.PercentageOfNodesToScore))
+	out.PercentageOfPlacementsToScore = (*int32)(unsafe.Pointer(in.PercentageOfPlacementsToScore))
 	if in.Plugins != nil {
 		in, out := &in.Plugins, &out.Plugins
 		*out = new(config.Plugins)
@@ -539,6 +542,7 @@ func autoConvert_config_KubeSchedulerProfile_To_v1_KubeSchedulerProfile(in *conf
 		return err
 	}
 	out.PercentageOfNodesToScore = (*int32)(unsafe.Pointer(in.PercentageOfNodesToScore))
+	out.PercentageOfPlacementsToScore = (*int32)(unsafe.Pointer(in.PercentageOfPlacementsToScore))
 	if in.Plugins != nil {
 		in, out := &in.Plugins, &out.Plugins
 		*out = new(configv1.Plugins)

--- a/pkg/scheduler/apis/config/validation/validation.go
+++ b/pkg/scheduler/apis/config/validation/validation.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apiserver/pkg/util/feature"
 	componentbasevalidation "k8s.io/component-base/config/validation"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	schedfeature "k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 )
@@ -69,6 +70,7 @@ func ValidateKubeSchedulerConfiguration(cc *config.KubeSchedulerConfiguration) u
 	}
 
 	errs = append(errs, validatePercentageOfNodesToScore(field.NewPath("percentageOfNodesToScore"), cc.PercentageOfNodesToScore))
+	errs = append(errs, validatePercentageOfPlacementsToScore(field.NewPath("percentageOfPlacementsToScore"), cc.PercentageOfPlacementsToScore))
 
 	if cc.PodInitialBackoffSeconds <= 0 {
 		errs = append(errs, field.Invalid(field.NewPath("podInitialBackoffSeconds"),
@@ -87,6 +89,18 @@ func validatePercentageOfNodesToScore(path *field.Path, percentageOfNodesToScore
 	if percentageOfNodesToScore != nil {
 		if *percentageOfNodesToScore < 0 || *percentageOfNodesToScore > 100 {
 			return field.Invalid(path, *percentageOfNodesToScore, "not in valid range [0-100]")
+		}
+	}
+	return nil
+}
+
+func validatePercentageOfPlacementsToScore(path *field.Path, percentageOfPlacementsToScore *int32) error {
+	if percentageOfPlacementsToScore != nil {
+		if !feature.DefaultFeatureGate.Enabled(features.TopologyAwareWorkloadScheduling) {
+			return field.Forbidden(path, "TopologyAwareWorkloadScheduling feature gate is disabled")
+		}
+		if *percentageOfPlacementsToScore < 0 || *percentageOfPlacementsToScore > 100 {
+			return field.Invalid(path, *percentageOfPlacementsToScore, "not in valid range [0-100]")
 		}
 	}
 	return nil
@@ -144,6 +158,7 @@ func validateKubeSchedulerProfile(path *field.Path, apiVersion string, profile *
 		errs = append(errs, field.Required(path.Child("schedulerName"), ""))
 	}
 	errs = append(errs, validatePercentageOfNodesToScore(path.Child("percentageOfNodesToScore"), profile.PercentageOfNodesToScore))
+	errs = append(errs, validatePercentageOfPlacementsToScore(path.Child("percentageOfPlacementsToScore"), profile.PercentageOfPlacementsToScore))
 	errs = append(errs, validatePluginConfig(path, apiVersion, profile)...)
 	return errs
 }

--- a/pkg/scheduler/apis/config/validation/validation_test.go
+++ b/pkg/scheduler/apis/config/validation/validation_test.go
@@ -23,7 +23,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	componentbaseconfig "k8s.io/component-base/config"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	configv1 "k8s.io/kubernetes/pkg/scheduler/apis/config/v1"
 	"k8s.io/utils/ptr"
@@ -196,8 +199,9 @@ func TestValidateKubeSchedulerConfigurationV1(t *testing.T) {
 	invalidPlugins.Profiles[0].Plugins.Score.Enabled = append(invalidPlugins.Profiles[0].Plugins.Score.Enabled, config.Plugin{Name: "GCEPDLimits"})
 
 	scenarios := map[string]struct {
-		config   *config.KubeSchedulerConfiguration
-		wantErrs field.ErrorList
+		featureOverrides featuregatetesting.FeatureOverrides
+		config           *config.KubeSchedulerConfiguration
+		wantErrs         field.ErrorList
 	}{
 		"good": {
 			config: validConfig,
@@ -253,6 +257,110 @@ func TestValidateKubeSchedulerConfigurationV1(t *testing.T) {
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
 					Field: "percentageOfNodesToScore",
+				},
+			},
+		},
+		"percentage-of-placements-to-score-forbidden-with-tas-disabled": {
+			featureOverrides: featuregatetesting.FeatureOverrides{
+				features.TopologyAwareWorkloadScheduling: false,
+			},
+			config: setPercentageOfPlacementsToScore(validConfig, 50),
+			wantErrs: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeForbidden,
+					Field: "percentageOfPlacementsToScore",
+				},
+			},
+		},
+		"percentage-of-placements-to-score-lower-bound": {
+			featureOverrides: featuregatetesting.FeatureOverrides{
+				features.GenericWorkload:                 true,
+				features.TopologyAwareWorkloadScheduling: true,
+			},
+			config: setPercentageOfPlacementsToScore(validConfig, 0),
+		},
+		"percentage-of-placements-to-score-upper-bound": {
+			featureOverrides: featuregatetesting.FeatureOverrides{
+				features.GenericWorkload:                 true,
+				features.TopologyAwareWorkloadScheduling: true,
+			},
+			config: setPercentageOfPlacementsToScore(validConfig, 100),
+		},
+		"percentage-of-placements-to-score-greater-than-100": {
+			featureOverrides: featuregatetesting.FeatureOverrides{
+				features.GenericWorkload:                 true,
+				features.TopologyAwareWorkloadScheduling: true,
+			},
+			config: setPercentageOfPlacementsToScore(validConfig, 101),
+			wantErrs: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "percentageOfPlacementsToScore",
+				},
+			},
+		},
+		"percentage-of-placements-to-score-less-than-0": {
+			featureOverrides: featuregatetesting.FeatureOverrides{
+				features.GenericWorkload:                 true,
+				features.TopologyAwareWorkloadScheduling: true,
+			},
+			config: setPercentageOfPlacementsToScore(validConfig, -1),
+			wantErrs: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "percentageOfPlacementsToScore",
+				},
+			},
+		},
+		"profile-percentage-of-placements-to-score-forbidden-with-tas-disabled": {
+			featureOverrides: featuregatetesting.FeatureOverrides{
+				features.TopologyAwareWorkloadScheduling: false,
+			},
+			config: setProfilePercentageOfPlacementsToScore(validConfig, 50),
+			wantErrs: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeForbidden,
+					Field: "profiles[0].percentageOfPlacementsToScore",
+				},
+			},
+		},
+		"profile-percentage-of-placements-to-score-lower-bound": {
+			featureOverrides: featuregatetesting.FeatureOverrides{
+				features.GenericWorkload:                 true,
+				features.TopologyAwareWorkloadScheduling: true,
+			},
+			config: setProfilePercentageOfPlacementsToScore(validConfig, 0),
+		},
+		"profile-percentage-of-placements-to-score-upper-bound": {
+			featureOverrides: featuregatetesting.FeatureOverrides{
+				features.GenericWorkload:                 true,
+				features.TopologyAwareWorkloadScheduling: true,
+			},
+			config: setProfilePercentageOfPlacementsToScore(validConfig, 100),
+		},
+		"profile-percentage-of-placements-to-score-greater-than-100": {
+			featureOverrides: featuregatetesting.FeatureOverrides{
+				features.GenericWorkload:                 true,
+				features.TopologyAwareWorkloadScheduling: true,
+			},
+			config: setProfilePercentageOfPlacementsToScore(validConfig, 101),
+			wantErrs: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "profiles[0].percentageOfPlacementsToScore",
+				},
+			},
+		},
+		"profile-percentage-of-placements-to-score-less-than-0": {
+			featureOverrides: featuregatetesting.FeatureOverrides{
+				features.GenericWorkload:                 true,
+				features.TopologyAwareWorkloadScheduling: true,
+			},
+			config: setProfilePercentageOfPlacementsToScore(validConfig, -1),
+			wantErrs: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "profiles[0].percentageOfPlacementsToScore",
 				},
 			},
 		},
@@ -401,6 +509,7 @@ func TestValidateKubeSchedulerConfigurationV1(t *testing.T) {
 
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, scenario.featureOverrides)
 			errs := ValidateKubeSchedulerConfiguration(scenario.config)
 			diff := cmp.Diff(scenario.wantErrs.ToAggregate(), errs, ignoreBadValueDetail)
 			if diff != "" {
@@ -408,4 +517,16 @@ func TestValidateKubeSchedulerConfigurationV1(t *testing.T) {
 			}
 		})
 	}
+}
+
+func setPercentageOfPlacementsToScore(config *config.KubeSchedulerConfiguration, value int32) *config.KubeSchedulerConfiguration {
+	newConfig := config.DeepCopy()
+	newConfig.PercentageOfPlacementsToScore = &value
+	return newConfig
+}
+
+func setProfilePercentageOfPlacementsToScore(config *config.KubeSchedulerConfiguration, value int32) *config.KubeSchedulerConfiguration {
+	newConfig := config.DeepCopy()
+	newConfig.Profiles[0].PercentageOfPlacementsToScore = &value
+	return newConfig
 }

--- a/pkg/scheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/zz_generated.deepcopy.go
@@ -198,6 +198,11 @@ func (in *KubeSchedulerConfiguration) DeepCopyInto(out *KubeSchedulerConfigurati
 		*out = new(int32)
 		**out = **in
 	}
+	if in.PercentageOfPlacementsToScore != nil {
+		in, out := &in.PercentageOfPlacementsToScore, &out.PercentageOfPlacementsToScore
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Profiles != nil {
 		in, out := &in.Profiles, &out.Profiles
 		*out = make([]KubeSchedulerProfile, len(*in))
@@ -238,6 +243,11 @@ func (in *KubeSchedulerProfile) DeepCopyInto(out *KubeSchedulerProfile) {
 	*out = *in
 	if in.PercentageOfNodesToScore != nil {
 		in, out := &in.PercentageOfNodesToScore, &out.PercentageOfNodesToScore
+		*out = new(int32)
+		**out = **in
+	}
+	if in.PercentageOfPlacementsToScore != nil {
+		in, out := &in.PercentageOfPlacementsToScore, &out.PercentageOfPlacementsToScore
 		*out = new(int32)
 		**out = **in
 	}

--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -291,6 +291,9 @@ type Framework interface {
 	// HasScorePlugins returns true if at least one Score plugin is defined.
 	HasScorePlugins() bool
 
+	// HasPlacementScorePlugins returns true if at least one PlacementScore plugin is defined.
+	HasPlacementScorePlugins() bool
+
 	// PodGroupPostFilterPlugins returns registered PodGroupPostFilter plugins.
 	PodGroupPostFilterPlugins() []PodGroupPostFilterPlugin
 
@@ -299,6 +302,9 @@ type Framework interface {
 
 	// PercentageOfNodesToScore returns percentageOfNodesToScore associated to a profile.
 	PercentageOfNodesToScore() *int32
+
+	// PercentageOfPlacementsToScore returns percentageOfPlacementsToScore associated to a profile.
+	PercentageOfPlacementsToScore() *int32
 
 	// SetPodNominator sets the PodNominator
 	SetPodNominator(nominator fwk.PodNominator)

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -94,9 +94,10 @@ type frameworkImpl struct {
 
 	sharedCSIManager fwk.CSIManager
 
-	metricsRecorder          *metrics.MetricAsyncRecorder
-	profileName              string
-	percentageOfNodesToScore *int32
+	metricsRecorder               *metrics.MetricAsyncRecorder
+	profileName                   string
+	percentageOfNodesToScore      *int32
+	percentageOfPlacementsToScore *int32
 
 	extenders []fwk.Extender
 	fwk.PodNominator
@@ -373,6 +374,7 @@ func NewFramework(ctx context.Context, r Registry, profile *config.KubeScheduler
 
 	f.profileName = profile.SchedulerName
 	f.percentageOfNodesToScore = profile.PercentageOfNodesToScore
+	f.percentageOfPlacementsToScore = profile.PercentageOfPlacementsToScore
 	if profile.Plugins == nil {
 		return f, nil
 	}
@@ -389,10 +391,11 @@ func NewFramework(ctx context.Context, r Registry, profile *config.KubeScheduler
 		pluginConfig[name] = profile.PluginConfig[i].Args
 	}
 	outputProfile := config.KubeSchedulerProfile{
-		SchedulerName:            f.profileName,
-		PercentageOfNodesToScore: f.percentageOfNodesToScore,
-		Plugins:                  profile.Plugins,
-		PluginConfig:             make([]config.PluginConfig, 0, len(pg)),
+		SchedulerName:                 f.profileName,
+		PercentageOfNodesToScore:      f.percentageOfNodesToScore,
+		PercentageOfPlacementsToScore: f.percentageOfPlacementsToScore,
+		Plugins:                       profile.Plugins,
+		PluginConfig:                  make([]config.PluginConfig, 0, len(pg)),
 	}
 
 	f.pluginsMap = make(map[string]fwk.Plugin)
@@ -2139,6 +2142,11 @@ func (f *frameworkImpl) HasScorePlugins() bool {
 	return len(f.scorePlugins) > 0
 }
 
+// HasPlacementScorePlugins returns true if at least one placementScore plugin is defined.
+func (f *frameworkImpl) HasPlacementScorePlugins() bool {
+	return len(f.placementScorePlugins) > 0
+}
+
 // PodGroupPostFilterPlugins returns registered PodGroup PostFilter plugins.
 func (f *frameworkImpl) PodGroupPostFilterPlugins() []framework.PodGroupPostFilterPlugin {
 	return f.podGroupPostFilterPlugins
@@ -2237,6 +2245,11 @@ func (f *frameworkImpl) ProfileName() string {
 // PercentageOfNodesToScore returns percentageOfNodesToScore associated to a profile.
 func (f *frameworkImpl) PercentageOfNodesToScore() *int32 {
 	return f.percentageOfNodesToScore
+}
+
+// PercentageOfPlacementsToScore returns percentageOfPlacementsToScore associated to a profile.
+func (f *frameworkImpl) PercentageOfPlacementsToScore() *int32 {
+	return f.percentageOfPlacementsToScore
 }
 
 // Parallelizer returns a parallelizer holding parallelism for scheduler.

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -70,9 +70,10 @@ const (
 	placementGeneratePlugin           = "placement-generate-plugin"
 	defaultPreemptionPlugin           = names.DefaultPreemption
 
-	testProfileName              = "test-profile"
-	testPercentageOfNodesToScore = 35
-	nodeName                     = "testNode"
+	testProfileName                   = "test-profile"
+	testPercentageOfNodesToScore      = 35
+	testPercentageOfPlacementsToScore = 10
+	nodeName                          = "testNode"
 
 	injectReason       = "injected status"
 	injectFilterReason = "injected filter status"
@@ -3666,9 +3667,10 @@ func TestRecordingMetrics(t *testing.T) {
 
 			recorder := metrics.NewMetricsAsyncRecorder(100, time.Nanosecond, ctx.Done())
 			profile := config.KubeSchedulerProfile{
-				PercentageOfNodesToScore: ptr.To[int32](testPercentageOfNodesToScore),
-				SchedulerName:            testProfileName,
-				Plugins:                  plugins,
+				PercentageOfNodesToScore:      ptr.To[int32](testPercentageOfNodesToScore),
+				PercentageOfPlacementsToScore: ptr.To[int32](testPercentageOfPlacementsToScore),
+				SchedulerName:                 testProfileName,
+				Plugins:                       plugins,
 			}
 			f, err := newFrameworkWithQueueSortAndBind(ctx, r, profile,
 				withMetricsRecorder(recorder),
@@ -3785,9 +3787,10 @@ func TestRunBindPlugins(t *testing.T) {
 			ctx, cancel := context.WithCancel(ctx)
 			recorder := metrics.NewMetricsAsyncRecorder(100, time.Nanosecond, ctx.Done())
 			profile := config.KubeSchedulerProfile{
-				SchedulerName:            testProfileName,
-				PercentageOfNodesToScore: ptr.To[int32](testPercentageOfNodesToScore),
-				Plugins:                  plugins,
+				SchedulerName:                 testProfileName,
+				PercentageOfNodesToScore:      ptr.To[int32](testPercentageOfNodesToScore),
+				PercentageOfPlacementsToScore: ptr.To[int32](testPercentageOfPlacementsToScore),
+				Plugins:                       plugins,
 			}
 			fwk, err := newFrameworkWithQueueSortAndBind(ctx, r, profile, withMetricsRecorder(recorder))
 			if err != nil {

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -39,6 +39,17 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+const (
+	// minFeasiblePlacementsToFind is the minimum number of placements that would be scored
+	// in each scheduling cycle.
+	minFeasiblePlacementsToFind = 1
+	// minFeasiblePlacementsPercentageToFind is the minimum percentage of placements that
+	// would be scored in each scheduling cycle. This is a semi-arbitrary value
+	// to ensure that a certain minimum of placements are checked for feasibility.
+	// This in turn helps ensure a minimum level of spreading.
+	minFeasiblePlacementsPercentageToFind = 5
+)
+
 // errPodGroupUnschedulable is used to describe that the pod group is unschedulable.
 var errPodGroupUnschedulable = fmt.Errorf("pod group is unschedulable")
 
@@ -673,6 +684,11 @@ func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context
 	var anyResult *podGroupAlgorithmResult
 	successfulResults := make(map[*fwk.Placement]*podGroupAlgorithmResult)
 
+	numPlacementsToFind := int32(1)
+	if schedFwk.HasPlacementScorePlugins() {
+		numPlacementsToFind = sched.numFeasiblePlacementsToFind(schedFwk.PercentageOfPlacementsToScore(), placements)
+	}
+
 	for _, placement := range placements {
 		logger.V(4).Info("Assuming placement in snapshot", "placement", placement.Name)
 		err := sched.nodeInfoSnapshot.AssumePlacement(placement)
@@ -693,6 +709,10 @@ func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context
 
 		if result.status.IsSuccess() || result.waitingOnPreemption {
 			successfulResults[placement] = &result
+		}
+
+		if len(successfulResults) >= int(numPlacementsToFind) {
+			break
 		}
 	}
 
@@ -717,6 +737,42 @@ func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context
 	}
 
 	return *successfulResults[bestPlacement]
+}
+
+// numFeasiblePlacementsToFind returns the number of feasible placements that once found, the scheduler stops
+// its search for more feasible placements.
+func (sched *Scheduler) numFeasiblePlacementsToFind(percentageOfPlacementsToScore *int32, placements []*fwk.Placement) (numPlacements int32) {
+	numAllPlacements := int32(len(placements))
+
+	if numAllPlacements < minFeasiblePlacementsToFind {
+		return numAllPlacements
+	}
+
+	// Use profile percentageOfPlacementsToScore if it's set. Otherwise, use global percentageOfPlacementsToScore.
+	var percentage int32
+	if percentageOfPlacementsToScore != nil {
+		percentage = *percentageOfPlacementsToScore
+	} else {
+		percentage = sched.percentageOfPlacementsToScore
+	}
+
+	// If neither is set or the set value is 0, linearly interpolate the value between (0, 100) and (5000, 10),
+	// that is for small clusters use 100% of the placements, and for large clusters use 10% of the placements,
+	// with a hard cap at 5% placements for even larger clusters.
+	if percentage == 0 {
+		numAllNodes := 0
+		for _, placement := range placements {
+			// We are summing up placement nodes as those can overlap or skip over certain nodes.
+			// For the purpose of this computation we care about the upper bound of computed nodes throughout the scheduling cycle,
+			// which can be different than the number of nodes in the cluster.
+			numAllNodes += len(placement.Nodes)
+		}
+		percentage = max(minFeasiblePlacementsPercentageToFind, int32(100-numAllNodes*9/500))
+	}
+
+	numPlacements = max(minFeasiblePlacementsToFind, int32(numAllPlacements)*percentage/100)
+
+	return numPlacements
 }
 
 // findBestPlacement uses PlacementScore plugins to determine the best placement based on the scheduling results.

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -2709,3 +2709,334 @@ func TestRunWorkloadAwarePreemption(t *testing.T) {
 		})
 	}
 }
+
+func TestNumFeasiblePlacementsToFind(t *testing.T) {
+	makePlacements := func(placementsCount, nodesCount int) []*fwk.Placement {
+		res := make([]*fwk.Placement, placementsCount)
+		j := 0
+		for i := range placementsCount {
+			nodes := make([]fwk.NodeInfo, 0)
+			for ; j < nodesCount*(i+1)/placementsCount; j++ {
+				nodes = append(nodes, framework.NewNodeInfo())
+			}
+			res[i] = &fwk.Placement{
+				Nodes: nodes,
+			}
+		}
+		return res
+	}
+
+	tests := []struct {
+		name              string
+		globalPercentage  int32
+		profilePercentage *int32
+		placementsCount   int
+		nodesCount        int
+		wantNumPlacements int32
+	}{
+		{
+			name:              "default limit for small cluster and small number of placements",
+			placementsCount:   10,
+			nodesCount:        100,
+			wantNumPlacements: 9,
+		},
+		{
+			name:              "default limit for large cluster and small number of placements",
+			placementsCount:   20,
+			nodesCount:        5000,
+			wantNumPlacements: 2,
+		},
+		{
+			name:              "default limit for small cluster and large number of placements",
+			placementsCount:   100,
+			nodesCount:        100,
+			wantNumPlacements: 99,
+		},
+		{
+			name:              "default limit for large cluster and large number of placements",
+			placementsCount:   1000,
+			nodesCount:        5000,
+			wantNumPlacements: 100,
+		},
+		{
+			name:              "default limit does not drop below 5%",
+			placementsCount:   10000,
+			nodesCount:        50000,
+			wantNumPlacements: 500,
+		},
+		{
+			name:              "non-default limit can drop below 5%",
+			globalPercentage:  1,
+			placementsCount:   10000,
+			nodesCount:        50000,
+			wantNumPlacements: 100,
+		},
+		{
+			name:              "limit cannot drop below 1 placement",
+			globalPercentage:  1,
+			placementsCount:   10,
+			nodesCount:        50000,
+			wantNumPlacements: 1,
+		},
+		{
+			name:              "both global and profile limit set, profile limit lower than global",
+			globalPercentage:  50,
+			profilePercentage: ptr.To[int32](5),
+			placementsCount:   1000,
+			nodesCount:        5000,
+			wantNumPlacements: 50,
+		},
+		{
+			name:              "both global and profile limit set, profile limit higher than global",
+			globalPercentage:  50,
+			profilePercentage: ptr.To[int32](55),
+			placementsCount:   1000,
+			nodesCount:        5000,
+			wantNumPlacements: 550,
+		},
+		{
+			name:              "both global and profile limit set, profile limit using default",
+			globalPercentage:  50,
+			profilePercentage: ptr.To[int32](0), // use default limit
+			placementsCount:   1000,
+			nodesCount:        5000,
+			wantNumPlacements: 100,
+		},
+		{
+			name:              "only profile limit set",
+			profilePercentage: ptr.To[int32](5),
+			placementsCount:   1000,
+			nodesCount:        5000,
+			wantNumPlacements: 50,
+		},
+		{
+			name:              "only global limit set",
+			globalPercentage:  50,
+			placementsCount:   1000,
+			nodesCount:        5000,
+			wantNumPlacements: 500,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sched := &Scheduler{
+				percentageOfPlacementsToScore: tt.globalPercentage,
+			}
+			placements := makePlacements(tt.placementsCount, tt.nodesCount)
+			if got := sched.numFeasiblePlacementsToFind(tt.profilePercentage, placements); got != tt.wantNumPlacements {
+				t.Errorf("Scheduler.numFeasiblePlacementsToFind() = %v, want %v", got, tt.wantNumPlacements)
+			}
+		})
+	}
+}
+
+type trackingPlacementScorePlugin struct {
+	lock             sync.Mutex
+	scoredPlacements sets.Set[string]
+}
+
+var _ fwk.PlacementScorePlugin = &trackingPlacementScorePlugin{}
+
+func (t *trackingPlacementScorePlugin) Name() string {
+	return "trackingPlacementScorePlugin"
+}
+
+func (t *trackingPlacementScorePlugin) PlacementScoreExtensions() fwk.PlacementScoreExtensions {
+	return nil
+}
+
+func (t *trackingPlacementScorePlugin) ScorePlacement(ctx context.Context, state fwk.PodGroupCycleState, podGroup fwk.PodGroupInfo, placement *fwk.PodGroupAssignments) (int64, *fwk.Status) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	t.scoredPlacements.Insert(placement.Name)
+	return 1, nil
+}
+
+type trackingFilterPlugin struct {
+	scoredNodes sets.Set[string]
+}
+
+var _ fwk.FilterPlugin = &trackingFilterPlugin{}
+
+func (t *trackingFilterPlugin) Name() string {
+	return "trackingFilterPlugin"
+}
+
+func (t *trackingFilterPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
+	t.scoredNodes.Insert(nodeInfo.Node().Name)
+	return nil
+}
+
+func TestPodGroupSchedulingPlacementAlgorithm_PlacementLimit(t *testing.T) {
+	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+		features.TopologyAwareWorkloadScheduling: true,
+		features.GenericWorkload:                 true,
+	})
+
+	tests := []struct {
+		name                         string
+		numFeasiblePlacements        int
+		numInfeasiblePlacements      int
+		percentageLimit              int32
+		skipScore                    bool
+		expectedNumScoredPlacements  int
+		expectedNumCheckedPlacements *int // nil if cannot be determined due to random placement order
+	}{
+		{
+			name:                        "Only limits the feasible placements",
+			numFeasiblePlacements:       3,
+			numInfeasiblePlacements:     97,
+			percentageLimit:             2,
+			expectedNumScoredPlacements: 2,
+		},
+		{
+			name:                         "Checks all placements in case there is no feasible placement",
+			numFeasiblePlacements:        0,
+			numInfeasiblePlacements:      100,
+			percentageLimit:              40,
+			expectedNumScoredPlacements:  0,
+			expectedNumCheckedPlacements: new(100),
+		},
+		{
+			name:                         "Does not score placements if limit is 1",
+			numFeasiblePlacements:        100,
+			numInfeasiblePlacements:      0,
+			percentageLimit:              1,
+			expectedNumScoredPlacements:  0,
+			expectedNumCheckedPlacements: new(1),
+		},
+		{
+			name:                         "Stops after a single placement if there are no score plugins",
+			numFeasiblePlacements:        100,
+			numInfeasiblePlacements:      0,
+			percentageLimit:              40,
+			skipScore:                    true,
+			expectedNumCheckedPlacements: new(1),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+
+			informerFactory := informers.NewSharedInformerFactory(clientsetfake.NewClientset(), 0)
+			queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
+
+			numNodes := test.numFeasiblePlacements + test.numInfeasiblePlacements
+			nodes := make([]*v1.Node, numNodes)
+
+			placementPlugin := &fakePlacementPlugin{
+				name:                     "fakePlacementPlugin",
+				generatePlacementsResult: make(map[string][]string),
+				filterStatus:             make(map[string]*fwk.Status),
+			}
+
+			for i := range numNodes {
+				nodeName := fmt.Sprintf("n%v", i)
+				nodes[i] = st.MakeNode().Name(nodeName).UID(nodeName).Obj()
+				placementName := fmt.Sprintf("p%v", i)
+				placementPlugin.generatePlacementsResult[placementName] = []string{nodeName}
+				placementPlugin.filterStatus[nodeName] = fwk.NewStatus(fwk.Unschedulable)
+			}
+
+			feasiblePlacements := sets.New[string]()
+			for placement, nodeNames := range placementPlugin.generatePlacementsResult {
+				if len(feasiblePlacements) == test.numFeasiblePlacements {
+					break
+				}
+				placementPlugin.filterStatus[nodeNames[0]] = fwk.NewStatus(fwk.Success)
+				feasiblePlacements.Insert(placement)
+			}
+
+			trackingFilter := &trackingFilterPlugin{scoredNodes: sets.New[string]()}
+			trackingScore := &trackingPlacementScorePlugin{scoredPlacements: sets.New[string]()}
+
+			registry := []tf.RegisterPluginFunc{
+				tf.RegisterPlacementGeneratePlugin(placementPlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+					return placementPlugin, nil
+				}),
+				tf.RegisterFilterPlugin(trackingFilter.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+					return trackingFilter, nil
+				}),
+				tf.RegisterFilterPlugin(placementPlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+					return placementPlugin, nil
+				}),
+			}
+
+			if !test.skipScore {
+				registry = append(registry,
+					tf.RegisterPlacementScorePlugin(trackingScore.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+						return trackingScore, nil
+					}, 1),
+				)
+			}
+
+			cache := internalcache.New(ctx, nil, true)
+			for _, node := range nodes {
+				cache.AddNode(logger, node)
+			}
+			snapshot := internalcache.NewEmptySnapshot()
+			if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
+				t.Fatalf("Failed to update snapshot: %v", err)
+			}
+
+			schedFwk, err := tf.NewFramework(ctx,
+				append(registry,
+					tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+					tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				),
+				"test-scheduler",
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithPodNominator(queue),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create new framework: %v", err)
+			}
+
+			sched := &Scheduler{
+				Cache:                         cache,
+				nodeInfoSnapshot:              snapshot,
+				SchedulingQueue:               queue,
+				Profiles:                      profile.Map{"test-scheduler": schedFwk},
+				percentageOfPlacementsToScore: test.percentageLimit,
+			}
+			sched.SchedulePod = sched.schedulePod
+
+			podGroupPod := st.MakePod().Name("foo").UID("foo").PodGroupName("pg").Obj()
+			pgInfo := &framework.QueuedPodGroupInfo{
+				QueuedPodInfos: []*framework.QueuedPodInfo{
+					{
+						PodInfo: &framework.PodInfo{Pod: podGroupPod},
+					},
+				},
+				PodGroupInfo: &framework.PodGroupInfo{
+					UnscheduledPods: []*v1.Pod{podGroupPod},
+				},
+			}
+
+			_ = sched.podGroupSchedulingPlacementAlgorithm(ctx, schedFwk, framework.NewCycleState(), pgInfo, runAllPostFilters)
+
+			if got := len(trackingScore.scoredPlacements); got != test.expectedNumScoredPlacements {
+				t.Errorf("Unexpected number of scored placements, want %d, got %d", test.expectedNumScoredPlacements, got)
+			}
+
+			if len(trackingScore.scoredPlacements) > 0 {
+				for skippedPlacement := range feasiblePlacements.Difference(trackingScore.scoredPlacements) {
+					placementNode := placementPlugin.generatePlacementsResult[skippedPlacement][0]
+					if trackingFilter.scoredNodes.Has(placementNode) {
+						t.Errorf("Unexpected checked node for skipped placement %s, want none, got %v", skippedPlacement, placementNode)
+					}
+				}
+			}
+
+			if test.expectedNumCheckedPlacements != nil {
+				// 1 unique node per placement
+				if got := len(trackingFilter.scoredNodes); got != *test.expectedNumCheckedPlacements {
+					t.Errorf("Unexpected number of checked placements, want %d, got %d", *test.expectedNumCheckedPlacements, got)
+				}
+			}
+		})
+	}
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -107,6 +107,8 @@ type Scheduler struct {
 
 	percentageOfNodesToScore int32
 
+	percentageOfPlacementsToScore int32
+
 	nextStartNodeIndex int
 
 	// logger *must* be initialized when creating a Scheduler,
@@ -135,6 +137,7 @@ type schedulerOptions struct {
 	kubeConfig             *restclient.Config
 	// Overridden by profile level percentageOfNodesToScore if set in v1.
 	percentageOfNodesToScore          int32
+	percentageOfPlacementsToScore     int32
 	podInitialBackoffSeconds          int64
 	podMaxBackoffSeconds              int64
 	podMaxInUnschedulablePodsDuration time.Duration
@@ -206,6 +209,16 @@ func WithPercentageOfNodesToScore(percentageOfNodesToScore *int32) Option {
 	}
 }
 
+// WithPercentageOfPlacementsToScore sets percentageOfPlacementsToScore for Scheduler.
+// The default value of 0 will use an adaptive percentage.
+func WithPercentageOfPlacementsToScore(percentageOfPlacementsToScore *int32) Option {
+	return func(o *schedulerOptions) {
+		if percentageOfPlacementsToScore != nil {
+			o.percentageOfPlacementsToScore = *percentageOfPlacementsToScore
+		}
+	}
+}
+
 // WithFrameworkOutOfTreeRegistry sets the registry for out-of-tree plugins. Those plugins
 // will be appended to the default registry.
 func WithFrameworkOutOfTreeRegistry(registry frameworkruntime.Registry) Option {
@@ -262,6 +275,7 @@ func WithBuildFrameworkCapturer(fc FrameworkCapturer) Option {
 var defaultSchedulerOptions = schedulerOptions{
 	clock:                             clock.RealClock{},
 	percentageOfNodesToScore:          schedulerapi.DefaultPercentageOfNodesToScore,
+	percentageOfPlacementsToScore:     schedulerapi.DefaultPercentageOfPlacementsToScore,
 	podInitialBackoffSeconds:          int64(internalqueue.DefaultPodInitialBackoffDuration.Seconds()),
 	podMaxBackoffSeconds:              int64(internalqueue.DefaultPodMaxBackoffDuration.Seconds()),
 	podMaxInUnschedulablePodsDuration: internalqueue.DefaultPodMaxInUnschedulablePodsDuration,
@@ -446,6 +460,7 @@ func New(ctx context.Context,
 		client:                                 client,
 		nodeInfoSnapshot:                       snapshot,
 		percentageOfNodesToScore:               options.percentageOfNodesToScore,
+		percentageOfPlacementsToScore:          options.percentageOfPlacementsToScore,
 		Extenders:                              extenders,
 		StopEverything:                         stopEverything,
 		SchedulingQueue:                        podQueue,

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -450,6 +450,51 @@ func TestWithPercentageOfNodesToScore(t *testing.T) {
 	}
 }
 
+// TestWithPercentageOfPlacementsToScore tests scheduler's PercentageOfPlacementsToScore is set correctly.
+func TestWithPercentageOfPlacementsToScore(t *testing.T) {
+	tests := []struct {
+		name                                string
+		percentageOfPlacementsToScoreConfig *int32
+		wantedPercentageOfPlacementsToScore int32
+	}{
+		{
+			name:                                "percentageOfPlacementsScore is nil",
+			percentageOfPlacementsToScoreConfig: nil,
+			wantedPercentageOfPlacementsToScore: schedulerapi.DefaultPercentageOfPlacementsToScore,
+		},
+		{
+			name:                                "percentageOfPlacementsScore is not nil",
+			percentageOfPlacementsToScoreConfig: ptr.To[int32](10),
+			wantedPercentageOfPlacementsToScore: 10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fake.NewClientset()
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			eventBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: client.EventsV1()})
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			sched, err := New(
+				ctx,
+				client,
+				informerFactory,
+				nil,
+				profile.NewRecorderFactory(eventBroadcaster),
+				WithPercentageOfPlacementsToScore(tt.percentageOfPlacementsToScoreConfig),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create scheduler: %v", err)
+			}
+			if sched.percentageOfPlacementsToScore != tt.wantedPercentageOfPlacementsToScore {
+				t.Errorf("scheduler.percentageOfPlacementsToScore = %v, want %v", sched.percentageOfPlacementsToScore, tt.wantedPercentageOfPlacementsToScore)
+			}
+		})
+	}
+}
+
 // getPodFromPriorityQueue is the function used in the TestDefaultErrorFunc test to get
 // the specific pod from the given priority queue. It returns the found pod in the priority queue.
 func getPodFromPriorityQueue(queue *internalqueue.PriorityQueue, pod *v1.Pod) *v1.Pod {

--- a/staging/src/k8s.io/kube-scheduler/config/v1/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1/types.go
@@ -68,6 +68,16 @@ type KubeSchedulerConfiguration struct {
 	// nodes will be scored. It is overridden by profile level PercentageOfNodesToScore.
 	PercentageOfNodesToScore *int32 `json:"percentageOfNodesToScore,omitempty"`
 
+	// PercentageOfPlacementsToScore is the percentage of all placements that once found feasible
+	// for running a pod group, the scheduler stops its search for more feasible placements in
+	// the cluster. This helps improve scheduler's performance. Scheduler always tries to find
+	// at least "minFeasiblePlacementsToFind" feasible placements no matter what the value of this flag is.
+	// Example: if the cluster size is 500 placements and the value of this flag is 30,
+	// then scheduler stops finding further feasible placements once it finds 150 feasible ones.
+	// When the value is 0, default percentage (5%--100% based on the generated placements) of the
+	// placements will be scored. It is overridden by profile level PercentageOfPlacementsToScore.
+	PercentageOfPlacementsToScore *int32 `json:"percentageOfPlacementsToScore,omitempty"`
+
 	// PodInitialBackoffSeconds is the initial backoff for unschedulable pods.
 	// If specified, it must be greater than 0. If this value is null, the default value (1s)
 	// will be used.
@@ -152,6 +162,17 @@ type KubeSchedulerProfile struct {
 	// nodes will be scored. It will override global PercentageOfNodesToScore. If it is empty,
 	// global PercentageOfNodesToScore will be used.
 	PercentageOfNodesToScore *int32 `json:"percentageOfNodesToScore,omitempty"`
+
+	// PercentageOfPlacementsToScore is the percentage of all placements that once found feasible
+	// for running a pod group, the scheduler stops its search for more feasible placements in
+	// the cluster. This helps improve scheduler's performance. Scheduler always tries to find
+	// at least "minFeasiblePlacementsToFind" feasible placements no matter what the value of this flag is.
+	// Example: if the cluster size is 500 placements and the value of this flag is 30,
+	// then scheduler stops finding further feasible placements once it finds 150 feasible ones.
+	// When the value is 0, default percentage (5%--100% based on the generated placements) of the
+	// placements will be scored. It will override global PercentageOfPlacementsToScore. If it is empty,
+	// global PercentageOfPlacementsToScore will be used.
+	PercentageOfPlacementsToScore *int32 `json:"percentageOfPlacementsToScore,omitempty"`
 
 	// Plugins specify the set of plugins that should be enabled or disabled.
 	// Enabled plugins are the ones that should be enabled in addition to the

--- a/staging/src/k8s.io/kube-scheduler/config/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1/zz_generated.deepcopy.go
@@ -218,6 +218,11 @@ func (in *KubeSchedulerConfiguration) DeepCopyInto(out *KubeSchedulerConfigurati
 		*out = new(int32)
 		**out = **in
 	}
+	if in.PercentageOfPlacementsToScore != nil {
+		in, out := &in.PercentageOfPlacementsToScore, &out.PercentageOfPlacementsToScore
+		*out = new(int32)
+		**out = **in
+	}
 	if in.PodInitialBackoffSeconds != nil {
 		in, out := &in.PodInitialBackoffSeconds, &out.PodInitialBackoffSeconds
 		*out = new(int64)
@@ -273,6 +278,11 @@ func (in *KubeSchedulerProfile) DeepCopyInto(out *KubeSchedulerProfile) {
 	}
 	if in.PercentageOfNodesToScore != nil {
 		in, out := &in.PercentageOfNodesToScore, &out.PercentageOfNodesToScore
+		*out = new(int32)
+		**out = **in
+	}
+	if in.PercentageOfPlacementsToScore != nil {
+		in, out := &in.PercentageOfPlacementsToScore, &out.PercentageOfPlacementsToScore
 		*out = new(int32)
 		**out = **in
 	}

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -117,6 +117,7 @@ func StartSchedulerWithDone(tCtx ktesting.TContext, cfg *kubeschedulerconfig.Kub
 		scheduler.WithKubeConfig(tCtx.RESTConfig()),
 		scheduler.WithProfiles(cfg.Profiles...),
 		scheduler.WithPercentageOfNodesToScore(cfg.PercentageOfNodesToScore),
+		scheduler.WithPercentageOfPlacementsToScore(cfg.PercentageOfPlacementsToScore),
 		scheduler.WithPodMaxBackoffSeconds(cfg.PodMaxBackoffSeconds),
 		scheduler.WithPodInitialBackoffSeconds(cfg.PodInitialBackoffSeconds),
 		scheduler.WithExtenders(cfg.Extenders...),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

One important optimization for pod throughput in TAS is to limit the number of scored placements, similar to how we limit the number of scored nodes in non-TAS. This PR introduces PercentageOfPlacementsToScore which can be used to control this limit, and proposes a default adaptive limit based on the generated placements.

I've chosen the default based on the following assumptions:

1. For large clusters, we will generally want to score fewer placements
2. For small clusters, we will generally want to score more placements

I defined large cluster to be one with 5000 nodes, for which we want to score 10% of the generated placements. I linearly interpolate the percentage up to 100% for clusters with 0 nodes, which results in the following formula: $100 - clusterSize \times \frac{9}{500}$.

Additionally, I enforce a lower bound on the adaptive percentage to 5%. The final formula for the number of placements looks like the following:

$$
numFeasiblePlacements = max(1, numPlacements \times \frac{max(5, 100 - clusterSize \times \frac{9}{500})}{100})
$$

Finally, instead of actually using the clusterSize, I take the total number of nodes to evaluate across all placements, which can be different due to overlaps or missing nodes. This is because we actually care about the number of evaluations rather than the real cluster size.

Here's a plot to visualize how numFeasiblePlacements changes depending on numPlacements and numNodes.

<img width="1600" height="1340" alt="feasible_placements_limit" src="https://github.com/user-attachments/assets/c2e3fcd1-84eb-4ad3-9236-ce95fc0a6a18" />

Note that for large clusters and small number of placements (less than 20, e.g. using zone topology), we may end up evaluating only a single placement. As an alternative, we could simply use number of placements for interpolating the percentage, but then we risk non-monotonicity similar to the one for the node limit: #138996.

Another approach for the default limit that I considered was to keep track of the cumulative number of evaluated nodes and stop evaluation once the node limit is hit. In pseudocode it could be expressed like so:

```
scoredNodes := 0
scoredNodesLimit := nodesLimit * len(podGroup)
for placement := range placements {
  placementScoredNodes := 0
  placementScheduling := NewPlacementScheduling(placement)
  for pod := range podGroup {
    podSchedulingResult := placementScheduling.SchedulePod(pod)
    if podSchedulingResult.IsSuccess() {
      placementScoredNodes += podSchedulingResult.scoredNodes
    }
  }

  if placementScheduling.IsSuccess() {
    scoredNodes += placementScoredNodes
  }

  if scoredNodes >= scoredNodesLimit {
    break
  }
}
```

Such approach could give similar throughput for TAS as for non-TAS. However I've decided against it as it would be hard to predict how many placements will be scored.

Another thing worth noting is that the adaptive node limit within placement is dictated by the number of nodes of that placement rather than the number of nodes in the whole cluster.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added PercentageOfPlacementsToScore to scheduler config which can be used to limit the number of evaluated placements in placement-based pod group scheduling cycle. If unset, the limit will be internally determined based on the generated placements. The field can only be set with TopologyAwareWorkloadScheduling feature gate enabled.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
