### PR TITLE
apiserver: proxy params to Pods and Services

### DIFF
--- a/pkg/registry/core/pod/rest/subresources.go
+++ b/pkg/registry/core/pod/rest/subresources.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/proxy"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -83,6 +84,19 @@ func (r *ProxyREST) Connect(ctx context.Context, id string, opts runtime.Object,
 		return nil, err
 	}
 	location.Path = net.JoinPreservingTrailingSlash(location.Path, proxyOpts.Path)
+	// UpgradeAwareHandler preserves raw query parameters for HTTP requests (by copying
+	// request.URL.RawQuery in ServeHTTP) but does not do so for upgraded connection requests
+	// (e.g., WebSockets/SPDY) unless UseRequestLocation is enabled.
+	//
+	// Modifying UpgradeAwareHandler to handle this is risky due to its widespread use and
+	// complexity. Instead, we preemptively copy the query parameters here. We only do so
+	// if location.RawQuery is empty to avoid overriding any query parameters defined by
+	// the resource location generator.
+	if requestInfo, ok := request.RequestInfoFrom(ctx); ok {
+		if len(location.RawQuery) == 0 {
+			location.RawQuery = requestInfo.RawQuery
+		}
+	}
 	// Return a proxy handler that uses the desired transport, wrapped with additional proxy handling (to get URL rewriting, X-Forwarded-* headers, etc)
 	return newThrottledUpgradeAwareProxyHandler(location, transport, true, false, responder), nil
 }

--- a/pkg/registry/core/service/proxy.go
+++ b/pkg/registry/core/service/proxy.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/proxy"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/capabilities"
@@ -73,6 +74,19 @@ func (r *ProxyREST) Connect(ctx context.Context, id string, opts runtime.Object,
 		return nil, err
 	}
 	location.Path = net.JoinPreservingTrailingSlash(location.Path, proxyOpts.Path)
+	// UpgradeAwareHandler preserves raw query parameters for HTTP requests (by copying
+	// request.URL.RawQuery in ServeHTTP) but does not do so for upgraded connection requests
+	// (e.g., WebSockets/SPDY) unless UseRequestLocation is enabled.
+	//
+	// Modifying UpgradeAwareHandler to handle this is risky due to its widespread use and
+	// complexity. Instead, we preemptively copy the query parameters here. We only do so
+	// if location.RawQuery is empty to avoid overriding any query parameters defined by
+	// the resource location generator.
+	if requestInfo, ok := request.RequestInfoFrom(ctx); ok {
+		if len(location.RawQuery) == 0 {
+			location.RawQuery = requestInfo.RawQuery
+		}
+	}
 	// Return a proxy handler that uses the desired transport, wrapped with additional proxy handling (to get URL rewriting, X-Forwarded-* headers, etc)
 	return newThrottledUpgradeAwareProxyHandler(location, transport, true, false, responder), nil
 }

