### PR TITLE
Add memory.event stats to MemoryStats

### DIFF
--- a/pkg/kubelet/stats/helper.go
+++ b/pkg/kubelet/stats/helper.go
@@ -77,6 +77,8 @@ func cadvisorInfoToCPUandMemoryStats(info *cadvisorapiv2.ContainerInfo) (*statsa
 			availableBytes := info.Spec.Memory.Limit - cstat.Memory.WorkingSet
 			memoryStats.AvailableBytes = &availableBytes
 		}
+		memoryStats.HighEvents = &cstat.Memory.Events.High
+		memoryStats.MaxEvents = &cstat.Memory.Events.Max
 		if utilfeature.DefaultFeatureGate.Enabled(features.KubeletPSI) {
 			memoryStats.PSI = cadvisorPSIToStatsPSI(&cstat.Memory.PSI)
 		}

--- a/pkg/kubelet/stats/helper_test.go
+++ b/pkg/kubelet/stats/helper_test.go
@@ -145,6 +145,29 @@ func TestMergeProcessStats(t *testing.T) {
 	}
 }
 
+// TestCadvisorMemoryEventsStruct checks the fields in cadvisor MemoryEvents structs. If cadvisor
+// MemoryEvents structs change, the conversion between cadvisor MemoryEvents and kubelet stats API
+// MemoryStats needs to be re-evaluated and updated.
+func TestCadvisorMemoryEventsStruct(t *testing.T) {
+	memoryEventsFields := map[string]reflect.Kind{
+		"High": reflect.Uint64,
+		"Max":  reflect.Uint64,
+	}
+
+	e := cadvisorapiv1.MemoryEvents{}
+	et := reflect.TypeOf(e)
+	for field := range et.Fields() {
+		wantKind, fieldExists := memoryEventsFields[field.Name]
+		if !fieldExists {
+			t.Errorf("cadvisorapiv1.MemoryEvents contains unknown field: %s. The conversion between cadvisor MemoryEvents and kubelet stats API MemoryStats needs to be re-evaluated and updated.", field.Name)
+			continue
+		}
+		if field.Type.Kind() != wantKind {
+			t.Errorf("unexpected cadvisorapiv1.MemoryEvents field %s type, want: %s, got: %s. The conversion between cadvisor MemoryEvents and kubelet stats API MemoryStats needs to be re-evaluated and updated.", field.Name, wantKind, field.Type.Kind())
+		}
+	}
+}
+
 // TestCadvisorPSIStruct checks the fields in cadvisor PSI structs. If cadvisor
 // PSI structs change, the conversion between cadvisor PSI structs and kubelet stats API structs needs to be re-evaluated and updated.
 func TestCadvisorPSIStructs(t *testing.T) {

--- a/pkg/kubelet/stats/provider_test.go
+++ b/pkg/kubelet/stats/provider_test.go
@@ -69,6 +69,8 @@ const (
 	offsetAcceleratorDutyCycle
 	offsetMemSwapUsageBytes
 	offsetPSIDataTotal
+	offsetMemHighEvents
+	offsetMemMaxEvents
 )
 
 var (
@@ -298,6 +300,10 @@ func getTestContainerInfo(seed int, podName string, podNamespace string, contain
 			},
 			Swap: uint64(seed + offsetMemSwapUsageBytes),
 			PSI:  getTestPSIStats(seed),
+			Events: cadvisorapiv1.MemoryEvents{
+				High: uint64(seed + offsetMemHighEvents),
+				Max:  uint64(seed + offsetMemMaxEvents),
+			},
 		},
 		Network: &cadvisorapiv2.NetworkStats{
 			Interfaces: []cadvisorapiv1.InterfaceStats{{
@@ -512,6 +518,8 @@ func checkMemoryStats(t *testing.T, label string, seed int, info cadvisorapiv2.C
 		assert.EqualValues(t, expected, *stats.AvailableBytes, label+".Mem.AvailableBytes")
 	}
 	checkPSIStats(t, label+".Mem", seed, stats.PSI)
+	assert.EqualValues(t, seed+offsetMemHighEvents, *stats.HighEvents, label+".Mem.HighEvents")
+	assert.EqualValues(t, seed+offsetMemMaxEvents, *stats.MaxEvents, label+".Mem.MaxEvents")
 }
 
 func checkIOStats(t *testing.T, label string, seed int, info cadvisorapiv2.ContainerInfo, stats *statsapi.IOStats) {

--- a/staging/src/k8s.io/kubelet/pkg/apis/stats/v1alpha1/types.go
+++ b/staging/src/k8s.io/kubelet/pkg/apis/stats/v1alpha1/types.go
@@ -264,6 +264,12 @@ type MemoryStats struct {
 	// Cumulative number of major page faults.
 	// +optional
 	MajorPageFaults *uint64 `json:"majorPageFaults,omitempty"`
+	// Cumulative count of cgroup v2 memory.high throttle events.
+	// +optional
+	HighEvents *uint64 `json:"highEvents,omitempty"`
+	// Cumulative count of cgroup v2 memory.max limit hit events.
+	// +optional
+	MaxEvents *uint64 `json:"maxEvents,omitempty"`
 	// Memory PSI stats.
 	// +optional
 	PSI *PSIStats `json:"psi,omitempty"`

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -116,6 +116,8 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 						"RSSBytes":        bounded(1*e2evolume.Mb, memoryLimit),
 						"PageFaults":      bounded(1000, 1e9),
 						"MajorPageFaults": bounded(0, 1e9),
+						"HighEvents":      memoryEventExpectation(),
+						"MaxEvents":       memoryEventExpectation(),
 						"PSI":             psiExpectation(),
 					}),
 					"IO":                 ioExpectation(maxStatsAge),
@@ -145,6 +147,8 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 				"RSSBytes":        bounded(1*e2evolume.Kb, memoryLimit),
 				"PageFaults":      bounded(0, expectedPageFaultsUpperBound),
 				"MajorPageFaults": bounded(0, expectedMajorPageFaultsUpperBound),
+				"HighEvents":      memoryEventExpectation(),
+				"MaxEvents":       memoryEventExpectation(),
 				"PSI":             psiExpectation(),
 			})
 			runtimeContExpectations := sysContExpectations().(*gstruct.FieldsMatcher)
@@ -167,6 +171,8 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 					"RSSBytes":        bounded(100*e2evolume.Kb, memoryLimit),
 					"PageFaults":      bounded(1000, 1e9),
 					"MajorPageFaults": bounded(0, 1e9),
+					"HighEvents":      memoryEventExpectation(),
+					"MaxEvents":       memoryEventExpectation(),
 					"PSI":             psiExpectation(),
 				})
 				systemContainers["misc"] = miscContExpectations
