### PR TITLE
kubectl: filter top pod metrics using pod field selectors

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
@@ -202,7 +202,7 @@ func (o TopPodOptions) RunTopPod() error {
 		return err
 	}
 
-	if len(o.FieldSelector) > 0 {
+	if len(metrics.Items) != 0 && len(o.FieldSelector) > 0 {
 		metrics, err = filterPodMetricsByFieldSelector(o, metrics, labelSelector, fieldSelector)
 		if err != nil {
 			return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
@@ -197,9 +197,16 @@ func (o TopPodOptions) RunTopPod() error {
 	if !metricsAPIAvailable {
 		return errors.New("Metrics API not available")
 	}
-	metrics, err := getMetricsFromMetricsAPI(o.MetricsClient, o.Namespace, o.ResourceName, o.AllNamespaces, labelSelector, fieldSelector)
+	metrics, err := getMetricsFromMetricsAPI(o.MetricsClient, o.Namespace, o.ResourceName, o.AllNamespaces, labelSelector)
 	if err != nil {
 		return err
+	}
+
+	if len(o.FieldSelector) > 0 {
+		metrics, err = filterPodMetricsByFieldSelector(o, metrics, labelSelector, fieldSelector)
+		if err != nil {
+			return err
+		}
 	}
 
 	// First we check why no metrics have been received.
@@ -222,7 +229,7 @@ func (o TopPodOptions) RunTopPod() error {
 	return o.Printer.PrintPodMetrics(metrics.Items, o.PrintContainers, o.AllNamespaces, o.NoHeaders, o.SortBy, o.Sum)
 }
 
-func getMetricsFromMetricsAPI(metricsClient metricsclientset.Interface, namespace, resourceName string, allNamespaces bool, labelSelector labels.Selector, fieldSelector fields.Selector) (*metricsapi.PodMetricsList, error) {
+func getMetricsFromMetricsAPI(metricsClient metricsclientset.Interface, namespace, resourceName string, allNamespaces bool, labelSelector labels.Selector) (*metricsapi.PodMetricsList, error) {
 	var err error
 	ns := metav1.NamespaceAll
 	if !allNamespaces {
@@ -236,7 +243,7 @@ func getMetricsFromMetricsAPI(metricsClient metricsclientset.Interface, namespac
 		}
 		versionedMetrics.Items = []metricsv1beta1api.PodMetrics{*m}
 	} else {
-		versionedMetrics, err = metricsClient.MetricsV1beta1().PodMetricses(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector.String(), FieldSelector: fieldSelector.String()})
+		versionedMetrics, err = metricsClient.MetricsV1beta1().PodMetricses(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector.String()})
 		if err != nil {
 			return nil, err
 		}
@@ -287,4 +294,34 @@ func checkPodAge(pod *corev1.Pod) error {
 		klog.V(2).Infof("Metrics not yet available for pod %s/%s, age: %s", pod.Namespace, pod.Name, age.String())
 		return nil
 	}
+}
+
+func filterPodMetricsByFieldSelector(o TopPodOptions, metrics *metricsapi.PodMetricsList, labelSelector labels.Selector, fieldSelector fields.Selector) (*metricsapi.PodMetricsList, error) {
+	ns := metav1.NamespaceAll
+	if !o.AllNamespaces {
+		ns = o.Namespace
+	}
+
+	pods, err := o.PodClient.Pods(ns).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: labelSelector.String(),
+		FieldSelector: fieldSelector.String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	selectedPods := make(map[string]struct{}, len(pods.Items))
+	for _, pod := range pods.Items {
+		selectedPods[pod.Namespace+"/"+pod.Name] = struct{}{}
+	}
+
+	filtered := make([]metricsapi.PodMetrics, 0, len(metrics.Items))
+	for _, metric := range metrics.Items {
+		if _, ok := selectedPods[metric.Namespace+"/"+metric.Name]; ok {
+			filtered = append(filtered, metric)
+		}
+	}
+
+	metrics.Items = filtered
+	return metrics, nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_test.go
@@ -588,3 +588,99 @@ func testV1beta1PodMetricsData() []metricsv1beta1api.PodMetrics {
 		},
 	}
 }
+
+func TestTopPodFieldSelectorFiltersMetrics(t *testing.T) {
+	testNS := "testns"
+
+	metricsList := testV1beta1PodMetricsData()
+	metricsList[0].Namespace = testNS
+	metricsList[1].Namespace = testNS
+	metricsList[2].Namespace = testNS
+
+	fakemetricsClientset := &metricsfake.Clientset{}
+	fakemetricsClientset.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+		return true, &metricsv1beta1api.PodMetricsList{
+			ListMeta: metav1.ListMeta{
+				ResourceVersion: "2",
+			},
+			Items: metricsList,
+		}, nil
+	})
+
+	tf := cmdtesting.NewTestFactory().WithNamespace(testNS)
+	defer tf.Cleanup()
+
+	ns := scheme.Codecs.WithoutConversion()
+	tf.Client = &fake.RESTClient{
+		NegotiatedSerializer: ns,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Path {
+			case "/api":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apibody)))}, nil
+			case "/apis":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apisbodyWithMetrics)))}, nil
+			case "/api/v1/namespaces/" + testNS + "/pods":
+				body, _ := marshallBody(v1.PodList{
+					ListMeta: metav1.ListMeta{
+						ResourceVersion: "2",
+					},
+					Items: []v1.Pod{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "pod1",
+								Namespace: testNS,
+							},
+							Spec: v1.PodSpec{
+								NodeName: "node-a",
+							},
+						},
+					},
+				})
+
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: body}, nil
+
+			default:
+				t.Fatalf("unexpected request: %#v\nGot URL: %#v", req, req.URL)
+				return nil, nil
+			}
+		}),
+	}
+
+	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
+
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
+	cmd := NewCmdTopPod(tf, nil, streams)
+
+	cmdOptions := &TopPodOptions{
+		FieldSelector: "spec.nodeName=node-a",
+		IOStreams:     streams,
+	}
+
+	if err := cmdOptions.Complete(tf, cmd, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	cmdOptions.MetricsClient = fakemetricsClientset
+
+	if err := cmdOptions.Validate(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cmdOptions.RunTopPod(); err != nil {
+		t.Fatal(err)
+	}
+
+	result := buf.String()
+
+	if !strings.Contains(result, "pod1") {
+		t.Errorf("expected metrics for pod1, got:\n%s", result)
+	}
+
+	if strings.Contains(result, "pod2") {
+		t.Errorf("unexpected metrics for pod2, got:\n%s", result)
+	}
+
+	if strings.Contains(result, "pod3") {
+		t.Errorf("unexpected metrics for pod3, got:\n%s", result)
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -210,10 +210,27 @@ func TestTopPod(t *testing.T) {
 					return true, res, nil
 				})
 			}
+			podList := &v1.PodList{
+				Items: []v1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: testNS},
+						Spec:       v1.PodSpec{NodeName: "node-a"},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: testNS},
+						Spec:       v1.PodSpec{NodeName: "node-b"},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod3", Namespace: testNS},
+						Spec:       v1.PodSpec{NodeName: "node-c"},
+					},
+				},
+			}
 
 			tf := cmdtesting.NewTestFactory().WithNamespace(testNS)
 			defer tf.Cleanup()
 
