### PR TITLE
Add metrics related to workload-aware preemption

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -6436,10 +6436,69 @@
   componentEndpoints:
   - component: kube-scheduler
     endpoint: /metrics
+- name: preemption_evaluation_duration_seconds
+  subsystem: scheduler
+  help: Duration in seconds for identifying the target preemption victims.
+  type: Histogram
+  stabilityLevel: ALPHA
+  labels:
+  - preemptor
+  - result
+  buckets:
+  - 0.001
+  - 0.002
+  - 0.004
+  - 0.008
+  - 0.016
+  - 0.032
+  - 0.064
+  - 0.128
+  - 0.256
+  - 0.512
+  - 1.024
+  - 2.048
+  - 4.096
+  - 8.192
+  - 16.384
+  - 32.768
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
+- name: preemption_execution_duration_seconds
+  subsystem: scheduler
+  help: Duration in seconds for preempting the target preemption victims. With async
+    preemption enabled, preemption execution does not block the scheduling of other
+    pods.
+  type: Histogram
+  stabilityLevel: ALPHA
+  labels:
+  - preemptor
+  - result
+  buckets:
+  - 0.001
+  - 0.002
+  - 0.004
+  - 0.008
+  - 0.016
+  - 0.032
+  - 0.064
+  - 0.128
+  - 0.256
+  - 0.512
+  - 1.024
+  - 2.048
+  - 4.096
+  - 8.192
+  - 16.384
+  - 32.768
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: preemption_goroutines_duration_seconds
   subsystem: scheduler
   help: Duration in seconds for running goroutines for the preemption.
   type: Histogram
+  deprecatedVersion: 1.37.0
   stabilityLevel: ALPHA
   labels:
   - result
@@ -6474,6 +6533,40 @@
   stabilityLevel: ALPHA
   labels:
   - result
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
+- name: preemption_pdb_violations_total
+  subsystem: scheduler
+  help: Total number of pod disruption budget violations caused by preemption.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - preemptor
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
+- name: preemption_workload_disruptions
+  subsystem: scheduler
+  help: Number of workload preemption units being preempted. A single preemption unit
+    can be all pods in a pod group (in case of DisruptionMode=all), or a single pod
+    (in case of DisruptionMode=single).
+  type: Histogram
+  stabilityLevel: ALPHA
+  labels:
+  - preemptor
+  buckets:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+  - 64
+  - 128
+  - 256
+  - 512
+  - 1024
   componentEndpoints:
   - component: kube-scheduler
     endpoint: /metrics
@@ -6574,6 +6667,37 @@
   stabilityLevel: ALPHA
   labels:
   - operation
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
+- name: workload_preemption_attempts_total
+  subsystem: scheduler
+  help: Total preemption attempts initiated by workload (including pod groups) in
+    the cluster till now.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - result
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
+- name: workload_preemption_victims
+  subsystem: scheduler
+  help: Number of pod preemption victims caused by workload preemption.
+  type: Histogram
+  stabilityLevel: ALPHA
+  buckets:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+  - 64
+  - 128
+  - 256
+  - 512
+  - 1024
   componentEndpoints:
   - component: kube-scheduler
     endpoint: /metrics
@@ -8508,7 +8632,8 @@
     endpoint: /metrics
 - name: preemption_victims
   subsystem: scheduler
-  help: Number of selected preemption victims
+  help: Number of selected preemption victims for preemption initiated by a single
+    pod
   type: Histogram
   stabilityLevel: STABLE
   buckets:

--- a/hack/tools/instrumentation/testdata/stable-metrics-list.yaml
+++ b/hack/tools/instrumentation/testdata/stable-metrics-list.yaml
@@ -1114,7 +1114,8 @@
   stabilityLevel: STABLE
 - name: preemption_victims
   subsystem: scheduler
-  help: Number of selected preemption victims
+  help: Number of selected preemption victims for preemption initiated by a single
+    pod
   type: Histogram
   stabilityLevel: STABLE
   buckets:

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -24,6 +24,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1"
+	schedulingapi "k8s.io/api/scheduling/v1alpha3"
 	"k8s.io/apimachinery/pkg/runtime"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
