### PR TITLE
Fix storage version migrator chaos test flake

### DIFF
--- a/test/integration/storageversionmigrator/storageversionmigrator_test.go
+++ b/test/integration/storageversionmigrator/storageversionmigrator_test.go
@@ -310,6 +310,9 @@ func TestStorageVersionMigrationDuringChaos(t *testing.T) {
 	ctx := ktesting.Init(t)
 
 	svmTest := svmSetup(ctx, t)
+	// The chaos workload deletes these objects concurrently with migration, so the
+	// controller can legitimately observe them during list and get 404 on patch.
+	svmTest.allowChaosNotFoundEvents = true
 
 	svmTest.createChaos(ctx, t)
 

--- a/test/integration/storageversionmigrator/util.go
+++ b/test/integration/storageversionmigrator/util.go
@@ -255,6 +255,7 @@ type svmTest struct {
 	server                      *kubeapiservertesting.TestServer
 	apiextensionsclient         *apiextensionsclientset.Clientset
 	filePathForEncryptionConfig string
+	allowChaosNotFoundEvents    bool
 }
 
 func svmSetup(ctx context.Context, t *testing.T) *svmTest {
@@ -320,6 +321,9 @@ func svmSetup(ctx context.Context, t *testing.T) *svmTest {
 			if event.User != "system:serviceaccount:kube-system:storage-version-migrator-controller" {
 				return false
 			}
+			if svmTest.isExpectedSVMControllerAuditEvent(event) {
+				return false
+			}
 			if !validCodes.Has(event.Code) {
 				t.Errorf("svm controller had invalid response code for event: %#v", event)
 				return true
@@ -338,6 +342,17 @@ func svmSetup(ctx context.Context, t *testing.T) *svmTest {
 	})
 
 	return svmTest
+}
+
+func (svm *svmTest) isExpectedSVMControllerAuditEvent(event utils.AuditEvent) bool {
+	if !svm.allowChaosNotFoundEvents {
+		return false
+	}
+	return event.Code == http.StatusNotFound &&
+		event.Verb == "patch" &&
+		event.Namespace == defaultNamespace &&
+		event.Resource == crdName+"s" &&
+		strings.Contains(event.RequestURI, "/chaos-cr-")
 }
 
 func createKubeConfigFileForRestConfig(t *testing.T, restConfig *rest.Config) string {


### PR DESCRIPTION
Fixes #139370

The chaos test intentionally creates and deletes `chaos-cr-*` objects while SVM migrations are running. The migrator can list one of these transient objects and then receive a 404 when patching it after the chaos worker deletes it.

This keeps the audit assertion strict by default, but allows the chaos test to ignore only the expected SVM controller patch 404s for `chaos-cr-*` resources.