### PR TITLE
Unset WasFlushedFromUnschedulable for gated pods

### DIFF
--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -735,6 +735,9 @@ func (p *PriorityQueue) moveToActiveQ(logger klog.Logger, entity framework.Queue
 		if p.unschedulableEntities.get(entity) == nil {
 			logger.V(5).Info("Entity moved to an internal scheduling queue, because it is gated", "type", entity.Type(), "entity", klog.KObj(entity), "event", event, "queue", unschedulableQ)
 		}
+		// Clearing WasFlushedFromUnschedulable is typically done on scheduling failure, but in case the flushed pod was gated, it never attempts scheduling.
+		// We clear it here to ensure it's not set the next time the pod is woken up by a non-flush event.
+		entity.SetWasFlushedFromUnschedulable(false)
 		p.unschedulableEntities.addOrUpdate(entity, gatedBefore, event)
 		// Entity not moved to activeQ.
 		return false
@@ -762,6 +765,9 @@ func (p *PriorityQueue) moveToBackoffQ(logger klog.Logger, entity framework.Queu
 			if uInfo := p.unschedulableEntities.get(entity); uInfo == nil {
 				logger.V(5).Info("Entity moved to an internal scheduling queue, because it is gated", "type", entity.Type(), "entity", klog.KObj(entity), "event", event, "queue", unschedulableQ)
 			}
+			// Clearing WasFlushedFromUnschedulable is typically done on scheduling failure, but in case the flushed pod was gated, it never attempts scheduling.
+			// We clear it here to ensure it's not set the next time the pod is woken up by a non-flush event.
+			entity.SetWasFlushedFromUnschedulable(false)
 			p.unschedulableEntities.addOrUpdate(entity, gatedBefore, event)
 			return false
 		}

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -3583,6 +3583,137 @@ func TestFlushUnschedulableEntitiesLeftoverSetsFlag(t *testing.T) {
 	}
 }
 
