### PR TITLE
test/integration: fix flaky TestStorageVersionMigrationDuringChaos by extracting audit validation helper

### DIFF
--- a/test/integration/storageversionmigrator/storageversionmigrator_test.go
+++ b/test/integration/storageversionmigrator/storageversionmigrator_test.go
@@ -19,6 +19,7 @@ package storageversionmigrator
 import (
 	"bytes"
 	"context"
+	"net/http"
 	"strconv"
 	"sync"
 	"testing"
@@ -169,7 +170,8 @@ func TestStorageVersionMigrationWithCRD(t *testing.T) {
 
 	crVersions := make(map[string]versions)
 
-	svmTest := svmSetup(ctx, t)
+	// chaos goroutines delete objects mid-migration, producing expected 404s on patch
+	svmTest := svmSetup(ctx, t, http.StatusNotFound)
 	certCtx := svmTest.setupServerCert(t)
 
 	// simulate monkeys creating and deleting CRs
@@ -309,7 +311,8 @@ func TestStorageVersionMigrationDuringChaos(t *testing.T) {
 
 	ctx := ktesting.Init(t)
 
-	svmTest := svmSetup(ctx, t)
+	// chaos goroutines delete objects mid-migration, producing expected 404s on patch
+	svmTest := svmSetup(ctx, t, http.StatusNotFound)
 
 	svmTest.createChaos(ctx, t)
 

--- a/test/integration/storageversionmigrator/util.go
+++ b/test/integration/storageversionmigrator/util.go
@@ -257,7 +257,7 @@ type svmTest struct {
 	filePathForEncryptionConfig string
 }
 
-func svmSetup(ctx context.Context, t *testing.T) *svmTest {
+func svmSetup(ctx context.Context, t *testing.T, allowedCodes ...int32) *svmTest {
 	t.Helper()
 
 	filePathForEncryptionConfig, err := createEncryptionConfig(t, resources["initialEncryptionConfig"])
@@ -315,18 +315,7 @@ func svmSetup(ctx context.Context, t *testing.T) *svmTest {
 	}
 
 	t.Cleanup(func() {
-		var validCodes = sets.New[int32](http.StatusOK, http.StatusConflict) // make sure SVM controller never creates
-		_ = svmTest.countMatchingAuditEvents(t, func(event utils.AuditEvent) bool {
-			if event.User != "system:serviceaccount:kube-system:storage-version-migrator-controller" {
-				return false
-			}
-			if !validCodes.Has(event.Code) {
-				t.Errorf("svm controller had invalid response code for event: %#v", event)
-				return true
-			}
-			return false
-		})
-
+		svmTest.assertNoInvalidSVMControllerResponses(t, allowedCodes...)
 		kcm.TearDownFn()
 		server.TearDownFn()
 		utiltesting.CloseAndRemove(t, svmTest.logFile)
@@ -350,6 +339,26 @@ func createKubeConfigFileForRestConfig(t *testing.T, restConfig *rest.Config) st
 		t.Fatal(err)
 	}
 	return kubeConfigFile
+}
+
+// assertNoInvalidSVMControllerResponses checks that the SVM controller only received
+// expected HTTP response codes. Pass allowedCodes to permit codes beyond OK and Conflict.
+func (svm *svmTest) assertNoInvalidSVMControllerResponses(t *testing.T, allowedCodes ...int32) {
+	t.Helper()
+	validCodes := sets.New[int32](http.StatusOK, http.StatusConflict)
+	for _, code := range allowedCodes {
+		validCodes.Insert(code)
+	}
+	_ = svm.countMatchingAuditEvents(t, func(event utils.AuditEvent) bool {
+		if event.User != "system:serviceaccount:kube-system:storage-version-migrator-controller" {
+			return false
+		}
+		if !validCodes.Has(event.Code) {
+			t.Errorf("svm controller had invalid response code for event: %#v", event)
+			return true
+		}
+		return false
+	})
 }
 
 func createEncryptionConfig(t *testing.T, encryptionConfig string) (


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:

`TestStorageVersionMigrationDuringChaos` was flaking at ~75% failure rate under stress on both x86 and ppc64le. The root cause was that `svmSetup` registered a global audit invariant check that rejected any HTTP response code from the SVM controller other than 200 and 409. During chaos tests, the controller legitimately receives 404s when it tries to patch objects that were concurrently deleted by chaos goroutines — this is expected and correct behavior, not a controller bug.

The underlying design problem was that `svmSetup` was doing two unrelated
things: setting up infrastructure AND asserting audit invariants with
hardcoded valid codes, leaving no way for tests to customize what response
codes are acceptable for their scenario.

This PR:
- Removes the hardcoded audit check from `svmSetup`
- Introduces `assertNoInvalidSVMControllerResponses(t, allowedCodes ...int32)` so each test explicitly declares its own audit invariants
- Fixes `TestStorageVersionMigrationDuringChaos` by allowing 404 on patch
- Also fixes the same latent issue in `TestStorageVersionMigrationWithCRD` which also runs chaos goroutines but was never protected against this
- Keeps `TestStorageVersionMigration` under the strict check (no extra codes)

#### Which issue(s) this PR is related to:

Related to #139370

#### Special notes for your reviewer:

The audit check removal from `svmSetup` is intentional - the check is now explicitly registered by each test with the appropriate allowed codes for its scenario, making test invariants visible and customizable rather than hidden in shared setup.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```