### PR TITLE
perf: introduce stopChurn opcode in scheduler_perf framework

### DIFF
--- a/test/integration/scheduler_perf/executor.go
+++ b/test/integration/scheduler_perf/executor.go
@@ -72,6 +72,7 @@ type WorkloadExecutor struct {
 	nextNodeIndex                int
 	opts                         *schedulerPerfOptions
 	cpuProfileFile               *os.File
+	churnCancels                 []context.CancelFunc
 }
 
 func (e *WorkloadExecutor) wait() {
@@ -355,6 +356,10 @@ func (e *WorkloadExecutor) runChurnOp(tCtx ktesting.TContext, opIndex int, op *c
 		return fmt.Errorf("unable to create namespace %v: %w", namespace, err)
 	}
 
+	// Create a cancellable child context for background churn loop
+	churnCtx, churnCancel := context.WithCancel(tCtx)
+	e.churnCancels = append(e.churnCancels, churnCancel)
+
 	var churnFns []func(name string) string
 
 	for i, path := range op.TemplatePaths {
@@ -378,13 +383,13 @@ func (e *WorkloadExecutor) runChurnOp(tCtx ktesting.TContext, opIndex int, op *c
 
 		churnFns = append(churnFns, func(name string) string {
 			if name != "" {
-				if err := dynRes.Delete(tCtx, name, metav1.DeleteOptions{}); err != nil && !errors.Is(err, context.Canceled) {
+				if err := dynRes.Delete(churnCtx, name, metav1.DeleteOptions{}); err != nil && !errors.Is(err, context.Canceled) {
 					tCtx.Errorf("op %d: unable to delete %v: %v", opIndex, name, err)
 				}
 				return ""
 			}
 
-			live, err := dynRes.Create(tCtx, unstructuredObj, metav1.CreateOptions{})
+			live, err := dynRes.Create(churnCtx, unstructuredObj, metav1.CreateOptions{})
 			if err != nil {
 				return ""
 			}
@@ -415,7 +420,7 @@ func (e *WorkloadExecutor) runChurnOp(tCtx ktesting.TContext, opIndex int, op *c
 						churnFns[i]("")
 					}
 					count++
-				case <-tCtx.Done():
+				case <-churnCtx.Done():
 					return
 				}
 			}
@@ -439,7 +444,7 @@ func (e *WorkloadExecutor) runChurnOp(tCtx ktesting.TContext, opIndex int, op *c
 						retVals[i][count%op.Number] = churnFns[i](retVals[i][count%op.Number])
 					}
 					count++
-				case <-tCtx.Done():
+				case <-churnCtx.Done():
 					return
 				}
 			}
@@ -524,6 +529,16 @@ func (e *WorkloadExecutor) runStopCollectingProfileOp(tCtx ktesting.TContext, _ 
 		return nil
 	default:
 		return fmt.Errorf("unsupported profile type %q", op.Type)
+	}
+}
+
+func (e *WorkloadExecutor) stopAllBackgroundChurns(tCtx ktesting.TContext) {
+	if len(e.churnCancels) > 0 {
+		tCtx.Logf("Stopping all background churn generators (active: %d)", len(e.churnCancels))
+		for _, cancel := range e.churnCancels {
+			cancel()
+		}
+		e.churnCancels = nil
 	}
 }
 

--- a/test/integration/scheduler_perf/executor.go
+++ b/test/integration/scheduler_perf/executor.go
@@ -72,7 +72,7 @@ type WorkloadExecutor struct {
 	nextNodeIndex                int
 	opts                         *schedulerPerfOptions
 	cpuProfileFile               *os.File
-	churnCancels                 []context.CancelFunc
+	churnCancels                 map[string]context.CancelFunc
 }
 
 func (e *WorkloadExecutor) wait() {
@@ -92,6 +92,8 @@ func (e *WorkloadExecutor) runOp(tCtx ktesting.TContext, op realOp, opIndex int)
 		return e.runDeletePodsOp(tCtx, opIndex, concreteOp)
 	case *churnOp:
 		return e.runChurnOp(tCtx, opIndex, concreteOp)
+	case *stopChurnOp:
+		return e.runStopChurnOp(tCtx, concreteOp)
 	case *barrierOp:
 		return e.runBarrierOp(tCtx, opIndex, concreteOp)
 	case *sleepOp:
@@ -358,7 +360,17 @@ func (e *WorkloadExecutor) runChurnOp(tCtx ktesting.TContext, opIndex int, op *c
 
 	// Create a cancellable child context for background churn loop
 	churnCtx, churnCancel := context.WithCancel(tCtx)
-	e.churnCancels = append(e.churnCancels, churnCancel)
+	if e.churnCancels == nil {
+		e.churnCancels = make(map[string]context.CancelFunc)
+	}
+	name := op.Name
+	if name == "" {
+		name = "default"
+	}
+	if cancel, ok := e.churnCancels[name]; ok {
+		cancel()
+	}
+	e.churnCancels[name] = churnCancel
 
 	var churnFns []func(name string) string
 
@@ -450,6 +462,22 @@ func (e *WorkloadExecutor) runChurnOp(tCtx ktesting.TContext, opIndex int, op *c
 			}
 		}()
 	}
+	return nil
+}
+
+func (e *WorkloadExecutor) runStopChurnOp(tCtx ktesting.TContext, op *stopChurnOp) error {
+	if op.Name != "" {
+		cancel, ok := e.churnCancels[op.Name]
+		if !ok {
+			return fmt.Errorf("no active churn generator with name %q", op.Name)
+		}
+		tCtx.Logf("Stopping background churn generator: %q", op.Name)
+		cancel()
+		delete(e.churnCancels, op.Name)
+		return nil
+	}
+
+	e.stopAllBackgroundChurns(tCtx)
 	return nil
 }
 

