### PR TITLE
Improve test coverage for feature gates testing

### DIFF
--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -910,6 +910,101 @@ func TestAddPod(t *testing.T) {
 	}
 }
 
+func TestAddPod_MoveUnschedulablePodsWithGenericWorkload(t *testing.T) {
+	unschedulablePods := []*v1.Pod{
+		st.MakePod().Name("unsched-pod-1").SchedulerName("supported-scheduler").Namespace("ns1").UID("unsched-pod-1").Obj(),
+		st.MakePod().Name("unsched-pod-2").SchedulerName("supported-scheduler").Namespace("ns1").UID("unsched-pod-2").Obj(),
+	}
+
+	tests := []struct {
+		name                         string
+		genericWorkloadEnabled       bool
+		expectInActiveOrBackOffQueue bool
+	}{
+		{
+			name:                         "do not move unschedulable pods to active/backoff queue when GangScheduling is disabled",
+			genericWorkloadEnabled:       false,
+			expectInActiveOrBackOffQueue: false,
+		},
+		{
+			name:                         "move unschedulable pods to active/backoff queue when GangScheduling is enabled",
+			genericWorkloadEnabled:       true,
+			expectInActiveOrBackOffQueue: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, tt.genericWorkloadEnabled)
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			queueingHintMap := internalqueue.QueueingHintMapPerProfile{
+				"supported-scheduler": {
+					framework.EventUnscheduledPodAdd: {
+						{
+							PluginName: "fooPlugin1",
+							QueueingHintFn: func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+								return fwk.Queue, nil
+							},
+						},
+					},
+				},
+			}
+
+			sched := &Scheduler{
+				Cache:           internalcache.New(ctx, nil, tt.genericWorkloadEnabled, false),
+				SchedulingQueue: internalqueue.NewTestQueue(ctx, newDefaultQueueSort(), internalqueue.WithQueueingHintMapPerProfile(queueingHintMap)),
+				logger:          logger,
+				Profiles: profile.Map{
+					"supported-scheduler": nil,
+				},
+			}
+
+			// Put test pod(s) into unschedulable queue.
+			for _, pod := range unschedulablePods {
+				sched.SchedulingQueue.Add(ctx, pod)
+				entity, err := sched.SchedulingQueue.Pop(logger)
+				if err != nil {
+					t.Fatalf("Pop failed: %v", err)
+				}
+				poppedPod := entity.(*framework.QueuedPodInfo)
+				poppedPod.UnschedulablePlugins = sets.New("fooPlugin1")
+				if err := sched.SchedulingQueue.AddUnschedulablePodIfNotPresent(logger, poppedPod, sched.SchedulingQueue.SchedulingCycle()); err != nil {
+					t.Fatalf("Unexpected error from AddUnschedulablePodIfNotPresent: %v", err)
+				}
+			}
+
+			// Add a new pod to trigger the event handler.
+			newPod := st.MakePod().Name("pod1").SchedulerName("supported-scheduler").Namespace("ns1").UID("pod1").Obj()
+			sched.addPod(newPod)
+
+			// Check if the unschedulable pod(s) were moved to active queue or backoff queue.
+			podsInActiveOrBackoff := append(sched.SchedulingQueue.PodsInActiveQ(), sched.SchedulingQueue.PodsInBackoffQ()...)
+			var movedPods []*v1.Pod
+			for _, p := range podsInActiveOrBackoff {
+				for _, expectedPod := range unschedulablePods {
+					if p.Name == expectedPod.Name {
+						movedPods = append(movedPods, p)
+						break
+					}
+				}
+			}
+
+			diff := cmp.Diff(movedPods, unschedulablePods)
+			if tt.expectInActiveOrBackOffQueue {
+				if diff != "" {
+					t.Errorf("Expected all unschedulable pods to be moved, got: \n%s", diff)
+				}
+			} else {
+				if diff == "" {
+					t.Errorf("Expected no unschedulable pods to be moved, got: \n%s", diff)
+				}
+			}
+		})
+	}
+}
+
 func TestUpdatePod(t *testing.T) {
 	pod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").SchedulerName("supported-scheduler").Obj()
 	updatedPod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Labels(map[string]string{"foo": "bar"}).ResourceVersion("2").SchedulerName("supported-scheduler").Obj()

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -910,6 +910,106 @@ func TestAddPod(t *testing.T) {
 	}
 }
 
