### PR TITLE
CPUmanager checkpoint v1 removal

### DIFF
--- a/pkg/kubelet/cm/cpumanager/state/checkpoint.go
+++ b/pkg/kubelet/cm/cpumanager/state/checkpoint.go
@@ -33,7 +33,6 @@ import (
 // CPUManagerCheckpointV4 serializes checkpoint data to a string, following the
 // same approach used in the allocation manager (see pkg/kubelet/allocation/state/checkpoint.go).
 // The embedded V2 version is for keeping forward compatibility.
-var _ checkpointmanager.Checkpoint = &CPUManagerCheckpointV1{}
 var _ checkpointmanager.Checkpoint = &CPUManagerCheckpointV2{}
 var _ checkpointmanager.Checkpoint = &CPUManagerCheckpointV3{}
 var _ checkpointmanager.Checkpoint = &CPUManagerCheckpointV4{}
@@ -83,24 +82,10 @@ type CPUManagerCheckpointV2 struct {
 	Checksum      checksum.Checksum            `json:"checksum"`
 }
 
-// CPUManagerCheckpointV1 struct is used to store CPU/pod assignments in a checkpoint in v1 format
-type CPUManagerCheckpointV1 struct {
-	PolicyName    string            `json:"policyName"`
-	DefaultCPUSet string            `json:"defaultCpuSet"`
-	Entries       map[string]string `json:"entries,omitempty"`
-	Checksum      checksum.Checksum `json:"checksum"`
-}
-
 // NewCPUManagerCheckpoint returns an instance of Checkpoint
 func newCPUManagerCheckpoint() *CPUManagerCheckpoint {
 	//nolint:staticcheck // unexported-type-in-api user-facing error message
 	return newCPUManagerCheckpointV4()
-}
-
-func newCPUManagerCheckpointV1() *CPUManagerCheckpointV1 {
-	return &CPUManagerCheckpointV1{
-		Entries: make(map[string]string),
-	}
 }
 
 func newCPUManagerCheckpointV2() *CPUManagerCheckpointV2 {
@@ -126,14 +111,6 @@ func newCPUManagerCheckpointV4() *CPUManagerCheckpointV4 {
 			PodEntries: make(PodCPUAssignments),
 		},
 	}
-}
-
-// MarshalCheckpoint returns marshalled checkpoint in v1 format
-func (cp *CPUManagerCheckpointV1) MarshalCheckpoint() ([]byte, error) {
-	// make sure checksum wasn't set before so it doesn't affect output checksum
-	cp.Checksum = 0
-	cp.Checksum = checksum.New(cp)
-	return json.Marshal(*cp)
 }
 
 // MarshalCheckpoint returns marshalled checkpoint in v2 format
@@ -195,11 +172,6 @@ func (cp *CPUManagerCheckpoint) MarshalCheckpoint() ([]byte, error) {
 	return json.Marshal(*cp)
 }
 
