### PR TITLE
volume/util: always call setPerms even when payload is unchanged

### DIFF
--- a/pkg/volume/util/atomic_writer.go
+++ b/pkg/volume/util/atomic_writer.go
@@ -88,7 +88,8 @@ const (
 // setPerms is an optional pointer to a function that caller can provide to set the
 // permissions of the newly created files before they are published. The function is
 // passed subPath which is the name of the timestamped directory that was created
-// under target directory.
+// under target directory, or an empty string if the payload was unchanged (no new
+// timestamped directory was created). Callers must handle both cases.
 //
 // The Write algorithm is:
 //
@@ -107,7 +108,11 @@ const (
 //
 //  6. The payload is written to the new timestamped directory.
 //
-//  7. Permissions are set (if setPerms is not nil) on the new timestamped directory and files.
+//  7. Permissions are set (if setPerms is not nil) on the new timestamped directory
+//     and files. If the payload was unchanged (no write was needed), setPerms is
+//     still called with an empty subPath to ensure permissions are correct after
+//     potential partial failures (e.g., a process crash between file write and the
+//     previous setPerms call).
 //
 //  8. A symlink to the new timestamped directory ..data_tmp is created that will
 //     become the new data directory.
@@ -240,6 +245,13 @@ func (w *AtomicWriter) Write(payload map[string]FileProjection, setPerms func(su
 				klog.Errorf("%s: error removing new ts directory %s: %v", w.logContext, tsDir, err)
 			}
 			klog.Errorf("%s: error renaming symbolic link for data directory %s: %v", w.logContext, newDataDirPath, err)
+			return err
+		}
+	} else if setPerms != nil {
+		// (7) Even when the payload is unchanged, setPerms must still be called to
+		// ensure file permissions are correct.
+		if err := setPerms(""); err != nil {
+			klog.Errorf("%s: error applying ownership settings: %v", w.logContext, err)
 			return err
 		}
 	}

--- a/pkg/volume/util/atomic_writer_test.go
+++ b/pkg/volume/util/atomic_writer_test.go
@@ -1018,6 +1018,19 @@ func TestSetPerms(t *testing.T) {
 		t.Fatalf("unexpected number of calls to setPerms: %v", setPermsCalled)
 	}
 
+	// Test that setPerms() is called even when the payload has not changed.
+	setPermsCalled = 0
+	err = writer.Write(payload1, func(_ string) error {
+		setPermsCalled++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error writing: %v", err)
+	}
+	if setPermsCalled != 1 {
+		t.Fatalf("expected setPerms to be called once for unchanged payload, got: %v", setPermsCalled)
+	}
+
 	// Test that errors from setPerms() are propagated.
 	payload2 := map[string]FileProjection{
 		"foo/bar.txt": {Mode: 0644, Data: []byte("foo2")},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`AtomicWriter.Write` skipped the `setPerms` callback when `shouldWrite` was false (payload content unchanged). If the kubelet crashed after writing files to the timestamp directory but before `setPerms` ran, the files were left with mode 0600. On the next kubelet start the token content was still identical, so `shouldWrite` remained false and `setPerms` was never called, leaving the token permanently unreadable by the pod process.

Always invoke `setPerms` regardless of `shouldWrite`. All callers discard the `subPath` argument, so passing an empty string when no new timestamp directory was created is safe.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A