### PR TITLE
discovery: fix bogus `rep` protobuf marker on `EndpointSlice.AddressType`

### DIFF
--- a/staging/src/k8s.io/api/discovery/v1/types.go
+++ b/staging/src/k8s.io/api/discovery/v1/types.go
@@ -51,7 +51,7 @@ type EndpointSlice struct {
 	// +required
 	// +k8s:alpha(since: "1.36")=+k8s:required
 	// +k8s:alpha(since: "1.36")=+k8s:immutable
-	AddressType AddressType `json:"addressType" protobuf:"bytes,4,rep,name=addressType"`
+	AddressType AddressType `json:"addressType" protobuf:"bytes,4,opt,name=addressType"`
 
 	// endpoints is a list of unique endpoints in this slice. Each slice may
 	// include a maximum of 1000 endpoints.

--- a/staging/src/k8s.io/api/discovery/v1beta1/types.go
+++ b/staging/src/k8s.io/api/discovery/v1beta1/types.go
@@ -48,7 +48,7 @@ type EndpointSlice struct {
 	// +required
 	// +k8s:alpha(since: "1.36")=+k8s:required
 	// +k8s:alpha(since: "1.36")=+k8s:immutable
-	AddressType AddressType `json:"addressType" protobuf:"bytes,4,rep,name=addressType"`
+	AddressType AddressType `json:"addressType" protobuf:"bytes,4,opt,name=addressType"`
 
 	// endpoints is a list of unique endpoints in this slice. Each slice may
 	// include a maximum of 1000 endpoints.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The AddressType field on discovery/v1 and discovery/v1beta1 EndpointSlice is a scalar (`type AddressType string`) but its protobuf struct tag carries the `rep` (repeated) marker instead of `opt`. Switch both to `opt` to match sibling scalar fields like Endpoint.Hostname.

This is cosmetic at the wire level: go-to-protobuf infers wire kind from the Go type, so generated.proto already emits `optional string addressType = 4;` and generated.pb.go encodes it as a single scalar. No re-generation is required and no wire format changes.

The reason for fixing it anyway is that this bad tag currently ripples into downstream projects that generate "slim" type sets to avoid the full k8s.io/api dependency. Fixing it here at the source will ensure the fix will flow through all of those downstream consumers.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A