### PR TITLE
skipping sync: item and owners exist in cache and not terminating

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -494,6 +494,57 @@ func ownerRefsToUIDs(refs []metav1.OwnerReference) []types.UID {
 	return ret
 }
 
+func (gc *GarbageCollector) shouldSyncItem(item *node) bool {
+	// should sync item as follows:
+	// 1. item no owners
+	// 2. item not found in informer
+	// 3. item record absentOwnerCache
+	// 4. item is beingDeleted or deletingDependents
+	if len(item.getOwners()) == 0 {
+		return true
+	}
+	if !item.isObserved() {
+		return true
+	}
+	if gc.absentOwnerCache.Has(item.identity) {
+		return true
+	}
+	if item.isBeingDeleted() || item.isDeletingDependents() {
+		return true
+	}
+
+	// should sync item when owners as follows:
+	// 1. owners not exist
+	// 2. owners not found in informer
+	// 3. owners record absentOwnerCache
+	// 4. two owner references coordinate fields not match
+	// 5. item and owners namespaces not match
+	// 6. owners is beingDeleted or deletingDependents
+	for _, owner := range item.getOwners() {
+		ownerNode, exist := gc.dependencyGraphBuilder.uidToNode.Read(owner.UID)
+		if !exist {
+			return true
+		}
+		if !ownerNode.isObserved() {
+			return true
+		}
+		if gc.absentOwnerCache.Has(ownerNode.identity) {
+			return true
+		}
+		if !ownerReferenceMatchesCoordinates(owner, ownerNode.identity.OwnerReference) {
+			return true
+		}
+		ownerIsNamespaced := len(ownerNode.identity.Namespace) > 0
+		if ownerIsNamespaced && ownerNode.identity.Namespace != item.identity.Namespace {
+			return true
+		}
+		if ownerNode.isBeingDeleted() || ownerNode.isDeletingDependents() {
+			return true
+		}
+	}
+	return false
+}
+
 // attemptToDeleteItem looks up the live API object associated with the node,
 // and issues a delete IFF the uid matches, the item is not blocked on deleting dependents,
 // and all owner references are dangling.
@@ -515,6 +566,12 @@ func (gc *GarbageCollector) attemptToDeleteItem(ctx context.Context, item *node)
 		)
 		return nil
 	}
+
+	// skipping sync: item and owners exist in cache and not terminating
+	if !gc.shouldSyncItem(item) {
+		return nil
+	}
+
 	// TODO: It's only necessary to talk to the API server if this is a
 	// "virtual" node. The local graph could lag behind the real status, but in
 	// practice, the difference is small.

--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -256,6 +256,199 @@ func serilizeOrDie(t *testing.T, object interface{}) []byte {
 	return data
 }
 
