### PR TITLE
Make minCount mutable in Workload and PodGroup APIs

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -19841,7 +19841,7 @@
       "description": "GangSchedulingPolicy defines the parameters for gang scheduling.",
       "properties": {
         "minCount": {
-          "description": "MinCount is the minimum number of pods that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer.",
+          "description": "MinCount is the minimum number of pods that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer. This field is mutable to support workload scaling.\n\nNote that the scheduler operates on an eventually consistent model. Updates to minCount may not be immediately reflected in scheduling decisions due to propagation delays. If minCount is updated while a scheduling cycle is in progress for that group, the new value may not take effect until the next cycle. Moreover, minCount is only enforced during scheduling, meaning that modifications to this field do not affect already-scheduled pods, applying only to those evaluated in future cycles.",
           "format": "int32",
           "type": "integer"
         }
@@ -19975,15 +19975,15 @@
       "type": "object"
     },
     "io.k8s.api.scheduling.v1alpha3.PodGroupSchedulingPolicy": {
-      "description": "PodGroupSchedulingPolicy defines the scheduling configuration for a PodGroup. Exactly one policy must be set.",
+      "description": "PodGroupSchedulingPolicy defines the scheduling configuration for a PodGroup. Exactly one policy must be set. The policy is chosen at creation time by setting either the Basic or Gang field. The PodGroup may not change policy after creation. Fields within chosen policy may be updated after creation when their individual fields allow it.",
       "properties": {
         "basic": {
           "$ref": "#/definitions/io.k8s.api.scheduling.v1alpha3.BasicSchedulingPolicy",
-          "description": "Basic specifies that the pods in this group should be scheduled using standard Kubernetes scheduling behavior."
+          "description": "Basic specifies that the pods in this group should be scheduled using standard Kubernetes scheduling behavior. Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward."
         },
         "gang": {
           "$ref": "#/definitions/io.k8s.api.scheduling.v1alpha3.GangSchedulingPolicy",
-          "description": "Gang specifies that the pods in this group should be scheduled using all-or-nothing semantics."
+          "description": "Gang specifies that the pods in this group should be scheduled using all-or-nothing semantics. Setting this field at group creation time opts this group to gang scheduling; this field cannot be set or unset afterward. The minCount field within Gang scheduling policy remains mutable after group creation."
         }
       },
       "type": "object",
@@ -20035,7 +20035,7 @@
         },
         "schedulingPolicy": {
           "$ref": "#/definitions/io.k8s.api.scheduling.v1alpha3.PodGroupSchedulingPolicy",
-          "description": "SchedulingPolicy defines the scheduling policy for this instance of the PodGroup. Controllers are expected to fill this field by copying it from a PodGroupTemplate. This field is immutable."
+          "description": "SchedulingPolicy defines the scheduling policy for this instance of the PodGroup. Controllers are expected to fill this field by copying it from a PodGroupTemplate."
         }
       },
       "required": [
@@ -20080,19 +20080,19 @@
       "properties": {
         "disruptionMode": {
           "$ref": "#/definitions/io.k8s.api.scheduling.v1alpha3.DisruptionMode",
-          "description": "DisruptionMode defines the mode in which a given PodGroup can be disrupted. One of Single, All."
+          "description": "DisruptionMode defines the mode in which a given PodGroup can be disrupted. One of Single, All. This field is immutable."
         },
         "name": {
           "description": "Name is a unique identifier for the PodGroupTemplate within the Workload. It must be a DNS label. This field is immutable.",
           "type": "string"
         },
         "priority": {
-          "description": "Priority is the value of priority of pod groups created from this template. Various system components use this field to find the priority of the pod group. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.",
+          "description": "Priority is the value of priority of pod groups created from this template. Various system components use this field to find the priority of the pod group. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority. This field is immutable.",
           "format": "int32",
           "type": "integer"
         },
         "priorityClassName": {
-          "description": "PriorityClassName indicates the priority that should be considered when scheduling a pod group created from this template. If no priority class is specified, admission control can set this to the global default priority class if it exists. Otherwise, pod groups created from this template will have the priority set to zero.",
+          "description": "PriorityClassName indicates the priority that should be considered when scheduling a pod group created from this template. If no priority class is specified, admission control can set this to the global default priority class if it exists. Otherwise, pod groups created from this template will have the priority set to zero. This field is immutable.",
           "type": "string"
         },
         "resourceClaims": {
@@ -20110,7 +20110,7 @@
         },
         "schedulingConstraints": {
           "$ref": "#/definitions/io.k8s.api.scheduling.v1alpha3.PodGroupSchedulingConstraints",
-          "description": "SchedulingConstraints defines optional scheduling constraints (e.g. topology) for this PodGroupTemplate. This field is only available when the TopologyAwareWorkloadScheduling feature gate is enabled."
+          "description": "SchedulingConstraints defines optional scheduling constraints (e.g. topology) for this PodGroupTemplate. This field is only available when the TopologyAwareWorkloadScheduling feature gate is enabled. This field is immutable."
         },
         "schedulingPolicy": {
           "$ref": "#/definitions/io.k8s.api.scheduling.v1alpha3.PodGroupSchedulingPolicy",
@@ -20272,7 +20272,7 @@
           "description": "ControllerRef is an optional reference to the controlling object, such as a Deployment or Job. This field is intended for use by tools like CLIs to provide a link back to the original workload definition. This field is immutable."
         },
         "podGroupTemplates": {
-          "description": "PodGroupTemplates is the list of templates that make up the Workload. The maximum number of templates is 8. This field is immutable.",
+          "description": "PodGroupTemplates is the list of templates that make up the Workload. The maximum number of templates is 8. Templates cannot be added or removed after the workload is created. Existing templates may still be updated where their individual fields allow it.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.scheduling.v1alpha3.PodGroupTemplate"
           },

--- a/api/openapi-spec/v3/apis__scheduling.k8s.io__v1alpha3_openapi.json
+++ b/api/openapi-spec/v3/apis__scheduling.k8s.io__v1alpha3_openapi.json
@@ -44,7 +44,7 @@
         "properties": {
           "minCount": {
             "default": 0,
-            "description": "MinCount is the minimum number of pods that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer.",
+            "description": "MinCount is the minimum number of pods that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer. This field is mutable to support workload scaling.\n\nNote that the scheduler operates on an eventually consistent model. Updates to minCount may not be immediately reflected in scheduling decisions due to propagation delays. If minCount is updated while a scheduling cycle is in progress for that group, the new value may not take effect until the next cycle. Moreover, minCount is only enforced during scheduling, meaning that modifications to this field do not affect already-scheduled pods, applying only to those evaluated in future cycles.",
             "format": "int32",
             "type": "integer"
           }
@@ -200,7 +200,7 @@
         "type": "object"
       },
       "io.k8s.api.scheduling.v1alpha3.PodGroupSchedulingPolicy": {
-        "description": "PodGroupSchedulingPolicy defines the scheduling configuration for a PodGroup. Exactly one policy must be set.",
+        "description": "PodGroupSchedulingPolicy defines the scheduling configuration for a PodGroup. Exactly one policy must be set. The policy is chosen at creation time by setting either the Basic or Gang field. The PodGroup may not change policy after creation. Fields within chosen policy may be updated after creation when their individual fields allow it.",
         "properties": {
           "basic": {
             "allOf": [
@@ -208,7 +208,7 @@
                 "$ref": "#/components/schemas/io.k8s.api.scheduling.v1alpha3.BasicSchedulingPolicy"
               }
             ],
-            "description": "Basic specifies that the pods in this group should be scheduled using standard Kubernetes scheduling behavior."
+            "description": "Basic specifies that the pods in this group should be scheduled using standard Kubernetes scheduling behavior. Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward."
           },
           "gang": {
             "allOf": [
@@ -216,7 +216,7 @@
                 "$ref": "#/components/schemas/io.k8s.api.scheduling.v1alpha3.GangSchedulingPolicy"
               }
             ],
-            "description": "Gang specifies that the pods in this group should be scheduled using all-or-nothing semantics."
+            "description": "Gang specifies that the pods in this group should be scheduled using all-or-nothing semantics. Setting this field at group creation time opts this group to gang scheduling; this field cannot be set or unset afterward. The minCount field within Gang scheduling policy remains mutable after group creation."
           }
         },
         "type": "object",
@@ -288,7 +288,7 @@
               }
             ],
             "default": {},
-            "description": "SchedulingPolicy defines the scheduling policy for this instance of the PodGroup. Controllers are expected to fill this field by copying it from a PodGroupTemplate. This field is immutable."
+            "description": "SchedulingPolicy defines the scheduling policy for this instance of the PodGroup. Controllers are expected to fill this field by copying it from a PodGroupTemplate."
           }
         },
         "required": [
@@ -337,7 +337,7 @@
                 "$ref": "#/components/schemas/io.k8s.api.scheduling.v1alpha3.DisruptionMode"
               }
             ],
-            "description": "DisruptionMode defines the mode in which a given PodGroup can be disrupted. One of Single, All."
+            "description": "DisruptionMode defines the mode in which a given PodGroup can be disrupted. One of Single, All. This field is immutable."
           },
           "name": {
             "default": "",
@@ -345,12 +345,12 @@
             "type": "string"
           },
           "priority": {
-            "description": "Priority is the value of priority of pod groups created from this template. Various system components use this field to find the priority of the pod group. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.",
+            "description": "Priority is the value of priority of pod groups created from this template. Various system components use this field to find the priority of the pod group. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority. This field is immutable.",
             "format": "int32",
             "type": "integer"
           },
           "priorityClassName": {
-            "description": "PriorityClassName indicates the priority that should be considered when scheduling a pod group created from this template. If no priority class is specified, admission control can set this to the global default priority class if it exists. Otherwise, pod groups created from this template will have the priority set to zero.",
+            "description": "PriorityClassName indicates the priority that should be considered when scheduling a pod group created from this template. If no priority class is specified, admission control can set this to the global default priority class if it exists. Otherwise, pod groups created from this template will have the priority set to zero. This field is immutable.",
             "type": "string"
           },
           "resourceClaims": {
@@ -372,7 +372,7 @@
                 "$ref": "#/components/schemas/io.k8s.api.scheduling.v1alpha3.PodGroupSchedulingConstraints"
               }
             ],
