### PR TITLE
Add dynamic client test of unstructured number coercion.

### DIFF
--- a/test/integration/client/dynamic_client_test.go
+++ b/test/integration/client/dynamic_client_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	cbor "k8s.io/apimachinery/pkg/runtime/serializer/cbor/direct"
 	"k8s.io/apimachinery/pkg/types"
+	kjson "k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/features"
@@ -307,7 +308,7 @@ func TestUnstructuredExtract(t *testing.T) {
 		},
 	}
 	mgr := "testManager"
-	podData, err := json.Marshal(pod)
+	podData, err := kjson.Marshal(pod)
 	if err != nil {
 		t.Fatalf("failed to marshal pod into bytes: %v", err)
 	}
@@ -617,6 +618,64 @@ func TestDynamicClientCBOREnablement(t *testing.T) {
 						t.Errorf("unexpected error: %v", err)
 					}
 				})
+			}
+		})
+	}
+}
+
+// TestDynamicClientIntegersFromManifestToNativeResource verifies that programs can unmarshal a JSON
+// manifest into an unstructured via encoding/json and use it in a request to a native resource that
+// has integer fields. With JSON as the request encoding, this works because an int and a float with
+// the same value serialize to identical bytes. CBOR distinguishes between floating-point numbers
+// and integers in serialized representation, so Kubernetes must accept integral-valued floating
+// point numbers when decoding into Go int and uint types to support this use case.
+func TestDynamicClientIntegersFromManifestToNativeResource(t *testing.T) {
+	priorityClassJSON := []byte(`{
+		"apiVersion": "scheduling.k8s.io/v1",
+		"kind": "PriorityClass",
+		"metadata": {
+			"name": "test-dynamic-client-create-from-json"
+		},
+		"value": 1000,
+		"description": "test priority class"
+	}`)
+
+	var obj map[string]interface{}
+	// This intentionally uses encoding/json instead of k8s.io/apimachinery/pkg/util/json
+	// because the former decodes all JSON numbers to float64 and because client programs in the
+	// ecosystem also use it.
+	if err := json.Unmarshal(priorityClassJSON, &obj); err != nil {
+		t.Fatalf("failed to unmarshal JSON: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		cbor bool
+	}{
+		{name: "json", cbor: false},
+		{name: "cbor", cbor: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CBORServingAndStorage, tc.cbor)
+			clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsAllowCBOR, tc.cbor)
+			clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsPreferCBOR, tc.cbor)
+
+			server := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
+			defer server.TearDownFn()
+
+			dynamicClient, err := dynamic.NewForConfig(server.ClientConfig)
+			if err != nil {
+				t.Fatalf("unexpected error creating dynamic client: %v", err)
+			}
+
+			gvr := schema.GroupVersionResource{Group: "scheduling.k8s.io", Version: "v1", Resource: "priorityclasses"}
+			_, err = dynamicClient.Resource(gvr).Create(
+				context.TODO(),
+				&unstructured.Unstructured{Object: obj},
+				metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+			)
+			if err != nil {
+				t.Fatalf("unexpected error creating PriorityClass: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This test covers the scenario where an integer appearing in a manifest is unmarshalled into an unstructured as a float64 value using encoding/json, then sent using the dynamic client in a request to a native API resource. In JSON, the serialized form of the integer is the same whether the originating Go value was a float or an int, so it will successfully decode into an int-typed API field as long as it has no fractional component and does not overflow the destination type. CBOR, on the other hand, has distinct representations for integers versus floating-point numbers. In order to preserve compatibility with existing programs that do this, the CBOR serializer must allow integral-valued CBOR floats to be decoded into the Go integer types.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

N/A

#### Special notes for your reviewer:

https://github.com/kubernetes/enhancements/pull/6044#discussion_r3164091057

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
