### PR TITLE
apiserver: add BenchmarkCacherInitSecrets

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_init_bench_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_init_bench_test.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
@@ -40,7 +41,9 @@ func BenchmarkCacherInit(b *testing.B) {
 
 	ctx := context.Background()
 
-	server, etcdStorage := newCorev1EtcdTestStorage(b)
+	server, etcdStorage := newCorev1EtcdTestStorage(b, "/pods/", schema.GroupResource{Resource: "pods"},
+		func() runtime.Object { return &corev1.Pod{} },
+		func() runtime.Object { return &corev1.PodList{} })
 	b.Cleanup(func() { server.Terminate(b) })
 
 	seedCorev1PodsParallel(b, ctx, etcdStorage, 1, pods, 32)
@@ -77,6 +80,102 @@ func BenchmarkCacherInit(b *testing.B) {
 		b.StartTimer()
 	}
 	b.ReportMetric(float64(pods), "pods/cache")
+}
+
+func BenchmarkCacherInitSecrets(b *testing.B) {
+	const secrets = 2_000
+	const payloadBytes = 512 << 10 // 512 KiB per Secret; ~1 GiB total
+
+	ctx := context.Background()
+
+	server, etcdStorage := newCorev1EtcdTestStorage(b, "/secrets/", schema.GroupResource{Resource: "secrets"},
+		func() runtime.Object { return &corev1.Secret{} },
+		func() runtime.Object { return &corev1.SecretList{} })
+	b.Cleanup(func() { server.Terminate(b) })
+
+	seedCorev1SecretsParallel(b, ctx, etcdStorage, secrets, payloadBytes, 32)
+
+	config := Config{
+		Storage:             etcdStorage,
+		Versioner:           storage.APIObjectVersioner{},
+		GroupResource:       schema.GroupResource{Resource: "secrets"},
+		EventsHistoryWindow: DefaultEventFreshDuration,
+		ResourcePrefix:      "/secrets/",
+		KeyFunc: func(obj runtime.Object) (string, error) {
+			return storage.NamespaceKeyFunc("/secrets/", obj)
+		},
+		GetAttrsFunc: getCorev1SecretAttrs,
+		NewFunc:      func() runtime.Object { return &corev1.Secret{} },
+		NewListFunc:  func() runtime.Object { return &corev1.SecretList{} },
+		Codec:        corev1ProtoCodec,
+		Clock:        clock.RealClock{},
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		cacher, err := NewCacherFromConfig(config)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := cacher.Wait(ctx); err != nil {
+			b.Fatal(err)
+		}
+		b.StopTimer()
+		cacher.Stop()
+		etcd3.TestOnlyResetResourceSizeEstimator(etcdStorage)
+		b.StartTimer()
+	}
+	b.ReportMetric(float64(secrets), "secrets/cache")
+	b.ReportMetric(float64(payloadBytes), "bytes/secret")
+}
+
+func seedCorev1SecretsParallel(b *testing.B, ctx context.Context, etcdStorage storage.Interface, count, payloadBytes, workers int) {
+	b.Helper()
+
+	payload := make([]byte, payloadBytes)
+	ns := utilrand.String(10)
+
+	g, gctx := errgroup.WithContext(ctx)
+	jobs := make(chan *corev1.Secret, workers*4)
+
+	for range workers {
+		g.Go(func() error {
+			var out corev1.Secret
+			for s := range jobs {
+				key := fmt.Sprintf("/secrets/%s/%s", s.Namespace, s.Name)
+				if err := etcdStorage.Create(gctx, key, s, &out, 0); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+
+	g.Go(func() error {
+		defer close(jobs)
+		for range count {
+			s := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns,
+					Name:      "secret-" + utilrand.String(10),
+					UID:       uuid.NewUUID(),
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{"payload": payload},
+			}
+			select {
+			case jobs <- s:
+			case <-gctx.Done():
+				return gctx.Err()
+			}
+		}
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		b.Fatalf("seed: %v", err)
+	}
 }
 
 func loadExemplarPod(b *testing.B) *corev1.Pod {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_testing_utils_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_testing_utils_test.go
@@ -61,7 +61,7 @@ func init() {
 	utilruntime.Must(metav1.AddMetaToScheme(scheme))
 	scheme.AddUnversionedTypes(corev1.SchemeGroupVersion, &metav1.Status{})
 	pb := protobuf.NewSerializer(scheme, scheme)
-	corev1ProtoCodec = codecs.CodecForVersions(pb, pb, schema.GroupVersions{corev1.SchemeGroupVersion}, nil)
+	corev1ProtoCodec = codecs.CodecForVersions(pb, pb, schema.GroupVersions{corev1.SchemeGroupVersion}, schema.GroupVersions{corev1.SchemeGroupVersion})
 	examplev1ProtoCodec = codecs.CodecForVersions(pb, pb, schema.GroupVersions{examplev1.SchemeGroupVersion}, nil)
 }
 
@@ -110,9 +110,9 @@ func computePodKey(obj *example.Pod) string {
 	return fmt.Sprintf("/pods/%s/%s", obj.Namespace, obj.Name)
 }
 
-func newCorev1EtcdTestStorage(t testing.TB) (*etcd3testing.EtcdTestServer, storage.Interface) {
+func newCorev1EtcdTestStorage(t testing.TB, resourcePrefix string, gr schema.GroupResource, newFunc, newListFunc func() runtime.Object) (*etcd3testing.EtcdTestServer, storage.Interface) {
 	cfg := testserver.NewTestConfig(t)
-	cfg.QuotaBackendBytes = 4 << 30 // 4 GiB (default 2 GiB is too small for 150k pods)
+	cfg.QuotaBackendBytes = 4 << 30 // 4 GiB
 	server := &etcd3testing.EtcdTestServer{V3Client: testserver.RunEtcd(t, cfg)}
 	versioner := storage.APIObjectVersioner{}
 	compactor := etcd3.NewCompactor(server.V3Client.Client, 0, clock.RealClock{}, nil)
@@ -121,11 +121,11 @@ func newCorev1EtcdTestStorage(t testing.TB) (*etcd3testing.EtcdTestServer, stora
 		server.V3Client,
 		compactor,
 		corev1ProtoCodec,
-		func() runtime.Object { return &corev1.Pod{} },
-		func() runtime.Object { return &corev1.PodList{} },
+		newFunc,
+		newListFunc,
 		etcd3testing.PathPrefix(),
-		"/pods/",
-		schema.GroupResource{Resource: "pods"},
+		resourcePrefix,
+		gr,
 		identity.NewEncryptCheckTransformer(),
 		etcd3.NewDefaultLeaseManagerConfig(),
 		etcd3.NewDefaultDecoder(corev1ProtoCodec, versioner),
@@ -150,6 +150,19 @@ func getCorev1PodAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 		"status.phase":       string(pod.Status.Phase),
 	}
 	return labels.Set(pod.Labels), fs, nil
+}
+
+func getCorev1SecretAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
+	secret, ok := obj.(*corev1.Secret)
+	if !ok {
+		return nil, nil, fmt.Errorf("not a secret")
+	}
+	fs := fields.Set{
+		"metadata.name":      secret.Name,
+		"metadata.namespace": secret.Namespace,
+		"type":               string(secret.Type),
+	}
+	return labels.Set(secret.Labels), fs, nil
 }
 
 func compactWatch(c *CacheDelegator, client *clientv3.Client) storagetesting.Compaction {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds BenchmarkCacherInitSecrets, a cacher cold-sync benchmark that seeds etcd with 2000 large (512 KiB) opaque Secrets (~1 GiB total) and measures Cacher construction + Ready.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
