### PR TITLE
Fix flaky TestNewMainKubelet tests by waiting for GC goroutines to finish

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -649,6 +649,7 @@ func NewMainKubelet(ctx context.Context,
 		podStartupLatencyTracker:     kubeDeps.PodStartupLatencyTracker,
 		healthChecker:                kubeDeps.HealthChecker,
 		flagz:                        kubeDeps.Flagz,
+		gcDoneCh:                     make(chan struct{}),
 	}
 
 	var secretManager secret.Manager
@@ -1591,6 +1592,9 @@ type Kubelet struct {
 
 	// podsServer is the server that provides the pods gRPC service.
 	podsServer *pods.PodsServer
+
+	// gcDoneCh is closed once all garbage collection goroutines have finished.
+	gcDoneCh chan struct{}
 }
 
 // ListPodStats is delegated to StatsProvider, which implements stats.Provider interface
@@ -1694,21 +1698,31 @@ func (kl *Kubelet) setupDataDirs(logger klog.Logger) error {
 func (kl *Kubelet) StartGarbageCollection(ctx context.Context) {
 	logger := klog.FromContext(ctx)
 	loggedContainerGCFailure := false
-	go wait.UntilWithContext(ctx, func(ctx context.Context) {
-		if err := kl.containerGC.GarbageCollect(ctx); err != nil {
-			logger.Error(err, "Container garbage collection failed")
-			kl.recorder.WithLogger(logger).Eventf(kl.nodeRef, v1.EventTypeWarning, events.ContainerGCFailed, "%s", err.Error())
-			loggedContainerGCFailure = true
-		} else {
-			var vLevel klog.Level = 4
-			if loggedContainerGCFailure {
-				vLevel = 1
-				loggedContainerGCFailure = false
-			}
 
-			logger.V(int(vLevel)).Info("Container garbage collection succeeded")
-		}
-	}, ContainerGCPeriod)
+	var wg sync.WaitGroup
+
+	wg.Go(func() {
+		wait.UntilWithContext(ctx, func(ctx context.Context) {
+			if err := kl.containerGC.GarbageCollect(ctx); err != nil {
+				logger.Error(err, "Container garbage collection failed")
+				kl.recorder.WithLogger(logger).Eventf(kl.nodeRef, v1.EventTypeWarning, events.ContainerGCFailed, "%s", err.Error())
+				loggedContainerGCFailure = true
+			} else {
+				var vLevel klog.Level = 4
+				if loggedContainerGCFailure {
+					vLevel = 1
+					loggedContainerGCFailure = false
+				}
+
+				logger.V(int(vLevel)).Info("Container garbage collection succeeded")
+			}
+		}, ContainerGCPeriod)
+	})
+
+	go func() {
+		wg.Wait()
+		close(kl.gcDoneCh)
+	}()
 
 	// when the high threshold is set to 100, and the max age is 0 (or the max age feature is disabled)
 	// stub the image GC manager
@@ -1719,26 +1733,33 @@ func (kl *Kubelet) StartGarbageCollection(ctx context.Context) {
 
 	prevImageGCFailed := false
 	beganGC := time.Now()
-	go wait.UntilWithContext(ctx, func(ctx context.Context) {
-		if err := kl.imageManager.GarbageCollect(ctx, beganGC); err != nil {
-			if prevImageGCFailed {
-				logger.Error(err, "Image garbage collection failed multiple times in a row")
-				// Only create an event for repeated failures
-				kl.recorder.WithLogger(logger).Event(kl.nodeRef, v1.EventTypeWarning, events.ImageGCFailed, err.Error())
+	wg.Go(func() {
+		wait.UntilWithContext(ctx, func(ctx context.Context) {
+			if err := kl.imageManager.GarbageCollect(ctx, beganGC); err != nil {
+				if prevImageGCFailed {
+					logger.Error(err, "Image garbage collection failed multiple times in a row")
+					// Only create an event for repeated failures
+					kl.recorder.WithLogger(logger).Event(kl.nodeRef, v1.EventTypeWarning, events.ImageGCFailed, err.Error())
+				} else {
+					logger.Error(err, "Image garbage collection failed once. Stats initialization may not have completed yet")
+				}
+				prevImageGCFailed = true
 			} else {
-				logger.Error(err, "Image garbage collection failed once. Stats initialization may not have completed yet")
-			}
-			prevImageGCFailed = true
-		} else {
-			var vLevel klog.Level = 4
-			if prevImageGCFailed {
-				vLevel = 1
-				prevImageGCFailed = false
-			}
+				var vLevel klog.Level = 4
+				if prevImageGCFailed {
+					vLevel = 1
+					prevImageGCFailed = false
+				}
 
-			logger.V(int(vLevel)).Info("Image garbage collection succeeded")
-		}
-	}, ImageGCPeriod)
+				logger.V(int(vLevel)).Info("Image garbage collection succeeded")
+			}
+		}, ImageGCPeriod)
+	})
+}
+
+// waitForGarbageCollectionDone waits for all garbage collection goroutines to finish.
+func (kl *Kubelet) waitForGarbageCollectionDone() {
+	<-kl.gcDoneCh
 }
 
 // initializeModules will initialize internal modules that do not require the container runtime to be up.

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -3301,6 +3301,7 @@ func createRemoteRuntimeService(ctx context.Context, endpoint string, t *testing
 
 func TestNewMainKubeletStandAlone(t *testing.T) {
 	logger, tCtx := ktesting.NewTestContext(t)
+	var testMainKubelet *Kubelet
 	tempDir, err := os.MkdirTemp("", "logs")
 	require.NoError(t, err)
 	containerLogsDir := ContainerLogsDir
@@ -3313,9 +3314,9 @@ func TestNewMainKubeletStandAlone(t *testing.T) {
 	// This is needed on Windows because a concurrent os.ReadDir in a GC goroutine
 	// can keep a handle to this directory in use and cause os.RemoveAll to fail.
 	t.Cleanup(func() {
+		testMainKubelet.waitForGarbageCollectionDone()
 		ContainerLogsDir = containerLogsDir
-		err := os.RemoveAll(tempDir)
-		require.NoError(t, err)
+		require.NoError(t, os.RemoveAll(tempDir))
 	})
 
 	ca, cert, key, err := generateCAAndCertKeyWithOptions(
@@ -3395,7 +3396,7 @@ func TestNewMainKubeletStandAlone(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RotateKubeletServerCertificate, false)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ReloadKubeletClientCAFile, false)
 
-	testMainKubelet, err := NewMainKubelet(
+	testMainKubelet, err = NewMainKubelet(
 		tCtx,
 		kubeCfg,
 		kubeDep,
@@ -3462,6 +3463,7 @@ func TestNewMainKubeletStandAlone(t *testing.T) {
 
 func TestNewMainKubeletWithCertAndCAReloadingEnabled(t *testing.T) {
 	logger, tCtx := ktesting.NewTestContext(t)
+	var testMainKubelet *Kubelet
 	tempDir, err := os.MkdirTemp("", "logs")
 	require.NoError(t, err)
 	containerLogsDir := ContainerLogsDir
@@ -3474,9 +3476,9 @@ func TestNewMainKubeletWithCertAndCAReloadingEnabled(t *testing.T) {
 	// This is needed on Windows because a concurrent os.ReadDir in a GC goroutine
 	// can keep a handle to this directory in use and cause os.RemoveAll to fail.
 	t.Cleanup(func() {
+		testMainKubelet.waitForGarbageCollectionDone()
 		ContainerLogsDir = containerLogsDir
-		err := os.RemoveAll(tempDir)
-		require.NoError(t, err)
+		require.NoError(t, os.RemoveAll(tempDir))
 	})
 
 	ca, cert, key, err := generateCAAndCertKeyWithOptions(
@@ -3556,7 +3558,7 @@ func TestNewMainKubeletWithCertAndCAReloadingEnabled(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RotateKubeletServerCertificate, false)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ReloadKubeletClientCAFile, true)
 
-	testMainKubelet, err := NewMainKubelet(
+	testMainKubelet, err = NewMainKubelet(
 		tCtx,
 		kubeCfg,
 		kubeDep,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR fixes a kubelet flaky unit test on Windows node. Due to race condition introduced by garbage collection goroutines, `TestNewMainKubelet*` test cases happen to fail with the following error.
```
kubelet_test.go:3308: 
     Error Trace:	C:/kubernetes/pkg/kubelet/kubelet_test.go:3308
        	            C:/kubernetes/pkg/kubelet/kubelet_test.go:3451
     Error:      	Received unexpected error:
        	         unlinkat C:\Users\azureuser\AppData\Local\Temp\logs70220397: The process cannot access the file because it is being used by another process.
     Test:       	TestNewMainKubeletStandAlone
FAIL: TestNewMainKubeletStandAlone (0.35s)
```
Consistent failures can be seen here: https://storage.googleapis.com/k8s-triage/index.html?text=TestNewMainKubelet.

This PR updates `StartGarbageCollection` method by adding a `sync.WaitGroup` for tracking GC goroutines and adds `gcDoneCh` channel to the `Kubelet` struct that is closed when all GC goroutines have finished. The affected tests now call `waitForGarbageCollectionDone()` in their cleanup callback before removing the temp directory.


#### Which issue(s) this PR is related to:
Fix for this issue has already been opened in #139245 PR, but solution there does not resolve the root problem.


#### Special notes for your reviewer:
N/A
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
N/A