### PR TITLE
DRA: Fix shared in-flight allocation accounting in error paths

### DIFF
--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -1330,7 +1330,7 @@ func (pl *DynamicResources) Unreserve(ctx context.Context, cs fwk.CycleState, po
 // If anything fails, we return an error and
 // the pod will have to go into the backoff queue. The scheduler will call
 // Unreserve as part of the error handling.
-func (pl *DynamicResources) PreBind(ctx context.Context, cs fwk.CycleState, pod *v1.Pod, nodeName string) *fwk.Status {
+func (pl *DynamicResources) PreBind(ctx context.Context, cs fwk.CycleState, pod *v1.Pod, nodeName string) (retStatus *fwk.Status) {
 	if !pl.enabled {
 		return nil
 	}
@@ -1351,10 +1351,15 @@ func (pl *DynamicResources) PreBind(ctx context.Context, cs fwk.CycleState, pod 
 
 	for index, claim := range state.claims.all() {
 		if !resourceclaim.IsReservedForPod(pod, claim, pl.fts.EnableDRAWorkloadResourceClaims) {
-			claim, err := pl.bindClaim(ctx, state, podGroupState, index, pod, nodeName)
+			claim, successCleanup, err := pl.bindClaim(ctx, state, podGroupState, index, pod, nodeName)
 			if err != nil {
 				return statusError(logger, err)
 			}
+			defer func() {
+				if retStatus.IsSuccess() && successCleanup != nil {
+					successCleanup()
+				}
+			}()
 			// Updated here such that Unreserve can work with patched claim.
 			state.claims.set(index, claim)
 		}
@@ -1467,7 +1472,9 @@ func (pl *DynamicResources) PreBindPreFlight(ctx context.Context, cs fwk.CycleSt
 // bindClaim gets called by PreBind for claim which is not reserved for the pod yet.
 // It might not even be allocated. bindClaim then ensures that the allocation
 // and reservation are recorded. This finishes the work started in Reserve.
-func (pl *DynamicResources) bindClaim(ctx context.Context, state *stateData, podGroupState *podGroupStateData, index int, pod *v1.Pod, nodeName string) (*resourceapi.ResourceClaim, error) {
+// Returns the updated claim, a function which (if not nil) should run when the
+// pod has been successfully bound, and an error if one occurred.
+func (pl *DynamicResources) bindClaim(ctx context.Context, state *stateData, podGroupState *podGroupStateData, index int, pod *v1.Pod, nodeName string) (*resourceapi.ResourceClaim, func(), error) {
 	logger := klog.FromContext(ctx)
 	claim := state.claims.get(index)
 	binding := state.claims.getBinding(index, pod)
@@ -1476,15 +1483,15 @@ func (pl *DynamicResources) bindClaim(ctx context.Context, state *stateData, pod
 	if claim == state.claims.extendedResourceClaim() {
 		// extended resource requests satisfied by device plugin
 		if allocation == nil && claim.Spec.Devices.Requests == nil {
-			return claim, nil
+			return claim, nil, nil
 		}
 		isExtendedResourceClaim = true
 	}
 	claimUIDs := []types.UID{claim.UID}
 	resourceClaimModified := false
+	var resourceVersion string
 	defer func() {
 		// Creating the claim may have failed.
-		resourceVersion := ""
 		claimUID := types.UID("")
 		if claim != nil {
 			resourceVersion = claim.ResourceVersion
@@ -1493,12 +1500,6 @@ func (pl *DynamicResources) bindClaim(ctx context.Context, state *stateData, pod
 
 		// The scheduler was handling allocation. Now that has
 		// completed, either successfully or with a failure.
-
-		// The claim should remain in-flight in case any more Pods in the
-		// PodGroup are still using the pending allocation. If binding failed
-		// (e.g. due to a conflict in writing the allocation), then we signal
-		// that this Pod no longer needs the pending allocation without removing it.
-		forceRemovePendingAllocation := false
 
 		if resourceClaimModified {
 			if isExtendedResourceClaim {
@@ -1510,18 +1511,18 @@ func (pl *DynamicResources) bindClaim(ctx context.Context, state *stateData, pod
 					logger.V(5).Info("Claim not stored in assume cache", "err", err, "claim", klog.KObj(claim), "uid", claimUID, "resourceVersion", resourceVersion)
 				} else {
 					logger.V(5).Info("Claim stored in assume cache", "claim", klog.KObj(claim), "uid", claimUID, "resourceVersion", resourceVersion)
-
-					// Once the pending allocation is recorded in the
-					// AssumeCache, we no longer need to keep it in-flight.
-					// Even if it happens to still be shared, the allocation in
-					// the AssumeCache is authoritative.
-					forceRemovePendingAllocation = true
 				}
 			}
 		}
+	}()
+
+	// This logic is deferred to the end of [DynamicResources.PreBind] and runs
+	// only when that will return a successful status. It removes any
+	// allocations from in-flight which were bound successfully.
+	prebindSuccessCleanup := func() {
 		if allocation != nil {
 			for _, claimUID := range claimUIDs {
-				if deleted := pl.draManager.ResourceClaims().MaybeRemoveClaimPendingAllocation(claimUID, forceRemovePendingAllocation); deleted {
+				if deleted := pl.draManager.ResourceClaims().MaybeRemoveClaimPendingAllocation(claimUID, true); deleted {
 					// If we are currently asynchronously Binding Pods in a
 					// PodGroup, then the pendingAllocations set does not need
 					// to be updated. New PodGroup scheduling cycles will start
@@ -1536,21 +1537,21 @@ func (pl *DynamicResources) bindClaim(ctx context.Context, state *stateData, pod
 				}
 			}
 		}
-	}()
+	}
 
 	// Create the special claim for extended resource backed by DRA
 	if isExtendedResourceClaim && isSpecialClaimName(claim.Name) {
 		var err error
 		claim, err = pl.createExtendedResourceClaimInAPI(ctx, pod, nodeName, state)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		resourceClaimModified = true
 		// Track the actual extended ResourceClaim from now.
 		// Relevant if we need to delete again in Unreserve.
 		if err := state.claims.updateExtendedResourceClaim(claim); err != nil {
-			return nil, fmt.Errorf("internal error: update extended ResourceClaim: %w", err)
+			return nil, nil, fmt.Errorf("internal error: update extended ResourceClaim: %w", err)
 		}
 	}
 
@@ -1626,7 +1627,7 @@ func (pl *DynamicResources) bindClaim(ctx context.Context, state *stateData, pod
 	})
 
 	if retryErr != nil {
-		return nil, retryErr
+		return nil, nil, retryErr
 	}
 
 	logger.V(5).Info("reserved", "pod", klog.KObj(pod), "node", nodeName, "resourceclaim", klog.Format(claim))
@@ -1636,11 +1637,11 @@ func (pl *DynamicResources) bindClaim(ctx context.Context, state *stateData, pod
 	if isExtendedResourceClaim {
 		err := pl.patchPodExtendedResourceClaimStatus(ctx, pod, claim, nodeName, state)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
-	return claim, nil
+	return claim, prebindSuccessCleanup, nil
 }
 
 // isClaimReadyForBinding checks whether a given resource claim is

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -1965,6 +1965,31 @@ func testPlugin(tCtx ktesting.TContext) {
 				},
 			},
 		},
+		"bind-failure-preserves-inflight-until-unreserve": {
+			pod:     podWithClaimName,
+			claims:  []*resourceapi.ResourceClaim{pendingClaim},
+			classes: []*resourceapi.DeviceClass{deviceClass},
+			objs:    []apiruntime.Object{workerNodeSlice},
+			want: want{
+				reserve: result{
+					inFlightClaims: []metav1.Object{allocatedClaim},
+				},
+				prebind: result{
+					inFlightClaims: []metav1.Object{addAllocationTimestamp(allocatedClaim)},
+					status:         fwk.NewStatus(fwk.Unschedulable, `claim bind error`),
+				},
+				unreserveAfterBindFailure: &result{},
+			},
+			reactors: []cgotesting.Reactor{
+				&cgotesting.SimpleReactor{
+					Verb:     "update",
+					Resource: "resourceclaims",
+					Reaction: func(action cgotesting.Action) (handled bool, ret apiruntime.Object, err error) {
+						return true, nil, apierrors.NewBadRequest("claim bind error")
+					},
+				},
+			},
+		},
 		"bind-podgroup-failure": {
 			enableDRAWorkloadResourceClaims: true,
 			pod:                             groupedPodWithClaimName,
@@ -2386,9 +2411,10 @@ func testPlugin(tCtx ktesting.TContext) {
 					inFlightClaims: []metav1.Object{extendedResourceClaimNoName},
 				},
 				prebind: result{
-					assumedClaim: addAllocationTimestamp(reserve(extendedResourceClaim, podWithExtendedResourceName)),
-					added:        []metav1.Object{addAllocationTimestamp(reserve(extendedResourceClaim, podWithExtendedResourceName))},
-					status:       fwk.NewStatus(fwk.Unschedulable, `patch error`),
+					inFlightClaims: []metav1.Object{addAllocationTimestamp(extendedResourceClaimNoName)},
+					assumedClaim:   addAllocationTimestamp(reserve(extendedResourceClaim, podWithExtendedResourceName)),
+					added:          []metav1.Object{addAllocationTimestamp(reserve(extendedResourceClaim, podWithExtendedResourceName))},
+					status:         fwk.NewStatus(fwk.Unschedulable, `patch error`),
 				},
 				postbind: result{
 					assumedClaim: reserve(extendedResourceClaim, podWithExtendedResourceName),
@@ -2494,7 +2520,8 @@ func testPlugin(tCtx ktesting.TContext) {
 					inFlightClaims: []metav1.Object{extendedResourceClaimNoName},
 				},
 				prebind: result{
-					status: fwk.NewStatus(fwk.Unschedulable, `claim creation errors`),
+					inFlightClaims: []metav1.Object{extendedResourceClaimNoName},
+					status:         fwk.NewStatus(fwk.Unschedulable, `claim creation errors`),
 				},
 				unreserveAfterBindFailure: &result{
 					removed: []metav1.Object{reserve(extendedResourceClaim, podWithExtendedResourceName)},
@@ -2700,7 +2727,8 @@ func testPlugin(tCtx ktesting.TContext) {
 					}()},
 				},
 				prebind: result{
-					assumedClaim: reserve(bindClaim, podWithClaimName),
+					inFlightClaims: []metav1.Object{bindClaim},
+					assumedClaim:   reserve(bindClaim, podWithClaimName),
 					changes: change{
 						claim: func(in *resourceapi.ResourceClaim) *resourceapi.ResourceClaim {
 							return reserve(bindClaim, podWithClaimName)
@@ -2731,7 +2759,8 @@ func testPlugin(tCtx ktesting.TContext) {
 					}()},
 				},
 				prebind: result{
-					assumedClaim: reserve(bindClaim, podWithClaimName),
+					inFlightClaims: []metav1.Object{bindClaim},
+					assumedClaim:   reserve(bindClaim, podWithClaimName),
 					changes: change{
 						claim: func(in *resourceapi.ResourceClaim) *resourceapi.ResourceClaim {
 							return reserve(bindClaim, podWithClaimName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When scheduling PodGroups, the DRA scheduler plugin tracks pending allocations shared between Pods in a PodGroup with reference counting. The Reserve phase increments the count, but both the PreBind and Unreserve phases were decrementing the count when PreBind failed. This PR removes the decrement from PreBind after it fails, relying on the existing decrement in Unreserve. More details in the commit message.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
#139417

#### Special notes for your reviewer:

This same commit was first added to #138775 as https://github.com/kubernetes/kubernetes/commit/c590f28730d367f1b3bc8a0e146be1ac012bd37a since it surfaced while running those new `scheduler_perf` tests. The same issue is present in existing integration tests as described by #139417, so giving this its own PR.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug when the GenericWorkload feature gate is enabled that could prevent Pods in the same PodGroup sharing the same ResourceClaim from successfully scheduling.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @pohly @dom4ha
/wg workload-aware-scheduling