### PR TITLE
Optimize PVC ref count aggregation via delta counts

### DIFF
--- a/pkg/scheduler/backend/cache/cache.go
+++ b/pkg/scheduler/backend/cache/cache.go
@@ -81,6 +81,13 @@ type cacheImpl struct {
 	// apiDispatcher is used for the methods that are expected to send API calls.
 	// It's non-nil only if the SchedulerAsyncAPICalls feature gate is enabled.
 	apiDispatcher fwk.APIDispatcher
+
+	// pvcRefCountsDelta contains the delta of changes to PVCRefCounts since the last snapshot.
+	// Keys are in the format "namespace/name". This data struct serves as an optimization for avoiding
+	// burdensome PVC ref count aggregations during scheduler cycles. PVCRefCountsDelta holds the incoming
+	// deltas from events handlers while within the scheduler cycle, we only apply and reset the delta to
+	// avoid global re-calculation.
+	pvcRefCountsDelta map[string]int
 }
 
 type podState struct {
@@ -101,6 +108,7 @@ func newCache(ctx context.Context, period time.Duration, apiDispatcher fwk.APIDi
 		podGroupStates:         make(map[podGroupKey]*podGroupState),
 		genericWorkloadEnabled: genericWorkloadEnabled,
 		apiDispatcher:          apiDispatcher,
+		pvcRefCountsDelta:      make(map[string]int),
 	}
 }
 
