### PR TITLE
Add a performance test scenario with low QPS on connection to API server

### DIFF
--- a/test/integration/scheduler_perf/misc/performance-config.yaml
+++ b/test/integration/scheduler_perf/misc/performance-config.yaml
@@ -88,6 +88,27 @@
       initNodes: 5000
       initPods: 5000
       measurePods: 50000
+  - name: 5kNodes_10kPods_LowQPSOnAPIServer_AsyncAPICallsDisabled
+    schedulerApiClientQPS: 100
+    schedulerApiClientBurst: 100
+    featureGates:
+      SchedulerAsyncAPICalls: false
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initPods: 1000
+      measurePods: 10000
+  - name: 5kNodes_10kPods_LowQPSOnAPIServer_AsyncAPICallsEnabled
+    schedulerApiClientQPS: 100
+    schedulerApiClientBurst: 100
+    featureGates:
+      SchedulerAsyncAPICalls: true
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initPods: 1000
+      measurePods: 10000
+
 # This test case simulates the scheduling of daemonset.
 # https://github.com/kubernetes/kubernetes/issues/124709
 - name: SchedulingDaemonset
@@ -517,47 +538,11 @@
       nodesWithoutExtendedResource: 0
       measurePods: 5000
 
-- name: SchedulingBasicWithLowQPSOnAPIServer
-  apiServerQPS: 100
-  apiServerBurst: 100
-  defaultPodTemplatePath: ../templates/pod-default.yaml
-  workloadTemplate:
-  - opcode: createNodes
-    countParam: $initNodes
-  - opcode: createPods
-    countParam: $initPods
-  - opcode: createPods
-    countParam: $measurePods
-    collectMetrics: true
-  workloads:
-  - name: 5kNodes_10kPods
-    featureGates:
-      SchedulerAsyncAPICalls: false
-    labels: [performance]
-    # Testing code uses the same client for API server connection as kubescheduler,
-    # therefore we cannot have throughput = max apiServerQPS. Throughput should be
-    # the same with AsyncAPICalls enabled and disabled.
-    threshold: 33
-    params:
-      initNodes: 5000
-      initPods: 1000
-      measurePods: 10000
-  - name: 5kNodes_10kPods_AsyncAPICallsEnabled
-    featureGates:
-      SchedulerAsyncAPICalls: true
-    labels: [performance]
-    # Throughput should be the same with AsyncAPICalls enabled and disabled.
-    threshold: 33
-    params:
-      initNodes: 5000
-      initPods: 1000
-      measurePods: 10000
-
 # This test simulates a limited QPS on connection to API server and a large number
 # of unschedulable pods circling between activeQ and backoffQ/unschedulable pool.
 - name: LowAPIServerQPSWithMultipleUnscheduledPods
-  apiServerQPS: 100
-  apiServerBurst: 100
+  schedulerApiClientQPS: 100
+  schedulerApiClientBurst: 100
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
@@ -602,9 +587,6 @@
     featureGates:
       SchedulerAsyncAPICalls: true
     labels: [performance]
-    # Expect much lower throughput because measurement starts before all pods
-    # from the first batch go through scheduling cycle.
-    threshold: 2
     params:
       initNodes: 1000
       largePods: 400
@@ -613,7 +595,6 @@
     featureGates:
       SchedulerAsyncAPICalls: false
     labels: [performance]
-    threshold: 45
     params:
       initNodes: 1000
       largePods: 400

--- a/test/integration/scheduler_perf/misc/performance-config.yaml
+++ b/test/integration/scheduler_perf/misc/performance-config.yaml
@@ -516,3 +516,105 @@
       nodesWithExtendedResource: 5000
       nodesWithoutExtendedResource: 0
       measurePods: 5000