--- a/test/integration/scheduler_perf/executor_test.go
+++ b/test/integration/scheduler_perf/executor_test.go
@@ -1221,15 +1221,124 @@ func TestProfileCollection(t *testing.T) {
 	})
 }
 
+func TestStopChurnOpCancellation(t *testing.T) {
+	tCtx := ktesting.Init(t)
+
+	t.Run("stop specific named churn", func(t *testing.T) {
+		called1, called2 := false, false
+		exec := &WorkloadExecutor{
+			churnCancels: map[string]context.CancelFunc{
+				"churn-1": func() { called1 = true },
+				"churn-2": func() { called2 = true },
+			},
+		}
+
+		op := &stopChurnOp{
+			Opcode: stopChurnOpcode,
+			Name:   "churn-1",
+		}
+
+		err := exec.runStopChurnOp(tCtx, op)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if !called1 {
+			t.Errorf("Expected churn-1 to be cancelled")
+		}
+		if called2 {
+			t.Errorf("Expected churn-2 not to be cancelled")
+		}
+		if _, exists := exec.churnCancels["churn-1"]; exists {
+			t.Errorf("Expected churn-1 to be deleted from map")
+		}
+		if _, exists := exec.churnCancels["churn-2"]; !exists {
+			t.Errorf("Expected churn-2 to remain in map")
+		}
+	})
+
+	t.Run("stop all churns when no name specified", func(t *testing.T) {
+		called1, called2 := false, false
+		exec := &WorkloadExecutor{
+			churnCancels: map[string]context.CancelFunc{
+				"churn-1": func() { called1 = true },
+				"churn-2": func() { called2 = true },
+			},
+		}
+
+		op := &stopChurnOp{
+			Opcode: stopChurnOpcode,
+			Name:   "",
+		}
+
+		err := exec.runStopChurnOp(tCtx, op)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if !called1 {
+			t.Errorf("Expected churn-1 to be cancelled")
+		}
+		if !called2 {
+			t.Errorf("Expected churn-2 to be cancelled")
+		}
+		if exec.churnCancels != nil {
+			t.Errorf("Expected churnCancels map to be nil after stopping all")
+		}
+	})
+
+	t.Run("stop non-existent named churn errors", func(t *testing.T) {
+		exec := &WorkloadExecutor{
+			churnCancels: map[string]context.CancelFunc{
+				"churn-1": func() {},
+			},
+		}
+
+		op := &stopChurnOp{
+			Opcode: stopChurnOpcode,
+			Name:   "churn-non-existent",
+		}
+
+		err := exec.runStopChurnOp(tCtx, op)
+		if err == nil {
+			t.Fatalf("Expected error when stopping non-existent named churn, got nil")
+		}
+		expectedErr := `no active churn generator with name "churn-non-existent"`
+		if err.Error() != expectedErr {
+			t.Errorf("Expected error message %q, got %q", expectedErr, err.Error())
+		}
+	})
+
+	t.Run("stop named churn when no churns exist errors", func(t *testing.T) {
+		exec := &WorkloadExecutor{
+			churnCancels: nil,
+		}
+
+		op := &stopChurnOp{
+			Opcode: stopChurnOpcode,
+			Name:   "churn-1",
+		}
+
+		err := exec.runStopChurnOp(tCtx, op)
+		if err == nil {
+			t.Fatalf("Expected error when stopping named churn with no active churns, got nil")
+		}
+		expectedErr := `no active churn generator with name "churn-1"`
+		if err.Error() != expectedErr {
+			t.Errorf("Expected error message %q, got %q", expectedErr, err.Error())
+		}
+	})
+}
+
 func TestStopAllBackgroundChurns(t *testing.T) {
 	tCtx := ktesting.Init(t)
 
 	t.Run("stop all churns when some churns exist", func(t *testing.T) {
 		called1, called2 := false, false
 		exec := &WorkloadExecutor{
-			churnCancels: []context.CancelFunc{
-				func() { called1 = true },
-				func() { called2 = true },
+			churnCancels: map[string]context.CancelFunc{
+				"churn-1": func() { called1 = true },
+				"churn-2": func() { called2 = true },
 			},
 		}
 
@@ -1242,7 +1351,7 @@ func TestStopAllBackgroundChurns(t *testing.T) {
 			t.Errorf("Expected churn-2 to be cancelled")
 		}
 		if exec.churnCancels != nil {
-			t.Errorf("Expected churnCancels slice to be nil after stopping all")
+			t.Errorf("Expected churnCancels map to be nil after stopping all")
 		}
 	})
 
@@ -1254,7 +1363,7 @@ func TestStopAllBackgroundChurns(t *testing.T) {
 		exec.stopAllBackgroundChurns(tCtx)
 
 		if exec.churnCancels != nil {
-			t.Errorf("Expected churnCancels slice to remain nil")
+			t.Errorf("Expected churnCancels map to remain nil")
 		}
 	})
 }

