### PR TITLE
kubectl cp: cancel remote tar when copy fails

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
@@ -24,6 +24,8 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
+	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -154,7 +156,7 @@ func NewCmdCp(f cmdutil.Factory, ioStreams genericiooptions.IOStreams) *cobra.Co
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate())
-			cmdutil.CheckErr(o.Run())
+			cmdutil.CheckErr(o.RunWithContext(cmd.Context()))
 		},
 	}
 	cmdutil.AddContainerVarFlags(cmd, &o.Container, o.Container)
@@ -235,8 +237,13 @@ func (o *CopyOptions) Validate() error {
 	return nil
 }
 
-// Run performs the execution
+// Run performs the execution.
 func (o *CopyOptions) Run() error {
+	return o.RunWithContext(context.Background())
+}
+
+// RunWithContext performs the execution using the command context.
+func (o *CopyOptions) RunWithContext(ctx context.Context) error {
 	srcSpec, err := extractFileSpec(o.args[0])
 	if err != nil {
 		return err
@@ -254,10 +261,10 @@ func (o *CopyOptions) Run() error {
 	}
 
 	if len(srcSpec.PodName) != 0 {
-		return o.copyFromPod(srcSpec, destSpec)
+		return o.copyFromPod(ctx, srcSpec, destSpec)
 	}
 	if len(destSpec.PodName) != 0 {
-		return o.copyToPod(srcSpec, destSpec, &exec.ExecOptions{})
+		return o.copyToPod(ctx, srcSpec, destSpec, &exec.ExecOptions{})
 	}
 	return fmt.Errorf("one of src or dest must be a remote file specification")
 }
@@ -266,7 +273,7 @@ func (o *CopyOptions) Run() error {
 // determines if the provided destination path exists on the
 // pod. If the destination path does not exist or is _not_ a
 // directory, an error is returned with the exit code received.
-func (o *CopyOptions) checkDestinationIsDir(dest fileSpec) error {
+func (o *CopyOptions) checkDestinationIsDir(ctx context.Context, dest fileSpec) error {
 	options := &exec.ExecOptions{
 		StreamOptions: exec.StreamOptions{
 			IOStreams: genericiooptions.IOStreams{
@@ -282,13 +289,13 @@ func (o *CopyOptions) checkDestinationIsDir(dest fileSpec) error {
 		Executor: o.Executor,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	done := make(chan error)
 
 	go func() {
-		done <- o.execute(options)
+		done <- o.execute(ctx, options)
 	}()
 
 	select {
@@ -299,16 +306,20 @@ func (o *CopyOptions) checkDestinationIsDir(dest fileSpec) error {
 	}
 }
 
-func (o *CopyOptions) copyToPod(src, dest fileSpec, options *exec.ExecOptions) error {
+func (o *CopyOptions) copyToPod(ctx context.Context, src, dest fileSpec, options *exec.ExecOptions) error {
 	if _, err := os.Stat(src.File.String()); err != nil {
 		return fmt.Errorf("%s doesn't exist in local filesystem", src.File)
 	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	reader, writer := io.Pipe()
 
 	srcFile := src.File.(localPath)
 	destFile := dest.File.(remotePath)
 
-	if err := o.checkDestinationIsDir(dest); err == nil {
+	if err := o.checkDestinationIsDir(ctx, dest); err == nil {
 		// If no error, dest.File was found to be a directory.
 		// Copy specified src into it
 		destFile = destFile.Join(srcFile.Base())
@@ -318,10 +329,6 @@ func (o *CopyOptions) copyToPod(src, dest fileSpec, options *exec.ExecOptions) e
 		return err
 	}
 
-	go func(src localPath, dest remotePath, writer io.WriteCloser) {
-		defer writer.Close()
-		cmdutil.CheckErr(makeTar(src, dest, writer))
-	}(srcFile, destFile, writer)
 	var cmdArr []string
 
 	if o.NoPreserve {
@@ -336,9 +343,9 @@ func (o *CopyOptions) copyToPod(src, dest fileSpec, options *exec.ExecOptions) e
 
 	options.StreamOptions = exec.StreamOptions{
 		IOStreams: genericiooptions.IOStreams{
-			In:     reader,
-			Out:    o.Out,
-			ErrOut: o.ErrOut,
+			In:     &contextReader{ctx: ctx, r: reader},
+			Out:    &contextWriter{ctx: ctx, w: o.Out},
+			ErrOut: &contextWriter{ctx: ctx, w: o.ErrOut},
 		},
 		Stdin: true,
 
@@ -348,62 +355,328 @@ func (o *CopyOptions) copyToPod(src, dest fileSpec, options *exec.ExecOptions) e
 
 	options.Command = cmdArr
 	options.Executor = o.Executor
-	return o.execute(options)
+
+	execDone := make(chan error, 1)
+	go func() {
+		execDone <- o.execute(ctx, options)
+	}()
+
+	tarDone := make(chan error, 1)
+	go func() {
+		tarDone <- makeTar(srcFile, destFile, writer)
+	}()
+
+	var execErr, tarErr error
+	select {
+	case execErr = <-execDone:
+		// Exec finished first (remote tar exited or failed); stop local tar.
+		_ = writer.Close()
+		_ = reader.Close()
+		select {
+		case tarErr = <-tarDone:
+		case <-time.After(30 * time.Second):
+		}
+		if execErr != nil {
+			return execErr
+		}
+		return wrapCopyWriteError(tarErr)
+
+	case tarErr = <-tarDone:
+		// Local tar finished; send EOF to remote tar and wait for it to exit.
+		_ = writer.Close()
+		if tarErr != nil {
+			// Local failure: kill remote tar immediately instead of waiting for EOF.
+			cancel()
+			_ = reader.Close()
+		}
+		select {
+		case execErr = <-execDone:
+		case <-time.After(30 * time.Second):
+			cancel()
+			_ = reader.Close()
+			return fmt.Errorf("timed out waiting for remote tar to complete")
+		}
+		if tarErr != nil {
+			return wrapCopyWriteError(tarErr)
+		}
+		return execErr
+	}
 }
 
-func (o *CopyOptions) copyFromPod(src, dest fileSpec) error {
-	reader := newTarPipe(src, o)
+// contextReader stops supplying stdin to the remote tar when the copy is cancelled.
+type contextReader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (cr *contextReader) Read(p []byte) (int, error) {
+	if err := cr.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return cr.r.Read(p)
+}
+
+// contextWriter stops forwarding remote output when the copy is cancelled.
+type contextWriter struct {
+	ctx context.Context
+	w   io.Writer
+}
+
+func (cw *contextWriter) Write(p []byte) (int, error) {
+	if err := cw.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return cw.w.Write(p)
+}
+
+// podToLocalTarCommand starts tar as the exec session process (no shell wrapper).
+// A shell pipeline leaves tar/cat as children of sh; when the stream closes, sh exits
+// and those children are reparented to the container init and keep running.
+func podToLocalTarCommand(path string, resumeFrom uint64) []string {
+	if resumeFrom > 0 {
+		escaped := strings.ReplaceAll(path, "'", `'\''`)
+		script := fmt.Sprintf("trap 'kill 0' TERM; tar cf - '%s' | tail -c+%d", escaped, resumeFrom)
+		return []string{"sh", "-c", script}
+	}
+	return []string{"tar", "cf", "-", path}
+}
+
+func podToLocalTarKillPattern(path string) string {
+	return fmt.Sprintf("tar cf - %s", path)
+}
+
+// killPodToLocalTarProcess stops orphaned tar from a failed pod-to-local copy.
+// Busybox tar may keep running after the exec stream closes; pkill is the exec
+// process itself (no shell) so it does not accumulate sh/cat/pkill zombies.
+func (o *CopyOptions) killPodToLocalTarProcess(src fileSpec, path string) {
+	pattern := podToLocalTarKillPattern(path)
+	for _, sig := range []string{"TERM", "KILL"} {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		options := &exec.ExecOptions{
+			StreamOptions: exec.StreamOptions{
+				IOStreams: genericiooptions.IOStreams{
+					Out:    io.Discard,
+					ErrOut: io.Discard,
+				},
+				Namespace: src.PodNamespace,
+				PodName:   src.PodName,
+			},
+			Command:  []string{"pkill", "-" + sig, "-f", pattern},
+			Executor: o.Executor,
+		}
+		_ = o.execute(ctx, options)
+		cancel()
+	}
+}
+
+func (o *CopyOptions) finishPodToLocalCopy(src fileSpec, path string, err error) error {
+	if err != nil {
+		o.killPodToLocalTarProcess(src, path)
+	}
+	return err
+}
+
+func (o *CopyOptions) copyFromPod(ctx context.Context, src, dest fileSpec) error {
+	if o.MaxTries != 0 {
+		return o.copyFromPodWithRetry(ctx, src, dest)
+	}
+	return o.copyFromPodOnce(ctx, src, dest)
+}
+
+// copyFromPodOnce copies from a pod without --retries. It mirrors copyToPod teardown:
+// cancel the exec stream and wait for the remote tar to exit instead of only closing
+// the local pipe (which can return "closed pipe" while tar keeps running in the pod).
+func (o *CopyOptions) copyFromPodOnce(ctx context.Context, src, dest fileSpec) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	reader, writer := io.Pipe()
+
 	srcFile := src.File.(remotePath)
 	destFile := dest.File.(localPath)
-	// remove extraneous path shortcuts - these could occur if a path contained extra "../"
-	// and attempted to navigate beyond "/" in a remote filesystem
 	prefix := stripPathShortcuts(srcFile.StripSlashes().Clean().String())
-	return o.untarAll(src.PodNamespace, src.PodName, prefix, srcFile, destFile, reader)
+
+	options := &exec.ExecOptions{
+		StreamOptions: exec.StreamOptions{
+			IOStreams: genericiooptions.IOStreams{
+				In:     nil,
+				Out:    &contextWriter{ctx: ctx, w: writer},
+				ErrOut: &contextWriter{ctx: ctx, w: o.ErrOut},
+			},
+			Namespace: src.PodNamespace,
+			PodName:   src.PodName,
+		},
+		Command:  podToLocalTarCommand(srcFile.String(), 0),
+		Executor: o.Executor,
+	}
+
+	execDone := make(chan error, 1)
+	go func() {
+		execDone <- o.execute(ctx, options)
+	}()
+
+	untarDone := make(chan error, 1)
+	go func() {
+		untarDone <- o.untarAll(src.PodNamespace, src.PodName, prefix, srcFile, destFile, reader)
+	}()
+
+	teardownStreams := func() {
+		cancel()
+		_ = writer.Close()
+		_ = reader.Close()
+	}
+
+	var execErr, untarErr error
+	select {
+	case execErr = <-execDone:
+		select {
+		case untarErr = <-untarDone:
+		case <-time.After(30 * time.Second):
+		}
+		teardownStreams()
+		if execErr != nil {
+			return o.finishPodToLocalCopy(src, srcFile.String(), execErr)
+		}
+		return o.finishPodToLocalCopy(src, srcFile.String(), wrapCopyWriteError(untarErr))
+
+	case untarErr = <-untarDone:
+		teardownStreams()
+		select {
+		case execErr = <-execDone:
+		case <-time.After(30 * time.Second):
+			return o.finishPodToLocalCopy(src, srcFile.String(), fmt.Errorf("timed out waiting for remote tar to complete"))
+		}
+		if untarErr != nil {
+			return o.finishPodToLocalCopy(src, srcFile.String(), wrapCopyWriteError(untarErr))
+		}
+		return o.finishPodToLocalCopy(src, srcFile.String(), execErr)
+	}
+}
+
+func (o *CopyOptions) copyFromPodWithRetry(ctx context.Context, src, dest fileSpec) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	tp := newTarPipe(src, o, ctx)
+	defer tp.Close()
+
+	srcFile := src.File.(remotePath)
+	destFile := dest.File.(localPath)
+	prefix := stripPathShortcuts(srcFile.StripSlashes().Clean().String())
+	err := o.untarAll(src.PodNamespace, src.PodName, prefix, srcFile, destFile, tp)
+	if err != nil {
+		cancel()
+		tp.waitExec(30 * time.Second)
+	}
+	return o.finishPodToLocalCopy(src, srcFile.String(), wrapCopyWriteError(err))
 }
 
 type TarPipe struct {
 	src       fileSpec
 	o         *CopyOptions
+	ctx       context.Context
 	reader    *io.PipeReader
 	outStream *io.PipeWriter
 	bytesRead uint64
 	retries   int
+
+	mu            sync.Mutex
+	sessionCancel context.CancelFunc
+	execDone      chan error
+	wg            sync.WaitGroup
+	closed        bool
 }
 
-func newTarPipe(src fileSpec, o *CopyOptions) *TarPipe {
-	t := new(TarPipe)
-	t.src = src
-	t.o = o
+func newTarPipe(src fileSpec, o *CopyOptions, ctx context.Context) *TarPipe {
+	t := &TarPipe{
+		src: src,
+		o:   o,
+		ctx: ctx,
+	}
 	t.initReadFrom(0)
 	return t
 }
 
+// Close stops the remote tar process and waits for the exec session to finish.
+func (t *TarPipe) Close() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.closed {
+		return nil
+	}
+	t.closed = true
+	t.endSessionLocked()
+	return nil
+}
+
+func (t *TarPipe) endSessionLocked() {
+	if t.sessionCancel != nil {
+		t.sessionCancel()
+		t.sessionCancel = nil
+	}
+	// Close the write half first so a blocked remote-command copy unblocks when the
+	// local untar stops reading (e.g. no space left on device on the host).
+	if t.outStream != nil {
+		_ = t.outStream.Close()
+		t.outStream = nil
+	}
+	if t.reader != nil {
+		_ = t.reader.Close()
+		t.reader = nil
+	}
+	t.wg.Wait()
+}
+
 func (t *TarPipe) initReadFrom(n uint64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.closed {
+		return
+	}
+	t.endSessionLocked()
+
 	t.reader, t.outStream = io.Pipe()
+	sessionCtx, sessionCancel := context.WithCancel(t.ctx)
+	t.sessionCancel = sessionCancel
+
 	options := &exec.ExecOptions{
 		StreamOptions: exec.StreamOptions{
 			IOStreams: genericiooptions.IOStreams{
 				In:     nil,
-				Out:    t.outStream,
-				ErrOut: t.o.Out,
+				Out:    &contextWriter{ctx: sessionCtx, w: t.outStream},
+				ErrOut: &contextWriter{ctx: sessionCtx, w: t.o.ErrOut},
 			},
 
 			Namespace: t.src.PodNamespace,
 			PodName:   t.src.PodName,
 		},
 
-		Command:  []string{"tar", "cf", "-", t.src.File.String()},
+		Command:  podToLocalTarCommand(t.src.File.String(), n),
 		Executor: t.o.Executor,
 	}
-	if t.o.MaxTries != 0 {
-		escapedPath := strings.ReplaceAll(t.src.File.String(), "'", `'\''`)
-		options.Command = []string{"sh", "-c", fmt.Sprintf("tar cf - '%s' | tail -c+%d", escapedPath, n)}
-	}
 
+	writer := t.outStream
+	t.execDone = make(chan error, 1)
+	t.wg.Add(1)
 	go func() {
-		defer t.outStream.Close()
-		cmdutil.CheckErr(t.o.execute(options))
+		defer t.wg.Done()
+		defer writer.Close()
+		t.execDone <- t.o.execute(sessionCtx, options)
 	}()
+}
+
+// waitExec blocks until the remote tar exec finishes or times out.
+func (t *TarPipe) waitExec(timeout time.Duration) {
+	t.mu.Lock()
+	done := t.execDone
+	t.mu.Unlock()
+	if done == nil {
+		return
+	}
+	select {
+	case <-done:
+	case <-time.After(timeout):
+	}
 }
 
 func (t *TarPipe) Read(p []byte) (n int, err error) {
@@ -411,11 +684,11 @@ func (t *TarPipe) Read(p []byte) (n int, err error) {
 	if err != nil {
 		if t.o.MaxTries < 0 || t.retries < t.o.MaxTries {
 			t.retries++
-			fmt.Printf("Resuming copy at %d bytes, retry %d/%d\n", t.bytesRead, t.retries, t.o.MaxTries)
+			fmt.Fprintf(t.o.ErrOut, "Resuming copy at %d bytes, retry %d/%d\n", t.bytesRead, t.retries, t.o.MaxTries)
 			t.initReadFrom(t.bytesRead + 1)
 			err = nil
 		} else {
-			fmt.Printf("Dropping out copy after %d retries\n", t.retries)
+			fmt.Fprintf(t.o.ErrOut, "Dropping out copy after %d retries\n", t.retries)
 		}
 	} else {
 		t.bytesRead += uint64(n)
@@ -562,8 +835,8 @@ func (o *CopyOptions) untarAll(ns, pod string, prefix string, src remotePath, de
 		if err != nil {
 			return err
 		}
-		defer outFile.Close()
 		if _, err := io.Copy(outFile, tarReader); err != nil {
+			outFile.Close()
 			return err
 		}
 		if err := outFile.Close(); err != nil {
@@ -574,7 +847,21 @@ func (o *CopyOptions) untarAll(ns, pod string, prefix string, src remotePath, de
 	return nil
 }
 
-func (o *CopyOptions) execute(options *exec.ExecOptions) error {
+func wrapCopyWriteError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, syscall.ENOSPC) {
+		return fmt.Errorf("copy failed: no space left on device: %w", err)
+	}
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) && errors.Is(pathErr.Err, syscall.ENOSPC) {
+		return fmt.Errorf("copy failed: no space left on device while writing %q: %w", pathErr.Path, err)
+	}
+	return err
+}
+
+func (o *CopyOptions) execute(ctx context.Context, options *exec.ExecOptions) error {
 	if len(options.Namespace) == 0 {
 		options.Namespace = o.Namespace
 	}
@@ -590,5 +877,9 @@ func (o *CopyOptions) execute(options *exec.ExecOptions) error {
 		return err
 	}
 
-	return options.Run()
+	if options.Executor == nil {
+		options.Executor = o.Executor
+	}
+
+	return options.RunWithContext(ctx)
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp_test.go
@@ -29,6 +29,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -731,7 +732,7 @@ func TestCopyFromPod(t *testing.T) {
 			dest:            destDir,
 			podName:         "pod-name",
 			retries:         1,
-			expectedCommand: `sh -c tar cf - '/tmp/path'\''with'\''quotes' | tail -c+1`,
+			expectedCommand: `sh -c trap 'kill 0' TERM; tar cf - '/tmp/path'\''with'\''quotes' | tail -c+1`,
 		},
 	}
 
@@ -741,7 +742,7 @@ func TestCopyFromPod(t *testing.T) {
 		if err := opts.Complete(tf, cmd, []string{test.src, test.dest}); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		remoteExec := &testingRemoteExecutor{}
+		remoteExec := &testingRemoteExecutor{writeEmptyTar: test.retries == 0}
 		opts.Executor = remoteExec
 		t.Run(name, func(t *testing.T) {
 			err := opts.Run()
@@ -774,6 +775,7 @@ func TestCopyFromPod(t *testing.T) {
 type testingRemoteExecutor struct {
 	capturedPath  string
 	capturedQuery string
+	writeEmptyTar bool
 }
 
 func (t *testingRemoteExecutor) Execute(url *url.URL, config *restclient.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool, terminalSizeQueue remotecommand.TerminalSizeQueue) error {
@@ -783,6 +785,13 @@ func (t *testingRemoteExecutor) Execute(url *url.URL, config *restclient.Config,
 func (t *testingRemoteExecutor) ExecuteWithContext(ctx context.Context, url *url.URL, config *restclient.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool, terminalSizeQueue remotecommand.TerminalSizeQueue) error {
 	t.capturedPath = url.Path
 	t.capturedQuery = url.RawQuery
+	if t.writeEmptyTar && stdout != nil {
+		// Empty tar stream so pod-to-local copy tests do not race on a closed pipe.
+		tw := tar.NewWriter(stdout)
+		if err := tw.Close(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -840,7 +849,7 @@ func TestCopyToPodNoPreserve(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			options := &kexec.ExecOptions{}
 			opts.NoPreserve = test.nopreserve
-			err = opts.copyToPod(src, dest, options)
+			err = opts.copyToPod(context.Background(), src, dest, options)
 			if !(reflect.DeepEqual(test.expectedCmd, options.Command)) {
 				t.Errorf("expected cmd: %v, got: %v", test.expectedCmd, options.Command)
 			}
@@ -1102,4 +1111,29 @@ type testWriter testing.T
 func (t *testWriter) Write(p []byte) (n int, err error) {
 	t.Log(string(p))
 	return len(p), nil
+}
+
+func TestTarPipeCloseCancelsSession(t *testing.T) {
+	tp := &TarPipe{ctx: context.Background()}
+	tp.reader, tp.outStream = io.Pipe()
+	sessionCtx, sessionCancel := context.WithCancel(tp.ctx)
+	tp.sessionCancel = sessionCancel
+
+	done := make(chan struct{})
+	tp.wg.Add(1)
+	go func() {
+		defer tp.wg.Done()
+		<-sessionCtx.Done()
+		close(done)
+	}()
+
+	if err := tp.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("session context was not cancelled after TarPipe.Close")
+	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
@@ -314,12 +314,18 @@ func (o *StreamOptions) SetupTTY() term.TTY {
 
 // Run executes a validated remote execution against a pod.
 func (p *ExecOptions) Run() error {
+	return p.RunWithContext(context.Background())
+}
+
+// RunWithContext executes a validated remote execution against a pod. The context
+// controls the lifetime of the remote command stream.
+func (p *ExecOptions) RunWithContext(ctx context.Context) error {
 	var err error
 	// we still need legacy pod getter when PodName in ExecOptions struct is provided,
 	// since there are any other command run this function by providing Podname with PodsGetter
 	// and without resource builder, eg: `kubectl cp`.
 	if len(p.PodName) != 0 {
-		p.Pod, err = p.PodClient.Pods(p.Namespace).Get(context.TODO(), p.PodName, metav1.GetOptions{})
+		p.Pod, err = p.PodClient.Pods(p.Namespace).Get(ctx, p.PodName, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -403,7 +409,7 @@ func (p *ExecOptions) Run() error {
 			TTY:       t.Raw,
 		}, scheme.ParameterCodec)
 
-		return p.Executor.Execute(req.URL(), p.Config, p.In, p.Out, p.ErrOut, t.Raw, sizeQueue)
+		return p.Executor.ExecuteWithContext(ctx, req.URL(), p.Config, p.In, p.Out, p.ErrOut, t.Raw, sizeQueue)
 	}
 
 	if err := t.Safe(fn); err != nil {

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1577,6 +1577,74 @@ metadata:
 				framework.Failf("Failed copying remote file contents. Expected %s but got %s", remoteContents, string(localData))
 			}
 		})
+
+		/*
+			Release: v1.35
+			Testname: Kubectl, copy failure does not leave tar running in pod
+			Description: When kubectl cp to a pod fails because the destination volume is full,
+				the remote tar process must not keep running in the pod.
+		*/
+		ginkgo.It("should not leave tar running when copy to pod fails on full volume", func(ctx context.Context) {
+			const (
+				volumeName   = "small-data"
+				volumeMount  = "/small-data"
+				sizeLimitMiB = 2
+				fileSizeMiB  = 5
+			)
+
+			sizeLimit := resource.MustParse(fmt.Sprintf("%dMi", sizeLimitMiB))
+			podName := "kubectl-cp-full-" + string(uuid.NewUUID())
+			grace := int64(0)
+
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: podName},
+				Spec: v1.PodSpec{
+					Volumes: []v1.Volume{{
+						Name: volumeName,
+						VolumeSource: v1.VolumeSource{
+							EmptyDir: &v1.EmptyDirVolumeSource{SizeLimit: &sizeLimit},
+						},
+					}},
+					Containers: []v1.Container{{
+						Name:    "busybox",
+						Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+						Command: []string{"/bin/sh"},
+						Args:    []string{"-c", e2epod.InfiniteSleepCommand},
+						VolumeMounts: []v1.VolumeMount{{
+							Name: volumeName, MountPath: volumeMount,
+						}},
+					}},
+					TerminationGracePeriodSeconds: &grace,
+					RestartPolicy:                 v1.RestartPolicyNever,
+				},
+			}
+
+			ginkgo.By("creating a pod with a small emptyDir volume")
+			e2epod.NewPodClient(f).CreateSync(ctx, pod)
+			defer func() {
+				e2epod.NewPodClient(f).DeleteSync(ctx, podName, metav1.DeleteOptions{GracePeriodSeconds: &grace}, e2epod.PodDeleteTimeout)
+			}()
+
+			ginkgo.By("creating a local file larger than the volume limit")
+			localFile, err := os.CreateTemp("", "kubectl-cp-large-")
+			framework.ExpectNoError(err)
+			defer os.Remove(localFile.Name())
+			framework.ExpectNoError(localFile.Truncate(int64(fileSizeMiB * 1024 * 1024)))
+			framework.ExpectNoError(localFile.Close())
+
+			podDest := fmt.Sprintf("%s:%s/", podName, volumeMount)
+			ginkgo.By("copying the file to the pod (expected to fail)")
+			_, stderr, err := e2ekubectl.RunKubectlWithFullOutput(ns, "cp", localFile.Name(), podDest)
+			gomega.Expect(err).To(gomega.HaveOccurred(), "kubectl cp should fail when the pod volume is full")
+			framework.Logf("kubectl cp stderr: %s", stderr)
+
+			ginkgo.By("checking that no tar extract process remains in the pod")
+			gomega.Eventually(func() string {
+				out, pollErr := e2ekubectl.RunKubectl(ns, "exec", podName, "--", "sh", "-c", "pgrep -f 'tar -xmf' || true")
+				framework.ExpectNoError(pollErr)
+				return strings.TrimSpace(out)
+			}, 30*time.Second, 2*time.Second).Should(gomega.BeEmpty())
+		})
 	})
 
 	ginkgo.Describe("Kubectl patch", func() {


### PR DESCRIPTION
When kubectl cp fails mid-stream (e.g. no space on the destination), cancel the exec context and close pipes so the pod-side tar process is stopped instead of left running.
Fixes: https://github.com/kubernetes/kubernetes/issues/139201
Author: kginon <kginon@redhat.com>

/kind bug
pod→local needed explicit pkill on your runtime/busybox even with context cancel — the e2e test covers local→pod; manual repro was pod→local with a full disk on the master.
 
Steps to verify the possible fix

on a local cluster  create a pod that uses busybox image below is my pod defintiion example
i use namespace ncms

`[root@vbm12-cloud-masterbm-0 cbis-admin (Active)]# cat mypod.yaml
apiVersion: v1
kind: Pod
metadata:
  name: kubectl-cp-repro
  namespace: ncms
spec:
  restartPolicy: Never
  containers:
  - name: busybox
    image: bcmt-registry:5000/busybox:1.37
    command: ["/bin/sh", "-c", "sleep infinity"]
    volumeMounts:
    - name: data
      mountPath: /data
  volumes:
  - name: data
    emptyDir: {}`
    
  inside the pod create a big file to copy from inside the pod outside , file location at /data/ folder
  
  `[root@vbm12-cloud-masterbm-0 cbis-admin (Active)]#  kubectl exec -it -n ncms kubectl-cp-repro -- dd if=/dev/zero of=/data/file5g bs=1M count=5120`
  
  On the local master node creating a tmp file system of smaller size 4GB to have not enough space
  MNT=/tmp/kubectl-cp-mnt
  IMG=/tmp/kubectl-cp-4g.img
  dd if=/dev/zero of="$IMG" bs=1M count=4096 status=progress
  mkfs.ext4 -F "$IMG"
  mkdir -p "$MNT"
  mount -o loop "$IMG" "$MNT"
  
  Copied now the compiled new kubectl to the master node and replacing the existing kubectl executable
  
  running on master node the following test
  
  for i in 1 2 3 4; do
  echo "=== $i ==="
  kubectl -n ncms cp kubectl-cp-repro:/data/file5g /tmp/kubectl-cp-mnt/file5g || true
  sleep 2
  kubectl -n ncms exec kubectl-cp-repro -- sh -c "pgrep -af 'tar cf' || echo none"
done
  
  At the end of there are no zombies
  
  [root@vbm12-cloud-masterbm-0 cbis-admin (Active)]# for i in 1 2 3 4; do   echo "=== $i ===";   $K -n ncms cp kubectl-cp-repro:/data/file5g /tmp/kubectl-cp-mnt/file5g || true;   sleep 2;   kubectl -n ncms exec kubectl-cp-repro -- sh -c "pgrep -af 'tar cf' || echo none"; done
=== 1 ===
tar: removing leading '/' from member names
E0522 21:54:14.930751 3391592 v2.go:151] "Copying stdout failed" err="io: read/write on closed pipe"
E0522 21:54:14.931156 3391592 v2.go:168] "Copying stderr failed" err="read message: read tcp 172.25.1.51:39438->172.25.1.51:8443: use of closed network connection"
error: copy failed: no space left on device: write /tmp/kubectl-cp-mnt/file5g: no space left on device
2389 sh -c pgrep -af 'tar cf' || echo none
=== 2 ===
tar: removing leading '/' from member names
E0522 21:54:25.814586 3392979 v2.go:151] "Copying stdout failed" err="io: read/write on closed pipe"
E0522 21:54:25.815264 3392979 v2.go:168] "Copying stderr failed" err="read message: read tcp 172.25.1.51:51848->172.25.1.51:8443: use of closed network connection"
error: copy failed: no space left on device: write /tmp/kubectl-cp-mnt/file5g: no space left on device
2394 sh -c pgrep -af 'tar cf' || echo none
=== 3 ===
tar: removing leading '/' from member names
E0522 21:54:36.549846 3393757 v2.go:151] "Copying stdout failed" err="io: read/write on closed pipe"
E0522 21:54:36.550699 3393757 v2.go:168] "Copying stderr failed" err="read message: read tcp 172.25.1.51:39360->172.25.1.51:8443: use of closed network connection"
error: copy failed: no space left on device: write /tmp/kubectl-cp-mnt/file5g: no space left on device
2399 sh -c pgrep -af 'tar cf' || echo none
=== 4 ===
tar: removing leading '/' from member names
E0522 21:54:47.805254 3394495 v2.go:151] "Copying stdout failed" err="io: read/write on closed pipe"
E0522 21:54:47.805984 3394495 v2.go:168] "Copying stderr failed" err="read message: read tcp 172.25.1.51:33584->172.25.1.51:8443: use of closed network connection"
error: copy failed: no space left on device: write /tmp/kubectl-cp-mnt/file5g: no space left on device
2404 sh -c pgrep -af 'tar cf' || echo none



<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
