### PR TITLE
fix(scheduler): do not schedule pods onto nodes in graceful shutdown

### DIFF
--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
@@ -21,6 +21,7 @@ package nodeshutdown
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sync"
@@ -30,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/record"
+	nodeutil "k8s.io/component-helpers/node/util"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
 	kubeletevents "k8s.io/kubernetes/pkg/kubelet/events"
@@ -345,7 +347,7 @@ func (m *managerImpl) ShutdownStatus() error {
 	defer m.nodeShuttingDownMutex.Unlock()
 
 	if m.nodeShuttingDownNow {
-		return fmt.Errorf("node is shutting down")
+		return errors.New(nodeutil.NodeShutdownMessage)
 	}
 	return nil
 }

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
@@ -21,6 +21,7 @@ package nodeshutdown
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -30,6 +31,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/record"
+	nodeutil "k8s.io/component-helpers/node/util"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
 	kubeletevents "k8s.io/kubernetes/pkg/kubelet/events"
@@ -242,7 +244,7 @@ func (m *managerImpl) ShutdownStatus() error {
 	defer m.nodeShuttingDownMutex.Unlock()
 
 	if m.nodeShuttingDownNow {
-		return fmt.Errorf("node is shutting down")
+		return errors.New(nodeutil.NodeShutdownMessage)
 	}
 	return nil
 }

--- a/pkg/kubelet/nodestatus/setters_test.go
+++ b/pkg/kubelet/nodestatus/setters_test.go
@@ -40,6 +40,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/featuregate"
 	"k8s.io/component-base/version"
