### PR TITLE
Bump cadvisor to 0.57.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/go-openapi/jsonreference v0.21.4
 	github.com/godbus/dbus/v5 v5.2.2
-	github.com/google/cadvisor v0.56.2
+	github.com/google/cadvisor v0.57.0
 	github.com/google/cel-go v0.27.0
 	github.com/google/gnostic-models v0.7.0
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
-github.com/google/cadvisor v0.56.2 h1:ra6p4Nxc4zT8VLbZscWUxhvjsqy+1AzMvuSdEM90o1w=
-github.com/google/cadvisor v0.56.2/go.mod h1:CWidr4DqGbkN4aKuOEjLB7Bab3gl01Xxm3co38C3xRU=
+github.com/google/cadvisor v0.57.0 h1:2LoXUZIJPR3VQJC1bZmqAGdh09yPfpS7MEeC4fJy80k=
+github.com/google/cadvisor v0.57.0/go.mod h1:z6bozbhp/EAWhJqF6KK78MESLoeAhi7pJ9g7fRYGPEc=
 github.com/google/cel-go v0.27.0 h1:e7ih85+4qVrBuqQWTW4FKSqZYokVuc3HnhH5keboFTo=
 github.com/google/cel-go v0.27.0/go.mod h1:tTJ11FWqnhw5KKpnWpvW9CJC3Y9GK4EIS0WXnBbebzw=
 github.com/google/gnostic-models v0.7.0 h1:qwTtogB15McXDaNqTZdzPJRHvaVJlAl+HVQnLmJEJxo=
@@ -251,10 +251,10 @@ github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3N
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/ipvs v1.1.0 h1:ONN4pGaZQgAx+1Scz5RvWV4Q7Gb+mvfRh3NsPS+1XQQ=
 github.com/moby/ipvs v1.1.0/go.mod h1:4VJMWuf098bsUMmZEiD4Tjk/O7mOn3l1PTD3s4OoYAs=
-github.com/moby/moby/api v1.52.0 h1:00BtlJY4MXkkt84WhUZPRqt5TvPbgig2FZvTbe3igYg=
-github.com/moby/moby/api v1.52.0/go.mod h1:8mb+ReTlisw4pS6BRzCMts5M49W5M7bKt1cJy/YbAqc=
-github.com/moby/moby/client v0.2.1 h1:1Grh1552mvv6i+sYOdY+xKKVTvzJegcVMhuXocyDz/k=
-github.com/moby/moby/client v0.2.1/go.mod h1:O+/tw5d4a1Ha/ZA/tPxIZJapJRUS6LNZ1wiVRxYHyUE=
+github.com/moby/moby/api v1.54.1 h1:TqVzuJkOLsgLDDwNLmYqACUuTehOHRGKiPhvH8V3Nn4=
+github.com/moby/moby/api v1.54.1/go.mod h1:+RQ6wluLwtYaTd1WnPLykIDPekkuyD/ROWQClE83pzs=
+github.com/moby/moby/client v0.4.0 h1:S+2XegzHQrrvTCvF6s5HFzcrywWQmuVnhOXe2kiWjIw=
+github.com/moby/moby/client v0.4.0/go.mod h1:QWPbvWchQbxBNdaLSpoKpCdf5E+WxFAgNHogCWDoa7g=
 github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
 github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/moby/sys/mountinfo v0.7.2 h1:1shs6aH5s4o5H2zQLn796ADW1wMrIwHsyJ2v9KouLrg=

