### PR TITLE
Make sure gated pods are flushed with the same frequency as non-gated

### DIFF
--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -1009,6 +1009,7 @@ func (p *PriorityQueue) AddUnschedulablePodIfNotPresent(logger klog.Logger, pInf
 	pInfo.BackoffExpiration = time.Time{}
 	// Clear the flush flag since the pod is returning to the queue after a scheduling attempt.
 	pInfo.WasFlushedFromUnschedulable = false
+	pInfo.FlushTimestamp = time.Time{}
 
 	if p.isPodGroupMember(pod) {
 		// Done has to be called before adding the unschedulable pod group member.
@@ -1105,6 +1106,7 @@ func (p *PriorityQueue) AddAttemptedPodGroupIfNeeded(logger klog.Logger, pgInfo 
 	pgInfo.BackoffExpiration = time.Time{}
 	// Clear the flush flag since the pod is returning to the queue after a scheduling attempt.
 	pgInfo.WasFlushedFromUnschedulable = false
+	pgInfo.FlushTimestamp = time.Time{}
 
 	rejectorPlugins := pgInfo.UnschedulablePlugins.Union(pgInfo.PendingPlugins)
 
@@ -1155,9 +1157,13 @@ func (p *PriorityQueue) flushUnschedulableEntitiesLeftover(logger klog.Logger) {
 	currentTime := p.clock.Now()
 	for _, entity := range p.unschedulableEntities.entityInfoMap {
 		lastScheduleTime := entity.GetTimestamp()
+		if flushTime := entity.GetFlushTimestamp(); flushTime.After(lastScheduleTime) {
+			lastScheduleTime = flushTime
+		}
 		// TODO(macsko): Once the PodGroups support queueing hints, we may want to extend the max duration for PodGroups.
 		if currentTime.Sub(lastScheduleTime) > p.podMaxInUnschedulablePodsDuration {
 			entity.SetWasFlushedFromUnschedulable(true)
+			entity.SetFlushTimestamp(currentTime)
 			entitiesToMove = append(entitiesToMove, entity)
 		}
 	}

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -3712,6 +3712,102 @@ func TestFlushUnschedulablePodsLeftoverSetsFlag_GatedPod(t *testing.T) {
 	}
 }
 
+// TestGatedPodFlushFrequency verifies that a gated pod is only flushed once every
+// podMaxInUnschedulablePodsDuration, and not on every periodic flush execution.
+func TestGatedPodFlushFrequency(t *testing.T) {
+	gatedPod := mustNewPodInfo(st.MakePod().Name("pod1").Namespace("ns1").UID("1").Obj())
+
+	tests := []struct {
+		name       string
+		entityInfo framework.QueuedEntityInfo
+	}{
+		{
+			name: "queued pod",
+			entityInfo: &framework.QueuedPodInfo{
+				PodInfo:        gatedPod,
+				QueueingParams: framework.QueueingParams{UnschedulablePlugins: sets.New("foo")},
+			},
+		},
+		{
+			name: "queued pod group",
+			entityInfo: &framework.QueuedPodGroupInfo{
+				PodGroupInfo:   &framework.PodGroupInfo{Namespace: gatedPod.GetNamespace(), Name: "pg", UnscheduledPods: []*v1.Pod{gatedPod.Pod}},
+				QueuedPodInfos: []*framework.QueuedPodInfo{{PodInfo: gatedPod, QueueingParams: framework.QueueingParams{UnschedulablePlugins: sets.New("foo")}}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := testingclock.NewFakeClock(time.Now())
+			m := makeEmptyQueueingHintMapPerProfile()
+			preEnqueuePluginName := "preEnqueuePlugin"
+			preEnqM := map[string]map[string]fwk.PreEnqueuePlugin{
+				"": {
+					preEnqueuePluginName: &preEnqueuePlugin{}, // Empty allowlist, gates all pods
+				},
+			}
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			// Use a user-defined 5-minute duration for clarity
+			flushDuration := 5 * time.Minute
+			q := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(c), WithQueueingHintMapPerProfile(m), WithPreEnqueuePluginMap(preEnqM),
+				WithPodMaxInUnschedulablePodsDuration(flushDuration))
+
+			getEntityFromAnyQueue := func() framework.QueuedEntityInfo {
+				var entity framework.QueuedEntityInfo
+				q.activeQ.underRLock(func(unlockedActiveQ unlockedActiveQueueReader) {
+					entity = q.getEntityFromAnyQueue(unlockedActiveQ, tt.entityInfo)
+				})
+				if entity == nil {
+					t.Fatalf("Failed to find entity in any queue")
+				}
+				return entity
+			}
+
+			// Add gated pod directly to unschedulableEntities
+			q.unschedulableEntities.addOrUpdate(tt.entityInfo, false, "test-setup")
+
+			// Step clock past the flush duration and trigger flush
+			// T=5:01
+			c.Step(flushDuration + time.Second)
+
+			q.flushUnschedulableEntitiesLeftover(logger)
+
+			actualEntity := getEntityFromAnyQueue()
+			// Verify that flush happened
+			firstFlushTime := actualEntity.GetFlushTimestamp()
+			if firstFlushTime.IsZero() {
+				t.Errorf("Expected FlushTimestamp to be set after the first leftover flush")
+			}
+
+			// Step clock by less than the flush duration and trigger flush
+			// T=9:01
+			c.Step(4 * time.Minute)
+			q.flushUnschedulableEntitiesLeftover(logger)
+
+			actualEntity = getEntityFromAnyQueue()
+			// Verify that flush didn't happen
+			if actualEntity.GetFlushTimestamp() != firstFlushTime {
+				t.Errorf("Expected FlushTimestamp to remain %v, but was updated to %v (pod was flushed prematurely)", firstFlushTime, actualEntity.GetFlushTimestamp())
+			}
+
+			// Step clock past the duration since the last flush
+			// T=10:02
+			c.Step(time.Minute + time.Second)
+			q.flushUnschedulableEntitiesLeftover(logger)
+
+			actualEntity = getEntityFromAnyQueue()
+			// Verify that flush happened
+			if !actualEntity.GetFlushTimestamp().After(firstFlushTime) {
+				t.Errorf("Expected FlushTimestamp to be updated to a newer time after 5 minutes elapsed, but remained %v", actualEntity.GetFlushTimestamp())
+			}
+		})
+	}
+}
+
 // TestAddAttemptedPodGroupIfNeeded verifies that AddAttemptedPodGroupIfNeeded
 // correctly handles pod groups with or without failed plugins.
 func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
@@ -3950,6 +4046,8 @@ func TestPriorityQueue_initPodMaxInUnschedulablePodsDuration(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			pInfo1.FlushTimestamp = time.Time{}
+			pInfo2.FlushTimestamp = time.Time{}
 			tCtx := ktesting.Init(t)
 			logger := klog.FromContext(tCtx)
 			var queue *PriorityQueue

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -583,10 +583,17 @@ type QueuedEntityInfo interface {
 	SetBackoffExpiration(t time.Time)
 	// SetGatingPlugin sets the GatingPlugin in QueueingParams.
 	SetGatingPlugin(gatingPlugin string, gatingEvents []fwk.ClusterEvent)
+	// GetFlushTimestamp returns the FlushTimestamp in QueueingParams.
+	GetFlushTimestamp() time.Time
+	// SetFlushTimestamp sets the FlushTimestamp in QueueingParams.
+	SetFlushTimestamp(t time.Time)
 }
 
 // QueueingParams holds parameters related to the queueing status and history of an entity
 // (Pod or PodGroup) in the scheduling queue.
+//
+// NOTE TO IMPLEMENTERS: Use higher-level structs (e.g., QueuedPodGroupInfo or QueuedPodInfo)
+// to define setters. Do not define setters directly for QueueingParams.
 type QueueingParams struct {
 	// The time entity added to the scheduling queue.
 	Timestamp time.Time
@@ -621,6 +628,8 @@ type QueueingParams struct {
 	// indicate queueing hint misconfigurations or event handling bugs.
 	// This flag is cleared when the entity returns to the queue for any reason.
 	WasFlushedFromUnschedulable bool
+	// FlushTimestamp tracks the last time this entity was flushed from the unschedulable queue.
+	FlushTimestamp time.Time
 	// The time when the entity is added to the active queue for the first time. The entity may be added
 	// back to the queue multiple times before it's successfully scheduled.
 	// It shouldn't be updated once initialized. It's used to record the e2e scheduling
@@ -682,10 +691,15 @@ func (qp *QueueingParams) GetGatingPluginEvents() []fwk.ClusterEvent {
 	return qp.GatingPluginEvents
 }
 
+func (qp *QueueingParams) GetFlushTimestamp() time.Time {
+	return qp.FlushTimestamp
+}
+
 // DeepCopy returns a deep copy of the QueueingParams object.
 func (qp *QueueingParams) DeepCopy() *QueueingParams {
 	return &QueueingParams{
 		Timestamp:                   qp.Timestamp,
+		FlushTimestamp:              qp.FlushTimestamp,
 		Attempts:                    qp.Attempts,
 		UnschedulableCount:          qp.UnschedulableCount,
 		InitialAttemptTimestamp:     qp.InitialAttemptTimestamp,
@@ -781,6 +795,10 @@ func (pqi *QueuedPodInfo) ClearRejectorPlugins() {
 	pqi.QueueingParams.PendingPlugins.Clear()
 	pqi.QueueingParams.GatingPlugin = ""
 	pqi.QueueingParams.GatingPluginEvents = nil
+}
+
+func (pqi *QueuedPodInfo) SetFlushTimestamp(t time.Time) {
+	pqi.FlushTimestamp = t
 }
 
 // QueuedPodGroupInfo is a PodGroupInfo wrapper with additional information related to
@@ -926,6 +944,11 @@ func (pgqi *QueuedPodGroupInfo) SetGatingPlugin(gatingPlugin string, gatingEvent
 	// as each pod has its own gating plugin and events.
 	pgqi.GatingPlugin = gatingPlugin
 	pgqi.GatingPluginEvents = gatingEvents
+}
+
+func (pgqi *QueuedPodGroupInfo) SetFlushTimestamp(t time.Time) {
+	// We don't need to set it for all members as it's only checked at the root level.
+	pgqi.FlushTimestamp = t
 }
 
 // PodGroupInfo is a wrapper around the PodGroup API object together with a list of pods that belong to the pod group.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/pull/139162 made gated pods react to flush, however introduced a bug where a gated pod won't update the Timestamp and will therefore react to flush every 30 seconds once the timestamp is past the max unschedulable duration.

Example scenario:

1. Pod fails scheduling and is added to the unschedulable queue
2. 5 minutes pass and the pod is flushed
3. PreEnqueue fails, and the pod remains in unschedulable
4. Since timestamp hasn't changed, the condition for flushing the pod remains true for each invocation of flush which happens every 30 seconds, until PreEnqueue succeeds:  https://github.com/kubernetes/kubernetes/blob/f15071f37174baf476617f175898beab3c9b8605/pkg/scheduler/backend/queue/scheduling_queue.go#L446-L448

We don't want to update Timestamp for gated pods, as it may impact the queue order. To workaround this, I added a FlushTimestamp which is set on flush, and take `max(Timestamp, FlushTimestamp)` as the last schedule time. This should not change the behavior for ungated pods.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
