### PR TITLE
test/e2e_dra: don't toggle locked gates for Kubelet

### DIFF
--- a/test/utils/localupcluster/localupcluster.go
+++ b/test/utils/localupcluster/localupcluster.go
@@ -49,9 +49,11 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/kubernetes/test/utils/client-go/ktesting"
 )
 
@@ -571,6 +573,8 @@ func dumpProcesses(tCtx ktesting.TContext) {
 
 // ToggleFeatureGates restarts the feature gated components with the specified feature gates.
 // The returned ModifyOptions can be passed to Modify to restore the original state.
+// Gates that are locked in the current release are automatically excluded from kubelet's
+// command line, since kubelet lacks --emulated-version support and would reject toggling a locked gate.
 func (c *Cluster) ToggleFeatureGates(tCtx ktesting.TContext, state string, featureGates string) ModifyOptions {
 	tCtx.Helper()
 
@@ -579,11 +583,29 @@ func (c *Cluster) ToggleFeatureGates(tCtx ktesting.TContext, state string, featu
 		FeatureGatesByComponent: make(map[ClusterComponentName]string),
 	}
 
+	allGates := utilfeature.DefaultMutableFeatureGate.GetAll()
+
 	for _, component := range featureGatedComponents {
-		opts.FeatureGatesByComponent[component] = featureGates
+		gates := featureGates
+		if component == Kubelet {
+			gates = filterLockedFeatureGates(featureGates, allGates)
+		}
+		opts.FeatureGatesByComponent[component] = gates
 	}
 
 	return c.Modify(tCtx, state, opts)
+}
+
+// filterLockedFeatureGates removes gates that are locked to their default value from the
+// feature gates string. Kubelet does not support --emulated-version and would reject
+// toggling a locked gate, so locked gates must be excluded from its command line.
+func filterLockedFeatureGates(featureGates string, allGates map[featuregate.Feature]featuregate.FeatureSpec) string {
+	filtered := slices.DeleteFunc(strings.Split(featureGates, ","), func(gate string) bool {
+		gateName := strings.TrimSpace(strings.SplitN(gate, "=", 2)[0])
+		spec, known := allGates[featuregate.Feature(gateName)]
+		return known && spec.LockToDefault
+	})
+	return strings.Join(filtered, ",")
 }
 
 // mergeFeatureGatesFlags merges the given feature gates (in "fg1=true,fg2=false" format)

--- a/test/utils/localupcluster/localupcluster_test.go
+++ b/test/utils/localupcluster/localupcluster_test.go
@@ -19,6 +19,8 @@ package localupcluster
 import (
 	"reflect"
 	"testing"
+
+	"k8s.io/component-base/featuregate"
 )
 
 func TestMergeFeatureGatesFlags(t *testing.T) {
@@ -128,6 +130,34 @@ func TestMergeFeatureGatesFlags(t *testing.T) {
 			}
 			if !reflect.DeepEqual(tc.cmdLine, cmdLineCopy) {
 				t.Errorf("input slice was mutated:\n got:  %q\n want: %q", tc.cmdLine, cmdLineCopy)
+			}
+		})
+	}
+}
+
+func TestFilterLockedFeatureGates(t *testing.T) {
+	allGates := map[featuregate.Feature]featuregate.FeatureSpec{
+		"Unlocked":      {Default: true, LockToDefault: false},
+		"LockedToTrue":  {Default: true, LockToDefault: true},
+		"LockedToFalse": {Default: false, LockToDefault: true},
+	}
+	for name, tc := range map[string]struct {
+		featureGates string
+		want         string
+	}{
+		"no-locked-gates":                   {featureGates: "Unlocked=false", want: "Unlocked=false"},
+		"locked-to-true-set-false-removed":  {featureGates: "LockedToTrue=false", want: ""},
+		"locked-to-true-set-true-removed":   {featureGates: "LockedToTrue=true", want: ""},
+		"locked-to-false-set-true-removed":  {featureGates: "LockedToFalse=true", want: ""},
+		"locked-to-false-set-false-removed": {featureGates: "LockedToFalse=false", want: ""},
+		"locked-gate-mixed":                 {featureGates: "Unlocked=false,LockedToTrue=false", want: "Unlocked=false"},
+		"unknown-gate-kept":                 {featureGates: "Unknown=true", want: "Unknown=true"},
+		"multiple-unlocked":                 {featureGates: "Unlocked=false,Unknown=true", want: "Unlocked=false,Unknown=true"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := filterLockedFeatureGates(tc.featureGates, allGates)
+			if got != tc.want {
+				t.Errorf("filterLockedFeatureGates(%q) = %q, want %q", tc.featureGates, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

Kubelet lacks --emulated-version support and cannot toggle feature gates that are locked in the binary. Modified ToggleFeatureGates to exclude locked feature gates from kubelet's --feature-gates.

This should fix https://github.com/kubernetes/kubernetes/pull/138488#discussion_r3315989862

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/138376

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```