### PR TITLE
Introduce proper LoadPreference method to read kuberc file

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/set.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/kubectl/pkg/kuberc"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
-	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -228,12 +227,12 @@ func (o *SetOptions) Run() error {
 
 // loadOrCreatePreference loads existing preference or creates a new one
 func (o *SetOptions) loadOrCreatePreference() (*v1beta1.Preference, error) {
-	data, err := os.ReadFile(o.KubeRCFile)
+	pref, err := kuberc.LoadPreference(o.KubeRCFile)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("error reading kuberc file: %w", err)
 	}
 
-	if os.IsNotExist(err) || len(data) == 0 {
+	if os.IsNotExist(err) || pref == nil {
 		return &v1beta1.Preference{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "kubectl.config.k8s.io/v1beta1",
@@ -242,12 +241,7 @@ func (o *SetOptions) loadOrCreatePreference() (*v1beta1.Preference, error) {
 		}, nil
 	}
 
-	var pref v1beta1.Preference
-	if err := yaml.Unmarshal(data, &pref); err != nil {
-		return nil, fmt.Errorf("error parsing kuberc file: %w", err)
-	}
-
-	return &pref, nil
+	return pref, nil
 }
 
 // parseOptions parses the --option flags into CommandOptionDefault structs

--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/view.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/view.go
@@ -26,11 +26,11 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
 	"k8s.io/kubectl/pkg/config/v1beta1"
 	"k8s.io/kubectl/pkg/kuberc"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
-	"sigs.k8s.io/yaml"
 )
 
 var (
@@ -112,7 +112,7 @@ func (o *ViewOptions) Validate() error {
 
 // Run executes the view command
 func (o *ViewOptions) Run() error {
-	data, err := os.ReadFile(o.KubeRCFile)
+	pref, err := kuberc.LoadPreference(o.KubeRCFile)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return fmt.Errorf("error reading kuberc file: %w", err)
@@ -132,11 +132,6 @@ func (o *ViewOptions) Run() error {
 			pref := kuberc.CreateDefaultPreference()
 			return kuberc.SavePreference(pref, o.KubeRCFile, o.Out)
 		}
-	}
-
-	var pref *v1beta1.Preference
-	if err := yaml.Unmarshal(data, &pref); err != nil {
-		return fmt.Errorf("error parsing kuberc file: %w", err)
 	}
 
 	if pref.Aliases == nil {

--- a/staging/src/k8s.io/kubectl/pkg/kuberc/marshal.go
+++ b/staging/src/k8s.io/kubectl/pkg/kuberc/marshal.go
@@ -26,17 +26,17 @@ import (
 	"path/filepath"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/config"
 	"k8s.io/kubectl/pkg/config/scheme"
 	"k8s.io/kubectl/pkg/config/v1beta1"
-	"sigs.k8s.io/yaml"
 )
 
-// decodePreference iterates over the yamls in kuberc file to find the supported kuberc version.
-// Once it finds, it returns the compatible kuberc object as well as accumulated errors during the iteration.
+// decodePreference iterates over the yamls in kuberc file to find the first supported Preference version.
+// Once it finds, it returns the internal object as well as accumulated errors during the iteration.
 func decodePreference(kubercFile string) (*config.Preference, error) {
 	kubercBytes, err := os.ReadFile(kubercFile)
 	if err != nil {
@@ -104,23 +104,38 @@ func decodePreference(kubercFile string) (*config.Preference, error) {
 	return nil, nil
 }
 
+// LoadPreference loads the kuberc file, and returns v1beta1.Preference object
+func LoadPreference(kubercFile string) (*v1beta1.Preference, error) {
+	internal, err := decodePreference(kubercFile)
+	if err != nil {
+		return nil, err
+	}
+	prefs, err := scheme.Scheme.ConvertToVersion(internal, v1beta1.SchemeGroupVersion)
+	if err != nil {
+		return nil, fmt.Errorf("error converting Preferences to v1beta1.Preferences: %w", err)
+	}
+	return prefs.(*v1beta1.Preference), nil
+}
+
 // SavePreference saves the preference to the kuberc file
-func SavePreference(pref *v1beta1.Preference, file string, out io.Writer) error {
-	dir := filepath.Dir(file)
+func SavePreference(pref *v1beta1.Preference, kubercFile string, out io.Writer) error {
+	dir := filepath.Dir(kubercFile)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("failed to create directory %s: %w", dir, err)
 	}
-
-	data, err := yaml.Marshal(pref)
+	file, err := os.OpenFile(kubercFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
-		return fmt.Errorf("failed to marshal preferences: %w", err)
-	}
-
-	if err := os.WriteFile(file, data, 0644); err != nil {
 		return fmt.Errorf("failed to write kuberc file: %w", err)
 	}
 
-	fmt.Fprintf(out, "Updated %s\n", file) // nolint:errcheck
+	const mediaType = runtime.ContentTypeYAML
+	yamlInfo, _ := runtime.SerializerInfoForMediaType(scheme.StrictCodecs.SupportedMediaTypes(), mediaType)
+	encoder := scheme.StrictCodecs.EncoderForVersion(yamlInfo.Serializer, v1beta1.SchemeGroupVersion)
+	if err := encoder.Encode(pref, file); err != nil {
+		return fmt.Errorf("failed to marshal preferences: %w", err)
+	}
+
+	fmt.Fprintf(out, "Updated %s\n", kubercFile) // nolint:errcheck
 	return nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig cli

#### What this PR does / why we need it:
This allows us to drop direct `yaml.Unmarshal` invocation and replace it with proper `kuberc.LoadPreference` invocations which rely on our conversion mechanisms.

This is coming from a conversation here: https://github.com/kubernetes/kubernetes/pull/135003#discussion_r2486318857

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
/assign @ardaguclu 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
