### PR TITLE
KEP-5491: list-type attribute should be able to evaluate in StoredExpressions env (e.g., scheduler) even if the feature gate is disabled

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/cel/compile.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/cel/compile.go
@@ -127,8 +127,7 @@ type compiler struct {
 	deviceType *apiservercel.DeclType
 	envset     *environment.EnvSet
 
-	// attributeType is used for cost estimation of attributes with unknown
-	// actual type, including list attributes.
+	// attributeType is the latest attribute type, used for cost estimation.
 	attributeType *apiservercel.DeclType
 
 	features Features
@@ -165,7 +164,8 @@ func (c compiler) CompileCELExpression(expression string, options Options) Compi
 		}
 	}
 
-	env, err := c.envset.Env(ptr.Deref(options.EnvType, environment.StoredExpressions))
+	envType := ptr.Deref(options.EnvType, environment.StoredExpressions)
+	env, err := c.envset.Env(envType)
 	if err != nil {
 		return resultError(fmt.Sprintf("unexpected error loading CEL environment: %v", err), apiservercel.ErrorTypeInternal)
 	}
@@ -175,18 +175,16 @@ func (c compiler) CompileCELExpression(expression string, options Options) Compi
 		return resultError("compilation failed: "+issues.String(), apiservercel.ErrorTypeInvalid)
 	}
 
-	// When the DRAListTypeAttributes feature is enabled,
-	// we use DynType instead of AnyType for the attributes
-	// so that standard iterate functions(e.g., exists, all etc.)
-	// and overridden includes function can work (See newCompiler() for details).
-	// Thus, the unknown return type can also be DynType, not just AnyType as before.
-	//
+	attributeReturnType, err := attributeTypeFromEnv(env)
+	if err != nil {
+		return resultError("unexpected error loading CEL environment: "+err.Error(), apiservercel.ErrorTypeInternal)
+	}
+
 	// This has to be valid because the end result of a CEL expression might be
-	// a boolean attribute, which then has AnyType/DynType.
+	// a boolean type, which then has the attribute type of this environment.
 	expectedReturnType := cel.BoolType