@@ -193,6 +199,8 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 							"RSSBytes":        bounded(1*e2evolume.Kb, 80*e2evolume.Mb),
 							"PageFaults":      bounded(100, expectedPageFaultsUpperBound),
 							"MajorPageFaults": bounded(0, expectedMajorPageFaultsUpperBound),
+							"HighEvents":      memoryEventExpectation(),
+							"MaxEvents":       memoryEventExpectation(),
 							"PSI":             psiExpectation(),
 						}),
 						"IO":           ioExpectation(maxStatsAge),
@@ -244,6 +252,8 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 					"RSSBytes":        bounded(1*e2evolume.Kb, 80*e2evolume.Mb),
 					"PageFaults":      bounded(0, expectedPageFaultsUpperBound),
 					"MajorPageFaults": bounded(0, expectedMajorPageFaultsUpperBound),
+					"HighEvents":      memoryEventExpectation(),
+					"MaxEvents":       memoryEventExpectation(),
 					"PSI":             psiExpectation(),
 				}),
 				"IO":   ioExpectation(maxStatsAge),
@@ -298,6 +308,8 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 						"RSSBytes":        bounded(1*e2evolume.Kb, memoryLimit),
 						"PageFaults":      bounded(1000, 1e9),
 						"MajorPageFaults": bounded(0, 1e9),
+						"HighEvents":      memoryEventExpectation(),
+						"MaxEvents":       memoryEventExpectation(),
 						"PSI":             psiExpectation(),
 					}),
 					"IO":   ioExpectation(maxStatsAge),
@@ -490,6 +502,95 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 			framework.ExpectNoError(e2epod.NewPodClient(f).Delete(ctx, pod.Name, metav1.DeleteOptions{}))
 		})
 	})
