### PR TITLE
kubelet: add test for killContainer early return when runtime stops quickly.

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kuberuntime
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -37,7 +38,9 @@ import (
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 
 	v1 "k8s.io/api/core/v1"
+	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	apitest "k8s.io/cri-api/pkg/apis/testing"
 	"k8s.io/kubernetes/test/utils/ktesting"
 
 	kubelettypes "k8s.io/kubelet/pkg/types"
@@ -1074,6 +1077,82 @@ func TestKillContainerGracePeriod(t *testing.T) {
 			require.Equal(t, test.expectedGracePeriod, actualGracePeriod)
 		})
 	}
+}
+
+func TestKillContainerReturnsImmediatelyWhenRuntimeStopsQuickly(t *testing.T) {
+
+	tCtx := ktesting.Init(t)
+
+	gp := int64(60)
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "uid"},
+		Spec: v1.PodSpec{
+			Containers:                    []v1.Container{{Name: "foo"}},
+			TerminationGracePeriodSeconds: &gp,
+		},
+	}
+
+	fakeRuntime, _, m, err := createTestRuntimeManager(tCtx)
+
+	require.NoError(t, err)
+
+	fakeRuntime.SetFakeContainers([]*apitest.FakeContainer{
+		{
+			ContainerStatus: runtimeapi.ContainerStatus{
+				Id: "container-id",
+				Metadata: &runtimeapi.ContainerMetadata{
+					Name:    "foo",
+					Attempt: 0,
+				},
+				State: runtimeapi.ContainerState_CONTAINER_RUNNING,
+			},
+			SandboxID: "sandbox-id",
+		},
+	})
+
+	hook := &stopContainerHook{
+		RuntimeService: m.runtimeService,
+		StopFunc: func(ctx context.Context, id string, timeout int64) error {
+			time.Sleep(5 * time.Second)
+			return nil
+		},
+	}
+	m.runtimeService = hook
+
+	start := time.Now()
+	err = m.killContainer(
+		tCtx,
+		pod,
+		kubecontainer.ContainerID{Type: apitest.FakeRuntimeName, ID: "container-id"},
+		"foo",
+		"test kill",
+		reasonUnknown,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	elapsed := time.Since(start)
+
+	require.Equal(t, gp, hook.GotTimeout)
+
+	require.Less(t, elapsed, 6*time.Second)
+}
+
+type stopContainerHook struct {
+	internalapi.RuntimeService
+
+	StopFunc   func(ctx context.Context, id string, timeout int64) error
+	GotTimeout int64
+}
+
+func (h *stopContainerHook) StopContainer(ctx context.Context, id string, timeout int64) error {
+	h.GotTimeout = timeout
+	if h.StopFunc != nil {
+		return h.StopFunc(ctx, id, timeout)
+	}
+	return h.RuntimeService.StopContainer(ctx, id, timeout)
 }
 
 // TestUpdateContainerResources tests updating a container in a Pod.


### PR DESCRIPTION
#### Description

This PR adds a unit test to verify that `killContainer` in the kubelet runtime manager returns promptly when the underlying runtime completes the stop operation before the full termination grace period elapses.

#### Why is this needed?

`killContainer` passes a termination grace period to the runtime via `StopContainer`. However, runtimes are not required to block for the entire duration and may return as soon as the container has stopped.

This test ensures and verifies the behaviour that kubelet does not unnecessarily wait for the full grace period and instead returns as soon as the runtime completes the stop operation.

#### What this PR does / why we need it:

- Adds a unit test `TestKillContainerReturnsImmediatelyWhenRuntimeStopsQuickly`
- Uses a fake runtime with a hook to simulate a fast container stop
- Verifies:
  - The correct timeout (terminationGracePeriodSeconds) is passed to the runtime
  - `killContainer` returns based on runtime completion rather than waiting for the full grace period

#### What type of PR is this?

/kind test

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This is a test-only change and does not modify production code. The test uses a hook around `RuntimeService.StopContainer` to simulate runtime behavior and capture the timeout passed by kubelet.

#### Does this PR introduce a user-facing change?

NONE

```release-note
NONE
```