### PR TITLE
Stop calling PlacementFeasible plugins after success

### DIFF
--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -191,7 +191,7 @@ type PlacementFeasiblePlugin interface {
 	// Return UnschedulableAndUnresolvable status if the pod group cannot be scheduled in the current placement.
 	// The scheduler will give up this placement and won't even evaluate remaining pods. The placement will remain eligible for preemption.
 	// Return Success status if the pod group can be scheduled in the current partially evaluated placement.
-	// After returning Success, the plugin should keep returning Success for the remaining pods.
+	// After returning Success, the plugin is assumed to return Success for the remaining pods and won't be called again for the current placement.
 	PlacementFeasible(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo) *fwk.Status
 }
 

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -2016,6 +2016,28 @@ func (f *frameworkImpl) runPermitPlugin(ctx context.Context, pl fwk.PermitPlugin
 	return status, timeout
 }
 
+const successfulPlacementFeasiblePluginsKey = "FrameworkPlacementFeasibleSuccess"
+
+type successfulPlacementFeasiblePluginsState struct {
+	plugins sets.Set[string]
+}
+
+func (s *successfulPlacementFeasiblePluginsState) Clone() fwk.StateData {
+	return &successfulPlacementFeasiblePluginsState{plugins: s.plugins.Clone()}
+}
+
+func getSuccessfulPlacementFeasiblePlugins(placementCycleState fwk.PlacementCycleState) (sets.Set[string], error) {
+	state, err := placementCycleState.Read(successfulPlacementFeasiblePluginsKey)
+	if err != nil {
+		if !errors.Is(err, fwk.ErrNotFound) {
+			return nil, err
+		}
+		state = &successfulPlacementFeasiblePluginsState{plugins: sets.New[string]()}
+		placementCycleState.Write(successfulPlacementFeasiblePluginsKey, state)
+	}
+	return state.(*successfulPlacementFeasiblePluginsState).plugins, nil
+}
+
 // RunPlacementFeasiblePlugins runs the set of configured Permit plugins that implement PlacementFeasible interface.
 // The result will be Success if all plugins return Success.
 // The only other valid statuses are UnschedulableAndUnresolvable and Unschedulable.
@@ -2028,9 +2050,18 @@ func (f *frameworkImpl) RunPlacementFeasiblePlugins(ctx context.Context, placeme
 		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PlacementFeasible, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
 	}()
 
