### PR TITLE
feat: Always enforce declarative validation

### DIFF
--- a/pkg/api/testing/validation.go
+++ b/pkg/api/testing/validation.go
@@ -30,7 +30,6 @@ import (
 	runtimetest "k8s.io/apimachinery/pkg/runtime/testing"
 	"k8s.io/apimachinery/pkg/test/coverage"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/apimachinery/pkg/util/version"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -221,13 +220,6 @@ type validationOption struct {
 	// to the versioned object fails.
 	IgnoreObjectConversionErrors bool
 
-	// MinEmulationVersion is the minimum emulation version that can be used in the
-	// "hand written validation" sub-test. When the test has already enabled a feature
-	// gate introduced after 1.35 (e.g. in 1.36+), setting the emulation version to
-	// 1.35 would fail because the feature gate did not exist at that version.
-	// If set to a version greater than 1.35, the sub-test is skipped.
-	MinEmulationVersion *version.Version
-
 	// Fuzzer is the fuzzer to use for generating test objects.
 	Fuzzer *randfill.Filler
 }
@@ -256,32 +248,19 @@ func WithFuzzer(fuzzer *randfill.Filler) ValidationTestConfig {
 	}
 }
 
-// WithMinEmulationVersion sets the minimum emulation version that can be used in the
-// "hand written validation" sub-test. Use this when the test has already enabled a
-// feature gate that was introduced after 1.35, which would cause the emulation version
-// downgrade to 1.35 to fail.
-func WithMinEmulationVersion(v *version.Version) ValidationTestConfig {
-	return func(o *validationOption) {
-		o.MinEmulationVersion = v
-	}
-}
-
 // VerifyValidationEquivalence provides a helper for testing the migration from
 // hand-written imperative validation to declarative validation. It ensures that
-// the validation logic remains consistent before and after the feature is enabled.
+// the validation logic remains consistent across enforcement modes.
 //
-// The function operates by running the provided validation function under four scenarios:
+// The function operates by running the provided validation function under three scenarios:
 //  1. With DeclarativeValidation and DeclarativeValidationBeta feature gates enabled,
 //     using the new declarative validation rules (Beta stage).
 //  2. With DeclarativeValidation enabled and DeclarativeValidationBeta disabled,
 //     using the new declarative validation rules (Standard stage).
-//  3. With DeclarativeValidation and DeclarativeValidationTakeover feature gates disabled,
-//     simulating the legacy hand-written validation.
-//  4. With all declarative rules enforced (including Alpha), ensuring that the full set of
+//  3. With all declarative rules enforced (including Alpha), ensuring that the full set of
 //     declarative validations is correctly implemented (testing only).
 //
-// It then asserts that the validation errors produced in all scenarios are equivalent,
-// guaranteeing a safe migration. It also checks the errors against an expected set.
+// It checks the errors against an expected set in each scenario.
 // It compares errors by field, origin and type; all three should match to be called equivalent.
 // It also make sure all versions of the given API returns equivalent errors.
 func VerifyValidationEquivalence(t *testing.T, ctx context.Context, obj runtime.Object, strategy rest.RESTCreateStrategy, expectedErrs field.ErrorList, testConfigs ...ValidationTestConfig) {
@@ -303,20 +282,17 @@ func VerifyValidationEquivalence(t *testing.T, ctx context.Context, obj runtime.
 
 // VerifyUpdateValidationEquivalence provides a helper for testing the migration from
 // hand-written imperative validation to declarative validation for update operations.
-// It ensures that the validation logic remains consistent before and after the feature is enabled.
+// It ensures that the validation logic remains consistent across enforcement modes.
 //
-// The function operates by running the provided validation function under four scenarios:
+// The function operates by running the provided validation function under three scenarios:
 //  1. With DeclarativeValidation and DeclarativeValidationBeta feature gates enabled,
 //     using the new declarative validation rules (Beta stage).
 //  2. With DeclarativeValidation enabled and DeclarativeValidationBeta disabled,
 //     using the new declarative validation rules (Standard stage).
-//  3. With DeclarativeValidation and DeclarativeValidationTakeover feature gates disabled,
-//     simulating the legacy hand-written validation.
-//  4. With all declarative rules enforced (including Alpha), ensuring that the full set of
+//  3. With all declarative rules enforced (including Alpha), ensuring that the full set of
 //     declarative validations is correctly implemented (testing only).
 //
-// It then asserts that the validation errors produced in all scenarios are equivalent,
-// guaranteeing a safe migration. It also checks the errors against an expected set.
+// It checks the errors against an expected set in each scenario.
 // It compares errors by field, origin and type; all three should match to be called equivalent.
 // It also make sure all versions of the given API returns equivalent errors.
 func VerifyUpdateValidationEquivalence(t *testing.T, ctx context.Context, obj, old runtime.Object, strategy rest.RESTUpdateStrategy, expectedErrs field.ErrorList, testConfigs ...ValidationTestConfig) {
@@ -353,12 +329,9 @@ func VerifyUpdateValidationEquivalenceFunc(t *testing.T, ctx context.Context, ob
 	VerifyVersionedValidationEquivalence(t, obj, old, testConfigs...)
 }
 
-// verifyValidationEquivalence is a generic helper that verifies validation equivalence with and without declarative validation.
+// verifyValidationEquivalence is a generic helper that verifies validation equivalence across declarative enforcement modes.
 func verifyValidationEquivalence(t *testing.T, expectedErrs field.ErrorList, runValidations func(context.Context) field.ErrorList, ctx context.Context, opt *validationOption, obj runtime.Object) {
 	t.Helper()
-	var declarativeBetaEnabledErrs field.ErrorList
-	var declarativeBetaDisabledErrs field.ErrorList
-	var imperativeErrs field.ErrorList
 
 	// Reset metrics to ensure a clean state for mismatch checking
 	legacyregistry.Reset()
@@ -374,12 +347,12 @@ func verifyValidationEquivalence(t *testing.T, expectedErrs field.ErrorList, run
 			features.DeclarativeValidation:     true,
 			features.DeclarativeValidationBeta: true,
 		})
-		declarativeBetaEnabledErrs = runValidations(ctx)
+		errs := runValidations(ctx)
 
 		if len(expectedErrs) > 0 {
-			errOutputMatcher.Test(t, expectedErrs, declarativeBetaEnabledErrs)
-		} else if len(declarativeBetaEnabledErrs) != 0 {
-			t.Errorf("expected no errors, but got: %v", declarativeBetaEnabledErrs)
+			errOutputMatcher.Test(t, expectedErrs, errs)
+		} else if len(errs) != 0 {
+			t.Errorf("expected no errors, but got: %v", errs)
 		}
 
 		// Ensure no mismatches were logged/metrics incremented
@@ -393,43 +366,19 @@ func verifyValidationEquivalence(t *testing.T, expectedErrs field.ErrorList, run
 			features.DeclarativeValidation:     true,
 			features.DeclarativeValidationBeta: false,
 		})
-		declarativeBetaDisabledErrs = runValidations(ctx)
+		errs := runValidations(ctx)
 
 		if len(expectedErrs) > 0 {
-			errOutputMatcher.Test(t, expectedErrs, declarativeBetaDisabledErrs)
-		} else if len(declarativeBetaDisabledErrs) != 0 {
-			t.Errorf("expected no errors, but got: %v", declarativeBetaDisabledErrs)
+			errOutputMatcher.Test(t, expectedErrs, errs)
+		} else if len(errs) != 0 {
+			t.Errorf("expected no errors, but got: %v", errs)
 		}
 
 		// Ensure no mismatches were logged/metrics incremented
 		testutil.AssertVectorCount(t, "apiserver_validation_declarative_validation_mismatch_total", nil, 0)
 	})
