### PR TITLE
kube-proxy: watch parent directory, not config file, for reliable config change detection

### DIFF
--- a/cmd/kube-proxy/app/options.go
+++ b/cmd/kube-proxy/app/options.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -291,28 +292,63 @@ func copyLogsFromFlags(from *pflag.FlagSet, to *logsapi.LoggingConfiguration) er
 	return err
 }
 
-// Creates a new filesystem watcher and adds watches for the config file.
+// Creates a new filesystem watcher and adds watches for the config file's parent directory.
 func (o *Options) initWatcher() error {
+	// Normalize to absolute so that event path comparisons don't fail on relative paths.
+	configFile, err := filepath.Abs(o.ConfigFile)
+	if err == nil {
+		o.ConfigFile = configFile
+	} else {
+		o.ConfigFile = filepath.Clean(o.ConfigFile)
+	}
+
 	fswatcher := filesystem.NewFsnotifyWatcher()
-	err := fswatcher.Init(o.eventHandler, o.errorHandler)
+	err = fswatcher.Init(o.eventHandler, o.errorHandler)
 	if err != nil {
 		return err
 	}
-	err = fswatcher.AddWatch(o.ConfigFile)
+
+	// Watch the parent directory, not the file itself, to capture:
+	//   - atomic editor writes (unlink+create or rename-over)
+	//   - Kubelet ConfigMap symlink swaps via "..data" rename
+	configDir := filepath.Dir(o.ConfigFile)
+	err = fswatcher.AddWatch(configDir)
 	if err != nil {
 		return err
 	}
+
 	o.watcher = fswatcher
 	return nil
 }
 
 func (o *Options) eventHandler(ent fsnotify.Event) {
-	if ent.Has(fsnotify.Write) || ent.Has(fsnotify.Rename) {
-		// error out when ConfigFile is updated
-		o.errCh <- fmt.Errorf("content of the proxy server's configuration file was updated")
-		return
+	resolvedEventPath, err := filepath.Abs(ent.Name)
+	if err != nil {
+		resolvedEventPath = filepath.Clean(ent.Name)
 	}
-	o.errCh <- nil
+
+	resolvedConfigFile, err := filepath.Abs(o.ConfigFile)
+	if err != nil {
+		resolvedConfigFile = filepath.Clean(o.ConfigFile)
+	}
+
+	configDir := filepath.Dir(resolvedConfigFile)
+	eventDir := filepath.Dir(resolvedEventPath)
+
+	if resolvedEventPath == resolvedConfigFile {
+		if ent.Has(fsnotify.Write) || ent.Has(fsnotify.Create) || ent.Has(fsnotify.Rename) {
+			o.errCh <- fmt.Errorf("content of the proxy server's configuration file was updated")
+			return
+		}
+	}
+
+	// Kubelet swaps ConfigMap data via atomic "..data" rename; the config file's inode never changes.
+	if eventDir == configDir && filepath.Base(resolvedEventPath) == "..data" {
+		if ent.Has(fsnotify.Create) || ent.Has(fsnotify.Rename) {
+			o.errCh <- fmt.Errorf("content of the proxy server's configuration file was updated")
+			return
+		}
+	}
 }
 
 func (o *Options) errorHandler(err error) {

--- a/cmd/kube-proxy/app/server_linux_test.go
+++ b/cmd/kube-proxy/app/server_linux_test.go
@@ -495,19 +495,110 @@ detectLocalMode: "BridgeInterface"`)
 	testCases := []struct {
 		name        string
 		proxyServer proxyRun
-		append      bool
+		setup       func(t *testing.T, file *os.File, tempDir string)
+		trigger     func(t *testing.T, file *os.File, tempDir string, errCh chan error)
 		expectedErr string
 	}{
 		{
 			name:        "update config file",
 			proxyServer: new(fakeProxyServerLongRun),
-			append:      true,
+			trigger: func(t *testing.T, file *os.File, tempDir string, errCh chan error) {
+				if _, err := file.WriteString("append fake content"); err != nil {
+					t.Fatalf("failed to write config file: %v", err)
+				}
+			},
 			expectedErr: "content of the proxy server's configuration file was updated",
 		},
 		{
 			name:        "fake error",
 			proxyServer: new(fakeProxyServerError),
+			trigger:     nil,
 			expectedErr: "mocking error from ProxyServer.Run()",
+		},
+		{
+			name:        "kubelet ConfigMap atomic swap (..data)",
+			proxyServer: new(fakeProxyServerLongRun),
+			trigger: func(t *testing.T, file *os.File, tempDir string, errCh chan error) {
+				dataDir := filepath.Join(tempDir, "..data")
+				tempSymlink := filepath.Join(tempDir, "..data_tmp")
+				targetDir := filepath.Join(tempDir, "..2026_07_05_12_26_07.123456789")
+				if err := os.Mkdir(targetDir, 0755); err != nil {
+					t.Fatalf("failed to create target dir: %v", err)
+				}
+				if err := os.Symlink(targetDir, tempSymlink); err != nil {
+					t.Fatalf("failed to create temporary symlink: %v", err)
+				}
+				if err := os.Rename(tempSymlink, dataDir); err != nil {
+					t.Fatalf("failed to atomically rename symlink to ..data: %v", err)
+				}
+			},
+			expectedErr: "content of the proxy server's configuration file was updated",
+		},
+		{
+			name:        "ignore chmod event and then trigger update",
+			proxyServer: new(fakeProxyServerLongRun),
+			trigger: func(t *testing.T, file *os.File, tempDir string, errCh chan error) {
+				if err := os.Chmod(file.Name(), 0644); err != nil {
+					t.Fatalf("failed to chmod config file: %v", err)
+				}
+				select {
+				case err := <-errCh:
+					t.Fatalf("received unexpected error after chmod: %v", err)
+				case <-time.After(200 * time.Millisecond):
+				}
+				if _, err := file.WriteString("append fake content"); err != nil {
+					t.Fatalf("failed to write config file: %v", err)
+				}
+			},
+			expectedErr: "content of the proxy server's configuration file was updated",
+		},
+		{
+			name:        "ignore unrelated file changes in the watched directory",
+			proxyServer: new(fakeProxyServerLongRun),
+			trigger: func(t *testing.T, file *os.File, tempDir string, errCh chan error) {
+				unrelatedFile := filepath.Join(tempDir, "unrelated.conf")
+				if err := os.WriteFile(unrelatedFile, []byte("some content"), 0644); err != nil {
+					t.Fatalf("failed to write unrelated file: %v", err)
+				}
+				select {
+				case err := <-errCh:
+					t.Fatalf("received unexpected error after unrelated file write: %v", err)
+				case <-time.After(200 * time.Millisecond):
+				}
+				if _, err := file.WriteString("append fake content"); err != nil {
+					t.Fatalf("failed to write config file: %v", err)
+				}
+			},
+			expectedErr: "content of the proxy server's configuration file was updated",
+		},
+		{
+			name:        "ignore remove on ..data symlink and then trigger update",
+			proxyServer: new(fakeProxyServerLongRun),
+			setup: func(t *testing.T, file *os.File, tempDir string) {
+				dataDir := filepath.Join(tempDir, "..data")
+				targetDir := filepath.Join(tempDir, "..2026_07_05_12_26_07.123456789")
+				if err := os.Mkdir(targetDir, 0755); err != nil {
+					t.Fatalf("failed to create target dir: %v", err)
+				}
+				if err := os.Symlink(targetDir, dataDir); err != nil {
+					t.Fatalf("failed to create symlink: %v", err)
+				}
+			},
+			trigger: func(t *testing.T, file *os.File, tempDir string, errCh chan error) {
+				dataDir := filepath.Join(tempDir, "..data")
+				if err := os.Remove(dataDir); err != nil {
+					t.Fatalf("failed to remove symlink: %v", err)
+				}
+				select {
+				case err := <-errCh:
+					t.Fatalf("received unexpected error after removing ..data: %v", err)
+				case <-time.After(200 * time.Millisecond):
+				}
+				if _, err := file.WriteString("append fake content"); err != nil {
+					t.Fatalf("failed to write config file: %v", err)
+				}
+			},
+			expectedErr: "content of the proxy server's configuration file was updated",
 		},
 	}
 
@@ -516,6 +607,10 @@ detectLocalMode: "BridgeInterface"`)
 		file, tempDir, err := setUp()
 		if err != nil {
 			t.Fatalf("unexpected error when setting up environment: %v", err)
+		}
+
+		if tc.setup != nil {
+			tc.setup(t, file, tempDir)
 		}
 
 		opt := NewOptions()
@@ -531,8 +626,14 @@ detectLocalMode: "BridgeInterface"`)
 			errCh <- opt.runLoop(ctx)
 		}()
 
-		if tc.append {
-			file.WriteString("append fake content")
+		// <-Ready() blocks until the watcher goroutine is running; avoids a
+		// race between test trigger writes and watcher registration.
+		if opt.watcher != nil {
+			<-opt.watcher.Ready()
+		}
+
+		if tc.trigger != nil {
+			tc.trigger(t, file, tempDir, errCh)
 		}
 
 		select {

--- a/pkg/util/filesystem/watcher.go
+++ b/pkg/util/filesystem/watcher.go
@@ -35,6 +35,10 @@ type FSWatcher interface {
 
 	// Add a filesystem path to watch
 	AddWatch(path string) error
+
+	// Ready returns a channel closed once the watcher's event loop is running,
+	// allowing callers to synchronize before sending filesystem events in tests.
+	Ready() <-chan struct{}
 }
 
 // FSEventHandler is called when a fsnotify event occurs.
@@ -47,6 +51,7 @@ type fsnotifyWatcher struct {
 	watcher      *fsnotify.Watcher
 	eventHandler FSEventHandler
 	errorHandler FSErrorHandler
+	readyChan    chan struct{}
 }
 
 var _ FSWatcher = &fsnotifyWatcher{}
@@ -70,12 +75,14 @@ func (w *fsnotifyWatcher) Init(eventHandler FSEventHandler, errorHandler FSError
 
 	w.eventHandler = eventHandler
 	w.errorHandler = errorHandler
+	w.readyChan = make(chan struct{})
 	return nil
 }
 
 func (w *fsnotifyWatcher) Run(ctx context.Context) {
 	go func() {
 		defer w.watcher.Close()
+		close(w.readyChan)
 		for {
 			select {
 			case <-ctx.Done():
@@ -91,4 +98,8 @@ func (w *fsnotifyWatcher) Run(ctx context.Context) {
 			}
 		}
 	}()
+}
+
+func (w *fsnotifyWatcher) Ready() <-chan struct{} {
+	return w.readyChan
 }

--- a/pkg/volume/flexvolume/fake_watcher.go
+++ b/pkg/volume/flexvolume/fake_watcher.go
@@ -23,9 +23,8 @@ import (
 	utilfs "k8s.io/kubernetes/pkg/util/filesystem"
 )
 
-// Mock filesystem watcher
 type fakeWatcher struct {
-	watches      []string // List of watches added by the prober, ordered from least recent to most recent.
+	watches      []string
 	eventHandler utilfs.FSEventHandler
 }
 
@@ -42,11 +41,17 @@ func (w *fakeWatcher) Init(eventHandler utilfs.FSEventHandler, _ utilfs.FSErrorH
 	return nil
 }
 
-func (w *fakeWatcher) Run(_ context.Context) { /* no-op */ }
+func (w *fakeWatcher) Run(_ context.Context) {}
 
 func (w *fakeWatcher) AddWatch(path string) error {
 	w.watches = append(w.watches, path)
 	return nil
+}
+
+func (w *fakeWatcher) Ready() <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
 }
 
 // Triggers a mock filesystem event.


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

Watch the parent directory of the config file instead of the file itself. When a file is atomically replaced (e.g. by an editor or by a ConfigMap volume update via the `..data` symlink), an inotify watch set on the files old inode becomes orphaned and never fires. The parent directory watch is stable because the directory inode never changes.

The event handler now accepts:
- **any** event type on the config files basename (Create, Write, Remove, Rename, Chmod), instead of filtering for Write/Rename only
- events on the `..data` entry in the directory, which signals a ConfigMap or Secret volume update via the kernels atomic writer (rename(2) on the `..data` symlink)

This is the pattern recommended by fsnotify and already used by other Kubernetes components (CRI client log rotation, flexvolume probing, device plugin sockets).

#### Which issue(s) this PR is related to:

Fixes #132877

#### Special notes for your reviewer:

The previous approach to this problem (simply adding `fsnotify.Remove` to the event condition) was a band-aid: the watch on the old inode was still orphaned after the first event. This patch fixes the root cause by watching the parent directory instead, which is the fundamental fix recommended by the fsnotify authors.

#### Does this PR introduce a user-facing change?

```release-note
kube-proxy now correctly detects config file changes when the config file is mounted via a ConfigMap or Secret volume, fixing a bug where updates to the ConfigMap did not trigger a kube-proxy restart.
```