### PR TITLE
perf: fix scheduler_perf framework orphaned scheduler on timeout

### DIFF
--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -799,6 +799,13 @@ func RunBenchmarkPerfScheduling(b *testing.B, configFile string, topicName strin
 
 					featureGates := featureGatesMerge(tc.FeatureGates, w.FeatureGates)
 					scheduler, informerFactory, schedulerDone, tCtx := setupTestCase(b, tc, featureGates, w, opts)
+					tCtx.TB().Cleanup(func() {
+						tCtx.Cancel("workload is done")
+						<-schedulerDone
+						// Reset metrics to prevent metrics generated in current workload gets
+						// carried over to the next workload.
+						legacyregistry.Reset()
+					})
 
 					err := w.isValid(tc.MetricsCollectorConfig)
 					if err != nil {
@@ -845,14 +852,6 @@ func RunBenchmarkPerfScheduling(b *testing.B, configFile string, topicName strin
 					if err = checkEmptyInFlightEvents(); err != nil {
 						tCtx.Errorf("%s: %s", w.Name, err)
 					}
-
-					tCtx.Cancel("workload is done")
-					// Wait for the scheduler to stop to avoid data races when resetting metrics.
-					<-schedulerDone
-
-					// Reset metrics to prevent metrics generated in current workload gets
-					// carried over to the next workload.
-					legacyregistry.Reset()
 
 					// Exactly one result is expected to contain the progress information.
 					for _, item := range results {
@@ -923,6 +922,13 @@ func RunIntegrationPerfScheduling(t *testing.T, configFile string, options ...Sc
 					}
 					featureGates := featureGatesMerge(tc.FeatureGates, w.FeatureGates)
 					scheduler, informerFactory, schedulerDone, tCtx := setupTestCase(t, tc, featureGates, w, opts)
+					tCtx.TB().Cleanup(func() {
+						tCtx.Cancel("workload is done")
+						<-schedulerDone
+						// Reset metrics to prevent metrics generated in current workload gets
+						// carried over to the next workload.
+						legacyregistry.Reset()
+					})
 					err := w.isValid(tc.MetricsCollectorConfig)
 					if err != nil {
 						t.Fatalf("workload %s is not valid: %v", w.Name, err)
@@ -937,14 +943,6 @@ func RunIntegrationPerfScheduling(t *testing.T, configFile string, options ...Sc
 					if err = checkEmptyInFlightEvents(); err != nil {
 						tCtx.Errorf("%s: %s", w.Name, err)
 					}
-
-					tCtx.Cancel("workload is done")
-					// Wait for the scheduler to stop to avoid data races when resetting metrics.
-					<-schedulerDone
-
-					// Reset metrics to prevent metrics generated in current workload gets
-					// carried over to the next workload.
-					legacyregistry.Reset()
 				})
 			}
 		})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This PR fixes a critical bug in the `scheduler_perf` integration and benchmark test framework where a test timeout or test failure (aborted via `t.Fatalf()`) leaves the background scheduler goroutine running.

**Why we need it:**
In this framework, the API server, etcd, and scheduler run as background processes. When a test completes normally, `tCtx.Cancel()` is called, which triggers the shutdown of these background processes.
However, if a test fails or times out midway (as often happens under massive scale benchmarks like 10,000-node runs), Go's testing framework immediately halts the current test goroutine, bypassing the inline cancellation and shutdown logic. 

This leaves the old scheduler running in the background. When subsequent tests run:
1. The test cleanup function has already restored the global default feature gates (e.g., enabling `OpportunisticBatching`).
2. The orphaned background scheduler pops a pod and runs a scheduling cycle under the newly restored feature gate.
3. Since it was initialized with the feature gate disabled, its internal batch cache pointer is `nil`, causing a `nil pointer dereference` SIGSEGV panic that crashes the entire test runner.

**How it is fixed:**
This PR moves the scheduler's shutdown and cancellation logic (`tCtx.Cancel()` and `<-schedulerDone`) into Go's native `tCtx.TB().Cleanup()` function. Cleanups registered on `testing.TB` are guaranteed to run, even when a test times out or aborts via `Fatalf()`. This ensures the background scheduler is always cleanly terminated before any subsequent tests begin execution.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
This is part 1 of the scheduler starvation benchmark tests. It fixes the underlying test framework timeout issues to make consecutive high-scale tests stable.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
