### PR TITLE
Wrap errors from pod group preemption

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -453,5 +453,10 @@ func filterPodsWithPDBViolation(podInfos []fwk.PodInfo, pdbs []*policy.PodDisrup
 
 // PodGroupPostFilter runs a default preemption for the pod group.
 func (pl *DefaultPreemption) PodGroupPostFilter(ctx context.Context, pg *schedulingapi.PodGroup, pods []*v1.Pod, pgSchedulingFunc framework.PodGroupSchedulingFunc) (*framework.PodGroupPostFilterResult, *fwk.Status) {
-	return pl.podGroupEvaluator.Preempt(ctx, pg, pods, pgSchedulingFunc)
+	res, status := pl.podGroupEvaluator.Preempt(ctx, pg, pods, pgSchedulingFunc)
+	msg := status.Message()
+	if len(msg) > 0 {
+		return res, fwk.NewStatus(status.Code(), "pod group preemption: "+msg)
+	}
+	return res, status
 }

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -2669,3 +2669,58 @@ func TestPreEnqueue(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultPreemption_PodGroupPostFilter_ErrorWrapping(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Create a node and a pod with an empty UID to induce a raw cache failure during preemption.
+	node := st.MakeNode().Name("node1").Capacity(veryLargeRes).Obj()
+	invalidPod := st.MakePod().Name("pod-empty-uid").UID("").Node("node1").Priority(lowPriority).Obj()
+
+	testPods := []*v1.Pod{invalidPod}
+	nodes := []*v1.Node{node}
+
+	client := clientsetfake.NewClientset(invalidPod)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	registeredPlugins := []tf.RegisterPluginFunc{
+		tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+		tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+	}
+	f, err := tf.NewFramework(ctx, registeredPlugins, "",
+		frameworkruntime.WithClientSet(client),
+		frameworkruntime.WithSnapshotSharedLister(internalcache.NewSnapshot(testPods, nodes)),
+		frameworkruntime.WithInformerFactory(informerFactory),
+		frameworkruntime.WithLogger(logger),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	features := feature.Features{
+		EnableWorkloadAwarePreemption: true,
+	}
+	pl, err := New(ctx, getDefaultDefaultPreemptionArgs(), f, features)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	preemptorPG := st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj()
+	preemptorPods := []*v1.Pod{st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()}
+	mockSchedulingFunc := func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
+		return nil, fwk.NewStatus(fwk.Unschedulable)
+	}
+
+	_, gotStatus := pl.PodGroupPostFilter(ctx, preemptorPG, preemptorPods, mockSchedulingFunc)
+
+	if gotStatus == nil || gotStatus.Code() != fwk.Error {
+		t.Fatalf("Expected status code %v, got status: %v", fwk.Error, gotStatus)
+	}
+
+	expectedMsg := "pod group preemption: cannot get cache key for pod with empty UID"
+	gotMsg := gotStatus.Message()
+	if gotMsg != expectedMsg {
+		t.Errorf("Expected wrapped error message %q, got %q", expectedMsg, gotMsg)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR wraps error from podgroup preemption with `pod group preemption:` prefix. This makes sure that SchedulerError messages for given PodGroup will clearly show that error is coming from pod group preemption.

#### Which issue(s) this PR is related to:

[KEP-5710](https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/5710-workload-aware-preemption#delayed-preemption)

#### Special notes for your reviewer:

This mimics behavior for default pod by pod preemption:  https://github.com/kubernetes/kubernetes/blob/ea692abff6bb8ed2b7e20d7e27de76f77bf083d6/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go#L158-L164

#### Does this PR introduce a user-facing change?

```release-note
Errors coming from pod group preemption are now prefixed with `pod group preemption:` message.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