@@ -61,6 +62,10 @@ type IsEligiblePodFunc func(nodeInfo fwk.NodeInfo, victim preemption.Victim, pre
 // as affinity between pods that are eligible to preempt each other isn't recommended.
 type MoreImportantVictimFunc func(victim1, victim2 preemption.Victim) bool
 
+type podGroupEvaluator interface {
+	Preempt(ctx context.Context, pg *schedulingapi.PodGroup, pods []*v1.Pod, podGroupSchedulingFunc fwk.PodGroupSchedulingFunc) (*fwk.PodGroupPostFilterResult, *fwk.Status)
+}
+
 // DefaultPreemption is a PostFilter plugin implements the preemption logic.
 type DefaultPreemption struct {
 	fh   fwk.Handle
@@ -70,7 +75,7 @@ type DefaultPreemption struct {
 	Executor          *preemption.Executor
 	Evaluator         *preemption.Evaluator
 	pgLister          fwk.PodGroupLister
-	podGroupEvaluator *preemption.PodGroupEvaluator
+	podGroupEvaluator podGroupEvaluator
 
 	// IsEligiblePod returns whether a victim (individual pod/pod group) is allowed to be preempted by a preemptor pod.
 	// This filtering is in addition to the internal requirement that the victim pod have lower
@@ -470,6 +475,10 @@ func (pl *DefaultPreemption) isPreemptionAllowedAcrossAllVictimNodes(victim *pre
 
 // PodGroupPostFilter runs a default preemption for the pod group.
 func (pl *DefaultPreemption) PodGroupPostFilter(ctx context.Context, state fwk.PodGroupCycleState, pgInfo fwk.PodGroupInfo, pgSchedulingFunc fwk.PodGroupSchedulingFunc) (postFilterResult *fwk.PodGroupPostFilterResult, status *fwk.Status) {
+	defer func() {
+		metrics.WorkloadPreemptionAttempts.WithLabelValues(status.Code().String()).Inc()
+	}()
+
 	if pl.fts.EnableCompositePodGroup && pgInfo.GetCompositePodGroup() != nil {
 		return nil, fwk.NewStatus(fwk.Unschedulable, "pod group preemption: not supported for composite pod groups yet")
 	}

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -46,6 +46,8 @@ import (
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/events"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	componentmetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/testutil"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
@@ -3687,4 +3689,86 @@ func (m *mockMutableSnapshotLister) StartMutations() error {
 
 func (m *mockMutableSnapshotLister) EndMutations() error {
 	return m.endMutationError
+}
+
+type mockPodGroupEvaluator struct {
+	status *fwk.Status
+}
+
+func (m *mockPodGroupEvaluator) Preempt(ctx context.Context, pg *v1alpha3.PodGroup, pods []*v1.Pod, podGroupSchedulingFunc fwk.PodGroupSchedulingFunc) (*fwk.PodGroupPostFilterResult, *fwk.Status) {
+	return nil, m.status
+}
+
+type mockHandle struct {
+	fwk.Handle
+}
+
+func (m *mockHandle) MutableSnapshotSharedLister() fwk.MutableSnapshotSharedLister {
+	return &mockMutableSnapshotLister{}
+}
+
+func TestDefaultPreemption_PodGroupPostFilter_WorkloadPreemptionAttempts(t *testing.T) {
+	tests := []struct {
+		name   string
+		status *fwk.Status
+	}{
+		{
+			name:   "preemption success",
+			status: fwk.NewStatus(fwk.Success),
+		},
+		{
+			name:   "preemption unschedulable",
+			status: fwk.NewStatus(fwk.Unschedulable),
+		},
+		{
+			name:   "preemption error",
+			status: fwk.NewStatus(fwk.Error),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			testRegistry := componentmetrics.NewKubeRegistry()
+			testRegistry.MustRegister(metrics.WorkloadPreemptionAttempts)
+
+			pl := &DefaultPreemption{
+				fh:                &mockHandle{},
+				podGroupEvaluator: &mockPodGroupEvaluator{status: tt.status},
+			}
+
+			expectedStatus := tt.status.Code().String()
+			stateBefore := captureWorkloadPreemptionAttempts(testRegistry, expectedStatus)
+
+			pgInfo := &framework.PodGroupInfo{PodGroup: st.MakePodGroup().Obj()}
+			pl.PodGroupPostFilter(ctx, nil, pgInfo, nil)
+
+			stateAfter := captureWorkloadPreemptionAttempts(testRegistry, expectedStatus)
+
+			diff := stateAfter.count - stateBefore.count
+			if diff != 1 {
+				t.Errorf("Expected %s count delta to be 1, got %d", expectedStatus, diff)
+			}
+		})
+	}
+}
+
+type workloadPreemptionAttemptsState struct {
+	count uint64
+}
+
+func captureWorkloadPreemptionAttempts(g componentmetrics.Gatherer, status string) workloadPreemptionAttemptsState {
+	state := workloadPreemptionAttemptsState{}
+	if count, err := getCounterFromGatherer(g, "scheduler_workload_preemption_attempts_total", status); err == nil {
+		state.count = count
+	}
+	return state
+}
+
+func getCounterFromGatherer(g componentmetrics.Gatherer, name string, resultLabelValue string) (uint64, error) {
+	vals, err := testutil.GetCounterValuesFromGatherer(g, name, nil, "result")
+	if err != nil {
+		return 0, err
+	}
+	return uint64(vals[resultLabelValue]), nil
 }

--- a/pkg/scheduler/framework/preemption/executor.go
+++ b/pkg/scheduler/framework/preemption/executor.go
@@ -34,7 +34,6 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
-	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 	fwk "k8s.io/kube-scheduler/framework"
 	apipod "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
@@ -165,12 +164,7 @@ func NewExecutor(fh fwk.Handle, fts feature.Features) *Executor {
 
 // actuatePodPreemption actuates the preemption given preemptorPod to be scheduled on targetNode and a list of
 // victims to be evicted.
-func (e *Executor) actuatePodPreemption(ctx context.Context, targetNode string, victims *extenderv1.Victims, preemptorPod *v1.Pod, pluginName string) *fwk.Status {
-	candidate := &candidate{
-		victims: victims,
-		name:    targetNode,
-	}
-
+func (e *Executor) actuatePodPreemption(ctx context.Context, candidate Candidate, preemptorPod *v1.Pod, pluginName string) *fwk.Status {
 	podPreemptor := &podExecutorPreemptor{Pod: preemptorPod}
 	if e.fts.EnableAsyncPreemption {
 		e.prepareCandidateAsync(candidate, podPreemptor, pluginName)
@@ -180,12 +174,7 @@ func (e *Executor) actuatePodPreemption(ctx context.Context, targetNode string, 
 }
 
 // actuatePodGroupPreemption actuates the preemption given preemptor pods, pod group and a list of victims to be evicted.
-func (e *Executor) actuatePodGroupPreemption(ctx context.Context, victims *extenderv1.Victims, preemptorPods []*v1.Pod, preemptor *schedulingapi.PodGroup, pluginName string) *fwk.Status {
-	candidate := &candidate{
-		victims: victims,
-		name:    "cluster",
-	}
-
+func (e *Executor) actuatePodGroupPreemption(ctx context.Context, candidate Candidate, preemptorPods []*v1.Pod, preemptor *schedulingapi.PodGroup, pluginName string) *fwk.Status {
 	podGroupPreemptor := &podGroupExecutorPreemptor{pg: preemptor, pods: preemptorPods}
 	if e.fts.EnableAsyncPreemption {
 		e.prepareCandidateAsync(candidate, podGroupPreemptor, pluginName)
@@ -202,6 +191,7 @@ func (e *Executor) actuatePodGroupPreemption(ctx context.Context, victims *exten
 //
 // See http://kep.k8s.io/4832 for how the async preemption works.
 func (e *Executor) prepareCandidateAsync(c Candidate, preemptor ExecutorPreemptor, pluginName string) {
+	observeVictims(preemptor, c)
 	// Intentionally create a new context, not using a ctx from the scheduling cycle, to create ctx,
 	// because this process could continue even after this scheduling cycle finishes.
 	ctx, cancel := context.WithCancel(context.Background())
@@ -221,8 +211,6 @@ func (e *Executor) prepareCandidateAsync(c Candidate, preemptor ExecutorPreempto
 		return
 	}
 
-	metrics.PreemptionVictims.Observe(float64(len(c.Victims().Pods)))
-
 	errCh := parallelize.NewResultChannel[error]()
 	// PreEnqueue only watches the last victim for completion, so activate when that victim won't emit a deletion event.
 	preemptedLastVictimInMemory := false
@@ -241,8 +229,15 @@ func (e *Executor) prepareCandidateAsync(c Candidate, preemptor ExecutorPreempto
 		logger := klog.FromContext(ctx)
 		startTime := time.Now()
 		result := metrics.GoroutineResultSuccess
-		defer metrics.PreemptionGoroutinesDuration.WithLabelValues(result).Observe(metrics.SinceInSeconds(startTime))
-		defer metrics.PreemptionGoroutinesExecutionTotal.WithLabelValues(result).Inc()
+		defer func() {
+			metrics.PreemptionExecutionDuration.WithLabelValues(preemptor.Type(), result).Observe(metrics.SinceInSeconds(startTime))
+		}()
+		defer func() {
+			metrics.PreemptionGoroutinesDuration.WithLabelValues(result).Observe(metrics.SinceInSeconds(startTime))
+		}()
+		defer func() {
+			metrics.PreemptionGoroutinesExecutionTotal.WithLabelValues(result).Inc()
+		}()
 		defer func() {
 			if result == metrics.GoroutineResultError || preemptedLastVictimInMemory {
 				// When API call isn't successful or no victim deletion event will be produced, the preemptor's
@@ -315,7 +310,12 @@ func (e *Executor) prepareCandidateAsync(c Candidate, preemptor ExecutorPreempto
 // - Reject the victim pods if they are in waitingPod map
 // - Clear the low-priority pods' nominatedNodeName status if needed
 func (e *Executor) prepareCandidate(ctx context.Context, c Candidate, preemptor ExecutorPreemptor, pluginName string) *fwk.Status {
-	metrics.PreemptionVictims.Observe(float64(len(c.Victims().Pods)))
+	observeVictims(preemptor, c)
+	startTime := time.Now()
+	metricsResult := metrics.GoroutineResultSuccess
+	defer func() {
+		metrics.PreemptionExecutionDuration.WithLabelValues(preemptor.Type(), metricsResult).Observe(metrics.SinceInSeconds(startTime))
+	}()
 
 	fh := e.fh
 	cs := e.fh.ClientSet()
@@ -336,6 +336,7 @@ func (e *Executor) prepareCandidate(ctx context.Context, c Candidate, preemptor 
 		}
 	}, pluginName)
 	if err := errCh.Receive(); err != nil {
+		metricsResult = metrics.GoroutineResultError
 		return fwk.AsStatus(err)
 	}
 
@@ -350,6 +351,25 @@ func (e *Executor) prepareCandidate(ctx context.Context, c Candidate, preemptor 
 	}
 
 	return nil
+}
+
+func observeVictims(preemptor ExecutorPreemptor, candidate Candidate) {
+	numVictims := float64(len(candidate.Victims().Pods))
+	if preemptor.Type() == "podgroup" {
+		metrics.WorkloadPreemptionVictims.Observe(numVictims)
+	} else {
+		metrics.PreemptionVictims.Observe(numVictims)
+	}
+
+	workloadDisruptions := float64(candidate.NumPodGroupDisruptions())
+	if workloadDisruptions > 0 {
+		metrics.PreemptionWorkloadDisruptions.WithLabelValues(preemptor.Type()).Observe(workloadDisruptions)
+	}
+
+	numPDBViolations := float64(candidate.Victims().NumPDBViolations)
+	if numPDBViolations > 0 {
+		metrics.PreemptionPDBViolations.WithLabelValues(preemptor.Type()).Add(numPDBViolations)
+	}
 }
 
 // IsPodRunningPreemption returns true if the pod is currently triggering preemption asynchronously.

--- a/pkg/scheduler/framework/preemption/executor_test.go
+++ b/pkg/scheduler/framework/preemption/executor_test.go
@@ -34,15 +34,20 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/events"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	componentmetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/features"
 	apicache "k8s.io/kubernetes/pkg/scheduler/backend/api_cache"
 	apidispatcher "k8s.io/kubernetes/pkg/scheduler/backend/api_dispatcher"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/backend/cache"
@@ -559,13 +564,81 @@ func TestPrepareCandidate(t *testing.T) {
 			expectedPreemptingMap: sets.New(types.UID("preemptor")),
 			expectedActivatedPods: map[string]*v1.Pod{preemptor.Name: preemptor},
 		},
+		{
+			name: "metrics: podgroup preemptor with workload disruptions",
+			candidate: &candidate{
+				name: node1Name,
+				victims: &extenderv1.Victims{
+					Pods: []*v1.Pod{
+						victim1,
+					},
+				},
+				numPodGroupDisruptions: 2,
+			},
+			preemptor:         preemptor,
+			preemptorPodGroup: podGroupPreemptor,
+			testPods: []*v1.Pod{
+				victim1,
+			},
+			nodeNames:             []string{node1Name},
+			expectedDeletedPod:    []string{"victim1"},
+			expectedStatus:        nil,
+			expectedPreemptingMap: sets.New(types.UID("pg1")),
+		},
+		{
+			name: "metrics: pod preemptor with PDB violations",
+			candidate: &candidate{
+				name: node1Name,
+				victims: &extenderv1.Victims{
+					Pods: []*v1.Pod{
+						victim1,
+					},
+					NumPDBViolations: 3,
+				},
+			},
+			preemptor: preemptor,
+			testPods: []*v1.Pod{
+				victim1,
+			},
+			nodeNames:             []string{node1Name},
+			expectedDeletedPod:    []string{"victim1"},
+			expectedStatus:        nil,
+			expectedPreemptingMap: sets.New(types.UID("preemptor")),
+		},
+		{
+			name: "metrics: podgroup preemptor with PDB violations and disruptions",
+			candidate: &candidate{
+				name: node1Name,
+				victims: &extenderv1.Victims{
+					Pods: []*v1.Pod{
+						victim1,
+					},
+					NumPDBViolations: 1,
+				},
+				numPodGroupDisruptions: 1,
+			},
+			preemptor:         preemptor,
+			preemptorPodGroup: podGroupPreemptor,
+			testPods: []*v1.Pod{
+				victim1,
+			},
+			nodeNames:             []string{node1Name},
+			expectedDeletedPod:    []string{"victim1"},
+			expectedStatus:        nil,
+			expectedPreemptingMap: sets.New(types.UID("pg1")),
+		},
 	}
 
 	for _, asyncPreemptionEnabled := range []bool{true, false} {
 		for _, asyncAPICallsEnabled := range []bool{true, false} {
 			for _, tt := range tests {
 				t.Run(fmt.Sprintf("%v (Async preemption enabled: %v, Async API calls enabled: %v)", tt.name, asyncPreemptionEnabled, asyncAPICallsEnabled), func(t *testing.T) {
-					metrics.Register()
+					featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
+					testRegistry := componentmetrics.NewKubeRegistry()
+					testRegistry.MustRegister(metrics.WorkloadPreemptionVictims)
+					testRegistry.MustRegister(metrics.PreemptionVictims)
+					testRegistry.MustRegister(metrics.PreemptionWorkloadDisruptions)
+					testRegistry.MustRegister(metrics.PreemptionPDBViolations)
 					logger, ctx := ktesting.NewTestContext(t)
 					ctx, cancel := context.WithCancel(ctx)
 					defer cancel()
@@ -666,12 +739,16 @@ func TestPrepareCandidate(t *testing.T) {
 
 					executor := NewExecutor(framework, feature.Features{EnableAsyncPreemption: asyncPreemptionEnabled})
 
+					var preemptor ExecutorPreemptor
+					if tt.preemptorPodGroup != nil {
+						preemptor = &podGroupExecutorPreemptor{pg: tt.preemptorPodGroup, pods: []*v1.Pod{tt.preemptor}}
+					} else {
+						preemptor = &podExecutorPreemptor{Pod: tt.preemptor}
+					}
+					metricsBefore := capturePreemptionMetricsState(testRegistry, preemptor.Type())
+
 					if asyncPreemptionEnabled {
-						if tt.preemptorPodGroup != nil {
-							executor.prepareCandidateAsync(tt.candidate, &podGroupExecutorPreemptor{pg: tt.preemptorPodGroup, pods: []*v1.Pod{tt.preemptor}}, "test-plugin")
-						} else {
-							executor.prepareCandidateAsync(tt.candidate, &podExecutorPreemptor{Pod: tt.preemptor}, "test-plugin")
-						}
+						executor.prepareCandidateAsync(tt.candidate, preemptor, "test-plugin")
 						executor.mu.Lock()
 
 						expectedMap := tt.expectedPreemptingMap
@@ -689,12 +766,7 @@ func TestPrepareCandidate(t *testing.T) {
 						close(requestStopper)
 					} else {
 						close(requestStopper) // no need to stop requests
-						var status *fwk.Status
-						if tt.preemptorPodGroup != nil {
-							status = executor.prepareCandidate(ctx, tt.candidate, &podGroupExecutorPreemptor{pg: tt.preemptorPodGroup, pods: []*v1.Pod{tt.preemptor}}, "test-plugin")
-						} else {
-							status = executor.prepareCandidate(ctx, tt.candidate, &podExecutorPreemptor{Pod: tt.preemptor}, "test-plugin")
-						}
+						status := executor.prepareCandidate(ctx, tt.candidate, preemptor, "test-plugin")
 						if tt.expectedStatus == nil {
 							if status != nil {
 								t.Errorf("expect nil status, but got %v", status)
@@ -771,6 +843,8 @@ func TestPrepareCandidate(t *testing.T) {
 					}); err != nil {
 						t.Fatal(lastErrMsg)
 					}
+
+					verifyPreemptionMetricsDelta(t, testRegistry, preemptor, tt.candidate, metricsBefore)
 				})
 			}
 		}
@@ -1786,4 +1860,217 @@ func TestIsPodGroupRunningPreemption(t *testing.T) {
 			}
 		})
 	}
+}
+
+type histogramState struct {
+	name  string
+	count uint64
+	sum   float64
+}
+
+func getHistogramFromGatherer(g componentmetrics.Gatherer, name string, labels map[string]string) (count uint64, sum float64, err error) {
+	hist, err := testutil.GetHistogramVecFromGatherer(g, name, labels)
+	if err != nil {
+		return 0, 0, err
+	}
+	return hist.GetAggregatedSampleCount(), hist.GetAggregatedSampleSum(), nil
+}
+
+func newHistogramState(g componentmetrics.Gatherer, name string, labels map[string]string) histogramState {
+	count, sum, err := getHistogramFromGatherer(g, name, labels)
+	if err != nil {
+		return histogramState{name: name}
+	}
+	return histogramState{name: name, count: count, sum: sum}
+}
+
+func (h histogramState) assertDelta(t *testing.T, before histogramState, expectedCount uint64, expectedSum float64) {
+	t.Helper()
+	diffCount := h.count - before.count
+	if diffCount != expectedCount {
+		t.Errorf("Expected %s count delta to be %d, got %d (before=%d, after=%d)", h.name, expectedCount, diffCount, before.count, h.count)
+	}
+	diffSum := h.sum - before.sum
+	if diffSum != expectedSum {
+		t.Errorf("Expected %s sum delta to be %f, got %f (before=%f, after=%f)", h.name, expectedSum, diffSum, before.sum, h.sum)
+	}
+}
+
+type counterState struct {
+	name string
+	val  float64
+}
+
+func newCounterState(g componentmetrics.Gatherer, name string, labels map[string]string, labelName string, key string) counterState {
+	vals, err := testutil.GetCounterValuesFromGatherer(g, name, labels, labelName)
+	if err != nil {
+		return counterState{name: name}
+	}
+	return counterState{name: fmt.Sprintf("%s{%s=%s}", name, labelName, key), val: vals[key]}
+}
+
+func (c counterState) assertDelta(t *testing.T, before counterState, expectedDiffVal float64) {
+	t.Helper()
+	diffVal := c.val - before.val
+	if diffVal != expectedDiffVal {
+		t.Errorf("Expected %s delta to be %f, got %f (before=%f, after=%f)", c.name, expectedDiffVal, diffVal, before.val, c.val)
+	}
+}
+
+type preemptionMetricsState struct {
+	workloadPreemptionVictims histogramState
+	preemptionVictims         histogramState
+	workloadDisruptions       histogramState
+	pdbViolations             counterState
+}
+
+func capturePreemptionMetricsState(g componentmetrics.Gatherer, preemptorType string) preemptionMetricsState {
+	return preemptionMetricsState{
+		workloadPreemptionVictims: newHistogramState(g, "scheduler_workload_preemption_victims", map[string]string{}),
+		preemptionVictims:         newHistogramState(g, "scheduler_preemption_victims", map[string]string{}),
+		workloadDisruptions:       newHistogramState(g, "scheduler_preemption_workload_disruptions", map[string]string{"preemptor": preemptorType}),
+		pdbViolations:             newCounterState(g, "scheduler_preemption_pdb_violations_total", map[string]string{}, "preemptor", preemptorType),
+	}
+}
+
+func verifyPreemptionMetricsDelta(t *testing.T, reg componentmetrics.KubeRegistry, preemptor ExecutorPreemptor, c Candidate, before preemptionMetricsState) {
+	t.Helper()
+	after := capturePreemptionMetricsState(reg, preemptor.Type())
+
+	preemptorType := preemptor.Type()
+	numVictims := float64(len(c.Victims().Pods))
+	numPDBViolations := float64(c.Victims().NumPDBViolations)
+	workloadDisruptions := float64(c.NumPodGroupDisruptions())
+
+	if preemptorType == "podgroup" {
+		after.workloadPreemptionVictims.assertDelta(t, before.workloadPreemptionVictims, 1, numVictims)
+		after.preemptionVictims.assertDelta(t, before.preemptionVictims, 0, 0)
+	} else {
+		after.preemptionVictims.assertDelta(t, before.preemptionVictims, 1, numVictims)
+		after.workloadPreemptionVictims.assertDelta(t, before.workloadPreemptionVictims, 0, 0)
+	}
+
+	expectedDisruptionsObservations := uint64(0)
+	if workloadDisruptions > 0 {
+		expectedDisruptionsObservations = 1
+	}
+	after.workloadDisruptions.assertDelta(t, before.workloadDisruptions, expectedDisruptionsObservations, workloadDisruptions)
+
+	after.pdbViolations.assertDelta(t, before.pdbViolations, numPDBViolations)
+}
+
+func TestPreemptionExecutionDurationMetric(t *testing.T) {
+	nodeName := "node1"
+
+	victim := st.MakePod().Name("victim").UID("victim").Node(nodeName).Priority(midPriority).Obj()
+	preemptor := st.MakePod().Name("preemptor").UID("preemptor").Priority(highPriority).Obj()
+
+	tests := []struct {
+		name                string
+		injectDeletionError bool
+		expectedResult      string
+	}{
+		{
+			name:           "success",
+			expectedResult: "success",
+		},
+		{
+			name:                "error",
+			injectDeletionError: true,
+			expectedResult:      "error",
+		},
+	}
+
+	for _, async := range []bool{false, true} {
+		for _, tt := range tests {
+			t.Run(fmt.Sprintf("%s (async=%v)", tt.name, async), func(t *testing.T) {
+				testRegistry := componentmetrics.NewKubeRegistry()
+				testRegistry.MustRegister(metrics.PreemptionExecutionDuration)
+
+				_, ctx := ktesting.NewTestContext(t)
+				ctx, cancel := context.WithCancel(ctx)
+				defer cancel()
+
+				cs := clientsetfake.NewClientset(victim)
+				if tt.injectDeletionError {
+					cs.PrependReactor("delete", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+						return true, nil, errors.New("delete failed")
+					})
+				}
+
+				informerFactory := informers.NewSharedInformerFactory(cs, 0)
+				eventBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: cs.EventsV1()})
+
+				queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
+				fwk, err := tf.NewFramework(
+					ctx,
+					[]tf.RegisterPluginFunc{
+						tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+						tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+					},
+					"",
+					frameworkruntime.WithClientSet(cs),
+					frameworkruntime.WithInformerFactory(informerFactory),
+					frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
+					frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
+					frameworkruntime.WithSnapshotSharedLister(internalcache.NewSnapshot([]*v1.Pod{victim}, []*v1.Node{st.MakeNode().Name(nodeName).Capacity(veryLargeRes).Obj()})),
+					frameworkruntime.WithEventRecorder(eventBroadcaster.NewRecorder(scheme.Scheme, "test-scheduler")),
+					frameworkruntime.WithPodNominator(queue),
+					frameworkruntime.WithPodActivator(queue),
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+				informerFactory.Start(ctx.Done())
+
+				executor := NewExecutor(fwk, feature.Features{EnableAsyncPreemption: async})
+				podPreemptor := &podExecutorPreemptor{Pod: preemptor}
+				candidate := &candidate{
+					name: nodeName,
+					victims: &extenderv1.Victims{
+						Pods: []*v1.Pod{victim},
+					},
+				}
+
+				// Capture metrics before
+				preemptorType := podPreemptor.Type()
+				stateBefore := captureExecutionDurationMetric(testRegistry, preemptorType, tt.expectedResult)
+
+				if async {
+					executor.prepareCandidateAsync(candidate, podPreemptor, "test-plugin")
+					// Wait for async preemption to complete
+					err := wait.PollUntilContextTimeout(ctx, time.Millisecond*50, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+						executor.mu.Lock()
+						defer executor.mu.Unlock()
+						return len(executor.preempting) == 0, nil
+					})
+					if err != nil {
+						t.Fatal("async preemption did not complete in time")
+					}
+				} else {
+					executor.prepareCandidate(ctx, candidate, podPreemptor, "test-plugin")
+				}
+
+				// Capture metrics after
+				stateAfter := captureExecutionDurationMetric(testRegistry, preemptorType, tt.expectedResult)
+
+				diff := stateAfter.count - stateBefore.count
+				if diff != 1 {
+					t.Errorf("Expected success count delta to be %d, got %d", 1, diff)
+				}
+			})
+		}
+	}
+}
+
+type executionDurationMetricState struct {
+	count uint64
+}
+
+func captureExecutionDurationMetric(g componentmetrics.Gatherer, preemptorType, status string) executionDurationMetricState {
+	state := executionDurationMetricState{}
+	if count, _, err := getHistogramFromGatherer(g, "scheduler_preemption_execution_duration_seconds", map[string]string{"preemptor": preemptorType, "result": status}); err == nil {
+		state.count = count
+	}
+	return state
 }

--- a/pkg/scheduler/framework/preemption/podgrouppreemption.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1"
@@ -30,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	policylisters "k8s.io/client-go/listers/policy/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
+	"k8s.io/kubernetes/pkg/scheduler/metrics"
 
 	"k8s.io/klog/v2"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
@@ -57,6 +59,29 @@ func NewPodGroupEvaluator(fh fwk.Handle, executor *Executor, enablePodGroupPreem
 	}
 }
 
+// evaluate determines the victims for preemption, without actuation.
+func (ev *PodGroupEvaluator) evaluate(ctx context.Context, preemptor *podGroupPreemptor, podGroupSchedulingFunc fwk.PodGroupSchedulingFunc) (res *selectVictimsResult, status *fwk.Status) {
+	startTime := time.Now()
+	defer func() {
+		metrics.PreemptionEvaluationDuration.WithLabelValues("podgroup", status.Code().String()).Observe(metrics.SinceInSeconds(startTime))
+	}()
+
+	// In case of workload-aware preemption, the domain is whole cluster.
+	// We do not make a snapshot of node info. Those nodes will be shared
+	// with the PodGroup scheduling algorithm passed as podGroupSchedulingFunc.
+	domain, err := newDomainForWorkloadPreemption(ev.Handle.MutableSnapshotSharedLister(), ev.podGroupSnapshot, "cluster-domain")
+	if err != nil {
+		return nil, fwk.AsStatus(fmt.Errorf("failed to create domain: %w", err))
+	}
+
+	pdbs, err := getPodDisruptionBudgets(ev.pdbLister)
+	if err != nil {
+		return nil, fwk.AsStatus(fmt.Errorf("failed to get pod disruption budgets: %w", err))
+	}
+
+	return ev.selectVictimsOnDomain(ctx, preemptor, domain, pdbs, podGroupSchedulingFunc)
+}
+
 // Preempt implements the preemption logic where the preemptor is a pod group
 // and the domain is the whole cluster. It preempts pod from the cluster
 // in order to make enough room for the pod group to be scheduled.
@@ -69,32 +94,26 @@ func NewPodGroupEvaluator(fh fwk.Handle, executor *Executor, enablePodGroupPreem
 // Then the logic tries to reprieve as many victims as possible with preemptor
 // pods assumed in their place.
 // The caller is expected to backup the NodeInfo before calling this function
-// and rollback the state to the backup after function is finished.
+// And rollback the state to the backup after function is finished.
 func (ev *PodGroupEvaluator) Preempt(ctx context.Context, pg *schedulingapi.PodGroup, pods []*v1.Pod, podGroupSchedulingFunc fwk.PodGroupSchedulingFunc) (*fwk.PodGroupPostFilterResult, *fwk.Status) {
-	// In case of workload-aware preemption, the domain is whole cluster.
-	// We do not make a snapshot of node info. Those nodes will be shared
-	// with the PodGroup scheduling algorithm passed as podGroupSchedulingFunc.
-	domain, err := newDomainForWorkloadPreemption(ev.Handle.MutableSnapshotSharedLister(), ev.podGroupSnapshot, "cluster-domain")
-	if err != nil {
-		return nil, fwk.AsStatus(fmt.Errorf("failed to create domain: %w", err))
-	}
 	preemptor := newPodGroupPreemptor(pg, pods, ev.enablePodGroupPreemptionPolicy)
-	pdbs, err := getPodDisruptionBudgets(ev.pdbLister)
-	if err != nil {
-		return nil, fwk.AsStatus(fmt.Errorf("failed to get pod disruption budgets: %w", err))
-	}
-
-	res, status := ev.selectVictimsOnDomain(ctx, preemptor, domain, pdbs, podGroupSchedulingFunc)
+	res, status := ev.evaluate(ctx, preemptor, podGroupSchedulingFunc)
 	if !status.IsSuccess() {
 		return nil, status
 	}
-	status = ev.Executor.actuatePodGroupPreemption(ctx, res.victims, preemptor.pods, preemptor.podGroup, names.DefaultPreemption)
+	candidate := &candidate{
+		victims:                res.victims,
+		numPodGroupDisruptions: res.numPodGroupDisruptions,
+		name:                   "cluster",
+	}
+	status = ev.Executor.actuatePodGroupPreemption(ctx, candidate, preemptor.pods, preemptor.podGroup, names.DefaultPreemption)
 	return &fwk.PodGroupPostFilterResult{NominatingInfos: res.nominatedNodeNames}, status
 }
 
 type selectVictimsResult struct {
-	nominatedNodeNames map[types.NamespacedName]*fwk.NominatingInfo
-	victims            *extenderv1.Victims
+	nominatedNodeNames     map[types.NamespacedName]*fwk.NominatingInfo
+	numPodGroupDisruptions int
+	victims                *extenderv1.Victims
 }
 
 // selectVictimsOnDomain selects a set of victims that can be removed from the
@@ -303,15 +322,20 @@ func (ev *PodGroupEvaluator) selectVictimsOnDomain(
 	sort.Slice(victimsToPreempt, func(i, j int) bool {
 		return MoreImportantVictim(victimsToPreempt[i], victimsToPreempt[j], true)
 	})
+	numPodGroupDisruptions := 0
 	var podsToPreempt []*v1.Pod
 	for _, v := range victimsToPreempt {
+		if v.IsPodGroup() {
+			numPodGroupDisruptions++
+		}
 		for _, pi := range v.Pods() {
 			podsToPreempt = append(podsToPreempt, pi.GetPod())
 		}
 	}
 
 	v := &extenderv1.Victims{
-		Pods: podsToPreempt,
+		Pods:             podsToPreempt,
+		NumPDBViolations: int64(numViolatingVictim),
 	}
 	n := make(map[types.NamespacedName]*fwk.NominatingInfo)
 	for _, p := range validAssignment {
@@ -323,7 +347,11 @@ func (ev *PodGroupEvaluator) selectVictimsOnDomain(
 		}
 	}
 
-	return &selectVictimsResult{nominatedNodeNames: n, victims: v}, nil
+	return &selectVictimsResult{
+		nominatedNodeNames:     n,
+		victims:                v,
+		numPodGroupDisruptions: numPodGroupDisruptions,
+	}, nil
 }
 
 func toPodNames(pods []fwk.PodInfo) string {

--- a/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/client-go/informers"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	componentmetrics "k8s.io/component-base/metrics"
 	"k8s.io/klog/v2/ktesting"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/features"
@@ -45,6 +46,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/queuesort"
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
+	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	tf "k8s.io/kubernetes/pkg/scheduler/testing/framework"
 	"k8s.io/kubernetes/pkg/scheduler/util"
@@ -123,15 +125,17 @@ func makePodGroupPreemptorWithPreemptionPolicy(pg *schedulingapi.PodGroup, pods 
 
 func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 	tests := []struct {
-		name            string
-		nodes           []*v1.Node
-		initPods        []*v1.Pod
-		initPodGroups   []*schedulingapi.PodGroup
-		preemptor       *podGroupPreemptor
-		pdbs            []*policy.PodDisruptionBudget
-		nodeCapacities  []nodeCapacity
-		expectedVictims []string
-		expectedStatus  *fwk.Status
+		name                           string
+		nodes                          []*v1.Node
+		initPods                       []*v1.Pod
+		initPodGroups                  []*schedulingapi.PodGroup
+		preemptor                      *podGroupPreemptor
+		pdbs                           []*policy.PodDisruptionBudget
+		nodeCapacities                 []nodeCapacity
+		expectedVictims                []string
+		expectedStatus                 *fwk.Status
+		expectedNumPodGroupDisruptions int
+		expectedNumPDBViolations       int
 	}{
 		{
 			name: "Priority: mix of no groups and pod groups",
@@ -180,8 +184,9 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					capacity: 2,
 				},
 			},
-			expectedVictims: []string{"p1"}, // p1 is less important than p2 because of later StartTime
-			expectedStatus:  fwk.NewStatus(fwk.Success),
+			expectedVictims:                []string{"p1"}, // p1 is less important than p2 because of later StartTime
+			expectedStatus:                 fwk.NewStatus(fwk.Success),
+			expectedNumPodGroupDisruptions: 1,
 		},
 		{
 			name: "Pod group with disruption mode group not reprieved",
@@ -210,8 +215,9 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					capacity: 1,
 				},
 			},
-			expectedVictims: []string{"p1", "p2"},
-			expectedStatus:  fwk.NewStatus(fwk.Success),
+			expectedVictims:                []string{"p1", "p2"},
+			expectedStatus:                 fwk.NewStatus(fwk.Success),
+			expectedNumPodGroupDisruptions: 1,
 		},
 		{
 			name: "Complex Mixed: Shared, different, and no groups",
@@ -264,8 +270,9 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					capacity: 2,
 				},
 			},
-			expectedVictims: []string{"p2"},
-			expectedStatus:  fwk.NewStatus(fwk.Success),
+			expectedVictims:                []string{"p2"},
+			expectedStatus:                 fwk.NewStatus(fwk.Success),
+			expectedNumPodGroupDisruptions: 1,
 		},
 		{
 			name: "PDB: Mixed groups",
@@ -292,8 +299,9 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					capacity: 2,
 				},
 			},
-			expectedVictims: []string{"victim-no-pdb"},
-			expectedStatus:  fwk.NewStatus(fwk.Success),
+			expectedVictims:                []string{"victim-no-pdb"},
+			expectedStatus:                 fwk.NewStatus(fwk.Success),
+			expectedNumPodGroupDisruptions: 1,
 		},
 		{
 			name: "PodGroup preemptor with PreemptLowerPriority preemption policy performs preemption",
@@ -796,8 +804,9 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					capacity: 2,
 				},
 			},
-			expectedVictims: []string{"p1"},
-			expectedStatus:  fwk.NewStatus(fwk.Success),
+			expectedVictims:          []string{"p1"},
+			expectedStatus:           fwk.NewStatus(fwk.Success),
+			expectedNumPDBViolations: 1,
 		},
 		{
 			name: "PodGroup: Preempt group as a whole",
@@ -827,8 +836,9 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					capacity: 2,
 				},
 			},
-			expectedVictims: []string{"p1", "p2"},
-			expectedStatus:  fwk.NewStatus(fwk.Success),
+			expectedVictims:                []string{"p1", "p2"},
+			expectedStatus:                 fwk.NewStatus(fwk.Success),
+			expectedNumPodGroupDisruptions: 1,
 		},
 		{
 			name: "PodGroup: Prefer single pod over podGroup for preemption candidate",
@@ -881,8 +891,9 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					capacity: 3,
 				},
 			},
-			expectedVictims: []string{"g1-1", "g1-2"},
-			expectedStatus:  fwk.NewStatus(fwk.Success),
+			expectedVictims:                []string{"g1-1", "g1-2"},
+			expectedStatus:                 fwk.NewStatus(fwk.Success),
+			expectedNumPodGroupDisruptions: 1,
 		},
 		{
 			name: "PDB: Unit violation if any member violates",
@@ -1007,8 +1018,9 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					capacity: 1,
 				},
 			},
-			expectedVictims: []string{"p1", "p2"},
-			expectedStatus:  fwk.NewStatus(fwk.Success),
+			expectedVictims:                []string{"p1", "p2"},
+			expectedStatus:                 fwk.NewStatus(fwk.Success),
+			expectedNumPodGroupDisruptions: 1,
 		},
 		{
 			name: "Priority divergence: candidate victim PodGroup has higher priority than the Pods from that group",
@@ -1122,8 +1134,9 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					capacity: 1,
 				},
 			},
