### PR TITLE
Add dependant tags for +k8s:listType

### DIFF
--- a/hack/kube-api-linter/kube-api-linter.yaml
+++ b/hack/kube-api-linter/kube-api-linter.yaml
@@ -47,6 +47,18 @@ lintersConfig:
         type: "All"
         dependsOn:
           - "k8s:optional"
+      - identifier: "k8s:listType=map"
+        type: "All"
+        dependsOn:
+          - "listType=map"
+      - identifier: "k8s:listType=set"
+        type: "All"
+        dependsOn:
+          - "listType=set"
+      - identifier: "k8s:listType=atomic"
+        type: "All"
+        dependsOn:
+          - "listType=atomic"
   # jsonTags:
   #   jsonTagRegex: "^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$" # The default regex is appropriate for our use case.
   # nomaps:


### PR DESCRIPTION

#### What type of PR is this?
/kind cleanup
/kind feature

#### What this PR does / why we need it:
This PR adds new rules to the `kube-api-linter` (`hack/kube-api-linter/kube-api-linter.yaml`) to enforce the inclusion of declarative validation (DV) triggering tags alongside standard list type markers. 

As brought up in [this comment](https://github.com/kubernetes/kubernetes/pull/139101#discussion_r3283550816) by @liggitt, failing to double-specify these tags (e.g., adding `+listType=map` but omitting `+k8s:listType=map`) leads to gaps in declarative validation coverage. 

To prevent developers from accidentally introducing new gaps, this PR updates the KAL config so that the declarative validation tags are now strictly dependent on the presence of the basic list tags. Specifically, it ensures:
- `k8s:listType=map` is enforced when `listType=map` is present.
- `k8s:listType=set` is enforced when `listType=set` is present.
- `k8s:listType=atomic` is enforced when `listType=atomic` is present.

#### Which issue(s) this PR is related to:
Addresses follow-up from PR #139101: https://github.com/kubernetes/kubernetes/pull/139101#discussion_r3283550816

#### Special notes for your reviewer:
* +k8s:listMapKey, +listMapKey will be automatically enforced by validation-gen and OpenAPI spec generator on the seeing the listMap tag. 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
