### PR TITLE
Add metrics for when expectations block reconciliation

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -2627,6 +2627,16 @@
   componentEndpoints:
   - component: kubelet
     endpoint: /metrics
+- name: expectations_waiting_total
+  subsystem: daemonset_controller
+  help: Total number of times DaemonSet expectations were checked and found unsatisfied.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - type
+  componentEndpoints:
+  - component: kube-controller-manager
+    endpoint: /metrics
 - name: stale_sync_skips_total
   subsystem: daemonset_controller
   help: Total number of DaemonSet syncs skipped due to a stale watch cache.
@@ -3238,6 +3248,16 @@
   - component: kube-scheduler
     endpoint: /metrics
   - component: kubelet
+    endpoint: /metrics
+- name: expectations_waiting_total
+  subsystem: job_controller
+  help: Total number of times Job expectations were checked and found unsatisfied.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - type
+  componentEndpoints:
+  - component: kube-controller-manager
     endpoint: /metrics
 - name: job_finished_indexes_total
   subsystem: job_controller
@@ -5672,6 +5692,16 @@
   stabilityLevel: ALPHA
   componentEndpoints:
   - component: kubelet
+    endpoint: /metrics
+- name: expectations_waiting_total
+  subsystem: replicaset_controller
+  help: Total number of times ReplicaSet expectations were checked and found unsatisfied.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - type
+  componentEndpoints:
+  - component: kube-controller-manager
     endpoint: /metrics
 - name: sorting_deletion_age_ratio
   subsystem: replicaset_controller

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -70,6 +70,10 @@ const (
 	// 500 pods. Just creation is limited to 20qps, and watching happens with ~10-30s
 	// latency/pod at the scale of 3000 pods over 100 nodes.
 	ExpectationsTimeout = 5 * time.Minute
+	// ExpectationsCreate indicates that the controller is waiting for creations.
+	ExpectationsCreate = "creates"
+	// ExpectationsDelete indicates that the controller is waiting for deletions.
+	ExpectationsDelete = "deletes"
 	// When batching pod creates, SlowStartInitialBatchSize is the size of the
 	// initial batch.  The size of each successive batch is twice the size of
 	// the previous batch.  For example, for a value of 1, batch sizes would be
@@ -165,9 +169,15 @@ type ControllerExpectationsInterface interface {
 	LowerExpectations(logger klog.Logger, controllerKey string, add, del int)
 }
 
+// ExpectationsMetrics is an interface for recording controller expectations metrics.
+type ExpectationsMetrics interface {
+	ObserveExpectationsWaiting(expType string)
+}
+
 // ControllerExpectations is a cache mapping controllers to what they expect to see before being woken up for a sync.
 type ControllerExpectations struct {
 	cache.Store
+	metrics ExpectationsMetrics
 }
 
 // GetExpectations returns the ControlleeExpectations of the given controller.
@@ -202,6 +212,15 @@ func (r *ControllerExpectations) SatisfiedExpectations(logger klog.Logger, contr
 			return true
 		} else {
 			logger.V(4).Info("Controller still waiting on expectations", "expectations", exp)
+			if r.metrics != nil {
+				adds, dels := exp.GetExpectations()
+				if adds > 0 {
+					r.metrics.ObserveExpectationsWaiting(ExpectationsCreate)
+				}
+				if dels > 0 {
+					r.metrics.ObserveExpectationsWaiting(ExpectationsDelete)
+				}
+			}
 			return false
 		}
 	} else if err != nil {
@@ -311,8 +330,11 @@ func (e *ControlleeExpectations) MarshalLog() interface{} {
 }
 
 // NewControllerExpectations returns a store for ControllerExpectations.
-func NewControllerExpectations() *ControllerExpectations {
-	return &ControllerExpectations{cache.NewStore(ExpKeyFunc)}
+func NewControllerExpectations(metrics ExpectationsMetrics) *ControllerExpectations {
+	return &ControllerExpectations{
+		Store:   cache.NewStore(ExpKeyFunc),
+		metrics: metrics,
+	}
 }
 
 // UIDSetKeyFunc to parse out the key from a UIDSet.

--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -69,7 +69,7 @@ func NewFakeControllerExpectationsLookup(ttl time.Duration) (*ControllerExpectat
 	ttlPolicy := &cache.TTLPolicy{TTL: ttl, Clock: fakeClock}
 	ttlStore := cache.NewFakeExpirationStore(
 		ExpKeyFunc, nil, ttlPolicy, fakeClock)
-	return &ControllerExpectations{ttlStore}, fakeClock
+	return &ControllerExpectations{Store: ttlStore, metrics: nil}, fakeClock
 }
 
 func newReplicationController(replicas int) *v1.ReplicationController {
@@ -258,7 +258,7 @@ func TestControllerExpectations(t *testing.T) {
 
 func TestUIDExpectations(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
-	uidExp := NewUIDTrackingControllerExpectations(NewControllerExpectations())
+	uidExp := NewUIDTrackingControllerExpectations(NewControllerExpectations(nil))
 	type test struct {
 		name        string
 		numReplicas int

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -205,7 +205,7 @@ func NewDaemonSetsController(
 			KubeClient: kubeClient,
 		},
 		burstReplicas: BurstReplicas,
-		expectations:  controller.NewControllerExpectations(),
+		expectations:  controller.NewControllerExpectations(expectationsMetrics{}),
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
@@ -1557,4 +1557,10 @@ func (dsc *DaemonSetsController) syncNodeUpdate(ctx context.Context, nodeName st
 	}
 
 	return nil
+}
+
+type expectationsMetrics struct{}
+
+func (expectationsMetrics) ObserveExpectationsWaiting(expType string) {
+	metrics.ExpectationsWaiting.WithLabelValues(expType).Inc()
 }

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -539,7 +539,7 @@ func TestExpectationsOnRecreate(t *testing.T) {
 
 	fakePodControl := newFakePodControl()
 	fakePodControl.podStore = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc) // fake store that we don't use
-	fakePodControl.expectations = controller.NewControllerExpectations()                 // fake expectations that we don't use
+	fakePodControl.expectations = controller.NewControllerExpectations(nil)              // fake expectations that we don't use
 	dsc.podControl = fakePodControl
 
 	manager := &daemonSetsController{

--- a/pkg/controller/daemon/metrics/metrics.go
+++ b/pkg/controller/daemon/metrics/metrics.go
@@ -36,6 +36,16 @@ var (
 		// These are the labels (dimensions)
 		[]string{"group", "resource"},
 	)
+
+	ExpectationsWaiting = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      DaemonControllerSubsystem,
+			Name:           "expectations_waiting_total",
+			Help:           "Total number of times DaemonSet expectations were checked and found unsatisfied.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"type"},
+	)
 )
 
 var registerMetrics sync.Once
@@ -44,5 +54,6 @@ var registerMetrics sync.Once
 func Register() {
 	registerMetrics.Do(func() {
 		legacyregistry.MustRegister(DaemonsetRequeueSkips)
+		legacyregistry.MustRegister(ExpectationsWaiting)
 	})
 }

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -258,7 +258,7 @@ func newControllerWithClock(ctx context.Context, kubeClient clientset.Interface,
 			Recorder:   eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "job-controller"}),
 			OnWrite:    podWriteCallback,
 		},
-		expectations:            controller.NewControllerExpectations(),
+		expectations:            controller.NewControllerExpectations(expectationsMetrics{}),
 		finalizerExpectations:   newUIDTrackingExpectations(),
 		queue:                   workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.NewTypedItemExponentialFailureRateLimiter[string](DefaultJobApiBackOff, MaxJobApiBackOff), workqueue.TypedRateLimitingQueueConfig[string]{Name: "job", Clock: clock}),
 		orphanQueue:             workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.NewTypedItemExponentialFailureRateLimiter[orphanPodKey](DefaultJobApiBackOff, MaxJobApiBackOff), workqueue.TypedRateLimitingQueueConfig[orphanPodKey]{Name: "job_orphan_pod", Clock: clock}),
