### PR TITLE
Don't enforce required and optional linter rule for opaqueFields

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_rules.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_rules.go
@@ -18,10 +18,10 @@ package main
 
 import (
 	"fmt"
-	"k8s.io/code-generator/cmd/validation-gen/util"
 	"path"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/code-generator/cmd/validation-gen/validators"
 	"k8s.io/gengo/v2/codetags"
 	"k8s.io/gengo/v2/types"
@@ -158,19 +158,19 @@ func hasRequirednessTag(tags []codetags.Tag) bool {
 }
 
 // hasNonOpaqueValidationTag returns true if tags contain any registered validation tag that is not opaqueType.
-func hasNonOpaqueValidationTag(tags []codetags.Tag) bool {
+func hasNonOpaqueValidationTag(extractor validators.ValidationExtractor, chainTags sets.Set[string], tags []codetags.Tag) bool {
 	for _, tag := range tags {
-		switch tag.Name {
-		case "k8s:optional", "k8s:opaqueType":
+		if tag.Name == "k8s:optional" || tag.Name == "k8s:opaqueType" {
 			continue
-		case "k8s:alpha", "k8s:beta", "k8s:eachVal", "k8s:eachKey", "k8s:ifEnabled", "k8s:ifDisabled", "k8s:subfield", "k8s:ifMode":
-			if tag.ValueTag != nil && hasNonOpaqueValidationTag([]codetags.Tag{*tag.ValueTag}) {
+		}
+		if chainTags.Has(tag.Name) {
+			if tag.ValueTag != nil && hasNonOpaqueValidationTag(extractor, chainTags, []codetags.Tag{*tag.ValueTag}) {
 				return true
 			}
 			continue
 		}
 		// Check if it's a known validation tag.
-		if _, err := validators.GetStability(tag.Name); err == nil {
+		if extractor.IsKnownTag(tag.Name) {
 			return true
 		}
 	}
@@ -180,152 +180,141 @@ func hasNonOpaqueValidationTag(tags []codetags.Tag) bool {
 // requiredAndOptional checks that fields (pointers, slices, maps, arrays) with validation
 // (either direct or transitive) explicitly declare +k8s:optional or +k8s:required.
 func requiredAndOptional(extractor validators.ValidationExtractor) lintRule {
-	// Cache for transitive validation check.
-	// Tri-state: key absent = unvisited, value nil = in-progress (cycle), value *bool = computed result.
-	hasValidation := make(map[*types.Type]*bool)
-
-	var hasTransitiveValidation func(t *types.Type, tags []codetags.Tag) (bool, bool, error)
-
-	hasValidationAfterOpacity := func(t *types.Type, scope validators.Scope, tags []codetags.Tag) (bool, error) {
-		if len(tags) == 0 {
-			return true, nil
+	chainTags := sets.New[string]()
+	for _, doc := range extractor.Docs() {
+		if doc.PayloadsType == codetags.ValueTypeTag {
+			chainTags.Insert(doc.Tag)
 		}
-
-		var valTags []codetags.Tag
-		for _, tag := range tags {
-			if _, err := validators.GetStability(tag.Name); err == nil {
-				valTags = append(valTags, tag)
-			}
-		}
-
-		vals, err := extractor.ExtractValidations(validators.Context{Scope: scope, Type: t}, valTags...)
-		if err != nil {
-			return false, err
-		}
-
-		nativeT := util.NativeType(t)
-		if vals.OpaqueType {
-			return false, nil
-		}
-		if nativeT.Kind == types.Map {
-			kVal, _, err := hasTransitiveValidation(nativeT.Key, nil)
-			if err != nil {
-				return false, err
-			}
-			eVal, _, err := hasTransitiveValidation(nativeT.Elem, nil)
-			if err != nil {
-				return false, err
-			}
-			hasKeyVal := kVal && !vals.OpaqueKeyType
-			hasElemVal := eVal && !vals.OpaqueValType
-			return hasKeyVal || hasElemVal, nil
-		}
-		if nativeT.Kind == types.Slice || nativeT.Kind == types.Array {
-			return !vals.OpaqueValType, nil
-		}
-		return true, nil
 	}
 
-	// hasTransitiveValidation returns (hasVal, cycleBroken, err).
-	// If cycleBroken is true, we cannot cache a negative result.
-	hasTransitiveValidation = func(t *types.Type, tags []codetags.Tag) (bool, bool, error) {
-		if hasNonOpaqueValidationTag(tags) {
+	type opacity struct {
+		typ, key, val bool
+	}
+
+	filterTags := func(tags []codetags.Tag) []codetags.Tag {
+		var filtered []codetags.Tag
+		for _, tag := range tags {
+			if extractor.IsKnownTag(tag.Name) {
+				filtered = append(filtered, tag)
+			}
+		}
+		return filtered
+	}
+
+	type cacheKey struct {
+		t  *types.Type
+		op opacity
+	}
+	hasValidation := make(map[cacheKey]*bool)
+
+	// returns hasValidation, hasCycle, error
+	var hasTransitiveValidation func(t *types.Type, op opacity) (bool, bool, error)
+	hasTransitiveValidation = func(t *types.Type, op opacity) (bool, bool, error) {
+		if op.typ {
+			return false, false, nil
+		}
+
+		ck := cacheKey{t, op}
+		visitedVal, visited := hasValidation[ck]
+		if visited {
+			if visitedVal == nil {
+				return false, true, nil // cycle detected
+			}
+			return *visitedVal, false, nil
+		}
+		hasValidation[ck] = nil
+
+		tTags, err := extractor.ExtractTags(validators.Context{Scope: validators.ScopeType, Type: t}, t.CommentLines)
+		if err != nil {
+			return false, false, err
+		}
+
+		typeVals, err := extractor.ExtractValidations(
+			validators.Context{Scope: validators.ScopeType, Type: t},
+			filterTags(tTags)...,
+		)
+		if err != nil {
+			return false, false, err
+		}
+
+		op.typ = op.typ || typeVals.OpaqueType
+		op.key = op.key || typeVals.OpaqueKeyType
+		op.val = op.val || typeVals.OpaqueValType
+
+		if op.typ {
+			hasVal := false
+			hasValidation[ck] = &hasVal
+			return false, false, nil
+		}
+
+		if typeVals.HasEmitable() {
+			hasVal := true
+			hasValidation[ck] = &hasVal
 			return true, false, nil
 		}
 
 		var hasVal, cycleBroken bool
-
-		if val, ok := hasValidation[t]; ok {
-			if val != nil {
-				hasVal = *val
-			} else {
-				cycleBroken = true
-			}
-		} else {
-			hasValidation[t] = nil // Mark in-progress
-			tTags, err := extractor.ExtractTags(validators.Context{Scope: validators.ScopeType, Type: t}, t.CommentLines)
+		switch t.Kind {
+		case types.Alias:
+			hasVal, cycleBroken, err = hasTransitiveValidation(t.Underlying, op)
+		case types.Slice, types.Array:
+			hasVal, cycleBroken, err = hasTransitiveValidation(t.Elem, opacity{typ: op.val})
+		case types.Map:
+			kVal, cbKey, err := hasTransitiveValidation(t.Key, opacity{typ: op.key})
 			if err != nil {
 				return false, false, err
 			}
-			hasVal = hasNonOpaqueValidationTag(tTags)
-
-			if !hasVal {
-				switch t.Kind {
-				case types.Alias:
-					var err error
-					hasVal, cycleBroken, err = hasTransitiveValidation(t.Underlying, nil)
-					if err != nil {
-						return false, false, err
-					}
-				case types.Slice, types.Array, types.Pointer:
-					var err error
-					hasVal, cycleBroken, err = hasTransitiveValidation(t.Elem, nil)
-					if err != nil {
-						return false, false, err
-					}
-				case types.Map:
-					hvKey, cbKey, err := hasTransitiveValidation(t.Key, nil)
-					if err != nil {
-						return false, false, err
-					}
-					if hvKey {
-						hasVal, cycleBroken = true, cbKey
-					} else {
-						hvElem, cbElem, err := hasTransitiveValidation(t.Elem, nil)
-						if err != nil {
-							return false, false, err
-						}
-						hasVal, cycleBroken = hvElem, cbKey || cbElem
-					}
-				case types.Struct:
-					for _, m := range t.Members {
-						mTags, err := extractor.ExtractTags(validators.Context{Scope: validators.ScopeField, Type: m.Type}, m.CommentLines)
-						if err != nil {
-							return false, false, err
-						}
-						hv, cb, err := hasTransitiveValidation(m.Type, mTags)
-						if err != nil {
-							return false, false, err
-						}
-						if hv {
-							hasVal = true
-						}
-						if cb {
-							cycleBroken = true
-						}
-						if hasVal {
-							break
-						}
-					}
-				}
+			eVal, cbVal, err := hasTransitiveValidation(t.Elem, opacity{typ: op.val})
+			if err != nil {
+				return false, false, err
 			}
-
-			// Type-level opacity overrides structural validation.
-			if hasVal {
-				var err error
-				hasVal, err = hasValidationAfterOpacity(t, validators.ScopeType, tTags)
+			hasVal = kVal || eVal
+			cycleBroken = cbKey || cbVal
+		case types.Pointer:
+			hasVal, cycleBroken, err = hasTransitiveValidation(t.Elem, op)
+		case types.Struct:
+			for _, m := range t.Members {
+				mTags, err := extractor.ExtractTags(validators.Context{Scope: validators.ScopeField, Type: m.Type}, m.CommentLines)
 				if err != nil {
 					return false, false, err
 				}
-			}
-
-			if hasVal || !cycleBroken {
-				hasValidation[t] = &hasVal
-			} else {
-				// Do not cache false if a cycle was broken, as validation could exist on another path.
-				delete(hasValidation, t)
+				if hasNonOpaqueValidationTag(extractor, chainTags, mTags) {
+					hasVal = true
+					break
+				}
+				fieldVals, err := extractor.ExtractValidations(
+					validators.Context{Scope: validators.ScopeField, Type: m.Type},
+					filterTags(mTags)...,
+				)
+				if err != nil {
+					return false, false, err
+				}
+				mOp := opacity{
+					typ: op.typ || fieldVals.OpaqueType,
+					key: op.key || fieldVals.OpaqueKeyType,
+					val: op.val || fieldVals.OpaqueValType,
+				}
+				hv, cb, err := hasTransitiveValidation(m.Type, mOp)
+				if err != nil {
+					return false, false, err
+				}
+				cycleBroken = cycleBroken || cb
+				if hv {
+					hasVal = true
+					break
+				}
 			}
 		}
 
-		// Field-level opacity overrides structural validation.
-		if hasVal {
-			var err error
-			hasVal, err = hasValidationAfterOpacity(t, validators.ScopeField, tags)
-			if err != nil {
-				return false, false, err
-			}
+		if err != nil {
+			return false, false, err
 		}
 
+		if !cycleBroken {
+			hasValidation[ck] = &hasVal
+		} else {
+			delete(hasValidation, ck)
+		}
 		return hasVal, cycleBroken, nil
 	}
 
@@ -336,7 +325,11 @@ func requiredAndOptional(extractor validators.ValidationExtractor) lintRule {
 		}
 
 		// Skip non-pointer structs (and aliases to them) as they don't support requiredness tags.
-		if util.NativeType(t).Kind == types.Struct {
+		underlying := t
+		for underlying.Kind == types.Alias {
+			underlying = underlying.Underlying
+		}
+		if underlying.Kind == types.Struct {
 			return "", nil
 		}
 
@@ -346,13 +339,30 @@ func requiredAndOptional(extractor validators.ValidationExtractor) lintRule {
 		}
 
 		// Check if it has validation (direct or active transitive)
-		hasDirectVal := hasNonOpaqueValidationTag(tags)
-		hasTransitiveVal, _, err := hasTransitiveValidation(t, tags)
+		if hasNonOpaqueValidationTag(extractor, chainTags, tags) {
+			return "field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden", nil
+		}
+
+		fieldVals, err := extractor.ExtractValidations(
+			validators.Context{Scope: validators.ScopeField, Type: t},
+			filterTags(tags)...,
+		)
 		if err != nil {
 			return fmt.Sprintf("invalid validation tags: %v", err), nil
 		}
 
-		if hasDirectVal || hasTransitiveVal {
+		topOp := opacity{
+			typ: fieldVals.OpaqueType,
+			key: fieldVals.OpaqueKeyType,
+			val: fieldVals.OpaqueValType,
+		}
+
+		hasTransitiveVal, _, err := hasTransitiveValidation(t, topOp)
+		if err != nil {
+			return fmt.Sprintf("invalid validation tags: %v", err), nil
+		}
+
+		if hasTransitiveVal {
 			return "field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden", nil
 		}
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_rules.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_rules.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"k8s.io/code-generator/cmd/validation-gen/util"
 	"path"
 	"strings"
 
@@ -156,14 +157,14 @@ func hasRequirednessTag(tags []codetags.Tag) bool {
 	return hasTag(tags, "k8s:optional") || hasTag(tags, "k8s:required") || hasTag(tags, "k8s:forbidden")
 }
 
-// hasAnyValidationTag returns true if tags contain any registered validation tag.
-func hasAnyValidationTag(tags []codetags.Tag) bool {
+// hasNonOpaqueValidationTag returns true if tags contain any registered validation tag that is not opaqueType.
+func hasNonOpaqueValidationTag(tags []codetags.Tag) bool {
 	for _, tag := range tags {
 		switch tag.Name {
-		case "k8s:optional":
+		case "k8s:optional", "k8s:opaqueType":
 			continue
-		case "k8s:alpha", "k8s:beta":
-			if tag.ValueTag != nil && hasAnyValidationTag([]codetags.Tag{*tag.ValueTag}) {
+		case "k8s:alpha", "k8s:beta", "k8s:eachVal", "k8s:eachKey", "k8s:ifEnabled", "k8s:ifDisabled", "k8s:subfield", "k8s:ifMode":
+			if tag.ValueTag != nil && hasNonOpaqueValidationTag([]codetags.Tag{*tag.ValueTag}) {
 				return true
 			}
 			continue
@@ -183,65 +184,91 @@ func requiredAndOptional(extractor validators.ValidationExtractor) lintRule {
 	// Tri-state: key absent = unvisited, value nil = in-progress (cycle), value *bool = computed result.
 	hasValidation := make(map[*types.Type]*bool)
 
-	// checkType recursively checks if a type has any validation (transitively).
-	var checkType func(t *types.Type) (bool, bool)
-	checkType = func(t *types.Type) (bool, bool) {
+	var hasTransitiveValidation func(t *types.Type, tags []codetags.Tag) (bool, bool)
+
+	// hasTransitiveValidation returns (hasVal, cycleBroken).
+	// If cycleBroken is true, we cannot cache a negative result.
+	hasTransitiveValidation = func(t *types.Type, tags []codetags.Tag) (bool, bool) {
+		if hasNonOpaqueValidationTag(tags) {
+			return true, false
+		}
+
+		var hasVal, cycleBroken bool
+
 		if val, ok := hasValidation[t]; ok {
-			if val == nil {
-				return false, true // Cycle detected, break conservatively
-			}
-			return *val, false
-		}
-		// Mark in-progress
-		hasValidation[t] = nil
-		extractedTags, err := extractor.ExtractTags(validators.Context{}, t.CommentLines)
-		hasVal := err == nil && hasAnyValidationTag(extractedTags)
-		cycleBroken := false
-
-		switch t.Kind {
-		case types.Alias:
-			if hv, cb := checkType(t.Underlying); hv {
-				hasVal = true
-			} else if cb {
+			if val != nil {
+				hasVal = *val
+			} else {
 				cycleBroken = true
 			}
-		case types.Struct:
-			for _, member := range t.Members {
-				memberTags, err := extractor.ExtractTags(validators.Context{}, member.CommentLines)
-				memberHasVal := err == nil && hasAnyValidationTag(memberTags)
-				if hv, cb := checkType(member.Type); hv {
-					memberHasVal = true
-				} else if cb {
-					cycleBroken = true
-				}
-				if memberHasVal {
-					hasVal = true
-				}
-			}
-		case types.Slice, types.Array, types.Pointer:
-			if hv, cb := checkType(t.Elem); hv {
-				hasVal = true
-			} else if cb {
-				cycleBroken = true
-			}
-		case types.Map:
-			if hv, cb := checkType(t.Key); hv {
-				hasVal = true
-			} else if cb {
-				cycleBroken = true
-			}
-			if hv, cb := checkType(t.Elem); hv {
-				hasVal = true
-			} else if cb {
-				cycleBroken = true
-			}
-		}
-
-		if hasVal || !cycleBroken {
-			hasValidation[t] = &hasVal
 		} else {
-			delete(hasValidation, t)
+			hasValidation[t] = nil // Mark in-progress
+			tTags, _ := extractor.ExtractTags(validators.Context{}, t.CommentLines)
+			hasVal = hasNonOpaqueValidationTag(tTags)
+
+			if !hasVal {
+				switch t.Kind {
+				case types.Alias:
+					hasVal, cycleBroken = hasTransitiveValidation(t.Underlying, nil)
+				case types.Slice, types.Array, types.Pointer:
+					hasVal, cycleBroken = hasTransitiveValidation(t.Elem, nil)
+				case types.Map:
+					hvKey, cbKey := hasTransitiveValidation(t.Key, nil)
+					if hvKey {
+						hasVal, cycleBroken = true, cbKey
+					} else {
+						hvElem, cbElem := hasTransitiveValidation(t.Elem, nil)
+						hasVal, cycleBroken = hvElem, cbKey || cbElem
+					}
+				case types.Struct:
+					for _, m := range t.Members {
+						mTags, _ := extractor.ExtractTags(validators.Context{}, m.CommentLines)
+						hv, cb := hasTransitiveValidation(m.Type, mTags)
+						if hv {
+							hasVal = true
+						}
+						if cb {
+							cycleBroken = true
+						}
+						if hasVal {
+							break
+						}
+					}
+				}
+			}
+
+			if hasVal || !cycleBroken {
+				hasValidation[t] = &hasVal
+			} else {
+				// Do not cache false if a cycle was broken, as validation could exist on another path.
+				delete(hasValidation, t)
+			}
 		}
+
+		// Field-level opacity overrides structural validation.
+		if hasVal && len(tags) > 0 {
+			var valTags []codetags.Tag
+			for _, tag := range tags {
+				if _, err := validators.GetStability(tag.Name); err == nil {
+					valTags = append(valTags, tag)
+				}
+			}
+
+			if vals, err := extractor.ExtractValidations(validators.Context{Scope: validators.ScopeField, Type: t}, valTags...); err == nil {
+				if vals.OpaqueType {
+					hasVal = false
+				} else if t.Kind == types.Map {
+					kVal, _ := hasTransitiveValidation(t.Key, nil)
+					eVal, _ := hasTransitiveValidation(t.Elem, nil)
+					hasKeyVal := kVal && !vals.OpaqueKeyType
+					hasElemVal := eVal && !vals.OpaqueValType
+					hasVal = hasKeyVal || hasElemVal
+				} else if t.Kind == types.Slice || t.Kind == types.Array {
+					hasVal = !vals.OpaqueValType
+				}
+			}
+		}
+
 		return hasVal, cycleBroken
 	}
 
@@ -252,11 +279,7 @@ func requiredAndOptional(extractor validators.ValidationExtractor) lintRule {
 		}
 
 		// Skip non-pointer structs (and aliases to them) as they don't support requiredness tags.
-		underlying := t
-		for underlying.Kind == types.Alias {
-			underlying = underlying.Underlying
-		}
-		if underlying.Kind == types.Struct {
+		if util.NativeType(t).Kind == types.Struct {
 			return "", nil
 		}
 
@@ -265,9 +288,9 @@ func requiredAndOptional(extractor validators.ValidationExtractor) lintRule {
 			return "", nil
 		}
 
-		// Check if it has validation (direct or transitive)
-		hasDirectVal := hasAnyValidationTag(tags)
-		hasTransitiveVal, _ := checkType(t)
+		// Check if it has validation (direct or active transitive)
+		hasDirectVal := hasNonOpaqueValidationTag(tags)
+		hasTransitiveVal, _ := hasTransitiveValidation(t, tags)
 
 		if hasDirectVal || hasTransitiveVal {
 			return "field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden", nil

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_rules.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_rules.go
@@ -184,13 +184,53 @@ func requiredAndOptional(extractor validators.ValidationExtractor) lintRule {
 	// Tri-state: key absent = unvisited, value nil = in-progress (cycle), value *bool = computed result.
 	hasValidation := make(map[*types.Type]*bool)
 
-	var hasTransitiveValidation func(t *types.Type, tags []codetags.Tag) (bool, bool)
+	var hasTransitiveValidation func(t *types.Type, tags []codetags.Tag) (bool, bool, error)
 
-	// hasTransitiveValidation returns (hasVal, cycleBroken).
+	hasValidationAfterOpacity := func(t *types.Type, scope validators.Scope, tags []codetags.Tag) (bool, error) {
+		if len(tags) == 0 {
+			return true, nil
+		}
+
+		var valTags []codetags.Tag
+		for _, tag := range tags {
+			if _, err := validators.GetStability(tag.Name); err == nil {
+				valTags = append(valTags, tag)
+			}
+		}
+
+		vals, err := extractor.ExtractValidations(validators.Context{Scope: scope, Type: t}, valTags...)
+		if err != nil {
+			return false, err
+		}
+
+		nativeT := util.NativeType(t)
+		if vals.OpaqueType {
+			return false, nil
+		}
+		if nativeT.Kind == types.Map {
+			kVal, _, err := hasTransitiveValidation(nativeT.Key, nil)
+			if err != nil {
+				return false, err
+			}
+			eVal, _, err := hasTransitiveValidation(nativeT.Elem, nil)
+			if err != nil {
+				return false, err
+			}
+			hasKeyVal := kVal && !vals.OpaqueKeyType
+			hasElemVal := eVal && !vals.OpaqueValType
+			return hasKeyVal || hasElemVal, nil
+		}
+		if nativeT.Kind == types.Slice || nativeT.Kind == types.Array {
+			return !vals.OpaqueValType, nil
+		}
+		return true, nil
+	}
+
+	// hasTransitiveValidation returns (hasVal, cycleBroken, err).
 	// If cycleBroken is true, we cannot cache a negative result.
-	hasTransitiveValidation = func(t *types.Type, tags []codetags.Tag) (bool, bool) {
+	hasTransitiveValidation = func(t *types.Type, tags []codetags.Tag) (bool, bool, error) {
 		if hasNonOpaqueValidationTag(tags) {
-			return true, false
+			return true, false, nil
 		}
 
 		var hasVal, cycleBroken bool
@@ -203,27 +243,50 @@ func requiredAndOptional(extractor validators.ValidationExtractor) lintRule {
 			}
 		} else {
 			hasValidation[t] = nil // Mark in-progress
-			tTags, _ := extractor.ExtractTags(validators.Context{}, t.CommentLines)
+			tTags, err := extractor.ExtractTags(validators.Context{Scope: validators.ScopeType, Type: t}, t.CommentLines)
+			if err != nil {
+				return false, false, err
+			}
 			hasVal = hasNonOpaqueValidationTag(tTags)
 
 			if !hasVal {
 				switch t.Kind {
 				case types.Alias:
-					hasVal, cycleBroken = hasTransitiveValidation(t.Underlying, nil)
+					var err error
+					hasVal, cycleBroken, err = hasTransitiveValidation(t.Underlying, nil)
+					if err != nil {
+						return false, false, err
+					}
 				case types.Slice, types.Array, types.Pointer:
-					hasVal, cycleBroken = hasTransitiveValidation(t.Elem, nil)
+					var err error
+					hasVal, cycleBroken, err = hasTransitiveValidation(t.Elem, nil)
+					if err != nil {
+						return false, false, err
+					}
 				case types.Map:
-					hvKey, cbKey := hasTransitiveValidation(t.Key, nil)
+					hvKey, cbKey, err := hasTransitiveValidation(t.Key, nil)
+					if err != nil {
+						return false, false, err
+					}
 					if hvKey {
 						hasVal, cycleBroken = true, cbKey
 					} else {
-						hvElem, cbElem := hasTransitiveValidation(t.Elem, nil)
+						hvElem, cbElem, err := hasTransitiveValidation(t.Elem, nil)
+						if err != nil {
+							return false, false, err
+						}
 						hasVal, cycleBroken = hvElem, cbKey || cbElem
 					}
 				case types.Struct:
 					for _, m := range t.Members {
-						mTags, _ := extractor.ExtractTags(validators.Context{}, m.CommentLines)
-						hv, cb := hasTransitiveValidation(m.Type, mTags)
+						mTags, err := extractor.ExtractTags(validators.Context{Scope: validators.ScopeField, Type: m.Type}, m.CommentLines)
+						if err != nil {
+							return false, false, err
+						}
+						hv, cb, err := hasTransitiveValidation(m.Type, mTags)
+						if err != nil {
+							return false, false, err
+						}
 						if hv {
 							hasVal = true
 						}
@@ -237,6 +300,15 @@ func requiredAndOptional(extractor validators.ValidationExtractor) lintRule {
 				}
 			}
 
+			// Type-level opacity overrides structural validation.
+			if hasVal {
+				var err error
+				hasVal, err = hasValidationAfterOpacity(t, validators.ScopeType, tTags)
+				if err != nil {
+					return false, false, err
+				}
+			}
+
 			if hasVal || !cycleBroken {
 				hasValidation[t] = &hasVal
 			} else {
@@ -246,30 +318,15 @@ func requiredAndOptional(extractor validators.ValidationExtractor) lintRule {
 		}
 
 		// Field-level opacity overrides structural validation.
-		if hasVal && len(tags) > 0 {
-			var valTags []codetags.Tag
-			for _, tag := range tags {
-				if _, err := validators.GetStability(tag.Name); err == nil {
-					valTags = append(valTags, tag)
-				}
-			}
-
-			if vals, err := extractor.ExtractValidations(validators.Context{Scope: validators.ScopeField, Type: t}, valTags...); err == nil {
-				if vals.OpaqueType {
-					hasVal = false
-				} else if t.Kind == types.Map {
-					kVal, _ := hasTransitiveValidation(t.Key, nil)
-					eVal, _ := hasTransitiveValidation(t.Elem, nil)
-					hasKeyVal := kVal && !vals.OpaqueKeyType
-					hasElemVal := eVal && !vals.OpaqueValType
-					hasVal = hasKeyVal || hasElemVal
-				} else if t.Kind == types.Slice || t.Kind == types.Array {
-					hasVal = !vals.OpaqueValType
-				}
+		if hasVal {
+			var err error
+			hasVal, err = hasValidationAfterOpacity(t, validators.ScopeField, tags)
+			if err != nil {
+				return false, false, err
 			}
 		}
 
-		return hasVal, cycleBroken
+		return hasVal, cycleBroken, nil
 	}
 
 	return func(container *types.Type, t *types.Type, tags []codetags.Tag) (string, error) {
@@ -290,7 +347,10 @@ func requiredAndOptional(extractor validators.ValidationExtractor) lintRule {
 
 		// Check if it has validation (direct or active transitive)
 		hasDirectVal := hasNonOpaqueValidationTag(tags)
-		hasTransitiveVal, _ := hasTransitiveValidation(t, tags)
+		hasTransitiveVal, _, err := hasTransitiveValidation(t, tags)
+		if err != nil {
+			return fmt.Sprintf("invalid validation tags: %v", err), nil
+		}
 
 		if hasDirectVal || hasTransitiveVal {
 			return "field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden", nil

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_test.go
@@ -484,8 +484,8 @@ func TestHasAnyValidationTag(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tags, _ := validator.ExtractTags(validators.Context{}, tt.comments)
-			if got := hasAnyValidationTag(tags); got != tt.want {
-				t.Errorf("hasAnyValidationTag() = %v, want %v", got, tt.want)
+			if got := hasNonOpaqueValidationTag(tags); got != tt.want {
+				t.Errorf("hasNonOpaqueValidationTag() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -552,145 +552,64 @@ func TestLintRequiredness(t *testing.T) {
 	}{
 		{
 			name: "pointer field without validation - no error",
-			typeToLint: &types.Type{
-				Name: types.Name{Package: "pkg", Name: "T"},
-				Kind: types.Struct,
-				Members: []types.Member{{
-					Name: "Foo",
-					Type: &types.Type{
-						Name: types.Name{Package: "pkg", Name: "Bar"},
-						Kind: types.Pointer,
-						Elem: &types.Type{Name: types.Name{Package: "", Name: "string"}},
-					},
-				}},
-			},
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testPtr(testType("string"))),
+			}),
 			wantError: "",
 		},
 		{
 			name: "pointer field with direct validation, no requireness - error",
-			typeToLint: &types.Type{
-				Name: types.Name{Package: "pkg", Name: "T"},
-				Kind: types.Struct,
-				Members: []types.Member{{
-					Name:         "Foo",
-					CommentLines: []string{"+k8s:minimum=0"},
-					Type: &types.Type{
-						Name: types.Name{Package: "pkg", Name: "Bar"},
-						Kind: types.Pointer,
-						Elem: &types.Type{Name: types.Name{Package: "", Name: "int"}},
-					},
-				}},
-			},
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testPtr(testType("int")), "+k8s:minimum=0"),
+			}),
 			wantError: "field Foo: field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden",
 		},
 		{
 			name: "pointer field with transitive validation, no requireness - error",
-			typeToLint: &types.Type{
-				Name: types.Name{Package: "pkg", Name: "T"},
-				Kind: types.Struct,
-				Members: []types.Member{{
-					Name: "Foo",
-					Type: &types.Type{
-						Name: types.Name{Package: "pkg", Name: "Nested"},
-						Kind: types.Pointer,
-						Elem: &types.Type{
-							Name: types.Name{Package: "pkg", Name: "Inner"},
-							Kind: types.Struct,
-							Members: []types.Member{{
-								Name:         "Bar",
-								CommentLines: []string{"+k8s:minimum=0"},
-								Type:         &types.Type{Name: types.Name{Package: "", Name: "int"}},
-							}},
-						},
-					},
-				}},
-			},
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testPtr(
+					testStruct("Inner", []types.Member{
+						testField("Bar", testType("int"), "+k8s:minimum=0"),
+					}),
+				)),
+			}),
 			wantError: "field Foo: field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden",
 		},
 		{
 			name: "pointer field with validation and +k8s:optional - no error",
-			typeToLint: &types.Type{
-				Name: types.Name{Package: "pkg", Name: "T"},
-				Kind: types.Struct,
-				Members: []types.Member{{
-					Name:         "Foo",
-					CommentLines: []string{"+k8s:optional", "+k8s:minimum=0"},
-					Type: &types.Type{
-						Name: types.Name{Package: "pkg", Name: "Bar"},
-						Kind: types.Pointer,
-						Elem: &types.Type{Name: types.Name{Package: "", Name: "int"}},
-					},
-				}},
-			},
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testPtr(testType("int")), "+k8s:optional", "+k8s:minimum=0"),
+			}),
 			wantError: "",
 		},
 		{
 			name: "slice field with validation, no requireness - error",
-			typeToLint: &types.Type{
-				Name: types.Name{Package: "pkg", Name: "T"},
-				Kind: types.Struct,
-				Members: []types.Member{{
-					Name:         "Items",
-					CommentLines: []string{"+k8s:maxItems=10"},
-					Type: &types.Type{
-						Name: types.Name{Package: "pkg", Name: "List"},
-						Kind: types.Slice,
-						Elem: &types.Type{Name: types.Name{Package: "", Name: "string"}},
-					},
-				}},
-			},
+			typeToLint: testStruct("T", []types.Member{
+				testField("Items", testSlice(testType("string")), "+k8s:maxItems=10"),
+			}),
 			wantError: "field Items: field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden",
 		},
 		{
 			name: "map field with validation, no requireness - error",
-			typeToLint: &types.Type{
-				Name: types.Name{Package: "pkg", Name: "T"},
-				Kind: types.Struct,
-				Members: []types.Member{{
-					Name:         "Data",
-					CommentLines: []string{"+k8s:maxItems=5"},
-					Type: &types.Type{
-						Name: types.Name{Package: "pkg", Name: "M"},
-						Kind: types.Map,
-						Key:  &types.Type{Name: types.Name{Package: "", Name: "string"}},
-						Elem: &types.Type{Name: types.Name{Package: "", Name: "string"}},
-					},
-				}},
-			},
+			typeToLint: testStruct("T", []types.Member{
+				testField("Data", testMap(testType("string"), testType("string")), "+k8s:maxItems=5"),
+			}),
 			wantError: "field Data: field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden",
 		},
 		{
 			name: "non-pointer struct field with validation - no error (exempt)",
-			typeToLint: &types.Type{
-				Name: types.Name{Package: "pkg", Name: "T"},
-				Kind: types.Struct,
-				Members: []types.Member{{
-					Name: "Nested",
-					Type: &types.Type{
-						Name:         types.Name{Package: "pkg", Name: "Inner"},
-						Kind:         types.Struct,
-						CommentLines: []string{"+k8s:minimum=0"},
-					},
-				}},
-			},
+			typeToLint: testStruct("T", []types.Member{
+				testField("Nested", testStruct("Inner", nil, "+k8s:minimum=0")),
+			}),
 			wantError: "",
 		},
 		{
 			name: "recursive type with pointer to self - no infinite loop",
 			typeToLint: func() *types.Type {
-				t := &types.Type{
-					Name: types.Name{Package: "pkg", Name: "Node"},
-					Kind: types.Struct,
+				t := testStruct("Node", nil)
+				t.Members = []types.Member{
+					testField("Next", testPtr(t), "+k8s:optional"),
 				}
-				t.Members = []types.Member{{
-					Name:         "Next",
-					CommentLines: []string{"+k8s:optional"},
-					Type: &types.Type{
-						Name: types.Name{Package: "pkg", Name: "NodePtr"},
-						Kind: types.Pointer,
-						Elem: t, // cycle
-					},
-				}}
 				return t
 			}(),
 			wantError: "",
@@ -698,19 +617,10 @@ func TestLintRequiredness(t *testing.T) {
 		{
 			name: "recursive type with pointer to self - no infinite loop, missing required validation",
 			typeToLint: func() *types.Type {
-				t := &types.Type{
-					Name: types.Name{Package: "pkg", Name: "Node"},
-					Kind: types.Struct,
+				t := testStruct("Node", nil)
+				t.Members = []types.Member{
+					testField("Next", testPtr(t), "+k8s:immutable"),
 				}
-				t.Members = []types.Member{{
-					Name:         "Next",
-					CommentLines: []string{"+k8s:immutable"},
-					Type: &types.Type{
-						Name: types.Name{Package: "pkg", Name: "NodePtr"},
-						Kind: types.Pointer,
-						Elem: t, // cycle
-					},
-				}}
 				return t
 			}(),
 			wantError: "field Next: field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden",
@@ -718,43 +628,160 @@ func TestLintRequiredness(t *testing.T) {
 		{
 			name: "recursive type with validation - detects validation on first visit",
 			typeToLint: func() *types.Type {
-				t := &types.Type{
-					Name:         types.Name{Package: "pkg", Name: "Node"},
-					Kind:         types.Struct,
-					CommentLines: []string{"+k8s:immutable"},
+				t := testStruct("Node", nil, "+k8s:immutable")
+				t.Members = []types.Member{
+					testField("Next", testPtr(t), "+k8s:optional"),
 				}
-				t.Members = []types.Member{{
-					Name:         "Next",
-					CommentLines: []string{"+k8s:optional"},
-					Type: &types.Type{
-						Name: types.Name{Package: "pkg", Name: "NodePtr"},
-						Kind: types.Pointer,
-						Elem: t, // cycle
-					},
-				}}
 				return t
 			}(),
 			wantError: "",
 		},
 		{
 			name: "array field with transitive validation, no requiredNess - error",
-			typeToLint: &types.Type{
-				Name: types.Name{Package: "pkg", Name: "T"},
-				Kind: types.Struct,
-				Members: []types.Member{{
-					Name: "Arr",
-					Type: &types.Type{
-						Name: types.Name{Package: "pkg", Name: "ArrType"},
-						Kind: types.Array,
-						Elem: &types.Type{
-							Name:         types.Name{Package: "pkg", Name: "Inner"},
-							Kind:         types.Struct,
-							CommentLines: []string{"+k8s:enum"},
-						},
-					},
-				}},
-			},
+			typeToLint: testStruct("T", []types.Member{
+				testField("Arr", testArray(testStruct("Inner", nil, "+k8s:enum"))),
+			}),
 			wantError: "field Arr: field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden",
+		},
+		{
+			name: "pointer field with transitive validation but marked opaqueType - no error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testPtr(
+					testStruct("Inner", []types.Member{
+						testField("Bar", testType("int"), "+k8s:minimum=0"),
+					}),
+				), "+k8s:opaqueType"),
+			}),
+			wantError: "",
+		},
+		{
+			name: "pointer to alias field with transitive validation but marked opaqueType - no error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testPtr(
+					testAlias("MyAlias",
+						testStruct("Inner", []types.Member{
+							testField("Bar", testType("int"), "+k8s:minimum=0"),
+						}),
+					),
+				), "+k8s:opaqueType"),
+			}),
+			wantError: "",
+		},
+		{
+			name: "alias field (to slice) with transitive validation but marked opaqueType - no error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testAlias("MyAlias",
+					testSlice(
+						testStruct("Inner", []types.Member{
+							testField("Bar", testType("int"), "+k8s:minimum=0"),
+						}),
+					),
+				), "+k8s:opaqueType"),
+			}),
+			wantError: "",
+		},
+		{
+			name: "slice field with transitive validation marked opaqueValType - no error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testSlice(
+					testStruct("Inner", []types.Member{
+						testField("Bar", testType("int"), "+k8s:minimum=0"),
+					}),
+				), "+k8s:eachVal=+k8s:opaqueType"),
+			}),
+			wantError: "",
+		},
+		{
+			name: "array field with transitive validation marked opaqueValType - no error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testArray(
+					testStruct("Inner", nil, "+k8s:enum"),
+				), "+k8s:eachVal=+k8s:opaqueType"),
+			}),
+			wantError: "",
+		},
+		{
+			name: "map field with transitive validation on key, marked opaqueKeyType - no error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testMap(
+					testAlias("KeyType", testType("string"), "+k8s:minimum=0"),
+					testType("string"),
+				), "+k8s:eachKey=+k8s:opaqueType"),
+			}),
+			wantError: "",
+		},
+		{
+			name: "map field with transitive validation on key, not marked opaqueKeyType - error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testMap(
+					testAlias("KeyType", testType("string"), "+k8s:minimum=0"),
+					testType("string"),
+				)),
+			}),
+			wantError: "field Foo: field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden",
+		},
+		{
+			name: "map field with transitive validation on value, marked opaqueValType - no error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testMap(
+					testType("string"),
+					testStruct("Inner", []types.Member{
+						testField("Bar", testType("int"), "+k8s:minimum=0"),
+					}),
+				), "+k8s:eachVal=+k8s:opaqueType"),
+			}),
+			wantError: "",
+		},
+		{
+			name: "map field with transitive validation on both, both marked opaque - no error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testMap(
+					testAlias("KeyType", testType("string"), "+k8s:minimum=0"),
+					testStruct("Inner", []types.Member{
+						testField("Bar", testType("int"), "+k8s:minimum=0"),
+					}),
+				), "+k8s:eachKey=+k8s:opaqueType", "+k8s:eachVal=+k8s:opaqueType"),
+			}),
+			wantError: "",
+		},
+		{
+			name: "map field with transitive validation on both, only key marked opaque - error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testMap(
+					testAlias("KeyType", testType("string"), "+k8s:minimum=0"),
+					testStruct("Inner", []types.Member{
+						testField("Bar", testType("int"), "+k8s:minimum=0"),
+					}),
+				), "+k8s:eachKey=+k8s:opaqueType"),
+			}),
+			wantError: "field Foo: field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden",
+		},
+		{
+			name: "map field with transitive validation on both, only value marked opaque - error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testMap(
+					testAlias("KeyType", testType("string"), "+k8s:minimum=0"),
+					testStruct("Inner", []types.Member{
+						testField("Bar", testType("int"), "+k8s:minimum=0"),
+					}),
+				), "+k8s:eachVal=+k8s:opaqueType"),
+			}),
+			wantError: "field Foo: field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden",
+		},
+		{
+			name: "pointer field with nested opaque field - bypasses transitive validation",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testPtr(
+					testStruct("Inner", []types.Member{
+						testField("Bar", testPtr(
+							testStruct("NestedInner", []types.Member{
+								testField("Val", testType("int"), "+k8s:minimum=0"),
+							}),
+						), "+k8s:opaqueType"),
+					}),
+				)),
+			}),
+			wantError: "",
 		},
 	}
 
