### PR TITLE
Retry admission webhooks on transport errors

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
@@ -279,22 +279,31 @@ func (a *mutatingDispatcher) callAttrMutatingHook(ctx context.Context, h *admiss
 		defer cancel()
 	}
 
-	r := client.Post().Body(request)
+	do := func() {
+		err = webhook.WithAdmissionWebhookTransportErrorRetry(ctx, func() error {
+			r := client.Post().Body(request)
 
-	// if the context has a deadline, set it as a parameter to inform the backend
-	if deadline, hasDeadline := ctx.Deadline(); hasDeadline {
-		// compute the timeout
-		if timeout := time.Until(deadline); timeout > 0 {
-			// if it's not an even number of seconds, round up to the nearest second
-			if truncated := timeout.Truncate(time.Second); truncated != timeout {
-				timeout = truncated + time.Second
+			// if the context has a deadline, set it as a parameter to inform the backend
+			if deadline, hasDeadline := ctx.Deadline(); hasDeadline {
+				// compute the timeout
+				if timeout := time.Until(deadline); timeout > 0 {
+					// if it's not an even number of seconds, round up to the nearest second
+					if truncated := timeout.Truncate(time.Second); truncated != timeout {
+						timeout = truncated + time.Second
+					}
+					// set the timeout
+					r.Timeout(timeout)
+				}
 			}
-			// set the timeout
-			r.Timeout(timeout)
-		}
-	}
 
-	do := func() { err = r.Do(ctx).Into(response) }
+			resp := response.DeepCopyObject()
+			if err := r.Do(ctx).Into(resp); err != nil {
+				return err
+			}
+			response = resp
+			return nil
+		})
+	}
 	if wd, ok := endpointsrequest.LatencyTrackersFrom(ctx); ok {
 		tmp := do
 		do = func() { wd.MutatingWebhookTracker.Track(tmp) }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/plugin_test.go
@@ -18,15 +18,20 @@ package mutating
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"reflect"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"k8s.io/api/admission/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/admission"
@@ -211,6 +216,162 @@ func TestAdmit(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestAdmitRetriesTransportError(t *testing.T) {
+	var attempts int32
+	var lock sync.Mutex
+	var uids []string
+	testServer := webhooktesting.NewTestServerWithHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		review := &v1beta1.AdmissionReview{}
+		if err := json.NewDecoder(r.Body).Decode(review); err != nil {
+			t.Errorf("failed to decode admission review: %v", err)
+			return
+		}
+		lock.Lock()
+		uids = append(uids, string(review.Request.UID))
+		lock.Unlock()
+
+		if atomic.AddInt32(&attempts, 1) == 1 {
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Errorf("expected response writer to support hijacking")
+				return
+			}
+			conn, _, err := hj.Hijack()
+			if err != nil {
+				t.Errorf("failed to hijack connection: %v", err)
+				return
+			}
+			conn.Close() //nolint:errcheck
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(&v1beta1.AdmissionReview{
+			Response: &v1beta1.AdmissionResponse{
+				Allowed: true,
+				Result: &metav1.Status{
+					Code: http.StatusOK,
+				},
+			},
+		}); err != nil {
+			t.Errorf("failed to encode admission review response: %v", err)
+			return
+		}
+	})
+	testServer.StartTLS()
+	defer testServer.Close()
+
+	serverURL, err := url.ParseRequestURI(testServer.URL)
+	if err != nil {
+		t.Fatalf("this should never happen? %v", err)
+	}
+
+	var testCase *webhooktesting.MutatingTest
+	testCases := webhooktesting.ConvertToMutatingTestCases(webhooktesting.NewNonMutatingTestCases(serverURL), "test-webhooks")
+	for i := range testCases {
+		tt := testCases[i]
+		if tt.Name == "match & allow (url)" {
+			testCase = &tt
+			break
+		}
+	}
+	if testCase == nil {
+		t.Fatal("failed to find allow url test case")
+	}
+
+	wh, err := NewMutatingWebhook(nil)
+	if err != nil {
+		t.Fatalf("failed to create mutating webhook: %v", err)
+	}
+
+	ns := "webhook-test"
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	client, informer := webhooktesting.NewFakeMutatingDataSource(ns, testCase.Webhooks, stopCh)
+
+	wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(new(int32))))
+	wh.SetExternalKubeClientSet(client)
+	wh.SetExternalKubeInformerFactory(informer)
+
+	informer.Start(stopCh)
+	informer.WaitForCacheSync(stopCh)
+
+	if err = wh.ValidateInitialization(); err != nil {
+		t.Fatalf("failed to validate initialization: %v", err)
+	}
+
+	err = wh.Admit(context.TODO(), webhooktesting.NewAttribute(ns, nil, false), webhooktesting.NewObjectInterfacesForTest())
+	if err != nil {
+		t.Fatalf("expected webhook to succeed after retry, got %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Fatalf("expected 2 webhook attempts, got %d", got)
+	}
+	lock.Lock()
+	defer lock.Unlock()
+	if len(uids) != 2 {
+		t.Fatalf("expected 2 AdmissionReview UIDs, got %d", len(uids))
+	}
+	if uids[0] != uids[1] {
+		t.Fatalf("expected retry to use the same AdmissionReview UID, got %q and %q", uids[0], uids[1])
+	}
+}
+
+func TestAdmitDoesNotRetryWebhookResponseErrors(t *testing.T) {
+	var attempts int32
+	testServer := webhooktesting.NewTestServerWithHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		http.Error(w, "webhook internal server error", http.StatusInternalServerError)
+	})
+	testServer.StartTLS()
+	defer testServer.Close()
+
+	serverURL, err := url.ParseRequestURI(testServer.URL)
+	if err != nil {
+		t.Fatalf("this should never happen? %v", err)
+	}
+
+	var testCase *webhooktesting.MutatingTest
+	testCases := webhooktesting.ConvertToMutatingTestCases(webhooktesting.NewNonMutatingTestCases(serverURL), "test-webhooks")
+	for i := range testCases {
+		tt := testCases[i]
+		if tt.Name == "match & allow (url)" {
+			testCase = &tt
+			break
+		}
+	}
+	if testCase == nil {
+		t.Fatal("failed to find allow url test case")
+	}
+
+	wh, err := NewMutatingWebhook(nil)
+	if err != nil {
+		t.Fatalf("failed to create mutating webhook: %v", err)
+	}
+
+	ns := "webhook-test"
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	client, informer := webhooktesting.NewFakeMutatingDataSource(ns, testCase.Webhooks, stopCh)
+
+	wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(new(int32))))
+	wh.SetExternalKubeClientSet(client)
+	wh.SetExternalKubeInformerFactory(informer)
+
+	informer.Start(stopCh)
+	informer.WaitForCacheSync(stopCh)
+
+	if err = wh.ValidateInitialization(); err != nil {
+		t.Fatalf("failed to validate initialization: %v", err)
+	}
+
+	if err = wh.Admit(context.TODO(), webhooktesting.NewAttribute(ns, nil, false), webhooktesting.NewObjectInterfacesForTest()); err == nil {
+		t.Fatal("expected webhook to fail")
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Fatalf("expected 1 webhook attempt, got %d", got)
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/retry.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/retry.go
@@ -1,0 +1,40 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"time"
+
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	webhookutil "k8s.io/apiserver/pkg/util/webhook"
+)
+
+// admissionWebhookRetryBackoff matches the default authentication and
+// authorization webhook retry backoff. The admission webhook timeout context
+// bounds the total retry duration.
+var admissionWebhookRetryBackoff = webhookutil.DefaultRetryBackoffWithInitialDelay(500 * time.Millisecond)
+
+// WithAdmissionWebhookTransportErrorRetry retries admission webhook calls for
+// transport-level failures where no admission response was received.
+func WithAdmissionWebhookTransportErrorRetry(ctx context.Context, webhookFn func() error) error {
+	return webhookutil.WithExponentialBackoff(ctx, admissionWebhookRetryBackoff, webhookFn, shouldRetryAdmissionWebhookCall)
+}
+
+func shouldRetryAdmissionWebhookCall(err error) bool {
+	return utilnet.IsConnectionReset(err) || utilnet.IsProbableEOF(err) || utilnet.IsHTTP2ConnectionLost(err)
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/retry_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/retry_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"errors"
+	"io"
+	"syscall"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestShouldRetryAdmissionWebhookCall(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantRetry bool
+	}{
+		{
+			name:      "connection reset",
+			err:       syscall.ECONNRESET,
+			wantRetry: true,
+		},
+		{
+			name:      "eof",
+			err:       io.EOF,
+			wantRetry: true,
+		},
+		{
+			name:      "unexpected eof",
+			err:       io.ErrUnexpectedEOF,
+			wantRetry: true,
+		},
+		{
+			name:      "http2 connection lost",
+			err:       errors.New("http2: client connection lost"),
+			wantRetry: true,
+		},
+		{
+			name:      "http response error",
+			err:       errors.New("the server rejected this request"),
+			wantRetry: false,
+		},
+		{
+			name:      "context canceled",
+			err:       context.Canceled,
+			wantRetry: false,
+		},
+		{
+			name:      "context deadline exceeded",
+			err:       context.DeadlineExceeded,
+			wantRetry: false,
+		},
+		{
+			name:      "status error",
+			err:       apierrors.FromObject(&metav1.Status{Status: metav1.StatusFailure, Code: 500}),
+			wantRetry: false,
+		},
+		{
+			name:      "internal server error",
+			err:       apierrors.NewInternalError(errors.New("boom")),
+			wantRetry: false,
+		},
+		{
+			name:      "too many requests",
+			err:       apierrors.NewTooManyRequests("rate limited", 1),
+			wantRetry: false,
+		},
+		{
+			name:      "forbidden",
+			err:       apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "pod", errors.New("denied")),
+			wantRetry: false,
+		},
+		{
+			name:      "nil",
+			err:       nil,
+			wantRetry: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldRetryAdmissionWebhookCall(tt.err); got != tt.wantRetry {
+				t.Fatalf("expected retry=%t, got %t", tt.wantRetry, got)
+			}
+		})
+	}
+}
+
+func TestWithAdmissionWebhookTransportErrorRetryHonorsContextDeadline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	attempts := 0
+	err := WithAdmissionWebhookTransportErrorRetry(ctx, func() error {
+		attempts++
+		return io.EOF
+	})
+	if err == nil {
+		t.Fatal("expected retry to return an error")
+	}
+	if attempts != 1 {
+		t.Fatalf("expected retry to stop after 1 attempt once the context deadline expires, got %d attempts", attempts)
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
@@ -280,22 +280,31 @@ func (d *validatingDispatcher) callHook(ctx context.Context, h *v1.ValidatingWeb
 		defer cancel()
 	}
 
-	r := client.Post().Body(request)
+	do := func() {
+		err = webhook.WithAdmissionWebhookTransportErrorRetry(ctx, func() error {
+			r := client.Post().Body(request)
 
-	// if the context has a deadline, set it as a parameter to inform the backend
-	if deadline, hasDeadline := ctx.Deadline(); hasDeadline {
-		// compute the timeout
-		if timeout := time.Until(deadline); timeout > 0 {
-			// if it's not an even number of seconds, round up to the nearest second
-			if truncated := timeout.Truncate(time.Second); truncated != timeout {
-				timeout = truncated + time.Second
+			// if the context has a deadline, set it as a parameter to inform the backend
+			if deadline, hasDeadline := ctx.Deadline(); hasDeadline {
+				// compute the timeout
+				if timeout := time.Until(deadline); timeout > 0 {
+					// if it's not an even number of seconds, round up to the nearest second
+					if truncated := timeout.Truncate(time.Second); truncated != timeout {
+						timeout = truncated + time.Second
+					}
+					// set the timeout
+					r.Timeout(timeout)
+				}
 			}
-			// set the timeout
-			r.Timeout(timeout)
-		}
-	}
 
-	do := func() { err = r.Do(ctx).Into(response) }
+			resp := response.DeepCopyObject()
+			if err := r.Do(ctx).Into(resp); err != nil {
+				return err
+			}
+			response = resp
+			return nil
+		})
+	}
 	if wd, ok := endpointsrequest.LatencyTrackersFrom(ctx); ok {
 		tmp := do
 		do = func() { wd.ValidatingWebhookTracker.Track(tmp) }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/plugin_test.go
@@ -18,14 +18,19 @@ package validating
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"k8s.io/api/admission/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	admissionmetrics "k8s.io/apiserver/pkg/admission/metrics"
 	webhooktesting "k8s.io/apiserver/pkg/admission/plugin/webhook/testing"
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
@@ -174,6 +179,183 @@ func TestValidate(t *testing.T) {
 		} else {
 			assert.Equal(t, tt.ExpectAnnotations, fakeAttr.GetAnnotations(auditinternal.LevelMetadata), tt.Name+": annotations not set as expected.")
 		}
+	}
+}
+
+func TestValidateRetriesTransportError(t *testing.T) {
+	var attempts int32
+	testServer := webhooktesting.NewTestServerWithHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&attempts, 1) == 1 {
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Errorf("expected response writer to support hijacking")
+				return
+			}
+			conn, _, err := hj.Hijack()
+			if err != nil {
+				t.Errorf("failed to hijack connection: %v", err)
+				return
+			}
+			conn.Close() //nolint:errcheck
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(&v1beta1.AdmissionReview{
+			Response: &v1beta1.AdmissionResponse{
+				Allowed: true,
+				Result: &metav1.Status{
+					Code: http.StatusOK,
+				},
+			},
+		}); err != nil {
+			t.Errorf("failed to encode admission review response: %v", err)
+			return
+		}
+	})
+	testServer.StartTLS()
+	defer testServer.Close()
+
+	serverURL, err := url.ParseRequestURI(testServer.URL)
+	if err != nil {
+		t.Fatalf("this should never happen? %v", err)
+	}
+
+	var testCase *webhooktesting.ValidatingTest
+	testCases := webhooktesting.NewNonMutatingTestCases(serverURL)
+	for i := range testCases {
+		tt := testCases[i]
+		if tt.Name == "match & allow (url)" {
+			testCase = &tt
+			break
+		}
+	}
+	if testCase == nil {
+		t.Fatal("failed to find allow url test case")
+	}
+
+	wh, err := NewValidatingAdmissionWebhook(nil)
+	if err != nil {
+		t.Fatalf("failed to create validating webhook: %v", err)
+	}
+
+	ns := "webhook-test"
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	client, informer := webhooktesting.NewFakeValidatingDataSource(ns, testCase.Webhooks, stopCh)
+
+	wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(new(int32))))
+	wh.SetExternalKubeClientSet(client)
+	wh.SetExternalKubeInformerFactory(informer)
+
+	informer.Start(stopCh)
+	informer.WaitForCacheSync(stopCh)
+
+	if err = wh.ValidateInitialization(); err != nil {
+		t.Fatalf("failed to validate initialization: %v", err)
+	}
+
+	err = wh.Validate(context.TODO(), webhooktesting.NewAttribute(ns, nil, false), webhooktesting.NewObjectInterfacesForTest())
+	if err != nil {
+		t.Fatalf("expected webhook to succeed after retry, got %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Fatalf("expected 2 webhook attempts, got %d", got)
+	}
+}
+
+func TestValidateDoesNotRetryWebhookResponseErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler func(http.ResponseWriter, *http.Request)
+	}{
+		{
+			name: "http 500",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "webhook internal server error", http.StatusInternalServerError)
+			},
+		},
+		{
+			name: "invalid admission review",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte("webhook invalid response")) //nolint:errcheck
+			},
+		},
+		{
+			name: "admission rejection",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if err := json.NewEncoder(w).Encode(&v1beta1.AdmissionReview{
+					Response: &v1beta1.AdmissionResponse{
+						Allowed: false,
+						Result: &metav1.Status{
+							Code: http.StatusForbidden,
+						},
+					},
+				}); err != nil {
+					t.Errorf("failed to encode admission review response: %v", err)
+					return
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var attempts int32
+			testServer := webhooktesting.NewTestServerWithHandler(t, func(w http.ResponseWriter, r *http.Request) {
+				atomic.AddInt32(&attempts, 1)
+				tt.handler(w, r)
+			})
+			testServer.StartTLS()
+			defer testServer.Close()
+
+			serverURL, err := url.ParseRequestURI(testServer.URL)
+			if err != nil {
+				t.Fatalf("this should never happen? %v", err)
+			}
+
+			testCases := webhooktesting.NewNonMutatingTestCases(serverURL)
+			var testCase *webhooktesting.ValidatingTest
+			for i := range testCases {
+				tt := testCases[i]
+				if tt.Name == "match & allow (url)" {
+					testCase = &tt
+					break
+				}
+			}
+			if testCase == nil {
+				t.Fatal("failed to find allow url test case")
+			}
+
+			wh, err := NewValidatingAdmissionWebhook(nil)
+			if err != nil {
+				t.Fatalf("failed to create validating webhook: %v", err)
+			}
+
+			ns := "webhook-test"
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			client, informer := webhooktesting.NewFakeValidatingDataSource(ns, testCase.Webhooks, stopCh)
+
+			wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(new(int32))))
+			wh.SetExternalKubeClientSet(client)
+			wh.SetExternalKubeInformerFactory(informer)
+
+			informer.Start(stopCh)
+			informer.WaitForCacheSync(stopCh)
+
+			if err = wh.ValidateInitialization(); err != nil {
+				t.Fatalf("failed to validate initialization: %v", err)
+			}
+
+			if err = wh.Validate(context.TODO(), webhooktesting.NewAttribute(ns, nil, false), webhooktesting.NewObjectInterfacesForTest()); err == nil {
+				t.Fatal("expected webhook to fail")
+			}
+			if got := atomic.LoadInt32(&attempts); got != 1 {
+				t.Fatalf("expected 1 webhook attempt, got %d", got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Retry admission webhook calls on selected transport-level errors, such as connection reset, probable EOF, and HTTP/2 connection lost.

A terminating webhook pod can close an existing keep-alive connection. Without retry, the API server fails the admission POST immediately even though another webhook endpoint may be available.

This change keeps the retry behavior local to admission webhook dispatchers instead of changing generic client-go retry behavior for all POST requests. Each attempt rebuilds the webhook POST request so the timeout query parameter is recalculated from the remaining context deadline.

#### Which issue(s) this PR is related to:

Fixes #127335

#### Special notes for your reviewer:

Retries are scoped to selected transport-level failures only. Admission rejection, invalid AdmissionReview responses, HTTP 5xx, 429, and other StatusError responses from the webhook continue to be handled by the existing admission logic.

A webhook backend may receive the same AdmissionReview more than once if it processed the request but the connection failed before the apiserver received a complete response. The apiserver only applies the result after receiving and verifying a complete AdmissionReview response, and mutating webhooks are expected to be idempotent and side-effect constrained.

Validation:

```
GOCACHE=/private/tmp/go-build-cache go test ./staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/... ./staging/src/k8s.io/apiserver/pkg/util/webhook/...
```

#### Does this PR introduce a user-facing change?

```release-note
The API server now retries admission webhook calls on selected transport-level errors, such as connection reset, probable EOF, and HTTP/2 connection lost.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