@@ -2249,4 +2249,10 @@ func managedByExternalController(jobObj *batch.Job) *string {
 		}
 	}
 	return nil
+}
+
+type expectationsMetrics struct{}
+
+func (expectationsMetrics) ObserveExpectationsWaiting(expType string) {
+	metrics.ExpectationsWaiting.WithLabelValues(expType).Inc()
 }

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -2803,7 +2803,7 @@ func TestPastDeadlineJobFinished(t *testing.T) {
 	manager.podStoreSynced = alwaysReady
 	manager.jobStoreSynced = alwaysReady
 	manager.expectations = FakeJobExpectations{
-		controller.NewControllerExpectations(), true, func() {
+		controller.NewControllerExpectations(nil), true, func() {
 		},
 	}
 	sharedInformerFactory.Start(ctx.Done())
@@ -6384,7 +6384,7 @@ func TestSyncJobExpectations(t *testing.T) {
 	podIndexer.Add(pods[0])
 
 	manager.expectations = FakeJobExpectations{
-		controller.NewControllerExpectations(), true, func() {
+		controller.NewControllerExpectations(nil), true, func() {
 			// If we check active pods before checking expectations, the job
 			// will create a new replica because it doesn't see this pod, but
 			// has fulfilled its expectations.

--- a/pkg/controller/job/metrics/metrics.go
+++ b/pkg/controller/job/metrics/metrics.go
@@ -172,6 +172,16 @@ Possible values of the "status" label are:
 		// These are the labels (dimensions)
 		[]string{"group", "resource"},
 	)
+
+	ExpectationsWaiting = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      JobControllerSubsystem,
+			Name:           "expectations_waiting_total",
+			Help:           "Total number of times Job expectations were checked and found unsatisfied.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"type"},
+	)
 )
 
 const (
@@ -226,5 +236,6 @@ func Register() {
 		legacyregistry.MustRegister(JobPodsCreationTotal)
 		legacyregistry.MustRegister(JobByExternalControllerTotal)
 		legacyregistry.MustRegister(JobRequeueSkips)
+		legacyregistry.MustRegister(ExpectationsWaiting)
 	})
 }

--- a/pkg/controller/replicaset/metrics/metrics.go
+++ b/pkg/controller/replicaset/metrics/metrics.go
@@ -44,6 +44,16 @@ var (
 		},
 		[]string{"group", "resource"},
 	)
+
+	ExpectationsWaiting = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      ReplicaSetControllerSubsystem,
+			Name:           "expectations_waiting_total",
+			Help:           "Total number of times ReplicaSet expectations were checked and found unsatisfied.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"type"},
+	)
 )
 
 // Register registers ReplicaSet controller metrics.
