### PR TITLE
Automated cherry pick of #139121: kubelet: defer CRI fallback removal to 1.38
#139122: kubeadm: defer runtime config warning to 1.38

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -133,10 +133,10 @@ func (crvc ContainerRuntimeVersionCheck) Check() (warnings, errorList []error) {
 		return nil, []error{errors.Wrap(err, "could not check if the runtime config is available")}
 	}
 	if !ok {
-		// TODO: return an error once the kubelet version is 1.37 or higher.
+		// TODO: return an error once the kubelet version is 1.38 or higher.
 		// https://github.com/kubernetes/kubeadm/issues/3229
 		err := errors.New("You must update your container runtime to a version that supports the CRI method RuntimeConfig. " +
-			"Falling back to using cgroupDriver from kubelet config will be removed in 1.37. " +
+			"Falling back to using cgroupDriver from kubelet config will be removed in 1.38. " +
 			"For more information, see https://git.k8s.io/enhancements/keps/sig-node/4033-group-driver-detection-over-cri")
 		warnings = append(warnings, err)
 	}

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1421,7 +1421,7 @@ func getCgroupDriverFromCRI(ctx context.Context, s *options.KubeletServer, kubeD
 			}
 			// CRI implementation doesn't support RuntimeConfig, fallback
 			legacyregistry.MustRegister(kubeletmetrics.CRILosingSupport)
-			kubeletmetrics.CRILosingSupport.WithLabelValues("1.37.0").Inc()
+			kubeletmetrics.CRILosingSupport.WithLabelValues("1.38.0").Inc()
 			logger.Info("CRI implementation should be updated to support RuntimeConfig. Falling back to using cgroupDriver from kubelet config.")
 			return nil
 		}

--- a/test/e2e_node/cgroup_driver_from_cri_test.go
+++ b/test/e2e_node/cgroup_driver_from_cri_test.go
@@ -66,7 +66,7 @@ var _ = SIGDescribe("Cgroup Driver From CRI", feature.CriProxy, framework.WithSe
 			samples := m[kubeletmetrics.KubeletSubsystem+"_"+kubeletmetrics.CRILosingSupportKey]
 
 			gomega.Expect(samples).NotTo(gomega.BeEmpty())
-			gomega.Expect(samples[0].Metric["version"]).To(gomega.BeEquivalentTo("1.37.0"))
+			gomega.Expect(samples[0].Metric["version"]).To(gomega.BeEquivalentTo("1.38.0"))
 		})
 		ginkgo.It("should not emit metric if CRI is new enough", func() {
 			restartKubelet(context.Background(), true)


### PR DESCRIPTION
Cherry pick of #139121 #139122 on release-1.36.

#139121: kubelet: defer CRI fallback removal to 1.38
#139122: kubeadm: defer runtime config warning to 1.38

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind feature


```release-note
kubelet: defer the configurations flags (and the related fallback behavior) deprecation removal timeline from 1.37 to 1.38 to align with containerd v1.7 support
kubeadm: the preflight check `ContainerRuntimeVersion` validates if the installed container runtime supports the `RuntimeConfig` gRPC method. For older kubelet versions than 1.38, it will return a preflight warning.
```