### PR TITLE
Fix DRA extended resource quota test race condition

### DIFF
--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -2546,6 +2546,21 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 			}
 			b.Create(tCtx, quota)
 
+			// Wait for the quota controller to initialize the status with zero usage.
+			// This prevents "status unknown for quota" errors when creating pods.
+			ginkgo.By("Waiting for ResourceQuota status to be initialized")
+			initialUsedResources := v1.ResourceList{}
+			for resourceName := range hard {
+				initialUsedResources[resourceName] = resource.MustParse("0")
+			}
+			gomega.Eventually(ctx, framework.GetObject(f.ClientSet.CoreV1().ResourceQuotas(quota.Namespace).Get, quota.Name, metav1.GetOptions{})).
+				WithTimeout(time.Minute).
+				Should(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"Status": gomega.Equal(v1.ResourceQuotaStatus{
+						Hard: hard,
+						Used: initialUsedResources,
+					})})))
+
 			// create a class with an extended resource
 			b.Create(tCtx, class)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake
/sig node
/sig scheduling
/wg device-management
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Similar to https://github.com/kubernetes/kubernetes/pull/128943, this PR fixes a race condition in the DRA extended resource quota E2E test that causes it to fail with "status unknown for quota" errors.

The test creates a ResourceQuota and immediately tries to create a pod, but the quota controller (which runs asynchronously) hasn't initialized the quota status yet. This causes the admission controller to reject the pod creation.
#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/issues/128410
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
This race condition was already documented and fixed in a similar DRA quota test but the fix was not applied when the extended resource quota test was added
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
"NONE"
```

The flake has been identified during the re-base of openshift's fork of Kubernetes.
```
Test '[sig-node] [DRA] [FeatureGate:DRAExtendedResource] [Beta] [Feature:DynamicResourceAllocation] must run a pod with extended resource with resource quota [KubeletMinVersion:1.35]' failed all 3 attempts.

=== Attempt 1: FAILED ===
  STEP: Creating a kubernetes client @ 05/12/26 19:57:25.449
  STEP: Building a namespace api object, basename dra @ 05/12/26 19:57:25.45
I0512 19:57:25.490968   13564 namespace.go:59] About to run a Kube e2e test, ensuring namespace/e2e-dra-9730 is privileged
  STEP: Waiting for a default service account to be provisioned in namespace @ 05/12/26 19:57:25.842
  STEP: Waiting for kube-root-ca.crt to be provisioned in namespace @ 05/12/26 19:57:25.846
I0512 19:57:25.851624   13564 deploy.go:123] selecting nodes
I0512 19:57:25.858993   13564 deploy.go:145] testing on nodes [ip-10-0-44-96.ec2.internal]
I0512 19:57:25.859166   13564 deploy.go:411] deploying driver e2e-dra-9730.k8s.io on nodes [ip-10-0-44-96.ec2.internal]
I0512 19:57:25.912344   13564 create.go:156] creating *v1.ReplicaSet: e2e-dra-9730/dra-test-driver
I0512 19:57:27.943661   13564 deploy.go:720] wait for plugin registration
I0512 19:57:29.945033   13564 builder.go:605] Creating *v1.DeviceClass e2e-dra-9730-class
I0512 19:57:29.977182   13564 dra.go:2505] Creating *v1.ResourceQuota test-quota
I0512 19:57:29.992169   13564 dra.go:2508] Creating *v1.DeviceClass e2e-dra-9730-class-resource-quota
I0512 19:57:30.012982   13564 dra.go:2538] Creating *v1.Pod tester-1
I0512 19:57:30.017491   13564 dra.go:2538] create *v1.Pod:
	<*errors.StatusError | 0xb1077666fa0>: 
	pods "tester-1" is forbidden: status unknown for quota: test-quota, resources: requests.deviceclass.resource.kubernetes.io/e2e-dra-9730-class-resource-quota,requests.e2e-dra-9730.k8s.io/resource-quota
	{
	    ErrStatus: 
	        code: 403
	        details:
	          kind: pods
	          name: tester-1
	        message: 'pods "tester-1" is forbidden: status unknown for quota: test-quota, resources:
	          requests.deviceclass.resource.kubernetes.io/e2e-dra-9730-class-resource-quota,requests.e2e-dra-9730.k8s.io/resource-quota'
	        metadata: {}
	        reason: Forbidden
	        status: Failure,
	}
  [FAILED] in [It] - k8s.io/kubernetes/test/e2e/dra/dra.go:2538 @ 05/12/26 19:57:30.017