+
+- name: SchedulingBasicWithLowQPSOnAPIServer
+  apiServerQPS: 100
+  apiServerBurst: 100
+  defaultPodTemplatePath: ../templates/pod-default.yaml
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $initNodes
+  - opcode: createPods
+    countParam: $initPods
+  - opcode: createPods
+    countParam: $measurePods
+    collectMetrics: true
+  workloads:
+  - name: 5kNodes_10kPods
+    featureGates:
+      SchedulerAsyncAPICalls: false
+    labels: [performance]
+    # Testing code uses the same client for API server connection as kubescheduler,
+    # therefore we cannot have throughput = max apiServerQPS. Throughput should be
+    # the same with AsyncAPICalls enabled and disabled.
+    threshold: 33
+    params:
+      initNodes: 5000
+      initPods: 1000
+      measurePods: 10000
+  - name: 5kNodes_10kPods_AsyncAPICallsEnabled
+    featureGates:
+      SchedulerAsyncAPICalls: true
+    labels: [performance]
+    # Throughput should be the same with AsyncAPICalls enabled and disabled.
+    threshold: 33
+    params:
+      initNodes: 5000
+      initPods: 1000
+      measurePods: 10000
+
+# This test simulates a limited QPS on connection to API server and a large number
+# of unschedulable pods circling between activeQ and backoffQ/unschedulable pool.
+- name: LowAPIServerQPSWithMultipleUnscheduledPods
+  apiServerQPS: 100
+  apiServerBurst: 100
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $initNodes
+    nodeTemplatePath: ../templates/node-default.yaml
+  - opcode: createPods
+    namespace: test
+    countParam: $largePods
+    podTemplatePath: templates/pod-with-pod-affinity-large-resource.yaml
+    # These pods are unschedulable because they have required affinity to pods
+    # with label "blue", and those will get created in the second batch.
+    # Test cannot wait for completion of the step, because pods won't get scheduled.
+    skipWaitToCompletion: true
+  - opcode: createPods
+    namespace: test
+    countParam: $measurePods
+    podTemplatePath: templates/pod-blue.yaml
+    collectMetrics: true
+  workloads:
+  - name: 5Nodes_5Large_5Measure
+    labels: [integration-test, short]
+    params:
+      initNodes: 5
+      largePods: 5
+      measurePods: 5
+  - name: 50Nodes_30Large_50Measure_AsyncAPICallsEnabled
+    featureGates:
+      SchedulerAsyncAPICalls: true
+    labels: [integration-test, short]
+    params:
+      initNodes: 50
+      largePods: 30
+      measurePods: 50
+  - name: 50Nodes_30Large_50Measure_AsyncAPICallsDisabled
+    featureGates:
+      SchedulerAsyncAPICalls: false
+    labels: [integration-test, short]
+    params:
+      initNodes: 50
+      largePods: 30
+      measurePods: 50
+  - name: 1kNodes_400Large_1kMeasure_AsyncAPICallsEnabled
+    featureGates:
+      SchedulerAsyncAPICalls: true
+    labels: [performance]
+    # Expect much lower throughput because measurement starts before all pods
+    # from the first batch go through scheduling cycle.
+    threshold: 2
+    params:
+      initNodes: 1000
+      largePods: 400
+      measurePods: 1000
+  - name: 1kNodes_400Large_1kMeasure_AsyncAPICallsDisabled
+    featureGates:
+      SchedulerAsyncAPICalls: false
+    labels: [performance]
+    threshold: 45
+    params:
+      initNodes: 1000
+      largePods: 400
+      measurePods: 1000

--- a/test/integration/scheduler_perf/misc/templates/pod-blue.yaml
+++ b/test/integration/scheduler_perf/misc/templates/pod-blue.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: pod-blue-
+  labels:
+    color: blue
+spec:
+  containers:
+  - image: registry.k8s.io/pause:3.10.2
+    name: pause
+    ports:
+    - containerPort: 80
+    resources:
+      limits:
+        cpu: 100m
+        memory: 500Mi
+      requests:
+        cpu: 100m
+        memory: 500Mi

--- a/test/integration/scheduler_perf/misc/templates/pod-with-pod-affinity-large-resource.yaml
+++ b/test/integration/scheduler_perf/misc/templates/pod-with-pod-affinity-large-resource.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: pod-with-pod-affinity-large-resource-
+spec:
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            color: blue
+        topologyKey: kubernetes.io/hostname
+  containers:
+  - image: registry.k8s.io/pause:3.10.2
+    name: pause
+    ports:
+    - containerPort: 80
+    resources:
+      limits:
+        cpu: "4"
+        memory: 32Gi
+      requests:
+        cpu: "4"
+        memory: 32Gi