-			expectedVictims: []string{"v1", "v2", "v3"},
-			expectedStatus:  fwk.NewStatus(fwk.Success),
+			expectedVictims:                []string{"v1", "v2", "v3"},
+			expectedStatus:                 fwk.NewStatus(fwk.Success),
+			expectedNumPodGroupDisruptions: 1,
 		},
 		{
 			name: "Gang scheduling: preempt a pod group victim but do not schedule full pod group",
@@ -1169,8 +1182,9 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					capacity: 1,
 				},
 			},
-			expectedVictims: []string{"v1", "v2"},
-			expectedStatus:  fwk.NewStatus(fwk.Success),
+			expectedVictims:                []string{"v1", "v2"},
+			expectedStatus:                 fwk.NewStatus(fwk.Success),
+			expectedNumPodGroupDisruptions: 1,
 		},
 		{
 			name: "Basic scheduling: schedule as many pods as possible without preempting higher priority pods",
@@ -1253,8 +1267,9 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					capacity: 1,
 				},
 			},
-			expectedVictims: []string{"v1", "v2", "v3"},
-			expectedStatus:  fwk.NewStatus(fwk.Success),
+			expectedVictims:                []string{"v1", "v2", "v3"},
+			expectedStatus:                 fwk.NewStatus(fwk.Success),
+			expectedNumPodGroupDisruptions: 1,
 		},
 		{
 			name: "Basic scheduling: preempt a pod group victim but do not schedule full pod group",
@@ -1300,8 +1315,9 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 					capacity: 1,
 				},
 			},