+			codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
 			ns := scheme.Codecs.WithoutConversion()
 
 			tf.Client = &fake.RESTClient{
@@ -224,6 +241,8 @@ func TestTopPod(t *testing.T) {
 						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apibody)))}, nil
 					case p == "/apis":
 						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apisbodyWithMetrics)))}, nil
+					case p == "/api/v1/namespaces/"+testNS+"/pods":
+						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, podList)}, nil
 					default:
 						t.Fatalf("%s: unexpected request: %#v\nGot URL: %#v",
 							testCase.name, req, req.URL)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it: 
kubectl top pod currently sends field selectors directly to the Metrics API. However, the Metrics API only supports metadata based field selectors, makes causing selectors such as `spec.nodeName` to fail.

This PR updates `kubectl top pod` to apply field selectors against the core Pod API and locally filter the returned pod metrics by namespace/name. This enables commands such as:
```
kubectl top pods -A --field-selector spec.nodeName=<node-name>
```
This is useful when investigating node resource pressure and identifying the most resource intensive pods running on a specific node.

#### Which issue(s) this PR is related to: Fixes https://github.com/kubernetes/kubernetes/issues/131896
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
Today, the Metrics API does not support `spec.nodeName` as a field selector. Because of this, the field selector is applied against the core Pod API, and the returned pod metrics are then filtered locally using the matching pod namespace/name results.

#### Does this PR introduce a user-facing change?

```release-note
Apply --field-selector to pod metrics when invoking kubectl top pod
```


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
