### PR TITLE
preserve http2 TLSClientConfig allocation side effect for client-go c…

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
@@ -176,6 +176,13 @@ func pingTimeoutSeconds() int {
 }
 
 func configureHTTP2Transport(t *http.Transport) error {
+	// Some tests on client-go depend on a side effect of setting the TLSClientConfig,
+	// which is not longer present since version 1.27. To keep the existing behavior
+	// we set the TLSClientConfig if it is not set.
+	// Ref: https://github.com/golang/net/commit/c9307462b7e76d9c3203671fd993b10bc5dbcb3c
+	if t.TLSClientConfig == nil {
+		t.TLSClientConfig = &tls.Config{}
+	}
 	t2, err := http2.ConfigureTransports(t)
 	if err != nil {
 		return err


### PR DESCRIPTION
…ompatibility

Preserve the legacy side effect of `http2.ConfigureTransports` where an empty `tls.Config` was automatically allocated if the transport's `TLSClientConfig` was `nil`.  In environments/toolchains compiling with Go 1.27+ where standard library HTTP/2 is preferred and `ConfigureTransports` acts as a no-op this side effect is dropped.

As a result, `TLSClientConfig` remains `nil`, causing downstream assertions like `TestNew/non-nil_dial_holder+internal` in `k8s.io/client-go/transport` to fail.

To retain the expected behavior across all Go toolchains and environment configurations, this change explicitly instantiates `t.TLSClientConfig` to `&tls.Config{}` if it is `nil` right before setting up HTTP/2.

References: 
- https://github.com/golang/net/commit/c9307462b7e76d9c3203671fd993b10bc5dbcb3c
- https://github.com/golang/go/issues/67810


/kind bug
/kind failing-test
```release-note
NONE
```

/assign @liggitt @enj 