### PR TITLE
Fix: pv_collector_total_pv_count reporting N/A plugin for all CSI-provisioned PVs

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -246,6 +246,11 @@ func newPersistentVolumeBinderController(ctx context.Context, controllerContext 
 		return nil, fmt.Errorf("failed to probe volume plugins when starting persistentvolume controller: %w", err)
 	}
 
+	metricsPlugins, err := ProbePersistentVolumePlugins(logger, controllerContext.ComponentConfig.PersistentVolumeBinderController.VolumeConfiguration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to probe metrics volume plugins when starting persistentvolume controller: %w", err)
+	}
+
 	client, err := controllerContext.NewClient("persistent-volume-binder")
 	if err != nil {
 		return nil, err
@@ -255,6 +260,7 @@ func newPersistentVolumeBinderController(ctx context.Context, controllerContext 
 		KubeClient:                client,
 		SyncPeriod:                controllerContext.ComponentConfig.PersistentVolumeBinderController.PVClaimBinderSyncPeriod.Duration,
 		VolumePlugins:             plugins,
+		MetricsVolumePlugins:      metricsPlugins,
 		VolumeInformer:            controllerContext.InformerFactory.Core().V1().PersistentVolumes(),
 		ClaimInformer:             controllerContext.InformerFactory.Core().V1().PersistentVolumeClaims(),
 		ClassInformer:             controllerContext.InformerFactory.Storage().V1().StorageClasses(),

--- a/pkg/controller/volume/persistentvolume/metrics/metrics_test.go
+++ b/pkg/controller/volume/persistentvolume/metrics/metrics_test.go
@@ -20,8 +20,13 @@ import (
 	"strings"
 	"testing"
 
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/testutil"
+	"k8s.io/kubernetes/pkg/volume"
+	"k8s.io/kubernetes/pkg/volume/csi"
+	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 )
 
 // TestVolumeOperationError tests recording metric when operation has error
@@ -39,5 +44,53 @@ volume_operation_errors_total{operation_name="deletion",plugin_name="kubernetes.
 
 	if err := testutil.GatherAndCompare(registry, strings.NewReader(want), "volume_operation_errors_total"); err != nil {
 		t.Errorf("failed to gather metrics: %v", err)
+	}
+}
+
+func TestGetPVPluginName(t *testing.T) {
+	csiPV := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-csi-pv"},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					Driver:       "ebs.csi.aws.com",
+					VolumeHandle: "vol-12345",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		plugins  []volume.VolumePlugin
+		pv       *v1.PersistentVolume
+		wantName string
+	}{
+		{
+			name:     "CSI PV with CSI plugin registered returns full qualified name",
+			plugins:  csi.ProbeVolumePlugins(),
+			pv:       csiPV,
+			wantName: "kubernetes.io/csi:ebs.csi.aws.com",
+		},
+		{
+			name:     "CSI PV without any plugins registered returns N/A",
+			plugins:  []volume.VolumePlugin{},
+			pv:       csiPV,
+			wantName: pluginNameNotAvailable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var pluginMgr volume.VolumePluginMgr
+			host := volumetest.NewFakeVolumeHost(t, t.TempDir(), nil, nil)
+			if err := pluginMgr.InitPlugins(tt.plugins, nil, host); err != nil {
+				t.Fatalf("InitPlugins: %v", err)
+			}
+			collector := &pvAndPVCCountCollector{pluginMgr: &pluginMgr}
+			if got := collector.getPVPluginName(tt.pv); got != tt.wantName {
+				t.Errorf("getPVPluginName() = %q, want %q", got, tt.wantName)
+			}
+		})
 	}
 }

