### PR TITLE
Replace ioutil in auth tests

### DIFF
--- a/pkg/auth/authorizer/abac/abac_test.go
+++ b/pkg/auth/authorizer/abac/abac_test.go
@@ -18,7 +18,6 @@ package abac
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -818,14 +817,14 @@ func TestSubjectMatches(t *testing.T) {
 }
 
 func newWithContents(t *testing.T, contents string) (PolicyList, error) {
-	f, err := ioutil.TempFile("", "abac_test")
+	f, err := os.CreateTemp("", "abac_test")
 	if err != nil {
 		t.Fatalf("unexpected error creating policyfile: %v", err)
 	}
 	f.Close()
 	defer os.Remove(f.Name())
 
-	if err := ioutil.WriteFile(f.Name(), []byte(contents), 0700); err != nil {
+	if err := os.WriteFile(f.Name(), []byte(contents), 0700); err != nil {
 		t.Fatalf("unexpected error writing policyfile: %v", err)
 	}
 

--- a/pkg/controller/certificates/signer/signer_test.go
+++ b/pkg/controller/certificates/signer/signer_test.go
@@ -24,8 +24,8 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -88,7 +88,7 @@ func TestSigner(t *testing.T) {
 		t.Fatalf("failed to create signer: %v", err)
 	}
 
-	csrb, err := ioutil.ReadFile("./testdata/kubelet.csr")
+	csrb, err := os.ReadFile("./testdata/kubelet.csr")
 	if err != nil {
 		t.Fatalf("failed to read CSR: %v", err)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Replaces deprecated `io/ioutil` usage in SIG Auth-related tests with the corresponding `os` package APIs.

This is a mechanical test-only cleanup:

- `pkg/controller/certificates/signer/signer_test.go`: `ioutil.ReadFile` -> `os.ReadFile`
- `pkg/auth/authorizer/abac/abac_test.go`: remove remaining `io/ioutil` usage by using `os.CreateTemp` and `os.WriteFile`

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Test-only cleanup. No production code behavior changes.

Validation:

- `gofmt -w pkg/auth/authorizer/abac/abac_test.go pkg/controller/certificates/signer/signer_test.go`
- `GOCACHE=/private/tmp/go-build-cache go test ./pkg/auth/authorizer/abac`
- `GOCACHE=/private/tmp/go-build-cache go test ./pkg/controller/certificates/signer`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```
