### PR TITLE
Mark github.com/envoyproxy/protoc-gen-validate as unwanted dependency

### DIFF
--- a/hack/unwanted-dependencies.json
+++ b/hack/unwanted-dependencies.json
@@ -24,6 +24,7 @@
       "github.com/bketelsen/crypt": "unused, crypto",
       "github.com/containerd/cgroups": "standardize on single cgroups library from runc, refer #128157",
       "github.com/davecgh/go-spew": "refer to #103942",
+      "github.com/envoyproxy/protoc-gen-validate": "unmaintained, archive mode, refer to #139389",
       "github.com/evanphx/json-patch/v5": "refer to https://github.com/kubernetes/kubernetes/pull/91622#issuecomment-637087847",
       "github.com/flynn/go-shlex": "unmaintained, archive mode",
       "github.com/form3tech-oss/jwt-go": "unmaintained, archive mode",
@@ -138,6 +139,9 @@
         "sigs.k8s.io/kustomize/api",
         "sigs.k8s.io/kustomize/kustomize/v5",
         "sigs.k8s.io/kustomize/kyaml"
+      ],
+      "github.com/envoyproxy/protoc-gen-validate": [
+        "google.golang.org/grpc"
       ],
       "github.com/flynn/go-shlex": [
         "github.com/coredns/caddy"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`github.com/envoyproxy/protoc-gen-validate` was archived upstream, which broke the periodic `check-dependency-archived-periodical` job (it runs [depstat](https://github.com/kubernetes-sigs/depstat) to flag dependencies whose GitHub repos are archived and not tracked in `hack/unwanted-dependencies.json`).

We don't import it directly — it enters the module graph transitively via gRPC's xDS deps (`google.golang.org/grpc` → `github.com/cncf/xds/go` / `github.com/envoyproxy/go-control-plane`) and is pruned / never compiled for kubernetes. This adds it to `spec.unwantedModules` along with the matching `status.unwantedReferences` entry the verifier computes, which turns the check green.

#### Which issue(s) this PR is related to:

Fixes #139389

#### Special notes for your reviewer:

Verified locally: the `dependencyverifier` run by `hack/lint-dependencies.sh` passes (exit 0) with this change.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig architecture
/area dependency
