### PR TITLE
kubeadm: fix dry-run CA copy paths in init certs

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/certs.go
+++ b/cmd/kubeadm/app/cmd/phases/init/certs.go
@@ -18,6 +18,7 @@ package phases
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -216,20 +217,25 @@ func runCAPhase(ca *certsphase.KubeadmCert) func(c workflow.RunData) error {
 
 		if cert, err := pkiutil.TryLoadCertFromDisk(data.CertificateDir(), ca.BaseName); err == nil {
 			certsphase.CheckCertificatePeriodValidity(ca.BaseName, cert)
+			srcCertPath, srcKeyPath := pkiutil.PathsForCertAndKey(data.CertificateDir(), ca.BaseName)
+			dryRunCertPath, dryRunKeyPath := pkiutil.PathsForCertAndKey(data.CertificateWriteDir(), ca.BaseName)
 
 			// If CA Cert existed while dryrun, copy CA Cert to dryrun dir for later use
 			if data.DryRun() {
-				err := filesutil.CopyFile(filepath.Join(data.CertificateDir(), kubeadmconstants.CACertName), filepath.Join(data.CertificateWriteDir(), kubeadmconstants.CACertName))
+				if err := os.MkdirAll(filepath.Dir(dryRunCertPath), os.FileMode(0700)); err != nil {
+					return errors.Wrapf(err, "failed to create directory %s", filepath.Dir(dryRunCertPath))
+				}
+				err := filesutil.CopyFile(srcCertPath, dryRunCertPath)
 				if err != nil {
-					return errors.Wrapf(err, "could not copy %s to dry run directory %s", kubeadmconstants.CACertName, data.CertificateWriteDir())
+					return errors.Wrapf(err, "could not copy %s to dry run directory %s", fmt.Sprintf("%s.crt", ca.BaseName), data.CertificateWriteDir())
 				}
 			}
 			if _, err := pkiutil.TryLoadKeyFromDisk(data.CertificateDir(), ca.BaseName); err == nil {
 				// If CA Key existed while dryrun, copy CA Key to dryrun dir for later use
 				if data.DryRun() {
-					err := filesutil.CopyFile(filepath.Join(data.CertificateDir(), kubeadmconstants.CAKeyName), filepath.Join(data.CertificateWriteDir(), kubeadmconstants.CAKeyName))
+					err := filesutil.CopyFile(srcKeyPath, dryRunKeyPath)
 					if err != nil {
-						return errors.Wrapf(err, "could not copy %s to dry run directory %s", kubeadmconstants.CAKeyName, data.CertificateWriteDir())
+						return errors.Wrapf(err, "could not copy %s to dry run directory %s", fmt.Sprintf("%s.key", ca.BaseName), data.CertificateWriteDir())
 					}
 				}
 				fmt.Printf("[certs] Using existing %s certificate authority\n", ca.BaseName)

--- a/cmd/kubeadm/app/cmd/phases/init/certs_test.go
+++ b/cmd/kubeadm/app/cmd/phases/init/certs_test.go
@@ -17,14 +17,18 @@ limitations under the License.
 package phases
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
+	certsphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/certs"
 	certstestutil "k8s.io/kubernetes/cmd/kubeadm/app/util/certs/testing"
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config/testing"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 	pkiutiltesting "k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil/testing"
 )
 
@@ -33,10 +37,19 @@ type testCertsData struct {
 	cfg *kubeadmapi.InitConfiguration
 }
 
+type testDryRunCertsData struct {
+	testCertsData
+	certificateDir      string
+	certificateWriteDir string
+}
+
 func (t *testCertsData) Cfg() *kubeadmapi.InitConfiguration { return t.cfg }
 func (t *testCertsData) ExternalCA() bool                   { return false }
 func (t *testCertsData) CertificateDir() string             { return t.cfg.CertificatesDir }
 func (t *testCertsData) CertificateWriteDir() string        { return t.cfg.CertificatesDir }
+func (t *testDryRunCertsData) DryRun() bool                 { return true }
+func (t *testDryRunCertsData) CertificateDir() string       { return t.certificateDir }
+func (t *testDryRunCertsData) CertificateWriteDir() string  { return t.certificateWriteDir }
 
 func TestCreateSparseCerts(t *testing.T) {
 	for _, test := range certstestutil.GetSparseCertTestCases(t) {
@@ -59,6 +72,48 @@ func TestCreateSparseCerts(t *testing.T) {
 
 			if err := r.Run([]string{}); (err != nil) != test.ExpectError {
 				t.Fatalf("expected error to be %t, got %t (%v)", test.ExpectError, (err != nil), err)
+			}
+		})
+	}
+}
+
+func TestRunCAPhaseCopiesExistingCAFilesToDryRunDir(t *testing.T) {
+	for _, ca := range []*certsphase.KubeadmCert{
+		certsphase.KubeadmCertRootCA(),
+		certsphase.KubeadmCertFrontProxyCA(),
+		certsphase.KubeadmCertEtcdCA(),
+	} {
+		t.Run(ca.Name, func(t *testing.T) {
+			pkiutiltesting.Reset()
+
+			sourceDir := t.TempDir()
+			writeDir := t.TempDir()
+			caCert, caKey := certstestutil.SetupCertificateAuthority(t)
+			certPath, _ := pkiutil.PathsForCertAndKey(sourceDir, ca.BaseName)
+			if err := os.MkdirAll(filepath.Dir(certPath), os.FileMode(0700)); err != nil {
+				t.Fatalf("failed to create source directory for %s: %v", ca.BaseName, err)
+			}
+			if err := pkiutil.WriteCertAndKey(sourceDir, ca.BaseName, caCert, caKey); err != nil {
+				t.Fatalf("failed to write source CA files for %s: %v", ca.BaseName, err)
+			}
+
+			cfg := configutil.GetDefaultInternalConfig(t)
+			cfg.CertificatesDir = sourceDir
+			data := &testDryRunCertsData{
+				testCertsData:       testCertsData{cfg: cfg},
+				certificateDir:      sourceDir,
+				certificateWriteDir: writeDir,
+			}
+
+			if err := runCAPhase(ca)(data); err != nil {
+				t.Fatalf("runCAPhase(%s) returned error: %v", ca.Name, err)
+			}
+
+			if _, err := pkiutil.TryLoadCertFromDisk(writeDir, ca.BaseName); err != nil {
+				t.Fatalf("expected copied cert for %s in dry-run dir: %v", ca.BaseName, err)
+			}
+			if _, err := pkiutil.TryLoadKeyFromDisk(writeDir, ca.BaseName); err != nil {
+				t.Fatalf("expected copied key for %s in dry-run dir: %v", ca.BaseName, err)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When kubeadm init runs in dry-run mode and reuses an existing CA, the init certs phase loads the CA using its BaseName but copies files to the dry-run directory using the hard-coded root CA file names.

That works for the root CA by coincidence, but it breaks reused non-root CAs such as front-proxy-ca and etcd-ca.

This PR fixes the dry-run copy logic to derive cert and key paths from the CA BaseName, preserving nested paths such as etcd/ca. It also creates the target subdirectory when needed and adds focused regression tests for front-proxy-ca and etcd-ca.
<!--
#### Which issue(s) this PR is related to:

Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".


#### Special notes for your reviewer:
-->
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: fixed kubeadm init phase certs --dry-run to correctly copy existing CA files.
```
<!--
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>

```docs

```
-->