+func TestShouldSyncItem(t *testing.T) {
+	ownerRef := metav1.OwnerReference{
+		UID:        "owner-uid-1",
+		Name:       "owner1",
+		Kind:       "ReplicationController",
+		APIVersion: "v1",
+	}
+	clusterScopedOwnerRef := metav1.OwnerReference{
+		UID:        "node-uid-1",
+		Name:       "node1",
+		Kind:       "Node",
+		APIVersion: "v1",
+	}
+
+	itemIdentity := objectReference{
+		OwnerReference: metav1.OwnerReference{
+			UID:        "item-uid-1",
+			Name:       "pod1",
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		Namespace: "ns1",
+	}
+	namespacedOwnerIdentity := objectReference{
+		OwnerReference: ownerRef,
+		Namespace:      "ns1",
+	}
+	clusterScopedOwnerIdentity := objectReference{
+		OwnerReference: clusterScopedOwnerRef,
+		Namespace:      "",
+	}
+
+	makeItem := func(modifiers ...func(*node)) *node {
+		n := &node{
+			identity:   itemIdentity,
+			dependents: make(map[*node]struct{}),
+		}
+		n.setOwners([]metav1.OwnerReference{ownerRef})
+		n.markObserved()
+		for _, m := range modifiers {
+			m(n)
+		}
+		return n
+	}
+
+	makeGC := func(modifiers ...func(*GarbageCollector)) *GarbageCollector {
+		gc := &GarbageCollector{
+			absentOwnerCache:       NewReferenceCache(500),
+			dependencyGraphBuilder: &GraphBuilder{uidToNode: &concurrentUIDToNode{uidToNode: make(map[types.UID]*node)}},
+		}
+		for _, m := range modifiers {
+			m(gc)
+		}
+		return gc
+	}
+
+	addOwnerNode := func(gc *GarbageCollector, ownerIdentity objectReference) *node {
+		ownerNode := &node{
+			identity:   ownerIdentity,
+			dependents: make(map[*node]struct{}),
+		}
+		ownerNode.markObserved()
+		gc.dependencyGraphBuilder.uidToNode.Write(ownerNode)
+		return ownerNode
+	}
+
+	tests := []struct {
+		name     string
+		item     *node
+		gc       *GarbageCollector
+		wantSync bool
+	}{
+		{
+			name:     "stable item with observed namespaced owner should not sync",
+			item:     makeItem(),
+			gc:       makeGC(func(gc *GarbageCollector) { addOwnerNode(gc, namespacedOwnerIdentity) }),
+			wantSync: false,
+		},
+		{
+			name:     "item with no owners should sync",
+			item:     makeItem(func(n *node) { n.setOwners(nil) }),
+			gc:       makeGC(),
+			wantSync: true,
+		},
+		{
+			name:     "unobserved item should sync",
+			item:     makeItem(func(n *node) { n.virtual = true }),
+			gc:       makeGC(func(gc *GarbageCollector) { addOwnerNode(gc, namespacedOwnerIdentity) }),
+			wantSync: true,
+		},
+		{
+			name:     "item in absentOwnerCache should sync",
+			item:     makeItem(),
+			gc:       makeGC(func(gc *GarbageCollector) { gc.absentOwnerCache.Add(itemIdentity) }),
+			wantSync: true,
+		},
+		{
+			name:     "item being deleted should sync",
+			item:     makeItem(func(n *node) { n.markBeingDeleted() }),
+			gc:       makeGC(func(gc *GarbageCollector) { addOwnerNode(gc, namespacedOwnerIdentity) }),
+			wantSync: true,
+		},
+		{
+			name:     "item deleting dependents should sync",
+			item:     makeItem(func(n *node) { n.markDeletingDependents() }),
+			gc:       makeGC(func(gc *GarbageCollector) { addOwnerNode(gc, namespacedOwnerIdentity) }),
+			wantSync: true,
+		},
+		{
+			name:     "owner not in graph should sync",
+			item:     makeItem(),
+			gc:       makeGC(),
+			wantSync: true,
+		},
+		{
+			name: "unobserved owner should sync",
+			item: makeItem(),
+			gc: makeGC(func(gc *GarbageCollector) {
+				ownerNode := addOwnerNode(gc, namespacedOwnerIdentity)
+				ownerNode.virtual = true
+			}),
+			wantSync: true,
+		},
+		{
+			name: "owner in absentOwnerCache should sync",
+			item: makeItem(),
+			gc: makeGC(func(gc *GarbageCollector) {
+				addOwnerNode(gc, namespacedOwnerIdentity)
+				gc.absentOwnerCache.Add(namespacedOwnerIdentity)
+			}),
+			wantSync: true,
+		},
+		{
+			name: "owner coordinate mismatch should sync",
+			item: makeItem(func(n *node) {
+				n.setOwners([]metav1.OwnerReference{{
+					UID:        "owner-uid-1",
+					Name:       "owner1",
+					Kind:       "Deployment",
+					APIVersion: "apps/v1",
+				}})
+			}),
+			gc:       makeGC(func(gc *GarbageCollector) { addOwnerNode(gc, namespacedOwnerIdentity) }),
+			wantSync: true,
+		},
+		{
+			name: "namespaced owner with mismatched namespace should sync",
+			item: makeItem(),
+			gc: makeGC(func(gc *GarbageCollector) {
+				differentNSIdentity := objectReference{
+					OwnerReference: ownerRef,
+					Namespace:      "ns2",
+				}
+				addOwnerNode(gc, differentNSIdentity)
+			}),
+			wantSync: true,
+		},
+		{
+			name:     "cluster-scoped owner with namespaced item should not sync",
+			item:     makeItem(func(n *node) { n.setOwners([]metav1.OwnerReference{clusterScopedOwnerRef}) }),
+			gc:       makeGC(func(gc *GarbageCollector) { addOwnerNode(gc, clusterScopedOwnerIdentity) }),
+			wantSync: false,
+		},
+		{
+			name: "owner being deleted should sync",
+			item: makeItem(),
+			gc: makeGC(func(gc *GarbageCollector) {
+				ownerNode := addOwnerNode(gc, namespacedOwnerIdentity)
+				ownerNode.markBeingDeleted()
+			}),
+			wantSync: true,
+		},
+		{
+			name: "owner deleting dependents should sync",
+			item: makeItem(),
+			gc: makeGC(func(gc *GarbageCollector) {
+				ownerNode := addOwnerNode(gc, namespacedOwnerIdentity)
+				ownerNode.markDeletingDependents()
+			}),
+			wantSync: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.gc.shouldSyncItem(tt.item)
+			if got != tt.wantSync {
+				t.Errorf("shouldSyncItem() = %v, want %v", got, tt.wantSync)
+			}
+		})
+	}
+}
+
 func TestAttemptToDeleteItemDeleteObjectNotFound(t *testing.T) {
 	pod := getPod("ExternallyDeletedPod", []metav1.OwnerReference{
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Our cluster has many resources with dependency relationships. When the kube-controller-manager starts, the garbage collector begins to build the dependency graph. The size of the attemptToDelete queue will exceed 240k , and the default queries per second (QPS) is set at 100. As a result, the garbage collector will take 82 minutes to become ready. During this period, the cascading delete will be blocked.  

This change involves no logic modifications; it simply skips unnecessary syncs to reduce requests to the kube-apiserver. The core idea is to skip the sync if both the resource and its owners exist which uid is match and are not in the Terminating state.





#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/pull/126114

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
