### PR TITLE
Fix Windows file locking race condition in Kubelet tests

### DIFF
--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -3312,9 +3312,7 @@ func TestNewMainKubeletStandAlone(t *testing.T) {
 	// This is needed on Windows because a concurrent os.ReadDir in a GC goroutine
 	// can keep a handle to this directory in use and cause os.RemoveAll to fail.
 	t.Cleanup(func() {
-		ContainerLogsDir = containerLogsDir
-		err := os.RemoveAll(tempDir)
-		require.NoError(t, err)
+		cleanUpTempDir(t, tempDir, containerLogsDir)
 	})
 
 	ca, cert, key, err := generateCAAndCertKeyWithOptions(
@@ -3473,9 +3471,7 @@ func TestNewMainKubeletWithCertAndCAReloadingEnabled(t *testing.T) {
 	// This is needed on Windows because a concurrent os.ReadDir in a GC goroutine
 	// can keep a handle to this directory in use and cause os.RemoveAll to fail.
 	t.Cleanup(func() {
-		ContainerLogsDir = containerLogsDir
-		err := os.RemoveAll(tempDir)
-		require.NoError(t, err)
+		cleanUpTempDir(t, tempDir, containerLogsDir)
 	})
 
 	ca, cert, key, err := generateCAAndCertKeyWithOptions(
@@ -5216,4 +5212,20 @@ func TestSyncPodRestartAllContainersRequeue(t *testing.T) {
 	// We expect SyncPod to be called once by us, and once recursively via UpdatePod -> fakePodWorkers.syncPodFn
 	// because the SyncResults contained a successful RemoveContainer action.
 	require.Equal(t, 1, callCount)
+}
+
+func cleanUpTempDir(t *testing.T, tempDir, originalLogsDir string) {
+	t.Helper()
+	ContainerLogsDir = originalLogsDir
+	// On Windows, we might need to retry RemoveAll because concurrent goroutines
+	// (like the garbage collector) might take a moment to exit and release file/dir handles.
+	var err error
+	for range 10 {
+		err = os.RemoveAll(tempDir)
+		if err == nil {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	require.NoError(t, err)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

Fixes a Windows-specific test cleanup race condition in `TestNewMainKubeletStandAlone` and `TestNewMainKubeletWithCertAndCAReloadingEnabled`. 

On Windows nodes, the file system prevents unlinking/deleting files or directories that are still held open by other active processes. During test teardown, `t.Cleanup` calls `os.RemoveAll` on the temp directory immediately after context cancellation. However, the asynchronous garbage collection goroutines can take a moment to fully exit, causing the cleanup to fail with a `The process cannot access the file because it is being used by another process` error.

Retrying `os.RemoveAll` with a small backoff (up to 10 retries with 100ms sleeps) to allow background goroutines to release their file/directory handles.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

I encountered this flake on a CI run of `pull-kubernetes-unit-windows-master`.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
