### PR TITLE
kubelet: skip containerfs.inodesFree thresholds when source inode signals are absent

### DIFF
--- a/pkg/kubelet/eviction/helpers.go
+++ b/pkg/kubelet/eviction/helpers.go
@@ -276,30 +276,34 @@ func UpdateContainerFsThresholds(thresholds []evictionapi.Threshold, imageFs, se
 				GracePeriod: softNodeFsDisk.GracePeriod,
 			})
 		}
-		if hardContainerFsINodes != -1 {
-			thresholds[hardContainerFsINodes] = evictionapi.Threshold{
-				Signal: evictionapi.SignalContainerFsInodesFree, Operator: hardNodeINodeDisk.Operator, Value: hardNodeINodeDisk.Value, MinReclaim: hardNodeINodeDisk.MinReclaim,
+		if hardNodeINodeDisk.Signal != "" {
+			if hardContainerFsINodes != -1 {
+				thresholds[hardContainerFsINodes] = evictionapi.Threshold{
+					Signal: evictionapi.SignalContainerFsInodesFree, Operator: hardNodeINodeDisk.Operator, Value: hardNodeINodeDisk.Value, MinReclaim: hardNodeINodeDisk.MinReclaim,
+				}
+			} else {
+				thresholds = append(thresholds, evictionapi.Threshold{
+					Signal:     evictionapi.SignalContainerFsInodesFree,
+					Operator:   hardNodeINodeDisk.Operator,
+					Value:      hardNodeINodeDisk.Value,
+					MinReclaim: hardNodeINodeDisk.MinReclaim,
+				})
 			}
-		} else {
-			thresholds = append(thresholds, evictionapi.Threshold{
-				Signal:     evictionapi.SignalContainerFsInodesFree,
-				Operator:   hardNodeINodeDisk.Operator,
-				Value:      hardNodeINodeDisk.Value,
-				MinReclaim: hardNodeINodeDisk.MinReclaim,
-			})
 		}
-		if softContainerFsINodes != -1 {
-			thresholds[softContainerFsINodes] = evictionapi.Threshold{
-				Signal: evictionapi.SignalContainerFsInodesFree, GracePeriod: softNodeINodeDisk.GracePeriod, Operator: softNodeINodeDisk.Operator, Value: softNodeINodeDisk.Value, MinReclaim: softNodeINodeDisk.MinReclaim,
+		if softNodeINodeDisk.Signal != "" {
+			if softContainerFsINodes != -1 {
+				thresholds[softContainerFsINodes] = evictionapi.Threshold{
+					Signal: evictionapi.SignalContainerFsInodesFree, GracePeriod: softNodeINodeDisk.GracePeriod, Operator: softNodeINodeDisk.Operator, Value: softNodeINodeDisk.Value, MinReclaim: softNodeINodeDisk.MinReclaim,
+				}
+			} else {
+				thresholds = append(thresholds, evictionapi.Threshold{
+					Signal:      evictionapi.SignalContainerFsInodesFree,
+					Operator:    softNodeINodeDisk.Operator,
+					Value:       softNodeINodeDisk.Value,
+					MinReclaim:  softNodeINodeDisk.MinReclaim,
+					GracePeriod: softNodeINodeDisk.GracePeriod,
+				})
 			}
-		} else {
-			thresholds = append(thresholds, evictionapi.Threshold{
-				Signal:      evictionapi.SignalContainerFsInodesFree,
-				Operator:    softNodeINodeDisk.Operator,
-				Value:       softNodeINodeDisk.Value,
-				MinReclaim:  softNodeINodeDisk.MinReclaim,
-				GracePeriod: softNodeINodeDisk.GracePeriod,
-			})
 		}
 	}
 	// Separate image filesystem case
@@ -329,30 +333,34 @@ func UpdateContainerFsThresholds(thresholds []evictionapi.Threshold, imageFs, se
 				GracePeriod: softImageFsDisk.GracePeriod,
 			})
 		}
-		if hardContainerFsINodes != -1 {
-			thresholds[hardContainerFsINodes] = evictionapi.Threshold{
-				Signal: evictionapi.SignalContainerFsInodesFree, GracePeriod: hardImageINodeDisk.GracePeriod, Operator: hardImageINodeDisk.Operator, Value: hardImageINodeDisk.Value, MinReclaim: hardImageINodeDisk.MinReclaim,
+		if hardImageINodeDisk.Signal != "" {
+			if hardContainerFsINodes != -1 {
+				thresholds[hardContainerFsINodes] = evictionapi.Threshold{
+					Signal: evictionapi.SignalContainerFsInodesFree, GracePeriod: hardImageINodeDisk.GracePeriod, Operator: hardImageINodeDisk.Operator, Value: hardImageINodeDisk.Value, MinReclaim: hardImageINodeDisk.MinReclaim,
+				}
+			} else {
+				thresholds = append(thresholds, evictionapi.Threshold{
+					Signal:     evictionapi.SignalContainerFsInodesFree,
+					Operator:   hardImageINodeDisk.Operator,
+					Value:      hardImageINodeDisk.Value,
+					MinReclaim: hardImageINodeDisk.MinReclaim,
+				})
 			}
-		} else {
-			thresholds = append(thresholds, evictionapi.Threshold{
-				Signal:     evictionapi.SignalContainerFsInodesFree,
-				Operator:   hardImageINodeDisk.Operator,
-				Value:      hardImageINodeDisk.Value,
-				MinReclaim: hardImageINodeDisk.MinReclaim,
-			})
 		}
-		if softContainerFsINodes != -1 {
-			thresholds[softContainerFsINodes] = evictionapi.Threshold{
-				Signal: evictionapi.SignalContainerFsInodesFree, GracePeriod: softImageINodeDisk.GracePeriod, Operator: softImageINodeDisk.Operator, Value: softImageINodeDisk.Value, MinReclaim: softImageINodeDisk.MinReclaim,
+		if softImageINodeDisk.Signal != "" {
+			if softContainerFsINodes != -1 {
+				thresholds[softContainerFsINodes] = evictionapi.Threshold{
+					Signal: evictionapi.SignalContainerFsInodesFree, GracePeriod: softImageINodeDisk.GracePeriod, Operator: softImageINodeDisk.Operator, Value: softImageINodeDisk.Value, MinReclaim: softImageINodeDisk.MinReclaim,
+				}
+			} else {
+				thresholds = append(thresholds, evictionapi.Threshold{
+					Signal:      evictionapi.SignalContainerFsInodesFree,
+					Operator:    softImageINodeDisk.Operator,
+					Value:       softImageINodeDisk.Value,
+					MinReclaim:  softImageINodeDisk.MinReclaim,
+					GracePeriod: softImageINodeDisk.GracePeriod,
+				})
 			}
-		} else {
-			thresholds = append(thresholds, evictionapi.Threshold{
-				Signal:      evictionapi.SignalContainerFsInodesFree,
-				Operator:    softImageINodeDisk.Operator,
-				Value:       softImageINodeDisk.Value,
-				MinReclaim:  softImageINodeDisk.MinReclaim,
-				GracePeriod: softImageINodeDisk.GracePeriod,
-			})
 		}
 	}
 	return thresholds, err

--- a/pkg/kubelet/eviction/helpers_test.go
+++ b/pkg/kubelet/eviction/helpers_test.go
@@ -3116,6 +3116,109 @@ func TestAddContainerFsThresholds(t *testing.T) {
 				},
 			},
 		},
+		{
+			description: "single filesystem with no inode thresholds (ZFS-like)",
+			imageFs:     false,
+			containerFs: false,
+			expectedContainerFsHard: evictionapi.Threshold{
+				Signal:   evictionapi.SignalContainerFsAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("100Mi"),
+				},
+				MinReclaim: &evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("1Gi"),
+				},
+			},
+			expectedContainerFsSoft: evictionapi.Threshold{
+				Signal:   evictionapi.SignalContainerFsAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("200Mi"),
+				},
+				GracePeriod: gracePeriod,
+				MinReclaim: &evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("1Gi"),
+				},
+			},
+			// Empty Signal means no containerfs.inodesFree thresholds expected.
+			expectedContainerFsINodesHard: evictionapi.Threshold{},
+			expectedContainerFsINodesSoft: evictionapi.Threshold{},
+			thresholdList: []evictionapi.Threshold{
+				{
+					Signal:   evictionapi.SignalNodeFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("100Mi"),
+					},
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("1Gi"),
+					},
+				},
+				{
+					Signal:   evictionapi.SignalNodeFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("200Mi"),
+					},
+					GracePeriod: gracePeriod,
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("1Gi"),
+					},
+				},
+			},
+		},
+		{
+			description: "separate image filesystem with no inode thresholds",
+			imageFs:     true,
+			containerFs: false,
+			expectedContainerFsHard: evictionapi.Threshold{
+				Signal:   evictionapi.SignalContainerFsAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("150Mi"),
+				},
+				MinReclaim: &evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("1.5Gi"),
+				},
+			},
+			expectedContainerFsSoft: evictionapi.Threshold{
+				Signal:   evictionapi.SignalContainerFsAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("300Mi"),
+				},
+				GracePeriod: gracePeriod,
+				MinReclaim: &evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("3Gi"),
+				},
+			},
+			expectedContainerFsINodesHard: evictionapi.Threshold{},
+			expectedContainerFsINodesSoft: evictionapi.Threshold{},
+			thresholdList: []evictionapi.Threshold{
+				{
+					Signal:   evictionapi.SignalImageFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("150Mi"),
+					},
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("1.5Gi"),
+					},
+				},
+				{
+					Signal:   evictionapi.SignalImageFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("300Mi"),
+					},
+					GracePeriod: gracePeriod,
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("3Gi"),
+					},
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -3160,11 +3263,19 @@ func TestAddContainerFsThresholds(t *testing.T) {
 			if softContainerFsMatch == -1 {
 				t.Fatalf("did not find soft containerfs.available")
 			}
-			if hardContainerFsINodesMatch == -1 {
+			// containerfs.inodesfree thresholds are only expected when the source
+			// inode signal (nodefs.inodesFree / imagefs.inodesFree) is present.
+			if testCase.expectedContainerFsINodesHard.Signal != "" && hardContainerFsINodesMatch == -1 {
 				t.Fatalf("did not find hard containerfs.inodesfree")
 			}
-			if softContainerFsINodesMatch == -1 {
+			if testCase.expectedContainerFsINodesHard.Signal == "" && hardContainerFsINodesMatch != -1 {
+				t.Fatalf("did not expect hard containerfs.inodesfree but found one")
+			}
+			if testCase.expectedContainerFsINodesSoft.Signal != "" && softContainerFsINodesMatch == -1 {
 				t.Fatalf("did not find soft containerfs.inodesfree")
+			}
+			if testCase.expectedContainerFsINodesSoft.Signal == "" && softContainerFsINodesMatch != -1 {
+				t.Fatalf("did not expect soft containerfs.inodesfree but found one")
 			}
 		})
 	}


### PR DESCRIPTION

ZFS doesn't do inodes the normal way — F_files and F_ffree come back as 0, so cAdvisor never reports inode stats and no observation gets made for containerfs.inodesFree. But the eviction manager kept asking for it every 10s, spamming "no observation found for eviction signal" forever. Turns out UpdateContainerFsThresholds was creating containerfs.inodesFree thresholds even when no source inode signal existed. Now it checks first ,, same pattern as the Windows fix in #137318, just ported to Linux/ZFS. Added 2 new test cases for the no-inode path. Fixes #139396. cc @kannon92.

```release-note
kubelet: stop logging spurious "no observation found for eviction signal" messages for containerfs.inodesFree on filesystems that don't report inode counts (e.g. ZFS).
```