### PR TITLE
Remove usage of assertion libraries in pkg/scheduler tests

### DIFF
--- a/pkg/scheduler/framework/autoscaler_contract/framework_contract_test.go
+++ b/pkg/scheduler/framework/autoscaler_contract/framework_contract_test.go
@@ -24,8 +24,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2/ktesting"
@@ -40,23 +38,22 @@ type frameworkContract interface {
 	RunReservePluginsReserve(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *fwk.Status
 }
 
-func TestFrameworkContract(t *testing.T) {
-	var f framework.Framework
-	var c frameworkContract = f
-	assert.Nil(t, c)
-}
+var f framework.Framework
+var _ frameworkContract = f
 
 func TestNewFramework(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
 	var f interface{}
 	if f, _ = runtime.NewFramework(ctx, nil, nil); f != nil {
-		_, ok := f.(framework.Framework)
-		assert.True(t, ok)
+		if _, ok := f.(framework.Framework); !ok {
+			t.Errorf("expected NewFramework to return a framework.Framework, got %T", f)
+		}
 	}
 }
 
 func TestNewCycleState(t *testing.T) {
 	var state interface{} = framework.NewCycleState()
-	_, ok := state.(*framework.CycleState)
-	assert.True(t, ok)
+	if _, ok := state.(*framework.CycleState); !ok {
+		t.Errorf("expected NewCycleState to return *framework.CycleState, got %T", state)
+	}
 }

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -32,8 +32,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	schedulingapi "k8s.io/api/scheduling/v1alpha3"
@@ -2233,7 +2231,9 @@ func testPlugin(tCtx ktesting.TContext) {
 			want:                      want{},
 			metrics: func(tCtx ktesting.TContext, g compbasemetrics.Gatherer) {
 				_, err := testutil.GetCounterValuesFromGatherer(g, "dynamic_resource_allocation_resourceclaim_creates_total", map[string]string{}, "status")
-				require.ErrorContains(tCtx, err, "not found")
+				if err == nil || !strings.Contains(err.Error(), "not found") {
+					tCtx.Fatalf("expected error containing %q, got: %v", "not found", err)
+				}
 			},
 		},
 		"extended-resource-one-device-plugin-one-dra": {
@@ -2303,7 +2303,9 @@ func testPlugin(tCtx ktesting.TContext) {
 			},
 			metrics: func(tCtx ktesting.TContext, g compbasemetrics.Gatherer) {
 				_, err := testutil.GetCounterValuesFromGatherer(g, "dynamic_resource_allocation_resourceclaim_creates_total", map[string]string{}, "status")
-				require.ErrorContains(tCtx, err, "not found")
+				if err == nil || !strings.Contains(err.Error(), "not found") {
+					tCtx.Fatalf("expected error containing %q, got: %v", "not found", err)
+				}
 			},
 		},
 		"extended-resource-name-with-resources": {
@@ -2325,8 +2327,12 @@ func testPlugin(tCtx ktesting.TContext) {
 			},
 			metrics: func(tCtx ktesting.TContext, g compbasemetrics.Gatherer) {
 				metric, err := testutil.GetCounterValuesFromGatherer(g, "dynamic_resource_allocation_resourceclaim_creates_total", map[string]string{}, "status")
-				require.NoError(tCtx, err)
-				require.Equal(tCtx, 1, int(metric["success"]))
+				if err != nil {
+					tCtx.Fatalf("unexpected error getting metric: %s", err)
+				}
+				if got := int(metric["success"]); got != 1 {
+					tCtx.Fatalf("expected 1 successful claim create, got %d", got)
+				}
 			},
 		},
 		"implicit-extended-resource-name-with-resources": {
@@ -2348,8 +2354,12 @@ func testPlugin(tCtx ktesting.TContext) {
 			},
 			metrics: func(tCtx ktesting.TContext, g compbasemetrics.Gatherer) {
 				metric, err := testutil.GetCounterValuesFromGatherer(g, "dynamic_resource_allocation_resourceclaim_creates_total", map[string]string{}, "status")
-				require.NoError(tCtx, err)
-				require.Equal(tCtx, 1, int(metric["success"]))
+				if err != nil {
+					tCtx.Fatalf("unexpected error getting metric: %s", err)
+				}
+				if got := int(metric["success"]); got != 1 {
+					tCtx.Fatalf("expected 1 successful claim create, got %d", got)
+				}
 			},
 		},
 		"implicit-extended-resource-name-two-containers-with-resources": {
@@ -2371,8 +2381,12 @@ func testPlugin(tCtx ktesting.TContext) {
 			},
 			metrics: func(tCtx ktesting.TContext, g compbasemetrics.Gatherer) {
 				metric, err := testutil.GetCounterValuesFromGatherer(g, "dynamic_resource_allocation_resourceclaim_creates_total", map[string]string{}, "status")
-				require.NoError(tCtx, err)
-				require.Equal(tCtx, 1, int(metric["success"]))
+				if err != nil {
+					tCtx.Fatalf("unexpected error getting metric: %s", err)
+				}
+				if got := int(metric["success"]); got != 1 {
+					tCtx.Fatalf("expected 1 successful claim create, got %d", got)
+				}
 			},
 		},
 		"extended-resource-name-with-resources-fail-patch": {
@@ -2396,8 +2410,12 @@ func testPlugin(tCtx ktesting.TContext) {
 			},
 			metrics: func(tCtx ktesting.TContext, g compbasemetrics.Gatherer) {
 				metric, err := testutil.GetCounterValuesFromGatherer(g, "dynamic_resource_allocation_resourceclaim_creates_total", map[string]string{}, "status")
-				require.NoError(tCtx, err)
-				require.Equal(tCtx, 1, int(metric["success"]))
+				if err != nil {
+					tCtx.Fatalf("unexpected error getting metric: %s", err)
+				}
+				if got := int(metric["success"]); got != 1 {
+					tCtx.Fatalf("expected 1 successful claim create, got %d", got)
+				}
 			},
 		},
 		"extended-resource-name-with-resources-has-claim": {
@@ -2419,7 +2437,9 @@ func testPlugin(tCtx ktesting.TContext) {
 			},
 			metrics: func(tCtx ktesting.TContext, g compbasemetrics.Gatherer) {
 				_, err := testutil.GetCounterValuesFromGatherer(g, "dynamic_resource_allocation_resourceclaim_creates_total", map[string]string{}, "status")
-				require.ErrorContains(tCtx, err, "not found")
+				if err == nil || !strings.Contains(err.Error(), "not found") {
+					tCtx.Fatalf("expected error containing %q, got: %v", "not found", err)
+				}
 			},
 		},
 		"extended-resource-name-with-resources-delete-claim": {
@@ -2441,7 +2461,9 @@ func testPlugin(tCtx ktesting.TContext) {
 			},
 			metrics: func(tCtx ktesting.TContext, g compbasemetrics.Gatherer) {
 				_, err := testutil.GetCounterValuesFromGatherer(g, "dynamic_resource_allocation_resourceclaim_creates_total", map[string]string{}, "status")
-				require.ErrorContains(tCtx, err, "not found")
+				if err == nil || !strings.Contains(err.Error(), "not found") {
+					tCtx.Fatalf("expected error containing %q, got: %v", "not found", err)
+				}
 			},
 		},
 		"extended-resource-name-bind-failure": {
@@ -2463,8 +2485,12 @@ func testPlugin(tCtx ktesting.TContext) {
 			},
 			metrics: func(tCtx ktesting.TContext, g compbasemetrics.Gatherer) {
 				metric, err := testutil.GetCounterValuesFromGatherer(g, "dynamic_resource_allocation_resourceclaim_creates_total", map[string]string{}, "status")
-				require.NoError(tCtx, err)
-				require.Equal(tCtx, 1, int(metric["success"]))
+				if err != nil {
+					tCtx.Fatalf("unexpected error getting metric: %s", err)
+				}
+				if got := int(metric["success"]); got != 1 {
+					tCtx.Fatalf("expected 1 successful claim create, got %d", got)
+				}
 			},
 		},
 		"extended-resource-name-skip-bind": {
@@ -2480,8 +2506,12 @@ func testPlugin(tCtx ktesting.TContext) {
 			},
 			metrics: func(tCtx ktesting.TContext, g compbasemetrics.Gatherer) {
 				metric, err := testutil.GetCounterValuesFromGatherer(g, "dynamic_resource_allocation_resourceclaim_creates_total", map[string]string{}, "status")
-				require.NoError(tCtx, err)
-				require.Equal(tCtx, 1, int(metric["success"]))
+				if err != nil {
+					tCtx.Fatalf("unexpected error getting metric: %s", err)
+				}
+				if got := int(metric["success"]); got != 1 {
+					tCtx.Fatalf("expected 1 successful claim create, got %d", got)
+				}
 			},
 		},
 		"extended-resource-name-claim-creation-failure": {
@@ -2511,8 +2541,12 @@ func testPlugin(tCtx ktesting.TContext) {
 			},
 			metrics: func(tCtx ktesting.TContext, g compbasemetrics.Gatherer) {
 				metric, err := testutil.GetCounterValuesFromGatherer(g, "dynamic_resource_allocation_resourceclaim_creates_total", map[string]string{}, "status")
-				require.NoError(tCtx, err)
-				require.Equal(tCtx, 1, int(metric["failure"]))
+				if err != nil {
+					tCtx.Fatalf("unexpected error getting metric: %s", err)
+				}
+				if got := int(metric["failure"]); got != 1 {
+					tCtx.Fatalf("expected 1 failed claim create, got %d", got)
+				}
 			},
 		},
 		"canceled": {
@@ -2768,13 +2802,17 @@ func testPlugin(tCtx ktesting.TContext) {
 					},
 					"driver", // group by driver label
 				)
-				require.NoError(tCtx, err)
+				if err != nil {
+					tCtx.Fatalf("unexpected error getting allocations metric: %s", err)
+				}
 
 				var totalAllocs float64
 				for _, v := range allocs {
 					totalAllocs += v
 				}
-				require.InEpsilon(tCtx, float64(1), totalAllocs, 0.1, "expected exactly one successful allocation with BindingConditions")
+				if totalAllocs < 0.9 || totalAllocs > 1.1 {
+					tCtx.Fatalf("expected exactly one successful allocation with BindingConditions, got %v", totalAllocs)
+				}
 
 				// Histogram: one success sample with requires_bindingconditions=true
 				hist, err := testutil.GetHistogramVecFromGatherer(
@@ -2784,8 +2822,12 @@ func testPlugin(tCtx ktesting.TContext) {
 						"status": "success",
 					},
 				)
-				require.NoError(tCtx, err)
-				require.Equal(tCtx, uint64(1), hist.GetAggregatedSampleCount(), "expected one success sample in wait duration histogram")
+				if err != nil {
+					tCtx.Fatalf("unexpected error getting histogram: %s", err)
+				}
+				if got := hist.GetAggregatedSampleCount(); got != 1 {
+					tCtx.Fatalf("expected one success sample in wait duration histogram, got %d", got)
+				}
 			},
 		},
 		"bound-claim-with-failed-binding": {
@@ -2912,13 +2954,17 @@ func testPlugin(tCtx ktesting.TContext) {
 					},
 					"driver",
 				)
