### PR TITLE
Fix readiness probe exiting too early during pod eviction

### DIFF
--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -227,9 +227,21 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 
 	// Worker should terminate if pod is terminated.
 	if status.Phase == v1.PodFailed || status.Phase == v1.PodSucceeded {
-		logger.V(3).Info("Pod is terminated, exiting probe worker",
-			"pod", klog.KObj(w.pod), "phase", status.Phase)
-		return false
+		// For readiness probes, keep probing until the published result is
+		// already Failure so the pod can transition to NotReady before being
+		// removed. During eviction the phase is set to PodFailed before
+		// containers are stopped, causing the probe worker to exit before it
+		// can detect the container becoming unready.
+		readinessResult, _ := w.resultsManager.Get(w.containerID)
+		if w.probeType == readiness && !w.containerID.IsEmpty() &&
+			readinessResult != results.Failure {
+			logger.V(3).Info("Pod is terminating but readiness probe has not failed yet, continuing to probe",
+				"pod", klog.KObj(w.pod), "phase", status.Phase)
+		} else {
+			logger.V(3).Info("Pod is terminated, exiting probe worker",
+				"pod", klog.KObj(w.pod), "phase", status.Phase)
+			return false
+		}
 	}
 
 	c, ok := podutil.GetContainerStatus(status.ContainerStatuses, w.container.Name)

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -854,6 +854,67 @@ func TestDoProbe_TerminatedContainerWithRestartPolicyNever(t *testing.T) {
 	expectResult(t, w, results.Failure, "regular container with pod restart policy Never")
 }
 
+func TestReadinessProbeContinuesDuringPodFailedPhase(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	m := newTestManager()
+	w := newTestWorker(m, readiness, v1.Probe{SuccessThreshold: 1, FailureThreshold: 1})
+
+	// Pod is running and readiness probe succeeds.
+	runningStatus := getTestRunningStatus()
+	m.statusManager.SetPodStatus(logger, w.pod, runningStatus)
+	m.prober.exec = fakeExecProber{probe.Success, nil}
+	expectContinue(t, w, w.doProbe(ctx), "initial success")
+	expectResult(t, w, results.Success, "initial success")
+
+	// Eviction sets phase to PodFailed while containers are still running.
+	// The readiness probe worker should keep probing.
+	evictedStatus := getTestRunningStatus()
+	evictedStatus.Phase = v1.PodFailed
+	m.statusManager.SetPodStatus(logger, w.pod, evictedStatus)
+
+	m.prober.exec = fakeExecProber{probe.Success, nil}
+	expectContinue(t, w, w.doProbe(ctx), "PodFailed but probe still succeeding")
+	expectResult(t, w, results.Success, "PodFailed but probe still succeeding")
+
+	// Container handles SIGTERM and becomes unready; probe now fails.
+	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	expectContinue(t, w, w.doProbe(ctx), "PodFailed and probe failing")
+	expectResult(t, w, results.Failure, "PodFailed and probe failing")
+
+	// Once the published result is Failure, the worker should exit.
+	if w.doProbe(ctx) {
+		t.Error("Expected probe worker to exit after readiness result became Failure in PodFailed phase")
+	}
+}
+
+func TestReadinessProbeExitsWhenContainerStopsDuringEviction(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	m := newTestManager()
+	w := newTestWorker(m, readiness, v1.Probe{SuccessThreshold: 1, FailureThreshold: 1})
+
+	runningStatus := getTestRunningStatus()
+	m.statusManager.SetPodStatus(logger, w.pod, runningStatus)
+	m.prober.exec = fakeExecProber{probe.Success, nil}
+	expectContinue(t, w, w.doProbe(ctx), "initial success")
+	expectResult(t, w, results.Success, "initial success")
+
+	// Eviction: phase is PodFailed and container has stopped running.
+	stoppedStatus := getTestRunningStatus()
+	stoppedStatus.Phase = v1.PodFailed
+	stoppedStatus.ContainerStatuses[0].State.Running = nil
+	stoppedStatus.ContainerStatuses[0].State.Terminated = &v1.ContainerStateTerminated{}
+	m.statusManager.SetPodStatus(logger, w.pod, stoppedStatus)
+
+	// First probe after container stops sets result to Failure (line 309).
+	w.doProbe(ctx)
+	expectResult(t, w, results.Failure, "container stopped during eviction")
+
+	// Next cycle: PodFailed + result is Failure => worker exits.
+	if w.doProbe(ctx) {
+		t.Error("Expected probe worker to exit after container stopped in PodFailed phase")
+	}
+}
+
 func TestLivenessProbeDisabledByStarted(t *testing.T) {
 	logger, ctx := ktesting.NewTestContext(t)
 	m := newTestManager()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/sig node
/kind bug

#### What this PR does / why we need it:

During pod eviction, the eviction manager sets phase to PodFailed before containers are stopped. The probe worker sees PodFailed and quits, so readiness probes never detect the container going unhealthy. The pod jumps from Ready to Error without NotReady, and traffic keeps routing to a dying pod.

Readiness probes continue running during PodFailed/PodSucceeded until the published result becomes Failure. Liveness/startup probes still exit immediately.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #124648 

#### Special notes for your reviewer:
For Readiness probes only, liveness and startup probes are unaffected.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed readiness probes stopping too early during pod eviction, causing pods to skip NotReady and receive traffic while terminating.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```