-	if ast.OutputType() == expectedReturnType ||
-		ast.OutputType() == cel.AnyType ||
-		ast.OutputType() == cel.DynType {
+	if ast.OutputType().IsExactType(expectedReturnType) ||
+		ast.OutputType().IsExactType(attributeReturnType) {
 		// Okay, is one of the acceptable types.
 	} else {
 		return resultError(fmt.Sprintf("must evaluate to %v or the unknown type, not %v", expectedReturnType.String(), ast.OutputType().String()), apiservercel.ErrorTypeInvalid)
@@ -236,6 +234,53 @@ func (c compiler) CompileCELExpression(expression string, options Options) Compi
 func (c *compiler) newCostEstimator() checker.CostEstimator {
 	base := &library.CostEstimator{SizeEstimator: &sizeEstimator{compiler: c}}
 	return &draCostEstimator{base: base}
+}
+
+// deviceFieldTypeFromEnv resolves a device field type from the actual CEL environment.
+// This is needed so NewExpressions uses the device type selected by VersionedOptions
+// and feature gates instead of the compiler's latest device type.
+func deviceFieldTypeFromEnv(env *cel.Env, field string) (*cel.Type, bool, error) {
+	var deviceType *cel.Type
+	for _, variable := range env.Variables() {
+		if variable.Name() == deviceVar {
+			deviceType = variable.Type()
+			break
+		}
+	}
+	if deviceType == nil {
+		return nil, false, fmt.Errorf("%q variable is not declared", deviceVar)
+	}
+
+	fieldType, ok := env.CELTypeProvider().FindStructFieldType(deviceType.TypeName(), field)
+	if !ok {
+		return nil, false, nil
+	}
+	if fieldType.Type == nil {
+		return nil, true, fmt.Errorf("%q field has no type", field)
+	}
+	return fieldType.Type, true, nil
+}
+
+// attributeTypeFromEnv resolves the attribute value type from the actual CEL environment.
+// This keeps return-type validation aligned with the VersionedOptions selection,
+// including NewExpressions environments where feature gates affect the device type.
+func attributeTypeFromEnv(env *cel.Env) (*cel.Type, error) {
+	attributesType, ok, err := deviceFieldTypeFromEnv(env, attributesVar)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("%q variable does not declare %q field", deviceVar, attributesVar)
+	}
+	outerMapParams := attributesType.Parameters()
+	if len(outerMapParams) != 2 {
+		return nil, fmt.Errorf("%q field should be a map, got %s", attributesVar, attributesType.String())
+	}
+	innerMapParams := outerMapParams[1].Parameters()
+	if len(innerMapParams) != 2 {
+		return nil, fmt.Errorf("%q field values should be maps, got %s", attributesVar, outerMapParams[1].String())
+	}
+	return innerMapParams[1], nil
 }
 
 // getAttributeValue returns the native representation of the one value that
@@ -345,7 +390,11 @@ func newCompiler(features Features) *compiler {
 		return result
 	}
 
-	attributeType := withMaxElements(
+	attributeTypeV131 := withMaxElements(
+		apiservercel.AnyType,
+		resourceapi.DeviceAttributeMaxValueLength,
+	)
+	attributeTypeV136ListTypeAttributes := withMaxElements(
 		// Use DynType so that iterate functions can work (e.g. exists, all)
 		// for list type attributes.
 		apiservercel.DynType,
@@ -353,12 +402,18 @@ func newCompiler(features Features) *compiler {
 		uint64(max(resourceapi.DeviceAttributeMaxValueLength, resourceapi.ResourceSliceMaxAttributeValuesPerDevice)),
 	)
 	// Each map is bound by the maximum number of different attributes.
-	innerAttributesMapType := apiservercel.NewMapType(idType, attributeType, resourceapi.ResourceSliceMaxAttributesAndCapacitiesPerDevice)
-	outerAttributesMapType := apiservercel.NewMapType(domainType, innerAttributesMapType, resourceapi.ResourceSliceMaxAttributesAndCapacitiesPerDevice)
+	innerAttributesMapTypeV131 := apiservercel.NewMapType(idType, attributeTypeV131, resourceapi.ResourceSliceMaxAttributesAndCapacitiesPerDevice)
+	outerAttributesMapTypeV131 := apiservercel.NewMapType(domainType, innerAttributesMapTypeV131, resourceapi.ResourceSliceMaxAttributesAndCapacitiesPerDevice)
+	innerAttributesMapTypeV136ListTypeAttributes := apiservercel.NewMapType(
+		idType, attributeTypeV136ListTypeAttributes, resourceapi.ResourceSliceMaxAttributesAndCapacitiesPerDevice,
+	)
+	outerAttributesMapTypeV136ListTypeAttributes := apiservercel.NewMapType(
+		domainType, innerAttributesMapTypeV136ListTypeAttributes, resourceapi.ResourceSliceMaxAttributesAndCapacitiesPerDevice,
+	)
 
 	fieldsV131 := []*apiservercel.DeclField{
 		field(driverVar, driverType, true),
-		field(attributesVar, outerAttributesMapType, true),
+		field(attributesVar, outerAttributesMapTypeV131, true),
 		field(capacityVar, outerCapacityMapType, true),
 	}
 	deviceTypeV131 := apiservercel.NewObjectType("kubernetes.DRADevice", fields(fieldsV131...))
@@ -367,6 +422,17 @@ func newCompiler(features Features) *compiler {
 	fieldsV134ConsumableCapacity := []*apiservercel.DeclField{field(multiAllocVar, multiAllocType, true)}
 	fieldsV134ConsumableCapacity = append(fieldsV134ConsumableCapacity, fieldsV131...)
 	deviceTypeV134ConsumableCapacity := apiservercel.NewObjectType("kubernetes.DRADevice", fields(fieldsV134ConsumableCapacity...))
+
+	fieldsV136ListTypeAttributes := []*apiservercel.DeclField{
+		field(driverVar, driverType, true),
+		field(attributesVar, outerAttributesMapTypeV136ListTypeAttributes, true),
+		field(capacityVar, outerCapacityMapType, true),
+	}
+	deviceTypeV136ListTypeAttributes := apiservercel.NewObjectType("kubernetes.DRADevice", fields(fieldsV136ListTypeAttributes...))
+
+	fieldsV136ConsumableCapacityListTypeAttributes := []*apiservercel.DeclField{field(multiAllocVar, multiAllocType, true)}
+	fieldsV136ConsumableCapacityListTypeAttributes = append(fieldsV136ConsumableCapacityListTypeAttributes, fieldsV136ListTypeAttributes...)
+	deviceTypeV136ConsumableCapacityListTypeAttributes := apiservercel.NewObjectType("kubernetes.DRADevice", fields(fieldsV136ConsumableCapacityListTypeAttributes...))
 
 	versioned := []environment.VersionedOptions{
 		{
@@ -381,12 +447,13 @@ func newCompiler(features Features) *compiler {
 				ext.Bindings(ext.BindingsVersion(0)),
 			},
 		},
-		// deviceTypeV131 and deviceTypeV134ConsumableCapacity are complimentary and picked
-		// based on the feature gate.
+		// NewExpressions selects one of these device declarations with FeatureEnabled.
+		// StoredExpressions ignores FeatureEnabled; the DeclTypeProvider keeps the
+		// last declaration for a shared type name, so keep these ordered oldest to newest.
 		{
 			IntroducedVersion: version.MajorMinor(1, 31),
 			FeatureEnabled: func() bool {
-				return !features.EnableConsumableCapacity
+				return !features.EnableConsumableCapacity && !features.EnableListTypeAttributes
 			},
 			EnvOptions: []cel.EnvOption{
 				cel.Variable(deviceVar, deviceTypeV131.CelType()),
@@ -398,13 +465,41 @@ func newCompiler(features Features) *compiler {
 		{
 			IntroducedVersion: version.MajorMinor(1, 34),
 			FeatureEnabled: func() bool {
-				return features.EnableConsumableCapacity
+				return features.EnableConsumableCapacity && !features.EnableListTypeAttributes
 			},
 			EnvOptions: []cel.EnvOption{
 				cel.Variable(deviceVar, deviceTypeV134ConsumableCapacity.CelType()),
 			},
 			DeclTypes: []*apiservercel.DeclType{
 				deviceTypeV134ConsumableCapacity,
+			},
+		},
+		{
+			// This type was added in 1.37, but 1.36 already behaved like this type
+			// when ListTypeAttributes was enabled and ConsumableCapacity was disabled.
+			IntroducedVersion: version.MajorMinor(1, 36),
+			FeatureEnabled: func() bool {
+				return !features.EnableConsumableCapacity && features.EnableListTypeAttributes
+			},
+			EnvOptions: []cel.EnvOption{
+				cel.Variable(deviceVar, deviceTypeV136ListTypeAttributes.CelType()),
+			},
+			DeclTypes: []*apiservercel.DeclType{
+				deviceTypeV136ListTypeAttributes,
+			},
+		},
+		{
+			// This type was added in 1.37, but 1.36 already behaved like this type
+			// when both ListTypeAttributes and ConsumableCapacity was enabled.
+			IntroducedVersion: version.MajorMinor(1, 36),
+			FeatureEnabled: func() bool {
+				return features.EnableConsumableCapacity && features.EnableListTypeAttributes
+			},
+			EnvOptions: []cel.EnvOption{
+				cel.Variable(deviceVar, deviceTypeV136ConsumableCapacityListTypeAttributes.CelType()),
+			},
+			DeclTypes: []*apiservercel.DeclType{
+				deviceTypeV136ConsumableCapacityListTypeAttributes,
 			},
 		},
 		{
@@ -428,7 +523,12 @@ func newCompiler(features Features) *compiler {
 		panic(fmt.Errorf("internal error building CEL environment: %w", err))
 	}
 	// return with newest deviceType
-	return &compiler{envset: envset, deviceType: deviceTypeV134ConsumableCapacity, features: features, attributeType: attributeType}
+	return &compiler{
+		envset:        envset,
+		deviceType:    deviceTypeV136ConsumableCapacityListTypeAttributes,
+		features:      features,
+		attributeType: attributeTypeV136ListTypeAttributes,
+	}
 }
 
 // includesFunc implements the "includes" function for CEL (<target>.includes(<arg>)),

--- a/staging/src/k8s.io/dynamic-resource-allocation/cel/compile.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/cel/compile.go
@@ -127,9 +127,8 @@ type compiler struct {
 	deviceType *apiservercel.DeclType
 	envset     *environment.EnvSet
 
-	// A variant of AnyType = https://github.com/kubernetes/kubernetes/blob/ec2e0de35a298363872897e5904501b029817af3/staging/src/k8s.io/apiserver/pkg/cel/types.go#L550:
-	// unknown actual type (could be bool, int, string, etc.) but with a known maximum size.
-	// If DRAListTypeAttributes is enabled, this also applies to list attributes, so that the cost estimator can take into account the size of the list.
+	// attributeType is used for cost estimation of attributes with unknown
+	// actual type, including list attributes.
 	attributeType *apiservercel.DeclType
 
 	features Features
@@ -187,7 +186,7 @@ func (c compiler) CompileCELExpression(expression string, options Options) Compi
 	expectedReturnType := cel.BoolType
 	if ast.OutputType() == expectedReturnType ||
 		ast.OutputType() == cel.AnyType ||
-		c.features.EnableListTypeAttributes && ast.OutputType() == cel.DynType {
+		ast.OutputType() == cel.DynType {
 		// Okay, is one of the acceptable types.
 	} else {
 		return resultError(fmt.Sprintf("must evaluate to %v or the unknown type, not %v", expectedReturnType.String(), ast.OutputType().String()), apiservercel.ErrorTypeInvalid)
@@ -242,35 +241,24 @@ func (c *compiler) newCostEstimator() checker.CostEstimator {
 // getAttributeValue returns the native representation of the one value that
 // should be stored in the attribute, otherwise an error. An error is
 // also returned when there is no supported value.
-//
-// If the DRAListTypeAttributes feature  is disabled and an attribute
-// contains a list value, then we fall through to returning the
-// "unsupported attribute value" error below.
-// This failure then aborts scheduling until ResourceSlices get updated.
-// This is better than incorrectly scheduling a pod
-// because that is harder to correct.
 func (c CompilationResult) getAttributeValue(attr resourceapi.DeviceAttribute) (any, error) {
-	if c.features.EnableListTypeAttributes {
-		switch {
-		case attr.IntValues != nil:
-			return attr.IntValues, nil
-		case attr.BoolValues != nil:
-			return attr.BoolValues, nil
-		case attr.StringValues != nil:
-			return attr.StringValues, nil
-		case attr.VersionValues != nil:
-			semVers := make([]apiservercel.Semver, len(attr.VersionValues))
-			for i, versionStr := range attr.VersionValues {
-				v, err := semver.Parse(versionStr)
-				if err != nil {
-					return nil, fmt.Errorf("parse semantic version: %w", err)
-				}
-				semVers[i] = apiservercel.Semver{Version: v}
-			}
-			return semVers, nil
-		}
-	}
 	switch {
+	case attr.IntValues != nil:
+		return attr.IntValues, nil
+	case attr.BoolValues != nil:
+		return attr.BoolValues, nil
+	case attr.StringValues != nil:
+		return attr.StringValues, nil
+	case attr.VersionValues != nil:
+		semVers := make([]apiservercel.Semver, len(attr.VersionValues))
+		for i, versionStr := range attr.VersionValues {
+			v, err := semver.Parse(versionStr)
+			if err != nil {
+				return nil, fmt.Errorf("parse semantic version: %w", err)
+			}
+			semVers[i] = apiservercel.Semver{Version: v}
+		}
+		return semVers, nil
 	case attr.IntValue != nil:
 		return *attr.IntValue, nil
 	case attr.BoolValue != nil:
@@ -357,20 +345,13 @@ func newCompiler(features Features) *compiler {
 		return result
 	}
 
-	attributeType := withMaxElements(apiservercel.AnyType, resourceapi.DeviceAttributeMaxValueLength)
-	if features.EnableListTypeAttributes {
-		attributeType = withMaxElements(
-			// use DynType instead of AnyType so that iterate functions can work(e.g., exists, all, etc.)
-			apiservercel.DynType,
-			// When DRAListTypeAttributes feature gate is enabled, we cannot
-			// determine statically whether an attribute will be a scalar or a list
-			// at compile time. MaxElements should describe
-			// - the max number of items when it's a list.
-			// - the max length of the string representation when it's a scalar.
-			// Thus, we set it to the larger one of the two cases.
-			uint64(max(resourceapi.DeviceAttributeMaxValueLength, resourceapi.ResourceSliceMaxAttributeValuesPerDevice)),
-		)
-	}
+	attributeType := withMaxElements(
+		// Use DynType so that iterate functions can work (e.g. exists, all)
+		// for list type attributes.
+		apiservercel.DynType,
+		// At compile time we don't know whether an attribute will be a scalar or list.
+		uint64(max(resourceapi.DeviceAttributeMaxValueLength, resourceapi.ResourceSliceMaxAttributeValuesPerDevice)),
+	)
 	// Each map is bound by the maximum number of different attributes.
 	innerAttributesMapType := apiservercel.NewMapType(idType, attributeType, resourceapi.ResourceSliceMaxAttributesAndCapacitiesPerDevice)
 	outerAttributesMapType := apiservercel.NewMapType(domainType, innerAttributesMapType, resourceapi.ResourceSliceMaxAttributesAndCapacitiesPerDevice)

--- a/staging/src/k8s.io/dynamic-resource-allocation/cel/compile_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/cel/compile_test.go
@@ -161,261 +161,223 @@ var testcases = map[string]struct {
 		expectCost:  5,
 	},
 	"macro-exists-on-int": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].name.exists(x, x > 0)`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {IntValue: new(int64(1))}},
-		driver:                   "dra.example.com",
-		expectMatchError:         "got 'types.Int', expected iterable type",
-		expectCost:               5 + ((3 + 3) * maxElementsListTypeEnabled /* (cost(loopCondition=="not_strictly_false(!accu)") + cost(loopStep=="accu && (x > 0)")) * maxElementsListTypeEnabled */),
+		expression:       `device.attributes["dra.example.com"].name.exists(x, x > 0)`,
+		attributes:       map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {IntValue: new(int64(1))}},
+		driver:           "dra.example.com",
+		expectMatchError: "got 'types.Int', expected iterable type",
+		expectCost:       5 + ((3 + 3) * maxElementsListTypeEnabled /* (cost(loopCondition=="not_strictly_false(!accu)") + cost(loopStep=="accu && (x > 0)")) * maxElementsListTypeEnabled */),
 	},
 	"macro-exists-on-bool": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].name.exists(x, x == true)`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {BoolValue: new(true)}},
-		driver:                   "dra.example.com",
-		expectMatchError:         "got 'types.Bool', expected iterable type",
-		expectCost:               5 + ((3 + 3) * maxElementsListTypeEnabled /* (cost(loopCondition=="not_strictly_false(!accu)") + cost(loopStep=="accu && (x > 0)")) * maxElementsListTypeEnabled */),
+		expression:       `device.attributes["dra.example.com"].name.exists(x, x == true)`,
+		attributes:       map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {BoolValue: new(true)}},
+		driver:           "dra.example.com",
+		expectMatchError: "got 'types.Bool', expected iterable type",
+		expectCost:       5 + ((3 + 3) * maxElementsListTypeEnabled /* (cost(loopCondition=="not_strictly_false(!accu)") + cost(loopStep=="accu && (x > 0)")) * maxElementsListTypeEnabled */),
 	},
 	"macro-exists-on-string": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].name.exists(x, x == "fish")`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValue: new("fish")}},
-		driver:                   "dra.example.com",
-		expectMatchError:         "got 'types.String', expected iterable type",
-		expectCost:               5 + ((3 + 3) * maxElementsListTypeEnabled /* (cost(loopCondition=="not_strictly_false(!accu)") + cost(loopStep=="accu && (x > 0)")) * maxElementsListTypeEnabled */),
+		expression:       `device.attributes["dra.example.com"].name.exists(x, x == "fish")`,
+		attributes:       map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValue: new("fish")}},
+		driver:           "dra.example.com",
+		expectMatchError: "got 'types.String', expected iterable type",
+		expectCost:       5 + ((3 + 3) * maxElementsListTypeEnabled /* (cost(loopCondition=="not_strictly_false(!accu)") + cost(loopStep=="accu && (x > 0)")) * maxElementsListTypeEnabled */),
 	},
-	"attribute-access-causes-match-error": {
-		enableListTypeAttributes: new(false),
-		expression:               `device.attributes["dra.example.com"].names`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"names": {StringValues: []string{"fish", "bird"}}},
-		driver:                   "dra.example.com",
-		expectMatchError:         "attribute names: unsupported attribute value",
-		expectCost:               4,
+	"list-result-type-causes-match-error": {
+		expression:       `device.attributes["dra.example.com"].names`,
+		attributes:       map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"names": {StringValues: []string{"fish", "bird"}}},
+		driver:           "dra.example.com",
+		expectMatchError: "CEL result of type list could not be converted to bool",
+		expectCost:       4,
+	},
+	"includes-function-can-evaluate": {
+		expression:  `device.attributes["dra.example.com"].name.includes("fish")`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValues: []string{"fish", "bird"}}},
+		driver:      "dra.example.com",
+		expectMatch: true,
+		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"list-of-bool": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].names.size() == 2`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"names": {BoolValues: []bool{true, false}}},
-		driver:                   "dra.example.com",
-		expectMatch:              true,
-		expectCost:               6,
+		expression:  `device.attributes["dra.example.com"].names.size() == 2`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"names": {BoolValues: []bool{true, false}}},
+		driver:      "dra.example.com",
+		expectMatch: true,
+		expectCost:  6,
 	},
 	"list-of-int": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].names.size() == 2`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"names": {IntValues: []int64{1, 2}}},
-		driver:                   "dra.example.com",
-		expectMatch:              true,
-		expectCost:               6,
+		expression:  `device.attributes["dra.example.com"].names.size() == 2`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"names": {IntValues: []int64{1, 2}}},
+		driver:      "dra.example.com",
+		expectMatch: true,
+		expectCost:  6,
 	},
 	"list-of-string": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].names.size() == 2`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"names": {StringValues: []string{"fish", "bird"}}},
-		driver:                   "dra.example.com",
-		expectMatch:              true,
-		expectCost:               6,
+		expression:  `device.attributes["dra.example.com"].names.size() == 2`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"names": {StringValues: []string{"fish", "bird"}}},
+		driver:      "dra.example.com",
+		expectMatch: true,
+		expectCost:  6,
 	},
 	"list-of-semver": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].names.size() == 2`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"names": {VersionValues: []string{"1.0.0", "2.0.0"}}},
-		driver:                   "dra.example.com",
-		expectMatch:              true,
-		expectCost:               6,
+		expression:  `device.attributes["dra.example.com"].names.size() == 2`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"names": {VersionValues: []string{"1.0.0", "2.0.0"}}},
+		driver:      "dra.example.com",
+		expectMatch: true,
+		expectCost:  6,
 	},
 	"macro-on-list-of-int": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].names.exists(x, x > 0)`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"names": {IntValues: []int64{1, 2}}},