-// UnmarshalCheckpoint tries to unmarshal passed bytes to checkpoint in v1 format
-func (cp *CPUManagerCheckpointV1) UnmarshalCheckpoint(blob []byte) error {
-	return json.Unmarshal(blob, cp)
-}
-
 // UnmarshalCheckpoint tries to unmarshal passed bytes to checkpoint in v2 format
 func (cp *CPUManagerCheckpointV2) UnmarshalCheckpoint(blob []byte) error {
 	return json.Unmarshal(blob, cp)
@@ -218,32 +190,6 @@ func (cp *CPUManagerCheckpoint) UnmarshalCheckpoint(blob []byte) error {
 	if err := json.Unmarshal([]byte(cp.Data), &cp.CheckpointData); err != nil {
 		return fmt.Errorf("failed to deserialize cpu manager checkpoint data: %w", err)
 	}
-	return nil
-}
-
-// VerifyChecksum verifies that current checksum of checkpoint is valid in v1 format
-func (cp *CPUManagerCheckpointV1) VerifyChecksum() error {
-	if cp.Checksum == 0 {
-		// accept empty checksum for compatibility with old file backend
-		return nil
-	}
-
-	ck := cp.Checksum
-	cp.Checksum = 0
-	object := dump.ForHash(cp)
-	object = strings.Replace(object, "CPUManagerCheckpointV1", "CPUManagerCheckpoint", 1)
-	cp.Checksum = ck
-
-	hash := fnv.New32a()
-	_, _ = fmt.Fprintf(hash, "%v", object)
-	actualCS := checksum.Checksum(hash.Sum32())
-	if cp.Checksum != actualCS {
-		return &errors.CorruptCheckpointError{
-			ActualCS:   uint64(actualCS),
-			ExpectedCS: uint64(cp.Checksum),
-		}
-	}
-
 	return nil
 }
 

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint.go
@@ -72,30 +72,6 @@ func NewCheckpointState(logger logr.Logger, stateDir, checkpointName, policyName
 	return stateCheckpoint, nil
 }
 
-// migrateV1CheckpointToV2Checkpoint() converts checkpoints from the v1 format to the v2 format
-func (sc *stateCheckpoint) migrateV1CheckpointToV2Checkpoint(src *CPUManagerCheckpointV1, dst *CPUManagerCheckpointV2) error {
-	if src.PolicyName != "" {
-		dst.PolicyName = src.PolicyName
-	}
-	if src.DefaultCPUSet != "" {
-		dst.DefaultCPUSet = src.DefaultCPUSet
-	}
-	for containerID, cset := range src.Entries {
-		podUID, containerName, err := sc.initialContainers.GetContainerRef(containerID)
-		if err != nil {
-			return fmt.Errorf("containerID '%v' not found in initial containers list", containerID)
-		}
-		if dst.Entries == nil {
-			dst.Entries = make(map[string]map[string]string)
-		}
-		if _, exists := dst.Entries[podUID]; !exists {
-			dst.Entries[podUID] = make(map[string]string)
-		}
-		dst.Entries[podUID][containerName] = cset
-	}
-	return nil
-}
-
 // migrateV2CheckpointToV3Checkpoint() converts checkpoints from the v2 format to the v3 format
 func (sc *stateCheckpoint) migrateV2CheckpointToV3Checkpoint(src *CPUManagerCheckpointV2, dst *CPUManagerCheckpointV3) {
 	if src.PolicyName != "" {
@@ -234,7 +210,7 @@ func (sc *stateCheckpoint) loadAndMigrateCheckpointV3() (*CPUManagerCheckpointV3
 	sc.logger.Info("could not load v3 checkpoint, falling back to v2", "err", err)
 
 	// Try to load as V2.
-	checkpointV2, err := sc.loadAndMigrateCheckpointV2()
+	checkpointV2, err := sc.loadCheckpointV2()
 	if err != nil {
 		return nil, err
 	}
@@ -249,44 +225,18 @@ func (sc *stateCheckpoint) loadAndMigrateCheckpointV3() (*CPUManagerCheckpointV3
 	return checkpointV3, nil
 }
 
-func (sc *stateCheckpoint) loadAndMigrateCheckpointV2() (*CPUManagerCheckpointV2, error) {
-	sc.logger.Info("trying to load v2 CPU manager checkpoint")
+// loadCheckpointV2 loads the checkpoint in V2.
+// This is the oldest supported version so there is no try to migrate from V1.
+func (sc *stateCheckpoint) loadCheckpointV2() (*CPUManagerCheckpointV2, error) {
+	sc.logger.Info("trying to load v2 cpu manager checkpoint")
 	checkpointV2 := newCPUManagerCheckpointV2()
 	err := sc.checkpointManager.GetCheckpoint(sc.checkpointName, checkpointV2)
 	if err == nil {
 		return checkpointV2, nil
 	}
-	if errors.Is(err, cperrors.ErrCheckpointNotFound) {
-		return nil, err
-	}
 
-	// Log the V2 load error and fall back to V1.
-	sc.logger.Info("could not load v2 checkpoint, falling back to v1", "err", err)
-
-	// Try to load as V1.
-	checkpointV1, err := sc.loadCheckpointV1()
-	if err == nil {
-		// Loaded V1, now migrate V1 -> V2.
-		sc.logger.Info("migrating CPU manager checkpoint from v1 to v2")
-		tmpV2 := newCPUManagerCheckpointV2()
-		if migrationErr := sc.migrateV1CheckpointToV2Checkpoint(checkpointV1, tmpV2); migrationErr != nil {
-			return nil, fmt.Errorf("failed to migrate checkpoint from v1 to v2: %w", migrationErr)
-		}
-		return tmpV2, nil
-	}
-
-	// All attempts failed. Return the last error we got (from the V1 read attempt).
+	// All attempts failed. Return the last error we got.
 	return nil, err
-}
-
-func (sc *stateCheckpoint) loadCheckpointV1() (*CPUManagerCheckpointV1, error) {
-	sc.logger.Info("trying to load v1 CPU manager checkpoint")
-	checkpointV1 := newCPUManagerCheckpointV1()
-	err := sc.checkpointManager.GetCheckpoint(sc.checkpointName, checkpointV1)
-	if err != nil {
-		return nil, err
-	}
-	return checkpointV1, nil
 }
 
 // saves state to a checkpoint, caller is responsible for locking

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -297,7 +297,7 @@ func TestCheckpointStateRestore(t *testing.T) {
 			},
 		},
 		{
-			"Restore checkpoint from checkpoint with v1 checksum",
+			"Fail to restore checkpoint from checkpoint with v1 checksum",
 			nil,
 			`{
 				"policyName": "none",
@@ -306,13 +306,11 @@ func TestCheckpointStateRestore(t *testing.T) {
 			}`,
 			"none",
 			containermap.ContainerMap{},
-			"",
-			&stateMemory{
-				defaultCPUSet: cpuset.New(1, 2, 3),
-			},
+			"checkpoint is corrupted",
+			nil,
 		},
 		{
-			"Restore checkpoint from v1 (migration)",
+			"Fail to restore checkpoint from v1 (migration)",
 			nil,
 			`{
 				"policyName": "static",
@@ -324,22 +322,9 @@ func TestCheckpointStateRestore(t *testing.T) {
 				"checksum": 2026311253
 			}`,
 			"static",
-			func() containermap.ContainerMap {
-				cm := containermap.NewContainerMap()
-				cm.Add("pod", "container1", "containerID1")
-				cm.Add("pod", "container2", "containerID2")
-				return cm
-			}(),
-			"",
-			&stateMemory{
-				assignments: ContainerCPUAssignments{
-					"pod": map[string]cpuset.CPUSet{
-						"container1": cpuset.New(4, 5, 6),
-						"container2": cpuset.New(1, 2, 3),
-					},
-				},
-				defaultCPUSet: cpuset.New(7, 8, 9),
-			},
+			containermap.ContainerMap{},
+			"cannot unmarshal string into Go struct field CPUManagerCheckpointV2.entries of type map[string]string",
+			nil,
 		},
 		{
 			"Restore checkpoint from v2 (migration)",


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR drops support for V1 checkpoint format in CPUManager.
This is a folow-up of https://github.com/kubernetes/kubernetes/pull/139102

Remove the CPUManagerCheckpointV1 struct and all related code including:
- V1 checkpoint type and its Marshal/Unmarshal/VerifyChecksum methods
- Migration logic from V1 to V2 checkpoint format
- V1 checkpoint loading fallback in loadCheckpointV2()

V2 is now the oldest supported checkpoint version. Attempting to load
V1 checkpoints will fail with a deserialization error instead of being
migrated. This simplifies the codebase by removing legacy migration path.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
