### PR TITLE
Fix CBOR apply patch request audit

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -18,6 +18,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -130,7 +131,17 @@ func PatchResource(r rest.Patcher, scope *RequestScope, admit admission.Interfac
 
 		admit = admission.WithAudit(admit)
 
-		audit.LogRequestPatch(req.Context(), patchBytes)
+		// Decode and convert the patch payload to JSON for storage into audit.
+		// the decision to reject the request for failure to decode before we record the request for audit.
+		//
+		// This guarantees that the audit event contains valid JSON, or the request is rejected.
+		patchForAudit, err := validateAndTranscodePatch(patchBytes, patchType)
+		if err != nil {
+			scope.err(err, w, req)
+			return
+		}
+
+		audit.LogRequestPatch(req.Context(), patchForAudit)
 		span.AddEvent("Recorded the audit event")
 
 		var baseContentType string
@@ -416,7 +427,7 @@ func (p *jsonPatcher) applyJSPatch(versionedJS []byte) (patchedJS []byte, strict
 		return patchedJS, strictErrors, nil
 	case types.MergePatchType:
 		if p.validationDirective == metav1.FieldValidationStrict || p.validationDirective == metav1.FieldValidationWarn {
-			v := map[string]interface{}{}
+			v := map[string]any{}
 			var err error
 			strictErrors, err = kjson.UnmarshalStrict(p.patchBytes, &v)
 			if err != nil {
@@ -493,8 +504,8 @@ type applyPatcher struct {
 	fieldManager        *managedfields.FieldManager
 	userAgent           string
 	validationDirective string
-	unmarshalFn         func(data []byte, v interface{}) error
-	unmarshalStrictFn   func(data []byte, v interface{}) error
+	unmarshalFn         func(data []byte, v any) error
+	unmarshalStrictFn   func(data []byte, v any) error
 }
 
 func (p *applyPatcher) applyPatchToCurrentObject(requestContext context.Context, obj runtime.Object) (runtime.Object, error) {
@@ -506,9 +517,9 @@ func (p *applyPatcher) applyPatchToCurrentObject(requestContext context.Context,
 		panic("FieldManager must be installed to run apply")
 	}
 
-	patchObj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	patchObj := &unstructured.Unstructured{Object: map[string]any{}}
 	if err := p.unmarshalFn(p.patch, &patchObj.Object); err != nil {
-		return nil, errors.NewBadRequest(fmt.Sprintf("error decoding YAML: %v", err))
+		return nil, errors.NewBadRequest(fmt.Sprintf("error decoding patch: %v", err))
 	}
 
 	obj, err := p.fieldManager.Apply(obj, patchObj, p.options.FieldManager, force)
@@ -519,9 +530,9 @@ func (p *applyPatcher) applyPatchToCurrentObject(requestContext context.Context,
 	// TODO: spawn something to track deciding whether a fieldValidation=Strict
 	// fatal error should return before an error from the apply operation
 	if p.validationDirective == metav1.FieldValidationStrict || p.validationDirective == metav1.FieldValidationWarn {
-		if err := p.unmarshalStrictFn(p.patch, &map[string]interface{}{}); err != nil {
+		if err := p.unmarshalStrictFn(p.patch, &map[string]any{}); err != nil {
 			if p.validationDirective == metav1.FieldValidationStrict {
-				return nil, errors.NewBadRequest(fmt.Sprintf("error strict decoding YAML: %v", err))
+				return nil, errors.NewBadRequest(fmt.Sprintf("error strict decoding patch: %v", err))
 			}
 			addStrictDecodingWarnings(requestContext, []error{err})
 		}
@@ -832,4 +843,30 @@ func patchToCreateOptions(po *metav1.PatchOptions) *metav1.CreateOptions {
 	}
 	co.TypeMeta.SetGroupVersionKind(metav1.SchemeGroupVersion.WithKind("CreateOptions"))
 	return co
+}
+
+func validateAndTranscodePatch(patchBytes []byte, patchType types.PatchType) ([]byte, error) {
+	switch patchType {
+	case types.ApplyCBORPatchType:
+		var obj any
+		if err := cbor.Unmarshal(patchBytes, &obj); err != nil {
+			return nil, errors.NewBadRequest(fmt.Sprintf("error decoding patch: %v", err))
+		}
+		jsonBytes, err := json.Marshal(obj)
+		if err != nil {
+			return nil, errors.NewBadRequest(fmt.Sprintf("error encoding patch: %v", err))
+		}
+		return jsonBytes, nil
+	case types.ApplyYAMLPatchType:
+		jsonBytes, err := yaml.ToJSON(patchBytes)
+		if err != nil {
+			return nil, errors.NewBadRequest(fmt.Sprintf("error encoding patch: %v", err))
+		}
+		return jsonBytes, nil
+	default:
+		if !json.Valid(patchBytes) {
+			return nil, errors.NewBadRequest("invalid JSON patch")
+		}
+		return patchBytes, nil
+	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	cbor "k8s.io/apimachinery/pkg/runtime/serializer/cbor/direct"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestValidateAndTranscodePatch(t *testing.T) {
+	tests := []struct {
+		name      string
+		patchType types.PatchType
+		patch     []byte
+		expected  []byte
+		expectErr bool
+	}{
+		{
+			name:      "JSONPatchType valid",
+			patchType: types.JSONPatchType,
+			patch:     []byte(`[{"op": "add", "path": "/a", "value": 1}]`),
+			expected:  []byte(`[{"op": "add", "path": "/a", "value": 1}]`),
+			expectErr: false,
+		},
+		{
+			name:      "JSONPatchType invalid",
+			patchType: types.JSONPatchType,
+			patch:     []byte(`[{"op": "add", "path": "/a", "value": 1`),
+			expected:  nil,
+			expectErr: true,
+		},
+		{
+			name:      "MergePatchType valid",
+			patchType: types.MergePatchType,
+			patch:     []byte(`{"a": 1}`),
+			expected:  []byte(`{"a": 1}`),
+			expectErr: false,
+		},
+		{
+			name:      "MergePatchType invalid",
+			patchType: types.MergePatchType,
+			patch:     []byte(`{"a": 1`),
+			expected:  nil,
+			expectErr: true,
+		},
+		{
+			name:      "StrategicMergePatchType valid",
+			patchType: types.StrategicMergePatchType,
+			patch:     []byte(`{"a": 1}`),
+			expected:  []byte(`{"a": 1}`),
+			expectErr: false,
+		},
+		{
+			name:      "StrategicMergePatchType invalid",
+			patchType: types.StrategicMergePatchType,
+			patch:     []byte(`{"a": 1`),
+			expected:  nil,
+			expectErr: true,
+		},
+		{
+			name:      "ApplyCBORPatchType valid",
+			patchType: types.ApplyCBORPatchType,
+			patch: func() []byte {
+				data := map[string]any{"a": 1}
+				b, _ := cbor.Marshal(data)
+				return b
+			}(),
+			expected:  []byte(`{"a":1}`),
+			expectErr: false,
+		},
+		{
+			name:      "ApplyCBORPatchType invalid",
+			patchType: types.ApplyCBORPatchType,
+			patch:     []byte{0xff, 0xff},
+			expected:  nil,
+			expectErr: true,
+		},
+		{
+			name:      "ApplyYAMLPatchType valid",
+			patchType: types.ApplyYAMLPatchType,
+			patch:     []byte("a: 1"),
+			expected:  []byte(`{"a":1}`),
+			expectErr: false,
+		},
+		{
+			name:      "ApplyYAMLPatchType invalid",
+			patchType: types.ApplyYAMLPatchType,
+			patch:     []byte(":\n  invalid"),
+			expected:  nil,
+			expectErr: true,
+		},
+		{
+			name:      "Empty patch bytes",
+			patchType: types.ApplyCBORPatchType,
+			patch:     []byte{},
+			expected:  nil,
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := validateAndTranscodePatch(tc.patch, tc.patchType)
+			if (err != nil) != tc.expectErr {
+				t.Fatalf("expected error: %v, got: %v", tc.expectErr, err)
+			}
+			if tc.expectErr {
+				return
+			}
+
+			// Normalize JSON to compare
+			if tc.patchType == types.ApplyCBORPatchType || tc.patchType == types.ApplyYAMLPatchType {
+				var gotMap, expectedMap any
+				if err := json.Unmarshal(got, &gotMap); err != nil {
+					t.Fatalf("failed to unmarshal got as JSON: %v. raw got: %s", err, string(got))
+				}
+				if err := json.Unmarshal(tc.expected, &expectedMap); err != nil {
+					t.Fatalf("failed to unmarshal expected as JSON: %v", err)
+				}
+				gotNorm, _ := json.Marshal(gotMap)
+				expectedNorm, _ := json.Marshal(expectedMap)
+				if !bytes.Equal(gotNorm, expectedNorm) {
+					t.Errorf("expected transcoded JSON:\n%s\ngot:\n%s", string(expectedNorm), string(gotNorm))
+				}
+			} else if !bytes.Equal(got, tc.expected) {
+				t.Errorf("expected unchanged bytes:\n%s\ngot:\n%s", string(tc.expected), string(got))
+			}
+		})
+	}
+}

--- a/test/integration/apiserver/field_validation_test.go
+++ b/test/integration/apiserver/field_validation_test.go
@@ -1368,7 +1368,7 @@ func testFieldValidationApplyCreate(t *testing.T, client clientset.Interface) {
 				FieldValidation: "Strict",
 				FieldManager:    "mgr",
 			},
-			strictDecodingError: `error strict decoding YAML: error converting YAML to JSON: yaml: unmarshal errors:
+			strictDecodingError: `error strict decoding patch: error converting YAML to JSON: yaml: unmarshal errors:
   line 10: key "paused" already set in map
   line 27: key "imagePullPolicy" already set in map`,
 		},
@@ -1448,7 +1448,7 @@ func testFieldValidationApplyUpdate(t *testing.T, client clientset.Interface) {
 				FieldValidation: "Strict",
 				FieldManager:    "mgr",
 			},
-			strictDecodingError: `error strict decoding YAML: error converting YAML to JSON: yaml: unmarshal errors:
+			strictDecodingError: `error strict decoding patch: error converting YAML to JSON: yaml: unmarshal errors:
   line 10: key "paused" already set in map
   line 27: key "imagePullPolicy" already set in map`,
 		},
@@ -2573,7 +2573,7 @@ func testFieldValidationApplyCreateCRD(t *testing.T, rest rest.Interface, gvk sc
 				FieldValidation: "Strict",
 				FieldManager:    "mgr",
 			},
-			strictDecodingError: `error strict decoding YAML: error converting YAML to JSON: yaml: unmarshal errors:
+			strictDecodingError: `error strict decoding patch: error converting YAML to JSON: yaml: unmarshal errors:
   line 10: key "knownField1" already set in map
   line 16: key "hostPort" already set in map`,
 		},
@@ -2659,7 +2659,7 @@ func testFieldValidationApplyCreateCRDSchemaless(t *testing.T, rest rest.Interfa
 				FieldValidation: "Strict",
 				FieldManager:    "mgr",
 			},
-			strictDecodingError: `error strict decoding YAML: error converting YAML to JSON: yaml: unmarshal errors:
+			strictDecodingError: `error strict decoding patch: error converting YAML to JSON: yaml: unmarshal errors:
   line 10: key "knownField1" already set in map
   line 16: key "hostPort" already set in map`,
 		},
@@ -2744,7 +2744,7 @@ func testFieldValidationApplyUpdateCRD(t *testing.T, rest rest.Interface, gvk sc
 				FieldValidation: "Strict",
 				FieldManager:    "mgr",
 			},
-			strictDecodingError: `error strict decoding YAML: error converting YAML to JSON: yaml: unmarshal errors:
+			strictDecodingError: `error strict decoding patch: error converting YAML to JSON: yaml: unmarshal errors:
   line 10: key "knownField1" already set in map
   line 16: key "hostPort" already set in map`,
 		},
@@ -2839,7 +2839,7 @@ func testFieldValidationApplyUpdateCRDSchemaless(t *testing.T, rest rest.Interfa
 				FieldValidation: "Strict",
 				FieldManager:    "mgr",
 			},
-			strictDecodingError: `error strict decoding YAML: error converting YAML to JSON: yaml: unmarshal errors:
+			strictDecodingError: `error strict decoding patch: error converting YAML to JSON: yaml: unmarshal errors:
   line 10: key "knownField1" already set in map
   line 16: key "hostPort" already set in map`,
 		},

--- a/test/integration/controlplane/audit/audit_test.go
+++ b/test/integration/controlplane/audit/audit_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package audit
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -32,6 +33,7 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -40,11 +42,20 @@ import (
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/mutating"
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
+	apiserveraudit "k8s.io/apiserver/pkg/audit"
 	clientset "k8s.io/client-go/kubernetes"
 	utiltesting "k8s.io/client-go/util/testing"
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/test/integration/framework"
 	"k8s.io/kubernetes/test/utils"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	cbor "k8s.io/apimachinery/pkg/runtime/serializer/cbor/direct"
+	"k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	clientfeatures "k8s.io/client-go/features"
+	clientfeaturestesting "k8s.io/client-go/features/testing"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 
 	jsonpatch "gopkg.in/evanphx/json-patch.v4"
 )
@@ -509,7 +520,7 @@ func getExpectedEvents(level auditinternal.Level, enableMutatingWebhook bool, na
 		requestObject = true
 	}
 	if level.GreaterOrEqual(auditinternal.LevelRequestResponse) {
-		// expect response obect in audit log
+		// expect response object in audit log
 		responseObject = true
 	}
 	return []utils.AuditEvent{
@@ -740,4 +751,282 @@ func createDeployment(t *testing.T, cs clientset.Interface, namespace string) *a
 	_, err := cs.AppsV1().Deployments(deploy.Namespace).Create(context.TODO(), deploy, metav1.CreateOptions{})
 	expectNoError(t, err, fmt.Sprintf("failed to create deployment %v", deploy))
 	return deploy
+}
+
+func TestAuditCBORPatch(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CBORServingAndStorage, true)
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.ClientsAllowCBOR, true)
+
+	version := "audit.k8s.io/v1"
+	namespace := "audit-cbor-patch"
+
+	auditPolicy := fmt.Sprintf(`
+apiVersion: %s
+kind: Policy
+rules:
+  - level: RequestResponse
+    namespaces: ["%s"]
+    resources:
+      - group: "" # core
+        resources: ["configmaps"]
+`, version, namespace)
+
+	policyFile, err := os.CreateTemp("", "audit-policy.yaml")
+	if err != nil {
+		t.Fatalf("Failed to create audit policy file: %v", err)
+	}
+	defer os.Remove(policyFile.Name()) //nolint:errcheck
+	if _, err := policyFile.Write([]byte(auditPolicy)); err != nil {
+		t.Fatalf("Failed to write audit policy file: %v", err)
+	}
+	policyFile.Close() //nolint:errcheck
+
+	logFile, err := os.CreateTemp("", "audit.log")
+	if err != nil {
+		t.Fatalf("Failed to create audit log file: %v", err)
+	}
+	defer utiltesting.CloseAndRemove(t, logFile)
+
+	result := kubeapiservertesting.StartTestServerOrDie(t, nil,
+		[]string{
+			"--audit-policy-file", policyFile.Name(),
+			"--audit-log-version", version,
+			"--audit-log-mode", "blocking",
+			"--audit-log-path", logFile.Name(),
+			"--feature-gates=CBORServingAndStorage=true",
+		},
+		framework.SharedEtcd(),
+	)
+	var tornDown bool
+	tearDown := func() {
+		if !tornDown {
+			result.TearDownFn()
+			tornDown = true
+		}
+	}
+	defer tearDown()
+
+	kubeclient := clientset.NewForConfigOrDie(result.ClientConfig)
+
+	_, err = kubeclient.CoreV1().Namespaces().Create(context.TODO(), &apiv1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: namespace},
+	}, metav1.CreateOptions{})
+	expectNoError(t, err, "failed to create namespace")
+
+	configMap := &apiv1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "audit-configmap",
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"map-key": "map-value",
+		},
+	}
+	_, err = kubeclient.CoreV1().ConfigMaps(namespace).Create(context.TODO(), configMap, metav1.CreateOptions{})
+	expectNoError(t, err, "failed to create audit-configmap")
+
+	patchMap := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]any{
+			"name":      "audit-configmap",
+			"namespace": namespace,
+		},
+		"data": map[string]any{
+			"map-key": "cbor-value",
+		},
+	}
+	cborBytes, err := cbor.Marshal(patchMap)
+	expectNoError(t, err, "failed to marshal CBOR patch")
+
+	_, err = kubeclient.CoreV1().RESTClient().Patch(types.ApplyCBORPatchType).
+		Namespace(namespace).
+		Resource("configmaps").
+		Name(configMap.Name).
+		Param("fieldManager", "audit_cbor_test").
+		Param("force", "true").
+		Body(cborBytes).
+		Do(context.TODO()).
+		Get()
+	expectNoError(t, err, "failed to patch configmap with CBOR")
+
+	yamlPatch := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: audit-configmap
+  namespace: ` + namespace + `
+data:
+  map-key: yaml-value
+`
+	_, err = kubeclient.CoreV1().RESTClient().Patch(types.ApplyYAMLPatchType).
+		Namespace(namespace).
+		Resource("configmaps").
+		Name(configMap.Name).
+		Param("fieldManager", "audit_yaml_test").
+		Param("force", "true").
+		Body([]byte(yamlPatch)).
+		Do(context.TODO()).
+		Get()
+	expectNoError(t, err, "failed to patch configmap with YAML")
+
+	// Send a malformed CBOR patch and expect early rejection with BadRequest
+	_, err = kubeclient.CoreV1().RESTClient().Patch(types.ApplyCBORPatchType).
+		Namespace(namespace).
+		Resource("configmaps").
+		Name(configMap.Name).
+		Param("fieldManager", "audit_cbor_malformed_test").
+		Param("force", "true").
+		Body([]byte{0xff, 0xff}).
+		Do(context.TODO()).
+		Get()
+	if err == nil {
+		t.Error("expected malformed CBOR patch to be rejected, but it succeeded")
+	} else if !apierrors.IsBadRequest(err) {
+		t.Errorf("expected BadRequest error for malformed CBOR patch, got: %v", err)
+	}
+
+	// Send a malformed YAML patch and expect early rejection with BadRequest
+	_, err = kubeclient.CoreV1().RESTClient().Patch(types.ApplyYAMLPatchType).
+		Namespace(namespace).
+		Resource("configmaps").
+		Name(configMap.Name).
+		Param("fieldManager", "audit_yaml_malformed_test").
+		Param("force", "true").
+		Body([]byte(":\n  invalid")).
+		Do(context.TODO()).
+		Get()
+	if err == nil {
+		t.Error("expected malformed YAML patch to be rejected, but it succeeded")
+	} else if !apierrors.IsBadRequest(err) {
+		t.Errorf("expected BadRequest error for malformed YAML patch, got: %v", err)
+	}
+
+	// Send a malformed JSON patch and expect early rejection with BadRequest
+	_, err = kubeclient.CoreV1().RESTClient().Patch(types.JSONPatchType).
+		Namespace(namespace).
+		Resource("configmaps").
+		Name(configMap.Name).
+		Param("fieldManager", "audit_jsonpatch_malformed_test").
+		Body([]byte(`[{"op": "add", "path": "/a", "value": 1`)).
+		Do(context.TODO()).
+		Get()
+	if err == nil {
+		t.Error("expected malformed JSON patch to be rejected, but it succeeded")
+	} else if !apierrors.IsBadRequest(err) {
+		t.Errorf("expected BadRequest error for malformed JSON patch, got: %v", err)
+	}
+
+	// Send a malformed Merge patch and expect early rejection with BadRequest
+	_, err = kubeclient.CoreV1().RESTClient().Patch(types.MergePatchType).
+		Namespace(namespace).
+		Resource("configmaps").
+		Name(configMap.Name).
+		Param("fieldManager", "audit_mergepatch_malformed_test").
+		Body([]byte(`{"a": 1`)).
+		Do(context.TODO()).
+		Get()
+	if err == nil {
+		t.Error("expected malformed Merge patch to be rejected, but it succeeded")
+	} else if !apierrors.IsBadRequest(err) {
+		t.Errorf("expected BadRequest error for malformed Merge patch, got: %v", err)
+	}
+
+	// Send a malformed Strategic Merge patch and expect early rejection with BadRequest
+	_, err = kubeclient.CoreV1().RESTClient().Patch(types.StrategicMergePatchType).
+		Namespace(namespace).
+		Resource("configmaps").
+		Name(configMap.Name).
+		Param("fieldManager", "audit_strategicmergepatch_malformed_test").
+		Body([]byte(`{"a": 1`)).
+		Do(context.TODO()).
+		Get()
+	if err == nil {
+		t.Error("expected malformed Strategic Merge patch to be rejected, but it succeeded")
+	} else if !apierrors.IsBadRequest(err) {
+		t.Errorf("expected BadRequest error for malformed Strategic Merge patch, got: %v", err)
+	}
+
+	// Stop the apiserver to flush audit logs
+	tearDown()
+
+	f, err := os.Open(logFile.Name())
+	expectNoError(t, err, "failed to open audit log file")
+	defer f.Close() //nolint:errcheck
+
+	var decodedEvents []auditinternal.Event
+	scanner := bufio.NewScanner(f)
+	gv := schema.GroupVersion{Group: auditinternal.GroupName, Version: "v1"}
+	decoder := apiserveraudit.Codecs.UniversalDecoder(gv)
+	for scanner.Scan() {
+		line := scanner.Text()
+		e := &auditinternal.Event{}
+		if err := runtime.DecodeInto(decoder, []byte(line), e); err != nil {
+			t.Fatalf("failed decoding buf: %s, err: %v", line, err)
+		}
+		decodedEvents = append(decodedEvents, *e)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("error reading log file: %v", err)
+	}
+
+	t.Logf("Total decoded events: %d", len(decodedEvents))
+	for _, ev := range decodedEvents {
+		t.Logf("Decoded Event: Verb=%q, Stage=%q, RequestURI=%q", ev.Verb, ev.Stage, ev.RequestURI)
+	}
+
+	var cborEvent, yamlEvent *auditinternal.Event
+	for i := range decodedEvents {
+		ev := &decodedEvents[i]
+		if ev.Verb == "patch" && ev.Stage == auditinternal.StageResponseComplete {
+			if strings.Contains(ev.RequestURI, "fieldManager=audit_cbor_test") {
+				cborEvent = ev
+			} else if strings.Contains(ev.RequestURI, "fieldManager=audit_yaml_test") {
+				yamlEvent = ev
+			}
+		}
+	}
+
+	if cborEvent == nil {
+		t.Fatal("CBOR patch audit event not found")
+	}
+	if yamlEvent == nil {
+		t.Fatal("YAML patch audit event not found")
+	}
+
+	if cborEvent.RequestObject == nil {
+		t.Error("CBOR patch event missing RequestObject")
+	} else {
+		unk := cborEvent.RequestObject
+		if unk.ContentType != "application/json" {
+			t.Errorf("Expected ContentType to be application/json, got %q", unk.ContentType)
+		}
+		var parsed map[string]any
+		if err := json.Unmarshal(unk.Raw, &parsed); err != nil {
+			t.Errorf("Failed to unmarshal RequestObject.Raw as JSON: %v. Raw: %s", err, string(unk.Raw))
+		} else {
+			data, _ := parsed["data"].(map[string]any)
+			if val, _ := data["map-key"].(string); val != "cbor-value" {
+				t.Errorf("Expected map-key to be %q, got %q", "cbor-value", val)
+			}
+		}
+	}
+
+	if yamlEvent.RequestObject == nil {
+		t.Error("YAML patch event missing RequestObject")
+	} else {
+		unk := yamlEvent.RequestObject
+		if unk.ContentType != "application/json" {
+			t.Errorf("Expected ContentType to be application/json, got %q", unk.ContentType)
+		}
+		var parsed map[string]any
+		if err := json.Unmarshal(unk.Raw, &parsed); err != nil {
+			t.Errorf("Failed to unmarshal RequestObject.Raw as JSON: %v. Raw: %s", err, string(unk.Raw))
+		} else {
+			data, _ := parsed["data"].(map[string]any)
+			if val, _ := data["map-key"].(string); val != "yaml-value" {
+				t.Errorf("Expected map-key to be %q, got %q", "yaml-value", val)
+			}
+		}
+	}
 }


### PR DESCRIPTION
Audit log CBOR apply patch with the appropriate content type 

Without this, serialization of the audit events fails due to binary data being present in the event.RequestObject.

Also, fix a couple of error messages.

/kind bug
/kind regression

```release-note
Fix audit request logging of malformed patch request bodies
```