### PR TITLE
fix(kubelet): include rootfs in container ephemeral storage limit checks

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -600,9 +600,7 @@ func (m *managerImpl) containerEphemeralStorageLimitEviction(logger klog.Logger,
 
 	for _, containerStat := range podStats.Containers {
 		containerUsed := diskUsage(containerStat.Logs)
-		if !*m.dedicatedImageFs {
-			containerUsed.Add(*diskUsage(containerStat.Rootfs))
-		}
+		containerUsed.Add(*diskUsage(containerStat.Rootfs))
 
 		if ephemeralStorageThreshold, ok := thresholdsMap[containerStat.Name]; ok {
 			if ephemeralStorageThreshold.Cmp(*containerUsed) < 0 {

--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -32,6 +32,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/record"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/klog/v2"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	kubeapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
@@ -3169,5 +3170,43 @@ func TestContainerEphemeralStorageLimitEvictionForRestartableInitContainers(t *t
 	}
 	if len(evictedPods) != 1 || evictedPods[0].Name != pod.Name {
 		t.Fatalf("Expected evicted pod %q, got %v", pod.Name, evictedPods)
+	}
+}
+
+func TestContainerEphemeralStorageLimitEvictionWithDedicatedImageFs(t *testing.T) {
+	pod := newPod("container-ephemeral-storage-limit", 0, []v1.Container{
+		newContainer("writer", nil, newResourceList("", "", "500Mi")),
+		newContainer("sidecar", nil, newResourceList("", "", "500Mi")),
+	}, nil)
+
+	writerUsed := uint64(resource.MustParse("700Mi").Value())
+	zeroUsed := uint64(0)
+	podStats := statsapi.PodStats{
+		Containers: []statsapi.ContainerStats{
+			{
+			Name:   "writer",
+			Logs:   &statsapi.FsStats{UsedBytes: &zeroUsed},
+			Rootfs: &statsapi.FsStats{UsedBytes: &writerUsed},
+			},
+			{
+			Name:   "sidecar",
+			Logs:   &statsapi.FsStats{UsedBytes: &zeroUsed},
+			Rootfs: &statsapi.FsStats{UsedBytes: &zeroUsed},
+			},
+		},
+	}
+
+	podKiller := &mockPodKiller{}
+	mgr := &managerImpl{
+		killPodFunc:      podKiller.killPodNow,
+		recorder:         &record.FakeRecorder{},
+		dedicatedImageFs: ptr.To(true),
+	}
+
+	if !mgr.containerEphemeralStorageLimitEviction(klog.Background(), podStats, pod) {
+		t.Fatalf("expected pod eviction")
+	}
+	if podKiller.pod != pod {
+		t.Fatalf("expected pod %q to be evicted", pod.Name)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes container-level ephemeral-storage limit eviction when `dedicatedImageFs=true`.

Previously, kubelet skipped container rootfs usage in the per-container ephemeral-storage limit check when a dedicated image filesystem was detected. Because of that, a container could exceed its own ephemeral-storage limit without eviction in a multi-container pod, as long as the pod-level usage stayed under the combined container limits.

This change makes the container limit check include both logs and rootfs usage, regardless of the image filesystem layout.

#### Which issue(s) this PR is related to:

Fixes #139205

#### Special notes for your reviewer:

Added a focused regression test for the `dedicatedImageFs=true` case with a multi-container pod where one container exceeds its own ephemeral-storage limit.

#### Does this PR introduce a user-facing change?

```release-note
Fixed kubelet container-level ephemeral-storage limit eviction when using a dedicated image filesystem.
