### PR TITLE
[metrics docs]: use prefix match for component mapping

### DIFF
--- a/hack/tools/instrumentation/endpoint_mapping.go
+++ b/hack/tools/instrumentation/endpoint_mapping.go
@@ -82,7 +82,7 @@ func (c *endpointMappingConfig) inferComponentEndpoints(filePath string) []metri
 
 func (c *endpointMappingConfig) isSharedPath(filePath string) bool {
 	for _, pattern := range c.SharedPaths {
-		if strings.Contains(filePath, pattern) {
+		if strings.HasPrefix(filePath, pattern) {
 			return true
 		}
 	}
@@ -93,7 +93,7 @@ func (c *endpointMappingConfig) inferComponents(filePath string, components map[
 	var matchingComponents []string
 	for component, patterns := range components {
 		for _, pattern := range patterns {
-			if strings.Contains(filePath, pattern) {
+			if strings.HasPrefix(filePath, pattern) {
 				matchingComponents = append(matchingComponents, component)
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
The instrumentation scanner previously used `strings.Contains` to match metric file paths against component directory patterns (such as `"pkg/controller/"`). Because nested staging repositories (like `apiextensions-apiserver`) replicate root directory structure names (`"pkg/controller/"`), metrics in staging repositories were incorrectly attributed to `kube-controller-manager` in the generated documentation.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
Detected in https://github.com/kubernetes/kubernetes/pull/137072#discussion_r3251126848

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

