### PR TITLE
reject quantity exponents that overflow the int32 scale

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -542,6 +542,12 @@ func TestQuantityParse(t *testing.T) {
 		"-3.01i",
 		"-3.01e-",
 
+		// exponents that do not fit in the int32 scale are rejected rather
+		// than silently truncated to an unrelated value
+		"1e2147483648",
+		"1e-2147483648",
+		"1e9223372036854775807",
+
 		// trailing whitespace is forbidden
 		" 1",
 		"1 ",

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/suffix.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/suffix.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resource
 
 import (
+	"math"
 	"strconv"
 )
 
@@ -189,6 +190,12 @@ func (sh *suffixHandler) interpret(suffix suffix) (base, exponent int32, fmt For
 	if len(suffix) > 1 && (suffix[0] == 'E' || suffix[0] == 'e') {
 		parsed, err := strconv.ParseInt(string(suffix[1:]), 10, 64)
 		if err != nil {
+			return 0, 0, DecimalExponent, false
+		}
+		// The exponent is held in an int32 scale that is negated when adapted to
+		// an inf.Scale, so reject anything that would not survive that round trip
+		// instead of silently truncating it to an unrelated value.
+		if parsed > math.MaxInt32 || parsed < -math.MaxInt32 {
 			return 0, 0, DecimalExponent, false
 		}
 		return 10, int32(parsed), DecimalExponent, true


### PR DESCRIPTION
interpret in suffix.go parses a quantity's decimal exponent at 64 bits but then narrows it with int32(parsed), so an exponent outside the int32 range is silently truncated to an unrelated value: 1e9223372036854775807 parses as 0.1 instead of being rejected. Exponents at the int32 boundary are worse, since the scale is negated when adapted to an inf.Scale and the overflow drives ParseQuantity into an unbounded big.Int computation. Reject out-of-range exponents in interpret rather than truncating them.

```release-note
Fixed quantity parsing to reject decimal exponents outside the int32 range instead of silently truncating them to an unrelated value.
```
