### PR TITLE
noderestriction: prevent kubelet updates to NodeAllocatableResourceClaimStatuses

### DIFF
--- a/plugin/pkg/admission/noderestriction/admission.go
+++ b/plugin/pkg/admission/noderestriction/admission.go
@@ -362,7 +362,7 @@ func (p *Plugin) admitPodStatus(nodeName string, a admission.Attributes) error {
 		if !extendedResourceClaimStatusEqual(oldPod.Status.ExtendedResourceClaimStatus, newPod.Status.ExtendedResourceClaimStatus) {
 			return admission.NewForbidden(a, fmt.Errorf("node %q cannot update extended resource claim status", nodeName))
 		}
-		if !apiequality.Semantic.DeepEqual(oldPod.Status.NodeAllocatableResourceClaimStatuses, newPod.Status.NodeAllocatableResourceClaimStatuses) {
+		if !nodeAllocatableResourceClaimStatusesEqual(oldPod.Status.NodeAllocatableResourceClaimStatuses, newPod.Status.NodeAllocatableResourceClaimStatuses) {
 			return admission.NewForbidden(a, fmt.Errorf("node %q cannot update node allocatable resource claim statuses", nodeName))
 		}
 		return nil
@@ -409,6 +409,36 @@ func extendedResourceClaimStatusEqual(statusA, statusB *api.PodExtendedResourceC
 	// But this cannot be guaranteed, so for the sake of correctness in all
 	// cases this code here has to check.
 	return slices.Equal(statusA.RequestMappings, statusB.RequestMappings)
+}
+
+func nodeAllocatableResourceClaimStatusesEqual(statusA, statusB []api.NodeAllocatableResourceClaimStatus) bool {
+	if len(statusA) != len(statusB) {
+		return false
+	}
+	// In most cases, status entries only get added once and not modified.
+	// But this cannot be guaranteed, so for the sake of correctness in all
+	// cases this code here has to check.
+	for i := range statusA {
+		if statusA[i].ResourceClaimName != statusB[i].ResourceClaimName {
+			return false
+		}
+		if !slices.Equal(statusA[i].Containers, statusB[i].Containers) {
+			return false
+		}
+		if len(statusA[i].Resources) != len(statusB[i].Resources) {
+			return false
+		}
+		for name, qtyA := range statusA[i].Resources {
+			qtyB, ok := statusB[i].Resources[name]
+			if !ok {
+				return false
+			}
+			if qtyA.Cmp(qtyB) != 0 {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // admitPodEviction allows to evict a pod if it is assigned to the current node.

--- a/plugin/pkg/admission/noderestriction/admission.go
+++ b/plugin/pkg/admission/noderestriction/admission.go
@@ -362,6 +362,9 @@ func (p *Plugin) admitPodStatus(nodeName string, a admission.Attributes) error {
 		if !extendedResourceClaimStatusEqual(oldPod.Status.ExtendedResourceClaimStatus, newPod.Status.ExtendedResourceClaimStatus) {
 			return admission.NewForbidden(a, fmt.Errorf("node %q cannot update extended resource claim status", nodeName))
 		}
+		if !apiequality.Semantic.DeepEqual(oldPod.Status.NodeAllocatableResourceClaimStatuses, newPod.Status.NodeAllocatableResourceClaimStatuses) {
+			return admission.NewForbidden(a, fmt.Errorf("node %q cannot update node allocatable resource claim statuses", nodeName))
+		}
 		return nil
 
 	default:

--- a/plugin/pkg/admission/noderestriction/admission_test.go
+++ b/plugin/pkg/admission/noderestriction/admission_test.go
@@ -1141,7 +1141,7 @@ func Test_nodePlugin_Admit(t *testing.T) {
 			name:       "forbid update of pod's node allocatable resource claim status",
 			podsGetter: existingPods,
 			attributes: admission.NewAttributesRecord(nodeAllocatableResourceClaimPod, claimpod, podKind, nodeAllocatableResourceClaimPod.Namespace, nodeAllocatableResourceClaimPod.Name, podResource, "status", admission.Update, &metav1.UpdateOptions{}, false, mynode),
-			err:        "annot update node allocatable resource claim statuses",
+			err:        "cannot update node allocatable resource claim statuses",
 		},
 
 		// My node object

--- a/plugin/pkg/admission/noderestriction/admission_test.go
+++ b/plugin/pkg/admission/noderestriction/admission_test.go
@@ -601,6 +601,15 @@ func Test_nodePlugin_Admit(t *testing.T) {
 	extendedResourceClaimPod, _ := makeTestPod("ns", "myclaimpod", "mynode", true)
 	extendedResourceClaimPod.Status.ExtendedResourceClaimStatus = &api.PodExtendedResourceClaimStatus{ResourceClaimName: "myclaim"}
 
+	nodeAllocatableResourceClaimPod, _ := makeTestPod("ns", "myclaimpod", "mynode", true)
+	nodeAllocatableResourceClaimPod.Status.NodeAllocatableResourceClaimStatuses = []api.NodeAllocatableResourceClaimStatus{
+		{
+			ResourceClaimName: "myclaim",
+			Containers:        []string{"mycontainer"},
+			Resources:         map[api.ResourceName]resource.Quantity{api.ResourceCPU: resource.MustParse("1")},
+		},
+	}
+
 	pcrServiceAccountIndex := cache.NewIndexer(cache.MetaNamespaceKeyFunc, nil)
 	pcrServiceAccounts := corev1lister.NewServiceAccountLister(pcrServiceAccountIndex)
 
@@ -1127,6 +1136,12 @@ func Test_nodePlugin_Admit(t *testing.T) {
 			podsGetter: existingPods,
 			attributes: admission.NewAttributesRecord(extendedResourceClaimPod, claimpod, podKind, extendedResourceClaimPod.Namespace, extendedResourceClaimPod.Name, podResource, "status", admission.Update, &metav1.UpdateOptions{}, false, mynode),
 			err:        "annot update extended resource claim status",
+		},
+		{
+			name:       "forbid update of pod's node allocatable resource claim status",
+			podsGetter: existingPods,
+			attributes: admission.NewAttributesRecord(nodeAllocatableResourceClaimPod, claimpod, podKind, nodeAllocatableResourceClaimPod.Namespace, nodeAllocatableResourceClaimPod.Name, podResource, "status", admission.Update, &metav1.UpdateOptions{}, false, mynode),
+			err:        "annot update node allocatable resource claim statuses",
 		},
 
 		// My node object


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The NodeRestriction admission plugin already forbids the kubelet from mutating `pod.status.ResourceClaimStatuses` and `pod.status.ExtendedResourceClaimStatus` via the pod-status subresource, but it does not yet enforce the same boundary for the sibling `pod.status.NodeAllocatableResourceClaimStatuses` field gated by the `DRANodeAllocatableResources` feature gate.

The kubelet status manager already treats the field as not-kubelet-owned and preserves it across status syncs (see commit [9fd706ccd90](https://github.com/kubernetes/kubernetes/commit/9fd706ccd90dd4596ef5d92796b6e058dd4f51ad
), "kubelet: do not destroy nodeAllocatableResourceClaimStatuses"). This PR mirrors that boundary in admission so the kubelet cannot stomp on a value the scheduler is responsible for, alongside the existing `ExtendedResourceClaimStatus` check in the same plugin.

`DRANodeAllocatableResources` is alpha and default-off in v1.36, so this is future-proofing rather than a fix for an observed bug.

#### Which issue(s) this PR is related to:

N/A

Related precedent: #138792.

#### Special notes for your reviewer:

The new check uses `apiequality.Semantic.DeepEqual` inline rather than introducing a third hand-rolled helper next to `resourceClaimStatusesEqual` and `extendedResourceClaimStatusEqual`. `NodeAllocatableResourceClaimStatus.Resources` is a `map[ResourceName]resource.Quantity`, and `Semantic.DeepEqual` already canonicalises `resource.Quantity` via `Cmp`, so the inline form is shorter and more correct than a reflect-based equality function would be.

Skew implication: a pre-`9fd706ccd90` kubelet talking to an apiserver with this check, with `DRANodeAllocatableResources` explicitly enabled, will see its destructive status patches correctly rejected. This is the same risk profile as the existing `ExtendedResourceClaimStatus` check and is the desired behavior.

/sig auth
/sig node

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
