### PR TITLE
Fix PodGroup workload-aware preemption dropping nominated nodes for unevaluated pods

### DIFF
--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -435,22 +435,6 @@ func TestCompletePodGroupAlgorithmResult_SetsPod(t *testing.T) {
 			t.Errorf("expected pod result %d status code %v, got %v", i+1, groupStatus.Code(), got.status.Code())
 		}
 	}
-
-	nominatedNodes := map[*v1.Pod]*fwk.NominatingInfo{
-		p2: {NominatingMode: fwk.ModeOverride, NominatedNodeName: "node2"},
-		p3: {NominatingMode: fwk.ModeOverride, NominatedNodeName: "node3"},
-	}
-	for i := range result.podResults {
-		if nodeNameInfo, ok := nominatedNodes[result.podResults[i].pod]; ok {
-			result.podResults[i].scheduleResult.nominatingInfo = nodeNameInfo
-		}
-	}
-	if result.podResults[1].scheduleResult.nominatingInfo.NominatedNodeName != "node2" {
-		t.Errorf("expected p2 nominated node node2, got %q", result.podResults[1].scheduleResult.nominatingInfo.NominatedNodeName)
-	}
-	if result.podResults[2].scheduleResult.nominatingInfo.NominatedNodeName != "node3" {
-		t.Errorf("expected p3 nominated node node3, got %q", result.podResults[2].scheduleResult.nominatingInfo.NominatedNodeName)
-	}
 }
 
 func TestPodGroupCycle_FillsPodResultsOnFewerResults(t *testing.T) {

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -392,6 +392,67 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 	}
 }
 