@@ -210,9 +218,6 @@ func (cache *cacheImpl) UpdateSnapshot(logger klog.Logger, nodeSnapshot *Snapsho
 	// status from having pods with required anti-affinity to NOT having pods with required
 	// anti-affinity or the other way around.
 	updateNodesHavePodsWithRequiredAntiAffinity := false
-	// usedPVCSet must be re-created whenever the head node generation is greater than
-	// last snapshot generation.
-	updateUsedPVCSet := false
 
 	// Forget all assumed pods from a previous snapshot version.
 	// This is a safety check in case any pod wasn't forgotten in the previous scheduling cycle.
@@ -242,18 +247,6 @@ func (cache *cacheImpl) UpdateSnapshot(logger klog.Logger, nodeSnapshot *Snapsho
 			if (len(existing.PodsWithRequiredAntiAffinity) > 0) != (len(clone.PodsWithRequiredAntiAffinity) > 0) {
 				updateNodesHavePodsWithRequiredAntiAffinity = true
 			}
-			if !updateUsedPVCSet {
-				if len(existing.PVCRefCounts) != len(clone.PVCRefCounts) {
-					updateUsedPVCSet = true
-				} else {
-					for pvcKey := range clone.PVCRefCounts {
-						if _, found := existing.PVCRefCounts[pvcKey]; !found {
-							updateUsedPVCSet = true
-							break
-						}
-					}
-				}
-			}
 			// We need to preserve the original pointer of the NodeInfo struct since it
 			// is used in the NodeInfoList, which we may not update.
 			*existing = *clone
@@ -272,7 +265,16 @@ func (cache *cacheImpl) UpdateSnapshot(logger klog.Logger, nodeSnapshot *Snapsho
 		updateAllLists = true
 	}
 
-	if updateAllLists || updateNodesHavePodsWithAffinity || updateNodesHavePodsWithRequiredAntiAffinity || updateUsedPVCSet {
+	// Apply the deltas for PVC reference count to the snapshot.
+	// This no-op if the snapshot is built afresh i.e. updateAllLists=true
+	if !updateAllLists {
+		if err := cache.applyPVCRefCountDelta(nodeSnapshot); err != nil {
+			logger.Error(err, "rebuilding node snapshot due to unexpected error from refreshing PVC ref counts")
+			updateAllLists = true
+		}
+	}
+
+	if updateAllLists || updateNodesHavePodsWithAffinity || updateNodesHavePodsWithRequiredAntiAffinity {
 		cache.updateNodeInfoSnapshotList(logger, nodeSnapshot, updateAllLists)
 	}
 
@@ -318,8 +320,8 @@ func (cache *cacheImpl) updatePodGroupStateSnapshot(snapshot *Snapshot) {
 func (cache *cacheImpl) updateNodeInfoSnapshotList(logger klog.Logger, snapshot *Snapshot, updateAll bool) {
 	snapshot.havePodsWithAffinityNodeInfoList = make([]fwk.NodeInfo, 0, cache.nodeTree.numNodes)
 	snapshot.havePodsWithRequiredAntiAffinityNodeInfoList = make([]fwk.NodeInfo, 0, cache.nodeTree.numNodes)
-	snapshot.usedPVCSet = sets.New[string]()
 	if updateAll {
+		snapshot.usedPVCRefCounts = make(map[string]int)
 		// Take a snapshot of the nodes order in the tree
 		snapshot.nodeInfoList = make([]fwk.NodeInfo, 0, cache.nodeTree.numNodes)
 		nodesList, err := cache.nodeTree.list()
@@ -335,13 +337,15 @@ func (cache *cacheImpl) updateNodeInfoSnapshotList(logger klog.Logger, snapshot 
 				if len(nodeInfo.PodsWithRequiredAntiAffinity) > 0 {
 					snapshot.havePodsWithRequiredAntiAffinityNodeInfoList = append(snapshot.havePodsWithRequiredAntiAffinityNodeInfoList, nodeInfo)
 				}
-				for key := range nodeInfo.PVCRefCounts {
-					snapshot.usedPVCSet.Insert(key)
+				for key, value := range nodeInfo.PVCRefCounts {
+					snapshot.usedPVCRefCounts[key] += value
 				}
 			} else {
 				utilruntime.HandleErrorWithLogger(logger, nil, "Node exists in nodeTree but not in NodeInfoMap, this should not happen", "node", klog.KRef("", nodeName))
 			}
 		}
+		// reset the deltas if update all
+		cache.pvcRefCountsDelta = map[string]int{}
 	} else {
 		for _, nodeInfo := range snapshot.nodeInfoList {
 			if len(nodeInfo.GetPodsWithAffinity()) > 0 {
@@ -349,9 +353,6 @@ func (cache *cacheImpl) updateNodeInfoSnapshotList(logger klog.Logger, snapshot 
 			}
 			if len(nodeInfo.GetPodsWithRequiredAntiAffinity()) > 0 {
 				snapshot.havePodsWithRequiredAntiAffinityNodeInfoList = append(snapshot.havePodsWithRequiredAntiAffinityNodeInfoList, nodeInfo)
-			}
-			for key := range nodeInfo.GetPVCRefCounts() {
-				snapshot.usedPVCSet.Insert(key)
 			}
 		}
 	}
@@ -444,6 +445,11 @@ func (cache *cacheImpl) addPod(logger klog.Logger, pod *v1.Pod, assumePod bool) 
 		n = newNodeInfoListItem(framework.NewNodeInfo())
 		cache.nodes[pod.Spec.NodeName] = n
 	}
+
+	// new_delta = old_delta + (PVCRefCounts_after − PVCRefCounts_before)
+	cache.refreshPVCRefCountsDelta(n.info, -1)
+	defer cache.refreshPVCRefCountsDelta(n.info, 1)
+
 	n.info.AddPod(pod)
 	cache.moveNodeInfoToHead(logger, pod.Spec.NodeName)
 	ps := &podState{
@@ -487,6 +493,10 @@ func (cache *cacheImpl) removePod(logger klog.Logger, pod *v1.Pod, forgetPod boo
 	if !ok {
 		utilruntime.HandleErrorWithLogger(logger, nil, "Node not found when trying to remove pod", "node", klog.KRef("", pod.Spec.NodeName), "podKey", key, "pod", klog.KObj(pod))
 	} else {
+		// new_delta = old_delta + (PVCRefCounts_after − PVCRefCounts_before)
+		cache.refreshPVCRefCountsDelta(n.info, -1)
+		defer cache.refreshPVCRefCountsDelta(n.info, 1)
+
 		if err := n.info.RemovePod(logger, pod); err != nil {
 			return err
 		}
@@ -677,6 +687,10 @@ func (cache *cacheImpl) RemoveNode(logger klog.Logger, node *v1.Node) error {
 	if !ok {
 		return fmt.Errorf("node %v is not found", node.Name)
 	}
+
+	// only subtract the PVCRefCount into the delta map
+	cache.refreshPVCRefCountsDelta(n.info, -1)
+
 	n.info.RemoveNode()
 	// We remove NodeInfo for this node only if there aren't any pods on this node.
 	// We can't do it unconditionally, because notifications about pods are delivered
@@ -908,4 +922,31 @@ func (cache *cacheImpl) BindPod(binding *v1.Binding) (<-chan error, error) {
 		return onFinish, err
 	}
 	return onFinish, nil
+}
+
+// refreshPVCRefCountsDelta accumulates the given node's PVC reference counts
+// into cache.pvcRefCountsDelta, which is later applied to the snapshot during
+// UpdateSnapshot. sign should be +1 to add the node's contribution or -1 to
+// remove it.
+func (cache *cacheImpl) refreshPVCRefCountsDelta(nodeInfo *framework.NodeInfo, sign int) {
+	for key, count := range nodeInfo.PVCRefCounts {
+		cache.pvcRefCountsDelta[key] += sign * count
+	}
+}
+
+// applyPVCRefCountDelta merges cache.pvcRefCountsDelta into the snapshot's
+// PVC ref counts, removes entries that reach zero, and clears the delta.
+func (cache *cacheImpl) applyPVCRefCountDelta(snapshot *Snapshot) error {
+	for key, delta := range cache.pvcRefCountsDelta {
+		snapshot.usedPVCRefCounts[key] += delta
+		if refCount := snapshot.usedPVCRefCounts[key]; refCount <= 0 {
+			if refCount < 0 {
+				delete(snapshot.usedPVCRefCounts, key)
+				return fmt.Errorf("PVC %s had negative ref count %v", key, refCount)
+			}
+			delete(snapshot.usedPVCRefCounts, key)
+		}
+	}
+	cache.pvcRefCountsDelta = map[string]int{}
+	return nil
 }

--- a/pkg/scheduler/backend/cache/cache_test.go
+++ b/pkg/scheduler/backend/cache/cache_test.go
@@ -2081,35 +2081,35 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 		expected                       []*v1.Node
 		expectedHavePodsWithAffinity   int
 		expectedPodGroupStatesSnapshot map[podGroupKey]*podGroupStateSnapshot
-		expectedUsedPVCSet             sets.Set[string]
+		expectedUsedPVCCounts          map[string]int
 	}{
 		{
-			name:               "Empty cache",
-			operations:         []operation{},
-			expected:           []*v1.Node{},
-			expectedUsedPVCSet: sets.New[string](),
+			name:                  "Empty cache",
+			operations:            []operation{},
+			expected:              []*v1.Node{},
+			expectedUsedPVCCounts: map[string]int{},
 		},
 		{
-			name:               "Single node",
-			operations:         []operation{addNode(1)},
-			expected:           []*v1.Node{nodes[1]},
-			expectedUsedPVCSet: sets.New[string](),
+			name:                  "Single node",
+			operations:            []operation{addNode(1)},
+			expected:              []*v1.Node{nodes[1]},
+			expectedUsedPVCCounts: map[string]int{},
 		},
 		{
 			name: "Add node, remove it, add it again",
 			operations: []operation{
 				addNode(1), updateSnapshot(), removeNode(1), addNode(1),
 			},
-			expected:           []*v1.Node{nodes[1]},
-			expectedUsedPVCSet: sets.New[string](),
+			expected:              []*v1.Node{nodes[1]},
+			expectedUsedPVCCounts: map[string]int{},
 		},
 		{
 			name: "Add node and remove it in the same cycle, add it again",
 			operations: []operation{
 				addNode(1), updateSnapshot(), addNode(2), removeNode(1),
 			},
-			expected:           []*v1.Node{nodes[2]},
-			expectedUsedPVCSet: sets.New[string](),
+			expected:              []*v1.Node{nodes[2]},
+			expectedUsedPVCCounts: map[string]int{},
 		},
 		{
 			name: "Add a few nodes, and snapshot in the middle",
@@ -2117,24 +2117,24 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 				addNode(0), updateSnapshot(), addNode(1), updateSnapshot(), addNode(2),
 				updateSnapshot(), addNode(3),
 			},
-			expected:           []*v1.Node{nodes[3], nodes[2], nodes[1], nodes[0]},
-			expectedUsedPVCSet: sets.New[string](),
+			expected:              []*v1.Node{nodes[3], nodes[2], nodes[1], nodes[0]},
+			expectedUsedPVCCounts: map[string]int{},
 		},
 		{
 			name: "Add a few nodes, and snapshot in the end",
 			operations: []operation{
 				addNode(0), addNode(2), addNode(5), addNode(6),
 			},
-			expected:           []*v1.Node{nodes[6], nodes[5], nodes[2], nodes[0]},
-			expectedUsedPVCSet: sets.New[string](),
+			expected:              []*v1.Node{nodes[6], nodes[5], nodes[2], nodes[0]},
+			expectedUsedPVCCounts: map[string]int{},
 		},
 		{
 			name: "Update some nodes",
 			operations: []operation{
 				addNode(0), addNode(1), addNode(5), updateSnapshot(), updateNode(1),
 			},
-			expected:           []*v1.Node{nodes[1], nodes[5], nodes[0]},
-			expectedUsedPVCSet: sets.New[string](),
+			expected:              []*v1.Node{nodes[1], nodes[5], nodes[0]},
+			expectedUsedPVCCounts: map[string]int{},
 		},
 		{
 			name: "Add a few nodes, and remove all of them",
@@ -2142,8 +2142,8 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 				addNode(0), addNode(2), addNode(5), addNode(6), updateSnapshot(),
 				removeNode(0), removeNode(2), removeNode(5), removeNode(6),
 			},
-			expected:           []*v1.Node{},
-			expectedUsedPVCSet: sets.New[string](),
+			expected:              []*v1.Node{},
+			expectedUsedPVCCounts: map[string]int{},
 		},
 		{
 			name: "Add a few nodes, and remove some of them",
@@ -2151,8 +2151,8 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 				addNode(0), addNode(2), addNode(5), addNode(6), updateSnapshot(),
 				removeNode(0), removeNode(6),
 			},
-			expected:           []*v1.Node{nodes[5], nodes[2]},
-			expectedUsedPVCSet: sets.New[string](),
+			expected:              []*v1.Node{nodes[5], nodes[2]},
+			expectedUsedPVCCounts: map[string]int{},
 		},
 		{
 			name: "Add a few nodes, remove all of them, and add more",
@@ -2161,8 +2161,8 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 				removeNode(2), removeNode(5), removeNode(6), updateSnapshot(),
 				addNode(7), addNode(9),
 			},
-			expected:           []*v1.Node{nodes[9], nodes[7]},
-			expectedUsedPVCSet: sets.New[string](),
+			expected:              []*v1.Node{nodes[9], nodes[7]},
+			expectedUsedPVCCounts: map[string]int{},
 		},
 		{
 			name: "Update nodes in particular order",
@@ -2170,8 +2170,8 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 				addNode(8), updateNode(2), updateNode(8), updateSnapshot(),
 				addNode(1),
 			},
-			expected:           []*v1.Node{nodes[1], nodes[8], nodes[2]},
-			expectedUsedPVCSet: sets.New[string](),
+			expected:              []*v1.Node{nodes[1], nodes[8], nodes[2]},
+			expectedUsedPVCCounts: map[string]int{},
 		},
 		{
 			name: "Add some nodes and some pods",
@@ -2179,24 +2179,24 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 				addNode(0), addNode(2), addNode(8), updateSnapshot(),
 				addPod(8), addPod(2),
 			},
-			expected:           []*v1.Node{nodes[2], nodes[8], nodes[0]},
-			expectedUsedPVCSet: sets.New[string](),
+			expected:              []*v1.Node{nodes[2], nodes[8], nodes[0]},
+			expectedUsedPVCCounts: map[string]int{},
 		},
 		{
 			name: "Updating a pod moves its node to the head",
 			operations: []operation{
 				addNode(0), addPod(0), addNode(2), addNode(4), updatePod(0),
 			},
-			expected:           []*v1.Node{nodes[0], nodes[4], nodes[2]},
-			expectedUsedPVCSet: sets.New[string](),
+			expected:              []*v1.Node{nodes[0], nodes[4], nodes[2]},
+			expectedUsedPVCCounts: map[string]int{},
 		},
 		{
 			name: "Add pod before its node",
 			operations: []operation{
 				addNode(0), addPod(1), updatePod(1), addNode(1),
 			},
-			expected:           []*v1.Node{nodes[1], nodes[0]},
-			expectedUsedPVCSet: sets.New[string](),
+			expected:              []*v1.Node{nodes[1], nodes[0]},
+			expectedUsedPVCCounts: map[string]int{},
 		},
 		{
 			name: "Remove node before its pods",
@@ -2205,8 +2205,8 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 				removeNode(1), updateSnapshot(),
 				updatePod(1), updatePod(11), removePod(1), removePod(11),
 			},
-			expected:           []*v1.Node{nodes[0]},
-			expectedUsedPVCSet: sets.New[string](),
+			expected:              []*v1.Node{nodes[0]},
+			expectedUsedPVCCounts: map[string]int{},
 		},
 		{
 			name: "Add Pods with affinity",
@@ -2215,15 +2215,15 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 			},
 			expected:                     []*v1.Node{nodes[1], nodes[0]},
 			expectedHavePodsWithAffinity: 1,
-			expectedUsedPVCSet:           sets.New[string](),
+			expectedUsedPVCCounts:        map[string]int{},
 		},
 		{
 			name: "Add Pods with PVC",
 			operations: []operation{
 				addNode(0), addPodWithPVC(0, 0, 0), updateSnapshot(), addNode(1),
 			},
-			expected:           []*v1.Node{nodes[1], nodes[0]},
-			expectedUsedPVCSet: sets.New("test-ns/test-pvc0"),
+			expected:              []*v1.Node{nodes[1], nodes[0]},
+			expectedUsedPVCCounts: map[string]int{"test-ns/test-pvc0": 1},
 		},
 		{
 			name: "Add multiple nodes with pods with affinity",
@@ -2232,15 +2232,29 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 			},
 			expected:                     []*v1.Node{nodes[1], nodes[0]},
 			expectedHavePodsWithAffinity: 2,
