### PR TITLE
Fix AddPod probe worker handling

### DIFF
--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -196,7 +196,7 @@ func (m *manager) AddPod(ctx context.Context, pod *v1.Pod) {
 			if _, ok := m.workers[key]; ok {
 				logger.V(8).Info("Startup probe already exists for container",
 					"pod", klog.KObj(pod), "containerName", c.Name)
-				return
+				continue
 			}
 			w := newWorker(m, startup, pod, c)
 			m.workers[key] = w
@@ -208,7 +208,7 @@ func (m *manager) AddPod(ctx context.Context, pod *v1.Pod) {
 			if _, ok := m.workers[key]; ok {
 				logger.V(8).Info("Readiness probe already exists for container",
 					"pod", klog.KObj(pod), "containerName", c.Name)
-				return
+				continue
 			}
 			w := newWorker(m, readiness, pod, c)
 			m.workers[key] = w
@@ -220,7 +220,7 @@ func (m *manager) AddPod(ctx context.Context, pod *v1.Pod) {
 			if _, ok := m.workers[key]; ok {
 				logger.V(8).Info("Liveness probe already exists for container",
 					"pod", klog.KObj(pod), "containerName", c.Name)
-				return
+				continue
 			}
 			w := newWorker(m, liveness, pod, c)
 			m.workers[key] = w

--- a/pkg/kubelet/prober/prober_manager_test.go
+++ b/pkg/kubelet/prober/prober_manager_test.go
@@ -133,6 +133,42 @@ func TestAddRemovePods(t *testing.T) {
 	}
 }
 
+func TestAddPodContinuesWhenProbeWorkerExists(t *testing.T) {
+	ctx := ktesting.Init(t)
+	m := newTestManager()
+	defer cleanup(t, m)
+
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: "existing_worker_pod",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Name:         "existing",
+				StartupProbe: defaultProbe,
+			}},
+		},
+	}
+
+	m.AddPod(ctx, &pod)
+	if err := expectProbes(m, []probeKey{{"existing_worker_pod", "existing", startup}}); err != nil {
+		t.Error(err)
+	}
+
+	pod.Spec.Containers = append(pod.Spec.Containers, v1.Container{
+		Name:           "next",
+		ReadinessProbe: defaultProbe,
+	})
+
+	m.AddPod(ctx, &pod)
+	if err := expectProbes(m, []probeKey{
+		{"existing_worker_pod", "existing", startup},
+		{"existing_worker_pod", "next", readiness},
+	}); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestAddRemovePodsWithRestartableInitContainer(t *testing.T) {
 	m := newTestManager()
 	defer cleanup(t, m)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig node

#### What this PR does / why we need it:
`AddPod` currently returns when it sees an existing probe worker for a container. That exits the whole function and skips later containers in the pod. This changes those checks to continue to the next container instead, so later containers still get their probe workers.

#### Which issue(s) this PR fixes:
Fixes #138928

#### Special notes for your reviewer:
Added a regression test that pre-creates an existing probe worker, then verifies `AddPod` still creates the worker for a later container.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Testing
```
go test ./pkg/kubelet/prober
```