+	nodeutil "k8s.io/component-helpers/node/util"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
@@ -1242,8 +1243,8 @@ func TestReadyCondition(t *testing.T) {
 		{
 			desc:                      "new, not ready: shutdown active",
 			node:                      withCapacity.DeepCopy(),
-			nodeShutdownManagerErrors: errors.New("node is shutting down"),
-			expectConditions:          []v1.NodeCondition{*makeReadyCondition(false, "node is shutting down", now, now)},
+			nodeShutdownManagerErrors: errors.New(nodeutil.NodeShutdownMessage),
+			expectConditions:          []v1.NodeCondition{*makeReadyCondition(false, nodeutil.NodeShutdownMessage, now, now)},
 		},
 		{
 			desc:             "new, not ready: runtime and network errors",

--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
+++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	nodeutil "k8s.io/component-helpers/node/util"
 	v1helper "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
@@ -47,6 +48,8 @@ const (
 	ErrReasonUnknownCondition = "node(s) had unknown conditions"
 	// ErrReasonUnschedulable is used for NodeUnschedulable predicate error.
 	ErrReasonUnschedulable = "node(s) were unschedulable"
+	// ErrReasonNodeShutdown is used for shutting down Node predicate error.
+	ErrReasonNodeShutdown = "node(s) were shutting down"
 )
 
 // EventsToRegister returns the possible events that may make a Pod
@@ -54,7 +57,7 @@ const (
 func (pl *NodeUnschedulable) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWithHint, error) {
 	return []fwk.ClusterEventWithHint{
 		// When QueueingHint is enabled, we don't use preCheck and we don't need to register UpdateNodeLabel event.
-		{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add | fwk.UpdateNodeTaint}, QueueingHintFn: pl.isSchedulableAfterNodeChange},
+		{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add | fwk.UpdateNodeTaint | fwk.UpdateNodeCondition}, QueueingHintFn: pl.isSchedulableAfterNodeChange},
 		// When the QueueingHint feature is enabled,
 		// the scheduling queue uses Pod/Update Queueing Hint
 		// to determine whether a Pod's update makes the Pod schedulable or not.
@@ -98,9 +101,11 @@ func (pl *NodeUnschedulable) isSchedulableAfterNodeChange(logger klog.Logger, po
 
 	// We queue this Pod when -
 	// 1. the node is updated from unschedulable to schedulable.
-	// 2. the node is added and is schedulable.
+	// 2. the node is updated from shutting down to not shutting down.
+	// 3. the node is added and is schedulable.
 	if (originalNode != nil && originalNode.Spec.Unschedulable && !modifiedNode.Spec.Unschedulable) ||
-		(originalNode == nil && !modifiedNode.Spec.Unschedulable) {
+		(originalNode != nil && nodeutil.IsNodeInGracefulShutdown(originalNode) && !nodeutil.IsNodeInGracefulShutdown(modifiedNode)) ||
+		(originalNode == nil && !modifiedNode.Spec.Unschedulable && !nodeutil.IsNodeInGracefulShutdown(modifiedNode)) {
 		logger.V(5).Info("node was created or updated, pod may be schedulable now", "pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
 		return fwk.Queue, nil
 	}
@@ -124,6 +129,9 @@ func (pl *NodeUnschedulable) SignPod(ctx context.Context, pod *v1.Pod) ([]fwk.Si
 // Filter invoked at the filter extension point.
 func (pl *NodeUnschedulable) Filter(ctx context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
 	node := nodeInfo.Node()
+	if nodeutil.IsNodeInGracefulShutdown(node) {
+		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonNodeShutdown)
+	}
 
 	if !node.Spec.Unschedulable {
 		return nil

--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
+++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	v1 "k8s.io/api/core/v1"
+	nodeutil "k8s.io/component-helpers/node/util"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
@@ -72,6 +73,23 @@ func TestNodeUnschedulable(t *testing.T) {
 					Unschedulable: true,
 				},
 			},
+		},
+		{
+			name:       "Does not schedule pod to shutting down node",
+			pod:        st.MakePod().Toleration(v1.TaintNodeNotReady).Obj(),
+			node:       st.MakeNode().Name("node").Condition(v1.NodeReady, v1.ConditionFalse, nodeutil.NodeShutdownMessage, "KubeletNotReady").Obj(),
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonNodeShutdown),
+		},
+		{
+			name:       "Does not schedule pod to node with shutdown reason",
+			pod:        &v1.Pod{},
+			node:       st.MakeNode().Name("node").Condition(v1.NodeReady, v1.ConditionFalse, "", nodeutil.NodeShutdownMessage).Obj(),
+			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonNodeShutdown),
+		},
+		{
+			name: "Schedule pod to not ready node without shutdown signal",
+			pod:  &v1.Pod{},
+			node: st.MakeNode().Name("node").Condition(v1.NodeReady, v1.ConditionFalse, "runtime error", "KubeletNotReady").Obj(),
 		},
 	}
 
@@ -128,6 +146,17 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
 			expectedHint: fwk.QueueSkip,
 		},
 		{
+			name: "skip-queue-on-shutting-down-node-added",
+			pod:  &v1.Pod{},
+			newObj: st.MakeNode().Name("node").Condition(
+				v1.NodeReady,
+				v1.ConditionFalse,
+				nodeutil.NodeShutdownMessage,
+				"KubeletNotReady",
+			).Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
 			name: "queue-on-schedulable-node-added",
 			pod:  &v1.Pod{},
 			newObj: &v1.Node{
@@ -136,6 +165,40 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
 				},
 			},
 			expectedHint: fwk.Queue,
+		},
+		{
+			name: "queue-on-shutdown-condition-cleared",
+			pod:  &v1.Pod{},
+			newObj: st.MakeNode().Name("node").Condition(
+				v1.NodeReady,
+				v1.ConditionTrue,
+				"kubelet is posting ready status",
+				"KubeletReady",
+			).Obj(),
+			oldObj: st.MakeNode().Name("node").Condition(
+				v1.NodeReady,
+				v1.ConditionFalse,
+				nodeutil.NodeShutdownMessage,
+				"KubeletNotReady",
+			).Obj(),
+			expectedHint: fwk.Queue,
+		},
+		{
+			name: "skip-queue-on-shutdown-condition-set",
+			pod:  &v1.Pod{},
+			newObj: st.MakeNode().Name("node").Condition(
+				v1.NodeReady,
+				v1.ConditionFalse,
+				nodeutil.NodeShutdownMessage,
+				"KubeletNotReady",
+			).Obj(),
+			oldObj: st.MakeNode().Name("node").Condition(
+				v1.NodeReady,
+				v1.ConditionTrue,
+				"kubelet is posting ready status",
+				"KubeletReady",
+			).Obj(),
+			expectedHint: fwk.QueueSkip,
 		},
 		{
 			name: "skip-unrelated-change-unschedulable-true",

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -980,7 +980,7 @@ func Test_UnionedGVKs(t *testing.T) {
 			want: map[fwk.EventResource]fwk.ActionType{
 				fwk.AssignedPod:           fwk.Add | fwk.UpdatePodLabel | fwk.UpdatePodScaleDown | fwk.Delete,
 				fwk.TargetPod:             fwk.UpdatePodLabel | fwk.UpdatePodToleration | fwk.UpdatePodSchedulingGatesEliminated | fwk.UpdatePodScaleDown,
-				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.Delete,
+				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.UpdateNodeCondition | fwk.Delete,
 				fwk.CSINode:               fwk.All - fwk.Delete,
 				fwk.CSIDriver:             fwk.Update,
 				fwk.CSIStorageCapacity:    fwk.All - fwk.Delete,
@@ -997,7 +997,7 @@ func Test_UnionedGVKs(t *testing.T) {
 			want: map[fwk.EventResource]fwk.ActionType{
 				fwk.AssignedPod:           fwk.Add | fwk.UpdatePodLabel | fwk.Delete,
 				fwk.TargetPod:             fwk.UpdatePodLabel | fwk.UpdatePodGeneratedResourceClaim | fwk.UpdatePodToleration | fwk.UpdatePodSchedulingGatesEliminated,
-				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.Delete,
+				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.UpdateNodeCondition | fwk.Delete,
 				fwk.CSINode:               fwk.All - fwk.Delete,
 				fwk.CSIDriver:             fwk.Update,
 				fwk.CSIStorageCapacity:    fwk.All - fwk.Delete,
@@ -1019,7 +1019,7 @@ func Test_UnionedGVKs(t *testing.T) {
 				fwk.AssignedPod: fwk.Add | fwk.UpdatePodLabel | fwk.UpdatePodScaleDown | fwk.Delete,
 				fwk.TargetPod:   fwk.UpdatePodGeneratedResourceClaim | fwk.UpdatePodToleration | fwk.UpdatePodSchedulingGatesEliminated | fwk.Update,
 				// NodeDeclaredFeatures adds fwk.UpdateNodeDeclaredFeature
-				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.Delete | fwk.UpdateNodeDeclaredFeature,
+				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.UpdateNodeCondition | fwk.Delete | fwk.UpdateNodeDeclaredFeature,
 				fwk.CSINode:               fwk.All - fwk.Delete,
 				fwk.CSIDriver:             fwk.Update,
 				fwk.CSIStorageCapacity:    fwk.All - fwk.Delete,
@@ -1055,7 +1055,7 @@ func Test_UnionedGVKs(t *testing.T) {
 				fwk.AssignedPod:           fwk.Add | fwk.UpdatePodLabel | fwk.UpdatePodScaleDown | fwk.Delete,
 				fwk.TargetPod:             fwk.UpdatePodLabel | fwk.UpdatePodGeneratedResourceClaim | fwk.UpdatePodScaleDown | fwk.UpdatePodToleration | fwk.UpdatePodSchedulingGatesEliminated | fwk.Update,
 				fwk.UnscheduledPod:        fwk.Add,
-				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.Delete | fwk.UpdateNodeDeclaredFeature,
+				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.UpdateNodeCondition | fwk.Delete | fwk.UpdateNodeDeclaredFeature,
 				fwk.CSINode:               fwk.All - fwk.Delete,
 				fwk.CSIDriver:             fwk.Update,
 				fwk.CSIStorageCapacity:    fwk.All - fwk.Delete,

--- a/staging/src/k8s.io/component-helpers/node/util/conditions.go
+++ b/staging/src/k8s.io/component-helpers/node/util/conditions.go
@@ -19,12 +19,18 @@ package util
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clientset "k8s.io/client-go/kubernetes"
+)
+
+const (
+	// NodeShutdownMessage is used by kubelet when reporting that graceful node shutdown is active.
+	NodeShutdownMessage = "node is shutting down"
 )
 
 // GetNodeCondition extracts the provided condition from the given status and returns that.
@@ -39,6 +45,18 @@ func GetNodeCondition(status *v1.NodeStatus, conditionType v1.NodeConditionType)
 		}
 	}
 	return -1, nil
+}
+
+// IsNodeInGracefulShutdown returns true when the NodeReady condition reports graceful node shutdown.
+func IsNodeInGracefulShutdown(node *v1.Node) bool {
+	if node == nil {
+		return false
+	}
+	_, condition := GetNodeCondition(&node.Status, v1.NodeReady)
+	if condition == nil || condition.Status != v1.ConditionFalse {
+		return false
+	}
+	return condition.Reason == NodeShutdownMessage || strings.Contains(condition.Message, NodeShutdownMessage)
 }
 
 // SetNodeCondition updates specific node condition with patch operation.

--- a/staging/src/k8s.io/component-helpers/node/util/conditions_test.go
+++ b/staging/src/k8s.io/component-helpers/node/util/conditions_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestIsNodeInGracefulShutdown(t *testing.T) {
+	testCases := []struct {
+		name string
+		node *v1.Node
+		want bool
+	}{
+		{
+			name: "nil node",
+		},
+		{
+			name: "ready node",
+			node: nodeWithReadyCondition(v1.ConditionTrue, "KubeletReady", "kubelet is posting ready status"),
+		},
+		{
+			name: "not ready without shutdown signal",
+			node: nodeWithReadyCondition(v1.ConditionFalse, "KubeletNotReady", "runtime error"),
+		},
+		{
+			name: "shutdown by message",
+			node: nodeWithReadyCondition(v1.ConditionFalse, "KubeletNotReady", NodeShutdownMessage),
+			want: true,
+		},
+		{
+			name: "shutdown by reason",
+			node: nodeWithReadyCondition(v1.ConditionFalse, NodeShutdownMessage, ""),
+			want: true,
+		},
+		{
+			name: "shutdown message with aggregated errors",
+			node: nodeWithReadyCondition(v1.ConditionFalse, "KubeletNotReady", "[runtime error, "+NodeShutdownMessage+"]"),
+			want: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsNodeInGracefulShutdown(tc.node); got != tc.want {
+				t.Fatalf("IsNodeInGracefulShutdown() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func nodeWithReadyCondition(status v1.ConditionStatus, reason, message string) *v1.Node {
+	return &v1.Node{
+		Status: v1.NodeStatus{
+			Conditions: []v1.NodeCondition{
+				{
+					Type:    v1.NodeReady,
+					Status:  status,
+					Reason:  reason,
+					Message: message,
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

During graceful node shutdown, kubelet marks the node as `NotReady` and reports that the node is shutting down. Pods that tolerate the `node.kubernetes.io/not-ready` taint can still be scheduled onto that node. Kubelet then rejects those pods locally in `nodeshutdown.Manager.Admit()` after the scheduler has already bound them, causing unnecessary bind/admit churn and delaying placement on healthy nodes.

This PR makes graceful node shutdown visible to scheduler filtering logic:

- Adds a shared graceful shutdown signal helper in `k8s.io/component-helpers/node/util`.
- Uses that helper from kubelet when reporting shutdown status.
- Uses that helper from the scheduler to reject nodes whose `NodeReady` condition indicates graceful shutdown.
- Keeps scheduler and kubelet aligned on the shutdown signal without introducing a direct dependency between scheduler code and kubelet internals.
- Registers `UpdateNodeCondition` queueing hints so pods rejected due to node shutdown are re-queued when the node leaves shutdown.

The scheduler rejects graceful-shutdown nodes in `Filter`, regardless of whether the pod tolerates `node.kubernetes.io/not-ready`.

`PreFilter` is intentionally not used here. Detecting graceful shutdown requires checking node conditions, and doing that in `PreFilter` would add an unconditional scan over all nodes for every scheduling attempt. Since graceful shutdown is rare and the check is cheap, applying it in `Filter` avoids unnecessary cluster-wide work while preserving the same scheduling correctness.

The shared helper avoids duplicating the shutdown text across components. If the shutdown signal changes later, kubelet and scheduler can continue to use the same definition, reducing the chance of one component drifting from the other while still avoiding a direct coupling between kubelet and scheduler packages.

#### Which issue(s) this PR is related to:

Fixes: #139246
Fixes: #130490

Related: #132379

#### Special notes for your reviewer:

The helper checks both the `NodeReady` condition `Reason` and `Message`. Kubernetes documentation describes graceful shutdown as a node condition reason, while current kubelet behavior reports it in the `NodeReady=False` condition message with reason `KubeletNotReady`.

#### Does this PR introduce a user-facing change?

```release-note
The scheduler no longer schedules pods onto nodes that are gracefully shutting down, even if the pod tolerates the `node.kubernetes.io/not-ready` taint.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```