-			expectedUsedPVCSet:           sets.New[string](),
+			expectedUsedPVCCounts:        map[string]int{},
 		},
 		{
 			name: "Add multiple nodes with pods with PVC",
 			operations: []operation{
 				addNode(0), addPodWithPVC(0, 0, 0), updateSnapshot(), addNode(1), addPodWithPVC(1, 1, 1), updateSnapshot(),
 			},
-			expected:           []*v1.Node{nodes[1], nodes[0]},
-			expectedUsedPVCSet: sets.New("test-ns/test-pvc0", "test-ns/test-pvc1"),
+			expected:              []*v1.Node{nodes[1], nodes[0]},
+			expectedUsedPVCCounts: map[string]int{"test-ns/test-pvc0": 1, "test-ns/test-pvc1": 1},
+		},
+		{
+			name: "Add multiple nodes with pods with multiple ref count PVC",
+			operations: []operation{
+				addNode(0), addPodWithPVC(0, 0, 0), addPodWithPVC(1, 0, 0), addPodWithPVC(2, 0, 1),
+				addNode(1), addPodWithPVC(3, 1, 0), addPodWithPVC(4, 1, 3), addPodWithPVC(5, 1, 1),
+				addNode(2), addPodWithPVC(7, 2, 3), addPodWithPVC(8, 2, 1), addPodWithPVC(9, 2, 1), updateSnapshot(),
+			},
+			expected: []*v1.Node{nodes[2], nodes[1], nodes[0]},
+			expectedUsedPVCCounts: map[string]int{
+				"test-ns/test-pvc0": 3,
+				"test-ns/test-pvc1": 4,
+				"test-ns/test-pvc3": 2,
+			},
 		},
 		{
 			name: "Add then Remove pods with affinity",
@@ -2249,23 +2263,56 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 			},
 			expected:                     []*v1.Node{nodes[0], nodes[1]},
 			expectedHavePodsWithAffinity: 0,