+func TestCompletePodGroupAlgorithmResult_SetsPod(t *testing.T) {
+	p1 := st.MakePod().Name("p1").UID("p1").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
+	p2 := st.MakePod().Name("p2").UID("p2").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
+	p3 := st.MakePod().Name("p3").UID("p3").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
+
+	qInfo1 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p1}}
+	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
+	qInfo3 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p3}}
+
+	podGroupInfo := &framework.QueuedPodGroupInfo{
+		QueuedPodInfos: []*framework.QueuedPodInfo{qInfo1, qInfo2, qInfo3},
+	}
+
+	_, ctx := ktesting.NewTestContext(t)
+	podGroupState := framework.NewCycleState()
+	groupStatus := fwk.NewStatus(fwk.Unschedulable, "pod group unschedulable")
+
+	result := completePodGroupAlgorithmResult(ctx, podGroupInfo, podGroupState, runAllPostFilters, podGroupAlgorithmResult{
+		status: groupStatus,
+		podResults: []algorithmResult{{
+			pod:    p1,
+			status: fwk.NewStatus(fwk.Unschedulable, "p1 unschedulable"),
+		}},
+	})
+
+	if len(result.podResults) != 3 {
+		t.Fatalf("expected 3 pod results, got %d", len(result.podResults))
+	}
+	if result.podResults[0].pod != p1 {
+		t.Errorf("expected pod result 0 to reference p1, got %v", result.podResults[0].pod)
+	}
+	for i, wantPod := range []*v1.Pod{p2, p3} {
+		got := result.podResults[i+1]
+		if got.pod != wantPod {
+			t.Errorf("expected pod result %d to reference %q, got %v", i+1, wantPod.Name, got.pod)
+		}
+		if got.podCtx == nil {
+			t.Errorf("expected pod result %d to have podCtx set", i+1)
+		}
+		if got.status.Code() != groupStatus.Code() {
+			t.Errorf("expected pod result %d status code %v, got %v", i+1, groupStatus.Code(), got.status.Code())
+		}
+	}
+
+	nominatedNodes := map[*v1.Pod]*fwk.NominatingInfo{
+		p2: {NominatingMode: fwk.ModeOverride, NominatedNodeName: "node2"},
+		p3: {NominatingMode: fwk.ModeOverride, NominatedNodeName: "node3"},
+	}
+	for i := range result.podResults {
+		if nodeNameInfo, ok := nominatedNodes[result.podResults[i].pod]; ok {
+			result.podResults[i].scheduleResult.nominatingInfo = nodeNameInfo
+		}
+	}
+	if result.podResults[1].scheduleResult.nominatingInfo.NominatedNodeName != "node2" {
+		t.Errorf("expected p2 nominated node node2, got %q", result.podResults[1].scheduleResult.nominatingInfo.NominatedNodeName)
+	}
+	if result.podResults[2].scheduleResult.nominatingInfo.NominatedNodeName != "node3" {
+		t.Errorf("expected p3 nominated node node3, got %q", result.podResults[2].scheduleResult.nominatingInfo.NominatedNodeName)
+	}
+}
+
 func TestPodGroupCycle_FillsPodResultsOnFewerResults(t *testing.T) {
 	testPodGroup := st.MakePodGroup().Name("pg").Namespace("default").Obj()
 	p1 := st.MakePod().Name("p1").UID("p1").PodGroupName("pg").SchedulerName("test-scheduler").Obj()

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -409,30 +409,34 @@ func TestCompletePodGroupAlgorithmResult_SetsPod(t *testing.T) {
 	podGroupState := framework.NewCycleState()
 	groupStatus := fwk.NewStatus(fwk.Unschedulable, "pod group unschedulable")
 
-	result := completePodGroupAlgorithmResult(ctx, podGroupInfo, podGroupState, runAllPostFilters, podGroupAlgorithmResult{
+	podGroupResult := podGroupAlgorithmResult{
 		status: groupStatus,
 		podResults: []algorithmResult{{
 			pod:    p1,
 			status: fwk.NewStatus(fwk.Unschedulable, "p1 unschedulable"),
 		}},
-	})
+	}
+	numInResult := len(podGroupResult.podResults)
+
+	result := completePodGroupAlgorithmResult(ctx, podGroupInfo, podGroupState, runAllPostFilters, podGroupResult)
 
 	if len(result.podResults) != 3 {
 		t.Fatalf("expected 3 pod results, got %d", len(result.podResults))
 	}
-	if result.podResults[0].pod != p1 {
-		t.Errorf("expected pod result 0 to reference p1, got %v", result.podResults[0].pod)
-	}
-	for i, wantPod := range []*v1.Pod{p2, p3} {
-		got := result.podResults[i+1]
+	wantPods := []*v1.Pod{p1, p2, p3}
+	for i, wantPod := range wantPods {
+		got := result.podResults[i]
 		if got.pod != wantPod {
-			t.Errorf("expected pod result %d to reference %q, got %v", i+1, wantPod.Name, got.pod)
+			t.Errorf("expected pod result %d to reference %q, got %v", i, wantPod.Name, got.pod)
+		}
+		if i < numInResult {
+			continue
 		}
 		if got.podCtx == nil {
-			t.Errorf("expected pod result %d to have podCtx set", i+1)
+			t.Errorf("expected pod result %d to have podCtx set", i)
 		}
 		if got.status.Code() != groupStatus.Code() {
-			t.Errorf("expected pod result %d status code %v, got %v", i+1, groupStatus.Code(), got.status.Code())
+			t.Errorf("expected pod result %d status code %v, got %v", i, groupStatus.Code(), got.status.Code())
 		}
 	}
 }


### PR DESCRIPTION


#### What type of PR is this?
 
/kind bug

#### What this PR does / why we need it:

Failure behavior
  After successful WAP, padded entries have algorithmResult.pod == nil. In podGroupCycle, nominated nodes are applied with:   pgPostFilterResult.NominatedNodeNames[result.podResults[i].pod]

 Lookup with a nil key does not panic; it simply returns ok == false. Those pods never get scheduleResult.nominatingInfo set, so FailureHandler does  not persist the expected nominated node for them.

 User-visible effect: 
only some PodGroup members get a nominated node after preemption; others behave as if preemption did not nominate them, which  can increase re-queuing, extra scheduling attempts, and inconsistent gang/workload scheduling state.

Expected behavior
  Every pod in the group should have a podResults entry whose pod field matches the *v1.Pod used as the key in NominatedNodeNames. After WAP, all pods   that received a nomination in PodGroupPostFilter should get nominatingInfo copied into their algorithmResult, then passed through
  submitPodGroupAlgorithmResult / FailureHandler like already-evaluated pods.

 Root cause
 PR #139130 introduced completePodGroupAlgorithmResult to fix incomplete podResults before WAP (moved padding out of submitPodGroupAlgorithmResult).
 The padding path initialized only podCtx and status, omitting pod, while the per-pod scheduling path always sets pod. WAP matching depends on pointer identity in map[*v1.Pod], so padded rows could never match preemption output.



#### Which issue(s) this PR is related to:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
