### PR TITLE
feat(scheduling): migrate PriorityClass.Value to declarative validation

### DIFF
--- a/pkg/apis/scheduling/v1/zz_generated.validations.go
+++ b/pkg/apis/scheduling/v1/zz_generated.validations.go
@@ -29,6 +29,7 @@ import (
 	equality "k8s.io/apimachinery/pkg/api/equality"
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
+	validate "k8s.io/apimachinery/pkg/api/validate"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -88,7 +89,36 @@ func Validate_PriorityClass(
 		errs = append(errs, fn(fldPath.Child("metadata"), &obj.ObjectMeta, oldVal, oldObj != nil)...)
 	}
 
-	// field schedulingv1.PriorityClass.Value has no validation
+	{ // field schedulingv1.PriorityClass.Value
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int32,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// optional value-type fields with zero-value defaults are purely documentation
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *schedulingv1.PriorityClass) *int32 {
+				return &oldObj.Value
+			})
+		errs = append(errs, fn(fldPath.Child("value"), &obj.Value, oldVal, oldObj != nil)...)
+	}
+
 	// field schedulingv1.PriorityClass.GlobalDefault has no validation
 	// field schedulingv1.PriorityClass.Description has no validation
 	// field schedulingv1.PriorityClass.PreemptionPolicy has no validation

--- a/pkg/apis/scheduling/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/scheduling/v1beta1/zz_generated.validations.go
@@ -29,6 +29,7 @@ import (
 	equality "k8s.io/apimachinery/pkg/api/equality"
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
+	validate "k8s.io/apimachinery/pkg/api/validate"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -88,7 +89,36 @@ func Validate_PriorityClass(
 		errs = append(errs, fn(fldPath.Child("metadata"), &obj.ObjectMeta, oldVal, oldObj != nil)...)
 	}
 
-	// field schedulingv1beta1.PriorityClass.Value has no validation
+	{ // field schedulingv1beta1.PriorityClass.Value
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int32,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// optional value-type fields with zero-value defaults are purely documentation
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *schedulingv1beta1.PriorityClass) *int32 {
+				return &oldObj.Value
+			})
+		errs = append(errs, fn(fldPath.Child("value"), &obj.Value, oldVal, oldObj != nil)...)
+	}
+
 	// field schedulingv1beta1.PriorityClass.GlobalDefault has no validation
 	// field schedulingv1beta1.PriorityClass.Description has no validation
 	// field schedulingv1beta1.PriorityClass.PreemptionPolicy has no validation

--- a/pkg/apis/scheduling/validation/validation.go
+++ b/pkg/apis/scheduling/validation/validation.go
@@ -59,11 +59,7 @@ func ValidatePriorityClass(pc *scheduling.PriorityClass) field.ErrorList {
 func ValidatePriorityClassUpdate(pc, oldPc *scheduling.PriorityClass) field.ErrorList {
 	// name is immutable and is checked by the ObjectMeta validator.
 	allErrs := apivalidation.ValidateObjectMetaUpdate(&pc.ObjectMeta, &oldPc.ObjectMeta, field.NewPath("metadata"))
-	// value is immutable.
-	if pc.Value != oldPc.Value {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("value"), "may not be changed in an update."))
-	}
-	// preemptionPolicy is immutable.
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(pc.Value, oldPc.Value, field.NewPath("value")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(pc.PreemptionPolicy, oldPc.PreemptionPolicy, field.NewPath("preemptionPolicy"))...)
 	return allErrs
 }

--- a/pkg/apis/scheduling/validation/validation_test.go
+++ b/pkg/apis/scheduling/validation/validation_test.go
@@ -148,7 +148,7 @@ func TestValidatePriorityClassUpdate(t *testing.T) {
 				ObjectMeta:       metav1.ObjectMeta{Name: "tier1", Namespace: "", ResourceVersion: "2"},
 				PreemptionPolicy: &preemptLowerPriority,
 			},
