### PR TITLE
Fix queue hint for anti-affinities

### DIFF
--- a/pkg/scheduler/framework/plugins/interpodaffinity/filtering.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/filtering.go
@@ -183,7 +183,8 @@ func (m *topologyToMatchedTermCountList) appendWithAntiAffinityTerms(terms []fwk
 	}
 }
 
-// returns true IFF the given pod matches all the given terms.
+// podMatchesAllAffinityTerms returns true if the given terms list is not empty and given pod matches all the given terms.
+// Useful for checking affinity. For anti-affinity, use podMatchesAnyAffinityTerms.
 func podMatchesAllAffinityTerms(terms []fwk.AffinityTerm, pod *v1.Pod) bool {
 	if len(terms) == 0 {
 		return false
@@ -196,6 +197,17 @@ func podMatchesAllAffinityTerms(terms []fwk.AffinityTerm, pod *v1.Pod) bool {
 		}
 	}
 	return true
+}
+
+// podMatchesAnyAffinityTerms returns true if the given pod matches any of the given terms.
+// Useful for checking anti-affinity.
+func podMatchesAnyAffinityTerms(terms []fwk.AffinityTerm, pod *v1.Pod) bool {
+	for _, t := range terms {
+		if t.Matches(pod, nil) {
+			return true
+		}
+	}
+	return false
 }
 
 // calculates the following for each existing pod on each node:

--- a/pkg/scheduler/framework/plugins/interpodaffinity/plugin.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/plugin.go
@@ -190,7 +190,7 @@ func (pl *InterPodAffinity) isSchedulableAfterAssignedPodChange(logger klog.Logg
 				"pod", klog.KObj(pod), "modifiedPod", klog.KObj(modifiedPod))
 			return fwk.Queue, nil
 		}
-		if podMatchesAllAffinityTerms(antiTerms, originalPod) && !podMatchesAllAffinityTerms(antiTerms, modifiedPod) {
+		if podMatchesAnyAffinityTerms(antiTerms, originalPod) && !podMatchesAnyAffinityTerms(antiTerms, modifiedPod) {
 			logger.V(5).Info("a scheduled pod was updated not to match the target pod's anti affinity, and the pod may be schedulable now",
 				"pod", klog.KObj(pod), "modifiedPod", klog.KObj(modifiedPod))
 			return fwk.Queue, nil
@@ -214,7 +214,7 @@ func (pl *InterPodAffinity) isSchedulableAfterAssignedPodChange(logger klog.Logg
 
 	// Pod is deleted. Return Queue when the deleted pod matches the target pod's anti-affinity or vice versa.
 
-	if podMatchesAllAffinityTerms(antiTerms, originalPod) {
+	if podMatchesAnyAffinityTerms(antiTerms, originalPod) {
 		logger.V(5).Info("a scheduled pod was deleted and it matches the target pod's anti-affinity. The pod may be schedulable now",
 			"pod", klog.KObj(pod), "originalPod", klog.KObj(originalPod))
 		return fwk.Queue, nil
@@ -224,7 +224,7 @@ func (pl *InterPodAffinity) isSchedulableAfterAssignedPodChange(logger klog.Logg
 	if err != nil {
 		return fwk.Queue, err
 	}
-	if podMatchesAllAffinityTerms(originalPodAntiTerms, pod) {
+	if podMatchesAnyAffinityTerms(originalPodAntiTerms, pod) {
 		logger.V(5).Info("a scheduled pod was deleted and the target pod matches the deleted pod's anti-affinity. The pod may be schedulable now",
 			"pod", klog.KObj(pod), "originalPod", klog.KObj(originalPod))
 		return fwk.Queue, nil

--- a/pkg/scheduler/framework/plugins/interpodaffinity/plugin_test.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/plugin_test.go
@@ -159,6 +159,40 @@ func Test_isSchedulableAfterAssignedPodChange(t *testing.T) {
 			oldPod:       st.MakePod().NominatedNodeName("fake-node").Label("service", "securityscan").Obj(),
 			expectedHint: fwk.Queue,
 		},
+		{
+			name: "modify pod label to change it from matching only one of target pod's anti-affinity terms to matching none",
+			pod: st.MakePod().UID("p").Name("p").
+				PodAntiAffinityIn("service", "region", []string{"securityscan"}, st.PodAntiAffinityWithRequiredReq).
+				PodAntiAffinityIn("app", "region", []string{"web"}, st.PodAntiAffinityWithRequiredReq).Obj(),
+			newPod:       st.MakePod().UID("other").Node("fake-node").Label("service", "foo").Label("app", "bar").Obj(),
+			oldPod:       st.MakePod().UID("other").Node("fake-node").Label("service", "securityscan").Label("app", "bar").Obj(),
+			expectedHint: fwk.Queue,
+		},
+		{
+			name: "modify pod label but it still matches one of target pod's anti-affinity terms",
+			pod: st.MakePod().UID("p").Name("p").
+				PodAntiAffinityIn("service", "region", []string{"securityscan"}, st.PodAntiAffinityWithRequiredReq).
+				PodAntiAffinityIn("app", "region", []string{"web"}, st.PodAntiAffinityWithRequiredReq).Obj(),
+			newPod:       st.MakePod().UID("other").Node("fake-node").Label("service", "foo").Label("app", "web").Obj(),
+			oldPod:       st.MakePod().UID("other").Node("fake-node").Label("service", "securityscan").Label("app", "bar").Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name: "delete a pod which matches only one of target pod's anti-affinity terms",
+			pod: st.MakePod().UID("p").Name("p").
+				PodAntiAffinityIn("service", "region", []string{"securityscan"}, st.PodAntiAffinityWithRequiredReq).
+				PodAntiAffinityIn("app", "region", []string{"web"}, st.PodAntiAffinityWithRequiredReq).Obj(),
+			oldPod:       st.MakePod().UID("other").Node("fake-node").Label("service", "securityscan").Obj(),
+			expectedHint: fwk.Queue,
+		},
+		{
+			name: "delete a pod with anti-affinity that matches pending pod on only one term",
+			pod:  st.MakePod().Name("p").Label("service", "securityscan").Obj(),
+			oldPod: st.MakePod().Node("fake-node").UID("other").
+				PodAntiAffinityIn("service", "region", []string{"securityscan"}, st.PodAntiAffinityWithRequiredReq).
+				PodAntiAffinityIn("app", "region", []string{"web"}, st.PodAntiAffinityWithRequiredReq).Obj(),
+			expectedHint: fwk.Queue,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

It's enough for a pod to match a single anti-affinity term for the anti-affinity to take effect. There's a bug in the queue hint logic, where we check for all anti-affinity terms.

For example, when a pod is deleted, it should return `fwk.Queue` if the pod matched **any** of the anti-affinity terms. Currently it only returns `fwk.Queue` if it matched **all** of the anti-affinity terms. See the added test cases for more examples.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed queue hint for inter-pod anti-affinity in case there are multiple terms, which might have caused delays in scheduling.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
