### PR TITLE
apimachinery: return 400 for SSA typed patch object schema errors

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/fieldmanager_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/fieldmanager_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -76,6 +77,50 @@ func TestFieldManagerUpdateNoErrors(t *testing.T) {
 
 	if after := f.ManagedFields(); !apiequality.Semantic.DeepEqual(before, after) {
 		t.Fatalf("expected idempotence, but managedFields changed:\nbefore: %v\n after: %v", mustMarshal(before), mustMarshal(after))
+	}
+}
+
+func TestApplyPatchObjectSchemaErrorReturnsBadRequest(t *testing.T) {
+	manager, err := internal.NewStructuredMergeManager(
+		fakeTypeConverter,
+		&internaltesting.FakeObjectConvertor{},
+		&internaltesting.FakeObjectDefaulter{},
+		schema.FromAPIVersionAndKind("v1", "Pod").GroupVersion(),
+		schema.FromAPIVersionAndKind("v1", "Pod").GroupVersion(),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("failed to create structured merge manager: %v", err)
+	}
+
+	liveObj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name": "test-pod",
+			},
+		},
+	}
+	patchObj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name": "test-pod",
+			},
+			"spec": map[string]interface{}{
+				"fieldNotDeclaredInSchema": "value",
+			},
+		},
+	}
+
+	_, _, err = manager.Apply(liveObj, patchObj, internal.NewEmptyManaged(), "fieldmanager_test_apply", false)
+	if err == nil {
+		t.Fatal("expected apply to fail for a field not declared in the schema")
+	}
+	if !apierrors.IsBadRequest(err) {
+		t.Fatalf("expected bad request error, got %T: %v", err, err)
 	}
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/structuredmerge.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/structuredmerge.go
@@ -144,7 +144,7 @@ func (f *structuredMergeManager) Apply(liveObj, patchObj runtime.Object, managed
 	// Don't allow duplicates in the applied object.
 	patchObjTyped, err := f.typeConverter.ObjectToTyped(patchObj)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create typed patch object (%v): %v", objectGVKNN(patchObj), err)
+		return nil, nil, errors.NewBadRequest(fmt.Sprintf("failed to create typed patch object (%v): %v", objectGVKNN(patchObj), err))
 	}
 
 	liveObjTyped, err := f.typeConverter.ObjectToTyped(liveObjVersioned, typed.AllowDuplicates)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

This PR fixes the error classification for one Server-Side Apply (SSA) failure path when applying to objects backed by a schema.

When `structuredmerge.Apply()` converts the incoming **patch object** to a typed representation, the conversion can fail if the patch contains fields that are not declared in the target schema. Today, that failure is returned as a plain `error`, which can later be surfaced by the apiserver as an HTTP 500 Internal Server Error.

Since this failure is caused by invalid client-provided patch content, this PR maps that specific patch-object conversion failure to `apierrors.NewBadRequest(...)`, while preserving the existing error message text.

The change is intentionally minimal:

- only the patch-object typed conversion error path is changed
- the analogous live-object typed conversion error path is left unchanged
- the existing error message text is preserved

This PR also adds a focused regression test that exercises the schema error path and verifies that the returned error is recognized as `BadRequest`.

#### Which issue(s) this PR fixes

Fixes #139253

#### Special notes for your reviewer

The production change is intentionally limited to:

```text
staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/structuredmerge.go
```

The live-object conversion error path is intentionally left unchanged. Unlike the patch object, the live object represents existing stored state, so a typed conversion failure there may indicate a server-side stored-object/schema inconsistency rather than invalid client input.

The regression test is a focused unit test in `managedfields/internal` that triggers the patch-object schema error path directly, instead of using a broader integration setup.

This PR uses `BadRequest` rather than `Invalid` because the failure happens while converting the incoming SSA patch object into a typed representation, before the request reaches the normal object validation flow that typically produces `Invalid` / HTTP 422 field errors.

In other words, this is treated as a malformed apply patch request rather than a successfully parsed object that later fails semantic validation.

Using `BadRequest` is also consistent with nearby error handling in the same `Apply()` method, which already returns `BadRequest` for other request-shape problems, such as:

- version mismatch in the apply patch
- non-nil `metadata.managedFields` in the patch

cc @cagataygurturk

#### Does this PR introduce a user-facing change?

```release-note
Server-Side Apply now returns HTTP 400 Bad Request instead of HTTP 500 Internal Server Error 
when an apply patch object contains fields not declared in the target schema.
```