-		driver:                   "dra.example.com",
-		expectMatch:              true,
-		expectCost:               5 + ((3 + 3) * maxElementsListTypeEnabled /* (cost(loopCondition=="not_strictly_false(!accu)") + cost(loopStep=="accu && (x > 0)")) * maxElementsListTypeEnabled */),
+		expression:  `device.attributes["dra.example.com"].names.exists(x, x > 0)`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"names": {IntValues: []int64{1, 2}}},
+		driver:      "dra.example.com",
+		expectMatch: true,
+		expectCost:  5 + ((3 + 3) * maxElementsListTypeEnabled /* (cost(loopCondition=="not_strictly_false(!accu)") + cost(loopStep=="accu && (x > 0)")) * maxElementsListTypeEnabled */),
 	},
 	"macro-on-list-of-string": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].names.all(x, x != "")`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"names": {StringValues: []string{"fish", "bird"}}},
-		driver:                   "dra.example.com",
-		expectMatch:              true,
-		expectCost:               5 + ((2 + 2) * maxElementsListTypeEnabled /* (cost(loopCondition=="not_strictly_false(accu)") + cost(loopStep=="accu && (x != "")")) * maxElementsListTypeEnabled */),
+		expression:  `device.attributes["dra.example.com"].names.all(x, x != "")`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"names": {StringValues: []string{"fish", "bird"}}},
+		driver:      "dra.example.com",
+		expectMatch: true,
+		expectCost:  5 + ((2 + 2) * maxElementsListTypeEnabled /* (cost(loopCondition=="not_strictly_false(accu)") + cost(loopStep=="accu && (x != "")")) * maxElementsListTypeEnabled */),
 	},
 	"macro-on-list-of-semver": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].names.all(x, x.isGreaterThan(semver("0.0.1")))`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"names": {VersionValues: []string{"1.0.0", "2.0.0"}}},
