### PR TITLE
Decouple EvictionManager admit handler from EvictionManager

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -76,8 +76,8 @@ type managerImpl struct {
 	containerGC ContainerGC
 	// protects access to internal state
 	sync.RWMutex
-	// node conditions are the set of conditions present
-	nodeConditions []v1.NodeConditionType
+	// node conditions state shared with the admit handler
+	state *NodeConditionsState
 	// captures when a node condition was last observed based on a threshold being met
 	nodeConditionsLastObservedAt nodeConditionsObservedAt
 	// nodeRef is a reference to the node
@@ -111,46 +111,47 @@ type managerImpl struct {
 // ensure it implements the required interface
 var _ Manager = &managerImpl{}
 
-// NewManager returns a configured Manager and an associated admission handler to enforce eviction configuration.
-func NewManager(
-	summaryProvider stats.SummaryProvider,
-	config Config,
-	killPodFunc KillPodFunc,
-	imageGC ImageGC,
-	containerGC ContainerGC,
-	recorder record.EventRecorder,
-	nodeRef *v1.ObjectReference,
-	clock clock.WithTicker,
-	localStorageCapacityIsolation bool,
-) (Manager, lifecycle.PodAdmitHandler) {
-	manager := &managerImpl{
-		clock:                         clock,
-		killPodFunc:                   killPodFunc,
-		imageGC:                       imageGC,
-		containerGC:                   containerGC,
-		config:                        config,
-		recorder:                      recorder,
-		summaryProvider:               summaryProvider,
-		nodeRef:                       nodeRef,
-		nodeConditionsLastObservedAt:  nodeConditionsObservedAt{},
-		thresholdsFirstObservedAt:     thresholdsObservedAt{},
-		dedicatedImageFs:              nil,
-		splitContainerImageFs:         nil,
-		thresholdNotifiers:            []ThresholdNotifier{},
-		localStorageCapacityIsolation: localStorageCapacityIsolation,
-	}
-	return manager, manager
+// NodeConditionsState allows sharing the current node conditions between the
+// eviction manager and the admit handler.
+type NodeConditionsState struct {
+	sync.RWMutex
+	conditions []v1.NodeConditionType
+}
+
+func NewNodeConditionsState() *NodeConditionsState {
+	return &NodeConditionsState{}
+}
+
+func (s *NodeConditionsState) Get() []v1.NodeConditionType {
+	s.RLock()
+	defer s.RUnlock()
+	return s.conditions
+}
+
+func (s *NodeConditionsState) Set(conditions []v1.NodeConditionType) {
+	s.Lock()
+	defer s.Unlock()
+	s.conditions = conditions
+}
+
+// AdmitHandler evaluates if pods can be admitted based on current node conditions.
+type AdmitHandler struct {
+	state *NodeConditionsState
+}
+
+// NewAdmitHandler returns a standalone PodAdmitHandler that uses NodeConditionsState.
+func NewAdmitHandler(state *NodeConditionsState) lifecycle.PodAdmitHandler {
+	return &AdmitHandler{state: state}
 }
 
 // Admit rejects a pod if its not safe to admit for node stability.
-func (m *managerImpl) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult {
-	m.RLock()
-	defer m.RUnlock()
+func (h *AdmitHandler) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult {
+	conditions := h.state.Get()
 
 	ctx := context.Background()
 	logger := klog.FromContext(ctx)
 
-	if len(m.nodeConditions) == 0 {
+	if len(conditions) == 0 {
 		return lifecycle.PodAdmitResult{Admit: true}
 	}
 	// Admit Critical pods even under resource pressure since they are required for system stability.
@@ -160,7 +161,7 @@ func (m *managerImpl) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAd
 	}
 
 	// Conditions other than memory pressure reject all pods
-	nodeOnlyHasMemoryPressureCondition := hasNodeCondition(m.nodeConditions, v1.NodeMemoryPressure) && len(m.nodeConditions) == 1
+	nodeOnlyHasMemoryPressureCondition := hasNodeCondition(conditions, v1.NodeMemoryPressure) && len(conditions) == 1
 	if nodeOnlyHasMemoryPressureCondition {
 		notBestEffort := v1.PodQOSBestEffort != v1qos.GetPodQOS(attrs.Pod)
 		if notBestEffort {
@@ -180,8 +181,41 @@ func (m *managerImpl) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAd
 	return lifecycle.PodAdmitResult{
 		Admit:   false,
 		Reason:  Reason,
-		Message: fmt.Sprintf(nodeConditionMessageFmt, m.nodeConditions),
+		Message: fmt.Sprintf(nodeConditionMessageFmt, conditions),
 	}
+}
+
+// NewManager returns a configured Manager and an associated admission handler to enforce eviction configuration.
+func NewManager(
+	summaryProvider stats.SummaryProvider,
+	config Config,
+	killPodFunc KillPodFunc,
+	imageGC ImageGC,
+	containerGC ContainerGC,
+	recorder record.EventRecorder,
+	nodeRef *v1.ObjectReference,
+	clock clock.WithTicker,
+	localStorageCapacityIsolation bool,
+	state *NodeConditionsState,
+) Manager {
+	manager := &managerImpl{
+		clock:                         clock,
+		killPodFunc:                   killPodFunc,
+		imageGC:                       imageGC,
+		containerGC:                   containerGC,
+		config:                        config,
+		recorder:                      recorder,
+		summaryProvider:               summaryProvider,
+		nodeRef:                       nodeRef,
+		nodeConditionsLastObservedAt:  nodeConditionsObservedAt{},
+		thresholdsFirstObservedAt:     thresholdsObservedAt{},
+		dedicatedImageFs:              nil,
+		splitContainerImageFs:         nil,
+		thresholdNotifiers:            []ThresholdNotifier{},
+		localStorageCapacityIsolation: localStorageCapacityIsolation,
+		state:                         state,
+	}
+	return manager
 }
 
 // Start starts the control loop to observe and response to low compute resources.
@@ -224,23 +258,17 @@ func (m *managerImpl) Start(ctx context.Context, diskInfoProvider DiskInfoProvid
 
 // IsUnderMemoryPressure returns true if the node is under memory pressure.
 func (m *managerImpl) IsUnderMemoryPressure() bool {
-	m.RLock()
-	defer m.RUnlock()
-	return hasNodeCondition(m.nodeConditions, v1.NodeMemoryPressure)
+	return hasNodeCondition(m.state.Get(), v1.NodeMemoryPressure)
 }
 
 // IsUnderDiskPressure returns true if the node is under disk pressure.
 func (m *managerImpl) IsUnderDiskPressure() bool {
-	m.RLock()
-	defer m.RUnlock()
-	return hasNodeCondition(m.nodeConditions, v1.NodeDiskPressure)
+	return hasNodeCondition(m.state.Get(), v1.NodeDiskPressure)
 }
 
 // IsUnderPIDPressure returns true if the node is under PID pressure.
 func (m *managerImpl) IsUnderPIDPressure() bool {
-	m.RLock()
-	defer m.RUnlock()
-	return hasNodeCondition(m.nodeConditions, v1.NodePIDPressure)
+	return hasNodeCondition(m.state.Get(), v1.NodePIDPressure)
 }
 
 // synchronize is the main control loop that enforces eviction thresholds.
@@ -347,7 +375,7 @@ func (m *managerImpl) synchronize(ctx context.Context, diskInfoProvider DiskInfo
 
 	// update internal state
 	m.Lock()
-	m.nodeConditions = nodeConditions
+	m.state.Set(nodeConditions)
 	m.thresholdsFirstObservedAt = thresholdsFirstObservedAt
 	m.nodeConditionsLastObservedAt = nodeConditionsLastObservedAt
 	m.thresholdsMet = thresholds

--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -318,6 +318,7 @@ func TestMemoryPressure_VerifyPodStatus(t *testing.T) {
 		},
 	}
 	summaryProvider := &fakeSummaryProvider{result: summaryStatsMaker("1500Mi", podStats)}
+	state := NewNodeConditionsState()
 	manager := &managerImpl{
 		clock:                        fakeClock,
 		killPodFunc:                  podKiller.killPodNow,
@@ -329,6 +330,7 @@ func TestMemoryPressure_VerifyPodStatus(t *testing.T) {
 		nodeRef:                      nodeRef,
 		nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
 		thresholdsFirstObservedAt:    thresholdsObservedAt{},
+		state:                        state,
 	}
 
 	// synchronize to detect the memory pressure
@@ -419,6 +421,7 @@ func TestPIDPressure_VerifyPodStatus(t *testing.T) {
 			},
 		}
 		summaryProvider := &fakeSummaryProvider{result: summaryStatsMaker("1500", "1000", podStats)}
+		state := NewNodeConditionsState()
 		manager := &managerImpl{
 			clock:                        fakeClock,
 			killPodFunc:                  podKiller.killPodNow,
@@ -430,6 +433,7 @@ func TestPIDPressure_VerifyPodStatus(t *testing.T) {
 			nodeRef:                      nodeRef,
 			nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
 			thresholdsFirstObservedAt:    thresholdsObservedAt{},
+			state:                        state,
 		}
 
 		// synchronize to detect the PID pressure
@@ -596,6 +600,7 @@ func TestDiskPressureNodeFs_VerifyPodStatus(t *testing.T) {
 			podStats:                  podStats,
 		}
 		summaryProvider := &fakeSummaryProvider{result: summaryStatsMaker(diskStat)}
+		state := NewNodeConditionsState()
 		manager := &managerImpl{
 			clock:                        fakeClock,
 			killPodFunc:                  podKiller.killPodNow,
@@ -607,6 +612,7 @@ func TestDiskPressureNodeFs_VerifyPodStatus(t *testing.T) {
 			nodeRef:                      nodeRef,
 			nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
 			thresholdsFirstObservedAt:    thresholdsObservedAt{},
+			state:                        state,
 		}
 
 		// synchronize
@@ -697,6 +703,7 @@ func TestMemoryPressure(t *testing.T) {
 		},
 	}
 	summaryProvider := &fakeSummaryProvider{result: summaryStatsMaker("2Gi", podStats)}
+	state := NewNodeConditionsState()
 	manager := &managerImpl{
 		clock:                        fakeClock,
 		killPodFunc:                  podKiller.killPodNow,
@@ -708,7 +715,9 @@ func TestMemoryPressure(t *testing.T) {
 		nodeRef:                      nodeRef,
 		nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
 		thresholdsFirstObservedAt:    thresholdsObservedAt{},
+		state:                        state,
 	}
+	admitHandler := NewAdmitHandler(state)
 
 	// create a best effort pod to test admission
 	bestEffortPodToAdmit, _ := podMaker("best-admit", defaultPriority, newResourceList("", "", ""), newResourceList("", "", ""), "0Gi")
@@ -729,7 +738,7 @@ func TestMemoryPressure(t *testing.T) {
 	// try to admit our pods (they should succeed)
 	expected := []bool{true, true}
 	for i, pod := range []*v1.Pod{bestEffortPodToAdmit, burstablePodToAdmit} {
-		if result := manager.Admit(&lifecycle.PodAdmitAttributes{Pod: pod}); expected[i] != result.Admit {
+		if result := admitHandler.Admit(&lifecycle.PodAdmitAttributes{Pod: pod}); expected[i] != result.Admit {
 			t.Errorf("Admit pod: %v, expected: %v, actual: %v", pod, expected[i], result.Admit)
 		}
 	}
@@ -822,7 +831,7 @@ func TestMemoryPressure(t *testing.T) {
 	// the best-effort pod should not admit, burstable should
 	expected = []bool{false, true}
 	for i, pod := range []*v1.Pod{bestEffortPodToAdmit, burstablePodToAdmit} {
-		if result := manager.Admit(&lifecycle.PodAdmitAttributes{Pod: pod}); expected[i] != result.Admit {
+		if result := admitHandler.Admit(&lifecycle.PodAdmitAttributes{Pod: pod}); expected[i] != result.Admit {
 			t.Errorf("Admit pod: %v, expected: %v, actual: %v", pod, expected[i], result.Admit)
 		}
 	}
@@ -850,7 +859,7 @@ func TestMemoryPressure(t *testing.T) {
 	// the best-effort pod should not admit, burstable should
 	expected = []bool{false, true}
 	for i, pod := range []*v1.Pod{bestEffortPodToAdmit, burstablePodToAdmit} {
-		if result := manager.Admit(&lifecycle.PodAdmitAttributes{Pod: pod}); expected[i] != result.Admit {
+		if result := admitHandler.Admit(&lifecycle.PodAdmitAttributes{Pod: pod}); expected[i] != result.Admit {
 			t.Errorf("Admit pod: %v, expected: %v, actual: %v", pod, expected[i], result.Admit)
 		}
 	}
@@ -878,7 +887,7 @@ func TestMemoryPressure(t *testing.T) {
 	// all pods should admit now
 	expected = []bool{true, true}
 	for i, pod := range []*v1.Pod{bestEffortPodToAdmit, burstablePodToAdmit} {
-		if result := manager.Admit(&lifecycle.PodAdmitAttributes{Pod: pod}); expected[i] != result.Admit {
+		if result := admitHandler.Admit(&lifecycle.PodAdmitAttributes{Pod: pod}); expected[i] != result.Admit {
 			t.Errorf("Admit pod: %v, expected: %v, actual: %v", pod, expected[i], result.Admit)
 		}
 	}
@@ -969,6 +978,7 @@ func TestPIDPressure(t *testing.T) {
 			}
 
 			summaryProvider := &fakeSummaryProvider{result: summaryStatsMaker(tc.totalPID, tc.noPressurePIDUsage, podStats)}
+			state := NewNodeConditionsState()
 			manager := &managerImpl{
 				clock:                        fakeClock,
 				killPodFunc:                  podKiller.killPodNow,
@@ -980,7 +990,9 @@ func TestPIDPressure(t *testing.T) {
 				nodeRef:                      nodeRef,
 				nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
 				thresholdsFirstObservedAt:    thresholdsObservedAt{},
+				state:                        state,
 			}
+			admitHandler := NewAdmitHandler(state)
 
 			// create a pod to test admission
 			podToAdmit, _ := podMaker("pod-to-admit", defaultPriority, 50)
@@ -998,7 +1010,7 @@ func TestPIDPressure(t *testing.T) {
 			}
 
 			// try to admit our pod (should succeed)
-			if result := manager.Admit(&lifecycle.PodAdmitAttributes{Pod: podToAdmit}); !result.Admit {
+			if result := admitHandler.Admit(&lifecycle.PodAdmitAttributes{Pod: podToAdmit}); !result.Admit {
 				t.Fatalf("Admit pod: %v, expected: %v, actual: %v", podToAdmit, true, result.Admit)
 			}
 
@@ -1092,7 +1104,7 @@ func TestPIDPressure(t *testing.T) {
 			}
 
 			// try to admit our pod (should fail)
-			if result := manager.Admit(&lifecycle.PodAdmitAttributes{Pod: podToAdmit}); result.Admit {
+			if result := admitHandler.Admit(&lifecycle.PodAdmitAttributes{Pod: podToAdmit}); result.Admit {
 				t.Fatalf("Admit pod: %v, expected: %v, actual: %v", podToAdmit, false, result.Admit)
 			}
 
@@ -1117,7 +1129,7 @@ func TestPIDPressure(t *testing.T) {
 			}
 
 			// try to admit our pod (should fail)
-			if result := manager.Admit(&lifecycle.PodAdmitAttributes{Pod: podToAdmit}); result.Admit {
+			if result := admitHandler.Admit(&lifecycle.PodAdmitAttributes{Pod: podToAdmit}); result.Admit {
 				t.Fatalf("Admit pod: %v, expected: %v, actual: %v", podToAdmit, false, result.Admit)
 			}
 
@@ -1141,7 +1153,7 @@ func TestPIDPressure(t *testing.T) {
 			}
 
 			// try to admit our pod (should succeed)
-			if result := manager.Admit(&lifecycle.PodAdmitAttributes{Pod: podToAdmit}); !result.Admit {
+			if result := admitHandler.Admit(&lifecycle.PodAdmitAttributes{Pod: podToAdmit}); !result.Admit {
 				t.Fatalf("Admit pod: %v, expected: %v, actual: %v", podToAdmit, true, result.Admit)
 			}
 		})
@@ -1149,7 +1161,8 @@ func TestPIDPressure(t *testing.T) {
 }
 
 func TestAdmitUnderNodeConditions(t *testing.T) {
-	manager := &managerImpl{}
+	state := NewNodeConditionsState()
+	admitHandler := NewAdmitHandler(state)
 	pods := []*v1.Pod{
 		newPod("guaranteed-pod", scheduling.DefaultPriorityWhenNoDefaultClassExists, makeContainersByQOS(v1.PodQOSGuaranteed), nil),
 		newPod("burstable-pod", scheduling.DefaultPriorityWhenNoDefaultClassExists, makeContainersByQOS(v1.PodQOSBurstable), nil),
@@ -1158,23 +1171,23 @@ func TestAdmitUnderNodeConditions(t *testing.T) {
 
 	expected := []bool{true, true, true}
 	for i, pod := range pods {
-		if result := manager.Admit(&lifecycle.PodAdmitAttributes{Pod: pod}); expected[i] != result.Admit {
+		if result := admitHandler.Admit(&lifecycle.PodAdmitAttributes{Pod: pod}); expected[i] != result.Admit {
 			t.Errorf("Admit pod: %v, expected: %v, actual: %v", pod, expected[i], result.Admit)
 		}
 	}
 
-	manager.nodeConditions = []v1.NodeConditionType{v1.NodeMemoryPressure}
+	state.Set([]v1.NodeConditionType{v1.NodeMemoryPressure})
 	expected = []bool{true, true, false}
 	for i, pod := range pods {
-		if result := manager.Admit(&lifecycle.PodAdmitAttributes{Pod: pod}); expected[i] != result.Admit {
+		if result := admitHandler.Admit(&lifecycle.PodAdmitAttributes{Pod: pod}); expected[i] != result.Admit {
 			t.Errorf("Admit pod: %v, expected: %v, actual: %v", pod, expected[i], result.Admit)
 		}
 	}
 
-	manager.nodeConditions = []v1.NodeConditionType{v1.NodeMemoryPressure, v1.NodeDiskPressure}
+	state.Set([]v1.NodeConditionType{v1.NodeMemoryPressure, v1.NodeDiskPressure})
 	expected = []bool{false, false, false}
 	for i, pod := range pods {
-		if result := manager.Admit(&lifecycle.PodAdmitAttributes{Pod: pod}); expected[i] != result.Admit {
+		if result := admitHandler.Admit(&lifecycle.PodAdmitAttributes{Pod: pod}); expected[i] != result.Admit {
 			t.Errorf("Admit pod: %v, expected: %v, actual: %v", pod, expected[i], result.Admit)
 		}
 	}
@@ -1347,6 +1360,7 @@ func TestDiskPressureNodeFs(t *testing.T) {
 			}
 			diskStatConst := diskStatStart
 			summaryProvider := &fakeSummaryProvider{result: summaryStatsMaker(diskStatStart)}
+			state := NewNodeConditionsState()
 			manager := &managerImpl{
 				clock:                        fakeClock,
 				killPodFunc:                  podKiller.killPodNow,
@@ -1358,7 +1372,9 @@ func TestDiskPressureNodeFs(t *testing.T) {
 				nodeRef:                      nodeRef,
 				nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
 				thresholdsFirstObservedAt:    thresholdsObservedAt{},
+				state:                        state,
 			}
+			admitHandler := NewAdmitHandler(state)
 
 			// create a best effort pod to test admission
 			podToAdmit, _ := podMaker("pod-to-admit", defaultPriority, newResourceList("", "", ""), newResourceList("", "", ""), "0Gi", "0Gi", "0Gi", nil)
@@ -1376,7 +1392,7 @@ func TestDiskPressureNodeFs(t *testing.T) {
 			}
 
 			// try to admit our pod (should succeed)
-			if result := manager.Admit(&lifecycle.PodAdmitAttributes{Pod: podToAdmit}); !result.Admit {
+			if result := admitHandler.Admit(&lifecycle.PodAdmitAttributes{Pod: podToAdmit}); !result.Admit {
 				t.Fatalf("Admit pod: %v, expected: %v, actual: %v", podToAdmit, true, result.Admit)
 			}
 
@@ -1481,7 +1497,7 @@ func TestDiskPressureNodeFs(t *testing.T) {
 			}
 
 			// try to admit our pod (should fail)
-			if result := manager.Admit(&lifecycle.PodAdmitAttributes{Pod: podToAdmit}); result.Admit {
+			if result := admitHandler.Admit(&lifecycle.PodAdmitAttributes{Pod: podToAdmit}); result.Admit {
 				t.Fatalf("Admit pod: %v, expected: %v, actual: %v", podToAdmit, false, result.Admit)
 			}
 
@@ -1506,7 +1522,7 @@ func TestDiskPressureNodeFs(t *testing.T) {
 			}
 
 			// try to admit our pod (should fail)
-			if result := manager.Admit(&lifecycle.PodAdmitAttributes{Pod: podToAdmit}); result.Admit {
+			if result := admitHandler.Admit(&lifecycle.PodAdmitAttributes{Pod: podToAdmit}); result.Admit {
 				t.Fatalf("Admit pod: %v, expected: %v, actual: %v", podToAdmit, false, result.Admit)
 			}
 
@@ -1531,7 +1547,7 @@ func TestDiskPressureNodeFs(t *testing.T) {
 			}
 
 			// try to admit our pod (should succeed)
-			if result := manager.Admit(&lifecycle.PodAdmitAttributes{Pod: podToAdmit}); !result.Admit {
+			if result := admitHandler.Admit(&lifecycle.PodAdmitAttributes{Pod: podToAdmit}); !result.Admit {
 				t.Fatalf("Admit pod: %v, expected: %v, actual: %v", podToAdmit, true, result.Admit)
 			}
 		})
@@ -1585,6 +1601,7 @@ func TestMinReclaim(t *testing.T) {
 		},
 	}
 	summaryProvider := &fakeSummaryProvider{result: summaryStatsMaker("2Gi", podStats)}
+	state := NewNodeConditionsState()
 	manager := &managerImpl{
 		clock:                        fakeClock,
 		killPodFunc:                  podKiller.killPodNow,
@@ -1596,6 +1613,7 @@ func TestMinReclaim(t *testing.T) {
 		nodeRef:                      nodeRef,
 		nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
 		thresholdsFirstObservedAt:    thresholdsObservedAt{},
+		state:                        state,
 	}
 
 	// synchronize
@@ -1871,6 +1889,7 @@ func TestNodeReclaimFuncs(t *testing.T) {
 			diskStatConst := diskStatStart
 			summaryProvider := &fakeSummaryProvider{result: summaryStatsMaker(diskStatStart)}
 			diskGC := &mockDiskGC{fakeSummaryProvider: summaryProvider, err: nil}
+			state := NewNodeConditionsState()
 			manager := &managerImpl{
 				clock:                        fakeClock,
 				killPodFunc:                  podKiller.killPodNow,
@@ -1882,6 +1901,7 @@ func TestNodeReclaimFuncs(t *testing.T) {
 				nodeRef:                      nodeRef,
 				nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
 				thresholdsFirstObservedAt:    thresholdsObservedAt{},
+				state:                        state,
 			}
 
 			// synchronize
@@ -2329,6 +2349,7 @@ func TestInodePressureFsInodes(t *testing.T) {
 			startingStatsConst := summaryStatsMaker(tc.nodeFsInodesFree, tc.nodeFsInodes, tc.imageFsInodesFree, tc.imageFsInodes, tc.containerFsInodesFree, tc.containerFsInodes, podStats)
 			startingStatsModified := summaryStatsMaker(tc.nodeFsInodesFree, tc.nodeFsInodes, tc.imageFsInodesFree, tc.imageFsInodes, tc.containerFsInodesFree, tc.containerFsInodes, podStats)
 			summaryProvider := &fakeSummaryProvider{result: startingStatsModified}
+			state := NewNodeConditionsState()
 			manager := &managerImpl{
 				clock:                        fakeClock,
 				killPodFunc:                  podKiller.killPodNow,
@@ -2340,7 +2361,9 @@ func TestInodePressureFsInodes(t *testing.T) {
 				nodeRef:                      nodeRef,
 				nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
 				thresholdsFirstObservedAt:    thresholdsObservedAt{},
+				state:                        state,
 			}
+			admitHandler := NewAdmitHandler(state)
 
 			// create a best effort pod to test admission
 			podToAdmit, _ := podMaker("pod-to-admit", defaultPriority, newResourceList("", "", ""), newResourceList("", "", ""), "0", "0", "0")
@@ -2358,7 +2381,7 @@ func TestInodePressureFsInodes(t *testing.T) {
 			}
 
 			// try to admit our pod (should succeed)
-			if result := manager.Admit(&lifecycle.PodAdmitAttributes{Pod: podToAdmit}); !result.Admit {
+			if result := admitHandler.Admit(&lifecycle.PodAdmitAttributes{Pod: podToAdmit}); !result.Admit {
 				t.Fatalf("Admit pod: %v, expected: %v, actual: %v", podToAdmit, true, result.Admit)
 			}
 
@@ -2448,7 +2471,7 @@ func TestInodePressureFsInodes(t *testing.T) {
 			}
 
 			// try to admit our pod (should fail)
-			if result := manager.Admit(&lifecycle.PodAdmitAttributes{Pod: podToAdmit}); result.Admit {
+			if result := admitHandler.Admit(&lifecycle.PodAdmitAttributes{Pod: podToAdmit}); result.Admit {
 				t.Fatalf("Admit pod: %v, expected: %v, actual: %v", podToAdmit, false, result.Admit)
 			}
 
@@ -2473,7 +2496,7 @@ func TestInodePressureFsInodes(t *testing.T) {
 			}
 
 			// try to admit our pod (should fail)
-			if result := manager.Admit(&lifecycle.PodAdmitAttributes{Pod: podToAdmit}); result.Admit {
+			if result := admitHandler.Admit(&lifecycle.PodAdmitAttributes{Pod: podToAdmit}); result.Admit {
 				t.Fatalf("Admit pod: %v, expected: %v, actual: %v", podToAdmit, false, result.Admit)
 			}
 
@@ -2498,7 +2521,7 @@ func TestInodePressureFsInodes(t *testing.T) {
 			}
 
 			// try to admit our pod (should succeed)
-			if result := manager.Admit(&lifecycle.PodAdmitAttributes{Pod: podToAdmit}); !result.Admit {
+			if result := admitHandler.Admit(&lifecycle.PodAdmitAttributes{Pod: podToAdmit}); !result.Admit {
 				t.Fatalf("Admit pod: %v, expected: %v, actual: %v", podToAdmit, true, result.Admit)
 			}
 		})
@@ -2564,6 +2587,7 @@ func TestStaticCriticalPodsAreNotEvicted(t *testing.T) {
 		},
 	}
 	summaryProvider := &fakeSummaryProvider{result: summaryStatsMaker("2Gi", podStats)}
+	state := NewNodeConditionsState()
 	manager := &managerImpl{
 		clock:                        fakeClock,
 		killPodFunc:                  podKiller.killPodNow,
@@ -2575,6 +2599,7 @@ func TestStaticCriticalPodsAreNotEvicted(t *testing.T) {
 		nodeRef:                      nodeRef,
 		nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
 		thresholdsFirstObservedAt:    thresholdsObservedAt{},
+		state:                        state,
 	}
 
 	fakeClock.Step(1 * time.Minute)
@@ -2726,6 +2751,7 @@ func TestStorageLimitEvictions(t *testing.T) {
 				podStats:              podStats,
 			}
 			summaryProvider := &fakeSummaryProvider{result: summaryStatsMaker(diskStat)}
+			state := NewNodeConditionsState()
 			manager := &managerImpl{
 				clock:                         fakeClock,
 				killPodFunc:                   podKiller.killPodNow,
@@ -2738,6 +2764,7 @@ func TestStorageLimitEvictions(t *testing.T) {
 				nodeConditionsLastObservedAt:  nodeConditionsObservedAt{},
 				thresholdsFirstObservedAt:     thresholdsObservedAt{},
 				localStorageCapacityIsolation: true,
+				state:                         state,
 			}
 
 			_, err := manager.synchronize(tCtx, diskInfoProvider, activePodsFunc)
@@ -2802,6 +2829,7 @@ func TestAllocatableMemoryPressure(t *testing.T) {
 		},
 	}
 	summaryProvider := &fakeSummaryProvider{result: summaryStatsMaker("4Gi", podStats)}
+	state := NewNodeConditionsState()
 	manager := &managerImpl{
 		clock:                        fakeClock,
 		killPodFunc:                  podKiller.killPodNow,
@@ -2813,7 +2841,9 @@ func TestAllocatableMemoryPressure(t *testing.T) {
 		nodeRef:                      nodeRef,
 		nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
 		thresholdsFirstObservedAt:    thresholdsObservedAt{},
+		state:                        state,
 	}
+	admitHandler := NewAdmitHandler(state)
 
 	// create a best effort pod to test admission
 	bestEffortPodToAdmit, _ := podMaker("best-admit", defaultPriority, newResourceList("", "", ""), newResourceList("", "", ""), "0Gi")
@@ -2834,7 +2864,7 @@ func TestAllocatableMemoryPressure(t *testing.T) {
 	// try to admit our pods (they should succeed)
 	expected := []bool{true, true}
 	for i, pod := range []*v1.Pod{bestEffortPodToAdmit, burstablePodToAdmit} {
-		if result := manager.Admit(&lifecycle.PodAdmitAttributes{Pod: pod}); expected[i] != result.Admit {
+		if result := admitHandler.Admit(&lifecycle.PodAdmitAttributes{Pod: pod}); expected[i] != result.Admit {
 			t.Errorf("Admit pod: %v, expected: %v, actual: %v", pod, expected[i], result.Admit)
 		}
 	}
@@ -2870,7 +2900,7 @@ func TestAllocatableMemoryPressure(t *testing.T) {
 	// the best-effort pod should not admit, burstable should
 	expected = []bool{false, true}
 	for i, pod := range []*v1.Pod{bestEffortPodToAdmit, burstablePodToAdmit} {
-		if result := manager.Admit(&lifecycle.PodAdmitAttributes{Pod: pod}); expected[i] != result.Admit {
+		if result := admitHandler.Admit(&lifecycle.PodAdmitAttributes{Pod: pod}); expected[i] != result.Admit {
 			t.Errorf("Admit pod: %v, expected: %v, actual: %v", pod, expected[i], result.Admit)
 		}
 	}
@@ -2903,7 +2933,7 @@ func TestAllocatableMemoryPressure(t *testing.T) {
 	// the best-effort pod should not admit, burstable should
 	expected = []bool{false, true}
 	for i, pod := range []*v1.Pod{bestEffortPodToAdmit, burstablePodToAdmit} {
-		if result := manager.Admit(&lifecycle.PodAdmitAttributes{Pod: pod}); expected[i] != result.Admit {
+		if result := admitHandler.Admit(&lifecycle.PodAdmitAttributes{Pod: pod}); expected[i] != result.Admit {
 			t.Errorf("Admit pod: %v, expected: %v, actual: %v", pod, expected[i], result.Admit)
 		}
 	}
@@ -2931,7 +2961,7 @@ func TestAllocatableMemoryPressure(t *testing.T) {
 	// all pods should admit now
 	expected = []bool{true, true}
 	for i, pod := range []*v1.Pod{bestEffortPodToAdmit, burstablePodToAdmit} {
-		if result := manager.Admit(&lifecycle.PodAdmitAttributes{Pod: pod}); expected[i] != result.Admit {
+		if result := admitHandler.Admit(&lifecycle.PodAdmitAttributes{Pod: pod}); expected[i] != result.Admit {
 			t.Errorf("Admit pod: %v, expected: %v, actual: %v", pod, expected[i], result.Admit)
 		}
 	}
@@ -2968,6 +2998,7 @@ func TestUpdateMemcgThreshold(t *testing.T) {
 	thresholdNotifier := NewMockThresholdNotifier(t)
 	thresholdNotifier.EXPECT().UpdateThreshold(mock.Anything, summaryProvider.result).Return(nil).Times(2)
 
+	state := NewNodeConditionsState()
 	manager := &managerImpl{
 		clock:                        fakeClock,
 		killPodFunc:                  podKiller.killPodNow,
@@ -2980,6 +3011,7 @@ func TestUpdateMemcgThreshold(t *testing.T) {
 		nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
 		thresholdsFirstObservedAt:    thresholdsObservedAt{},
 		thresholdNotifiers:           []ThresholdNotifier{thresholdNotifier},
+		state:                        state,
 	}
 
 	// The UpdateThreshold method should have been called once, since this is the first run.
@@ -3065,6 +3097,7 @@ func TestManagerWithLocalStorageCapacityIsolationOpen(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now())
 	diskInfoProvider := &mockDiskInfoProvider{dedicatedImageFs: ptr.To(false)}
 
+	state := NewNodeConditionsState()
 	mgr := &managerImpl{
 		clock:                         fakeClock,
 		killPodFunc:                   podKiller.killPodNow,
@@ -3076,6 +3109,7 @@ func TestManagerWithLocalStorageCapacityIsolationOpen(t *testing.T) {
 		nodeRef:                       nodeRef,
 		localStorageCapacityIsolation: true,
 		dedicatedImageFs:              diskInfoProvider.dedicatedImageFs,
+		state:                         state,
 	}
 
 	activePodsFunc := func() []*v1.Pod {
@@ -3143,6 +3177,7 @@ func TestContainerEphemeralStorageLimitEvictionForRestartableInitContainers(t *t
 	nodeRef := &v1.ObjectReference{Kind: "Node", Name: "test", UID: types.UID("test"), Namespace: ""}
 	fakeClock := testingclock.NewFakeClock(time.Now())
 
+	state := NewNodeConditionsState()
 	mgr := &managerImpl{
 		clock:                         fakeClock,
 		killPodFunc:                   podKiller.killPodNow,
@@ -3154,6 +3189,7 @@ func TestContainerEphemeralStorageLimitEvictionForRestartableInitContainers(t *t
 		nodeRef:                       nodeRef,
 		localStorageCapacityIsolation: true,
 		dedicatedImageFs:              ptr.To(false),
+		state:                         state,
 	}
 
 	activePodsFunc := func() []*v1.Pod {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1070,9 +1070,13 @@ func NewMainKubelet(ctx context.Context,
 		return eventTime.Sub(lastUpdate) > 600*time.Second
 	}
 
+	// Create a standalone eviction admit handler linked by a shared state.
+	evictionState := eviction.NewNodeConditionsState()
+	evictionAdmitHandler := eviction.NewAdmitHandler(evictionState)
+
 	// setup eviction manager
-	evictionManager, evictionAdmitHandler := eviction.NewManager(klet.resourceAnalyzer, evictionConfig,
-		killPodNow(ctx, klet.podWorkers, kubeDeps.Recorder), klet.imageManager, klet.containerGC, kubeDeps.Recorder, nodeRef, klet.clock, kubeCfg.LocalStorageCapacityIsolation)
+	evictionManager := eviction.NewManager(klet.resourceAnalyzer, evictionConfig,
+		killPodNow(ctx, klet.podWorkers, kubeDeps.Recorder), klet.imageManager, klet.containerGC, kubeDeps.Recorder, nodeRef, klet.clock, kubeCfg.LocalStorageCapacityIsolation, evictionState)
 
 	klet.evictionManager = evictionManager
 	handlers := []lifecycle.PodAdmitHandler{}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1146,9 +1146,14 @@ func NewMainKubelet(ctx context.Context,
 		v1.NamespaceNodeLease,
 		util.SetNodeOwnerFunc(ctx, klet.heartbeatClient, string(klet.nodeName)))
 
+	// Create a standalone shutdown admit handler linked by a shared state.
+	shutdownState := nodeshutdown.NewShutdownState()
+	shutdownAdmitHandler := nodeshutdown.NewAdmitHandler(shutdownState)
+
 	// setup node shutdown manager
 	shutdownManager := nodeshutdown.NewManager(&nodeshutdown.Config{
 		Logger:                           logger,
+		State:                            shutdownState,
 		VolumeManager:                    klet.volumeManager,
 		Recorder:                         kubeDeps.Recorder,
 		NodeRef:                          nodeRef,
@@ -1161,7 +1166,7 @@ func NewMainKubelet(ctx context.Context,
 		StateDirectory:                   rootDirectory,
 	})
 	klet.shutdownManager = shutdownManager
-	handlers = append(handlers, shutdownManager)
+	handlers = append(handlers, shutdownAdmitHandler)
 
 	klet.allocationManager.AddPodAdmitHandlers(append([]lifecycle.PodAdmitHandler{resizeAdmitHandler}, handlers...))
 

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -407,8 +407,10 @@ func newTestKubeletWithImageList(
 	handlers = append(handlers, allocation.NewPodResizesAdmitHandler(kubelet.containerManager, fakeRuntime, kubelet.allocationManager, logger))
 
 	// setup shutdown manager
+	shutdownState := nodeshutdown.NewShutdownState()
 	shutdownManager := nodeshutdown.NewManager(&nodeshutdown.Config{
 		Logger:                          logger,
+		State:                           shutdownState,
 		Recorder:                        fakeRecorder,
 		NodeRef:                         nodeRef,
 		GetPodsFunc:                     kubelet.podManager.GetPods,
@@ -422,7 +424,7 @@ func newTestKubeletWithImageList(
 	if err != nil {
 		t.Fatalf("Failed to create UserNsManager: %v", err)
 	}
-	handlers = append(handlers, shutdownManager)
+	handlers = append(handlers, nodeshutdown.NewAdmitHandler(shutdownState))
 
 	// Add this as cleanup predicate pod admitter
 	handlers = append(handlers, lifecycle.NewPredicateAdmitHandler(kubelet.GetCachedNode, lifecycle.NewAdmissionFailureHandlerStub(), kubelet.containerManager.UpdatePluginResources))

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -397,9 +397,14 @@ func newTestKubeletWithImageList(
 		UID:       types.UID(kubelet.nodeName),
 		Namespace: "",
 	}
+
+	// Create a standalone eviction admit handler linked by a shared state.
+	evictionState := eviction.NewNodeConditionsState()
+	evictionAdmitHandler := eviction.NewAdmitHandler(evictionState)
+
 	// setup eviction manager
-	evictionManager, evictionAdmitHandler := eviction.NewManager(kubelet.resourceAnalyzer, eviction.Config{},
-		killPodNow(tCtx, kubelet.podWorkers, fakeRecorder), kubelet.imageManager, kubelet.containerGC, fakeRecorder, nodeRef, kubelet.clock, kubelet.supportLocalStorageCapacityIsolation())
+	evictionManager := eviction.NewManager(kubelet.resourceAnalyzer, eviction.Config{},
+		killPodNow(tCtx, kubelet.podWorkers, fakeRecorder), kubelet.imageManager, kubelet.containerGC, fakeRecorder, nodeRef, kubelet.clock, kubelet.supportLocalStorageCapacityIsolation(), evictionState)
 
 	kubelet.evictionManager = evictionManager
 	handlers := []lifecycle.PodAdmitHandler{}

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -39,9 +40,6 @@ import (
 
 // Manager interface provides methods for Kubelet to manage node shutdown.
 type Manager interface {
-	lifecycle.PodAdmitHandler
-
-	Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult
 	Start(ctx context.Context) error
 	ShutdownStatus() error
 }
@@ -49,6 +47,7 @@ type Manager interface {
 // Config represents Manager configuration
 type Config struct {
 	Logger                           klog.Logger
+	State                            *ShutdownState
 	VolumeManager                    volumemanager.VolumeManager
 	Recorder                         record.EventRecorder
 	NodeRef                          *v1.ObjectReference
@@ -64,11 +63,6 @@ type Config struct {
 
 // managerStub is a fake node shutdown managerImpl .
 type managerStub struct{}
-
-// Admit returns a fake Pod admission which always returns true
-func (managerStub) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult {
-	return lifecycle.PodAdmitResult{Admit: true}
-}
 
 // Start is a no-op always returning nil for non linux platforms.
 func (managerStub) Start(context.Context) error {
@@ -299,4 +293,36 @@ func groupByPriority(shutdownGracePeriodByPodPriority []kubeletconfig.ShutdownGr
 		groups[index].Pods = append(groups[index].Pods, pod)
 	}
 	return groups
+}
+
+// ShutdownState is a lightweight object that tracks if the node is shutting down.
+type ShutdownState struct {
+	ShuttingDown atomic.Bool
+}
+
+// NewShutdownState creates a new ShutdownState.
+func NewShutdownState() *ShutdownState {
+	return &ShutdownState{}
+}
+
+// AdmitHandler evaluates if pods can be admitted based on the node shutdown state.
+type AdmitHandler struct {
+	state *ShutdownState
+}
+
+// NewAdmitHandler returns a standalone PodAdmitHandler that uses ShutdownState.
+func NewAdmitHandler(state *ShutdownState) lifecycle.PodAdmitHandler {
+	return &AdmitHandler{state: state}
+}
+
+// Admit rejects pods if the node is actively shutting down.
+func (h *AdmitHandler) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult {
+	if h.state.ShuttingDown.Load() {
+		return lifecycle.PodAdmitResult{
+			Admit:   false,
+			Reason:  NodeShutdownNotAdmittedReason,
+			Message: nodeShutdownNotAdmittedMessage,
+		}
+	}
+	return lifecycle.PodAdmitResult{Admit: true}
 }

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -34,7 +33,6 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	kubeletevents "k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/eviction"
-	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/pkg/kubelet/nodeshutdown/systemd"
 )
@@ -68,9 +66,8 @@ type managerImpl struct {
 	dbusCon     dbusInhibiter
 	inhibitLock systemd.InhibitLock
 
-	nodeShuttingDownMutex sync.Mutex
-	nodeShuttingDownNow   bool
-	podManager            *podManager
+	state      *ShutdownState
+	podManager *podManager
 
 	enableMetrics bool
 	storage       storage
@@ -97,6 +94,7 @@ func NewManager(conf *Config) Manager {
 		nodeRef:        conf.NodeRef,
 		getPods:        conf.GetPodsFunc,
 		syncNodeStatus: conf.SyncNodeStatusFunc,
+		state:          conf.State,
 		podManager:     podManager,
 		enableMetrics:  utilfeature.DefaultFeatureGate.Enabled(features.GracefulNodeShutdownBasedOnPodPriority),
 		storage: localStorage{
@@ -109,20 +107,6 @@ func NewManager(conf *Config) Manager {
 		"shutdownGracePeriodByPodPriority", podManager.shutdownGracePeriodByPodPriority,
 	)
 	return manager
-}
-
-// Admit rejects all pods if node is shutting
-func (m *managerImpl) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult {
-	nodeShuttingDown := m.ShutdownStatus() != nil
-
-	if nodeShuttingDown {
-		return lifecycle.PodAdmitResult{
-			Admit:   false,
-			Reason:  NodeShutdownNotAdmittedReason,
-			Message: nodeShutdownNotAdmittedMessage,
-		}
-	}
-	return lifecycle.PodAdmitResult{Admit: true}
 }
 
 // setMetrics sets the metrics for the node shutdown manager.
@@ -282,9 +266,7 @@ func (m *managerImpl) start(ctx context.Context) (chan struct{}, error) {
 					m.recorder.Event(m.nodeRef, v1.EventTypeNormal, kubeletevents.NodeShutdown, "Shutdown manager detected shutdown cancellation")
 				}
 
-				m.nodeShuttingDownMutex.Lock()
-				m.nodeShuttingDownNow = isShuttingDown
-				m.nodeShuttingDownMutex.Unlock()
+				m.state.ShuttingDown.Store(isShuttingDown)
 
 				if isShuttingDown {
 					// Update node status and ready condition
@@ -317,10 +299,7 @@ func (m *managerImpl) acquireInhibitLock() error {
 
 // ShutdownStatus will return an error if the node is currently shutting down.
 func (m *managerImpl) ShutdownStatus() error {
-	m.nodeShuttingDownMutex.Lock()
-	defer m.nodeShuttingDownMutex.Unlock()
-
-	if m.nodeShuttingDownNow {
+	if m.state.ShuttingDown.Load() {
 		return fmt.Errorf("node is shutting down")
 	}
 	return nil

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux_test.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux_test.go
@@ -340,6 +340,7 @@ func TestManager(t *testing.T) {
 			nodeRef := &v1.ObjectReference{Kind: "Node", Name: "test", UID: types.UID("test"), Namespace: ""}
 			manager := NewManager(&Config{
 				Logger:                          logger,
+				State:                           NewShutdownState(),
 				VolumeManager:                   fakeVolumeManager,
 				Recorder:                        fakeRecorder,
 				NodeRef:                         nodeRef,
@@ -365,7 +366,6 @@ func TestManager(t *testing.T) {
 				assert.NoError(t, err, "expected manager.Start() to not return error")
 				assert.True(t, fakeDbus.didInhibitShutdown, "expected that manager inhibited shutdown")
 				assert.NoError(t, manager.ShutdownStatus(), "expected that manager does not return error since shutdown is not active")
-				assert.True(t, manager.Admit(nil).Admit)
 
 				// Send fake shutdown event
 				select {
@@ -387,7 +387,6 @@ func TestManager(t *testing.T) {
 				}
 
 				assert.Error(t, manager.ShutdownStatus(), "expected that manager returns error since shutdown is active")
-				assert.False(t, manager.Admit(nil).Admit)
 				assert.Equal(t, tc.expectedPodToGracePeriodOverride, killedPodsToGracePeriods)
 				assert.Equal(t, tc.expectedDidOverrideInhibitDelay, fakeDbus.didOverrideInhibitDelay, "override system inhibit delay differs")
 				if tc.expectedPodStatuses != nil {
@@ -445,6 +444,7 @@ func TestFeatureEnabled(t *testing.T) {
 
 			manager := NewManager(&Config{
 				Logger:                          logger,
+				State:                           NewShutdownState(),
 				VolumeManager:                   fakeVolumeManager,
 				Recorder:                        fakeRecorder,
 				NodeRef:                         nodeRef,
@@ -504,6 +504,7 @@ func TestRestart(t *testing.T) {
 	nodeRef := &v1.ObjectReference{Kind: "Node", Name: "test", UID: types.UID("test"), Namespace: ""}
 	manager := NewManager(&Config{
 		Logger:                          logger,
+		State:                           NewShutdownState(),
 		VolumeManager:                   fakeVolumeManager,
 		Recorder:                        fakeRecorder,
 		NodeRef:                         nodeRef,
@@ -565,6 +566,7 @@ func TestStartDoesNotReconnectAfterContextCancel(t *testing.T) {
 
 	manager := NewManager(&Config{
 		Logger:                          logger,
+		State:                           NewShutdownState(),
 		VolumeManager:                   volumemanager.NewFakeVolumeManager([]v1.UniqueVolumeName{}, 0, nil, false),
 		Recorder:                        &record.FakeRecorder{},
 		NodeRef:                         &v1.ObjectReference{Kind: "Node", Name: "test", UID: types.UID("test"), Namespace: ""},
@@ -618,7 +620,6 @@ func Test_managerImpl_processShutdownEvent(t *testing.T) {
 		syncNodeStatus                   func(context.Context)
 		dbusCon                          dbusInhibiter
 		inhibitLock                      systemd.InhibitLock
-		nodeShuttingDownNow              bool
 		clock                            clock.Clock
 	}
 	tests := []struct {
@@ -671,15 +672,14 @@ func Test_managerImpl_processShutdownEvent(t *testing.T) {
 				),
 			)
 			m := &managerImpl{
-				logger:                logger,
-				recorder:              tt.fields.recorder,
-				nodeRef:               tt.fields.nodeRef,
-				getPods:               tt.fields.getPods,
-				syncNodeStatus:        tt.fields.syncNodeStatus,
-				dbusCon:               tt.fields.dbusCon,
-				inhibitLock:           tt.fields.inhibitLock,
-				nodeShuttingDownMutex: sync.Mutex{},
-				nodeShuttingDownNow:   tt.fields.nodeShuttingDownNow,
+				logger:         logger,
+				recorder:       tt.fields.recorder,
+				nodeRef:        tt.fields.nodeRef,
+				getPods:        tt.fields.getPods,
+				syncNodeStatus: tt.fields.syncNodeStatus,
+				dbusCon:        tt.fields.dbusCon,
+				inhibitLock:    tt.fields.inhibitLock,
+				state:          &ShutdownState{},
 				podManager: &podManager{
 					logger:                           logger,
 					volumeManager:                    tt.fields.volumeManager,

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -34,7 +33,6 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	kubeletevents "k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/eviction"
-	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/pkg/windows/service"
 
@@ -58,9 +56,8 @@ type managerImpl struct {
 	getPods        eviction.ActivePodsFunc
 	syncNodeStatus func(context.Context)
 
-	nodeShuttingDownMutex sync.Mutex
-	nodeShuttingDownNow   bool
-	podManager            *podManager
+	state      *ShutdownState
+	podManager *podManager
 
 	enableMetrics bool
 	storage       storage
@@ -98,6 +95,7 @@ func NewManager(conf *Config) Manager {
 		nodeRef:        conf.NodeRef,
 		getPods:        conf.GetPodsFunc,
 		syncNodeStatus: conf.SyncNodeStatusFunc,
+		state:          conf.State,
 		podManager:     podManager,
 		enableMetrics:  utilfeature.DefaultFeatureGate.Enabled(features.GracefulNodeShutdownBasedOnPodPriority),
 		storage: localStorage{
@@ -110,20 +108,6 @@ func NewManager(conf *Config) Manager {
 		"shutdownGracePeriodByPodPriority", podManager.shutdownGracePeriodByPodPriority,
 	)
 	return manager
-}
-
-// Admit rejects all pods if node is shutting
-func (m *managerImpl) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult {
-	nodeShuttingDown := m.ShutdownStatus() != nil
-
-	if nodeShuttingDown {
-		return lifecycle.PodAdmitResult{
-			Admit:   false,
-			Reason:  NodeShutdownNotAdmittedReason,
-			Message: nodeShutdownNotAdmittedMessage,
-		}
-	}
-	return lifecycle.PodAdmitResult{Admit: true}
 }
 
 // setMetrics sets the metrics for the node shutdown manager.
@@ -238,10 +222,7 @@ func (m *managerImpl) start() (chan struct{}, error) {
 
 // ShutdownStatus will return an error if the node is currently shutting down.
 func (m *managerImpl) ShutdownStatus() error {
-	m.nodeShuttingDownMutex.Lock()
-	defer m.nodeShuttingDownMutex.Unlock()
-
-	if m.nodeShuttingDownNow {
+	if m.state.ShuttingDown.Load() {
 		return fmt.Errorf("node is shutting down")
 	}
 	return nil
@@ -252,9 +233,7 @@ func (m *managerImpl) ProcessShutdownEvent(ctx context.Context) error {
 
 	m.recorder.Event(m.nodeRef, v1.EventTypeNormal, kubeletevents.NodeShutdown, "Shutdown manager detected preshutdown event")
 
-	m.nodeShuttingDownMutex.Lock()
-	m.nodeShuttingDownNow = true
-	m.nodeShuttingDownMutex.Unlock()
+	m.state.ShuttingDown.Store(true)
 
 	nodeStatusCtx := klog.NewContext(ctx, m.logger)
 	go m.syncNodeStatus(nodeStatusCtx)

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows_test.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows_test.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -88,6 +87,7 @@ func TestFeatureEnabled(t *testing.T) {
 
 			manager := NewManager(&Config{
 				Logger:                          logger,
+				State:                           NewShutdownState(),
 				VolumeManager:                   fakeVolumeManager,
 				Recorder:                        fakeRecorder,
 				NodeRef:                         nodeRef,
@@ -120,7 +120,6 @@ func Test_managerImpl_ProcessShutdownEvent(t *testing.T) {
 		getPods                          eviction.ActivePodsFunc
 		killPodFunc                      eviction.KillPodFunc
 		syncNodeStatus                   func(context.Context)
-		nodeShuttingDownNow              bool
 		clock                            clock.Clock
 	}
 	tests := []struct {
@@ -239,13 +238,12 @@ func Test_managerImpl_ProcessShutdownEvent(t *testing.T) {
 				),
 			)
 			m := &managerImpl{
-				logger:                logger,
-				recorder:              tt.fields.recorder,
-				nodeRef:               tt.fields.nodeRef,
-				getPods:               tt.fields.getPods,
-				syncNodeStatus:        tt.fields.syncNodeStatus,
-				nodeShuttingDownMutex: sync.Mutex{},
-				nodeShuttingDownNow:   tt.fields.nodeShuttingDownNow,
+				logger:         logger,
+				recorder:       tt.fields.recorder,
+				nodeRef:        tt.fields.nodeRef,
+				getPods:        tt.fields.getPods,
+				syncNodeStatus: tt.fields.syncNodeStatus,
+				state:          NewShutdownState(),
 				podManager: &podManager{
 					logger:                           logger,
 					volumeManager:                    tt.fields.volumeManager,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
#### What this PR does / why we need it:

Currently, Kubelet has a structural circular dependency during initialization involving the Allocation Manager, Eviction Manager, Image Manager, Container Runtime, and Pod Workers.

The initialization cycle looks like this:
AllocationManager -> requires EvictionManager (for its admit handler) -> requires ImageManager (to perform image garbage collection during disk pressure) -> requires ContainerRuntime -> requires PodWorkers -> requires AllocationManager.

The AllocationManager only needs the EvictionManager (AdmitHandler) to check a simple array of node conditions (e.g., MemoryPressure, DiskPressure) so it can reject new pods when resources are starved. However, because these components are tightly coupled, it is forced to depend on the entire heavy eviction and garbage collection logic of the EvictionManager.

This PR breaks the cycle using state segregation:

1. Extracted the node conditions array into a lightweight, thread-safe NodeConditionsState object.
2. Created a standalone EvictionAdmitHandler that only depends on this state.
3. The AllocationManager is now given this lightweight admit handler (breaking the dependency on ImageManager and ContainerRuntime).
4. The heavy EvictionManager is initialized later with the ImageManager, ContainerGC, and the shared NodeConditionsState, which it updates when its monitoring loop observes resource pressure.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Related to https://github.com/kubernetes/kubernetes/issues/132298
Similar work is done for ShutdonwManager: https://github.com/kubernetes/kubernetes/pull/138816
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
