### PR TITLE
Warn if v2 data in annotations is modified via v1

### DIFF
--- a/pkg/apis/autoscaling/helpers.go
+++ b/pkg/apis/autoscaling/helpers.go
@@ -16,12 +16,24 @@ limitations under the License.
 
 package autoscaling
 
+// RoundTripAnnotations returns the annotation keys used to round-trip data from later HPA versions into v1.
+func RoundTripAnnotations() []string {
+	return []string{
+		MetricSpecsAnnotation,
+		BehaviorSpecsAnnotation,
+		ToleranceScaleDownAnnotation,
+		ToleranceScaleUpAnnotation,
+		MetricStatusesAnnotation,
+		HorizontalPodAutoscalerConditionsAnnotation,
+	}
+}
+
 // DropRoundTripHorizontalPodAutoscalerAnnotations removes any annotations used to
-// serialize round-tripped fields from HorizontalPodAutoscaler later API versions,
+// serialize round-tripped fields from HorizontalPodAutoscaler later API versions into v1,
 // and returns false if no changes were made and the original input object was returned.
 //
 // It should always be called when converting internal -> external versions, prior
-// to setting any of the custom annotations:
+// to setting any of the custom annotations in v1:
 //
 //	annotations, copiedAnnotations := DropRoundTripHorizontalPodAutoscalerAnnotations(externalObj.Annotations)
 //	externalObj.Annotations = annotations
@@ -34,20 +46,16 @@ package autoscaling
 //	  externalObj.Annotations[...] = json.Marshal(...)
 //	}
 func DropRoundTripHorizontalPodAutoscalerAnnotations(in map[string]string) (out map[string]string, copied bool) {
-	_, hasMetricsSpecs := in[MetricSpecsAnnotation]
-	_, hasBehaviorSpecs := in[BehaviorSpecsAnnotation]
-	_, hasToleranceScaleDown := in[ToleranceScaleDownAnnotation]
-	_, hasToleranceScaleUp := in[ToleranceScaleUpAnnotation]
-	_, hasMetricsStatuses := in[MetricStatusesAnnotation]
-	_, hasConditions := in[HorizontalPodAutoscalerConditionsAnnotation]
-	if hasMetricsSpecs || hasBehaviorSpecs || hasToleranceScaleDown || hasToleranceScaleUp || hasMetricsStatuses || hasConditions {
-		out = DeepCopyStringMap(in)
-		delete(out, MetricSpecsAnnotation)
-		delete(out, BehaviorSpecsAnnotation)
-		delete(out, ToleranceScaleDownAnnotation)
-		delete(out, ToleranceScaleUpAnnotation)
-		delete(out, MetricStatusesAnnotation)
-		delete(out, HorizontalPodAutoscalerConditionsAnnotation)
+	for _, k := range RoundTripAnnotations() {
+		if _, exists := in[k]; exists {
+			if !copied {
+				out = DeepCopyStringMap(in)
+				copied = true
+			}
+			delete(out, k)
+		}
+	}
+	if copied {
 		return out, true
 	}
 	return in, false

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/strategy.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/strategy.go
@@ -19,17 +19,21 @@ package horizontalpodautoscaler
 import (
 	"context"
 
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
+	autoscalingv1 "k8s.io/kubernetes/pkg/apis/autoscaling/v1"
 	"k8s.io/kubernetes/pkg/apis/autoscaling/validation"
 	"k8s.io/kubernetes/pkg/features"
-	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
 )
 
 // autoscalerStrategy implements behavior for HorizontalPodAutoscalers
@@ -106,6 +110,9 @@ func (autoscalerStrategy) DeclarativeValidationConfig(ctx context.Context, obj, 
 
 // WarningsOnCreate returns warnings for the creation of the given object.
 func (autoscalerStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+	if isV1Request(ctx) && modifiedV1RoundTripAnnotations(obj, nil) {
+		return []string{"setting v2 data in annotations is unexpected; use the v2 API instead"}
+	}
 	return nil
 }
 
@@ -144,7 +151,41 @@ func (autoscalerStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.O
 
 // WarningsOnUpdate returns warnings for the given update.
 func (autoscalerStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+	if isV1Request(ctx) && modifiedV1RoundTripAnnotations(obj, old) {
+		return []string{"modifying v2 data in annotations is unexpected; use the v2 API instead"}
+	}
 	return nil
+}
+
+func isV1Request(ctx context.Context) bool {
+	requestInfo, found := genericapirequest.RequestInfoFrom(ctx)
+	return found &&
+		requestInfo.APIGroup == autoscalingv1.SchemeGroupVersion.Group &&
+		requestInfo.APIVersion == autoscalingv1.SchemeGroupVersion.Version
+}
+func modifiedV1RoundTripAnnotations(obj, old runtime.Object) bool {
+	var objAnnotations, oldAnnotations map[string]string
+
+	if objAccessor, err := meta.Accessor(obj); err != nil {
+		return false
+	} else {
+		objAnnotations = objAccessor.GetAnnotations()
+	}
+
+	if old != nil {
+		if oldAccessor, err := meta.Accessor(old); err != nil {
+			return false
+		} else {
+			oldAnnotations = oldAccessor.GetAnnotations()
+		}
+	}
+
+	for _, k := range autoscaling.RoundTripAnnotations() {
+		if objAnnotations[k] != oldAnnotations[k] {
+			return true
+		}
+	}
+	return false
 }
 
 func (autoscalerStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
@@ -186,6 +227,9 @@ func (autoscalerStatusStrategy) ValidateUpdate(ctx context.Context, obj, old run
 
 // WarningsOnUpdate returns warnings for the given update.
 func (autoscalerStatusStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+	if isV1Request(ctx) && modifiedV1RoundTripAnnotations(obj, old) {
+		return []string{"modifying v2 data in annotations is unexpected; use the v2 API instead"}
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Clarifies to v1 API users that messing with v2 data via annotations is unexpected and there is a better approach

/sig autoscaling
cc @adrianmoisey 

#### Which issue(s) this PR is related to:

https://docs.google.com/document/d/1vFIbnXKaJ8npE9Tt_TSxyRwEd4I6DbKOXnn2PoGTC6M/edit?tab=t.0

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