+func TestAddPod_MoveUnschedulablePodsWithGenericWorkload(t *testing.T) {
+	pod := st.MakePod().Name("pod1").SchedulerName("supported-scheduler").Namespace("ns1").UID("pod1").Obj()
+	unschedulablePodInfos := []*framework.QueuedPodInfo{
+		{
+			PodInfo: &framework.PodInfo{
+				Pod: st.MakePod().Name("unsched-pod-1").SchedulerName("supported-scheduler").Namespace("ns1").UID("unsched-pod-1").Obj(),
+			},
+			QueueingParams: framework.QueueingParams{
+				UnschedulablePlugins: sets.New("fooPlugin1"),
+			},
+		},
+		{
+			PodInfo: &framework.PodInfo{
+				Pod: st.MakePod().Name("unsched-pod-2").SchedulerName("supported-scheduler").Namespace("ns1").UID("unsched-pod-2").Obj(),
+			},
+			QueueingParams: framework.QueueingParams{
+				UnschedulablePlugins: sets.New("otherPlugin"),
+			},
+		},
+	}
+
+	tests := []struct {
+		name                   string
+		genericWorkloadEnabled bool
+		expectInActiveQ        sets.Set[string]
+	}{
+		{
+			name:                   "do not move unschedulable pods when GenericWorkload is disabled",
+			genericWorkloadEnabled: false,
+			expectInActiveQ:        sets.New("pod1"),
+		},
+		{
+			name:                   "only move unschedulable pods waiting on the triggered plugin when GenericWorkload is enabled",
+			genericWorkloadEnabled: true,
+			expectInActiveQ:        sets.New("pod1", "unsched-pod-1"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, tt.genericWorkloadEnabled)
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			queueingHintMap := internalqueue.QueueingHintMapPerProfile{
+				"supported-scheduler": {
+					framework.EventUnscheduledPodAdd: {
+						{
+							PluginName: "fooPlugin1",
+							QueueingHintFn: func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+								return fwk.Queue, nil
+							},
+						},
+					},
+				},
+			}
+
+			sched := &Scheduler{
+				Cache: internalcache.New(ctx, nil, tt.genericWorkloadEnabled, false),
+				SchedulingQueue: internalqueue.NewTestQueue(
+					ctx,
+					newDefaultQueueSort(),
+					internalqueue.WithQueueingHintMapPerProfile(queueingHintMap),
+					internalqueue.WithPodInitialBackoffDuration(0),
+					internalqueue.WithPodMaxBackoffDuration(0),
+				),
+				logger: logger,
+				Profiles: profile.Map{
+					"supported-scheduler": nil,
+				},
+			}
+
+			// Put test pod(s) into unschedulable queue.
+			for _, pInfo := range unschedulablePodInfos {
+				sched.SchedulingQueue.Add(ctx, pInfo.Pod)
+				if _, err := sched.SchedulingQueue.Pop(logger); err != nil {
+					t.Fatalf("Pop failed: %v", err)
+				}
+				if err := sched.SchedulingQueue.AddUnschedulablePodIfNotPresent(logger, pInfo, sched.SchedulingQueue.SchedulingCycle()); err != nil {
+					t.Fatalf("Unexpected error from AddUnschedulablePodIfNotPresent: %v", err)
+				}
+			}
+
+			// Add a new pod to trigger the event handler.
+			sched.addPod(pod)
+
+			// Check if unschedulable pods were moved.
+			// Since backoff time is set to 0, all moved pods should land in active queue.
+			gotInActiveQ := sets.New[string]()
+			for _, p := range sched.SchedulingQueue.PodsInActiveQ() {
+				gotInActiveQ.Insert(p.Name)
+			}
+
+			if diff := cmp.Diff(tt.expectInActiveQ, gotInActiveQ); diff != "" {
+				t.Errorf("Unexpected pods in active queue (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestUpdatePod(t *testing.T) {
 	pod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").SchedulerName("supported-scheduler").Obj()
 	updatedPod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Labels(map[string]string{"foo": "bar"}).ResourceVersion("2").SchedulerName("supported-scheduler").Obj()

--- a/pkg/scheduler/framework/events_test.go
+++ b/pkg/scheduler/framework/events_test.go
@@ -345,6 +345,42 @@ func TestExtractNodeFeaturesChange(t *testing.T) {
 	}
 }
 
+func TestNodeSchedulingPropertiesChange_NodeDeclaredFeatures(t *testing.T) {
+	tests := []struct {
+		name                        string
+		nodeDeclaredFeaturesEnabled bool
+		oldNode                     *v1.Node
+		newNode                     *v1.Node
+		wantEvents                  []fwk.ClusterEvent
+	}{
+		{
+			name:                        "scheduling properties changed with NodeDeclaredFeatures enabled",
+			nodeDeclaredFeaturesEnabled: true,
+			oldNode:                     &v1.Node{Status: v1.NodeStatus{DeclaredFeatures: []string{"featA"}}},
+			newNode:                     &v1.Node{Status: v1.NodeStatus{DeclaredFeatures: []string{"featA", "featB"}}},
+			wantEvents:                  []fwk.ClusterEvent{{Resource: fwk.Node, ActionType: fwk.UpdateNodeDeclaredFeature}},
+		},
+		{
+			name:                        "scheduling properties changed with NodeDeclaredFeatures disabled",
+			nodeDeclaredFeaturesEnabled: false,
+			oldNode:                     &v1.Node{Status: v1.NodeStatus{DeclaredFeatures: []string{"featA"}}},
+			newNode:                     &v1.Node{Status: v1.NodeStatus{DeclaredFeatures: []string{"featA", "featB"}}},
+			wantEvents:                  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.36"))
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NodeDeclaredFeatures, tt.nodeDeclaredFeaturesEnabled)
+			gotEvents := NodeSchedulingPropertiesChange(tt.newNode, tt.oldNode)
+			if diff := cmp.Diff(tt.wantEvents, gotEvents, cmpopts.EquateComparable(fwk.ClusterEvent{})); diff != "" {
+				t.Errorf("unexpected events (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func Test_podSchedulingPropertiesChange(t *testing.T) {
 	podWithBigRequest := &v1.Pod{
 		Spec: v1.PodSpec{

--- a/pkg/scheduler/framework/events_test.go
+++ b/pkg/scheduler/framework/events_test.go
@@ -345,6 +345,44 @@ func TestExtractNodeFeaturesChange(t *testing.T) {
 	}
 }
 
+func TestNodeSchedulingPropertiesChange_NodeDeclaredFeatures(t *testing.T) {
+	tests := []struct {
+		name                        string
+		nodeDeclaredFeaturesEnabled bool
+		oldNode                     *v1.Node
+		newNode                     *v1.Node
+		wantEvents                  []fwk.ClusterEvent
+	}{
+		{
+			name:                        "scheduling properties changed with NodeDeclaredFeatures enabled",
+			nodeDeclaredFeaturesEnabled: true,
+			oldNode:                     &v1.Node{Status: v1.NodeStatus{DeclaredFeatures: []string{"featA"}}},
+			newNode:                     &v1.Node{Status: v1.NodeStatus{DeclaredFeatures: []string{"featA", "featB"}}},
+			wantEvents:                  []fwk.ClusterEvent{{Resource: fwk.Node, ActionType: fwk.UpdateNodeDeclaredFeature}},
+		},
+		{
+			name:                        "scheduling properties changed with NodeDeclaredFeatures disabled",
+			nodeDeclaredFeaturesEnabled: false,
+			oldNode:                     &v1.Node{Status: v1.NodeStatus{DeclaredFeatures: []string{"featA"}}},
+			newNode:                     &v1.Node{Status: v1.NodeStatus{DeclaredFeatures: []string{"featA", "featB"}}},
+			wantEvents:                  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !tt.nodeDeclaredFeaturesEnabled {
+				featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.36"))
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NodeDeclaredFeatures, false)
+			}
+			gotEvents := NodeSchedulingPropertiesChange(tt.newNode, tt.oldNode)
+			if diff := cmp.Diff(tt.wantEvents, gotEvents, cmpopts.EquateComparable(fwk.ClusterEvent{})); diff != "" {
+				t.Errorf("unexpected events (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func Test_podSchedulingPropertiesChange(t *testing.T) {
 	podWithBigRequest := &v1.Pod{
 		Spec: v1.PodSpec{

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -18,10 +18,11 @@ package framework
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
@@ -3532,6 +3533,42 @@ func TestNodeInfo_PodsWithRequiredNonHostScopedAntiAffinity(t *testing.T) {
 	}
 }
 
+func TestUnrollWildCardResource_WithGenericWorkload(t *testing.T) {
+	tests := []struct {
+		name                  string
+		enableGenericWorkload bool
+		wantHasPodGroup       bool
+	}{
+		{
+			name:                  "Events should have PodGroup when GenericWorkload is enabled",
+			enableGenericWorkload: true,
+			wantHasPodGroup:       true,
+		},
+		{
+			name:                  "Events should not have PodGroup when GenericWorkload is disabled",
+			enableGenericWorkload: false,
+			wantHasPodGroup:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, tt.enableGenericWorkload)
+			events := UnrollWildCardResource()
+			hasPodGroup := false
+			for _, e := range events {
+				if e.Event.Resource == fwk.PodGroup {
+					hasPodGroup = true
+					break
+				}
+			}
+			if hasPodGroup != tt.wantHasPodGroup {
+				t.Errorf("UnrollWildCardResource() returned hasPodGroup = %v, want %v", hasPodGroup, tt.wantHasPodGroup)
+			}
+		})
+	}
+}
+
 func TestPodGroupInfoGetChildrenSorting(t *testing.T) {
 	now := time.Now()
 	pgInfo := func(name, namespace string, creationTime time.Time) *PodGroupInfo {
@@ -4419,6 +4456,7 @@ func TestPodGroupInfo_GetUnscheduledPods(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+
 			got := tt.pgi.GetUnscheduledPods()
 			if diff := cmp.Diff(tt.expected, got); diff != "" {
 				t.Errorf("GetUnscheduledPods() mismatch (-want +got):\n%s", diff)

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -18,10 +18,11 @@ package framework
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
@@ -3529,6 +3530,42 @@ func TestNodeInfo_PodsWithRequiredNonHostScopedAntiAffinity(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestUnrollWildCardResource_WithGenericWorkload(t *testing.T) {
+	tests := []struct {
+		name                  string
+		enableGenericWorkload bool
+		wantHasPodGroup       bool
+	}{
+		{
+			name:                  "Events should have PodGroup when GenericWorkload is enabled",
+			enableGenericWorkload: true,
+			wantHasPodGroup:       true,
+		},
+		{
+			name:                  "Events should not have PodGroup when GenericWorkload is disabled",
+			enableGenericWorkload: false,
+			wantHasPodGroup:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, tt.enableGenericWorkload)
+			events := UnrollWildCardResource()
+			hasPodGroup := false
+			for _, e := range events {
+				if e.Event.Resource == fwk.PodGroup {
+					hasPodGroup = true
+					break
+				}
+			}
+			if hasPodGroup != tt.wantHasPodGroup {
+				t.Errorf("Unexpected events returned from UnrollWildCardResource(): hasPodGroup = %v, want %v", hasPodGroup, tt.wantHasPodGroup)
+			}
+		})
 	}
 }
 

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -5278,6 +5278,7 @@ func TestScheduler_DeferredResizePostFilterPluginSkipping(t *testing.T) {
 				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
 				tf.RegisterPostFilterPlugin(dynamicresources.Name, frameworkruntime.FactoryAdapter(fts, dynamicresources.New)),
 				tf.RegisterPostFilterPlugin(defaultpreemption.Name, frameworkruntime.FactoryAdapter(fts, defaultpreemption.New)),
+
 				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
 			}
 
@@ -5285,6 +5286,7 @@ func TestScheduler_DeferredResizePostFilterPluginSkipping(t *testing.T) {
 				ctx,
 				registerPlugins, "",
 				frameworkruntime.WithSnapshotSharedLister(snapshot),
+
 				frameworkruntime.WithMutableSnapshotLister(snapshot),
 				frameworkruntime.WithInformerFactory(informerFactory),
 			)
@@ -5311,6 +5313,132 @@ func TestScheduler_DeferredResizePostFilterPluginSkipping(t *testing.T) {
 			if !strings.HasPrefix(reasons[0], tc.expectedReasonPrefix) {
 				t.Errorf("Expected reason to start with %q, got %q", tc.expectedReasonPrefix, reasons[0])
 			}
+		})
+	}
+}
+func TestSchedulePodWithOpportunisticBatching(t *testing.T) {
+	tests := []struct {
+		name                        string
+		enableOpportunisticBatching bool
+		wantEvaluatedNodes          int
+	}{
+		{
+			name:                        "scheduling a pod with OpportunisticBatching enabled should evaluate one node",
+			enableOpportunisticBatching: true,
+			wantEvaluatedNodes:          1,
+		},
+		{
+			name:                        "scheduling a pod with OpportunisticBatching disabled should evaluate all nodes",
+			enableOpportunisticBatching: false,
+			wantEvaluatedNodes:          2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.OpportunisticBatching, tt.enableOpportunisticBatching)
+
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			cache := internalcache.New(ctx, nil, false, false)
+			nodes := []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
+				st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
+			}
+			for _, node := range nodes {
+				cache.AddNode(logger, node)
+			}
+
+			cs := clientsetfake.NewClientset()
+			informerFactory := informers.NewSharedInformerFactory(cs, 0)
+			snapshot := internalcache.NewSnapshot(nil, nodes)
+
+			registerPlugins := []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterPluginAsExtensions(noderesources.Name, frameworkruntime.FactoryAdapter(feature.Features{}, noderesources.NewFit), "PreFilter", "Filter", "Score"),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+			}
+
+			schedFramework, err := tf.NewFramework(
+				ctx,
+				registerPlugins, "",
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithPodNominator(internalqueue.NewSchedulingQueue(nil, informerFactory)),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			sched := &Scheduler{
+				Cache:                    cache,
+				nodeInfoSnapshot:         snapshot,
+				percentageOfNodesToScore: schedulerapi.DefaultPercentageOfNodesToScore,
+				SchedulingQueue:          internalqueue.NewTestQueue(ctx, nil),
+			}
+			sched.applyDefaultHandlers()
+
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
+
+			// Schedule first pod.
+			pod1 := st.MakePod().Name("pod1").UID("pod1").Namespace(v1.NamespaceDefault).Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj()
+			sched.SchedulingQueue.Add(ctx, pod1)
+			entity1, err := sched.SchedulingQueue.Pop(logger)
+			if err != nil {
+				t.Fatalf("Pop failed: %v", err)
+			}
+			poppedPod1 := entity1.(*framework.QueuedPodInfo)
+			poppedPod1.PodSignature = []byte("test-batch-sig")
+
+			result1, err := sched.SchedulePod(ctx, schedFramework, framework.NewCycleState(), poppedPod1)
+			if err != nil {
+				t.Fatalf("Failed to schedule pod1: %v", err)
+			}
+			chosenNode := result1.SuggestedHost
+			if chosenNode != "node1" && chosenNode != "node2" {
+				t.Fatalf("Expected pod1 to be scheduled to node1 or node2, got: %s", chosenNode)
+			}
+
+			// Add pod1 to cache on the chosenNode (occupies chosenNode) and mark queue done.
+			pod1.Spec.NodeName = chosenNode
+			if err := cache.AddPod(logger, pod1); err != nil {
+				t.Fatalf("Failed to add pod1 to cache: %v", err)
+			}
+			if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
+				t.Fatalf("UpdateSnapshot failed: %v", err)
+			}
+			sched.SchedulingQueue.Done(pod1.UID)
+
+			otherNode := "node2"
+			if chosenNode == "node2" {
+				otherNode = "node1"
+			}
+
+			// Schedule second pod.
+			pod2 := st.MakePod().Name("pod2").UID("pod2").Namespace(v1.NamespaceDefault).Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj()
+			sched.SchedulingQueue.Add(ctx, pod2)
+			entity2, err := sched.SchedulingQueue.Pop(logger)
+			if err != nil {
+				t.Fatalf("Pop failed: %v", err)
+			}
+			poppedPod2 := entity2.(*framework.QueuedPodInfo)
+			poppedPod2.PodSignature = []byte("test-batch-sig")
+
+			result2, err := sched.SchedulePod(ctx, schedFramework, framework.NewCycleState(), poppedPod2)
+			if err != nil {
+				t.Fatalf("Failed to schedule pod2: %v", err)
+			}
+			if result2.SuggestedHost != otherNode {
+				t.Fatalf("Expected pod2 to be scheduled to %s, got: %s", otherNode, result2.SuggestedHost)
+			}
+
+			if result2.EvaluatedNodes != tt.wantEvaluatedNodes {
+				t.Errorf("Unexpected EvaluatedNodes for pod2, want: %d, got: %d", tt.wantEvaluatedNodes, result2.EvaluatedNodes)
+			}
+			sched.SchedulingQueue.Done(pod2.UID)
 		})
 	}
 }

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -5314,3 +5314,130 @@ func TestScheduler_DeferredResizePostFilterPluginSkipping(t *testing.T) {
 		})
 	}
 }
+
+func TestSchedulePodWithOpportunisticBatching(t *testing.T) {
+	tests := []struct {
+		name                        string
+		enableOpportunisticBatching bool
+		wantEvaluatedNodes          int
+	}{
+		{
+			name:                        "scheduling a pod with OpportunisticBatching enabled should evaluate one node",
+			enableOpportunisticBatching: true,
+			wantEvaluatedNodes:          1,
+		},
+		{
+			name:                        "scheduling a pod with OpportunisticBatching disabled should evaluate all nodes",
+			enableOpportunisticBatching: false,
+			wantEvaluatedNodes:          2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.OpportunisticBatching, tt.enableOpportunisticBatching)
+
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			cache := internalcache.New(ctx, nil, false, false)
+			nodes := []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
+				st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
+			}
+			for _, node := range nodes {
+				cache.AddNode(logger, node)
+			}
+
+			cs := clientsetfake.NewClientset()
+			informerFactory := informers.NewSharedInformerFactory(cs, 0)
+			snapshot := internalcache.NewSnapshot(nil, nodes)
+
+			registerPlugins := []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterPluginAsExtensions(noderesources.Name, frameworkruntime.FactoryAdapter(feature.Features{}, noderesources.NewFit), "PreFilter", "Filter", "Score"),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+			}
+
+			schedFramework, err := tf.NewFramework(
+				ctx,
+				registerPlugins, "",
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithPodNominator(internalqueue.NewSchedulingQueue(nil, informerFactory)),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			sched := &Scheduler{
+				Cache:                    cache,
+				nodeInfoSnapshot:         snapshot,
+				percentageOfNodesToScore: schedulerapi.DefaultPercentageOfNodesToScore,
+				SchedulingQueue:          internalqueue.NewTestQueue(ctx, nil),
+			}
+			sched.applyDefaultHandlers()
+
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
+
+			// Schedule first pod.
+			pod1 := st.MakePod().Name("pod1").UID("pod1").Namespace(v1.NamespaceDefault).Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj()
+			sched.SchedulingQueue.Add(ctx, pod1)
+			entity, err := sched.SchedulingQueue.Pop(logger)
+			if err != nil {
+				t.Fatalf("Pop failed: %v", err)
+			}
+			poppedPod := entity.(*framework.QueuedPodInfo)
+			poppedPod.PodSignature = []byte("test-batch-sig")
+
+			result, err := sched.SchedulePod(ctx, schedFramework, framework.NewCycleState(), poppedPod)
+			if err != nil {
+				t.Fatalf("Failed to schedule pod1: %v", err)
+			}
+			chosenNode := result.SuggestedHost
+			if chosenNode != "node1" && chosenNode != "node2" {
+				t.Fatalf("Expected pod1 to be scheduled to node1 or node2, got: %s", chosenNode)
+			}
+
+			// Add pod1 to cache on the chosenNode (occupies chosenNode) and mark queue done.
+			pod1.Spec.NodeName = chosenNode
+			if err := cache.AddPod(logger, pod1); err != nil {
+				t.Fatalf("Failed to add pod1 to cache: %v", err)
+			}
+			if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
+				t.Fatalf("UpdateSnapshot failed: %v", err)
+			}
+			sched.SchedulingQueue.Done(pod1.UID)
+
+			otherNode := "node2"
+			if chosenNode == "node2" {
+				otherNode = "node1"
+			}
+
+			// Schedule second pod.
+			pod2 := st.MakePod().Name("pod2").UID("pod2").Namespace(v1.NamespaceDefault).Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj()
+			sched.SchedulingQueue.Add(ctx, pod2)
+			entity, err = sched.SchedulingQueue.Pop(logger)
+			if err != nil {
+				t.Fatalf("Pop failed: %v", err)
+			}
+			poppedPod = entity.(*framework.QueuedPodInfo)
+			poppedPod.PodSignature = []byte("test-batch-sig")
+
+			result, err = sched.SchedulePod(ctx, schedFramework, framework.NewCycleState(), poppedPod)
+			if err != nil {
+				t.Fatalf("Failed to schedule pod2: %v", err)
+			}
+			if result.SuggestedHost != otherNode {
+				t.Fatalf("Expected pod2 to be scheduled to %s, got: %s", otherNode, result.SuggestedHost)
+			}
+
+			if result.EvaluatedNodes != tt.wantEvaluatedNodes {
+				t.Errorf("Unexpected EvaluatedNodes for pod2, want: %d, got: %d", tt.wantEvaluatedNodes, result.EvaluatedNodes)
+			}
+			sched.SchedulingQueue.Done(pod2.UID)
+		})
+	}
+}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -87,12 +87,14 @@ func TestSchedulerCreation(t *testing.T) {
 	}
 	customSnapshot := internalcache.NewEmptySnapshot()
 	cases := []struct {
-		name                 string
-		opts                 []Option
-		wantErr              string
-		wantProfiles         []string
-		wantExtenders        []string
-		wantNodeInfoSnapshot *internalcache.Snapshot
+		name                            string
+		isSchedulerAsyncAPICallsEnabled bool
+		opts                            []Option
+		wantErr                         string
+		wantProfiles                    []string
+		wantExtenders                   []string
+		wantNodeInfoSnapshot            *internalcache.Snapshot
+		wantAPIDispatcher               bool
 	}{
 		{
 			name: "valid out-of-tree registry",
@@ -203,10 +205,28 @@ func TestSchedulerCreation(t *testing.T) {
 			wantProfiles:         []string{"default-scheduler"},
 			wantNodeInfoSnapshot: customSnapshot,
 		},
+		{
+			name:                            "With SchedulerAsyncAPICalls enabled",
+			isSchedulerAsyncAPICallsEnabled: true,
+			opts: []Option{
+				WithProfiles(
+					schedulerapi.KubeSchedulerProfile{
+						SchedulerName: "default-scheduler",
+						Plugins: &schedulerapi.Plugins{
+							QueueSort: schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: "PrioritySort"}}},
+							Bind:      schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: "DefaultBinder"}}},
+						},
+					},
+				),
+			},
+			wantProfiles:      []string{"default-scheduler"},
+			wantAPIDispatcher: true,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.SchedulerAsyncAPICalls, tc.isSchedulerAsyncAPICallsEnabled)
 			client := fake.NewClientset()
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 
@@ -233,6 +253,10 @@ func TestSchedulerCreation(t *testing.T) {
 			}
 			if err != nil {
 				t.Fatalf("Failed to create scheduler: %v", err)
+			}
+
+			if gotAPIDispatcher := s.APIDispatcher != nil; tc.wantAPIDispatcher != gotAPIDispatcher {
+				t.Errorf("Unexpected APIDispatcher state, want: %v, got: %v", tc.wantAPIDispatcher, gotAPIDispatcher)
 			}
 
 			// Profiles

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -87,12 +87,14 @@ func TestSchedulerCreation(t *testing.T) {
 	}
 	customSnapshot := internalcache.NewEmptySnapshot()
 	cases := []struct {
-		name                 string
-		opts                 []Option
-		wantErr              string
-		wantProfiles         []string
-		wantExtenders        []string
-		wantNodeInfoSnapshot *internalcache.Snapshot
+		name                            string
+		opts                            []Option
+		wantErr                         string
+		wantProfiles                    []string
+		wantExtenders                   []string
+		wantNodeInfoSnapshot            *internalcache.Snapshot
+		isSchedulerAsyncAPICallsEnabled bool
+		wantAPIDispatcher               bool
 	}{
 		{
 			name: "valid out-of-tree registry",
@@ -203,10 +205,29 @@ func TestSchedulerCreation(t *testing.T) {
 			wantProfiles:         []string{"default-scheduler"},
 			wantNodeInfoSnapshot: customSnapshot,
 		},
+		{
+			name: "With SchedulerAsyncAPICalls enabled",
+			opts: []Option{
+				WithProfiles(
+					schedulerapi.KubeSchedulerProfile{
+						SchedulerName: "default-scheduler",
+						Plugins: &schedulerapi.Plugins{
+							QueueSort: schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: "PrioritySort"}}},
+							Bind:      schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: "DefaultBinder"}}},
+						},
+					},
+				),
+			},
+			wantProfiles:                    []string{"default-scheduler"},
+			isSchedulerAsyncAPICallsEnabled: true,
+			wantAPIDispatcher:               true,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.SchedulerAsyncAPICalls, tc.isSchedulerAsyncAPICallsEnabled)
+
 			client := fake.NewClientset()
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 
@@ -233,6 +254,10 @@ func TestSchedulerCreation(t *testing.T) {
 			}
 			if err != nil {
 				t.Fatalf("Failed to create scheduler: %v", err)
+			}
+
+			if tc.wantAPIDispatcher != (s.APIDispatcher != nil) {
+				t.Errorf("Unexpected APIDispatcher state, want: %v, got: %v", tc.wantAPIDispatcher, s.APIDispatcher != nil)
 			}
 
 			// Profiles


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig-scheduling

#### What this PR does / why we need it:
We want to ensure feature gates are properly covered in tests (as long as they are meaningful) for whether a feature gate is disabled or enabled.
So we are introducing these tests here.

#### Which issue(s) this PR is related to:
N/A

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