@@ -776,5 +803,76 @@ func TestLintRequiredness(t *testing.T) {
 				t.Errorf("lintRequiredness() error = %q, want %q", gotError, tt.wantError)
 			}
 		})
+	}
+}
+
+func testType(name string, comments ...string) *types.Type {
+	return &types.Type{
+		Name:         types.Name{Package: "", Name: name},
+		Kind:         types.Builtin,
+		CommentLines: comments,
+	}
+}
+
+func testPtr(elem *types.Type, comments ...string) *types.Type {
+	return &types.Type{
+		Name:         types.Name{Package: "pkg", Name: elem.Name.Name + "Ptr"},
+		Kind:         types.Pointer,
+		Elem:         elem,
+		CommentLines: comments,
+	}
+}
+
+func testStruct(name string, members []types.Member, comments ...string) *types.Type {
+	return &types.Type{
+		Name:         types.Name{Package: "pkg", Name: name},
+		Kind:         types.Struct,
+		Members:      members,
+		CommentLines: comments,
+	}
+}
+
+func testField(name string, fieldType *types.Type, comments ...string) types.Member {
+	return types.Member{
+		Name:         name,
+		Type:         fieldType,
+		CommentLines: comments,
+	}
+}
+
+func testSlice(elem *types.Type, comments ...string) *types.Type {
+	return &types.Type{
+		Name:         types.Name{Package: "pkg", Name: "[]" + elem.Name.Name},
+		Kind:         types.Slice,
+		Elem:         elem,
+		CommentLines: comments,
+	}
+}
+
+func testArray(elem *types.Type, comments ...string) *types.Type {
+	return &types.Type{
+		Name:         types.Name{Package: "pkg", Name: "array_" + elem.Name.Name},
+		Kind:         types.Array,
+		Elem:         elem,
+		CommentLines: comments,
+	}
+}
+
+func testMap(key, val *types.Type, comments ...string) *types.Type {
+	return &types.Type{
+		Name:         types.Name{Package: "pkg", Name: "map_" + key.Name.Name + "_" + val.Name.Name},
+		Kind:         types.Map,
+		Key:          key,
+		Elem:         val,
+		CommentLines: comments,
+	}
+}
+
+func testAlias(name string, underlying *types.Type, comments ...string) *types.Type {
+	return &types.Type{
+		Name:         types.Name{Package: "pkg", Name: name},
+		Kind:         types.Alias,
+		Underlying:   underlying,
+		CommentLines: comments,
 	}
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/code-generator/cmd/validation-gen/validators"
 	"k8s.io/gengo/v2/codetags"
 	"k8s.io/gengo/v2/generator"
@@ -481,10 +482,17 @@ func TestHasAnyValidationTag(t *testing.T) {
 		},
 	}
 