-			expectedVictims: []string{"v1", "v2"},
-			expectedStatus:  fwk.NewStatus(fwk.Success),
+			expectedVictims:                []string{"v1", "v2"},
+			expectedStatus:                 fwk.NewStatus(fwk.Success),
+			expectedNumPodGroupDisruptions: 1,
 		},
 	}
 
@@ -1450,6 +1466,12 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 			if diff := cmp.Diff(wantNames, gotNames); diff != "" {
 				t.Errorf("Victims mismatch (-want +got):\n%s", diff)
 			}
+			if res.numPodGroupDisruptions != tt.expectedNumPodGroupDisruptions {
+				t.Errorf("numPodGroupDisruptions mismatch. Want %d, Got %d", tt.expectedNumPodGroupDisruptions, res.numPodGroupDisruptions)
+			}
+			if res.victims.NumPDBViolations != int64(tt.expectedNumPDBViolations) {
+				t.Errorf("NumPDBViolations mismatch. Want %d, Got %d", tt.expectedNumPDBViolations, res.victims.NumPDBViolations)
+			}
 		})
 	}
 }
@@ -1566,4 +1588,103 @@ func (pa *mockProposedAssignment) GetPodInfo() fwk.PodInfo {
 
 func (pa *mockProposedAssignment) GetCycleState() fwk.CycleState {
 	return pa.cycleState
+}
+
+func TestPodGroupPreemptionEvaluationDurationMetric(t *testing.T) {
+	nodeName := "node1"
+	preemptorPod := st.MakePod().Name("p1").UID("p1").Obj()
+	preemptor := newPodGroupPreemptor(
+		st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
+		[]*v1.Pod{preemptorPod},
+		false,
+	)
+
+	tests := []struct {
+		name             string
+		evaluationStatus *fwk.Status
+	}{
+		{
+			name:             "scheduling success",
+			evaluationStatus: fwk.NewStatus(fwk.Success),
+		},
+		{
+			name:             "scheduling error",
+			evaluationStatus: fwk.NewStatus(fwk.Error, "failed to schedule"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testRegistry := componentmetrics.NewKubeRegistry()
+			testRegistry.MustRegister(metrics.PreemptionEvaluationDuration)
+
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			node := st.MakeNode().Name(nodeName).Obj()
+			victimPod := st.MakePod().Name("p2").UID("p2").Node(nodeName).Priority(lowPriority).Obj()
+
+			objs := []runtime.Object{node, victimPod, preemptorPod}
+			informerFactory := informers.NewSharedInformerFactory(clientsetfake.NewClientset(objs...), 0)
+			registeredPlugins := []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+			}
+			snapshot := internalcache.NewSnapshot([]*v1.Pod{victimPod}, []*v1.Node{node})
+			fh, err := tf.NewFramework(
+				ctx,
+				registeredPlugins, "",
+				frameworkruntime.WithPodNominator(internalqueue.NewSchedulingQueue(nil, informerFactory)),
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithMutableSnapshotLister(snapshot),
+				frameworkruntime.WithLogger(logger),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
+
+			pgLister := &mockPodGroupLister{podGroups: make(map[string]*schedulingapi.PodGroup)}
+
+			pl := &PodGroupEvaluator{
+				Handle:           fh,
+				podGroupSnapshot: pgLister,
+				pdbLister:        nil,
+			}
+
+			mockSchedulingFunc := func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
+				cycleState := framework.NewCycleState()
+				fh.RunPreFilterPlugins(ctx, cycleState, preemptorPod)
+				if tt.evaluationStatus.IsSuccess() {
+					return &fwk.PodGroupAssignments{
+						ProposedAssignments: []fwk.ProposedAssignment{
+							&mockProposedAssignment{pod: preemptorPod, nodeName: nodeName, cycleState: cycleState},
+						},
+					}, tt.evaluationStatus
+				}
+				return nil, tt.evaluationStatus
+			}
+
+			expectedStatus := tt.evaluationStatus.Code().String()
+			stateBefore := captureEvaluationDurationMetric(testRegistry, "podgroup", expectedStatus)
+
+			if err := pl.Handle.MutableSnapshotSharedLister().StartMutations(); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			pl.evaluate(ctx, preemptor, mockSchedulingFunc)
+			if err := pl.Handle.MutableSnapshotSharedLister().EndMutations(); err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			stateAfter := captureEvaluationDurationMetric(testRegistry, "podgroup", expectedStatus)
+
+			diff := stateAfter.count - stateBefore.count
+			if diff != 1 {
+				t.Errorf("Expected %s count delta to be 1, got %d", expectedStatus, diff)
+			}
+		})
+	}
 }

