### PR TITLE
scheduler: call Done before requeueing pod in AddUnschedulablePodIfNotPresent

### DIFF
--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -1024,6 +1024,14 @@ func (p *PriorityQueue) AddUnschedulablePodIfNotPresent(logger klog.Logger, pInf
 	// We check whether this Pod may change its scheduling result by any of events that happened during scheduling.
 	schedulingHint := p.determineSchedulingHintForInFlightPod(logger, pInfo)
 
+	// Done has to be called before requeueing the pod. Otherwise, a race can happen
+	// when the pod is re-added to activeQ/backoffQ and a concurrent Pop picks it up
+	// before Done is called: Pop finds the UID still in inFlightPods and silently
+	// discards the pod, causing it to be permanently lost from the queue.
+	// The same reasoning applies to pod group members above.
+	p.Done(pInfo.Pod.UID)
+	calledDone = true
+
 	// In this case, we try to requeue this Pod to activeQ/backoffQ.
 	queue := p.requeueEntityWithQueueingStrategy(logger, pInfo, schedulingHint, framework.ScheduleAttemptFailure)
 	logger.V(3).Info("Pod moved to an internal scheduling queue", "pod", klog.KObj(pod), "event", framework.ScheduleAttemptFailure, "queue", queue, "schedulingCycle", podSchedulingCycle, "hint", schedulingHint, "unschedulable plugins", rejectorPlugins)

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -1334,6 +1334,57 @@ func tryPop(t *testing.T, logger klog.Logger, q *PriorityQueue) framework.Queued
 	return gotEntity
 }
 
+// TestAddUnschedulablePodIfNotPresent_RaceWithConcurrentPop verifies that a pod
+// requeued by AddUnschedulablePodIfNotPresent is not silently dropped when a
+// concurrent Pop picks it up before Done() is called.
+//
+// The race: without calling Done() before requeueEntityWithQueueingStrategy,
+// a goroutine already waiting in Pop can grab the pod from activeQ while its
+// UID is still present in inFlightPods. unlockedMoveEntityToInFlight then
+// detects the duplicate and discards the pod permanently.
+func TestAddUnschedulablePodIfNotPresent_RaceWithConcurrentPop(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	pod := st.MakePod().Name("pod1").UID("pod1").Obj()
+	// Disable backoff so the pod goes to activeQ (not backoffQ) on requeue,
+	// which is required to trigger the broadcast that wakes the waiting Pop.
+	q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), []runtime.Object{pod},
+		WithPodMaxBackoffDuration(0))
+	q.Add(ctx, pod)
+
+	// Simulate a failed scheduling attempt.
+	poppedPod := popPod(t, logger, q, pod)
+	poppedPod.UnschedulablePlugins = sets.New("fooPlugin1")
+
+	// Force-activate the pod so that AddUnschedulablePodIfNotPresent requeues it
+	// back to activeQ via the ForceActivate wildcard event.
+	q.Activate(logger, map[string]*v1.Pod{pod.Name: pod})
+
+	// Start a goroutine blocked in Pop before AddUnschedulablePodIfNotPresent runs.
+	// This models the scheduler loop racing to pick the pod up the moment it appears.
+	poppedCh := make(chan *framework.QueuedPodInfo, 1)
+	go func() {
+		poppedCh <- popPod(t, logger, q, pod)
+	}()
+	// Give the goroutine time to reach aq.cond.Wait() inside pop().
+	time.Sleep(100 * time.Millisecond)
+
+	if err := q.AddUnschedulablePodIfNotPresent(logger, poppedPod, q.SchedulingCycle()); err != nil {
+		t.Errorf("unexpected error from AddUnschedulablePodIfNotPresent: %v", err)
+	}
+
+	select {
+	case <-time.After(10 * time.Second):
+		t.Error("Pop timed out: pod was silently dropped from the scheduling queue")
+	case popped := <-poppedCh:
+		if popped.Pod.UID != pod.UID {
+			t.Errorf("unexpected pod: want %s, got %s", pod.UID, popped.Pod.UID)
+		}
+	}
+}
+
 func TestPriorityQueue_Pop(t *testing.T) {
 	highPriorityPodInfo2 := mustNewPodInfo(
 		st.MakePod().Name("hpp2").Namespace("ns1").UID("hpp2ns1").Priority(highPriority).Obj(),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`AddUnschedulablePodIfNotPresent` defers `Done()` to the end of the function, but the broadcast that wakes waiting `Pop` callers fires before that deferred call. On a multi-CPU system a `Pop` goroutine can acquire `aq.lock` in the window between the broadcast and the deferred `Done()`, find the pod UID still present in `inFlightPods`, and have `unlockedMoveEntityToInFlight` silently discard it — causing the pod to vanish from the scheduling queue permanently with no error logged.

Fix by calling `Done()` explicitly after `determineSchedulingHintForInFlightPod` (which reads `inFlightPods`) but before `requeueEntityWithQueueingStrategy` (which triggers the broadcast). This mirrors the ordering already used for pod group members in the same function, with the identical rationale.

#### Which issue(s) this PR is related to:

Fixes #139186

#### Special notes for your reviewer:

The analogous fix for pod group members already exists at lines 1011–1012 of the same function, with a comment explaining exactly this race. This PR applies the same pattern to the non-pod-group path that was missing it.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where a pod could be permanently lost from the scheduling
queue when a concurrent Pop picked it up before Done() was called in
AddUnschedulablePodIfNotPresent.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```