### PR TITLE
scheduler: make adaptive feasible-node limit monotonic

### DIFF
--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -875,17 +875,13 @@ func (sched *Scheduler) numFeasibleNodesToFind(percentageOfNodesToScore *int32, 
 	}
 
 	if percentage == 0 {
-		percentage = int32(50) - numAllNodes/125
-		if percentage < minFeasibleNodesPercentageToFind {
-			percentage = minFeasibleNodesPercentageToFind
-		}
+		return adaptiveNumFeasibleNodesToFind(numAllNodes)
 	}
 
 	numNodes = numAllNodes * percentage / 100
 	if numNodes < minFeasibleNodesToFind {
 		return minFeasibleNodesToFind
 	}
-
 	return numNodes
 }
 
@@ -1340,4 +1336,17 @@ func updatePod(ctx context.Context, client clientset.Interface, apiCacher fwk.AP
 		podStatusCopy.NominatedNodeName = nominatingInfo.NominatedNodeName
 	}
 	return util.PatchPodStatus(ctx, client, pod.Name, pod.Namespace, &pod.Status, podStatusCopy)
+}
+
+func adaptiveNumFeasibleNodesToFind(n int32) int32 {
+	if n <= 100 {
+		return n
+	}
+	if n <= 1000 {
+		return 100 + (n-100)*320/900
+	}
+	if n <= 5000 {
+		return 420 + (n-1000)*80/4000
+	}
+	return 500 + (n-5000)/20
 }

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -55,11 +55,6 @@ const (
 	// certain minimum of nodes are checked for feasibility. This in turn helps
 	// ensure a minimum level of spreading.
 	minFeasibleNodesToFind = 100
-	// minFeasibleNodesPercentageToFind is the minimum percentage of nodes that
-	// would be scored in each scheduling cycle. This is a semi-arbitrary value
-	// to ensure that a certain minimum of nodes are checked for feasibility.
-	// This in turn helps ensure a minimum level of spreading.
-	minFeasibleNodesPercentageToFind = 5
 )
 
 // ScheduleOne does the entire scheduling workflow for a single scheduling entity (either a pod or a pod group).
@@ -1338,15 +1333,24 @@ func updatePod(ctx context.Context, client clientset.Interface, apiCacher fwk.AP
 	return util.PatchPodStatus(ctx, client, pod.Name, pod.Namespace, &pod.Status, podStatusCopy)
 }
 
-func adaptiveNumFeasibleNodesToFind(n int32) int32 {
-	if n <= 100 {
-		return n
+// adaptiveNumFeasibleNodesToFind returns the number of feasible nodes that once found, the scheduler stops
+// its search for more feasible nodes.
+// This function is used to calculate the number of feasible nodes to find based on the number of all nodes.
+// The formula is based on the observation that the number of feasible nodes to find is a function of the number of all nodes.
+// The formula is:
+// - if the number of all nodes is less than or equal to 100, return the number of all nodes
+// - if the number of all nodes is greater than 100 and less than or equal to 1000, return 100 + (number of all nodes - 100)*320/900
+// - if the number of all nodes is greater than 1000 and less than or equal to 5000, return 420 + (number of all nodes - 1000)*80/4000
+// - if the number of all nodes is greater than 5000, return 500 + (number of all nodes - 5000)/20
+func adaptiveNumFeasibleNodesToFind(numAllNodes int32) int32 {
+	if numAllNodes <= 100 {
+		return numAllNodes
 	}
-	if n <= 1000 {
-		return 100 + (n-100)*320/900
+	if numAllNodes <= 1000 {
+		return 100 + (numAllNodes-100)*320/900
 	}
-	if n <= 5000 {
-		return 420 + (n-1000)*80/4000
+	if numAllNodes <= 5000 {
+		return 420 + (numAllNodes-1000)*80/4000
 	}
-	return 500 + (n-5000)/20
+	return 500 + (numAllNodes-5000)/20
 }

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -4405,6 +4405,16 @@ func TestNumFeasibleNodesToFind(t *testing.T) {
 		},
 		{
 			name:         "not set profile percentageOfNodesToScore and nodes number more than 50*125",
+			numAllNodes:  3000,
+			wantNumNodes: 780,
+		},
+		{
+			name:         "not set profile percentageOfNodesToScore and nodes number more than 50*125",
+			numAllNodes:  5000,
+			wantNumNodes: 500,
+		},
+		{
+			name:         "not set profile percentageOfNodesToScore and nodes number more than 50*125",
 			numAllNodes:  6000,
 			wantNumNodes: 300,
 		},

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -4406,7 +4406,7 @@ func TestNumFeasibleNodesToFind(t *testing.T) {
 		{
 			name:         "not set profile percentageOfNodesToScore and nodes number more than 50*125",
 			numAllNodes:  3000,
-			wantNumNodes: 780,
+			wantNumNodes: 460,
 		},
 		{
 			name:         "not set profile percentageOfNodesToScore and nodes number more than 50*125",
@@ -4416,7 +4416,7 @@ func TestNumFeasibleNodesToFind(t *testing.T) {
 		{
 			name:         "not set profile percentageOfNodesToScore and nodes number more than 50*125",
 			numAllNodes:  6000,
-			wantNumNodes: 300,
+			wantNumNodes: 550,
 		},
 		{
 			name:              "set profile percentageOfNodesToScore and nodes number more than 50*125",


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

Nodes | Before| After
-- | -- | --
1 | 1 | 1
100 | 100 | 100
200 | 100 | 135
500 | 230 | 242
1000 | 420 | 420
2000 | **680** | **440**
3000 | **780** | **460**
4000 | **720** | **480**
5000 | 500 | 500
6000 | **300** | **550**
7000 | **350** | **600**
10000 | 500 | 750
20000 | 1000 | 1250


#### Which issue(s) this PR is related to:
xref #138996

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Kube-scheduler now uses a monotonic adaptive default for `percentageOfNodesToScore` when the field is unset or set to `0`, avoiding cases where larger clusters could score fewer feasible nodes than smaller clusters.
```