### PR TITLE
DRA E2E: improve DRAExtendedResource tests go GA graduation

### DIFF
--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -2822,6 +2822,10 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 			framework.ExpectNoError(err, "start pod")
 
 			ginkgo.By("Check that pod is processed by the DRA driver")
+			pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			gomega.Expect(pod.Status.ExtendedResourceClaimStatus).NotTo(gomega.BeNil(),
+				"after device plugin uninstall, DRA must serve the resource and create a special claim")
 			containerEnv := []string{
 				"container_0_request_0", "true",
 			}
@@ -2967,6 +2971,29 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 			ginkgo.By("Check that pod is processed by the DRA driver")
 			containerEnv := []string{"container_0_request_0", "true"}
 			drautils.TestContainerEnv(tCtx, pod, pod.Spec.Containers[0].Name, false, containerEnv...)
+		})
+		// When both a device plugin and a DRA driver advertise the same resource
+		// name on the same node, the device-plugin path wins.
+		// 1.35 is required because of https://github.com/kubernetes/kubernetes/issues/133488.
+		f.It("must prefer device plugin over DRA when both advertise the same resource on a node", f.WithSerial(), f.WithKubeletMinVersion("1.35"), func(ctx context.Context) {
+			tCtx := f.TContext(ctx)
+			// Deploy DP on nodes.NodeNames[0], where the DRA driver is also active.
+			extendedResourceName := deployDevicePlugin(tCtx, f, nodes.NodeNames[0:1], false)
+			gomega.Expect(string(extendedResourceName)).To(gomega.Equal(e2enode.SampleDeviceResourceName))
+
+			res := v1.ResourceList{extendedResourceName: resource.MustParse("1")}
+			pod := b.Pod()
+			pod.Spec.Containers[0].Resources.Requests = res
+			pod.Spec.Containers[0].Resources.Limits = res
+			b.Create(tCtx, b.ClassWithExtendedResource(e2enode.SampleDeviceResourceName), pod)
+
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod), "start pod")
+
+			pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			// Device plugin wins: no special claim created.
+			gomega.Expect(pod.Status.ExtendedResourceClaimStatus).To(gomega.BeNil(),
+				"when both DP and DRA advertise the same resource on a node, DP must win and no special claim should be created")
 		})
 	})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Improves DRAExtendedResource test coverage for GA graduation. The KEP requires the following mixed-node scenarios to be tested:

- Cluster with some nodes using device plugin and others using DRA for the same resource name
- Verify pods can be scheduled to either type of node appropriately
- Ensure one node cannot have both device plugin and DRA for same resource simultaneously
- Validate node transition: remove device plugin, add DRA driver on same node

The first two points are already covered by the existing `must run pods with extended resource on dra nodes and device plugin nodes` test. The transition scenario is covered by the existing `process extended resources after device plugin uninstall` test. 

This PR adds the remaining coverage:

Same-node precedence test `must prefer device plugin over DRA when both advertise the same resource on a node`:
when both a device plugin and a DRA driver advertise the same resource name on one node, filterExtendedResources takes the DRA path only when allocatable == 0, so the device plugin wins and no special ResourceClaim is created. This effectively enforces the "one node cannot have both" invariant: even if both mechanisms are present, only one is active for a given pod, and the result is observable via ExtendedResourceClaimStatus.

DP -> DRA transition: strengthens process extended resources after device plugin uninstall with an ExtendedResourceClaimStatus assertion, explicitly confirming the DRA claim path is taken after device plugin removal — not just that the pod runs.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/138447

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```