--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -256,12 +256,16 @@ type testCase struct {
 	// SchedulerConfigPath is the path of scheduler configuration
 	// Optional
 	SchedulerConfigPath string
-	// APIServerQPS overrides the max QPS of the connection to the API server.
+	// SchedulerAPIClientQPS overrides the max QPS of the connection to the API server used by
+	// kubescheduler under test. The connection used by the test framework (for creating/deleting
+	// nodes, pods etc.) is not impacted by this setting.
 	// Optional
-	APIServerQPS *float32
-	// APIServerBurst overrides the throttle limit for bursts in the connection to the API server.
+	SchedulerAPIClientQPS *float32
+	// SchedulerAPIClientBurst overrides the throttle limit for bursts in the connection to the
+	// API server used by kubescheduler under test. The connection used by the test framework
+	// (for creating/deleting nodes, pods etc.) is not impacted by this setting.
 	// Optional
-	APIServerBurst *int
+	SchedulerAPIClientBurst *int
 	// Default path to spec file describing the pods to create.
 	// This path can be overridden in createPodsOp by setting PodTemplatePath .
 	// Optional
@@ -326,6 +330,14 @@ type Workload struct {
 	// Explicitly setting a feature in this map overrides the test case settings.
 	// Optional
 	FeatureGates map[featuregate.Feature]bool
+	// SchedulerAPIClientQPS overrides the max QPS of the connection to the API server.
+	// If set, it overrides the value set on the testCase level.
+	// Optional
+	SchedulerAPIClientQPS *float32
+	// SchedulerAPIClientBurst overrides the throttle limit for bursts in the connection to the API server.
+	// If set, it overrides the value set on the testCase level.
+	// Optional
+	SchedulerAPIClientBurst *int
 }
 
 // GetParam retrieves a parameter from the Workload's parameters as an integer.
@@ -721,7 +733,16 @@ func setupTestCase(t testing.TB, tc *testCase, featureGates map[featuregate.Feat
 	timeout := 30 * time.Minute
 	tCtx = tCtx.WithTimeout(timeout, fmt.Sprintf("timed out after the %s per-test timeout", timeout))
 
-	return setupClusterForWorkload(tCtx, tc.SchedulerConfigPath, featureGates, tc.APIServerQPS, tc.APIServerBurst, opts)
+	qps := tc.SchedulerAPIClientQPS
+	if workload.SchedulerAPIClientQPS != nil {
+		qps = workload.SchedulerAPIClientQPS
+	}
+	burst := tc.SchedulerAPIClientBurst
+	if workload.SchedulerAPIClientBurst != nil {
+		burst = workload.SchedulerAPIClientBurst
+	}
+
+	return setupClusterForWorkload(tCtx, tc.SchedulerConfigPath, featureGates, qps, burst, opts)
 }
 
 func featureGatesMerge(src map[featuregate.Feature]bool, overrides map[featuregate.Feature]bool) map[featuregate.Feature]bool {

--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -256,6 +256,12 @@ type testCase struct {
 	// SchedulerConfigPath is the path of scheduler configuration
 	// Optional
 	SchedulerConfigPath string
+	// APIServerQPS overrides the max QPS of the connection to the API server.
+	// Optional
+	APIServerQPS *float32
+	// APIServerBurst overrides the throttle limit for bursts in the connection to the API server.
+	// Optional
+	APIServerBurst *int
 	// Default path to spec file describing the pods to create.
 	// This path can be overridden in createPodsOp by setting PodTemplatePath .
 	// Optional
@@ -715,7 +721,7 @@ func setupTestCase(t testing.TB, tc *testCase, featureGates map[featuregate.Feat
 	timeout := 30 * time.Minute
 	tCtx = tCtx.WithTimeout(timeout, fmt.Sprintf("timed out after the %s per-test timeout", timeout))
 
-	return setupClusterForWorkload(tCtx, tc.SchedulerConfigPath, featureGates, opts)
+	return setupClusterForWorkload(tCtx, tc.SchedulerConfigPath, featureGates, tc.APIServerQPS, tc.APIServerBurst, opts)
 }
 
 func featureGatesMerge(src map[featuregate.Feature]bool, overrides map[featuregate.Feature]bool) map[featuregate.Feature]bool {
@@ -993,7 +999,7 @@ func unrollWorkloadTemplate(tb ktesting.TB, wt []op, w *Workload) []op {
 	return unrolled
 }
 
-func setupClusterForWorkload(tCtx ktesting.TContext, configPath string, featureGates map[featuregate.Feature]bool, opts *schedulerPerfOptions) (*scheduler.Scheduler, informers.SharedInformerFactory, <-chan struct{}, ktesting.TContext) {
+func setupClusterForWorkload(tCtx ktesting.TContext, configPath string, featureGates map[featuregate.Feature]bool, qps *float32, burst *int, opts *schedulerPerfOptions) (*scheduler.Scheduler, informers.SharedInformerFactory, <-chan struct{}, ktesting.TContext) {
 	var cfg *config.KubeSchedulerConfiguration
 	var err error
 	if configPath != "" {
@@ -1005,7 +1011,7 @@ func setupClusterForWorkload(tCtx ktesting.TContext, configPath string, featureG
 			tCtx.Fatalf("validate scheduler config file failed: %v", err)
 		}
 	}
-	return mustSetupCluster(tCtx, cfg, featureGates, opts)
+	return mustSetupCluster(tCtx, cfg, featureGates, qps, burst, opts)
 }
 
 func labelsMatch(actualLabels, requiredLabels map[string]string) bool {

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -124,16 +124,23 @@ func mustSetupCluster(tCtx ktesting.TContext, config *config.KubeSchedulerConfig
 		tCtx.Cancel("test is done")
 	})
 
-	cfg := restclient.CopyConfig(server.ClientConfig)
-	cfg.QPS = 5000.0
-	cfg.Burst = 5000
+	// 1. Testing framework client configuration (default/static limits)
+	testingFrameworkCfg := restclient.CopyConfig(server.ClientConfig)
+	testingFrameworkCfg.QPS = 5000.0
+	testingFrameworkCfg.Burst = 5000
+	frameworkTCtx := tCtx.WithRESTConfig(testingFrameworkCfg)
 
+	// 2. Scheduler client configuration (custom limits)
+	schedulerCfg := restclient.CopyConfig(server.ClientConfig)
+	schedulerCfg.QPS = 5000.0
+	schedulerCfg.Burst = 5000
 	if qps != nil {
-		cfg.QPS = *qps
+		schedulerCfg.QPS = *qps
 	}
 	if burst != nil {
-		cfg.Burst = *burst
+		schedulerCfg.Burst = *burst
 	}
+	schedulerTCtx := tCtx.WithRESTConfig(schedulerCfg)
 
 	// use default component config if config here is nil
 	if config == nil {
@@ -144,14 +151,12 @@ func mustSetupCluster(tCtx ktesting.TContext, config *config.KubeSchedulerConfig
 		}
 	}
 
-	tCtx = tCtx.WithRESTConfig(cfg)
-
 	// Not all config options will be effective but only those mostly related with scheduler performance will
 	// be applied to start a scheduler, most of them are defined in `scheduler.schedulerOptions`.
-	scheduler, informerFactory, done := util.StartSchedulerWithDone(tCtx, config, opts.outOfTreePluginRegistry)
-	util.StartFakePVController(tCtx, tCtx.Client(), informerFactory)
-	runGC := util.CreateGCController(tCtx, tCtx, *cfg, informerFactory)
-	runNS := util.CreateNamespaceController(tCtx, tCtx, *cfg, informerFactory)
+	scheduler, informerFactory, done := util.StartSchedulerWithDone(schedulerTCtx, config, opts.outOfTreePluginRegistry)
+	util.StartFakePVController(frameworkTCtx, frameworkTCtx.Client(), informerFactory)
+	runGC := util.CreateGCController(frameworkTCtx, frameworkTCtx, *testingFrameworkCfg, informerFactory)
+	runNS := util.CreateNamespaceController(frameworkTCtx, frameworkTCtx, *testingFrameworkCfg, informerFactory)
 	runResourceClaimController := func() {}
 	if enabledFeatures[features.DynamicResourceAllocation] {
 		// Testing of DRA with inline resource claims depends on this
@@ -161,16 +166,16 @@ func mustSetupCluster(tCtx ktesting.TContext, config *config.KubeSchedulerConfig
 			PrioritizedList:        true,
 			WorkloadResourceClaims: enabledFeatures[features.DRAWorkloadResourceClaims],
 		}
-		runResourceClaimController = util.CreateResourceClaimController(tCtx, tCtx, tCtx.Client(), informerFactory, features)
+		runResourceClaimController = util.CreateResourceClaimController(frameworkTCtx, frameworkTCtx, frameworkTCtx.Client(), informerFactory, features)
 	}
 
-	informerFactory.Start(tCtx.Done())
-	informerFactory.WaitForCacheSync(tCtx.Done())
+	informerFactory.Start(frameworkTCtx.Done())
+	informerFactory.WaitForCacheSync(frameworkTCtx.Done())
 	go runGC()
 	go runNS()
 	go runResourceClaimController()
 
-	return scheduler, informerFactory, done, tCtx
+	return scheduler, informerFactory, done, frameworkTCtx
 }
 
 func isAttempted(pod *v1.Pod) bool {

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -93,7 +93,7 @@ func newDefaultComponentConfig() (*config.KubeSchedulerConfiguration, error) {
 // remove resources after finished.
 // Notes on rate limiter:
 //   - client rate limit is set to 5000.
-func mustSetupCluster(tCtx ktesting.TContext, config *config.KubeSchedulerConfiguration, enabledFeatures map[featuregate.Feature]bool, opts *schedulerPerfOptions) (*scheduler.Scheduler, informers.SharedInformerFactory, <-chan struct{}, ktesting.TContext) {
+func mustSetupCluster(tCtx ktesting.TContext, config *config.KubeSchedulerConfiguration, enabledFeatures map[featuregate.Feature]bool, qps *float32, burst *int, opts *schedulerPerfOptions) (*scheduler.Scheduler, informers.SharedInformerFactory, <-chan struct{}, ktesting.TContext) {
 	var runtimeConfig []string
 	if enabledFeatures[features.DynamicResourceAllocation] {
 		runtimeConfig = append(runtimeConfig, fmt.Sprintf("%s=true", resourceapi.SchemeGroupVersion))
@@ -124,11 +124,16 @@ func mustSetupCluster(tCtx ktesting.TContext, config *config.KubeSchedulerConfig
 		tCtx.Cancel("test is done")
 	})
 
-	// TODO: client connection configuration, such as QPS or Burst is configurable in theory, this could be derived from the `config`, need to
-	// support this when there is any testcase that depends on such configuration.
 	cfg := restclient.CopyConfig(server.ClientConfig)
 	cfg.QPS = 5000.0
 	cfg.Burst = 5000
+
+	if qps != nil {
+		cfg.QPS = *qps
+	}
+	if burst != nil {
+		cfg.Burst = *burst
+	}
 
 	// use default component config if config here is nil
 	if config == nil {

--- a/test/integration/scheduler_perf/util_test.go
+++ b/test/integration/scheduler_perf/util_test.go
@@ -85,3 +85,104 @@ func Test_uniqueLVCombos(t *testing.T) {
 		})
 	}
 }
+
+// Test_separateClientConnections verifies that kubescheduler under test and test framework use
+// two separate client connections (and configurations) to the API server, and that connection
+// parameters set on workload or testcase level are correctly interpreted.
+func Test_separateClientConnections(t *testing.T) {
+	var (
+		tcQPS   float32 = 10.0
+		tcBurst         = 20
+		wQPS    float32 = 123.45
+		wBurst          = 678
+	)
+
+	tests := []struct {
+		name          string
+		testCaseQPS   *float32
+		testCaseBurst *int
+		workloadQPS   *float32
+		workloadBurst *int
+		expectedQPS   float32
+		expectedBurst int
+	}{
+		{
+			name:          "workload override takes precedence",
+			testCaseQPS:   &tcQPS,
+			testCaseBurst: &tcBurst,
+			workloadQPS:   &wQPS,
+			workloadBurst: &wBurst,
+			expectedQPS:   wQPS,
+			expectedBurst: wBurst,
+		},
+		{
+			name:          "fallback to testCase baseline when workload limits are nil",
+			testCaseQPS:   &tcQPS,
+			testCaseBurst: &tcBurst,
+			workloadQPS:   nil,
+			workloadBurst: nil,
+			expectedQPS:   tcQPS,
+			expectedBurst: tcBurst,
+		},
+		{
+			name:          "global default fallback when both are nil",
+			testCaseQPS:   nil,
+			testCaseBurst: nil,
+			workloadQPS:   nil,
+			workloadBurst: nil,
+			expectedQPS:   5000.0,
+			expectedBurst: 5000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := &testCase{
+				Name:                    "TestTC",
+				SchedulerAPIClientQPS:   tt.testCaseQPS,
+				SchedulerAPIClientBurst: tt.testCaseBurst,
+			}
+			w := &Workload{
+				Name:                    "TestWorkload",
+				SchedulerAPIClientQPS:   tt.workloadQPS,
+				SchedulerAPIClientBurst: tt.workloadBurst,
+			}
+
+			scheduler, _, done, frameworkTCtx := setupTestCase(t, tc, nil, w, &schedulerPerfOptions{})
+
+			frameworkTCtx.Cleanup(func() {
+				frameworkTCtx.Cancel("test is done")
+				<-done
+			})
+
+			// Verify framework QPS and Burst are at their default values (5000)
+			frameworkCfg := frameworkTCtx.RESTConfig()
+			if frameworkCfg == nil {
+				t.Fatal("Expected non-nil framework REST config")
+			}
+			if frameworkCfg.QPS != 5000.0 {
+				t.Errorf("Expected framework QPS to be 5000.0, got %f", frameworkCfg.QPS)
+			}
+			if frameworkCfg.Burst != 5000 {
+				t.Errorf("Expected framework Burst to be 5000, got %d", frameworkCfg.Burst)
+			}
+
+			// Verify scheduler QPS and Burst match the expected values
+			if len(scheduler.Profiles) == 0 {
+				t.Fatal("Expected at least one scheduler profile")
+			}
+			for _, profile := range scheduler.Profiles {
+				schedulerCfg := profile.KubeConfig()
+				if schedulerCfg == nil {
+					t.Fatal("Expected non-nil scheduler REST config")
+				}
+				if schedulerCfg.QPS != tt.expectedQPS {
+					t.Errorf("Expected scheduler QPS to be %f, got %f", tt.expectedQPS, schedulerCfg.QPS)
+				}
+				if schedulerCfg.Burst != tt.expectedBurst {
+					t.Errorf("Expected scheduler Burst to be %d, got %d", tt.expectedBurst, schedulerCfg.Burst)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind dependency

/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

1) PR exposes configuration settings for test API server - max QPS and burst throttle limit. This allows to run tests simulating a slowdown in API server, which has been observed in some outages related to kubescheduler.

2) PR adds a simple test scenario that runs with a low QPS:
Create X nodes, create A pods that are not schedulable (because of required affinity that is not satisfied), create B pods that match A's affinity and are successfully scheduled (and measure their scheduling throughput); scheduling of B pods moves A pods to activeQ, but they remain unschedulable because of their size (they take up resources of an entire node, so can't fit on a node together with a B pod).

#### Which issue(s) this PR is related to:
[#134261](https://github.com/kubernetes/kubernetes/issues/134261)

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
This was co-authored by AI, I reviewed all code and corrected it where needed.

More scenarios coming in another PR. I wanted to make this one as small as possible.

I ran the new tests locally and verified that A pods are indeed moved to activeQ after any B pod gets scheduled.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
