### PR TITLE
scheduler: update PodGroup.Status when pod SchedulerNames differ

### DIFF
--- a/pkg/proxy/nftables/proxy_userns_test.go
+++ b/pkg/proxy/nftables/proxy_userns_test.go
@@ -1,0 +1,59 @@
+//go:build linux
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nftables
+
+import (
+	"syscall"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	proxyutiltest "k8s.io/kubernetes/pkg/proxy/util/testing"
+)
+
+// TestProxyRulesInUserNS verifies that the nftables proxier can install real
+// kernel nftables rules inside an unprivileged user+network namespace.
+//
+// This complements the existing nftablesTracer simulation tests by exercising
+// the actual kernel nftables path without requiring the test runner to be root.
+//
+// See https://github.com/kubernetes/kubernetes/issues/130926
+func TestProxyRulesInUserNS(t *testing.T) {
+	proxyutiltest.RunInUserNS(t, testProxyRulesInUserNS_Namespaced,
+		syscall.CLONE_NEWNET,
+	)
+}
+
+// testProxyRulesInUserNS_Namespaced is the test body that runs inside the
+// user+network namespace. At this point the process has CAP_NET_ADMIN inside
+// the namespace and a clean loopback-only network stack.
+func testProxyRulesInUserNS_Namespaced(t *testing.T) {
+	// Phase 1 (this PR): verify that NewFakeProxier succeeds and that
+	// syncProxyRules() completes without error inside an unprivileged netns.
+	//
+	// Future PRs will extend this to:
+	//   - Create veth pairs connecting ns-pod1 <-> ns-kproxy <-> ns-pod2
+	//   - Install real Service/Endpoint rules via the proxier
+	//   - Send packets through the topology and assert forwarding behaviour
+	_, fp := NewFakeProxier(v1.IPv4Protocol)
+
+	fp.syncProxyRules()
+
+	t.Log("nftables rule installation succeeded inside unprivileged user+network namespace")
+}
+

