### PR TITLE
apiserver: reuse pooled allocators for protobuf non-watch responses

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -109,6 +109,15 @@ func SerializeObject(mediaType string, encoder runtime.Encoder, hw http.Response
 		ctx:             ctx,
 	}
 
+	var memoryAllocator runtime.MemoryAllocator
+	if encoderWithAllocator, supportsAllocator := encoder.(runtime.EncoderWithAllocator); supportsAllocator {
+		memoryAllocator = runtime.AllocatorPool.Get().(*runtime.Allocator)
+		encoder = runtime.NewEncoderWithAllocator(encoderWithAllocator, memoryAllocator)
+	}
+	if memoryAllocator != nil {
+		defer runtime.AllocatorPool.Put(memoryAllocator)
+	}
+
 	err := encoder.Encode(object, w)
 	if err == nil {
 		err = w.Close()

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	_ "embed"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -47,6 +48,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/runtime/serializer/protobuf"
+	"k8s.io/apimachinery/pkg/types"
 	rand2 "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apiserver/pkg/features"
@@ -55,6 +57,9 @@ import (
 )
 
 const benchmarkSeed = 100
+
+//go:embed testdata/exemplar_pod.yaml
+var allocatorBenchmarkExemplarPodYAML []byte
 
 func TestSerializeObjectParallel(t *testing.T) {
 	largePayload := bytes.Repeat([]byte("0123456789abcdef"), defaultGzipThresholdBytes/16+1)
@@ -762,6 +767,149 @@ func BenchmarkSerializeObject(b *testing.B) {
 					for _, gzip := range []bool{true, false} {
 						b.Run(fmt.Sprintf("Compression=%v", gzip), func(b *testing.B) {
 							benchmarkSerializeObject(b, payload, gzip)
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+func benchmarkProtobufEncodeWithAllocator(b *testing.B, encoder runtime.EncoderWithAllocator, object runtime.Object, pooled bool) {
+	simpleAllocator := &runtime.SimpleAllocator{}
+	discard := io.Discard
+
+	b.StopTimer()
+	if pooled {
+		allocator := runtime.AllocatorPool.Get().(*runtime.Allocator)
+		if err := encoder.EncodeWithAllocator(object, discard, allocator); err != nil {
+			runtime.AllocatorPool.Put(allocator)
+			b.Fatalf("warm pooled allocator: %v", err)
+		}
+		runtime.AllocatorPool.Put(allocator)
+	} else {
+		if err := encoder.EncodeWithAllocator(object, discard, simpleAllocator); err != nil {
+			b.Fatalf("warm simple allocator: %v", err)
+		}
+	}
+	b.StartTimer()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		var err error
+		if pooled {
+			allocator := runtime.AllocatorPool.Get().(*runtime.Allocator)
+			err = encoder.EncodeWithAllocator(object, discard, allocator)
+			runtime.AllocatorPool.Put(allocator)
+		} else {
+			err = encoder.EncodeWithAllocator(object, discard, simpleAllocator)
+		}
+		if err != nil {
+			b.Fatalf("unexpected encode error: %v", err)
+		}
+	}
+}
+
+func benchmarkProtobufEncodeWithAllocatorParallel(b *testing.B, encoder runtime.EncoderWithAllocator, object runtime.Object, pooled bool) {
+	discard := io.Discard
+
+	b.StopTimer()
+	if pooled {
+		allocator := runtime.AllocatorPool.Get().(*runtime.Allocator)
+		if err := encoder.EncodeWithAllocator(object, discard, allocator); err != nil {
+			runtime.AllocatorPool.Put(allocator)
+			b.Fatalf("warm pooled allocator: %v", err)
+		}
+		runtime.AllocatorPool.Put(allocator)
+	} else {
+		simpleAllocator := &runtime.SimpleAllocator{}
+		if err := encoder.EncodeWithAllocator(object, discard, simpleAllocator); err != nil {
+			b.Fatalf("warm simple allocator: %v", err)
+		}
+	}
+	b.StartTimer()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		simpleAllocator := &runtime.SimpleAllocator{}
+		for pb.Next() {
+			var err error
+			if pooled {
+				allocator := runtime.AllocatorPool.Get().(*runtime.Allocator)
+				err = encoder.EncodeWithAllocator(object, discard, allocator)
+				runtime.AllocatorPool.Put(allocator)
+			} else {
+				err = encoder.EncodeWithAllocator(object, discard, simpleAllocator)
+			}
+			if err != nil {
+				b.Fatalf("unexpected encode error: %v", err)
+			}
+		}
+	})
+}
+
+func allocatorBenchmarkItems(b *testing.B, n int) *v1.PodList {
+	b.Helper()
+	pod := v1.Pod{}
+	if len(allocatorBenchmarkExemplarPodYAML) == 0 {
+		b.Fatal("allocator benchmark exemplar pod is empty")
+	}
+	if err := yaml.Unmarshal(allocatorBenchmarkExemplarPodYAML, &pod); err != nil {
+		b.Fatalf("decode allocator benchmark exemplar pod: %v", err)
+	}
+
+	nodeNames := make([]string, 25)
+	for i := range nodeNames {
+		nodeNames[i] = rand2.String(10)
+	}
+	list := &v1.PodList{
+		Items: make([]v1.Pod, n),
+	}
+	for i := range n {
+		list.Items[i] = *pod.DeepCopy()
+		list.Items[i].Namespace = rand2.String(10)
+		list.Items[i].Name = list.Items[i].GenerateName + rand2.String(10)
+		list.Items[i].UID = types.UID(rand2.String(36))
+		list.Items[i].ResourceVersion = ""
+		list.Items[i].Spec.NodeName = nodeNames[rand.Intn(len(nodeNames))]
+	}
+	return list
+}
+
+func BenchmarkStreamingProtobufPodListAllocatorReuse(b *testing.B) {
+	counts := []int{50, 500, 5_000}
+	modes := []struct {
+		name     string
+		parallel bool
+	}{
+		{name: "Mode=Single", parallel: false},
+		{name: "Mode=Parallel", parallel: true},
+	}
+	allocators := []struct {
+		name   string
+		pooled bool
+	}{
+		{name: "Allocator=Simple", pooled: false},
+		{name: "Allocator=Pooled", pooled: true},
+	}
+
+	for _, mode := range modes {
+		b.Run(mode.name, func(b *testing.B) {
+			for _, count := range counts {
+				b.Run(fmt.Sprintf("Pods=%d", count), func(b *testing.B) {
+					podList := allocatorBenchmarkItems(b, count)
+					serializer := protobuf.NewSerializerWithOptions(nil, nil, protobuf.SerializerOptions{
+						StreamingCollectionsEncoding: true,
+					})
+					for _, allocator := range allocators {
+						b.Run(allocator.name, func(b *testing.B) {
+							if mode.parallel {
+								benchmarkProtobufEncodeWithAllocatorParallel(b, serializer, podList, allocator.pooled)
+								return
+							}
+							benchmarkProtobufEncodeWithAllocator(b, serializer, podList, allocator.pooled)
 						})
 					}
 				})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR reuses pooled allocators for non-watch responses when the selected encoder implements `runtime.EncoderWithAllocator`.

Today, the LIST/GET response path in `SerializeObject()` calls `Encode()` directly. For protobuf serializers, that means falling back to `SimpleAllocator` on non-watch LIST/GET responses, even though allocator-aware encoding is already supported by the serializer stack.

This change wires `runtime.AllocatorPool` into the non-watch response path, following the same allocator pattern that is already used by WATCH responses:
- watch handler allocator wiring:
  - https://github.com/kubernetes/kubernetes/blob/f19af9936b4a07db8adc631ad2f4c2a1a7452f16/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go#L133-L158


- original watch-side PR: https://github.com/kubernetes/kubernetes/pull/108186


#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Local benchmark results for protobuf  encoding showed a substantial reduction in allocation size:

- Count=500
  - SimpleAllocator: `115822 ns/op`, `540673 B/op`
  - AllocatorPool: `59285 ns/op`, `59 B/op`

- Count=5000
  - SimpleAllocator: `707521 ns/op`, `5382152 B/op`
  - AllocatorPool: `597676 ns/op`, `2649 B/op`


#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