-		driver:                   "dra.example.com",
-		expectMatch:              true,
-		expectCost:               5 + ((2 + 4) * maxElementsListTypeEnabled /* (cost(loopCondition=="not_strictly_false(accu)") + cost(loopStep=="accu && (x.isGreaterThan(semver("0.0.1"))")) * maxElementsListTypeEnabled */),
+		expression:  `device.attributes["dra.example.com"].names.all(x, x.isGreaterThan(semver("0.0.1")))`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"names": {VersionValues: []string{"1.0.0", "2.0.0"}}},
+		driver:      "dra.example.com",
+		expectMatch: true,
+		expectCost:  5 + ((2 + 4) * maxElementsListTypeEnabled /* (cost(loopCondition=="not_strictly_false(accu)") + cost(loopStep=="accu && (x.isGreaterThan(semver("0.0.1"))")) * maxElementsListTypeEnabled */),
 	},
-	"includes-function-undeclared-error": {
-		enableConsumableCapacity: false,
+	"includes-function-compilation-error": {
 		enableListTypeAttributes: new(false),
 		// "includes" is injected via VersionedOptions.FeatureEnabled.
 		// Use NewExpressions here because normal StoredExpressions ignores VersionedOptions.FeatureEnabled.
 		envType:            ptr.To(environment.NewExpressions),
-		expression:         `device.attributes["dra.example.com"].name.includes("fish")`,
+		expression:         `device.attributes["dra.example.com"].attr.includes("fish")`,
 		driver:             "dra.example.com",
 		expectCompileError: "undeclared reference to 'includes'",
 	},
-	"includes-function-on-bool-scalar-positive": {
+	"includes-function-compilation-and-eval-success": {
 		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].name.includes(true)`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {BoolValue: new(true)}},
-		driver:                   "dra.example.com",
-		expectMatch:              true,
-		expectCost:               4 + 48, /* cost of "includes" is max list length */
+		// "includes" is injected via VersionedOptions.FeatureEnabled.
+		// Use NewExpressions here because normal StoredExpressions ignores VersionedOptions.FeatureEnabled.
+		envType:     ptr.To(environment.NewExpressions),
+		expression:  `device.attributes["dra.example.com"].attr.includes("fish")`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"attr": {StringValue: new("fish")}},
+		driver:      "dra.example.com",
+		expectMatch: true,
+		expectCost:  4 + 48, /* cost of "includes" is max list length */
+	},
+	"includes-function-on-bool-scalar-positive": {
+		expression:  `device.attributes["dra.example.com"].name.includes(true)`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {BoolValue: new(true)}},
+		driver:      "dra.example.com",
+		expectMatch: true,
+		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-bool-scalar-negative": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].name.includes(true)`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {BoolValue: new(false)}},
-		driver:                   "dra.example.com",
-		expectMatch:              false,
-		expectCost:               4 + 48, /* cost of "includes" is max list length */
+		expression:  `device.attributes["dra.example.com"].name.includes(true)`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {BoolValue: new(false)}},
+		driver:      "dra.example.com",
+		expectMatch: false,
+		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-bool-list-positive": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].name.includes(true)`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {BoolValues: []bool{true, false}}},
-		driver:                   "dra.example.com",
-		expectMatch:              true,
-		expectCost:               4 + 48, /* cost of "includes" is max list length */
+		expression:  `device.attributes["dra.example.com"].name.includes(true)`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {BoolValues: []bool{true, false}}},
+		driver:      "dra.example.com",
+		expectMatch: true,
+		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-bool-list-negative": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].name.includes(false)`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {BoolValues: []bool{true, true}}},
-		driver:                   "dra.example.com",
-		expectMatch:              false,
-		expectCost:               4 + 48, /* cost of "includes" is max list length */
+		expression:  `device.attributes["dra.example.com"].name.includes(false)`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {BoolValues: []bool{true, true}}},
+		driver:      "dra.example.com",
+		expectMatch: false,
+		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-int-scalar-positive": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].name.includes(1)`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {IntValue: new(int64(1))}},
-		driver:                   "dra.example.com",
-		expectMatch:              true,
-		expectCost:               4 + 48, /* cost of "includes" is max list length */
+		expression:  `device.attributes["dra.example.com"].name.includes(1)`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {IntValue: new(int64(1))}},
+		driver:      "dra.example.com",
+		expectMatch: true,
+		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-int-scalar-negative": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].name.includes(1)`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {IntValue: new(int64(2))}},
-		driver:                   "dra.example.com",
-		expectMatch:              false,
-		expectCost:               4 + 48, /* cost of "includes" is max list length */
+		expression:  `device.attributes["dra.example.com"].name.includes(1)`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {IntValue: new(int64(2))}},
+		driver:      "dra.example.com",
+		expectMatch: false,
+		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-int-list-positive": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].name.includes(1)`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {IntValues: []int64{1, 2}}},
-		driver:                   "dra.example.com",
-		expectMatch:              true,
-		expectCost:               4 + 48, /* cost of "includes" is max list length */
+		expression:  `device.attributes["dra.example.com"].name.includes(1)`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {IntValues: []int64{1, 2}}},
+		driver:      "dra.example.com",
+		expectMatch: true,
+		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-int-list-negative": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].name.includes(3)`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {IntValues: []int64{1, 2}}},
-		driver:                   "dra.example.com",
-		expectMatch:              false,
-		expectCost:               4 + 48, /* cost of "includes" is max list length */
+		expression:  `device.attributes["dra.example.com"].name.includes(3)`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {IntValues: []int64{1, 2}}},
+		driver:      "dra.example.com",
+		expectMatch: false,
+		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-string-scalar-positive": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].name.includes("fish")`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValue: new("fish")}},
-		driver:                   "dra.example.com",
-		expectMatch:              true,
-		expectCost:               4 + 48, /* cost of "includes" is max list length */
+		expression:  `device.attributes["dra.example.com"].name.includes("fish")`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValue: new("fish")}},
+		driver:      "dra.example.com",
+		expectMatch: true,
+		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-string-scalar-negative": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].name.includes("bird")`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValue: new("fish")}},
-		driver:                   "dra.example.com",
-		expectMatch:              false,
-		expectCost:               4 + 48, /* cost of "includes" is max list length */
+		expression:  `device.attributes["dra.example.com"].name.includes("bird")`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValue: new("fish")}},
+		driver:      "dra.example.com",
+		expectMatch: false,
+		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-string-list-positive": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].name.includes("fish")`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValues: []string{"fish", "bird"}}},
-		driver:                   "dra.example.com",
-		expectMatch:              true,
-		expectCost:               4 + 48, /* cost of "includes" is max list length */
+		expression:  `device.attributes["dra.example.com"].name.includes("fish")`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValues: []string{"fish", "bird"}}},
+		driver:      "dra.example.com",
+		expectMatch: true,
+		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-string-list-negative": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].name.includes("cat")`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValues: []string{"fish", "bird"}}},
-		driver:                   "dra.example.com",
-		expectMatch:              false,
-		expectCost:               4 + 48, /* cost of "includes" is max list length */
+		expression:  `device.attributes["dra.example.com"].name.includes("cat")`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValues: []string{"fish", "bird"}}},
+		driver:      "dra.example.com",
+		expectMatch: false,
+		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-semver-scalar-positive": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].name.includes(semver("1.0.0"))`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {VersionValue: new("1.0.0")}},
-		driver:                   "dra.example.com",
-		expectMatch:              true,
-		expectCost:               4 + 48 /* cost of "includes" is max list length */ + 1,
+		expression:  `device.attributes["dra.example.com"].name.includes(semver("1.0.0"))`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {VersionValue: new("1.0.0")}},
+		driver:      "dra.example.com",
+		expectMatch: true,
+		expectCost:  4 + 48 /* cost of "includes" is max list length */ + 1,
 	},
 	"includes-function-on-semver-scalar-negative": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].name.includes(semver("2.0.0"))`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {VersionValue: new("1.0.0")}},
-		driver:                   "dra.example.com",
-		expectMatch:              false,
-		expectCost:               4 + 48 /* cost of "includes" is max list length */ + 1,
+		expression:  `device.attributes["dra.example.com"].name.includes(semver("2.0.0"))`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {VersionValue: new("1.0.0")}},
+		driver:      "dra.example.com",
+		expectMatch: false,
+		expectCost:  4 + 48 /* cost of "includes" is max list length */ + 1,
 	},
 	"includes-function-on-semver-list-positive": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].name.includes(semver("1.0.0"))`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {VersionValues: []string{"1.0.0", "2.0.0"}}},
