### PR TITLE
fix: watchCache ring buffer idle shrink for memory leak

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -1190,6 +1190,7 @@ func (c *Cacher) Stop() {
 	c.ready.stop()
 	c.stopLock.Unlock()
 	close(c.stopCh)
+	c.watchCache.Stop()
 	c.stopWg.Wait()
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -138,7 +138,7 @@ type watchCache struct {
 	eventHandler func(*watchCacheEvent)
 
 	// for testing timeouts.
-	clock clock.Clock
+	clock clock.WithTicker
 
 	// eventFreshDuration defines the minimum watch history watchcache will store.
 	eventFreshDuration time.Duration
@@ -161,6 +161,9 @@ type watchCache struct {
 	snapshottingEnabled atomic.Bool
 
 	getCurrentRV func(context.Context) (uint64, error)
+
+	// stopCh is closed to signal the idle shrink goroutine to stop.
+	stopCh chan struct{}
 }
 
 func newWatchCache(
@@ -194,6 +197,7 @@ func newWatchCache(
 		groupResource:       groupResource,
 		waitingUntilFresh:   progressRequester,
 		getCurrentRV:        getCurrentRV,
+		stopCh:              make(chan struct{}),
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
 		wc.snapshottingEnabled.Store(true)
@@ -203,7 +207,49 @@ func newWatchCache(
 	wc.cond = sync.NewCond(wc.RLocker())
 	wc.indexValidator = wc.isIndexValidLocked
 
+	wc.startIdleShrinkLoop()
+
 	return wc
+}
+
+// Stop closes the stop channel to signal the idle shrink goroutine to stop.
+func (w *watchCache) Stop() {
+	close(w.stopCh)
+}
+
+// startIdleShrinkLoop starts a background goroutine that periodically attempts to shrink
+// the cache if it's been idle. This fixes the memory leak where the cache grows during
+// bursts but never shrinks afterward.
+func (w *watchCache) startIdleShrinkLoop() {
+	go func() {
+		ticker := w.clock.NewTicker(w.eventFreshDuration)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C():
+				w.Lock()
+				w.maybeShrinkIdleLocked()
+				w.Unlock()
+			case <-w.stopCh:
+				return
+			}
+		}
+	}()
+}
+
+// maybeShrinkIdleLocked attempts to shrink the cache if it's idle (has fewer active events
+// than half its capacity). Unlike resizeCacheLocked, this bypasses the isCacheFullLocked
+// gate to allow shrinking when the ring is not completely full.
+// Assumes that lock is already held for write.
+func (w *watchCache) maybeShrinkIdleLocked() {
+	eventCount := w.endIndex - w.startIndex
+	// Only shrink if we have much fewer events than capacity
+	if eventCount < w.capacity/2 {
+		newCapacity := max(eventCount, w.lowerBoundCapacity)
+		if newCapacity < w.capacity {
+			w.doCacheResizeLocked(newCapacity)
+		}
+	}
 }
 
 // capacityUpperBound denotes the maximum possible capacity of the watch cache

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
@@ -1406,3 +1406,60 @@ func TestCacheSnapshots(t *testing.T) {
 	assert.Len(t, elements, 1)
 	assert.Equal(t, makeTestPod("foo", 600), elements[0].(*store.Element).Object)
 }
+
+// TestMaybeShrinkIdleLocked verifies that maybeShrinkIdleLocked correctly shrinks the cache
+// when events are sparse (eventCount < capacity/2). This tests the core logic of the fix
+// for issue #139250 where the cache would grow during bursts but never shrink afterward.
+func TestMaybeShrinkIdleLocked(t *testing.T) {
+	store := newTestWatchCache(100, DefaultEventFreshDuration, &cache.Indexers{})
+	defer store.Stop()
+
+	// Phase 1: Grow the cache by filling it with events during a "burst"
+	// Create many events rapidly to trigger capacity growth.
+	store.lowerBoundCapacity = 50
+	store.upperBoundCapacity = 200
+	for i := 0; i < 150; i++ {
+		event := &watchCacheEvent{
+			Key:        fmt.Sprintf("event-%d", i),
+			RecordTime: store.clock.Now(),
+		}
+		store.Lock()
+		store.updateCache(event)
+		store.Unlock()
+	}
+
+	grownCapacity := store.capacity
+	if grownCapacity <= 100 {
+		t.Fatalf("expected capacity to grow beyond 100, but got %d", grownCapacity)
+	}
+
+	// Phase 2: Simulate idle by removing most events (keeping only a few)
+	// Move the startIndex forward to "delete" old events, leaving only ~25% of the capacity in use.
+	store.Lock()
+	store.startIndex = store.endIndex - (grownCapacity / 4)
+	eventCount := store.endIndex - store.startIndex
+	store.Unlock()
+
+	if eventCount >= grownCapacity/2 {
+		t.Fatalf("setup error: expected sparse events (< capacity/2), but got %d events in capacity %d", eventCount, grownCapacity)
+	}
+
+	// Phase 3: Call maybeShrinkIdleLocked and verify capacity reduces
+	store.Lock()
+	store.maybeShrinkIdleLocked()
+	store.Unlock()
+
+	if store.capacity >= grownCapacity {
+		t.Errorf("expected capacity to shrink from %d, but it's still %d", grownCapacity, store.capacity)
+	}
+
+	// Verify capacity is at least the lower bound
+	if store.capacity < store.lowerBoundCapacity {
+		t.Errorf("capacity %d is below lower bound %d", store.capacity, store.lowerBoundCapacity)
+	}
+
+	// Verify event data is still intact
+	if store.endIndex-store.startIndex != eventCount {
+		t.Errorf("expected %d events after shrink, but got %d", eventCount, store.endIndex-store.startIndex)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Adds idle shrink loop to watchCache ring buffer so memory is reclaimed after event bursts.

#### Which issue(s) this PR is related to:

Addresses kubernetes/kubernetes#139250

```release-note
NONE
```