### PR TITLE
hack: use toolchain-specific gofmt for formatting checks

### DIFF
--- a/hack/update-gofmt.sh
+++ b/hack/update-gofmt.sh
@@ -40,5 +40,12 @@ function git_find() {
         ':(glob)**/*.go' \
         "$@"
 }
+# GOTOOLCHAIN has no effect on the version of gofmt.
+# We need to find right gofmt, otherwise the one in PATH will be used.
+gofmt="$(go env GOROOT)/bin/gofmt"
+if [[ ! -x "${gofmt}" ]]; then
+  echo "Failed to find $gofmt"
+  exit 1
+fi
 
-git_find -z | xargs -0 gofmt -s -w
+git_find -z | xargs -0 "${gofmt}" -s -w

--- a/hack/update-gofmt.sh
+++ b/hack/update-gofmt.sh
@@ -44,7 +44,7 @@ function git_find() {
 # We need to find right gofmt, otherwise the one in PATH will be used.
 gofmt="$(go env GOROOT)/bin/gofmt"
 if [[ ! -x "${gofmt}" ]]; then
-  echo "Failed to find $gofmt"
+kube::log::error 'Failed to find gofmt under GOTOOLCHAIN'
   exit 1
 fi
 

--- a/hack/update-gofmt.sh
+++ b/hack/update-gofmt.sh
@@ -44,7 +44,7 @@ function git_find() {
 # We need to find right gofmt, otherwise the one in PATH will be used.
 gofmt="$(go env GOROOT)/bin/gofmt"
 if [[ ! -x "${gofmt}" ]]; then
-kube::log::error 'Failed to find gofmt under GOTOOLCHAIN'
+  echo "Failed to find $gofmt" >&2
   exit 1
 fi
 

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -47,11 +47,19 @@ find_files() {
     \) -name '*.go'
 }
 
+# GOTOOLCHAIN has no effect on the version of gofmt.
+# We need to find right gofmt, otherwise the one in PATH will be used.
+gofmt="$(go env GOROOT)/bin/gofmt"
+if [[ ! -x "${gofmt}" ]]; then
+  echo "Failed to find $gofmt"
+  exit 1
+fi
+
 # gofmt exits with non-zero exit code if it finds a problem unrelated to
 # formatting (e.g., a file does not parse correctly). Without "|| true" this
 # would have led to no useful error message from gofmt, because the script would
 # have failed before getting to the "echo" in the block below.
-diff=$(find_files | xargs gofmt -d -s 2>&1) || true
+diff=$(find_files | xargs "${gofmt}" -d -s 2>&1) || true
 if [[ -n "${diff}" ]]; then
   echo "${diff}" >&2
   echo >&2

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -51,7 +51,7 @@ find_files() {
 # We need to find right gofmt, otherwise the one in PATH will be used.
 gofmt="$(go env GOROOT)/bin/gofmt"
 if [[ ! -x "${gofmt}" ]]; then
-  echo "Failed to find $gofmt"
+  echo "Failed to find $gofmt" >&2
   exit 1
 fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

Ensures that code formatting updates and verifications are executed using the project's target Go toolchain version (specified in .go-version) instead of the host system's global gofmt executable. Bypasses PATH configuration limits by dynamically resolving and calling the GOROOT-aligned gofmt binary, which prevents version mismatches in containerized development setups.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
