### PR TITLE
doc: clarify ConfigMap BinaryData not propagated to container env vars

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -6521,7 +6521,7 @@
             "format": "byte",
             "type": "string"
           },
-          "description": "BinaryData contains the binary data. Each key must consist of alphanumeric characters, '-', '_' or '.'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet.",
+          "description": "BinaryData contains the binary data. Each key must consist of alphanumeric characters, '-', '_' or '.'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet. Note: BinaryData keys are not currently propagated to container env vars via ConfigMapKeyRef or ConfigMapRef env sources; only Data keys are used.",
           "type": "object"
         },
         "data": {
@@ -6554,7 +6554,7 @@
       ]
     },
     "io.k8s.api.core.v1.ConfigMapEnvSource": {
-      "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
+      "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables. Keys in the BinaryData field are not currently propagated to container env vars.",
       "properties": {
         "name": {
           "description": "Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
@@ -6571,7 +6571,7 @@
       "description": "Selects a key from a ConfigMap.",
       "properties": {
         "key": {
-          "description": "The key to select.",
+          "description": "The key to select from the ConfigMap's Data field. Keys in the BinaryData field are not currently propagated to container env vars.",
           "type": "string"
         },
         "name": {

--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -877,7 +877,7 @@
               "format": "byte",
               "type": "string"
             },
-            "description": "BinaryData contains the binary data. Each key must consist of alphanumeric characters, '-', '_' or '.'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet.",
+            "description": "BinaryData contains the binary data. Each key must consist of alphanumeric characters, '-', '_' or '.'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet. Note: BinaryData keys are not currently propagated to container env vars via ConfigMapKeyRef or ConfigMapRef env sources; only Data keys are used.",
             "type": "object"
           },
           "data": {
@@ -915,7 +915,7 @@
         ]
       },
       "io.k8s.api.core.v1.ConfigMapEnvSource": {
-        "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
+        "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables. Keys in the BinaryData field are not currently propagated to container env vars.",
         "properties": {
           "name": {
             "default": "",
@@ -934,7 +934,7 @@
         "properties": {
           "key": {
             "default": "",
-            "description": "The key to select.",
+            "description": "The key to select from the ConfigMap's Data field. Keys in the BinaryData field are not currently propagated to container env vars.",
             "type": "string"
           },
           "name": {

--- a/api/openapi-spec/v3/apis__apps__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__apps__v1_openapi.json
@@ -1602,7 +1602,7 @@
         "type": "object"
       },
       "io.k8s.api.core.v1.ConfigMapEnvSource": {
-        "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
+        "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables. Keys in the BinaryData field are not currently propagated to container env vars.",
         "properties": {
           "name": {
             "default": "",
@@ -1621,7 +1621,7 @@
         "properties": {
           "key": {
             "default": "",
-            "description": "The key to select.",
+            "description": "The key to select from the ConfigMap's Data field. Keys in the BinaryData field are not currently propagated to container env vars.",
             "type": "string"
           },
           "name": {

--- a/api/openapi-spec/v3/apis__batch__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__batch__v1_openapi.json
@@ -959,7 +959,7 @@
         "type": "object"
       },
       "io.k8s.api.core.v1.ConfigMapEnvSource": {
-        "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
+        "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables. Keys in the BinaryData field are not currently propagated to container env vars.",
         "properties": {
           "name": {
             "default": "",
@@ -978,7 +978,7 @@
         "properties": {
           "key": {
             "default": "",
-            "description": "The key to select.",
+            "description": "The key to select from the ConfigMap's Data field. Keys in the BinaryData field are not currently propagated to container env vars.",
             "type": "string"
           },
           "name": {

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -20314,7 +20314,7 @@ func schema_k8sio_api_core_v1_ConfigMap(ref common.ReferenceCallback) common.Ope
 					},
 					"binaryData": {
 						SchemaProps: spec.SchemaProps{
-							Description: "BinaryData contains the binary data. Each key must consist of alphanumeric characters, '-', '_' or '.'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet.",
+							Description: "BinaryData contains the binary data. Each key must consist of alphanumeric characters, '-', '_' or '.'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet. Note: BinaryData keys are not currently propagated to container env vars via ConfigMapKeyRef or ConfigMapRef env sources; only Data keys are used.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,
@@ -20339,7 +20339,7 @@ func schema_k8sio_api_core_v1_ConfigMapEnvSource(ref common.ReferenceCallback) c
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
+				Description: "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables. Keys in the BinaryData field are not currently propagated to container env vars.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
@@ -20380,7 +20380,7 @@ func schema_k8sio_api_core_v1_ConfigMapKeySelector(ref common.ReferenceCallback)
 					},
 					"key": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The key to select.",
+							Description: "The key to select from the ConfigMap's Data field. Keys in the BinaryData field are not currently propagated to container env vars.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -547,6 +547,8 @@ message ConfigMap {
   // the Data field, this is enforced during validation process.
   // Using this field will require 1.10+ apiserver and
   // kubelet.
+  // Note: BinaryData keys are not currently propagated to container env vars
+  // via ConfigMapKeyRef or ConfigMapRef env sources; only Data keys are used.
   // +optional
   map<string, bytes> binaryData = 3;
 }
@@ -556,6 +558,7 @@ message ConfigMap {
 //
 // The contents of the target ConfigMap's Data field will represent the
 // key-value pairs as environment variables.
+// Keys in the BinaryData field are not currently propagated to container env vars.
 message ConfigMapEnvSource {
   // The ConfigMap to select from.
   optional LocalObjectReference localObjectReference = 1;
@@ -571,7 +574,8 @@ message ConfigMapKeySelector {
   // The ConfigMap to select from.
   optional LocalObjectReference localObjectReference = 1;
 
-  // The key to select.
+  // The key to select from the ConfigMap's Data field.
+  // Keys in the BinaryData field are not currently propagated to container env vars.
   optional string key = 2;
 
   // Specify whether the ConfigMap or its key must be defined

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2572,7 +2572,8 @@ type ResourceFieldSelector struct {
 type ConfigMapKeySelector struct {
 	// The ConfigMap to select from.
 	LocalObjectReference `json:"" protobuf:"bytes,1,opt,name=localObjectReference"`
-	// The key to select.
+	// The key to select from the ConfigMap's Data field.
+	// Keys in the BinaryData field are not currently propagated to container env vars.
 	Key string `json:"key" protobuf:"bytes,2,opt,name=key"`
 	// Specify whether the ConfigMap or its key must be defined
 	// +optional
@@ -2610,6 +2611,7 @@ type EnvFromSource struct {
 //
 // The contents of the target ConfigMap's Data field will represent the
 // key-value pairs as environment variables.
+// Keys in the BinaryData field are not currently propagated to container env vars.
 type ConfigMapEnvSource struct {
 	// The ConfigMap to select from.
 	LocalObjectReference `json:"" protobuf:"bytes,1,opt,name=localObjectReference"`
@@ -8094,6 +8096,8 @@ type ConfigMap struct {
 	// the Data field, this is enforced during validation process.
 	// Using this field will require 1.10+ apiserver and
 	// kubelet.
+	// Note: BinaryData keys are not currently propagated to container env vars
+	// via ConfigMapKeyRef or ConfigMapRef env sources; only Data keys are used.
 	// +optional
 	BinaryData map[string][]byte `json:"binaryData,omitempty" protobuf:"bytes,3,rep,name=binaryData"`
 }

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -278,7 +278,7 @@ var map_ConfigMap = map[string]string{
 	"metadata":   "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
 	"immutable":  "Immutable, if set to true, ensures that data stored in the ConfigMap cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil.",
 	"data":       "Data contains the configuration data. Each key must consist of alphanumeric characters, '-', '_' or '.'. Values with non-UTF-8 byte sequences must use the BinaryData field. The keys stored in Data must not overlap with the keys in the BinaryData field, this is enforced during validation process.",
-	"binaryData": "BinaryData contains the binary data. Each key must consist of alphanumeric characters, '-', '_' or '.'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet.",
+	"binaryData": "BinaryData contains the binary data. Each key must consist of alphanumeric characters, '-', '_' or '.'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet. Note: BinaryData keys are not currently propagated to container env vars via ConfigMapKeyRef or ConfigMapRef env sources; only Data keys are used.",
 }
 
 func (ConfigMap) SwaggerDoc() map[string]string {
@@ -286,7 +286,7 @@ func (ConfigMap) SwaggerDoc() map[string]string {
 }
 
 var map_ConfigMapEnvSource = map[string]string{
-	"":         "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
+	"":         "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables. Keys in the BinaryData field are not currently propagated to container env vars.",
 	"optional": "Specify whether the ConfigMap must be defined",
 }
 
@@ -296,7 +296,7 @@ func (ConfigMapEnvSource) SwaggerDoc() map[string]string {
 
 var map_ConfigMapKeySelector = map[string]string{
 	"":         "Selects a key from a ConfigMap.",
-	"key":      "The key to select.",
+	"key":      "The key to select from the ConfigMap's Data field. Keys in the BinaryData field are not currently propagated to container env vars.",
 	"optional": "Specify whether the ConfigMap or its key must be defined",
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmap.go
@@ -54,6 +54,8 @@ type ConfigMapApplyConfiguration struct {
 	// the Data field, this is enforced during validation process.
 	// Using this field will require 1.10+ apiserver and
 	// kubelet.
+	// Note: BinaryData keys are not currently propagated to container env vars
+	// via ConfigMapKeyRef or ConfigMapRef env sources; only Data keys are used.
 	BinaryData map[string][]byte `json:"binaryData,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmapenvsource.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmapenvsource.go
@@ -26,6 +26,7 @@ package v1
 //
 // The contents of the target ConfigMap's Data field will represent the
 // key-value pairs as environment variables.
+// Keys in the BinaryData field are not currently propagated to container env vars.
 type ConfigMapEnvSourceApplyConfiguration struct {
 	// The ConfigMap to select from.
 	LocalObjectReferenceApplyConfiguration `json:""`

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmapkeyselector.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/configmapkeyselector.go
@@ -25,7 +25,8 @@ package v1
 type ConfigMapKeySelectorApplyConfiguration struct {
 	// The ConfigMap to select from.
 	LocalObjectReferenceApplyConfiguration `json:""`
-	// The key to select.
+	// The key to select from the ConfigMap's Data field.
+	// Keys in the BinaryData field are not currently propagated to container env vars.
 	Key *string `json:"key,omitempty"`
 	// Specify whether the ConfigMap or its key must be defined
 	Optional *bool `json:"optional,omitempty"`


### PR DESCRIPTION
Document that ConfigMap.BinaryData keys are not currently propagated to
container environment variables via ConfigMapKeyRef or ConfigMapRef env sources.
Only the Data field is used when resolving env vars from ConfigMaps.

Updates doc comments on:
- ConfigMapKeySelector.Key
- ConfigMapEnvSource type
- ConfigMap.BinaryData field

Fixes #139170
Related: #139132