### PR TITLE
scheduler: eliminate time.Now() from MoreImportantPod

### DIFF
--- a/pkg/scheduler/util/utils.go
+++ b/pkg/scheduler/util/utils.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
@@ -47,14 +46,16 @@ func GetPodFullName(pod *v1.Pod) string {
 	return pod.Name + "_" + pod.Namespace
 }
 
-// GetPodStartTime returns start time of the given pod or current timestamp
+// GetPodStartTime returns start time of the given pod or its creation time
 // if it hasn't started yet.
 func GetPodStartTime(pod *v1.Pod) *metav1.Time {
 	if pod.Status.StartTime != nil {
 		return pod.Status.StartTime
 	}
 	// Assumed pods and bound pods that haven't started don't have a StartTime yet.
-	return &metav1.Time{Time: time.Now()}
+	// We use CreationTimestamp instead of time.Now() to avoid dynamically generating
+	// a timestamp during sorting, which breaks sort's strict weak ordering.
+	return &pod.CreationTimestamp
 }
 
 // GetEarliestPodStartTime returns the earliest start time of all pods that

--- a/pkg/scheduler/util/utils.go
+++ b/pkg/scheduler/util/utils.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
@@ -39,6 +40,8 @@ import (
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 )
 
+var maxPodStartTime = metav1.NewTime(time.Date(9999, time.December, 31, 23, 59, 59, 0, time.UTC))
+
 // GetPodFullName returns a name that uniquely identifies a pod.
 func GetPodFullName(pod *v1.Pod) string {
 	// Use underscore as the delimiter because it is not allowed in pod name
@@ -46,16 +49,16 @@ func GetPodFullName(pod *v1.Pod) string {
 	return pod.Name + "_" + pod.Namespace
 }
 
-// GetPodStartTime returns start time of the given pod or its creation time
+// GetPodStartTime returns start time of the given pod or a stable maximum timestamp
 // if it hasn't started yet.
 func GetPodStartTime(pod *v1.Pod) *metav1.Time {
 	if pod.Status.StartTime != nil {
 		return pod.Status.StartTime
 	}
 	// Assumed pods and bound pods that haven't started don't have a StartTime yet.
-	// We use CreationTimestamp instead of time.Now() to avoid dynamically generating
-	// a timestamp during sorting, which breaks sort's strict weak ordering.
-	return &pod.CreationTimestamp
+	// Treat them as newer than started pods without generating a timestamp during
+	// sorting, which would break sort's strict weak ordering.
+	return &maxPodStartTime
 }
 
 // GetEarliestPodStartTime returns the earliest start time of all pods that

--- a/pkg/scheduler/util/utils.go
+++ b/pkg/scheduler/util/utils.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -40,7 +41,7 @@ import (
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 )
 
-var maxPodStartTime = metav1.NewTime(time.Date(9999, time.December, 31, 23, 59, 59, 0, time.UTC))
+var maxPodStartTime = metav1.NewTime(time.Unix(0, math.MaxInt64).UTC())
 
 // GetPodFullName returns a name that uniquely identifies a pod.
 func GetPodFullName(pod *v1.Pod) string {

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -167,6 +167,90 @@ func TestMoreImportantPod(t *testing.T) {
 	}
 }
 
+func TestMoreImportantPodCreationTimestamp(t *testing.T) {
+	var priority int32 = 1
+	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	newPod := func(name string, creationTimestamp time.Time) *v1.Pod {
+		return &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				CreationTimestamp: metav1.NewTime(creationTimestamp),
+			},
+			Spec: v1.PodSpec{
+				Priority: &priority,
+			},
+		}
+	}
+
+	olderPod := newPod("older-pod", baseTime)
+	newerPod := newPod("newer-pod", baseTime.Add(time.Second))
+	sameTimePod := newPod("same-time-pod", baseTime)
+
+	tests := []struct {
+		name     string
+		pod1     *v1.Pod
+		pod2     *v1.Pod
+		expected bool
+	}{
+		{
+			name:     "older creation timestamp is more important",
+			pod1:     olderPod,
+			pod2:     newerPod,
+			expected: true,
+		},
+		{
+			name:     "newer creation timestamp is less important",
+			pod1:     newerPod,
+			pod2:     olderPod,
+			expected: false,
+		},
+		{
+			name:     "same creation timestamp does not order pods",
+			pod1:     olderPod,
+			pod2:     sameTimePod,
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := MoreImportantPod(test.pod1, test.pod2)
+			if got != test.expected {
+				t.Errorf("expected %t but got %t", test.expected, got)
+			}
+		})
+	}
+}
+
+func BenchmarkMoreImportantPodWithoutStartTime(b *testing.B) {
+	var priority int32 = 1
+	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	pod1 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pod1",
+			CreationTimestamp: metav1.NewTime(baseTime),
+		},
+		Spec: v1.PodSpec{
+			Priority: &priority,
+		},
+	}
+	pod2 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pod2",
+			CreationTimestamp: metav1.NewTime(baseTime.Add(time.Second)),
+		},
+		Spec: v1.PodSpec{
+			Priority: &priority,
+		},
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		MoreImportantPod(pod1, pod2)
+	}
+}
+
 func TestPatchPodStatus(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -90,7 +90,8 @@ func TestGetEarliestPodStartTime(t *testing.T) {
 				newPriorityPodWithStartTime("pod1", 1, currentTime.Add(-time.Second)),
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "pod2",
+						Name:              "pod2",
+						CreationTimestamp: metav1.NewTime(currentTime),
 					},
 					Spec: v1.PodSpec{
 						Priority: &priority,

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -167,11 +167,11 @@ func TestMoreImportantPod(t *testing.T) {
 	}
 }
 
-func TestMoreImportantPodCreationTimestamp(t *testing.T) {
+func TestMoreImportantPodWithoutStartTime(t *testing.T) {
 	var priority int32 = 1
 	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	newPod := func(name string, creationTimestamp time.Time) *v1.Pod {
+	newPod := func(name string, creationTimestamp time.Time, startTime *metav1.Time) *v1.Pod {
 		return &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              name,
@@ -180,12 +180,14 @@ func TestMoreImportantPodCreationTimestamp(t *testing.T) {
 			Spec: v1.PodSpec{
 				Priority: &priority,
 			},
+			Status: v1.PodStatus{StartTime: startTime},
 		}
 	}
 
-	olderPod := newPod("older-pod", baseTime)
-	newerPod := newPod("newer-pod", baseTime.Add(time.Second))
-	sameTimePod := newPod("same-time-pod", baseTime)
+	startedAt := metav1.NewTime(baseTime.Add(time.Hour))
+	startedPod := newPod("started-pod", baseTime.Add(time.Hour), &startedAt)
+	unstartedOlderPod := newPod("unstarted-older-pod", baseTime, nil)
+	unstartedNewerPod := newPod("unstarted-newer-pod", baseTime.Add(2*time.Hour), nil)
 
 	tests := []struct {
 		name     string
@@ -194,21 +196,21 @@ func TestMoreImportantPodCreationTimestamp(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "older creation timestamp is more important",
-			pod1:     olderPod,
-			pod2:     newerPod,
+			name:     "started pod is more important than unstarted pod",
+			pod1:     startedPod,
+			pod2:     unstartedOlderPod,
 			expected: true,
 		},
 		{
-			name:     "newer creation timestamp is less important",
-			pod1:     newerPod,
-			pod2:     olderPod,
+			name:     "unstarted pod is less important than started pod",
+			pod1:     unstartedOlderPod,
+			pod2:     startedPod,
 			expected: false,
 		},
 		{
-			name:     "same creation timestamp does not order pods",
-			pod1:     olderPod,
-			pod2:     sameTimePod,
+			name:     "creation timestamp does not order unstarted pods",
+			pod1:     unstartedOlderPod,
+			pod2:     unstartedNewerPod,
 			expected: false,
 		},
 	}
@@ -225,21 +227,14 @@ func TestMoreImportantPodCreationTimestamp(t *testing.T) {
 
 func BenchmarkMoreImportantPodWithoutStartTime(b *testing.B) {
 	var priority int32 = 1
-	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	pod1 := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "pod1",
-			CreationTimestamp: metav1.NewTime(baseTime),
-		},
+		ObjectMeta: metav1.ObjectMeta{Name: "pod1"},
 		Spec: v1.PodSpec{
 			Priority: &priority,
 		},
 	}
 	pod2 := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "pod2",
-			CreationTimestamp: metav1.NewTime(baseTime.Add(time.Second)),
-		},
+		ObjectMeta: metav1.ObjectMeta{Name: "pod2"},
 		Spec: v1.PodSpec{
 			Priority: &priority,
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR eliminates the use of `time.Now()` in `GetPodStartTime`, which is used when ordering potential victims during scheduler preemption.

When a Pod does not have a `StartTime`, `GetPodStartTime` now returns a stable maximum timestamp.

##### Rationale

1. **Correctness (Strict Weak Ordering)**: Calling `time.Now()` from a `sort.Slice` comparison function can produce different results for the same Pods during sorting. A stable fallback preserves strict weak ordering.
2. **Preserving Preemption Semantics**: A Pod without `StartTime` has not started yet and should be treated as newer, and therefore less important, than an already started Pod. Using `CreationTimestamp` would incorrectly treat a long-pending Pod as older than a running Pod and change victim selection behavior.
3. **Performance**: The stable fallback avoids repeated `time.Now()` calls in the preemption sorting path.

##### Behavior Without StartTime

Pods without `StartTime` use the same stable maximum timestamp. Therefore:

- A started Pod is considered more important than an unstarted Pod of the same priority.
- Two unstarted Pods of the same priority are not ordered by their creation timestamps.
- Comparisons remain stable throughout sorting.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- `make test WHAT=./pkg/scheduler/util`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

AI usage disclosure:
YES, AI is used to update and verify the test.
