### PR TITLE
Handle cancelled pod sandbox creation

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
@@ -18,14 +18,20 @@ package kuberuntime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"runtime"
 	"sort"
+	"strings"
+	"time"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
 	kubetypes "k8s.io/apimachinery/pkg/types"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	crierror "k8s.io/cri-api/pkg/errors"
 	"k8s.io/klog/v2"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	runtimeutil "k8s.io/kubernetes/pkg/kubelet/kuberuntime/util"
@@ -33,6 +39,8 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	netutils "k8s.io/utils/net"
 )
+
+const podSandboxRecoveryTimeout = 2 * time.Minute
 
 // createPodSandbox creates a pod sandbox and returns (podSandBoxID, message, error).
 func (m *kubeGenericRuntimeManager) createPodSandbox(ctx context.Context, pod *v1.Pod, attempt uint32) (string, string, error) {
@@ -66,12 +74,100 @@ func (m *kubeGenericRuntimeManager) createPodSandbox(ctx context.Context, pod *v
 
 	podSandBoxID, err := m.runtimeService.RunPodSandbox(ctx, podSandboxConfig, runtimeHandler)
 	if err != nil {
+		if recoveredPodSandboxID, recovered := m.recoverPodSandboxFromRunPodSandboxError(ctx, pod, attempt, err); recovered {
+			return recoveredPodSandboxID, "", nil
+		}
 		message := fmt.Sprintf("Failed to create sandbox for pod %q: %v", format.Pod(pod), err)
 		logger.Error(err, "Failed to create sandbox for pod", "pod", klog.KObj(pod))
 		return "", message, err
 	}
 
 	return podSandBoxID, "", nil
+}
+
+func shouldRecoverPodSandboxFromRunPodSandboxError(err error) bool {
+	// Keep plain context errors as a fallback for non-gRPC runtime service implementations.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	switch status.Code(err) {
+	case codes.Canceled, codes.DeadlineExceeded, codes.AlreadyExists, codes.FailedPrecondition:
+		return true
+	}
+
+	// Some CRI implementations report sandbox name reservation conflicts only in the
+	// error message. Keep this as a compatibility fallback for runtime-specific
+	// wording such as containerd's sandbox name reservation error.
+	errMsg := err.Error()
+	return strings.Contains(errMsg, "failed to reserve sandbox name") &&
+		strings.Contains(errMsg, "is reserved for")
+}
+
+func (m *kubeGenericRuntimeManager) recoverPodSandboxFromRunPodSandboxError(ctx context.Context, pod *v1.Pod, attempt uint32, runErr error) (string, bool) {
+	if !shouldRecoverPodSandboxFromRunPodSandboxError(runErr) {
+		return "", false
+	}
+
+	logger := klog.FromContext(ctx)
+	recoveryCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), podSandboxRecoveryTimeout)
+	defer cancel()
+
+	sandboxes, err := m.getSandboxes(recoveryCtx, listOptions{podUID: pod.UID})
+	if err != nil {
+		logger.Error(err, "Failed to inspect pod sandboxes after RunPodSandbox error", "pod", klog.KObj(pod), "runPodSandboxError", runErr)
+		return "", false
+	}
+	sort.Sort(podSandboxByCreatedThenID(sandboxes))
+
+	readySandboxID := ""
+	for _, sandbox := range sandboxes {
+		if !podSandboxMatchesPod(sandbox, pod, attempt) {
+			continue
+		}
+		if sandbox.GetState() == runtimeapi.PodSandboxState_SANDBOX_READY {
+			if readySandboxID == "" {
+				readySandboxID = sandbox.Id
+			}
+			continue
+		}
+		m.removePodSandboxAfterRunPodSandboxError(recoveryCtx, pod, sandbox.Id, runErr)
+	}
+
+	if readySandboxID != "" {
+		logger.V(4).Info("Using ready pod sandbox found after RunPodSandbox error", "podSandboxID", readySandboxID, "pod", klog.KObj(pod), "runPodSandboxError", runErr)
+		return readySandboxID, true
+	}
+
+	return "", false
+}
+
+func (m *kubeGenericRuntimeManager) removePodSandboxAfterRunPodSandboxError(ctx context.Context, pod *v1.Pod, podSandboxID string, runErr error) {
+	logger := klog.FromContext(ctx)
+	logger.V(4).Info("Removing pod sandbox after RunPodSandbox error", "podSandboxID", podSandboxID, "pod", klog.KObj(pod), "runPodSandboxError", runErr)
+	if err := m.runtimeService.StopPodSandbox(ctx, podSandboxID); err != nil {
+		if crierror.IsNotFound(err) {
+			return
+		}
+		logger.Error(err, "Failed to stop pod sandbox after RunPodSandbox error", "podSandboxID", podSandboxID, "pod", klog.KObj(pod), "runPodSandboxError", runErr)
+		return
+	}
+	if err := m.runtimeService.RemovePodSandbox(ctx, podSandboxID); err != nil {
+		logger.Error(err, "Failed to remove pod sandbox after RunPodSandbox error", "podSandboxID", podSandboxID, "pod", klog.KObj(pod), "runPodSandboxError", runErr)
+	}
+}
+
+func podSandboxMatchesPod(sandbox *runtimeapi.PodSandbox, pod *v1.Pod, attempt uint32) bool {
+	if sandbox == nil || sandbox.Id == "" {
+		return false
+	}
+	metadata := sandbox.GetMetadata()
+	if metadata == nil {
+		return false
+	}
+	return metadata.GetName() == pod.Name &&
+		metadata.GetNamespace() == pod.Namespace &&
+		metadata.GetUid() == string(pod.UID) &&
+		metadata.GetAttempt() == attempt
 }
 
 // generatePodSandboxConfig generates pod sandbox config from v1.Pod.

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -24,11 +26,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	apitest "k8s.io/cri-api/pkg/apis/testing"
 	"k8s.io/kubernetes/pkg/features"
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	"k8s.io/kubernetes/pkg/kubelet/runtimeclass"
@@ -93,6 +98,192 @@ func TestCreatePodSandbox(t *testing.T) {
 	assert.Len(t, sandboxes, 1)
 	assert.Equal(t, sandboxes[0].Id, fmt.Sprintf("%s_%s_%s_1", pod.Name, pod.Namespace, pod.UID))
 	assert.Equal(t, runtimeapi.PodSandboxState_SANDBOX_READY, sandboxes[0].State)
+}
+
+func TestCreatePodSandboxRemovesSandboxAfterCancelledRunPodSandbox(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	runErr := status.Error(codes.Canceled, "stream terminated by RST_STREAM with error code: CANCEL")
+	fakeRuntime, _, m, err := createTestRuntimeManager(tCtx, withErrors(map[string][]error{
+		"RunPodSandbox": {runErr},
+	}))
+	require.NoError(t, err)
+	pod := newTestPod()
+	const attempt uint32 = 1
+	sandbox := makeFakePodSandbox(tCtx, m, sandboxTemplate{
+		pod:     pod,
+		attempt: attempt,
+		state:   runtimeapi.PodSandboxState_SANDBOX_NOTREADY,
+	})
+	fakeRuntime.SetFakeSandboxes([]*apitest.FakePodSandbox{sandbox})
+
+	id, _, err := m.createPodSandbox(tCtx, pod, attempt)
+
+	assert.Empty(t, id)
+	assert.ErrorIs(t, err, runErr)
+	assertCallBefore(t, fakeRuntime.GetCalls(), "StopPodSandbox", "RemovePodSandbox")
+	sandboxes, err := fakeRuntime.ListPodSandbox(tCtx, &runtimeapi.PodSandboxFilter{Id: sandbox.Id})
+	require.NoError(t, err)
+	assert.Empty(t, sandboxes)
+}
+
+func TestCreatePodSandboxRemovesSandboxAfterReservedNameRunPodSandboxError(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	runErr := status.Error(codes.FailedPrecondition, `failed to reserve sandbox name "bar_new_12345678_1": name "bar_new_12345678_1" is reserved for "1234"`)
+	fakeRuntime, _, m, err := createTestRuntimeManager(tCtx, withErrors(map[string][]error{
+		"RunPodSandbox": {runErr},
+	}))
+	require.NoError(t, err)
+	pod := newTestPod()
+	const attempt uint32 = 1
+	sandbox := makeFakePodSandbox(tCtx, m, sandboxTemplate{
+		pod:     pod,
+		attempt: attempt,
+		state:   runtimeapi.PodSandboxState_SANDBOX_NOTREADY,
+	})
+	fakeRuntime.SetFakeSandboxes([]*apitest.FakePodSandbox{sandbox})
+
+	id, _, err := m.createPodSandbox(tCtx, pod, attempt)
+
+	assert.Empty(t, id)
+	assert.ErrorIs(t, err, runErr)
+	assertCallBefore(t, fakeRuntime.GetCalls(), "StopPodSandbox", "RemovePodSandbox")
+	sandboxes, err := fakeRuntime.ListPodSandbox(tCtx, &runtimeapi.PodSandboxFilter{Id: sandbox.Id})
+	require.NoError(t, err)
+	assert.Empty(t, sandboxes)
+}
+
+func TestCreatePodSandboxReusesReadySandboxAndRemovesNonReadySandboxAfterReservedNameRunPodSandboxError(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	runErr := status.Error(codes.FailedPrecondition, `failed to reserve sandbox name "bar_new_12345678_1": name "bar_new_12345678_1" is reserved for "1234"`)
+	fakeRuntime, _, m, err := createTestRuntimeManager(tCtx, withErrors(map[string][]error{
+		"RunPodSandbox": {runErr},
+	}))
+	require.NoError(t, err)
+	pod := newTestPod()
+	const attempt uint32 = 1
+	sandbox := makeFakePodSandbox(tCtx, m, sandboxTemplate{
+		pod:     pod,
+		attempt: attempt,
+		state:   runtimeapi.PodSandboxState_SANDBOX_READY,
+	})
+	nonReadySandbox := makeFakePodSandbox(tCtx, m, sandboxTemplate{
+		pod:     pod,
+		attempt: attempt,
+		state:   runtimeapi.PodSandboxState_SANDBOX_NOTREADY,
+	})
+	nonReadySandbox.Id += "-not-ready"
+	fakeRuntime.SetFakeSandboxes([]*apitest.FakePodSandbox{sandbox, nonReadySandbox})
+
+	id, _, err := m.createPodSandbox(tCtx, pod, attempt)
+
+	assert.NoError(t, err)
+	assert.Equal(t, sandbox.Id, id)
+	assertCallBefore(t, fakeRuntime.GetCalls(), "StopPodSandbox", "RemovePodSandbox")
+	sandboxes, err := fakeRuntime.ListPodSandbox(tCtx, &runtimeapi.PodSandboxFilter{Id: nonReadySandbox.Id})
+	require.NoError(t, err)
+	assert.Empty(t, sandboxes)
+	sandboxes, err = fakeRuntime.ListPodSandbox(tCtx, &runtimeapi.PodSandboxFilter{Id: sandbox.Id})
+	require.NoError(t, err)
+	assert.Len(t, sandboxes, 1)
+}
+
+func TestCreatePodSandboxReturnsRunPodSandboxErrorWhenRecoveryRemoveFails(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	runErr := status.Error(codes.Canceled, "stream terminated by RST_STREAM with error code: CANCEL")
+	fakeRuntime, _, m, err := createTestRuntimeManager(tCtx, withErrors(map[string][]error{
+		"RunPodSandbox":    {runErr},
+		"RemovePodSandbox": {errors.New("remove failed")},
+	}))
+	require.NoError(t, err)
+	pod := newTestPod()
+	const attempt uint32 = 1
+	sandbox := makeFakePodSandbox(tCtx, m, sandboxTemplate{
+		pod:     pod,
+		attempt: attempt,
+		state:   runtimeapi.PodSandboxState_SANDBOX_NOTREADY,
+	})
+	fakeRuntime.SetFakeSandboxes([]*apitest.FakePodSandbox{sandbox})
+
+	id, _, err := m.createPodSandbox(tCtx, pod, attempt)
+
+	assert.Empty(t, id)
+	assert.ErrorIs(t, err, runErr)
+	assertCallBefore(t, fakeRuntime.GetCalls(), "StopPodSandbox", "RemovePodSandbox")
+	sandboxes, err := fakeRuntime.ListPodSandbox(tCtx, &runtimeapi.PodSandboxFilter{Id: sandbox.Id})
+	require.NoError(t, err)
+	assert.Len(t, sandboxes, 1)
+}
+
+func TestShouldRecoverPodSandboxFromRunPodSandboxError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "plain context canceled",
+			err:  context.Canceled,
+			want: true,
+		},
+		{
+			name: "plain context deadline exceeded",
+			err:  context.DeadlineExceeded,
+			want: true,
+		},
+		{
+			name: "grpc canceled",
+			err:  status.Error(codes.Canceled, "canceled"),
+			want: true,
+		},
+		{
+			name: "grpc deadline exceeded",
+			err:  status.Error(codes.DeadlineExceeded, "deadline exceeded"),
+			want: true,
+		},
+		{
+			name: "grpc already exists",
+			err:  status.Error(codes.AlreadyExists, "sandbox already exists"),
+			want: true,
+		},
+		{
+			name: "grpc failed precondition",
+			err:  status.Error(codes.FailedPrecondition, "sandbox name conflict"),
+			want: true,
+		},
+		{
+			name: "reserved name message",
+			err:  errors.New(`failed to reserve sandbox name "bar_new_12345678_1": name "bar_new_12345678_1" is reserved for "1234"`),
+			want: true,
+		},
+		{
+			name: "permission denied",
+			err:  status.Error(codes.PermissionDenied, "permission denied"),
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, shouldRecoverPodSandboxFromRunPodSandboxError(test.err))
+		})
+	}
+}
+
+func assertCallBefore(t *testing.T, calls []string, before, after string) {
+	t.Helper()
+	beforeIndex := -1
+	afterIndex := -1
+	for i, call := range calls {
+		if call == before && beforeIndex == -1 {
+			beforeIndex = i
+		}
+		if call == after && afterIndex == -1 {
+			afterIndex = i
+		}
+	}
+	require.NotEqual(t, -1, beforeIndex, "%s not called; calls: %#v", before, calls)
+	require.NotEqual(t, -1, afterIndex, "%s not called; calls: %#v", after, calls)
+	assert.Less(t, beforeIndex, afterIndex)
 }
 
 func TestGeneratePodSandboxLinuxConfigSeccomp(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

When `RunPodSandbox` is cancelled, times out, or reports a sandbox-name conflict, kubelet now inspects pod sandboxes for the same pod UID and attempt. If a matching sandbox is already ready, kubelet uses it. Any matching non-ready sandboxes are stopped and removed so the runtime can release sandbox-name reservations before the next retry.

The recovery uses a short bounded context detached from the cancelled `RunPodSandbox` call so cleanup can proceed without blocking indefinitely.

#### Which issue(s) this PR is related to:

Fixes #139097

#### Special notes for your reviewer:

This handles both the initial cancelled/deadline `RunPodSandbox` error and the retry-side `failed to reserve sandbox name ... is reserved for ...` error reported by containerd.

#### Does this PR introduce a user-facing change?

```release-note
Kubelet now recovers from cancelled or timed-out CRI RunPodSandbox calls by reusing a matching ready sandbox or stopping and removing matching non-ready sandboxes before retrying pod sandbox creation.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI assistance disclosure

AI tools were used while preparing this PR. I reviewed the changes and am responsible for them.
