### PR TITLE
Increase pod count in NodeDeclaredFeatures plugin scheduler perf test

### DIFF
--- a/test/integration/scheduler_perf/nodedeclaredfeatures/performance-config.yaml
+++ b/test/integration/scheduler_perf/nodedeclaredfeatures/performance-config.yaml
@@ -48,7 +48,7 @@
       params:
         nodes: 5000
         initPods: 5000
-        measurePods: 5000
+        measurePods: 50000
         numNodeDeclaredFeatures: 20
     - name: 5000Nodes40DeclaredFeatures
       labels: [performance]
@@ -58,7 +58,7 @@
       params:
         nodes: 5000
         initPods: 5000
-        measurePods: 5000
+        measurePods: 50000
         numNodeDeclaredFeatures: 40
     - name: 5000Nodes100DeclaredFeatures
       labels: [performance]
@@ -68,5 +68,5 @@
       params:
         nodes: 5000
         initPods: 5000
-        measurePods: 5000
+        measurePods: 50000
         numNodeDeclaredFeatures: 100


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
Increase `measurePods` count from 5,000 to 50,000 for the `nodedeclaredfeatures` plugin scheduler perf test. 

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Scheduling 5,000 pods completes in under 5 seconds, scaling to 50,000 pods extends the scheduling window to get more stable results. 

Currently, including startup and pod scheduling, the test takes ~25 - 28 seconds ([example](https://prow.k8s.io/view/gcs/kubernetes-ci-logs/logs/ci-benchmark-scheduler-perf-master/2056281618233954304/)) and many of the perf tests run for around 1 minute (including the baseline NodeDeclaredFeaturesDisabled test)


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
N/A
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/5328
```