-				require.NoError(tCtx, err)
+				if err != nil {
+					tCtx.Fatalf("unexpected error getting timeouts metric: %s", err)
+				}
 
 				var totalTimeouts float64
 				for _, v := range timeouts {
 					totalTimeouts += v
 				}
-				require.InEpsilon(tCtx, float64(1), totalTimeouts, 0.1, "expected exactly one timeout with BindingConditions")
+				if totalTimeouts < 0.9 || totalTimeouts > 1.1 {
+					tCtx.Fatalf("expected exactly one timeout with BindingConditions, got %v", totalTimeouts)
+				}
 
 				// Histogram: one timeout sample with requires_bindingconditions=true
 				hist, err := testutil.GetHistogramVecFromGatherer(
@@ -2928,8 +2974,12 @@ func testPlugin(tCtx ktesting.TContext) {
 						"status": "timeout",
 					},
 				)
-				require.NoError(tCtx, err)
-				require.Equal(tCtx, uint64(1), hist.GetAggregatedSampleCount(), "expected one timeout sample in wait duration histogram")
+				if err != nil {
+					tCtx.Fatalf("unexpected error getting histogram: %s", err)
+				}
+				if got := hist.GetAggregatedSampleCount(); got != 1 {
+					tCtx.Fatalf("expected one timeout sample in wait duration histogram, got %d", got)
+				}
 			},
 		},
 		"bound-claim-with-mixed-binding-conditions": {
@@ -3506,7 +3556,9 @@ func testPlugin(tCtx ktesting.TContext) {
 				featuregatetesting.SetFeatureGateEmulationVersionDuringTest(tCtx, utilfeature.DefaultFeatureGate, version.MustParse("1.35"))
 				featuregatetesting.SetFeatureGateDuringTest(tCtx, utilfeature.DefaultFeatureGate, features.DRAAdminAccess, false)
 
-				require.False(tCtx, tc.enableDRAWorkloadResourceClaims, "DRAWorkloadResourceClaims cannot be enabled when DRAAdminAccess is disabled")
+				if tc.enableDRAWorkloadResourceClaims {
+					tCtx.Fatalf("DRAWorkloadResourceClaims cannot be enabled when DRAAdminAccess is disabled")
+				}
 			} else {
 				// These features can't be set with pre-1.36 emulation
 				featuregatetesting.SetFeatureGatesDuringTest(tCtx, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
@@ -3540,7 +3592,9 @@ func testPlugin(tCtx ktesting.TContext) {
 			nodeInfo := framework.NewNodeInfo()
 			result, status := testCtx.p.PreFilter(tCtx, testCtx.state, tc.pod, []fwk.NodeInfo{nodeInfo})
 			tCtx.Run("prefilter", func(tCtx ktesting.TContext) {
-				assert.Equal(tCtx, tc.want.preFilterResult, result)
+				if diff := cmp.Diff(tc.want.preFilterResult, result); diff != "" {
+					tCtx.Errorf("PreFilter result mismatch (-want,+got):\n%s", diff)
+				}
 				testCtx.verify(tCtx, tc.want.prefilter, initialObjects, tc.pod, result, status)
 			})
 			unschedulable := status.IsRejected()
@@ -3587,7 +3641,9 @@ func testPlugin(tCtx ktesting.TContext) {
 					score, status := testCtx.p.Score(tCtx, testCtx.state, tc.pod, potentialNode)
 					nodeName := potentialNode.Node().Name
 					tCtx.Run(fmt.Sprintf("score/%s", nodeName), func(tCtx ktesting.TContext) {
-						assert.Equal(tCtx, tc.want.scoreResult.forNode(nodeName), score)
+						if want := tc.want.scoreResult.forNode(nodeName); score != want {
+							tCtx.Errorf("Score mismatch for node %s: got %d, want %d", nodeName, score, want)
+						}
 						testCtx.verify(tCtx, tc.want.score.forNode(nodeName), initialObjects, tc.pod, nil, status)
 					})
 					scores = append(scores, fwk.NodeScore{Name: nodeName, Score: score})
@@ -3596,7 +3652,9 @@ func testPlugin(tCtx ktesting.TContext) {
 				initialObjects = testCtx.listAll(tCtx)
 				status := testCtx.p.NormalizeScore(tCtx, testCtx.state, tc.pod, scores)
 				tCtx.Run("normalizeScore", func(tCtx ktesting.TContext) {
-					assert.Equal(tCtx, tc.want.normalizeScoreResult, scores)
+					if diff := cmp.Diff(tc.want.normalizeScoreResult, scores); diff != "" {
+						tCtx.Errorf("NormalizeScore mismatch (-want,+got):\n%s", diff)
+					}
 					testCtx.verify(tCtx, tc.want.normalizeScore, initialObjects, tc.pod, nil, status)
 				})
 			}
@@ -3648,10 +3706,14 @@ func testPlugin(tCtx ktesting.TContext) {
 					initialObjects = testCtx.updateAPIServer(tCtx, initialObjects, tc.prepare.prebind)
 					preBindPreFlightResult, preBindPreFlightStatus := testCtx.p.PreBindPreFlight(tCtx, testCtx.state, tc.pod, selectedNodeName)
 					tCtx.Run("preBindPreFlightStatus", func(tContext ktesting.TContext) {
-						assert.Equal(tCtx, tc.want.preBindPreFlightStatus, preBindPreFlightStatus)
+						if diff := cmp.Diff(tc.want.preBindPreFlightStatus, preBindPreFlightStatus); diff != "" {
+							tCtx.Errorf("PreBindPreFlight status mismatch (-want,+got):\n%s", diff)
+						}
 					})
 					tCtx.Run("preBindPreFlightResult", func(tContext ktesting.TContext) {
-						assert.Equal(tCtx, &fwk.PreBindPreFlightResult{AllowParallel: true}, preBindPreFlightResult)
+						if diff := cmp.Diff(&fwk.PreBindPreFlightResult{AllowParallel: true}, preBindPreFlightResult); diff != "" {
+							tCtx.Errorf("PreBindPreFlight result mismatch (-want,+got):\n%s", diff)
+						}
 					})
 					preBindStatus := testCtx.p.PreBind(tCtx, testCtx.state, tc.pod, selectedNodeName)
 					tCtx.Run("prebind", func(tCtx ktesting.TContext) {
@@ -3673,7 +3735,9 @@ func testPlugin(tCtx ktesting.TContext) {
 				initialObjects = testCtx.updateAPIServer(tCtx, initialObjects, tc.prepare.postfilter)
 				result, status := testCtx.p.PostFilter(tCtx, testCtx.state, tc.pod, nil /* filteredNodeStatusMap not used by plugin */)
 				tCtx.Run("postfilter", func(tCtx ktesting.TContext) {
-					assert.Equal(tCtx, tc.want.postFilterResult, result)
+					if diff := cmp.Diff(tc.want.postFilterResult, result); diff != "" {
+						tCtx.Errorf("PostFilter result mismatch (-want,+got):\n%s", diff)
+					}
 					testCtx.verify(tCtx, tc.want.postfilter, initialObjects, tc.pod, nil, status)
 				})
 			}
@@ -3716,12 +3780,18 @@ type testContext struct {
 func (tc *testContext) verify(tCtx ktesting.TContext, expected result, initialObjects []metav1.Object, testPod *v1.Pod, result interface{}, status *fwk.Status) {
 	tCtx.Helper()
 	if expected.status == nil {
-		assert.Nil(tCtx, status)
+		if status != nil {
+			tCtx.Errorf("expected nil status, got: %v", status)
+		}
 	} else if actualErr := status.AsError(); actualErr != nil {
 		// Compare only the error strings.
-		assert.ErrorContains(tCtx, actualErr, expected.status.AsError().Error())
+		if !strings.Contains(actualErr.Error(), expected.status.AsError().Error()) {
+			tCtx.Errorf("expected error containing %q, got: %q", expected.status.AsError().Error(), actualErr.Error())
+		}
 	} else {
-		assert.Equal(tCtx, expected.status, status)
+		if diff := cmp.Diff(expected.status, status); diff != "" {
+			tCtx.Errorf("status mismatch (-want,+got):\n%s", diff)
+		}
 	}
 	objects := tc.listAll(tCtx)
 	wantObjects := update(initialObjects, expected.changes)
@@ -3967,7 +4037,9 @@ func setup(tCtx ktesting.TContext, args *config.DynamicResourcesArgs, nodes []*v
 		KubeClient:             tc.client,
 	}
 	resourceSliceTracker, err := resourceslicetracker.StartTracker(tCtx, resourceSliceTrackerOpts)
-	require.NoError(tCtx, err, "couldn't start resource slice tracker")
+	if err != nil {
+		tCtx.Fatalf("couldn't start resource slice tracker: %s", err)
+	}
 	doneCheckers = append(doneCheckers, resourceSliceTracker.HasSyncedChecker())
 
 	claimsCache := assumecache.NewAssumeCache(tCtx.Logger(), tc.informerFactory.Resource().V1().ResourceClaims().Informer(), "resource claim", "", nil)
@@ -3987,7 +4059,9 @@ func setup(tCtx ktesting.TContext, args *config.DynamicResourcesArgs, nodes []*v
 	if features.EnableDRAExtendedResource {
 		cache := tc.draManager.DeviceClassResolver().(*extendedresourcecache.ExtendedResourceCache)
 		deviceClassHandlerRegistration, err := tc.informerFactory.Resource().V1().DeviceClasses().Informer().AddEventHandler(cache)
-		require.NoError(tCtx, err, "failed to add device class informer event handler")
+		if err != nil {
+			tCtx.Fatalf("failed to add device class informer event handler: %s", err)
+		}
 		doneCheckers = append(doneCheckers, deviceClassHandlerRegistration.HasSyncedChecker())
 	}
 
@@ -4684,7 +4758,9 @@ func Test_computesScore(t *testing.T) {
 			if tc.expectErr {
 				t.Fatal("expected error, got none")
 			}
-			assert.Equal(t, tc.expectedScore, score)
+			if score != tc.expectedScore {
+				t.Errorf("expected score %d, got %d", tc.expectedScore, score)
+			}
 		})
 	}
 }
@@ -4855,7 +4931,9 @@ func TestNormalizeScore(t *testing.T) {
 			}
 			scores := tc.scores
 			_ = pl.NormalizeScore(context.Background(), nil, nil, scores)
-			assert.Equal(t, tc.expectedScores, scores)
+			if diff := cmp.Diff(tc.expectedScores, scores); diff != "" {
+				t.Errorf("NormalizeScore mismatch (-want,+got):\n%s", diff)
+			}
 		})
 	}
 }

--- a/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity_test.go
+++ b/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -1361,11 +1360,17 @@ func Test_isSchedulableAfterNodeChange(t *testing.T) {
 
 			actualHint, err := p.(*NodeAffinity).isSchedulableAfterNodeChange(logger, tc.pod, tc.oldObj, tc.newObj)
 			if tc.expectedErr {
-				require.Error(t, err)
+				if err == nil {
+					t.Fatalf("expected error but got nil")
+				}
 				return
 			}
-			require.NoError(t, err)
-			require.Equal(t, tc.expectedHint, actualHint)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if actualHint != tc.expectedHint {
+				t.Fatalf("expected hint %s, got %s", tc.expectedHint, actualHint)
+			}
 		})
 	}
 }

--- a/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/assert"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -215,7 +214,9 @@ func TestBrokenLinearFunction(t *testing.T) {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
 			function := helper.BuildBrokenLinearFunction(test.points)
 			for _, assertion := range test.assertions {
-				assert.InDelta(t, assertion.expected, function(assertion.p), 0.1, "points=%v, p=%d", test.points, assertion.p)
+				if got := function(assertion.p); got != assertion.expected {
+					t.Errorf("points=%v, p=%d: expected %d, got %d", test.points, assertion.p, assertion.expected, got)
+				}
 			}
 		})
 	}