--- a/vendor/github.com/google/cadvisor/container/containerd/client.go
+++ b/vendor/github.com/google/cadvisor/container/containerd/client.go
@@ -168,12 +168,16 @@ func (c *client) Version(ctx context.Context) (string, error) {
 
 func containerFromProto(containerpb *containersapi.Container) *containers.Container {
 	var runtime containers.RuntimeInfo
+	var createdAt time.Time
 	// TODO: is nil check required for containerpb
 	if containerpb.Runtime != nil {
 		runtime = containers.RuntimeInfo{
 			Name:    containerpb.Runtime.Name,
 			Options: containerpb.Runtime.Options,
 		}
+	}
+	if containerpb.GetCreatedAt() != nil {
+		createdAt = containerpb.GetCreatedAt().AsTime()
 	}
 	return &containers.Container{
 		ID:          containerpb.ID,
@@ -184,5 +188,6 @@ func containerFromProto(containerpb *containersapi.Container) *containers.Contai
 		Snapshotter: containerpb.Snapshotter,
 		SnapshotKey: containerpb.SnapshotKey,
 		Extensions:  containerpb.Extensions,
+		CreatedAt:   createdAt,
 	}
 }

--- a/vendor/github.com/google/cadvisor/container/crio/client.go
+++ b/vendor/github.com/google/cadvisor/container/crio/client.go
@@ -45,6 +45,7 @@ type Info struct {
 	StorageDriver string `json:"storage_driver"`
 	StorageRoot   string `json:"storage_root"`
 	StorageImage  string `json:"storage_image"`
+	CgroupDriver  string `json:"cgroup_driver"`
 }
 
 // ContainerInfo represents a given container information

--- a/vendor/github.com/google/cadvisor/container/crio/factory.go
+++ b/vendor/github.com/google/cadvisor/container/crio/factory.go
@@ -34,6 +34,9 @@ import (
 // The namespace under which crio aliases are unique.
 const CrioNamespace = "crio"
 
+// The namespace suffix under which crio aliases are unique when using systemd.
+const CrioNamespaceSuffix = ".scope"
+
 // The namespace systemd runs components under.
 const SystemdNamespace = "system-systemd"
 
@@ -63,6 +66,8 @@ type crioFactory struct {
 	includedMetrics container.MetricSet
 
 	client CrioClient
+
+	cgroupDriver string
 }
 
 func (f *crioFactory) String() string {
@@ -116,15 +121,28 @@ func (f *crioFactory) CanHandleAndAccept(name string) (bool, bool, error) {
 		// TODO(runcom): should we include crio-conmon cgroups?
 		return false, false, nil
 	}
-	if !strings.HasPrefix(path.Base(name), CrioNamespace) {
-		return false, false, nil
-	}
 	if strings.HasPrefix(path.Base(name), SystemdNamespace) {
 		return true, false, nil
+	}
+	if !strings.HasPrefix(path.Base(name), CrioNamespace) {
+		return false, false, nil
 	}
 	// if the container is not associated with CRI-O, we can't handle it or accept it.
 	if !isContainerName(name) {
 		return false, false, nil
+	}
+
+	// When using systemd as the cgroup driver, sandbox containers don't have
+	// the .scope suffix. Filter them out to prevent cadvisor from trying to
+	// query cri-o for containers that don't exist in the runtime, which causes
+	// 404 errors and can lead to deadlocks during kubelet restart.
+	// See: https://github.com/cri-o/cri-o/issues/8748
+	// See: https://github.com/google/cadvisor/pull/3457
+	if f.cgroupDriver == "systemd" {
+		if !strings.HasSuffix(path.Base(name), CrioNamespaceSuffix) {
+			// This is a sandbox container when using systemd
+			return true, false, nil
+		}
 	}
 	return true, true, nil
 }
@@ -161,6 +179,7 @@ func Register(factory info.MachineInfoFactory, fsInfo fs.FsInfo, includedMetrics
 		storageDriver:      storageDriver(info.StorageDriver),
 		storageDir:         info.StorageRoot,
 		includedMetrics:    includedMetrics,
+		cgroupDriver:       info.CgroupDriver,
 	}
 
 	container.RegisterContainerHandlerFactory(f, []watcher.ContainerWatchSource{watcher.Raw})

--- a/vendor/github.com/google/cadvisor/container/libcontainer/handler.go
+++ b/vendor/github.com/google/cadvisor/container/libcontainer/handler.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/opencontainers/cgroups"
 	"github.com/opencontainers/cgroups/fs2"
+	"github.com/opencontainers/cgroups/fscommon"
 	"k8s.io/klog/v2"
 
 	"github.com/google/cadvisor/container"
@@ -91,6 +92,10 @@ func (h *Handler) GetStats() (*info.ContainerStats, error) {
 		klog.V(4).Infof("Ignoring errors when gathering stats for root cgroup since some controllers don't have stats on the root cgroup: %v", err)
 	}
 	stats := newContainerStats(cgroupStats, h.includedMetrics)
+
+	if cgroups.IsCgroup2UnifiedMode() {
+		setMemoryEvents(h.cgroupManager.Path(""), stats)
+	}
 
 	if h.includedMetrics.Has(container.ProcessSchedulerMetrics) {
 		stats.Cpu.Schedstat, err = h.schedulerStatsFromProcs()
@@ -860,6 +865,15 @@ func setMemoryStats(s *cgroups.Stats, ret *info.ContainerStats) {
 		}
 	}
 	ret.Memory.WorkingSet = workingSet
+}
+
+func setMemoryEvents(cgroupPath string, ret *info.ContainerStats) {
+	if val, err := fscommon.GetValueByKey(cgroupPath, "memory.events", "high"); err == nil {
+		ret.Memory.Events.High = val
+	}
+	if val, err := fscommon.GetValueByKey(cgroupPath, "memory.events", "max"); err == nil {
+		ret.Memory.Events.Max = val
+	}
 }
 
 func setCPUSetStats(s *cgroups.Stats, ret *info.ContainerStats) {

--- a/vendor/github.com/google/cadvisor/info/v1/container.go
+++ b/vendor/github.com/google/cadvisor/info/v1/container.go
@@ -49,6 +49,10 @@ type ContainerSpec struct {
 	// Time at which the container was created.
 	CreationTime time.Time `json:"creation_time,omitempty"`
 
+	// Time at which the container was started.
+	// This may be unset if the runtime does not provide it.
+	StartTime time.Time `json:"start_time,omitempty"`
+
 	// Metadata labels associated with this container.
 	Labels map[string]string `json:"labels,omitempty"`
 	// Metadata envs associated with this container. Only whitelisted envs are added.
@@ -187,6 +191,12 @@ func (s *ContainerSpec) Eq(b *ContainerSpec) bool {
 	// Creation within 1s of each other.
 	diff := s.CreationTime.Sub(b.CreationTime)
 	if (diff > time.Second) || (diff < -time.Second) {
+		return false
+	}
+
+	// Start time within 1s of each other.
+	startDiff := s.StartTime.Sub(b.StartTime)
+	if (startDiff > time.Second) || (startDiff < -time.Second) {
 		return false
 	}
 
@@ -446,6 +456,13 @@ type MemoryStats struct {
 	HierarchicalData MemoryStatsMemoryData `json:"hierarchical_data,omitempty"`
 
 	PSI PSIStats `json:"psi"`
+
+	Events MemoryEvents `json:"events,omitempty"`
+}
+
+type MemoryEvents struct {
+	High uint64 `json:"high"`
+	Max  uint64 `json:"max"`
 }
 
 type CPUSetStats struct {
@@ -1127,6 +1144,9 @@ type OomKillEventData struct {
 
 	// The name of the killed process
 	ProcessName string `json:"process_name"`
+
+	// the constraint that triggered the OOM
+	Constraint string `json:"constraint"`
 }
 
 // Information related to a container deletion event

--- a/vendor/github.com/google/cadvisor/info/v2/container.go
+++ b/vendor/github.com/google/cadvisor/info/v2/container.go
@@ -69,6 +69,10 @@ type ContainerSpec struct {
 	// Time at which the container was created.
 	CreationTime time.Time `json:"creation_time,omitempty"`
 
+	// Time at which the container was started.
+	// This may be unset if the runtime does not provide it.
+	StartTime time.Time `json:"start_time,omitempty"`
+
 	// Other names by which the container is known within a certain namespace.
 	// This is unique within that namespace.
 	Aliases []string `json:"aliases,omitempty"`

--- a/vendor/github.com/google/cadvisor/info/v2/conversion.go
+++ b/vendor/github.com/google/cadvisor/info/v2/conversion.go
@@ -285,6 +285,7 @@ func InstCpuStats(last, cur *v1.ContainerStats) (*CpuInstStats, error) {
 func ContainerSpecFromV1(specV1 *v1.ContainerSpec, aliases []string, namespace string) ContainerSpec {
 	specV2 := ContainerSpec{
 		CreationTime:     specV1.CreationTime,
+		StartTime:        specV1.StartTime,
 		HasCpu:           specV1.HasCpu,
 		HasMemory:        specV1.HasMemory,
 		HasHugetlb:       specV1.HasHugetlb,

--- a/vendor/github.com/google/cadvisor/manager/container.go
+++ b/vendor/github.com/google/cadvisor/manager/container.go
@@ -47,9 +47,13 @@ import (
 	"k8s.io/utils/clock"
 )
 
+const jitterDefault = 1.0
+
 // Housekeeping interval.
 var enableLoadReader = flag.Bool("enable_load_reader", false, "Whether to enable cpu load reader")
 var HousekeepingInterval = flag.Duration("housekeeping_interval", 1*time.Second, "Interval between container housekeepings")
+var InitialSplayFactor = flag.Float64("initial_splay_factor", jitterDefault, "Factor for the initial splay b/w the container housekeepings, default is 1.0. If negative value is passed, the value will be reset to default")
+var JitterFactor = flag.Float64("jitter_factor", jitterDefault, "Factor for the jitters after the initial splay b/w the container housekeepings, default is 1.0. If negative value is passed, the value will be reset to default")
 
 // TODO: replace regular expressions with something simpler, such as strings.Split().
 // cgroup type chosen to fetch the cgroup path of a process.
@@ -91,6 +95,9 @@ type containerData struct {
 	housekeepingInterval     time.Duration
 	maxHousekeepingInterval  time.Duration
 	allowDynamicHousekeeping bool
+	firstHousekeeping        bool
+	initialSplayFactor       float64
+	jitterFactor             float64
 	infoLastUpdatedTime      atomicTime // Unix nano
 	statsLastUpdatedTime     atomicTime // Unix nano
 	lastErrorTime            time.Time
@@ -121,11 +128,11 @@ type containerData struct {
 }
 
 // jitter returns a time.Duration between duration and duration + maxFactor * duration,
-// to allow clients to avoid converging on periodic behavior.  If maxFactor is 0.0, a
-// suggested default value will be chosen.
+// to allow clients to avoid converging on periodic behavior. If maxFactor is 0.0, no
+// jitter is applied. If maxFactor is negative, a suggested default value will be chosen.
 func jitter(duration time.Duration, maxFactor float64) time.Duration {
-	if maxFactor <= 0.0 {
-		maxFactor = 1.0
+	if maxFactor < 0.0 {
+		maxFactor = jitterDefault
 	}
 	wait := duration + time.Duration(rand.Float64()*maxFactor*float64(duration))
 	return wait
@@ -458,6 +465,9 @@ func newContainerData(containerName string, memoryCache *memory.InMemoryCache, h
 		housekeepingInterval:     *HousekeepingInterval,
 		maxHousekeepingInterval:  maxHousekeepingInterval,
 		allowDynamicHousekeeping: allowDynamicHousekeeping,
+		firstHousekeeping:        true,
+		initialSplayFactor:       *InitialSplayFactor,
+		jitterFactor:             *JitterFactor,
 		logUsage:                 logUsage,
 		loadAvg:                  -1.0, // negative value indicates uninitialized.
 		loadDAvg:                 -1.0, // negative value indicates uninitialized.
@@ -491,7 +501,6 @@ func newContainerData(containerName string, memoryCache *memory.InMemoryCache, h
 		cont.summaryReader = nil
 		klog.V(5).Infof("Failed to create summary reader for %q: %v", ref.Name, err)
 	}
-
 	return cont, nil
 }
 
@@ -519,7 +528,13 @@ func (cd *containerData) nextHousekeepingInterval() time.Duration {
 		}
 	}
 
-	return jitter(cd.housekeepingInterval, 1.0)
+	jitterFactor := cd.jitterFactor
+	if cd.firstHousekeeping {
+		jitterFactor = cd.initialSplayFactor
+		cd.firstHousekeeping = false
+	}
+
+	return jitter(cd.housekeepingInterval, jitterFactor)
 }
 
 // TODO(vmarmol): Implement stats collecting as a custom collector.

--- a/vendor/github.com/google/cadvisor/manager/manager.go
+++ b/vendor/github.com/google/cadvisor/manager/manager.go
@@ -1238,6 +1238,7 @@ func (m *manager) watchForNewOoms() error {
 					OomKill: &info.OomKillEventData{
 						Pid:         oomInstance.Pid,
 						ProcessName: oomInstance.ProcessName,
+						Constraint:  oomInstance.Constraint,
 					},
 				},
 			}

--- a/vendor/github.com/google/cadvisor/metrics/prometheus.go
+++ b/vendor/github.com/google/cadvisor/metrics/prometheus.go
@@ -518,6 +518,20 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 						},
 					}
 				},
+			}, {
+				name:      "container_memory_events_high_total",
+				help:      "Cumulative count of memory.high throttle events for the container",
+				valueType: prometheus.CounterValue,
+				getValues: func(s *info.ContainerStats) metricValues {
+					return metricValues{{value: float64(s.Memory.Events.High), timestamp: s.Timestamp}}
+				},
+			}, {
+				name:      "container_memory_events_max_total",
+				help:      "Cumulative count of memory.max limit hit events for the container",
+				valueType: prometheus.CounterValue,
+				getValues: func(s *info.ContainerStats) metricValues {
+					return metricValues{{value: float64(s.Memory.Events.Max), timestamp: s.Timestamp}}
+				},
 			},
 		}...)
 	}
@@ -1881,11 +1895,12 @@ func NewPrometheusCollector(i infoProvider, f ContainerLabelsFunc, includedMetri
 }
 
 var (
-	versionInfoDesc = prometheus.NewDesc("cadvisor_version_info", "A metric with a constant '1' value labeled by kernel version, OS version, docker version, cadvisor version & cadvisor revision.", []string{"kernelVersion", "osVersion", "dockerVersion", "cadvisorVersion", "cadvisorRevision"}, nil)
-	startTimeDesc   = prometheus.NewDesc("container_start_time_seconds", "Start time of the container since unix epoch in seconds.", nil, nil)
-	cpuPeriodDesc   = prometheus.NewDesc("container_spec_cpu_period", "CPU period of the container.", nil, nil)
-	cpuQuotaDesc    = prometheus.NewDesc("container_spec_cpu_quota", "CPU quota of the container.", nil, nil)
-	cpuSharesDesc   = prometheus.NewDesc("container_spec_cpu_shares", "CPU share of the container.", nil, nil)
+	versionInfoDesc  = prometheus.NewDesc("cadvisor_version_info", "A metric with a constant '1' value labeled by kernel version, OS version, docker version, cadvisor version & cadvisor revision.", []string{"kernelVersion", "osVersion", "dockerVersion", "cadvisorVersion", "cadvisorRevision"}, nil)
+	creationTimeDesc = prometheus.NewDesc("container_creation_time_seconds", "Container creation time since unix epoch in seconds.", nil, nil)
+	startTimeDesc    = prometheus.NewDesc("container_start_time_seconds", "Start time of the container since unix epoch in seconds.", nil, nil)
+	cpuPeriodDesc    = prometheus.NewDesc("container_spec_cpu_period", "CPU period of the container.", nil, nil)
+	cpuQuotaDesc     = prometheus.NewDesc("container_spec_cpu_quota", "CPU quota of the container.", nil, nil)
+	cpuSharesDesc    = prometheus.NewDesc("container_spec_cpu_shares", "CPU share of the container.", nil, nil)
 )
 
 // Describe describes all the metrics ever exported by cadvisor. It
@@ -1895,6 +1910,7 @@ func (c *PrometheusCollector) Describe(ch chan<- *prometheus.Desc) {
 	for _, cm := range c.containerMetrics {
 		ch <- cm.desc([]string{})
 	}
+	ch <- creationTimeDesc
 	ch <- startTimeDesc
 	ch <- cpuPeriodDesc
 	ch <- cpuQuotaDesc
@@ -2006,8 +2022,15 @@ func (c *PrometheusCollector) collectContainersInfo(ch chan<- prometheus.Metric)
 		}
 
 		// Container spec
-		desc := prometheus.NewDesc("container_start_time_seconds", "Start time of the container since unix epoch in seconds.", labels, nil)
+		desc := prometheus.NewDesc("container_creation_time_seconds", "Container creation time since unix epoch in seconds.", labels, nil)
 		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, float64(cont.Spec.CreationTime.Unix()), values...)
+
+		desc = prometheus.NewDesc("container_start_time_seconds", "Start time of the container since unix epoch in seconds.", labels, nil)
+		startTime := cont.Spec.CreationTime
+		if !cont.Spec.StartTime.IsZero() {
+			startTime = cont.Spec.StartTime
+		}
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, float64(startTime.Unix()), values...)
 
 		if cont.Spec.HasCpu {
 			desc = prometheus.NewDesc("container_spec_cpu_period", "CPU period of the container.", labels, nil)

--- a/vendor/github.com/google/cadvisor/metrics/prometheus_fake.go
+++ b/vendor/github.com/google/cadvisor/metrics/prometheus_fake.go
@@ -299,6 +299,7 @@ func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, v2.Req
 					Limit: 100,
 				},
 				CreationTime: time.Unix(1257894000, 0),
+				StartTime:    time.Unix(1257895000, 0),
 				Labels: map[string]string{
 					"foo.label": "bar",
 				},
@@ -387,6 +388,10 @@ func (p testSubcontainersInfoProvider) GetRequestedContainersInfo(string, v2.Req
 								Avg300: 0.2,
 								Total:  2000,
 							},
+						},
+						Events: info.MemoryEvents{
+							High: 42,
+							Max:  5,
 						},
 					},
 					Hugetlb: map[string]info.HugetlbStats{

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -272,7 +272,7 @@ github.com/golang/protobuf/ptypes/wrappers
 # github.com/google/btree v1.1.3
 ## explicit; go 1.18
 github.com/google/btree
-# github.com/google/cadvisor v0.56.2
+# github.com/google/cadvisor v0.57.0
 ## explicit; go 1.24.0
 github.com/google/cadvisor/cache/memory
 github.com/google/cadvisor/client/v2


### PR DESCRIPTION
#### What type of PR is this?

/kind dependency

#### What this PR does / why we need it:

This bumps cadvisor to 0.57.0; there’s no major change there, but it does add container creation timestamps.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