--- a/pkg/registry/core/service/proxy_test.go
+++ b/pkg/registry/core/service/proxy_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/proxy"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	api "k8s.io/kubernetes/pkg/apis/core"
+)
+
+type fakeRedirector struct {
+	location  *url.URL
+	transport http.RoundTripper
+	err       error
+}
+
+func (f *fakeRedirector) ResourceLocation(ctx context.Context, id string) (*url.URL, http.RoundTripper, error) {
+	return f.location, f.transport, f.err
+}
+
+type fakeResponder struct {
+	err error
+}
+
+func (f *fakeResponder) Error(err error) {
+	f.err = err
+}
+
+func (f *fakeResponder) Object(statusCode int, obj runtime.Object) {}
+
+func TestProxyConnectRawQuery(t *testing.T) {
+	tests := []struct {
+		name             string
+		initialRawQuery  string
+		requestRawQuery  string
+		expectedRawQuery string
+	}{
+		{
+			name:             "empty initial query, has request query",
+			initialRawQuery:  "",
+			requestRawQuery:  "foo=bar",
+			expectedRawQuery: "foo=bar",
+		},
+		{
+			name:             "has initial query, has request query",
+			initialRawQuery:  "existing=param",
+			requestRawQuery:  "foo=bar",
+			expectedRawQuery: "existing=param",
+		},
+		{
+			name:             "has initial query, empty request query",
+			initialRawQuery:  "existing=param",
+			requestRawQuery:  "",
+			expectedRawQuery: "existing=param",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			redirector := &fakeRedirector{
+				location: &url.URL{
+					Scheme:   "http",
+					Host:     "localhost:1234",
+					RawQuery: tc.initialRawQuery,
+				},
+			}
+			r := &ProxyREST{
+				Redirector: redirector,
+			}
+
+			ctx := context.Background()
+			if tc.requestRawQuery != "" || tc.initialRawQuery != "" {
+				info := &request.RequestInfo{
+					RawQuery: tc.requestRawQuery,
+				}
+				ctx = request.WithRequestInfo(ctx, info)
+			}
+
+			handler, err := r.Connect(ctx, "test-service", &api.ServiceProxyOptions{}, &fakeResponder{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if handler == nil {
+				t.Fatal("handler should not be nil")
+			}
+
+			upgradeHandler, ok := handler.(*proxy.UpgradeAwareHandler)
+			if !ok {
+				t.Fatalf("expected *proxy.UpgradeAwareHandler, got %T", handler)
+			}
+
+			if upgradeHandler.Location.RawQuery != tc.expectedRawQuery {
+				t.Errorf("expected RawQuery to be %q, got %q", tc.expectedRawQuery, upgradeHandler.Location.RawQuery)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo.go
@@ -69,6 +69,8 @@ type RequestInfo struct {
 	// LabelSelector contains the unparsed field selector from a request.  It is only present if the apiserver
 	// honors field selectors for the verb this request is associated with.
 	LabelSelector string
+	// RawQuery contains the raw query string of the request.
+	RawQuery string
 }
 
 // specialVerbs contains just strings which are used in REST paths for special actions that don't fall under the normal
@@ -130,6 +132,7 @@ func (r *RequestInfoFactory) NewRequestInfo(req *http.Request) (*RequestInfo, er
 		IsResourceRequest: false,
 		Path:              req.URL.Path,
 		Verb:              strings.ToLower(req.Method),
+		RawQuery:          req.URL.RawQuery,
 	}
 
 	currentParts := splitPath(req.URL.Path)

--- a/test/integration/apiserver/proxy/main_test.go
+++ b/test/integration/apiserver/proxy/main_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestMain(m *testing.M) {
+	framework.EtcdMain(m.Run)
+}

--- a/test/integration/apiserver/proxy/proxy_test.go
+++ b/test/integration/apiserver/proxy/proxy_test.go
@@ -1,0 +1,574 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/net/websocket"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
+	"k8s.io/kubernetes/pkg/controlplane"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func buildWebsocketConfig(u *url.URL, config *restclient.Config) (*websocket.Config, error) {
+	tlsConfig, err := restclient.TLSConfigFor(config)
+	if err != nil {
+		return nil, err
+	}
+	if u.Scheme == "https" {
+		u.Scheme = "wss"
+	} else {
+		u.Scheme = "ws"
+	}
+	cfg, err := websocket.NewConfig(u.String(), "http://localhost")
+	if err != nil {
+		return nil, err
+	}
+	cfg.Header = make(http.Header)
+	if len(config.BearerToken) > 0 {
+		cfg.Header.Set("Authorization", "Bearer "+config.BearerToken)
+	}
+	cfg.TlsConfig = tlsConfig
+	return cfg, nil
+}
+
+func TestProxyForwarding(t *testing.T) {
+	ns := "default"
+	fakeHTTPPodIP := "10.0.0.10"
+	fakeHTTPSPodIP := "10.0.0.20"
+
+	// 1. Setup HTTP Backend
+	receivedHTTPQuery := make(chan string, 10)
+	httpBackendHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Upgrade") == "websocket" {
+			receivedHTTPQuery <- r.URL.RawQuery
+			websocket.Handler(func(ws *websocket.Conn) {
+				_, _ = ws.Write([]byte("hello-ws"))
+			}).ServeHTTP(w, r)
+			return
+		}
+		receivedHTTPQuery <- r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello-http"))
+	})
+
+	httpBackendServer := httptest.NewServer(httpBackendHandler)
+	defer httpBackendServer.Close()
+
+	httpBackendURL, err := url.Parse(httpBackendServer.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	httpBackendPort := httpBackendURL.Port()
+	httpBackendPortVal, err := strconv.Atoi(httpBackendPort)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 2. Setup HTTPS Backend
+	receivedHTTPSQuery := make(chan string, 10)
+	httpsBackendHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Upgrade") == "websocket" {
+			receivedHTTPSQuery <- r.URL.RawQuery
+			websocket.Handler(func(ws *websocket.Conn) {
+				_, _ = ws.Write([]byte("hello-wss"))
+			}).ServeHTTP(w, r)
+			return
+		}
+		receivedHTTPSQuery <- r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello-https"))
+	})
+
+	httpsBackendServer := httptest.NewTLSServer(httpsBackendHandler)
+	defer httpsBackendServer.Close()
+
+	httpsBackendURL, err := url.Parse(httpsBackendServer.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	httpsBackendPort := httpsBackendURL.Port()
+	httpsBackendPortVal, err := strconv.Atoi(httpsBackendPort)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	originalDialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	proxyDialer := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return originalDialer.DialContext(ctx, network, addr)
+		}
+		switch host {
+		case fakeHTTPPodIP:
+			if port != httpBackendPort {
+				t.Errorf("Expected dialer to dial port %s for fakeHTTPPodIP, got %s", httpBackendPort, port)
+			}
+			addr = net.JoinHostPort("127.0.0.1", httpBackendPort)
+		case fakeHTTPSPodIP:
+			if port != httpsBackendPort {
+				t.Errorf("Expected dialer to dial port %s for fakeHTTPSPodIP, got %s", httpsBackendPort, port)
+			}
+			addr = net.JoinHostPort("127.0.0.1", httpsBackendPort)
+		}
+		return originalDialer.DialContext(ctx, network, addr)
+	}
+
+	setup := framework.TestServerSetup{
+		ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
+			opts.Admission.GenericAdmission.DisablePlugins = []string{"ServiceAccount"}
+		},
+		ModifyServerConfig: func(config *controlplane.Config) {
+			config.ControlPlane.Extra.ProxyTransport.DialContext = proxyDialer
+		},
+	}
+	_, clientConfig, tearDown := framework.StartTestServer(context.TODO(), t, setup)
+	defer tearDown()
+
+	clientset, err := kubernetes.NewForConfig(clientConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create Pod pointing to HTTP Backend with a fake global unicast IP
+	httpPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "http-pod", Namespace: ns},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "nginx", Image: "nginx"}},
+		},
+	}
+	createdHTTPPod, err := clientset.CoreV1().Pods(ns).Create(context.TODO(), httpPod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	createdHTTPPod.Status.PodIP = fakeHTTPPodIP
+	createdHTTPPod.Status.Phase = corev1.PodRunning
+	_, err = clientset.CoreV1().Pods(ns).UpdateStatus(context.TODO(), createdHTTPPod, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create Pod pointing to HTTPS Backend with a fake global unicast IP
+	httpsPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "https-pod", Namespace: ns},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "nginx", Image: "nginx"}},
+		},
+	}
+	createdHTTPSPod, err := clientset.CoreV1().Pods(ns).Create(context.TODO(), httpsPod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	createdHTTPSPod.Status.PodIP = fakeHTTPSPodIP
+	createdHTTPSPod.Status.Phase = corev1.PodRunning
+	_, err = clientset.CoreV1().Pods(ns).UpdateStatus(context.TODO(), createdHTTPSPod, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create Services pointing to our pods
+	httpService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "http-service", Namespace: ns},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Port:       80,
+					TargetPort: intstr.FromInt(httpBackendPortVal),
+				},
+			},
+		},
+	}
+	_, err = clientset.CoreV1().Services(ns).Create(context.TODO(), httpService, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//nolint:staticcheck // SA1019 Endpoints is deprecated, but still used in the apiserver
+	httpEndpoints := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{Name: "http-service", Namespace: ns},
+		//nolint:staticcheck // SA1019 EndpointSubset is deprecated, but still used in the apiserver
+		Subsets: []corev1.EndpointSubset{
+			{
+				Addresses: []corev1.EndpointAddress{
+					{
+						IP: fakeHTTPPodIP,
+						TargetRef: &corev1.ObjectReference{
+							Kind:      "Pod",
+							Name:      "http-pod",
+							Namespace: ns,
+						},
+					},
+				},
+				Ports: []corev1.EndpointPort{
+					{
+						Name: "http",
+						Port: int32(httpBackendPortVal),
+					},
+				},
+			},
+		},
+	}
+	_, err = clientset.CoreV1().Endpoints(ns).Create(context.TODO(), httpEndpoints, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	httpsService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "https-service", Namespace: ns},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "https",
+					Port:       443,
+					TargetPort: intstr.FromInt(httpsBackendPortVal),
+				},
+			},
+		},
+	}
+	_, err = clientset.CoreV1().Services(ns).Create(context.TODO(), httpsService, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//nolint:staticcheck // SA1019 Endpoints is deprecated, but still used in the apiserver
+	httpsEndpoints := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{Name: "https-service", Namespace: ns},
+		//nolint:staticcheck // SA1019 EndpointSubset is deprecated, but still used in the apiserver
+		Subsets: []corev1.EndpointSubset{
+			{
+				Addresses: []corev1.EndpointAddress{
+					{
+						IP: fakeHTTPSPodIP,
+						TargetRef: &corev1.ObjectReference{
+							Kind:      "Pod",
+							Name:      "https-pod",
+							Namespace: ns,
+						},
+					},
+				},
+				Ports: []corev1.EndpointPort{
+					{
+						Name: "https",
+						Port: int32(httpsBackendPortVal),
+					},
+				},
+			},
+		},
+	}
+	_, err = clientset.CoreV1().Endpoints(ns).Create(context.TODO(), httpsEndpoints, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Helper for constructing clients
+	httpClient, err := restclient.HTTPClientFor(clientConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Subtest 1: HTTP Pod Proxy
+	t.Run("HTTP", func(t *testing.T) {
+		proxyPath := "/api/v1/namespaces/" + ns + "/pods/http-pod:" + httpBackendPort + "/proxy/?foo=bar"
+		resp, err := httpClient.Get(clientConfig.Host + proxyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close() //nolint:errcheck
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected 200 OK, got %d", resp.StatusCode)
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(body) != "hello-http" {
+			t.Errorf("expected 'hello-http', got %q", string(body))
+		}
+
+		select {
+		case q := <-receivedHTTPQuery:
+			if !strings.Contains(q, "foo=bar") {
+				t.Errorf("expected query 'foo=bar', got %q", q)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for query string")
+		}
+	})
+
+	// Subtest 2: HTTPS Pod Proxy
+	t.Run("HTTPS", func(t *testing.T) {
+		proxyPath := "/api/v1/namespaces/" + ns + "/pods/https:https-pod:" + httpsBackendPort + "/proxy/?foo=bar"
+		resp, err := httpClient.Get(clientConfig.Host + proxyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close() //nolint:errcheck
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected 200 OK, got %d", resp.StatusCode)
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(body) != "hello-https" {
+			t.Errorf("expected 'hello-https', got %q", string(body))
+		}
+
+		select {
+		case q := <-receivedHTTPSQuery:
+			if !strings.Contains(q, "foo=bar") {
+				t.Errorf("expected query 'foo=bar', got %q", q)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for query string")
+		}
+	})
+
+	// Subtest 3: WS (WebSocket Unsecured) Pod Proxy
+	t.Run("WS", func(t *testing.T) {
+		proxyPath := "/api/v1/namespaces/" + ns + "/pods/http-pod:" + httpBackendPort + "/proxy/?foo=bar"
+		u, err := url.Parse(clientConfig.Host + proxyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wsc, err := buildWebsocketConfig(u, clientConfig)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wsConn, err := websocket.DialConfig(wsc)
+		if err != nil {
+			t.Fatalf("websocket Dial failed: %v", err)
+		}
+		defer wsConn.Close() //nolint:errcheck
+
+		var msg = make([]byte, 512)
+		n, err := wsConn.Read(msg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(msg[:n]) != "hello-ws" {
+			t.Errorf("expected 'hello-ws', got %q", string(msg[:n]))
+		}
+
+		select {
+		case q := <-receivedHTTPQuery:
+			if !strings.Contains(q, "foo=bar") {
+				t.Errorf("expected query 'foo=bar', got %q", q)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for query string")
+		}
+	})
+
+	// Subtest 4: WSS (WebSocket Secured) Pod Proxy
+	t.Run("WSS", func(t *testing.T) {
+		proxyPath := "/api/v1/namespaces/" + ns + "/pods/https:https-pod:" + httpsBackendPort + "/proxy/?foo=bar"
+		u, err := url.Parse(clientConfig.Host + proxyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wsc, err := buildWebsocketConfig(u, clientConfig)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wsConn, err := websocket.DialConfig(wsc)
+		if err != nil {
+			t.Fatalf("websocket Dial failed: %v", err)
+		}
+		defer wsConn.Close() //nolint:errcheck
+
+		var msg = make([]byte, 512)
+		n, err := wsConn.Read(msg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(msg[:n]) != "hello-wss" {
+			t.Errorf("expected 'hello-wss', got %q", string(msg[:n]))
+		}
+
+		select {
+		case q := <-receivedHTTPSQuery:
+			if !strings.Contains(q, "foo=bar") {
+				t.Errorf("expected query 'foo=bar', got %q", q)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for query string")
+		}
+	})
+
+	// Subtest 5: HTTP Service Proxy
+	t.Run("HTTPService", func(t *testing.T) {
+		proxyPath := "/api/v1/namespaces/" + ns + "/services/http-service:80/proxy/?foo=bar"
+		resp, err := httpClient.Get(clientConfig.Host + proxyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close() //nolint:errcheck
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected 200 OK, got %d", resp.StatusCode)
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(body) != "hello-http" {
+			t.Errorf("expected 'hello-http', got %q", string(body))
+		}
+
+		select {
+		case q := <-receivedHTTPQuery:
+			if !strings.Contains(q, "foo=bar") {
+				t.Errorf("expected query 'foo=bar', got %q", q)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for query string")
+		}
+	})
+
+	// Subtest 6: HTTPS Service Proxy
+	t.Run("HTTPSService", func(t *testing.T) {
+		proxyPath := "/api/v1/namespaces/" + ns + "/services/https:https-service:443/proxy/?foo=bar"
+		resp, err := httpClient.Get(clientConfig.Host + proxyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close() //nolint:errcheck
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected 200 OK, got %d", resp.StatusCode)
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(body) != "hello-https" {
+			t.Errorf("expected 'hello-https', got %q", string(body))
+		}
+
+		select {
+		case q := <-receivedHTTPSQuery:
+			if !strings.Contains(q, "foo=bar") {
+				t.Errorf("expected query 'foo=bar', got %q", q)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for query string")
+		}
+	})
+
+	// Subtest 7: WS Service Proxy
+	t.Run("WSService", func(t *testing.T) {
+		proxyPath := "/api/v1/namespaces/" + ns + "/services/http-service:80/proxy/?foo=bar"
+		u, err := url.Parse(clientConfig.Host + proxyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wsc, err := buildWebsocketConfig(u, clientConfig)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wsConn, err := websocket.DialConfig(wsc)
+		if err != nil {
+			t.Fatalf("websocket Dial failed: %v", err)
+		}
+		defer wsConn.Close() //nolint:errcheck
+
+		var msg = make([]byte, 512)
+		n, err := wsConn.Read(msg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(msg[:n]) != "hello-ws" {
+			t.Errorf("expected 'hello-ws', got %q", string(msg[:n]))
+		}
+
+		select {
+		case q := <-receivedHTTPQuery:
+			if !strings.Contains(q, "foo=bar") {
+				t.Errorf("expected query 'foo=bar', got %q", q)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for query string")
+		}
+	})
+
+	// Subtest 8: WSS Service Proxy
+	t.Run("WSSService", func(t *testing.T) {
+		proxyPath := "/api/v1/namespaces/" + ns + "/services/https:https-service:443/proxy/?foo=bar"
+		u, err := url.Parse(clientConfig.Host + proxyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wsc, err := buildWebsocketConfig(u, clientConfig)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wsConn, err := websocket.DialConfig(wsc)
+		if err != nil {
+			t.Fatalf("websocket Dial failed: %v", err)
+		}
+		defer wsConn.Close() //nolint:errcheck
+
+		var msg = make([]byte, 512)
+		n, err := wsConn.Read(msg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(msg[:n]) != "hello-wss" {
+			t.Errorf("expected 'hello-wss', got %q", string(msg[:n]))
+		}
+
+		select {
+		case q := <-receivedHTTPSQuery:
+			if !strings.Contains(q, "foo=bar") {
+				t.Errorf("expected query 'foo=bar', got %q", q)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for query string")
+		}
+	})
+}


### PR DESCRIPTION
The apiserver exposes a functionality to proxy request to pods, nodes and services.

For HTTP request, it proxies the request including the query parameters. However, when the request is upgraded to another protocol, like websockets, the query parameters are omitted.

The main problem is that the apiserver reuses the UpgradeAwareHandler for a bunch of codepaths, and changing a behavior like that can conflict with another features that may depend on the query parameters (exec, portforward, logs, ...)

Since the UpgradeAwareHandler on upgrades respect the passed location, we just pass the query parameters on the Pods and Services connect methods, so it is forwarded and not stripped.

/kind bug
/kind dependency

```release-note
apiserver: Preserve query parameters on WebSocket and other upgraded protocol proxy connections to Pods and Services.
```

Fixes: #77142

/sig api-machinery
/assign @liggitt 

> Human at the wheel, AI in the passenger seat