### PR TITLE
Automated cherry pick of #139143: Fix informer store setting store version to noop

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/store.go
+++ b/staging/src/k8s.io/client-go/tools/cache/store.go
@@ -402,6 +402,9 @@ func WithTransformer(transformer TransformFunc) StoreOption {
 func WithStoreMetrics(identifier InformerNameAndResource, metrics InformerMetricsProvider) StoreOption {
 	return func(c *cache) {
 		c.identifier = identifier
+		if metrics == nil {
+			metrics = globalInformerMetricsProvider
+		}
 		c.metrics = metrics
 	}
 }

--- a/staging/src/k8s.io/client-go/tools/cache/store_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/store_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -244,5 +245,21 @@ func TestCacheTransactionShouldIndexErrors(t *testing.T) {
 				t.Errorf("unexpected error: %v", txnErr)
 			}
 		})
+	}
+}
+
+func TestWithStoreMetricsDefaulting(t *testing.T) {
+	name, err := NewInformerName("test-informer")
+	if err != nil {
+		t.Fatalf("failed to create informer name: %v", err)
+	}
+	defer name.Release()
+	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	id := name.WithResource(gvr)
+
+	s := NewStore(testStoreKeyFunc, WithStoreMetrics(id, nil)).(*cache)
+
+	if s.metrics == nil {
+		t.Errorf("expected c.metrics to be populated, got nil")
 	}
 }


### PR DESCRIPTION
Cherry pick of #139143 on release-1.36.

#139143: Fix informer store setting store version to noop

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
NONE
```