--- a/pkg/scheduler/framework/plugins/noderesources/resource_allocation_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_allocation_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -844,15 +843,21 @@ func TestNodeMatchCaching(t *testing.T) {
 
 			// First call should be a cache miss
 			_, found1 := scorer.getCachedNodeMatch(testNode.Name, tc.nodeNameToMatch, tc.allNodesMatch, nodeSelectorStr)
-			assert.False(t, found1, "Cache should be empty initially")
+			if found1 {
+				t.Errorf("Cache should be empty initially")
+			}
 
 			// Simulate setting a cached result
 			scorer.setCachedNodeMatch(testNode.Name, tc.nodeNameToMatch, tc.allNodesMatch, nodeSelectorStr, tc.expectedMatch)
 
 			// Second call should be a cache hit
 			matches2, found2 := scorer.getCachedNodeMatch(testNode.Name, tc.nodeNameToMatch, tc.allNodesMatch, nodeSelectorStr)
-			assert.True(t, found2, "Result should be found in cache")
-			assert.Equal(t, tc.expectedMatch, matches2, "Cached result should match expected value")
+			if !found2 {
+				t.Errorf("Result should be found in cache")
+			}
+			if matches2 != tc.expectedMatch {
+				t.Errorf("Cached result should match expected value, got %v, want %v", matches2, tc.expectedMatch)
+			}
 		})
 	}
 }

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -1073,8 +1072,12 @@ func TestVolumeBinding(t *testing.T) {
 
 			t.Logf("Verify: call PreFilter and check status")
 			gotPreFilterResult, gotPreFilterStatus := p.PreFilter(ctx, state, item.pod, nil)
-			assert.Equal(t, item.wantPreFilterStatus, gotPreFilterStatus)
-			assert.Equal(t, item.wantPreFilterResult, gotPreFilterResult)
+			if diff := cmp.Diff(item.wantPreFilterStatus, gotPreFilterStatus); diff != "" {
+				t.Errorf("PreFilter status mismatch (-want,+got):\n%s", diff)
+			}
+			if diff := cmp.Diff(item.wantPreFilterResult, gotPreFilterResult); diff != "" {
+				t.Errorf("PreFilter result mismatch (-want,+got):\n%s", diff)
+			}
 
 			if !gotPreFilterStatus.IsSuccess() {
 				// scheduler framework will skip Filter if PreFilter fails
@@ -1104,7 +1107,9 @@ func TestVolumeBinding(t *testing.T) {
 			t.Logf("Verify: call Filter and check status")
 			for i, nodeInfo := range nodeInfos {
 				gotStatus := p.Filter(ctx, state, item.pod, nodeInfo)
-				assert.Equal(t, item.wantFilterStatus[i], gotStatus)
+				if diff := cmp.Diff(item.wantFilterStatus[i], gotStatus); diff != "" {
+					t.Errorf("Unexpected Filter status for node %s (-want,+got):\n%s", nodeInfo.Node().Name, diff)
+				}
 			}
 
 			t.Logf("Verify: call PreScore and check status")
@@ -1185,7 +1190,9 @@ func Test_PreBindPreFlight(t *testing.T) {
 			if !status.Equal(item.wantStatus) {
 				t.Errorf("PreBindPreFlight failed - got: %v, want: %v", status, item.wantStatus)
 			}
-			assert.Equal(t, &fwk.PreBindPreFlightResult{AllowParallel: true}, result)
+			if diff := cmp.Diff(&fwk.PreBindPreFlightResult{AllowParallel: true}, result); diff != "" {
+				t.Errorf("PreBindPreFlight result mismatch (-want,+got):\n%s", diff)
+			}
 		})
 	}
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
-	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
@@ -1470,7 +1469,9 @@ func TestNewInformerFactoryTrim(t *testing.T) {
 			},
 		},
 	}}
