### PR TITLE
Don't emit Warning ClaimMisbound for volume populator prime PVCs

### DIFF
--- a/pkg/controller/volume/persistentvolume/binder_test.go
+++ b/pkg/controller/volume/persistentvolume/binder_test.go
@@ -496,6 +496,26 @@ func TestSync(t *testing.T) {
 			test:            testSyncClaim,
 		},
 		{
+			// syncClaim with a volume populator prime claim. The PV has been
+			// rebound from the prime claim to the original claim (which carries a
+			// dataSourceRef), so the prime claim is intentionally misbound. Check
+			// that it is still marked Lost but the event is downgraded to Normal.
+			name:            "3-7 - bound prime claim rebound by volume populator",
+			initialVolumes:  newVolumeArray("volume3-7", "10Gi", "uid3-7-orig", "claim3-7-orig", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
+			expectedVolumes: newVolumeArray("volume3-7", "10Gi", "uid3-7-orig", "claim3-7-orig", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classEmpty),
+			initialClaims: append(
+				newClaimArray("claim3-7", "uid3-7", "10Gi", "volume3-7", v1.ClaimPending, nil, volume.AnnBindCompleted),
+				claimWithDataSourceRef("hello", "Hello", "hello.example.com", newClaimArray("claim3-7-orig", "uid3-7-orig", "10Gi", "volume3-7", v1.ClaimPending, nil, volume.AnnBindCompleted))...,
+			),
+			expectedClaims: append(
+				newClaimArray("claim3-7", "uid3-7", "10Gi", "volume3-7", v1.ClaimLost, nil, volume.AnnBindCompleted),
+				claimWithDataSourceRef("hello", "Hello", "hello.example.com", newClaimArray("claim3-7-orig", "uid3-7-orig", "10Gi", "volume3-7", v1.ClaimPending, nil, volume.AnnBindCompleted))...,
+			),
+			expectedEvents: []string{"Normal ClaimLost"},
+			errors:         noerrors,
+			test:           testSyncClaim,
+		},
+		{
 			// syncClaim with claim bound to unbound volume. Check it's bound
 			// even if the claim's selector doesn't match the volume. Also
 			// check that Pending phase is set to Bound

--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -544,6 +544,15 @@ func claimWithDataSource(name, kind, apiGroup string, claims []*v1.PersistentVol
 	return claims
 }
 
+func claimWithDataSourceRef(name, kind, apiGroup string, claims []*v1.PersistentVolumeClaim) []*v1.PersistentVolumeClaim {
+	claims[0].Spec.DataSourceRef = &v1.TypedObjectReference{
+		Name:     name,
+		Kind:     kind,
+		APIGroup: &apiGroup,
+	}
+	return claims
+}
+
 func annotateClaim(claim *v1.PersistentVolumeClaim, ann map[string]string) *v1.PersistentVolumeClaim {
 	if claim.Annotations == nil {
 		claim.Annotations = map[string]string{}

--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -546,14 +546,65 @@ func (ctrl *PersistentVolumeController) syncBoundClaim(ctx context.Context, clai
 			return nil
 		} else {
 			// Claim is bound but volume has a different claimant.
+			// This is normally an error condition, but it also happens during the
+			// expected volume populator flow: a populator binds a PV to a temporary
+			// "prime" PVC, populates it, then rebinds the PV to the original PVC.
+			// After the rebind the prime PVC is still bound (spec.volumeName is
+			// immutable) but the PV now references the original claim. The Lost
+			// transition is still correct (lib-volume-populator polls for it), but
+			// the event should not be a Warning. Detect this by checking whether the
+			// PV's current claimant carries a dataSourceRef.
+			eventType := v1.EventTypeWarning
+			reason := "ClaimMisbound"
+			message := "Two claims are bound to the same volume, this one is bound incorrectly"
+			if ctrl.isVolumePopulatorRebind(volume) {
+				eventType = v1.EventTypeNormal
+				reason = "ClaimLost"
+				message = "Volume has been rebound to its target claim by a volume populator; this prime claim is no longer needed"
+			}
 			// Set the claim phase to 'Lost', which is a terminal
 			// phase.
-			if _, err = ctrl.updateClaimStatusWithEvent(ctx, claim, v1.ClaimLost, nil, v1.EventTypeWarning, "ClaimMisbound", "Two claims are bound to the same volume, this one is bound incorrectly"); err != nil {
+			if _, err = ctrl.updateClaimStatusWithEvent(ctx, claim, v1.ClaimLost, nil, eventType, reason, message); err != nil {
 				return err
 			}
 			return nil
 		}
 	}
+}
+
+// isVolumePopulatorRebind reports whether the given volume was rebound to its
+// target claim by a volume populator. Populators bind a PV to a temporary
+// "prime" PVC, populate it, then rebind the PV to the original PVC, which
+// carries a populator dataSourceRef. When that is the case, a prime PVC observing the
+// rebind is expected behavior rather than a misbinding error, so the PV
+// controller should not emit a Warning event for it. The lookup is
+// best-effort: if the target claim cannot be found it returns false and the
+// caller falls back to the default (Warning) behavior.
+func (ctrl *PersistentVolumeController) isVolumePopulatorRebind(volume *v1.PersistentVolume) bool {
+	if volume.Spec.ClaimRef == nil {
+		return false
+	}
+	claimName := claimrefToClaimKey(volume.Spec.ClaimRef)
+	obj, found, err := ctrl.claims.GetByKey(claimName)
+	if err != nil {
+		return false
+	}
+	if !found {
+		obj, err = ctrl.claimLister.PersistentVolumeClaims(volume.Spec.ClaimRef.Namespace).Get(volume.Spec.ClaimRef.Name)
+		if err != nil {
+			return false
+		}
+	}
+	targetClaim, ok := obj.(*v1.PersistentVolumeClaim)
+	if !ok {
+		return false
+	}
+	// Make sure the cached claim is the one the volume actually references,
+	// not a stale or recreated claim that happens to share the name.
+	if targetClaim.UID != volume.Spec.ClaimRef.UID {
+		return false
+	}
+	return storagehelpers.IsPopulatorDataSource(targetClaim)
 }
 
 // syncVolume is the main controller method to decide what to do with a volume.

--- a/staging/src/k8s.io/component-helpers/storage/volume/pv_helpers.go
+++ b/staging/src/k8s.io/component-helpers/storage/volume/pv_helpers.go
@@ -82,6 +82,25 @@ const (
 	PVDeletionInTreeProtectionFinalizer = "kubernetes.io/pv-controller"
 )
 
+// IsPopulatorDataSource returns true if the PVC's DataSourceRef references a
+// custom resource (non-empty API group), indicating that the PVC uses a volume
+// populator. PVCs cloning from another PVC (core group) or restoring from a
+// VolumeSnapshot are handled natively by the CSI provisioner and do not use
+// the volume populator mechanism.
+func IsPopulatorDataSource(claim *v1.PersistentVolumeClaim) bool {
+	ref := claim.Spec.DataSourceRef
+	if ref == nil {
+		return false
+	}
+	if ref.APIGroup == nil || *ref.APIGroup == "" {
+		return false
+	}
+	if *ref.APIGroup == "snapshot.storage.k8s.io" && ref.Kind == "VolumeSnapshot" {
+		return false
+	}
+	return true
+}
+
 // IsDelayBindingProvisioning checks if claim provisioning with selected-node annotation
 func IsDelayBindingProvisioning(claim *v1.PersistentVolumeClaim) bool {
 	// When feature VolumeScheduling enabled,

--- a/staging/src/k8s.io/component-helpers/storage/volume/pv_helpers_test.go
+++ b/staging/src/k8s.io/component-helpers/storage/volume/pv_helpers_test.go
@@ -406,3 +406,59 @@ func makeTestVolume(uid types.UID, name string, capacity string, available bool,
 	}
 	return &pv
 }
+
+func TestIsPopulatorDataSource(t *testing.T) {
+	cdiGroup := "cdi.kubevirt.io"
+	snapshotGroup := "snapshot.storage.k8s.io"
+	emptyGroup := ""
+
+	tests := []struct {
+		name     string
+		ref      *v1.TypedObjectReference
+		expected bool
+	}{
+		{
+			name:     "nil DataSourceRef",
+			ref:      nil,
+			expected: false,
+		},
+		{
+			name:     "nil APIGroup",
+			ref:      &v1.TypedObjectReference{Kind: "DataVolume", Name: "dv1"},
+			expected: false,
+		},
+		{
+			name:     "empty APIGroup",
+			ref:      &v1.TypedObjectReference{APIGroup: &emptyGroup, Kind: "PersistentVolumeClaim", Name: "pvc1"},
+			expected: false,
+		},
+		{
+			name:     "VolumeSnapshot",
+			ref:      &v1.TypedObjectReference{APIGroup: &snapshotGroup, Kind: "VolumeSnapshot", Name: "snap1"},
+			expected: false,
+		},
+		{
+			name:     "custom populator (CDI DataVolume)",
+			ref:      &v1.TypedObjectReference{APIGroup: &cdiGroup, Kind: "DataVolume", Name: "dv1"},
+			expected: true,
+		},
+		{
+			name:     "custom populator (other kind in snapshot group)",
+			ref:      &v1.TypedObjectReference{APIGroup: &snapshotGroup, Kind: "VolumeSnapshotContent", Name: "vsc1"},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			claim := &v1.PersistentVolumeClaim{
+				Spec: v1.PersistentVolumeClaimSpec{
+					DataSourceRef: tt.ref,
+				},
+			}
+			if got := IsPopulatorDataSource(claim); got != tt.expected {
+				t.Errorf("IsPopulatorDataSource() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
/kind bug
/sig storage

**PR does**

Volume populators built on lib-volume-populator create a temporary "prime" PVC, provision and populate a PV through it, then rebind the PV to the original PVC. After the rebind, the prime PVC hits the misbound branch in `syncBoundClaim` and receives a `Warning ClaimMisbound` event on every populator operation. This is a false positive ,,the rebind is the designed flow, not an error.

`spec.volumeName` is immutable once set, so the populator cannot clear it on the prime PVC before rebinding; the fix has to be on the PV controller side.

This PR detects the populator rebind by checking whether the PV's current claimant carries a `dataSourceRef`. When it does, the prime PVC still transitions to `Lost` (lib-volume-populator polls for this), but the event is downgraded from `Warning ClaimMisbound` to `Normal ClaimLost`. Genuine misbindings keep the `Warning`.

Fixes #139408

**Does this PR introduce a user-facing change?**

```release-note
The PV controller no longer emits a spurious `Warning ClaimMisbound` event on volume populator prime PVCs after the populator rebinds the volume to the target PVC. The prime PVC still transitions to `Lost`, but the event is now `Normal ClaimLost`.
```