### PR TITLE
e2e_node: avoid polluting e2e_node command line with helper packages

### DIFF
--- a/test/e2e_node/builder/build.go
+++ b/test/e2e_node/builder/build.go
@@ -17,7 +17,6 @@ limitations under the License.
 package builder
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"os/exec"
@@ -28,9 +27,9 @@ import (
 	"k8s.io/kubernetes/test/utils"
 )
 
-var k8sBinDir = flag.String("k8s-bin-dir", "", "Directory containing k8s kubelet binaries.")
-var useDockerizedBuild = flag.Bool("use-dockerized-build", false, "Use dockerized build for test artifacts")
-var targetBuildArch = flag.String("target-build-arch", "linux/amd64", "Target architecture for the test artifacts for dockerized build")
+var k8sBinDir = CommandLine.String("k8s-bin-dir", "", "Directory containing k8s kubelet binaries.")
+var useDockerizedBuild = CommandLine.Bool("use-dockerized-build", false, "Use dockerized build for test artifacts")
+var targetBuildArch = CommandLine.String("target-build-arch", "linux/amd64", "Target architecture for the test artifacts for dockerized build")
 
 var buildCGOTargets = []string{
 	"cmd/kubelet",

--- a/test/e2e_node/builder/commandline.go
+++ b/test/e2e_node/builder/commandline.go
@@ -1,0 +1,26 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	"flag"
+)
+
+// CommandLine is where this package adds its command line flags.
+// A command using it should call Init to choose name and error handling
+// or copy the flags.
+var CommandLine = &flag.FlagSet{}

--- a/test/e2e_node/remote/commandline.go
+++ b/test/e2e_node/remote/commandline.go
@@ -1,0 +1,26 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"flag"
+)
+
+// CommandLine is where this package adds its command line flags.
+// A command using it should call Init to choose name and error handling
+// or copy the flags.
+var CommandLine = &flag.FlagSet{}

