### PR TITLE
DRA E2E: simplify kind.yaml

### DIFF
--- a/test/e2e/dra/kind.yaml
+++ b/test/e2e/dra/kind.yaml
@@ -1,5 +1,10 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+runtimeConfig:
+  "resource.k8s.io/v1alpha3": "true"
+  "resource.k8s.io/v1beta1": "true"
+  "resource.k8s.io/v1beta2": "true"
+  "scheduling.k8s.io/v1alpha3": "true"
 containerdConfigPatches:
 # Enable CDI as described in
 # https://github.com/container-orchestrated-devices/container-device-interface#containerd-configuration
@@ -35,10 +40,6 @@ kubeadmConfigPatches:
             value: "5"
           - name: "vmodule"
             value: "controller=6" # resourceclaim/controller.go - should have renamed it when copying the controller it was based on!
-    apiServer:
-        extraArgs:
-          - name: "runtime-config"
-            value: "resource.k8s.io/v1alpha3=true,resource.k8s.io/v1beta1=true,resource.k8s.io/v1beta2=true,scheduling.k8s.io/v1alpha3=true"
   - |
     kind: InitConfiguration
     apiVersion: kubeadm.k8s.io/v1beta4
@@ -64,9 +65,6 @@ kubeadmConfigPatches:
         extraArgs:
           v: "5"
           vmodule: "controller=6" # resourceclaim/controller.go - should have renamed it when copying the controller it was based on!
-    apiServer:
-        extraArgs:
-          runtime-config: "resource.k8s.io/v1alpha3=true,resource.k8s.io/v1beta1=true,resource.k8s.io/v1beta2=true,scheduling.k8s.io/v1alpha3=true"
   - |
     kind: InitConfiguration
     apiVersion: kubeadm.k8s.io/v1beta3
@@ -83,5 +81,5 @@ kubeadmConfigPatches:
 #
 #    --config <(cat test/e2e/dra/kind.yaml; echo "  <some feature>: true")
 featureGates:
-  DynamicResourceAllocation: true
-  NodeLogQuery: true
+  DynamicResourceAllocation: true # Still needed for n-3 testing against kubelet 1.33. Can be removed once we only test against 1.34.
+  NodeLogQuery: true # Still needed for n-3/2/1 testing. Can be removed once we only test against >= 1.36.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Runtime config can be set via the kind config, which is simpler than setting the apiserver parameter. 

DynamicResourceAllocation is enabled by default nowadays, but still needs to be set for the current n-3 skew testing which picks 1.33 (1.37 still in alpha). Similar for NodeLogQuery (GA in 1.36).

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/139405#issuecomment-4597929303

#### Special notes for your reviewer:

Long-term the goal is to make kind.yaml a "GA-only" config, but right now the jobs using it aren't ready for that.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