-			expectedUsedPVCSet:           sets.New[string](),
+			expectedUsedPVCCounts:        map[string]int{},
 		},
 		{
 			name: "Add then Remove pod with PVC",
 			operations: []operation{
 				addNode(0), addPodWithPVC(0, 0, 0), updateSnapshot(), removePodWithPVC(0, 0, 0), addPodWithPVC(2, 0, 2), updateSnapshot(),
 			},
-			expected:           []*v1.Node{nodes[0]},
-			expectedUsedPVCSet: sets.New("test-ns/test-pvc2"),
+			expected:              []*v1.Node{nodes[0]},
+			expectedUsedPVCCounts: map[string]int{"test-ns/test-pvc2": 1},
+		},
+		{
+			name: "Add pod with PVC then terminate node without cleaning up pods",
+			operations: []operation{
+				addNode(0), addNode(1), addPodWithPVC(0, 0, 0), addPodWithPVC(1, 1, 1), updateSnapshot(),
+				removeNode(0), updateSnapshot(),
+			},
+			expected:              []*v1.Node{nodes[1]},
+			expectedUsedPVCCounts: map[string]int{"test-ns/test-pvc1": 1},
+		},
+		{
+			name: "Add pod with multiple ref count PVC then terminate node without cleaning up pods",
+			operations: []operation{
+				addNode(0), addNode(1), addPodWithPVC(0, 0, 0), addPodWithPVC(1, 1, 1), addPodWithPVC(2, 1, 1),
+				addPodWithPVC(3, 1, 2), addPodWithPVC(4, 0, 3), addPodWithPVC(5, 0, 0),
+				addPodWithPVC(6, 1, 2), addPodWithPVC(7, 0, 4), addPodWithPVC(8, 1, 2), updateSnapshot(),
+				removeNode(0), updateSnapshot(),
+			},
+			expected:              []*v1.Node{nodes[1]},
+			expectedUsedPVCCounts: map[string]int{"test-ns/test-pvc1": 2, "test-ns/test-pvc2": 3},
+		},
+		{
+			name: "Add pod with multiple ref count PVC then terminate node before cleaning up pods (node and pods events in reversed order)",
+			operations: []operation{
+				addNode(0), addNode(1), addPodWithPVC(0, 0, 0), addPodWithPVC(1, 1, 1), addPodWithPVC(2, 1, 1),
+				addPodWithPVC(3, 1, 2), addPodWithPVC(4, 0, 3), addPodWithPVC(5, 0, 0),
+				addPodWithPVC(6, 1, 2), addPodWithPVC(7, 0, 4), addPodWithPVC(8, 1, 2), updateSnapshot(),
+				// Pod and node deletion
+				removeNode(0), updateSnapshot(),
+				removePodWithPVC(4, 0, 3), removePodWithPVC(5, 0, 0), updateSnapshot(),
+			},
+			expected:              []*v1.Node{nodes[1]},
+			expectedUsedPVCCounts: map[string]int{"test-ns/test-pvc1": 2, "test-ns/test-pvc2": 3},
 		},
 		{
 			name: "Add then Remove pod with PVC and add same pod again",
 			operations: []operation{
 				addNode(0), addPodWithPVC(0, 0, 0), updateSnapshot(), removePodWithPVC(0, 0, 0), addPodWithPVC(0, 0, 0), updateSnapshot(),
 			},
-			expected:           []*v1.Node{nodes[0]},
-			expectedUsedPVCSet: sets.New("test-ns/test-pvc0"),
+			expected:              []*v1.Node{nodes[0]},
+			expectedUsedPVCCounts: map[string]int{"test-ns/test-pvc0": 1},
 		},
 		{
 			name: "Add and Remove multiple pods with PVC with same ref count length different content",
@@ -2273,8 +2320,8 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 				addNode(0), addNode(1), addPodWithPVC(0, 0, 0), addPodWithPVC(1, 1, 1), updateSnapshot(),
 				removePodWithPVC(0, 0, 0), removePodWithPVC(1, 1, 1), addPodWithPVC(2, 0, 2), addPodWithPVC(3, 1, 3), updateSnapshot(),
 			},
