### PR TITLE
Make podgroup preemption integration test to check NNN info without setting clearingNominatedNodeNameAfterBinding to flase

### DIFF
--- a/test/integration/scheduler/preemption/podgrouppreemption_test.go
+++ b/test/integration/scheduler/preemption/podgrouppreemption_test.go
@@ -19,6 +19,7 @@ package preemption
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -27,26 +28,32 @@ import (
 	schedulingapi "k8s.io/api/scheduling/v1alpha3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	configv1 "k8s.io/kube-scheduler/config/v1"
+	fwk "k8s.io/kube-scheduler/framework"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler"
+	configtesting "k8s.io/kubernetes/pkg/scheduler/apis/config/testing"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
+	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	testutils "k8s.io/kubernetes/test/integration/util"
+	"k8s.io/utils/ptr"
 )
 
 // TestPodGroupPreemption tests preemption scenarios involving pod groups.
 func TestPodGroupPreemption(t *testing.T) {
 	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-		features.GenericWorkload:                       true,
-		features.GangScheduling:                        true,
-		features.WorkloadAwarePreemption:               true,
-		features.ClearingNominatedNodeNameAfterBinding: false,
+		features.GenericWorkload:         true,
+		features.GangScheduling:          true,
+		features.WorkloadAwarePreemption: true,
 	})
-
 	tests := []struct {
 		name                       string
 		nodes                      []*v1.Node
@@ -730,8 +737,49 @@ func TestPodGroupPreemption(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			registry := make(frameworkruntime.Registry)
+
+			// Register mock bind plugin that will register NNN information during binding.
+			mockBindPluginName := "mockBindPlugin"
+			var bindPlugin = mockBindPlugin{
+				name:       mockBindPluginName,
+				realPlugin: nil,
+				nnnInfo:    sync.Map{},
+			}
+			err := registry.Register(mockBindPluginName, func(ctx context.Context, o runtime.Object, fh fwk.Handle) (fwk.Plugin, error) {
+				db, err := defaultbinder.New(ctx, o, fh)
+				if err != nil {
+					t.Fatalf("Error creating a default binder plugin: %v", err)
+				}
+				bindPlugin.realPlugin = db.(fwk.BindPlugin)
+				return &bindPlugin, nil
+			})
+			if err != nil {
+				t.Fatalf("Error registering a bind plugin: %v", err)
+			}
+
+			cfg := configtesting.V1ToInternalWithDefaults(t, configv1.KubeSchedulerConfiguration{
+				Profiles: []configv1.KubeSchedulerProfile{{
+					SchedulerName: ptr.To(v1.DefaultSchedulerName),
+					Plugins: &configv1.Plugins{
+						MultiPoint: configv1.PluginSet{
+							Enabled: []configv1.Plugin{
+								{Name: mockBindPluginName},
+							},
+							Disabled: []configv1.Plugin{
+								{Name: names.DefaultBinder},
+							},
+						},
+					},
+				}},
+			})
+
+			// Set PodMaxBackoff to 1 second to turn on backoff and allow apiCacher to get information about
+			// pod NNN. Without this we might have a race between starting binding and update of apiCacher.
 			testCtx := testutils.InitTestSchedulerWithNS(t, "podgroup-preemption",
-				scheduler.WithPodMaxBackoffSeconds(0),
+				scheduler.WithProfiles(cfg.Profiles...),
+				scheduler.WithFrameworkOutOfTreeRegistry(registry),
+				scheduler.WithPodMaxBackoffSeconds(1),
 				scheduler.WithPodInitialBackoffSeconds(0))
 			cs, ns := testCtx.ClientSet, testCtx.NS.Name
 
@@ -766,7 +814,7 @@ func TestPodGroupPreemption(t *testing.T) {
 				}
 			}
 
-			// Wait for initial pods to be scheduled
+			// 3. Wait for initial pods to be scheduled
 			for _, p := range tt.initialPods {
 				if err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 10*time.Second, false,
 					testutils.PodScheduled(cs, ns, p.Name)); err != nil {
@@ -774,7 +822,7 @@ func TestPodGroupPreemption(t *testing.T) {
 				}
 			}
 
-			// 3. Create preemptor pods
+			// 4. Create preemptor pods
 			for _, p := range tt.preemptorPods {
 				p.Namespace = ns
 				if _, err := cs.CoreV1().Pods(ns).Create(testCtx.Ctx, p, metav1.CreateOptions{}); err != nil {
@@ -782,7 +830,7 @@ func TestPodGroupPreemption(t *testing.T) {
 				}
 			}
 
-			// 4. Wait for preemption to complete if WAP calls are expected
+			// 5. Wait for preemption to complete if WAP calls are expected
 			if tt.expectedPodsPreemptedByWAP > 0 {
 				err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 10*time.Second, false, func(ctx context.Context) (bool, error) {
 					wapCalls := 0
@@ -811,7 +859,7 @@ func TestPodGroupPreemption(t *testing.T) {
 			for _, podName := range tt.expectedUnschedulable {
 				if err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 10*time.Second, false,
 					testutils.PodUnschedulable(cs, ns, podName)); err != nil {
-					t.Errorf("Pod %s was expected to be unschedulableso  but wasn't: %v", podName, err)
+					t.Errorf("Pod %s was expected to be unschedulable but wasn't: %v", podName, err)
 				}
 			}
 
@@ -843,15 +891,30 @@ func TestPodGroupPreemption(t *testing.T) {
 
 			// 9. Verify preemptor pods have nominated node name
 			for _, podName := range tt.expectedToHaveNNNInfo {
-				pod, err := cs.CoreV1().Pods(ns).Get(testCtx.Ctx, podName, metav1.GetOptions{})
-				if err != nil {
-					t.Errorf("Error getting pod %s: %v", podName, err)
-					continue
-				}
-				if err := testutils.WaitForNominatedNodeName(testCtx.Ctx, cs, pod); err != nil {
-					t.Errorf("Error waiting for nominated node name for pod %s: %v", podName, err)
+				if node, ok := bindPlugin.nnnInfo.Load(podName); !ok || node.(string) == "" {
+					t.Errorf("Pod %s was expected to have nominated node name but didn't", podName)
 				}
 			}
 		})
 	}
 }
+
+// mockBindPlugin is a fake plugin that registers NNN information during binding.
+type mockBindPlugin struct {
+	name       string
+	realPlugin fwk.BindPlugin
+	nnnInfo    sync.Map
+}
+
+func (bp *mockBindPlugin) Name() string {
+	return bp.name
+}
+
+func (bp *mockBindPlugin) Bind(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *fwk.Status {
+	if p.Status.NominatedNodeName != "" {
+		bp.nnnInfo.Store(p.Name, p.Status.NominatedNodeName)
+	}
+	return bp.realPlugin.Bind(ctx, state, p, nodeName)
+}
+
+var _ fwk.BindPlugin = &mockBindPlugin{}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR allows testing behaviour of preemption without setting clearingNominatedNodeNameAfterBinding to false.
It is using default value of the flag, so if flag will be removed this will not be a problem for this test. Behaviour for different settings of clearingNominatedNodeNameAfterBinding is tested in other place.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
