### PR TITLE
perf: add starvation performance tests

### DIFF
--- a/test/integration/scheduler_perf/starvation/performance-config.yaml
+++ b/test/integration/scheduler_perf/starvation/performance-config.yaml
@@ -1,0 +1,128 @@
+- name: StarvationIndependent
+  metricsCollectorConfig:
+    metrics:
+      scheduler_queue_incoming_pods_total:
+      - label: event
+        values: [ScheduleAttemptFailure, AssignedPodAdd, BackoffComplete, UnscheduledPodAdd, ForceActivate]
+      - label: queue
+        values: [active, backoff, unschedulable]
+      scheduler_scheduling_attempt_duration_seconds:
+      - label: result
+        values: [scheduled, unschedulable, error]
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $initNodes
+    nodeTemplatePath: templates/node.yaml
+  - opcode: createNamespaces
+    prefix: starvation
+    count: 1
+  # Start churn generator to continuously generate PodAdd/PodDelete events
+  - opcode: churn
+    mode: recreate
+    number: 600
+    intervalMilliseconds: 1000
+    namespace: starvation-0
+    templatePaths:
+    - templates/churn-pod.yaml
+  # Inject massive batch of independent, high-priority, unschedulable pods
+  - opcode: createPods
+    countParam: $cloggerPods
+    podTemplatePath: templates/clogger-pod.yaml
+    namespace: starvation-0
+    skipWaitToCompletion: true
+  # Wait until all unschedulable cloggers are attempted by the scheduler
+  - opcode: barrier
+    stageRequirement: Attempted
+  # Start metrics collection specifically for the victim pods
+  - opcode: startCollectingMetrics
+    name: victim
+    namespaces: [starvation-0]
+  # Create victim pods and wait for them to schedule
+  - opcode: createPods
+    countParam: $starvationProne
+    podTemplatePath: templates/victim-pod.yaml
+    namespace: starvation-0
+  - opcode: stopCollectingMetrics
+  workloads:
+  - name: 10Nodes_100Cloggers
+    labels: [integration-test, short]
+    params:
+      initNodes: 10
+      cloggerPods: 100
+      starvationProne: 50
+  - name: 10000Nodes_10000Cloggers
+    labels: [performance]
+    params:
+      initNodes: 10000
+      cloggerPods: 10000
+      starvationProne: 500
+- name: StarvationPodGroup
+  featureGates:
+    GenericWorkload: true
+  metricsCollectorConfig:
+    metrics:
+      scheduler_queue_incoming_pods_total:
+      - label: event
+        values: [ScheduleAttemptFailure, AssignedPodAdd, BackoffComplete, UnscheduledPodAdd, ForceActivate]
+      - label: queue
+        values: [active, backoff, unschedulable]
+      scheduler_scheduling_attempt_duration_seconds:
+      - label: result
+        values: [scheduled, unschedulable, error]
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $initNodes
+    nodeTemplatePath: templates/node.yaml
+  - opcode: createNamespaces
+    prefix: starvation
+    count: 1
+  # Create the single PodGroup podgroup-0 using Basic scheduling policy under the Workload API
+  # and wait for the scheduler's informer cache to reflect the newly created PodGroup object
+  - opcode: createPodGroups
+    namespace: starvation-0
+    templatePath: templates/podgroup.yaml
+    countParam: $initPodGroups
+    templateParams:
+      minCount: $cloggerPods
+  # Start churn generator to continuously generate PodAdd/PodDelete events
+  - opcode: churn
+    mode: recreate
+    number: 600
+    intervalMilliseconds: 1000
+    namespace: starvation-0
+    templatePaths:
+    - templates/churn-pod.yaml
+  # Inject massive batch of podgroup-managed, high-priority, unschedulable pods
+  - opcode: createPods
+    countParam: $cloggerPods
+    podTemplatePath: templates/clogger-podgroup-pod.yaml
+    namespace: starvation-0
+    skipWaitToCompletion: true
+  # Wait until all unschedulable cloggers are attempted by the scheduler
+  - opcode: barrier
+    stageRequirement: Attempted
+  # Start metrics collection specifically for the victim pods
+  - opcode: startCollectingMetrics
+    name: victim
+    namespaces: [starvation-0]
+  # Create victim pods and wait for them to schedule
+  - opcode: createPods
+    countParam: $starvationProne
+    podTemplatePath: templates/victim-pod.yaml
+    namespace: starvation-0
+  - opcode: stopCollectingMetrics
+  workloads:
+  - name: 10Nodes_100Cloggers_Podgroup
+    labels: [integration-test, short]
+    params:
+      initNodes: 10
+      initPodGroups: 1
+      cloggerPods: 100
+      starvationProne: 50
+  - name: 10000Nodes_10000Cloggers_Podgroup
+    labels: [performance]
+    params:
+      initNodes: 10000
+      initPodGroups: 1
+      cloggerPods: 10000
+      starvationProne: 500

