### PR TITLE
Remove klog TODOs from allocation manager

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager.go
+++ b/pkg/kubelet/allocation/allocation_manager.go
@@ -110,6 +110,7 @@ type Manager interface {
 type manager struct {
 	allocated state.State
 
+	logger        klog.Logger
 	admitHandlers lifecycle.PodAdmitHandlers
 	statusManager status.Manager
 	sourcesReady  config.SourcesReady
@@ -125,7 +126,8 @@ type manager struct {
 	recorder record.EventRecorderLogger
 }
 
-func NewManager(checkpointDirectory string,
+func NewManager(logger klog.Logger,
+	checkpointDirectory string,
 	statusManager status.Manager,
 	triggerPodSync func(pod *v1.Pod),
 	getActivePods func() []*v1.Pod,
@@ -133,12 +135,10 @@ func NewManager(checkpointDirectory string,
 	sourcesReady config.SourcesReady,
 	recorder record.EventRecorderLogger,
 ) Manager {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
 	return &manager{
 		allocated: newStateImpl(logger, checkpointDirectory, allocatedPodsStateFile),
 
+		logger:        logger,
 		statusManager: statusManager,
 		admitHandlers: lifecycle.PodAdmitHandlers{},
 		sourcesReady:  sourcesReady,
@@ -156,7 +156,7 @@ func newStateImpl(logger klog.Logger, checkpointDirectory, checkpointName string
 		return state.NewNoopStateCheckpoint()
 	}
 
-	stateImpl, err := state.NewStateCheckpoint(checkpointDirectory, checkpointName)
+	stateImpl, err := state.NewStateCheckpoint(logger, checkpointDirectory, checkpointName)
 	if err != nil {
 		// This is a critical, non-recoverable failure.
 		logger.Error(err, "Failed to initialize allocation checkpoint manager",
@@ -170,6 +170,7 @@ func newStateImpl(logger klog.Logger, checkpointDirectory, checkpointName string
 // NewInMemoryManager returns an allocation manager that doesn't persist state.
 // For testing purposes only!
 func NewInMemoryManager(
+	logger klog.Logger,
 	statusManager status.Manager,
 	triggerPodSync func(pod *v1.Pod),
 	getActivePods func() []*v1.Pod,
@@ -178,8 +179,9 @@ func NewInMemoryManager(
 	recorder record.EventRecorderLogger,
 ) Manager {
 	return &manager{
-		allocated: state.NewStateMemory(nil),
+		allocated: state.NewStateMemory(logger, nil),
 
+		logger:        logger,
 		statusManager: statusManager,
 		admitHandlers: lifecycle.PodAdmitHandlers{},
 		sourcesReady:  sourcesReady,
@@ -212,10 +214,7 @@ func (m *manager) Run(ctx context.Context) {
 }
 
 func (m *manager) RetryPendingResizes(trigger string) {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
-	m.retryPendingResizes(logger, trigger)
+	m.retryPendingResizes(m.logger, trigger)
 }
 
 func (m *manager) retryPendingResizes(logger klog.Logger, trigger string) []*v1.Pod {
@@ -274,9 +273,6 @@ func (m *manager) retryPendingResizes(logger klog.Logger, trigger string) []*v1.
 }
 
 func (m *manager) PushPendingResize(uid types.UID) {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
 	m.allocationMutex.Lock()
 	defer m.allocationMutex.Unlock()
 
@@ -289,7 +285,7 @@ func (m *manager) PushPendingResize(uid types.UID) {
 
 	// Add the pod to the pending resizes list and sort by priority.
 	m.podsWithPendingResizes = append(m.podsWithPendingResizes, uid)
-	m.sortPendingResizes(logger)
+	m.sortPendingResizes(m.logger)
 }
 
 // sortPendingResizes sorts the list of pending resizes:
@@ -479,10 +475,7 @@ func updatePodFromAllocation(pod *v1.Pod, allocated state.PodResourceInfo) (*v1.
 
 // SetAllocatedResources checkpoints the resources allocated to a pod's containers
 func (m *manager) SetAllocatedResources(pod *v1.Pod) error {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
-	return m.allocated.SetPodResourceInfo(logger, pod.UID, allocationFromPod(pod))
+	return m.allocated.SetPodResourceInfo(m.logger, pod.UID, allocationFromPod(pod))
 }
 
 func allocationFromPod(pod *v1.Pod) state.PodResourceInfo {
@@ -509,9 +502,6 @@ func (m *manager) AddPodAdmitHandlers(handlers lifecycle.PodAdmitHandlers) {
 }
 
 func (m *manager) AddPod(activePods []*v1.Pod, pod *v1.Pod) (bool, string, string) {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
 	m.allocationMutex.Lock()
 	defer m.allocationMutex.Unlock()
 
@@ -523,13 +513,13 @@ func (m *manager) AddPod(activePods []*v1.Pod, pod *v1.Pod) (bool, string, strin
 
 	// Check if we can admit the pod; if so, update the allocation.
 	allocatedPods := m.getAllocatedPods(activePods)
-	ok, reason, message := m.canAdmitPod(logger, allocatedPods, pod, lifecycle.AddOperation)
+	ok, reason, message := m.canAdmitPod(m.logger, allocatedPods, pod, lifecycle.AddOperation)
 
 	if ok && utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		// Checkpoint the resource values at which the Pod has been admitted or resized.
 		if err := m.SetAllocatedResources(pod); err != nil {
 			// TODO(vinaykul,InPlacePodVerticalScaling): Can we recover from this in some way? Investigate
-			logger.Error(err, "SetPodAllocation failed", "pod", klog.KObj(pod))
+			m.logger.Error(err, "SetPodAllocation failed", "pod", klog.KObj(pod))
 		}
 	}
 
@@ -537,12 +527,9 @@ func (m *manager) AddPod(activePods []*v1.Pod, pod *v1.Pod) (bool, string, strin
 }
 
 func (m *manager) RemovePod(uid types.UID) {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
 	if err := m.allocated.RemovePod(uid); err != nil {
 		// If the deletion fails, it will be retried by RemoveOrphanedPods, so we can safely ignore the error.
-		logger.V(3).Info("Failed to delete pod allocation", "podUID", uid, "err", err)
+		m.logger.V(3).Info("Failed to delete pod allocation", "podUID", uid, "err", err)
 	}
 }
 

--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -2425,6 +2425,7 @@ func makeAllocationManager(t *testing.T, runtime *containertest.FakeRuntime, all
 		containerManager = cm.NewFakeContainerManagerWithNodeConfig(*nodeConfig)
 	}
 	allocationManager := NewInMemoryManager(
+		logger,
 		statusManager,
 		func(pod *v1.Pod) {
 			/* For testing, just mark the pod as having a pod sync triggered in an annotation. */

--- a/pkg/kubelet/allocation/state/state_checkpoint.go
+++ b/pkg/kubelet/allocation/state/state_checkpoint.go
@@ -34,6 +34,7 @@ var _ State = &stateCheckpoint{}
 
 type stateCheckpoint struct {
 	mux               sync.RWMutex
+	logger            klog.Logger
 	cache             State
 	checkpointManager checkpointmanager.CheckpointManager
 	checkpointName    string
@@ -41,10 +42,7 @@ type stateCheckpoint struct {
 }
 
 // NewStateCheckpoint creates new State for keeping track of pod resource information with checkpoint backend
-func NewStateCheckpoint(stateDir, checkpointName string) (State, error) {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
+func NewStateCheckpoint(logger klog.Logger, stateDir, checkpointName string) (State, error) {
 	checkpointManager, err := checkpointmanager.NewCheckpointManager(stateDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize checkpoint manager for pod resource information tracking: %w", err)
@@ -58,7 +56,8 @@ func NewStateCheckpoint(stateDir, checkpointName string) (State, error) {
 	}
 
 	stateCheckpoint := &stateCheckpoint{
-		cache:             NewStateMemory(pra),
+		logger:            logger,
+		cache:             NewStateMemory(logger, pra),
 		checkpointManager: checkpointManager,
 		checkpointName:    checkpointName,
 		lastChecksum:      checksum,
@@ -138,30 +137,24 @@ func (sc *stateCheckpoint) GetPodResourceInfo(podUID types.UID) (PodResourceInfo
 
 // SetContainerResoruces sets resources information for a pod's container
 func (sc *stateCheckpoint) SetContainerResources(podUID types.UID, containerName string, resources v1.ResourceRequirements) error {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
 	err := sc.cache.SetContainerResources(podUID, containerName, resources)
 	if err != nil {
 		return err
 	}
-	return sc.storeState(logger)
+	return sc.storeState(sc.logger)
 }
 
 // SetPodLevelResources sets resources information for a pod's resources at pod-level.
 func (sc *stateCheckpoint) SetPodLevelResources(podUID types.UID, resInfo *v1.ResourceRequirements) error {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
 	err := sc.cache.SetPodLevelResources(podUID, resInfo)
 	if err != nil {
 		return err
 	}
-	return sc.storeState(logger)
+	return sc.storeState(sc.logger)
 }
 
 // SetPodResourceInfo sets pod resource information

--- a/pkg/kubelet/allocation/state/state_checkpoint_test.go
+++ b/pkg/kubelet/allocation/state/state_checkpoint_test.go
@@ -33,12 +33,14 @@ import (
 const testCheckpoint = "pod_status_manager_state"
 
 func newTestStateCheckpoint(t *testing.T) *stateCheckpoint {
+	logger, _ := ktesting.NewTestContext(t)
 	testingDir := getTestDir(t)
-	cache := NewStateMemory(PodResourceInfoMap{})
+	cache := NewStateMemory(logger, PodResourceInfoMap{})
 	checkpointManager, err := checkpointmanager.NewCheckpointManager(testingDir)
 	require.NoError(t, err, "failed to create checkpoint manager")
 	checkpointName := "pod_state_checkpoint"
 	sc := &stateCheckpoint{
+		logger:            logger,
 		cache:             cache,
 		checkpointManager: checkpointManager,
 		checkpointName:    checkpointName,
@@ -118,7 +120,7 @@ func Test_stateCheckpoint_storeState(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			logger, _ := ktesting.NewTestContext(t)
 			testDir := getTestDir(t)
-			originalSC, err := NewStateCheckpoint(testDir, testCheckpoint)
+			originalSC, err := NewStateCheckpoint(logger, testDir, testCheckpoint)
 			require.NoError(t, err)
 
 			for podUID, alloc := range tt.args.resInfoMap {
@@ -129,7 +131,7 @@ func Test_stateCheckpoint_storeState(t *testing.T) {
 			actual := originalSC.GetPodResourceInfoMap()
 			verifyPodResourceAllocation(t, &tt.args.resInfoMap, &actual, "stored pod resource allocation is not equal to original pod resource allocation")
 
-			newSC, err := NewStateCheckpoint(testDir, testCheckpoint)
+			newSC, err := NewStateCheckpoint(logger, testDir, testCheckpoint)
 			require.NoError(t, err)
 
 			actual = newSC.GetPodResourceInfoMap()
@@ -192,7 +194,7 @@ func Test_stateCheckpoint_formatUpgraded(t *testing.T) {
 
 	require.Equal(t, expectedPodResourceAllocation, actualPodResourceAllocation, "pod resource allocation info is not equal")
 
-	sc.cache = NewStateMemory(actualPodResourceAllocation)
+	sc.cache = NewStateMemory(logger, actualPodResourceAllocation)
 
 	actualPodResourceAllocation = sc.cache.GetPodResourceInfoMap()
 

--- a/pkg/kubelet/allocation/state/state_mem.go
+++ b/pkg/kubelet/allocation/state/state_mem.go
@@ -27,21 +27,20 @@ import (
 
 type stateMemory struct {
 	sync.RWMutex
+	logger       klog.Logger
 	podResources PodResourceInfoMap
 }
 
 var _ State = &stateMemory{}
 
 // NewStateMemory creates new State to track resources resourcesated to pods
-func NewStateMemory(resources PodResourceInfoMap) State {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
+func NewStateMemory(logger klog.Logger, resources PodResourceInfoMap) State {
 	if resources == nil {
 		resources = PodResourceInfoMap{}
 	}
 	logger.V(2).Info("Initialized new in-memory state store for pod resource information tracking")
 	return &stateMemory{
+		logger:       logger,
 		podResources: resources,
 	}
 }
@@ -90,10 +89,6 @@ func (s *stateMemory) GetPodResourceInfo(podUID types.UID) (PodResourceInfo, boo
 }
 
 func (s *stateMemory) SetContainerResources(podUID types.UID, containerName string, resources v1.ResourceRequirements) error {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
-
 	s.Lock()
 	defer s.Unlock()
 
@@ -111,14 +106,11 @@ func (s *stateMemory) SetContainerResources(podUID types.UID, containerName stri
 	podInfo.ContainerResources[containerName] = resources
 	s.podResources[podUID] = podInfo
 
-	logger.V(3).Info("Updated container resource information", "podUID", podUID, "containerName", containerName, "resources", resources)
+	s.logger.V(3).Info("Updated container resource information", "podUID", podUID, "containerName", containerName, "resources", resources)
 	return nil
 }
 
 func (s *stateMemory) SetPodLevelResources(podUID types.UID, resources *v1.ResourceRequirements) error {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
 	s.Lock()
 	defer s.Unlock()
 
@@ -131,7 +123,7 @@ func (s *stateMemory) SetPodLevelResources(podUID types.UID, resources *v1.Resou
 
 	s.podResources[podUID] = podInfo
 
-	logger.V(3).Info("Updated pod-level resource info", "podUID", podUID, "resources", resources)
+	s.logger.V(3).Info("Updated pod-level resource info", "podUID", podUID, "resources", resources)
 	return nil
 }
 
@@ -145,13 +137,10 @@ func (s *stateMemory) SetPodResourceInfo(logger klog.Logger, podUID types.UID, r
 }
 
 func (s *stateMemory) RemovePod(podUID types.UID) error {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
 	s.Lock()
 	defer s.Unlock()
 	delete(s.podResources, podUID)
-	logger.V(3).Info("Deleted pod resource information", "podUID", podUID)
+	s.logger.V(3).Info("Deleted pod resource information", "podUID", podUID)
 	return nil
 }
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -702,6 +702,7 @@ func NewMainKubelet(ctx context.Context,
 		klet.statusManager.AddPodUpdateNotifier(klet.podsServer)
 	}
 	klet.allocationManager = allocation.NewManager(
+		klog.FromContext(ctx),
 		klet.getRootDir(),
 		klet.statusManager,
 		klet.syncPodNow,

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -341,6 +341,7 @@ func newTestKubeletWithImageList(
 	}
 
 	kubelet.allocationManager = allocation.NewInMemoryManager(
+		logger,
 		kubelet.statusManager,
 		func(pod *v1.Pod) { kubelet.HandlePodSyncs(tCtx, []*v1.Pod{pod}) },
 		kubelet.GetActivePods,

--- a/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/component-base/logs/logreduction"
 	internalapi "k8s.io/cri-api/pkg/apis"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/credentialprovider"
 	"k8s.io/kubernetes/pkg/kubelet/allocation/state"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
@@ -114,7 +115,7 @@ func newFakeKubeRuntimeManager(ctx context.Context, runtimeService internalapi.R
 		logManager:             logs.NewStubContainerLogManager(),
 		memoryThrottlingFactor: 0.9,
 		podLogsDirectory:       fakePodLogsDirectory,
-		actuatedState:          state.NewStateMemory(nil),
+		actuatedState:          state.NewStateMemory(klog.FromContext(ctx), nil),
 	}
 
 	// Initialize swap controller availability check (always false for tests)

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -372,7 +372,7 @@ func NewKubeGenericRuntimeManager(
 		versionCacheTTL,
 	)
 
-	kubeRuntimeManager.actuatedState, err = state.NewStateCheckpoint(rootDirectory, actuatedPodsStateFile)
+	kubeRuntimeManager.actuatedState, err = state.NewStateCheckpoint(klog.FromContext(ctx), rootDirectory, actuatedPodsStateFile)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to initialize actuated state checkpoint: %w", err)
 	}

--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -397,7 +397,7 @@ func createPodWorkers(logger klog.Logger) (*podWorkers, *containertest.FakeRunti
 	return createPodWorkersWithLogger(logger)
 }
 
-func createPodWorkersWithLogger(_ klog.Logger) (*podWorkers, *containertest.FakeRuntime, map[types.UID][]syncPodRecord) {
+func createPodWorkersWithLogger(logger klog.Logger) (*podWorkers, *containertest.FakeRuntime, map[types.UID][]syncPodRecord) {
 	lock := sync.Mutex{}
 	processed := make(map[types.UID][]syncPodRecord)
 	fakeRecorder := &record.FakeRecorder{}
@@ -460,7 +460,7 @@ func createPodWorkersWithLogger(_ klog.Logger) (*podWorkers, *containertest.Fake
 		time.Second,
 		time.Millisecond,
 		fakeCache,
-		allocation.NewInMemoryManager(nil, nil, nil, nil, nil, nil),
+		allocation.NewInMemoryManager(logger, nil, nil, nil, nil, nil, nil),
 	)
 	workers := w.(*podWorkers)
 	workers.clock = clock
@@ -2151,7 +2151,7 @@ func (kl *simpleFakeKubelet) SyncTerminatedPod(ctx context.Context, pod *v1.Pod,
 // TestFakePodWorkers verifies that the fakePodWorkers behaves the same way as the real podWorkers
 // for their invocation of the syncPodFn.
 func TestFakePodWorkers(t *testing.T) {
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 	fakeRecorder := &record.FakeRecorder{}
 	fakeRuntime := &containertest.FakeRuntime{}
 	fakeCache := containertest.NewFakeCache(fakeRuntime)
@@ -2168,7 +2168,7 @@ func TestFakePodWorkers(t *testing.T) {
 		time.Second,
 		time.Second,
 		fakeCache,
-		allocation.NewInMemoryManager(nil, nil, nil, nil, nil, nil),
+		allocation.NewInMemoryManager(logger, nil, nil, nil, nil, nil, nil),
 	)
 	fakePodWorkers := &fakePodWorkers{
 		syncPodFn: kubeletForFakeWorkers.SyncPod,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR wires a contextual logger into the kubelet allocation manager and allocation state implementations, then removes the remaining klog.TODO() usage from pkg/kubelet/allocation.

This moves allocation logging along the contextual logging migration path while keeping the existing Manager and State method interfaces stable.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation:
- GOCACHE=/private/tmp/go-build-cache go test ./pkg/kubelet/allocation/state
- GOCACHE=/private/tmp/go-build-cache go test ./pkg/kubelet/allocation -run TestNonExistent
- GOCACHE=/private/tmp/go-build-cache go test ./pkg/kubelet/kuberuntime -run TestNonExistent
- GOCACHE=/private/tmp/go-build-cache go test ./pkg/kubelet -run TestNonExistent

Note: GOCACHE=/private/tmp/go-build-cache go test ./pkg/kubelet/allocation/... fails on this macOS environment because in-place pod resize is reported as unsupported on the node, causing existing resize expectation failures.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