+	chainTags := sets.New[string]()
+	for _, doc := range validator.Docs() {
+		if doc.PayloadsType == codetags.ValueTypeTag {
+			chainTags.Insert(doc.Tag)
+		}
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tags, _ := validator.ExtractTags(validators.Context{}, tt.comments)
-			if got := hasNonOpaqueValidationTag(tags); got != tt.want {
+			if got := hasNonOpaqueValidationTag(validator, chainTags, tags); got != tt.want {
 				t.Errorf("hasNonOpaqueValidationTag() = %v, want %v", got, tt.want)
 			}
 		})
@@ -545,6 +553,10 @@ func TestHasRequirednessTag(t *testing.T) {
 }
 
 func TestLintRequiredness(t *testing.T) {
+	sharedAlias := testAlias("MyAlias", testSlice(testStruct("Inner", []types.Member{
+		testField("Bar", testType("int"), "+k8s:minimum=0"),
+	})))
+
 	tests := []struct {
 		name       string
 		typeToLint *types.Type
@@ -873,6 +885,21 @@ func TestLintRequiredness(t *testing.T) {
 			wantError: "",
 		},
 		{
+			name: "alias field (to slice) with local validation tag and elements marked opaque on the type definition - reports error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Widgets", testAlias("WidgetList",
+					testSlice(
+						testStruct("Inner", []types.Member{
+							testField("Bar", testType("int"), "+k8s:minimum=0"),
+						}),
+					),
+					"+k8s:maxItems=100",
+					"+k8s:eachVal=+k8s:opaqueType",
+				)),
+			}),
+			wantError: "field Widgets: field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden",
+		},
+		{
 			name: "pointer field with transitive malformed tag on alias type definition - reports error as lint warning instead of crashing",
 			typeToLint: testStruct("T", []types.Member{
 				testField("Foo", testPtr(
@@ -880,6 +907,25 @@ func TestLintRequiredness(t *testing.T) {
 				)),
 			}),
 			wantError: "field Foo: invalid validation tags: tag \"k8s:minimum\": can only be used on integer types (pkg.MyString -> string)",
+		},
+		{
+			name: "pointer field with transitive malformed tag on struct type definition - reports error as lint warning instead of crashing",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testPtr(
+					testStruct("MyStruct", []types.Member{
+						testField("Bar", testType("int")),
+					}, "+k8s:minimum=0"),
+				)),
+			}),
+			wantError: "field Foo: invalid validation tags: tag \"k8s:minimum\": can only be used on integer types (pkg.MyStruct)",
+		},
+		{
+			name: "same alias used with different opacity contexts caches correctly",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", sharedAlias, "+k8s:opaqueType"),
+				testField("Bar", sharedAlias),
+			}),
+			wantError: "field Bar: field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden",
 		},
 	}
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_test.go
@@ -639,7 +639,9 @@ func TestLintRequiredness(t *testing.T) {
 		{
 			name: "array field with transitive validation, no requiredNess - error",
 			typeToLint: testStruct("T", []types.Member{
-				testField("Arr", testArray(testStruct("Inner", nil, "+k8s:enum"))),
+				testField("Arr", testArray(testStruct("Inner", []types.Member{
+					testField("Bar", testType("int"), "+k8s:minimum=0"),
+				}))),
 			}),
 			wantError: "field Arr: field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden",
 		},
@@ -695,7 +697,9 @@ func TestLintRequiredness(t *testing.T) {
 			name: "array field with transitive validation marked opaqueValType - no error",
 			typeToLint: testStruct("T", []types.Member{
 				testField("Foo", testArray(
-					testStruct("Inner", nil, "+k8s:enum"),
+					testStruct("Inner", []types.Member{
+						testField("Bar", testType("int"), "+k8s:minimum=0"),
+					}),
 				), "+k8s:eachVal=+k8s:opaqueType"),
 			}),
 			wantError: "",
@@ -704,8 +708,8 @@ func TestLintRequiredness(t *testing.T) {
 			name: "map field with transitive validation on key, marked opaqueKeyType - no error",
 			typeToLint: testStruct("T", []types.Member{
 				testField("Foo", testMap(
-					testAlias("KeyType", testType("string"), "+k8s:minimum=0"),
-					testType("string"),
+					testAlias("KeyType", types.String, "+k8s:minLength=1"),
+					types.String,
 				), "+k8s:eachKey=+k8s:opaqueType"),
 			}),
 			wantError: "",
@@ -714,8 +718,8 @@ func TestLintRequiredness(t *testing.T) {
 			name: "map field with transitive validation on key, not marked opaqueKeyType - error",
 			typeToLint: testStruct("T", []types.Member{
 				testField("Foo", testMap(
-					testAlias("KeyType", testType("string"), "+k8s:minimum=0"),
-					testType("string"),
+					testAlias("KeyType", types.String, "+k8s:minLength=1"),
+					types.String,
 				)),
 			}),
 			wantError: "field Foo: field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden",
@@ -724,7 +728,7 @@ func TestLintRequiredness(t *testing.T) {
 			name: "map field with transitive validation on value, marked opaqueValType - no error",
 			typeToLint: testStruct("T", []types.Member{
 				testField("Foo", testMap(
-					testType("string"),
+					types.String,
 					testStruct("Inner", []types.Member{
 						testField("Bar", testType("int"), "+k8s:minimum=0"),
 					}),
@@ -736,7 +740,7 @@ func TestLintRequiredness(t *testing.T) {
 			name: "map field with transitive validation on both, both marked opaque - no error",
 			typeToLint: testStruct("T", []types.Member{
 				testField("Foo", testMap(
-					testAlias("KeyType", testType("string"), "+k8s:minimum=0"),
+					testAlias("KeyType", types.String, "+k8s:minLength=1"),
 					testStruct("Inner", []types.Member{
 						testField("Bar", testType("int"), "+k8s:minimum=0"),
 					}),
@@ -748,7 +752,7 @@ func TestLintRequiredness(t *testing.T) {
 			name: "map field with transitive validation on both, only key marked opaque - error",
 			typeToLint: testStruct("T", []types.Member{
 				testField("Foo", testMap(
-					testAlias("KeyType", testType("string"), "+k8s:minimum=0"),
+					testAlias("KeyType", types.String, "+k8s:minLength=1"),
 					testStruct("Inner", []types.Member{
 						testField("Bar", testType("int"), "+k8s:minimum=0"),
 					}),
@@ -760,7 +764,7 @@ func TestLintRequiredness(t *testing.T) {
 			name: "map field with transitive validation on both, only value marked opaque - error",
 			typeToLint: testStruct("T", []types.Member{
 				testField("Foo", testMap(
-					testAlias("KeyType", testType("string"), "+k8s:minimum=0"),
+					testAlias("KeyType", types.String, "+k8s:minLength=1"),
 					testStruct("Inner", []types.Member{
 						testField("Bar", testType("int"), "+k8s:minimum=0"),
 					}),
@@ -782,6 +786,100 @@ func TestLintRequiredness(t *testing.T) {
 				)),
 			}),
 			wantError: "",
+		},
+		{
+			name: "alias field (to slice) with transitive validation but no opacity tags on type - error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testAlias("MyAlias",
+					testSlice(
+						testStruct("Inner", []types.Member{
+							testField("Bar", testType("int"), "+k8s:minimum=0"),
+						}),
+					),
+				)),
+			}),
+			wantError: "field Foo: field with validation must have +k8s:optional, +k8s:required or +k8s:forbidden",
+		},
+		{
+			name: "alias field (to slice) with transitive validation and eachVal marked opaque on the field - no error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testAlias("MyAlias",
+					testSlice(
+						testStruct("Inner", []types.Member{
+							testField("Bar", testType("int"), "+k8s:minimum=0"),
+						}),
+					),
+				), "+k8s:eachVal=+k8s:opaqueType"),
+			}),
+			wantError: "",
+		},
+		{
+			name: "alias field (to slice) with transitive validation and eachVal marked opaque on the type definition - no error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testAlias("MyAlias",
+					testSlice(
+						testStruct("Inner", []types.Member{
+							testField("Bar", testType("int"), "+k8s:minimum=0"),
+						}),
+					),
+					"+k8s:eachVal=+k8s:opaqueType",
+				)),
+			}),
+			wantError: "",
+		},
+		{
+			name: "pointer to alias field (to slice) with transitive validation, eachVal marked opaque on type definition - no error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testPtr(
+					testAlias("MyAlias",
+						testSlice(
+							testStruct("Inner", []types.Member{
+								testField("Bar", testType("int"), "+k8s:minimum=0"),
+							}),
+						),
+						"+k8s:eachVal=+k8s:opaqueType",
+					),
+				)),
+			}),
+			wantError: "",
+		},
+		{
+			name: "alias field (to map) with transitive validation, eachVal marked opaque on type definition - no error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testAlias("MyAlias",
+					testMap(
+						types.String,
+						testStruct("Inner", []types.Member{
+							testField("Bar", testType("int"), "+k8s:minimum=0"),
+						}),
+					),
+					"+k8s:eachVal=+k8s:opaqueType",
+				)),
+			}),
+			wantError: "",
+		},
+		{
+			name: "pointer to alias field (to struct) with transitive validation, opaqueType marked on type definition - no error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testPtr(
+					testAlias("MyAlias",
+						testStruct("Inner", []types.Member{
+							testField("Bar", testType("int"), "+k8s:minimum=0"),
+						}),
+						"+k8s:opaqueType",
+					),
+				)),
+			}),
+			wantError: "",
+		},
+		{
+			name: "pointer field with transitive malformed tag on alias type definition - reports error as lint warning instead of crashing",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testPtr(
+					testAlias("MyString", testType("string"), "+k8s:minimum=0"),
+				)),
+			}),
+			wantError: "field Foo: invalid validation tags: tag \"k8s:minimum\": can only be used on integer types (pkg.MyString -> string)",
 		},
 	}
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry.go
@@ -224,6 +224,9 @@ type ValidationExtractor interface {
 
 	// Stability returns the stability level for a given tag.
 	Stability(tag string) (TagStabilityLevel, error)
+
+	// IsKnownTag returns true if the tag is a registered validation tag.
+	IsKnownTag(tag string) bool
 }
 
 // Stability returns the stability level for a given tag.