--- a/test/integration/scheduler_perf/executor_test.go
+++ b/test/integration/scheduler_perf/executor_test.go
@@ -1220,3 +1220,41 @@ func TestProfileCollection(t *testing.T) {
 		}
 	})
 }
+
+func TestStopAllBackgroundChurns(t *testing.T) {
+	tCtx := ktesting.Init(t)
+
+	t.Run("stop all churns when some churns exist", func(t *testing.T) {
+		called1, called2 := false, false
+		exec := &WorkloadExecutor{
+			churnCancels: []context.CancelFunc{
+				func() { called1 = true },
+				func() { called2 = true },
+			},
+		}
+
+		exec.stopAllBackgroundChurns(tCtx)
+
+		if !called1 {
+			t.Errorf("Expected churn-1 to be cancelled")
+		}
+		if !called2 {
+			t.Errorf("Expected churn-2 to be cancelled")
+		}
+		if exec.churnCancels != nil {
+			t.Errorf("Expected churnCancels slice to be nil after stopping all")
+		}
+	})
+
+	t.Run("stop all churns when no churns exist", func(t *testing.T) {
+		exec := &WorkloadExecutor{
+			churnCancels: nil,
+		}
+
+		exec.stopAllBackgroundChurns(tCtx)
+
+		if exec.churnCancels != nil {
+			t.Errorf("Expected churnCancels slice to remain nil")
+		}
+	})
+}

