### PR TITLE
Use go-cmp in host stats provider test

### DIFF
--- a/pkg/kubelet/stats/host_stats_provider_test.go
+++ b/pkg/kubelet/stats/host_stats_provider_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package stats
 
 import (
-	"reflect"
 	"testing"
 
 	cadvisorapi "github.com/google/cadvisor/lib/model"
+	"github.com/google/go-cmp/cmp"
 
 	kubecontainertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 
@@ -59,8 +59,8 @@ func Test_hostStatsProvider_getPodEtcHostsStats(t *testing.T) {
 				t.Errorf("getPodEtcHostsStats() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getPodEtcHostsStats() got = %v, want %v", got, tt.want)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("getPodEtcHostsStats() diff (-want,+got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Updates `Test_hostStatsProvider_getPodEtcHostsStats` to use `cmp.Diff` instead of `reflect.DeepEqual`, so test failures show a structured diff.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Validation:
- `make test WHAT=./pkg/kubelet/stats GOFLAGS='-run=Test_hostStatsProvider_getPodEtcHostsStats'`

Full package test note:
- `make test WHAT=./pkg/kubelet/stats` currently fails in unrelated tests: `TestFilterTerminatedContainerInfoAndAssembleByPodCgroupKey` and `TestListPodStatsStrictlyFromCRI`.