### PR TITLE
fix(scheduler): ensure popped PodInfo remains unchanged during schedu…

### DIFF
--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -1215,6 +1215,16 @@ func (sched *Scheduler) handleSchedulingFailure(ctx context.Context, podFwk fram
 		metrics.PodScheduleError(podFwk.ProfileName(), metrics.SinceInSeconds(start))
 	}
 
+	// Keep the popped podInfo stable: build the copy for requeueing from
+	// QueueingParams only — PodInfo is replaced below from the informer cache,
+	// so deep-copying it is unnecessary. QueueingParams.DeepCopy clones the set
+	// fields (UnschedulablePlugins, PendingPlugins) so that ClearRejectorPlugins
+	// on the copy doesn't mutate the popped object's sets.
+	podInfoCopy := &framework.QueuedPodInfo{
+		QueueingParams: *podInfo.QueueingParams.DeepCopy(),
+		PodInfo:        podInfo.PodInfo,
+		PodSignature:   podInfo.PodSignature,
+	}
 	pod := podInfo.Pod
 	err := status.AsError()
 	errMsg := status.Message()
@@ -1223,13 +1233,13 @@ func (sched *Scheduler) handleSchedulingFailure(ctx context.Context, podFwk fram
 	// These fields will be repopulated below for FitError cases.
 	// We clear them here (rather than at Pop) because we sometimes want to use them
 	// for logging when a pod schedules successfully (e.g., after being flushed).
-	podInfo.ClearRejectorPlugins()
+	podInfoCopy.ClearRejectorPlugins()
 
 	if err == ErrNoNodesAvailable {
 		logger.V(2).Info("Unable to schedule pod; no nodes are registered to the cluster; waiting", "pod", klog.KObj(pod))
 	} else if fitError, ok := err.(*framework.FitError); ok { // Inject UnschedulablePlugins to PodInfo, which will be used later for moving Pods between queues efficiently.
-		podInfo.UnschedulablePlugins = fitError.Diagnosis.UnschedulablePlugins
-		podInfo.PendingPlugins = fitError.Diagnosis.PendingPlugins
+		podInfoCopy.UnschedulablePlugins = fitError.Diagnosis.UnschedulablePlugins
+		podInfoCopy.PendingPlugins = fitError.Diagnosis.PendingPlugins
 		logger.V(2).Info("Unable to schedule pod; no fit; waiting", "pod", klog.KObj(pod), "err", errMsg)
 	} else if errors.Is(err, errPodGroupUnschedulable) {
 		logger.V(2).Info("Unable to schedule pod belonging to a pod group; waiting", "pod", klog.KObj(pod), "err", errMsg)
@@ -1257,9 +1267,9 @@ func (sched *Scheduler) handleSchedulingFailure(ctx context.Context, podFwk fram
 			// As <cachedPod> is from SharedInformer, we need to do a DeepCopy() here.
 			// ignore this err since apiserver doesn't properly validate affinity terms
 			// and we can't fix the validation for backwards compatibility.
-			podInfo.PodInfo, _ = framework.NewPodInfo(cachedPod.DeepCopy())
-			pod = podInfo.Pod
-			if err := sched.SchedulingQueue.AddUnschedulablePodIfNotPresent(logger, podInfo, sched.SchedulingQueue.SchedulingCycle()); err != nil {
+			podInfoCopy.PodInfo, _ = framework.NewPodInfo(cachedPod.DeepCopy())
+			pod = podInfoCopy.Pod
+			if err := sched.SchedulingQueue.AddUnschedulablePodIfNotPresent(logger, podInfoCopy, sched.SchedulingQueue.SchedulingCycle()); err != nil {
 				utilruntime.HandleErrorWithContext(ctx, err, "Error occurred")
 			}
 			calledDone = true
@@ -1271,7 +1281,7 @@ func (sched *Scheduler) handleSchedulingFailure(ctx context.Context, podFwk fram
 	// and the time the scheduler receives a Pod Update for the nominated pod.
 	// Here we check for nil only for tests.
 	if sched.SchedulingQueue != nil {
-		sched.SchedulingQueue.AddNominatedPod(logger, podInfo.PodInfo, nominatingInfo)
+		sched.SchedulingQueue.AddNominatedPod(logger, podInfoCopy.PodInfo, nominatingInfo)
 	}
 
 	if err == nil {

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -1387,6 +1387,109 @@ func TestHandleSchedulingFailureSkipsRecreatedPod(t *testing.T) {
 	}
 }
 
+func TestHandleSchedulingFailureDoesNotMutatePoppedPodInfo(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	queuedPod := st.MakePod().Name("foo").Namespace("ns").UID("uid").SchedulerName(testSchedulerName).Annotation("source", "queue").Obj()
+	cachedPod := queuedPod.DeepCopy()
+	cachedPod.Annotations = map[string]string{"source": "informer"}
+
+	client := clientsetfake.NewClientset(cachedPod)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	eventBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: client.EventsV1()})
+
+	schedFramework, err := tf.NewFramework(ctx,
+		[]tf.RegisterPluginFunc{
+			tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+			tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+		},
+		testSchedulerName,
+		frameworkruntime.WithClientSet(client),
+		frameworkruntime.WithEventRecorder(eventBroadcaster.NewRecorder(scheme.Scheme, testSchedulerName)),
+		frameworkruntime.WithInformerFactory(informerFactory),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ar := metrics.NewMetricsAsyncRecorder(10, time.Second, ctx.Done())
+	queue := internalqueue.NewSchedulingQueue(nil, informerFactory, internalqueue.WithMetricsRecorder(ar))
+	sched := &Scheduler{
+		client:          client,
+		SchedulingQueue: queue,
+	}
+
+	informerFactory.Start(ctx.Done())
+	informerFactory.WaitForCacheSync(ctx.Done())
+
+	queue.Add(ctx, queuedPod)
+	popped, err := queue.Pop(logger)
+	if err != nil {
+		t.Fatalf("Pop: %v", err)
+	}
+
+	poppedPod := popped.(*framework.QueuedPodInfo)
+	originalPodInfo := poppedPod.PodInfo
+	originalPod := poppedPod.Pod
+	poppedPod.UnschedulablePlugins = sets.New("previous")
+	poppedPod.PendingPlugins = sets.New("previous-pending")
+
+	fitErr := &framework.FitError{
+		Pod:         queuedPod,
+		NumAllNodes: 1,
+		Diagnosis: framework.Diagnosis{
+			NodeToStatus: framework.NewNodeToStatus(map[string]*fwk.Status{
+				"node1": fwk.NewStatus(fwk.Unschedulable, "node(s) didn't fit"),
+			}, fwk.NewStatus(fwk.UnschedulableAndUnresolvable)),
+			UnschedulablePlugins: sets.New("current-unschedulable"),
+			PendingPlugins:       sets.New("current-pending"),
+		},
+	}
+	status := fwk.NewStatus(fwk.Unschedulable).WithError(fitErr)
+
+	nominatingInfo := &fwk.NominatingInfo{NominatingMode: fwk.ModeOverride, NominatedNodeName: "node1"}
+	sched.handleSchedulingFailure(ctx, schedFramework, poppedPod, status, nominatingInfo, time.Now())
+
+	// Pointer-identity check: the old code did podInfo.PodInfo = framework.NewPodInfo(...)
+	// which would replace the .PodInfo field on the popped object (same pointer as poppedPod).
+	// With the fix only podInfoCopy.PodInfo is replaced, so poppedPod.PodInfo must still
+	// equal the value it had before the call.
+	if poppedPod.PodInfo != originalPodInfo {
+		t.Fatalf("expected popped PodInfo to remain unchanged")
+	}
+	if poppedPod.Pod != originalPod {
+		t.Fatalf("expected popped Pod to remain unchanged")
+	}
+	if diff := cmp.Diff(map[string]string{"source": "queue"}, poppedPod.Pod.Annotations); diff != "" {
+		t.Fatalf("unexpected popped pod annotations (-want,+got):\n%s", diff)
+	}
+	if diff := cmp.Diff(sets.New("previous"), poppedPod.UnschedulablePlugins); diff != "" {
+		t.Fatalf("unexpected popped pod unschedulable plugins (-want,+got):\n%s", diff)
+	}
+	if diff := cmp.Diff(sets.New("previous-pending"), poppedPod.PendingPlugins); diff != "" {
+		t.Fatalf("unexpected popped pod pending plugins (-want,+got):\n%s", diff)
+	}
+
+	requeuedPodInfo, ok := queue.GetPod(cachedPod.Name, cachedPod.Namespace, nil)
+	if !ok {
+		t.Fatalf("expected pod to be requeued")
+	}
+	if requeuedPodInfo.PodInfo == originalPodInfo {
+		t.Fatalf("expected requeued PodInfo to be a copy")
+	}
+	if diff := cmp.Diff(map[string]string{"source": "informer"}, requeuedPodInfo.Pod.Annotations); diff != "" {
+		t.Fatalf("unexpected requeued pod annotations (-want,+got):\n%s", diff)
+	}
+	if diff := cmp.Diff(sets.New("current-unschedulable"), requeuedPodInfo.UnschedulablePlugins); diff != "" {
+		t.Fatalf("unexpected requeued pod unschedulable plugins (-want,+got):\n%s", diff)
+	}
+	if diff := cmp.Diff(sets.New("current-pending"), requeuedPodInfo.PendingPlugins); diff != "" {
+		t.Fatalf("unexpected requeued pod pending plugins (-want,+got):\n%s", diff)
+	}
+}
+
 type constSigPluginConfig struct {
 	name       string
 	signature  []fwk.SignFragment


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig scheduling

#### What this PR does / why we need it:

This avoids mutating the popped `QueuedPodInfo` in `handleSchedulingFailure` while it can still be observed by concurrent scheduling queue update paths.

The failure handler now prepares a copied `QueuedPodInfo` for requeueing and nominated-pod updates, leaving the in-flight popped object stable until the queue marks it done.

#### Which issue(s) this PR is related to:

Related: #139340

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```