### PR TITLE
WIP: E2E node: enable using release archives for periodic jobs

### DIFF
--- a/cluster/gce/gci/mounter/main.go
+++ b/cluster/gce/gci/mounter/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package main
 
 import (
-	"k8s.io/kubernetes/test/e2e_node/plugins/gcp-credential-provider/pkg"
+	"k8s.io/kubernetes/cluster/gce/gci/mounter/pkg"
 )
 
 func main() {

--- a/cluster/gce/gci/mounter/pkg/mounter.go
+++ b/cluster/gce/gci/mounter/pkg/mounter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package pkg
 
 import (
 	"fmt"
@@ -35,7 +35,7 @@ const (
 	defaultRootfs    = "/home/kubernetes/containerized_mounter/rootfs"
 )
 
-func main() {
+func Main() {
 
 	if len(os.Args) < 2 {
 		fmt.Fprintf(os.Stderr, "Command failed: must provide a command to run.\n")

--- a/test/e2e_node/builder/build.go
+++ b/test/e2e_node/builder/build.go
@@ -32,47 +32,29 @@ var k8sBinDir = flag.String("k8s-bin-dir", "", "Directory containing k8s kubelet
 var useDockerizedBuild = flag.Bool("use-dockerized-build", false, "Use dockerized build for test artifacts")
 var targetBuildArch = flag.String("target-build-arch", "linux/amd64", "Target architecture for the test artifacts for dockerized build")
 
-var buildCGOTargets = []string{
+var buildTargets = []string{
 	"cmd/kubelet",
-}
-
-var buildNoCGOTargets = []string{
 	"test/e2e_node/e2e_node.test",
 	"github.com/onsi/ginkgo/v2/ginkgo",
 	"cluster/gce/gci/mounter",
 	"test/e2e_node/plugins/gcp-credential-provider",
 }
 
-// BuildGo builds k8s binaries.
+// BuildGo builds some default k8s binaries.
 func BuildGo() error {
-	if err := BuildTargets(true); err != nil {
-		return fmt.Errorf("unable to build cgo targets : %w", err)
-	}
-	if err := BuildTargets(false); err != nil {
-		return fmt.Errorf("unable to build non-cgo targets : %w", err)
-	}
-	return nil
+	return BuildTargets(buildTargets...)
 }
 
-// BuildGo builds k8s binaries.
-func BuildTargets(cgo bool) error {
+// BuildGo builds the specified k8s binaries (= WHAT targets).
+func BuildTargets(targets ...string) error {
 	klog.Infof("Building k8s binaries...")
 	k8sRoot, err := utils.GetK8sRootDir()
 	if err != nil {
 		return fmt.Errorf("failed to locate kubernetes root directory %v", err)
 	}
-	targets := buildCGOTargets
-	if !cgo {
-		targets = buildNoCGOTargets
-	}
 	what := strings.Join(targets, " ")
 	cmd := exec.Command("make", "-C", k8sRoot,
 		fmt.Sprintf("WHAT=%s", what))
-	if cgo {
-		cmd.Args = append(cmd.Args, "CGO_ENABLED=1")
-	} else {
-		cmd.Args = append(cmd.Args, "CGO_ENABLED=0")
-	}
 	if IsDockerizedBuild() {
 		klog.Infof("Building dockerized k8s binaries targets %s for architecture %s", targets, GetTargetBuildArch())
 		// Multi-architecture build is only supported in dockerized build

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -26,6 +26,8 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	"os"
 	"os/exec"
@@ -39,6 +41,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
 	cliflag "k8s.io/component-base/cli/flag"
+	mounter "k8s.io/kubernetes/cluster/gce/gci/mounter/pkg"
 	"k8s.io/kubernetes/pkg/util/rlimit"
 	commontest "k8s.io/kubernetes/test/e2e/common"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -48,6 +51,7 @@ import (
 	e2etestfiles "k8s.io/kubernetes/test/e2e/framework/testfiles"
 	e2etestingmanifests "k8s.io/kubernetes/test/e2e/testing-manifests"
 	"k8s.io/kubernetes/test/e2e_node/criproxy"
+	gcpcredentialprovider "k8s.io/kubernetes/test/e2e_node/plugins/gcp-credential-provider/pkg"
 	"k8s.io/kubernetes/test/e2e_node/services"
 	e2enodetestingmanifests "k8s.io/kubernetes/test/e2e_node/testing-manifests"
 	system "k8s.io/system-validators/validators"
@@ -120,6 +124,20 @@ func init() {
 }
 
 func TestMain(m *testing.M) {
+	// e2e_node.test can behave like several other commands which are required
+	// when doing node testing on a remote virtual machine.
+	cmdName := filepath.Base(os.Args[0])
+	switch {
+	case strings.HasPrefix(cmdName, "gcp-credential-provider"):
+		gcpcredentialprovider.Main()
+	case strings.HasPrefix(cmdName, "mounter"):
+		mounter.Main()
+	default:
+		testMain(m)
+	}
+}
+
+func testMain(m *testing.M) {
 	// Copy go flags in TestMain, to ensure go test flags are registered (no longer available in init() as of go1.13)
 	e2econfig.CopyFlags(e2econfig.Flags, flag.CommandLine)
 	framework.RegisterCommonFlags(flag.CommandLine)

--- a/test/e2e_node/plugins/gcp-credential-provider/pkg/main.go
+++ b/test/e2e_node/plugins/gcp-credential-provider/pkg/main.go
@@ -1,0 +1,179 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pkg
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"reflect"
+	"strings"
+	"time"
+
+	"gopkg.in/go-jose/go-jose.v2/jwt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	credentialproviderv1 "k8s.io/kubelet/pkg/apis/credentialprovider/v1"
+)
+
+const (
+	metadataTokenEndpoint = "http://metadata.google.internal./computeMetadata/v1/instance/service-accounts/default/token"
+
+	pluginModeEnvVar = "PLUGIN_MODE"
+)
+
+func Main() {
+	if err := getCredentials(metadataTokenEndpoint, os.Stdin, os.Stdout); err != nil {
+		klog.Fatalf("failed to get credentials: %v", err)
+	}
+}
+
+func getCredentials(tokenEndpoint string, r io.Reader, w io.Writer) error {
+	provider := &provider{
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+		tokenEndpoint: tokenEndpoint,
+	}
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	var authRequest credentialproviderv1.CredentialProviderRequest
+	err = json.Unmarshal(data, &authRequest)
+	if err != nil {
+		return err
+	}
+
+	pluginUsingServiceAccount := os.Getenv(pluginModeEnvVar) == "serviceaccount"
+	if pluginUsingServiceAccount {
+		if len(authRequest.ServiceAccountToken) == 0 {
+			return errors.New("service account token is empty")
+		}
+		expectedAnnotations := map[string]string{
+			"domain.io/identity-id":   "123456",
+			"domain.io/identity-type": "serviceaccount",
+		}
+		if !reflect.DeepEqual(authRequest.ServiceAccountAnnotations, expectedAnnotations) {
+			return fmt.Errorf("unexpected service account annotations, want: %v, got: %v", expectedAnnotations, authRequest.ServiceAccountAnnotations)
+		}
+		// The service account token is not actually used for authentication by this test plugin.
+		// We extract the claims from the token to validate the audience.
+		// This is solely for testing assertions and is not an actual security layer.
+		// Post validation in this block, we proceed with the default flow for fetching credentials.
+		c, err := getClaims(authRequest.ServiceAccountToken)
+		if err != nil {
+			return err
+		}
+		// The audience in the token should match the audience configured in tokenAttributes.serviceAccountTokenAudience
+		// in CredentialProviderConfig.
+		if len(c.Audience) != 1 || c.Audience[0] != "test-audience" {
+			return fmt.Errorf("unexpected audience: %v", c.Audience)
+		}
+	} else {
+		if len(authRequest.ServiceAccountToken) > 0 {
+			return errors.New("service account token is not expected")
+		}
+		if len(authRequest.ServiceAccountAnnotations) > 0 {
+			return errors.New("service account annotations are not expected")
+		}
+	}
+
+	auth, err := provider.Provide(authRequest.Image)
+	if err != nil {
+		return err
+	}
+
+	response := &credentialproviderv1.CredentialProviderResponse{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CredentialProviderResponse",
+			APIVersion: "credentialprovider.kubelet.k8s.io/v1",
+		},
+		CacheKeyType: credentialproviderv1.RegistryPluginCacheKeyType,
+		Auth:         auth,
+	}
+
+	if pluginUsingServiceAccount {
+		response.CacheKeyType = credentialproviderv1.GlobalPluginCacheKeyType
+	}
+
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		// The error from json.Marshal is intentionally not included so as to not leak credentials into the logs
+		return errors.New("error marshaling response")
+	}
+
+	return nil
+}
+
+// getClaims is used to extract claims from the service account token when the plugin is running in service account mode
+// This is solely for testing assertions and is not an actual security layer.
+// We get claims and validate the audience of the token (audience in the token matches the audience configured
+// in tokenAttributes.serviceAccountTokenAudience in CredentialProviderConfig).
+func getClaims(tokenData string) (claims, error) {
+	if strings.HasPrefix(strings.TrimSpace(tokenData), "{") {
+		return claims{}, errors.New("token is not a JWS")
+	}
+	parts := strings.Split(tokenData, ".")
+	if len(parts) != 3 {
+		return claims{}, errors.New("token is not a JWS")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return claims{}, fmt.Errorf("error decoding token payload: %w", err)
+	}
+
+	var c claims
+	d := json.NewDecoder(strings.NewReader(string(payload)))
+	d.DisallowUnknownFields()
+	if err := d.Decode(&c); err != nil {
+		return claims{}, fmt.Errorf("error decoding token payload: %w", err)
+	}
+
+	return c, nil
+}
+
+type claims struct {
+	jwt.Claims
+	privateClaims
+}
+
+// copied from https://github.com/kubernetes/kubernetes/blob/60c4c2b2521fb454ce69dee737e3eb91a25e0535/pkg/serviceaccount/claims.go#L51-L67
+
+type privateClaims struct {
+	Kubernetes kubernetes `json:"kubernetes.io,omitempty"`
+}
+
+type kubernetes struct {
+	Namespace string           `json:"namespace,omitempty"`
+	Svcacct   ref              `json:"serviceaccount,omitempty"`
+	Pod       *ref             `json:"pod,omitempty"`
+	Secret    *ref             `json:"secret,omitempty"`
+	Node      *ref             `json:"node,omitempty"`
+	WarnAfter *jwt.NumericDate `json:"warnafter,omitempty"`
+}
+
+type ref struct {
+	Name string `json:"name,omitempty"`
+	UID  string `json:"uid,omitempty"`
+}

--- a/test/e2e_node/plugins/gcp-credential-provider/pkg/main_test.go
+++ b/test/e2e_node/plugins/gcp-credential-provider/pkg/main_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package pkg
 
 import (
 	"bytes"

--- a/test/e2e_node/plugins/gcp-credential-provider/pkg/provider.go
+++ b/test/e2e_node/plugins/gcp-credential-provider/pkg/provider.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Originally copied from pkg/credentialproviders/gcp
-package main
+package pkg
 
 import (
 	"encoding/json"

--- a/test/e2e_node/remote/node_e2e.go
+++ b/test/e2e_node/remote/node_e2e.go
@@ -42,8 +42,8 @@ func init() {
 
 // SetupTestPackage sets up the test package with binaries k8s required for node e2e tests
 func (n *NodeE2ERemote) SetupTestPackage(tardir, systemSpecName string) error {
-	// Build the executables
-	if err := builder.BuildGo(); err != nil {
+	// Build the executables required below.
+	if err := builder.BuildTargets("cmd/kubelet", "test/e2e_node/e2e_node.test", "github.com/onsi/ginkgo/v2/ginkgo"); err != nil {
 		return fmt.Errorf("failed to build the dependencies: %w", err)
 	}
 
@@ -59,7 +59,7 @@ func (n *NodeE2ERemote) SetupTestPackage(tardir, systemSpecName string) error {
 	}
 
 	// Copy binaries
-	requiredBins := []string{"kubelet", "e2e_node.test", "ginkgo", "mounter", "gcp-credential-provider"}
+	requiredBins := []string{"kubelet", "e2e_node.test", "ginkgo"}
 	for _, bin := range requiredBins {
 		source := filepath.Join(buildOutputDir, bin)
 		klog.V(2).Infof("Copying binaries from %s", source)
@@ -69,6 +69,17 @@ func (n *NodeE2ERemote) SetupTestPackage(tardir, systemSpecName string) error {
 		out, err := exec.Command("cp", source, filepath.Join(tardir, bin)).CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("failed to copy %q: %v Output: %q", bin, err, out)
+		}
+	}
+
+	// When e2e_node.test is invoked through these symlinks, it behaves like these
+	// separate binaries.
+	e2eNodeBinary := "e2e_node.test"
+	for _, alias := range []string{"mounter", "gcp-credential-provider"} {
+		symlink := filepath.Join(tardir, alias)
+		klog.V(2).Infof("Creating symlink %s -> %s", symlink, e2eNodeBinary)
+		if err := os.Symlink(e2eNodeBinary, symlink); err != nil {
+			return fmt.Errorf("failed to create symlink %q: %w", alias, err)
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Periodic jobs can be run with less resources in Prow when they merely download the latest pre-built release archives instead of building Kubernetes from source. This PR enables that by:
- Building the functionality of mounter and gcp-credentials-provider into e2e_node.test, activated by invoking that binary through a symlink (i.e., with a different os.Args[0]).
- Stopping to build those separate binaries, using e2e_node.test instead.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The alternative would be to put the additional binaries into the release archives. The approach with extending e2e_node.test is used instead because e2e_node.test is already contained in the released tar balls and making it self-contained avoids putting more knowledge about E2E node testing into the release build process. 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
