### PR TITLE
Automated cherry pick of #138740: flowcontrol: cover declarative Required rule for PriorityLevelConfiguration type field

### DIFF
--- a/pkg/apis/flowcontrol/validation/validation.go
+++ b/pkg/apis/flowcontrol/validation/validation.go
@@ -416,7 +416,11 @@ func ValidatePriorityLevelConfigurationSpec(spec *flowcontrol.PriorityLevelConfi
 			allErrs = append(allErrs, ValidateLimitedPriorityLevelConfiguration(spec.Limited, requestGV, fldPath.Child("limited"), opts)...)
 		}
 	default:
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("type"), spec.Type, supportedPriorityLevelEnablement.List()))
+		if len(spec.Type) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("type"), "").MarkCoveredByDeclarative())
+		} else {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("type"), spec.Type, supportedPriorityLevelEnablement.List()))
+		}
 	}
 	return allErrs
 }
@@ -475,7 +479,11 @@ func ValidateLimitResponse(lr flowcontrol.LimitResponse, fldPath *field.Path) fi
 			allErrs = append(allErrs, ValidatePriorityLevelQueuingConfiguration(lr.Queuing, fldPath.Child("queuing"))...)
 		}
 	default:
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("type"), lr.Type, supportedLimitResponseType.List()))
+		if len(lr.Type) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("type"), "").MarkCoveredByDeclarative())
+		} else {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("type"), lr.Type, supportedLimitResponseType.List()))
+		}
 	}
 	return allErrs
 }

--- a/pkg/apis/flowcontrol/validation/validation_test.go
+++ b/pkg/apis/flowcontrol/validation/validation_test.go
@@ -1127,6 +1127,38 @@ func TestPriorityLevelConfigurationValidation(t *testing.T) {
 		expectedErrors: field.ErrorList{
 			field.Forbidden(field.NewPath("metadata").Child("annotations"), fmt.Sprintf("annotation '%s' is forbidden", flowcontrolv1beta3.PriorityLevelPreserveZeroConcurrencySharesKey)),
 		},
+	}, {
+		name: "spec.type empty should fail with required",
+		priorityLevelConfiguration: &flowcontrol.PriorityLevelConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-empty-type",
+			},
+			Spec: flowcontrol.PriorityLevelConfigurationSpec{
+				Type: "",
+			},
+		},
+		expectedErrors: field.ErrorList{
+			field.Required(field.NewPath("spec").Child("type"), "").MarkCoveredByDeclarative(),
+		},
+	}, {
+		name: "spec.limited.limitResponse.type empty should fail with required",
+		priorityLevelConfiguration: &flowcontrol.PriorityLevelConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-empty-lr-type",
+			},
+			Spec: flowcontrol.PriorityLevelConfigurationSpec{
+				Type: flowcontrol.PriorityLevelEnablementLimited,
+				Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
+					NominalConcurrencyShares: 42,
+					LimitResponse: flowcontrol.LimitResponse{
+						Type: "",
+					},
+				},
+			},
+		},
+		expectedErrors: field.ErrorList{
+			field.Required(field.NewPath("spec").Child("limited").Child("limitResponse").Child("type"), "").MarkCoveredByDeclarative(),
+		},
 	}}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/pkg/registry/flowcontrol/prioritylevelconfiguration/declarative_validation_test.go
+++ b/pkg/registry/flowcontrol/prioritylevelconfiguration/declarative_validation_test.go
@@ -103,6 +103,18 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				field.Forbidden(specPath.Child("limited", "limitResponse", "queuing"), "").MarkCoveredByDeclarative().MarkAlpha(),
 			},
 		},
+		"spec.type: empty": {
+			input: mkPLC(tweakSpecType(""), tweakLimited(nil)),
+			expectedErrs: field.ErrorList{
+				field.Required(specPath.Child("type"), "").MarkCoveredByDeclarative().MarkAlpha(),
+			},
+		},
+		"limitResponse.type: empty": {
+			input: mkPLC(tweakLimitResponseType("")),
+			expectedErrs: field.ErrorList{
+				field.Required(specPath.Child("limited", "limitResponse", "type"), "").MarkCoveredByDeclarative().MarkAlpha(),
+			},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -223,6 +235,13 @@ func tweakExempt() func(*flowcontrol.PriorityLevelConfiguration) {
 func tweakLimited(limited *flowcontrol.LimitedPriorityLevelConfiguration) func(*flowcontrol.PriorityLevelConfiguration) {
 	return func(obj *flowcontrol.PriorityLevelConfiguration) {
 		obj.Spec.Limited = limited
+	}
+}
+
+// tweakSpecType sets the Spec.Type field directly.
+func tweakSpecType(t flowcontrol.PriorityLevelEnablement) func(*flowcontrol.PriorityLevelConfiguration) {
+	return func(obj *flowcontrol.PriorityLevelConfiguration) {
+		obj.Spec.Type = t
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #138740 on release-1.36.

#138740: flowcontrol: cover declarative Required rule for PriorityLevelConfiguration type field

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
None
```

----------
This cherry-picking is needed to eliminate the mismatch validation error between generated validation vs handwritten validation.