### PR TITLE
DRA e2e: fix apiServer runtime-config

### DIFF
--- a/test/e2e/dra/kind.yaml
+++ b/test/e2e/dra/kind.yaml
@@ -37,7 +37,8 @@ kubeadmConfigPatches:
             value: "controller=6" # resourceclaim/controller.go - should have renamed it when copying the controller it was based on!
     apiServer:
         extraArgs:
-          runtime-config: "resource.k8s.io/v1alpha3=true,resource.k8s.io/v1beta1=true,resource.k8s.io/v1beta2=true,scheduling.k8s.io/v1alpha3=true"
+          - name: "runtime-config"
+            value: "resource.k8s.io/v1alpha3=true,resource.k8s.io/v1beta1=true,resource.k8s.io/v1beta2=true,scheduling.k8s.io/v1alpha3=true"
   - |
     kind: InitConfiguration
     apiVersion: kubeadm.k8s.io/v1beta4


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

The kubeadm v1beta4 ClusterConfiguration changed ExtraArgs from map[string]string to []Arg (list of {name, value} pairs). The scheduler and controllerManager sections already used the new list format, but apiServer.extraArgs still used the old map format, causing the --runtime-config flag to be silently dropped when kind uses v1beta4.

Without runtime-config, resource.k8s.io/v1beta1, v1beta2 and v1alpha3 default to disabled, so the API server skips them with "has no resources" and tests using those API versions get 404.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/139405

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
