### PR TITLE
Generalize cpumanager checkpoint remaining fixes

### DIFF
--- a/pkg/kubelet/cm/cpumanager/state/checkpoint.go
+++ b/pkg/kubelet/cm/cpumanager/state/checkpoint.go
@@ -52,6 +52,7 @@ type CPUManagerCheckpointData struct {
 // The Data string with DataChecksum is the authoritative V4 payload.
 type CPUManagerCheckpoint struct {
 	// Backward compatibility
+	// The embedded V2 checkpoint must not be enhanced and should be removed as soon as the oldest supported version understands V4.
 	CPUManagerCheckpointV2 `json:",inline"`
 
 	// Data is a serialized CPUManagerCheckpointData

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint.go
@@ -195,7 +195,8 @@ func (sc *stateCheckpoint) loadAndMigrateCheckpointV4() (*CPUManagerCheckpointV4
 
 	if len(checkpointV4.Data) > 0 || checkpointV4.DataChecksum != 0 {
 		// This is a corrupted V4 checkpoint version. Don't fall back to previous versions, but return error.
-		sc.logger.Error(err, "could not load v4 checkpoint, not falling back to previous versions")
+		err = fmt.Errorf("could not load v4 checkpoint: %w", err)
+		sc.logger.Error(err, "not falling back to previous versions")
 		return nil, err
 	}
 

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -123,7 +123,7 @@ func TestCheckpointStateRestore(t *testing.T) {
 			}`,
 			"none",
 			containermap.ContainerMap{},
-			"failed to deserialize cpu manager checkpoint data: unexpected end of JSON input",
+			"could not load v4 checkpoint: failed to deserialize cpu manager checkpoint data: unexpected end of JSON input",
 			nil,
 		},
 		{
@@ -143,7 +143,7 @@ func TestCheckpointStateRestore(t *testing.T) {
 			}`,
 			"none",
 			containermap.ContainerMap{},
-			`checkpoint is corrupted`,
+			"could not load v4 checkpoint: checkpoint is corrupted",
 			nil,
 		},
 		// In below testcase V2 part of checkpoint is intentionally corrupted to verify that it is not used.


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
The PR with CPUmanager checkpoint generalization to v4 with embedded v2 (https://github.com/kubernetes/kubernetes/pull/139102) was merged.

There were some unaddressed review comments, that are fixed by this PR:

* Adding comment about embedded V2 structure
(based on https://github.com/kubernetes/kubernetes/pull/139102#discussion_r3301880524)

* Improving V4 checkpoint corruption error
(based on https://github.com/kubernetes/kubernetes/pull/139102#discussion_r3302477288)

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