--- a/test/integration/scheduler_perf/starvation/starvation_test.go
+++ b/test/integration/scheduler_perf/starvation/starvation_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package starvation
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	_ "k8s.io/component-base/logs/json/register"
+	perf "k8s.io/kubernetes/test/integration/scheduler_perf"
+)
+
+func TestMain(m *testing.M) {
+	if err := perf.InitTests(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	m.Run()
+}
+
+func TestSchedulerPerf(t *testing.T) {
+	perf.RunIntegrationPerfScheduling(t, "performance-config.yaml")
+}
+
+func BenchmarkPerfScheduling(b *testing.B) {
+	perf.RunBenchmarkPerfScheduling(b, "performance-config.yaml", "starvation", nil)
+}

--- a/test/integration/scheduler_perf/starvation/templates/churn-pod.yaml
+++ b/test/integration/scheduler_perf/starvation/templates/churn-pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: pod-churn-
+  labels:
+    service: target
+spec:
+  priority: 10000
+  containers:
+  - image: registry.k8s.io/pause:3.10.1
+    name: pause
+    resources:
+      requests:
+        cpu: 10m
+        memory: 10Mi

--- a/test/integration/scheduler_perf/starvation/templates/clogger-pod.yaml
+++ b/test/integration/scheduler_perf/starvation/templates/clogger-pod.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: pod-clogger-
+spec:
+  priority: 1000
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      # Term 1: Direct match on target label
+      - labelSelector:
+          matchExpressions:
+          - key: service
+            operator: In
+            values:
+            - target
+        namespaces: ["starvation-0", "default", "kube-system"]
+        topologyKey: kubernetes.io/hostname
+
+      # Term 2: Match on key existence (forces more selector processing)
+      - labelSelector:
+          matchExpressions:
+          - key: service
+            operator: Exists
+          - key: service
+            operator: NotIn
+            values:
+            - non-existent-value
+        namespaces: ["starvation-0", "default"]
+        topologyKey: kubernetes.io/hostname
+
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      # Term 1: Direct anti-affinity match
+      - labelSelector:
+          matchExpressions:
+          - key: service
+            operator: In
+            values:
+            - target
+        namespaces: ["starvation-0", "default", "kube-system"]
+        topologyKey: kubernetes.io/hostname
+  containers:
+  - image: registry.k8s.io/pause:3.10.1
+    name: pause

--- a/test/integration/scheduler_perf/starvation/templates/clogger-podgroup-pod.yaml
+++ b/test/integration/scheduler_perf/starvation/templates/clogger-podgroup-pod.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: pod-clogger-podgroup-
+spec:
+  priority: 1000
+  schedulingGroup:
+    podGroupName: podgroup-0
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      # Term 1: Direct match on target label
+      - labelSelector:
+          matchExpressions:
+          - key: service
+            operator: In
+            values:
+            - target
+        namespaces: ["starvation-0", "default", "kube-system"]
+        topologyKey: kubernetes.io/hostname
+
+      # Term 2: Match on key existence (forces more selector processing)
+      - labelSelector:
+          matchExpressions:
+          - key: service
+            operator: Exists
+          - key: service
+            operator: NotIn
+            values:
+            - non-existent-value
+        namespaces: ["starvation-0", "default"]
+        topologyKey: kubernetes.io/hostname
+
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      # Term 1: Direct anti-affinity match
+      - labelSelector:
+          matchExpressions:
+          - key: service
+            operator: In
+            values:
+            - target
+        namespaces: ["starvation-0", "default", "kube-system"]
+        topologyKey: kubernetes.io/hostname
+  containers:
+  - image: registry.k8s.io/pause:3.10.1
+    name: pause

--- a/test/integration/scheduler_perf/starvation/templates/node.yaml
+++ b/test/integration/scheduler_perf/starvation/templates/node.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Node
+metadata:
+  generateName: starvation-node-
+spec: {}
+status:
+  capacity:
+    pods: "110"
+    cpu: "4"
+    memory: 8Gi
+  conditions:
+    - status: "True"
+      type: Ready
+  phase: Running

--- a/test/integration/scheduler_perf/starvation/templates/podgroup.yaml
+++ b/test/integration/scheduler_perf/starvation/templates/podgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: scheduling.k8s.io/v1alpha3
+kind: PodGroup
+metadata:
+  name: podgroup-{{.Index}}
+spec:
+  schedulingPolicy:
+    gang:
+      minCount: {{.minCount}}

--- a/test/integration/scheduler_perf/starvation/templates/victim-pod.yaml
+++ b/test/integration/scheduler_perf/starvation/templates/victim-pod.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: pod-victim-
+spec:
+  priority: 0
+  containers:
+  - image: registry.k8s.io/pause:3.10.1
+    name: pause
+    resources:
+      requests:
+        cpu: 10m
+        memory: 10Mi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR introduces a new suite of scheduler integration performance and benchmark tests (`test/integration/scheduler_perf/starvation`) to measure scheduler latency, throughput, memory usage, and queue contention/scheduling attempt metrics under a massive priority starvation scenario.

The suite implements and compares two distinct architectural scheduling patterns at a scale of 10,000 nodes:
1. **Independent Pods**: 10,000 independent, high-priority, unschedulable pods are individually evaluated in the scheduling queue, causing heavy queue contention and starving the 500 low-priority "victim" pods.
2. **PodGroup Gang Scheduling**: Uses the Gang Scheduling plugin to schedule pods as a group. Rejects unfeasible workloads at the early `PreEnqueue` phase instead of executing full individual scheduling cycles.

These benchmarks validate the effectiveness of group-level admission/scheduling constraints under heavy cluster load. Initial test runs demonstrate that **PodGroup Gang Scheduling** reduces total scheduling duration by ~2.9x, net duration by ~23x, and reduces unschedulable scheduling latency by three orders of magnitude (~10ms down to ~6μs).

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:



#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