-		driver:                   "dra.example.com",
-		expectMatch:              true,
-		expectCost:               4 + 48 /* cost of "includes" is max list length */ + 1,
+		expression:  `device.attributes["dra.example.com"].name.includes(semver("1.0.0"))`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {VersionValues: []string{"1.0.0", "2.0.0"}}},
+		driver:      "dra.example.com",
+		expectMatch: true,
+		expectCost:  4 + 48 /* cost of "includes" is max list length */ + 1,
 	},
 	"includes-function-on-semver-list-negative": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].name.includes(semver("3.0.0"))`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {VersionValues: []string{"1.0.0", "2.0.0"}}},
-		driver:                   "dra.example.com",
-		expectMatch:              false,
-		expectCost:               4 + 48 /* cost of "includes" is max list length */ + 1,
+		expression:  `device.attributes["dra.example.com"].name.includes(semver("3.0.0"))`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {VersionValues: []string{"1.0.0", "2.0.0"}}},
+		driver:      "dra.example.com",
+		expectMatch: false,
+		expectCost:  4 + 48 /* cost of "includes" is max list length */ + 1,
 	},
 	"includes-function-on-very-long-list-positive": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               fmt.Sprintf(`device.attributes["dra.example.com"].name.includes("value-%d")`, resourceapi.ResourceSliceMaxAttributeValuesPerDevice),
+		expression: fmt.Sprintf(`device.attributes["dra.example.com"].name.includes("value-%d")`, resourceapi.ResourceSliceMaxAttributeValuesPerDevice),
 		attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValues: func() []string {
 			values := make([]string, resourceapi.ResourceSliceMaxAttributeValuesPerDevice)
 			for i := range values {
@@ -428,9 +390,7 @@ var testcases = map[string]struct {
 		expectCost:  4 + 48, /* cost of "includes" is max list length */
 	},
 	"includes-function-on-very-long-list-runtime-error": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               fmt.Sprintf(`device.attributes["dra.example.com"].name.includes("value-%d")`, resourceapi.ResourceSliceMaxAttributeValuesPerDevice+1),
+		expression: fmt.Sprintf(`device.attributes["dra.example.com"].name.includes("value-%d")`, resourceapi.ResourceSliceMaxAttributeValuesPerDevice+1),
 		attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {StringValues: func() []string {
 			values := make([]string, resourceapi.ResourceSliceMaxAttributeValuesPerDevice+1)
 			for i := range values {
@@ -449,13 +409,11 @@ var testcases = map[string]struct {
 		// because it's designed for checking whether a value is included in an device attribute list.
 		// Instead, the cost estimation of "in" operator is based on maxElementsListTypeEnabled
 		// (MaxElements in AttributeType(cel.DeclType)) as this operator is CEL standard one.
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `1 in device.attributes["dra.example.com"].names`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"names": {IntValues: []int64{1, 2, 3}}},
-		driver:                   "dra.example.com",
-		expectMatch:              true,
-		expectCost:               4 + 64, /* cost of "in" is maxElementsListTypeEnabled*/
+		expression:  `1 in device.attributes["dra.example.com"].names`,
+		attributes:  map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"names": {IntValues: []int64{1, 2, 3}}},
+		driver:      "dra.example.com",
+		expectMatch: true,
+		expectCost:  4 + 64, /* cost of "in" is maxElementsListTypeEnabled*/
 	},
 	"version": {
 		expression:  `device.attributes["dra.example.com"].name.isGreaterThan(semver("0.0.1"))`,
@@ -473,13 +431,11 @@ var testcases = map[string]struct {
 		expectCost:  7,
 	},
 	"macro-exists-on-version": {
-		enableListTypeAttributes: new(true),
-		envType:                  ptr.To(environment.NewExpressions),
-		expression:               `device.attributes["dra.example.com"].name.exists(x, x.isGreaterThan(semver("0.0.1")))`,
-		attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {VersionValue: new("1.0.0")}},
-		driver:                   "dra.example.com",
-		expectMatchError:         "got 'cel.Semver', expected iterable type",
-		expectCost:               5 + ((3 + 4) * maxElementsListTypeEnabled /* (cost(loopCondition=="not_strictly_false(!accu)") + cost(loopStep=="accu && (x.isGreaterThan(semver("0.0.1"))")) * maxElementsListTypeEnabled */),
+		expression:       `device.attributes["dra.example.com"].name.exists(x, x.isGreaterThan(semver("0.0.1")))`,
+		attributes:       map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{"name": {VersionValue: new("1.0.0")}},
+		driver:           "dra.example.com",
+		expectMatchError: "got 'cel.Semver', expected iterable type",
+		expectCost:       5 + ((3 + 4) * maxElementsListTypeEnabled /* (cost(loopCondition=="not_strictly_false(!accu)") + cost(loopStep=="accu && (x.isGreaterThan(semver("0.0.1"))")) * maxElementsListTypeEnabled */),
 	},
 	"quantity": {
 		expression:  `device.capacity["dra.example.com"].name.isGreaterThan(quantity("1Ki"))`,
@@ -712,18 +668,20 @@ func TestCEL(t *testing.T) {
 				t.Fatalf("FAILURE: expected result %v, got %v", scenario.expectMatch, match)
 			}
 		}
-		if scenario.enableListTypeAttributes == nil {
-			t.Run(name+"-list-type-attributes-false", func(t *testing.T) {
-				run(t, false)
-			})
-			t.Run(name+"-list-type-attributes-true", func(t *testing.T) {
-				run(t, true)
-			})
-		} else {
-			t.Run(fmt.Sprintf("%s-list-type-attributes-%v", name, *scenario.enableListTypeAttributes), func(t *testing.T) {
-				run(t, *scenario.enableListTypeAttributes)
-			})
-		}
+		t.Run(name, func(t *testing.T) {
+			if scenario.enableListTypeAttributes == nil {
+				t.Run("list-type-attributes=false", func(t *testing.T) {
+					run(t, false)
+				})
+				t.Run("list-type-attributes=true", func(t *testing.T) {
+					run(t, true)
+				})
+			} else {
+				t.Run(fmt.Sprintf("list-type-attributes=%v", *scenario.enableListTypeAttributes), func(t *testing.T) {
+					run(t, *scenario.enableListTypeAttributes)
+				})
+			}
+		})
 	}
 }
 

--- a/staging/src/k8s.io/dynamic-resource-allocation/cel/compile_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/cel/compile_test.go
@@ -685,6 +685,181 @@ func TestCEL(t *testing.T) {
 	}
 }
 
+// TestCEL's main table focuses on expression behavior. This covers the env x feature
+// matrix explicitly with small expressions tied to each feature-dependent declaration.
+func TestCELFeatureCombinations(t *testing.T) {
+	// compileExpectations lists which feature-dependent expression categories should
+	// compile for one environment and feature-gate combination.
+	type compileExpectations struct {
+		// scalarAttribute covers expressions that access a scalar attribute.
+		scalarAttribute bool
+		// listTypeAttributes covers list-valued attribute access.
+		listTypeAttributes bool
+		// includesFunc covers the includes function introduced by DRAListTypeAttributes.
+		includesFunc bool
+		// multipleAllocations covers fields introduced by DRAConsumableCapacity.
+		multipleAllocations bool
+	}
+
+	type expressionTest struct {
+		expression     string
+		device         Device
+		expectsCompile bool
+	}
+
+	// StoredExpressions ignores FeatureEnabled() in VersionedOptions,
+	// so it always compiles all expressions that are valid in the current version
+	storedExpressionsCompileExpectations := compileExpectations{
+		scalarAttribute:     true,
+		listTypeAttributes:  true,
+		includesFunc:        true,
+		multipleAllocations: true,
+	}
+
+	tests := map[string]struct {
+		envType        environment.Type
+		features       Features
+		expectsCompile compileExpectations
+	}{
+		"stored-expressions-no-features": {
+			envType:        environment.StoredExpressions,
+			expectsCompile: storedExpressionsCompileExpectations,
+		},
+		"stored-expressions-consumable-capacity": {
+			envType:        environment.StoredExpressions,
+			features:       Features{EnableConsumableCapacity: true},
+			expectsCompile: storedExpressionsCompileExpectations,
+		},
+		"stored-expressions-list-type-attributes": {
+			envType:        environment.StoredExpressions,
+			features:       Features{EnableListTypeAttributes: true},
+			expectsCompile: storedExpressionsCompileExpectations,
+		},
+		"stored-expressions-all-features": {
+			envType:        environment.StoredExpressions,
+			features:       Features{EnableConsumableCapacity: true, EnableListTypeAttributes: true},
+			expectsCompile: storedExpressionsCompileExpectations,
+		},
+		"new-expressions-no-features": {
+			envType: environment.NewExpressions,
+			expectsCompile: compileExpectations{
+				scalarAttribute: true,
+			},
+		},
+		"new-expressions-consumable-capacity": {
+			envType:  environment.NewExpressions,
+			features: Features{EnableConsumableCapacity: true},
+			expectsCompile: compileExpectations{
+				scalarAttribute:     true,
+				multipleAllocations: true,
+			},
+		},
+		"new-expressions-list-type-attributes": {
+			envType:  environment.NewExpressions,
+			features: Features{EnableListTypeAttributes: true},
+			expectsCompile: compileExpectations{
+				scalarAttribute:    true,
+				listTypeAttributes: true,
+				includesFunc:       true,
+			},
+		},
+		"new-expressions-all-features": {
+			envType:  environment.NewExpressions,
+			features: Features{EnableConsumableCapacity: true, EnableListTypeAttributes: true},
+			expectsCompile: compileExpectations{
+				scalarAttribute:     true,
+				listTypeAttributes:  true,
+				includesFunc:        true,
+				multipleAllocations: true,
+			},
+		},
+	}
+
+	expressions := func(expectsCompile compileExpectations) map[string]expressionTest {
+		return map[string]expressionTest{
+			"scalar-attribute": {
+				expression: `device.attributes["dra.example.com"].ready`,
+				device: Device{
+					Driver: "dra.example.com",
+					Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"ready": {BoolValue: new(true)},
+					},
+				},
+				expectsCompile: expectsCompile.scalarAttribute,
+			},
+			"list-attribute": {
+				expression: `device.attributes["dra.example.com"].ids.exists(id, id == 1)`,
+				device: Device{
+					Driver: "dra.example.com",
+					Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"ids": {IntValues: []int64{1, 2}},
+					},
+				},
+				expectsCompile: expectsCompile.listTypeAttributes,
+			},
+			"includes-function": {
+				expression: `device.attributes["dra.example.com"].name.includes("fish")`,
+				device: Device{
+					Driver: "dra.example.com",
+					Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"name": {StringValue: new("fish")},
+					},
+				},
+				expectsCompile: expectsCompile.includesFunc,
+			},
+			"multiple-allocations": {
+				expression: `device.allowMultipleAllocations`,
+				device: Device{
+					Driver:                   "dra.example.com",
+					AllowMultipleAllocations: new(true),
+					Attributes:               map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{},
+				},
+				expectsCompile: expectsCompile.multipleAllocations,
+			},
+			"list-attribute-with-multiple-allocations": {
+				expression: `device.allowMultipleAllocations && device.attributes["dra.example.com"].ids.exists(id, id == 1)`,
+				device: Device{
+					Driver:                   "dra.example.com",
+					AllowMultipleAllocations: new(true),
+					Attributes: map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"ids": {IntValues: []int64{1, 2}},
+					},
+				},
+				expectsCompile: expectsCompile.listTypeAttributes && expectsCompile.multipleAllocations,
+			},
+		}
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			for exprName, exprTC := range expressions(tc.expectsCompile) {
+				t.Run(exprName, func(t *testing.T) {
+					_, ctx := ktesting.NewTestContext(t)
+					envType := tc.envType
+					result := GetCompiler(tc.features).CompileCELExpression(exprTC.expression, Options{EnvType: &envType})
+					if result.Error != nil {
+						if exprTC.expectsCompile {
+							t.Fatalf("unexpected compile error: %v", result.Error)
+						}
+						return
+					}
+					if !exprTC.expectsCompile {
+						t.Fatalf("expected compile error")
+					}
+
+					match, _, err := result.DeviceMatches(ctx, exprTC.device)
+					if err != nil {
+						t.Fatalf("unexpected evaluation error: %v", err)
+					}
+					if !match {
+						t.Fatalf("expected match")
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestInterrupt(t *testing.T) {
 	for _, name := range []string{"timeout", "deadline", "cancel"} {
 		t.Run(name, func(t *testing.T) {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -6075,8 +6075,7 @@ func TestAllocator(t *testing.T,
 			)),
 			node: node(node1, region1),
 
-			expectResults: []any{},
-			expectError:   gomega.MatchError(gomega.ContainSubstring("unsupported attribute value")),
+			expectResults: nil,
 		},
 		"list-attributes-distinct-constraint-scalar-string-values-all-distinct": {
 			features: Features{
@@ -6369,8 +6368,7 @@ func TestAllocator(t *testing.T,
 			)),
 			node: node(node1, region1),
 
-			expectResults: []any{},
-			expectError:   gomega.MatchError(gomega.ContainSubstring("unsupported attribute value")),
+			expectResults: nil,
 		},
 
 		"allocation-mode-all-with-multi-host-resource-pool": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR makes list-type attributes be able to evaluate in the StoredExpressions environment(e.g., scheduler) even if the feature gate(`ListTypeAttributes`) is disabled.

This is needed during supported n/n-1 rollout skew (and the feature gate disabled->enabled transitions on scheduler), where CEL selectors already persisted in the apiserver with newer version may contain list-based attributes, and older or feature-gate-off evaluators (in the scheduler) must still read and evaluate them instead of blocking scheduling due to kubernetes version skew policy.


#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/137899
KEP: https://github.com/kubernetes/enhancements/issues/5491

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

##### 1. CEL can be evaluated. But pods will become Pending in some cases

Please note that this PR just fixes to allow list-type attributes to be evaluated in the scheduler's CEL environment. This means the allocator in the scheduler still could not support `matchAttribute` or `distinctAttribute` when the version skew scenario (scheduler is n-1 and apiserver is n), or flipping the feature gate scenario (the apiserver is enabled, and the scheduler is still disabled). This is because allocator initialization depends solely on the set of enabled feature gates:

https://github.com/kubernetes/kubernetes/tree/v1.36.1/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go#L74-L86

Thus, 
- Pods referencing `ResourceClaim`s with just list-types attributes (or/and `.includes` is used in device selector) would be able to schedule as expected (not facing CEL compilation/evaluation errors).
- But, pods referencing `ResourceClaim`s with `matchConstarint/distinctConstraint` with list-type attributes would still fail (allocator just returns `nil`(not an error), and the pod will remain `Pending`) because the iniaizlized allocator(incubating or stable) does not support list-type aware constraints. This would be resolved only after the scheduler's feature gate was enabled or the version skew was resolved.

##### 2. Introduced Versioned attributeType&deviceVar Type for better maintainability

From private communication with @pohly, this PR introduces _versioned_ `attributeType`, and so `deviceVar` type will be varied according to the emulated version and feature gate combinations in https://github.com/kubernetes/kubernetes/pull/139395/commits/3b2949f4fd9e501dff55f07e1e252c4029d27394.

This improves maintainability/safety for future feature additions.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
KEP-5491: the list-type attributes, `.includes` function, and macros can now be evaluated even when the `ListTypeAttributes` feature gate is disabled in the scheduler to avoid users from facing errors during rolling-upgrade or flipping the feature gate scenario.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/issues/5491
```
