### PR TITLE
Rewrite RunBenchmarkStoreListCreate into write throughput benchmark RunBenchmarkWriteThroughput

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -770,7 +770,7 @@ func BenchmarkStoreList(b *testing.B) {
 	}
 	for _, dims := range dimensions {
 		b.Run(fmt.Sprintf("Namespaces=%d/Pods=%d/Nodes=%d", dims.namespaceCount, dims.namespaceCount*dims.podPerNamespaceCount, dims.nodeCount), func(b *testing.B) {
-			data := storagetesting.PrepareBenchchmarkData(dims.namespaceCount, dims.podPerNamespaceCount, dims.nodeCount)
+			data := storagetesting.PrepareBenchmarkData(dims.namespaceCount, dims.podPerNamespaceCount, dims.nodeCount)
 			ctx, cacher, _, terminate := testSetupWithEtcdServer(b, withNodeNameAndNamespaceIndex)
 			b.Cleanup(terminate)
 			var out example.Pod
@@ -791,7 +791,7 @@ func BenchmarkStoreList(b *testing.B) {
 
 func BenchmarkStoreStats(b *testing.B) {
 	klog.SetLogger(logr.Discard())
-	data := storagetesting.PrepareBenchchmarkData(50, 3_000, 5_000)
+	data := storagetesting.PrepareBenchmarkData(50, 3_000, 5_000)
 	ctx, cacher, _, terminate := testSetupWithEtcdServer(b)
 	b.Cleanup(terminate)
 	var out example.Pod

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
 
 	"k8s.io/apimachinery/pkg/api/apitesting"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -724,22 +725,27 @@ func (c *createWrapper) Create(ctx context.Context, key string, obj, out runtime
 		return true, nil
 	})
 }
-
-func BenchmarkStoreCreateList(b *testing.B) {
+func BenchmarkStoreWriteThroughput(b *testing.B) {
 	klog.SetLogger(logr.Discard())
-	for _, rvm := range []metav1.ResourceVersionMatch{metav1.ResourceVersionMatchNotOlderThan, metav1.ResourceVersionMatchExact} {
-		b.Run(fmt.Sprintf("RV=%s", rvm), func(b *testing.B) {
-			for _, useIndex := range []bool{true, false} {
-				b.Run(fmt.Sprintf("Indexed=%v", useIndex), func(b *testing.B) {
-					opts := []setupOption{}
-					if useIndex {
-						opts = append(opts, withNodeNameAndNamespaceIndex)
-					}
-					ctx, cacher, _, terminate := testSetupWithEtcdServer(b, opts...)
-					b.Cleanup(terminate)
-					storagetesting.RunBenchmarkStoreListCreate(ctx, b, cacher, rvm)
-				})
-			}
+	dimensions := []struct {
+		namespaceCount       int
+		podPerNamespaceCount int
+		nodeCount            int
+	}{
+		{
+			namespaceCount:       50,
+			podPerNamespaceCount: 3_000,
+			nodeCount:            5_000,
+		},
+	}
+	for _, dims := range dimensions {
+		b.Run(fmt.Sprintf("Namespaces=%d/Pods=%d/Nodes=%d", dims.namespaceCount, dims.namespaceCount*dims.podPerNamespaceCount, dims.nodeCount), func(b *testing.B) {
+			opts := []setupOption{withNodeNameAndNamespaceIndex}
+			ctx, cacher, _, terminate := testSetupWithEtcdServer(b, opts...)
+			b.Cleanup(terminate)
+			data := storagetesting.PrepareBenchmarkData(dims.namespaceCount, dims.podPerNamespaceCount, dims.nodeCount)
+			b.ResetTimer()
+			storagetesting.RunBenchmarkWriteThroughput(ctx, b, cacher, data, true)
 		})
 	}
 }
@@ -773,13 +779,7 @@ func BenchmarkStoreList(b *testing.B) {
 			data := storagetesting.PrepareBenchmarkData(dims.namespaceCount, dims.podPerNamespaceCount, dims.nodeCount)
 			ctx, cacher, _, terminate := testSetupWithEtcdServer(b, withNodeNameAndNamespaceIndex)
 			b.Cleanup(terminate)
-			var out example.Pod
-			for _, pod := range data.Pods {
-				err := cacher.Create(ctx, computePodKey(pod), pod, &out, 0)
-				if err != nil {
-					b.Fatal(err)
-				}
-			}
+			require.NoError(b, storagetesting.PrecreateBenchmarkPods(ctx, cacher, data))
 			for _, useIndex := range []bool{true, false} {
 				b.Run(fmt.Sprintf("Indexed=%v", useIndex), func(b *testing.B) {
 					storagetesting.RunBenchmarkStoreList(ctx, b, cacher, data, useIndex)

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -1024,16 +1024,27 @@ func BenchmarkStore_GetList(b *testing.B) {
 	}
 }
 
-func BenchmarkStoreListCreate(b *testing.B) {
+func BenchmarkStoreWriteThroughput(b *testing.B) {
 	klog.SetLogger(logr.Discard())
-	b.Run("RV=NotOlderThan", func(b *testing.B) {
-		ctx, store, _ := testSetup(b)
-		storagetesting.RunBenchmarkStoreListCreate(ctx, b, store, metav1.ResourceVersionMatchNotOlderThan)
-	})
-	b.Run("RV=ExactMatch", func(b *testing.B) {
-		ctx, store, _ := testSetup(b)
-		storagetesting.RunBenchmarkStoreListCreate(ctx, b, store, metav1.ResourceVersionMatchExact)
-	})
+	dimensions := []struct {
+		namespaceCount       int
+		podPerNamespaceCount int
+		nodeCount            int
+	}{
+		{
+			namespaceCount:       50,
+			podPerNamespaceCount: 3_000,
+			nodeCount:            5_000,
+		},
+	}
+	for _, dims := range dimensions {
+		b.Run(fmt.Sprintf("Namespaces=%d/Pods=%d/Nodes=%d", dims.namespaceCount, dims.namespaceCount*dims.podPerNamespaceCount, dims.nodeCount), func(b *testing.B) {
+			ctx, store, _ := testSetup(b)
+			data := storagetesting.PrepareBenchmarkData(dims.namespaceCount, dims.podPerNamespaceCount, dims.nodeCount)
+			b.ResetTimer()
+			storagetesting.RunBenchmarkWriteThroughput(ctx, b, store, data, false)
+		})
+	}
 }
 
 func BenchmarkStoreList(b *testing.B) {
@@ -1066,13 +1077,7 @@ func BenchmarkStoreList(b *testing.B) {
 			b.Run(fmt.Sprintf("SizeBasedListCostEstimate=%v/Namespaces=%d/Pods=%d/Nodes=%d", sizeBasedEnabled, dims.namespaceCount, dims.namespaceCount*dims.podPerNamespaceCount, dims.nodeCount), func(b *testing.B) {
 				data := storagetesting.PrepareBenchmarkData(dims.namespaceCount, dims.podPerNamespaceCount, dims.nodeCount)
 				ctx, store, _ := testSetup(b)
-				var out example.Pod
-				for _, pod := range data.Pods {
-					err := store.Create(ctx, computePodKey(pod), pod, &out, 0)
-					if err != nil {
-						b.Fatal(err)
-					}
-				}
+				require.NoError(b, storagetesting.PrecreateBenchmarkPods(ctx, store, data))
 				storagetesting.RunBenchmarkStoreList(ctx, b, store, data, false)
 			})
 		}
@@ -1133,13 +1138,7 @@ func BenchmarkStoreStats(b *testing.B) {
 	klog.SetLogger(logr.Discard())
 	data := storagetesting.PrepareBenchmarkData(50, 3_000, 5_000)
 	ctx, store, _ := testSetup(b)
-	var out example.Pod
-	for _, pod := range data.Pods {
-		err := store.Create(ctx, computePodKey(pod), pod, &out, 0)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
+	require.NoError(b, storagetesting.PrecreateBenchmarkPods(ctx, store, data))
 	storagetesting.RunBenchmarkStoreStats(ctx, b, store)
 }
 
@@ -1150,13 +1149,7 @@ func BenchmarkStatsCacheCleanKeys(b *testing.B) {
 	podPerNamespaceCount := 3_000
 	data := storagetesting.PrepareBenchmarkData(namespaceCount, podPerNamespaceCount, 5_000)
 	ctx, store, _ := testSetup(b)
-	var out example.Pod
-	for _, pod := range data.Pods {
-		err := store.Create(ctx, computePodKey(pod), pod, &out, 0)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
+	require.NoError(b, storagetesting.PrecreateBenchmarkPods(ctx, store, data))
 	// List to fetch object sizes for statsCache.
 	listOut := &example.PodList{}
 	err := store.GetList(ctx, "/pods/", storage.ListOptions{Recursive: true, Predicate: storage.Everything}, listOut)

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -1064,7 +1064,7 @@ func BenchmarkStoreList(b *testing.B) {
 		for _, sizeBasedEnabled := range []bool{true, false} {
 			featuregatetesting.SetFeatureGateDuringTest(b, utilfeature.DefaultFeatureGate, features.SizeBasedListCostEstimate, sizeBasedEnabled)
 			b.Run(fmt.Sprintf("SizeBasedListCostEstimate=%v/Namespaces=%d/Pods=%d/Nodes=%d", sizeBasedEnabled, dims.namespaceCount, dims.namespaceCount*dims.podPerNamespaceCount, dims.nodeCount), func(b *testing.B) {
-				data := storagetesting.PrepareBenchchmarkData(dims.namespaceCount, dims.podPerNamespaceCount, dims.nodeCount)
+				data := storagetesting.PrepareBenchmarkData(dims.namespaceCount, dims.podPerNamespaceCount, dims.nodeCount)
 				ctx, store, _ := testSetup(b)
 				var out example.Pod
 				for _, pod := range data.Pods {
@@ -1131,7 +1131,7 @@ func TestGetCurrentResourceVersion(t *testing.T) {
 
 func BenchmarkStoreStats(b *testing.B) {
 	klog.SetLogger(logr.Discard())
-	data := storagetesting.PrepareBenchchmarkData(50, 3_000, 5_000)
+	data := storagetesting.PrepareBenchmarkData(50, 3_000, 5_000)
 	ctx, store, _ := testSetup(b)
 	var out example.Pod
 	for _, pod := range data.Pods {
@@ -1148,7 +1148,7 @@ func BenchmarkStatsCacheCleanKeys(b *testing.B) {
 	klog.SetLogger(logr.Discard())
 	namespaceCount := 50
 	podPerNamespaceCount := 3_000
-	data := storagetesting.PrepareBenchchmarkData(namespaceCount, podPerNamespaceCount, 5_000)
+	data := storagetesting.PrepareBenchmarkData(namespaceCount, podPerNamespaceCount, 5_000)
 	ctx, store, _ := testSetup(b)
 	var out example.Pod
 	for _, pod := range data.Pods {

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_benchmarks.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_benchmarks.go
@@ -20,10 +20,13 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/apis/example"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/storage"
@@ -48,38 +52,319 @@ var (
 	namespace scope = "Namespace"
 )
 
-func RunBenchmarkStoreListCreate(ctx context.Context, b *testing.B, store storage.Interface, match metav1.ResourceVersionMatch) {
-	objectCount := atomic.Uint64{}
-	data := PrepareBenchchmarkData(1, b.N, 1)
+const (
+	loadNone            = "None"
+	loadWatcher         = "Watcher"
+	loadLister          = "Lister"
+	loadWatchList       = "WatchList"
+	trafficDeleteCreate = "DeleteCreate"
+	trafficPatch        = "Patch"
+)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		pod := data.Pods[i]
-		podOut := &example.Pod{}
-		err := store.Create(ctx, computePodKey(pod), pod, podOut, 0)
-		if err != nil {
-			panic(fmt.Sprintf("Unexpected error %s", err))
-		}
-		listOut := &example.PodList{}
-		err = store.GetList(ctx, "/pods/", storage.ListOptions{
-			Recursive:            true,
-			ResourceVersion:      podOut.ResourceVersion,
-			ResourceVersionMatch: match,
-			Predicate: storage.SelectionPredicate{
-				Label: labels.Everything(),
-				Field: fields.Everything(),
-				Limit: 1,
-			},
-		}, listOut)
-		if err != nil {
-			panic(fmt.Sprintf("Unexpected error %s", err))
-		}
-		if len(listOut.Items) != 1 {
-			b.Errorf("Expected to get 1 element, got %d", len(listOut.Items))
-		}
-		objectCount.Add(uint64(len(listOut.Items)))
+func RunBenchmarkWriteThroughput(ctx context.Context, b *testing.B, store storage.Interface, data BenchmarkData, hasIndex bool) {
+	require.NoError(b, PrecreateBenchmarkPods(ctx, store, data))
+	require.NoError(b, waitForConsistent(ctx, store))
+
+	for _, trafficType := range []string{trafficDeleteCreate, trafficPatch} {
+		b.Run(fmt.Sprintf("Traffic=%s", trafficType), func(b *testing.B) {
+			for _, parallelism := range []int{25} {
+				b.Run(fmt.Sprintf("Parallelism=%d", parallelism), func(b *testing.B) {
+					for _, loadType := range []string{loadNone, loadWatcher, loadLister, loadWatchList} {
+						useIndexOptions := []bool{false}
+						if hasIndex && loadType != loadNone {
+							useIndexOptions = []bool{false, true}
+						}
+						for _, readIndexed := range useIndexOptions {
+							b.Run(fmt.Sprintf("Background=%s/UseIndex=%v", loadType, readIndexed), func(b *testing.B) {
+								b.SetParallelism(parallelism)
+								runBenchmarkWriteThroughput(ctx, b, store, data, trafficType, loadType, readIndexed)
+							})
+						}
+					}
+				})
+			}
+		})
 	}
-	b.ReportMetric(float64(objectCount.Load())/float64(b.N), "objects/op")
+}
+
+func runBenchmarkWriteThroughput(ctx context.Context, b *testing.B, store storage.Interface, data BenchmarkData, trafficType string, loadType string, readIndexed bool) {
+	stopBackgroundLoadCh := make(chan struct{})
+	var workersWg sync.WaitGroup
+	var stopOnce sync.Once
+	stopBackgroundLoad := func() {
+		stopOnce.Do(func() {
+			close(stopBackgroundLoadCh)
+			workersWg.Wait()
+		})
+	}
+	defer stopBackgroundLoad()
+
+	var writes atomic.Uint64
+	var watchEvents atomic.Uint64
+	var listCalls atomic.Uint64
+	var listObjects atomic.Uint64
+
+	switch loadType {
+	case loadNone:
+	case loadWatcher:
+		startBackgroundWatchers(ctx, store, data, 10, readIndexed, &workersWg, stopBackgroundLoadCh, &watchEvents)
+	case loadLister:
+		startBackgroundListers(ctx, store, data, 1, readIndexed, &workersWg, stopBackgroundLoadCh, &listCalls, &listObjects)
+	case loadWatchList:
+		startBackgroundWatchListers(ctx, store, data, 1, readIndexed, &workersWg, stopBackgroundLoadCh, &listCalls, &listObjects)
+	default:
+		panic(fmt.Sprintf("Unknown load type: %s", loadType))
+	}
+	writes.Store(0)
+	watchEvents.Store(0)
+	listCalls.Store(0)
+	listObjects.Store(0)
+	b.ResetTimer()
+	start := time.Now()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			writes.Add(runTraffic(ctx, b, store, data, trafficType))
+		}
+	})
+	end := time.Now()
+	elapsedSeconds := end.Sub(start).Seconds()
+	require.NoError(b, waitForConsistent(ctx, store))
+	consistentDelaySeconds := float64(time.Since(end).Nanoseconds()) / float64(time.Second.Nanoseconds())
+	b.ReportMetric(consistentDelaySeconds, "seconds-delay")
+	b.ReportMetric(float64(writes.Load())/elapsedSeconds, "writes/s")
+
+	stopBackgroundLoad()
+
+	switch loadType {
+	case loadWatcher:
+		b.ReportMetric(float64(watchEvents.Load())/elapsedSeconds, "watch-events/s")
+	case loadLister, loadWatchList:
+		b.ReportMetric(float64(listCalls.Load())/elapsedSeconds, "list-calls/s")
+		b.ReportMetric(float64(listObjects.Load())/elapsedSeconds, "list-objs/s")
+	}
+}
+
+func waitForConsistent(ctx context.Context, store storage.Interface) error {
+	listOut := &example.PodList{}
+	err := store.GetList(ctx, "/pods/", storage.ListOptions{
+		Recursive: true,
+		Predicate: storage.SelectionPredicate{
+			Label: labels.Everything(),
+			Field: fields.Everything(),
+			Limit: 1,
+		},
+	}, listOut)
+	if err != nil {
+		return fmt.Errorf("unexpected error waiting for consistency: %w", err)
+	}
+	return nil
+}
+
+func runTraffic(ctx context.Context, b *testing.B, store storage.Interface, data BenchmarkData, trafficType string) (writes uint64) {
+	var podOut *example.Pod
+	switch trafficType {
+	case trafficDeleteCreate:
+		i := rand.Intn(len(data.PodKeys))
+		podOut = &example.Pod{}
+		err := store.Delete(ctx, data.PodKeys[i], podOut, nil, storage.ValidateAllObjectFunc, nil, storage.DeleteOptions{})
+		if err == nil {
+			writes += 1
+		} else if !storage.IsNotFound(err) {
+			panic(fmt.Sprintf("Unexpected error on Delete %q: %v", data.PodKeys[i], err))
+		}
+		pod := data.Pods[i]
+		podOut = &example.Pod{}
+		err = store.Create(ctx, data.PodKeys[i], pod, podOut, 0)
+		if err == nil {
+			writes += 1
+		} else if !storage.IsExist(err) {
+			panic(fmt.Sprintf("Unexpected error on Create %q: %v", data.PodKeys[i], err))
+		}
+	case trafficPatch:
+		i := rand.Intn(len(data.PodKeys))
+		podOut = &example.Pod{}
+		err := store.GuaranteedUpdate(ctx, data.PodKeys[i], podOut, false, nil, patchFunc(i), nil)
+		if err != nil {
+			panic(fmt.Sprintf("Unexpected error on Patch %q: %v", data.PodKeys[i], err))
+		} else {
+			writes += 1
+		}
+		// Execute patch second time to match 2 operations.
+		j := rand.Intn(len(data.PodKeys))
+		podOut = &example.Pod{}
+		err = store.GuaranteedUpdate(ctx, data.PodKeys[j], podOut, false, nil, patchFunc(j), nil)
+		if err != nil {
+			panic(fmt.Sprintf("Unexpected error on Patch %q: %v", data.PodKeys[j], err))
+		} else {
+			writes += 1
+		}
+	default:
+		panic(fmt.Sprintf("Unknown traffic type: %s", trafficType))
+	}
+	return writes
+}
+
+func patchFunc(i int) func(input runtime.Object, res storage.ResponseMeta) (runtime.Object, *uint64, error) {
+	return func(input runtime.Object, res storage.ResponseMeta) (runtime.Object, *uint64, error) {
+		curr := input.(*example.Pod)
+		if curr.Annotations == nil {
+			curr.Annotations = make(map[string]string)
+		}
+		curr.Annotations["updated-by-benchmark"] = strconv.Itoa(i)
+		return curr, nil, nil
+	}
+}
+
+func startBackgroundWatchers(ctx context.Context, store storage.Interface, data BenchmarkData, count int, readIndexed bool, wg *sync.WaitGroup, stopCh <-chan struct{}, eventCounter *atomic.Uint64) {
+	for i := range count {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			opts := storage.ListOptions{
+				Recursive: true,
+				Predicate: storage.Everything,
+			}
+			if readIndexed {
+				nodeName := "default-node"
+				if len(data.NodeNames) > 0 {
+					nodeName = data.NodeNames[i%len(data.NodeNames)]
+				}
+				opts.Predicate.GetAttrs = podAttr
+				opts.Predicate.IndexFields = []string{"spec.nodeName"}
+				opts.Predicate.Field = fields.SelectorFromSet(fields.Set{"spec.nodeName": nodeName})
+			}
+			w, err := store.Watch(ctx, "/pods/", opts)
+			if err != nil {
+				return
+			}
+			defer w.Stop()
+			for {
+				select {
+				case <-stopCh:
+					return
+				case <-ctx.Done():
+					return
+				case ev, ok := <-w.ResultChan():
+					if !ok {
+						return
+					}
+					eventCounter.Add(1)
+					_ = ev
+				}
+			}
+		}(i)
+	}
+}
+
+func startBackgroundListers(ctx context.Context, store storage.Interface, data BenchmarkData, count int, readIndexed bool, wg *sync.WaitGroup, stopCh <-chan struct{}, listCounter *atomic.Uint64, objCounter *atomic.Uint64) {
+	for i := range count {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			listOut := &example.PodList{}
+			ticker := time.NewTicker(10 * time.Millisecond)
+			defer ticker.Stop()
+			opts := storage.ListOptions{
+				Recursive: true,
+				Predicate: storage.Everything,
+			}
+			if readIndexed {
+				nodeName := "default-node"
+				if len(data.NodeNames) > 0 {
+					nodeName = data.NodeNames[i%len(data.NodeNames)]
+				}
+				opts.Predicate.GetAttrs = podAttr
+				opts.Predicate.IndexFields = []string{"spec.nodeName"}
+				opts.Predicate.Field = fields.SelectorFromSet(fields.Set{"spec.nodeName": nodeName})
+			}
+			for {
+				select {
+				case <-stopCh:
+					return
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					err := store.GetList(ctx, "/pods/", opts, listOut)
+					if err == nil {
+						listCounter.Add(1)
+						objCounter.Add(uint64(len(listOut.Items)))
+					}
+				}
+			}
+		}(i)
+	}
+}
+
+func startBackgroundWatchListers(ctx context.Context, store storage.Interface, data BenchmarkData, count int, readIndexed bool, wg *sync.WaitGroup, stopCh <-chan struct{}, listCounter *atomic.Uint64, objCounter *atomic.Uint64) {
+	for i := range count {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			opts := storage.ListOptions{
+				Recursive:         true,
+				Predicate:         storage.Everything,
+				SendInitialEvents: new(true),
+			}
+			opts.Predicate.AllowWatchBookmarks = true
+
+			if readIndexed {
+				nodeName := "default-node"
+				if len(data.NodeNames) > 0 {
+					nodeName = data.NodeNames[i%len(data.NodeNames)]
+				}
+				opts.Predicate.GetAttrs = podAttr
+				opts.Predicate.IndexFields = []string{"spec.nodeName"}
+				opts.Predicate.Field = fields.SelectorFromSet(fields.Set{"spec.nodeName": nodeName})
+			}
+
+			for {
+				select {
+				case <-stopCh:
+					return
+				case <-ctx.Done():
+					return
+				default:
+				}
+
+				w, err := store.Watch(ctx, "/pods/", opts)
+				if err != nil {
+					time.Sleep(10 * time.Millisecond)
+					continue
+				}
+
+				initialFinished := false
+				for !initialFinished {
+					select {
+					case <-stopCh:
+						w.Stop()
+						return
+					case <-ctx.Done():
+						w.Stop()
+						return
+					case ev, ok := <-w.ResultChan():
+						if !ok {
+							initialFinished = true
+							break
+						}
+						switch ev.Type {
+						case watch.Bookmark:
+							pod, ok := ev.Object.(*example.Pod)
+							if !ok {
+								panic("Unexpected type in event")
+							}
+							if pod.Annotations != nil && pod.Annotations[metav1.InitialEventsAnnotationKey] == "true" {
+								initialFinished = true
+							}
+						default:
+							objCounter.Add(1)
+						}
+					}
+				}
+				w.Stop()
+				listCounter.Add(1)
+			}
+		}(i)
+	}
 }
 
 func RunBenchmarkStoreList(ctx context.Context, b *testing.B, store storage.Interface, data BenchmarkData, useIndex bool) {
@@ -202,7 +487,7 @@ func podAttr(obj runtime.Object) (labels.Set, fields.Set, error) {
 	}, nil
 }
 
-func PrepareBenchchmarkData(namespaceCount, podPerNamespaceCount, nodeCount int) (data BenchmarkData) {
+func PrepareBenchmarkData(namespaceCount, podPerNamespaceCount, nodeCount int) (data BenchmarkData) {
 	exemplar := loadExemplarPod()
 	data.NodeNames = make([]string, nodeCount)
 	for i := 0; i < nodeCount; i++ {
@@ -216,13 +501,27 @@ func PrepareBenchchmarkData(namespaceCount, podPerNamespaceCount, nodeCount int)
 			p := exemplar.DeepCopy()
 			randomizePod(p, namespace, data.NodeNames[rand.Intn(nodeCount)])
 			data.Pods = append(data.Pods, p)
+			data.PodKeys = append(data.PodKeys, computePodKey(p))
 		}
 	}
 	return data
 }
 
+func PrecreateBenchmarkPods(ctx context.Context, store storage.Interface, data BenchmarkData) error {
+	podOut := &example.Pod{}
+	for _, pod := range data.Pods {
+		key := computePodKey(pod)
+		err := store.Create(ctx, key, pod, podOut, 0)
+		if err != nil && !storage.IsExist(err) {
+			return fmt.Errorf("unexpected error pre-creating pod %q: %w", key, err)
+		}
+	}
+	return nil
+}
+
 type BenchmarkData struct {
 	Pods           []*example.Pod
+	PodKeys        []string
 	NamespaceNames []string
 	NodeNames      []string
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_benchmarks.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_benchmarks.go
@@ -204,7 +204,6 @@ func podAttr(obj runtime.Object) (labels.Set, fields.Set, error) {
 
 func PrepareBenchchmarkData(namespaceCount, podPerNamespaceCount, nodeCount int) (data BenchmarkData) {
 	exemplar := loadExemplarPod()
-
 	data.NodeNames = make([]string, nodeCount)
 	for i := 0; i < nodeCount; i++ {
 		data.NodeNames[i] = rand.String(10)


### PR DESCRIPTION
/kind feature

```release-note
NONE
```


Adding a benchmark to allow for easier iteration and collaboration on watch cache performance. Some interesting findings:
* **The Cacher as a Read-Shield:** Under heavy unindexed polling (Background=Lister), direct etcd write throughput plummets to 1.25k writes/s, while the cacher shields the database to maintain 23k writes/s (+1733%).
* **The Baseline Tax of Caching:** With zero background reads (Background=None), the cacher introduces a baseline penalty. It handles 23.7k writes/s for DeleteCreate compared to raw etcd's 33.5k (-29%).
* **Watch Fan-Out Scaling:** The cacher massively outperforms etcd at distributing events, successfully pushing 725k watch-events/s (+772%) during Patch traffic compared to etcd's 83k.
* **Validated Propagation Delays:** For Patch traffic, both handle similar writes (etcd: 53k, cacher: 63k, +19%) with near-identical delays (~45ms). However, for DeleteCreate, despite highly similar throughput (etcd: 30k, cacher: 26.5k, -11%), the cacher suffers a massive near-1-second delay (969.3ms) compared to etcd's 44.5ms.
* **DeleteCreate vs. Patch Cost:**  Under WatchList load, the cacher processes Patches at 63.4k writes/s (42ms delay) but processes DeleteCreates at only 26.4k writes/s (969ms delay). 

Raw benchmark results:
```
                                                                                 │     etcd.bench      │               cacher.bench                │
                                                                                 │       sec/op        │      sec/op        vs base                │
StoreWriteThroughput/Traffic=DeleteCreate/Background=None/UseIndex=false-24              61.59µ ±   5%   105.89µ ±     76%   +71.92% (p=0.002 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Background=Watcher/UseIndex=false-24           105.4µ ±   4%    189.8µ ±     20%   +80.01% (p=0.002 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Background=Lister/UseIndex=false-24        8487806.2µ ± 372%    193.1µ ±    929%  -100.00% (p=0.002 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Background=WatchList/UseIndex=false-24         69.34µ ±   8%   173.96µ ±      9%  +150.87% (p=0.002 n=6)
StoreWriteThroughput/Traffic=Patch/Background=None/UseIndex=false-24                     47.52µ ±  61%    97.08µ ±     61%  +104.28% (p=0.015 n=6)
StoreWriteThroughput/Traffic=Patch/Background=Watcher/UseIndex=false-24                  55.26µ ±  14%    71.05µ ±     35%   +28.59% (p=0.015 n=6)
StoreWriteThroughput/Traffic=Patch/Background=Lister/UseIndex=false-24             11596233.13µ ± 101%    46.20µ ± 313093%  -100.00% (p=0.002 n=6)
StoreWriteThroughput/Traffic=Patch/Background=WatchList/UseIndex=false-24                39.25µ ±  10%    32.92µ ±     11%   -16.12% (p=0.002 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Background=Watcher/UseIndex=true-24                             147.6µ ±     32%
StoreWriteThroughput/Traffic=DeleteCreate/Background=Lister/UseIndex=true-24                              172.7µ ±     43%
StoreWriteThroughput/Traffic=DeleteCreate/Background=WatchList/UseIndex=true-24                           153.1µ ±     31%
StoreWriteThroughput/Traffic=Patch/Background=Watcher/UseIndex=true-24                                    35.55µ ±      4%
StoreWriteThroughput/Traffic=Patch/Background=Lister/UseIndex=true-24                                     31.75µ ±      8%
StoreWriteThroughput/Traffic=Patch/Background=WatchList/UseIndex=true-24                                  32.26µ ±     10%
geomean                                                                                  1.209m           84.88µ             -92.08%

                                                                                 │  etcd.bench   │               cacher.bench               │
                                                                                 │ seconds-delay │  seconds-delay   vs base                 │
StoreWriteThroughput/Traffic=DeleteCreate/Background=None/UseIndex=false-24         39.00m ± 13%    93.86m ± 1672%          ~ (p=1.000 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Background=Watcher/UseIndex=false-24      48.38m ± 16%   389.20m ±  136%          ~ (p=0.065 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Background=Lister/UseIndex=false-24       40.43m ± 11%   145.62m ±  503%   +260.19% (p=0.002 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Background=WatchList/UseIndex=false-24    44.51m ± 15%   969.30m ±   50%  +2077.71% (p=0.002 n=6)
StoreWriteThroughput/Traffic=Patch/Background=None/UseIndex=false-24                42.81m ±  6%   111.23m ±  481%          ~ (p=1.000 n=6)
StoreWriteThroughput/Traffic=Patch/Background=Watcher/UseIndex=false-24             54.91m ± 17%    30.56m ±  144%          ~ (p=0.065 n=6)
StoreWriteThroughput/Traffic=Patch/Background=Lister/UseIndex=false-24              44.58m ± 15%    78.53m ±   57%          ~ (p=0.065 n=6)
StoreWriteThroughput/Traffic=Patch/Background=WatchList/UseIndex=false-24           45.81m ± 20%    42.65m ±  142%          ~ (p=0.937 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Background=Watcher/UseIndex=true-24                       600.0m ±   70%
StoreWriteThroughput/Traffic=DeleteCreate/Background=Lister/UseIndex=true-24                         1.219 ±   98%
StoreWriteThroughput/Traffic=DeleteCreate/Background=WatchList/UseIndex=true-24                     695.1m ±   78%
StoreWriteThroughput/Traffic=Patch/Background=Watcher/UseIndex=true-24                              47.62m ±   84%
StoreWriteThroughput/Traffic=Patch/Background=Lister/UseIndex=true-24                               34.27m ±  210%
StoreWriteThroughput/Traffic=Patch/Background=WatchList/UseIndex=true-24                            30.77m ±  237%
geomean                                                                             44.83m          143.0m           +178.33%

                                                                                 │  etcd.bench  │              cacher.bench              │
                                                                                 │   writes/s   │   writes/s     vs base                 │
StoreWriteThroughput/Traffic=DeleteCreate/Background=None/UseIndex=false-24        33.53k ±  5%    23.77k ± 24%    -29.11% (p=0.002 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Background=Watcher/UseIndex=false-24     19.70k ±  4%    15.44k ± 30%    -21.60% (p=0.026 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Background=Lister/UseIndex=false-24      1.256k ± 11%   23.029k ± 42%  +1733.52% (p=0.002 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Background=WatchList/UseIndex=false-24   30.04k ±  7%    26.48k ±  6%    -11.85% (p=0.004 n=6)
StoreWriteThroughput/Traffic=Patch/Background=None/UseIndex=false-24               44.25k ± 38%    27.95k ± 37%    -36.83% (p=0.041 n=6)
StoreWriteThroughput/Traffic=Patch/Background=Watcher/UseIndex=false-24            37.75k ± 13%    28.95k ± 26%    -23.31% (p=0.015 n=6)
StoreWriteThroughput/Traffic=Patch/Background=Lister/UseIndex=false-24             1.619k ± 11%   57.364k ± 81%  +3443.14% (p=0.002 n=6)
StoreWriteThroughput/Traffic=Patch/Background=WatchList/UseIndex=false-24          53.06k ±  9%    63.46k ±  6%    +19.59% (p=0.002 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Background=Watcher/UseIndex=true-24                      25.00k ± 17%
StoreWriteThroughput/Traffic=DeleteCreate/Background=Lister/UseIndex=true-24                       23.90k ± 17%
StoreWriteThroughput/Traffic=DeleteCreate/Background=WatchList/UseIndex=true-24                    26.59k ± 19%
StoreWriteThroughput/Traffic=Patch/Background=Watcher/UseIndex=true-24                             59.28k ±  5%
StoreWriteThroughput/Traffic=Patch/Background=Lister/UseIndex=true-24                              66.59k ±  8%
StoreWriteThroughput/Traffic=Patch/Background=WatchList/UseIndex=true-24                           65.25k ±  6%
geomean                                                                            15.64k          33.95k          +91.96%

                                                                               │   etcd.bench   │              cacher.bench              │
                                                                               │ watch-events/s │ watch-events/s  vs base                │
StoreWriteThroughput/Traffic=DeleteCreate/Background=Watcher/UseIndex=false-24     94.77k ± 16%   380.10k ±  40%  +301.09% (p=0.002 n=6)
StoreWriteThroughput/Traffic=Patch/Background=Watcher/UseIndex=false-24            83.20k ± 23%   725.62k ± 110%  +772.11% (p=0.002 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Background=Watcher/UseIndex=true-24                       476.9 ±  37%
StoreWriteThroughput/Traffic=Patch/Background=Watcher/UseIndex=true-24                              275.6 ±  14%
geomean                                                                            88.80k          13.80k         +491.44%

                                                                                 │    etcd.bench     │              cacher.bench              │
                                                                                 │   list-calls/s    │  list-calls/s    vs base               │
StoreWriteThroughput/Traffic=DeleteCreate/Background=Lister/UseIndex=false-24       967.500 ± 327%      9.224 ±  2413%  -99.05% (p=0.002 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Background=WatchList/UseIndex=false-24      0.000 ±   0%      2.990 ±    37%        ? (p=0.002 n=6)
StoreWriteThroughput/Traffic=Patch/Background=Lister/UseIndex=false-24             1619.000 ± 103%      5.826 ± 91404%        ~ (p=0.065 n=6)
StoreWriteThroughput/Traffic=Patch/Background=WatchList/UseIndex=false-24              0.0m ±   0%     878.2m ±    16%        ? (p=0.002 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Background=Lister/UseIndex=true-24                            16.99 ±    60%
StoreWriteThroughput/Traffic=DeleteCreate/Background=WatchList/UseIndex=true-24                         6.268 ±    15%
StoreWriteThroughput/Traffic=Patch/Background=Lister/UseIndex=true-24                                   89.53 ±     9%
StoreWriteThroughput/Traffic=Patch/Background=WatchList/UseIndex=true-24                                5.335 ±    11%
geomean                                                                                            ¹    7.194           ?
¹ summaries must be >0 to compute geomean

                                                                                 │    etcd.bench     │               cacher.bench                │
                                                                                 │    list-objs/s    │   list-objs/s     vs base                 │
StoreWriteThroughput/Traffic=DeleteCreate/Background=Lister/UseIndex=false-24       191.487M ± 1194%    1.382M ±  2416%    -99.28% (p=0.002 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Background=WatchList/UseIndex=false-24      17.21k ±    7%   164.81k ±    25%   +857.61% (p=0.002 n=6)
StoreWriteThroughput/Traffic=Patch/Background=Lister/UseIndex=false-24             364285.7k ±  238%    873.9k ± 91394%    -99.76% (p=0.041 n=6)
StoreWriteThroughput/Traffic=Patch/Background=WatchList/UseIndex=false-24             12.87k ±   10%   225.57k ±     3%  +1653.33% (p=0.002 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Background=Lister/UseIndex=true-24                             390.3 ±    60%
StoreWriteThroughput/Traffic=DeleteCreate/Background=WatchList/UseIndex=true-24                          146.4 ±    14%
StoreWriteThroughput/Traffic=Patch/Background=Lister/UseIndex=true-24                                   2.059k ±     9%
StoreWriteThroughput/Traffic=Patch/Background=WatchList/UseIndex=true-24                                 124.9 ±     5%
geomean                                                                               1.982M            12.66k             -76.78%


```

/cc @mborsz