### PR TITLE
Add SIG instrumentation owners for new storage metrics directory

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/metrics/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/storage/metrics/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - sig-instrumentation-approvers
+reviewers:
+  - sig-instrumentation-reviewers
+labels:
+  - sig/instrumentation


### PR DESCRIPTION
/kind cleanup

```release-note
NONE
```

Add owner for directory created in https://github.com/kubernetes/kubernetes/pull/139082