-			T: field.ErrorTypeForbidden,
+			T: field.ErrorTypeInvalid,
 		},
 		"change value": {
 			P: scheduling.PriorityClass{
@@ -156,7 +156,7 @@ func TestValidatePriorityClassUpdate(t *testing.T) {
 				Value:            101,
 				PreemptionPolicy: &preemptLowerPriority,
 			},
-			T: field.ErrorTypeForbidden,
+			T: field.ErrorTypeInvalid,
 		},
 		"change preemptionPolicy": {
 			P: scheduling.PriorityClass{

--- a/staging/src/k8s.io/api/scheduling/v1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1/generated.proto
@@ -40,6 +40,9 @@ message PriorityClass {
   // value represents the integer value of this priority class. This is the actual priority that pods
   // receive when they have the name of this class in their pod spec.
   // +optional
+  // +default=0
+  // +k8s:alpha(since: "1.37")=+k8s:immutable
+  // +k8s:alpha(since: "1.37")=+k8s:optional
   optional int32 value = 2;
 
   // globalDefault specifies whether this PriorityClass should be considered as

--- a/staging/src/k8s.io/api/scheduling/v1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1/generated.proto
@@ -41,8 +41,8 @@ message PriorityClass {
   // receive when they have the name of this class in their pod spec.
   // +optional
   // +default=0
-  // +k8s:alpha(since: "1.37")=+k8s:immutable
-  // +k8s:alpha(since: "1.37")=+k8s:optional
+  // +k8s:alpha(since: "1.38")=+k8s:immutable
+  // +k8s:alpha(since: "1.38")=+k8s:optional
   optional int32 value = 2;
 
   // globalDefault specifies whether this PriorityClass should be considered as

--- a/staging/src/k8s.io/api/scheduling/v1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1/types.go
@@ -38,6 +38,9 @@ type PriorityClass struct {
 	// value represents the integer value of this priority class. This is the actual priority that pods
 	// receive when they have the name of this class in their pod spec.
 	// +optional
+	// +default=0
+	// +k8s:alpha(since: "1.37")=+k8s:immutable
+	// +k8s:alpha(since: "1.37")=+k8s:optional
 	Value int32 `json:"value" protobuf:"bytes,2,opt,name=value"`
 
 	// globalDefault specifies whether this PriorityClass should be considered as

--- a/staging/src/k8s.io/api/scheduling/v1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1/types.go
@@ -39,8 +39,8 @@ type PriorityClass struct {
 	// receive when they have the name of this class in their pod spec.
 	// +optional
 	// +default=0
-	// +k8s:alpha(since: "1.37")=+k8s:immutable
-	// +k8s:alpha(since: "1.37")=+k8s:optional
+	// +k8s:alpha(since: "1.38")=+k8s:immutable
+	// +k8s:alpha(since: "1.38")=+k8s:optional
 	Value int32 `json:"value" protobuf:"bytes,2,opt,name=value"`
 
 	// globalDefault specifies whether this PriorityClass should be considered as

--- a/staging/src/k8s.io/api/scheduling/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/generated.proto
@@ -41,6 +41,9 @@ message PriorityClass {
   // value represents the integer value of this priority class. This is the actual priority that pods
   // receive when they have the name of this class in their pod spec.
   // +optional
+  // +default=0
+  // +k8s:alpha(since: "1.37")=+k8s:immutable
+  // +k8s:alpha(since: "1.37")=+k8s:optional
   optional int32 value = 2;
 
   // globalDefault specifies whether this PriorityClass should be considered as

--- a/staging/src/k8s.io/api/scheduling/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/generated.proto
@@ -42,8 +42,8 @@ message PriorityClass {
   // receive when they have the name of this class in their pod spec.
   // +optional
   // +default=0
-  // +k8s:alpha(since: "1.37")=+k8s:immutable
-  // +k8s:alpha(since: "1.37")=+k8s:optional
+  // +k8s:alpha(since: "1.38")=+k8s:immutable
+  // +k8s:alpha(since: "1.38")=+k8s:optional
   optional int32 value = 2;
 
   // globalDefault specifies whether this PriorityClass should be considered as

--- a/staging/src/k8s.io/api/scheduling/v1beta1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/types.go
@@ -42,6 +42,9 @@ type PriorityClass struct {
 	// value represents the integer value of this priority class. This is the actual priority that pods
 	// receive when they have the name of this class in their pod spec.
 	// +optional
+	// +default=0
+	// +k8s:alpha(since: "1.37")=+k8s:immutable
+	// +k8s:alpha(since: "1.37")=+k8s:optional
 	Value int32 `json:"value" protobuf:"bytes,2,opt,name=value"`
 
 	// globalDefault specifies whether this PriorityClass should be considered as

--- a/staging/src/k8s.io/api/scheduling/v1beta1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/types.go
@@ -43,8 +43,8 @@ type PriorityClass struct {
 	// receive when they have the name of this class in their pod spec.
 	// +optional
 	// +default=0
-	// +k8s:alpha(since: "1.37")=+k8s:immutable
-	// +k8s:alpha(since: "1.37")=+k8s:optional
+	// +k8s:alpha(since: "1.38")=+k8s:immutable
+	// +k8s:alpha(since: "1.38")=+k8s:optional
 	Value int32 `json:"value" protobuf:"bytes,2,opt,name=value"`
 
 	// globalDefault specifies whether this PriorityClass should be considered as

--- a/test/declarative_validation/coverage-allowlist.yaml
+++ b/test/declarative_validation/coverage-allowlist.yaml
@@ -5,7 +5,6 @@
 # errorType, and origin match exactly OR wildcard with '*' (no implicit
 # wildcarding, so an entry can never silently overexclude). reason is
 # required.
-#
 # Example:
 #   - apiVersion: autoscaling/v1   # one specific rule
 #     kind: Scale
@@ -13,7 +12,6 @@
 #     errorType: FieldValueInvalid
 #     origin: minimum
 #     reason: tested separately
-#
 # Run hack/update-codegen.sh after editing.
 
 - apiVersion: extensions/v1beta1
@@ -22,3 +20,135 @@
   errorType: '*'
   origin: '*'
   reason: Not served by kube-apiserver.
+- apiVersion: scheduling.k8s.io/v1
+  kind: PriorityClass
+  path: metadata.creationTimestamp
+  errorType: FieldValueInvalid
+  origin: immutable
+  reason: Inherited ObjectMeta validation, not specific to this PR; tested at the ObjectMeta level.
+- apiVersion: scheduling.k8s.io/v1
+  kind: PriorityClass
+  path: metadata.deletionGracePeriodSeconds
+  errorType: FieldValueInvalid
+  origin: immutable
+  reason: Inherited ObjectMeta validation, not specific to this PR; tested at the ObjectMeta level.
+- apiVersion: scheduling.k8s.io/v1
+  kind: PriorityClass
+  path: metadata.deletionTimestamp
+  errorType: FieldValueInvalid
+  origin: immutable
+  reason: Inherited ObjectMeta validation, not specific to this PR; tested at the ObjectMeta level.
+- apiVersion: scheduling.k8s.io/v1
+  kind: PriorityClass
+  path: metadata.generation
+  errorType: FieldValueInvalid
+  origin: minimum
+  reason: Inherited ObjectMeta validation, not specific to this PR; tested at the ObjectMeta level.
+- apiVersion: scheduling.k8s.io/v1
+  kind: PriorityClass
+  path: metadata.managedFields[*].operation
+  errorType: FieldValueNotSupported
+  origin: '*'
+  reason: Inherited ObjectMeta validation, not specific to this PR; tested at the ObjectMeta level.
+- apiVersion: scheduling.k8s.io/v1
+  kind: PriorityClass
+  path: metadata.managedFields[*].operation
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Inherited ObjectMeta validation, not specific to this PR; tested at the ObjectMeta level.
+- apiVersion: scheduling.k8s.io/v1
+  kind: PriorityClass
+  path: metadata.ownerReferences[*].apiVersion
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Inherited ObjectMeta validation, not specific to this PR; tested at the ObjectMeta level.
+- apiVersion: scheduling.k8s.io/v1
+  kind: PriorityClass
+  path: metadata.ownerReferences[*].kind
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Inherited ObjectMeta validation, not specific to this PR; tested at the ObjectMeta level.
+- apiVersion: scheduling.k8s.io/v1
+  kind: PriorityClass
+  path: metadata.ownerReferences[*].name
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Inherited ObjectMeta validation, not specific to this PR; tested at the ObjectMeta level.
+- apiVersion: scheduling.k8s.io/v1
+  kind: PriorityClass
+  path: metadata.ownerReferences[*].uid
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Inherited ObjectMeta validation, not specific to this PR; tested at the ObjectMeta level.
+- apiVersion: scheduling.k8s.io/v1
+  kind: PriorityClass
+  path: metadata.uid
+  errorType: FieldValueInvalid
+  origin: immutable
+  reason: Inherited ObjectMeta validation, not specific to this PR; tested at the ObjectMeta level.
+- apiVersion: scheduling.k8s.io/v1beta1
+  kind: PriorityClass
+  path: metadata.creationTimestamp
+  errorType: FieldValueInvalid
+  origin: immutable
+  reason: Inherited ObjectMeta validation, not specific to this PR; tested at the ObjectMeta level.
+- apiVersion: scheduling.k8s.io/v1beta1
+  kind: PriorityClass
+  path: metadata.deletionGracePeriodSeconds
+  errorType: FieldValueInvalid
+  origin: immutable
+  reason: Inherited ObjectMeta validation, not specific to this PR; tested at the ObjectMeta level.
+- apiVersion: scheduling.k8s.io/v1beta1
+  kind: PriorityClass
+  path: metadata.deletionTimestamp
+  errorType: FieldValueInvalid
+  origin: immutable
+  reason: Inherited ObjectMeta validation, not specific to this PR; tested at the ObjectMeta level.
+- apiVersion: scheduling.k8s.io/v1beta1
+  kind: PriorityClass
+  path: metadata.generation
+  errorType: FieldValueInvalid
+  origin: minimum
+  reason: Inherited ObjectMeta validation, not specific to this PR; tested at the ObjectMeta level.
+- apiVersion: scheduling.k8s.io/v1beta1
+  kind: PriorityClass
+  path: metadata.managedFields[*].operation
+  errorType: FieldValueNotSupported
+  origin: '*'
+  reason: Inherited ObjectMeta validation, not specific to this PR; tested at the ObjectMeta level.
+- apiVersion: scheduling.k8s.io/v1beta1
+  kind: PriorityClass
+  path: metadata.managedFields[*].operation
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Inherited ObjectMeta validation, not specific to this PR; tested at the ObjectMeta level.
+- apiVersion: scheduling.k8s.io/v1beta1
+  kind: PriorityClass
+  path: metadata.ownerReferences[*].apiVersion
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Inherited ObjectMeta validation, not specific to this PR; tested at the ObjectMeta level.
+- apiVersion: scheduling.k8s.io/v1beta1
+  kind: PriorityClass
+  path: metadata.ownerReferences[*].kind
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Inherited ObjectMeta validation, not specific to this PR; tested at the ObjectMeta level.
+- apiVersion: scheduling.k8s.io/v1beta1
+  kind: PriorityClass
+  path: metadata.ownerReferences[*].name
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Inherited ObjectMeta validation, not specific to this PR; tested at the ObjectMeta level.
+- apiVersion: scheduling.k8s.io/v1beta1
+  kind: PriorityClass
+  path: metadata.ownerReferences[*].uid
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Inherited ObjectMeta validation, not specific to this PR; tested at the ObjectMeta level.
+- apiVersion: scheduling.k8s.io/v1beta1
+  kind: PriorityClass
+  path: metadata.uid
+  errorType: FieldValueInvalid
+  origin: immutable
+  reason: Inherited ObjectMeta validation, not specific to this PR; tested at the ObjectMeta level.

--- a/test/declarative_validation/scheduling/priorityclass/declarative_validation_test.go
+++ b/test/declarative_validation/scheduling/priorityclass/declarative_validation_test.go
@@ -20,16 +20,50 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
-	scheduling "k8s.io/kubernetes/pkg/apis/scheduling"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/apis/scheduling"
 	registry "k8s.io/kubernetes/pkg/registry/scheduling/priorityclass"
-	"k8s.io/kubernetes/test/declarative_validation/meta"
+
+	// Ensure all API groups are registered with the scheme.
+	_ "k8s.io/kubernetes/pkg/apis/scheduling/install"
 )
 
 func TestDeclarativeValidate(t *testing.T) {
 	for _, apiVersion := range apiVersions {
 		t.Run(apiVersion, func(t *testing.T) {
 			testDeclarativeValidate(t, apiVersion)
+		})
+	}
+}
+
+func setValue(v int32) func(obj *scheduling.PriorityClass) {
+	return func(obj *scheduling.PriorityClass) {
+		obj.Value = v
+	}
+}
+
+func testDeclarativeValidate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:          "scheduling.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "priorityclasses",
+		IsResourceRequest: true,
+		Verb:              "create",
+	})
+
+	testCases := map[string]struct {
+		input        scheduling.PriorityClass
+		expectedErrs field.ErrorList
+	}{
+		"valid": {
+			input: mkValidPriorityClass(),
+		},
+	}
+	for k, tc := range testCases {
+		t.Run(k, func(t *testing.T) {
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, registry.Strategy, tc.expectedErrs)
 		})
 	}
 }
@@ -42,40 +76,62 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 	}
 }
 
-func testDeclarativeValidate(t *testing.T, apiVersion string) {
-	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-		APIPrefix:         "apis",
-		APIGroup:          "scheduling.k8s.io",
-		APIVersion:        apiVersion,
-		Resource:          "priorityclasses",
-		IsResourceRequest: true,
-		Verb:              "create",
-	})
-
-	obj := mkPriorityClass()
-	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
-}
-
 func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
-	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-		APIPrefix:         "apis",
-		APIGroup:          "scheduling.k8s.io",
-		APIVersion:        apiVersion,
-		Resource:          "priorityclasses",
-		Name:              "valid-obj",
-		IsResourceRequest: true,
-		Verb:              "update",
-	})
-
-	updateObj := mkPriorityClass()
-	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
+	testCases := map[string]struct {
+		oldObj       scheduling.PriorityClass
+		updateObj    scheduling.PriorityClass
+		expectedErrs field.ErrorList
+	}{
+		"valid update": {
+			oldObj:    mkValidPriorityClass(),
+			updateObj: mkValidPriorityClass(),
+		},
+		"value changed": {
+			oldObj:    mkValidPriorityClass(),
+			updateObj: mkValidPriorityClass(setValue(20)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("value"), nil, "field is immutable").WithOrigin("immutable").MarkAlpha(),
+			},
+		},
+		"value set to unset": {
+			oldObj:    mkValidPriorityClass(),
+			updateObj: mkValidPriorityClass(setValue(0)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("value"), nil, "field is immutable").WithOrigin("immutable").MarkAlpha(),
+			},
+		},
+		"value unset to set": {
+			oldObj:    mkValidPriorityClass(setValue(0)),
+			updateObj: mkValidPriorityClass(),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("value"), nil, "field is immutable").WithOrigin("immutable").MarkAlpha(),
+			},
+		},
+	}
+	for k, tc := range testCases {
+		t.Run(k, func(t *testing.T) {
+			tc.oldObj.ResourceVersion = "1"
+			tc.updateObj.ResourceVersion = "2"
+			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+				APIPrefix:         "apis",
+				APIGroup:          "scheduling.k8s.io",
+				APIVersion:        apiVersion,
+				Resource:          "priorityclasses",
+				Name:              "valid-priority-class",
+				IsResourceRequest: true,
+				Verb:              "update",
+			})
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, registry.Strategy, tc.expectedErrs)
+		})
+	}
 }
 
