### PR TITLE
authentication: use constant-time compare in static token authenticator

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/tokenfile/tokenfile.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/tokenfile/tokenfile.go
@@ -18,6 +18,7 @@ package tokenfile
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/csv"
 	"fmt"
 	"io"
@@ -91,9 +92,17 @@ func NewCSV(path string) (*TokenAuthenticator, error) {
 }
 
 func (a *TokenAuthenticator) AuthenticateToken(ctx context.Context, value string) (*authenticator.Response, bool, error) {
-	user, ok := a.tokens[value]
-	if !ok {
-		return nil, false, nil
+	// Linear scan with crypto/subtle.ConstantTimeCompare to avoid the
+	// byte-by-byte timing oracle on the map-lookup memcmp step at the bucket.
+	// The sibling bootstrap token authenticator (plugin/pkg/auth/authenticator/
+	// token/bootstrap/bootstrap.go) uses the same idiom for its token-vs-secret
+	// compare. Static token files are typically small (the feature is deprecated
+	// per KEP-2799), so the O(N) scan cost is acceptable.
+	valueBytes := []byte(value)
+	for storedToken, info := range a.tokens {
+		if subtle.ConstantTimeCompare([]byte(storedToken), valueBytes) == 1 {
+			return &authenticator.Response{User: info}, true, nil
+		}
 	}
-	return &authenticator.Response{User: user}, true, nil
+	return nil, false, nil
 }


### PR DESCRIPTION
### What type of PR is this?

/kind cleanup

### What this PR does / why we need it

`TokenAuthenticator.AuthenticateToken` at `staging/src/k8s.io/apiserver/pkg/authentication/token/tokenfile/tokenfile.go:94` looked up bearer tokens via `a.tokens[value]`. Go map lookup hashes the key and then byte-compares it against stored keys in the bucket. The byte-compare step is not constant-time, so a caller with timing visibility into `AuthenticateToken` can in principle learn token bytes through the prefix-length signal of the memcmp.

The sibling bootstrap token authenticator at `plugin/pkg/auth/authenticator/token/bootstrap/bootstrap.go` already uses `crypto/subtle.ConstantTimeCompare` for the same class of compare. This PR brings the static token file authenticator to the same hardening baseline.

### Change

`AuthenticateToken` now linear-scans the token map with `subtle.ConstantTimeCompare` for each compare. The change is O(N) over the number of stored tokens. Static token files are typically very small (the feature is deprecated per KEP-2799), so the cost is acceptable. A short comment block explains the reason in-line so a future contributor does not regress to map lookup.

### Which issue(s) this PR is related to

None linked.

### Special notes for your reviewer

I am happy to revise if the team would rather:
- Keep the map-lookup hot path for a fast miss, then `ConstantTimeCompare` only on the found key (this still leaks bucket-collision timing through the initial lookup, so I chose the linear scan).
- Skip the change entirely on the basis that the static token file is deprecated. Defensible position; the PR is offered as defense-in-depth on the path that still ships.

### Does this PR introduce a user-facing change?

```release-note
NONE
```

### Additional documentation

None required.

---

`/sig auth`
`/area apiserver`
`/kind cleanup`
