### PR TITLE
Filter `InstanceNotFound` errors to return nil

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller.go
@@ -224,7 +224,11 @@ func (c *CloudNodeLifecycleController) getProviderID(ctx context.Context, node *
 // shutdownInCloudProvider returns true if the node is shutdown on the cloud provider
 func (c *CloudNodeLifecycleController) shutdownInCloudProvider(ctx context.Context, node *v1.Node) (bool, error) {
 	if instanceV2, ok := c.cloud.InstancesV2(); ok {
-		return instanceV2.InstanceShutdown(ctx, node)
+		shutdown, err := instanceV2.InstanceShutdown(ctx, node)
+		if err != nil && errors.Is(err, cloudprovider.InstanceNotFound) {
+			return false, nil
+		}
+		return shutdown, err
 	}
 
 	instances, ok := c.cloud.Instances()
@@ -251,7 +255,11 @@ func (c *CloudNodeLifecycleController) shutdownInCloudProvider(ctx context.Conte
 // ensureNodeExistsByProviderID checks if the instance exists by the provider id,
 func (c *CloudNodeLifecycleController) ensureNodeExistsByProviderID(ctx context.Context, node *v1.Node) (bool, error) {
 	if instanceV2, ok := c.cloud.InstancesV2(); ok {
-		return instanceV2.InstanceExists(ctx, node)
+		exists, err := instanceV2.InstanceExists(ctx, node)
+		if err != nil && errors.Is(err, cloudprovider.InstanceNotFound) {
+			return false, nil
+		}
+		return exists, err
 	}
 
 	instances, ok := c.cloud.Instances()

--- a/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller.go
@@ -251,6 +251,9 @@ func (c *CloudNodeLifecycleController) shutdownInCloudProvider(ctx context.Conte
 	if instanceV2, ok := c.cloud.InstancesV2(); ok {
 		shutdown, err := instanceV2.InstanceShutdown(ctx, node)
 		observeInstanceOp(instanceShutdownOp, err)
+		if err != nil && errors.Is(err, cloudprovider.InstanceNotFound) {
+			return false, nil
+		}
 		return shutdown, err
 	}
 
@@ -284,6 +287,9 @@ func (c *CloudNodeLifecycleController) ensureNodeExistsByProviderID(ctx context.
 			observeInstanceOp(instanceExistsOp, cloudprovider.InstanceNotFound)
 		} else {
 			observeInstanceOp(instanceExistsOp, err)
+		}
+		if err != nil && errors.Is(err, cloudprovider.InstanceNotFound) {
+			return false, nil
 		}
 		return exists, err
 	}


### PR DESCRIPTION

#### What type of PR is this?
/kind bug

#### Fixes
Partially #141364, cloud provider changes also required to return standard errors

#### What this PR does / why we need it:
The cloud-node-lifecycle controller is responsible for deleting node objects whose backing cloud instance no longer
exists. While doing so it calls `ensureNodeExistsByProviderID(node)` and, when that cannot find the node without any error, it deletes the node, as explained in this [comment](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller.go#L152-L153) in `ManageNodes()`.

`ensureNodeExistsByProviderID` has two implementations selected by which interface the cloud provider exposes:
  - The legacy `Instances` (v1) path looks up the provider ID via `getProviderID`, which can return the typed sentinel `cloudprovider.InstanceNotFound` when the instance is gone. The v1 code [converts that sentinel to `(false, nil)`](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/cloud-provider/controllers/nodelifecycle/node_lifecycle_controller.go#L264-L266).
  - The newer `InstancesV2` path simply returns whatever `instanceV2.InstanceExists(ctx, node)` returns.

This means that when a v2 provider that returns `cloudprovider.InstanceNotFound` from `InstanceExists`, it results in a non-nil error, which short-circuits the loop and the node is left in place.

Changes in this PR mirrors the v1 behavior on the v2 paths. Both `ensureNodeExistsByProviderID` and `shutdownInCloudProvider` (The same asymmetry exists here between its v1 and v2 branches) now filter `cloudprovider.InstanceNotFound` and return `(false, nil)` so the controller proceeds with cleanup.


First noticed the bug on a cluster where a node had empty `spec.providerID`. This happened as the cloud-controller-manager was unable to populate the providerID due to an unrelated issue.
CCM logs showed this in the log message, hinting that the above was indeed happening
```
2026-xx-xx xx:xx:xx | {"log":"error checking if node xxxxxx: instance not found","logtag":"F","pid":"1","severity":"ERR","source":"node_lifecycle_controller.go:156"}
```
This node also was not cleaned by the CCM and had to be manually deleted.

#### Which issue(s) this PR is related to:
N/A


#### Special notes for your reviewer:
Unit tests have completed successfully with no errors, unsure how to test further

#### Does this PR introduce a user-facing change?
```release-note
NONE
```