### PR TITLE
Fixing pkg/scheduler/framework unit test issue on Windows

### DIFF
--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -94,7 +94,7 @@ var (
 
 func TestPodGroupMemberPodsOrderingFunc(t *testing.T) {
 	timestamp := time.Now()
-	timestampNewer := time.Now()
+	timestampNewer := timestamp.Add(time.Second)
 
 	// Desired order: pod3 > pod5 > (pod1 = pod4) > pod2.
 	pInfo1 := &QueuedPodInfo{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:

/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR fixes a persistent unit test issue on Windows
https://testgrid.k8s.io/sig-windows-signal#windows-unit-master

Time resolution is less granular on Windows in go so the back to back calls to time.Now() are resolving to the same time causing this failure

```log
[sig-scheduling] k8s.io/kubernetes/pkg/scheduler: framework expand_less	2s
{Failed  === RUN   TestPodGroupMemberPodsOrderingFunc/older_timestamp_comes_first
    types_test.go:190: Unexpected result, want -1, got 0
--- FAIL: TestPodGroupMemberPodsOrderingFunc/older_timestamp_comes_first (0.00s)

=== RUN   TestPodGroupMemberPodsOrderingFunc/newer_timestamp_comes_second
    types_test.go:190: Unexpected result, want 1, got 0
--- FAIL: TestPodGroupMemberPodsOrderingFunc/newer_timestamp_comes_second (0.00s)

=== RUN   TestPodGroupMemberPodsOrderingFunc
--- FAIL: TestPodGroupMemberPodsOrderingFunc (0.00s)
}
```

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig windows
/cc @zylxjtu 