-			expected:           []*v1.Node{nodes[1], nodes[0]},
-			expectedUsedPVCSet: sets.New("test-ns/test-pvc2", "test-ns/test-pvc3"),
+			expected:              []*v1.Node{nodes[1], nodes[0]},
+			expectedUsedPVCCounts: map[string]int{"test-ns/test-pvc2": 1, "test-ns/test-pvc3": 1},
 		},
 		{
 			name: "Add, Update and Remove multiple pods with SchedulingGroup",
@@ -2283,7 +2330,8 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 				addPodWithPodGroupName(2), updateSnapshot(),
 				updatePodWithPodGroupName(0), removePodWithPodGroupName(1), updateSnapshot(),
 			},
-			expected: []*v1.Node{nodes[1], nodes[0], nodes[2]},
+			expected:              []*v1.Node{nodes[1], nodes[0], nodes[2]},
+			expectedUsedPVCCounts: map[string]int{},
 			expectedPodGroupStatesSnapshot: map[podGroupKey]*podGroupStateSnapshot{
 				newPodGroupKey("test-ns", "pg-0"): {
 					podGroupStateData: podGroupStateData{
@@ -2311,8 +2359,8 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 				addPodWithPVC(3, 1, 3), addPodWithPVC(4, 0, 0), addPodWithPVC(5, 1, 1), updateSnapshot(),
 				removePodWithPVC(0, 0, 0), removePodWithPVC(3, 1, 3), removePodWithPVC(4, 0, 0), updateSnapshot(),
 			},
-			expected:           []*v1.Node{nodes[0], nodes[1]},
-			expectedUsedPVCSet: sets.New("test-ns/test-pvc1", "test-ns/test-pvc2"),
+			expected:              []*v1.Node{nodes[0], nodes[1]},
+			expectedUsedPVCCounts: map[string]int{"test-ns/test-pvc1": 1, "test-ns/test-pvc2": 1},
 		},
 		{
 			name: "Assume and forget in cache, and in snapshot",
@@ -2321,8 +2369,8 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 				assumePod(8), assumePodInSnapshot(4), assumePod(0), forgetPod(0),
 				assumePodInSnapshot(2), forgetPodInSnapshot(4), updateSnapshot(),
 			},
-			expected:           []*v1.Node{nodes[0], nodes[8], nodes[4], nodes[2]},
-			expectedUsedPVCSet: sets.New[string](),
+			expected:              []*v1.Node{nodes[0], nodes[8], nodes[4], nodes[2]},
+			expectedUsedPVCCounts: map[string]int{},
 		},
 		{
 			name: "Assume and forget in cache, and in snapshot, with affinity",
@@ -2333,7 +2381,7 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 			},
 			expected:                     []*v1.Node{nodes[0], nodes[8], nodes[4], nodes[2]},
 			expectedHavePodsWithAffinity: 1,
-			expectedUsedPVCSet:           sets.New[string](),
+			expectedUsedPVCCounts:        map[string]int{},
 		},
 		{
 			name: "Assume and forget in cache, and in snapshot, with PVC",
@@ -2342,8 +2390,19 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 				assumePodWithPVC(8, 8, 8), assumePodWithPVCInSnapshot(4, 4, 4), assumePodWithPVC(0, 0, 0), forgetPodWithPVC(0, 0, 0),
 				assumePodWithPVCInSnapshot(2, 2, 2), forgetPodWithPVCInSnapshot(4, 4, 4), updateSnapshot(),
 			},
-			expected:           []*v1.Node{nodes[0], nodes[8], nodes[4], nodes[2]},
-			expectedUsedPVCSet: sets.New("test-ns/test-pvc8"),
+			expected:              []*v1.Node{nodes[0], nodes[8], nodes[4], nodes[2]},
+			expectedUsedPVCCounts: map[string]int{"test-ns/test-pvc8": 1},
+		},
+		{
+			name: "Assume and forget in cache, and in snapshot, with multiple PVC ref counts",
+			operations: []operation{
+				addNode(0), addNode(2), addNode(4), addNode(8), updateSnapshot(),
+				assumePodWithPVC(8, 8, 0), assumePodWithPVCInSnapshot(4, 4, 0), assumePodWithPVC(0, 0, 0), forgetPodWithPVC(0, 0, 0),
+				assumePodWithPVC(1, 2, 0), assumePodWithPVCInSnapshot(3, 4, 0), assumePodWithPVC(5, 0, 0), forgetPodWithPVC(5, 0, 0),
+				assumePodWithPVC(2, 2, 0), assumePodWithPVCInSnapshot(10, 4, 0), forgetPodWithPVCInSnapshot(4, 4, 0), updateSnapshot(),
+			},
+			expected:              []*v1.Node{nodes[2], nodes[0], nodes[8], nodes[4]},
+			expectedUsedPVCCounts: map[string]int{"test-ns/test-pvc0": 3},
 		},
 	}
 
@@ -2359,19 +2418,27 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 				op(t)
 			}
 