--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -158,6 +158,7 @@ type PersistentVolumeController struct {
 	eventBroadcaster          record.EventBroadcaster
 	eventRecorder             record.EventRecorder
 	volumePluginMgr           vol.VolumePluginMgr
+	metricsPluginMgr          vol.VolumePluginMgr
 	enableDynamicProvisioning bool
 	resyncPeriod              time.Duration
 

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -64,7 +64,8 @@ import (
 type ControllerParameters struct {
 	KubeClient                clientset.Interface
 	SyncPeriod                time.Duration
-	VolumePlugins             []vol.VolumePlugin
+	VolumePlugins             []vol.VolumePlugin // subset: provisionable/deletable/recyclable only
+	MetricsVolumePlugins      []vol.VolumePlugin // full set: all PV plugins, used for plugin_name metric label
 	VolumeInformer            coreinformers.PersistentVolumeInformer
 	ClaimInformer             coreinformers.PersistentVolumeClaimInformer
 	ClassInformer             storageinformers.StorageClassInformer
@@ -103,6 +104,10 @@ func NewController(ctx context.Context, p ControllerParameters) (*PersistentVolu
 	// Prober is nil because PV is not aware of Flexvolume.
 	if err := controller.volumePluginMgr.InitPlugins(p.VolumePlugins, nil /* prober */, controller); err != nil {
 		return nil, fmt.Errorf("could not initialize volume plugins for PersistentVolume Controller: %w", err)
+	}
+
+	if err := controller.metricsPluginMgr.InitPlugins(p.MetricsVolumePlugins, nil /* prober */, controller); err != nil {
+		return nil, fmt.Errorf("could not initialize metrics volume plugins for PersistentVolume Controller: %w", err)
 	}
 
 	logger := klog.FromContext(ctx)
@@ -340,7 +345,7 @@ func (ctrl *PersistentVolumeController) Run(ctx context.Context) {
 	}
 
 	ctrl.initializeCaches(logger, ctrl.volumeLister, ctrl.claimLister)
-	metrics.Register(ctrl.volumes.store, ctrl.claims, &ctrl.volumePluginMgr)
+	metrics.Register(ctrl.volumes.store, ctrl.claims, &ctrl.metricsPluginMgr)
 	volumeutil.RegisterMetrics()
 
 	wg.Go(func() {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind regression

#### What this PR does / why we need it:

The metric `pv_collector_total_pv_count` (which feeds the `kube_persistentvolume_plugin_type_counts` recording rule) reports `plugin_name="N/A"` for all CSI-provisioned PersistentVolumes instead of the correct `kubernetes.io/csi:<driver>` value.

**Root cause:** Commit 9e29f95618c ("Refactor controller-manager volume plugins") replaced `ProbeControllerVolumePlugins` with `ProbeProvisionableRecyclableVolumePlugins` for the PV binder controller. The new function filters plugins to only those implementing `ProvisionableVolumePlugin`, `DeletableVolumePlugin`, or `RecyclableVolumePlugin`. The CSI plugin (`kubernetes.io/csi`) implements none of these interfaces — it delegates all operations to external CSI drivers — so it was silently dropped from `volumePluginMgr`.

`metrics.Register` was still passed `&ctrl.volumePluginMgr`, so at metric collection time `getPVPluginName()` called `pluginMgr.FindPluginBySpec()` for each PV. For any CSI PV, this returned `ErrNoPluginMatched`, causing the code to fall back to the `pluginNameNotAvailable` sentinel (`"N/A"`).

**Fix:** Initialize a dedicated `metricsPluginMgr` from `ProbePersistentVolumePlugins` (which returns all plugins with no filter, including CSI) and pass that to `metrics.Register` instead of `volumePluginMgr`. The operational `volumePluginMgr` (used for provisioning/recycling) is unchanged.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The offending commit is 9e29f95618c. Before that change, the old `ProbeControllerVolumePlugins` included the CSI plugin unconditionally, so `volumePluginMgr` could resolve CSI PVs. The refactor correctly narrowed `volumePluginMgr` for operational purposes but inadvertently broke metric collection, which needs a broader plugin set.

The fix intentionally keeps `volumePluginMgr` narrow (provisionable/deletable/recyclable only) and introduces a separate `metricsPluginMgr` to avoid any unintended side effects on the provisioning/recycling paths.

#### Does this PR introduce a user-facing change?

```release-note
Fixed `pv_collector_total_pv_count` metric reporting `plugin_name="N/A"` for CSI-provisioned PersistentVolumes. The label now correctly shows `kubernetes.io/csi:<driver-name>` (e.g. `kubernetes.io/csi:ebs.csi.aws.com`).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
 ```
