### PR TITLE
[Test][DRA] Fix flaky test by assigning initial ResourceVersion "1"

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller_test.go
@@ -131,7 +131,7 @@ func TestControllerSyncPool(t *testing.T) {
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
-					ResourceVersion("0").
+					ResourceVersion("1").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
@@ -610,7 +610,7 @@ func TestControllerSyncPool(t *testing.T) {
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
-					ResourceVersion("0").
+					ResourceVersion("1").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 3, ResourceSliceCount: 1}).Obj(),
@@ -796,7 +796,7 @@ func TestControllerSyncPool(t *testing.T) {
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName3)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 4}).Obj(),
 				*MakeResourceSlice().Name(generateName4+"0").GenerateName(generateName4).
-					ResourceVersion("0").
+					ResourceVersion("1").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName4)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 4}).Obj(),
@@ -819,7 +819,7 @@ func TestControllerSyncPool(t *testing.T) {
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(encodeIndex(0, resourceSliceIndexMinLength) + "-" + driverName + "-0").
 					GenerateName(encodeIndex(0, resourceSliceIndexMinLength) + "-" + driverName + "-").
-					ResourceVersion("0").
+					ResourceVersion("1").
 					AllNodes(true).
 					NodeName("").
 					NodeSelector(nil).
@@ -843,7 +843,7 @@ func TestControllerSyncPool(t *testing.T) {
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(generateName1 + "0").GenerateName(generateName1).
-					ResourceVersion("0").
+					ResourceVersion("1").
 					AppOwnerReferences(ownerName).NodeSelector(nodeSelector).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).Obj(),
@@ -864,7 +864,7 @@ func TestControllerSyncPool(t *testing.T) {
 			expectedStats: Stats{NumCreates: 1},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
-					ResourceVersion("0").
+					ResourceVersion("1").
 					NodeOwnerReferences(ownerName, string(nodeUID)).
 					AllNodes(true).
 					NodeName("").
@@ -889,7 +889,7 @@ func TestControllerSyncPool(t *testing.T) {
 			expectedStats: Stats{NumCreates: 1},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
-					ResourceVersion("0").
+					ResourceVersion("1").
 					NodeOwnerReferences(ownerName, string(nodeUID)).
 					NodeSelector(nodeSelector).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName)}).
@@ -910,7 +910,7 @@ func TestControllerSyncPool(t *testing.T) {
 			expectedStats: Stats{NumCreates: 1},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
-					ResourceVersion("0").
+					ResourceVersion("1").
 					NodeOwnerReferences(ownerName, string(nodeUID)).
 					PerDeviceNodeSelection(true).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName, nodeSelector)}).
@@ -981,7 +981,7 @@ func TestControllerSyncPool(t *testing.T) {
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
-					ResourceVersion("0").
+					ResourceVersion("1").
 					AppOwnerReferences(ownerName).
 					AllNodes(false).
 					NodeName("").
@@ -997,7 +997,7 @@ func TestControllerSyncPool(t *testing.T) {
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 2}).
 					Obj(),
 				*MakeResourceSlice().Name(resourceSlice2).GenerateName(generateName2).
-					ResourceVersion("0").
+					ResourceVersion("1").
 					AppOwnerReferences(ownerName).
 					AllNodes(false).
 					NodeName("").
@@ -1060,7 +1060,7 @@ func TestControllerSyncPool(t *testing.T) {
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
-					ResourceVersion("0").
+					ResourceVersion("1").
 					AppOwnerReferences(ownerName).
 					AllNodes(false).
 					NodeName("").
@@ -1070,7 +1070,7 @@ func TestControllerSyncPool(t *testing.T) {
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 2}).
 					Obj(),
 				*MakeResourceSlice().Name(resourceSlice2).GenerateName(generateName2).
-					ResourceVersion("0").
+					ResourceVersion("1").
 					AppOwnerReferences(ownerName).
 					AllNodes(false).
 					NodeName("").
@@ -1109,7 +1109,7 @@ func TestControllerSyncPool(t *testing.T) {
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
-					ResourceVersion("0").
+					ResourceVersion("1").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).
 					Devices(func() []resourceapi.Device {
@@ -1147,7 +1147,7 @@ func TestControllerSyncPool(t *testing.T) {
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
-					ResourceVersion("0").
+					ResourceVersion("1").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).
 					Devices([]resourceapi.Device{newDevice(deviceName)}).
@@ -1322,17 +1322,17 @@ func TestControllerSyncPool(t *testing.T) {
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
-					ResourceVersion("0").
+					ResourceVersion("1").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName1)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 3}).Obj(),
 				*MakeResourceSlice().Name(resourceSlice2).GenerateName(generateName2).
-					ResourceVersion("0").
+					ResourceVersion("1").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName2)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 3}).Obj(),
 				*MakeResourceSlice().Name(resourceSlice3).GenerateName(generateName3).
-					ResourceVersion("0").
+					ResourceVersion("1").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName3)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 3}).Obj(),
@@ -1372,7 +1372,7 @@ func TestControllerSyncPool(t *testing.T) {
 			},
 			expectedResourceSlices: []resourceapi.ResourceSlice{
 				*MakeResourceSlice().Name(generateName1+"0").GenerateName(generateName1).
-					ResourceVersion("0").
+					ResourceVersion("1").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName1)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 3}).Obj(),
@@ -1381,7 +1381,7 @@ func TestControllerSyncPool(t *testing.T) {
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName2)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 3}).Obj(),
 				*MakeResourceSlice().Name(generateName3+"1").GenerateName(generateName3).
-					ResourceVersion("0").
+					ResourceVersion("1").
 					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
 					Driver(driverName).Devices([]resourceapi.Device{newDevice(deviceName3)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 2, ResourceSliceCount: 3}).Obj(),
@@ -1629,8 +1629,9 @@ func createResourceSliceCreateReactor(features features, timeAdded metav1.Time) 
 		mutex.Lock()
 		defer mutex.Unlock()
 		resourceslice := action.(k8stesting.CreateAction).GetObject().(*resourceapi.ResourceSlice)
-		// Assign initial ResourceVersion "0" to newly created slices.
-		resourceslice.ResourceVersion = "0"
+		// Assign initial ResourceVersion "1" to newly created slices.
+		// Avoid using "0" because "0" and "" are treated the same by client-go's MutationCache.
+		resourceslice.ResourceVersion = "1"
 		if resourceslice.Name == "" && resourceslice.GenerateName != "" {
 			resourceslice.Name = fmt.Sprintf("%s%d", resourceslice.GenerateName, nameCounter)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In `client-go`'s `MutationCache`, both `ResourceVersion("")` (empty) and `ResourceVersion("0")` are parsed as 0. See https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go#L230-L240. Consequently, this makes https://github.com/kubernetes/kubernetes/pull/137911 ineffective at fixing the original flakiness described in https://github.com/kubernetes/kubernetes/pull/136641#issuecomment-4076468216.

Ran the tests 100 times and succeeded
```bash
make test WHAT=./staging/src/k8s.io/dynamic-resource-allocation/resourceslice \
  GOFLAGS="-v -run=TestControllerSyncPool/multiple-resourceslices-existing-with-different-resource-pool-generation -count=100"
```
#### Which issue(s) this PR is related to:
Fix flaky tests from https://github.com/kubernetes/kubernetes/pull/137911
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```