### PR TITLE
resttest.Tester: ensure that the user is always present in the context for authorizer decisions

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go
@@ -1194,20 +1194,14 @@ func (t *Tester) testGetDifferentNamespace(obj runtime.Object) {
 	objMeta := t.getObjectMetaOrFail(obj)
 	objMeta.SetName(t.namer(5))
 
-	ctx1 := genericapirequest.WithNamespace(genericapirequest.NewContext(), "bar3")
-	if t.requestInfo != nil {
-		ctx1 = genericapirequest.WithRequestInfo(ctx1, t.requestInfo)
-	}
+	ctx1 := genericapirequest.WithNamespace(t.TestContext(), "bar3")
 	objMeta.SetNamespace(genericapirequest.NamespaceValue(ctx1))
 	_, err := t.storage.(rest.Creater).Create(ctx1, obj, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	ctx2 := genericapirequest.WithNamespace(genericapirequest.NewContext(), "bar4")
-	if t.requestInfo != nil {
-		ctx2 = genericapirequest.WithRequestInfo(ctx2, t.requestInfo)
-	}
+	ctx2 := genericapirequest.WithNamespace(t.TestContext(), "bar4")
 	objMeta.SetNamespace(genericapirequest.NamespaceValue(ctx2))
 	_, err = t.storage.(rest.Creater).Create(ctx2, obj, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
 	if err != nil {
@@ -1261,14 +1255,8 @@ func (t *Tester) testGetFound(obj runtime.Object) {
 }
 
 func (t *Tester) testGetMimatchedNamespace(obj runtime.Object) {
-	ctx1 := genericapirequest.WithNamespace(genericapirequest.NewContext(), "bar1")
-	if t.requestInfo != nil {
-		ctx1 = genericapirequest.WithRequestInfo(ctx1, t.requestInfo)
-	}
-	ctx2 := genericapirequest.WithNamespace(genericapirequest.NewContext(), "bar2")
-	if t.requestInfo != nil {
-		ctx2 = genericapirequest.WithRequestInfo(ctx2, t.requestInfo)
-	}
+	ctx1 := genericapirequest.WithNamespace(t.TestContext(), "bar1")
+	ctx2 := genericapirequest.WithNamespace(t.TestContext(), "bar2")
 	objMeta := t.getObjectMetaOrFail(obj)
 	objMeta.SetName(t.namer(4))
 	objMeta.SetNamespace(genericapirequest.NamespaceValue(ctx1))


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR is needed to support always passing a user via the Context.


EDIT: this was discovered during the EvictionRequest API implementation. It is not needed anymore, but could be useful for other features in the future.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
