### PR TITLE
apiserver: avoid 500 for canceled requests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status.go
@@ -73,7 +73,7 @@ func ErrorToAPIStatus(err error) *metav1.Status {
 		// error by not using pkg/api/errors, or unexpected failure
 		// cases.
 		if !errors.Is(err, context.Canceled) {
-			runtime.HandleError(fmt.Errorf("apiserver received an error that is not an metav1.Status: %#+v: %v", err, err))
+			runtime.HandleError(fmt.Errorf("apiserver received an error that is not an metav1.Status: %#+v: %w", err, err))
 		}
 		return &metav1.Status{
 			TypeMeta: metav1.TypeMeta{

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status.go
@@ -17,6 +17,8 @@ limitations under the License.
 package responsewriters
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -63,12 +65,16 @@ func ErrorToAPIStatus(err error) *metav1.Status {
 		//TODO: replace me with NewConflictErr
 		case storage.IsConflict(err):
 			status = http.StatusConflict
+		case errors.Is(err, context.Canceled):
+			status = http.StatusRequestTimeout
 		}
 		// Log errors that were not converted to an error status
 		// by REST storage - these typically indicate programmer
 		// error by not using pkg/api/errors, or unexpected failure
 		// cases.
-		runtime.HandleError(fmt.Errorf("apiserver received an error that is not an metav1.Status: %#+v: %v", err, err))
+		if !errors.Is(err, context.Canceled) {
+			runtime.HandleError(fmt.Errorf("apiserver received an error that is not an metav1.Status: %#+v: %v", err, err))
+		}
 		return &metav1.Status{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Status",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status.go
@@ -73,7 +73,7 @@ func ErrorToAPIStatus(err error) *metav1.Status {
 		// error by not using pkg/api/errors, or unexpected failure
 		// cases.
 		if !errors.Is(err, context.Canceled) {
-			runtime.HandleError(fmt.Errorf("apiserver received an error that is not an metav1.Status: %#+v: %w", err, err))
+			runtime.HandleError(fmt.Errorf("apiserver received an error that is not an metav1.Status: %w", err))
 		}
 		return &metav1.Status{
 			TypeMeta: metav1.TypeMeta{

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package responsewriters
 
 import (
+	"context"
 	stderrs "errors"
 	"net/http"
 	"reflect"
@@ -42,6 +43,12 @@ func TestBadStatusErrorToAPIStatus(t *testing.T) {
 
 func TestAPIStatus(t *testing.T) {
 	cases := map[error]metav1.Status{
+		context.Canceled: {
+			Status:  metav1.StatusFailure,
+			Code:    http.StatusRequestTimeout,
+			Reason:  metav1.StatusReasonUnknown,
+			Message: context.Canceled.Error(),
+		},
 		errors.NewNotFound(schema.GroupResource{Group: "legacy.kubernetes.io", Resource: "foos"}, "bar"): {
 			Status:  metav1.StatusFailure,
 			Code:    http.StatusNotFound,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR updates `ErrorToAPIStatus` to avoid classifying `context.Canceled` request failures as HTTP 500 Internal Server Error.

Currently, canceled client requests fall through the generic error path in `responsewriters/status.go`, which:

* returns HTTP 500
* increments 5xx request metrics
* emits noisy `runtime.HandleError(...)` log entries

This patch:

* recognizes `context.Canceled`
* maps it to `408 Request Timeout`
* suppresses noisy `HandleError` logging for canceled requests
* adds regression coverage in `status_test.go`

#### Which issue(s) this PR is related to:

Fixes #139256

#### Special notes for your reviewer:

The original issue discussion proposed using HTTP 499 (`Client Closed Request`), but Kubernetes does not currently appear to use 499 elsewhere in-tree, while `http.StatusRequestTimeout` is already documented as a valid apiserver response code in `installer.go`.

This patch intentionally keeps the change minimal and avoids introducing a new non-standard status code while still preventing incorrect 5xx classification.

This PR focuses specifically on the `ErrorToAPIStatus` classification path; broader cancellation handling in `writers.go` and `filters/timeout.go` may warrant follow-up work.

#### Does this PR introduce a user-facing change?

```release-note
Improved kube-apiserver handling of canceled client requests by avoiding incorrect HTTP 500 classification for context.Canceled errors.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
