### PR TITLE
self-nominate ndixita to be a sig-node reviewer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -283,6 +283,7 @@ aliases:
     - ffromani
     - tallclair
     - natasha41575
+    - ndixita
   sig-network-approvers:
     - aojea
     - bowei


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

self-nominating ndixita for sig-node reviewer status

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

# Qualification Summary



*   **Member for at least 3 months**
    *   Active contributor to SIG-Node since April 2023
        *   https://github.com/kubernetes/org/issues/4142 
*   **Primary reviewer for at least 5 PRs to the codebase** 
    *   https://github.com/kubernetes/kubernetes/pull/134768 
        *   https://github.com/kubernetes/kubernetes/pull/134768/changes#r2933867405 
        *   https://github.com/kubernetes/kubernetes/pull/134768#discussion_r2692282434 
        *   https://github.com/kubernetes/kubernetes/pull/134768#discussion_r2692081677 
        *   https://github.com/kubernetes/kubernetes/pull/134768#discussion_r2789811298 
        *   https://github.com/kubernetes/kubernetes/pull/134768#pullrequestreview-3782440887 
    *   https://github.com/kubernetes/kubernetes/pull/137584
        *   https://github.com/kubernetes/kubernetes/pull/137584#discussion_r2940719637 
        *   https://github.com/kubernetes/kubernetes/pull/137584#discussion_r2949165712 
    *   https://github.com/kubernetes/kubernetes/pull/132277 
        *   https://github.com/kubernetes/kubernetes/pull/132277#discussion_r2151036049 
    *   https://github.com/kubernetes/kubernetes/pull/130577 
        *   https://github.com/kubernetes/kubernetes/pull/130577#issuecomment-2741466105 
    *   https://github.com/kubernetes/kubernetes/pull/133279  
        *   https://github.com/kubernetes/kubernetes/pull/133279#discussion_r2240444220  
        *   PR 133279 was created from this PR that has a history of review comments https://github.com/kubernetes/kubernetes/pull/132634#discussion_r2178223203 

            https://github.com/kubernetes/kubernetes/pull/132634#pullrequestreview-2976461957  


            https://github.com/kubernetes/kubernetes/pull/132634#pullrequestreview-2976451237  

*   https://github.com/kubernetes/kubernetes/pull/132605
    *   https://github.com/kubernetes/kubernetes/pull/132605#discussion_r2226826204 
    *   https://github.com/kubernetes/kubernetes/pull/132605#discussion_r2226913914 
*   **Reviewed or merged at least 20 substantial PRs to the codebase**
    *   Reviewed (16): https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+reviewed-by%3Andixita+is%3Amerged+label%3Asig%2Fnode+
    *   Merged (17)

        https://github.com/kubernetes/kubernetes/pulls?q=is%3Apr+author%3Andixita+is%3Amerged+label%3Asig%2Fnode+ 


**Code Quality & Technical Ownership:** Established a strong focus on code quality and architectural standards through the primary ownership of KEP-2837 ([Pod Level Resources](https://github.com/kubernetes/enhancements/issues/5419)), KEP-5419 ([In-Place Pod-Level Resources Resize](https://github.com/kubernetes/enhancements/issues/5419)). These features required navigating and understanding a broad cross-section of the Kubernetes codebase as they impacted numerous core components, including the API server, the scheduler in the control plane, the resource managers in the Kubelet (Topology, CPU, and Memory managers), and the container manager.



*   **Domain Expertise:** Actively influencing core designs through the review and monitoring of complex features such as Memory QoS with cgroupv2, [PSI](https://github.com/kubernetes/enhancements/pull/4230)  