--- a/pkg/scheduler/framework/preemption/preemption.go
+++ b/pkg/scheduler/framework/preemption/preemption.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math"
 	"sync"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1"
@@ -35,6 +36,7 @@ import (
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	"k8s.io/kubernetes/pkg/scheduler/util"
 )
 
@@ -88,6 +90,74 @@ func NewEvaluator(pluginName string, fh fwk.Handle, i Interface, executor *Execu
 	return ev
 }
 
+// evaluate determines victims for preemption, without actuation.
+func (ev *Evaluator) evaluate(ctx context.Context, state fwk.CycleState, pod *v1.Pod, m fwk.NodeToStatusReader) (_ Candidate, _ *fwk.PostFilterResult, status *fwk.Status) {
+	logger := klog.FromContext(ctx)
+	startTime := time.Now()
+	defer func() {
+		metrics.PreemptionEvaluationDuration.WithLabelValues("pod", status.Code().String()).Observe(metrics.SinceInSeconds(startTime))
+	}()
+
+	// 0) Fetch the latest version of <pod>.
+	// It's safe to directly fetch pod here. Because the informer cache has already been
+	// initialized when creating the Scheduler obj.
+	// However, tests may need to manually initialize the shared pod informer.
+	podNamespace, podName := pod.Namespace, pod.Name
+	pod, err := ev.PodLister.Pods(podNamespace).Get(podName)
+	if err != nil {
+		logger.Error(err, "Could not get the updated preemptor pod object", "pod", klog.KRef(podNamespace, podName))
+		return nil, nil, fwk.AsStatus(err)
+	}
+
+	// 1) Ensure the preemptor is eligible to preempt other pods.
+	nominatedNodeStatus := m.Get(pod.Status.NominatedNodeName)
+	if ok, msg := ev.PodEligibleToPreemptOthers(ctx, pod, nominatedNodeStatus); !ok {
+		logger.V(5).Info("Pod is not eligible for preemption", "pod", klog.KObj(pod), "reason", msg)
+		return nil, nil, fwk.NewStatus(fwk.Unschedulable, msg)
+	}
+
+	// 2) Find all preemption candidates.
+	allNodes, err := ev.Handler.MutableSnapshotSharedLister().NodeInfos().List()
+	if err != nil {
+		return nil, nil, fwk.AsStatus(err)
+	}
+
+	candidates, nodeToStatusMap, err := ev.findCandidates(ctx, state, allNodes, pod, m)
+	if err != nil && len(candidates) == 0 {
+		return nil, nil, fwk.AsStatus(err)
+	}
+
+	// Return a FitError only when there are no candidates that fit the pod.
+	if len(candidates) == 0 {
+		logger.V(2).Info("No preemption candidate is found; preemption is not helpful for scheduling", "pod", klog.KObj(pod))
+		fitError := &framework.FitError{
+			Pod:         pod,
+			NumAllNodes: len(allNodes),
+			Diagnosis: framework.Diagnosis{
+				NodeToStatus: nodeToStatusMap,
+				// Leave UnschedulablePlugins or PendingPlugins as nil as it won't be used on moving Pods.
+			},
+		}
+		fitError.Diagnosis.NodeToStatus.SetAbsentNodesStatus(fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "Preemption is not helpful for scheduling"))
+		// Specify nominatedNodeName to clear the pod's nominatedNodeName status, if applicable.
+		return nil, framework.NewPostFilterResultWithNominatedNode(""), fwk.NewStatus(fwk.Unschedulable, fitError.Error())
+	}
+
+	// 3) Interact with registered Extenders to filter out some candidates if needed.
+	candidates, status = ev.callExtenders(logger, pod, candidates)
+	if !status.IsSuccess() {
+		return nil, nil, status
+	}
+
+	// 4) Find the best candidate.
+	bestCandidate := ev.SelectCandidate(ctx, candidates)
+	if bestCandidate == nil || len(bestCandidate.Name()) == 0 {
+		return nil, nil, fwk.NewStatus(fwk.Unschedulable, "no candidate node for preemption")
+	}
+
+	return bestCandidate, nil, fwk.NewStatus(fwk.Success)
+}
+
 // Preempt returns a PostFilterResult carrying suggested nominatedNodeName, along with a Status.
 // The semantics of returned <PostFilterResult, Status> varies on different scenarios:
 //
