### PR TITLE
CPUmanager checkpoint generalization to v4 with embedded v2

### DIFF
--- a/pkg/kubelet/cm/cpumanager/state/checkpoint.go
+++ b/pkg/kubelet/cm/cpumanager/state/checkpoint.go
@@ -148,7 +148,17 @@ func (cp *CPUManagerCheckpointV2) MarshalCheckpoint() ([]byte, error) {
 func (cp *CPUManagerCheckpointV3) MarshalCheckpoint() ([]byte, error) {
 	// make sure checksum wasn't set before so it doesn't affect output checksum
 	cp.Checksum = 0
-	cp.Checksum = checksum.New(cp)
+
+	// In order to preserve rollback compatibility we must generate a checksum using
+	// the legacy struct name "CPUManagerCheckpoint" instead of "CPUManagerCheckpointV3".
+	// Older Kubelets do not have the string replacement logic
+	// and expect the original struct name.
+	object := dump.ForHash(cp)
+	object = strings.Replace(object, "CPUManagerCheckpointV3", "CPUManagerCheckpoint", 1)
+	hash := fnv.New32a()
+	_, _ = fmt.Fprintf(hash, "%v", object)
+	cp.Checksum = checksum.Checksum(hash.Sum32())
+
 	return json.Marshal(*cp)
 }
 

--- a/pkg/kubelet/cm/cpumanager/state/checkpoint.go
+++ b/pkg/kubelet/cm/cpumanager/state/checkpoint.go
@@ -267,8 +267,25 @@ func (cp *CPUManagerCheckpointV3) VerifyChecksum() error {
 	ck := cp.Checksum
 	cp.Checksum = 0
 	err := ck.Verify(cp)
+	if err == nil {
+		cp.Checksum = ck
+		return nil
+	}
+
+	object := dump.ForHash(cp)
+	object = strings.Replace(object, "CPUManagerCheckpointV3", "CPUManagerCheckpoint", 1)
 	cp.Checksum = ck
-	return err
+
+	hash := fnv.New32a()
+	_, _ = fmt.Fprintf(hash, "%v", object)
+	actualCS := checksum.Checksum(hash.Sum32())
+	if cp.Checksum != actualCS {
+		return &errors.CorruptCheckpointError{
+			ActualCS:   uint64(actualCS),
+			ExpectedCS: uint64(cp.Checksum),
+		}
+	}
+	return nil
 }
 
 // VerifyChecksum verifies that current checksum of checkpoint is valid in v4 format

--- a/pkg/kubelet/cm/cpumanager/state/checkpoint.go
+++ b/pkg/kubelet/cm/cpumanager/state/checkpoint.go
@@ -30,22 +30,43 @@ import (
 	"k8s.io/utils/dump"
 )
 
+// CPUManagerCheckpointV4 serializes checkpoint data to a string, following the
+// same approach used in the allocation manager (see pkg/kubelet/allocation/state/checkpoint.go).
 var _ checkpointmanager.Checkpoint = &CPUManagerCheckpointV1{}
 var _ checkpointmanager.Checkpoint = &CPUManagerCheckpointV2{}
 var _ checkpointmanager.Checkpoint = &CPUManagerCheckpointV3{}
+var _ checkpointmanager.Checkpoint = &CPUManagerCheckpointV4{}
 var _ checkpointmanager.Checkpoint = &CPUManagerCheckpoint{}
 
-// CPUManagerCheckpoint struct is used to store cpu/pod assignments in a checkpoint in v3 format
+// CPUManagerCheckpointData struct is used to store cpu/pod assignments, which is part of a checkpoint in v4 format
+type CPUManagerCheckpointData struct {
+	PolicyName    string                       `json:"policyName"`
+	DefaultCPUSet string                       `json:"defaultCpuSet"`
+	Entries       map[string]map[string]string `json:"entries,omitempty"`
+	PodEntries    PodCPUAssignments            `json:"podEntries,omitempty"`
+}
+
+// CPUManagerCheckpoint represents a structure to store cpu manager checkpoint data
 type CPUManagerCheckpoint struct {
+	// CPUManagerCheckpointData embedded actual data, not serialized directly
+	CheckpointData CPUManagerCheckpointData `json:"-"`
+	// Data is a serialized CPUManagerCheckpointData
+	Data string `json:"data"`
+	// Checksum is a checksum of Data
+	Checksum checksum.Checksum `json:"checksum"`
+}
+
+// CPUManagerCheckpoint struct is used to store cpu/pod assignments in a checkpoint in v4 format
+type CPUManagerCheckpointV4 = CPUManagerCheckpoint
+
+// CPUManagerCheckpointV3 struct is used to store cpu/pod assignments in a checkpoint in v3 format
+type CPUManagerCheckpointV3 struct {
 	PolicyName    string                       `json:"policyName"`
 	DefaultCPUSet string                       `json:"defaultCpuSet"`
 	Entries       map[string]map[string]string `json:"entries,omitempty"`
 	PodEntries    PodCPUAssignments            `json:"podEntries,omitempty"`
 	Checksum      checksum.Checksum            `json:"checksum"`
 }
-
-// CPUManagerCheckpoint struct is used to store cpu/pod assignments in a checkpoint in v3 format
-type CPUManagerCheckpointV3 = CPUManagerCheckpoint
 
 // CPUManagerCheckpointV2 struct is used to store cpu/pod assignments in a checkpoint in v2 format
 type CPUManagerCheckpointV2 struct {
@@ -66,7 +87,7 @@ type CPUManagerCheckpointV1 struct {
 // NewCPUManagerCheckpoint returns an instance of Checkpoint
 func newCPUManagerCheckpoint() *CPUManagerCheckpoint {
 	//nolint:staticcheck // unexported-type-in-api user-facing error message
-	return newCPUManagerCheckpointV3()
+	return newCPUManagerCheckpointV4()
 }
 
 func newCPUManagerCheckpointV1() *CPUManagerCheckpointV1 {
@@ -81,10 +102,19 @@ func newCPUManagerCheckpointV2() *CPUManagerCheckpointV2 {
 	}
 }
 
-func newCPUManagerCheckpointV3() *CPUManagerCheckpoint {
-	return &CPUManagerCheckpoint{
+func newCPUManagerCheckpointV3() *CPUManagerCheckpointV3 {
+	return &CPUManagerCheckpointV3{
 		Entries:    make(map[string]map[string]string),
 		PodEntries: make(PodCPUAssignments),
+	}
+}
+
+func newCPUManagerCheckpointV4() *CPUManagerCheckpointV4 {
+	return &CPUManagerCheckpoint{
+		CheckpointData: CPUManagerCheckpointData{
+			Entries:    make(map[string]map[string]string),
+			PodEntries: make(PodCPUAssignments),
+		},
 	}
 }
 
@@ -115,10 +145,22 @@ func (cp *CPUManagerCheckpointV2) MarshalCheckpoint() ([]byte, error) {
 }
 
 // MarshalCheckpoint returns marshalled checkpoint in v3 format
-func (cp *CPUManagerCheckpoint) MarshalCheckpoint() ([]byte, error) {
+func (cp *CPUManagerCheckpointV3) MarshalCheckpoint() ([]byte, error) {
 	// make sure checksum wasn't set before so it doesn't affect output checksum
 	cp.Checksum = 0
 	cp.Checksum = checksum.New(cp)
+	return json.Marshal(*cp)
+}
+
+// MarshalCheckpoint returns marshalled checkpoint in v4 format
+func (cp *CPUManagerCheckpoint) MarshalCheckpoint() ([]byte, error) {
+	data, err := json.Marshal(cp.CheckpointData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize cpu manager checkpoint data: %w", err)
+	}
+	cp.Data = string(data)
+	cp.Checksum = checksum.New(cp.Data)
+
 	return json.Marshal(*cp)
 }
 
@@ -133,8 +175,19 @@ func (cp *CPUManagerCheckpointV2) UnmarshalCheckpoint(blob []byte) error {
 }
 
 // UnmarshalCheckpoint tries to unmarshal passed bytes to checkpoint in v3 format
-func (cp *CPUManagerCheckpoint) UnmarshalCheckpoint(blob []byte) error {
+func (cp *CPUManagerCheckpointV3) UnmarshalCheckpoint(blob []byte) error {
 	return json.Unmarshal(blob, cp)
+}
+
+// UnmarshalCheckpoint tries to unmarshal passed bytes to checkpoint in v4 format
+func (cp *CPUManagerCheckpoint) UnmarshalCheckpoint(blob []byte) error {
+	if err := json.Unmarshal(blob, cp); err != nil {
+		return fmt.Errorf("failed to deserialize cpu manager checkpoint: %w", err)
+	}
+	if err := json.Unmarshal([]byte(cp.Data), &cp.CheckpointData); err != nil {
+		return fmt.Errorf("failed to deserialize cpu manager checkpoint data: %w", err)
+	}
+	return nil
 }
 
 // VerifyChecksum verifies that current checksum of checkpoint is valid in v1 format
@@ -200,10 +253,15 @@ func (cp *CPUManagerCheckpointV2) VerifyChecksum() error {
 }
 
 // VerifyChecksum verifies that current checksum of checkpoint is valid in v3 format
-func (cp *CPUManagerCheckpoint) VerifyChecksum() error {
+func (cp *CPUManagerCheckpointV3) VerifyChecksum() error {
 	ck := cp.Checksum
 	cp.Checksum = 0
 	err := ck.Verify(cp)
 	cp.Checksum = ck
 	return err
+}
+
+// VerifyChecksum verifies that current checksum of checkpoint is valid in v4 format
+func (cp *CPUManagerCheckpoint) VerifyChecksum() error {
+	return cp.Checksum.Verify(cp.Data)
 }

--- a/pkg/kubelet/cm/cpumanager/state/checkpoint.go
+++ b/pkg/kubelet/cm/cpumanager/state/checkpoint.go
@@ -32,6 +32,7 @@ import (
 
 // CPUManagerCheckpointV4 serializes checkpoint data to a string, following the
 // same approach used in the allocation manager (see pkg/kubelet/allocation/state/checkpoint.go).
+// The embedded V2 version is for keeping forward compatibility.
 var _ checkpointmanager.Checkpoint = &CPUManagerCheckpointV1{}
 var _ checkpointmanager.Checkpoint = &CPUManagerCheckpointV2{}
 var _ checkpointmanager.Checkpoint = &CPUManagerCheckpointV3{}
@@ -46,14 +47,20 @@ type CPUManagerCheckpointData struct {
 	PodEntries    PodCPUAssignments            `json:"podEntries,omitempty"`
 }
 
-// CPUManagerCheckpoint represents a structure to store cpu manager checkpoint data
+// CPUManagerCheckpoint represents a structure to store cpu manager checkpoint data.
+// Dual-checksum format for backward compatibility.
+// The Data string with DataChecksum is the authoritative V4 payload.
 type CPUManagerCheckpoint struct {
-	// CPUManagerCheckpointData embedded actual data, not serialized directly
-	CheckpointData CPUManagerCheckpointData `json:"-"`
+	// Backward compatibility
+	CPUManagerCheckpointV2 `json:",inline"`
+
 	// Data is a serialized CPUManagerCheckpointData
 	Data string `json:"data"`
-	// Checksum is a checksum of Data
-	Checksum checksum.Checksum `json:"checksum"`
+	// DataChecksum is a checksum of Data string
+	DataChecksum checksum.Checksum `json:"dataChecksum"`
+
+	// CheckpointData holds actual data, not serialized directly
+	CheckpointData CPUManagerCheckpointData `json:"-"`
 }
 
 // CPUManagerCheckpoint struct is used to store cpu/pod assignments in a checkpoint in v4 format
@@ -111,6 +118,9 @@ func newCPUManagerCheckpointV3() *CPUManagerCheckpointV3 {
 
 func newCPUManagerCheckpointV4() *CPUManagerCheckpointV4 {
 	return &CPUManagerCheckpoint{
+		CPUManagerCheckpointV2: CPUManagerCheckpointV2{
+			Entries: make(map[string]map[string]string),
+		},
 		CheckpointData: CPUManagerCheckpointData{
 			Entries:    make(map[string]map[string]string),
 			PodEntries: make(PodCPUAssignments),
@@ -162,14 +172,25 @@ func (cp *CPUManagerCheckpointV3) MarshalCheckpoint() ([]byte, error) {
 	return json.Marshal(*cp)
 }
 
-// MarshalCheckpoint returns marshalled checkpoint in v4 format
+// MarshalCheckpoint returns marshalled checkpoint in v4 format with dual checksum for backward compatibility.
 func (cp *CPUManagerCheckpoint) MarshalCheckpoint() ([]byte, error) {
 	data, err := json.Marshal(cp.CheckpointData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to serialize cpu manager checkpoint data: %w", err)
 	}
 	cp.Data = string(data)
-	cp.Checksum = checksum.New(cp.Data)
+	cp.DataChecksum = checksum.New(cp.Data)
+
+	cp.PolicyName = cp.CheckpointData.PolicyName
+	cp.DefaultCPUSet = cp.CheckpointData.DefaultCPUSet
+	cp.Entries = cp.CheckpointData.Entries
+
+	cp.Checksum = 0
+	object := dump.ForHash(&cp.CPUManagerCheckpointV2)
+	object = strings.Replace(object, "CPUManagerCheckpointV2", "CPUManagerCheckpoint", 1)
+	hash := fnv.New32a()
+	_, _ = fmt.Fprintf(hash, "%v", object)
+	cp.Checksum = checksum.Checksum(hash.Sum32())
 
 	return json.Marshal(*cp)
 }
@@ -288,7 +309,8 @@ func (cp *CPUManagerCheckpointV3) VerifyChecksum() error {
 	return nil
 }
 
-// VerifyChecksum verifies that current checksum of checkpoint is valid in v4 format
+// VerifyChecksum verifies that current checksum of checkpoint is valid in v4 format.
+// DataChecksum is the authoritative checksum over Data.
 func (cp *CPUManagerCheckpoint) VerifyChecksum() error {
-	return cp.Checksum.Verify(cp.Data)
+	return cp.DataChecksum.Verify(cp.Data)
 }

--- a/pkg/kubelet/cm/cpumanager/state/checkpoint.go
+++ b/pkg/kubelet/cm/cpumanager/state/checkpoint.go
@@ -39,7 +39,7 @@ var _ checkpointmanager.Checkpoint = &CPUManagerCheckpointV3{}
 var _ checkpointmanager.Checkpoint = &CPUManagerCheckpointV4{}
 var _ checkpointmanager.Checkpoint = &CPUManagerCheckpoint{}
 
-// CPUManagerCheckpointData struct is used to store cpu/pod assignments, which is part of a checkpoint in v4 format
+// CPUManagerCheckpointData struct is used to store CPU/pod assignments, which is part of a checkpoint in v4 format
 type CPUManagerCheckpointData struct {
 	PolicyName    string                       `json:"policyName"`
 	DefaultCPUSet string                       `json:"defaultCpuSet"`
@@ -47,7 +47,7 @@ type CPUManagerCheckpointData struct {
 	PodEntries    PodCPUAssignments            `json:"podEntries,omitempty"`
 }
 
-// CPUManagerCheckpoint represents a structure to store cpu manager checkpoint data.
+// CPUManagerCheckpoint represents a structure to store CPU manager checkpoint data.
 // Dual-checksum format for backward compatibility.
 // The Data string with DataChecksum is the authoritative V4 payload.
 type CPUManagerCheckpoint struct {
@@ -63,10 +63,10 @@ type CPUManagerCheckpoint struct {
 	CheckpointData CPUManagerCheckpointData `json:"-"`
 }
 
-// CPUManagerCheckpoint struct is used to store cpu/pod assignments in a checkpoint in v4 format
+// CPUManagerCheckpoint struct is used to store CPU/pod assignments in a checkpoint in v4 format
 type CPUManagerCheckpointV4 = CPUManagerCheckpoint
 
-// CPUManagerCheckpointV3 struct is used to store cpu/pod assignments in a checkpoint in v3 format
+// CPUManagerCheckpointV3 struct is used to store CPU/pod assignments in a checkpoint in v3 format
 type CPUManagerCheckpointV3 struct {
 	PolicyName    string                       `json:"policyName"`
 	DefaultCPUSet string                       `json:"defaultCpuSet"`
@@ -75,7 +75,7 @@ type CPUManagerCheckpointV3 struct {
 	Checksum      checksum.Checksum            `json:"checksum"`
 }
 
-// CPUManagerCheckpointV2 struct is used to store cpu/pod assignments in a checkpoint in v2 format
+// CPUManagerCheckpointV2 struct is used to store CPU/pod assignments in a checkpoint in v2 format
 type CPUManagerCheckpointV2 struct {
 	PolicyName    string                       `json:"policyName"`
 	DefaultCPUSet string                       `json:"defaultCpuSet"`
@@ -83,7 +83,7 @@ type CPUManagerCheckpointV2 struct {
 	Checksum      checksum.Checksum            `json:"checksum"`
 }
 
-// CPUManagerCheckpointV1 struct is used to store cpu/pod assignments in a checkpoint in v1 format
+// CPUManagerCheckpointV1 struct is used to store CPU/pod assignments in a checkpoint in v1 format
 type CPUManagerCheckpointV1 struct {
 	PolicyName    string            `json:"policyName"`
 	DefaultCPUSet string            `json:"defaultCpuSet"`

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint.go
@@ -211,6 +211,9 @@ func (sc *stateCheckpoint) loadAndMigrateCheckpointV3() (*CPUManagerCheckpointV3
 		return nil, err
 	}
 
+	// Reset V3 (as it might contain some remaining data from previous load attempt)
+	checkpointV3 = newCPUManagerCheckpointV3()
+
 	// Loaded V2, now migrate to V3.
 	sc.logger.Info("migrating cpu manager checkpoint from v2 to v3")
 	sc.migrateV2CheckpointToV3Checkpoint(checkpointV2, checkpointV3)

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint.go
@@ -96,7 +96,7 @@ func (sc *stateCheckpoint) migrateV1CheckpointToV2Checkpoint(src *CPUManagerChec
 	return nil
 }
 
-// migrateV2CheckpointToV3Checkpoint() converts checkpoints from the v1 format to the v2 format
+// migrateV2CheckpointToV3Checkpoint() converts checkpoints from the v2 format to the v3 format
 func (sc *stateCheckpoint) migrateV2CheckpointToV3Checkpoint(src *CPUManagerCheckpointV2, dst *CPUManagerCheckpointV3) {
 	if src.PolicyName != "" {
 		dst.PolicyName = src.PolicyName
@@ -113,19 +113,35 @@ func (sc *stateCheckpoint) migrateV2CheckpointToV3Checkpoint(src *CPUManagerChec
 	}
 }
 
+// migrateV3CheckpointToV4Checkpoint() converts checkpoints from the v3 format to the v4 format
+func (sc *stateCheckpoint) migrateV3CheckpointToV4Checkpoint(src *CPUManagerCheckpointV3, dst *CPUManagerCheckpointV4) {
+	if src.PolicyName != "" {
+		dst.CheckpointData.PolicyName = src.PolicyName
+	}
+	if src.DefaultCPUSet != "" {
+		dst.CheckpointData.DefaultCPUSet = src.DefaultCPUSet
+	}
+	if len(src.Entries) > 0 {
+		dst.CheckpointData.Entries = make(map[string]map[string]string, len(src.Entries))
+		for podUID, containerEntries := range src.Entries {
+			dst.CheckpointData.Entries[podUID] = make(map[string]string, len(containerEntries))
+			maps.Copy(dst.CheckpointData.Entries[podUID], containerEntries)
+		}
+	}
+	if len(src.PodEntries) > 0 {
+		dst.CheckpointData.PodEntries = make(PodCPUAssignments, len(src.PodEntries))
+		for podUID, podEntries := range src.PodEntries {
+			dst.CheckpointData.PodEntries[podUID] = PodEntry{CPUSet: podEntries.CPUSet.Clone()}
+		}
+	}
+}
+
 // restores state from a checkpoint and creates it if it doesn't exist
 func (sc *stateCheckpoint) restoreState() error {
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
 
-	var checkpoint any
-	var err error
-	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) {
-		checkpoint, err = sc.loadAndMigrateCheckpointV3()
-	} else {
-		checkpoint, err = sc.loadAndMigrateCheckpointV2()
-	}
-
+	cp, err := sc.loadAndMigrateCheckpointV4()
 	if err != nil {
 		if errors.Is(err, cperrors.ErrCheckpointNotFound) {
 			return sc.storeState()
@@ -136,49 +152,28 @@ func (sc *stateCheckpoint) restoreState() error {
 	var tmpDefaultCPUSet cpuset.CPUSet
 	var tmpContainerCPUSet cpuset.CPUSet
 	tmpAssignments := ContainerCPUAssignments{}
-	tmpPodAssignments := PodCPUAssignments{}
 
-	switch cp := checkpoint.(type) {
-	case *CPUManagerCheckpointV3:
-		if sc.policyName != cp.PolicyName {
-			return fmt.Errorf("configured policy %q differs from state checkpoint policy %q", sc.policyName, cp.PolicyName)
-		}
-		if tmpDefaultCPUSet, err = cpuset.Parse(cp.DefaultCPUSet); err != nil {
-			return fmt.Errorf("could not parse default cpu set %q: %w", cp.DefaultCPUSet, err)
-		}
-		for pod := range cp.Entries {
-			tmpAssignments[pod] = make(map[string]cpuset.CPUSet, len(cp.Entries[pod]))
-			for container, cpuString := range cp.Entries[pod] {
-				if tmpContainerCPUSet, err = cpuset.Parse(cpuString); err != nil {
-					return fmt.Errorf("could not parse cpuset %q for container %q in pod %q: %w", cpuString, container, pod, err)
-				}
-				tmpAssignments[pod][container] = tmpContainerCPUSet
+	if sc.policyName != cp.CheckpointData.PolicyName {
+		return fmt.Errorf("configured policy %q differs from state checkpoint policy %q", sc.policyName, cp.CheckpointData.PolicyName)
+	}
+	if tmpDefaultCPUSet, err = cpuset.Parse(cp.CheckpointData.DefaultCPUSet); err != nil {
+		return fmt.Errorf("could not parse default cpu set %q: %w", cp.CheckpointData.DefaultCPUSet, err)
+	}
+	for pod := range cp.CheckpointData.Entries {
+		tmpAssignments[pod] = make(map[string]cpuset.CPUSet, len(cp.CheckpointData.Entries[pod]))
+		for container, cpuString := range cp.CheckpointData.Entries[pod] {
+			if tmpContainerCPUSet, err = cpuset.Parse(cpuString); err != nil {
+				return fmt.Errorf("could not parse cpuset %q for container %q in pod %q: %w", cpuString, container, pod, err)
 			}
+			tmpAssignments[pod][container] = tmpContainerCPUSet
 		}
-		maps.Copy(tmpPodAssignments, cp.PodEntries)
-		sc.cache.SetPodCPUAssignments(tmpPodAssignments)
-	case *CPUManagerCheckpointV2:
-		if sc.policyName != cp.PolicyName {
-			return fmt.Errorf("configured policy %q differs from state checkpoint policy %q", sc.policyName, cp.PolicyName)
-		}
-		if tmpDefaultCPUSet, err = cpuset.Parse(cp.DefaultCPUSet); err != nil {
-			return fmt.Errorf("could not parse default cpu set %q: %w", cp.DefaultCPUSet, err)
-		}
-		for pod := range cp.Entries {
-			tmpAssignments[pod] = make(map[string]cpuset.CPUSet, len(cp.Entries[pod]))
-			for container, cpuString := range cp.Entries[pod] {
-				if tmpContainerCPUSet, err = cpuset.Parse(cpuString); err != nil {
-					return fmt.Errorf("could not parse cpuset %q for container %q in pod %q: %w", cpuString, container, pod, err)
-				}
-				tmpAssignments[pod][container] = tmpContainerCPUSet
-			}
-		}
-	default:
-		return fmt.Errorf("unknown checkpoint version %T", cp)
 	}
 
 	sc.cache.SetDefaultCPUSet(tmpDefaultCPUSet)
 	sc.cache.SetCPUAssignments(tmpAssignments)
+	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) {
+		sc.cache.SetPodCPUAssignments(cp.CheckpointData.PodEntries)
+	}
 
 	sc.logger.V(2).Info("restored state from checkpoint")
 	sc.logger.V(2).Info("defaultCPUSet", "defaultCpuSet", tmpDefaultCPUSet.String())
@@ -186,9 +181,40 @@ func (sc *stateCheckpoint) restoreState() error {
 	return nil
 }
 
-// loadAndMigrateCheckpoint loads the latest checkpoint and migrates it from older versions if needed.
-func (sc *stateCheckpoint) loadAndMigrateCheckpointV3() (*CPUManagerCheckpointV3, error) {
+// loadAndMigrateCheckpointV3 loads the latest checkpoint and migrates it from older versions if needed.
+func (sc *stateCheckpoint) loadAndMigrateCheckpointV4() (*CPUManagerCheckpointV4, error) {
+	sc.logger.Info("trying to load v4 cpu manager checkpoint")
+	checkpointV4 := newCPUManagerCheckpointV4()
+	err := sc.checkpointManager.GetCheckpoint(sc.checkpointName, checkpointV4)
+	if err == nil {
+		return checkpointV4, nil
+	}
+	if errors.Is(err, cperrors.ErrCheckpointNotFound) {
+		return nil, err
+	}
+
+	// Log the V4 load error and fall back to V3.
+	sc.logger.Info("could not load v4 checkpoint, falling back to v3", "err", err)
+
 	// Try to load as V3.
+	checkpointV3, err := sc.loadAndMigrateCheckpointV3()
+	if err != nil {
+		return nil, err
+	}
+
+	// Reset V4 (as it might contain some remaining data from previous load attempt)
+	checkpointV4 = newCPUManagerCheckpointV4()
+
+	// Loaded V3, now migrate to V4.
+	sc.logger.Info("migrating cpu manager checkpoint from v3 to v4")
+	sc.migrateV3CheckpointToV4Checkpoint(checkpointV3, checkpointV4)
+
+	return checkpointV4, nil
+}
+
+// loadAndMigrateCheckpointV3 loads the checkpoint in V3 and migrates it from older versions if needed.
+func (sc *stateCheckpoint) loadAndMigrateCheckpointV3() (*CPUManagerCheckpointV3, error) {
+	sc.logger.Info("trying to load v3 cpu manager checkpoint")
 	checkpointV3 := newCPUManagerCheckpointV3()
 	err := sc.checkpointManager.GetCheckpoint(sc.checkpointName, checkpointV3)
 	if err == nil {
@@ -199,11 +225,7 @@ func (sc *stateCheckpoint) loadAndMigrateCheckpointV3() (*CPUManagerCheckpointV3
 	}
 
 	// Log the V3 load error and fall back to V2.
-	if errors.Is(err, cperrors.CorruptCheckpointError{}) {
-		sc.logger.Error(err, "V3 checkpoint is corrupt, falling back to V2")
-	} else {
-		sc.logger.Info("could not load V3 checkpoint, falling back to V2", "err", err)
-	}
+	sc.logger.Info("could not load v3 checkpoint, falling back to v2", "err", err)
 
 	// Try to load as V2.
 	checkpointV2, err := sc.loadAndMigrateCheckpointV2()
@@ -222,7 +244,7 @@ func (sc *stateCheckpoint) loadAndMigrateCheckpointV3() (*CPUManagerCheckpointV3
 }
 
 func (sc *stateCheckpoint) loadAndMigrateCheckpointV2() (*CPUManagerCheckpointV2, error) {
-	// Try to load as V2.
+	sc.logger.Info("trying to load v2 cpu manager checkpoint")
 	checkpointV2 := newCPUManagerCheckpointV2()
 	err := sc.checkpointManager.GetCheckpoint(sc.checkpointName, checkpointV2)
 	if err == nil {
@@ -233,11 +255,7 @@ func (sc *stateCheckpoint) loadAndMigrateCheckpointV2() (*CPUManagerCheckpointV2
 	}
 
 	// Log the V2 load error and fall back to V1.
-	if errors.Is(err, cperrors.CorruptCheckpointError{}) {
-		sc.logger.Error(err, "V2 checkpoint is corrupt, falling back to V1")
-	} else {
-		sc.logger.Info("could not load V2 checkpoint, falling back to V1", "err", err)
-	}
+	sc.logger.Info("could not load v2 checkpoint, falling back to v1", "err", err)
 
 	// Try to load as V1.
 	checkpointV1, err := sc.loadCheckpointV1()
@@ -256,6 +274,7 @@ func (sc *stateCheckpoint) loadAndMigrateCheckpointV2() (*CPUManagerCheckpointV2
 }
 
 func (sc *stateCheckpoint) loadCheckpointV1() (*CPUManagerCheckpointV1, error) {
+	sc.logger.Info("trying to load v1 cpu manager checkpoint")
 	checkpointV1 := newCPUManagerCheckpointV1()
 	err := sc.checkpointManager.GetCheckpoint(sc.checkpointName, checkpointV1)
 	if err != nil {
@@ -266,49 +285,21 @@ func (sc *stateCheckpoint) loadCheckpointV1() (*CPUManagerCheckpointV1, error) {
 
 // saves state to a checkpoint, caller is responsible for locking
 func (sc *stateCheckpoint) storeState() error {
-	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) {
-		return sc.storeStateV3()
-	}
-	return sc.storeStateV2()
-}
-
-// saves state to a checkpoint, caller is responsible for locking
-func (sc *stateCheckpoint) storeStateV3() error {
 	checkpoint := newCPUManagerCheckpoint()
-	checkpoint.PolicyName = sc.policyName
-	checkpoint.DefaultCPUSet = sc.cache.GetDefaultCPUSet().String()
+	checkpoint.CheckpointData.PolicyName = sc.policyName
+	checkpoint.CheckpointData.DefaultCPUSet = sc.cache.GetDefaultCPUSet().String()
 
 	assignments := sc.cache.GetCPUAssignments()
 	for pod := range assignments {
-		checkpoint.Entries[pod] = make(map[string]string, len(assignments[pod]))
+		checkpoint.CheckpointData.Entries[pod] = make(map[string]string, len(assignments[pod]))
 		for container, cset := range assignments[pod] {
-			checkpoint.Entries[pod][container] = cset.String()
+			checkpoint.CheckpointData.Entries[pod][container] = cset.String()
 		}
 	}
 
-	podAssignments := sc.cache.GetPodCPUAssignments()
-	maps.Copy(checkpoint.PodEntries, podAssignments)
-
-	err := sc.checkpointManager.CreateCheckpoint(sc.checkpointName, checkpoint)
-	if err != nil {
-		sc.logger.Error(err, "Failed to save checkpoint")
-		return err
-	}
-	return nil
-}
-
-// saves state to a checkpoint, caller is responsible for locking
-func (sc *stateCheckpoint) storeStateV2() error {
-	checkpoint := newCPUManagerCheckpointV2()
-	checkpoint.PolicyName = sc.policyName
-	checkpoint.DefaultCPUSet = sc.cache.GetDefaultCPUSet().String()
-
-	assignments := sc.cache.GetCPUAssignments()
-	for pod := range assignments {
-		checkpoint.Entries[pod] = make(map[string]string, len(assignments[pod]))
-		for container, cset := range assignments[pod] {
-			checkpoint.Entries[pod][container] = cset.String()
-		}
+	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) {
+		podAssignments := sc.cache.GetPodCPUAssignments()
+		maps.Copy(checkpoint.CheckpointData.PodEntries, podAssignments)
 	}
 
 	err := sc.checkpointManager.CreateCheckpoint(sc.checkpointName, checkpoint)

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint.go
@@ -45,7 +45,7 @@ type stateCheckpoint struct {
 	initialContainers containermap.ContainerMap
 }
 
-// NewCheckpointState creates new State for keeping track of cpu/pod assignment with checkpoint backend
+// NewCheckpointState creates new State for keeping track of CPU/pod assignment with checkpoint backend
 func NewCheckpointState(logger logr.Logger, stateDir, checkpointName, policyName string, initialContainers containermap.ContainerMap) (State, error) {
 	// we store a logger instance because the checkpointmanager code gets no context yet, so it's pointless to add on our outer layer
 	// since we store a checkpoint, we can use the relatively expensive "WithName".
@@ -157,7 +157,7 @@ func (sc *stateCheckpoint) restoreState() error {
 		return fmt.Errorf("configured policy %q differs from state checkpoint policy %q", sc.policyName, cp.CheckpointData.PolicyName)
 	}
 	if tmpDefaultCPUSet, err = cpuset.Parse(cp.CheckpointData.DefaultCPUSet); err != nil {
-		return fmt.Errorf("could not parse default cpu set %q: %w", cp.CheckpointData.DefaultCPUSet, err)
+		return fmt.Errorf("could not parse default CPU set %q: %w", cp.CheckpointData.DefaultCPUSet, err)
 	}
 	for pod := range cp.CheckpointData.Entries {
 		tmpAssignments[pod] = make(map[string]cpuset.CPUSet, len(cp.CheckpointData.Entries[pod]))
@@ -183,7 +183,7 @@ func (sc *stateCheckpoint) restoreState() error {
 
 // loadAndMigrateCheckpointV4 loads the latest checkpoint and migrates it from older versions if needed.
 func (sc *stateCheckpoint) loadAndMigrateCheckpointV4() (*CPUManagerCheckpointV4, error) {
-	sc.logger.Info("trying to load v4 cpu manager checkpoint")
+	sc.logger.Info("trying to load v4 CPU manager checkpoint")
 	checkpointV4 := newCPUManagerCheckpointV4()
 	err := sc.checkpointManager.GetCheckpoint(sc.checkpointName, checkpointV4)
 	if err == nil {
@@ -195,7 +195,7 @@ func (sc *stateCheckpoint) loadAndMigrateCheckpointV4() (*CPUManagerCheckpointV4
 
 	if len(checkpointV4.Data) > 0 || checkpointV4.DataChecksum != 0 {
 		// This is a corrupted V4 checkpoint version. Don't fall back to previous versions, but return error.
-		sc.logger.Error(err, "could not load v4 checkpoint, no falling back to previous versions")
+		sc.logger.Error(err, "could not load v4 checkpoint, not falling back to previous versions")
 		return nil, err
 	}
 
@@ -212,7 +212,7 @@ func (sc *stateCheckpoint) loadAndMigrateCheckpointV4() (*CPUManagerCheckpointV4
 	checkpointV4 = newCPUManagerCheckpointV4()
 
 	// Loaded V3, now migrate to V4.
-	sc.logger.Info("migrating cpu manager checkpoint from v3 to v4")
+	sc.logger.Info("migrating CPU manager checkpoint from v3 to v4")
 	sc.migrateV3CheckpointToV4Checkpoint(checkpointV3, checkpointV4)
 
 	return checkpointV4, nil
@@ -220,7 +220,7 @@ func (sc *stateCheckpoint) loadAndMigrateCheckpointV4() (*CPUManagerCheckpointV4
 
 // loadAndMigrateCheckpointV3 loads the checkpoint in V3 and migrates it from older versions if needed.
 func (sc *stateCheckpoint) loadAndMigrateCheckpointV3() (*CPUManagerCheckpointV3, error) {
-	sc.logger.Info("trying to load v3 cpu manager checkpoint")
+	sc.logger.Info("trying to load v3 CPU manager checkpoint")
 	checkpointV3 := newCPUManagerCheckpointV3()
 	err := sc.checkpointManager.GetCheckpoint(sc.checkpointName, checkpointV3)
 	if err == nil {
@@ -243,14 +243,14 @@ func (sc *stateCheckpoint) loadAndMigrateCheckpointV3() (*CPUManagerCheckpointV3
 	checkpointV3 = newCPUManagerCheckpointV3()
 
 	// Loaded V2, now migrate to V3.
-	sc.logger.Info("migrating cpu manager checkpoint from v2 to v3")
+	sc.logger.Info("migrating CPU manager checkpoint from v2 to v3")
 	sc.migrateV2CheckpointToV3Checkpoint(checkpointV2, checkpointV3)
 
 	return checkpointV3, nil
 }
 
 func (sc *stateCheckpoint) loadAndMigrateCheckpointV2() (*CPUManagerCheckpointV2, error) {
-	sc.logger.Info("trying to load v2 cpu manager checkpoint")
+	sc.logger.Info("trying to load v2 CPU manager checkpoint")
 	checkpointV2 := newCPUManagerCheckpointV2()
 	err := sc.checkpointManager.GetCheckpoint(sc.checkpointName, checkpointV2)
 	if err == nil {
@@ -267,7 +267,7 @@ func (sc *stateCheckpoint) loadAndMigrateCheckpointV2() (*CPUManagerCheckpointV2
 	checkpointV1, err := sc.loadCheckpointV1()
 	if err == nil {
 		// Loaded V1, now migrate V1 -> V2.
-		sc.logger.Info("migrating cpu manager checkpoint from v1 to v2")
+		sc.logger.Info("migrating CPU manager checkpoint from v1 to v2")
 		tmpV2 := newCPUManagerCheckpointV2()
 		if migrationErr := sc.migrateV1CheckpointToV2Checkpoint(checkpointV1, tmpV2); migrationErr != nil {
 			return nil, fmt.Errorf("failed to migrate checkpoint from v1 to v2: %w", migrationErr)
@@ -280,7 +280,7 @@ func (sc *stateCheckpoint) loadAndMigrateCheckpointV2() (*CPUManagerCheckpointV2
 }
 
 func (sc *stateCheckpoint) loadCheckpointV1() (*CPUManagerCheckpointV1, error) {
-	sc.logger.Info("trying to load v1 cpu manager checkpoint")
+	sc.logger.Info("trying to load v1 CPU manager checkpoint")
 	checkpointV1 := newCPUManagerCheckpointV1()
 	err := sc.checkpointManager.GetCheckpoint(sc.checkpointName, checkpointV1)
 	if err != nil {

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint.go
@@ -181,7 +181,7 @@ func (sc *stateCheckpoint) restoreState() error {
 	return nil
 }
 
-// loadAndMigrateCheckpointV3 loads the latest checkpoint and migrates it from older versions if needed.
+// loadAndMigrateCheckpointV4 loads the latest checkpoint and migrates it from older versions if needed.
 func (sc *stateCheckpoint) loadAndMigrateCheckpointV4() (*CPUManagerCheckpointV4, error) {
 	sc.logger.Info("trying to load v4 cpu manager checkpoint")
 	checkpointV4 := newCPUManagerCheckpointV4()
@@ -190,6 +190,12 @@ func (sc *stateCheckpoint) loadAndMigrateCheckpointV4() (*CPUManagerCheckpointV4
 		return checkpointV4, nil
 	}
 	if errors.Is(err, cperrors.ErrCheckpointNotFound) {
+		return nil, err
+	}
+
+	if len(checkpointV4.Data) > 0 || checkpointV4.DataChecksum != 0 {
+		// This is a corrupted V4 checkpoint version. Don't fall back to previous versions, but return error.
+		sc.logger.Error(err, "could not load v4 checkpoint, no falling back to previous versions")
 		return nil, err
 	}
 

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -322,7 +322,7 @@ func TestCheckpointStateRestore(t *testing.T) {
 						"cpuSet":"7-9"
 					}
 				},
-				"checksum": 2284712151
+				"checksum": 766259872
 			}`,
 			"static",
 			containermap.ContainerMap{},
@@ -354,7 +354,7 @@ func TestCheckpointStateRestore(t *testing.T) {
 						"cpuSet":"7-9"
 					}
 				},
-				"checksum": 2284712151
+				"checksum": 766259872
 			}`,
 			"static",
 			containermap.ContainerMap{},
@@ -771,6 +771,43 @@ func TestCPUManagerCheckpoint_MarshalCheckpoint_HashCompatibility(t *testing.T) 
 			if writtenChecksum != expectedLegacyChecksum {
 				t.Errorf("Written Checksum %d does not match legacy calculation %d. Forward compatibility broken.", writtenChecksum, expectedLegacyChecksum)
 			}
+		})
+	}
+}
+
+func TestCPUManagerCheckpointV3_VerifyChecksum_Compatibility(t *testing.T) {
+	testCases := []struct {
+		name     string
+		checksum checksum.Checksum
+	}{
+		{
+			name:     "accepts legacy v3 checksum",
+			checksum: 766259872,
+		},
+		{
+			name:     "accepts current v3 checksum",
+			checksum: 2284712151,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cp := &CPUManagerCheckpointV3{
+				PolicyName:    "static",
+				DefaultCPUSet: "1-2",
+				Entries: map[string]map[string]string{
+					"pod1": {
+						"container1": "5-6",
+						"container2": "3-4",
+					},
+				},
+				PodEntries: PodCPUAssignments{
+					"pod2": {CPUSet: cpuset.New(7, 8, 9)},
+				},
+				Checksum: tc.checksum,
+			}
+
+			require.NoError(t, cp.VerifyChecksum())
 		})
 	}
 }

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -812,6 +812,68 @@ func TestCPUManagerCheckpointV3_VerifyChecksum_Compatibility(t *testing.T) {
 	}
 }
 
+func TestCPUManagerCheckpoint_RoundTrip(t *testing.T) {
+	testCases := []struct {
+		name     string
+		original checkpointmanager.Checkpoint
+		restored checkpointmanager.Checkpoint
+		verify   func(t *testing.T, original, restored checkpointmanager.Checkpoint)
+	}{
+		{
+			name: "V2 checkpoint",
+			original: &CPUManagerCheckpointV2{
+				PolicyName:    "static",
+				DefaultCPUSet: "0-3",
+				Entries: map[string]map[string]string{
+					"pod1": {"container1": "4-5"},
+				},
+			},
+			restored: newCPUManagerCheckpointV2(),
+			verify: func(t *testing.T, original, restored checkpointmanager.Checkpoint) {
+				o := original.(*CPUManagerCheckpointV2)
+				r := restored.(*CPUManagerCheckpointV2)
+				require.Equal(t, o.PolicyName, r.PolicyName)
+				require.Equal(t, o.DefaultCPUSet, r.DefaultCPUSet)
+				require.Equal(t, o.Entries, r.Entries)
+			},
+		},
+		{
+			name: "V3 checkpoint",
+			original: &CPUManagerCheckpointV3{
+				PolicyName:    "static",
+				DefaultCPUSet: "0-3",
+				Entries: map[string]map[string]string{
+					"pod1": {"container1": "4-5"},
+				},
+				PodEntries: PodCPUAssignments{
+					"pod2": {CPUSet: cpuset.New(6, 7)},
+				},
+			},
+			restored: newCPUManagerCheckpointV3(),
+			verify: func(t *testing.T, original, restored checkpointmanager.Checkpoint) {
+				o := original.(*CPUManagerCheckpointV3)
+				r := restored.(*CPUManagerCheckpointV3)
+				require.Equal(t, o.PolicyName, r.PolicyName)
+				require.Equal(t, o.DefaultCPUSet, r.DefaultCPUSet)
+				require.Equal(t, o.Entries, r.Entries)
+				require.Equal(t, o.PodEntries, r.PodEntries)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := tc.original.MarshalCheckpoint()
+			require.NoError(t, err)
+
+			require.NoError(t, tc.restored.UnmarshalCheckpoint(data))
+			require.NoError(t, tc.restored.VerifyChecksum())
+
+			tc.verify(t, tc.original, tc.restored)
+		})
+	}
+}
+
 func removeAll(dir string, t *testing.T) {
 	t.Helper()
 	if err := os.RemoveAll(dir); err != nil {

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -690,53 +690,88 @@ func AssertStateEqual(t *testing.T, sf State, sm State) {
 	}
 }
 
-func TestCPUManagerCheckpointV2_MarshalCheckpoint_ForwardCompatibility(t *testing.T) {
-	// 1. Create a V2 checkpoint using the struct defined in the current codebase (1.36+)
-	currentCheckpoint := &CPUManagerCheckpointV2{
-		PolicyName:    "none",
-		DefaultCPUSet: "1-3",
-		Entries:       make(map[string]map[string]string),
+func TestCPUManagerCheckpoint_MarshalCheckpoint_HashCompatibility(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		currentCheckpoint      any
+		expectedLegacyChecksum func() checksum.Checksum
+	}{
+		{
+			name: "V2 checkpoint",
+			currentCheckpoint: &CPUManagerCheckpointV2{
+				PolicyName:    "none",
+				DefaultCPUSet: "1-3",
+				Entries:       make(map[string]map[string]string),
+			},
+			expectedLegacyChecksum: func() checksum.Checksum {
+				type CPUManagerCheckpoint struct {
+					PolicyName    string                       `json:"policyName"`
+					DefaultCPUSet string                       `json:"defaultCpuSet"`
+					Entries       map[string]map[string]string `json:"entries,omitempty"`
+					Checksum      checksum.Checksum            `json:"checksum"`
+				}
+				return checksum.New(&CPUManagerCheckpoint{
+					PolicyName:    "none",
+					DefaultCPUSet: "1-3",
+					Entries:       make(map[string]map[string]string),
+				})
+			},
+		},
+		{
+			name: "V3 checkpoint",
+			currentCheckpoint: &CPUManagerCheckpointV3{
+				PolicyName:    "none",
+				DefaultCPUSet: "1-3",
+				Entries:       make(map[string]map[string]string),
+				PodEntries:    PodCPUAssignments{"pod": PodEntry{cpuset.New(4, 5)}},
+			},
+			expectedLegacyChecksum: func() checksum.Checksum {
+				type CPUManagerCheckpoint struct {
+					PolicyName    string                       `json:"policyName"`
+					DefaultCPUSet string                       `json:"defaultCpuSet"`
+					Entries       map[string]map[string]string `json:"entries,omitempty"`
+					PodEntries    PodCPUAssignments            `json:"podEntries,omitempty"`
+					Checksum      checksum.Checksum            `json:"checksum"`
+				}
+				return checksum.New(&CPUManagerCheckpoint{
+					PolicyName:    "none",
+					DefaultCPUSet: "1-3",
+					Entries:       make(map[string]map[string]string),
+					PodEntries:    PodCPUAssignments{"pod": PodEntry{cpuset.New(4, 5)}},
+				})
+			},
+		},
 	}
 
-	// Marshal it using the logic that forces the "CPUManagerCheckpoint" name
-	data, err := currentCheckpoint.MarshalCheckpoint()
-	if err != nil {
-		t.Fatalf("Failed to marshal checkpoint: %v", err)
-	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// 1. Marshal the checkpoint using the logic that forces the "CPUManagerCheckpoint" name
+			data, err := tc.currentCheckpoint.(interface{ MarshalCheckpoint() ([]byte, error) }).MarshalCheckpoint()
+			if err != nil {
+				t.Fatalf("Failed to marshal checkpoint: %v", err)
+			}
 
-	// 2. Unmarshal the raw JSON to extract the checksum that was actually written to the file
-	var result map[string]interface{}
-	if err := json.Unmarshal(data, &result); err != nil {
-		t.Fatalf("Failed to unmarshal JSON: %v", err)
-	}
+			// 2. Unmarshal the raw JSON to extract the checksum that was actually written to the file
+			var result map[string]interface{}
+			if err := json.Unmarshal(data, &result); err != nil {
+				t.Fatalf("Failed to unmarshal JSON: %v", err)
+			}
 
-	actualChecksumFloat, ok := result["checksum"].(float64)
-	if !ok {
-		t.Fatalf("Checksum field missing or invalid type")
-	}
-	writtenChecksum := checksum.Checksum(uint64(actualChecksumFloat))
+			actualChecksumFloat, ok := result["checksum"].(float64)
+			if !ok {
+				t.Fatalf("Checksum field missing or invalid type")
+			}
+			writtenChecksum := checksum.Checksum(uint64(actualChecksumFloat))
 
-	// 3. Reconstruct how versions 1.35 and earlier would calculate the checksum
-	// by defining a struct with the exact legacy name and fields.
-	type CPUManagerCheckpoint struct {
-		PolicyName    string                       `json:"policyName"`
-		DefaultCPUSet string                       `json:"defaultCpuSet"`
-		Entries       map[string]map[string]string `json:"entries,omitempty"`
-		Checksum      checksum.Checksum            `json:"checksum"`
-	}
+			// 3. Compute the expected legacy checksum
+			expectedLegacyChecksum := tc.expectedLegacyChecksum()
 
-	legacyCheckpoint := &CPUManagerCheckpoint{
-		PolicyName:    currentCheckpoint.PolicyName,
-		DefaultCPUSet: currentCheckpoint.DefaultCPUSet,
-		Entries:       currentCheckpoint.Entries,
-	}
-
-	expectedLegacyChecksum := checksum.New(legacyCheckpoint)
-
-	// 4. Assert that the checksum written by our 1.36+ code matches
-	// what a 1.35 Kubelet would expect to see.
-	if writtenChecksum != expectedLegacyChecksum {
-		t.Errorf("Written Checksum %d does not match legacy calculation %d. Forward compatibility broken.", writtenChecksum, expectedLegacyChecksum)
+			// 4. Assert that the checksum written by our 1.36+ code matches
+			// what a 1.35 Kubelet would expect to see.
+			if writtenChecksum != expectedLegacyChecksum {
+				t.Errorf("Written Checksum %d does not match legacy calculation %d. Forward compatibility broken.", writtenChecksum, expectedLegacyChecksum)
+			}
+		})
 	}
 }
 

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -18,13 +18,17 @@ package state
 
 import (
 	"encoding/json"
+	"fmt"
+	"maps"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/component-base/featuregate"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
@@ -37,27 +41,96 @@ import (
 
 const testingCheckpoint = "cpumanager_checkpoint_test"
 
+type FeatureGateCombination map[featuregate.Feature]bool
+
+// allFeatureGateCombinations generates all combinations of provided feature gates.
+// Each combination is represented as a map of feature name to its state (enabled/disabled).
+// Combinations are constructed:
+//   - starting with single empty combination
+//   - then for each feature gate all combinations are appended twice to new slice
+//     (once with feature disabled and once with feature enabled)
+//   - combination list is replaced with new slice
+//
+// For example, given two features A and B, allFeatureGateCombinations will build combinations:
+// * Initial: `[{}]`
+// * After A: `[{A: false}, {A: true}]`
+// * After B: `[{A: false, B: false}, {A: false, B: true}, {A: true, B: false}, {A: true, B: true}]`
+func allFeatureGateCombinations(gates []featuregate.Feature) []FeatureGateCombination {
+	combinations := []FeatureGateCombination{make(FeatureGateCombination)}
+	for _, gate := range gates {
+		var newCombinations []FeatureGateCombination
+		for _, combination := range combinations {
+			// Append combination copy with the feature disabled
+			disabled := maps.Clone(combination)
+			disabled[gate] = false
+			newCombinations = append(newCombinations, disabled)
+
+			// Append combination with the feature enabled
+			combination[gate] = true
+			newCombinations = append(newCombinations, combination)
+		}
+		combinations = newCombinations
+	}
+	return combinations
+}
+
+func describe(comb FeatureGateCombination) string {
+	keys := slices.Sorted(maps.Keys(comb))
+	if len(keys) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%s=%v", keys[0], comb[keys[0]])
+	for _, key := range keys[1:] {
+		fmt.Fprintf(&sb, ",%s=%v", key, comb[key])
+	}
+	return sb.String()
+}
+
 func TestCheckpointStateRestore(t *testing.T) {
 	testCases := []struct {
-		description                     string
-		checkpointContent               string
-		policyName                      string
-		initialContainers               containermap.ContainerMap
-		expectedError                   string
-		expectedState                   *stateMemory
-		podLevelResourceManagersEnabled bool
+		description       string
+		fgRequirements    FeatureGateCombination
+		checkpointContent string
+		policyName        string
+		initialContainers containermap.ContainerMap
+		expectedError     string
+		expectedState     *stateMemory
 	}{
 		{
 			"Restore non-existing checkpoint",
+			nil,
 			"",
 			"none",
 			containermap.ContainerMap{},
 			"",
 			&stateMemory{},
-			false,
+		},
+		{
+			"Fail to restore checkpoint without data section",
+			nil,
+			`{
+				"checksum": 1234
+			}`,
+			"none",
+			containermap.ContainerMap{},
+			"checkpoint is corrupted",
+			nil,
+		},
+		{
+			"Fail to restore checkpoint without checksum section (fall back to empty v2 version)",
+			nil,
+			`{
+				"data": "{\"policyName\":\"none\",\"defaultCPUSet\":\"4-6\"}"
+			}`,
+			"none",
+			containermap.ContainerMap{},
+			`configured policy "none" differs from state checkpoint policy ""`,
+			nil,
 		},
 		{
 			"Restore default cpu set",
+			nil,
 			`{
 				"data": "{\"policyName\":\"none\",\"defaultCPUSet\":\"4-6\"}",
 				"checksum": 657950972
@@ -68,10 +141,10 @@ func TestCheckpointStateRestore(t *testing.T) {
 			&stateMemory{
 				defaultCPUSet: cpuset.New(4, 5, 6),
 			},
-			false,
 		},
 		{
 			"Restore valid checkpoint",
+			nil,
 			`{
 				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"7-9\",\"entries\":{\"pod\":{\"container1\":\"4-6\",\"container2\":\"1-3\"}}}",
 				"checksum": 1420829534
@@ -88,10 +161,10 @@ func TestCheckpointStateRestore(t *testing.T) {
 				},
 				defaultCPUSet: cpuset.New(7, 8, 9),
 			},
-			false,
 		},
 		{
-			"Restore checkpoint with invalid checksum",
+			"Fail to restore checkpoint with invalid checksum",
+			nil,
 			`{
 				"data": "{\"policyName\":\"none\",\"defaultCPUSet\":\"4-6\"}",
 				"checksum": 1234
@@ -99,20 +172,20 @@ func TestCheckpointStateRestore(t *testing.T) {
 			"none",
 			containermap.ContainerMap{},
 			"checkpoint is corrupted",
-			&stateMemory{},
-			false,
+			nil,
 		},
 		{
-			"Restore checkpoint with invalid JSON",
+			"Fail to restore checkpoint with invalid JSON",
+			nil,
 			`{`,
 			"none",
 			containermap.ContainerMap{},
 			"unexpected end of JSON input",
-			&stateMemory{},
-			false,
+			nil,
 		},
 		{
-			"Restore checkpoint with invalid policy name",
+			"Fail to restore checkpoint with invalid policy name",
+			nil,
 			`{
 				"data": "{\"policyName\":\"other\",\"defaultCPUSet\":\"1-3\"}",
 				"checksum": 2380595610
@@ -120,11 +193,11 @@ func TestCheckpointStateRestore(t *testing.T) {
 			"none",
 			containermap.ContainerMap{},
 			`configured policy "none" differs from state checkpoint policy "other"`,
-			&stateMemory{},
-			false,
+			nil,
 		},
 		{
-			"Restore checkpoint with unparsable default cpu set",
+			"Fail to restore checkpoint with unparsable default cpu set",
+			nil,
 			`{
 				"data": "{\"policyName\":\"none\",\"defaultCPUSet\":\"1.3\"}",
 				"checksum": 3033143655
@@ -132,11 +205,11 @@ func TestCheckpointStateRestore(t *testing.T) {
 			"none",
 			containermap.ContainerMap{},
 			`could not parse default cpu set "1.3": strconv.Atoi: parsing "1.3": invalid syntax`,
-			&stateMemory{},
-			false,
+			nil,
 		},
 		{
-			"Restore checkpoint with unparsable assignment entry",
+			"Fail to restore checkpoint with unparsable assignment entry",
+			nil,
 			`{
 				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"1-3\",\"entries\":{\"pod\":{\"container1\":\"4-6\",\"container2\":\"asd\"}}}",
 				"checksum": 3794806925
@@ -144,11 +217,25 @@ func TestCheckpointStateRestore(t *testing.T) {
 			"static",
 			containermap.ContainerMap{},
 			`could not parse cpuset "asd" for container "container2" in pod "pod": strconv.Atoi: parsing "asd": invalid syntax`,
-			&stateMemory{},
-			false,
+			nil,
+		},
+		{
+			"Restore checkpoint ignoring unknown fields in data section",
+			nil,
+			`{
+				"data": "{\"policyName\":\"none\",\"defaultCPUSet\":\"4-6\",\"unknownField\":\"value\"}",
+				"checksum": 3492408555
+			}`,
+			"none",
+			containermap.ContainerMap{},
+			"",
+			&stateMemory{
+				defaultCPUSet: cpuset.New(4, 5, 6),
+			},
 		},
 		{
 			"Restore checkpoint from checkpoint with v1 checksum",
+			nil,
 			`{
 				"policyName": "none",
 				"defaultCPUSet": "1-3",
@@ -160,10 +247,10 @@ func TestCheckpointStateRestore(t *testing.T) {
 			&stateMemory{
 				defaultCPUSet: cpuset.New(1, 2, 3),
 			},
-			false,
 		},
 		{
-			"Restore checkpoint with migration",
+			"Restore checkpoint from v1 (migration)",
+			nil,
 			`{
 				"policyName": "static",
 				"defaultCPUSet": "7-9",
@@ -190,40 +277,10 @@ func TestCheckpointStateRestore(t *testing.T) {
 				},
 				defaultCPUSet: cpuset.New(7, 8, 9),
 			},
-			false,
 		},
 		{
-			"Restore checkpoint from v1 (migration) with PodLevelResourceManagers enabled",
-			`{
-				"policyName": "none",
-				"defaultCPUSet": "1-3",
-				"entries": {
-					"containerID1": "4-6",
-					"containerID2": "1-3"
-				},
-				"checksum": 3680390589
-			}`,
-			"none",
-			func() containermap.ContainerMap {
-				cm := containermap.NewContainerMap()
-				cm.Add("pod", "container1", "containerID1")
-				cm.Add("pod", "container2", "containerID2")
-				return cm
-			}(),
-			"",
-			&stateMemory{
-				assignments: ContainerCPUAssignments{
-					"pod": map[string]cpuset.CPUSet{
-						"container1": cpuset.New(4, 5, 6),
-						"container2": cpuset.New(1, 2, 3),
-					},
-				},
-				defaultCPUSet: cpuset.New(1, 2, 3),
-			},
-			true,
-		},
-		{
-			"Restore checkpoint from v2 (migration) with PodLevelResourceManagers enabled",
+			"Restore checkpoint from v2 (migration)",
+			nil,
 			`{
 				"policyName": "static",
 				"defaultCPUSet": "7-9",
@@ -247,10 +304,42 @@ func TestCheckpointStateRestore(t *testing.T) {
 				},
 				defaultCPUSet: cpuset.New(7, 8, 9),
 			},
-			true,
+		},
+		{
+			"Restore checkpoint from v3 (migration) with PodLevelResourceManagers disabled",
+			FeatureGateCombination{features.PodLevelResourceManagers: false},
+			`{
+				"policyName": "static",
+				"defaultCPUSet": "1-2",
+				"entries": {
+					"pod1": {
+						"container1": "5-6",
+						"container2": "3-4"
+					}
+				},
+				"podEntries": {
+					"pod2": {
+						"cpuSet":"7-9"
+					}
+				},
+				"checksum": 2284712151
+			}`,
+			"static",
+			containermap.ContainerMap{},
+			"",
+			&stateMemory{
+				assignments: ContainerCPUAssignments{
+					"pod1": map[string]cpuset.CPUSet{
+						"container1": cpuset.New(5, 6),
+						"container2": cpuset.New(3, 4),
+					},
+				},
+				defaultCPUSet: cpuset.New(1, 2),
+			},
 		},
 		{
 			"Restore checkpoint from v3 (migration) with PodLevelResourceManagers enabled",
+			FeatureGateCombination{features.PodLevelResourceManagers: true},
 			`{
 				"policyName": "static",
 				"defaultCPUSet": "1-2",
@@ -284,20 +373,13 @@ func TestCheckpointStateRestore(t *testing.T) {
 					},
 				},
 			},
-			true,
 		},
 		{
-			"Restore checkpoint from v2 (migration) with PodLevelResourceManagers disabled",
+			"Restore valid v4 checkpoint with PodLevelResourceManagers disabled",
+			FeatureGateCombination{features.PodLevelResourceManagers: false},
 			`{
-				"policyName": "none",
-				"defaultCPUSet": "1-2",
-				"entries": {
-					"pod": {
-						"container1": "5-6",
-						"container2": "3-4"
-					}
-				},
-				"checksum": 3610638499
+				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"1-3\",\"entries\":{\"pod\":{\"container1\":\"4-6\",\"container2\":\"7-9\"}},\"podEntries\":{\"pod\":{\"cpuSet\":\"4-10\"}}}",
+				"checksum": 2328898362
 			}`,
 			"static",
 			containermap.ContainerMap{},
@@ -305,48 +387,16 @@ func TestCheckpointStateRestore(t *testing.T) {
 			&stateMemory{
 				assignments: ContainerCPUAssignments{
 					"pod": map[string]cpuset.CPUSet{
-						"container1": cpuset.New(5, 6),
-						"container2": cpuset.New(3, 4),
-					},
-				},
-				defaultCPUSet: cpuset.New(1, 2),
-			},
-			false,
-		},
-		{
-			"Restore checkpoint from v3 (migration) with PodLevelResourceManagers disabled",
-			`{
-				"policyName": "none",
-				"defaultCPUSet": "1-3",
-				"entries": {
-					"pod1": {
-						"container1": "4-6",
-						"container2": "1-3"
-					}
-				},
-				"podEntries": {
-					"pod2": {
-						"cpuSet":"7-9"
-					}
-				},
-				"checksum": 751755688
-			}`,
-			"none",
-			containermap.ContainerMap{},
-			"",
-			&stateMemory{
-				assignments: ContainerCPUAssignments{
-					"pod1": map[string]cpuset.CPUSet{
 						"container1": cpuset.New(4, 5, 6),
-						"container2": cpuset.New(1, 2, 3),
+						"container2": cpuset.New(7, 8, 9),
 					},
 				},
 				defaultCPUSet: cpuset.New(1, 2, 3),
 			},
-			false,
 		},
 		{
-			"Restore valid v4 checkpoint",
+			"Restore valid v4 checkpoint with PodLevelResourceManagers enabled",
+			FeatureGateCombination{features.PodLevelResourceManagers: true},
 			`{
 				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"1-3\",\"entries\":{\"pod\":{\"container1\":\"4-6\",\"container2\":\"7-9\"}},\"podEntries\":{\"pod\":{\"cpuSet\":\"4-10\"}}}",
 				"checksum": 2328898362
@@ -368,84 +418,6 @@ func TestCheckpointStateRestore(t *testing.T) {
 					},
 				},
 			},
-			true,
-		},
-		{
-			"Restore valid v4 checkpoint with PodLevelResourceManagers disabled",
-			`{
-				"data": "{\"policyName\":\"none\",\"defaultCPUSet\":\"1-3\",\"entries\":{\"pod\":{\"container1\":\"4-6\",\"container2\":\"1-3\"}},\"podEntries\":{\"pod\":{\"cpuSet\":\"4-6\"}}}",
-				"checksum": 3246418529
-			}`,
-			"none",
-			containermap.ContainerMap{},
-			"",
-			&stateMemory{
-				assignments: ContainerCPUAssignments{
-					"pod": map[string]cpuset.CPUSet{
-						"container1": cpuset.New(4, 5, 6),
-						"container2": cpuset.New(1, 2, 3),
-					},
-				},
-				defaultCPUSet: cpuset.New(1, 2, 3),
-			},
-			false,
-		},
-		{
-			"Restore non-existing checkpoint with PodLevelResourceManagers enabled",
-			"",
-			"none",
-			containermap.ContainerMap{},
-			"",
-			&stateMemory{},
-			true,
-		},
-		{
-			"Restore corrupt checkpoint with PodLevelResourceManagers enabled",
-			`{
-				"data": "{\"policyName\":\"none\",\"defaultCPUSet\":\"4-6\"}",
-				"checksum": 1234
-			}`,
-			"none",
-			containermap.ContainerMap{},
-			"checkpoint is corrupted",
-			&stateMemory{},
-			true,
-		},
-		{
-			"Restore checkpoint without data section",
-			`{
-				"checksum": 1234
-			}`,
-			"none",
-			containermap.ContainerMap{},
-			"checkpoint is corrupted",
-			&stateMemory{},
-			false,
-		},
-		{
-			"Restore checkpoint without checksum section falls back to empty v2 version",
-			`{
-				"data": "{\"policyName\":\"none\",\"defaultCPUSet\":\"4-6\"}"
-			}`,
-			"none",
-			containermap.ContainerMap{},
-			`configured policy "none" differs from state checkpoint policy ""`,
-			&stateMemory{},
-			false,
-		},
-		{
-			"Restore checkpoint ignoring unknown fields in data section",
-			`{
-				"data": "{\"policyName\":\"none\",\"defaultCPUSet\":\"4-6\",\"unknownField\":\"value\"}",
-				"checksum": 3492408555
-			}`,
-			"none",
-			containermap.ContainerMap{},
-			"",
-			&stateMemory{
-				defaultCPUSet: cpuset.New(4, 5, 6),
-			},
-			false,
 		},
 	}
 
@@ -457,36 +429,57 @@ func TestCheckpointStateRestore(t *testing.T) {
 	cpm, err := checkpointmanager.NewCheckpointManager(testingDir)
 	require.NoErrorf(t, err, "could not create testing checkpoint manager: %v", err)
 
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			if tc.podLevelResourceManagersEnabled {
-				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResources, true)
-				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResourceManagers, true)
+	// list of all features verified in this test
+	featureGateList := []featuregate.Feature{
+		features.PodLevelResourceManagers,
+	}
+	// iterate over all possible enabled/disabled feature combinations
+	for _, fgComb := range allFeatureGateCombinations(featureGateList) {
+		// run all testcases for current feature combination
+		t.Run(describe(fgComb), func(t *testing.T) {
+			for _, key := range slices.Sorted(maps.Keys(fgComb)) {
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, key, fgComb[key])
 			}
 
-			// ensure there is no previous checkpoint
-			cpm.RemoveCheckpoint(testingCheckpoint)
+			for _, tc := range testCases {
+				// verify feature gate requirements for testcase
+				skip := false
+				for fg, requiredState := range tc.fgRequirements {
+					state, exist := fgComb[fg]
+					if !exist || requiredState != state {
+						skip = true
+					}
+				}
+				if skip {
+					continue
+				}
 
-			// prepare checkpoint for testing
-			if strings.TrimSpace(tc.checkpointContent) != "" {
-				checkpoint := &testutil.MockCheckpoint{Content: tc.checkpointContent}
-				err = cpm.CreateCheckpoint(testingCheckpoint, checkpoint)
-				require.NoErrorf(t, err, "could not create testing checkpoint: %v", err)
+				t.Run(tc.description, func(t *testing.T) {
+					// ensure there is no previous checkpoint
+					err = cpm.RemoveCheckpoint(testingCheckpoint)
+					require.NoErrorf(t, err, "could not remove previous checkpoint: %v", err)
+
+					// prepare checkpoint for testing
+					if strings.TrimSpace(tc.checkpointContent) != "" {
+						checkpoint := &testutil.MockCheckpoint{Content: tc.checkpointContent}
+						err = cpm.CreateCheckpoint(testingCheckpoint, checkpoint)
+						require.NoErrorf(t, err, "could not create testing checkpoint: %v", err)
+					}
+
+					logger, _ := ktesting.NewTestContext(t)
+					restoredState, err := NewCheckpointState(logger, testingDir, testingCheckpoint, tc.policyName, tc.initialContainers)
+					if strings.TrimSpace(tc.expectedError) == "" {
+						require.NoError(t, err)
+					} else {
+						require.Error(t, err)
+						require.ErrorContains(t, err, "could not restore state from checkpoint")
+						require.ErrorContains(t, err, tc.expectedError)
+						return
+					}
+
+					AssertStateEqual(t, restoredState, tc.expectedState)
+				})
 			}
-
-			logger, _ := ktesting.NewTestContext(t)
-			restoredState, err := NewCheckpointState(logger, testingDir, testingCheckpoint, tc.policyName, tc.initialContainers)
-			if strings.TrimSpace(tc.expectedError) == "" {
-				require.NoError(t, err)
-			} else {
-				require.Error(t, err)
-				require.ErrorContains(t, err, "could not restore state from checkpoint")
-				require.ErrorContains(t, err, tc.expectedError)
-				return
-			}
-
-			// compare state after restoration with the one expected
-			AssertStateEqual(t, restoredState, tc.expectedState)
 		})
 	}
 }

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -59,10 +59,8 @@ func TestCheckpointStateRestore(t *testing.T) {
 		{
 			"Restore default cpu set",
 			`{
-				"policyName": "none",
-				"defaultCPUSet": "4-6",
-				"entries": {},
-				"checksum": 354655845
+				"data": "{\"policyName\":\"none\",\"defaultCPUSet\":\"4-6\"}",
+				"checksum": 657950972
 			}`,
 			"none",
 			containermap.ContainerMap{},
@@ -75,17 +73,10 @@ func TestCheckpointStateRestore(t *testing.T) {
 		{
 			"Restore valid checkpoint",
 			`{
-				"policyName": "none",
-				"defaultCPUSet": "1-3",
-				"entries": {
-					"pod": {
-						"container1": "4-6",
-						"container2": "1-3"
-					}
-				},
-				"checksum": 3610638499
+				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"7-9\",\"entries\":{\"pod\":{\"container1\":\"4-6\",\"container2\":\"1-3\"}}}",
+				"checksum": 1420829534
 			}`,
-			"none",
+			"static",
 			containermap.ContainerMap{},
 			"",
 			&stateMemory{
@@ -95,17 +86,15 @@ func TestCheckpointStateRestore(t *testing.T) {
 						"container2": cpuset.New(1, 2, 3),
 					},
 				},
-				defaultCPUSet: cpuset.New(1, 2, 3),
+				defaultCPUSet: cpuset.New(7, 8, 9),
 			},
 			false,
 		},
 		{
 			"Restore checkpoint with invalid checksum",
 			`{
-				"policyName": "none",
-				"defaultCPUSet": "4-6",
-				"entries": {},
-				"checksum": 1337
+				"data": "{\"policyName\":\"none\",\"defaultCPUSet\":\"4-6\"}",
+				"checksum": 1234
 			}`,
 			"none",
 			containermap.ContainerMap{},
@@ -125,10 +114,8 @@ func TestCheckpointStateRestore(t *testing.T) {
 		{
 			"Restore checkpoint with invalid policy name",
 			`{
-				"policyName": "other",
-				"defaultCPUSet": "1-3",
-				"entries": {},
-				"checksum": 1394507217
+				"data": "{\"policyName\":\"other\",\"defaultCPUSet\":\"1-3\"}",
+				"checksum": 2380595610
 			}`,
 			"none",
 			containermap.ContainerMap{},
@@ -139,10 +126,8 @@ func TestCheckpointStateRestore(t *testing.T) {
 		{
 			"Restore checkpoint with unparsable default cpu set",
 			`{
-				"policyName": "none",
-				"defaultCPUSet": "1.3",
-				"entries": {},
-				"checksum": 3021697696
+				"data": "{\"policyName\":\"none\",\"defaultCPUSet\":\"1.3\"}",
+				"checksum": 3033143655
 			}`,
 			"none",
 			containermap.ContainerMap{},
@@ -153,17 +138,10 @@ func TestCheckpointStateRestore(t *testing.T) {
 		{
 			"Restore checkpoint with unparsable assignment entry",
 			`{
-				"policyName": "none",
-				"defaultCPUSet": "1-3",
-				"entries": {
-					"pod": {
-						"container1": "4-6",
-						"container2": "asd"
-					}
-				},
-				"checksum": 962272150
+				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"1-3\",\"entries\":{\"pod\":{\"container1\":\"4-6\",\"container2\":\"asd\"}}}",
+				"checksum": 3794806925
 			}`,
-			"none",
+			"static",
 			containermap.ContainerMap{},
 			`could not parse cpuset "asd" for container "container2" in pod "pod": strconv.Atoi: parsing "asd": invalid syntax`,
 			&stateMemory{},
@@ -187,15 +165,15 @@ func TestCheckpointStateRestore(t *testing.T) {
 		{
 			"Restore checkpoint with migration",
 			`{
-				"policyName": "none",
-				"defaultCPUSet": "1-3",
+				"policyName": "static",
+				"defaultCPUSet": "7-9",
 				"entries": {
 					"containerID1": "4-6",
 					"containerID2": "1-3"
 				},
-				"checksum": 3680390589
+				"checksum": 2026311253
 			}`,
-			"none",
+			"static",
 			func() containermap.ContainerMap {
 				cm := containermap.NewContainerMap()
 				cm.Add("pod", "container1", "containerID1")
@@ -210,7 +188,7 @@ func TestCheckpointStateRestore(t *testing.T) {
 						"container2": cpuset.New(1, 2, 3),
 					},
 				},
-				defaultCPUSet: cpuset.New(1, 2, 3),
+				defaultCPUSet: cpuset.New(7, 8, 9),
 			},
 			false,
 		},
@@ -247,17 +225,17 @@ func TestCheckpointStateRestore(t *testing.T) {
 		{
 			"Restore checkpoint from v2 (migration) with PodLevelResourceManagers enabled",
 			`{
-				"policyName": "none",
-				"defaultCPUSet": "1-3",
+				"policyName": "static",
+				"defaultCPUSet": "7-9",
 				"entries": {
 					"pod": {
 						"container1": "4-6",
 						"container2": "1-3"
 					}
 				},
-				"checksum": 3610638499
+				"checksum": 1942532442
 			}`,
-			"none",
+			"static",
 			containermap.ContainerMap{},
 			"",
 			&stateMemory{
@@ -267,7 +245,44 @@ func TestCheckpointStateRestore(t *testing.T) {
 						"container2": cpuset.New(1, 2, 3),
 					},
 				},
-				defaultCPUSet: cpuset.New(1, 2, 3),
+				defaultCPUSet: cpuset.New(7, 8, 9),
+			},
+			true,
+		},
+		{
+			"Restore checkpoint from v3 (migration) with PodLevelResourceManagers enabled",
+			`{
+				"policyName": "static",
+				"defaultCPUSet": "1-2",
+				"entries": {
+					"pod1": {
+						"container1": "5-6",
+						"container2": "3-4"
+					}
+				},
+				"podEntries": {
+					"pod2": {
+						"cpuSet":"7-9"
+					}
+				},
+				"checksum": 2284712151
+			}`,
+			"static",
+			containermap.ContainerMap{},
+			"",
+			&stateMemory{
+				assignments: ContainerCPUAssignments{
+					"pod1": map[string]cpuset.CPUSet{
+						"container1": cpuset.New(5, 6),
+						"container2": cpuset.New(3, 4),
+					},
+				},
+				defaultCPUSet: cpuset.New(1, 2),
+				podAssignments: PodCPUAssignments{
+					"pod2": PodEntry{
+						CPUSet: cpuset.New(7, 8, 9),
+					},
+				},
 			},
 			true,
 		},
@@ -275,21 +290,53 @@ func TestCheckpointStateRestore(t *testing.T) {
 			"Restore checkpoint from v2 (migration) with PodLevelResourceManagers disabled",
 			`{
 				"policyName": "none",
-				"defaultCPUSet": "1-3",
+				"defaultCPUSet": "1-2",
 				"entries": {
 					"pod": {
+						"container1": "5-6",
+						"container2": "3-4"
+					}
+				},
+				"checksum": 3610638499
+			}`,
+			"static",
+			containermap.ContainerMap{},
+			"",
+			&stateMemory{
+				assignments: ContainerCPUAssignments{
+					"pod": map[string]cpuset.CPUSet{
+						"container1": cpuset.New(5, 6),
+						"container2": cpuset.New(3, 4),
+					},
+				},
+				defaultCPUSet: cpuset.New(1, 2),
+			},
+			false,
+		},
+		{
+			"Restore checkpoint from v3 (migration) with PodLevelResourceManagers disabled",
+			`{
+				"policyName": "none",
+				"defaultCPUSet": "1-3",
+				"entries": {
+					"pod1": {
 						"container1": "4-6",
 						"container2": "1-3"
 					}
 				},
-				"checksum": 3610638499
+				"podEntries": {
+					"pod2": {
+						"cpuSet":"7-9"
+					}
+				},
+				"checksum": 751755688
 			}`,
 			"none",
 			containermap.ContainerMap{},
 			"",
 			&stateMemory{
 				assignments: ContainerCPUAssignments{
-					"pod": map[string]cpuset.CPUSet{
+					"pod1": map[string]cpuset.CPUSet{
 						"container1": cpuset.New(4, 5, 6),
 						"container2": cpuset.New(1, 2, 3),
 					},
@@ -299,22 +346,35 @@ func TestCheckpointStateRestore(t *testing.T) {
 			false,
 		},
 		{
-			"Restore valid v3 checkpoint with PodLevelResourceManagers enabled",
+			"Restore valid v4 checkpoint",
 			`{
-				"policyName": "none",
-				"defaultCPUSet": "1-3",
-				"entries": {
-					"pod": {
-						"container1": "4-6",
-						"container2": "1-3"
-					}
+				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"1-3\",\"entries\":{\"pod\":{\"container1\":\"4-6\",\"container2\":\"7-9\"}},\"podEntries\":{\"pod\":{\"cpuSet\":\"4-10\"}}}",
+				"checksum": 2328898362
+			}`,
+			"static",
+			containermap.ContainerMap{},
+			"",
+			&stateMemory{
+				assignments: ContainerCPUAssignments{
+					"pod": map[string]cpuset.CPUSet{
+						"container1": cpuset.New(4, 5, 6),
+						"container2": cpuset.New(7, 8, 9),
+					},
 				},
-				"podEntries": {
-					"pod": {
-						"cpuSet": "4-6"
-					}
+				defaultCPUSet: cpuset.New(1, 2, 3),
+				podAssignments: PodCPUAssignments{
+					"pod": PodEntry{
+						CPUSet: cpuset.New(4, 5, 6, 7, 8, 9, 10),
+					},
 				},
-				"checksum": 2649431787
+			},
+			true,
+		},
+		{
+			"Restore valid v4 checkpoint with PodLevelResourceManagers disabled",
+			`{
+				"data": "{\"policyName\":\"none\",\"defaultCPUSet\":\"1-3\",\"entries\":{\"pod\":{\"container1\":\"4-6\",\"container2\":\"1-3\"}},\"podEntries\":{\"pod\":{\"cpuSet\":\"4-6\"}}}",
+				"checksum": 3246418529
 			}`,
 			"none",
 			containermap.ContainerMap{},
@@ -324,48 +384,6 @@ func TestCheckpointStateRestore(t *testing.T) {
 					"pod": map[string]cpuset.CPUSet{
 						"container1": cpuset.New(4, 5, 6),
 						"container2": cpuset.New(1, 2, 3),
-					},
-				},
-				podAssignments: PodCPUAssignments{
-					"pod": PodEntry{
-						CPUSet: cpuset.New(4, 5, 6),
-					},
-				},
-				defaultCPUSet: cpuset.New(1, 2, 3),
-			},
-			true,
-		},
-		{
-			"Restore valid v3 checkpoint with PodLevelResourceManagers disabled",
-			`{
-				"policyName": "none",
-				"defaultCPUSet": "1-3",
-				"entries": {
-					"pod": {
-						"container1": "4-6",
-						"container2": "1-3"
-					}
-				},
-				"podEntries": {
-					"pod": {
-						"cpuSet": "4-6"
-					}
-				},
-				"checksum": 2649431787
-			}`,
-			"none",
-			containermap.ContainerMap{},
-			"could not restore state from checkpoint",
-			&stateMemory{
-				assignments: ContainerCPUAssignments{
-					"pod": map[string]cpuset.CPUSet{
-						"container1": cpuset.New(4, 5, 6),
-						"container2": cpuset.New(1, 2, 3),
-					},
-				},
-				podAssignments: PodCPUAssignments{
-					"pod": PodEntry{
-						CPUSet: cpuset.New(4, 5, 6),
 					},
 				},
 				defaultCPUSet: cpuset.New(1, 2, 3),
@@ -384,17 +402,50 @@ func TestCheckpointStateRestore(t *testing.T) {
 		{
 			"Restore corrupt checkpoint with PodLevelResourceManagers enabled",
 			`{
-				"policyName": "none",
-				"defaultCPUSet": "1-3",
-				"entries": {},
-				"podEntries": {},
-				"checksum": 12345
+				"data": "{\"policyName\":\"none\",\"defaultCPUSet\":\"4-6\"}",
+				"checksum": 1234
 			}`,
 			"none",
 			containermap.ContainerMap{},
 			"checkpoint is corrupted",
 			&stateMemory{},
 			true,
+		},
+		{
+			"Restore checkpoint without data section",
+			`{
+				"checksum": 1234
+			}`,
+			"none",
+			containermap.ContainerMap{},
+			"checkpoint is corrupted",
+			&stateMemory{},
+			false,
+		},
+		{
+			"Restore checkpoint without checksum section falls back to empty v2 version",
+			`{
+				"data": "{\"policyName\":\"none\",\"defaultCPUSet\":\"4-6\"}"
+			}`,
+			"none",
+			containermap.ContainerMap{},
+			`configured policy "none" differs from state checkpoint policy ""`,
+			&stateMemory{},
+			false,
+		},
+		{
+			"Restore checkpoint ignoring unknown fields in data section",
+			`{
+				"data": "{\"policyName\":\"none\",\"defaultCPUSet\":\"4-6\",\"unknownField\":\"value\"}",
+				"checksum": 3492408555
+			}`,
+			"none",
+			containermap.ContainerMap{},
+			"",
+			&stateMemory{
+				defaultCPUSet: cpuset.New(4, 5, 6),
+			},
+			false,
 		},
 	}
 
@@ -637,6 +688,12 @@ func AssertStateEqual(t *testing.T, sf State, sm State) {
 	cpuassignmentSm := sm.GetCPUAssignments()
 	if !reflect.DeepEqual(cpuassignmentSf, cpuassignmentSm) {
 		t.Errorf("State CPU assignments mismatch. Have %s, want %s", cpuassignmentSf, cpuassignmentSm)
+	}
+
+	podcpuassignmentSf := sf.GetPodCPUAssignments()
+	podcpuassignmentSm := sm.GetPodCPUAssignments()
+	if !reflect.DeepEqual(podcpuassignmentSf, podcpuassignmentSm) {
+		t.Errorf("State CPU assignments mismatch. Have %s, want %s", podcpuassignmentSf, podcpuassignmentSm)
 	}
 }
 

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -110,30 +110,52 @@ func TestCheckpointStateRestore(t *testing.T) {
 			"Fail to restore checkpoint without data section",
 			nil,
 			`{
-				"checksum": 1234
+				"policyName": "static",
+				"defaultCPUSet": "7-9",
+				"entries": {
+					"pod": {
+						"container1": "4-6",
+						"container2": "1-3"
+					}
+				},
+				"checksum": 1942532442,
+				"dataChecksum": 1234
 			}`,
 			"none",
 			containermap.ContainerMap{},
-			"checkpoint is corrupted",
+			"failed to deserialize cpu manager checkpoint data: unexpected end of JSON input",
 			nil,
 		},
 		{
-			"Fail to restore checkpoint without checksum section (fall back to empty v2 version)",
+			"Fail to restore checkpoint without dataChecksum section",
 			nil,
 			`{
-				"data": "{\"policyName\":\"none\",\"defaultCPUSet\":\"4-6\"}"
+				"policyName": "static",
+				"defaultCPUSet": "7-9",
+				"entries": {
+					"pod": {
+						"container1": "4-6",
+						"container2": "1-3"
+					}
+				},
+				"checksum": 1942532442,
+				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"7-9\",\"entries\":{\"pod\":{\"container1\":\"4-6\",\"container2\":\"1-3\"}}}"
 			}`,
 			"none",
 			containermap.ContainerMap{},
-			`configured policy "none" differs from state checkpoint policy ""`,
+			`checkpoint is corrupted`,
 			nil,
 		},
+		// In below testcase V2 part of checkpoint is intentionally corrupted to verify that it is not used.
 		{
 			"Restore default cpu set",
 			nil,
 			`{
+				"policyName": "other",
+				"defaultCPUSet": "1-9",
+				"checksum": 1234,
 				"data": "{\"policyName\":\"none\",\"defaultCPUSet\":\"4-6\"}",
-				"checksum": 657950972
+				"dataChecksum": 657950972
 			}`,
 			"none",
 			containermap.ContainerMap{},
@@ -142,12 +164,16 @@ func TestCheckpointStateRestore(t *testing.T) {
 				defaultCPUSet: cpuset.New(4, 5, 6),
 			},
 		},
+		// In below testcase V2 part of checkpoint is intentionally corrupted to verify that it is not used.
 		{
 			"Restore valid checkpoint",
 			nil,
 			`{
+				"policyName": "other",
+				"defaultCPUSet": "1-9",
+				"checksum": 1234,
 				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"7-9\",\"entries\":{\"pod\":{\"container1\":\"4-6\",\"container2\":\"1-3\"}}}",
-				"checksum": 1420829534
+				"dataChecksum": 1420829534
 			}`,
 			"static",
 			containermap.ContainerMap{},
@@ -166,10 +192,19 @@ func TestCheckpointStateRestore(t *testing.T) {
 			"Fail to restore checkpoint with invalid checksum",
 			nil,
 			`{
-				"data": "{\"policyName\":\"none\",\"defaultCPUSet\":\"4-6\"}",
-				"checksum": 1234
+				"policyName": "static",
+				"defaultCPUSet": "7-9",
+				"entries": {
+					"pod": {
+						"container1": "4-6",
+						"container2": "1-3"
+					}
+				},
+				"checksum": 1942532442,
+				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"7-9\",\"entries\":{\"pod\":{\"container1\":\"4-6\",\"container2\":\"1-3\"}}}",
+				"dataChecksum": 1234
 			}`,
-			"none",
+			"static",
 			containermap.ContainerMap{},
 			"checkpoint is corrupted",
 			nil,
@@ -183,48 +218,76 @@ func TestCheckpointStateRestore(t *testing.T) {
 			"unexpected end of JSON input",
 			nil,
 		},
+		// In below testcase policyName in V2 part of checkpoint is intentionally unaligned with data section.
 		{
 			"Fail to restore checkpoint with invalid policy name",
 			nil,
 			`{
-				"data": "{\"policyName\":\"other\",\"defaultCPUSet\":\"1-3\"}",
-				"checksum": 2380595610
+				"policyName": "static",
+				"defaultCPUSet": "7-9",
+				"entries": {
+					"pod": {
+						"container1": "4-6",
+						"container2": "1-3"
+					}
+				},
+				"checksum": 1942532442,
+				"data": "{\"policyName\":\"other\",\"defaultCPUSet\":\"7-9\",\"entries\":{\"pod\":{\"container1\":\"4-6\",\"container2\":\"1-3\"}}}",
+				"dataChecksum": 1432271708
 			}`,
 			"none",
 			containermap.ContainerMap{},
 			`configured policy "none" differs from state checkpoint policy "other"`,
 			nil,
 		},
+		// In below testcase defaultCPUSet in V2 part of checkpoint is intentionally unaligned with data section.
 		{
 			"Fail to restore checkpoint with unparsable default cpu set",
 			nil,
 			`{
+				"policyName": "none",
+				"defaultCPUSet": "7-9",
+				"checksum": 98002435,
 				"data": "{\"policyName\":\"none\",\"defaultCPUSet\":\"1.3\"}",
-				"checksum": 3033143655
+				"dataChecksum": 3033143655
 			}`,
 			"none",
 			containermap.ContainerMap{},
 			`could not parse default cpu set "1.3": strconv.Atoi: parsing "1.3": invalid syntax`,
 			nil,
 		},
+		// In below testcase entries in V2 part of checkpoint are intentionally unaligned with data section.
 		{
 			"Fail to restore checkpoint with unparsable assignment entry",
 			nil,
 			`{
+				"policyName": "static",
+				"defaultCPUSet": "1-3",
+				"entries": {
+					"pod": {
+						"container1": "4-6",
+						"container2": "7-9"
+					}
+				},
+				"checksum": 1659543133,
 				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"1-3\",\"entries\":{\"pod\":{\"container1\":\"4-6\",\"container2\":\"asd\"}}}",
-				"checksum": 3794806925
+				"dataChecksum": 3794806925
 			}`,
 			"static",
 			containermap.ContainerMap{},
 			`could not parse cpuset "asd" for container "container2" in pod "pod": strconv.Atoi: parsing "asd": invalid syntax`,
 			nil,
 		},
+		// In below testcase V2 part of checkpoint is intentionally corrupted to verify that it is not used.
 		{
 			"Restore checkpoint ignoring unknown fields in data section",
 			nil,
 			`{
+				"policyName": "other",
+				"defaultCPUSet": "1-9",
+				"checksum": 1234,
 				"data": "{\"policyName\":\"none\",\"defaultCPUSet\":\"4-6\",\"unknownField\":\"value\"}",
-				"checksum": 3492408555
+				"dataChecksum": 3492408555
 			}`,
 			"none",
 			containermap.ContainerMap{},
@@ -374,12 +437,16 @@ func TestCheckpointStateRestore(t *testing.T) {
 				},
 			},
 		},
+		// In below testcase V2 part of checkpoint is intentionally corrupted to verify that it is not used.
 		{
 			"Restore valid v4 checkpoint with PodLevelResourceManagers disabled",
 			FeatureGateCombination{features.PodLevelResourceManagers: false},
 			`{
+				"policyName": "other",
+				"defaultCPUSet": "1-9",
+				"checksum": 1234,
 				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"1-3\",\"entries\":{\"pod\":{\"container1\":\"4-6\",\"container2\":\"7-9\"}},\"podEntries\":{\"pod\":{\"cpuSet\":\"4-10\"}}}",
-				"checksum": 2328898362
+				"dataChecksum": 2328898362
 			}`,
 			"static",
 			containermap.ContainerMap{},
@@ -394,12 +461,16 @@ func TestCheckpointStateRestore(t *testing.T) {
 				defaultCPUSet: cpuset.New(1, 2, 3),
 			},
 		},
+		// In below testcase V2 part of checkpoint is intentionally corrupted to verify that it is not used.
 		{
 			"Restore valid v4 checkpoint with PodLevelResourceManagers enabled",
 			FeatureGateCombination{features.PodLevelResourceManagers: true},
 			`{
+				"policyName": "other",
+				"defaultCPUSet": "1-9",
+				"checksum": 1234,
 				"data": "{\"policyName\":\"static\",\"defaultCPUSet\":\"1-3\",\"entries\":{\"pod\":{\"container1\":\"4-6\",\"container2\":\"7-9\"}},\"podEntries\":{\"pod\":{\"cpuSet\":\"4-10\"}}}",
-				"checksum": 2328898362
+				"dataChecksum": 2328898362
 			}`,
 			"static",
 			containermap.ContainerMap{},

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -148,7 +148,7 @@ func TestCheckpointStateRestore(t *testing.T) {
 		},
 		// In below testcase V2 part of checkpoint is intentionally corrupted to verify that it is not used.
 		{
-			"Restore default cpu set",
+			"Restore default CPU set",
 			nil,
 			`{
 				"policyName": "other",
@@ -164,7 +164,7 @@ func TestCheckpointStateRestore(t *testing.T) {
 				defaultCPUSet: cpuset.New(4, 5, 6),
 			},
 		},
-		// In below testcase V2 part of checkpoint is intentionally corrupted to verify that it is not used.
+		// In below test case V2 part of checkpoint is intentionally corrupted to verify that it is not used.
 		{
 			"Restore valid checkpoint",
 			nil,
@@ -218,7 +218,7 @@ func TestCheckpointStateRestore(t *testing.T) {
 			"unexpected end of JSON input",
 			nil,
 		},
-		// In below testcase policyName in V2 part of checkpoint is intentionally unaligned with data section.
+		// In below test case policyName in V2 part of checkpoint is intentionally unaligned with data section.
 		{
 			"Fail to restore checkpoint with invalid policy name",
 			nil,
@@ -242,7 +242,7 @@ func TestCheckpointStateRestore(t *testing.T) {
 		},
 		// In below testcase defaultCPUSet in V2 part of checkpoint is intentionally unaligned with data section.
 		{
-			"Fail to restore checkpoint with unparsable default cpu set",
+			"Fail to restore checkpoint with unparsable default CPU set",
 			nil,
 			`{
 				"policyName": "none",
@@ -253,7 +253,7 @@ func TestCheckpointStateRestore(t *testing.T) {
 			}`,
 			"none",
 			containermap.ContainerMap{},
-			`could not parse default cpu set "1.3": strconv.Atoi: parsing "1.3": invalid syntax`,
+			`could not parse default CPU set "1.3": strconv.Atoi: parsing "1.3": invalid syntax`,
 			nil,
 		},
 		// In below testcase entries in V2 part of checkpoint are intentionally unaligned with data section.

--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -401,7 +401,7 @@ func TestCheckpointStateRestore(t *testing.T) {
 	// create temp dir
 	testingDir, err := os.MkdirTemp("", "cpumanager_state_test")
 	require.NoError(t, err)
-	defer os.RemoveAll(testingDir)
+	defer removeAll(testingDir, t)
 	// create checkpoint manager for testing
 	cpm, err := checkpointmanager.NewCheckpointManager(testingDir)
 	require.NoErrorf(t, err, "could not create testing checkpoint manager: %v", err)
@@ -466,7 +466,7 @@ func TestCheckpointStateStore(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(testingDir)
+	defer removeAll(testingDir, t)
 
 	cpm, err := checkpointmanager.NewCheckpointManager(testingDir)
 	if err != nil {
@@ -540,7 +540,7 @@ func TestCheckpointStateHelpers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(testingDir)
+	defer removeAll(testingDir, t)
 
 	cpm, err := checkpointmanager.NewCheckpointManager(testingDir)
 	if err != nil {
@@ -600,7 +600,7 @@ func TestCheckpointStateClear(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer os.RemoveAll(testingDir)
+			defer removeAll(testingDir, t)
 
 			logger, _ := ktesting.NewTestContext(t)
 			state, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "none", nil)
@@ -687,5 +687,12 @@ func TestCPUManagerCheckpointV2_MarshalCheckpoint_ForwardCompatibility(t *testin
 	// what a 1.35 Kubelet would expect to see.
 	if writtenChecksum != expectedLegacyChecksum {
 		t.Errorf("Written Checksum %d does not match legacy calculation %d. Forward compatibility broken.", writtenChecksum, expectedLegacyChecksum)
+	}
+}
+
+func removeAll(dir string, t *testing.T) {
+	t.Helper()
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("unable to remove dir %s: %v", dir, err)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The CPU manager checkpoint requires generalization and introducing new version that will solve simultaneously used V2 and V3 versions (see https://github.com/kubernetes/kubernetes/pull/137820 for more details)

Such solution was applied by PRs: https://github.com/kubernetes/kubernetes/pull/137820 followed by https://github.com/kubernetes/kubernetes/pull/139053
but caused issues with forward compatibility that were dtected by DRA-n-1, DRA-n-2 and DRA-n-3 tests run by CI:
https://github.com/kubernetes/kubernetes/issues/139069

So the PRs were reverted by https://github.com/kubernetes/kubernetes/pull/139077


This PR implements one of the designs described: https://github.com/kubernetes/kubernetes/issues/139069#issuecomment-4459527414
following sketch: https://github.com/kubernetes/kubernetes/pull/139083
and solving the issue of forward compatibility.

The second one is implemented here: https://github.com/kubernetes/kubernetes/pull/139103

#### Which issue(s) this PR is related to:
Related to https://github.com/kubernetes/kubernetes/issues/139069

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
