### PR TITLE
fix goroutine leak from watch.Filter

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/watch/filter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/filter.go
@@ -36,6 +36,7 @@ func Filter(w Interface, f FilterFunc) Interface {
 	fw := &filteredWatch{
 		incoming: w,
 		result:   make(chan Event),
+		done:     make(chan struct{}),
 		f:        f,
 	}
 	go fw.loop()
@@ -45,6 +46,8 @@ func Filter(w Interface, f FilterFunc) Interface {
 type filteredWatch struct {
 	incoming Interface
 	result   chan Event
+	done     chan struct{}
+	stopOnce sync.Once
 	f        FilterFunc
 }
 
@@ -53,9 +56,12 @@ func (fw *filteredWatch) ResultChan() <-chan Event {
 	return fw.result
 }
 
-// Stop stops the upstream watch, which will eventually stop this watch.
+// Stop stops the upstream watch and unblocks this watch if it is waiting to send an event.
 func (fw *filteredWatch) Stop() {
-	fw.incoming.Stop()
+	fw.stopOnce.Do(func() {
+		close(fw.done)
+		fw.incoming.Stop()
+	})
 }
 
 // loop waits for new values, filters them, and resends them.
@@ -64,7 +70,11 @@ func (fw *filteredWatch) loop() {
 	for event := range fw.incoming.ResultChan() {
 		filtered, keep := fw.f(event)
 		if keep {
-			fw.result <- filtered
+			select {
+			case fw.result <- filtered:
+			case <-fw.done:
+				return
+			}
 		}
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/watch/filter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/filter_test.go
@@ -18,7 +18,10 @@ package watch_test
 
 import (
 	"reflect"
+	goruntime "runtime"
+	"strings"
 	"testing"
+	"time"
 
 	. "k8s.io/apimachinery/pkg/watch"
 )
@@ -111,4 +114,36 @@ func TestRecorder(t *testing.T) {
 	if !reflect.DeepEqual(recordedEvents, events) {
 		t.Errorf("got %v, expected %v", recordedEvents, events)
 	}
+}
+
+func TestFilterStopUnblocksPendingSend(t *testing.T) {
+	source := NewFake()
+	filterReached := make(chan struct{})
+	filtered := Filter(source, func(e Event) (Event, bool) {
+		close(filterReached)
+		return e, true
+	})
+
+	go source.Add(testType("foo"))
+
+	select {
+	case <-filterReached:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for filter to receive event")
+	}
+
+	filtered.Stop()
+
+	for start := time.Now(); time.Since(start) < 5*time.Second; time.Sleep(10 * time.Millisecond) {
+		if !filteredWatchLoopRunning() {
+			return
+		}
+	}
+	t.Fatal("filtered watch loop is still running after Stop")
+}
+
+func filteredWatchLoopRunning() bool {
+	buf := make([]byte, 1<<20)
+	n := goruntime.Stack(buf, true)
+	return strings.Contains(string(buf[:n]), "k8s.io/apimachinery/pkg/watch.(*filteredWatch).loop")
 }


### PR DESCRIPTION
 #### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
use watch.Filter with Reflector can cause goroutine leak, this PR try to address this issue.

#### Which issue(s) this PR is related to:
Fixes #113254

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