--- a/test/integration/scheduler_perf/operations.go
+++ b/test/integration/scheduler_perf/operations.go
@@ -518,6 +518,9 @@ func (dpo deletePodsOp) patchParams(w *Workload) (realOp, error) {
 type churnOp struct {
 	// Must be "churnOp".
 	Opcode operationCode
+	// Name of the churn operation. Optional.
+	// If empty, stopChurnOp stops all background churns.
+	Name string
 	// Value must be one of the followings:
 	// - recreate. In this mode, API objects will be created for N cycles, and then
 	//   deleted in the next N cycles. N is specified by the "Number" field.
@@ -884,4 +887,23 @@ func divideFloat(i, j any) float64 {
 
 func mod(a, b any) int {
 	return int(toFloat64(a)) % int(toFloat64(b))
+}
+
+// stopChurnOp defines an op that cancels any running background churn operation.
+type stopChurnOp struct {
+	Opcode operationCode
+	// Name of the churn operation to stop. Optional.
+	Name string
+}
+
+func (sco *stopChurnOp) isValid(_ bool) error {
+	return nil
+}
+
+func (*stopChurnOp) collectsMetrics() bool {
+	return false
+}
+
+func (sco stopChurnOp) patchParams(_ *Workload) (realOp, error) {
+	return &sco, nil
 }

--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -1135,6 +1135,9 @@ func runWorkload(tCtx ktesting.TContext, tc *testCase, w *Workload, topicName st
 		return nil, fmt.Errorf("the parameters %v are defined on workload %s, but unused.\nPlease make sure there are no typos", unusedParams, w.Name)
 	}
 
+	// Stopping all churn generators to avoid adding inflight events after the workload is done.
+	executor.stopAllBackgroundChurns(tCtx)
+
 	// Some tests have unschedulable pods. Do not add an implicit barrier at the
 	// end as we do not want to wait for them.
 	return executor.dataItems, nil

--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -75,6 +75,7 @@ const (
 	sleepOpcode                  operationCode = "sleep"
 	startCollectingMetricsOpcode operationCode = "startCollectingMetrics"
 	stopCollectingMetricsOpcode  operationCode = "stopCollectingMetrics"
+	stopChurnOpcode              operationCode = "stopChurn"
 	waitForPodGroupsOpcode       operationCode = "waitForPodGroups"
 	startCollectingProfileOpcode operationCode = "startCollectingProfile"
 	stopCollectingProfileOpcode  operationCode = "stopCollectingProfile"
@@ -515,6 +516,7 @@ func (op *op) UnmarshalJSON(b []byte) error {
 		sleepOpcode:                  &sleepOp{},
 		startCollectingMetricsOpcode: &startCollectingMetricsOp{},
 		stopCollectingMetricsOpcode:  &stopCollectingMetricsOp{},
+		stopChurnOpcode:              &stopChurnOp{},
 		waitForPodGroupsOpcode:       &waitForPodGroups{},
 		startCollectingProfileOpcode: &startCollectingProfileOp{},
 		stopCollectingProfileOpcode:  &stopCollectingProfileOp{},
@@ -1135,7 +1137,7 @@ func runWorkload(tCtx ktesting.TContext, tc *testCase, w *Workload, topicName st
 		return nil, fmt.Errorf("the parameters %v are defined on workload %s, but unused.\nPlease make sure there are no typos", unusedParams, w.Name)
 	}
 
-	// Stopping all churn generators to avoid adding inflight events after the workload is done.
+	// Stopping all churn generators to avoid adding inflight evens after the workload is done.
 	executor.stopAllBackgroundChurns(tCtx)
 
 	// Some tests have unschedulable pods. Do not add an implicit barrier at the


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR introduces a new `stopChurn` opcode to the `scheduler_perf` integration testing framework with support for tracking and stopping multiple concurrent churn generators.

Currently, the `churn` opcode starts a background churn generator (creating/deleting pods) that runs for the entire remaining lifetime of the workload run. There is no mechanism to stop a background churn loop in the middle of a workload template sequence, nor is there support for managing multiple concurrent/overlapping churn generators without resource leaks.

To resolve this, this PR:
1. Adds an optional `Name` field to both the `churn` and `stopChurn` opcodes.
2. Updates `WorkloadExecutor` to track background churn cancellation functions in a map (`churnCancels`) indexed by their name.
3. Implements named and multi-cancellation logic in `runStopChurnOp`:
   - **Named Cancellation**: If a `Name` is specified, it cancels and cleans up only that specific background churn generator.
   - **Bulk Cancellation**: If no `Name` is specified, it cancels and cleans up **all** currently active background churn generators.
4. Includes comprehensive unit tests (`TestStopChurnOpCancellation`) verifying correct cancellation and map state tracking for both scenarios.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This is a prerequisite framework change needed for subsequent scheduler performance/starvation benchmark tests that utilize the `stopChurn` opcode. The starvation performance tests themselves are introduced in #139421.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