@@ -107,67 +177,15 @@ func NewEvaluator(pluginName string, fh fwk.Handle, i Interface, executor *Execu
 func (ev *Evaluator) Preempt(ctx context.Context, state fwk.CycleState, pod *v1.Pod, m fwk.NodeToStatusReader) (*fwk.PostFilterResult, *fwk.Status) {
 	logger := klog.FromContext(ctx)
 
-	// 0) Fetch the latest version of <pod>.
-	// It's safe to directly fetch pod here. Because the informer cache has already been
-	// initialized when creating the Scheduler obj.
-	// However, tests may need to manually initialize the shared pod informer.
-	podNamespace, podName := pod.Namespace, pod.Name
-	pod, err := ev.PodLister.Pods(podNamespace).Get(podName)
-	if err != nil {
-		logger.Error(err, "Could not get the updated preemptor pod object", "pod", klog.KRef(podNamespace, podName))
-		return nil, fwk.AsStatus(err)
-	}
-
-	// 1) Ensure the preemptor is eligible to preempt other pods.
-	nominatedNodeStatus := m.Get(pod.Status.NominatedNodeName)
-	if ok, msg := ev.PodEligibleToPreemptOthers(ctx, pod, nominatedNodeStatus); !ok {
-		logger.V(5).Info("Pod is not eligible for preemption", "pod", klog.KObj(pod), "reason", msg)
-		return nil, fwk.NewStatus(fwk.Unschedulable, msg)
-	}
-
-	// 2) Find all preemption candidates.
-	allNodes, err := ev.Handler.MutableSnapshotSharedLister().NodeInfos().List()
-	if err != nil {
-		return nil, fwk.AsStatus(err)
-	}
-
-	candidates, nodeToStatusMap, err := ev.findCandidates(ctx, state, allNodes, pod, m)
-	if err != nil && len(candidates) == 0 {
-		return nil, fwk.AsStatus(err)
-	}
-
-	// Return a FitError only when there are no candidates that fit the pod.
-	if len(candidates) == 0 {
-		logger.V(2).Info("No preemption candidate is found; preemption is not helpful for scheduling", "pod", klog.KObj(pod))
-		fitError := &framework.FitError{
-			Pod:         pod,
-			NumAllNodes: len(allNodes),
-			Diagnosis: framework.Diagnosis{
-				NodeToStatus: nodeToStatusMap,
-				// Leave UnschedulablePlugins or PendingPlugins as nil as it won't be used on moving Pods.
-			},
-		}
-		fitError.Diagnosis.NodeToStatus.SetAbsentNodesStatus(fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "Preemption is not helpful for scheduling"))
-		// Specify nominatedNodeName to clear the pod's nominatedNodeName status, if applicable.
-		return framework.NewPostFilterResultWithNominatedNode(""), fwk.NewStatus(fwk.Unschedulable, fitError.Error())
-	}
-
-	// 3) Interact with registered Extenders to filter out some candidates if needed.
-	candidates, status := ev.callExtenders(logger, pod, candidates)
+	bestCandidate, fitErrorResult, status := ev.evaluate(ctx, state, pod, m)
 	if !status.IsSuccess() {
-		return nil, status
-	}
-
-	// 4) Find the best candidate.
-	bestCandidate := ev.SelectCandidate(ctx, candidates)
-	if bestCandidate == nil || len(bestCandidate.Name()) == 0 {
-		return nil, fwk.NewStatus(fwk.Unschedulable, "no candidate node for preemption")
+		return fitErrorResult, status
 	}
 
 	logger.V(2).Info("the target node for the preemption is determined", "node", bestCandidate.Name(), "pod", klog.KObj(pod))
 
 	// 5) Actuate the preemption.
-	if status := ev.executor.actuatePodPreemption(ctx, bestCandidate.Name(), bestCandidate.Victims(), pod, ev.PluginName); !status.IsSuccess() {
+	if status := ev.executor.actuatePodPreemption(ctx, bestCandidate, pod, ev.PluginName); !status.IsSuccess() {
 		return nil, status
 	}
 

--- a/pkg/scheduler/framework/preemption/preemption_test.go
+++ b/pkg/scheduler/framework/preemption/preemption_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/client-go/informers"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	componentmetrics "k8s.io/component-base/metrics"
 	"k8s.io/klog/v2/ktesting"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 	fwk "k8s.io/kube-scheduler/framework"
@@ -940,4 +941,113 @@ func TestGetVictimsOnNode(t *testing.T) {
 			}
 		})
 	}
