### PR TITLE
Fix Windows in-cluster service account paths

### DIFF
--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	gruntime "runtime"
 	"strings"
@@ -49,6 +50,16 @@ const (
 )
 
 var ErrNotInCluster = errors.New("unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined")
+
+const serviceAccountRoot = "/var/run/secrets/kubernetes.io/serviceaccount"
+
+func serviceAccountFilePath(goos, filename string) string {
+	path := path.Join(serviceAccountRoot, filename)
+	if goos == "windows" {
+		return "c:" + path
+	}
+	return path
+}
 
 // Config holds the common attributes that can be passed to a Kubernetes client on
 // initialization.
@@ -541,10 +552,8 @@ func DefaultKubernetesUserAgent() string {
 // running inside a pod running on kubernetes. It will return ErrNotInCluster
 // if called from a process not running in a kubernetes environment.
 func InClusterConfig() (*Config, error) {
-	const (
-		tokenFile  = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-		rootCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-	)
+	tokenFile := serviceAccountFilePath(gruntime.GOOS, "token")
+	rootCAFile := serviceAccountFilePath(gruntime.GOOS, "ca.crt")
 	host, port := os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT")
 	if len(host) == 0 || len(port) == 0 {
 		return nil, ErrNotInCluster

--- a/staging/src/k8s.io/client-go/rest/config_test.go
+++ b/staging/src/k8s.io/client-go/rest/config_test.go
@@ -140,6 +140,36 @@ func TestBuildUserAgent(t *testing.T) {
 			"beos", "itanium", "baaaaaaaaad"))
 }
 
+func TestServiceAccountFilePath(t *testing.T) {
+	testCases := []struct {
+		name     string
+		goos     string
+		filename string
+		want     string
+	}{
+		{
+			name:     "linux",
+			goos:     "linux",
+			filename: "token",
+			want:     "/var/run/secrets/kubernetes.io/serviceaccount/token",
+		},
+		{
+			name:     "windows",
+			goos:     "windows",
+			filename: "token",
+			want:     "c:/var/run/secrets/kubernetes.io/serviceaccount/token",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := serviceAccountFilePath(tc.goos, tc.filename); got != tc.want {
+				t.Fatalf("serviceAccountFilePath(%q, %q) = %q, want %q", tc.goos, tc.filename, got, tc.want)
+			}
+		})
+	}
+}
+
 // This function untestable since it doesn't accept arguments.
 func TestDefaultKubernetesUserAgent(t *testing.T) {
 	assert.New(t).Contains(DefaultKubernetesUserAgent(), "kubernetes")

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
+	gruntime "runtime"
 	"strings"
 	"unicode"
 
@@ -34,7 +36,16 @@ import (
 const (
 	// clusterExtensionKey is reserved in the cluster extensions list for exec plugin config.
 	clusterExtensionKey = "client.authentication.k8s.io/exec"
+	serviceAccountRoot  = "/var/run/secrets/kubernetes.io/serviceaccount"
 )
+
+func serviceAccountFilePath(goos, filename string) string {
+	path := path.Join(serviceAccountRoot, filename)
+	if goos == "windows" {
+		return "c:" + path
+	}
+	return path
+}
 
 var (
 	// ClusterDefaults has the same behavior as the old EnvVar and DefaultCluster fields
@@ -651,7 +662,7 @@ func (config *inClusterClientConfig) Namespace() (string, bool, error) {
 	}
 
 	// Fall back to the namespace associated with the service account token, if available
-	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+	if data, err := os.ReadFile(serviceAccountFilePath(gruntime.GOOS, "namespace")); err == nil {
 		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
 			return ns, false, nil
 		}
@@ -666,7 +677,7 @@ func (config *inClusterClientConfig) ConfigAccess() ConfigAccess {
 
 // Possible returns true if loading an inside-kubernetes-cluster is possible.
 func (config *inClusterClientConfig) Possible() bool {
-	fi, err := os.Stat("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	fi, err := os.Stat(serviceAccountFilePath(gruntime.GOOS, "token"))
 	return os.Getenv("KUBERNETES_SERVICE_HOST") != "" &&
 		os.Getenv("KUBERNETES_SERVICE_PORT") != "" &&
 		err == nil && !fi.IsDir()

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
@@ -284,6 +284,36 @@ func createCAValidTestConfig() *clientcmdapi.Config {
 	return config
 }
 
+func TestServiceAccountFilePath(t *testing.T) {
+	testCases := []struct {
+		name     string
+		goos     string
+		filename string
+		want     string
+	}{
+		{
+			name:     "linux",
+			goos:     "linux",
+			filename: "namespace",
+			want:     "/var/run/secrets/kubernetes.io/serviceaccount/namespace",
+		},
+		{
+			name:     "windows",
+			goos:     "windows",
+			filename: "namespace",
+			want:     "c:/var/run/secrets/kubernetes.io/serviceaccount/namespace",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := serviceAccountFilePath(tc.goos, tc.filename); got != tc.want {
+				t.Fatalf("serviceAccountFilePath(%q, %q) = %q, want %q", tc.goos, tc.filename, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestDisableCompression(t *testing.T) {
 	config := createValidTestConfig()
 	clientBuilder := NewNonInteractiveClientConfig(*config, "clean", &ConfigOverrides{


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This fixes in-cluster configuration lookup on Windows when a process is running from a working directory on a drive other than `C:`.

`client-go` previously used `/var/run/secrets/kubernetes.io/serviceaccount/...` directly. On Windows, that path is rooted on the current drive, so running `kubectl` from `T:` caused it to look under `T:/var/run/...` even though Kubernetes mounts the service account files under `C:/var/run/...`.

The PR centralizes service account file path construction for `rest.InClusterConfig()` and `clientcmd` in-cluster detection/namespace lookup so Windows resolves those defaults under `c:/var/run/...`, while non-Windows platforms keep the existing `/var/run/...` paths.

#### Which issue(s) this PR fixes:

Fixes #104443

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
Fixed in-cluster client configuration on Windows when the current working directory is on a drive other than C:.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

Validation:

```console
GOCACHE=/private/tmp/go-build-cache go test ./staging/src/k8s.io/client-go/rest ./staging/src/k8s.io/client-go/tools/clientcmd
git diff --check
```
