### PR TITLE
scheduler: always activate preemptor after async preemption

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -2615,12 +2615,12 @@ func TestPreEnqueue(t *testing.T) {
 
 			finishPreemption := make(chan struct{})
 
-			p.Executor.PreemptPod = func(ctx context.Context, c preemption.Candidate, preemptor preemption.ExecutorPreemptor, victim *v1.Pod, pluginName string) error {
+			p.Executor.PreemptPod = func(ctx context.Context, c preemption.Candidate, preemptor preemption.ExecutorPreemptor, victim *v1.Pod, pluginName string) (bool, error) {
 				if !tt.features.EnableAsyncPreemption {
-					return nil
+					return false, nil
 				}
 				<-finishPreemption
-				return nil
+				return true, nil
 			}
 
 			// Fill the cycle state

--- a/pkg/scheduler/framework/preemption/executor.go
+++ b/pkg/scheduler/framework/preemption/executor.go
@@ -87,7 +87,7 @@ type Executor struct {
 
 	// PreemptPod is a function that actually makes API calls to preempt a specific Pod.
 	// This is exposed to be replaced during tests.
-	PreemptPod func(ctx context.Context, c Candidate, preemptor ExecutorPreemptor, victim *v1.Pod, pluginName string) error
+	PreemptPod func(ctx context.Context, c Candidate, preemptor ExecutorPreemptor, victim *v1.Pod, pluginName string) (deleteEventExpected bool, err error)
 }
 
 // NewExecutor creates a new preemption executor.
@@ -100,10 +100,11 @@ func NewExecutor(fh fwk.Handle, fts feature.Features) *Executor {
 		fts:                          fts,
 	}
 
-	e.PreemptPod = func(ctx context.Context, c Candidate, preemptor ExecutorPreemptor, victim *v1.Pod, pluginName string) error {
+	e.PreemptPod = func(ctx context.Context, c Candidate, preemptor ExecutorPreemptor, victim *v1.Pod, pluginName string) (bool, error) {
 		logger := klog.FromContext(ctx)
 
 		skipAPICall := false
+		deleteEventExpected := false
 		eventMessage := fmt.Sprintf("Preempted by %s %v on node %v", preemptor.Type(), preemptor.UID(), c.Name())
 		// If the victim is a WaitingPod, try to preempt it without a delete call (victim will go back to backoff queue).
 		// Otherwise we should delete the victim.
@@ -135,20 +136,21 @@ func NewExecutor(fh fwk.Handle, fts feature.Features) *Executor {
 				if err := util.PatchPodStatus(ctx, fh.ClientSet(), victim.Name, victim.Namespace, &victim.Status, newStatus); err != nil {
 					if !apierrors.IsNotFound(err) {
 						logger.Error(err, "Could not add DisruptionTarget condition due to preemption", "preemptor", klog.KObj(preemptor), "victim", klog.KObj(victim))
-						return err
+						return false, err
 					}
 					logger.V(2).Info("Victim Pod is already deleted", "preemptor", klog.KObj(preemptor), "victim", klog.KObj(victim), "node", c.Name())
-					return nil
+					return false, nil
 				}
 			}
 			if err := util.DeletePod(ctx, fh.ClientSet(), victim); err != nil {
 				if !apierrors.IsNotFound(err) {
 					logger.Error(err, "Tried to preempted pod", "pod", klog.KObj(victim), "preemptor", klog.KObj(preemptor))
-					return err
+					return false, err
 				}
 				logger.V(2).Info("Victim Pod is already deleted", "preemptor", klog.KObj(preemptor), "victim", klog.KObj(victim), "node", c.Name())
-				return nil
+				return false, nil
 			}
+			deleteEventExpected = true
 			logger.V(2).Info("Preemptor Pod preempted victim Pod", "preemptor", klog.KObj(preemptor), "victim", klog.KObj(victim), "node", c.Name())
 		} else {
 			eventMessage += " (in kube-scheduler memory)."
@@ -156,7 +158,7 @@ func NewExecutor(fh fwk.Handle, fts feature.Features) *Executor {
 
 		fh.EventRecorder().WithLogger(logger).Eventf(victim, preemptor.Obj(), v1.EventTypeNormal, "Preempted", "Preempting", eventMessage)
 
-		return nil
+		return deleteEventExpected, nil
 	}
 
 	return e
@@ -225,7 +227,7 @@ func (e *Executor) prepareCandidateAsync(c Candidate, preemptor ExecutorPreempto
 	errCh := parallelize.NewResultChannel[error]()
 	preemptPod := func(index int) {
 		victim := victimPods[index]
-		if err := e.PreemptPod(ctx, c, preemptor, victim, pluginName); err != nil {
+		if _, err := e.PreemptPod(ctx, c, preemptor, victim, pluginName); err != nil {
 			errCh.SendWithCancel(err, cancel)
 		}
 	}
@@ -281,6 +283,7 @@ func (e *Executor) prepareCandidateAsync(c Candidate, preemptor ExecutorPreempto
 			}
 		}
 
+		shouldActivate := false
 		// If any of the previous victims failed to be preempted, then we can skip
 		// the preemption attempt for the last victim Pod to expedite the preemptor's
 		// re-entry to the scheduling cycle.
@@ -290,15 +293,25 @@ func (e *Executor) prepareCandidateAsync(c Candidate, preemptor ExecutorPreempto
 			e.lastVictimsPendingPreemption[preemptor.UID()] = pendingVictim{namespace: lastVictim.Namespace, name: lastVictim.Name}
 			e.mu.Unlock()
 
-			if err := e.PreemptPod(ctx, c, preemptor, lastVictim, pluginName); err != nil {
+			deleteEventExpected, err := e.PreemptPod(ctx, c, preemptor, lastVictim, pluginName)
+			if err != nil {
 				utilruntime.HandleErrorWithContext(ctx, err, "Error occurred during async preemption of the last victim")
 				result = metrics.GoroutineResultError
+			} else if !deleteEventExpected {
+				// The last successful preemption step didn't trigger a new AssignedPod/Delete
+				// event for this preemptor. This happens, for example, when another
+				// preemptor has already deleted the eventual last victim or when the victim
+				// was preempted in scheduler memory. Wake the preemptor explicitly.
+				shouldActivate = true
 			}
 		}
 		e.mu.Lock()
 		e.preempting.Delete(preemptor.UID())
 		delete(e.lastVictimsPendingPreemption, preemptor.UID())
 		e.mu.Unlock()
+		if shouldActivate {
+			e.fh.Activate(logger, preemptor.Pods())
+		}
 
 		logger.V(2).Info("Async Preemption finished completely", "preemptor", klog.KObj(preemptor), "node", c.Name(), "result", result)
 	}()
@@ -325,7 +338,7 @@ func (e *Executor) prepareCandidate(ctx context.Context, c Candidate, preemptor 
 			logger.V(2).Info("Victim Pod is already being deleted, skipping the API call for it", "preemptor", klog.KObj(preemptor), "node", c.Name(), "victim", klog.KObj(victim))
 			return
 		}
-		if err := e.PreemptPod(ctx, c, preemptor, victim, pluginName); err != nil {
+		if _, err := e.PreemptPod(ctx, c, preemptor, victim, pluginName); err != nil {
 			errCh.SendWithCancel(err, cancel)
 		}
 	}, pluginName)

--- a/pkg/scheduler/framework/preemption/executor_test.go
+++ b/pkg/scheduler/framework/preemption/executor_test.go
@@ -404,6 +404,7 @@ func TestPrepareCandidate(t *testing.T) {
 			nodeNames:             []string{node1Name},
 			expectedStatus:        nil,
 			expectedPreemptingMap: sets.New(types.UID("preemptor")),
+			expectedActivatedPods: map[string]*v1.Pod{preemptor.Name: preemptor},
 		},
 		{
 			name: "one victim with same condition",
@@ -903,7 +904,7 @@ func TestPrepareCandidateAsyncSetsPreemptingSets(t *testing.T) {
 					// preemptPodCallsCounter helps verify if the last victim pod gets preempted after other victims.
 					preemptPodCallsCounter := 0
 					preemptFunc := executor.PreemptPod
-					executor.PreemptPod = func(ctx context.Context, c Candidate, preemptor ExecutorPreemptor, victim *v1.Pod, pluginName string) error {
+					executor.PreemptPod = func(ctx context.Context, c Candidate, preemptor ExecutorPreemptor, victim *v1.Pod, pluginName string) (bool, error) {
 						// Verify contents of the sets: preempting and lastVictimsPendingPreemption before preemption of subsequent pods.
 						executor.mu.RLock()
 						preemptPodCallsCounter++
@@ -1311,6 +1312,7 @@ func TestPreemptPod(t *testing.T) {
 		addVictimToPrebind bool
 		addVictimToWaiting bool
 		expectCancel       bool
+		expectDeleteEvent  bool
 		expectedActions    []string
 	}{
 		{
@@ -1318,6 +1320,7 @@ func TestPreemptPod(t *testing.T) {
 			addVictimToPrebind: true,
 			addVictimToWaiting: false,
 			expectCancel:       true,
+			expectDeleteEvent:  false,
 			expectedActions:    []string{},
 		},
 		{
@@ -1325,6 +1328,7 @@ func TestPreemptPod(t *testing.T) {
 			addVictimToPrebind: false,
 			addVictimToWaiting: true,
 			expectCancel:       false,
+			expectDeleteEvent:  false,
 			expectedActions:    []string{},
 		},
 		{
@@ -1332,6 +1336,7 @@ func TestPreemptPod(t *testing.T) {
 			addVictimToPrebind: false,
 			addVictimToWaiting: false,
 			expectCancel:       false,
+			expectDeleteEvent:  true,
 			expectedActions:    []string{"patch", "delete"},
 		},
 	}
@@ -1391,9 +1396,12 @@ func TestPreemptPod(t *testing.T) {
 					preemptor = &podGroupExecutorPreemptor{pg: preemptorPodGroup, pods: preemptorPods}
 				}
 
-				err = pe.PreemptPod(ctx, &candidate{name: "fake-node"}, preemptor, victimPod, "test-plugin")
+				deleteEventExpected, err := pe.PreemptPod(ctx, &candidate{name: "fake-node"}, preemptor, victimPod, "test-plugin")
 				if err != nil {
 					t.Fatal(err)
+				}
+				if deleteEventExpected != tt.expectDeleteEvent {
+					t.Fatalf("Expected deleteEventExpected=%v, got %v", tt.expectDeleteEvent, deleteEventExpected)
 				}
 				if tt.expectCancel {
 					if victimCtx.Err() == nil {

--- a/test/integration/scheduler/nominated_node_name/nominated_node_name_test.go
+++ b/test/integration/scheduler/nominated_node_name/nominated_node_name_test.go
@@ -492,7 +492,7 @@ func TestPreemptionAndNominatedNodeNameScenarios(t *testing.T) {
 						}
 
 						preemptPodFn := preemptionPlugin.Executor.PreemptPod
-						preemptionPlugin.Executor.PreemptPod = func(ctx context.Context, c preemption.Candidate, preemptor preemption.ExecutorPreemptor, victim *v1.Pod, pluginName string) error {
+						preemptionPlugin.Executor.PreemptPod = func(ctx context.Context, c preemption.Candidate, preemptor preemption.ExecutorPreemptor, victim *v1.Pod, pluginName string) (bool, error) {
 							// block the preemption goroutine to complete until the test case allows it to proceed.
 							lock.Lock()
 							ch, ok := preemptionDoneChannels[preemptor.GetName()]

--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -1248,7 +1248,7 @@ func TestAsyncPreemption(t *testing.T) {
 					}
 
 					preemptPodFn := preemptionPlugin.Executor.PreemptPod
-					preemptionPlugin.Executor.PreemptPod = func(ctx context.Context, c preemption.Candidate, preemptor preemption.ExecutorPreemptor, victim *v1.Pod, pluginName string) error {
+					preemptionPlugin.Executor.PreemptPod = func(ctx context.Context, c preemption.Candidate, preemptor preemption.ExecutorPreemptor, victim *v1.Pod, pluginName string) (bool, error) {
 						// block the preemption goroutine to complete until the test case allows it to proceed.
 						lock.Lock()
 						ch, ok := preemptionDoneChannels[preemptor.GetName()]


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:

```
go test -c ./test/integration/scheduler/preemption -o /tmp/preemption-master.test

stress \
  -p 1 \
  -failfast \
  -count 50 \
  -timeout 3m \
  -o /tmp/master-asyncpreemption-subtest-stress \
  /tmp/preemption-master.test \
  -test.run '^TestAsyncPreemption/Lower_priority_Pod_can_select_the_same_place_where_the_higher_priority_Pod_is_preempting_if_the_node_is_big_enough \(Async_API_calls_enabled:_true\)$' \
  -test.timeout=2m
```
I can reproduce it like this. 1/21 running.

```
go test -v ./test/integration/scheduler/preemption -run 'TestAsyncPreemption/Lower_priority_Pod_can_select_the_same_place_where_the_higher_priority_Pod_is_preempting_if_the_node_is_big_enough' -count=3 -timeout 20m
```

```
stress \
  -p 1 \
  -count 100 \
  -timeout 4m \
  -o /tmp/asyncpreemption-stress \
  /tmp/preemption.test \
  -test.run '^TestAsyncPreemption$' \
  -test.timeout=3m
```

passed with the fix.

#### Which issue(s) this PR is related to:
Fixes #138268

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```