+}
+
+type evaluationDurationMetricState struct {
+	count uint64
+}
+
+func captureEvaluationDurationMetric(g componentmetrics.Gatherer, preemptorType string, status string) evaluationDurationMetricState {
+	state := evaluationDurationMetricState{}
+	if count, _, err := getHistogramFromGatherer(g, "scheduler_preemption_evaluation_duration_seconds", map[string]string{"preemptor": preemptorType, "result": status}); err == nil {
+		state.count = count
+	}
+	return state
+}
+
+func TestPreemptionEvaluationDurationMetric(t *testing.T) {
+	nodeName := "node1"
+	victim := st.MakePod().Name("victim").UID("victim").Node(nodeName).Priority(midPriority).Obj()
+	preemptor := st.MakePod().Name("preemptor").UID("preemptor").Priority(highPriority).Obj()
+	node := st.MakeNode().Name(nodeName).Obj()
+
+	tests := []struct {
+		name           string
+		podEligible    bool
+		expectedStatus string
+	}{
+		{
+			name:           "eligible preemptor, success",
+			podEligible:    true,
+			expectedStatus: "Success",
+		},
+		{
+			name:           "ineligible preemptor, unschedulable",
+			podEligible:    false,
+			expectedStatus: "Unschedulable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testRegistry := componentmetrics.NewKubeRegistry()
+			testRegistry.MustRegister(metrics.PreemptionEvaluationDuration)
+
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			cs := clientsetfake.NewClientset(node, victim, preemptor)
+			informerFactory := informers.NewSharedInformerFactory(cs, 0)
+
+			snapshot := internalcache.NewSnapshot([]*v1.Pod{victim}, []*v1.Node{node})
+			fh, err := tf.NewFramework(
+				ctx,
+				[]tf.RegisterPluginFunc{
+					tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+					tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				},
+				"",
+				frameworkruntime.WithClientSet(cs),
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
+				frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithMutableSnapshotLister(snapshot),
+				frameworkruntime.WithPodNominator(internalqueue.NewSchedulingQueue(nil, informerFactory)),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
+
+			fakePostPlugin := &FakePostFilterPlugin{numViolatingVictim: 0}
+			customInterface := &customEvaluationInterface{
+				Interface:   fakePostPlugin,
+				podEligible: tt.podEligible,
+			}
+
+			pe := NewEvaluator("FakePostFilter", fh, customInterface, NewExecutor(fh, feature.Features{}))
+
+			state := framework.NewCycleState()
+			m := framework.NewNodeToStatus(
+				map[string]*fwk.Status{nodeName: fwk.NewStatus(fwk.Unschedulable)},
+				fwk.NewStatus(fwk.UnschedulableAndUnresolvable),
+			)
+
+			stateBefore := captureEvaluationDurationMetric(testRegistry, "pod", tt.expectedStatus)
+
+			pe.evaluate(ctx, state, preemptor, m)
+
+			stateAfter := captureEvaluationDurationMetric(testRegistry, "pod", tt.expectedStatus)
+
+			diff := stateAfter.count - stateBefore.count
+			if diff != 1 {
+				t.Errorf("Expected %s count delta to be 1, got %d", tt.expectedStatus, diff)
+			}
+		})
+	}
+}
+
+type customEvaluationInterface struct {
+	Interface
+	podEligible bool
+}
+
+func (c *customEvaluationInterface) PodEligibleToPreemptOthers(_ context.Context, pod *v1.Pod, nominatedNodeStatus *fwk.Status) (bool, string) {
+	if c.podEligible {
+		return true, ""
+	}
+	return false, "not eligible"
 }

