### PR TITLE
Don't generate the test target for opaque fields and value

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/test_targets.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/test_targets.go
@@ -392,9 +392,9 @@ func collectRules(node *typeNode) fieldRules {
 		}
 	}
 
-	var walkNode func(*typeNode, string)
+	var walkNode func(*typeNode, string, bool, bool)
 	var walkChild func(*childNode, string)
-	walkNode = func(n *typeNode, path string) {
+	walkNode = func(n *typeNode, path string, skipElem, skipKey bool) {
 		if n == nil || seen[n] {
 			return
 		}
@@ -411,10 +411,10 @@ func collectRules(node *typeNode) fieldRules {
 		for _, fld := range n.fields {
 			walkChild(fld, joinPath(path, fld.jsonName))
 		}
-		if n.elem != nil {
+		if n.elem != nil && !skipElem {
 			walkChild(n.elem, joinPath(path, "[*]"))
 		}
-		if n.key != nil {
+		if n.key != nil && !skipKey {
 			walkChild(n.key, path)
 		}
 		if n.underlying != nil {
@@ -428,9 +428,10 @@ func collectRules(node *typeNode) fieldRules {
 		record(path, c.fieldValidations.Functions)
 		record(joinPath(path, "[*]"), c.fieldValIterations.Functions)
 		record(path, c.fieldKeyIterations.Functions)
-		walkNode(c.node, path)
+		walkNode(c.node, path, c.fieldValidations.OpaqueValType, c.fieldValidations.OpaqueKeyType)
+
 	}
-	walkNode(node, "")
+	walkNode(node, "", false, false)
 	return rules
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR ensures that the `validation-gen` tool respects "opaque" tags when generating test targets. Specifically, it updates `staging/src/k8s.io/code-generator/cmd/validation-gen/test_targets.go` to prevent the generator from recursively walking into fields, map keys, or slice/map values that are marked as opaque via `+k8s:opaqueType`.

Without this change, the generator creates test targets for the internal structure of these fields, which contradicts the purpose of the opaque tags (which is to treat the type as a "black box" and ignore its internal validations).

A follow up  PR will use this, which help in preventing regression. 

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:
The logic in `collectRules` was updated to guard calls to `walkNode` and `walkChild` with checks for `OpaqueValType` and `OpaqueKeyType`.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
#### Additional documentation:
N/A