### PR TITLE
refactor(apiserver): move storage list metrics to shared package  (unify storage list metrics-part1)

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/routes/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/metrics.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apiserver/pkg/server/mux"
 	cachermetrics "k8s.io/apiserver/pkg/storage/cacher/metrics"
 	etcd3metrics "k8s.io/apiserver/pkg/storage/etcd3/metrics"
+	storagemetrics "k8s.io/apiserver/pkg/storage/metrics"
 	flowcontrolmetrics "k8s.io/apiserver/pkg/util/flowcontrol/metrics"
 	peerproxymetrics "k8s.io/apiserver/pkg/util/peerproxy/metrics"
 	proxymetrics "k8s.io/apiserver/pkg/util/proxy/metrics"
@@ -50,6 +51,7 @@ func (m MetricsWithReset) Install(c *mux.PathRecorderMux) {
 // register apiserver and etcd metrics
 func register() {
 	apimetrics.Register()
+	storagemetrics.Register()
 	cachermetrics.Register()
 	etcd3metrics.Register()
 	flowcontrolmetrics.Register()

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage"
+	storagemetrics "k8s.io/apiserver/pkg/storage/metrics"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	compbasemetrics "k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
@@ -142,38 +143,6 @@ var (
 		},
 		[]string{},
 	)
-	listStorageCount = compbasemetrics.NewCounterVec(
-		&compbasemetrics.CounterOpts{
-			Name:           "apiserver_storage_list_total",
-			Help:           "Number of LIST requests served from storage",
-			StabilityLevel: compbasemetrics.ALPHA,
-		},
-		[]string{"group", "resource"},
-	)
-	listStorageNumFetched = compbasemetrics.NewCounterVec(
-		&compbasemetrics.CounterOpts{
-			Name:           "apiserver_storage_list_fetched_objects_total",
-			Help:           "Number of objects read from storage in the course of serving a LIST request",
-			StabilityLevel: compbasemetrics.ALPHA,
-		},
-		[]string{"group", "resource"},
-	)
-	listStorageNumSelectorEvals = compbasemetrics.NewCounterVec(
-		&compbasemetrics.CounterOpts{
-			Name:           "apiserver_storage_list_evaluated_objects_total",
-			Help:           "Number of objects tested in the course of serving a LIST request from storage",
-			StabilityLevel: compbasemetrics.ALPHA,
-		},
-		[]string{"group", "resource"},
-	)
-	listStorageNumReturned = compbasemetrics.NewCounterVec(
-		&compbasemetrics.CounterOpts{
-			Name:           "apiserver_storage_list_returned_objects_total",
-			Help:           "Number of objects returned for a LIST request from storage",
-			StabilityLevel: compbasemetrics.ALPHA,
-		},
-		[]string{"group", "resource"},
-	)
 	decodeErrorCounts = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
 			Namespace:      "apiserver",
@@ -203,10 +172,6 @@ func Register() {
 		legacyregistry.MustRegister(etcdBookmarkCounts)
 		legacyregistry.MustRegister(etcdBookmarkTotal)
 		legacyregistry.MustRegister(etcdLeaseObjectCounts)
-		legacyregistry.MustRegister(listStorageCount)
-		legacyregistry.MustRegister(listStorageNumFetched)
-		legacyregistry.MustRegister(listStorageNumSelectorEvals)
-		legacyregistry.MustRegister(listStorageNumReturned)
 		legacyregistry.MustRegister(decodeErrorCounts)
 	})
 }
@@ -299,10 +264,7 @@ func UpdateLeaseObjectCount(count int64) {
 
 // RecordStorageListMetrics notes various metrics of the cost to serve a LIST request
 func RecordStorageListMetrics(groupResource schema.GroupResource, numFetched, numEvald, numReturned int) {
-	listStorageCount.WithLabelValues(groupResource.Group, groupResource.Resource).Inc()
-	listStorageNumFetched.WithLabelValues(groupResource.Group, groupResource.Resource).Add(float64(numFetched))
-	listStorageNumSelectorEvals.WithLabelValues(groupResource.Group, groupResource.Resource).Add(float64(numEvald))
-	listStorageNumReturned.WithLabelValues(groupResource.Group, groupResource.Resource).Add(float64(numReturned))
+	storagemetrics.RecordStorageListMetrics(groupResource, numFetched, numEvald, numReturned)
 }
 
 type Monitor interface {

--- a/staging/src/k8s.io/apiserver/pkg/storage/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/metrics/metrics.go
@@ -1,0 +1,79 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	compbasemetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+var (
+	listStorageCount = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Name:           "apiserver_storage_list_total",
+			Help:           "Number of LIST requests served from storage",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"group", "resource"},
+	)
+	listStorageNumFetched = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Name:           "apiserver_storage_list_fetched_objects_total",
+			Help:           "Number of objects read from storage in the course of serving a LIST request",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"group", "resource"},
+	)
+	listStorageNumSelectorEvals = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Name:           "apiserver_storage_list_evaluated_objects_total",
+			Help:           "Number of objects tested in the course of serving a LIST request from storage",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"group", "resource"},
+	)
+	listStorageNumReturned = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Name:           "apiserver_storage_list_returned_objects_total",
+			Help:           "Number of objects returned for a LIST request from storage",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"group", "resource"},
+	)
+	registerMetrics sync.Once
+)
+
+// Register registers storage LIST metrics.
+func Register() {
+	registerMetrics.Do(func() {
+		legacyregistry.MustRegister(listStorageCount)
+		legacyregistry.MustRegister(listStorageNumFetched)
+		legacyregistry.MustRegister(listStorageNumSelectorEvals)
+		legacyregistry.MustRegister(listStorageNumReturned)
+	})
+}
+
+// RecordStorageListMetrics notes various metrics of the cost to serve a LIST request.
+func RecordStorageListMetrics(groupResource schema.GroupResource, numFetched, numEvald, numReturned int) {
+	listStorageCount.WithLabelValues(groupResource.Group, groupResource.Resource).Inc()
+	listStorageNumFetched.WithLabelValues(groupResource.Group, groupResource.Resource).Add(float64(numFetched))
+	listStorageNumSelectorEvals.WithLabelValues(groupResource.Group, groupResource.Resource).Add(float64(numEvald))
+	listStorageNumReturned.WithLabelValues(groupResource.Group, groupResource.Resource).Add(float64(numReturned))
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR is the first step of splitting the work originally proposed in #138883.

It moves the existing `apiserver_storage_list_*` metric definitions from
`pkg/storage/etcd3/metrics` into a shared `pkg/storage/metrics` package.

The goal is to unify the storage list metrics at the `storage` layer, instead of
keeping them defined separately in `etcd3` and `cacher`.

#### Which issue(s) this PR is related to:

Issue: #138264
Original work #138883

#### Special notes for your reviewer:

This PR is intended as stage 1 of the original work in #138883.

Planned follow-up stages:
- stage 1: move the existing `apiserver_storage_list_*` metrics into the shared `pkg/storage/metrics` package
- stage 2: add the new labels needed for the unified storage metrics (`index` and `storage`)
- stage 3: deprecate the old cache-specific metrics

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```