### PR TITLE
fix: resource.ParseQuantity handles values near math.MaxInt64

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/math.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/math.go
@@ -25,7 +25,7 @@ import (
 const (
 	// maxInt64Factors is the highest value that will be checked when removing factors of 10 from an int64.
 	// It is also the maximum decimal digits that can be represented with an int64.
-	maxInt64Factors = 18
+	maxInt64Factors = 19
 )
 
 var (

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -323,7 +323,8 @@ func ParseQuantity(str string) (Quantity, error) {
 			var value int64
 			value, err := strconv.ParseInt(shifted, 10, 64)
 			if err != nil {
-				return Quantity{}, ErrNumeric
+				// value overflows int64, fall through to decimal path
+				goto useDec
 			}
 			if result, ok := int64Multiply(value, int64(mantissa)); ok {
 				if !positive {
@@ -344,11 +345,11 @@ func ParseQuantity(str string) (Quantity, error) {
 			}
 		}
 	}
-
-	amount := new(inf.Dec)
-	if _, ok := amount.SetString(value); !ok {
-		return Quantity{}, ErrNumeric
-	}
+	useDec:
+		amount := new(inf.Dec)
+		if _, ok := amount.SetString(value); !ok {
+			return Quantity{}, ErrNumeric
+		}
 
 	// So that no one but us has to think about suffixes, remove it.
 	if base == 10 {

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -23,6 +23,7 @@ import (
 	"math/big"
 	"math/rand"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"unicode"
@@ -1818,5 +1819,53 @@ func TestQuantityRoundtripCBOR(t *testing.T) {
 			}
 			t.Errorf("Expected equal: %v, %v (cbor was '%s')", initial, final, diag)
 		}
+	}
+}
+
+func TestParseLargeQuantity(t *testing.T) {
+	tests := []struct {
+		input     string
+		expectErr bool
+		expectI64 bool
+		expectVal int64
+	}{
+		{
+			input:     strconv.FormatInt(math.MaxInt64, 10), // 9223372036854775807
+			expectErr: false,
+			expectI64: true,
+			expectVal: math.MaxInt64,
+		},
+		{
+			input:     strconv.FormatInt(math.MaxInt64-1, 10), // 9223372036854775806
+			expectErr: false,
+			expectI64: true,
+			expectVal: math.MaxInt64 - 1,
+		},
+		{
+			input:     "9223372036854775808", // math.MaxInt64 + 1, too big for int64
+			expectErr: false,
+			expectI64: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			q, err := ParseQuantity(tc.input)
+			if tc.expectErr && err == nil {
+				t.Errorf("expected error for input %q but got none", tc.input)
+				return
+			}
+			if !tc.expectErr && err != nil {
+				t.Errorf("unexpected error for input %q: %v", tc.input, err)
+				return
+			}
+			val, ok := q.AsInt64()
+			if ok != tc.expectI64 {
+				t.Errorf("input %q: AsInt64() ok=%v, want %v", tc.input, ok, tc.expectI64)
+			}
+			if tc.expectI64 && val != tc.expectVal {
+				t.Errorf("input %q: AsInt64() value=%v, want %v", tc.input, val, tc.expectVal)
+			}
+		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
ParseQuantity was incorrectly routing 19-digit values (near math.MaxInt64)
into the slow decimal path instead of the fast integer path, causing
AsInt64() to return false for values that are perfectly valid int64 numbers.

Root cause: maxInt64Factors was set to 18, but math.MaxInt64
(9223372036854775807) has 19 digits, causing precision to calculate as -1
and bypass the fast integer path entirely.

Two fixes:
1. Bumped maxInt64Factors from 18 to 19 in math.go
2. Changed quantity.go to fall through to the decimal path on
   strconv.ParseInt overflow error, instead of returning ErrNumeric.
   This ensures values larger than math.MaxInt64 are valid quantities
   stored as decimals rather than hard errors.

#### Which issue(s) this PR is related to:
Fixes #135487

#### Does this PR introduce a user-facing change?
Fixed a bug where resource.ParseQuantity failed to use the fast integer
path for 19-digit values near math.MaxInt64, causing AsInt64() to
incorrectly return false for valid int64 values.
