### PR TITLE
scheduler: update PodGroup.Status when pod SchedulerNames differ

### DIFF
--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -61,6 +61,12 @@ func (sched *Scheduler) scheduleOnePodGroup(ctx context.Context, podGroupInfo *f
 			}
 			sched.FailureHandler(ctx, podFwk, podInfo, fwk.AsStatus(err), clearNominatedNode, time.Now())
 		}
+		sched.updatePodGroupCondition(ctx, podGroupInfo, &metav1.Condition{
+			Type:    schedulingapi.PodGroupScheduled,
+			Status:  metav1.ConditionFalse,
+			Reason:  schedulingapi.PodGroupReasonSchedulerError,
+			Message: err.Error(),
+		})
 		err := sched.SchedulingQueue.AddAttemptedPodGroupIfNeeded(logger, podGroupInfo, sched.SchedulingQueue.SchedulingCycle())
 		if err != nil {
 			utilruntime.HandleErrorWithContext(ctx, err, "Failed to pod group back to scheduling queue", "podGroup", klog.KObj(podGroupInfo))

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -2924,3 +2924,85 @@ func TestPodGroupCycle_NominatedNodes(t *testing.T) {
 		t.Errorf("Expected p2 to not be nominated, got %v", capturedFailureHandler[p2.Name])
 	}
 }
+
+func TestScheduleOnePodGroup_SchedulerNameMismatchUpdatesStatus(t *testing.T) {
+	p1 := st.MakePod().Name("p1").UID("p1").PodGroupName("pg").SchedulerName("sched1").Obj()
+	p2 := st.MakePod().Name("p2").UID("p2").PodGroupName("pg").SchedulerName("sched2").Obj()
+	qInfo1 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p1}}
+	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
+	testPodGroup := &schedulingv1alpha3.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
+	}
+	podGroupInfo := &framework.QueuedPodGroupInfo{
+		QueuedPodInfos: []*framework.QueuedPodInfo{qInfo1, qInfo2},
+		PodGroupInfo: &framework.PodGroupInfo{
+			Name:      "pg",
+			Namespace: "default",
+		},
+	}
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	registry := frameworkruntime.Registry{
+		queuesort.Name:     queuesort.New,
+		defaultbinder.Name: defaultbinder.New,
+	}
+	profileCfg := config.KubeSchedulerProfile{
+		SchedulerName: "sched1",
+		Plugins: &config.Plugins{
+			QueueSort: config.PluginSet{
+				Enabled: []config.Plugin{{Name: queuesort.Name}},
+			},
+			Bind: config.PluginSet{
+				Enabled: []config.Plugin{{Name: defaultbinder.Name}},
+			},
+		},
+	}
+	schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
+		frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create new framework: %v", err)
+	}
+
+	client := clientsetfake.NewClientset(testPodGroup)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	podGroupLister := informerFactory.Scheduling().V1alpha3().PodGroups().Lister()
+	informerFactory.Start(ctx.Done())
+	informerFactory.WaitForCacheSync(ctx.Done())
+
+	sched := &Scheduler{
+		Profiles:        profile.Map{"sched1": schedFwk, "sched2": schedFwk},
+		SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
+		Cache:           internalcache.New(ctx, nil, true),
+		client:          client,
+		podGroupLister:  podGroupLister,
+		FailureHandler: func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
+		},
+	}
+
+	sched.scheduleOnePodGroup(ctx, podGroupInfo)
+
+	pg, err := client.SchedulingV1alpha3().PodGroups("default").Get(ctx, "pg", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get PodGroup: %v", err)
+	}
+	expectedCondition := metav1.Condition{
+		Type:   schedulingapi.PodGroupScheduled,
+		Status: metav1.ConditionFalse,
+		Reason: schedulingapi.PodGroupReasonSchedulerError,
+	}
+	var matchedCondition *metav1.Condition
+	for i := range pg.Status.Conditions {
+		if pg.Status.Conditions[i].Type == schedulingapi.PodGroupScheduled {
+			matchedCondition = &pg.Status.Conditions[i]
+			break
+		}
+	}
+	if matchedCondition == nil {
+		t.Errorf("Expected PodGroup.Status.Conditions to contain PodGroupScheduled condition, got: %+v", pg.Status.Conditions)
+	} else if diff := cmp.Diff(expectedCondition, *matchedCondition, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime", "Message", "ObservedGeneration")); diff != "" {
+		t.Errorf("Unexpected condition (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
When `frameworkForPodGroup()` detects mismatched `.spec.schedulerName` values across pods in a group, it returns an error early and calls `FailureHandler` for each pod — but never reaches `submitPodGroupAlgorithmResult()`, so `PodGroup.Status.Conditions` is never updated. Operators have no visibility into why the pod group failed scheduling.

This fix calls `updatePodGroupCondition()` with `PodGroupReasonSchedulerError` at the early-exit path so the mismatch reason is visible in `PodGroup.Status`.

**Which issue(s) this PR is related to:**
Fixes #139293

**Special notes for your reviewer:**
Unit test added in pkg/scheduler/schedule_one_podgroup_test.go covering the scheduler name mismatch path.

**Does this PR introduce a user-facing change?**
`PodGroup.Status.Conditions` now reflects the reason when scheduling fails due to mismatched `.spec.schedulerName` across pods in the group.

```release-note
PodGroup.Status.Conditions now reflects the failure reason when scheduling is rejected due to mismatched .spec.schedulerName across pods in a group.
```