### PR TITLE
Automated cherry pick of #138016: fix PodGroup protection test flake by waiting for pod watch before delete

### DIFF
--- a/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller_test.go
+++ b/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller_test.go
@@ -386,6 +386,17 @@ func TestPodGroupProtectionController(t *testing.T) {
 			go ctrl.Run(ctx, 1)
 
 			if test.podToDelete != "" {
+				if err := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+					for _, action := range client.Actions() {
+						if action.GetVerb() == "watch" && action.GetResource().Resource == "pods" {
+							return true, nil
+						}
+					}
+					return false, nil
+				}); err != nil {
+					t.Fatalf("timed out waiting for pod informer watch to start: %v", err)
+				}
+
 				if err := client.CoreV1().Pods(defaultNS).Delete(ctx, test.podToDelete, metav1.DeleteOptions{}); err != nil {
 					t.Fatalf("deleting pod: %v", err)
 				}

--- a/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller_test.go
+++ b/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller_test.go
@@ -385,7 +385,7 @@ func TestPodGroupProtectionController(t *testing.T) {
 			informerFactory.WaitForCacheSync(ctx.Done())
 			go ctrl.Run(ctx, 1)
 
-			// Create a dummy pod to "warm up" the watch pipe.
+			// In order to reduce test flakiness, make sure that the pod-to-delete is visible in the client set. Create a dummy pod to "warm up" the watch pipe.
 			// Since it's created after LIST (WaitForCacheSync), the informer must see it via WATCH.
 			syncPod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "sync-pod", Namespace: defaultNS}}
 			_, err = client.CoreV1().Pods(defaultNS).Create(ctx, syncPod, metav1.CreateOptions{})

--- a/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller_test.go
+++ b/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller_test.go
@@ -385,18 +385,23 @@ func TestPodGroupProtectionController(t *testing.T) {
 			informerFactory.WaitForCacheSync(ctx.Done())
 			go ctrl.Run(ctx, 1)
 
-			if test.podToDelete != "" {
-				if err := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
-					for _, action := range client.Actions() {
-						if action.GetVerb() == "watch" && action.GetResource().Resource == "pods" {
-							return true, nil
-						}
-					}
-					return false, nil
-				}); err != nil {
-					t.Fatalf("timed out waiting for pod informer watch to start: %v", err)
-				}
+			// Create a dummy pod to "warm up" the watch pipe.
+			// Since it's created after LIST (WaitForCacheSync), the informer must see it via WATCH.
+			syncPod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "sync-pod", Namespace: defaultNS}}
+			_, err = client.CoreV1().Pods(defaultNS).Create(ctx, syncPod, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("creating sync pod: %v", err)
+			}
 
+			err = wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+				_, err = podInformer.Lister().Pods(defaultNS).Get(syncPod.Name)
+				return err == nil, nil
+			})
+			if err != nil {
+				t.Fatalf("timed out waiting for informer to see the sync pod: %v", err)
+			}
+
+			if test.podToDelete != "" {
 				if err := client.CoreV1().Pods(defaultNS).Delete(ctx, test.podToDelete, metav1.DeleteOptions{}); err != nil {
 					t.Fatalf("deleting pod: %v", err)
 				}


### PR DESCRIPTION
Cherry pick of #138016 on release-1.36.

#138016: fix PodGroup protection test flake by waiting for pod watch before delete

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind flake


```release-note
None
```