@@ -51,5 +61,9 @@ func Register(registrationFunc func(metrics.Registerable) error) error {
 	if err := registrationFunc(SortingDeletionAgeRatio); err != nil {
 		return err
 	}
-	return registrationFunc(ReplicaSetRequeueSkips)
+	if err := registrationFunc(ReplicaSetRequeueSkips); err != nil {
+		return err
+	}
+
+	return registrationFunc(ExpectationsWaiting)
 }

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -210,7 +210,7 @@ func NewBaseController(logger klog.Logger, rsInformer appsinformers.ReplicaSetIn
 		podControl:       podControl,
 		eventBroadcaster: eventBroadcaster,
 		burstReplicas:    burstReplicas,
-		expectations:     controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
+		expectations:     controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations(expectationsMetrics{})),
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{Name: queueName},
@@ -993,4 +993,10 @@ func getPodKeys(pods []*v1.Pod) []string {
 		podKeys = append(podKeys, controller.PodKey(pod))
 	}
 	return podKeys
+}
+
+type expectationsMetrics struct{}
+
+func (expectationsMetrics) ObserveExpectationsWaiting(expType string) {
+	metrics.ExpectationsWaiting.WithLabelValues(expType).Inc()
 }

--- a/pkg/controller/replicaset/replica_set_test.go
+++ b/pkg/controller/replicaset/replica_set_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/onsi/gomega"
 	"math/rand"
 	"net/http/httptest"
 	"net/url"
@@ -30,6 +29,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/onsi/gomega"
 
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -1126,7 +1127,7 @@ func TestRSSyncExpectations(t *testing.T) {
 	postExpectationsPod := pods.Items[1]
 
 	manager.expectations = controller.NewUIDTrackingControllerExpectations(FakeRSExpectations{
-		controller.NewControllerExpectations(), true, func() {
+		controller.NewControllerExpectations(nil), true, func() {
 			// If we check active pods before checking expectataions, the
 			// ReplicaSet will create a new replica because it doesn't see
 			// this pod, but has fulfilled its expectations.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds metrics to controllers that rely on expectations to track the number of times they have not been satisfied. 

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/5647
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add metrics for controllers that use expectations to show how often they stall. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
