### PR TITLE
etcd: update etcd image to v3.7.0-rc.0

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -64,7 +64,7 @@ dependencies:
 
   # etcd
   - name: "etcd"
-    version: 3.6.11
+    version: 3.7.0-rc.0
     refPaths:
     - path: cluster/gce/manifests/etcd.manifest
       match: etcd_docker_tag|etcd_version

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1914,7 +1914,7 @@ def resolve(host):
   fi
 
   if [[ -n "${ETCD_PROGRESS_NOTIFY_INTERVAL:-}" ]]; then
-    etcd_extra_args+=" --experimental-watch-progress-notify-interval=${ETCD_PROGRESS_NOTIFY_INTERVAL}"
+    etcd_extra_args+=" --watch-progress-notify-interval=${ETCD_PROGRESS_NOTIFY_INTERVAL}"
   fi
 
   for host in $(echo "${INITIAL_ETCD_CLUSTER:-${host_name}}" | tr "," "\n"); do

--- a/cluster/gce/manifests/etcd.manifest
+++ b/cluster/gce/manifests/etcd.manifest
@@ -18,7 +18,7 @@
     {
     "name": "etcd-container",
     {{security_context}}
-    "image": "{{ pillar.get('etcd_docker_repository', 'registry.k8s.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.6.11-0') }}",
+    "image": "{{ pillar.get('etcd_docker_repository', 'registry.k8s.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.7.0-rc.0-0') }}",
     "resources": {
       "requests": {
         "cpu": {{ cpulimit }}
@@ -43,7 +43,7 @@
         "value": "{{ pillar.get('storage_backend', 'etcd3') }}"
       },
       { "name": "TARGET_VERSION",
-        "value": "{{ pillar.get('etcd_version', '3.6.11') }}"
+        "value": "{{ pillar.get('etcd_version', '3.7.0-rc.0') }}"
       },
       {
         "name": "DO_NOT_MOVE_BINARIES",

--- a/cluster/gce/upgrade-aliases.sh
+++ b/cluster/gce/upgrade-aliases.sh
@@ -170,8 +170,8 @@ export KUBE_GCE_ENABLE_IP_ALIASES=true
 export SECONDARY_RANGE_NAME="pods-default"
 export STORAGE_BACKEND="etcd3"
 export STORAGE_MEDIA_TYPE="application/vnd.kubernetes.protobuf"
-export ETCD_IMAGE=3.6.11-0
-export ETCD_VERSION=3.6.11
+export ETCD_IMAGE=3.7.0-rc.0-0
+export ETCD_VERSION=3.7.0-rc.0
 
 # Upgrade master with updated kube envs
 "${KUBE_ROOT}/cluster/gce/upgrade.sh" -M -l

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -327,7 +327,7 @@ const (
 	MinExternalEtcdVersion = "3.5.24-0"
 
 	// DefaultEtcdVersion indicates the default etcd version that kubeadm uses
-	DefaultEtcdVersion = "3.6.11-0"
+	DefaultEtcdVersion = "3.7.0-rc.0-0"
 
 	// Etcd defines variable used internally when referring to etcd component
 	Etcd = "etcd"
@@ -509,9 +509,9 @@ var (
 	// an etcd version even if the map is not yet updated before a release. The user will
 	// get a warning in that case, so ideally the map should be updated for each release.
 	SupportedEtcdVersion = map[uint8]string{
-		34: "3.6.11-0",
-		35: "3.6.11-0",
-		36: "3.6.11-0",
+		34: "3.7.0-rc.0-0",
+		35: "3.7.0-rc.0-0",
+		36: "3.7.0-rc.0-0",
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows

--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -16,7 +16,7 @@
 
 # A set of helpers for starting/running etcd for tests
 
-ETCD_VERSION=${ETCD_VERSION:-3.6.11}
+ETCD_VERSION=${ETCD_VERSION:-3.7.0-rc.0}
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 ETCD_PORT=${ETCD_PORT:-2379}
 # This is intentionally not called ETCD_LOG_LEVEL:

--- a/staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
+++ b/staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
@@ -26,4 +26,4 @@ spec:
         imagePullPolicy: Never
         args: [ "--etcd-servers=http://localhost:2379" ]
       - name: etcd
-        image: registry.k8s.io/etcd:v3.6.11
+        image: registry.k8s.io/etcd:v3.7.0-rc.0

--- a/test/e2e/testing-manifests/statefulset/etcd/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/etcd/statefulset.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: etcd
-        image: registry.k8s.io/etcd:3.6.11-0
+        image: registry.k8s.io/etcd:3.7.0-rc.0-0
         imagePullPolicy: Always
         ports:
         - containerPort: 2380

--- a/test/integration/apimachinery/watchlist_test.go
+++ b/test/integration/apimachinery/watchlist_test.go
@@ -44,7 +44,7 @@ func TestReflectorWatchListFallback(t *testing.T) {
 	logger, ctx := ktesting.NewTestContext(t)
 
 	t.Log("Starting etcd that will be used by two different instances of kube-apiserver")
-	etcdURL, etcdTearDownFn, err := framework.RunCustomEtcd(logger, "etcd_watchlist", []string{"--experimental-watch-progress-notify-interval", "1s"})
+	etcdURL, etcdTearDownFn, err := framework.RunCustomEtcd(logger, "etcd_watchlist", []string{"--watch-progress-notify-interval", "1s"})
 	require.NoError(t, err)
 	defer etcdTearDownFn()
 	etcdOptions := framework.DefaultEtcdOptions()

--- a/test/integration/apiserver/watchcache_test.go
+++ b/test/integration/apiserver/watchcache_test.go
@@ -38,7 +38,7 @@ import (
 // setup create kube-apiserver backed up by two separate etcds,
 // with one of them containing events and the other all other objects.
 func multiEtcdSetup(ctx context.Context, t *testing.T) (clientset.Interface, framework.TearDownFunc) {
-	etcdArgs := []string{"--experimental-watch-progress-notify-interval", "1s"}
+	etcdArgs := []string{"--watch-progress-notify-interval", "1s"}
 	etcd0URL, stopEtcd0, err := framework.RunCustomEtcd(klog.FromContext(ctx).WithName("etcd0"), "etcd_watchcache0", etcdArgs)
 	if err != nil {
 		t.Fatalf("Couldn't start etcd: %v", err)

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -215,7 +215,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[AppArmorLoader] = Config{list.PromoterE2eRegistry, "apparmor-loader", "1.4"}
 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.37.0-1"}
 	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.9.1"}
-	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.6.11-0"}
+	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.7.0-rc.0-0"}
 	configs[InvalidRegistryImage] = Config{list.InvalidRegistry, "alpine", "3.1"}
 	configs[IpcUtils] = Config{list.PromoterE2eRegistry, "ipc-utils", "1.4"}
 	configs[GlibcDnsTesting] = Config{list.PromoterE2eRegistry, "glibc-dns-testing", "2.0.0"}


### PR DESCRIPTION
#### What type of PR is this?

/kind dependency

#### What this PR does / why we need it:

Update etcd image to v3.7.0-rc.0

#### Which issue(s) this PR is related to:

Consumes the image promoted in https://github.com/kubernetes/k8s.io/pull/9556

Following similar patterns as https://github.com/kubernetes/kubernetes/pull/102062

#### Does this PR introduce a user-facing change?

```release-note
Updated the default etcd version to 3.7.0-rc.0
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```