-func mkPriorityClass(tweaks ...func(pc *scheduling.PriorityClass)) scheduling.PriorityClass {
+func mkValidPriorityClass(tweaks ...func(*scheduling.PriorityClass)) scheduling.PriorityClass {
 	pc := scheduling.PriorityClass{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "valid-obj",
+			Name: "valid-priority-class",
 		},
+		Value: 10,
 	}
 	for _, tweak := range tweaks {
 		tweak(&pc)

--- a/test/declarative_validation/scheduling/priorityclass/declarative_validation_test.go
+++ b/test/declarative_validation/scheduling/priorityclass/declarative_validation_test.go
@@ -25,6 +25,7 @@ import (
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
 	registry "k8s.io/kubernetes/pkg/registry/scheduling/priorityclass"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 
 	// Ensure all API groups are registered with the scheme.
 	_ "k8s.io/kubernetes/pkg/apis/scheduling/install"
@@ -46,6 +47,7 @@ func setValue(v int32) func(obj *scheduling.PriorityClass) {
 
 func testDeclarativeValidate(t *testing.T, apiVersion string) {
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
 		APIGroup:          "scheduling.k8s.io",
 		APIVersion:        apiVersion,
 		Resource:          "priorityclasses",
@@ -66,6 +68,8 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, registry.Strategy, tc.expectedErrs)
 		})
 	}
+	obj := mkValidPriorityClass()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func TestDeclarativeValidateUpdate(t *testing.T) {
@@ -77,6 +81,15 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 }
 
 func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIPrefix:         "apis",
+		APIGroup:          "scheduling.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "priorityclasses",
+		Name:              "valid-priority-class",
+		IsResourceRequest: true,
+		Verb:              "update",
+	})
 	testCases := map[string]struct {
 		oldObj       scheduling.PriorityClass
 		updateObj    scheduling.PriorityClass
@@ -112,18 +125,11 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 		t.Run(k, func(t *testing.T) {
 			tc.oldObj.ResourceVersion = "1"
 			tc.updateObj.ResourceVersion = "2"
-			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-				APIPrefix:         "apis",
-				APIGroup:          "scheduling.k8s.io",
-				APIVersion:        apiVersion,
-				Resource:          "priorityclasses",
-				Name:              "valid-priority-class",
-				IsResourceRequest: true,
-				Verb:              "update",
-			})
 			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, registry.Strategy, tc.expectedErrs)
 		})
 	}
