### PR TITLE
fix: declare correct error types for +k8s:update guardrail

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/test_targets.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/test_targets.go
@@ -437,14 +437,18 @@ func collectRules(node *typeNode) fieldRules {
 
 // recordRules descends fg, accumulating Wrapper/MultiWrapperFunction
 // PathFragments into suffix, and records (basePath+suffix, Rule) at each
-// emitting leaf (Emits != nil).
+// emitting leaf. A FunctionGen may declare multiple Emissions when the
+// runtime emits errors of different types or at different path fragments
+// from the same call (e.g. UpdateSlice with NoAddItem and NoRemoveItem).
 func recordRules(rules fieldRules, basePath string, fg validators.FunctionGen, suffix string) {
-	if fg.Emits != nil {
-		path := basePath + suffix + fg.Emits.PathFragment
-		rules[path] = append(rules[path], rule{
-			ErrorType: string(fg.Emits.Type),
-			Origin:    fg.Emits.Origin,
-		})
+	if len(fg.Emits) > 0 {
+		for _, e := range fg.Emits {
+			path := basePath + suffix + e.PathFragment
+			rules[path] = append(rules[path], rule{
+				ErrorType: string(e.Type),
+				Origin:    e.Origin,
+			})
+		}
 		return
 	}
 	for _, arg := range fg.Args {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/update.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/update.go
@@ -294,7 +294,7 @@ func generateSliceValidation(listByPath map[string]*listMetadata, context Contex
 
 	// Use ShortCircuit flag so these run in the same group as +k8s:optional
 	fn := Function(updateTagName, ShortCircuit, updateSliceValidator, args...).
-		WithEmits(Emission{field.ErrorTypeInvalid, "update", ""})
+		WithEmits(compoundUpdateEmissions(constraints, false)...)
 	return Validations{Functions: []FunctionGen{fn}}, nil
 }
 
@@ -303,7 +303,7 @@ func generateSliceValidation(listByPath map[string]*listMetadata, context Contex
 func generateMapValidation(constraints []validate.UpdateConstraint) Validations {
 	// Use ShortCircuit flag so these run in the same group as +k8s:optional
 	fn := Function(updateTagName, ShortCircuit, updateMapValidator, constraintIdentifierArgs(constraints)...).
-		WithEmits(Emission{field.ErrorTypeInvalid, "update", ""})
+		WithEmits(compoundUpdateEmissions(constraints, true)...)
 	return Validations{Functions: []FunctionGen{fn}}
 }
 
@@ -330,10 +330,47 @@ func emitScalarUpdate(context Context, constraints []validate.UpdateConstraint) 
 		validatorFunc = updateValueByReflectValidator
 	}
 
-	// Use ShortCircuit flag so these run in the same group as +k8s:optional
+	// Use ShortCircuit flag so these run in the same group as +k8s:optional.
+	// Scalar/pointer/struct fields only accept NoSet/NoUnset/NoModify
+	// (validateConstraintsForType rejects the rest), all of which emit
+	// field.Invalid at the field path.
 	fn := Function(updateTagName, ShortCircuit, validatorFunc, constraintIdentifierArgs(constraints)...).
 		WithEmits(Emission{field.ErrorTypeInvalid, "update", ""})
 	return Validations{Functions: []FunctionGen{fn}}
+}
+
+// compoundUpdateEmissions returns the (deduplicated) Emissions UpdateSlice or
+// UpdateMap produces for the given constraints. Order is stable for
+// reproducible codegen. NoModify is rejected for compound types upstream, so
+// only NoSet/NoUnset/NoAddItem/NoRemoveItem are handled here.
+//
+//   - NoSet/NoUnset       -> Invalid at the field path
+//   - NoAddItem           -> Forbidden at fldPath.Index(i)/fldPath.Key(k) ("[*]")
+//   - NoRemoveItem, slice -> Forbidden at fldPath ("")
+//   - NoRemoveItem, map   -> Forbidden at fldPath.Key(k) ("[*]"), shared with NoAddItem
+func compoundUpdateEmissions(constraints []validate.UpdateConstraint, isMap bool) []Emission {
+	var hasInvalid, hasAdd, hasRemove bool
+	for _, c := range constraints {
+		switch c {
+		case validate.NoSet, validate.NoUnset:
+			hasInvalid = true
+		case validate.NoAddItem:
+			hasAdd = true
+		case validate.NoRemoveItem:
+			hasRemove = true
+		}
+	}
+	var out []Emission
+	if hasInvalid {
+		out = append(out, Emission{field.ErrorTypeInvalid, "update", ""})
+	}
+	if hasAdd || (hasRemove && isMap) {
+		out = append(out, Emission{field.ErrorTypeForbidden, "update", "[*]"})
+	}
+	if hasRemove && !isMap {
+		out = append(out, Emission{field.ErrorTypeForbidden, "update", ""})
+	}
+	return out
 }
 
 // constraintIdentifierArgs builds the constraint arguments in deterministic order.

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
@@ -577,10 +577,12 @@ type FunctionGen struct {
 	// embedded or handled, and should not be wrapped by levelTagValidator.
 	StabilityLevelSelfManaged bool
 
-	// Emits, when non-nil, declares the field.Error the runtime validator
-	// produces on failure. Set via WithEmits; nil for wrappers and
-	// non-emitting validators.
-	Emits *Emission
+	// Emits, when non-empty, declares the field.Errors the runtime validator
+	// produces on failure. Set via WithEmits; empty for wrappers and
+	// non-emitting validators. A single function call may emit errors of
+	// different types and/or at different path fragments (e.g. UpdateSlice
+	// with NoAddItem and NoRemoveItem), so this is a slice.
+	Emits []Emission
 }
 
 // WithTypeArgs returns a derived FunctionGen with type arguments.
@@ -612,10 +614,11 @@ func (fg FunctionGen) WithStabilityLevel(level ValidationStabilityLevel) Functio
 	return fg
 }
 
-// WithEmits returns a new FunctionGen that declares the field.Error the
-// runtime validator produces on failure.
-func (fg FunctionGen) WithEmits(emits Emission) FunctionGen {
-	fg.Emits = &emits
+// WithEmits returns a new FunctionGen that declares the field.Errors the
+// runtime validator produces on failure. A function may emit more than one
+// distinct (type, path) tuple — pass each as a separate Emission.
+func (fg FunctionGen) WithEmits(emits ...Emission) FunctionGen {
+	fg.Emits = emits
 	return fg
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
 The declarative-validation guardrails added in #138872 declared every `+k8s:update` error as `field.Invalid` at the field path, but the runtime emits `field.Forbidden` at index/key paths for `NoAddItem` and `NoRemoveItem`. Fields using these constraints fail `AssertDeclarativeCoverage` with uncovered-rule errors (reported on #139279).

The fix:
  - Map each `UpdateConstraint` to the runtime's actual `(ErrorType, PathFragment)` it emits:
    - `NoSet/NoUnset/NoModify` → `Invalid` at the field path
    - `NoAddItem` → `Forbidden` at `fldPath.Index(i)`/`fldPath.Key(k)` (`[*]`)
    - `NoRemoveItem` on slice → `Forbidden` at `fldPath`
    - `NoRemoveItem` on map → `Forbidden` at `fldPath.Key(k)` (`[*]`)
  - Promote `FunctionGen.Emits` to `[]Emission` so a single call (e.g. `UpdateSlice` with both `NoAddItem` and `NoRemoveItem`) can declare  multiple `(ErrorType, PathFragment)` tuples. `WithEmits` becomes variadic; all existing single-emission call sites compile unchanged.
  - `recordRules` iterates over `fg.Emits` and registers each tuple.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
A broader guardrail — generating `RegisterDeclaredRules` for `output_tests/` packages and hooking `testscheme` to call `RecordObservedRules`, so this class of declared-vs-observed mismatch fails at unit-test time — is worth doing but belongs in its own PR.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
