### PR TITLE
Handle missing compact_rev_key in etcd3 compactor

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/compact.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/compact.go
@@ -231,8 +231,17 @@ func Compact(ctx context.Context, client *clientv3.Client, expectVersion, rev in
 	currentRev = resp.Header.Revision
 
 	if !resp.Succeeded {
-		currentVersion = resp.Responses[0].GetResponseRange().Kvs[0].Version
-		compactRev, err = strconv.ParseInt(string(resp.Responses[0].GetResponseRange().Kvs[0].Value), 10, 64)
+		if len(resp.Responses) == 0 {
+			klog.V(4).Infof("etcd: compact revision key %q is missing, resetting compact time", compactRevKey)
+			return 0, currentRev, 0, nil
+		}
+		rangeResp := resp.Responses[0].GetResponseRange()
+		if rangeResp == nil || len(rangeResp.Kvs) == 0 {
+			klog.V(4).Infof("etcd: compact revision key %q is missing, resetting compact time", compactRevKey)
+			return 0, currentRev, 0, nil
+		}
+		currentVersion = rangeResp.Kvs[0].Version
+		compactRev, err = strconv.ParseInt(string(rangeResp.Kvs[0].Value), 10, 64)
 		if err != nil {
 			return currentVersion, currentRev, 0, nil
 		}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/compact_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/compact_test.go
@@ -218,3 +218,57 @@ func TestCompactConflict(t *testing.T) {
 		t.Errorf("Expect current revision = %d, get = %d", wantCurrentRev, curRev3)
 	}
 }
+
+func TestCompactMissingCompactRevKey(t *testing.T) {
+	client := testserver.RunEtcd(t, nil).Client
+	ctx := context.Background()
+
+	putResp, err := client.Put(ctx, "/somekey", "data")
+	if err != nil {
+		t.Fatalf("Put failed: %v", err)
+	}
+
+	t.Log("Compact once to advance local compact time")
+	currentVersion, currentRev, compactRev, err := Compact(ctx, client, 0, putResp.Header.Revision)
+	if err != nil {
+		t.Fatalf("compact failed: %v", err)
+	}
+	if currentVersion != 1 {
+		t.Fatalf("currentVersion = %d, expected 1", currentVersion)
+	}
+	if compactRev != putResp.Header.Revision {
+		t.Fatalf("compactRev = %d, expected %d", compactRev, putResp.Header.Revision)
+	}
+
+	t.Log("Remove compact revision key to simulate an empty recreated backend")
+	if _, err := client.Delete(ctx, compactRevKey); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	t.Log("Compact should reset local compact time instead of panicking")
+	currentVersion, currentRev, compactRev, err = Compact(ctx, client, currentVersion, currentRev)
+	if err != nil {
+		t.Fatalf("compact failed: %v", err)
+	}
+	if currentVersion != 0 {
+		t.Errorf("currentVersion = %d, expected 0", currentVersion)
+	}
+	if compactRev != 0 {
+		t.Errorf("compactRev = %d, expected 0", compactRev)
+	}
+	if currentRev == 0 {
+		t.Errorf("currentRev = %d, expected non-zero", currentRev)
+	}
+
+	t.Log("Next compaction should recreate compact revision key")
+	currentVersion, _, compactRev, err = Compact(ctx, client, currentVersion, currentRev)
+	if err != nil {
+		t.Fatalf("compact failed: %v", err)
+	}
+	if currentVersion != 1 {
+		t.Errorf("currentVersion = %d, expected 1", currentVersion)
+	}
+	if compactRev != currentRev {
+		t.Errorf("compactRev = %d, expected %d", compactRev, currentRev)
+	}
+}

--- a/test/integration/apiserver/etcd_compactor_test.go
+++ b/test/integration/apiserver/etcd_compactor_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2/ktesting"
+	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+const compactRevKey = "compact_rev_key"
+
+func TestAPIServerCompactorHandlesMissingCompactRevKey(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+
+	etcdURL, stopEtcd, err := framework.RunCustomEtcd(logger, "etcd_compactor", nil)
+	if err != nil {
+		t.Fatalf("Couldn't start etcd: %v", err)
+	}
+	t.Cleanup(stopEtcd)
+
+	etcdOptions := framework.DefaultEtcdOptions()
+	etcdOptions.StorageConfig.Transport.ServerList = []string{etcdURL}
+
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, append(framework.DefaultTestServerFlags(), "--etcd-compaction-interval=100ms"), &etcdOptions.StorageConfig)
+	t.Cleanup(server.TearDownFn)
+
+	clientSet, err := kubernetes.NewForConfig(server.ClientConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kvClient := server.EtcdClient.KV
+	waitForCompactRevKeyVersion(ctx, t, kvClient, 2)
+
+	if _, err := kvClient.Delete(ctx, compactRevKey); err != nil {
+		t.Fatalf("failed to delete %q: %v", compactRevKey, err)
+	}
+
+	// Before the fix, the next compaction cycle panicked in the apiserver
+	// goroutine because the fallback Get response had no Kvs entry.
+	waitForCompactRevKeyVersion(ctx, t, kvClient, 1)
+
+	if _, err := clientSet.CoreV1().Namespaces().Create(ctx, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "compactor-still-running"}}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("apiserver did not stay healthy after compact_rev_key was recreated: %v", err)
+	}
+}
+
+func waitForCompactRevKeyVersion(ctx context.Context, t *testing.T, kvClient clientv3.KV, version int64) {
+	t.Helper()
+	if err := wait.PollUntilContextTimeout(ctx, 20*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+		resp, err := kvClient.Get(ctx, compactRevKey)
+		if err != nil {
+			return false, err
+		}
+		if len(resp.Kvs) == 0 {
+			return false, nil
+		}
+		return resp.Kvs[0].Version >= version, nil
+	}); err != nil {
+		t.Fatalf("timed out waiting for %q version >= %d: %v", compactRevKey, version, err)
+	}
+}


### PR DESCRIPTION
/kind bug
/sig api-machinery
/area etcd

**What this PR does / why we need it**:
Handles the case where the etcd compactor's CAS transaction falls back to reading `compact_rev_key`, but that key is absent. This can happen if the backing etcd store is recreated or restored without the key while kube-apiserver still has a non-zero in-memory compact time. Instead of indexing an empty KV response and panicking, the compactor resets its compact time and continues.

**Which issue(s) this PR fixes**:
Fixes #139252

**Special notes for your reviewer**:
Added a regression test that deletes `compact_rev_key` after advancing compact time, verifies the next compaction does not panic, and verifies the following compaction recreates the key.

**Does this PR introduce a user-facing change?**:
```release-note
Fixed a kube-apiserver panic in the etcd3 compactor when `compact_rev_key` is absent after the backing etcd store is recreated or restored.
```

**Tested**:
- `go test ./staging/src/k8s.io/apiserver/pkg/storage/etcd3 -run TestCompactMissingCompactRevKey -count=1`
- `go test ./staging/src/k8s.io/apiserver/pkg/storage/etcd3 -count=1`
