### PR TITLE
fix: use proper pluralization for GVR resource names in informer-gen

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/informer.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/informer.go
@@ -31,6 +31,38 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// pluralizeName converts a Kind name to its plural form using English pluralization rules.
+// Examples: Pod -> pods, Policy -> policies, Class -> classes
+func pluralizeName(kindName string) string {
+	singularName := strings.ToLower(kindName)
+
+	// Apply English pluralization rules based on suffix
+	switch {
+	case strings.HasSuffix(singularName, "z"):
+		// Double 'z' before adding 'es' (quiz -> quizzes)
+		return singularName + "zes"
+	case strings.HasSuffix(singularName, "s"), strings.HasSuffix(singularName, "x"),
+		strings.HasSuffix(singularName, "ch"), strings.HasSuffix(singularName, "sh"):
+		return singularName + "es"
+	case strings.HasSuffix(singularName, "y") && len(singularName) > 1 &&
+		!isVowel(rune(singularName[len(singularName)-2])):
+		// If 'y' is preceded by consonant, replace 'y' with 'ies'
+		return singularName[:len(singularName)-1] + "ies"
+	default:
+		return singularName + "s"
+	}
+}
+
+// isVowel returns true if the rune is an English vowel.
+func isVowel(r rune) bool {
+	switch r {
+	case 'a', 'e', 'i', 'o', 'u':
+		return true
+	default:
+		return false
+	}
+}
+
 // informerGenerator produces a file of listers for a given GroupVersion and
 // type.
 type informerGenerator struct {
@@ -103,7 +135,7 @@ func (g *informerGenerator) GenerateType(c *generator.Context, t *types.Type, w 
 		"namespaceAll":                             c.Universe.Type(metav1NamespaceAll),
 		"namespaced":                               !tags.NonNamespaced,
 		"newLister":                                c.Universe.Function(types.Name{Package: listerPackage, Name: "New" + t.Name.Name + "Lister"}),
-		"resourceName":                             strings.ToLower(t.Name.Name) + "s",
+		"resourceName":                             pluralizeName(t.Name.Name),
 		"runtimeObject":                            c.Universe.Type(runtimeObject),
 		"schemaGroupVersionResource":               c.Universe.Type(schemaGroupVersionResource),
 		"timeDuration":                             c.Universe.Type(timeDuration),

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/informer_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/informer_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generators
+
+import (
+	"testing"
+)
+
+func TestPluralizeName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		// Regular plurals (add 's')
+		{
+			name:     "simple singular",
+			input:    "Pod",
+			expected: "pods",
+		},
+		{
+			name:     "simple singular uppercase",
+			input:    "Node",
+			expected: "nodes",
+		},
+		// Words ending in 'y' preceded by consonant → strip 'y', add 'ies'
+		{
+			name:     "y-ending with consonant",
+			input:    "Policy",
+			expected: "policies",
+		},
+		{
+			name:     "affinity-like",
+			input:    "BlockAffinity",
+			expected: "blockaffinities",
+		},
+		{
+			name:     "NetworkPolicy",
+			input:    "GlobalNetworkPolicy",
+			expected: "globalnetworkpolicies",
+		},
+		// Words ending in 's' → add 'es'
+		{
+			name:     "s-ending",
+			input:    "Class",
+			expected: "classes",
+		},
+		{
+			name:     "s-ending componentstatus",
+			input:    "ComponentStatus",
+			expected: "componentstatuses",
+		},
+		// Words ending in 'ch' → add 'es'
+		{
+			name:     "ch-ending",
+			input:    "Watch",
+			expected: "watches",
+		},
+		// Words ending in 'sh' → add 'es'
+		{
+			name:     "sh-ending",
+			input:    "Trash",
+			expected: "trashes",
+		},
+		// Words ending in 'x' → add 'es'
+		{
+			name:     "x-ending",
+			input:    "Index",
+			expected: "indexes",
+		},
+		// Words ending in 'z' → add 'es'
+		{
+			name:     "z-ending",
+			input:    "Quiz",
+			expected: "quizzes",
+		},
+		// Words ending in 'y' preceded by vowel → add 's'
+		{
+			name:     "y-ending with vowel",
+			input:    "Array",
+			expected: "arrays",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := pluralizeName(tt.input)
+			if result != tt.expected {
+				t.Errorf("pluralizeName(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsVowel(t *testing.T) {
+	tests := []struct {
+		r        rune
+		expected bool
+	}{
+		{'a', true},
+		{'e', true},
+		{'i', true},
+		{'o', true},
+		{'u', true},
+		{'b', false},
+		{'c', false},
+		{'y', false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.r), func(t *testing.T) {
+			result := isVowel(tt.r)
+			if result != tt.expected {
+				t.Errorf("isVowel(%q) = %v, want %v", tt.r, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Uses proper English pluralization in informer-gen instead of naive string concatenation.

#### Which issue(s) this PR is related to:

Addresses kubernetes/kubernetes#139383

```release-note
NONE
```