### PR TITLE
golangci-lint: re-enable newexpr hint in modernize linter

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -509,10 +509,6 @@ linters:
         # consistency with existing code
         # and it's just syntactic sugar.
         - any
-        # simplify code by using go1.26's new(expr)
-        # should only be updated in old code where it really matters (= always disable in base)
-        # and needs to remain disabled as hint until Go 1.26 is also available for backported code (https://github.com/kubernetes/kubernetes/issues/137595)
-        - newexpr
         # Suggest replacing omitempty with omitzero for struct fields.
         #
         # Disabled because might interfere

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -550,8 +550,7 @@ linters:
         # A useful hint for new code.
         - minmax
         # simplify code by using go1.26's new(expr)
-        # should only be updated in old code where it really matters (= always disable in base)
-        # and needs to remain disabled as hint until Go 1.26 is also available for backported code (https://github.com/kubernetes/kubernetes/issues/137595)
+        # should only be updated in old code where it really matters.
         - newexpr
         # use iterators instead of Len/At-style APIs
         # should only be updated in old code where it really matters.

--- a/hack/golangci.yaml.in
+++ b/hack/golangci.yaml.in
@@ -309,12 +309,9 @@ linters:
         #
         # A useful hint for new code.
         - minmax
-        {{- end }}
         # simplify code by using go1.26's new(expr)
-        # should only be updated in old code where it really matters (= always disable in base)
-        # and needs to remain disabled as hint until Go 1.26 is also available for backported code (https://github.com/kubernetes/kubernetes/issues/137595)
+        # should only be updated in old code where it really matters.
         - newexpr
-        {{- if .Base }}
         # use iterators instead of Len/At-style APIs
         # should only be updated in old code where it really matters.
         - stditerators


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`release-1.36` is using go1.26, I think we can re-enable `newexpr` hint in modernize linter.

#### Which issue(s) this PR is related to:

Fixed #137595

#### Special notes for your reviewer:

/sig testing
/sig architecture

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
