### PR TITLE
e2e: skip HostCleanup test when worker has no NodeExternalIP

### DIFF
--- a/test/e2e/node/kubelet.go
+++ b/test/e2e/node/kubelet.go
@@ -189,7 +189,7 @@ func getHostExternalAddress(ctx context.Context, client clientset.Interface, p *
 		}
 	}
 	if externalAddress == "" {
-		err = fmt.Errorf("No external address for pod %v on node %v",
+		e2eskipper.Skipf("No NodeExternalIP for pod %v on node %v, test requires SSH-reachable worker nodes",
 			p.Name, p.Spec.NodeName)
 	}
 	return


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

Fixes failures on https://testgrid.k8s.io/sig-scalability-gce#gce-master-scale-correctness where worker nodes have no NodeExternalIP. Converts the error into a Skipf.

Failures are on 5/12, 5/14. 5/16 passed because of scheduling luck with the heapster node that does have ssh access.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