-            "description": "SchedulingConstraints defines optional scheduling constraints (e.g. topology) for this PodGroupTemplate. This field is only available when the TopologyAwareWorkloadScheduling feature gate is enabled."
+            "description": "SchedulingConstraints defines optional scheduling constraints (e.g. topology) for this PodGroupTemplate. This field is only available when the TopologyAwareWorkloadScheduling feature gate is enabled. This field is immutable."
           },
           "schedulingPolicy": {
             "allOf": [
@@ -567,7 +567,7 @@
             "description": "ControllerRef is an optional reference to the controlling object, such as a Deployment or Job. This field is intended for use by tools like CLIs to provide a link back to the original workload definition. This field is immutable."
           },
           "podGroupTemplates": {
-            "description": "PodGroupTemplates is the list of templates that make up the Workload. The maximum number of templates is 8. This field is immutable.",
+            "description": "PodGroupTemplates is the list of templates that make up the Workload. The maximum number of templates is 8. Templates cannot be added or removed after the workload is created. Existing templates may still be updated where their individual fields allow it.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.scheduling.v1alpha3.PodGroupTemplate"
             },

--- a/pkg/apis/scheduling/types.go
+++ b/pkg/apis/scheduling/types.go
@@ -141,7 +141,8 @@ type WorkloadSpec struct {
 	ControllerRef *TypedLocalObjectReference
 
 	// PodGroupTemplates is the list of templates that make up the Workload.
-	// The maximum number of templates is 8. This field is immutable.
+	// The maximum number of templates is 8. Templates cannot be added or removed after the workload is created.
+	// Existing templates may still be updated where their individual fields allow it.
 	//
 	// +required
 	// +listType=map
@@ -189,6 +190,7 @@ type PodGroupTemplate struct {
 
 	// SchedulingConstraints defines optional scheduling constraints (e.g. topology) for this PodGroupTemplate.
 	// This field is only available when the TopologyAwareWorkloadScheduling feature gate is enabled.
+	// This field is immutable.
 	//
 	// +optional
 	// +featureGate=TopologyAwareWorkloadScheduling
@@ -215,6 +217,7 @@ type PodGroupTemplate struct {
 
 	// DisruptionMode defines the mode in which a given PodGroup can be disrupted.
 	// One of Single, All.
+	// This field is immutable.
 	//
 	// +optional
 	DisruptionMode *DisruptionMode
@@ -223,6 +226,7 @@ type PodGroupTemplate struct {
 	// a pod group created from this template. If no priority class is specified, admission
 	// control can set this to the global default priority class if it exists. Otherwise,
 	// pod groups created from this template will have the priority set to zero.
+	// This field is immutable.
 	//
 	// +optional
 	PriorityClassName string
@@ -232,23 +236,30 @@ type PodGroupTemplate struct {
 	// Priority Admission Controller is enabled, it prevents users from setting this field.
 	// The admission controller populates this field from PriorityClassName.
 	// The higher the value, the higher the priority.
+	// This field is immutable.
 	//
 	// +optional
 	Priority *int32
 }
 
 // PodGroupSchedulingPolicy defines the scheduling configuration for a PodGroup.
-// Exactly one policy must be set.
+// Exactly one policy must be set. The policy is chosen at creation time by setting either the
+// Basic or Gang field. The PodGroup may not change policy after creation.
+// Fields within chosen policy may be updated after creation when their individual fields allow it.
+//
 // +union
 type PodGroupSchedulingPolicy struct {
 	// Basic specifies that the pods in this group should be scheduled using
-	// standard Kubernetes scheduling behavior.
+	// standard Kubernetes scheduling behavior. Setting this field at group creation time
+	// opts this group to basic scheduling; this field cannot be changed afterward.
 	//
 	// +optional
 	Basic *BasicSchedulingPolicy
 
 	// Gang specifies that the pods in this group should be scheduled using
-	// all-or-nothing semantics.
+	// all-or-nothing semantics. Setting this field at group creation time
+	// opts this group to gang scheduling; this field cannot be set or unset afterward.
+	// The minCount field within Gang scheduling policy remains mutable after group creation.
 	//
 	// +optional
 	Gang *GangSchedulingPolicy
@@ -267,7 +278,15 @@ type BasicSchedulingPolicy struct {
 type GangSchedulingPolicy struct {
 	// MinCount is the minimum number of pods that must be schedulable or scheduled
 	// at the same time for the scheduler to admit the entire group.
-	// It must be a positive integer.
+	// It must be a positive integer. This field is mutable to support workload scaling.
+	//
+	// Note that the scheduler operates on an eventually consistent model. Updates
+	// to minCount may not be immediately reflected in scheduling decisions due to
+	// propagation delays. If minCount is updated while a scheduling cycle is in
+	// progress for that group, the new value may not take effect until the next
+	// cycle. Moreover, minCount is only enforced during scheduling, meaning that
+	// modifications to this field do not affect already-scheduled pods, applying
+	// only to those evaluated in future cycles.
 	//
 	// +required
 	MinCount int32
@@ -393,7 +412,6 @@ type PodGroupSpec struct {
 
 	// SchedulingPolicy defines the scheduling policy for this instance of the PodGroup.
 	// Controllers are expected to fill this field by copying it from a PodGroupTemplate.
-	// This field is immutable.
 	//
 	// +required
 	SchedulingPolicy PodGroupSchedulingPolicy

--- a/pkg/apis/scheduling/v1alpha3/zz_generated.validations.go
+++ b/pkg/apis/scheduling/v1alpha3/zz_generated.validations.go
@@ -499,6 +499,10 @@ func Validate_PodGroupSchedulingPolicy(
 			}
 			// call field-attached validations
 			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
@@ -528,6 +532,10 @@ func Validate_PodGroupSchedulingPolicy(
 			// call field-attached validations
 			earlyReturn := false
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if e := validate.UpdatePointer(ctx, op, fldPath, obj, oldObj, validate.NoSet, validate.NoUnset).MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -597,15 +605,6 @@ func Validate_PodGroupSpec(
 				if equality.Semantic.DeepEqual(obj, oldObj) {
 					return nil
 				}
-			}
-			// call field-attached validations
-			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_PodGroupSchedulingPolicy(ctx, op, fldPath, obj, oldObj)...)
@@ -994,6 +993,10 @@ func Validate_PodGroupTemplate(
 			if e := validate.IfOption(ctx, op, fldPath, obj, oldObj, "TopologyAwareWorkloadScheduling", true, validate.OptionalPointer).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
 			if earlyReturn {
 				return // do not proceed
 			}
@@ -1021,6 +1024,10 @@ func Validate_PodGroupTemplate(
 			}
 			// call field-attached validations
 			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 4).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
@@ -1067,6 +1074,10 @@ func Validate_PodGroupTemplate(
 			}
 			// call field-attached validations
 			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
@@ -1097,6 +1108,10 @@ func Validate_PodGroupTemplate(
 			}
 			// call field-attached validations
 			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
 			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
@@ -1128,6 +1143,10 @@ func Validate_PodGroupTemplate(
 			}
 			// call field-attached validations
 			earlyReturn := false
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
 			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
@@ -1505,15 +1524,18 @@ func Validate_WorkloadSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
 			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 8).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
 			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if e := validate.UpdateSlice(ctx, op, fldPath, obj, oldObj,
+				func(a schedulingv1alpha3.PodGroupTemplate, b schedulingv1alpha3.PodGroupTemplate) bool {
+					return a.Name == b.Name
+				}, validate.NoAddItem, validate.NoRemoveItem).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -54001,7 +54001,7 @@ func schema_k8sio_api_scheduling_v1alpha3_GangSchedulingPolicy(ref common.Refere
 				Properties: map[string]spec.Schema{
 					"minCount": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MinCount is the minimum number of pods that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer.",
+							Description: "MinCount is the minimum number of pods that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer. This field is mutable to support workload scaling.\n\nNote that the scheduler operates on an eventually consistent model. Updates to minCount may not be immediately reflected in scheduling decisions due to propagation delays. If minCount is updated while a scheduling cycle is in progress for that group, the new value may not take effect until the next cycle. Moreover, minCount is only enforced during scheduling, meaning that modifications to this field do not affect already-scheduled pods, applying only to those evaluated in future cycles.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -54217,18 +54217,18 @@ func schema_k8sio_api_scheduling_v1alpha3_PodGroupSchedulingPolicy(ref common.Re
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "PodGroupSchedulingPolicy defines the scheduling configuration for a PodGroup. Exactly one policy must be set.",
+				Description: "PodGroupSchedulingPolicy defines the scheduling configuration for a PodGroup. Exactly one policy must be set. The policy is chosen at creation time by setting either the Basic or Gang field. The PodGroup may not change policy after creation. Fields within chosen policy may be updated after creation when their individual fields allow it.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"basic": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Basic specifies that the pods in this group should be scheduled using standard Kubernetes scheduling behavior.",
+							Description: "Basic specifies that the pods in this group should be scheduled using standard Kubernetes scheduling behavior. Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward.",
 							Ref:         ref(schedulingv1alpha3.BasicSchedulingPolicy{}.OpenAPIModelName()),
 						},
 					},
 					"gang": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Gang specifies that the pods in this group should be scheduled using all-or-nothing semantics.",
+							Description: "Gang specifies that the pods in this group should be scheduled using all-or-nothing semantics. Setting this field at group creation time opts this group to gang scheduling; this field cannot be set or unset afterward. The minCount field within Gang scheduling policy remains mutable after group creation.",
 							Ref:         ref(schedulingv1alpha3.GangSchedulingPolicy{}.OpenAPIModelName()),
 						},
 					},
@@ -54267,7 +54267,7 @@ func schema_k8sio_api_scheduling_v1alpha3_PodGroupSpec(ref common.ReferenceCallb
 					},
 					"schedulingPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SchedulingPolicy defines the scheduling policy for this instance of the PodGroup. Controllers are expected to fill this field by copying it from a PodGroupTemplate. This field is immutable.",
+							Description: "SchedulingPolicy defines the scheduling policy for this instance of the PodGroup. Controllers are expected to fill this field by copying it from a PodGroupTemplate.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(schedulingv1alpha3.PodGroupSchedulingPolicy{}.OpenAPIModelName()),
 						},
@@ -54416,7 +54416,7 @@ func schema_k8sio_api_scheduling_v1alpha3_PodGroupTemplate(ref common.ReferenceC
 					},
 					"schedulingConstraints": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SchedulingConstraints defines optional scheduling constraints (e.g. topology) for this PodGroupTemplate. This field is only available when the TopologyAwareWorkloadScheduling feature gate is enabled.",
+							Description: "SchedulingConstraints defines optional scheduling constraints (e.g. topology) for this PodGroupTemplate. This field is only available when the TopologyAwareWorkloadScheduling feature gate is enabled. This field is immutable.",
 							Ref:         ref(schedulingv1alpha3.PodGroupSchedulingConstraints{}.OpenAPIModelName()),
 						},
 					},
@@ -54445,20 +54445,20 @@ func schema_k8sio_api_scheduling_v1alpha3_PodGroupTemplate(ref common.ReferenceC
 					},
 					"disruptionMode": {
 						SchemaProps: spec.SchemaProps{
-							Description: "DisruptionMode defines the mode in which a given PodGroup can be disrupted. One of Single, All.",
+							Description: "DisruptionMode defines the mode in which a given PodGroup can be disrupted. One of Single, All. This field is immutable.",
 							Ref:         ref(schedulingv1alpha3.DisruptionMode{}.OpenAPIModelName()),
 						},
 					},
 					"priorityClassName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PriorityClassName indicates the priority that should be considered when scheduling a pod group created from this template. If no priority class is specified, admission control can set this to the global default priority class if it exists. Otherwise, pod groups created from this template will have the priority set to zero.",
+							Description: "PriorityClassName indicates the priority that should be considered when scheduling a pod group created from this template. If no priority class is specified, admission control can set this to the global default priority class if it exists. Otherwise, pod groups created from this template will have the priority set to zero. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"priority": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Priority is the value of priority of pod groups created from this template. Various system components use this field to find the priority of the pod group. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.",
+							Description: "Priority is the value of priority of pod groups created from this template. Various system components use this field to find the priority of the pod group. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority. This field is immutable.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -54721,7 +54721,7 @@ func schema_k8sio_api_scheduling_v1alpha3_WorkloadSpec(ref common.ReferenceCallb
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "PodGroupTemplates is the list of templates that make up the Workload. The maximum number of templates is 8. This field is immutable.",
+							Description: "PodGroupTemplates is the list of templates that make up the Workload. The maximum number of templates is 8. Templates cannot be added or removed after the workload is created. Existing templates may still be updated where their individual fields allow it.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/registry/scheduling/podgroup/storage/storage_test.go
+++ b/pkg/registry/scheduling/podgroup/storage/storage_test.go
@@ -131,10 +131,12 @@ func TestUpdate(t *testing.T) {
 			return pg
 		},
 		// invalid update
-		// Update MinCount
+		// Switch scheduling policy
 		func(obj runtime.Object) runtime.Object {
 			pg := obj.(*scheduling.PodGroup)
-			pg.Spec.SchedulingPolicy.Gang.MinCount = 4
+			pg.Spec.SchedulingPolicy = scheduling.PodGroupSchedulingPolicy{
+				Basic: &scheduling.BasicSchedulingPolicy{},
+			}
 			return pg
 		},
 		// invalid update

--- a/pkg/registry/scheduling/podgroup/strategy_test.go
+++ b/pkg/registry/scheduling/podgroup/strategy_test.go
@@ -96,6 +96,7 @@ var (
 	maximumError           = "must be less than or equal to 1000000000"
 	subdomainNameError     = "lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters"
 	forbiddenError         = "Forbidden"
+	notAllowedToUnsetError = "field cannot be cleared once set"
 )
 
 func TestStrategy(t *testing.T) {
@@ -288,7 +289,7 @@ func TestStrategyUpdate(t *testing.T) {
 		oldObj                        *scheduling.PodGroup
 		newObj                        *scheduling.PodGroup
 		enableTopologyAwareScheduling bool
-		expectValidationError         string
+		expectValidationErrors        []string
 	}{
 		"no changes": {
 			oldObj: podGroup,
@@ -301,7 +302,7 @@ func TestStrategyUpdate(t *testing.T) {
 				newPodGroup.Name += "bar"
 				return newPodGroup
 			}(),
-			expectValidationError: fieldImmutableError,
+			expectValidationErrors: []string{fieldImmutableError},
 		},
 		"updating pod group template ref not allowed": {
 			oldObj: podGroup,
@@ -315,16 +316,15 @@ func TestStrategyUpdate(t *testing.T) {
 				}
 				return newPodGroup
 			}(),
-			expectValidationError: fieldImmutableError,
+			expectValidationErrors: []string{fieldImmutableError},
 		},
-		"changing min count in gang scheduling policy not allowed": {
+		"changing min count in gang scheduling is allowed": {
 			oldObj: podGroup,
 			newObj: func() *scheduling.PodGroup {
 				newPodGroup := podGroup.DeepCopy()
 				newPodGroup.Spec.SchedulingPolicy.Gang.MinCount = 4
 				return newPodGroup
 			}(),
-			expectValidationError: fieldImmutableError,
 		},
 		"changing scheduling policy not allowed": {
 			oldObj: podGroup,
@@ -335,45 +335,45 @@ func TestStrategyUpdate(t *testing.T) {
 				}
 				return newPodGroup
 			}(),
-			expectValidationError: fieldImmutableError,
+			expectValidationErrors: []string{fieldImmutableError, notAllowedToUnsetError},
 		},
 		"changing scheduling constraints not allowed": {
 			oldObj:                        podGroupWithSchedulingConstraints("foo"),
 			newObj:                        podGroupWithSchedulingConstraints(),
 			enableTopologyAwareScheduling: true,
-			expectValidationError:         fieldImmutableError,
+			expectValidationErrors:        []string{fieldImmutableError},
 		},
 		"changing topology constraints not allowed": {
 			oldObj:                        podGroupWithSchedulingConstraints("foo"),
 			newObj:                        podGroupWithSchedulingConstraints(),
 			enableTopologyAwareScheduling: true,
-			expectValidationError:         fieldImmutableError,
+			expectValidationErrors:        []string{fieldImmutableError},
 		},
 		"changing topology key not allowed": {
 			oldObj:                        podGroupWithSchedulingConstraints("foo"),
 			newObj:                        podGroupWithSchedulingConstraints("foobar"),
 			enableTopologyAwareScheduling: true,
-			expectValidationError:         fieldImmutableError,
+			expectValidationErrors:        []string{fieldImmutableError},
 		},
 		"changing scheduling constraints not allowed with TAS disabled": {
-			oldObj:                podGroupWithSchedulingConstraints("foo"),
-			newObj:                podGroupWithSchedulingConstraints(),
-			expectValidationError: forbiddenError,
+			oldObj:                 podGroupWithSchedulingConstraints("foo"),
+			newObj:                 podGroupWithSchedulingConstraints(),
+			expectValidationErrors: []string{forbiddenError},
 		},
 		"changing topology constraints not allowed with TAS disabled": {
-			oldObj:                podGroupWithSchedulingConstraints("foo"),
-			newObj:                podGroupWithSchedulingConstraints(),
-			expectValidationError: forbiddenError,
+			oldObj:                 podGroupWithSchedulingConstraints("foo"),
+			newObj:                 podGroupWithSchedulingConstraints(),
+			expectValidationErrors: []string{forbiddenError},
 		},
 		"changing topology key not allowed with TAS disabled": {
-			oldObj:                podGroupWithSchedulingConstraints("foo"),
-			newObj:                podGroupWithSchedulingConstraints("foobar"),
-			expectValidationError: forbiddenError,
+			oldObj:                 podGroupWithSchedulingConstraints("foo"),
+			newObj:                 podGroupWithSchedulingConstraints("foobar"),
+			expectValidationErrors: []string{forbiddenError},
 		},
 		"changing disruption mode not allowed": {
-			oldObj:                podGroup,
-			newObj:                podGroupWithDisruptionModeAll(),
-			expectValidationError: fieldImmutableError,
+			oldObj:                 podGroup,
+			newObj:                 podGroupWithDisruptionModeAll(),
+			expectValidationErrors: []string{fieldImmutableError},
 		},
 		"changing priority class name not allowed": {
 			oldObj: podGroup,
@@ -382,7 +382,7 @@ func TestStrategyUpdate(t *testing.T) {
 				pg.Spec.PriorityClassName = "high-priority"
 				return pg
 			}(),
-			expectValidationError: fieldImmutableError,
+			expectValidationErrors: []string{fieldImmutableError},
 		},
 		"changing priority not allowed": {
 			oldObj: podGroup,
@@ -391,7 +391,7 @@ func TestStrategyUpdate(t *testing.T) {
 				pg.Spec.Priority = new(int32(2000))
 				return pg
 			}(),
-			expectValidationError: fieldImmutableError,
+			expectValidationErrors: []string{fieldImmutableError},
 		},
 	}
 
@@ -410,18 +410,20 @@ func TestStrategyUpdate(t *testing.T) {
 			errs := strategy.ValidateUpdate(ctx, newPodGroup, podGroup)
 			errs = strategy.ValidateDeclaratively(ctx, newPodGroup, podGroup, errs, operation.Update, strategy.DeclarativeValidationConfig(ctx, newPodGroup, podGroup))
 			if len(errs) != 0 {
-				if tc.expectValidationError == "" {
+				if len(tc.expectValidationErrors) == 0 {
 					t.Fatalf("unexpected error(s): %v", errs)
 				}
-				if len(errs) != 1 {
-					t.Fatalf("exactly one error expected")
+				if len(errs) != len(tc.expectValidationErrors) {
+					t.Fatalf("expected %d errors, got %d", len(tc.expectValidationErrors), len(errs))
 				}
-				if errMsg := errs[0].Error(); !strings.Contains(errMsg, tc.expectValidationError) {
-					t.Fatalf("error %#v does not contain the expected message %q", errMsg, tc.expectValidationError)
+				for i, err := range errs {
+					if !strings.Contains(err.Error(), tc.expectValidationErrors[i]) {
+						t.Fatalf("error %#v does not contain the expected message %q", err.Error(), tc.expectValidationErrors[i])
+					}
 				}
 				return
 			}
-			if tc.expectValidationError != "" {
+			if len(tc.expectValidationErrors) != 0 {
 				t.Fatal("expected validation error(s), got none")
 			}
 		})

--- a/pkg/registry/scheduling/workload/storage/storage_test.go
+++ b/pkg/registry/scheduling/workload/storage/storage_test.go
@@ -116,10 +116,12 @@ func TestUpdate(t *testing.T) {
 			return w
 		},
 		// invalid update
-		// Update MinCount
+		// Switch scheduling policy
 		func(obj runtime.Object) runtime.Object {
 			w := obj.(*scheduling.Workload)
-			w.Spec.PodGroupTemplates[0].SchedulingPolicy.Gang.MinCount = 4
+			w.Spec.PodGroupTemplates[0].SchedulingPolicy = scheduling.PodGroupSchedulingPolicy{
+				Basic: &scheduling.BasicSchedulingPolicy{},
+			}
 			return w
 		},
 	)

--- a/pkg/registry/scheduling/workload/strategy_test.go
+++ b/pkg/registry/scheduling/workload/strategy_test.go
@@ -55,11 +55,14 @@ var (
 		},
 	}
 
-	fieldImmutableError = "field is immutable"
-	minCountError       = "must be greater than or equal to 1"
-	tooManyItemsError   = "must have at most 1 item"
-	requiredError       = "Required value"
-	subdomainNameError  = "lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters"
+	fieldImmutableError     = "field is immutable"
+	minCountError           = "must be greater than or equal to 1"
+	tooManyItemsError       = "must have at most 1 item"
+	requiredError           = "Required value"
+	subdomainNameError      = "lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters"
+	itemCannotBeAddedError  = "item may not be added"
+	forbiddenError          = "Forbidden"
+	fieldCannotBeUnsetError = "field cannot be cleared once set"
 )
 
 func TestWorkloadStrategy(t *testing.T) {
@@ -251,7 +254,7 @@ func TestStrategyUpdate(t *testing.T) {
 		oldObj                        *scheduling.Workload
 		newObj                        *scheduling.Workload
 		enableTopologyAwareScheduling bool
-		expectValidationError         string
+		expectValidationErrors        []string
 		expectWorkload                *scheduling.Workload
 	}{
 		"no changes": {
@@ -266,7 +269,7 @@ func TestStrategyUpdate(t *testing.T) {
 				w.Name += "bar"
 				return w
 			}(),
-			expectValidationError: fieldImmutableError,
+			expectValidationErrors: []string{fieldImmutableError},
 		},
 		"invalid spec update - controllerRef": {
 			oldObj: workload,
@@ -278,16 +281,18 @@ func TestStrategyUpdate(t *testing.T) {
 				}
 				return w
 			}(),
-			expectValidationError: fieldImmutableError,
+			expectValidationErrors: []string{fieldImmutableError},
 		},
 		"invalid spec update - podGroupTemplates": {
 			oldObj: workload,
 			newObj: func() *scheduling.Workload {
 				w := workload.DeepCopy()
-				w.Spec.PodGroupTemplates[0].SchedulingPolicy.Gang.MinCount = 4
+				w.Spec.PodGroupTemplates[0].SchedulingPolicy = scheduling.PodGroupSchedulingPolicy{
+					Basic: &scheduling.BasicSchedulingPolicy{},
+				}
 				return w
 			}(),
-			expectValidationError: fieldImmutableError,
+			expectValidationErrors: []string{fieldImmutableError, fieldCannotBeUnsetError},
 		},
 		"valid update with scheduling constraints unchanged and TAS disabled": {
 			oldObj: func() *scheduling.Workload {
@@ -357,7 +362,7 @@ func TestStrategyUpdate(t *testing.T) {
 				}
 				return workload
 			}(),
-			expectValidationError: fieldImmutableError,
+			expectValidationErrors: []string{forbiddenError, fieldImmutableError},
 		},
 		"changing topology key not allowed with TAS enabled": {
 			oldObj: func() *scheduling.Workload {
@@ -375,7 +380,7 @@ func TestStrategyUpdate(t *testing.T) {
 				return workload
 			}(),
 			enableTopologyAwareScheduling: true,
-			expectValidationError:         fieldImmutableError,
+			expectValidationErrors:        []string{fieldImmutableError},
 		},
 		"topology constraint addition is dropped with TAS disabled": {
 			oldObj: workload,
@@ -406,10 +411,11 @@ func TestStrategyUpdate(t *testing.T) {
 				workload.Spec.PodGroupTemplates[1].SchedulingConstraints = &scheduling.PodGroupSchedulingConstraints{
 					Topology: []scheduling.TopologyConstraint{{Key: "foo"}},
 				}
+				workload.Spec.PodGroupTemplates[1].Name = "bar1"
 				return workload
 			}(),
 			enableTopologyAwareScheduling: true,
-			expectValidationError:         fieldImmutableError,
+			expectValidationErrors:        []string{itemCannotBeAddedError},
 		},
 		"adding scheduling constraints not allowed with TAS disabled": {
 			oldObj: func() *scheduling.Workload {
@@ -428,9 +434,10 @@ func TestStrategyUpdate(t *testing.T) {
 				workload.Spec.PodGroupTemplates[1].SchedulingConstraints = &scheduling.PodGroupSchedulingConstraints{
 					Topology: []scheduling.TopologyConstraint{{Key: "foo"}},
 				}
+				workload.Spec.PodGroupTemplates[1].Name = "bar1"
 				return workload
 			}(),
-			expectValidationError: fieldImmutableError,
+			expectValidationErrors: []string{itemCannotBeAddedError},
 		},
 		"adding scheduling constraints not allowed with TAS enabled": {
 			oldObj: func() *scheduling.Workload {
@@ -449,10 +456,11 @@ func TestStrategyUpdate(t *testing.T) {
 				workload.Spec.PodGroupTemplates[1].SchedulingConstraints = &scheduling.PodGroupSchedulingConstraints{
 					Topology: []scheduling.TopologyConstraint{{Key: "foo"}},
 				}
+				workload.Spec.PodGroupTemplates[1].Name = "bar1"
 				return workload
 			}(),
 			enableTopologyAwareScheduling: true,
-			expectValidationError:         fieldImmutableError,
+			expectValidationErrors:        []string{itemCannotBeAddedError},
 		},
 		"changing disruption mode": {
 			oldObj: workload,
@@ -461,7 +469,7 @@ func TestStrategyUpdate(t *testing.T) {
 				w.Spec.PodGroupTemplates[0].DisruptionMode = &scheduling.DisruptionMode{Single: &scheduling.SingleDisruptionMode{}}
 				return w
 			}(),
-			expectValidationError: fieldImmutableError,
+			expectValidationErrors: []string{fieldImmutableError},
 		},
 		"changing priorityClassName": {
 			oldObj: func() *scheduling.Workload {
@@ -474,7 +482,7 @@ func TestStrategyUpdate(t *testing.T) {
 				w.Spec.PodGroupTemplates[0].PriorityClassName = "low-priority"
 				return w
 			}(),
-			expectValidationError: fieldImmutableError,
+			expectValidationErrors: []string{fieldImmutableError},
 		},
 	}
 
@@ -492,18 +500,23 @@ func TestStrategyUpdate(t *testing.T) {
 			errs := Strategy.ValidateUpdate(ctx, newWorkload, oldWorkload)
 			errs = Strategy.ValidateDeclaratively(ctx, newWorkload, oldWorkload, errs, operation.Update, Strategy.DeclarativeValidationConfig(ctx, newWorkload, oldWorkload))
 			if len(errs) != 0 {
-				if tc.expectValidationError == "" {
+				if len(tc.expectValidationErrors) == 0 {
 					t.Fatalf("unexpected error(s): %v", errs)
 				}
-				if len(errs) != 1 {
-					t.Fatalf("exactly one error expected")
+				for _, e := range errs {
+					t.Logf("error: %v", e)
 				}
-				if errMsg := errs[0].Error(); !strings.Contains(errMsg, tc.expectValidationError) {
-					t.Fatalf("error %#v does not contain the expected message %q", errMsg, tc.expectValidationError)
+				if len(errs) != len(tc.expectValidationErrors) {
+					t.Fatalf("%d errors expected", len(tc.expectValidationErrors))
+				}
+				for i, err := range errs {
+					if !strings.Contains(err.Error(), tc.expectValidationErrors[i]) {
+						t.Fatalf("error %#v does not contain the expected message %q", err.Error(), tc.expectValidationErrors[i])
+					}
 				}
 				return
 			}
-			if tc.expectValidationError != "" {
+			if len(tc.expectValidationErrors) != 0 {
 				t.Fatal("expected validation error(s), got none")
 			}
 			if warnings := Strategy.WarningsOnUpdate(ctx, newWorkload, oldWorkload); len(warnings) != 0 {

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
@@ -80,8 +80,9 @@ func (pl *GangScheduling) EventsToRegister(_ context.Context) ([]fwk.ClusterEven
 		{Event: fwk.ClusterEvent{Resource: fwk.UnscheduledPod, ActionType: fwk.Add}, QueueingHintFn: pl.isSchedulableAfterPodAdded},
 		{Event: fwk.ClusterEvent{Resource: fwk.AssignedPod, ActionType: fwk.Add}, QueueingHintFn: pl.isSchedulableAfterPodAdded},
 		// A PodGroup being added can be making a waiting gang schedulable.
-		// PodGroups are immutable, so there's no need to handle PodGroup/Update event.
 		{Event: fwk.ClusterEvent{Resource: fwk.PodGroup, ActionType: fwk.Add}, QueueingHintFn: pl.isSchedulableAfterPodGroupAdded},
+		// A PodGroup update to MinCount may make it schedulable
+		{Event: fwk.ClusterEvent{Resource: fwk.PodGroup, ActionType: fwk.Update}, QueueingHintFn: pl.isSchedulableAfterPodGroupUpdated},
 	}, nil
 }
 
@@ -101,6 +102,39 @@ func (pl *GangScheduling) isSchedulableAfterPodAdded(logger klog.Logger, pod *v1
 
 	logger.V(5).Info("another pod was added and it matches the target pod's scheduling group, which may make the pod schedulable",
 		"pod", klog.KObj(pod), "schedulingGroup", pod.Spec.SchedulingGroup, "addedPod", klog.KObj(addedPod), "addedPodSchedulingGroup", addedPod.Spec.SchedulingGroup)
+	return fwk.Queue, nil
+}
+
+// isSchedulableAfterPodGroupUpdated triggers re-enqueueing of the group's pods if the minCount requirement has decreased.
+func (pl *GangScheduling) isSchedulableAfterPodGroupUpdated(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+	oldPodGroup, newPodGroup, err := util.As[*schedulingapi.PodGroup](oldObj, newObj)
+	if err != nil {
+		return fwk.Queue, err
+	}
+
+	// Only consider updates for the PodGroup this pod belongs to
+	if pod.Spec.SchedulingGroup == nil || pod.Namespace != newPodGroup.Namespace || *pod.Spec.SchedulingGroup.PodGroupName != newPodGroup.Name {
+		logger.V(5).Info("pod group was updated but it doesn't match the target pod's scheduling group",
+			"pod", klog.KObj(pod), "schedulingGroup", pod.Spec.SchedulingGroup, "updatedPodGroup", klog.KObj(newPodGroup))
+		return fwk.QueueSkip, nil
+	}
+
+	oldPolicy := oldPodGroup.Spec.SchedulingPolicy
+	newPolicy := newPodGroup.Spec.SchedulingPolicy
+
+	// Non-gang policies should not be updated.
+	if newPolicy.Gang == nil || oldPolicy.Gang == nil {
+		logger.V(5).Info("pod group was updated but it's not a gang policy, this is unexpected, enqueuing pod", "pod", klog.KObj(pod), "podGroup", klog.KObj(newPodGroup))
+		return fwk.Queue, nil
+	}
+
+	// If the gang scheduling policy minCount did not decrease, it will not make the waiting pods schedulable.
+	if newPolicy.Gang.MinCount >= oldPolicy.Gang.MinCount {
+		logger.V(5).Info("PodGroup minCount did not decrease, skipping", "pod", klog.KObj(pod), "podGroup", klog.KObj(newPodGroup), "oldMinCount", oldPolicy.Gang.MinCount, "newMinCount", newPolicy.Gang.MinCount)
+		return fwk.QueueSkip, nil
+	}
+
+	logger.V(5).Info("pod group was updated and minCount decreased, enqueuing pod", "pod", klog.KObj(pod), "podGroup", klog.KObj(newPodGroup), "oldMinCount", oldPolicy.Gang.MinCount, "newMinCount", newPolicy.Gang.MinCount)
 	return fwk.Queue, nil
 }
 

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -157,6 +157,98 @@ func Test_isSchedulableAfterPodGroupAdded(t *testing.T) {
 	}
 }
 
+func Test_isSchedulableAfterPodGroupUpdated(t *testing.T) {
+	tests := []struct {
+		name         string
+		pod          *v1.Pod
+		oldPodGroup  *schedulingapi.PodGroup
+		newPodGroup  *schedulingapi.PodGroup
+		expectedHint fwk.QueueingHint
+		expectErr    bool
+	}{
+		{
+			name:         "minCount decreased matches target pod",
+			pod:          st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
+			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).TemplateRef("t", "w").Obj(),
+			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).TemplateRef("t", "w").Obj(),
+			expectedHint: fwk.Queue,
+		},
+		{
+			name:         "update Basic policy",
+			pod:          st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
+			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").BasicPolicy().TemplateRef("t", "w").Obj(),
+			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").BasicPolicy().Obj(),
+			expectedHint: fwk.Queue,
+		},
+		{
+			name:         "minCount increased matches target pod",
+			pod:          st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
+			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).TemplateRef("t", "w").Obj(),
+			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).TemplateRef("t", "w").Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name:         "minCount unchanged matches target pod",
+			pod:          st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
+			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).TemplateRef("t", "w").Obj(),
+			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).TemplateRef("t", "w").Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name:         "minCount decreased but pod group name doesn't match target pod",
+			pod:          st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg-other").Obj(),
+			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).TemplateRef("t", "w").Obj(),
+			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).TemplateRef("t", "w").Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name:         "minCount decreased but pod group namespace doesn't match target pod",
+			pod:          st.MakePod().Namespace("ns-other").Name("p").PodGroupName("pg").Obj(),
+			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).TemplateRef("t", "w").Obj(),
+			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).TemplateRef("t", "w").Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name:         "pod without a scheduling group is skipped",
+			pod:          st.MakePod().Namespace("ns1").Name("p").Obj(),
+			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).TemplateRef("t", "w").Obj(),
+			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).TemplateRef("t", "w").Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+
+			informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(), 0)
+			fh, err := frameworkruntime.NewFramework(ctx, nil, nil,
+				frameworkruntime.WithInformerFactory(informerFactory),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create framework: %v", err)
+			}
+
+			p, err := New(ctx, nil, fh, feature.Features{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			actualHint, err := p.(*GangScheduling).isSchedulableAfterPodGroupUpdated(logger, tc.pod, tc.oldPodGroup, tc.newPodGroup)
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("Expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.expectedHint, actualHint); diff != "" {
+				t.Errorf("Expected QueuingHint doesn't match (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
 type podActivatorMock struct {
 	activatedPods []*v1.Pod
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1053,7 +1053,7 @@ func Test_UnionedGVKs(t *testing.T) {
 				fwk.DeviceClass:           fwk.All - fwk.Delete,
 				fwk.ResourceClaim:         fwk.All - fwk.Delete,
 				fwk.ResourceSlice:         fwk.All - fwk.Delete,
-				fwk.PodGroup:              fwk.Add,
+				fwk.PodGroup:              fwk.Add | fwk.Update,
 			},
 			enableGenericWorkload:           true,
 			enableInPlacePodVerticalScaling: true,

--- a/staging/src/k8s.io/api/scheduling/v1alpha3/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1alpha3/generated.proto
@@ -61,7 +61,15 @@ message DisruptionMode {
 message GangSchedulingPolicy {
   // MinCount is the minimum number of pods that must be schedulable or scheduled
   // at the same time for the scheduler to admit the entire group.
-  // It must be a positive integer.
+  // It must be a positive integer. This field is mutable to support workload scaling.
+  //
+  // Note that the scheduler operates on an eventually consistent model. Updates
+  // to minCount may not be immediately reflected in scheduling decisions due to
+  // propagation delays. If minCount is updated while a scheduling cycle is in
+  // progress for that group, the new value may not take effect until the next
+  // cycle. Moreover, minCount is only enforced during scheduling, meaning that
+  // modifications to this field do not affect already-scheduled pods, applying
+  // only to those evaluated in future cycles.
   //
   // +required
   // +k8s:required
@@ -191,23 +199,32 @@ message PodGroupSchedulingConstraints {
 }
 
 // PodGroupSchedulingPolicy defines the scheduling configuration for a PodGroup.
-// Exactly one policy must be set.
+// Exactly one policy must be set. The policy is chosen at creation time by setting either the
+// Basic or Gang field. The PodGroup may not change policy after creation.
+// Fields within chosen policy may be updated after creation when their individual fields allow it.
+//
 // +union
 message PodGroupSchedulingPolicy {
   // Basic specifies that the pods in this group should be scheduled using
-  // standard Kubernetes scheduling behavior.
+  // standard Kubernetes scheduling behavior. Setting this field at group creation time
+  // opts this group to basic scheduling; this field cannot be changed afterward.
   //
   // +optional
   // +k8s:optional
   // +k8s:unionMember
+  // +k8s:immutable
   optional BasicSchedulingPolicy basic = 1;
 
   // Gang specifies that the pods in this group should be scheduled using
-  // all-or-nothing semantics.
+  // all-or-nothing semantics. Setting this field at group creation time
+  // opts this group to gang scheduling; this field cannot be set or unset afterward.
+  // The minCount field within Gang scheduling policy remains mutable after group creation.
   //
   // +optional
   // +k8s:optional
   // +k8s:unionMember
+  // +k8s:update=NoSet
+  // +k8s:update=NoUnset
   optional GangSchedulingPolicy gang = 2;
 }
 
@@ -223,10 +240,8 @@ message PodGroupSpec {
 
   // SchedulingPolicy defines the scheduling policy for this instance of the PodGroup.
   // Controllers are expected to fill this field by copying it from a PodGroupTemplate.
-  // This field is immutable.
   //
   // +required
-  // +k8s:immutable
   optional PodGroupSchedulingPolicy schedulingPolicy = 2;
 
   // SchedulingConstraints defines optional scheduling constraints (e.g. topology) for this PodGroup.
@@ -363,11 +378,13 @@ message PodGroupTemplate {
 
   // SchedulingConstraints defines optional scheduling constraints (e.g. topology) for this PodGroupTemplate.
   // This field is only available when the TopologyAwareWorkloadScheduling feature gate is enabled.
+  // This field is immutable.
   //
   // +featureGate=TopologyAwareWorkloadScheduling
   // +optional
   // +k8s:ifDisabled(TopologyAwareWorkloadScheduling)=+k8s:forbidden
   // +k8s:ifEnabled(TopologyAwareWorkloadScheduling)=+k8s:optional
+  // +k8s:immutable
   optional PodGroupSchedulingConstraints schedulingConstraints = 3;
 
   // ResourceClaims defines which ResourceClaims may be shared among Pods in
@@ -391,23 +408,28 @@ message PodGroupTemplate {
   // +k8s:listMapKey=name
   // +k8s:maxItems=4
   // +featureGate=DRAWorkloadResourceClaims
+  // +k8s:immutable
   repeated PodGroupResourceClaim resourceClaims = 4;
 
   // DisruptionMode defines the mode in which a given PodGroup can be disrupted.
   // One of Single, All.
+  // This field is immutable.
   //
   // +optional
   // +k8s:optional
+  // +k8s:immutable
   optional DisruptionMode disruptionMode = 5;
 
   // PriorityClassName indicates the priority that should be considered when scheduling
   // a pod group created from this template. If no priority class is specified, admission
   // control can set this to the global default priority class if it exists. Otherwise,
   // pod groups created from this template will have the priority set to zero.
+  // This field is immutable.
   //
   // +optional
   // +k8s:optional
   // +k8s:format=k8s-long-name
+  // +k8s:immutable
   optional string priorityClassName = 6;
 
   // Priority is the value of priority of pod groups created from this template. Various
@@ -415,10 +437,12 @@ message PodGroupTemplate {
   // Priority Admission Controller is enabled, it prevents users from setting this field.
   // The admission controller populates this field from PriorityClassName.
   // The higher the value, the higher the priority.
+  // This field is immutable.
   //
   // +optional
   // +k8s:optional
   // +k8s:maximum=1000000000 # HighestUserDefinablePriority
+  // +k8s:immutable
   optional int32 priority = 7;
 }
 
@@ -539,7 +563,8 @@ message WorkloadSpec {
   optional TypedLocalObjectReference controllerRef = 1;
 
   // PodGroupTemplates is the list of templates that make up the Workload.
-  // The maximum number of templates is 8. This field is immutable.
+  // The maximum number of templates is 8. Templates cannot be added or removed after the workload is created.
+  // Existing templates may still be updated where their individual fields allow it.
   //
   // +required
   // +listType=map
@@ -548,7 +573,8 @@ message WorkloadSpec {
   // +k8s:listType=map
   // +k8s:listMapKey=name
   // +k8s:maxItems=8
-  // +k8s:immutable
+  // +k8s:update=NoAddItem
+  // +k8s:update=NoRemoveItem
   repeated PodGroupTemplate podGroupTemplates = 2;
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1alpha3/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha3/types.go
@@ -71,7 +71,8 @@ type WorkloadSpec struct {
 	ControllerRef *TypedLocalObjectReference `json:"controllerRef,omitempty" protobuf:"bytes,1,opt,name=controllerRef"`
 
 	// PodGroupTemplates is the list of templates that make up the Workload.
-	// The maximum number of templates is 8. This field is immutable.
+	// The maximum number of templates is 8. Templates cannot be added or removed after the workload is created.
+	// Existing templates may still be updated where their individual fields allow it.
 	//
 	// +required
 	// +listType=map
@@ -80,7 +81,8 @@ type WorkloadSpec struct {
 	// +k8s:listType=map
 	// +k8s:listMapKey=name
 	// +k8s:maxItems=8
-	// +k8s:immutable
+	// +k8s:update=NoAddItem
+	// +k8s:update=NoRemoveItem
 	PodGroupTemplates []PodGroupTemplate `json:"podGroupTemplates" protobuf:"bytes,2,rep,name=podGroupTemplates"`
 }
 
@@ -132,11 +134,13 @@ type PodGroupTemplate struct {
 
 	// SchedulingConstraints defines optional scheduling constraints (e.g. topology) for this PodGroupTemplate.
 	// This field is only available when the TopologyAwareWorkloadScheduling feature gate is enabled.
+	// This field is immutable.
 	//
 	// +featureGate=TopologyAwareWorkloadScheduling
 	// +optional
 	// +k8s:ifDisabled(TopologyAwareWorkloadScheduling)=+k8s:forbidden
 	// +k8s:ifEnabled(TopologyAwareWorkloadScheduling)=+k8s:optional
+	// +k8s:immutable
 	SchedulingConstraints *PodGroupSchedulingConstraints `json:"schedulingConstraints" protobuf:"bytes,3,opt,name=schedulingConstraints"`
 
 	// ResourceClaims defines which ResourceClaims may be shared among Pods in
@@ -160,23 +164,28 @@ type PodGroupTemplate struct {
 	// +k8s:listMapKey=name
 	// +k8s:maxItems=4
 	// +featureGate=DRAWorkloadResourceClaims
+	// +k8s:immutable
 	ResourceClaims []PodGroupResourceClaim `json:"resourceClaims,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name" protobuf:"bytes,4,rep,name=resourceClaims"`
 
 	// DisruptionMode defines the mode in which a given PodGroup can be disrupted.
 	// One of Single, All.
+	// This field is immutable.
 	//
 	// +optional
 	// +k8s:optional
+	// +k8s:immutable
 	DisruptionMode *DisruptionMode `json:"disruptionMode,omitempty" protobuf:"bytes,5,opt,name=disruptionMode"`
 
 	// PriorityClassName indicates the priority that should be considered when scheduling
 	// a pod group created from this template. If no priority class is specified, admission
 	// control can set this to the global default priority class if it exists. Otherwise,
 	// pod groups created from this template will have the priority set to zero.
+	// This field is immutable.
 	//
 	// +optional
 	// +k8s:optional
 	// +k8s:format=k8s-long-name
+	// +k8s:immutable
 	PriorityClassName string `json:"priorityClassName,omitempty" protobuf:"bytes,6,opt,name=priorityClassName"`
 
 	// Priority is the value of priority of pod groups created from this template. Various
@@ -184,31 +193,42 @@ type PodGroupTemplate struct {
 	// Priority Admission Controller is enabled, it prevents users from setting this field.
 	// The admission controller populates this field from PriorityClassName.
 	// The higher the value, the higher the priority.
+	// This field is immutable.
 	//
 	// +optional
 	// +k8s:optional
 	// +k8s:maximum=1000000000 # HighestUserDefinablePriority
+	// +k8s:immutable
 	Priority *int32 `json:"priority,omitempty" protobuf:"varint,7,opt,name=priority"`
 }
 
 // PodGroupSchedulingPolicy defines the scheduling configuration for a PodGroup.
-// Exactly one policy must be set.
+// Exactly one policy must be set. The policy is chosen at creation time by setting either the
+// Basic or Gang field. The PodGroup may not change policy after creation.
+// Fields within chosen policy may be updated after creation when their individual fields allow it.
+//
 // +union
 type PodGroupSchedulingPolicy struct {
 	// Basic specifies that the pods in this group should be scheduled using
-	// standard Kubernetes scheduling behavior.
+	// standard Kubernetes scheduling behavior. Setting this field at group creation time
+	// opts this group to basic scheduling; this field cannot be changed afterward.
 	//
 	// +optional
 	// +k8s:optional
 	// +k8s:unionMember
+	// +k8s:immutable
 	Basic *BasicSchedulingPolicy `json:"basic,omitempty" protobuf:"bytes,1,opt,name=basic"`
 
 	// Gang specifies that the pods in this group should be scheduled using
-	// all-or-nothing semantics.
+	// all-or-nothing semantics. Setting this field at group creation time
+	// opts this group to gang scheduling; this field cannot be set or unset afterward.
+	// The minCount field within Gang scheduling policy remains mutable after group creation.
 	//
 	// +optional
 	// +k8s:optional
 	// +k8s:unionMember
+	// +k8s:update=NoSet
+	// +k8s:update=NoUnset
 	Gang *GangSchedulingPolicy `json:"gang,omitempty" protobuf:"bytes,2,opt,name=gang"`
 }
 
@@ -225,7 +245,15 @@ type BasicSchedulingPolicy struct {
 type GangSchedulingPolicy struct {
 	// MinCount is the minimum number of pods that must be schedulable or scheduled
 	// at the same time for the scheduler to admit the entire group.
-	// It must be a positive integer.
+	// It must be a positive integer. This field is mutable to support workload scaling.
+	//
+	// Note that the scheduler operates on an eventually consistent model. Updates
+	// to minCount may not be immediately reflected in scheduling decisions due to
+	// propagation delays. If minCount is updated while a scheduling cycle is in
+	// progress for that group, the new value may not take effect until the next
+	// cycle. Moreover, minCount is only enforced during scheduling, meaning that
+	// modifications to this field do not affect already-scheduled pods, applying
+	// only to those evaluated in future cycles.
 	//
 	// +required
 	// +k8s:required
@@ -369,10 +397,8 @@ type PodGroupSpec struct {
 
 	// SchedulingPolicy defines the scheduling policy for this instance of the PodGroup.
 	// Controllers are expected to fill this field by copying it from a PodGroupTemplate.
-	// This field is immutable.
 	//
 	// +required
-	// +k8s:immutable
 	SchedulingPolicy PodGroupSchedulingPolicy `json:"schedulingPolicy" protobuf:"bytes,2,opt,name=schedulingPolicy"`
 
 	// SchedulingConstraints defines optional scheduling constraints (e.g. topology) for this PodGroup.

--- a/staging/src/k8s.io/api/scheduling/v1alpha3/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha3/types_swagger_doc_generated.go
@@ -55,7 +55,7 @@ func (DisruptionMode) SwaggerDoc() map[string]string {
 
 var map_GangSchedulingPolicy = map[string]string{
 	"":         "GangSchedulingPolicy defines the parameters for gang scheduling.",
-	"minCount": "MinCount is the minimum number of pods that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer.",
+	"minCount": "MinCount is the minimum number of pods that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer. This field is mutable to support workload scaling.\n\nNote that the scheduler operates on an eventually consistent model. Updates to minCount may not be immediately reflected in scheduling decisions due to propagation delays. If minCount is updated while a scheduling cycle is in progress for that group, the new value may not take effect until the next cycle. Moreover, minCount is only enforced during scheduling, meaning that modifications to this field do not affect already-scheduled pods, applying only to those evaluated in future cycles.",
 }
 
 func (GangSchedulingPolicy) SwaggerDoc() map[string]string {
@@ -114,9 +114,9 @@ func (PodGroupSchedulingConstraints) SwaggerDoc() map[string]string {
 }
 
 var map_PodGroupSchedulingPolicy = map[string]string{
-	"":      "PodGroupSchedulingPolicy defines the scheduling configuration for a PodGroup. Exactly one policy must be set.",
-	"basic": "Basic specifies that the pods in this group should be scheduled using standard Kubernetes scheduling behavior.",
-	"gang":  "Gang specifies that the pods in this group should be scheduled using all-or-nothing semantics.",
+	"":      "PodGroupSchedulingPolicy defines the scheduling configuration for a PodGroup. Exactly one policy must be set. The policy is chosen at creation time by setting either the Basic or Gang field. The PodGroup may not change policy after creation. Fields within chosen policy may be updated after creation when their individual fields allow it.",
+	"basic": "Basic specifies that the pods in this group should be scheduled using standard Kubernetes scheduling behavior. Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward.",
+	"gang":  "Gang specifies that the pods in this group should be scheduled using all-or-nothing semantics. Setting this field at group creation time opts this group to gang scheduling; this field cannot be set or unset afterward. The minCount field within Gang scheduling policy remains mutable after group creation.",
 }
 
 func (PodGroupSchedulingPolicy) SwaggerDoc() map[string]string {
@@ -126,7 +126,7 @@ func (PodGroupSchedulingPolicy) SwaggerDoc() map[string]string {
 var map_PodGroupSpec = map[string]string{
 	"":                      "PodGroupSpec defines the desired state of a PodGroup.",
 	"podGroupTemplateRef":   "PodGroupTemplateRef references an optional PodGroup template within other object (e.g. Workload) that was used to create the PodGroup. This field is immutable.",
-	"schedulingPolicy":      "SchedulingPolicy defines the scheduling policy for this instance of the PodGroup. Controllers are expected to fill this field by copying it from a PodGroupTemplate. This field is immutable.",
+	"schedulingPolicy":      "SchedulingPolicy defines the scheduling policy for this instance of the PodGroup. Controllers are expected to fill this field by copying it from a PodGroupTemplate.",
 	"schedulingConstraints": "SchedulingConstraints defines optional scheduling constraints (e.g. topology) for this PodGroup. Controllers are expected to fill this field by copying it from a PodGroupTemplate. This field is immutable. This field is only available when the TopologyAwareWorkloadScheduling feature gate is enabled.",
 	"resourceClaims":        "ResourceClaims defines which ResourceClaims may be shared among Pods in the group. Pods consume the devices allocated to a PodGroup's claim by defining a claim in its own Spec.ResourceClaims that matches the PodGroup's claim exactly. The claim must have the same name and refer to the same ResourceClaim or ResourceClaimTemplate.\n\nThis is an alpha-level field and requires that the DRAWorkloadResourceClaims feature gate is enabled.\n\nThis field is immutable.",
 	"disruptionMode":        "DisruptionMode defines the mode in which a given PodGroup can be disrupted. Controllers are expected to fill this field by copying it from a PodGroupTemplate. One of Single, All. Defaults to Single if unset. This field is immutable.",
@@ -152,11 +152,11 @@ var map_PodGroupTemplate = map[string]string{
 	"":                      "PodGroupTemplate represents a template for a set of pods with a scheduling policy.",
 	"name":                  "Name is a unique identifier for the PodGroupTemplate within the Workload. It must be a DNS label. This field is immutable.",
 	"schedulingPolicy":      "SchedulingPolicy defines the scheduling policy for this PodGroupTemplate.",
-	"schedulingConstraints": "SchedulingConstraints defines optional scheduling constraints (e.g. topology) for this PodGroupTemplate. This field is only available when the TopologyAwareWorkloadScheduling feature gate is enabled.",
+	"schedulingConstraints": "SchedulingConstraints defines optional scheduling constraints (e.g. topology) for this PodGroupTemplate. This field is only available when the TopologyAwareWorkloadScheduling feature gate is enabled. This field is immutable.",
 	"resourceClaims":        "ResourceClaims defines which ResourceClaims may be shared among Pods in the group. Pods consume the devices allocated to a PodGroup's claim by defining a claim in its own Spec.ResourceClaims that matches the PodGroup's claim exactly. The claim must have the same name and refer to the same ResourceClaim or ResourceClaimTemplate.\n\nThis is an alpha-level field and requires that the DRAWorkloadResourceClaims feature gate is enabled.\n\nThis field is immutable.",
-	"disruptionMode":        "DisruptionMode defines the mode in which a given PodGroup can be disrupted. One of Single, All.",
-	"priorityClassName":     "PriorityClassName indicates the priority that should be considered when scheduling a pod group created from this template. If no priority class is specified, admission control can set this to the global default priority class if it exists. Otherwise, pod groups created from this template will have the priority set to zero.",
-	"priority":              "Priority is the value of priority of pod groups created from this template. Various system components use this field to find the priority of the pod group. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.",
+	"disruptionMode":        "DisruptionMode defines the mode in which a given PodGroup can be disrupted. One of Single, All. This field is immutable.",
+	"priorityClassName":     "PriorityClassName indicates the priority that should be considered when scheduling a pod group created from this template. If no priority class is specified, admission control can set this to the global default priority class if it exists. Otherwise, pod groups created from this template will have the priority set to zero. This field is immutable.",
+	"priority":              "Priority is the value of priority of pod groups created from this template. Various system components use this field to find the priority of the pod group. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority. This field is immutable.",
 }
 
 func (PodGroupTemplate) SwaggerDoc() map[string]string {
@@ -233,7 +233,7 @@ func (WorkloadPodGroupTemplateReference) SwaggerDoc() map[string]string {
 var map_WorkloadSpec = map[string]string{
 	"":                  "WorkloadSpec defines the desired state of a Workload.",
 	"controllerRef":     "ControllerRef is an optional reference to the controlling object, such as a Deployment or Job. This field is intended for use by tools like CLIs to provide a link back to the original workload definition. This field is immutable.",
-	"podGroupTemplates": "PodGroupTemplates is the list of templates that make up the Workload. The maximum number of templates is 8. This field is immutable.",
+	"podGroupTemplates": "PodGroupTemplates is the list of templates that make up the Workload. The maximum number of templates is 8. Templates cannot be added or removed after the workload is created. Existing templates may still be updated where their individual fields allow it.",
 }
 
 func (WorkloadSpec) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1alpha3/gangschedulingpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1alpha3/gangschedulingpolicy.go
@@ -25,7 +25,15 @@ package v1alpha3
 type GangSchedulingPolicyApplyConfiguration struct {
 	// MinCount is the minimum number of pods that must be schedulable or scheduled
 	// at the same time for the scheduler to admit the entire group.
-	// It must be a positive integer.
+	// It must be a positive integer. This field is mutable to support workload scaling.
+	//
+	// Note that the scheduler operates on an eventually consistent model. Updates
+	// to minCount may not be immediately reflected in scheduling decisions due to
+	// propagation delays. If minCount is updated while a scheduling cycle is in
+	// progress for that group, the new value may not take effect until the next
+	// cycle. Moreover, minCount is only enforced during scheduling, meaning that
+	// modifications to this field do not affect already-scheduled pods, applying
+	// only to those evaluated in future cycles.
 	MinCount *int32 `json:"minCount,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1alpha3/podgroupschedulingpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1alpha3/podgroupschedulingpolicy.go
@@ -26,13 +26,18 @@ import (
 // with apply.
 //
 // PodGroupSchedulingPolicy defines the scheduling configuration for a PodGroup.
-// Exactly one policy must be set.
+// Exactly one policy must be set. The policy is chosen at creation time by setting either the
+// Basic or Gang field. The PodGroup may not change policy after creation.
+// Fields within chosen policy may be updated after creation when their individual fields allow it.
 type PodGroupSchedulingPolicyApplyConfiguration struct {
 	// Basic specifies that the pods in this group should be scheduled using
-	// standard Kubernetes scheduling behavior.
+	// standard Kubernetes scheduling behavior. Setting this field at group creation time
+	// opts this group to basic scheduling; this field cannot be changed afterward.
 	Basic *schedulingv1alpha3.BasicSchedulingPolicy `json:"basic,omitempty"`
 	// Gang specifies that the pods in this group should be scheduled using
-	// all-or-nothing semantics.
+	// all-or-nothing semantics. Setting this field at group creation time
+	// opts this group to gang scheduling; this field cannot be set or unset afterward.
+	// The minCount field within Gang scheduling policy remains mutable after group creation.
 	Gang *GangSchedulingPolicyApplyConfiguration `json:"gang,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1alpha3/podgroupspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1alpha3/podgroupspec.go
@@ -28,7 +28,6 @@ type PodGroupSpecApplyConfiguration struct {
 	PodGroupTemplateRef *PodGroupTemplateReferenceApplyConfiguration `json:"podGroupTemplateRef,omitempty"`
 	// SchedulingPolicy defines the scheduling policy for this instance of the PodGroup.
 	// Controllers are expected to fill this field by copying it from a PodGroupTemplate.
-	// This field is immutable.
 	SchedulingPolicy *PodGroupSchedulingPolicyApplyConfiguration `json:"schedulingPolicy,omitempty"`
 	// SchedulingConstraints defines optional scheduling constraints (e.g. topology) for this PodGroup.
 	// Controllers are expected to fill this field by copying it from a PodGroupTemplate.

--- a/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1alpha3/podgrouptemplate.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1alpha3/podgrouptemplate.go
@@ -30,6 +30,7 @@ type PodGroupTemplateApplyConfiguration struct {
 	SchedulingPolicy *PodGroupSchedulingPolicyApplyConfiguration `json:"schedulingPolicy,omitempty"`
 	// SchedulingConstraints defines optional scheduling constraints (e.g. topology) for this PodGroupTemplate.
 	// This field is only available when the TopologyAwareWorkloadScheduling feature gate is enabled.
+	// This field is immutable.
 	SchedulingConstraints *PodGroupSchedulingConstraintsApplyConfiguration `json:"schedulingConstraints,omitempty"`
 	// ResourceClaims defines which ResourceClaims may be shared among Pods in
 	// the group. Pods consume the devices allocated to a PodGroup's claim by
@@ -44,17 +45,20 @@ type PodGroupTemplateApplyConfiguration struct {
 	ResourceClaims []PodGroupResourceClaimApplyConfiguration `json:"resourceClaims,omitempty"`
 	// DisruptionMode defines the mode in which a given PodGroup can be disrupted.
 	// One of Single, All.
+	// This field is immutable.
 	DisruptionMode *DisruptionModeApplyConfiguration `json:"disruptionMode,omitempty"`
 	// PriorityClassName indicates the priority that should be considered when scheduling
 	// a pod group created from this template. If no priority class is specified, admission
 	// control can set this to the global default priority class if it exists. Otherwise,
 	// pod groups created from this template will have the priority set to zero.
+	// This field is immutable.
 	PriorityClassName *string `json:"priorityClassName,omitempty"`
 	// Priority is the value of priority of pod groups created from this template. Various
 	// system components use this field to find the priority of the pod group. When
 	// Priority Admission Controller is enabled, it prevents users from setting this field.
 	// The admission controller populates this field from PriorityClassName.
 	// The higher the value, the higher the priority.
+	// This field is immutable.
 	Priority *int32 `json:"priority,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1alpha3/workloadspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1alpha3/workloadspec.go
@@ -29,7 +29,8 @@ type WorkloadSpecApplyConfiguration struct {
 	// This field is immutable.
 	ControllerRef *TypedLocalObjectReferenceApplyConfiguration `json:"controllerRef,omitempty"`
 	// PodGroupTemplates is the list of templates that make up the Workload.
-	// The maximum number of templates is 8. This field is immutable.
+	// The maximum number of templates is 8. Templates cannot be added or removed after the workload is created.
+	// Existing templates may still be updated where their individual fields allow it.
 	PodGroupTemplates []PodGroupTemplateApplyConfiguration `json:"podGroupTemplates,omitempty"`
 }
 

--- a/test/declarative_validation/scheduling/podgroup/declarative_validation_test.go
+++ b/test/declarative_validation/scheduling/podgroup/declarative_validation_test.go
@@ -334,6 +334,10 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			oldObj:    mkValidPodGroup(setResourceVersion("1")),
 			updateObj: mkValidPodGroup(setResourceVersion("1")),
 		},
+		"valid update minCount": {
+			oldObj:    mkValidPodGroup(setResourceVersion("1")),
+			updateObj: mkValidPodGroup(setResourceVersion("1"), setPodGroupMinCount(10)),
+		},
 		"invalid update empty podGroupTemplateRef": {
 			oldObj:    mkValidPodGroup(setResourceVersion("1")),
 			updateObj: mkValidPodGroup(setResourceVersion("1"), setEmptyPodGroupTemplateRef()),
@@ -366,27 +370,32 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			oldObj:    mkValidPodGroup(setResourceVersion("1")),
 			updateObj: mkValidPodGroup(setResourceVersion("1"), clearPodGroupPolicy()),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "schedulingPolicy"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "schedulingPolicy"), nil, "").WithOrigin("union"),
+				field.Invalid(field.NewPath("spec", "schedulingPolicy", "gang"), nil, "").WithOrigin("update"),
 			},
 		},
 		"invalid update with both basic and gang": {
 			oldObj:    mkValidPodGroup(setResourceVersion("1")),
 			updateObj: mkValidPodGroup(setResourceVersion("1"), setBothPolicies()),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "schedulingPolicy"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "schedulingPolicy"), nil, "").WithOrigin("union"),
+				field.Invalid(field.NewPath("spec", "schedulingPolicy", "basic"), nil, "").WithOrigin("immutable"),
 			},
 		},
 		"invalid update of gang minCount": {
 			oldObj:    mkValidPodGroup(setResourceVersion("1")),
-			updateObj: mkValidPodGroup(setResourceVersion("1"), setPodGroupMinCount(10)),
+			updateObj: mkValidPodGroup(setResourceVersion("1"), setPodGroupMinCount(-1)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "schedulingPolicy"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "schedulingPolicy", "gang", "minCount"), nil, "").WithOrigin("minimum"),
 			},
 		},
 		"invalid update from gang to basic policy": {
-			oldObj:       mkValidPodGroup(setResourceVersion("1")),
-			updateObj:    mkValidPodGroup(setResourceVersion("1"), setBasicPolicy()),
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "schedulingPolicy"), nil, "").WithOrigin("immutable")},
+			oldObj:    mkValidPodGroup(setResourceVersion("1")),
+			updateObj: mkValidPodGroup(setResourceVersion("1"), setBasicPolicy()),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "schedulingPolicy", "basic"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "schedulingPolicy", "gang"), nil, "").WithOrigin("update"),
+			},
 		},
 		"valid update with unchanged scheduling constraints and TAS disabled": {
 			oldObj:    mkValidPodGroup(setResourceVersion("1"), addTopologyConstraint("foo")),

--- a/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1alpha3_test.go
@@ -85,8 +85,13 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"spec.schedulingPolicy": {
-				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 				{ErrorType: "FieldValueInvalid", Origin: "union"},
+			},
+			"spec.schedulingPolicy.basic": {
+				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
+			},
+			"spec.schedulingPolicy.gang": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
 			},
 			"spec.schedulingPolicy.gang.minCount": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},

--- a/test/declarative_validation/scheduling/workload/declarative_validation_test.go
+++ b/test/declarative_validation/scheduling/workload/declarative_validation_test.go
@@ -353,6 +353,10 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			oldObj:    mkValidWorkload(setResourceVersion("1"), setControllerRef("apps", "Deployment", "my-deployment")),
 			updateObj: mkValidWorkload(setResourceVersion("1"), setControllerRef("apps", "Deployment", "my-deployment")),
 		},
+		"valid update with minCount changed": {
+			oldObj:    mkValidWorkload(setResourceVersion("1"), setControllerRef("apps", "Deployment", "my-deployment")),
+			updateObj: mkValidWorkload(setResourceVersion("1"), setControllerRef("apps", "Deployment", "my-deployment"), setPodGroupMinCount(0, 10)),
+		},
 		"set controllerRef": {
 			oldObj:       mkValidWorkload(setResourceVersion("1")),
 			updateObj:    mkValidWorkload(setResourceVersion("1"), setControllerRef("apps", "Deployment", "different-deployment")),
@@ -373,14 +377,15 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			updateObj: mkValidWorkload(setResourceVersion("1"), setEmptyPodGroupTemplates()),
 			expectedErrs: field.ErrorList{
 				field.Required(field.NewPath("spec", "podGroupTemplates"), "must have at least one item"),
-				field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "").WithOrigin("immutable"),
+				field.Forbidden(field.NewPath("spec", "podGroupTemplates"), "").WithOrigin("update"),
 			},
 		},
 		"change podGroupTemplate name": {
 			oldObj:    mkValidWorkload(setResourceVersion("1"), addPodGroupTemplate("worker1")),
 			updateObj: mkValidWorkload(setResourceVersion("1"), addPodGroupTemplate("worker2")),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "").WithOrigin("immutable"),
+				field.Forbidden(field.NewPath("spec", "podGroupTemplates").Index(1), "").WithOrigin("update"),
+				field.Forbidden(field.NewPath("spec", "podGroupTemplates"), "").WithOrigin("update"),
 			},
 		},
 		"invalid update too many podGroupTemplates": {
@@ -388,42 +393,62 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			updateObj: mkValidWorkload(setResourceVersion("1"), setManyPodGroupTemplates(scheduling.WorkloadMaxPodGroupTemplates+1)),
 			expectedErrs: field.ErrorList{
 				field.TooMany(field.NewPath("spec", "podGroupTemplates"), scheduling.WorkloadMaxPodGroupTemplates+1, scheduling.WorkloadMaxPodGroupTemplates).WithOrigin("maxItems"),
-				field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "").WithOrigin("immutable"),
+				field.Forbidden(field.NewPath("spec", "podGroupTemplates").Index(0), "").WithOrigin("update"),
+				field.Forbidden(field.NewPath("spec", "podGroupTemplates").Index(1), "").WithOrigin("update"),
+				field.Forbidden(field.NewPath("spec", "podGroupTemplates").Index(2), "").WithOrigin("update"),
+				field.Forbidden(field.NewPath("spec", "podGroupTemplates").Index(3), "").WithOrigin("update"),
+				field.Forbidden(field.NewPath("spec", "podGroupTemplates").Index(4), "").WithOrigin("update"),
+				field.Forbidden(field.NewPath("spec", "podGroupTemplates").Index(5), "").WithOrigin("update"),
+				field.Forbidden(field.NewPath("spec", "podGroupTemplates").Index(6), "").WithOrigin("update"),
+				field.Forbidden(field.NewPath("spec", "podGroupTemplates").Index(7), "").WithOrigin("update"),
+				field.Forbidden(field.NewPath("spec", "podGroupTemplates").Index(8), "").WithOrigin("update"),
+				field.Forbidden(field.NewPath("spec", "podGroupTemplates"), "").WithOrigin("update"),
 			},
 		},
 		"add podGroupTemplate": {
-			oldObj:       mkValidWorkload(setResourceVersion("1")),
-			updateObj:    mkValidWorkload(setResourceVersion("1"), addPodGroupTemplate("worker1")),
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "").WithOrigin("immutable")},
+			oldObj:    mkValidWorkload(setResourceVersion("1")),
+			updateObj: mkValidWorkload(setResourceVersion("1"), addPodGroupTemplate("worker1")),
+			expectedErrs: field.ErrorList{
+				field.Forbidden(field.NewPath("spec", "podGroupTemplates").Index(1), "").WithOrigin("update"),
+			},
 		},
 		"remove podGroupTemplate": {
-			oldObj:       mkValidWorkload(setResourceVersion("1"), addPodGroupTemplate("worker1")),
-			updateObj:    mkValidWorkload(setResourceVersion("1")),
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "").WithOrigin("immutable")},
+			oldObj:    mkValidWorkload(setResourceVersion("1"), addPodGroupTemplate("worker1")),
+			updateObj: mkValidWorkload(setResourceVersion("1")),
+			expectedErrs: field.ErrorList{
+				field.Forbidden(field.NewPath("spec", "podGroupTemplates"), "").WithOrigin("update"),
+			},
 		},
 		"invalid update with neither basic nor gang": {
 			oldObj:    mkValidWorkload(setResourceVersion("1")),
 			updateObj: mkValidWorkload(setResourceVersion("1"), clearPodGroupPolicy(0)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingPolicy"), nil, "").WithOrigin("union"),
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingPolicy", "gang"), nil, "").WithOrigin("update"),
 			},
 		},
 		"invalid update with both basic and gang": {
 			oldObj:    mkValidWorkload(setResourceVersion("1")),
 			updateObj: mkValidWorkload(setResourceVersion("1"), setBothPolicies(0)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingPolicy"), nil, "").WithOrigin("union"),
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingPolicy", "basic"), nil, "").WithOrigin("immutable"),
 			},
 		},
 		"invalid update of gang minCount": {
-			oldObj:       mkValidWorkload(setResourceVersion("1")),
-			updateObj:    mkValidWorkload(setResourceVersion("1"), setPodGroupMinCount(0, 10)),
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "").WithOrigin("immutable")},
+			oldObj:    mkValidWorkload(setResourceVersion("1")),
+			updateObj: mkValidWorkload(setResourceVersion("1"), setPodGroupMinCount(0, -1)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingPolicy", "gang", "minCount"), nil, "").WithOrigin("minimum"),
+			},
 		},
-		"valid update from gang to basic policy": {
-			oldObj:       mkValidWorkload(setResourceVersion("1")),
-			updateObj:    mkValidWorkload(setResourceVersion("1"), setBasicPolicy(0)),
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "").WithOrigin("immutable")},
+		"invalid update from gang to basic policy": {
+			oldObj:    mkValidWorkload(setResourceVersion("1")),
+			updateObj: mkValidWorkload(setResourceVersion("1"), setBasicPolicy(0)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingPolicy", "basic"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingPolicy", "gang"), nil, "").WithOrigin("update"),
+			},
 		},
 		"valid update with unchanged scheduling constraints": {
 			oldObj:                        mkValidWorkload(setResourceVersion("1"), addTopologyConstraint(0, "foo")),
@@ -434,45 +459,62 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			oldObj:                        mkValidWorkload(setResourceVersion("1"), addTopologyConstraint(0, "foo")),
 			updateObj:                     mkValidWorkload(setResourceVersion("1"), setSchedulingConstraints(0)),
 			enableTopologyAwareScheduling: true,
-			expectedErrs:                  field.ErrorList{field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "field is immutable").WithOrigin("immutable")},
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingConstraints"), nil, "field is immutable").WithOrigin("immutable"),
+			},
 		},
 		"invalid update to topology constraints": {
 			oldObj:                        mkValidWorkload(setResourceVersion("1"), addTopologyConstraint(0, "foo")),
 			updateObj:                     mkValidWorkload(setResourceVersion("1"), addTopologyConstraint(0, "foo"), addTopologyConstraint(0, "bar")),
 			enableTopologyAwareScheduling: true,
-			expectedErrs:                  field.ErrorList{field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "field is immutable").WithOrigin("immutable")},
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingConstraints"), nil, "field is immutable").WithOrigin("immutable"),
+			},
 		},
 		"invalid update to topology key": {
 			oldObj:                        mkValidWorkload(setResourceVersion("1"), addTopologyConstraint(0, "foo")),
 			updateObj:                     mkValidWorkload(setResourceVersion("1"), addTopologyConstraint(0, "bar")),
 			enableTopologyAwareScheduling: true,
-			expectedErrs:                  field.ErrorList{field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "field is immutable").WithOrigin("immutable")},
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingConstraints"), nil, "field is immutable").WithOrigin("immutable"),
+			},
 		},
 		"valid update with unchanged scheduling constraints with TAS disabled": {
 			oldObj:    mkValidWorkload(setResourceVersion("1"), addTopologyConstraint(0, "foo")),
 			updateObj: mkValidWorkload(setResourceVersion("1"), addTopologyConstraint(0, "foo")),
 		},
 		"invalid update to scheduling constraints with TAS disabled": {
-			oldObj:       mkValidWorkload(setResourceVersion("1"), addTopologyConstraint(0, "foo")),
-			updateObj:    mkValidWorkload(setResourceVersion("1"), setSchedulingConstraints(0)),
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "field is immutable").WithOrigin("immutable")},
+			oldObj:    mkValidWorkload(setResourceVersion("1"), addTopologyConstraint(0, "foo")),
+			updateObj: mkValidWorkload(setResourceVersion("1"), setSchedulingConstraints(0)),
+			expectedErrs: field.ErrorList{
+				field.Forbidden(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingConstraints"), ""),
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingConstraints"), nil, "field is immutable").WithOrigin("immutable"),
+			},
 		},
 		"invalid update to topology constraints with TAS disabled": {
-			oldObj:       mkValidWorkload(setResourceVersion("1"), addTopologyConstraint(0, "foo")),
-			updateObj:    mkValidWorkload(setResourceVersion("1"), addTopologyConstraint(0, "foo"), addTopologyConstraint(0, "bar")),
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "field is immutable").WithOrigin("immutable")},
+			oldObj:    mkValidWorkload(setResourceVersion("1"), addTopologyConstraint(0, "foo")),
+			updateObj: mkValidWorkload(setResourceVersion("1"), addTopologyConstraint(0, "foo"), addTopologyConstraint(0, "bar")),
+			expectedErrs: field.ErrorList{
+				field.Forbidden(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingConstraints"), ""),
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingConstraints"), nil, "field is immutable").WithOrigin("immutable"),
+			},
 		},
 		"invalid update to topology key with TAS disabled": {
-			oldObj:       mkValidWorkload(setResourceVersion("1"), addTopologyConstraint(0, "foo")),
-			updateObj:    mkValidWorkload(setResourceVersion("1"), addTopologyConstraint(0, "bar")),
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "field is immutable").WithOrigin("immutable")},
+			oldObj:    mkValidWorkload(setResourceVersion("1"), addTopologyConstraint(0, "foo")),
+			updateObj: mkValidWorkload(setResourceVersion("1"), addTopologyConstraint(0, "bar")),
+			expectedErrs: field.ErrorList{
+				field.Forbidden(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingConstraints"), ""),
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingConstraints"), nil, "field is immutable").WithOrigin("immutable"),
+			},
 		},
 		"invalid add of resource claims, DRA workload resource claims disabled": {
 			oldObj: mkValidWorkload(setResourceVersion("1")),
 			updateObj: mkValidWorkload(setResourceVersion("1"), addResourceClaims(
 				scheduling.PodGroupResourceClaim{Name: "my-claim", ResourceClaimTemplateName: new("my-template")},
 			)),
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "").WithOrigin("immutable")},
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("resourceClaims"), nil, "").WithOrigin("immutable"),
+			},
 		},
 		"invalid add of resource claims, DRA workload resource claims enabled": {
 			oldObj: mkValidWorkload(setResourceVersion("1")),
@@ -480,7 +522,9 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				scheduling.PodGroupResourceClaim{Name: "my-claim", ResourceClaimTemplateName: new("my-template")},
 			)),
 			enableDRAWorkloadResourceClaims: true,
-			expectedErrs:                    field.ErrorList{field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "").WithOrigin("immutable")},
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("resourceClaims"), nil, "").WithOrigin("immutable"),
+			},
 		},
 		"invalid update of resource claims, DRA workload resource claims disabled": {
 			oldObj: mkValidWorkload(setResourceVersion("1"), addResourceClaims(
@@ -489,7 +533,9 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			updateObj: mkValidWorkload(setResourceVersion("1"), addResourceClaims(
 				scheduling.PodGroupResourceClaim{Name: "my-other-claim", ResourceClaimTemplateName: new("my-template")},
 			)),
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "").WithOrigin("immutable")},
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("resourceClaims"), nil, "").WithOrigin("immutable"),
+			},
 		},
 		"invalid update of resource claims, DRA workload resource claims enabled": {
 			oldObj: mkValidWorkload(setResourceVersion("1"), addResourceClaims(
@@ -499,14 +545,18 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				scheduling.PodGroupResourceClaim{Name: "my-other-claim", ResourceClaimTemplateName: new("my-template")},
 			)),
 			enableDRAWorkloadResourceClaims: true,
-			expectedErrs:                    field.ErrorList{field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "").WithOrigin("immutable")},
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("resourceClaims"), nil, "").WithOrigin("immutable"),
+			},
 		},
 		"invalid remove of resource claims, DRA workload resource claims disabled": {
 			oldObj: mkValidWorkload(setResourceVersion("1"), addResourceClaims(
 				scheduling.PodGroupResourceClaim{Name: "my-claim", ResourceClaimTemplateName: new("my-template")},
 			)),
-			updateObj:    mkValidWorkload(setResourceVersion("1")),
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "").WithOrigin("immutable")},
+			updateObj: mkValidWorkload(setResourceVersion("1")),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("resourceClaims"), nil, "").WithOrigin("immutable"),
+			},
 		},
 		"invalid remove of resource claims, DRA workload resource claims enabled": {
 			oldObj: mkValidWorkload(setResourceVersion("1"), addResourceClaims(
@@ -514,22 +564,28 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			)),
 			updateObj:                       mkValidWorkload(setResourceVersion("1")),
 			enableDRAWorkloadResourceClaims: true,
-			expectedErrs:                    field.ErrorList{field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "").WithOrigin("immutable")},
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("resourceClaims"), nil, "").WithOrigin("immutable"),
+			},
 		},
 		"invalid update of disruption mode": {
-			oldObj:       mkValidWorkload(setResourceVersion("1"), setDisruptionModeSingle(0)),
-			updateObj:    mkValidWorkload(setResourceVersion("1"), setDisruptionModeAll(0)),
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "").WithOrigin("immutable")},
+			oldObj:    mkValidWorkload(setResourceVersion("1"), setDisruptionModeSingle(0)),
+			updateObj: mkValidWorkload(setResourceVersion("1"), setDisruptionModeAll(0)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("disruptionMode"), nil, "").WithOrigin("immutable"),
+			},
 		},
 		"invalid update of priority class name": {
 			oldObj:       mkValidWorkload(setResourceVersion("1"), setPriorityClassName(0, "low-priority")),
 			updateObj:    mkValidWorkload(setResourceVersion("1"), setPriorityClassName(0, "high-priority")),
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "").WithOrigin("immutable")},
+			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("priorityClassName"), nil, "").WithOrigin("immutable")},
 		},
 		"invalid update of priority": {
-			oldObj:       mkValidWorkload(setResourceVersion("1"), setPriority(0, 1000)),
-			updateObj:    mkValidWorkload(setResourceVersion("1"), setPriority(0, 2000)),
-			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "podGroupTemplates"), nil, "").WithOrigin("immutable")},
+			oldObj:    mkValidWorkload(setResourceVersion("1"), setPriority(0, 1000)),
+			updateObj: mkValidWorkload(setResourceVersion("1"), setPriority(0, 2000)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("priority"), nil, "").WithOrigin("immutable"),
+			},
 		},
 	}
 	for k, tc := range testCases {

--- a/test/declarative_validation/scheduling/workload/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/scheduling/workload/zz_generated.validations.v1alpha3_test.go
@@ -45,14 +45,16 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"spec.podGroupTemplates": {
-				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
+				{ErrorType: "FieldValueForbidden", Origin: "update"},
 				{ErrorType: "FieldValueRequired"},
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
 			},
 			"spec.podGroupTemplates[*]": {
 				{ErrorType: "FieldValueDuplicate"},
+				{ErrorType: "FieldValueForbidden", Origin: "update"},
 			},
 			"spec.podGroupTemplates[*].disruptionMode": {
+				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 				{ErrorType: "FieldValueInvalid", Origin: "union"},
 			},
 			"spec.podGroupTemplates[*].name": {
@@ -60,12 +62,15 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"spec.podGroupTemplates[*].priority": {
+				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 				{ErrorType: "FieldValueInvalid", Origin: "maximum"},
 			},
 			"spec.podGroupTemplates[*].priorityClassName": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-long-name"},
+				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
 			"spec.podGroupTemplates[*].resourceClaims": {
+				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
 			},
 			"spec.podGroupTemplates[*].resourceClaims[*]": {
@@ -84,6 +89,7 @@ func init() {
 			},
 			"spec.podGroupTemplates[*].schedulingConstraints": {
 				{ErrorType: "FieldValueForbidden"},
+				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
 			"spec.podGroupTemplates[*].schedulingConstraints.topology": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
@@ -94,6 +100,12 @@ func init() {
 			},
 			"spec.podGroupTemplates[*].schedulingPolicy": {
 				{ErrorType: "FieldValueInvalid", Origin: "union"},
+			},
+			"spec.podGroupTemplates[*].schedulingPolicy.basic": {
+				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
+			},
+			"spec.podGroupTemplates[*].schedulingPolicy.gang": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
 			},
 			"spec.podGroupTemplates[*].schedulingPolicy.gang.minCount": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},

--- a/test/integration/scheduler/podgroup/podgroup_test.go
+++ b/test/integration/scheduler/podgroup/podgroup_test.go
@@ -49,6 +49,7 @@ func TestPodGroupScheduling(t *testing.T) {
 		PodGroupTemplate(st.MakePodGroupTemplate().Name("t1").MinCount(3).Obj()).
 		PodGroupTemplate(st.MakePodGroupTemplate().Name("t2").BasicPolicy().Obj()).
 		PodGroupTemplate(st.MakePodGroupTemplate().Name("t-mid").MinCount(2).Obj()).
+		PodGroupTemplate(st.MakePodGroupTemplate().Name("t-mutable").MinCount(5).Obj()).
 		Obj()
 	otherWorkload := st.MakeWorkload().Name("other-workload").
 		PodGroupTemplate(st.MakePodGroupTemplate().Name("t").MinCount(3).Obj()).
@@ -61,6 +62,13 @@ func TestPodGroupScheduling(t *testing.T) {
 		Priority(100).MinCount(3).Obj()
 
 	basicPodGroup := st.MakePodGroup().Name("pg1").TemplateRef("t2", "workload").Priority(100).BasicPolicy().Obj()
+	podGroupWithMinCount5 := st.MakePodGroup().Name("pg-mutable").TemplateRef("t-mutable", "workload").Priority(100).MinCount(5).Obj()
+
+	mutP1 := st.MakePod().Name("mut-p1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-mutable").Priority(105).Obj()
+	mutP2 := st.MakePod().Name("mut-p2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-mutable").Priority(104).Obj()
+	mutP3 := st.MakePod().Name("mut-p3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-mutable").Priority(103).Obj()
+	mutP4 := st.MakePod().Name("mut-p4").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-mutable").Priority(102).Obj()
+	mutP5 := st.MakePod().Name("mut-p5").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-mutable").Priority(101).Obj()
 
 	p1 := st.MakePod().Name("p1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").
 		PodGroupName("pg1").Priority(100).Obj()
@@ -514,6 +522,97 @@ func TestPodGroupScheduling(t *testing.T) {
 				{
 					Name:                     "Verify the entire gang becomes unschedulable",
 					WaitForPodsUnschedulable: []string{"mid-p1", "mid-p2"},
+				},
+			},
+		},
+		{
+			name: "gang pods are unschedulable due to lack of quorum, then scheduled when minCount is decreased",
+			steps: []stepsframework.Step{
+				{
+					Name:           "Create the PodGroup object with minCount=5",
+					CreatePodGroup: podGroupWithMinCount5,
+				},
+				{
+					Name:       "Create 4 pods belonging to the gang (quorum is 5)",
+					CreatePods: []*v1.Pod{mutP1, mutP2, mutP3, mutP4},
+				},
+				{
+					Name:                               "Verify gang pods are gated at PreEnqueue",
+					WaitForPodsInUnschedulableEntities: []string{"mut-p1", "mut-p2", "mut-p3", "mut-p4"},
+				},
+				{
+					Name:           "Update the PodGroup with decreased minCount=4",
+					UpdatePodGroup: (&st.PodGroupWrapper{PodGroup: *podGroupWithMinCount5.DeepCopy()}).MinCount(4).Obj(),
+				},
+				{
+					Name:                 "Verify all gang pods are immediately re-queued and scheduled successfully",
+					WaitForPodsScheduled: []string{"mut-p1", "mut-p2", "mut-p3", "mut-p4"},
+				},
+			},
+		},
+		{
+			name: "gang pods are unschedulable due to lack of space, then scheduled when minCount is decreased",
+			steps: []stepsframework.Step{
+				{
+					Name:           "Create the PodGroup object with minCount=5",
+					CreatePodGroup: podGroupWithMinCount5,
+				},
+				{
+					Name:       "Create 5 pods belonging to the gang",
+					CreatePods: []*v1.Pod{mutP1, mutP2, mutP3, mutP4, mutP5},
+				},
+				{
+					Name:                     "Verify gang pods are unschedulable",
+					WaitForPodsUnschedulable: []string{"mut-p1", "mut-p2", "mut-p3", "mut-p4", "mut-p5"},
+				},
+				{
+					Name:           "Update the PodGroup with decreased minCount=4",
+					UpdatePodGroup: (&st.PodGroupWrapper{PodGroup: *podGroupWithMinCount5.DeepCopy()}).MinCount(4).Obj(),
+				},
+				{
+					Name:                 "Verify 4 gang pods are immediately re-queued and scheduled successfully",
+					WaitForPodsScheduled: []string{"mut-p1", "mut-p2", "mut-p3", "mut-p4"},
+				},
+				{
+					Name:                     "Verify the last gang pod is unschedulable",
+					WaitForPodsUnschedulable: []string{"mut-p5"},
+				},
+			},
+		},
+		{
+			name: "gang pods are unschedulable due to lack of quorum, and remain unschedulable without triggering reschedule when minCount is increased",
+			steps: []stepsframework.Step{
+				{
+					Name:           "Create the PodGroup object with minCount=5",
+					CreatePodGroup: podGroupWithMinCount5,
+				},
+				{
+					Name:       "Create 4 pods belonging to the gang (quorum is 5)",
+					CreatePods: []*v1.Pod{mutP1, mutP2, mutP3, mutP4},
+				},
+				{
+					Name:                               "Verify gang pods are gated at PreEnqueue",
+					WaitForPodsInUnschedulableEntities: []string{"mut-p1", "mut-p2", "mut-p3", "mut-p4"},
+				},
+				{
+					Name: "Verify scheduling attempts of all gang pods is 0",
+					VerifyPodSchedulingAttempts: &stepsframework.VerifyPodsSchedulingAttempts{
+						PodNames:     []string{"mut-p1", "mut-p2", "mut-p3", "mut-p4"},
+						PodGroupName: "pg-mutable",
+						Attempts:     0,
+					},
+				},
+				{
+					Name:           "Update the PodGroup with increased minCount=6",
+					UpdatePodGroup: (&st.PodGroupWrapper{PodGroup: *podGroupWithMinCount5.DeepCopy()}).MinCount(6).Obj(),
+				},
+				{
+					Name: "Verify scheduling attempts of all gang pods is still 0 (did not trigger reschedule/requeue)",
+					VerifyPodSchedulingAttempts: &stepsframework.VerifyPodsSchedulingAttempts{
+						PodNames:     []string{"mut-p1", "mut-p2", "mut-p3", "mut-p4"},
+						PodGroupName: "pg-mutable",
+						Attempts:     0,
+					},
 				},
 			},
 		},

--- a/test/integration/scheduler/podgroup/stepsframework/stepsframework.go
+++ b/test/integration/scheduler/podgroup/stepsframework/stepsframework.go
@@ -24,6 +24,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	schedulingapi "k8s.io/api/scheduling/v1alpha3"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -53,6 +54,12 @@ type VerifyAssignments struct {
 type VerifyAssignedInOneDomain struct {
 	Pods        []string
 	TopologyKey string
+}
+
+type VerifyPodsSchedulingAttempts struct {
+	PodNames     []string
+	PodGroupName string
+	Attempts     int
 }
 
 type UpdatePod struct {
@@ -127,6 +134,8 @@ type Step struct {
 	CreateNodes []*v1.Node
 	// CreatePodGroup is use to create a pod group and wait for it to be ready.
 	CreatePodGroup *schedulingapi.PodGroup
+	// UpdatePodGroup is used to update an existing pod group and wait for it to propagate.
+	UpdatePodGroup *schedulingapi.PodGroup
 	// CreatePods is use to create pods in the cluster.
 	CreatePods []*v1.Pod
 	// CreateWorkloads is use to create workloads in the cluster.
@@ -153,6 +162,8 @@ type Step struct {
 	VerifyAssignments *VerifyAssignments
 	// VerifyAssignedInOneDomain is use to verify that the pods are assigned to nodes in the same domain.
 	VerifyAssignedInOneDomain *VerifyAssignedInOneDomain
+	// VerifyPodSchedulingAttempts is used to check the scheduling attempts of a pods.
+	VerifyPodSchedulingAttempts *VerifyPodsSchedulingAttempts
 	// RunScheduleOne is use to run the scheduling once.
 	// This operation should be used only when the test is not deploying the scheduler's goroutine
 	// (testCtx.Scheduler.Run).
@@ -241,6 +252,38 @@ func createPodGroup(testCtx *testutils.TestContext, ns string, pg *schedulingapi
 	)
 	if err != nil {
 		return fmt.Errorf("failed to wait for pod group %s to be discoverable by scheduler: %w", pgCopy.Name, err)
+	}
+	return nil
+}
+
+func updatePodGroup(testCtx *testutils.TestContext, ns string, pg *schedulingapi.PodGroup) error {
+	cs := testCtx.ClientSet
+	pgCopy := pg.DeepCopy()
+	pgCopy.Namespace = ns
+
+	existing, err := cs.SchedulingV1alpha3().PodGroups(ns).Get(testCtx.Ctx, pgCopy.Name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get existing pod group %s for update: %w", pgCopy.Name, err)
+	}
+	pgCopy.ResourceVersion = existing.ResourceVersion
+
+	if _, err := cs.SchedulingV1alpha3().PodGroups(ns).Update(testCtx.Ctx, pgCopy, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("failed to update pod group %s: %w", pgCopy.Name, err)
+	}
+	err = wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
+		func(_ context.Context) (bool, error) {
+			listerPG, err := testCtx.InformerFactory.Scheduling().V1alpha3().PodGroups().Lister().PodGroups(ns).Get(pgCopy.Name)
+			if err != nil {
+				return false, err
+			}
+			if apiequality.Semantic.DeepEqual(listerPG.Spec.SchedulingPolicy, pgCopy.Spec.SchedulingPolicy) {
+				return true, nil
+			}
+			return false, nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to wait for pod group %s update to be discoverable by scheduler: %w", pgCopy.Name, err)
 	}
 	return nil
 }
@@ -434,6 +477,22 @@ func verifyAssignedInOneDomain(testCtx *testutils.TestContext, ns string, verify
 	return nil
 }
 
+func verifyPodSchedulingAttempts(testCtx *testutils.TestContext, ns string, check *VerifyPodsSchedulingAttempts) error {
+	podGroupName := check.PodGroupName
+	for _, podName := range check.PodNames {
+		pInfo, ok := testCtx.Scheduler.SchedulingQueue.GetPod(podName, ns, &v1.PodSchedulingGroup{
+			PodGroupName: &podGroupName,
+		})
+		if !ok {
+			return fmt.Errorf("pod %s not found in scheduling queue", podName)
+		}
+		if pInfo.Attempts != check.Attempts {
+			return fmt.Errorf("expected pod %s scheduling attempts to be %d, but got %d", podName, check.Attempts, pInfo.Attempts)
+		}
+	}
+	return nil
+}
+
 func runScheduleOne(testCtx *testutils.TestContext) {
 	testCtx.Scheduler.ScheduleOne(testCtx.Ctx)
 }
@@ -455,6 +514,8 @@ func RunSteps(testCtx *testutils.TestContext, t *testing.T, ns string, steps []S
 			err = createPods(testCtx, ns, step.CreatePods)
 		case step.CreatePodGroup != nil:
 			err = createPodGroup(testCtx, ns, step.CreatePodGroup)
+		case step.UpdatePodGroup != nil:
+			err = updatePodGroup(testCtx, ns, step.UpdatePodGroup)
 		case step.CreateWorkloads != nil:
 			err = createWorkloads(testCtx, ns, step.CreateWorkloads)
 		case step.DeletePods != nil:
@@ -479,6 +540,8 @@ func RunSteps(testCtx *testutils.TestContext, t *testing.T, ns string, steps []S
 			err = verifyAssignments(testCtx, ns, step.VerifyAssignments)
 		case step.VerifyAssignedInOneDomain != nil:
 			err = verifyAssignedInOneDomain(testCtx, ns, step.VerifyAssignedInOneDomain)
+		case step.VerifyPodSchedulingAttempts != nil:
+			err = verifyPodSchedulingAttempts(testCtx, ns, step.VerifyPodSchedulingAttempts)
 		case step.RunScheduleOne:
 			runScheduleOne(testCtx)
 		default:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind api-change

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR makes minCount in Workload and PodGroup APIs mutable. This is implementation of change proposed in https://github.com/kubernetes/enhancements/pull/6076
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #139278
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
minCount can be modify after setting in PodGroup and PodGroupTemplate, modifying template is not influencing already existing podgroups. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[Other doc]: https://docs.google.com/document/d/1tflhZdsgxCXfVgb2OrNFuodBStVXd3fdLz-SlC2zxHU
[KEP]: keps/sig-scheduling/4671-gang-scheduling/kep.yaml
```
