### PR TITLE
apiserver: use explicit initialized flag in monitorCache

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -250,11 +250,12 @@ func (s *EtcdOptions) ApplyWithStorageFactoryTo(factory serverstorage.StorageFac
 }
 
 type monitorCache struct {
-	mu       sync.RWMutex
-	closed   bool
-	monitors []metrics.Monitor
-	factory  serverstorage.StorageFactory
-	stopCh   <-chan struct{}
+	mu          sync.RWMutex
+	initialized bool
+	closed      bool
+	monitors    []metrics.Monitor
+	factory     serverstorage.StorageFactory
+	stopCh      <-chan struct{}
 }
 
 var createMonitor = storagefactory.CreateMonitor
@@ -277,7 +278,7 @@ func (c *monitorCache) get() ([]metrics.Monitor, error) {
 		c.mu.RUnlock()
 		return nil, fmt.Errorf("monitor cache is closed")
 	}
-	if c.monitors != nil {
+	if c.initialized {
 		result := c.monitors
 		c.mu.RUnlock()
 		return result, nil
@@ -295,7 +296,7 @@ func (c *monitorCache) initialize() ([]metrics.Monitor, error) {
 	if c.closed {
 		return nil, fmt.Errorf("monitor cache is closed")
 	}
-	if c.monitors != nil {
+	if c.initialized {
 		return c.monitors, nil
 	}
 
@@ -311,6 +312,7 @@ func (c *monitorCache) initialize() ([]metrics.Monitor, error) {
 		monitors = append(monitors, m)
 	}
 	c.monitors = monitors
+	c.initialized = true
 
 	go func() {
 		<-c.stopCh

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
@@ -559,6 +559,23 @@ func TestMonitorCache(t *testing.T) {
 			},
 		},
 		{
+			name: "marks initialized after first get",
+			test: func(t *testing.T) {
+				cache := newTestCache(t)
+				setCreateMonitor(t, func(cfg storagebackend.Config) (metrics.Monitor, error) {
+					return &fakeMonitor{}, nil
+				})
+
+				if _, err := cache.get(); err != nil {
+					t.Fatalf("get() returned error: %v", err)
+				}
+
+				if !cache.initialized {
+					t.Fatal("expected cache to be marked initialized after first get()")
+				}
+			},
+		},
+		{
 			name: "concurrent get calls all return the first initialized monitors",
 			test: func(t *testing.T) {
 				cache := newTestCache(t)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

When factory.Configs() returns an empty slice, the monitors field stays nil
after initialize(), so the c.monitors != nil guard in get() never triggers and
every call re-enters initialize(), spawning an extra cleanup goroutine each time.

Use an explicit initialized bool field instead, set unconditionally after the
first successful initialize(), so the fast path works regardless of whether any
monitors were created.

#### Which issue(s) this PR is related to:

Aligns https://github.com/kubernetes/kubernetes/pull/138075

#### Special notes for your reviewer:

n/a

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

n/a