I0512 19:57:30.037287   13564 builder.go:621] delete pods, podgroups, and claims
I0512 19:57:30.145991   13564 builder.go:674] Waiting for resources on ip-10-0-44-96.ec2.internal to be unprepared
I0512 19:57:30.146070   13564 builder.go:678] waiting for claims to be deallocated and deleted
I0512 19:57:31.513331   13564 deploy.go:704] scaling down driver proxy pods for e2e-dra-9730.k8s.io
I0512 19:57:33.583398   13564 tcontext.go:457] Waiting for ResourceSlices of driver e2e-dra-9730.k8s.io to be removed...
  STEP: dump namespace information after failure @ 05/12/26 19:57:33.677
  STEP: Collecting events from namespace "e2e-dra-9730". @ 05/12/26 19:57:33.677
  STEP: Found 8 events. @ 05/12/26 19:57:33.679
I0512 19:57:33.679764   13564 dump.go:53] At 0001-01-01 00:00:00 +0000 UTC - event for dra-test-driver-v878g: { } Scheduled: Successfully assigned e2e-dra-9730/dra-test-driver-v878g to ip-10-0-44-96.ec2.internal
I0512 19:57:33.679785   13564 dump.go:53] At 2026-05-12 19:57:25 +0000 UTC - event for dra-test-driver: {replicaset-controller } SuccessfulCreate: Created pod: dra-test-driver-v878g
I0512 19:57:33.679797   13564 dump.go:53] At 2026-05-12 19:57:26 +0000 UTC - event for dra-test-driver-v878g: {multus } AddedInterface: Add eth0 [10.129.3.9/23] from ovn-kubernetes
I0512 19:57:33.679824   13564 dump.go:53] At 2026-05-12 19:57:26 +0000 UTC - event for dra-test-driver-v878g: {kubelet ip-10-0-44-96.ec2.internal} Pulled: Container image "quay.io/openshift/community-e2e-images:e2e-30-registry-k8s-io-sig-storage-hostpathplugin-v1-17-1-thKi_291aDqGI3Q7" already present on machine and can be accessed by the pod
I0512 19:57:33.679845   13564 dump.go:53] At 2026-05-12 19:57:27 +0000 UTC - event for dra-test-driver-v878g: {kubelet ip-10-0-44-96.ec2.internal} Created: Container created
I0512 19:57:33.679870   13564 dump.go:53] At 2026-05-12 19:57:27 +0000 UTC - event for dra-test-driver-v878g: {kubelet ip-10-0-44-96.ec2.internal} Started: Container started
I0512 19:57:33.679892   13564 dump.go:53] At 2026-05-12 19:57:31 +0000 UTC - event for dra-test-driver: {replicaset-controller } SuccessfulDelete: Deleted pod: dra-test-driver-v878g
I0512 19:57:33.679906   13564 dump.go:53] At 2026-05-12 19:57:31 +0000 UTC - event for dra-test-driver-v878g: {kubelet ip-10-0-44-96.ec2.internal} Killing: Stopping container pause
I0512 19:57:33.683529   13564 resource.go:151] POD                    NODE                        PHASE    GRACE  CONDITIONS
I0512 19:57:33.683581   13564 resource.go:158] dra-test-driver-v878g  ip-10-0-44-96.ec2.internal  Running  30s    [{PodReadyToStartContainers 2 True 0001-01-01 00:00:00 +0000 UTC 2026-05-12 19:57:26 +0000 UTC  } {Initialized 2 True 0001-01-01 00:00:00 +0000 UTC 2026-05-12 19:57:25 +0000 UTC  } {Ready 2 True 0001-01-01 00:00:00 +0000 UTC 2026-05-12 19:57:27 +0000 UTC  } {ContainersReady 2 True 0001-01-01 00:00:00 +0000 UTC 2026-05-12 19:57:27 +0000 UTC  } {PodScheduled 2 True 0001-01-01 00:00:00 +0000 UTC 2026-05-12 19:57:25 +0000 UTC  }]
I0512 19:57:33.683596   13564 resource.go:161] 
I0512 19:57:33.748137   13564 dump.go:81] skipping dumping cluster info - cluster too large
  STEP: Destroying namespace "e2e-dra-9730" for this suite. @ 05/12/26 19:57:33.748

fail [k8s.io/kubernetes/test/e2e/dra/dra.go:2538]: FATAL ERROR:
	create *v1.Pod: pods "tester-1" is forbidden: status unknown for quota: test-quota, resources: requests.deviceclass.resource.kubernetes.io/e2e-dra-9730-class-resource-quota,requests.e2e-dra-9730.k8s.io/resource-quota

```