### PR TITLE
Tolerate json/v2 in unstructured and YAML tests

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections_test.go
@@ -19,6 +19,7 @@ package json
 import (
 	"bytes"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -51,6 +52,10 @@ func testCollectionsEncoding(t *testing.T, s *Serializer, streamingEnabled bool)
 		in           runtime.Object
 		cannotStream bool
 		expect       string
+		// allow provides allowed alternate representations.
+		// For the json v1->v2 transition, this is used to tolerate changes
+		// in how malformed input in munged.
+		allow []string
 	}{
 		// Preserving the distinction between integers and floating-point numbers
 		{
@@ -114,6 +119,8 @@ func testCollectionsEncoding(t *testing.T, s *Serializer, streamingEnabled bool)
 				},
 			},
 			expect: "{\"items\":[],\"key\":\"\\ufffd\"}\n",
+			// Go json/v2 emits U+FFFD as raw UTF-8 bytes rather than the \ufffd escape.
+			allow: []string{"{\"items\":[],\"key\":\"\ufffd\"}\n"},
 		},
 		{
 			name: "UnstructuredList items invalid UTF-8 ",
@@ -127,6 +134,8 @@ func testCollectionsEncoding(t *testing.T, s *Serializer, streamingEnabled bool)
 				},
 			},
 			expect: "{\"items\":[{\"key\":\"\\ufffd\"}]}\n",
+			// Go json/v2 emits U+FFFD as raw UTF-8 bytes rather than the \ufffd escape.
+			allow: []string{"{\"items\":[{\"key\":\"\ufffd\"}]}\n"},
 		},
 		// Preserving the distinction between absent, present-but-null, and present-and-empty states for slices and maps
 		{
@@ -577,8 +586,8 @@ func testCollectionsEncoding(t *testing.T, s *Serializer, streamingEnabled bool)
 				t.Fatalf("unexpected error: %v", err)
 			}
 			t.Logf("encoded: %s", buf.String())
-			if diff := cmp.Diff(buf.String(), tc.expect); diff != "" {
-				t.Errorf("not matching:\n%s", diff)
+			if got := buf.String(); got != tc.expect && !slices.Contains(tc.allow, got) {
+				t.Errorf("not matching:\n%s", cmp.Diff(got, tc.expect))
 			}
 			expectStreaming := !tc.cannotStream && streamingEnabled
 			if expectStreaming && buf.writeCount <= 1 {

--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"math/rand"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -274,9 +275,9 @@ func TestDecodeBrokenJSON(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error with json: prefix, got no error")
 	}
-	const msg = `json: offset 28: invalid character '"' after object key:value pair`
-	if msg != err.Error() {
-		t.Fatalf("expected %q, got %q", msg, err.Error())
+	const msg = `json: .*invalid character.*".*after object key:value pair`
+	if matched, _ := regexp.MatchString(msg, err.Error()); !matched {
+		t.Fatalf("expected string matching %q, got %q", msg, err.Error())
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:

- Fixes unstructured tests to tolerate json/v2 munged invalid UTF-8 inputs
- Fixes YAML tests to tolerate error message with slightly different reported char offset in error message

https://github.com/kubernetes/kubernetes/issues/139159#issuecomment-4488246298

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
