### PR TITLE
Clarify events.k8s.io/v1 Event.Reason is machine-readable

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13700,7 +13700,7 @@
           "type": "string"
         },
         "reason": {
-          "description": "reason is why the action was taken. It is human-readable. This field cannot be empty for new Events and it can have at most 128 characters.",
+          "description": "reason is why the action was taken. It is a short, machine-readable CamelCase string, e.g. `FailedScheduling`. This field cannot be empty for new Events and it can have at most 128 characters.",
           "type": "string"
         },
         "regarding": {

--- a/api/openapi-spec/v3/apis__events.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__events.k8s.io__v1_openapi.json
@@ -117,7 +117,7 @@
             "type": "string"
           },
           "reason": {
-            "description": "reason is why the action was taken. It is human-readable. This field cannot be empty for new Events and it can have at most 128 characters.",
+            "description": "reason is why the action was taken. It is a short, machine-readable CamelCase string, e.g. `FailedScheduling`. This field cannot be empty for new Events and it can have at most 128 characters.",
             "type": "string"
           },
           "regarding": {

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -34996,7 +34996,7 @@ func schema_k8sio_api_events_v1_Event(ref common.ReferenceCallback) common.OpenA
 					},
 					"reason": {
 						SchemaProps: spec.SchemaProps{
-							Description: "reason is why the action was taken. It is human-readable. This field cannot be empty for new Events and it can have at most 128 characters.",
+							Description: "reason is why the action was taken. It is a short, machine-readable CamelCase string, e.g. `FailedScheduling`. This field cannot be empty for new Events and it can have at most 128 characters.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -34987,7 +34987,7 @@ func schema_k8sio_api_events_v1_Event(ref common.ReferenceCallback) common.OpenA
 					},
 					"reason": {
 						SchemaProps: spec.SchemaProps{
-							Description: "reason is why the action was taken. It is human-readable. This field cannot be empty for new Events and it can have at most 128 characters.",
+							Description: "reason is why the action was taken. It is a short, machine-readable CamelCase string, e.g. `FailedScheduling`. This field cannot be empty for new Events and it can have at most 128 characters.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/staging/src/k8s.io/api/events/v1/generated.proto
+++ b/staging/src/k8s.io/api/events/v1/generated.proto
@@ -60,7 +60,8 @@ message Event {
   // This field cannot be empty for new Events and it can have at most 128 characters.
   optional string action = 6;
 
-  // reason is why the action was taken. It is human-readable.
+  // reason is why the action was taken. It is a short, machine-readable
+  // CamelCase string, e.g. `FailedScheduling`.
   // This field cannot be empty for new Events and it can have at most 128 characters.
   optional string reason = 7;
 

--- a/staging/src/k8s.io/api/events/v1/generated.proto
+++ b/staging/src/k8s.io/api/events/v1/generated.proto
@@ -64,7 +64,8 @@ message Event {
   // +required
   optional string action = 6;
 
-  // reason is why the action was taken. It is human-readable.
+  // reason is why the action was taken. It is a short, machine-readable
+  // CamelCase string, e.g. `FailedScheduling`.
   // This field cannot be empty for new Events and it can have at most 128 characters.
   // +required
   optional string reason = 7;

--- a/staging/src/k8s.io/api/events/v1/types.go
+++ b/staging/src/k8s.io/api/events/v1/types.go
@@ -58,7 +58,8 @@ type Event struct {
 	// This field cannot be empty for new Events and it can have at most 128 characters.
 	Action string `json:"action,omitempty" protobuf:"bytes,6,name=action"`
 
-	// reason is why the action was taken. It is human-readable.
+	// reason is why the action was taken. It is a short, machine-readable
+	// CamelCase string, e.g. `FailedScheduling`.
 	// This field cannot be empty for new Events and it can have at most 128 characters.
 	Reason string `json:"reason,omitempty" protobuf:"bytes,7,name=reason"`
 

--- a/staging/src/k8s.io/api/events/v1/types.go
+++ b/staging/src/k8s.io/api/events/v1/types.go
@@ -62,7 +62,8 @@ type Event struct {
 	// +required
 	Action string `json:"action,omitempty" protobuf:"bytes,6,name=action"`
 
-	// reason is why the action was taken. It is human-readable.
+	// reason is why the action was taken. It is a short, machine-readable
+	// CamelCase string, e.g. `FailedScheduling`.
 	// This field cannot be empty for new Events and it can have at most 128 characters.
 	// +required
 	Reason string `json:"reason,omitempty" protobuf:"bytes,7,name=reason"`

--- a/staging/src/k8s.io/api/events/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/events/v1/types_swagger_doc_generated.go
@@ -35,7 +35,7 @@ var map_Event = map[string]string{
 	"reportingController":      "reportingController is the name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`. This field cannot be empty for new Events.",
 	"reportingInstance":        "reportingInstance is the ID of the controller instance, e.g. `kubelet-xyzf`. This field cannot be empty for new Events and it can have at most 128 characters.",
 	"action":                   "action is what action was taken/failed regarding to the regarding object. It is machine-readable. This field cannot be empty for new Events and it can have at most 128 characters.",
-	"reason":                   "reason is why the action was taken. It is human-readable. This field cannot be empty for new Events and it can have at most 128 characters.",
+	"reason":                   "reason is why the action was taken. It is a short, machine-readable CamelCase string, e.g. `FailedScheduling`. This field cannot be empty for new Events and it can have at most 128 characters.",
 	"regarding":                "regarding contains the object this Event is about. In most cases it's an Object reporting controller implements, e.g. ReplicaSetController implements ReplicaSets and this event is emitted because it acts on some changes in a ReplicaSet object.",
 	"related":                  "related is the optional secondary object for more complex actions. E.g. when regarding object triggers a creation or deletion of related object.",
 	"note":                     "note is a human-readable description of the status of this operation. Maximal length of the note is 1kB, but libraries should be prepared to handle values up to 64kB.",

--- a/staging/src/k8s.io/client-go/applyconfigurations/events/v1/event.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/events/v1/event.go
@@ -55,7 +55,8 @@ type EventApplyConfiguration struct {
 	// action is what action was taken/failed regarding to the regarding object. It is machine-readable.
 	// This field cannot be empty for new Events and it can have at most 128 characters.
 	Action *string `json:"action,omitempty"`
-	// reason is why the action was taken. It is human-readable.
+	// reason is why the action was taken. It is a short, machine-readable
+	// CamelCase string, e.g. `FailedScheduling`.
 	// This field cannot be empty for new Events and it can have at most 128 characters.
 	Reason *string `json:"reason,omitempty"`
 	// regarding contains the object this Event is about. In most cases it's an Object reporting controller


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

More clarification about `events.k8s.io/v1` `Event.Reason` description.

#### Which issue(s) this PR is related to:

Fixed #121374

#### Special notes for your reviewer:

No behavior change. Only documentation improves.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
