### PR TITLE
Fix midnight date window check in TestLegacyServiceAccountTokenTracking

### DIFF
--- a/test/integration/serviceaccount/service_account_test.go
+++ b/test/integration/serviceaccount/service_account_test.go
@@ -305,7 +305,7 @@ func TestLegacyServiceAccountTokenTracking(t *testing.T) {
 			if !ok {
 				t.Fatalf("Secret wasn't labeled with %q", serviceaccount.LastUsedLabelKey)
 			}
-			if date != dateBefore || date != dateAfter {
+			if date != dateBefore && date != dateAfter {
 				t.Fatalf("Secret was labeled with wrong date: %q", date)
 			}
 		})
@@ -323,7 +323,7 @@ func TestLegacyServiceAccountTokenTracking(t *testing.T) {
 		if !ok {
 			return false, fmt.Errorf("configMap doesn't contain key %q", legacytokentracking.ConfigMapDataKey)
 		}
-		if date != dateBefore || date != dateAfter {
+		if date != dateBefore && date != dateAfter {
 			return false, fmt.Errorf("configMap contains a wrong date %q", date)
 		}
 		return true, nil


### PR DESCRIPTION
Fixes #139284.

## Summary
- allow either `dateBefore` or `dateAfter` in the secret label assertion
- allow either boundary date in the ConfigMap assertion
- preserve the intended midnight-tolerant behavior of the test

## Testing
- `PATH="/Users/hoangvu/Code/OSS/kubernetes/third_party/etcd:$PATH" go test ./test/integration/serviceaccount -run TestLegacyServiceAccountTokenTracking -count=1`