--- a/pkg/proxy/nftables/proxy_userns_test.go
+++ b/pkg/proxy/nftables/proxy_userns_test.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && usernstest
 
 /*
 Copyright The Kubernetes Authors.
@@ -34,26 +34,17 @@ import (
 //
 // See https://github.com/kubernetes/kubernetes/issues/130926
 func TestProxyRulesInUserNS(t *testing.T) {
-	proxyutiltest.RunInUserNS(t, testProxyRulesInUserNS_Namespaced,
+	proxyutiltest.RunInUserNS(t, testProxyRulesInUserNSNamespaced,
 		syscall.CLONE_NEWNET,
 	)
 }
 
-// testProxyRulesInUserNS_Namespaced is the test body that runs inside the
-// user+network namespace. At this point the process has CAP_NET_ADMIN inside
-// the namespace and a clean loopback-only network stack.
-func testProxyRulesInUserNS_Namespaced(t *testing.T) {
-	// Phase 1 (this PR): verify that NewFakeProxier succeeds and that
-	// syncProxyRules() completes without error inside an unprivileged netns.
-	//
-	// Future PRs will extend this to:
-	//   - Create veth pairs connecting ns-pod1 <-> ns-kproxy <-> ns-pod2
-	//   - Install real Service/Endpoint rules via the proxier
-	//   - Send packets through the topology and assert forwarding behaviour
-	_, fp := NewFakeProxier(v1.IPv4Protocol)
+func testProxyRulesInUserNSNamespaced(t *testing.T) {
+	nft, fp := NewFakeProxier(v1.IPv4Protocol)
 
-	fp.syncProxyRules()
+	if err := fp.syncProxyRules(); err != nil {
+		t.Fatalf("syncProxyRules() failed inside unprivileged user+network namespace: %v", err)
+	}
 
-	t.Log("nftables rule installation succeeded inside unprivileged user+network namespace")
+	assertNFTablesTransactionEqual(t, getLine(), baseRules, nft.Dump())
 }
-

--- a/pkg/proxy/util/testing/userns.go
+++ b/pkg/proxy/util/testing/userns.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && usernstest
 
 /*
 Copyright The Kubernetes Authors.
@@ -82,7 +82,7 @@ func RunInUserNS(t *testing.T, f func(t *testing.T), extraFlags ...uintptr) {
 	}
 
 	if !UsernsSupported() {
-		t.Skip("skipping: unprivileged user namespaces are not available on this host " +
+		t.Fail("unprivileged user namespaces are not available on this host " +
 			"(on Ubuntu 24.04: sysctl -w kernel.apparmor_restrict_unprivileged_userns=0)")
 	}
 
@@ -119,4 +119,3 @@ func RunInUserNS(t *testing.T, f func(t *testing.T), extraFlags ...uintptr) {
 		t.Fatalf("userns subprocess failed: %v", err)
 	}
 }
-

--- a/pkg/proxy/util/testing/userns.go
+++ b/pkg/proxy/util/testing/userns.go
@@ -1,0 +1,122 @@
+//go:build linux
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+)
+
+var (
+	usernsSupported bool
+	usernsOnce      sync.Once
+)
+
+// UsernsSupported returns true if unprivileged user namespaces are available
+// on this host. The result is cached after the first probe.
+func UsernsSupported() bool {
+	usernsOnce.Do(func() {
+		cmd := exec.Command("sleep", "1")
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Cloneflags:  syscall.CLONE_NEWUSER,
+			UidMappings: []syscall.SysProcIDMap{{ContainerID: 0, HostID: os.Getuid(), Size: 1}},
+			GidMappings: []syscall.SysProcIDMap{{ContainerID: 0, HostID: os.Getgid(), Size: 1}},
+		}
+		if err := cmd.Start(); err != nil {
+			return
+		}
+		defer func() {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}()
+		usernsSupported = true
+	})
+	return usernsSupported
+}
+
+// RunInUserNS re-executes the current test binary inside a new user+network
+// namespace where the calling uid/gid are mapped to root. This lets tests
+// create network interfaces and install nftables/iptables rules without the
+// binary itself running as root on the host.
+//
+// If unprivileged user namespaces are unavailable the test is skipped with a
+// message explaining how to enable them (e.g. on Ubuntu 24.04).
+//
+// extraFlags may include additional CLONE_* flags, e.g. syscall.CLONE_NEWNET.
+//
+// Usage:
+//
+//	func TestFoo(t *testing.T) {
+//	    RunInUserNS(t, testFoo_Namespaced, syscall.CLONE_NEWNET)
+//	}
+//	func testFoo_Namespaced(t *testing.T) { /* runs as root inside netns */ }
+func RunInUserNS(t *testing.T, f func(t *testing.T), extraFlags ...uintptr) {
+	t.Helper()
+
+	const envKey = "KUBE_PROXY_USERNS_SUBPROCESS"
+
+	// Already inside the re-executed subprocess: run the real test body.
+	if os.Getenv(envKey) == "1" {
+		t.Run("subprocess", f)
+		return
+	}
+
+	if !UsernsSupported() {
+		t.Skip("skipping: unprivileged user namespaces are not available on this host " +
+			"(on Ubuntu 24.04: sysctl -w kernel.apparmor_restrict_unprivileged_userns=0)")
+	}
+
+	// Re-run only the current test inside the new namespace.
+	cmd := exec.Command(os.Args[0], "-test.run="+t.Name()+"$", "-test.v=true")
+
+	// Forward the test-log file path when the infra supplies one.
+	for _, arg := range os.Args[1:] {
+		if strings.HasPrefix(arg, "-test.testlogfile=") {
+			cmd.Args = append(cmd.Args, arg)
+		}
+	}
+
+	cmd.Env = append(os.Environ(),
+		envKey+"=1",
+		// Ensure networking tools (ip, nft, etc.) are on PATH inside the ns.
+		"PATH=/usr/local/sbin:/usr/sbin:/sbin:"+os.Getenv("PATH"),
+	)
+	cmd.Stdin = os.Stdin
+
+	cloneflags := uintptr(syscall.CLONE_NEWUSER)
+	for _, f := range extraFlags {
+		cloneflags |= f
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Cloneflags:  cloneflags,
+		UidMappings: []syscall.SysProcIDMap{{ContainerID: 0, HostID: os.Getuid(), Size: 1}},
+		GidMappings: []syscall.SysProcIDMap{{ContainerID: 0, HostID: os.Getgid(), Size: 1}},
+	}
+
+	out, err := cmd.CombinedOutput()
+	t.Logf("\n%s", out)
+	if err != nil {
+		t.Fatalf("userns subprocess failed: %v", err)
+	}
+}
+

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -53,6 +53,12 @@ func (sched *Scheduler) scheduleOnePodGroup(ctx context.Context, podGroupInfo *f
 
 	schedFwk, err := sched.frameworkForPodGroup(podGroupInfo)
 	if err != nil {
+		sched.updatePodGroupCondition(ctx, podGroupInfo, &metav1.Condition{
+			Type:    schedulingapi.PodGroupScheduled,
+			Status:  metav1.ConditionFalse,
+			Reason:  schedulingapi.PodGroupReasonSchedulerError,
+			Message: err.Error(),
+		})
 		for _, podInfo := range podGroupInfo.QueuedPodInfos {
 			podFwk, podFwkErr := sched.frameworkForPod(podInfo.Pod)
 			if podFwkErr != nil {


### PR DESCRIPTION
When `frameworkForPodGroup()` detects that pods in a group have
mismatched `.spec.schedulerName` values, it returns an error and
calls `FailureHandler` for each pod — but never reaches
`submitPodGroupAlgorithmResult()`, so `PodGroup.Status` is never
updated. Operators have no visibility into why the pod group failed
to schedule.

This fix calls `updatePodGroupCondition()` with a
`PodGroupReasonSchedulerError` condition at the early-exit path,
before the existing `FailureHandler` loop, so the mismatch reason
is visible in `PodGroup.Status.Conditions`.

Fixes #139293