### PR TITLE
kubelet: short circut killPodNow if the pod's status is finished

### DIFF
--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -866,6 +866,14 @@ func (p *podWorkers) UpdatePod(ctx context.Context, options UpdatePodOptions) {
 	// once a pod is terminated by UID, it cannot reenter the pod worker (until the UID is purged by housekeeping)
 	if status.IsFinished() {
 		updateLogger.V(4).Info("Pod is finished processing, no further updates")
+		// If we received a kill request with a CompletedCh, close it immediately since
+		// the pod is already finished and no further work will be done.
+		if options.KillPodOptions != nil {
+			if ch := options.KillPodOptions.CompletedCh; ch != nil {
+				close(ch)
+			}
+			options.KillPodOptions = nil
+		}
 		return
 	}
 

--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -2256,6 +2256,42 @@ func TestKillPodNowFunc(t *testing.T) {
 	}
 }
 
+// TestKillPodNowFuncFinishedPod verifies killPodNow returns immediately on an already-finished pod.
+// Regression test for https://github.com/kubernetes/kubernetes/issues/118679
+func TestKillPodNowFuncFinishedPod(t *testing.T) {
+	fakeRecorder := &record.FakeRecorder{Events: make(chan string, 10)}
+	logger, tCtx := ktesting.NewTestContext(t)
+	podWorkers, _, _ := createPodWorkers(logger)
+	pod := newNamedPod("test", "ns", "test", false)
+
+	// Set up pod as already finished
+	podWorkers.podLock.Lock()
+	podWorkers.podSyncStatuses[pod.UID] = &podSyncStatus{
+		terminatingAt: time.Now().Add(-time.Minute),
+		terminatedAt:  time.Now().Add(-time.Second),
+		finished:      true,
+		fullname:      pod.Name + "_" + pod.Namespace,
+	}
+	podWorkers.podLock.Unlock()
+
+	// Attempt to kill the finished pod - should return immediately without 10s timeout
+	gracePeriod := int64(0)
+	start := time.Now()
+	err := killPodNow(tCtx, podWorkers, fakeRecorder)(pod, true, &gracePeriod, nil)
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("killPodNow took %v, expected immediate return", elapsed)
+	}
+	select {
+	case event := <-fakeRecorder.Events:
+		t.Errorf("Unexpected ExceededGracePeriod event: %v", event)
+	default:
+	}
+}
+
 func Test_allowPodStart(t *testing.T) {
 	testCases := []struct {
 		desc                               string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:
fixes a small papercut when a pod would qualify for eviction, has already exited, and thus momentarily stalls waiting for an exit that won't happen again
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
fixes https://github.com/kubernetes/kubernetes/issues/118679

#### Special notes for your reviewer:
helped by claude 4.5
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