-	require.NoError(t, cs.Tracker().Add(pd))
+	if err := cs.Tracker().Add(pd); err != nil {
+		t.Fatalf("failed to add pod to tracker: %s", err)
+	}
 
 	informerFactory := NewInformerFactory(cs, 0)
 	lister := informerFactory.Core().V1().Pods().Lister()
@@ -1481,6 +1482,10 @@ func TestNewInformerFactoryTrim(t *testing.T) {
 	informerFactory.WaitForCacheSync(ctx.Done())
 
 	p, err := lister.Pods("default").Get("test")
-	require.NoError(t, err)
-	require.Empty(t, p.GetManagedFields(), "expected managedFields to be trimmed by the transform")
+	if err != nil {
+		t.Fatalf("unexpected error getting pod: %s", err)
+	}
+	if len(p.GetManagedFields()) != 0 {
+		t.Fatalf("expected managedFields to be trimmed by the transform, got: %v", p.GetManagedFields())
+	}
 }


### PR DESCRIPTION
## What type of PR is this?

/kind cleanup
/sig scheduling

## What this PR does / why we need it:

Removes usage of `github.com/stretchr/testify` assertion libraries (`assert` and `require`) from `pkg/scheduler` tests, replacing them with `cmp.Diff` and standard `t.Errorf`/`t.Fatalf` calls per SIG Scheduling guidelines.

Changes across 7 test files:
- `require.*` calls replaced with `t.Fatalf` (stops test on failure)
- `assert.*` calls replaced with `t.Errorf` (continues on failure)
- Struct/slice comparisons use `cmp.Diff`
- Primitive comparisons use simple `!=`
- Autoscaler contract interface check moved to package-level compile-time assertion

After this change, `pkg/scheduler` has no remaining references to `stretchr/testify`.

## Which issue(s) this PR fixes:

Fixes #130407

## Special notes for your reviewer:

Previous PRs (#130710, #131145, #132612) were all closed by the lifecycle bot. This implementation incorporates @macsko's review feedback from those PRs.

**Note on diff size after rebase:** this PR is larger than when it was first opened (+272/-109, was +170/-72). Since then, upstream added roughly 34 new `assert.`/`require.` calls to these files — most of them in `dynamicresources_test.go`, alongside the new `PodGroupPostFilter` tests. Those are converted here as well, since dropping the testify imports would otherwise break the build.

Verified locally: `go vet ./pkg/scheduler/...`, `gofmt -l pkg/scheduler/`, and `go test ./pkg/scheduler/...` are all clean.

## Does this PR introduce a user-facing change?

```release-note
NONE
```