+
+	framework.Context("when querying /stats/summary for memory events", framework.WithSerial(), framework.WithNodeConformance(), func() {
+		ginkgo.It("should report memory.high events for burstable pods", func(ctx context.Context) {
+			podName := "memory-high-events-pod"
+			ginkgo.By("Creating a burstable pod that exceeds its memory.high threshold")
+			// With MemoryQoS enabled on cgroupv2, memory.high is set for burstable pods using the formula:
+			// memory.high = requests + 0.9 * (limits - requests)
+			// For requests=100M and limits=200M: memory.high ≈ 190M
+			podSpec := getStressTestPod(podName, "memory-high-events", []string{})
+			podSpec.Spec.Containers[0].Command = []string{"/bin/sh", "-c"}
+			podSpec.Spec.Containers[0].Args = []string{
+				"i=0; while true; do dd if=/dev/zero of=testfile.$i bs=1M count=39 &>/dev/null; i=$(((i+1)%5)); sleep 0.1; done",
+			}
+			podSpec.Spec.Containers[0].Resources = v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("200M"),
+				},
+				Requests: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("100M"),
+				},
+			}
+			pod := e2epod.NewPodClient(f).Create(ctx, podSpec)
+
+			ginkgo.By("Waiting for the pod to start")
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod))
+
+			ginkgo.By("Validating memory.high events")
+			var highEventsMatcher types.GomegaMatcher
+			if IsCgroup2UnifiedMode() && utilfeature.DefaultFeatureGate.Enabled(features.MemoryQoS) {
+				highEventsMatcher = gstruct.PointTo(gomega.BeNumerically(">", uint64(0)))
+			} else {
+				highEventsMatcher = gstruct.PointTo(gomega.BeNumerically("==", uint64(0)))
+			}
+			gomega.Eventually(ctx, func(g gomega.Gomega) {
+				summary, err := getNodeSummary(ctx)
+				framework.ExpectNoError(err)
+				g.Expect(summary.Pods).To(gstruct.MatchElements(summaryObjectID, gstruct.IgnoreExtras, gstruct.Elements{
+					fmt.Sprintf("%s::%s", f.Namespace.Name, podName): gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Memory": gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+							"HighEvents": highEventsMatcher,
+						})),
+					}),
+				}))
+			}, 2*time.Minute, 15*time.Second).Should(gomega.Succeed())
+			framework.ExpectNoError(e2epod.NewPodClient(f).Delete(ctx, pod.Name, metav1.DeleteOptions{}))
+		})
+
+		ginkgo.It("should report memory.max events when memory limit is hit", func(ctx context.Context) {
+			podName := "memory-events-pod"
+			ginkgo.By("Creating a pod that exceeds its memory limit")
+			podSpec := getStressTestPod(podName, "memory-events", []string{})
+			podSpec.Spec.Containers[0].Command = []string{"/bin/sh", "-c"}
+			podSpec.Spec.Containers[0].Args = []string{
+				"i=0; while true; do dd if=/dev/zero of=testfile.$i bs=1M count=50 &>/dev/null; i=$(((i+1)%5)); sleep 0.1; done",
+			}
+			podSpec.Spec.Containers[0].Resources = v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("200M"),
+				},
+				Requests: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("200M"),
+				},
+			}
+			pod := e2epod.NewPodClient(f).Create(ctx, podSpec)
+
+			ginkgo.By("Waiting for the pod to start")
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod))
+
+			ginkgo.By("Validating memory.max events")
+			var maxEventsMatcher types.GomegaMatcher
+			if IsCgroup2UnifiedMode() {
+				maxEventsMatcher = gstruct.PointTo(gomega.BeNumerically(">", uint64(0)))
+			} else {
+				maxEventsMatcher = gstruct.PointTo(gomega.BeNumerically("==", uint64(0)))
+			}
+			gomega.Eventually(ctx, func(g gomega.Gomega) {
+				summary, err := getNodeSummary(ctx)
+				framework.ExpectNoError(err)
+				g.Expect(summary.Pods).To(gstruct.MatchElements(summaryObjectID, gstruct.IgnoreExtras, gstruct.Elements{
+					fmt.Sprintf("%s::%s", f.Namespace.Name, podName): gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Memory": gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+							"MaxEvents": maxEventsMatcher,
+						})),
+					}),
+				}))
+			}, 2*time.Minute, 15*time.Second).Should(gomega.Succeed())
+			framework.ExpectNoError(e2epod.NewPodClient(f).Delete(ctx, pod.Name, metav1.DeleteOptions{}))
+		})
+	})
 })
 
 func getSummaryTestPods(f *framework.Framework, numRestarts int32, names ...string) []*v1.Pod {
@@ -637,6 +738,10 @@ func recordSystemCgroupProcesses(ctx context.Context) {
 			}
 		}
 	}
+}
+
+func memoryEventExpectation() types.GomegaMatcher {
+	return bounded(0, uint64(math.MaxUint64))
 }
 
 func psiExpectation() types.GomegaMatcher {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

PR [cadvisor#3870](https://github.com/google/cadvisor/pull/3870) exposes `memory.events` (high/max) through cadvisor's Prometheus metrics and REST API. This follow-up surface them through kubelet's Summary Stats API.

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/issues/5986
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Expose cgroup v2 memory.events in kubelet Summary Stats API
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
