### PR TITLE
kubelet: handle nil volume specs in ASW

### DIFF
--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
@@ -679,9 +679,13 @@ func (asw *actualStateOfWorld) addVolume(logger klog.Logger,
 
 	volumePlugin, err := asw.volumePluginMgr.FindPluginBySpec(volumeSpec)
 	if err != nil || volumePlugin == nil {
+		volumeSpecName := ""
+		if volumeSpec != nil {
+			volumeSpecName = volumeSpec.Name()
+		}
 		return fmt.Errorf(
 			"failed to get Plugin from volumeSpec for volume %q err=%v",
-			volumeSpec.Name(),
+			volumeSpecName,
 			err)
 	}
 

--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world_test.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world_test.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -83,6 +84,29 @@ func Test_MarkVolumeAsAttached_Positive_NewVolume(t *testing.T) {
 	verifyVolumeExistsAsw(t, generatedVolumeName, true /* shouldExist */, asw)
 	verifyVolumeExistsInUnmountedVolumes(t, generatedVolumeName, asw)
 	verifyVolumeDoesntExistInGloballyMountedVolumes(t, generatedVolumeName, asw)
+}
+
+// Calls MarkVolumeAsAttached() with a nil volume spec.
+// Verifies it returns an error and leaves the actual state unchanged.
+func Test_MarkVolumeAsAttached_Negative_NilVolumeSpec(t *testing.T) {
+	// Arrange
+	volumePluginMgr, _ := volumetesting.GetTestKubeletVolumePluginMgr(t)
+	asw := NewActualStateOfWorld("mynode" /* nodeName */, volumePluginMgr)
+
+	// Act
+	logger, _ := ktesting.NewTestContext(t)
+	err := asw.MarkVolumeAsAttached(logger, emptyVolumeName, nil, "" /* nodeName */, "" /* devicePath */)
+
+	// Assert
+	if err == nil {
+		t.Fatal("MarkVolumeAsAttached did not fail. Expected error for nil volume spec, got nil")
+	}
+	if !strings.Contains(err.Error(), "volume spec is nil") {
+		t.Fatalf("MarkVolumeAsAttached returned unexpected error. Expected to contain %q, got %q", "volume spec is nil", err.Error())
+	}
+	if attachedVolumes := asw.GetAttachedVolumes(); len(attachedVolumes) != 0 {
+		t.Fatalf("MarkVolumeAsAttached mutated actual state. Expected no attached volumes, got %v", attachedVolumes)
+	}
 }
 
 // Calls MarkVolumeAsAttached() once to add volume, specifying a name --


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node

#### What changed

`MarkVolumeAsAttached` now handles a nil `volumeSpec` on the plugin lookup error path without dereferencing it.

#### Why

`MarkVolumeAsAttached` eventually calls `VolumePluginMgr.FindPluginBySpec`, which already returns an error when the volume spec is nil. The actual state cache then dereferenced that nil spec while formatting the error message. That could panic before returning the plugin-manager error, and actual state should remain unchanged.

This updates that error path to return the plugin-manager error without mutating actual state, and adds a regression test for the nil volume spec case.

#### Which issue(s) this PR is related to:

Related to #109717

#### How tested

- `go test ./pkg/kubelet/volumemanager/cache -run Test_MarkVolumeAsAttached_Negative_NilVolumeSpec -count=1`

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```