### PR TITLE
kubectl: filter forbidden errors for category-expanded resources

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -87,8 +87,9 @@ type Builder struct {
 	limitChunks       int64
 	requestTransforms []RequestTransform
 
-	resources   []string
-	subresource string
+	resources                 []string
+	subresource               string
+	categoryExpandedResources sets.Set[schema.GroupResource]
 
 	namespace    string
 	allNamespace bool
@@ -104,8 +105,9 @@ type Builder struct {
 
 	requireObject bool
 
-	singleResourceType bool
-	continueOnError    bool
+	singleResourceType   bool
+	continueOnError      bool
+	categoryExpanderErrs []utilerrors.Matcher
 
 	singleItemImplied bool
 
@@ -645,6 +647,7 @@ func (b *Builder) ResourceTypeOrNameArgs(allowEmptySelector bool, args ...string
 // aliases found in it
 func (b *Builder) ReplaceAliases(input string) string {
 	replaced := []string{}
+	explicitlyRequestedResources := sets.New[schema.GroupResource]()
 	for _, arg := range strings.Split(input, ",") {
 		if b.categoryExpanderFn == nil {
 			continue
@@ -658,6 +661,10 @@ func (b *Builder) ReplaceAliases(input string) string {
 		if resources, ok := categoryExpander.Expand(arg); ok {
 			asStrings := []string{}
 			for _, resource := range resources {
+				if b.categoryExpandedResources == nil {
+					b.categoryExpandedResources = sets.New[schema.GroupResource]()
+				}
+				b.categoryExpandedResources.Insert(resource)
 				if len(resource.Group) == 0 {
 					asStrings = append(asStrings, resource.Resource)
 					continue
@@ -665,8 +672,14 @@ func (b *Builder) ReplaceAliases(input string) string {
 				asStrings = append(asStrings, resource.Resource+"."+resource.Group)
 			}
 			arg = strings.Join(asStrings, ",")
+		} else {
+			_, groupResource := schema.ParseResourceArg(arg)
+			explicitlyRequestedResources.Insert(groupResource)
 		}
 		replaced = append(replaced, arg)
+	}
+	if b.categoryExpandedResources != nil {
+		b.categoryExpandedResources.Delete(explicitlyRequestedResources.UnsortedList()...)
 	}
 	return strings.Join(replaced, ",")
 }
@@ -756,6 +769,14 @@ func (b *Builder) RequireObject(require bool) *Builder {
 // the first error is returned from a VisitorFunc.
 func (b *Builder) ContinueOnError() *Builder {
 	b.continueOnError = true
+	return b
+}
+
+// IgnoreErrorsForCategoryExpansion filters errors for resources reached through category expansion.
+func (b *Builder) IgnoreErrorsForCategoryExpansion(fns ...ErrMatchFunc) *Builder {
+	for _, fn := range fns {
+		b.categoryExpanderErrs = append(b.categoryExpanderErrs, utilerrors.Matcher(fn))
+	}
 	return b
 }
 
@@ -943,7 +964,14 @@ func (b *Builder) visitBySelector() *Result {
 		if mapping.Scope.Name() != meta.RESTScopeNameNamespace {
 			selectorNamespace = ""
 		}
-		visitors = append(visitors, NewSelector(client, mapping, selectorNamespace, labelSelector, fieldSelector, b.limitChunks))
+		visitor := Visitor(NewSelector(client, mapping, selectorNamespace, labelSelector, fieldSelector, b.limitChunks))
+		if b.categoryExpandedResources.Has(mapping.Resource.GroupResource()) && len(b.categoryExpanderErrs) > 0 {
+			visitor = categoryExpandedResourceErrorFilter{
+				Visitor:  visitor,
+				matchers: b.categoryExpanderErrs,
+			}
+		}
+		visitors = append(visitors, visitor)
 	}
 	if b.continueOnError {
 		result.visitor = EagerVisitorList(visitors)
@@ -974,6 +1002,15 @@ func (b *Builder) getClient(gv schema.GroupVersion) (RESTClient, error) {
 	}
 
 	return NewClientWithOptions(client, b.requestTransforms...), nil
+}
+
+type categoryExpandedResourceErrorFilter struct {
+	Visitor
+	matchers []utilerrors.Matcher
+}
+
+func (v categoryExpandedResourceErrorFilter) Visit(fn VisitorFunc) error {
+	return utilerrors.FilterOut(v.Visitor.Visit(fn), v.matchers...)
 }
 
 func (b *Builder) visitByResource() *Result {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -475,6 +475,7 @@ func (o *GetOptions) Run(f cmdutil.Factory, args []string) error {
 		RequestChunksOf(chunkSize).
 		ResourceTypeOrNameArgs(true, args...).
 		ContinueOnError().
+		IgnoreErrorsForCategoryExpansion(apierrors.IsForbidden).
 		Latest().
 		Flatten().
 		TransformRequests(o.transformRequests).

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
@@ -426,6 +426,110 @@ service/baz   <unknown>
 	}
 }
 
+func TestGetCategorySuppressesForbiddenFromDeniedExpandedResource(t *testing.T) {
+	pods, _, _ := cmdtesting.TestData()
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+	forbiddenBody := `{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"services is forbidden: User \"test\" cannot list resource \"services\" in API group \"\" in the namespace \"test\"","reason":"Forbidden","details":{"kind":"services"},"code":403}`
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case p == "/namespaces/test/pods" && m == "GET":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)}, nil
+			case p == "/namespaces/test/replicationcontrollers" && m == "GET":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &corev1.ReplicationControllerList{})}, nil
+			case p == "/namespaces/test/services" && m == "GET":
+				return &http.Response{StatusCode: http.StatusForbidden, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(strings.NewReader(forbiddenBody))}, nil
+			case p == "/namespaces/test/statefulsets" && m == "GET":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &appsv1.StatefulSetList{})}, nil
+			case p == "/namespaces/test/horizontalpodautoscalers" && m == "GET":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &autoscalingv1.HorizontalPodAutoscalerList{})}, nil
+			case p == "/namespaces/test/jobs" && m == "GET":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &batchv1.JobList{})}, nil
+			case p == "/namespaces/test/cronjobs" && m == "GET":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &batchv1beta1.CronJobList{})}, nil
+			case p == "/namespaces/test/daemonsets" && m == "GET":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &appsv1.DaemonSetList{})}, nil
+			case p == "/namespaces/test/deployments" && m == "GET":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &extensionsv1beta1.DeploymentList{})}, nil
+			case p == "/namespaces/test/replicasets" && m == "GET":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &extensionsv1beta1.ReplicaSetList{})}, nil
+			default:
+				t.Fatalf("request url: %#v,and request: %#v", req.URL, req)
+				return nil, nil
+			}
+		}),
+	}
+
+	var gotFatal string
+	cmdutil.BehaviorOnFatal(func(str string, code int) {
+		gotFatal = str
+	})
+	defer cmdutil.DefaultBehaviorOnFatal()
+
+	streams, _, buf, bufErr := genericiooptions.NewTestIOStreams()
+	cmd := NewCmdGet("kubectl", tf, streams)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.Run(cmd, []string{"all"})
+
+	if gotFatal != "" {
+		t.Fatalf("expected no error from category-expanded forbidden resource, got %q", gotFatal)
+	}
+	if !strings.Contains(buf.String(), "foo") {
+		t.Fatalf("expected allowed resource output, got %q", buf.String())
+	}
+	if e, a := "", bufErr.String(); e != a {
+		t.Errorf("expected\n%v\ngot\n%v", e, a)
+	}
+	if strings.Contains(strings.ToLower(buf.String()), "forbidden") || strings.Contains(strings.ToLower(bufErr.String()), "forbidden") {
+		t.Fatalf("expected forbidden error to be suppressed, got stdout %q stderr %q", buf.String(), bufErr.String())
+	}
+
+	gotFatal = ""
+	streams, _, buf, bufErr = genericiooptions.NewTestIOStreams()
+	cmd = NewCmdGet("kubectl", tf, streams)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.Run(cmd, []string{"services"})
+
+	if !strings.Contains(gotFatal, "services is forbidden") {
+		t.Fatalf("expected forbidden error from direct resource, got %q", gotFatal)
+	}
+
+	gotFatal = ""
+	streams, _, buf, bufErr = genericiooptions.NewTestIOStreams()
+	cmd = NewCmdGet("kubectl", tf, streams)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.Run(cmd, []string{"pods,services"})
+
+	if !strings.Contains(gotFatal, "services is forbidden") {
+		t.Fatalf("expected forbidden error from explicit resource, got %q", gotFatal)
+	}
+	if !strings.Contains(buf.String(), "foo") {
+		t.Fatalf("expected allowed resource output, got %q", buf.String())
+	}
+
+	gotFatal = ""
+	streams, _, buf, bufErr = genericiooptions.NewTestIOStreams()
+	cmd = NewCmdGet("kubectl", tf, streams)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.Run(cmd, []string{"all,services"})
+
+	if !strings.Contains(gotFatal, "services is forbidden") {
+		t.Fatalf("expected forbidden error from resource that was also explicitly requested, got %q", gotFatal)
+	}
+	if !strings.Contains(buf.String(), "foo") {
+		t.Fatalf("expected allowed resource output, got %q", buf.String())
+	}
+}
+
 func TestGetMultipleTableResourceTypesShowKinds(t *testing.T) {
 	pods, svcs, _ := cmdtesting.TestData()
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`kubectl get <category>` can expand to multiple resource types. If one expanded type is allowed and another returns `403 Forbidden`, kubectl currently surfaces the Forbidden error even though the user requested the category.

PR suppresses Forbidden errors only for resources reached solely through category expansion.

Direct and explicit requests still return Forbidden, including:

```bash
kubectl get services
kubectl get pods,services
kubectl get all,services
```

keeps the fix narrower than kubernetes/kubernetes#136968 and avoids adding a generic `--ignore-forbidden` flag.

#### Which issue(s) this PR fixes:

Fixes kubernetes/kubectl#1853

#### Notes for Reviewer:

The test covers category expansion, direct forbidden requests, explicit multi-resource requests, and the mixed `all,services` edge case.

#### Does this PR introduce a user-facing change?

```release-note
kubectl get <category> now suppresses Forbidden errors for resource types reached only through category expansion, while preserving Forbidden errors for explicitly requested resources.
```
