### PR TITLE
kubelet: defer CRI fallback removal to 1.38

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1421,7 +1421,7 @@ func getCgroupDriverFromCRI(ctx context.Context, s *options.KubeletServer, kubeD
 			}
 			// CRI implementation doesn't support RuntimeConfig, fallback
 			legacyregistry.MustRegister(kubeletmetrics.CRILosingSupport)
-			kubeletmetrics.CRILosingSupport.WithLabelValues("1.37.0").Inc()
+			kubeletmetrics.CRILosingSupport.WithLabelValues("1.38.0").Inc()
 			logger.Info("CRI implementation should be updated to support RuntimeConfig. Falling back to using cgroupDriver from kubelet config.")
 			return nil
 		}

--- a/test/e2e_node/cgroup_driver_from_cri_test.go
+++ b/test/e2e_node/cgroup_driver_from_cri_test.go
@@ -66,7 +66,7 @@ var _ = SIGDescribe("Cgroup Driver From CRI", feature.CriProxy, framework.WithSe
 			samples := m[kubeletmetrics.KubeletSubsystem+"_"+kubeletmetrics.CRILosingSupportKey]
 
 			gomega.Expect(samples).NotTo(gomega.BeEmpty())
-			gomega.Expect(samples[0].Metric["version"]).To(gomega.BeEquivalentTo("1.37.0"))
+			gomega.Expect(samples[0].Metric["version"]).To(gomega.BeEquivalentTo("1.38.0"))
 		})
 		ginkgo.It("should not emit metric if CRI is new enough", func() {
 			restartKubelet(context.Background(), true)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Updates the kubelet `cri_losing_support` metric removal timeline from `1.37.0` to `1.38.0`, along with the matching node e2e expectation.

#### Which issue(s) this PR is related to:

Related: https://github.com/kubernetes/enhancements/pull/6087
KEP: https://github.com/kubernetes/enhancements/issues/4033

#### Special notes for your reviewer:

None.

#### Does this PR introduce a user-facing change?

```release-note
kubelet: defer the configurations flags (and the related fallback behavior) deprecation removal timeline from 1.37 to 1.38 to align with containerd v1.7 support
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```