### PR TITLE
apiserver: iterator-based JSON list encoding-part1

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
@@ -360,6 +360,12 @@ type CacheableObject interface {
 	GetObject() Object
 }
 
+// ObjectIterator produces objects one at a time for streaming serializers.
+// It returns io.EOF when there are no more objects to produce.
+type ObjectIterator interface {
+	Next() (Object, error)
+}
+
 // Unstructured objects store values as map[string]interface{}, with only values that can be serialized
 // to JSON allowed.
 type Unstructured interface {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections.go
@@ -32,6 +32,20 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+type sliceObjectIterator struct {
+	items []runtime.Object
+	index int
+}
+
+func (it *sliceObjectIterator) Next() (runtime.Object, error) {
+	if it.index >= len(it.items) {
+		return nil, io.EOF
+	}
+	item := it.items[it.index]
+	it.index++
+	return item, nil
+}
+
 func streamEncodeCollections(obj runtime.Object, w io.Writer) (bool, error) {
 	list, ok := obj.(*unstructured.UnstructuredList)
 	if ok {
@@ -90,6 +104,10 @@ func getListMeta(list runtime.Object) (metav1.TypeMeta, metav1.ListMeta, []runti
 }
 
 func streamingEncodeList(w io.Writer, typeMeta metav1.TypeMeta, listMeta metav1.ListMeta, items []runtime.Object) error {
+	var iter runtime.ObjectIterator
+	if items != nil {
+		iter = &sliceObjectIterator{items: items}
+	}
 	// Start
 	if _, err := w.Write([]byte(`{`)); err != nil {
 		return err
@@ -113,7 +131,7 @@ func streamingEncodeList(w io.Writer, typeMeta metav1.TypeMeta, listMeta metav1.
 	}
 
 	// Items
-	if err := encodeItemsObjectSlice(w, items); err != nil {
+	if err := encodeItemsObjectIterator(w, iter); err != nil {
 		return err
 	}
 
@@ -122,29 +140,35 @@ func streamingEncodeList(w io.Writer, typeMeta metav1.TypeMeta, listMeta metav1.
 	return err
 }
 
-func encodeItemsObjectSlice(w io.Writer, items []runtime.Object) (err error) {
-	if items == nil {
-		err := encodeKeyValuePair(w, "items", nil, nil)
-		return err
+func encodeItemsObjectIterator(w io.Writer, iter runtime.ObjectIterator) (err error) {
+	if iter == nil {
+		return encodeKeyValuePair(w, "items", nil, nil)
 	}
 	_, err = w.Write([]byte(`"items":[`))
 	if err != nil {
 		return err
 	}
-	suffix := []byte(",")
-	for i, item := range items {
-		if i == len(items)-1 {
-			suffix = nil
+
+	first := true
+	for {
+		item, err := iter.Next()
+		if err == io.EOF {
+			break
 		}
-		err := encodeValue(w, item, suffix)
 		if err != nil {
+			return err
+		}
+		if !first {
+			if _, err := w.Write([]byte(",")); err != nil {
+				return err
+			}
+		}
+		first = false
+		if err := encodeValue(w, item, nil); err != nil {
 			return err
 		}
 	}
 	_, err = w.Write([]byte("]"))
-	if err != nil {
-		return err
-	}
 	return err
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
see #139026
1. `versioning` and `encoding` are split into two layers, but the current contract requires `versioning` to materialize and pass an entire versioned item slice upward.
2. This means typed list version conversion happens as a full-slice operation, which causes extra copying and unnecessary memory usage for large lists.


The goal of this refactor is to remove that full-slice version conversion behavior.

This PR is stage 1 of that work.

It changes the encoding-side consumption model so that streamed JSON list encoding can consume items through an explicit iterator contract.

Concretely, this PR:

- adds a shared `runtime.ObjectIterator` abstraction
- updates the JSON list encoder to consume items via `Next()`
- preserves current behavior of versioner


current: 
```
version conversion(full slice)

encoder -> get full slice -> streamed encode
```
stage1 (this PR): 
```
version conversion(full slice)

encoder -> loop: call Next() -> Next() returns next item in slice (still from full slice) -> encode item by item
```
final target:
```
no longer performs full conversion

encoder -> loop: call Next() (implemented by versioner) -> Next() converts version and returns single item -> encode item by item
```
#### Which issue(s) this PR is related to:

Related to #139026

#### Special notes for your reviewer:

- stage 1: introduce iterator-based consumption in the encoding layer (this PR)
- stage 2: introduce iterator-based production helpers in the versioning layer
- stage 3: connect producer and consumer so version conversion no longer requires a full slice
- stage 4: tests

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```