### PR TITLE
Add createPodGroupOp to schedulerPerf

### DIFF
--- a/test/integration/scheduler_perf/executor.go
+++ b/test/integration/scheduler_perf/executor.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	schedulingapi "k8s.io/api/scheduling/v1alpha3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -95,8 +96,8 @@ func (e *WorkloadExecutor) runOp(tCtx ktesting.TContext, op realOp, opIndex int)
 		return e.runBarrierOp(tCtx, opIndex, concreteOp)
 	case *sleepOp:
 		return e.runSleepOp(tCtx, concreteOp)
-	case *waitForPodGroups:
-		return e.runWaitForPodGroupsOp(tCtx, concreteOp)
+	case *createPodGroups:
+		return e.runCreatePodGroupsOp(tCtx, concreteOp)
 	case *startCollectingMetricsOp:
 		return e.runStartCollectingMetricsOp(tCtx, opIndex, concreteOp)
 	case *stopCollectingMetricsOp:
@@ -195,12 +196,35 @@ func (e *WorkloadExecutor) runSleepOp(tCtx ktesting.TContext, op *sleepOp) error
 	return nil
 }
 
-// runWaitForPodGroupsOp executes the waitForPodGroups operation.
-// It polls the scheduler's informer cache until the expected number of pod groups
-// are visible in the given namespace. This ensures that subsequent operations
-// (like creating pods that reference these pod groups) won't fail due to cache lag.
+// runCreatePodGroupsOp executes the createPodGroups operation.
+// It creates the configured number of PodGroups from a template and
+// then waits for them to be visible in the scheduler's informer cache.
+// This ensures that subsequent operations (like creating pods that reference these pod groups) won't fail due to cache lag.
 // It timeouts after 10 seconds if the condition is not met.