--- a/test/e2e_node/remote/gce/gce_runner.go
+++ b/test/e2e_node/remote/gce/gce_runner.go
@@ -20,7 +20,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -69,17 +68,17 @@ func (e *envs) Set(value string) error {
 // nodeEnvs is the node envs from the flag `node-env`.
 var nodeEnvs = make(envs)
 
-var project = flag.String("project", "", "gce project the hosts live in (gce)")
-var zone = flag.String("zone", "", "gce zone that the hosts live in (gce)")
-var instanceMetadata = flag.String("instance-metadata", "", "key/value metadata for instances separated by '=' or '<', 'k=v' means the key is 'k' and the value is 'v'; 'k<p' means the key is 'k' and the value is extracted from the local path 'p', e.g. k1=v1,k2<p2  (gce)")
-var imageProject = flag.String("image-project", "", "gce project the hosts live in  (gce)")
-var instanceType = flag.String("instance-type", "e2-medium", "GCP Machine type to use for test")
-var preemptibleInstances = flag.Bool("preemptible-instances", false, "If true, gce instances will be configured to be preemptible  (gce)")
-var network = flag.String("network", "", "Specifies the network that the VM instance are a part of")
-var subnet = flag.String("subnet", "", "Specifies the subnet that the VM instance are a part of")
+var project = remote.CommandLine.String("project", "", "gce project the hosts live in (gce)")
+var zone = remote.CommandLine.String("zone", "", "gce zone that the hosts live in (gce)")
+var instanceMetadata = remote.CommandLine.String("instance-metadata", "", "key/value metadata for instances separated by '=' or '<', 'k=v' means the key is 'k' and the value is 'v'; 'k<p' means the key is 'k' and the value is extracted from the local path 'p', e.g. k1=v1,k2<p2  (gce)")
+var imageProject = remote.CommandLine.String("image-project", "", "gce project the hosts live in  (gce)")
+var instanceType = remote.CommandLine.String("instance-type", "e2-medium", "GCP Machine type to use for test")
+var preemptibleInstances = remote.CommandLine.Bool("preemptible-instances", false, "If true, gce instances will be configured to be preemptible  (gce)")
+var network = remote.CommandLine.String("network", "", "Specifies the network that the VM instance are a part of")
+var subnet = remote.CommandLine.String("subnet", "", "Specifies the subnet that the VM instance are a part of")
 
 func init() {
-	flag.Var(&nodeEnvs, "node-env", "An environment variable passed to instance as metadata, e.g. when '--node-env=PATH=/usr/bin' is specified, there will be an extra instance metadata 'PATH=/usr/bin'.")
+	remote.CommandLine.Var(&nodeEnvs, "node-env", "An environment variable passed to instance as metadata, e.g. when '--node-env=PATH=/usr/bin' is specified, there will be an extra instance metadata 'PATH=/usr/bin'.")
 }
 
 type GCERunner struct {

--- a/test/e2e_node/remote/remote.go
+++ b/test/e2e_node/remote/remote.go
@@ -17,7 +17,6 @@ limitations under the License.
 package remote
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -31,8 +30,8 @@ import (
 	"k8s.io/klog/v2"
 )
 
-var testTimeout = flag.Duration("test-timeout", 45*time.Minute, "How long (in golang duration format) to wait for ginkgo tests to complete.")
-var resultsDir = flag.String("results-dir", "/tmp/", "Directory to scp test results to.")
+var testTimeout = CommandLine.Duration("test-timeout", 45*time.Minute, "How long (in golang duration format) to wait for ginkgo tests to complete.")
+var resultsDir = CommandLine.String("results-dir", "/tmp/", "Directory to scp test results to.")
 
 const archiveName = "e2e_node_test.tar.gz"
 

--- a/test/e2e_node/remote/run_remote_suite.go
+++ b/test/e2e_node/remote/run_remote_suite.go
@@ -17,7 +17,6 @@ limitations under the License.
 package remote
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -29,18 +28,18 @@ import (
 	"k8s.io/klog/v2"
 )
 
-var mode = flag.String("mode", "gce", "Mode to operate in. One of gce|ssh. Defaults to gce")
-var testArgs = flag.String("test_args", "", "Space-separated list of arguments to pass to Ginkgo test runner.")
-var instanceNamePrefix = flag.String("instance-name-prefix", "", "prefix for instance names")
-var imageConfigFile = flag.String("image-config-file", "", "yaml file describing images to run")
-var imageConfigDir = flag.String("image-config-dir", "", "(optional) path to image config files")
-var images = flag.String("images", "", "images to test")
-var hosts = flag.String("hosts", "", "hosts to test")
-var cleanup = flag.Bool("cleanup", true, "If true remove files from remote hosts and delete temporary instances")
-var deleteInstances = flag.Bool("delete-instances", true, "If true, delete any instances created")
-var buildOnly = flag.Bool("build-only", false, "If true, build e2e_node_test.tar.gz and exit.")
-var gubernator = flag.Bool("gubernator", false, "If true, output Gubernator link to view logs")
-var ginkgoFlags = flag.String("ginkgo-flags", "", "Passed to ginkgo to specify additional flags such as --skip=.")
+var mode = CommandLine.String("mode", "gce", "Mode to operate in. One of gce|ssh. Defaults to gce")
+var testArgs = CommandLine.String("test_args", "", "Space-separated list of arguments to pass to Ginkgo test runner.")
+var instanceNamePrefix = CommandLine.String("instance-name-prefix", "", "prefix for instance names")
+var imageConfigFile = CommandLine.String("image-config-file", "", "yaml file describing images to run")
+var imageConfigDir = CommandLine.String("image-config-dir", "", "(optional) path to image config files")
+var images = CommandLine.String("images", "", "images to test")
+var hosts = CommandLine.String("hosts", "", "hosts to test")
+var cleanup = CommandLine.Bool("cleanup", true, "If true remove files from remote hosts and delete temporary instances")
+var deleteInstances = CommandLine.Bool("delete-instances", true, "If true, delete any instances created")
+var buildOnly = CommandLine.Bool("build-only", false, "If true, build e2e_node_test.tar.gz and exit.")
+var gubernator = CommandLine.Bool("gubernator", false, "If true, output Gubernator link to view logs")
+var ginkgoFlags = CommandLine.String("ginkgo-flags", "", "Passed to ginkgo to specify additional flags such as --skip=.")
 var (
 	arc Archive
 )
@@ -53,7 +52,7 @@ type Archive struct {
 }
 
 func getFlag(name string) string {
-	lookup := flag.Lookup(name)
+	lookup := CommandLine.Lookup(name)
 	if lookup == nil {
 		return ""
 	}

--- a/test/e2e_node/remote/ssh.go
+++ b/test/e2e_node/remote/ssh.go
@@ -17,7 +17,6 @@ limitations under the License.
 package remote
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"os/exec"
@@ -28,10 +27,10 @@ import (
 	"k8s.io/klog/v2"
 )
 
-var sshOptions = flag.String("ssh-options", "", "Commandline options passed to ssh.")
-var sshEnv = flag.String("ssh-env", "", "Use predefined ssh options for environment.  Options: gce")
-var sshKey = flag.String("ssh-key", "", "Path to ssh private key.")
-var sshUser = flag.String("ssh-user", "", "Use predefined user for ssh.")
+var sshOptions = CommandLine.String("ssh-options", "", "Commandline options passed to ssh.")
+var sshEnv = CommandLine.String("ssh-env", "", "Use predefined ssh options for environment.  Options: gce")
+var sshKey = CommandLine.String("ssh-key", "", "Path to ssh private key.")
+var sshUser = CommandLine.String("ssh-user", "", "Use predefined user for ssh.")
 
 var sshOptionsMap map[string]string
 var sshDefaultKeyMap map[string]string

--- a/test/e2e_node/runner/local/run_local.go
+++ b/test/e2e_node/runner/local/run_local.go
@@ -42,6 +42,7 @@ var kubeletConfigFile = flag.String("kubelet-config-file", "", "The KubeletConfi
 var debugTool = flag.String("debug-tool", "", "'delve', 'dlv' or 'gdb': run e2e_node.test under that debugger")
 
 func main() {
+	copyFlags(builder.CommandLine, flag.CommandLine)
 	klog.InitFlags(nil)
 	flag.Parse()
 
@@ -101,6 +102,12 @@ func main() {
 		klog.Exitf("Test failed: %v", err)
 	}
 	return
+}
+
+func copyFlags(from, to *flag.FlagSet) {
+	from.VisitAll(func(f *flag.Flag) {
+		to.Var(f.Value, f.Name, f.Usage)
+	})
 }
 
 func addGinkgoArgPrefix(ginkgoFlags string) string {

--- a/test/e2e_node/runner/remote/run_remote.go
+++ b/test/e2e_node/runner/remote/run_remote.go
@@ -26,18 +26,23 @@ import (
 
 	"k8s.io/klog/v2"
 
+	"k8s.io/kubernetes/test/e2e_node/builder"
 	"k8s.io/kubernetes/test/e2e_node/remote"
 	_ "k8s.io/kubernetes/test/e2e_node/remote/gce"
 	"k8s.io/kubernetes/test/e2e_node/system"
 )
 
-var testSuite = flag.String("test-suite", "default", "Test suite the runner initializes with. Currently support default|cadvisor|conformance")
-var _ = flag.String("system-spec-name", "", fmt.Sprintf("The name of the system spec used for validating the image in the node conformance test. The specs are at %s. If unspecified, the default built-in spec (system.DefaultSpec) will be used.", system.SystemSpecPath))
-var _ = flag.String("extra-envs", "", "The extra environment variables needed for node e2e tests. Format: a list of key=value pairs, e.g., env1=val1,env2=val2")
-var _ = flag.String("runtime-config", "", "The runtime configuration for the API server on the node e2e tests.. Format: a list of key=value pairs, e.g., env1=val1,env2=val2")
-var _ = flag.String("kubelet-config-file", "", "The KubeletConfiguration file that should be applied to the kubelet")
+var testSuite = remote.CommandLine.String("test-suite", "default", "Test suite the runner initializes with. Currently support default|cadvisor|conformance")
+
+// Unused, preserved for backward compatibility? `kubetest2 noop -test=node` passes at least `-runtime-config`.
+var _ = remote.CommandLine.String("system-spec-name", "", fmt.Sprintf("The name of the system spec used for validating the image in the node conformance test. The specs are at %s. If unspecified, the default built-in spec (system.DefaultSpec) will be used.", system.SystemSpecPath))
+var _ = remote.CommandLine.String("extra-envs", "", "The extra environment variables needed for node e2e tests. Format: a list of key=value pairs, e.g., env1=val1,env2=val2")
+var _ = remote.CommandLine.String("runtime-config", "", "The runtime configuration for the API server on the node e2e tests.. Format: a list of key=value pairs, e.g., env1=val1,env2=val2")
+var _ = remote.CommandLine.String("kubelet-config-file", "", "The KubeletConfiguration file that should be applied to the kubelet")
 
 func main() {
+	copyFlags(remote.CommandLine, flag.CommandLine)
+	copyFlags(builder.CommandLine, flag.CommandLine)
 	klog.InitFlags(nil)
 	flag.Parse()
 
@@ -48,4 +53,10 @@ func main() {
 			remote.GetTestSuiteKeys())
 	}
 	remote.RunRemoteTestSuite(suite)
+}
+
+func copyFlags(from, to *flag.FlagSet) {
+	from.VisitAll(func(f *flag.Flag) {
+		to.Var(f.Value, f.Name, f.Usage)
+	})
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

e2e_node.test depends on test/e2e_node/builder and test/e2e_node/remote because test/e2e_node/services uses some small helper functions from those two packages. But e2e_node.test itself never builds any Go binaries, nor does it run remote testing - that functionality is provided by the separate test/e2e_node/runner commands!

Therefore these two packages should not put their command line flags into flag.CommandLine because then they show up in the command line of e2e_node test unnecessarily.

This change removes the following flags from the e2e_node.test command line:

    diff -r before/e2e_node after/e2e_node
    7,8d6
    <       --build-only                                                 If true, build e2e_node_test.tar.gz and exit.
    <       --cleanup                                                    If true remove files from remote hosts and delete temporary instances (default true)
    20d17
    <       --delete-instances                                           If true, delete any instances created (default true)
    42d38
    <       --ginkgo-flags string                                        Passed to ginkgo to specify additional flags such as --skip=.
    95d90
    <       --gubernator                                                 If true, output Gubernator link to view logs
    97d91
    <       --hosts string                                               hosts to test
    99,100d92
    <       --image-config-dir string                                    (optional) path to image config files
    <       --image-config-file string                                   yaml file describing images to run
    103d94
    <       --images string                                              images to test
    105,106d95
    <       --instance-name-prefix string                                prefix for instance names
    <       --k8s-bin-dir string                                         Directory containing k8s kubelet binaries.
    120d108
    <       --mode string                                                Mode to operate in. One of gce|ssh. Defaults to gce (default "gce")
    133d120
    <       --results-dir string                                         Directory to scp test results to. (default "/tmp/")
    142,145d128
    <       --ssh-env string                                             Use predefined ssh options for environment.  Options: gce
    <       --ssh-key string                                             Path to ssh private key.
    <       --ssh-options string                                         Commandline options passed to ssh.
    <       --ssh-user string                                            Use predefined user for ssh.
    160,161d142
    <       --target-build-arch string                                   Target architecture for the test artifacts for dockerized build (default "linux/amd64")
    <       --test-timeout duration                                      How long (in golang duration format) to wait for ginkgo tests to complete. (default 45m0s)
    196d176
    <       --test_args string                                           Space-separated list of arguments to pass to Ginkgo test runner.
    198d177
    <       --use-dockerized-build                                       Use dockerized build for test artifacts


#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This was found while working on https://github.com/kubernetes/kubernetes/pull/139129.

Here's evidence that these flags are indeed unusable:
```console
$ go test -v ./test/e2e_node -args --build-only
  W0520 12:05:19.743126   26286 test_context.go:505] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
...
Summarizing 1 Failure:
  [FAIL] [SynchronizedBeforeSuite] 
  /nvme/gopath/src/k8s.io/kubernetes/test/e2e_node/e2e_node_suite_test.go:236

Ran 0 of 1211 Specs in 0.094 seconds
FAIL! -- A BeforeSuite node failed so all tests were skipped.
--- FAIL: TestE2eNode (0.12s)
FAIL
FAIL	k8s.io/kubernetes/test/e2e_node	0.204s
FAIL
```


#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @bart0sh 