### PR TITLE
fix: preserve original status code in podGroup scheduling algorithms

### DIFF
--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -340,7 +340,7 @@ func (sched *Scheduler) podGroupSchedulingDefaultAlgorithm(ctx context.Context, 
 
 		if !podResult.status.IsSuccess() && !podResult.status.IsRejected() {
 			// When the algorithm returns error or unexpected status, stop evaluating the rest of the pods.
-			result.status = fwk.AsStatus(fmt.Errorf("failed to schedule other pod from a pod group: %w", podResult.status.AsError()))
+			result.status = fwk.NewStatus(podResult.status.Code()).WithError(fmt.Errorf("failed to schedule other pod from a pod group: %w", podResult.status.AsError()))
 			break
 		}
 
@@ -350,7 +350,7 @@ func (sched *Scheduler) podGroupSchedulingDefaultAlgorithm(ctx context.Context, 
 
 		if placementFeasibleStatus.IsError() {
 			// When the algorithm returns error or unexpected status, stop evaluating the rest of the pods.
-			result.status = fwk.AsStatus(fmt.Errorf("failed to evaluate placement feasibility: %w", placementFeasibleStatus.AsError()))
+			result.status = fwk.NewStatus(placementFeasibleStatus.Code()).WithError(fmt.Errorf("failed to evaluate placement feasibility: %w", placementFeasibleStatus.AsError()))
 			break
 		}
 

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -666,7 +666,7 @@ func TestPodGroupCycle_PodGroupPostFilter(t *testing.T) {
 	}
 }
 
-func TestPodGroupSchedulingAlgorithm(t *testing.T) {
+func TestPodGroupSchedulingDefaultAlgorithm(t *testing.T) {
 	testNode := st.MakeNode().Name("node1").UID("node1").Obj()
 
 	p1 := st.MakePod().Name("p1").UID("p1").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
@@ -1058,7 +1058,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 					t.Fatalf("Failed to update snapshot: %v", err)
 				}
 
-				result := sched.podGroupSchedulingAlgorithm(ctx, schedFwk, framework.NewCycleState(), podGroupInfo, runAllPostFilters)
+				result := sched.podGroupSchedulingDefaultAlgorithm(ctx, schedFwk, framework.NewCycleState(), podGroupInfo, runAllPostFilters)
 
 				if result.status.Code() != tt.expectedGroupStatusCode {
 					t.Errorf("Expected group status code: %v, got: %v", tt.expectedGroupStatusCode, result.status.Code())


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This PR ensures that internal Pod and placement evaluation statuses in `pkg/scheduler/schedule_one_podgroup.go` are mapped while preserving their original structured Status codes.

While the code is correct currently (there are no status codes that are not handled by the conditions in code), it makes AI assisted test debugging hard as agents consistently trip over the status code swallowing and treat it as a root cause of the failures.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:
The `TestPodGroupSchedulingAlgorithm` test suite was extended and validated locally, testing directly against the default algorithm.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```