-			if len(test.expected) != len(cache.nodes) {
-				t.Errorf("unexpected number of nodes. Expected: %v, got: %v", len(test.expected), len(cache.nodes))
+			cacheNodeSize := 0
+			for _, n := range cache.nodes {
+				if n.info.Node() != nil { // non-deleted nodes
+					cacheNodeSize++
+				}
+			}
+			if len(test.expected) != cacheNodeSize {
+				t.Errorf("unexpected number of nodes. Expected: %v, got: %v", len(test.expected), cacheNodeSize)
 			}
 			var i int
 			// Check that cache is in the expected state.
 			for node := cache.headNode; node != nil; node = node.next {
-				if node.info.Node() != nil && node.info.Node().Name != test.expected[i].Name {
-					t.Errorf("unexpected node. Expected: %v, got: %v, index: %v", test.expected[i].Name, node.info.Node().Name, i)
+				if node.info.Node() != nil {
+					if node.info.Node().Name != test.expected[i].Name {
+						t.Errorf("unexpected node. Expected: %v, got: %v, index: %v", test.expected[i].Name, node.info.Node().Name, i)
+					}
+					i++
 				}
-				i++
 			}
 			// Make sure we visited all the cached nodes in the above for loop.
-			if i != len(cache.nodes) {
+			if i != cacheNodeSize {
 				t.Errorf("Not all the nodes were visited by following the NodeInfo linked list. Expected to see %v nodes, saw %v.", len(cache.nodes), i)
 			}
 
@@ -2386,7 +2453,7 @@ func TestSchedulerCache_UpdateSnapshot(t *testing.T) {
 			}
 
 			// Compare content of the used PVC set
-			if diff := cmp.Diff(test.expectedUsedPVCSet, snapshot.usedPVCSet); diff != "" {
+			if diff := cmp.Diff(test.expectedUsedPVCCounts, snapshot.usedPVCRefCounts); diff != "" {
 				t.Errorf("Unexpected usedPVCSet (-want +got):\n%s", diff)
 			}
 
@@ -2422,7 +2489,7 @@ func compareCacheWithNodeInfoSnapshot(t *testing.T, cache *cacheImpl, snapshot *
 
 	expectedNodeInfoList := make([]fwk.NodeInfo, 0, cache.nodeTree.numNodes)
 	expectedHavePodsWithAffinityNodeInfoList := make([]fwk.NodeInfo, 0, cache.nodeTree.numNodes)
-	expectedUsedPVCSet := sets.New[string]()
+	expectedUsedPVCSet := map[string]int{}
 	nodesList, err := cache.nodeTree.list()
 	if err != nil {
 		t.Fatal(err)
@@ -2433,8 +2500,8 @@ func compareCacheWithNodeInfoSnapshot(t *testing.T, cache *cacheImpl, snapshot *
 			if len(n.PodsWithAffinity) > 0 {
 				expectedHavePodsWithAffinityNodeInfoList = append(expectedHavePodsWithAffinityNodeInfoList, n)
 			}
-			for key := range n.PVCRefCounts {
-				expectedUsedPVCSet.Insert(key)
+			for key, count := range n.PVCRefCounts {
+				expectedUsedPVCSet[key] += count
 			}
 		} else {
 			return fmt.Errorf("node %q exist in nodeTree but not in NodeInfoMap, this should not happen", nodeName)
@@ -2455,9 +2522,9 @@ func compareCacheWithNodeInfoSnapshot(t *testing.T, cache *cacheImpl, snapshot *
 		}
 	}
 
-	for key := range expectedUsedPVCSet {
-		if !snapshot.usedPVCSet.Has(key) {
-			return fmt.Errorf("expected PVC %s to exist in UsedPVCSet but it is not found", key)
+	for key, count := range expectedUsedPVCSet {
+		if snapshot.usedPVCRefCounts[key] != count {
+			return fmt.Errorf("expected PVC %s to exist in UsedPVCSet. Expected: %v, got: %v", key, snapshot.usedPVCRefCounts[key], count)
 		}
 	}
 

--- a/pkg/scheduler/backend/cache/snapshot.go
+++ b/pkg/scheduler/backend/cache/snapshot.go
@@ -52,10 +52,10 @@ type Snapshot struct {
 	// havePodsWithRequiredAntiAffinityNodeInfoList is the list of nodes with at least one pod declaring
 	// required anti-affinity terms.
 	havePodsWithRequiredAntiAffinityNodeInfoList []fwk.NodeInfo
-	// usedPVCSet contains a set of PVC names that have one or more scheduled pods using them,
+	// usedPVCRefCounts contains the number of nodes using each PVC across the cluster,
 	// keyed in the format "namespace/name".
-	usedPVCSet sets.Set[string]
-	generation int64
+	usedPVCRefCounts map[string]int
+	generation       int64
 	// assumedPods maps a pod key to an assumed pod object during a single pod group scheduling cycle.
 	// This map should be emptied before the next cycle starts.
 	assumedPods map[string]*v1.Pod
@@ -79,7 +79,7 @@ var _ fwk.SharedLister = &Snapshot{}
 func NewEmptySnapshot() *Snapshot {
 	return &Snapshot{
 		nodeInfoMap:            make(map[string]*framework.NodeInfo),
-		usedPVCSet:             sets.New[string](),
+		usedPVCRefCounts:       make(map[string]int),
 		assumedPods:            make(map[string]*v1.Pod),
 		podGroupStates:         make(map[podGroupKey]*podGroupStateSnapshot),
 		genericWorkloadEnabled: utilfeature.DefaultFeatureGate.Enabled(features.GenericWorkload),
@@ -107,7 +107,7 @@ func NewSnapshot(pods []*v1.Pod, nodes []*v1.Node) *Snapshot {
 	s.nodeInfoList = nodeInfoList
 	s.havePodsWithAffinityNodeInfoList = havePodsWithAffinityNodeInfoList
 	s.havePodsWithRequiredAntiAffinityNodeInfoList = havePodsWithRequiredAntiAffinityNodeInfoList
-	s.usedPVCSet = createUsedPVCSet(pods)
+	s.usedPVCRefCounts = createUsedPVCRefCounts(nodeInfoMap)
 	if s.genericWorkloadEnabled {
 		s.podGroupStates = createPodGroupStates(pods)
 	}
@@ -213,23 +213,14 @@ func createNodeInfoMap(pods []*v1.Pod, nodes []*v1.Node) map[string]*framework.N
 	return nodeNameToInfo
 }
 
-func createUsedPVCSet(pods []*v1.Pod) sets.Set[string] {
-	usedPVCSet := sets.New[string]()
-	for _, pod := range pods {
-		if pod.Spec.NodeName == "" {
-			continue
-		}
-
-		for _, v := range pod.Spec.Volumes {
-			if v.PersistentVolumeClaim == nil {
-				continue
-			}
-
-			key := framework.GetNamespacedName(pod.Namespace, v.PersistentVolumeClaim.ClaimName)
-			usedPVCSet.Insert(key)
+func createUsedPVCRefCounts(nodeInfoMap map[string]*framework.NodeInfo) map[string]int {
+	usedPVCRefCounts := make(map[string]int)
+	for _, nodeInfo := range nodeInfoMap {
+		for pvcKey, count := range nodeInfo.PVCRefCounts {
+			usedPVCRefCounts[pvcKey] += count
 		}
 	}
-	return usedPVCSet
+	return usedPVCRefCounts
 }
 
 // getNodeImageStates returns the given node's image states based on the given imageExistence map.
@@ -330,7 +321,7 @@ func (s *Snapshot) Get(nodeName string) (fwk.NodeInfo, error) {
 }
 
 func (s *Snapshot) IsPVCUsedByPods(key string) bool {
-	return s.usedPVCSet.Has(key)
+	return s.usedPVCRefCounts[key] > 0
 }
 
 // AssumePod assumes a given pod in the snapshot.

--- a/pkg/scheduler/backend/cache/snapshot_test.go
+++ b/pkg/scheduler/backend/cache/snapshot_test.go
@@ -188,53 +188,6 @@ func TestCreateImageExistenceMap(t *testing.T) {
 	}
 }
 
-func TestCreateUsedPVCSet(t *testing.T) {
-	tests := []struct {
-		name     string
-		pods     []*v1.Pod
-		expected sets.Set[string]
-	}{
-		{
-			name:     "empty pods list",
-			pods:     []*v1.Pod{},
-			expected: sets.New[string](),
-		},
-		{
-			name: "pods not scheduled",
-			pods: []*v1.Pod{
-				st.MakePod().Name("foo").Namespace("foo").Obj(),
-				st.MakePod().Name("bar").Namespace("bar").Obj(),
-			},
-			expected: sets.New[string](),
-		},
-		{
-			name: "scheduled pods that do not use any PVC",
-			pods: []*v1.Pod{
-				st.MakePod().Name("foo").Namespace("foo").Node("node-1").Obj(),
-				st.MakePod().Name("bar").Namespace("bar").Node("node-2").Obj(),
-			},
-			expected: sets.New[string](),
-		},
-		{
-			name: "scheduled pods that use PVC",
-			pods: []*v1.Pod{
-				st.MakePod().Name("foo").Namespace("foo").Node("node-1").PVC("pvc1").Obj(),
-				st.MakePod().Name("bar").Namespace("bar").Node("node-2").PVC("pvc2").Obj(),
-			},
-			expected: sets.New("foo/pvc1", "bar/pvc2"),
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			usedPVCs := createUsedPVCSet(test.pods)
-			if diff := cmp.Diff(test.expected, usedPVCs); diff != "" {
-				t.Errorf("Unexpected usedPVCs (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
 func TestNewSnapshot(t *testing.T) {
 	podWithAnnotations := st.MakePod().Name("foo").Namespace("ns").Node("node-1").Annotations(map[string]string{"custom": "annotation"}).Obj()
 	podWithPort := st.MakePod().Name("foo").Namespace("foo").Node("node-0").ContainerPort([]v1.ContainerPort{{HostPort: 8080}}).Obj()
@@ -247,6 +200,7 @@ func TestNewSnapshot(t *testing.T) {
 		st.MakePod().Name("foo").Namespace("foo").Node("node-0").PVC("pvc0").Obj(),
 		st.MakePod().Name("bar").Namespace("bar").Node("node-1").PVC("pvc1").Obj(),
 		st.MakePod().Name("baz").Namespace("baz").Node("node-2").PVC("pvc2").Obj(),
+		st.MakePod().Name("bak").Namespace("baz").Node("node-2").PVC("pvc2").Obj(),
 	}
 	testCases := []struct {
 		name                         string
@@ -256,12 +210,13 @@ func TestNewSnapshot(t *testing.T) {
 		expectedNumNodes             int
 		expectedPodsWithAffinity     int
 		expectedPodsWithAntiAffinity int
-		expectedUsedPVCSet           sets.Set[string]
+		expectedUsedPVCCounts        map[string]int
 	}{
 		{
-			name:  "no pods no nodes",
-			pods:  nil,
-			nodes: nil,
+			name:                  "no pods no nodes",
+			pods:                  nil,
+			nodes:                 nil,
+			expectedUsedPVCCounts: map[string]int{},
 		},
 		{
 			name: "single pod single node",
@@ -278,7 +233,8 @@ func TestNewSnapshot(t *testing.T) {
 					},
 				},
 			},
-			expectedNumNodes: 1,
+			expectedNumNodes:      1,
+			expectedUsedPVCCounts: map[string]int{},
 		},
 		{
 			name: "multiple nodes, pods with PVCs",
@@ -305,8 +261,8 @@ func TestNewSnapshot(t *testing.T) {
 					},
 				},
 			},
-			expectedNumNodes:   3,
-			expectedUsedPVCSet: sets.New("foo/pvc0", "bar/pvc1", "baz/pvc2"),
+			expectedNumNodes:      3,
+			expectedUsedPVCCounts: map[string]int{"foo/pvc0": 1, "bar/pvc1": 1, "baz/pvc2": 2},
 		},
 		{
 			name: "multiple nodes, pod with affinity",
@@ -346,6 +302,7 @@ func TestNewSnapshot(t *testing.T) {
 			},
 			expectedNumNodes:         3,
 			expectedPodsWithAffinity: 1,
+			expectedUsedPVCCounts:    map[string]int{},
 		},
 		{
 			name: "multiple nodes, pod with affinity, pod with anti-affinity",
@@ -391,6 +348,7 @@ func TestNewSnapshot(t *testing.T) {
 			expectedNumNodes:             2,
 			expectedPodsWithAffinity:     1,
 			expectedPodsWithAntiAffinity: 1,
+			expectedUsedPVCCounts:        map[string]int{},
 		},
 	}
 
@@ -433,13 +391,13 @@ func TestNewSnapshot(t *testing.T) {
 				t.Errorf("unexpected antiAffinityList number, want: %v, got: %v", test.expectedPodsWithAntiAffinity, len(antiAffinityList))
 			}
 
-			for key := range test.expectedUsedPVCSet {
+			for key := range test.expectedUsedPVCCounts {
 				if !snapshot.IsPVCUsedByPods(key) {
 					t.Errorf("unexpected IsPVCUsedByPods for %s, want: true, got: false", key)
 				}
 			}
 
-			if diff := cmp.Diff(test.expectedUsedPVCSet, snapshot.usedPVCSet); diff != "" {
+			if diff := cmp.Diff(test.expectedUsedPVCCounts, snapshot.usedPVCRefCounts); diff != "" {
 				t.Errorf("Unexpected usedPVCSet (-want +got):\n%s", diff)
 			}
 		})
@@ -940,5 +898,105 @@ func TestSnapshot_MultipleBackups(t *testing.T) {
 	_, err = s.BackupSnapshot()
 	if err != nil {
 		t.Fatalf("failed to prepare a backup after restoring: %v", err)
+	}
+}
+
+func TestSnapshot_CreateUsedPVCRefCounts(t *testing.T) {
+	tests := []struct {
+		name                string
+		nodeInfoMap         map[string]*framework.NodeInfo
+		expectedPVCRefCount map[string]int
+	}{
+		{
+			name:                "empty map should generate empty counts",
+			nodeInfoMap:         map[string]*framework.NodeInfo{},
+			expectedPVCRefCount: map[string]int{},
+		},
+		{
+			name: "1 single node with one PVC should produce a ref count of 1",
+			nodeInfoMap: map[string]*framework.NodeInfo{
+				"test-node-1": {
+					PVCRefCounts: map[string]int{
+						"test-pvc-1": 1,
+					},
+				},
+			},
+			expectedPVCRefCount: map[string]int{
+				"test-pvc-1": 1,
+			},
+		},
+		{
+			name: "2 nodes sharing the same PVC should accumulate ref count to 2",
+			nodeInfoMap: map[string]*framework.NodeInfo{
+				"test-node-1": {
+					PVCRefCounts: map[string]int{
+						"test-pvc-1": 1,
+					},
+				},
+				"test-node-2": {
+					PVCRefCounts: map[string]int{
+						"test-pvc-1": 1,
+					},
+				},
+			},
+			expectedPVCRefCount: map[string]int{
+				"test-pvc-1": 2,
+			},
+		},
+		{
+			name: "2 nodes with mixed shared and unique PVCs should produce correct ref counts",
+			nodeInfoMap: map[string]*framework.NodeInfo{
+				"test-node-1": {
+					PVCRefCounts: map[string]int{
+						"test-pvc-1": 1,
+						"test-pvc-2": 1,
+					},
+				},
+				"test-node-2": {
+					PVCRefCounts: map[string]int{
+						"test-pvc-1": 1,
+						"test-pvc-3": 1,
+					},
+				},
+			},
+			expectedPVCRefCount: map[string]int{
+				"test-pvc-1": 2,
+				"test-pvc-2": 1,
+				"test-pvc-3": 1,
+			},
+		},
+		{
+			name: "2 nodes with per-node PVC counts greater than one should sum across nodes",
+			nodeInfoMap: map[string]*framework.NodeInfo{
+				"test-node-1": {
+					PVCRefCounts: map[string]int{
+						"test-pvc-1": 1,
+						"test-pvc-2": 2,
+						"test-pvc-3": 1,
+					},
+				},
+				"test-node-2": {
+					PVCRefCounts: map[string]int{
+						"test-pvc-1": 1,
+						"test-pvc-2": 1,
+						"test-pvc-3": 2,
+					},
+				},
+			},
+			expectedPVCRefCount: map[string]int{
+				"test-pvc-1": 2,
+				"test-pvc-2": 3,
+				"test-pvc-3": 3,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := createUsedPVCRefCounts(tt.nodeInfoMap)
+			if diff := cmp.Diff(actual, tt.expectedPVCRefCount); diff != "" {
+				t.Errorf("Unexpected pvcRefCount (-want, +got):\n%s", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/sig scheduling
/sig scalability
/cc @macsko @mengqiy @hakuna-matatah 


<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR fixes a performance issue in kube-scheduler that its throughput (in pods/sec) tapers down significantly when processing large number of pods with PVC mounts. See more details in the original issue below:

Fixes: https://github.com/kubernetes/kubernetes/issues/138426

The following graph shows the throughput stayed healthy for scheduling 100k pods with pre-provisioned PVC mounts, where the throughput is mostly above 300 while before the fix the throughput can drop down to 10~20.

<img width="864" height="477" alt="Screenshot 2026-05-21 at 4 14 40 PM" src="https://github.com/user-attachments/assets/d7b41e7a-a62e-4bd6-9056-c6136016d734" />


#### Which issue(s) this PR is related to:

- https://github.com/kubernetes/kubernetes/issues/138426

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Optimized kube-scheduler performance for Pods with PersistentVolumeClaim mounts by processing only delta counts between scheduling cycles.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