@@ -243,6 +246,17 @@ func (reg *registry) Stability(tag string) (TagStabilityLevel, error) {
 // GetStability returns the stability level for a given tag from the global registry.
 func GetStability(tag string) (TagStabilityLevel, error) {
 	return globalRegistry.Stability(tag)
+}
+
+// IsKnownTag returns true if the tag has been registered as a validation tag.
+func (reg *registry) IsKnownTag(tag string) bool {
+	_, err := reg.Stability(tag)
+	return err == nil
+}
+
+// IsKnownTag returns true if the given tag is a registered validation tag.
+func IsKnownTag(tag string) bool {
+	return globalRegistry.IsKnownTag(tag)
 }
 
 // InitGlobalValidator must be called exactly once by the main application to

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry_test.go
@@ -57,3 +57,36 @@ func TestGetStability(t *testing.T) {
 		})
 	}
 }
+
+func TestIsKnownTag(t *testing.T) {
+	tests := []struct {
+		tagName  string
+		expected bool
+	}{
+		{
+			tagName:  "k8s:validateTrueAlpha",
+			expected: true,
+		},
+		{
+			tagName:  "k8s:validateTrueBeta",
+			expected: true,
+		},
+		{
+			tagName:  "k8s:required",
+			expected: true,
+		},
+		{
+			tagName:  "k8s:unknownTag",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tagName, func(t *testing.T) {
+			got := IsKnownTag(tt.tagName)
+			if got != tt.expected {
+				t.Errorf("IsKnownTag(%q) = %v, want %v", tt.tagName, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
This PR updates the `validation-gen` linter to respect "opaque" validation tags, allowing opaque fields to bypass the requirement for `+k8s:optional`, `+k8s:required`, or `+k8s:forbidden` even if their underlying types contain validation. 

Previously, the `requiredAndOptional` lint rule would enforce these requiredness tags on any pointer, slice, or map field that transitively contained validation. This PR introduces support for `+k8s:opaqueType` which signal to the linter that the validation of the underlying type should be treated as hidden at that specific field level.

**Key changes:**
- **New Helper:** Added `hasNonOpaqueValidationTag` to identify validation tags while ignoring the new opacity markers.
- **Refactored Transitive Validation:** The `checkType` function was refactored into `hasTransitiveValidation`, which now correctly handles cycles and caches results to improve performance.
- **Opacity Logic:** Integrated checks for `OpaqueType`, `OpaqueKeyType`, and `OpaqueValType` during the transitive validation walk.
- **Test Coverage:** Added comprehensive test cases in `lint_test.go` covering pointer fields, aliases, slices, and maps with various opaque configurations.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
The refactoring of the transitive validation check into `hasTransitiveValidation` was necessary to allow the linter to see the field-level tags (like `+k8s:opaqueType`) before deciding whether to recurse into the type's structure.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation:
N/A