### PR TITLE
test/nodeshutdown: fix goroutine leak in TestMonitorShutdown

### DIFF
--- a/pkg/kubelet/nodeshutdown/systemd/inhibit_linux_test.go
+++ b/pkg/kubelet/nodeshutdown/systemd/inhibit_linux_test.go
@@ -162,7 +162,9 @@ func TestMonitorShutdown(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			fakeSystemBus := &fakeSystemDBus{}
+			fakeSystemBus := &fakeSystemDBus{
+				signalChannel: make(chan *dbus.Signal, 1),
+			}
 			bus := DBusCon{
 				SystemBus: fakeSystemBus,
 			}
@@ -186,6 +188,8 @@ func TestMonitorShutdown(t *testing.T) {
 			signal := &dbus.Signal{Body: []interface{}{tc.shutdownActive}}
 			fakeSystemBus.signalChannel <- signal
 			<-done
+
+			close(fakeSystemBus.signalChannel)
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Fixes a goroutine leak in `TestMonitorShutdown` — the goroutine spawned inside `MonitorShutdown()` blocked on `busChan` forever because the fake bus never closed it. Adding `close(fakeSystemBus.signalChannel)` after the test completes triggers the existing exit path (`ok=false`), allowing the goroutine to exit cleanly.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #139324

#### Special notes for your reviewer:

No production code changes — test-only fix. The goroutine already has the correct exit path when `busChan` is closed; the bug was simply that  nothing ever closed it in the test.

#### Test Result

Before:

```
docker run --rm -v $(pwd):/k8s -w /k8s golang:1.26 go test ./pkg/kubelet/nodeshutdown/systemd/ -run TestMonitorShutdown -v -race
=== RUN   TestMonitorShutdown
=== RUN   TestMonitorShutdown/shutdown_is_active
=== RUN   TestMonitorShutdown/shutdown_is_not_active
=== NAME  TestMonitorShutdown
    inhibit_linux_test.go:194: found unexpected goroutines:
        [Goroutine 10 in state chan receive, with k8s.io/kubernetes/pkg/kubelet/nodeshutdown/systemd.(*DBusCon).MonitorShutdown.func1 on top of the stack:
        k8s.io/kubernetes/pkg/kubelet/nodeshutdown/systemd.(*DBusCon).MonitorShutdown.func1()
        	/k8s/pkg/kubelet/nodeshutdown/systemd/inhibit_linux.go:151 +0x54
        created by k8s.io/kubernetes/pkg/kubelet/nodeshutdown/systemd.(*DBusCon).MonitorShutdown in goroutine 9
        	/k8s/pkg/kubelet/nodeshutdown/systemd/inhibit_linux.go:149 +0x294
         Goroutine 13 in state chan receive, with k8s.io/kubernetes/pkg/kubelet/nodeshutdown/systemd.(*DBusCon).MonitorShutdown.func1 on top of the stack:
        k8s.io/kubernetes/pkg/kubelet/nodeshutdown/systemd.(*DBusCon).MonitorShutdown.func1()
        	/k8s/pkg/kubelet/nodeshutdown/systemd/inhibit_linux.go:151 +0x54
        created by k8s.io/kubernetes/pkg/kubelet/nodeshutdown/systemd.(*DBusCon).MonitorShutdown in goroutine 12
        	/k8s/pkg/kubelet/nodeshutdown/systemd/inhibit_linux.go:149 +0x294
        ]
--- FAIL: TestMonitorShutdown (0.46s)
    --- PASS: TestMonitorShutdown/shutdown_is_active (0.00s)
    --- PASS: TestMonitorShutdown/shutdown_is_not_active (0.00s)
FAIL
FAIL	k8s.io/kubernetes/pkg/kubelet/nodeshutdown/systemd	0.466s
FAIL
```

After fix: 

```
docker run --rm -v $(pwd):/k8s -w /k8s golang:1.26 go test ./pkg/kubelet/nodeshutdown/systemd/ -run TestMonitorShutdown -v -race
=== RUN   TestMonitorShutdown
=== RUN   TestMonitorShutdown/shutdown_is_active
=== RUN   TestMonitorShutdown/shutdown_is_not_active
--- PASS: TestMonitorShutdown (0.00s)
    --- PASS: TestMonitorShutdown/shutdown_is_active (0.00s)
    --- PASS: TestMonitorShutdown/shutdown_is_not_active (0.00s)
PASS
ok  	k8s.io/kubernetes/pkg/kubelet/nodeshutdown/systemd	1.007s
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
