### PR TITLE
cacher: warm etcd mvcc backend before timing BenchmarkCacherInit

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_init_bench_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_init_bench_test.go
@@ -61,6 +61,18 @@ func BenchmarkCacherInit(b *testing.B) {
 		Clock:        clock.RealClock{},
 	}
 
+	// Warm up before timing: the first cacher init pays one-time cold
+	// costs and is reliably ~20% slower than steady state.
+	warm, err := NewCacherFromConfig(config)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := warm.Wait(ctx); err != nil {
+		b.Fatal(err)
+	}
+	warm.Stop()
+	etcd3.TestOnlyResetResourceSizeEstimator(etcdStorage)
+
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds an untimed warmup cycle before `b.ResetTimer()` in `BenchmarkCacherInit` so timed iterations exclude one-time cold costs (the first cacher init is reliably ~20% slower than steady state).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```