### PR TITLE
Move kubectl apply e2e tests to dedicated file

### DIFF
--- a/test/e2e/kubectl/apply.go
+++ b/test/e2e/kubectl/apply.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/ginkgo/v2"
 
 	clientset "k8s.io/client-go/kubernetes"
@@ -32,7 +33,7 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 )
 
-var _ = SIGDescribe("Kubectl client", func() {
+var _ = SIGDescribe("kubectl apply", func() {
 	defer ginkgo.GinkgoRecover()
 	f := framework.NewDefaultFramework("kubectl")
 	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
@@ -44,81 +45,138 @@ var _ = SIGDescribe("Kubectl client", func() {
 		ns = f.Namespace.Name
 	})
 
-	ginkgo.Describe("Kubectl apply", func() {
-		ginkgo.It("should apply a new configuration to an existing RC", func(ctx context.Context) {
-			controllerJSON := commonutils.SubstituteImageName(string(readTestFileOrDie(agnhostControllerFilename)))
+	ginkgo.It("should apply a new configuration to an existing RC", func(ctx context.Context) {
+		controllerJSON := commonutils.SubstituteImageName(string(readTestFileOrDie(agnhostControllerFilename)))
 
-			ginkgo.By("creating Agnhost RC")
-			e2ekubectl.RunKubectlOrDieInput(ns, controllerJSON, "create", "-f", "-")
-			ginkgo.By("applying a modified configuration")
-			stdin := modifyReplicationControllerConfiguration(controllerJSON)
-			e2ekubectl.NewKubectlCommand(ns, "apply", "-f", "-").
-				WithStdinReader(stdin).
-				ExecOrDie(ns)
-			ginkgo.By("checking the result")
-			forEachReplicationController(ctx, c, ns, "app", "agnhost", validateReplicationControllerConfiguration)
-		})
-		ginkgo.It("should reuse port when apply to an existing SVC", func(ctx context.Context) {
-			serviceJSON := readTestFileOrDie(agnhostServiceFilename)
+		ginkgo.By("creating Agnhost RC")
+		e2ekubectl.RunKubectlOrDieInput(ns, controllerJSON, "create", "-f", "-")
+		ginkgo.By("applying a modified configuration")
+		stdin := modifyReplicationControllerConfiguration(controllerJSON)
+		e2ekubectl.NewKubectlCommand(ns, "apply", "-f", "-").
+			WithStdinReader(stdin).
+			ExecOrDie(ns)
+		ginkgo.By("checking the result")
+		forEachReplicationController(ctx, c, ns, "app", "agnhost", validateReplicationControllerConfiguration)
+	})
+	ginkgo.It("should reuse port when apply to an existing SVC", func(ctx context.Context) {
+		serviceJSON := readTestFileOrDie(agnhostServiceFilename)
 
-			ginkgo.By("creating Agnhost SVC")
-			e2ekubectl.RunKubectlOrDieInput(ns, string(serviceJSON), "create", "-f", "-")
+		ginkgo.By("creating Agnhost SVC")
+		e2ekubectl.RunKubectlOrDieInput(ns, string(serviceJSON), "create", "-f", "-")
 
-			ginkgo.By("getting the original port")
-			originalNodePort := e2ekubectl.RunKubectlOrDie(ns, "get", "service", "agnhost-primary", "-o", "jsonpath={.spec.ports[0].port}")
+		ginkgo.By("getting the original port")
+		originalNodePort := e2ekubectl.RunKubectlOrDie(ns, "get", "service", "agnhost-primary", "-o", "jsonpath={.spec.ports[0].port}")
 
-			ginkgo.By("applying the same configuration")
-			e2ekubectl.RunKubectlOrDieInput(ns, string(serviceJSON), "apply", "-f", "-")
+		ginkgo.By("applying the same configuration")
+		e2ekubectl.RunKubectlOrDieInput(ns, string(serviceJSON), "apply", "-f", "-")
 
-			ginkgo.By("getting the port after applying configuration")
-			currentNodePort := e2ekubectl.RunKubectlOrDie(ns, "get", "service", "agnhost-primary", "-o", "jsonpath={.spec.ports[0].port}")
+		ginkgo.By("getting the port after applying configuration")
+		currentNodePort := e2ekubectl.RunKubectlOrDie(ns, "get", "service", "agnhost-primary", "-o", "jsonpath={.spec.ports[0].port}")
 
-			ginkgo.By("checking the result")
-			if originalNodePort != currentNodePort {
-				framework.Failf("port should keep the same")
+		ginkgo.By("checking the result")
+		if originalNodePort != currentNodePort {
+			framework.Failf("port should keep the same")
+		}
+	})
+
+	ginkgo.It("apply set/view last-applied", func(ctx context.Context) {
+		deployment1Yaml := commonutils.SubstituteImageName(string(readTestFileOrDie(agnhostDeployment1Filename)))
+		deployment2Yaml := commonutils.SubstituteImageName(string(readTestFileOrDie(agnhostDeployment2Filename)))
+		deployment3Yaml := commonutils.SubstituteImageName(string(readTestFileOrDie(agnhostDeployment3Filename)))
+
+		ginkgo.By("deployment replicas number is 2")
+		e2ekubectl.RunKubectlOrDieInput(ns, deployment1Yaml, "apply", "-f", "-")
+
+		ginkgo.By("check the last-applied matches expectations annotations")
+		output := e2ekubectl.RunKubectlOrDieInput(ns, deployment1Yaml, "apply", "view-last-applied", "-f", "-", "-o", "json")
+		requiredString := "\"replicas\": 2"
+		if !strings.Contains(output, requiredString) {
+			framework.Failf("Missing %s in kubectl view-last-applied", requiredString)
+		}
+
+		ginkgo.By("apply file doesn't have replicas")
+		e2ekubectl.RunKubectlOrDieInput(ns, deployment2Yaml, "apply", "set-last-applied", "-f", "-")
+
+		ginkgo.By("check last-applied has been updated, annotations doesn't have replicas")
+		output = e2ekubectl.RunKubectlOrDieInput(ns, deployment1Yaml, "apply", "view-last-applied", "-f", "-", "-o", "json")
+		requiredString = "\"replicas\": 2"
+		if strings.Contains(output, requiredString) {
+			framework.Failf("Presenting %s in kubectl view-last-applied", requiredString)
+		}
+
+		ginkgo.By("scale set replicas to 3")
+		agnhostDeploy := "agnhost-deployment"
+		debugDiscovery()
+		e2ekubectl.RunKubectlOrDie(ns, "scale", "deployment", agnhostDeploy, "--replicas=3")
+
+		ginkgo.By("apply file doesn't have replicas but image changed")
+		e2ekubectl.RunKubectlOrDieInput(ns, deployment3Yaml, "apply", "-f", "-")
+
+		ginkgo.By("verify replicas still is 3 and image has been updated")
+		output = e2ekubectl.RunKubectlOrDieInput(ns, deployment3Yaml, "get", "-f", "-", "-o", "json")
+		requiredItems := []string{"\"replicas\": 3", imageutils.GetE2EImage(imageutils.AgnhostPrev)}
+		for _, item := range requiredItems {
+			if !strings.Contains(output, item) {
+				framework.Failf("Missing %s in kubectl apply", item)
 			}
-		})
+		}
+	})
 
-		ginkgo.It("apply set/view last-applied", func(ctx context.Context) {
-			deployment1Yaml := commonutils.SubstituteImageName(string(readTestFileOrDie(agnhostDeployment1Filename)))
-			deployment2Yaml := commonutils.SubstituteImageName(string(readTestFileOrDie(agnhostDeployment2Filename)))
-			deployment3Yaml := commonutils.SubstituteImageName(string(readTestFileOrDie(agnhostDeployment3Filename)))
+	ginkgo.Describe("Kubectl prune with applyset", func() {
+		ginkgo.It("should apply and prune objects", func(ctx context.Context) {
+			framework.Logf("applying manifest1")
+			manifest1 := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm1
+  namespace: {{ns}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm2
+  namespace: {{ns}}
+`
 
-			ginkgo.By("deployment replicas number is 2")
-			e2ekubectl.RunKubectlOrDieInput(ns, deployment1Yaml, "apply", "-f", "-")
+			manifest1 = strings.ReplaceAll(manifest1, "{{ns}}", ns)
+			args := []string{"apply", "--prune", "--applyset=applyset1", "-f", "-"}
+			e2ekubectl.NewKubectlCommand(ns, args...).AppendEnv([]string{"KUBECTL_APPLYSET=true"}).WithStdinData(manifest1).ExecOrDie(ns)
 
-			ginkgo.By("check the last-applied matches expectations annotations")
-			output := e2ekubectl.RunKubectlOrDieInput(ns, deployment1Yaml, "apply", "view-last-applied", "-f", "-", "-o", "json")
-			requiredString := "\"replicas\": 2"
-			if !strings.Contains(output, requiredString) {
-				framework.Failf("Missing %s in kubectl view-last-applied", requiredString)
+			framework.Logf("checking which objects exist")
+			objects := mustListObjectsInNamespace(ctx, c, ns)
+			names := mustGetNames(objects)
+			if diff := cmp.Diff(names, []string{"cm1", "cm2"}); diff != "" {
+				framework.Failf("unexpected configmap names (-want +got):\n%s", diff)
 			}
 
-			ginkgo.By("apply file doesn't have replicas")
-			e2ekubectl.RunKubectlOrDieInput(ns, deployment2Yaml, "apply", "set-last-applied", "-f", "-")
+			framework.Logf("applying manifest2")
+			manifest2 := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm1
+  namespace: {{ns}}
+`
+			manifest2 = strings.ReplaceAll(manifest2, "{{ns}}", ns)
 
-			ginkgo.By("check last-applied has been updated, annotations doesn't have replicas")
-			output = e2ekubectl.RunKubectlOrDieInput(ns, deployment1Yaml, "apply", "view-last-applied", "-f", "-", "-o", "json")
-			requiredString = "\"replicas\": 2"
-			if strings.Contains(output, requiredString) {
-				framework.Failf("Presenting %s in kubectl view-last-applied", requiredString)
+			e2ekubectl.NewKubectlCommand(ns, args...).AppendEnv([]string{"KUBECTL_APPLYSET=true"}).WithStdinData(manifest2).ExecOrDie(ns)
+
+			framework.Logf("checking which objects exist")
+			objects = mustListObjectsInNamespace(ctx, c, ns)
+			names = mustGetNames(objects)
+			if diff := cmp.Diff(names, []string{"cm1"}); diff != "" {
+				framework.Failf("unexpected configmap names (-want +got):\n%s", diff)
 			}
 
-			ginkgo.By("scale set replicas to 3")
-			agnhostDeploy := "agnhost-deployment"
-			debugDiscovery()
-			e2ekubectl.RunKubectlOrDie(ns, "scale", "deployment", agnhostDeploy, "--replicas=3")
+			framework.Logf("applying manifest2 (again)")
+			e2ekubectl.NewKubectlCommand(ns, args...).AppendEnv([]string{"KUBECTL_APPLYSET=true"}).WithStdinData(manifest2).ExecOrDie(ns)
 
-			ginkgo.By("apply file doesn't have replicas but image changed")
-			e2ekubectl.RunKubectlOrDieInput(ns, deployment3Yaml, "apply", "-f", "-")
-
-			ginkgo.By("verify replicas still is 3 and image has been updated")
-			output = e2ekubectl.RunKubectlOrDieInput(ns, deployment3Yaml, "get", "-f", "-", "-o", "json")
-			requiredItems := []string{"\"replicas\": 3", imageutils.GetE2EImage(imageutils.AgnhostPrev)}
-			for _, item := range requiredItems {
-				if !strings.Contains(output, item) {
-					framework.Failf("Missing %s in kubectl apply", item)
-				}
+			framework.Logf("checking which objects exist")
+			objects = mustListObjectsInNamespace(ctx, c, ns)
+			names = mustGetNames(objects)
+			if diff := cmp.Diff(names, []string{"cm1"}); diff != "" {
+				framework.Failf("unexpected configmap names (-want +got):\n%s", diff)
 			}
 		})
 	})

--- a/test/e2e/kubectl/apply.go
+++ b/test/e2e/kubectl/apply.go
@@ -1,0 +1,125 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// OWNER = sig/cli
+
+package kubectl
+
+import (
+	"context"
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+
+	clientset "k8s.io/client-go/kubernetes"
+	commonutils "k8s.io/kubernetes/test/e2e/common"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = SIGDescribe("Kubectl client", func() {
+	defer ginkgo.GinkgoRecover()
+	f := framework.NewDefaultFramework("kubectl")
+	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+
+	var c clientset.Interface
+	var ns string
+	ginkgo.BeforeEach(func() {
+		c = f.ClientSet
+		ns = f.Namespace.Name
+	})
+
+	ginkgo.Describe("Kubectl apply", func() {
+		ginkgo.It("should apply a new configuration to an existing RC", func(ctx context.Context) {
+			controllerJSON := commonutils.SubstituteImageName(string(readTestFileOrDie(agnhostControllerFilename)))
+
+			ginkgo.By("creating Agnhost RC")
+			e2ekubectl.RunKubectlOrDieInput(ns, controllerJSON, "create", "-f", "-")
+			ginkgo.By("applying a modified configuration")
+			stdin := modifyReplicationControllerConfiguration(controllerJSON)
+			e2ekubectl.NewKubectlCommand(ns, "apply", "-f", "-").
+				WithStdinReader(stdin).
+				ExecOrDie(ns)
+			ginkgo.By("checking the result")
+			forEachReplicationController(ctx, c, ns, "app", "agnhost", validateReplicationControllerConfiguration)
+		})
+		ginkgo.It("should reuse port when apply to an existing SVC", func(ctx context.Context) {
+			serviceJSON := readTestFileOrDie(agnhostServiceFilename)
+
+			ginkgo.By("creating Agnhost SVC")
+			e2ekubectl.RunKubectlOrDieInput(ns, string(serviceJSON), "create", "-f", "-")
+
+			ginkgo.By("getting the original port")
+			originalNodePort := e2ekubectl.RunKubectlOrDie(ns, "get", "service", "agnhost-primary", "-o", "jsonpath={.spec.ports[0].port}")
+
+			ginkgo.By("applying the same configuration")
+			e2ekubectl.RunKubectlOrDieInput(ns, string(serviceJSON), "apply", "-f", "-")
+
+			ginkgo.By("getting the port after applying configuration")
+			currentNodePort := e2ekubectl.RunKubectlOrDie(ns, "get", "service", "agnhost-primary", "-o", "jsonpath={.spec.ports[0].port}")
+
+			ginkgo.By("checking the result")
+			if originalNodePort != currentNodePort {
+				framework.Failf("port should keep the same")
+			}
+		})
+
+		ginkgo.It("apply set/view last-applied", func(ctx context.Context) {
+			deployment1Yaml := commonutils.SubstituteImageName(string(readTestFileOrDie(agnhostDeployment1Filename)))
+			deployment2Yaml := commonutils.SubstituteImageName(string(readTestFileOrDie(agnhostDeployment2Filename)))
+			deployment3Yaml := commonutils.SubstituteImageName(string(readTestFileOrDie(agnhostDeployment3Filename)))
+
+			ginkgo.By("deployment replicas number is 2")
+			e2ekubectl.RunKubectlOrDieInput(ns, deployment1Yaml, "apply", "-f", "-")
+
+			ginkgo.By("check the last-applied matches expectations annotations")
+			output := e2ekubectl.RunKubectlOrDieInput(ns, deployment1Yaml, "apply", "view-last-applied", "-f", "-", "-o", "json")
+			requiredString := "\"replicas\": 2"
+			if !strings.Contains(output, requiredString) {
+				framework.Failf("Missing %s in kubectl view-last-applied", requiredString)
+			}
+
+			ginkgo.By("apply file doesn't have replicas")
+			e2ekubectl.RunKubectlOrDieInput(ns, deployment2Yaml, "apply", "set-last-applied", "-f", "-")
+
+			ginkgo.By("check last-applied has been updated, annotations doesn't have replicas")
+			output = e2ekubectl.RunKubectlOrDieInput(ns, deployment1Yaml, "apply", "view-last-applied", "-f", "-", "-o", "json")
+			requiredString = "\"replicas\": 2"
+			if strings.Contains(output, requiredString) {
+				framework.Failf("Presenting %s in kubectl view-last-applied", requiredString)
+			}
+
+			ginkgo.By("scale set replicas to 3")
+			agnhostDeploy := "agnhost-deployment"
+			debugDiscovery()
+			e2ekubectl.RunKubectlOrDie(ns, "scale", "deployment", agnhostDeploy, "--replicas=3")
+
+			ginkgo.By("apply file doesn't have replicas but image changed")
+			e2ekubectl.RunKubectlOrDieInput(ns, deployment3Yaml, "apply", "-f", "-")
+
+			ginkgo.By("verify replicas still is 3 and image has been updated")
+			output = e2ekubectl.RunKubectlOrDieInput(ns, deployment3Yaml, "get", "-f", "-", "-o", "json")
+			requiredItems := []string{"\"replicas\": 3", imageutils.GetE2EImage(imageutils.AgnhostPrev)}
+			for _, item := range requiredItems {
+				if !strings.Contains(output, item) {
+					framework.Failf("Missing %s in kubectl apply", item)
+				}
+			}
+		})
+	})
+})

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -40,7 +40,6 @@ import (
 	"time"
 
 	openapi_v2 "github.com/google/gnostic-models/openapiv2"
-	"github.com/google/go-cmp/cmp"
 
 	"sigs.k8s.io/yaml"
 
@@ -931,65 +930,6 @@ metadata:
 			for _, component := range components {
 				ginkgo.By("getting status of " + component)
 				e2ekubectl.RunKubectlOrDie(ns, "get", "componentstatuses", component)
-			}
-		})
-	})
-
-	ginkgo.Describe("Kubectl prune with applyset", func() {
-		ginkgo.It("should apply and prune objects", func(ctx context.Context) {
-			framework.Logf("applying manifest1")
-			manifest1 := `
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cm1
-  namespace: {{ns}}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cm2
-  namespace: {{ns}}
-`
-
-			manifest1 = strings.ReplaceAll(manifest1, "{{ns}}", ns)
-			args := []string{"apply", "--prune", "--applyset=applyset1", "-f", "-"}
-			e2ekubectl.NewKubectlCommand(ns, args...).AppendEnv([]string{"KUBECTL_APPLYSET=true"}).WithStdinData(manifest1).ExecOrDie(ns)
-
-			framework.Logf("checking which objects exist")
-			objects := mustListObjectsInNamespace(ctx, c, ns)
-			names := mustGetNames(objects)
-			if diff := cmp.Diff(names, []string{"cm1", "cm2"}); diff != "" {
-				framework.Failf("unexpected configmap names (-want +got):\n%s", diff)
-			}
-
-			framework.Logf("applying manifest2")
-			manifest2 := `
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cm1
-  namespace: {{ns}}
-`
-			manifest2 = strings.ReplaceAll(manifest2, "{{ns}}", ns)
-
-			e2ekubectl.NewKubectlCommand(ns, args...).AppendEnv([]string{"KUBECTL_APPLYSET=true"}).WithStdinData(manifest2).ExecOrDie(ns)
-
-			framework.Logf("checking which objects exist")
-			objects = mustListObjectsInNamespace(ctx, c, ns)
-			names = mustGetNames(objects)
-			if diff := cmp.Diff(names, []string{"cm1"}); diff != "" {
-				framework.Failf("unexpected configmap names (-want +got):\n%s", diff)
-			}
-
-			framework.Logf("applying manifest2 (again)")
-			e2ekubectl.NewKubectlCommand(ns, args...).AppendEnv([]string{"KUBECTL_APPLYSET=true"}).WithStdinData(manifest2).ExecOrDie(ns)
-
-			framework.Logf("checking which objects exist")
-			objects = mustListObjectsInNamespace(ctx, c, ns)
-			names = mustGetNames(objects)
-			if diff := cmp.Diff(names, []string{"cm1"}); diff != "" {
-				framework.Failf("unexpected configmap names (-want +got):\n%s", diff)
 			}
 		})
 	})

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -270,6 +270,38 @@ func hostIsLocal(host string) bool {
 	return false
 }
 
+func debugDiscovery() {
+	home := os.Getenv("HOME")
+	if len(home) == 0 {
+		framework.Logf("no $HOME envvar set")
+		return
+	}
+
+	cacheDir := filepath.Join(home, ".kube", "cache", "discovery")
+	err := filepath.Walk(cacheDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// only pay attention to $host_$port/v1/serverresources.json files
+		subpath := strings.TrimPrefix(path, cacheDir+string(filepath.Separator))
+		parts := filepath.SplitList(subpath)
+		if len(parts) != 3 || parts[1] != "v1" || parts[2] != "serverresources.json" {
+			return nil
+		}
+		framework.Logf("%s modified at %s (current time: %s)", path, info.ModTime(), time.Now())
+
+		data, readError := os.ReadFile(path)
+		if readError != nil {
+			framework.Logf("%s error: %v", path, readError)
+		} else {
+			framework.Logf("%s content: %s", path, string(data))
+		}
+		return nil
+	})
+	framework.Logf("scanned %s for discovery docs: %v", home, err)
+}
+
 var _ = SIGDescribe("Kubectl client", func() {
 	defer ginkgo.GinkgoRecover()
 	f := framework.NewDefaultFramework("kubectl")
@@ -305,38 +337,6 @@ var _ = SIGDescribe("Kubectl client", func() {
 			e2edebug.DumpAllNamespaceInfo(ctx, f.ClientSet, ns)
 			framework.Failf("Verified %d of %d pods , error: %v", len(pods), atLeast, err)
 		}
-	}
-
-	debugDiscovery := func() {
-		home := os.Getenv("HOME")
-		if len(home) == 0 {
-			framework.Logf("no $HOME envvar set")
-			return
-		}
-
-		cacheDir := filepath.Join(home, ".kube", "cache", "discovery")
-		err := filepath.Walk(cacheDir, func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-
-			// only pay attention to $host_$port/v1/serverresources.json files
-			subpath := strings.TrimPrefix(path, cacheDir+string(filepath.Separator))
-			parts := filepath.SplitList(subpath)
-			if len(parts) != 3 || parts[1] != "v1" || parts[2] != "serverresources.json" {
-				return nil
-			}
-			framework.Logf("%s modified at %s (current time: %s)", path, info.ModTime(), time.Now())
-
-			data, readError := os.ReadFile(path)
-			if readError != nil {
-				framework.Logf("%s error: %v", path, readError)
-			} else {
-				framework.Logf("%s content: %s", path, string(data))
-			}
-			return nil
-		})
-		framework.Logf("scanned %s for discovery docs: %v", home, err)
 	}
 
 	ginkgo.Describe("Update Demo", func() {
@@ -990,85 +990,6 @@ metadata:
 			names = mustGetNames(objects)
 			if diff := cmp.Diff(names, []string{"cm1"}); diff != "" {
 				framework.Failf("unexpected configmap names (-want +got):\n%s", diff)
-			}
-		})
-	})
-
-	ginkgo.Describe("Kubectl apply", func() {
-		ginkgo.It("should apply a new configuration to an existing RC", func(ctx context.Context) {
-			controllerJSON := commonutils.SubstituteImageName(string(readTestFileOrDie(agnhostControllerFilename)))
-
-			ginkgo.By("creating Agnhost RC")
-			e2ekubectl.RunKubectlOrDieInput(ns, controllerJSON, "create", "-f", "-")
-			ginkgo.By("applying a modified configuration")
-			stdin := modifyReplicationControllerConfiguration(controllerJSON)
-			e2ekubectl.NewKubectlCommand(ns, "apply", "-f", "-").
-				WithStdinReader(stdin).
-				ExecOrDie(ns)
-			ginkgo.By("checking the result")
-			forEachReplicationController(ctx, c, ns, "app", "agnhost", validateReplicationControllerConfiguration)
-		})
-		ginkgo.It("should reuse port when apply to an existing SVC", func(ctx context.Context) {
-			serviceJSON := readTestFileOrDie(agnhostServiceFilename)
-
-			ginkgo.By("creating Agnhost SVC")
-			e2ekubectl.RunKubectlOrDieInput(ns, string(serviceJSON[:]), "create", "-f", "-")
-
-			ginkgo.By("getting the original port")
-			originalNodePort := e2ekubectl.RunKubectlOrDie(ns, "get", "service", "agnhost-primary", "-o", "jsonpath={.spec.ports[0].port}")
-
-			ginkgo.By("applying the same configuration")
-			e2ekubectl.RunKubectlOrDieInput(ns, string(serviceJSON[:]), "apply", "-f", "-")
-
-			ginkgo.By("getting the port after applying configuration")
-			currentNodePort := e2ekubectl.RunKubectlOrDie(ns, "get", "service", "agnhost-primary", "-o", "jsonpath={.spec.ports[0].port}")
-
-			ginkgo.By("checking the result")
-			if originalNodePort != currentNodePort {
-				framework.Failf("port should keep the same")
-			}
-		})
-
-		ginkgo.It("apply set/view last-applied", func(ctx context.Context) {
-			deployment1Yaml := commonutils.SubstituteImageName(string(readTestFileOrDie(agnhostDeployment1Filename)))
-			deployment2Yaml := commonutils.SubstituteImageName(string(readTestFileOrDie(agnhostDeployment2Filename)))
-			deployment3Yaml := commonutils.SubstituteImageName(string(readTestFileOrDie(agnhostDeployment3Filename)))
-
-			ginkgo.By("deployment replicas number is 2")
-			e2ekubectl.RunKubectlOrDieInput(ns, deployment1Yaml, "apply", "-f", "-")
-
-			ginkgo.By("check the last-applied matches expectations annotations")
-			output := e2ekubectl.RunKubectlOrDieInput(ns, deployment1Yaml, "apply", "view-last-applied", "-f", "-", "-o", "json")
-			requiredString := "\"replicas\": 2"
-			if !strings.Contains(output, requiredString) {
-				framework.Failf("Missing %s in kubectl view-last-applied", requiredString)
-			}
-
-			ginkgo.By("apply file doesn't have replicas")
-			e2ekubectl.RunKubectlOrDieInput(ns, deployment2Yaml, "apply", "set-last-applied", "-f", "-")
-
-			ginkgo.By("check last-applied has been updated, annotations doesn't have replicas")
-			output = e2ekubectl.RunKubectlOrDieInput(ns, deployment1Yaml, "apply", "view-last-applied", "-f", "-", "-o", "json")
-			requiredString = "\"replicas\": 2"
-			if strings.Contains(output, requiredString) {
-				framework.Failf("Presenting %s in kubectl view-last-applied", requiredString)
-			}
-
-			ginkgo.By("scale set replicas to 3")
-			agnhostDeploy := "agnhost-deployment"
-			debugDiscovery()
-			e2ekubectl.RunKubectlOrDie(ns, "scale", "deployment", agnhostDeploy, "--replicas=3")
-
-			ginkgo.By("apply file doesn't have replicas but image changed")
-			e2ekubectl.RunKubectlOrDieInput(ns, deployment3Yaml, "apply", "-f", "-")
-
-			ginkgo.By("verify replicas still is 3 and image has been updated")
-			output = e2ekubectl.RunKubectlOrDieInput(ns, deployment3Yaml, "get", "-f", "-", "-o", "json")
-			requiredItems := []string{"\"replicas\": 3", imageutils.GetE2EImage(imageutils.AgnhostPrev)}
-			for _, item := range requiredItems {
-				if !strings.Contains(output, item) {
-					framework.Failf("Missing %s in kubectl apply", item)
-				}
 			}
 		})
 	})


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
As sig-cli, we have agreed that we need to move the e2e tests located under gigantic kubectl.go to respective files. This PR does this for apply tests by moving them under `apply.go` file.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
This PR must not make any logical or functional changes. All changes must be mechanical movements.

#### Does this PR introduce a user-facing change?
```release-note
None
```