### PR TITLE
E2E test for gang scheduling

### DIFF
--- a/test/e2e/scheduling/gang_scheduling.go
+++ b/test/e2e/scheduling/gang_scheduling.go
@@ -1,0 +1,142 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling
+
+import (
+	"context"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = SIGDescribe("GangScheduling", framework.WithFeatureGate(features.GangScheduling), func() {
+	f := framework.NewDefaultFramework("gang-scheduling")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	removePodGroup := func(ctx context.Context, pgName string) {
+		cs := f.ClientSet
+		ns := f.Namespace.Name
+		ginkgo.By("Deleting PodGroup")
+		err := cs.SchedulingV1alpha3().PodGroups(ns).Delete(ctx, pgName, metav1.DeleteOptions{})
+		framework.ExpectNoError(err, "failed to delete PodGroup")
+	}
+
+	f.It("should schedule pods only when quorum is reached", func(ctx context.Context) {
+		cs := f.ClientSet
+		ns := f.Namespace.Name
+
+		ginkgo.By("Creating a PodGroup with MinCount=2")
+		pgName := "test-pg"
+		pg := &schedulingv1alpha3.PodGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pgName,
+				Namespace: ns,
+			},
+			Spec: schedulingv1alpha3.PodGroupSpec{
+				SchedulingPolicy: schedulingv1alpha3.PodGroupSchedulingPolicy{
+					Gang: &schedulingv1alpha3.GangSchedulingPolicy{
+						MinCount: 2,
+					},
+				},
+			},
+		}
+		_, err := cs.SchedulingV1alpha3().PodGroups(ns).Create(ctx, pg, metav1.CreateOptions{})
+		framework.ExpectNoError(err, "failed to create PodGroup")
+		defer removePodGroup(ctx, pgName)
+
+		ginkgo.By("Creating first pod in the gang")
+		p1 := e2epod.MakePod(ns, nil, nil, admissionapi.LevelPrivileged, "")
+		p1.Spec.SchedulingGroup = &v1.PodSchedulingGroup{
+			PodGroupName: &pgName,
+		}
+		p1, err = cs.CoreV1().Pods(ns).Create(ctx, p1, metav1.CreateOptions{})
+		framework.ExpectNoError(err, "failed to create pod p1")
+
+		ginkgo.By("Verifying pod p1 remains Pending")
+		gomega.Consistently(ctx, func() v1.PodPhase {
+			pod, err := cs.CoreV1().Pods(ns).Get(ctx, p1.Name, metav1.GetOptions{})
+			if err != nil {
+				return v1.PodUnknown
+			}
+			return pod.Status.Phase
+		}, 10*time.Second, 1*time.Second).Should(gomega.Equal(v1.PodPending))
+
+		ginkgo.By("Creating second pod in the gang")
+		p2 := e2epod.MakePod(ns, nil, nil, admissionapi.LevelPrivileged, "")
+		p2.Spec.SchedulingGroup = &v1.PodSchedulingGroup{
+			PodGroupName: &pgName,
+		}
+		p2, err = cs.CoreV1().Pods(ns).Create(ctx, p2, metav1.CreateOptions{})
+		framework.ExpectNoError(err, "failed to create pod p2")
+
+		ginkgo.By("Verifying both pods are scheduled")
+		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, cs, p1.Name, ns), "pod p1 failed to run")
+		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, cs, p2.Name, ns), "pod p2 failed to run")
+	})
+
+	f.It("should schedule pods with basic scheduling policy", func(ctx context.Context) {
+		cs := f.ClientSet
+		ns := f.Namespace.Name
+
+		ginkgo.By("Creating a PodGroup with Basic policy")
+		pgName := "test-pg"
+		pg := &schedulingv1alpha3.PodGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pgName,
+				Namespace: ns,
+			},
+			Spec: schedulingv1alpha3.PodGroupSpec{
+				SchedulingPolicy: schedulingv1alpha3.PodGroupSchedulingPolicy{
+					Basic: &schedulingv1alpha3.BasicSchedulingPolicy{},
+				},
+			},
+		}
+		_, err := cs.SchedulingV1alpha3().PodGroups(ns).Create(ctx, pg, metav1.CreateOptions{})
+		framework.ExpectNoError(err, "failed to create PodGroup")
+
+		ginkgo.By("Creating first pod in the group")
+		p1 := e2epod.MakePod(ns, nil, nil, admissionapi.LevelPrivileged, "")
+		p1.Spec.SchedulingGroup = &v1.PodSchedulingGroup{
+			PodGroupName: &pgName,
+		}
+		p1, err = cs.CoreV1().Pods(ns).Create(ctx, p1, metav1.CreateOptions{})
+		framework.ExpectNoError(err, "failed to create pod p1")
+
+		ginkgo.By("Verifying first pod is scheduled immediately")
+		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, cs, p1.Name, ns), "pod p1 failed to run")
+
+		ginkgo.By("Creating second pod in the group")
+		p2 := e2epod.MakePod(ns, nil, nil, admissionapi.LevelPrivileged, "")
+		p2.Spec.SchedulingGroup = &v1.PodSchedulingGroup{
+			PodGroupName: &pgName,
+		}
+		p2, err = cs.CoreV1().Pods(ns).Create(ctx, p2, metav1.CreateOptions{})
+		framework.ExpectNoError(err, "failed to create pod p2")
+
+		ginkgo.By("Verifying second pod is scheduled immediately")
+		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, cs, p2.Name, ns), "pod p2 failed to run")
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
  This PR adds End-to-End (E2E) tests for the Gang Scheduling feature in gang_scheduling.go.                                                                                                                                                                                                                                                                                                    
  The new tests cover:                                                                                                                                                                                                                                                                                                                                                                                 
  * Quorum Scheduling: Verifies that pods in a gang (PodGroup) are only scheduled when the minimum count (MinCount) is reached.
  * PodGroup Basic scheduling policy: Verifies that pods related to the PodGroup won't be in a pending state when reaching minCount and will be scheduled immediately.
                                                                                                                                                                                                                                                                    
#### Which issue(s) this PR is related to:
N/A
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
The tests depend on the  GangScheduling  feature gate being enabled.    

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/4671-gang-scheduling
```