+func TestFlushUnschedulablePodsLeftoverSetsFlag_GatedPod(t *testing.T) {
+	tests := []struct {
+		name                            string
+		gatedBeforeFlush                bool
+		gatedAfterFlush                 bool
+		backingOff                      bool
+		wantWasFlushedFromUnschedulable bool
+		wantQ                           string
+	}{
+		{
+			name:                            "flag is set when pod is not gated",
+			wantWasFlushedFromUnschedulable: true,
+			wantQ:                           activeQ,
+		},
+		{
+			name:                            "flag is set when pod is no longer gated",
+			gatedBeforeFlush:                true,
+			wantWasFlushedFromUnschedulable: true,
+			wantQ:                           activeQ,
+		},
+		{
+			name:                            "flag is unset when pod is newly gated",
+			gatedAfterFlush:                 true,
+			wantWasFlushedFromUnschedulable: false,
+			wantQ:                           unschedulableQ,
+		},
+		{
+			name:                            "flag is unset when pod is still gated",
+			gatedBeforeFlush:                true,
+			gatedAfterFlush:                 true,
+			wantWasFlushedFromUnschedulable: false,
+			wantQ:                           unschedulableQ,
+		},
+		{
+			name:                            "flag is set when pod is not gated and backoff is not complete",
+			backingOff:                      true,
+			wantWasFlushedFromUnschedulable: true,
+			wantQ:                           backoffQ,
+		},
+		{
+			name:                            "flag is set when pod is no longer gated and backoff is not complete",
+			gatedBeforeFlush:                true,
+			backingOff:                      true,
+			wantWasFlushedFromUnschedulable: true,
+			wantQ:                           backoffQ,
+		},
+		{
+			name:                            "flag is unset when pod is newly gated and backoff is not complete",
+			gatedAfterFlush:                 true,
+			backingOff:                      true,
+			wantWasFlushedFromUnschedulable: false,
+			wantQ:                           unschedulableQ,
+		},
+		{
+			name:                            "flag is unset when pod is still gated and backoff is not complete",
+			gatedBeforeFlush:                true,
+			gatedAfterFlush:                 true,
+			backingOff:                      true,
+			wantWasFlushedFromUnschedulable: false,
+			wantQ:                           unschedulableQ,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const allowedLabel = "allow"
+			const preEnqueuePluginName = "preEnqueuePlugin"
+
+			var backoffDuration time.Duration
+			if tt.backingOff {
+				backoffDuration = DefaultPodMaxInUnschedulablePodsDuration + time.Minute
+			}
+
+			c := testingclock.NewFakeClock(time.Now())
+			m := makeEmptyQueueingHintMapPerProfile()
+			preEnqM := map[string]map[string]fwk.PreEnqueuePlugin{
+				"": {
+					preEnqueuePluginName: &preEnqueuePlugin{allowlists: []string{allowedLabel}},
+				},
+			}
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			q := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(c), WithQueueingHintMapPerProfile(m), WithPreEnqueuePluginMap(preEnqM),
+				WithPodInitialBackoffDuration(backoffDuration), WithPodMaxBackoffDuration(backoffDuration))
+
+			pod := st.MakePod().Name("pod1").Namespace("ns1").UID("1").Label(allowedLabel, "").Obj()
+			podInfo := &framework.QueuedPodInfo{PodInfo: mustNewPodInfo(pod), QueueingParams: framework.QueueingParams{UnschedulablePlugins: sets.New("foo")}}
+			if tt.gatedBeforeFlush {
+				podInfo = setQueuedPodInfoGated(podInfo, preEnqueuePluginName, []fwk.ClusterEvent{})
+			}
+
+			q.Add(ctx, podInfo.Pod)
+			_, err := q.Pop(logger)
+			if err != nil {
+				t.Fatalf("Failed to pop from active queue: %v", err)
+			}
+
+			if tt.gatedAfterFlush {
+				delete(pod.Labels, allowedLabel)
+			}
+
+			err = q.AddUnschedulablePodIfNotPresent(logger, podInfo, q.SchedulingCycle())
+			if err != nil {
+				t.Fatalf("Failed to add pod to unschedulable: %v", err)
+			}
+
+			// Advance time past the flush duration and flush
+			c.Step(DefaultPodMaxInUnschedulablePodsDuration + time.Second)
+			q.flushUnschedulableEntitiesLeftover(logger)
+
+			queueSizes := map[string]int{
+				unschedulableQ: len(q.UnschedulablePods()),
+				backoffQ:       len(q.PodsInBackoffQ()),
+				activeQ:        len(q.PodsInActiveQ()),
+			}
+
+			if queueSizes[tt.wantQ] == 0 {
+				t.Errorf("Pod not found in %s", tt.wantQ)
+			}
+			actualPod, ok := q.GetPod(podInfo.Pod.Name, podInfo.Pod.Namespace, nil)
+			if !ok {
+				t.Fatalf("Pod not found in scheduling queue")
+			}
+			if actualPod.WasFlushedFromUnschedulable != tt.wantWasFlushedFromUnschedulable {
+				t.Errorf("Unexpected WasFlushedFromUnschedulable value: %v", actualPod.WasFlushedFromUnschedulable)
+			}
+		})
+	}
+}
+
 // TestAddAttemptedPodGroupIfNeeded verifies that AddAttemptedPodGroupIfNeeded
 // correctly handles pod groups with or without failed plugins.
 func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/pull/139162 made gated pods react to flush, however introduced a bug because WasFlushedFromUnschedulable was not cleared. In effect, the `pod_scheduled_after_flush_total` metric may count incorrectly.

Example scenario:

1. Pod fails scheduling and is added to unschedulable queue
2. 5 minutes pass and the pod is flushed, setting WasFlushedFromUnschedulable to true: https://github.com/kubernetes/kubernetes/blob/f15071f37174baf476617f175898beab3c9b8605/pkg/scheduler/backend/queue/scheduling_queue.go#L1153-L1156
3. PreEnqueue fails, and the pod remains in unschedulable
4. Pod is waken up by a proper event and scheduled successfully
5. Since WasFlushedFromUnschedulable was never set back to false, the metric is incremented when it shouldn't be at https://github.com/kubernetes/kubernetes/blob/f15071f37174baf476617f175898beab3c9b8605/pkg/scheduler/schedule_one.go#L481-L485

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