-func (e *WorkloadExecutor) runWaitForPodGroupsOp(tCtx ktesting.TContext, op *waitForPodGroups) error {
+func (e *WorkloadExecutor) runCreatePodGroupsOp(tCtx ktesting.TContext, op *createPodGroups) error {
+	if err := createNamespaceIfNotPresent(tCtx, op.Namespace, &e.numPodsScheduledPerNamespace); err != nil {
+		return err
+	}
+
+	tCtx.Logf("creating %d PodGroups in namespace %q", op.Count, op.Namespace)
+
+	for index := range op.Count {
+		env := make(map[string]any)
+		maps.Copy(env, op.TemplateParams)
+		env["Index"] = index
+
+		obj := &schedulingapi.PodGroup{}
+		if err := getSpecFromTextTemplateFile(op.TemplatePath, env, obj); err != nil {
+			return fmt.Errorf("%s: %w", op.TemplatePath, err)
+		}
+
+		if err := e.createPodGroupWithRetry(tCtx, obj, op.Namespace, op.TemplatePath); err != nil {
+			return err
+		}
+	}
+
+	// Wait for pod groups to be visible in the scheduler's informer cache.
+	// It times out after 10 seconds if the condition is not met.
 	tCtx.Logf("waiting for %d PodGroups in namespace %q", op.Count, op.Namespace)
 	err := wait.PollUntilContextTimeout(tCtx, 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 		podGroups, err := e.podGroupInformer.Lister().PodGroups(op.Namespace).List(labels.Everything())
@@ -213,9 +237,36 @@ func (e *WorkloadExecutor) runWaitForPodGroupsOp(tCtx ktesting.TContext, op *wai
 		return false, nil
 	})
 	if err != nil {
-		return fmt.Errorf("timed out waiting for PodGroups: %w", err)
+		return fmt.Errorf("timed out waiting for PodGroups to be cached: %w", err)
 	}
+
 	return nil
+}
+
+func (e *WorkloadExecutor) createPodGroupWithRetry(tCtx ktesting.TContext, obj *schedulingapi.PodGroup, namespace, templatePath string) error {
+	ctx, cancel := context.WithTimeout(tCtx, 20*time.Second)
+
+	defer cancel()
+	for {
+		_, err := tCtx.Client().SchedulingV1alpha3().PodGroups(namespace).Create(ctx, obj, metav1.CreateOptions{
+			FieldValidation: "Strict",
+		})
+
+		if err == nil {
+			return nil
+		}
+
+		// Fail fast on non-retriable client errors (invalid specs, bad requests, forbidden access).
+		if apierrors.IsInvalid(err) || apierrors.IsBadRequest(err) || apierrors.IsForbidden(err) {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%s: timed out (%w) while creating %q, last error was: %w", templatePath, context.Cause(ctx), klog.KObj(obj), err)
+		case <-time.After(time.Second):
+		}
+	}
 }
 
 func (e *WorkloadExecutor) runStopCollectingMetrics(tCtx ktesting.TContext, opIndex int) error {

--- a/test/integration/scheduler_perf/executor_test.go
+++ b/test/integration/scheduler_perf/executor_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
+	schedulingapi "k8s.io/api/scheduling/v1alpha3"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -459,6 +460,62 @@ func TestRunOp(t *testing.T) {
 			},
 			expectedFailure: true,
 		},
+		{
+			name: "Create PodGroups",
+			op: &createPodGroups{
+				Opcode:       createPodGroupsOpcode,
+				Namespace:    "namespace-0",
+				TemplatePath: *newPodGroupTemplateFile(t, "namespace-0"),
+				Count:        2,
+			},
+			verifyFuncs: []verifyFunc{
+				verifyCount(2),
+				verifyNamespaceCreated("namespace-0"),
+				verifyObj(
+					&schedulingapi.PodGroup{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "namespace-0",
+						},
+						Spec: schedulingapi.PodGroupSpec{
+							SchedulingPolicy: schedulingapi.PodGroupSchedulingPolicy{
+								Gang: &schedulingapi.GangSchedulingPolicy{
+									MinCount: 3,
+								},
+							},
+						},
+					}),
+			},
+		},
+		{
+			name: "Create PodGroups with Invalid Template Path",
+			op: &createPodGroups{
+				Opcode:       createPodGroupsOpcode,
+				Namespace:    "namespace-0",
+				TemplatePath: "non-existent-file.yaml",
+				Count:        1,
+			},
+			expectedFailure: true,
+		},
+		{
+			name: "Create PodGroups with empty namespace",
+			op: &createPodGroups{
+				Opcode:       createPodGroupsOpcode,
+				Namespace:    "",
+				TemplatePath: *newPodGroupTemplateFile(t, ""),
+				Count:        1,
+			},
+			expectedFailure: true,
+		},
+		{
+			name: "Create PodGroups with zero count",
+			op: &createPodGroups{
+				Opcode:       createPodGroupsOpcode,
+				Namespace:    "namespace-0",
+				TemplatePath: *newPodGroupTemplateFile(t, "namespace-0"),
+				Count:        0,
+			},
+			expectedFailure: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -469,6 +526,8 @@ func TestRunOp(t *testing.T) {
 
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			podInformer := informerFactory.Core().V1().Pods()
+			podGroupInformer := informerFactory.Scheduling().V1alpha3().PodGroups()
+			podGroupInformer.Informer()
 			informerFactory.Start(tCtx.Done())
 			informerFactory.WaitForCacheSync(tCtx.Done())
 
@@ -478,8 +537,9 @@ func TestRunOp(t *testing.T) {
 				testCase: &testCase{
 					DefaultPodTemplatePath: newPodTemplateFile(t, "namespace-0"),
 				},
-				podInformer: podInformer,
-				workload:    tt.workload,
+				podInformer:      podInformer,
+				podGroupInformer: podGroupInformer,
+				workload:         tt.workload,
 			}
 
 			opToRun := tt.op
@@ -546,6 +606,14 @@ func verifyCount(expectedCount int) verifyFunc {
 			}
 			if got := len(pods.Items); got != expectedCount {
 				return fmt.Errorf("unexpected pod count: got %d, want %d", got, expectedCount)
+			}
+		case *createPodGroups:
+			pgs, err := tCtx.Client().SchedulingV1alpha3().PodGroups(concreteOp.Namespace).List(tCtx, metav1.ListOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to list pod groups: %w", err)
+			}
+			if got := len(pgs.Items); got != expectedCount {
+				return fmt.Errorf("unexpected pod group count: got %d, want %d", got, expectedCount)
 			}
 		default:
 			return fmt.Errorf("verifyCount doesn't support this operation type: %T", op)
@@ -711,6 +779,34 @@ func verifyObj(expectedObj any) verifyFunc {
 			}
 			got = gotPods
 			want = wantPods
+		case *createPodGroups:
+			expectedPodGroupTemplate, ok := expectedObj.(*schedulingapi.PodGroup)
+			if !ok {
+				return fmt.Errorf("expectedObj must be *schedulingapi.PodGroup when op is *createPodGroups, got %T", expectedObj)
+			}
+
+			namespace := expectedPodGroupTemplate.Namespace
+			if namespace == "" {
+				return fmt.Errorf("expectedPodGroupTemplate.Namespace must be set")
+			}
+
+			podGroupsList, listErr := tCtx.Client().SchedulingV1alpha3().PodGroups(namespace).List(tCtx, metav1.ListOptions{})
+			if listErr != nil {
+				return fmt.Errorf("failed to list pod groups: %w", listErr)
+			}
+			gotPodGroups := podGroupsList.Items
+
+			wantPodGroups := make([]schedulingapi.PodGroup, len(gotPodGroups))
+			for i := range gotPodGroups {
+				wantPodGroups[i] = *expectedPodGroupTemplate
+			}
+
+			cmpOpts = []cmp.Option{
+				cmpopts.EquateEmpty(),
+				cmpOptsIgnoreObjectMeta,
+			}
+			got = gotPodGroups
+			want = wantPodGroups
 		default:
 			return fmt.Errorf("verifyObj doesn't support this operation type for cmp.Diff: %T", opDetails)
 		}
@@ -748,7 +844,7 @@ func createObjTemplateFile(t *testing.T, obj any) *string {
 	}()
 
 	switch obj := obj.(type) {
-	case *v1.Node, *v1.Pod, *v1.PersistentVolume, *v1.PersistentVolumeClaim:
+	case *v1.Node, *v1.Pod, *v1.PersistentVolume, *v1.PersistentVolumeClaim, *schedulingapi.PodGroup:
 		if err := json.NewEncoder(f).Encode(obj); err != nil {
 			t.Fatalf("Failed to encode the template to %s: %v", templateFile, err)
 		}
@@ -1036,6 +1132,23 @@ func newPodTemplateFile(t *testing.T, namespace string) *string {
 		},
 	}
 	return createObjTemplateFile(t, pod)
+}
+
+func newPodGroupTemplateFile(t *testing.T, namespace string) *string {
+	pg := &schedulingapi.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gang-{{.Index}}",
+			Namespace: namespace,
+		},
+		Spec: schedulingapi.PodGroupSpec{
+			SchedulingPolicy: schedulingapi.PodGroupSchedulingPolicy{
+				Gang: &schedulingapi.GangSchedulingPolicy{
+					MinCount: 3,
+				},
+			},
+		},
+	}
+	return createObjTemplateFile(t, pg)
 }
 
 func newPersistentVolumeTemplateFile(t *testing.T) *string {

--- a/test/integration/scheduler_perf/operations.go
+++ b/test/integration/scheduler_perf/operations.go
@@ -637,38 +637,59 @@ func (so sleepOp) patchParams(w *Workload) (realOp, error) {
 	return &so, nil
 }
 
-// waitForPodGroups defines an op that waits for a specific number of PodGroup objects to be visible in the scheduler's cache.
-type waitForPodGroups struct {
-	// Must be waitForPodGroupsOpcode.
+// createPodGroups defines an op where PodGroups get created from a YAML template
+// then waits for them to be visible in the scheduler's informer cache.
+type createPodGroups struct {
+	// Must match createPodGroupsOpcode.
 	Opcode operationCode
-	// Namespace the objects should be in.
+	// Namespace the objects should be created in.
 	Namespace string
-	// Count determines how many objects to wait for.
+	// Path to spec file describing the PodGroup to create.
+	TemplatePath string
+	// Params to be passed to the template.
+	TemplateParams map[string]any
+	// Count determines how many PodGroups get created.
 	Count int
 	// CountParam is the name of the parameter that determines the count.
 	CountParam string
 }
 
-func (w *waitForPodGroups) isValid(allowParameterization bool) error {
-	if !isValidCount(allowParameterization, w.Count, w.CountParam) {
-		return fmt.Errorf("invalid Count=%d / CountParam=%q", w.Count, w.CountParam)
+func (cpg *createPodGroups) isValid(allowParameterization bool) error {
+	if cpg.TemplatePath == "" {
+		return fmt.Errorf("templatePath must be set")
+	}
+	if cpg.Namespace == "" {
+		return fmt.Errorf("namespace must be set")
+	}
+	if !isValidCount(allowParameterization, cpg.Count, cpg.CountParam) {
+		return fmt.Errorf("invalid Count=%d / CountParam=%q", cpg.Count, cpg.CountParam)
+	}
+	if !allowParameterization && cpg.Count < 1 {
+		return fmt.Errorf("count must be greater than 0, got %d", cpg.Count)
 	}
 	return nil
 }
 
-func (w *waitForPodGroups) collectsMetrics() bool {
+func (cpg *createPodGroups) collectsMetrics() bool {
 	return false
 }
 
-func (w waitForPodGroups) patchParams(workload *Workload) (realOp, error) {
-	if w.CountParam != "" {
+func (cpg createPodGroups) patchParams(w *Workload) (realOp, error) {
+	if cpg.CountParam != "" {
+		count, err := w.Params.get(cpg.CountParam[1:])
+		if err != nil {
+			return nil, err
+		}
+		cpg.Count = count
+	}
+	if len(cpg.TemplateParams) > 0 {
 		var err error
-		w.Count, err = workload.Params.get(w.CountParam[1:])
+		cpg.TemplateParams, err = resolveTemplateParams(cpg.TemplateParams, w)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return &w, (&w).isValid(false)
+	return &cpg, cpg.isValid(false)
 }
 
 // startCollectingMetricsOp defines an op that starts metrics collectors.

--- a/test/integration/scheduler_perf/podgroup/basicscheduling/performance-config.yaml
+++ b/test/integration/scheduler_perf/podgroup/basicscheduling/performance-config.yaml
@@ -11,25 +11,22 @@
   - opcode: createNodes
     countParam: $initNodes
   - opcode: createNamespaces
-    prefix: basic
+    prefix: basic-ns
     count: 1
-  - opcode: createAny
-    # Create pod groups, each has a basic scheduling policy specified in pod group template.
+  - opcode: createPodGroups
+    # Create pod groups, and wait for the scheduler's informer cache to reflect the newly created pod group objects.
     # Each pod group is named basic-group-0, basic-group-1, ... basic-group-(n-1).
+    # Each group has basic scheduling policy specified in the pod group template.
     countParam: $initPodGroups
-    namespace: basic-0
+    namespace: basic-ns-0
     templatePath: templates/podgroup.yaml
     templateParams:
       podsPerGroup: $podsPerGroup
-  - opcode: waitForPodGroups
-    # Wait for the scheduler's informer cache to reflect the newly created PodGroup objects.
-    namespace: basic-0
-    countParam: $initPodGroups
   - opcode: createPods
     # Create pods with reference to the pod groups according to their indices (e.g., pods 0-2 → basic-group-0, pods 3-5 → basic-group-1, etc.).
     countParam: $initPodGroups
     countMultiplierParam: $podsPerGroup
-    namespace: basic-0
+    namespace: basic-ns-0
     podTemplatePath: templates/basic-pod.yaml
     collectMetrics: true
     templateParams:

--- a/test/integration/scheduler_perf/podgroup/gangscheduling/performance-config.yaml
+++ b/test/integration/scheduler_perf/podgroup/gangscheduling/performance-config.yaml
@@ -12,25 +12,22 @@
   - opcode: createNodes
     countParam: $initNodes
   - opcode: createNamespaces
-    prefix: gang
+    prefix: gang-ns
     count: 1
-  - opcode: createAny
-    # Create pod groups (gangs), each has a min count policy specified in pod group template.
-    # Each pod group is named gang-0, gang-1, ... gang-(n-1).
+  - opcode: createPodGroups
+    # Create pod groups, and wait for the scheduler's informer cache to reflect the newly created pod group objects.
+    # Each pod group is named gang-0, gang-1, ..., gang-(n-1), where n is the number of pod groups.
+    # Each group has gang policy and min count specified in the pod group template.
     countParam: $initPodGroups
-    namespace: gang-0
+    namespace: gang-ns-0
     templatePath: templates/podgroup.yaml
     templateParams:
       podsPerGroup: $podsPerGroup
-  - opcode: waitForPodGroups
-    # Wait for the scheduler's informer cache to reflect the newly created PodGroup objects.
-    namespace: gang-0
-    countParam: $initPodGroups
   - opcode: createPods
     # Create pods with reference to the pod groups (gangs) according to their indices (e.g., pods 0-2 → gang-0, pods 3-5 → gang-1, etc.).
     countParam: $initPodGroups
     countMultiplierParam: $podsPerGroup
-    namespace: gang-0
+    namespace: gang-ns-0
     podTemplatePath: templates/gang-pod.yaml
     collectMetrics: true
     templateParams:

--- a/test/integration/scheduler_perf/podgroup/tas/performance-config.yaml
+++ b/test/integration/scheduler_perf/podgroup/tas/performance-config.yaml
@@ -14,25 +14,22 @@
     countParam: $initNodes
     nodeTemplatePath: templates/node.yaml
   - opcode: createNamespaces
-    prefix: tas
+    prefix: tas-ns
     count: 1
-  - opcode: createAny
-    # Create pod groups (gangs), each has a min count policy and topology constraint specified in pod group template.
-    # Each pod group is named gang-0, gang-1, ... gang-(n-1).
+  - opcode: createPodGroups
+    # Create pod groups, and wait for the scheduler's informer cache to reflect the newly created pod group objects.
+    # Each pod group is named gang-0, gang-1, ..., gang-(n-1), where n is the number of pod groups.
+    # Each group has gang policy, min count, and topology constraints specified in the pod group template.
     countParam: $initPodGroups
-    namespace: tas-0
+    namespace: tas-ns-0
     templatePath: templates/podgroup.yaml
     templateParams:
       podsPerGroup: $podsPerGroup
-  - opcode: waitForPodGroups
-    # Wait for the scheduler's informer cache to reflect the newly created PodGroup objects.
-    namespace: tas-0
-    countParam: $initPodGroups
   - opcode: createPods
     # Create pods with reference to the pod groups (gangs) according to their indices (e.g., pods 0-2 → gang-0, pods 3-5 → gang-1, etc.).
     countParam: $initPodGroups
     countMultiplierParam: $podsPerGroup
-    namespace: tas-0
+    namespace: tas-ns-0
     podTemplatePath: templates/gang-pod.yaml
     collectMetrics: true
     templateParams:

--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -75,7 +75,7 @@ const (
 	sleepOpcode                  operationCode = "sleep"
 	startCollectingMetricsOpcode operationCode = "startCollectingMetrics"
 	stopCollectingMetricsOpcode  operationCode = "stopCollectingMetrics"
-	waitForPodGroupsOpcode       operationCode = "waitForPodGroups"
+	createPodGroupsOpcode        operationCode = "createPodGroups"
 	startCollectingProfileOpcode operationCode = "startCollectingProfile"
 	stopCollectingProfileOpcode  operationCode = "stopCollectingProfile"
 )
@@ -515,7 +515,7 @@ func (op *op) UnmarshalJSON(b []byte) error {
 		sleepOpcode:                  &sleepOp{},
 		startCollectingMetricsOpcode: &startCollectingMetricsOp{},
 		stopCollectingMetricsOpcode:  &stopCollectingMetricsOp{},
-		waitForPodGroupsOpcode:       &waitForPodGroups{},
+		createPodGroupsOpcode:        &createPodGroups{},
 		startCollectingProfileOpcode: &startCollectingProfileOp{},
 		stopCollectingProfileOpcode:  &stopCollectingProfileOp{},
 		// TODO(#94601): add a delete nodes op to simulate scaling behaviour?


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig-scheduling

#### What this PR does / why we need it:

Previously, we used `createAnyOp` to create `PodGroup` object and `waitForPodGroupsOp` to wait until such podgroups are visible to scheduler's informer cache.
But because `PodGroup` is now considered a top-level object in kube-scheduler and will be extensively used in tests, it is better to create an operation specific for podGroups, that does both functionalities together called `createPodGroupOp`.

### Few Additional Changes include:
Adjusting namespace names to be more readable.

#### Which issue(s) this PR is related to:
Fixes [#<139027>](https://github.com/kubernetes/kubernetes/issues/139027)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```