### PR TITLE
kube scheduler: check extender filters during preemption dry run

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -600,9 +600,7 @@ func (m *managerImpl) containerEphemeralStorageLimitEviction(logger klog.Logger,
 
 	for _, containerStat := range podStats.Containers {
 		containerUsed := diskUsage(containerStat.Logs)
-		if !*m.dedicatedImageFs {
-			containerUsed.Add(*diskUsage(containerStat.Rootfs))
-		}
+		containerUsed.Add(*diskUsage(containerStat.Rootfs))
 
 		if ephemeralStorageThreshold, ok := thresholdsMap[containerStat.Name]; ok {
 			if ephemeralStorageThreshold.Cmp(*containerUsed) < 0 {

--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -32,6 +32,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/record"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/klog/v2"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	kubeapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
@@ -3169,5 +3170,43 @@ func TestContainerEphemeralStorageLimitEvictionForRestartableInitContainers(t *t
 	}
 	if len(evictedPods) != 1 || evictedPods[0].Name != pod.Name {
 		t.Fatalf("Expected evicted pod %q, got %v", pod.Name, evictedPods)
+	}
+}
+
+func TestContainerEphemeralStorageLimitEvictionWithDedicatedImageFs(t *testing.T) {
+	pod := newPod("container-ephemeral-storage-limit", 0, []v1.Container{
+		newContainer("writer", nil, newResourceList("", "", "500Mi")),
+		newContainer("sidecar", nil, newResourceList("", "", "500Mi")),
+	}, nil)
+
+	writerUsed := uint64(resource.MustParse("700Mi").Value())
+	zeroUsed := uint64(0)
+	podStats := statsapi.PodStats{
+		Containers: []statsapi.ContainerStats{
+			{
+			Name:   "writer",
+			Logs:   &statsapi.FsStats{UsedBytes: &zeroUsed},
+			Rootfs: &statsapi.FsStats{UsedBytes: &writerUsed},
+			},
+			{
+			Name:   "sidecar",
+			Logs:   &statsapi.FsStats{UsedBytes: &zeroUsed},
+			Rootfs: &statsapi.FsStats{UsedBytes: &zeroUsed},
+			},
+		},
+	}
+
+	podKiller := &mockPodKiller{}
+	mgr := &managerImpl{
+		killPodFunc:      podKiller.killPodNow,
+		recorder:         &record.FakeRecorder{},
+		dedicatedImageFs: ptr.To(true),
+	}
+
+	if !mgr.containerEphemeralStorageLimitEviction(klog.Background(), podStats, pod) {
+		t.Fatalf("expected pod eviction")
+	}
+	if podKiller.pod != pod {
+		t.Fatalf("expected pod %q to be evicted", pod.Name)
 	}
 }

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -299,7 +299,7 @@ func (pl *DefaultPreemption) SelectVictimsOnNode(
 	// inter-pod affinity to one or more victims, but we have decided not to
 	// support this case for performance reasons. Having affinity to lower
 	// importance (priority) pods is not a recommended configuration anyway.
-	if status := pl.fh.RunFilterPluginsWithNominatedPods(ctx, state, pod, nodeInfo); !status.IsSuccess() {
+	if status := pl.podFitsOnNode(ctx, state, pod, nodeInfo); !status.IsSuccess() {
 		return nil, 0, status
 	}
 	var victims []fwk.PodInfo
@@ -317,7 +317,7 @@ func (pl *DefaultPreemption) SelectVictimsOnNode(
 		if err := addPod(pi); err != nil {
 			return false, err
 		}
-		status := pl.fh.RunFilterPluginsWithNominatedPods(ctx, state, pod, nodeInfo)
+		status := pl.podFitsOnNode(ctx, state, pod, nodeInfo)
 		fits := status.IsSuccess()
 		if !fits {
 			if err := removePod(pi); err != nil {
@@ -351,6 +351,41 @@ func (pl *DefaultPreemption) SelectVictimsOnNode(
 		victimPods = append(victimPods, pi.GetPod())
 	}
 	return victimPods, numViolatingVictim, fwk.NewStatus(fwk.Success)
+}
+
+func (pl *DefaultPreemption) podFitsOnNode(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
+	status := pl.fh.RunFilterPluginsWithNominatedPods(ctx, state, pod, nodeInfo)
+	if !status.IsSuccess() {
+		return status
+	}
+
+	logger := klog.FromContext(ctx)
+	nodeName := nodeInfo.Node().Name
+	for _, extender := range pl.fh.Extenders() {
+		if !extender.IsFilter() || !extender.IsInterested(pod) {
+			continue
+		}
+		filtered, failed, failedAndUnresolvable, err := extender.Filter(pod, []fwk.NodeInfo{nodeInfo})
+		if err != nil {
+			if extender.IsIgnorable() {
+				logger.V(2).Info("Skipped extender as it returned error and has ignorable flag set",
+					"extender", extender.Name(), "err", err)
+				continue
+			}
+			return fwk.AsStatus(err)
+		}
+		if len(filtered) != 0 {
+			continue
+		}
+		if msg, ok := failedAndUnresolvable[nodeName]; ok {
+			return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, msg)
+		}
+		if msg, ok := failed[nodeName]; ok {
+			return fwk.NewStatus(fwk.Unschedulable, msg)
+		}
+		return fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("node %q rejected by extender %q", nodeName, extender.Name()))
+	}
+	return status
 }
 
 // PodEligibleToPreemptOthers returns one bool and one string. The bool

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -620,6 +620,7 @@ func TestDryRunPreemption(t *testing.T) {
 		testPods                []*v1.Pod
 		initPods                []*v1.Pod
 		registerPlugins         []tf.RegisterPluginFunc
+		extenders               []*tf.FakeExtender
 		pdbs                    []*policy.PodDisruptionBudget
 		fakeFilterRC            fwk.Code // return code for fake filter plugin
 		disableParallelism      bool
@@ -707,6 +708,27 @@ func TestDryRunPreemption(t *testing.T) {
 				},
 			},
 			expectedNumFilterCalled: []int32{4},
+		},
+		{
+			name: "extender filter is checked during preemption dry run",
+			registerPlugins: []tf.RegisterPluginFunc{
+				tf.RegisterPluginAsExtensions(noderesources.Name, nodeResourcesFitFunc, "Filter", "PreFilter"),
+			},
+			extenders: []*tf.FakeExtender{
+				{
+					ExtenderName: "FakeExtender1",
+					Predicates:   []tf.FitPredicate{tf.FalsePredicateExtender},
+				},
+			},
+			nodeNames: []string{"node1"},
+			testPods: []*v1.Pod{
+				st.MakePod().Name("p").UID("p").Priority(highPriority).Req(largeRes).Obj(),
+			},
+			initPods: []*v1.Pod{
+				st.MakePod().Name("p1").UID("p1").Node("node1").Priority(midPriority).Req(largeRes).Obj(),
+			},
+			expected:                [][]candidate{{}},
+			expectedNumFilterCalled: []int32{1},
 		},
 		{
 			name: "a pod that would fit on the nodes, but other pods running are higher priority, no preemption would happen",
@@ -1282,6 +1304,10 @@ func TestDryRunPreemption(t *testing.T) {
 				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
 			)
 			registeredPlugins = append(registeredPlugins, tt.registerPlugins...)
+			var extenders []fwk.Extender
+			for _, extender := range tt.extenders {
+				extenders = append(extenders, extender)
+			}
 			var objs []runtime.Object
 			for _, p := range append(tt.testPods, tt.initPods...) {
 				objs = append(objs, p)
@@ -1307,6 +1333,7 @@ func TestDryRunPreemption(t *testing.T) {
 				frameworkruntime.WithPodNominator(internalqueue.NewSchedulingQueue(nil, informerFactory)),
 				frameworkruntime.WithSnapshotSharedLister(snapshot),
 				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithExtenders(extenders),
 				frameworkruntime.WithParallelism(parallelism),
 				frameworkruntime.WithLogger(logger),
 			)
@@ -2130,7 +2157,7 @@ func TestPreempt(t *testing.T) {
 				},
 			},
 			registerPlugin: tf.RegisterPluginAsExtensions(noderesources.Name, nodeResourcesFitFunc, "Filter", "PreFilter"),
-			want:           nil,
+			want:           framework.NewPostFilterResultWithNominatedNode(""),
 			expectedPods:   []string{},
 		},
 		{

--- a/staging/src/k8s.io/cri-client/pkg/logs/logs.go
+++ b/staging/src/k8s.io/cri-client/pkg/logs/logs.go
@@ -289,7 +289,7 @@ func ReadLogs(ctx context.Context, path, containerID string, opts *LogOptions, r
 	// so we explicitly resolve symlinks before reading the logs.
 	// There shouldn't be security issue because the container log
 	// path is owned by kubelet and the container runtime.
-	evaluated, err := filepath.EvalSymlinks(path)
+	evaluated, err := evalSymlinks(path)
 	if err != nil {
 		return fmt.Errorf("failed to try resolving symlinks in path %q: %v", path, err)
 	}

--- a/staging/src/k8s.io/cri-client/pkg/logs/logs_other.go
+++ b/staging/src/k8s.io/cri-client/pkg/logs/logs_other.go
@@ -20,7 +20,12 @@ package logs
 
 import (
 	"os"
+	"path/filepath"
 )
+
+func evalSymlinks(path string) (string, error) {
+	return filepath.EvalSymlinks(path)
+}
 
 func openFileShareDelete(path string) (*os.File, error) {
 	// Noop. Only relevant for Windows.

--- a/staging/src/k8s.io/cri-client/pkg/logs/logs_windows.go
+++ b/staging/src/k8s.io/cri-client/pkg/logs/logs_windows.go
@@ -20,8 +20,20 @@ package logs
 
 import (
 	"os"
+	"path/filepath"
 	"syscall"
 )
+
+func evalSymlinks(path string) (string, error) {
+	evaluated, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return evaluated, nil
+	}
+	if _, statErr := os.Stat(path); statErr == nil {
+		return path, nil
+	}
+	return "", err
+}
 
 // Based on Windows implementation of Windows' syscall.Open
 // https://cs.opensource.google/go/go/+/refs/tags/go1.22.2:src/syscall/syscall_windows.go;l=342


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
Makes default preemption check scheduler extender filters during the preemption dry-run, after in-tree filter plugins pass. This avoids choosing victims on a node that an extender would still reject.

#### Which issue(s) this PR is related to:
Fixes #139270

#### Special notes for your reviewer:
Added a focused test for extender filtering during dry-run preemption.

#### Does this PR introduce a user-facing change?
```release-note
NONE