+	successfulPlugins, err := getSuccessfulPlacementFeasiblePlugins(placementCycleState)
+	if err != nil {
+		return fwk.AsStatus(fmt.Errorf("failed to get successful placement feasible plugins from cycle state: %w", err))
+	}
+
 	for _, pl := range f.placementFeasiblePlugins {
+		if successfulPlugins.Has(pl.Name()) {
+			continue
+		}
 		plStatus := f.runPlacementFeasiblePlugin(ctx, pl, placementCycleState, podGroupInfo)
 		if plStatus.IsSuccess() {
+			successfulPlugins.Insert(pl.Name())
 			continue
 		}
 		if plStatus.Code() == fwk.Unschedulable {

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -897,6 +897,109 @@ func TestRunPlacementFeasiblePlugins(t *testing.T) {
 	}
 }
 
+func TestRunPlacementFeasiblePlugins_SuccessfulPlugins(t *testing.T) {
+	type placementFeasiblePluginRun struct {
+		useNewCycleState bool
+		expectedStatus   *fwk.Status
+		expectedCalled   []bool
+	}
+
+	tests := []struct {
+		name    string
+		plugins []*mockPlacementFeasiblePlugin
+		runs    []placementFeasiblePluginRun
+	}{
+		{
+			name: "Plugins successful on first run are skipped on second run with same cycle state",
+			plugins: []*mockPlacementFeasiblePlugin{
+				{name: "p1", status: nil},
+				{name: "p2", status: nil},
+			},
+			runs: []placementFeasiblePluginRun{
+				{
+					expectedStatus: nil,
+					expectedCalled: []bool{true, true},
+				},
+				{
+					expectedStatus: nil,
+					expectedCalled: []bool{false, false},
+				},
+			},
+		},
+		{
+			name: "Plugins successful on first run are called on second run with new cycle state",
+			plugins: []*mockPlacementFeasiblePlugin{
+				{name: "p1", status: nil},
+				{name: "p2", status: nil},
+			},
+			runs: []placementFeasiblePluginRun{
+				{
+					expectedStatus: nil,
+					expectedCalled: []bool{true, true},
+				},
+				{
+					useNewCycleState: true,
+					expectedStatus:   nil,
+					expectedCalled:   []bool{true, true},
+				},
+			},
+		},
+		{
+			name: "Plugins that fail on first run are called on second run with same cycle state",
+			plugins: []*mockPlacementFeasiblePlugin{
+				{name: "p1", status: fwk.NewStatus(fwk.Unschedulable, "unschedulable")},
+				{name: "p2", status: nil},
+			},
+			runs: []placementFeasiblePluginRun{
+				{
+					expectedStatus: fwk.NewStatus(fwk.Unschedulable, "unschedulable").WithPlugin("p1"),
+					expectedCalled: []bool{true, true},
+				},
+				{
+					expectedStatus: fwk.NewStatus(fwk.Unschedulable, "unschedulable").WithPlugin("p1"),
+					expectedCalled: []bool{true, false},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			f := &frameworkImpl{
+				placementFeasiblePlugins: make([]framework.PlacementFeasiblePlugin, len(tc.plugins)),
+			}
+			for i, p := range tc.plugins {
+				f.placementFeasiblePlugins[i] = p
+			}
+
+			var state fwk.PlacementCycleState = framework.NewCycleState()
+
+			for rIdx, run := range tc.runs {
+				if run.useNewCycleState {
+					state = framework.NewCycleState()
+				}
+
+				for _, p := range tc.plugins {
+					p.called = false
+				}
+
+				status := f.RunPlacementFeasiblePlugins(ctx, state, nil)
+
+				if diff := cmp.Diff(run.expectedStatus, status, statusCmpOpts...); diff != "" {
+					t.Errorf("Run %d: Unexpected status (-want, +got):\n%s", rIdx, diff)
+				}
+
+				for i, p := range tc.plugins {
+					if p.called != run.expectedCalled[i] {
+						t.Errorf("Run %d: Expected plugin %s called=%v, got %v", rIdx, p.name, run.expectedCalled[i], p.called)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestNewFrameworkMultiPointExpansion(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -3591,6 +3694,8 @@ func withMetricsRecorder(recorder *metrics.MetricAsyncRecorder) Option {
 
 func TestRecordingMetrics(t *testing.T) {
 	state.SetRecordPluginMetrics(true)
+	initialState := state.Clone()
+	state := initialState
 	tests := []struct {
 		name               string
 		action             func(ctx context.Context, f framework.Framework)
@@ -3773,6 +3878,7 @@ func TestRecordingMetrics(t *testing.T) {
 			ctx, cancel := context.WithCancel(ctx)
 			metrics.FrameworkExtensionPointDuration.Reset()
 			metrics.PluginExecutionDuration.Reset()
+			state = initialState.Clone()
 
 			plugin := &TestPlugin{name: testPlugin, inj: tt.inject}
 			r := make(Registry)

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -939,7 +939,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 				},
 			},
 			podGroupFeasibleStatuses: []fwk.Code{
-				fwk.Success,
+				fwk.Unschedulable,
 				fwk.Error,
 			},
 			expectedGroupStatusCode: fwk.Error,
@@ -981,7 +981,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 				},
 			},
 			podGroupFeasibleStatuses: []fwk.Code{
-				fwk.Success,
+				fwk.Unschedulable,
 				fwk.Error,
 			},
 			expectedGroupStatusCode: fwk.Error,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

As discussed in https://github.com/kubernetes/kubernetes/pull/138643#discussion_r3275386333, plugins that return success from PlacementFeasible extension point, don't need that extension point to be called again for the same placement.

This is because we assume PlacementFeasible plugin should never switch from Success to non-success as more pods are evaluated for a pod group.

This change prevents bugs where a plugin breaks that assumption, and potentially improves performance by skipping redundant checks.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
