### PR TITLE
Restore ability to plumb binary data through envvar values

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -478,7 +478,7 @@ type Image struct {
 // EnvVar represents the environment variable.
 type EnvVar struct {
 	Name  string
-	Value string
+	Value string // TODO: switch to []byte
 }
 
 // Annotation represents an annotation.

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -782,7 +782,7 @@ func (kl *Kubelet) makeEnvironmentVariables(ctx context.Context, pod *v1.Pod, co
 	var (
 		configMaps = make(map[string]*v1.ConfigMap)
 		secrets    = make(map[string]*v1.Secret)
-		tmpEnv     = make(map[string]string)
+		tmpEnv     = make(map[string]string) // TODO: switch to map[string][]byte
 	)
 
 	// Env will override EnvFrom variables.
@@ -814,6 +814,7 @@ func (kl *Kubelet) makeEnvironmentVariables(ctx context.Context, pod *v1.Pod, co
 					k = envFrom.Prefix + k
 				}
 
+				// TODO: validate no NUL bytes
 				tmpEnv[k] = v
 			}
 		case envFrom.SecretRef != nil:
@@ -841,6 +842,7 @@ func (kl *Kubelet) makeEnvironmentVariables(ctx context.Context, pod *v1.Pod, co
 					k = envFrom.Prefix + k
 				}
 
+				// TODO: validate no NUL bytes
 				tmpEnv[k] = string(v)
 			}
 		}
@@ -934,6 +936,7 @@ func (kl *Kubelet) makeEnvironmentVariables(ctx context.Context, pod *v1.Pod, co
 					}
 					return result, fmt.Errorf("couldn't find key %v in Secret %v/%v", key, pod.Namespace, name)
 				}
+				// TODO: validate no NUL bytes
 				runtimeVal = string(runtimeValBytes)
 			case utilfeature.DefaultFeatureGate.Enabled(features.EnvFiles) && envVar.ValueFrom.FileKeyRef != nil:
 				f := envVar.ValueFrom.FileKeyRef

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	codes "google.golang.org/grpc/codes"
+
 	crierror "k8s.io/cri-api/pkg/errors"
 
 	"github.com/opencontainers/selinux/go-selinux"
@@ -398,7 +399,7 @@ func (m *kubeGenericRuntimeManager) generateContainerConfig(ctx context.Context,
 		e := opts.Envs[idx]
 		envs[idx] = &runtimeapi.KeyValue{
 			Key:   e.Name,
-			Value: e.Value,
+			Value: []byte(e.Value),
 		}
 	}
 	config.Envs = envs

--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.pb.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.pb.go
@@ -4268,7 +4268,7 @@ func (x *ImageSpec) GetImageRef() string {
 type KeyValue struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Key           string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
-	Value         string                 `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	Value         []byte                 `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4310,11 +4310,11 @@ func (x *KeyValue) GetKey() string {
 	return ""
 }
 
-func (x *KeyValue) GetValue() string {
+func (x *KeyValue) GetValue() []byte {
 	if x != nil {
 		return x.Value
 	}
-	return ""
+	return nil
 }
 
 // LinuxContainerResources specifies Linux specific configuration for
@@ -11823,7 +11823,7 @@ const file_staging_src_k8s_io_cri_api_pkg_apis_runtime_v1_api_proto_rawDesc = ""
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"2\n" +
 	"\bKeyValue\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value\"\x95\x04\n" +
+	"\x05value\x18\x02 \x01(\fR\x05value\"\x95\x04\n" +
 	"\x17LinuxContainerResources\x12\x1d\n" +
 	"\n" +
 	"cpu_period\x18\x01 \x01(\x03R\tcpuPeriod\x12\x1b\n" +

--- a/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.proto
+++ b/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1/api.proto
@@ -951,7 +951,7 @@ message ImageSpec {
 
 message KeyValue {
     string key = 1;
-    string value = 2;
+    bytes value = 2;
 }
 
 // LinuxContainerResources specifies Linux specific configuration for


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

Restores pre-1.34 ability to use Secret API objects with binary data as container env values

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/139132

#### Special notes for your reviewer:

This changes the cri-api value field from `string` to `bytes`. This encodes identically on the wire, but removes the requirement that the value be valid utf-8. That requirement was not enforced in practice prior to 1.34, due to the use of gogo protobuf to encode on the kubelet side and decode on the container runtime side.

This does not yet ripple out type changes in kubelet packages to make this field a []byte, since we likely will backport this to 1.34+.

A follow-up should make the value fields `[]byte` to clarify non-utf8 data is possible.

#### Does this PR introduce a user-facing change?
```release-note
Fixes a 1.34+ regression handling containers with environment values set from Secret API objects containing binary non-utf8 data.
```

/hold for discussion
/sig node architecture
cc @kubernetes/sig-node-api-reviews @kubernetes/api-reviewers 