--- a/pkg/scheduler/framework/preemption/types.go
+++ b/pkg/scheduler/framework/preemption/types.go
@@ -361,11 +361,15 @@ type Candidate interface {
 	Victims() *extenderv1.Victims
 	// Name returns the target domain(for pod group)/node name where the preemptor gets nominated to run.
 	Name() string
+	// NumPodGroupDisruptions returns the number of preemption units that affect pod groups.
+	// A single preemption unit can be all pods in a pod group (for DisruptionMode=all) or a single pod (for DisruptionMode=single).
+	NumPodGroupDisruptions() int
 }
 
 type candidate struct {
-	victims *extenderv1.Victims
-	name    string
+	victims                *extenderv1.Victims
+	numPodGroupDisruptions int
+	name                   string
 }
 
 // Victims returns s.victims.
@@ -376,6 +380,11 @@ func (s *candidate) Victims() *extenderv1.Victims {
 // Name returns s.name.
 func (s *candidate) Name() string {
 	return s.name
+}
+
+// NumPodGroupDisruptions returns s.numPodGroupDisruptions.
+func (s *candidate) NumPodGroupDisruptions() int {
+	return s.numPodGroupDisruptions
 }
 
 type candidateList struct {

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -181,6 +181,13 @@ var (
 	DRABindingConditionsAllocationsTotal *metrics.CounterVec
 	DRABindingConditionsPreBindDuration  *metrics.HistogramVec
 
+	WorkloadPreemptionAttempts    *metrics.CounterVec
+	WorkloadPreemptionVictims     *metrics.Histogram
+	PreemptionWorkloadDisruptions *metrics.HistogramVec
+	PreemptionEvaluationDuration  *metrics.HistogramVec
+	PreemptionExecutionDuration   *metrics.HistogramVec
+	PreemptionPDBViolations       *metrics.CounterVec
+
 	// metricsList is a list of all metrics that should be registered always, regardless of any feature gate's value.
 	metricsList []metrics.Registerable
 )
@@ -213,6 +220,12 @@ func Register() {
 				podGroupScheduleAttempts,
 				podGroupSchedulingLatency,
 				PodGroupSchedulingAlgorithmLatency,
+				WorkloadPreemptionAttempts,
+				WorkloadPreemptionVictims,
+				PreemptionWorkloadDisruptions,
+				PreemptionEvaluationDuration,
+				PreemptionExecutionDuration,
+				PreemptionPDBViolations,
 			)
 		}
 		if utilfeature.DefaultFeatureGate.Enabled(features.DRADeviceBindingConditions) {
@@ -264,7 +277,7 @@ func InitMetrics() {
 		&metrics.HistogramOpts{
 			Subsystem: SchedulerSubsystem,
 			Name:      "preemption_victims",
-			Help:      "Number of selected preemption victims",
+			Help:      "Number of selected preemption victims for preemption initiated by a single pod",
 			// we think #victims>64 is pretty rare, therefore [64, +Inf) is considered a single bucket.
 			Buckets:        metrics.ExponentialBuckets(1, 2, 7),
 			StabilityLevel: metrics.STABLE,
@@ -419,11 +432,12 @@ func InitMetrics() {
 
 	PreemptionGoroutinesDuration = metrics.NewHistogramVec(
 		&metrics.HistogramOpts{
-			Subsystem:      SchedulerSubsystem,
-			Name:           "preemption_goroutines_duration_seconds",
-			Help:           "Duration in seconds for running goroutines for the preemption.",
-			Buckets:        metrics.ExponentialBuckets(0.01, 2, 20),
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         SchedulerSubsystem,
+			Name:              "preemption_goroutines_duration_seconds",
+			Help:              "Duration in seconds for running goroutines for the preemption.",
+			Buckets:           metrics.ExponentialBuckets(0.01, 2, 20),
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.37.0",
 		},
 		[]string{"result"})
 
@@ -532,6 +546,59 @@ func InitMetrics() {
 			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel: metrics.ALPHA,
 		})
+
+	// Workload preemption
+	WorkloadPreemptionAttempts = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      SchedulerSubsystem,
+			Name:           "workload_preemption_attempts_total",
+			Help:           "Total preemption attempts initiated by workload (including pod groups) in the cluster till now.",
+			StabilityLevel: metrics.ALPHA,
+		}, []string{"result"})
+	WorkloadPreemptionVictims = metrics.NewHistogram(
+		&metrics.HistogramOpts{
+			Subsystem: SchedulerSubsystem,
+			Name:      "workload_preemption_victims",
+			Help:      "Number of pod preemption victims caused by workload preemption.",
+			// Start with 1 with the last bucket being [1024, Inf)
+			Buckets:        metrics.ExponentialBuckets(1, 2, 11),
+			StabilityLevel: metrics.ALPHA,
+		})
+	PreemptionWorkloadDisruptions = metrics.NewHistogramVec(
+		&metrics.HistogramOpts{
+			Subsystem: SchedulerSubsystem,
+			Name:      "preemption_workload_disruptions",
+			Help:      "Number of workload preemption units being preempted. A single preemption unit can be all pods in a pod group (in case of DisruptionMode=all), or a single pod (in case of DisruptionMode=single).",
+			// Start with 1 with the last bucket being [1024, Inf)
+			Buckets:        metrics.ExponentialBuckets(1, 2, 11),
+			StabilityLevel: metrics.ALPHA,
+		}, []string{"preemptor"})
+	PreemptionEvaluationDuration = metrics.NewHistogramVec(
+		&metrics.HistogramOpts{
+			Subsystem: SchedulerSubsystem,
+			Name:      "preemption_evaluation_duration_seconds",
+			Help:      "Duration in seconds for identifying the target preemption victims.",
+			// Start with 1ms with the last bucket being [~32.8s, Inf)
+			Buckets:        metrics.ExponentialBuckets(0.001, 2, 16),
+			StabilityLevel: metrics.ALPHA,
+		}, []string{"preemptor", "result"})
+	PreemptionExecutionDuration = metrics.NewHistogramVec(
+		&metrics.HistogramOpts{
+			Subsystem: SchedulerSubsystem,
+			Name:      "preemption_execution_duration_seconds",
+			Help:      "Duration in seconds for preempting the target preemption victims. With async preemption enabled, preemption execution does not block the scheduling of other pods.",
+			// Start with 1ms with the last bucket being [~32.8s, Inf)
+			Buckets:        metrics.ExponentialBuckets(0.001, 2, 16),
+			StabilityLevel: metrics.ALPHA,
+		}, []string{"preemptor", "result"})
+	PreemptionPDBViolations = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      SchedulerSubsystem,
+			Name:           "preemption_pdb_violations_total",
+			Help:           "Total number of pod disruption budget violations caused by preemption.",
+			StabilityLevel: metrics.ALPHA,
+		}, []string{"preemptor"},
+	)
 
 	metricsList = []metrics.Registerable{
 		scheduleAttempts,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

This PR adds metrics that can be useful for evaluating workload aware preemption:
* total attempts to see the demand for workload preemption
* victims disrupting workloads to see how preemption impacts workloads
* victims violating pod disruption budget to compare pod vs pod group preemptors
* preemption evaluation and execution duration to see the performance impact of preemption

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added metrics related to workload preemption in alpha stability behind WorkloadAwarePreemption feature gate.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
