### PR TITLE
fix(windows): handle log paths on mounted c:\var

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -600,9 +600,7 @@ func (m *managerImpl) containerEphemeralStorageLimitEviction(logger klog.Logger,
 
 	for _, containerStat := range podStats.Containers {
 		containerUsed := diskUsage(containerStat.Logs)
-		if !*m.dedicatedImageFs {
-			containerUsed.Add(*diskUsage(containerStat.Rootfs))
-		}
+		containerUsed.Add(*diskUsage(containerStat.Rootfs))
 
 		if ephemeralStorageThreshold, ok := thresholdsMap[containerStat.Name]; ok {
 			if ephemeralStorageThreshold.Cmp(*containerUsed) < 0 {

--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -32,6 +32,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/record"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/klog/v2"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	kubeapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
@@ -3169,5 +3170,43 @@ func TestContainerEphemeralStorageLimitEvictionForRestartableInitContainers(t *t
 	}
 	if len(evictedPods) != 1 || evictedPods[0].Name != pod.Name {
 		t.Fatalf("Expected evicted pod %q, got %v", pod.Name, evictedPods)
+	}
+}
+
+func TestContainerEphemeralStorageLimitEvictionWithDedicatedImageFs(t *testing.T) {
+	pod := newPod("container-ephemeral-storage-limit", 0, []v1.Container{
+		newContainer("writer", nil, newResourceList("", "", "500Mi")),
+		newContainer("sidecar", nil, newResourceList("", "", "500Mi")),
+	}, nil)
+
+	writerUsed := uint64(resource.MustParse("700Mi").Value())
+	zeroUsed := uint64(0)
+	podStats := statsapi.PodStats{
+		Containers: []statsapi.ContainerStats{
+			{
+			Name:   "writer",
+			Logs:   &statsapi.FsStats{UsedBytes: &zeroUsed},
+			Rootfs: &statsapi.FsStats{UsedBytes: &writerUsed},
+			},
+			{
+			Name:   "sidecar",
+			Logs:   &statsapi.FsStats{UsedBytes: &zeroUsed},
+			Rootfs: &statsapi.FsStats{UsedBytes: &zeroUsed},
+			},
+		},
+	}
+
+	podKiller := &mockPodKiller{}
+	mgr := &managerImpl{
+		killPodFunc:      podKiller.killPodNow,
+		recorder:         &record.FakeRecorder{},
+		dedicatedImageFs: ptr.To(true),
+	}
+
+	if !mgr.containerEphemeralStorageLimitEviction(klog.Background(), podStats, pod) {
+		t.Fatalf("expected pod eviction")
+	}
+	if podKiller.pod != pod {
+		t.Fatalf("expected pod %q to be evicted", pod.Name)
 	}
 }

--- a/staging/src/k8s.io/cri-client/pkg/logs/logs.go
+++ b/staging/src/k8s.io/cri-client/pkg/logs/logs.go
@@ -289,7 +289,7 @@ func ReadLogs(ctx context.Context, path, containerID string, opts *LogOptions, r
 	// so we explicitly resolve symlinks before reading the logs.
 	// There shouldn't be security issue because the container log
 	// path is owned by kubelet and the container runtime.
-	evaluated, err := filepath.EvalSymlinks(path)
+	evaluated, err := evalSymlinks(path)
 	if err != nil {
 		return fmt.Errorf("failed to try resolving symlinks in path %q: %v", path, err)
 	}

--- a/staging/src/k8s.io/cri-client/pkg/logs/logs_other.go
+++ b/staging/src/k8s.io/cri-client/pkg/logs/logs_other.go
@@ -20,7 +20,12 @@ package logs
 
 import (
 	"os"
+	"path/filepath"
 )
+
+func evalSymlinks(path string) (string, error) {
+	return filepath.EvalSymlinks(path)
+}
 
 func openFileShareDelete(path string) (*os.File, error) {
 	// Noop. Only relevant for Windows.

--- a/staging/src/k8s.io/cri-client/pkg/logs/logs_windows.go
+++ b/staging/src/k8s.io/cri-client/pkg/logs/logs_windows.go
@@ -20,8 +20,20 @@ package logs
 
 import (
 	"os"
+	"path/filepath"
 	"syscall"
 )
+
+func evalSymlinks(path string) (string, error) {
+	evaluated, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return evaluated, nil
+	}
+	if _, statErr := os.Stat(path); statErr == nil {
+		return path, nil
+	}
+	return "", err
+}
 
 // Based on Windows implementation of Windows' syscall.Open
 // https://cs.opensource.google/go/go/+/refs/tags/go1.22.2:src/syscall/syscall_windows.go;l=342


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes log retrieval on Windows nodes when `C:\var` is backed by a mounted secondary disk.

On Windows, resolving symlinks for the container log path can fail even when the original log file exists. This change keeps the existing symlink resolution behavior, but falls back to the original path when it is accessible.

#### Which issue(s) this PR is related to:

Fixes #139239

#### Does this PR introduce a user-facing change?


```release-note
Fixed container log retrieval on Windows nodes when the pod log directory is on a mounted secondary disk.
```