### PR TITLE
Lease controller: cancel in-flight sync from Stop to prevent shutdown…

### DIFF
--- a/staging/src/k8s.io/component-helpers/apimachinery/lease/controller.go
+++ b/staging/src/k8s.io/component-helpers/apimachinery/lease/controller.go
@@ -77,6 +77,12 @@ type controller struct {
 
 	reconcilingLock sync.Mutex
 	stopCalled      atomic.Bool
+
+	// cancelSyncLock protects cancelSync.
+	cancelSyncLock sync.Mutex
+	// cancelSync cancels the Run context so Stop can interrupt an in-flight sync
+	// before waiting on reconcilingLock.
+	cancelSync context.CancelFunc
 }
 
 // NewController constructs and returns a controller
@@ -116,7 +122,14 @@ func (c *controller) Start(stopCh <-chan struct{}) error {
 		klog.FromContext(ctx).Error(err, "error deleting old lease", "lease", klog.KRef(c.leaseNamespace, c.leaseName))
 	}
 
-	go c.Run(wait.ContextForChannel(stopCh))
+	runCtx, cancel := context.WithCancel(wait.ContextForChannel(stopCh))
+	c.cancelSyncLock.Lock()
+	c.cancelSync = cancel
+	if c.stopCalled.Load() {
+		cancel()
+	}
+	c.cancelSyncLock.Unlock()
+	go c.Run(runCtx)
 	return nil
 }
 
@@ -127,6 +140,11 @@ func (c *controller) Stop() {
 	}
 
 	c.stopCalled.Store(true)
+	c.cancelSyncLock.Lock()
+	if c.cancelSync != nil {
+		c.cancelSync()
+	}
+	c.cancelSyncLock.Unlock()
 	// Ensure that there will be no race condition with the sync.
 	c.reconcilingLock.Lock()
 	defer c.reconcilingLock.Unlock()


### PR DESCRIPTION
… deadlock

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind flake

#### What this PR does / why we need it:

Fixes a deadlock in the apiserver-identity-lease controller's shutdown sequence when sync is stuck on an API call blocked by a misbehaving admission webhook.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Flake issue: #138608 

#### Background

`TestBrokenWebhook` registers a fail-closed `ValidatingWebhookConfiguration` that points at a non-existent service, then restarts the apiserver. The webhook intercepts all mutating API operations, including the writes the apiserver-identity-lease controller makes against `coordination.k8s.io/leases`.

If the lease controller's *first* `Create` (issued during apiserver startup) races against the test installing the webhook **and loses**, `latestLease` stays nil. From that point on, every subsequent `sync` call enters `backoffEnsureLease`, which loops forever calling `Create` until either the call succeeds or its context cancels. With the broken webhook, the call never succeeds.

The deadlock chain at shutdown:

```
Stop() waits on reconcilingLock
  └─ sync holds reconcilingLock, stuck in backoffEnsureLease
       └─ backoffEnsureLease only exits on ctx.Done()
            └─ ctx is derived from RunPostStartHooks's ctx, which uses
               WithoutCancel of the parent — only cancels when
               notAcceptingNewRequestCh signals
                 └─ notAcceptingNewRequestCh signals only after
                    preShutdownHooksHasStoppedCh signals
                      └─ preShutdownHooksHasStoppedCh signals only after
                         RunPreShutdownHooks returns
                           └─ RunPreShutdownHooks waits for Stop() to return
                              └─ back to the top
```

`TestBrokenWebhook` times out at 10m as a result. See verified failing run [ci-kubernetes-integration-1-36/2056150753738756096](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-integration-1-36/2056150753738756096): `controller.go:201 "Failed to ensure lease exists, will retry"` log lines continue every 7s from `23:14:47` (Restarting apiserver) through the test timeout, with no `"Cleaning up lease on exit"` ever appearing.

#### What this PR changes

Adds a `context.CancelFunc` field on the controller, wires it up in `Start()` via `context.WithCancel(wait.ContextForChannel(stopCh))`, and invokes it in `Stop()` before acquiring `reconcilingLock`. This gives `Stop()` a direct way to interrupt sync's in-flight API call so the lock is released promptly, without depending on caller-side cancellation.

The cancel function is protected by a mutex so `Start()` and `Stop()` can safely race during apiserver shutdown. If `Stop()` is called before `Start()` finishes wiring the cancel function, `Start()` cancels the run context immediately after installing it.

This same pattern is seen in `decorated_watcher.go`: https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/decorated_watcher.go#L33

#### Special notes for your reviewer:

Reviewers may want to spot-check that `Stop()`'s invariants are preserved: cleanup `Delete` still runs after `reconcilingLock` is acquired, sync's serialization is unchanged, and the `Stop`/`sync` race fix from #119083 still holds.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
