### PR TITLE
node: markPodsNotReady on false→unknown node transition

### DIFF
--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -765,7 +765,7 @@ func (nc *Controller) monitorNodeHealth(ctx context.Context) error {
 
 			_, needsRetry := nc.nodesToRetry.Load(node.Name)
 			switch {
-			case currentReadyCondition.Status != v1.ConditionTrue && observedReadyCondition.Status == v1.ConditionTrue:
+			case currentReadyCondition.Status != v1.ConditionTrue && observedReadyCondition.Status != currentReadyCondition.Status:
 				// Report node event only once when status changed.
 				controllerutil.RecordNodeStatusChange(logger, nc.recorder, node, "NodeNotReady")
 				fallthrough

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
@@ -2127,6 +2127,54 @@ func TestMonitorNodeHealthMarkPodsNotReady(t *testing.T) {
 			},
 			expectedPodStatusUpdate: true,
 		},
+		// Node was already NotReady (false) and now transitions to Unknown after
+		// the grace period expires (e.g., containerd crashes → node False, then
+		// kubelet also stops → node Unknown). Pods must be marked NotReady even
+		// though the prior state was not True.
+		// Regression test for https://github.com/kubernetes/kubernetes/issues/112733.
+		{
+			fakeNodeHandler: &testutil.FakeNodeHandler{
+				Existing: []*v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "node0",
+							CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+						},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{
+									Type:               v1.NodeReady,
+									Status:             v1.ConditionFalse,
+									LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+									LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+								},
+							},
+							Capacity: v1.ResourceList{
+								v1.ResourceName(v1.ResourceCPU):    resource.MustParse("10"),
+								v1.ResourceName(v1.ResourceMemory): resource.MustParse("10G"),
+							},
+						},
+					},
+				},
+				Clientset: fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*testutil.NewPod("pod0", "node0")}}),
+			},
+			timeToPass: 1 * time.Minute,
+			newNodeStatus: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{
+						Type:               v1.NodeReady,
+						Status:             v1.ConditionFalse,
+						LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+					},
+				},
+				Capacity: v1.ResourceList{
+					v1.ResourceName(v1.ResourceCPU):    resource.MustParse("10"),
+					v1.ResourceName(v1.ResourceMemory): resource.MustParse("10G"),
+				},
+			},
+			expectedPodStatusUpdate: true,
+		},
 	}
 
 	tCtx := ktesting.Init(t)


### PR DESCRIPTION
> This PR was written in part with the assistance of generative AI

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

When a node transitions from `Ready=False` to `Ready=Unknown` (e.g., containerd crashes making the node `False`, then kubelet also stops and the grace period expires making it `Unknown`), `MarkPodsNotReady` was not called. The `switch` in `monitorNodeHealth` only fired when `observedReadyCondition.Status == ConditionTrue`, missing the `False→Unknown` transition entirely.

This means pods on such nodes remained `Ready` despite the node being unreachable, causing traffic to continue being forwarded to a broken node.

The fix changes the trigger condition from "was previously `True`" to "the status has actually changed to a non-True value" (`observedReady != currentReady`), covering all transitions: `True→False`, `True→Unknown`, and the previously missed `False→Unknown`.

#### Which issue(s) this PR is related to:

Fixes #112733

#### Special notes for your reviewer:

- The production change is a single condition on line 768 of `node_lifecycle_controller.go` — `observedReadyCondition.Status == v1.ConditionTrue` becomes `observedReadyCondition.Status != currentReadyCondition.Status`.
- PR #137527 covers the same one-line fix; opening a fresh PR since it has had no reviews or `ok-to-test` for ~2 months.
- A new unit test case is added to `TestMonitorNodeHealthMarkPodsNotReady` covering the `False→Unknown` scenario (`expectedPodStatusUpdate: true`).

#### Does this PR introduce a user-facing change?

```release-note
Fix: node lifecycle controller now calls MarkPodsNotReady when a node transitions from NotReady (false) to Unreachable (unknown), preventing pods from incorrectly remaining Ready when kubelet stops after a prior node failure.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```