-	// 3. Legacy Hand Written Validation
-	// TODO: Remove this test case in 1.39 when emulation for 1.35 is no longer needed.
-	emulationVersion := version.MustParse("1.35")
-	skipHandWritten := opt.MinEmulationVersion != nil && opt.MinEmulationVersion.GreaterThan(emulationVersion)
-	t.Run("hand written validation", func(t *testing.T) {
-		if skipHandWritten {
-			t.Skipf("skipping: minimum emulation version %s is greater than %s", opt.MinEmulationVersion, emulationVersion)
-		}
-		// Even when DeclarativeValidation gate is disabled, if the object's strategy has explicit
-		// declarative enforcement enabled, Standard declarative validations still run and are enforced.
-		// Emulating 1.35 ensures the DeclarativeValidationBeta gate is also effectively disabled (evaluated as false)
-		// because the feature gate was not introduced until 1.36.
-		featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, emulationVersion)
-		featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-			features.DeclarativeValidation: false,
-		})
-		imperativeErrs = runValidations(ctx)
 
-		if len(expectedErrs) > 0 {
-			errOutputMatcher.Test(t, expectedErrs, imperativeErrs)
-		} else if len(imperativeErrs) != 0 {
-			t.Errorf("expected no errors, but got: %v", imperativeErrs)
-		}
-	})
-
-	// 4. Declarative Validation with All Rules Enforced (Testing Only)
+	// 3. Declarative Validation with All Rules Enforced (Testing Only)
 	// This sub-test ensures that all declarative validation rules (including those marked as Alpha)
 	// are correctly implemented and match the expected errors. It uses a special context
 	// to force enforcement of all declarative rules and filter out their handwritten counterparts.
@@ -471,31 +420,6 @@ func verifyValidationEquivalence(t *testing.T, expectedErrs field.ErrorList, run
 		// Ensure no mismatches were logged/metrics incremented
 		testutil.AssertVectorCount(t, "apiserver_validation_declarative_validation_mismatch_total", nil, 0)
 	})
-
-	if t.Failed() {
-		// There is no point in moving forward, if any of above tests failed for any reason. Running follow up tests will return noise.
-		t.SkipNow()
-	}
-
-	// The equivalenceMatcher is used to verify that the output errors from hand-written imperative validation
-	// are equivalent to the output errors in all declarative validation scenarios (Beta enabled/disabled).
-	// This ensures that enabling the feature gates does not change the validation outcome.
-	equivalenceMatcher := field.ErrorMatcher{}.ByType().ByOrigin()
-	if len(opt.NormalizationRules) > 0 {
-		equivalenceMatcher = equivalenceMatcher.ByFieldNormalized(opt.NormalizationRules)
-	} else {
-		equivalenceMatcher = equivalenceMatcher.ByField()
-	}
-
-	if !skipHandWritten {
-		// The imperative validation may produce duplicate errors, which is not supported by the ErrorMatcher.
-		// TODO: remove this once ErrorMatcher has been extended to handle this form of deduplication.
-		imperativeErrs = deDuplicateErrors(imperativeErrs, equivalenceMatcher)
-
-		// Verify equivalence across all scenarios
-		equivalenceMatcher.Test(t, imperativeErrs, declarativeBetaEnabledErrs)
-		equivalenceMatcher.Test(t, imperativeErrs, declarativeBetaDisabledErrs)
-	}
 }
 
 // recordObservedRules extracts the GVK for obj (preferring the scheme's
@@ -512,22 +436,4 @@ func recordObservedRules(ctx context.Context, obj runtime.Object, errs field.Err
 	}
 	gvk := schema.GroupVersionKind{Group: info.APIGroup, Version: info.APIVersion, Kind: kind}
 	coverage.RecordObservedRules(gvk, errs)
-}
-
-// deDuplicateErrors removes duplicate errors from an ErrorList based on the provided matcher.
-func deDuplicateErrors(errs field.ErrorList, matcher field.ErrorMatcher) field.ErrorList {
-	var deduped field.ErrorList
-	for _, err := range errs {
-		found := false
-		for _, existingErr := range deduped {
-			if matcher.Matches(existingErr, err) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			deduped = append(deduped, err)
-		}
-	}
-	return deduped
 }

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage_test.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -181,7 +180,8 @@ func TestUpdateStatus(t *testing.T) {
 	storage, statusStorage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	ctx := genericapirequest.NewDefaultContext()
+	ctx := genericregistrytest.NewNamespaceScopeContext(storage.Store, metav1.NamespaceDefault)
+	statusCtx := genericregistrytest.NewNamespaceScopeContext(storage.Store, metav1.NamespaceDefault, "status")
 	key, _ := storage.KeyFunc(ctx, "foo")
 	autoscalerStart := validNewHorizontalPodAutoscaler("foo")
 	err := storage.Storage.Create(ctx, key, autoscalerStart, nil, 0, false)
@@ -201,7 +201,7 @@ func TestUpdateStatus(t *testing.T) {
 		},
 	}
 