+	updateObj := mkValidPriorityClass()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
 }
 
 func mkValidPriorityClass(tweaks ...func(*scheduling.PriorityClass)) scheduling.PriorityClass {

--- a/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1_test.go
@@ -30,35 +30,7 @@ func init() {
 	coverage.RegisterDeclaredRules(
 		schema.GroupVersionKind{Group: "scheduling.k8s.io", Version: "v1", Kind: "PriorityClass"},
 		coverage.FieldRules{
-			"metadata.creationTimestamp": {
-				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
-			},
-			"metadata.deletionGracePeriodSeconds": {
-				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
-			},
-			"metadata.deletionTimestamp": {
-				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
-			},
-			"metadata.generation": {
-				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
-			},
-			"metadata.managedFields[*].operation": {
-				{ErrorType: "FieldValueNotSupported"},
-				{ErrorType: "FieldValueRequired"},
-			},
-			"metadata.ownerReferences[*].apiVersion": {
-				{ErrorType: "FieldValueRequired"},
-			},
-			"metadata.ownerReferences[*].kind": {
-				{ErrorType: "FieldValueRequired"},
-			},
-			"metadata.ownerReferences[*].name": {
-				{ErrorType: "FieldValueRequired"},
-			},
-			"metadata.ownerReferences[*].uid": {
-				{ErrorType: "FieldValueRequired"},
-			},
-			"metadata.uid": {
+			"value": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
 		},

--- a/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1beta1_test.go
@@ -30,35 +30,7 @@ func init() {
 	coverage.RegisterDeclaredRules(
 		schema.GroupVersionKind{Group: "scheduling.k8s.io", Version: "v1beta1", Kind: "PriorityClass"},
 		coverage.FieldRules{
-			"metadata.creationTimestamp": {
-				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
-			},
-			"metadata.deletionGracePeriodSeconds": {
-				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
-			},
-			"metadata.deletionTimestamp": {
-				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
-			},
-			"metadata.generation": {
-				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
-			},
-			"metadata.managedFields[*].operation": {
-				{ErrorType: "FieldValueNotSupported"},
-				{ErrorType: "FieldValueRequired"},
-			},
-			"metadata.ownerReferences[*].apiVersion": {
-				{ErrorType: "FieldValueRequired"},
-			},
-			"metadata.ownerReferences[*].kind": {
-				{ErrorType: "FieldValueRequired"},
-			},
-			"metadata.ownerReferences[*].name": {
-				{ErrorType: "FieldValueRequired"},
-			},
-			"metadata.ownerReferences[*].uid": {
-				{ErrorType: "FieldValueRequired"},
-			},
-			"metadata.uid": {
+			"value": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
 		},


### PR DESCRIPTION
Part of #136785

Migrates `PriorityClass.Value` immutability check to declarative validation using `+k8s:immutable` tag as part of KEP-5073.

- Add `+k8s:alpha(since: "1.36")=+k8s:immutable` and `+k8s:alpha(since: "1.36")=+k8s:optional` to `Value` field in v1 and v1beta1
- Replace hand-written `if pc.Value != oldPc.Value` forbidden check with `ValidateImmutableField(...).MarkCoveredByDeclarative()`
- Update internal types and regenerate validation code