### PR TITLE
Automated cherry pick of #139017: Fix dra scoring bug with mixed allocated and unallocated claims

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -1071,7 +1071,7 @@ func (pl *DynamicResources) unreservePodGroupClaims(ctx context.Context, pod *v1
 }
 
 func (pl *DynamicResources) Score(ctx context.Context, cs fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) (int64, *fwk.Status) {
-	if !pl.enabled {
+	if !pl.enabled || !pl.fts.EnableDRAPrioritizedList {
 		return 0, nil
 	}
 	logger := klog.FromContext(ctx)
@@ -1100,13 +1100,29 @@ func (pl *DynamicResources) Score(ctx context.Context, cs fwk.CycleState, pod *v
 
 func computeScore(iterator iter.Seq2[int, *resourceapi.ResourceClaim], allocations nodeAllocation) (int64, error) {
 	var score int64
-	for i, claim := range iterator {
+	unallocatedIndex := 0
+	for _, claim := range iterator {
 		// Collect the names for all allocated subrequests.
 		allocatedSubRequests := sets.New[string]()
-		if i >= len(allocations.allocationResults) {
-			return 0, fmt.Errorf("number of allocations %d is smaller than number of claims", len(allocations.allocationResults))
+
+		var allocation *resourceapi.AllocationResult
+		// The allocation for a claim can be in two places:
+		// 1. For claims allocated in a previous cycle (e.g. PodGroup claims), the allocation
+		//    is already in claim.Status.Allocation.
+		// 2. For claims allocated in this cycle (in Filter), the allocation is in
+		//    allocations.allocationResults.
+		// Since we iterate over all claims, we must check both and maintain a separate index
+		// for claims that needed allocation in this cycle.
+		if claim.Status.Allocation != nil {
+			allocation = claim.Status.Allocation
+		} else {
+			if unallocatedIndex >= len(allocations.allocationResults) {
+				return 0, fmt.Errorf("number of allocations %d is smaller than number of claims needing allocation", len(allocations.allocationResults))
+			}
+			allocation = &allocations.allocationResults[unallocatedIndex]
+			unallocatedIndex++
 		}
-		allocation := allocations.allocationResults[i]
+
 		for _, res := range allocation.Devices.Results {
 			request := res.Request
 			if resourceclaim.IsSubRequestRef(request) {

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -4467,6 +4467,19 @@ func Test_computesScore(t *testing.T) {
 			allocations: nodeAllocation{},
 			expectErr:   true,
 		},
+		"mix-of-allocated-and-unallocated-claims": {
+			claims: []*resourceapi.ResourceClaim{
+				allocatedClaim,
+				pendingClaim2,
+			},
+			allocations: nodeAllocation{
+				allocationResults: []resourceapi.AllocationResult{
+					*allocationResult2,
+				},
+			},
+			expectedScore: 0,
+			expectErr:     false,
+		},
 		"single-request-only-subrequest-allocated": {
 			claims: []*resourceapi.ResourceClaim{
 				st.MakeResourceClaim().


### PR DESCRIPTION
Cherry pick of #139017 on release-1.36.

#139017: Fix dra scoring bug with mixed allocated and unallocated claims

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
Fixed a bug where Pods that share multi-node claims and also have per-node claims can get stuck in Pending.
```