-	_, _, err = statusStorage.Update(ctx, autoscalerIn.Name, rest.DefaultUpdatedObjectInfo(autoscalerIn), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false, &metav1.UpdateOptions{})
+	_, _, err = statusStorage.Update(statusCtx, autoscalerIn.Name, rest.DefaultUpdatedObjectInfo(autoscalerIn), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, false, &metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/pkg/registry/resource/resourcepoolstatusrequest/strategy.go
+++ b/pkg/registry/resource/resourcepoolstatusrequest/strategy.go
@@ -69,12 +69,6 @@ func (*resourcePoolStatusRequestStrategy) Validate(ctx context.Context, obj runt
 	return validation.ValidateResourcePoolStatusRequest(request)
 }
 
-// DeclarativeValidationConfig implements rest.DeclarativeValidationConfigurer to supply declarative
-// validation options to the generic BeforeCreate/BeforeUpdate code path.
-func (*resourcePoolStatusRequestStrategy) DeclarativeValidationConfig(ctx context.Context, obj, oldObj runtime.Object) rest.DeclarativeValidationConfig {
-	return rest.DeclarativeValidationConfig{}
-}
-
 func (*resourcePoolStatusRequestStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
 	return nil
 }

--- a/pkg/registry/resource/resourcepoolstatusrequest/strategy.go
+++ b/pkg/registry/resource/resourcepoolstatusrequest/strategy.go
@@ -72,7 +72,7 @@ func (*resourcePoolStatusRequestStrategy) Validate(ctx context.Context, obj runt
 // DeclarativeValidationConfig implements rest.DeclarativeValidationConfigurer to supply declarative
 // validation options to the generic BeforeCreate/BeforeUpdate code path.
 func (*resourcePoolStatusRequestStrategy) DeclarativeValidationConfig(ctx context.Context, obj, oldObj runtime.Object) rest.DeclarativeValidationConfig {
-	return rest.DeclarativeValidationConfig{DeclarativeEnforcement: true}
+	return rest.DeclarativeValidationConfig{}
 }
 
 func (*resourcePoolStatusRequestStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {

--- a/pkg/registry/scheduling/podgroup/strategy.go
+++ b/pkg/registry/scheduling/podgroup/strategy.go
@@ -86,7 +86,7 @@ func (*podGroupStrategy) DeclarativeValidationConfig(ctx context.Context, obj, o
 	if utilfeature.DefaultFeatureGate.Enabled(features.WorkloadAwarePreemption) {
 		opts = append(opts, string(features.WorkloadAwarePreemption))
 	}
-	return rest.DeclarativeValidationConfig{Options: opts, DeclarativeEnforcement: true}
+	return rest.DeclarativeValidationConfig{Options: opts}
 }
 
 func (*podGroupStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {

--- a/pkg/registry/scheduling/workload/strategy.go
+++ b/pkg/registry/scheduling/workload/strategy.go
@@ -65,7 +65,7 @@ func (workloadStrategy) DeclarativeValidationConfig(ctx context.Context, obj, ol
 	if utilfeature.DefaultFeatureGate.Enabled(features.WorkloadAwarePreemption) {
 		opts = append(opts, string(features.WorkloadAwarePreemption))
 	}
-	return rest.DeclarativeValidationConfig{DeclarativeEnforcement: true, Options: opts}
+	return rest.DeclarativeValidationConfig{Options: opts}
 }
 
 func (workloadStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -104,10 +104,10 @@ const (
 	// kep: http://kep.k8s.io/5073
 	// beta: v1.33
 	//
-	// Enables running declarative validation of APIs, where declared. When enabled, APIs with
-	// declarative validation rules will validate objects using the generated
-	// declarative validation code and compare the results to the regular imperative validation.
-	// See DeclarativeValidationBeta for more.
+	// When enabled, results of declarative validation are compared against handwritten
+	// validation and mismatches are logged as metrics. Declarative validation itself is
+	// always executed independent of this gate; per-tag enforcement is controlled by the
+	// lifecycle prefix and the DeclarativeValidationBeta gate.
 	DeclarativeValidation featuregate.Feature = "DeclarativeValidation"
 
 	// owner: @jpbetz @aaron-prindle @yongruilin
@@ -120,11 +120,10 @@ const (
 	// In Shadow mode, declarative validation is executed and mismatches against handwritten
 	// validation are logged as metrics, but failures do not reject requests.
 	// Handwritten validation remains authoritative and enforced.
-	// Enforcement logic for resources using WithDeclarativeEnforcement():
+	// Enforcement by lifecycle prefix:
 	// - Standard tags (no prefix): Always Enforced (Bypasses this gate).
 	// - Beta tags (+k8s:beta): Enforced when this gate is enabled (default), otherwise Shadowed.
 	// - Alpha tags (+k8s:alpha): Always Shadowed.
-	// This gate has no effect if the master DeclarativeValidation feature gate is disabled.
 	DeclarativeValidationBeta featuregate.Feature = "DeclarativeValidationBeta"
 
 	// owner: @jpbetz @aaron-prindle @yongruilin

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
@@ -85,11 +85,6 @@ type DeclarativeValidationConfig struct {
 	// expect. These often correspond to feature gates.
 	Options []string
 
-	// DeclarativeEnforcement indicates that declarative validations should
-	// follow the fine-grained Validation Lifecycle. When set, declarative
-	// validation is always executed regardless of feature gates.
-	DeclarativeEnforcement bool
-
 	// NormalizationRules are applied to field paths when comparing
 	// handwritten and declarative validation errors.
 	NormalizationRules []field.NormalizationRule
@@ -323,34 +318,23 @@ func gatherDeclarativeValidationMismatches(imperativeErrs, declarativeErrs field
 }
 
 // createDeclarativeValidationPanicHandler returns a function with panic recovery logic
-// that will increment the panic metric and either log or append errors based on the shouldFail parameter.
-func createDeclarativeValidationPanicHandler(ctx context.Context, errs *field.ErrorList, shouldFail bool, validationIdentifier string) func() {
-	logger := klog.FromContext(ctx)
+// that increments the panic metric and appends an InternalError to errs.
+func createDeclarativeValidationPanicHandler(errs *field.ErrorList, validationIdentifier string) func() {
 	return func() {
 		if r := recover(); r != nil {
-			// Increment the panic metric counter
 			validationmetrics.Metrics.IncDeclarativeValidationPanicMetric(validationIdentifier)
-
-			const errorFmt = "panic during declarative validation: %v"
-			if shouldFail {
-				// If shouldFail is enabled, output as a validation error as authoritative validator panicked and validation should error
-				*errs = append(*errs, field.InternalError(nil, fmt.Errorf(errorFmt, r)))
-			} else {
-				// if shouldFail not enabled, log the panic as an error message
-				logger.Error(nil, fmt.Sprintf(errorFmt, r))
-			}
+			*errs = append(*errs, field.InternalError(nil, fmt.Errorf("panic during declarative validation: %v", r)))
 		}
 	}
 }
 
-// panicSafeValidateFunc wraps an validation function with panic recovery logic.
-// The returned function will execute the wrapped function and handle any panics by
-// incrementing the panic metric, and logging an error message
+// panicSafeValidateFunc wraps a validation function with panic recovery logic.
+// On panic, the panic metric is incremented and an InternalError is returned in errs.
 func panicSafeValidateFunc(
 	validateFunc func(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, o *ValidationConfigOption) field.ErrorList,
 ) func(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, o *ValidationConfigOption) field.ErrorList {
 	return func(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, o *ValidationConfigOption) (errs field.ErrorList) {
-		defer createDeclarativeValidationPanicHandler(ctx, &errs, o.DeclarativeEnforcement, o.ValidationIdentifier)()
+		defer createDeclarativeValidationPanicHandler(&errs, o.ValidationIdentifier)()
 		return validateFunc(ctx, scheme, obj, oldObj, o)
 	}
 }
@@ -393,19 +377,17 @@ func metricIdentifier(ctx context.Context, scheme *runtime.Scheme, obj runtime.O
 }
 
 // ValidateDeclarativelyWithMigrationChecks executes declarative validation and implements the Validation Lifecycle strategy.
-// It manages the transition from handwritten (HV) to declarative (DV) validation by controlling enforcement:
-//   - Standard: Enforced if declarativeEnforcement is set. HV counterparts are expected to be deleted from source.
-//   - Beta: Enforced if declarativeEnforcement is set AND DeclarativeValidationBeta feature gate is enabled.
-//     When enforced, corresponding HV errors are filtered out. Otherwise, DV is shadowed.
-//   - Alpha: Always shadowed; HV remains authoritative.
+// Declarative validation is always authoritative; the lifecycle prefix on each tag controls the visible behavior:
+//   - Standard (no prefix): Enforced. HV counterparts are expected to be deleted from source.
+//   - Beta (+k8s:beta): Enforced when DeclarativeValidationBeta is enabled. Otherwise shadowed (HV remains authoritative).
+//   - Alpha (+k8s:alpha): Always shadowed; HV remains authoritative.
 //
-// Mismatches between HV and DV are logged if the DeclarativeValidation gate is enabled.
-// Mismatch checking is limited to Alpha and Beta stages when explicit enforcement is active.
+// Mismatches between HV and DV are logged when the DeclarativeValidation gate is enabled. Only Alpha and
+// Beta errors are mismatch-checked, since Standard DV errors may have no HV counterpart in new APIs.
 //
-// For testing purposes, WithAllDeclarativeEnforcedForTest can be used to enforce all declarative validations
-// regardless of feature gates and filter all covered handwritten validations.
+// For testing purposes, WithAllDeclarativeEnforcedForTest enforces all declarative validations regardless
+// of lifecycle and filters all covered handwritten validations.
 func ValidateDeclarativelyWithMigrationChecks(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, errs field.ErrorList, opType operation.Type, config DeclarativeValidationConfig) field.ErrorList {
-	declarativeValidationEnabled := utilfeature.DefaultFeatureGate.Enabled(features.DeclarativeValidation)
 	betaEnabled := utilfeature.DefaultFeatureGate.Enabled(features.DeclarativeValidationBeta)
 	// allDeclarativeEnforced indicates that we should check all declarative errors for testing purposes.
 	allDeclarativeEnforced := ctx.Value(allDeclarativeEnforcedKey) == true
@@ -417,44 +399,24 @@ func ValidateDeclarativelyWithMigrationChecks(ctx context.Context, scheme *runti
 		klog.FromContext(ctx).Error(err, "failed to generate complete validation identifier for declarative validation")
 	}
 
-	// Directly create the config and call the core validation logic.
 	cfg := &ValidationConfigOption{
 		OpType:                      opType,
 		ValidationIdentifier:        validationIdentifier,
 		DeclarativeValidationConfig: config,
 	}
 
-	// Short-circuit if neither DeclarativeValidation is enabled nor the object is explicitly configured for declarative enforcement.
-	if !declarativeValidationEnabled && !cfg.DeclarativeEnforcement && !allDeclarativeEnforced {
-		return errs
-	}
-
-	// Call the panic-safe wrapper with the real validation function.
-	// We should fail if validation is enforced.
 	declarativeErrs := panicSafeValidateFunc(validateDeclaratively)(ctx, scheme, obj, oldObj, cfg)
 
-	if declarativeValidationEnabled {
-		// Log mismatches.
-		// When explicit strategy is used (declarativeEnforcement), Standard errors are authoritative
-		// and may not have handwritten counterparts (e.g., in new APIs).
-		// We only mismatch check Alpha and Beta errors in this mode.
-		mismatchCandidateErrs := declarativeErrs
-		if cfg.DeclarativeEnforcement {
-			mismatchCandidateErrs = nil
-			for _, err := range declarativeErrs {
-				if err.IsAlpha() || err.IsBeta() {
-					mismatchCandidateErrs = append(mismatchCandidateErrs, err)
-				}
+	if utilfeature.DefaultFeatureGate.Enabled(features.DeclarativeValidation) {
+		// Standard errors are authoritative and may not have handwritten counterparts (e.g., in new APIs).
+		// Only Alpha and Beta errors are eligible for mismatch checking.
+		var mismatchCandidateErrs field.ErrorList
+		for _, err := range declarativeErrs {
+			if err.IsAlpha() || err.IsBeta() {
+				mismatchCandidateErrs = append(mismatchCandidateErrs, err)
 			}
 		}
-
-		// We pass betaEnabled (and enforcement) as the takeover flag to avoid changing logic elsewhere for now.
-		compareDeclarativeErrorsAndEmitMismatches(ctx, errs, mismatchCandidateErrs, validationIdentifier, cfg.DeclarativeEnforcement && betaEnabled, *cfg)
-	}
-
-	if !cfg.DeclarativeEnforcement && !allDeclarativeEnforced {
-		// If enforcement is not enabled, we shadow declarative errors with hand-written ones, so we return early here.
-		return errs
+		compareDeclarativeErrorsAndEmitMismatches(ctx, errs, mismatchCandidateErrs, validationIdentifier, betaEnabled, *cfg)
 	}
 
 	// Filter HV errors

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
@@ -317,26 +317,16 @@ func gatherDeclarativeValidationMismatches(imperativeErrs, declarativeErrs field
 	return mismatchDetails
 }
 
-// createDeclarativeValidationPanicHandler returns a function with panic recovery logic
-// that increments the panic metric and appends an InternalError to errs.
-func createDeclarativeValidationPanicHandler(errs *field.ErrorList, validationIdentifier string) func() {
-	return func() {
+// runDeclarativeValidationWithRecover invokes validateDeclaratively with panic recovery.
+// On panic, the panic metric is incremented and an InternalError is appended to the returned errors.
+func runDeclarativeValidationWithRecover(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, o *ValidationConfigOption) (errs field.ErrorList) {
+	defer func() {
 		if r := recover(); r != nil {
-			validationmetrics.Metrics.IncDeclarativeValidationPanicMetric(validationIdentifier)
-			*errs = append(*errs, field.InternalError(nil, fmt.Errorf("panic during declarative validation: %v", r)))
+			validationmetrics.Metrics.IncDeclarativeValidationPanicMetric(o.ValidationIdentifier)
+			errs = append(errs, field.InternalError(nil, fmt.Errorf("panic during declarative validation: %v", r)))
 		}
-	}
-}
-
-// panicSafeValidateFunc wraps a validation function with panic recovery logic.
-// On panic, the panic metric is incremented and an InternalError is returned in errs.
-func panicSafeValidateFunc(
-	validateFunc func(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, o *ValidationConfigOption) field.ErrorList,
-) func(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, o *ValidationConfigOption) field.ErrorList {
-	return func(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, o *ValidationConfigOption) (errs field.ErrorList) {
-		defer createDeclarativeValidationPanicHandler(&errs, o.ValidationIdentifier)()
-		return validateFunc(ctx, scheme, obj, oldObj, o)
-	}
+	}()
+	return validateDeclaratively(ctx, scheme, obj, oldObj, o)
 }
 
 func metricIdentifier(ctx context.Context, scheme *runtime.Scheme, obj runtime.Object, opType operation.Type) (string, error) {
@@ -405,7 +395,7 @@ func ValidateDeclarativelyWithMigrationChecks(ctx context.Context, scheme *runti
 		DeclarativeValidationConfig: config,
 	}
 
-	declarativeErrs := panicSafeValidateFunc(validateDeclaratively)(ctx, scheme, obj, oldObj, cfg)
+	declarativeErrs := runDeclarativeValidationWithRecover(ctx, scheme, obj, oldObj, cfg)
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.DeclarativeValidation) {
 		// Standard errors are authoritative and may not have handwritten counterparts (e.g., in new APIs).

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
@@ -465,11 +465,9 @@ func TestWithRecover(t *testing.T) {
 	obj := &runtime.Unknown{}
 
 	testCases := []struct {
-		name               string
-		validateFn         func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList
-		enforcementEnabled bool
-		wantErrs           field.ErrorList
-		expectLogRegex     string
+		name       string
+		validateFn func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList
+		wantErrs   field.ErrorList
 	}{
 		{
 			name: "no panic",
@@ -478,73 +476,35 @@ func TestWithRecover(t *testing.T) {
 					field.Invalid(field.NewPath("field"), "value", "reason"),
 				}
 			},
-			enforcementEnabled: false,
 			wantErrs: field.ErrorList{
 				field.Invalid(field.NewPath("field"), "value", "reason"),
 			},
-			expectLogRegex: "",
 		},
 		{
-			name: "panic with enforcement disabled",
+			name: "panic returns InternalError",
 			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList {
 				panic("test panic")
 			},
-			enforcementEnabled: false,
-			wantErrs:           nil,
-			// logs have a prefix of the form - E0309 21:05:33.865030 1926106 validate.go:199]
-			expectLogRegex: "E.*panic during declarative validation: test panic",
-		},
-		{
-			name: "panic with enforcement enabled",
-			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList {
-				panic("test panic")
-			},
-			enforcementEnabled: true,
 			wantErrs: field.ErrorList{
 				field.InternalError(nil, fmt.Errorf("panic during declarative validation: test panic")),
 			},
-			expectLogRegex: "",
 		},
 		{
 			name: "nil return, no panic",
 			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList {
 				return nil
 			},
-			enforcementEnabled: false,
-			wantErrs:           nil,
-			expectLogRegex:     "",
+			wantErrs: nil,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var buf bytes.Buffer
-			klog.SetOutput(&buf)
-			klog.LogToStderr(false)
-			defer klog.LogToStderr(true)
-
 			wrapped := panicSafeValidateFunc(tc.validateFn)
-			gotErrs := wrapped(ctx, scheme, obj, nil, &ValidationConfigOption{ValidationIdentifier: "test_validationIdentifier", OpType: operation.Create, DeclarativeValidationConfig: DeclarativeValidationConfig{Options: options, DeclarativeEnforcement: tc.enforcementEnabled}})
+			gotErrs := wrapped(ctx, scheme, obj, nil, &ValidationConfigOption{ValidationIdentifier: "test_validationIdentifier", OpType: operation.Create, DeclarativeValidationConfig: DeclarativeValidationConfig{Options: options}})
 
-			klog.Flush()
-			logOutput := buf.String()
-
-			// Compare gotErrs vs. tc.wantErrs
 			if !equalErrorLists(gotErrs, tc.wantErrs) {
 				t.Errorf("panicSafeValidateFunc() gotErrs = %#v, want %#v", gotErrs, tc.wantErrs)
-			}
-
-			// Check logs if needed
-			if tc.expectLogRegex != "" {
-				matched, err := regexp.MatchString(tc.expectLogRegex, logOutput)
-				if err != nil {
-					t.Fatalf("Bad regex: %v", err)
-				}
-				if !matched {
-					t.Errorf("Expected log output %q, but got:\n%s", tc.expectLogRegex, logOutput)
-				}
-			} else if strings.Contains(logOutput, "panic during declarative validation") {
-				t.Errorf("Unexpected panic log found: %s", logOutput)
 			}
 		})
 	}
@@ -558,11 +518,9 @@ func TestWithRecoverUpdate(t *testing.T) {
 	oldObj := &runtime.Unknown{}
 
 	testCases := []struct {
-		name               string
-		validateFn         func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList
-		enforcementEnabled bool
-		wantErrs           field.ErrorList
-		expectLogRegex     string
+		name       string
+		validateFn func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList
+		wantErrs   field.ErrorList
 	}{
 		{
 			name: "no panic",
@@ -571,74 +529,35 @@ func TestWithRecoverUpdate(t *testing.T) {
 					field.Invalid(field.NewPath("field"), "value", "reason"),
 				}
 			},
-			enforcementEnabled: false,
 			wantErrs: field.ErrorList{
 				field.Invalid(field.NewPath("field"), "value", "reason"),
 			},
-			expectLogRegex: "",
 		},
 		{
-			name: "panic with enforcement disabled",
+			name: "panic returns InternalError",
 			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList {
 				panic("test update panic")
 			},
-			enforcementEnabled: false,
-			wantErrs:           nil,
-			// logs have a prefix of the form - E0309 21:05:33.865030 1926106 validate.go:199]
-			expectLogRegex: "E.*panic during declarative validation: test update panic",
-		},
-		{
-			name: "panic with enforcement enabled",
-			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList {
-				panic("test update panic")
-			},
-			enforcementEnabled: true,
 			wantErrs: field.ErrorList{
 				field.InternalError(nil, fmt.Errorf("panic during declarative validation: test update panic")),
 			},
-			expectLogRegex: "",
 		},
 		{
 			name: "nil return, no panic",
 			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList {
 				return nil
 			},
-			enforcementEnabled: false,
-			wantErrs:           nil,
-			expectLogRegex:     "",
+			wantErrs: nil,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var buf bytes.Buffer
-			klog.SetOutput(&buf)
-			klog.LogToStderr(false)
-			defer klog.LogToStderr(true)
-
-			// Pass the enforcement flag to panicSafeValidateUpdateFunc
 			wrapped := panicSafeValidateFunc(tc.validateFn)
-			gotErrs := wrapped(ctx, scheme, obj, oldObj, &ValidationConfigOption{ValidationIdentifier: "test_validationIdentifier", OpType: operation.Update, DeclarativeValidationConfig: DeclarativeValidationConfig{Options: options, DeclarativeEnforcement: tc.enforcementEnabled}})
+			gotErrs := wrapped(ctx, scheme, obj, oldObj, &ValidationConfigOption{ValidationIdentifier: "test_validationIdentifier", OpType: operation.Update, DeclarativeValidationConfig: DeclarativeValidationConfig{Options: options}})
 
-			klog.Flush()
-			logOutput := buf.String()
-
-			// Compare gotErrs with wantErrs
 			if !equalErrorLists(gotErrs, tc.wantErrs) {
 				t.Errorf("panicSafeValidateUpdateFunc() gotErrs = %#v, want %#v", gotErrs, tc.wantErrs)
-			}
-
-			// Verify log output
-			if tc.expectLogRegex != "" {
-				matched, err := regexp.MatchString(tc.expectLogRegex, logOutput)
-				if err != nil {
-					t.Fatalf("Bad regex: %v", err)
-				}
-				if !matched {
-					t.Errorf("Expected log pattern %q, but got:\n%s", tc.expectLogRegex, logOutput)
-				}
-			} else if strings.Contains(logOutput, "panic during declarative validation") {
-				t.Errorf("Unexpected panic log found: %s", logOutput)
 			}
 		})
 	}
@@ -832,86 +751,65 @@ func TestValidateDeclarativelyWithMigrationChecks(t *testing.T) {
 	errDVAlpha := field.Invalid(field.NewPath("spec", "alpha"), "decAlpha", "declarative alpha").MarkAlpha()
 
 	testCases := []struct {
-		name                   string
-		dvFeatureEnabled       bool
-		declarativeEnforcement bool
-		betaGateEnabled        bool
-		imperativeErrors       field.ErrorList
-		declarativeErrors      field.ErrorList
-		expectedErrors         field.ErrorList
-		shouldPanic            bool
+		name              string
+		dvFeatureEnabled  bool
+		betaGateEnabled   bool
+		imperativeErrors  field.ErrorList
+		declarativeErrors field.ErrorList
+		expectedErrors    field.ErrorList
+		shouldPanic       bool
 	}{
 		{
-			name:              "Feature Disabled, Not Enforced -> Skips declarative, Returns HV",
+			name:              "Feature Disabled -> Enforces Standard (HV kept+DV returned, duplicate expected if HV not deleted)",
 			imperativeErrors:  field.ErrorList{errHVStandardCovered},
-			declarativeErrors: field.ErrorList{errDVStandard},
-			expectedErrors:    field.ErrorList{errHVStandardCovered},
+			declarativeErrors: field.ErrorList{errDVStandard, errDVAdditional},
+			expectedErrors:    field.ErrorList{errHVStandardCovered, errDVStandard, errDVAdditional},
 		},
 		{
-			name:                   "Feature Disabled, Enforced -> Enforces Standard (HV kept+DV returned, duplicate expected if HV not deleted)",
-			declarativeEnforcement: true,
-			imperativeErrors:       field.ErrorList{errHVStandardCovered},
-			declarativeErrors:      field.ErrorList{errDVStandard, errDVAdditional},
-			expectedErrors:         field.ErrorList{errHVStandardCovered, errDVStandard, errDVAdditional},
-		},
-		{
-			name:              "Feature Enabled, Not Enforced -> Returns imperative (Shadow Mode)",
+			name:              "Feature Enabled -> Enforces Standard (HV kept+DV returned, duplicate expected if HV not deleted)",
 			dvFeatureEnabled:  true,
 			imperativeErrors:  field.ErrorList{errHVStandardCovered},
-			declarativeErrors: field.ErrorList{errDVStandard},
-			expectedErrors:    field.ErrorList{errHVStandardCovered},
+			declarativeErrors: field.ErrorList{errDVStandard, errDVAdditional},
+			expectedErrors:    field.ErrorList{errHVStandardCovered, errDVStandard, errDVAdditional},
 		},
 		{
-			name:                   "Feature Enabled, Enforced -> Enforces Standard (HV kept+DV returned, duplicate expected if HV not deleted)",
-			dvFeatureEnabled:       true,
-			declarativeEnforcement: true,
-			imperativeErrors:       field.ErrorList{errHVStandardCovered},
-			declarativeErrors:      field.ErrorList{errDVStandard, errDVAdditional},
-			expectedErrors:         field.ErrorList{errHVStandardCovered, errDVStandard, errDVAdditional},
-		},
-		{
-			name:                   "Feature Disabled, Enforced, Panics -> Returns InternalError",
-			declarativeEnforcement: true,
-			imperativeErrors:       field.ErrorList{errHVStandardCovered},
-			shouldPanic:            true,
+			name:             "Feature Disabled, Panics -> Returns InternalError",
+			imperativeErrors: field.ErrorList{errHVStandardCovered},
+			shouldPanic:      true,
 			// Standard HV is kept. Panic error appended.
 			expectedErrors: append(field.ErrorList{errHVStandardCovered}, field.InternalError(nil, fmt.Errorf("panic during declarative validation: test panic"))),
 		},
 		{
-			name:                   "Feature Enabled, Enforced, InternalError -> Returns InternalError",
-			dvFeatureEnabled:       true,
-			declarativeEnforcement: true,
-			imperativeErrors:       field.ErrorList{errHVStandardCovered},
-			declarativeErrors:      field.ErrorList{field.InternalError(nil, fmt.Errorf("internal error"))},
+			name:              "Feature Enabled, InternalError -> Returns InternalError",
+			dvFeatureEnabled:  true,
+			imperativeErrors:  field.ErrorList{errHVStandardCovered},
+			declarativeErrors: field.ErrorList{field.InternalError(nil, fmt.Errorf("internal error"))},
 			// Standard HV kept. Internal error appended.
 			expectedErrors: field.ErrorList{errHVStandardCovered, field.InternalError(nil, fmt.Errorf("internal error"))},
 		},
 		{
-			name:                   "Enforced, Beta Gate Enabled -> Enforces Beta (HV removed, DV returned)",
-			dvFeatureEnabled:       true,
-			declarativeEnforcement: true,
-			betaGateEnabled:        true,
-			imperativeErrors:       field.ErrorList{errHVBetaCovered},
-			declarativeErrors:      field.ErrorList{errDVBeta},
-			expectedErrors:         field.ErrorList{errDVBeta},
+			name:              "Beta Gate Enabled -> Enforces Beta (HV removed, DV returned)",
+			dvFeatureEnabled:  true,
+			betaGateEnabled:   true,
+			imperativeErrors:  field.ErrorList{errHVBetaCovered},
+			declarativeErrors: field.ErrorList{errDVBeta},
+			expectedErrors:    field.ErrorList{errDVBeta},
 		},
 		{
-			name:                   "Enforced, Beta Gate Disabled -> Shadows Beta (HV kept, DV hidden)",
-			dvFeatureEnabled:       true,
-			declarativeEnforcement: true,
-			betaGateEnabled:        false,
-			imperativeErrors:       field.ErrorList{errHVBetaCovered},
-			declarativeErrors:      field.ErrorList{errDVBeta},
-			expectedErrors:         field.ErrorList{errHVBetaCovered},
+			name:              "Beta Gate Disabled -> Shadows Beta (HV kept, DV hidden)",
+			dvFeatureEnabled:  true,
+			betaGateEnabled:   false,
+			imperativeErrors:  field.ErrorList{errHVBetaCovered},
+			declarativeErrors: field.ErrorList{errDVBeta},
+			expectedErrors:    field.ErrorList{errHVBetaCovered},
 		},
 		{
-			name:                   "Enforced, Alpha -> Shadows Alpha (HV kept, DV hidden)",
-			dvFeatureEnabled:       true,
-			declarativeEnforcement: true,
-			betaGateEnabled:        true,
-			imperativeErrors:       field.ErrorList{errHVAlpha},
-			declarativeErrors:      field.ErrorList{errDVAlpha},
-			expectedErrors:         field.ErrorList{errHVAlpha},
+			name:              "Alpha -> Shadows Alpha (HV kept, DV hidden)",
+			dvFeatureEnabled:  true,
+			betaGateEnabled:   true,
+			imperativeErrors:  field.ErrorList{errHVAlpha},
+			declarativeErrors: field.ErrorList{errDVAlpha},
+			expectedErrors:    field.ErrorList{errHVAlpha},
 		},
 	}
 
@@ -952,11 +850,7 @@ func TestValidateDeclarativelyWithMigrationChecks(t *testing.T) {
 			inputErrs := make(field.ErrorList, len(tc.imperativeErrors))
 			copy(inputErrs, tc.imperativeErrors)
 
-			config := DeclarativeValidationConfig{
-				DeclarativeEnforcement: tc.declarativeEnforcement,
-			}
-
-			gotErrs := ValidateDeclarativelyWithMigrationChecks(ctx, localScheme, obj, nil, inputErrs, operation.Create, config)
+			gotErrs := ValidateDeclarativelyWithMigrationChecks(ctx, localScheme, obj, nil, inputErrs, operation.Create, DeclarativeValidationConfig{})
 
 			if !equalErrorLists(gotErrs, tc.expectedErrors) {
 				t.Errorf("Expected errors: %v, got: %v", tc.expectedErrors, gotErrs)

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
@@ -175,7 +175,7 @@ func TestValidateDeclaratively(t *testing.T) {
 			} else {
 				cfg.OpType = operation.Update
 			}
-			results := panicSafeValidateFunc(validateDeclaratively)(ctx, scheme, tc.object, tc.oldObject, cfg)
+			results := runDeclarativeValidationWithRecover(ctx, scheme, tc.object, tc.oldObject, cfg)
 			matcher := field.ErrorMatcher{}.ByType().ByField().ByOrigin()
 			matcher.Test(t, tc.expected, results)
 		})
@@ -458,31 +458,32 @@ func TestCompareDeclarativeErrorsAndEmitMismatches(t *testing.T) {
 	}
 }
 
-func TestWithRecover(t *testing.T) {
-	ctx := context.Background()
-	scheme := runtime.NewScheme()
-	var options []string
-	obj := &runtime.Unknown{}
+func TestRunDeclarativeValidationWithRecover(t *testing.T) {
+	ctx := genericapirequest.WithRequestInfo(context.Background(), &genericapirequest.RequestInfo{
+		APIGroup:   "",
+		APIVersion: "v1",
+	})
+	obj := &v1.Pod{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"}}
 
 	testCases := []struct {
 		name       string
-		validateFn func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList
+		opType     operation.Type
+		oldObj     runtime.Object
+		validateFn func(ctx context.Context, op operation.Operation, object, oldObject any) field.ErrorList
 		wantErrs   field.ErrorList
 	}{
 		{
-			name: "no panic",
-			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList {
-				return field.ErrorList{
-					field.Invalid(field.NewPath("field"), "value", "reason"),
-				}
+			name:   "no panic on create",
+			opType: operation.Create,
+			validateFn: func(context.Context, operation.Operation, any, any) field.ErrorList {
+				return field.ErrorList{field.Invalid(field.NewPath("field"), "value", "reason")}
 			},
-			wantErrs: field.ErrorList{
-				field.Invalid(field.NewPath("field"), "value", "reason"),
-			},
+			wantErrs: field.ErrorList{field.Invalid(field.NewPath("field"), "value", "reason")},
 		},
 		{
-			name: "panic returns InternalError",
-			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList {
+			name:   "panic on create returns InternalError",
+			opType: operation.Create,
+			validateFn: func(context.Context, operation.Operation, any, any) field.ErrorList {
 				panic("test panic")
 			},
 			wantErrs: field.ErrorList{
@@ -490,52 +491,10 @@ func TestWithRecover(t *testing.T) {
 			},
 		},
 		{
-			name: "nil return, no panic",
-			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList {
-				return nil
-			},
-			wantErrs: nil,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			wrapped := panicSafeValidateFunc(tc.validateFn)
-			gotErrs := wrapped(ctx, scheme, obj, nil, &ValidationConfigOption{ValidationIdentifier: "test_validationIdentifier", OpType: operation.Create, DeclarativeValidationConfig: DeclarativeValidationConfig{Options: options}})
-
-			if !equalErrorLists(gotErrs, tc.wantErrs) {
-				t.Errorf("panicSafeValidateFunc() gotErrs = %#v, want %#v", gotErrs, tc.wantErrs)
-			}
-		})
-	}
-}
-
-func TestWithRecoverUpdate(t *testing.T) {
-	ctx := context.Background()
-	scheme := runtime.NewScheme()
-	var options []string
-	obj := &runtime.Unknown{}
-	oldObj := &runtime.Unknown{}
-
-	testCases := []struct {
-		name       string
-		validateFn func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList
-		wantErrs   field.ErrorList
-	}{
-		{
-			name: "no panic",
-			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList {
-				return field.ErrorList{
-					field.Invalid(field.NewPath("field"), "value", "reason"),
-				}
-			},
-			wantErrs: field.ErrorList{
-				field.Invalid(field.NewPath("field"), "value", "reason"),
-			},
-		},
-		{
-			name: "panic returns InternalError",
-			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList {
+			name:   "panic on update returns InternalError",
+			opType: operation.Update,
+			oldObj: &v1.Pod{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"}},
+			validateFn: func(context.Context, operation.Operation, any, any) field.ErrorList {
 				panic("test update panic")
 			},
 			wantErrs: field.ErrorList{
@@ -543,8 +502,9 @@ func TestWithRecoverUpdate(t *testing.T) {
 			},
 		},
 		{
-			name: "nil return, no panic",
-			validateFn: func(context.Context, *runtime.Scheme, runtime.Object, runtime.Object, *ValidationConfigOption) field.ErrorList {
+			name:   "nil return, no panic",
+			opType: operation.Create,
+			validateFn: func(context.Context, operation.Operation, any, any) field.ErrorList {
 				return nil
 			},
 			wantErrs: nil,
@@ -553,11 +513,18 @@ func TestWithRecoverUpdate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			wrapped := panicSafeValidateFunc(tc.validateFn)
-			gotErrs := wrapped(ctx, scheme, obj, oldObj, &ValidationConfigOption{ValidationIdentifier: "test_validationIdentifier", OpType: operation.Update, DeclarativeValidationConfig: DeclarativeValidationConfig{Options: options}})
+			scheme := runtime.NewScheme()
+			scheme.AddKnownTypes(schema.GroupVersion{Version: "v1"}, &v1.Pod{})
+			scheme.AddValidationFunc(&v1.Pod{}, tc.validateFn)
+
+			cfg := &ValidationConfigOption{
+				ValidationIdentifier: "test_validationIdentifier",
+				OpType:               tc.opType,
+			}
+			gotErrs := runDeclarativeValidationWithRecover(ctx, scheme, obj, tc.oldObj, cfg)
 
 			if !equalErrorLists(gotErrs, tc.wantErrs) {
-				t.Errorf("panicSafeValidateUpdateFunc() gotErrs = %#v, want %#v", gotErrs, tc.wantErrs)
+				t.Errorf("runDeclarativeValidationWithRecover() gotErrs = %#v, want %#v", gotErrs, tc.wantErrs)
 			}
 		})
 	}

--- a/test/declarative_validation/scheduling/podgroup/declarative_validation_test.go
+++ b/test/declarative_validation/scheduling/podgroup/declarative_validation_test.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/apimachinery/pkg/util/version"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -347,7 +346,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				features.GangScheduling:                  tc.enableWorkloadAwarePreemption,
 				features.WorkloadAwarePreemption:         tc.enableWorkloadAwarePreemption,
 			})
-			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, strategy, tc.expectedErrs, apitesting.WithMinEmulationVersion(version.MustParse("1.36")))
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, strategy, tc.expectedErrs)
 		})
 	}
 }
@@ -571,7 +570,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				features.WorkloadAwarePreemption:         tc.enableWorkloadAwarePreemption,
 			})
 			strategy := registry.NewStrategy()
-			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, strategy, tc.expectedErrs, apitesting.WithMinEmulationVersion(version.MustParse("1.36")))
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, strategy, tc.expectedErrs)
 		})
 	}
 }

--- a/test/declarative_validation/scheduling/workload/declarative_validation_test.go
+++ b/test/declarative_validation/scheduling/workload/declarative_validation_test.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/apimachinery/pkg/util/version"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -377,7 +376,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				features.GangScheduling:                  tc.enableWorkloadAwarePreemption,
 				features.WorkloadAwarePreemption:         tc.enableWorkloadAwarePreemption,
 			})
-			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, registry.Strategy, tc.expectedErrs, apitesting.WithMinEmulationVersion(version.MustParse("1.36")))
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, registry.Strategy, tc.expectedErrs)
 		})
 	}
 }
@@ -622,7 +621,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				IsResourceRequest: true,
 				Verb:              "update",
 			})
-			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, registry.Strategy, tc.expectedErrs, apitesting.WithMinEmulationVersion(version.MustParse("1.36")))
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, registry.Strategy, tc.expectedErrs)
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature 

#### What this PR does / why we need it:
Removes the per-strategy `DeclarativeEnforcement` opt-in field on `DeclarativeValidationConfig`. Declarative validation now runs unconditionally for every strategy embedding `rest.DeclarativeValidation`. Per-tag enforcement remains controlled by the lifecycle prefix (`+k8s:alpha`, `+k8s:beta`, none) and the `DeclarativeValidationBeta` feature gate.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
