### PR TITLE
DRA: pass ListTypeAttributes to AllocatorFeatures

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -661,6 +661,7 @@ func AllocatorFeatures(fts feature.Features) structured.Features {
 		DeviceTaints:           fts.EnableDRADeviceTaints,
 		DeviceBindingAndStatus: fts.EnableDRADeviceBindingConditions && fts.EnableDRAResourceClaimDeviceStatus,
 		ConsumableCapacity:     fts.EnableDRAConsumableCapacity,
+		ListTypeAttributes:     fts.EnableDRAListTypeAttributes,
 	}
 }
 

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"reflect"
 	"slices"
 	"sort"
 	"strings"
@@ -4390,14 +4391,25 @@ func (m *mockDeviceClassResolver) GetDeviceClass(resourceName v1.ResourceName) *
 // k8s.io/dynamic-resource-allocation/structured because that code has no access
 // to feature gate definitions.
 func TestAllocatorSelection(t *testing.T) {
+	// We want to be sure that each feature as identified by the fields in structured.Features
+	// is covered by a dedicated test cases.
+	allFeatures := sets.New[string]()
+	coveredFeatures := sets.New[string]()
+	featureType := reflect.TypeFor[structured.Features]()
+	for field := range featureType.Fields() {
+		allFeatures.Insert(field.Name)
+	}
+
 	for name, tc := range map[string]struct {
 		features             string
+		usingFeatureGroup    bool
 		expectImplementation string
 	}{
 		// The most conservative implementation: only used when explicitly asking
 		// for the most stable Kubernetes (no alpha or beta features).
 		"only-GA": {
 			features:             "AllAlpha=false,AllBeta=false",
+			usingFeatureGroup:    true,
 			expectImplementation: "stable",
 		},
 
@@ -4405,13 +4417,47 @@ func TestAllocatorSelection(t *testing.T) {
 		// is used.
 		"default": {
 			features:             "",
+			usingFeatureGroup:    true,
 			expectImplementation: "incubating",
 		},
 
-		// Alpha features need the experimental implementation.
+		// Alpha features may need the experimental implementation, if there are any
+		// and if those influence allocation.
 		"alpha": {
 			features:             "AllAlpha=true,AllBeta=true",
+			usingFeatureGroup:    true,
+			expectImplementation: "experimental",
+		},
+
+		// Let's also determine which allocator is picked for each of the
+		// individual features which influence that decision.
+		"AdminAccess": {
+			features:             "AllAlpha=false,AllBeta=false,DRAAdminAccess=true",
+			expectImplementation: "stable",
+		},
+		"ConsumableCapacity": {
+			features:             "AllAlpha=false,AllBeta=false,DRAConsumableCapacity=true",
 			expectImplementation: "incubating",
+		},
+		"DeviceBindingAndStatus": {
+			features:             "AllAlpha=false,AllBeta=false,DRAResourceClaimDeviceStatus=true,DRADeviceBindingConditions=true",
+			expectImplementation: "incubating",
+		},
+		"DeviceTaints": {
+			features:             "AllAlpha=false,AllBeta=false,DRADeviceTaints=true",
+			expectImplementation: "stable",
+		},
+		"ListTypeAttributes": {
+			features:             "AllAlpha=false,AllBeta=false,DRAListTypeAttributes=true",
+			expectImplementation: "experimental",
+		},
+		"PartitionableDevices": {
+			features:             "AllAlpha=false,AllBeta=false,DRAPartitionableDevices=true",
+			expectImplementation: "stable",
+		},
+		"PrioritizedList": {
+			features:             "AllAlpha=false,AllBeta=false,DRAPrioritizedList=true",
+			expectImplementation: "stable",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -4429,7 +4475,20 @@ func TestAllocatorSelection(t *testing.T) {
 			if !strings.Contains(allocatorType, tc.expectImplementation) {
 				tCtx.Fatalf("Expected allocator implementation %q, got %s", tc.expectImplementation, allocatorType)
 			}
+
+			if !tc.usingFeatureGroup {
+				for field := range featureType.Fields() {
+					if !reflect.ValueOf(features).FieldByName(field.Name).IsZero() {
+						coveredFeatures.Insert(field.Name)
+					}
+				}
+			}
 		})
+	}
+
+	notCovered := allFeatures.Difference(coveredFeatures)
+	if len(notCovered) > 0 {
+		t.Errorf("Some feature fields in %T were never set by any of the dedicated sub-tests: %s\nA test case for a new feature is missing and/or AllocatorFeatures was not updated to set the field.", structured.Features{}, strings.Join(sets.List(notCovered), ", "))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Pass `EnableDRAListTypeAttributes` to `AllocatorFeatures()` so the experimental allocator is selected when the `DRAListTypeAttributes` feature gate is enabled

## Problem

KEP-5491 added the `DRAListTypeAttributes` feature gate and implemented list-type attribute intersection matching in the experimental allocator (`allocator_experimental.go`). However, the feature gate was only wired to the CEL cache (`cel.Features`), not to `AllocatorFeatures()`.

Without this fix, the scheduler always selects the incubating allocator (which doesn't support list attributes), even when `DRAListTypeAttributes=true`. The experimental allocator's intersection matching code is never reached.

## Test plan

- Enable `DRAListTypeAttributes` feature gate on API server and scheduler
- Create ResourceSlice devices with `ints` (list) attributes
- Create ResourceClaim with `matchAttribute` referencing a list attribute
- Verify the scheduler selects devices using non-empty intersection matching

Tested on a bare-metal cluster (Dell R7725, AMD EPYC 9825, NPS4) with 4 DRA drivers publishing `numaNode` as a list attribute. Without this fix, all `matchAttribute` claims with list attributes fail to allocate. With this fix, intersection matching works correctly.