### PR TITLE
kubelet: expand unit test coverage of cgroup update and read calls

### DIFF
--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -147,7 +147,18 @@ type cgroupCommon struct {
 
 	// useSystemd tells if systemd cgroup manager should be used.
 	useSystemd bool
+
+	// isUnifiedOverride is used to override the default behavior of isUnified() for testing purposes.
+	isUnifiedOverride *bool
 }
+
+func (m *cgroupCommon) isUnified() bool {
+	if m.isUnifiedOverride != nil {
+		return *m.isUnifiedOverride
+	}
+	return libcontainercgroups.IsCgroup2UnifiedMode()
+}
+
 
 // Make sure that cgroupV1impl and cgroupV2impl implement the CgroupManager interface
 var _ CgroupManager = &cgroupV1impl{}
@@ -293,7 +304,7 @@ func (m *cgroupCommon) toResources(logger klog.Logger, resourceConfig *ResourceC
 		resources.Memory = *resourceConfig.Memory
 	}
 	if resourceConfig.CPUShares != nil {
-		if libcontainercgroups.IsCgroup2UnifiedMode() {
+		if m.isUnified() {
 			resources.CpuWeight = getCPUWeight(resourceConfig.CPUShares)
 		} else {
 			resources.CpuShares = *resourceConfig.CPUShares
@@ -317,7 +328,7 @@ func (m *cgroupCommon) toResources(logger klog.Logger, resourceConfig *ResourceC
 	// Ideally unified is used for all the resources when running on cgroup v2.
 	// It doesn't make difference for the memory.max limit, but for e.g. the cpu controller
 	// you can specify the correct setting without relying on the conversions performed by the OCI runtime.
-	if resourceConfig.Unified != nil && libcontainercgroups.IsCgroup2UnifiedMode() {
+	if resourceConfig.Unified != nil && m.isUnified() {
 		resources.Unified = make(map[string]string)
 		for k, v := range resourceConfig.Unified {
 			resources.Unified[k] = v
@@ -328,7 +339,7 @@ func (m *cgroupCommon) toResources(logger klog.Logger, resourceConfig *ResourceC
 
 func (m *cgroupCommon) maybeSetHugetlb(logger klog.Logger, resourceConfig *ResourceConfig, resources *libcontainercgroups.Resources) {
 	// Check if hugetlb is supported.
-	if libcontainercgroups.IsCgroup2UnifiedMode() {
+	if m.isUnified() {
 		if !getSupportedUnifiedControllers().Has("hugetlb") {
 			logger.V(6).Info("Optional subsystem not supported: hugetlb")
 			return

--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -147,6 +147,16 @@ type cgroupCommon struct {
 
 	// useSystemd tells if systemd cgroup manager should be used.
 	useSystemd bool
+
+	// isCgroup2UnifiedModeOverride is used to override the default behavior of isCgroup2UnifiedMode() for testing purposes.
+	isCgroup2UnifiedModeOverride *bool
+}
+
+func (m *cgroupCommon) isCgroup2UnifiedMode() bool {
+	if m.isCgroup2UnifiedModeOverride != nil {
+		return *m.isCgroup2UnifiedModeOverride
+	}
+	return libcontainercgroups.IsCgroup2UnifiedMode()
 }
 
 // Make sure that cgroupV1impl and cgroupV2impl implement the CgroupManager interface
@@ -293,7 +303,7 @@ func (m *cgroupCommon) toResources(logger klog.Logger, resourceConfig *ResourceC
 		resources.Memory = *resourceConfig.Memory
 	}
 	if resourceConfig.CPUShares != nil {
-		if libcontainercgroups.IsCgroup2UnifiedMode() {
+		if m.isCgroup2UnifiedMode() {
 			resources.CpuWeight = getCPUWeight(resourceConfig.CPUShares)
 		} else {
 			resources.CpuShares = *resourceConfig.CPUShares
@@ -317,7 +327,7 @@ func (m *cgroupCommon) toResources(logger klog.Logger, resourceConfig *ResourceC
 	// Ideally unified is used for all the resources when running on cgroup v2.
 	// It doesn't make difference for the memory.max limit, but for e.g. the cpu controller
 	// you can specify the correct setting without relying on the conversions performed by the OCI runtime.
-	if resourceConfig.Unified != nil && libcontainercgroups.IsCgroup2UnifiedMode() {
+	if resourceConfig.Unified != nil && m.isCgroup2UnifiedMode() {
 		resources.Unified = make(map[string]string)
 		for k, v := range resourceConfig.Unified {
 			resources.Unified[k] = v
@@ -328,7 +338,7 @@ func (m *cgroupCommon) toResources(logger klog.Logger, resourceConfig *ResourceC
 
 func (m *cgroupCommon) maybeSetHugetlb(logger klog.Logger, resourceConfig *ResourceConfig, resources *libcontainercgroups.Resources) {
 	// Check if hugetlb is supported.
-	if libcontainercgroups.IsCgroup2UnifiedMode() {
+	if m.isCgroup2UnifiedMode() {
 		if !getSupportedUnifiedControllers().Has("hugetlb") {
 			logger.V(6).Info("Optional subsystem not supported: hugetlb")
 			return

--- a/pkg/kubelet/cm/cgroup_manager_linux_test.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux_test.go
@@ -22,6 +22,13 @@ import (
 	"path"
 	"reflect"
 	"testing"
+
+	libcontainercgroups "github.com/opencontainers/cgroups"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/klog/v2/ktesting"
+	"k8s.io/utils/cpuset"
+	"k8s.io/utils/ptr"
 )
 
 // TestNewCgroupName tests confirms that #68416 is fixed
@@ -205,5 +212,177 @@ func TestCpuWeightToCPUShares(t *testing.T) {
 			t.Errorf("cpuWeight: %v, expectedCpuShares: %v, actualCpuShares: %v",
 				testCase.cpuWeight, testCase.expectedCpuShares, actual)
 		}
+	}
+}
+
+func TestCgroupCommonToResources(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	m := &cgroupCommon{
+		subsystems: &CgroupSubsystems{
+			MountPoints: map[string]string{
+				"hugetlb": "/sys/fs/cgroup/hugetlb",
+			},
+		},
+	}
+	t.Cleanup(func() {
+		m.isUnifiedOverride = nil
+	})
+
+	tests := []struct {
+		name              string
+		resourceConfig    *ResourceConfig
+		validateCgroupsV1 func(t *testing.T, res *libcontainercgroups.Resources)
+		validateCgroupsV2 func(t *testing.T, res *libcontainercgroups.Resources)
+	}{
+		{
+			name:           "nil config yields default empty resources",
+			resourceConfig: nil,
+			validateCgroupsV1: func(t *testing.T, res *libcontainercgroups.Resources) {
+				require.NotNil(t, res)
+				assert.True(t, res.SkipDevices)
+				assert.True(t, res.SkipFreezeOnSet)
+				assert.Equal(t, int64(0), res.Memory)
+				assert.Equal(t, uint64(0), res.CpuShares)
+				assert.Equal(t, uint64(0), res.CpuWeight)
+			},
+			validateCgroupsV2: func(t *testing.T, res *libcontainercgroups.Resources) {
+				require.NotNil(t, res)
+				assert.True(t, res.SkipDevices)
+				assert.True(t, res.SkipFreezeOnSet)
+				assert.Equal(t, int64(0), res.Memory)
+				assert.Equal(t, uint64(0), res.CpuShares)
+				assert.Equal(t, uint64(0), res.CpuWeight)
+			},
+		},
+		{
+			name: "memory limits translation",
+			resourceConfig: &ResourceConfig{
+				Memory: ptr.To[int64](500 * 1024 * 1024),
+			},
+			validateCgroupsV1: func(t *testing.T, res *libcontainercgroups.Resources) {
+				assert.Equal(t, int64(500*1024*1024), res.Memory)
+			},
+			validateCgroupsV2: func(t *testing.T, res *libcontainercgroups.Resources) {
+				assert.Equal(t, int64(500*1024*1024), res.Memory)
+			},
+		},
+		{
+			name: "cpu limits period and quota translation",
+			resourceConfig: &ResourceConfig{
+				CPUPeriod: ptr.To[uint64](100000),
+				CPUQuota:  ptr.To[int64](50000),
+			},
+			validateCgroupsV1: func(t *testing.T, res *libcontainercgroups.Resources) {
+				assert.Equal(t, uint64(100000), res.CpuPeriod)
+				assert.Equal(t, int64(50000), res.CpuQuota)
+			},
+			validateCgroupsV2: func(t *testing.T, res *libcontainercgroups.Resources) {
+				assert.Equal(t, uint64(100000), res.CpuPeriod)
+				assert.Equal(t, int64(50000), res.CpuQuota)
+			},
+		},
+		{
+			name: "pids limit translation",
+			resourceConfig: &ResourceConfig{
+				PidsLimit: ptr.To[int64](1000),
+			},
+			validateCgroupsV1: func(t *testing.T, res *libcontainercgroups.Resources) {
+				assert.Equal(t, ptr.To[int64](1000), res.PidsLimit)
+			},
+			validateCgroupsV2: func(t *testing.T, res *libcontainercgroups.Resources) {
+				assert.Equal(t, ptr.To[int64](1000), res.PidsLimit)
+			},
+		},
+		{
+			name: "cpuset translation and string serialization",
+			resourceConfig: &ResourceConfig{
+				CPUSet: cpuset.New(1, 2, 3),
+			},
+			validateCgroupsV1: func(t *testing.T, res *libcontainercgroups.Resources) {
+				assert.Equal(t, "1-3", res.CpusetCpus)
+			},
+			validateCgroupsV2: func(t *testing.T, res *libcontainercgroups.Resources) {
+				assert.Equal(t, "1-3", res.CpusetCpus)
+			},
+		},
+		{
+			name: "cpu shares to weight non-trivial translation",
+			resourceConfig: &ResourceConfig{
+				CPUShares: ptr.To[uint64](1024),
+			},
+			validateCgroupsV1: func(t *testing.T, res *libcontainercgroups.Resources) {
+				assert.Equal(t, uint64(1024), res.CpuShares)
+				assert.Equal(t, uint64(0), res.CpuWeight)
+			},
+			validateCgroupsV2: func(t *testing.T, res *libcontainercgroups.Resources) {
+				assert.Equal(t, uint64(39), res.CpuWeight)
+				assert.Equal(t, uint64(0), res.CpuShares)
+			},
+		},
+		{
+			name: "unified maps translation conditionally enabled",
+			resourceConfig: &ResourceConfig{
+				Unified: map[string]string{
+					"memory.min": "104857600",
+					"memory.low": "209715200",
+				},
+			},
+			validateCgroupsV1: func(t *testing.T, res *libcontainercgroups.Resources) {
+				assert.Nil(t, res.Unified)
+			},
+			validateCgroupsV2: func(t *testing.T, res *libcontainercgroups.Resources) {
+				require.NotNil(t, res.Unified)
+				assert.Equal(t, "104857600", res.Unified["memory.min"])
+				assert.Equal(t, "209715200", res.Unified["memory.low"])
+			},
+		},
+		{
+			name: "hugepages limit conversion and host padding",
+			resourceConfig: &ResourceConfig{
+				HugePageLimit: map[int64]int64{
+					2 * 1024 * 1024: 1024 * 1024 * 1024,
+				},
+			},
+			validateCgroupsV1: func(t *testing.T, res *libcontainercgroups.Resources) {
+				if len(libcontainercgroups.HugePageSizes()) > 0 {
+					require.NotEmpty(t, res.HugetlbLimit)
+					found := false
+					for _, limit := range res.HugetlbLimit {
+						if limit.Pagesize == "2MB" {
+							assert.Equal(t, uint64(1024*1024*1024), limit.Limit)
+							found = true
+						}
+					}
+					assert.True(t, found, "Should have found translated 2MB hugepage limit under cgroup v1")
+				}
+			},
+			validateCgroupsV2: func(t *testing.T, res *libcontainercgroups.Resources) {
+				if len(libcontainercgroups.HugePageSizes()) > 0 {
+					require.NotEmpty(t, res.HugetlbLimit)
+					found := false
+					for _, limit := range res.HugetlbLimit {
+						if limit.Pagesize == "2MB" {
+							assert.Equal(t, uint64(1024*1024*1024), limit.Limit)
+							found = true
+						}
+					}
+					assert.True(t, found, "Should have found translated 2MB hugepage limit under cgroup v2")
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// 1. Validate cgroup v1 mode
+			m.isUnifiedOverride = ptr.To(false)
+			resV1 := m.toResources(logger, tc.resourceConfig)
+			tc.validateCgroupsV1(t, resV1)
+
+			// 2. Validate cgroup v2 mode	
+			m.isUnifiedOverride = ptr.To(true)
+			resV2 := m.toResources(logger, tc.resourceConfig)
+			tc.validateCgroupsV2(t, resV2)
+		})
 	}
 }

--- a/pkg/kubelet/cm/cgroup_manager_linux_test.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux_test.go
@@ -19,9 +19,18 @@ limitations under the License.
 package cm
 
 import (
+	"os"
 	"path"
+	"path/filepath"
 	"reflect"
 	"testing"
+
+	libcontainercgroups "github.com/opencontainers/cgroups"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2/ktesting"
+	"k8s.io/utils/cpuset"
 )
 
 // TestNewCgroupName tests confirms that #68416 is fixed
@@ -205,5 +214,352 @@ func TestCpuWeightToCPUShares(t *testing.T) {
 			t.Errorf("cpuWeight: %v, expectedCpuShares: %v, actualCpuShares: %v",
 				testCase.cpuWeight, testCase.expectedCpuShares, actual)
 		}
+	}
+}
+
+func TestCgroupCommonToResources(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	m := &cgroupCommon{
+		subsystems: &CgroupSubsystems{
+			MountPoints: map[string]string{
+				"hugetlb": "/sys/fs/cgroup/hugetlb",
+			},
+		},
+	}
+	t.Cleanup(func() {
+		m.isCgroup2UnifiedModeOverride = nil
+	})
+
+	tests := []struct {
+		name              string
+		resourceConfig    *ResourceConfig
+		validateCgroupsV1 func(t *testing.T, res *libcontainercgroups.Resources)
+		validateCgroupsV2 func(t *testing.T, res *libcontainercgroups.Resources)
+	}{
+		{
+			name:           "nil config yields default empty resources",
+			resourceConfig: nil,
+			validateCgroupsV1: func(t *testing.T, res *libcontainercgroups.Resources) {
+				require.NotNil(t, res)
+				assert.True(t, res.SkipDevices)
+				assert.True(t, res.SkipFreezeOnSet)
+				assert.Equal(t, int64(0), res.Memory)
+				assert.Equal(t, uint64(0), res.CpuShares)
+				assert.Equal(t, uint64(0), res.CpuWeight)
+			},
+			validateCgroupsV2: func(t *testing.T, res *libcontainercgroups.Resources) {
+				require.NotNil(t, res)
+				assert.True(t, res.SkipDevices)
+				assert.True(t, res.SkipFreezeOnSet)
+				assert.Equal(t, int64(0), res.Memory)
+				assert.Equal(t, uint64(0), res.CpuShares)
+				assert.Equal(t, uint64(0), res.CpuWeight)
+			},
+		},
+		{
+			name: "memory limits translation",
+			resourceConfig: &ResourceConfig{
+				Memory: new(int64(500 * 1024 * 1024)),
+			},
+			validateCgroupsV1: func(t *testing.T, res *libcontainercgroups.Resources) {
+				assert.Equal(t, int64(500*1024*1024), res.Memory)
+			},
+			validateCgroupsV2: func(t *testing.T, res *libcontainercgroups.Resources) {
+				assert.Equal(t, int64(500*1024*1024), res.Memory)
+			},
+		},
+		{
+			name: "cpu limits period and quota translation",
+			resourceConfig: &ResourceConfig{
+				CPUPeriod: new(uint64(100000)),
+				CPUQuota:  new(int64(50000)),
+			},
+			validateCgroupsV1: func(t *testing.T, res *libcontainercgroups.Resources) {
+				assert.Equal(t, uint64(100000), res.CpuPeriod)
+				assert.Equal(t, int64(50000), res.CpuQuota)
+			},
+			validateCgroupsV2: func(t *testing.T, res *libcontainercgroups.Resources) {
+				assert.Equal(t, uint64(100000), res.CpuPeriod)
+				assert.Equal(t, int64(50000), res.CpuQuota)
+			},
+		},
+		{
+			name: "pids limit translation",
+			resourceConfig: &ResourceConfig{
+				PidsLimit: new(int64(1000)),
+			},
+			validateCgroupsV1: func(t *testing.T, res *libcontainercgroups.Resources) {
+				assert.Equal(t, new(int64(1000)), res.PidsLimit)
+			},
+			validateCgroupsV2: func(t *testing.T, res *libcontainercgroups.Resources) {
+				assert.Equal(t, new(int64(1000)), res.PidsLimit)
+			},
+		},
+		{
+			name: "cpuset translation and string serialization",
+			resourceConfig: &ResourceConfig{
+				CPUSet: cpuset.New(1, 2, 3),
+			},
+			validateCgroupsV1: func(t *testing.T, res *libcontainercgroups.Resources) {
+				assert.Equal(t, "1-3", res.CpusetCpus)
+			},
+			validateCgroupsV2: func(t *testing.T, res *libcontainercgroups.Resources) {
+				assert.Equal(t, "1-3", res.CpusetCpus)
+			},
+		},
+		{
+			name: "cpu shares to weight non-trivial translation",
+			resourceConfig: &ResourceConfig{
+				CPUShares: new(uint64(1024)),
+			},
+			validateCgroupsV1: func(t *testing.T, res *libcontainercgroups.Resources) {
+				assert.Equal(t, uint64(1024), res.CpuShares)
+				assert.Equal(t, uint64(0), res.CpuWeight)
+			},
+			validateCgroupsV2: func(t *testing.T, res *libcontainercgroups.Resources) {
+				assert.Equal(t, uint64(39), res.CpuWeight)
+				assert.Equal(t, uint64(0), res.CpuShares)
+			},
+		},
+		{
+			name: "unified maps translation conditionally enabled",
+			resourceConfig: &ResourceConfig{
+				Unified: map[string]string{
+					"memory.min": "104857600",
+					"memory.low": "209715200",
+				},
+			},
+			validateCgroupsV1: func(t *testing.T, res *libcontainercgroups.Resources) {
+				assert.Nil(t, res.Unified)
+			},
+			validateCgroupsV2: func(t *testing.T, res *libcontainercgroups.Resources) {
+				require.NotNil(t, res.Unified)
+				assert.Equal(t, "104857600", res.Unified["memory.min"])
+				assert.Equal(t, "209715200", res.Unified["memory.low"])
+			},
+		},
+		{
+			name: "hugepages limit conversion and host padding",
+			resourceConfig: &ResourceConfig{
+				HugePageLimit: map[int64]int64{
+					2 * 1024 * 1024: 1024 * 1024 * 1024,
+				},
+			},
+			validateCgroupsV1: func(t *testing.T, res *libcontainercgroups.Resources) {
+				if len(libcontainercgroups.HugePageSizes()) > 0 {
+					require.NotEmpty(t, res.HugetlbLimit)
+					found := false
+					for _, limit := range res.HugetlbLimit {
+						if limit.Pagesize == "2MB" {
+							assert.Equal(t, uint64(1024*1024*1024), limit.Limit)
+							found = true
+						}
+					}
+					assert.True(t, found, "Should have found translated 2MB hugepage limit under cgroup v1")
+				}
+			},
+			validateCgroupsV2: func(t *testing.T, res *libcontainercgroups.Resources) {
+				if len(libcontainercgroups.HugePageSizes()) > 0 {
+					require.NotEmpty(t, res.HugetlbLimit)
+					found := false
+					for _, limit := range res.HugetlbLimit {
+						if limit.Pagesize == "2MB" {
+							assert.Equal(t, uint64(1024*1024*1024), limit.Limit)
+							found = true
+						}
+					}
+					assert.True(t, found, "Should have found translated 2MB hugepage limit under cgroup v2")
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// 1. Validate cgroup v1 mode
+			m.isCgroup2UnifiedModeOverride = new(bool)
+			resV1 := m.toResources(logger, tc.resourceConfig)
+			tc.validateCgroupsV1(t, resV1)
+
+			// 2. Validate cgroup v2 mode
+			m.isCgroup2UnifiedModeOverride = new(true)
+			resV2 := m.toResources(logger, tc.resourceConfig)
+			tc.validateCgroupsV2(t, resV2)
+		})
+	}
+}
+
+func TestCgroupManagerGetCgroupConfig(t *testing.T) {
+	libcontainercgroups.TestMode = true
+	t.Cleanup(func() {
+		libcontainercgroups.TestMode = false
+	})
+
+	cgroupName := CgroupName([]string{"test-pod"})
+	adaptedName := cgroupName.ToCgroupfs()
+
+	tests := []struct {
+		name     string
+		resource v1.ResourceName
+
+		setupFilesV1 func(t *testing.T, podDir string)
+		setupFilesV2 func(t *testing.T, podDir string)
+
+		expectErr   bool
+		mountPoints map[string]string
+		expectedCfg *ResourceConfig
+	}{
+		{
+			name:     "valid CPU quota, period, and shares",
+			resource: v1.ResourceCPU,
+			setupFilesV1: func(t *testing.T, podDir string) {
+				require.NoError(t, os.WriteFile(filepath.Join(podDir, "cpu.cfs_quota_us"), []byte("50000\n"), 0644))
+				require.NoError(t, os.WriteFile(filepath.Join(podDir, "cpu.cfs_period_us"), []byte("100000\n"), 0644))
+				require.NoError(t, os.WriteFile(filepath.Join(podDir, "cpu.shares"), []byte("998\n"), 0644))
+			},
+			setupFilesV2: func(t *testing.T, podDir string) {
+				require.NoError(t, os.WriteFile(filepath.Join(podDir, cgroupv2CpuMaxFile), []byte("50000 100000\n"), 0644))
+				require.NoError(t, os.WriteFile(filepath.Join(podDir, cgroupv2CpuWeightFile), []byte("39\n"), 0644))
+			},
+			expectedCfg: &ResourceConfig{
+				CPUQuota:  new(int64(50000)),
+				CPUPeriod: new(uint64(100000)),
+				CPUShares: new(uint64(998)),
+			},
+		},
+		{
+			name:     "unlimited CPU quota ('max')",
+			resource: v1.ResourceCPU,
+			setupFilesV1: func(t *testing.T, podDir string) {
+				require.NoError(t, os.WriteFile(filepath.Join(podDir, "cpu.cfs_quota_us"), []byte("-1\n"), 0644))
+				require.NoError(t, os.WriteFile(filepath.Join(podDir, "cpu.cfs_period_us"), []byte("100000\n"), 0644))
+				require.NoError(t, os.WriteFile(filepath.Join(podDir, "cpu.shares"), []byte("2597\n"), 0644))
+			},
+			setupFilesV2: func(t *testing.T, podDir string) {
+				require.NoError(t, os.WriteFile(filepath.Join(podDir, cgroupv2CpuMaxFile), []byte("max 100000\n"), 0644))
+				require.NoError(t, os.WriteFile(filepath.Join(podDir, cgroupv2CpuWeightFile), []byte("100\n"), 0644))
+			},
+			expectedCfg: &ResourceConfig{
+				CPUQuota:  new(int64(-1)),
+				CPUPeriod: new(uint64(100000)),
+				CPUShares: new(uint64(2597)),
+			},
+		},
+		{
+			name:     "valid memory limit",
+			resource: v1.ResourceMemory,
+			setupFilesV1: func(t *testing.T, podDir string) {
+				require.NoError(t, os.WriteFile(filepath.Join(podDir, cgroupv1MemLimitFile), []byte("209715200\n"), 0644))
+			},
+			setupFilesV2: func(t *testing.T, podDir string) {
+				require.NoError(t, os.WriteFile(filepath.Join(podDir, cgroupv2MemLimitFile), []byte("209715200\n"), 0644))
+			},
+			expectedCfg: &ResourceConfig{
+				Memory: new(int64(209715200)),
+			},
+		},
+		{
+			name:     "memory limit max returns -1 limit",
+			resource: v1.ResourceMemory,
+			setupFilesV1: func(t *testing.T, podDir string) {
+				require.NoError(t, os.WriteFile(filepath.Join(podDir, cgroupv1MemLimitFile), []byte("max\n"), 0644))
+			},
+			setupFilesV2: func(t *testing.T, podDir string) {
+				require.NoError(t, os.WriteFile(filepath.Join(podDir, cgroupv2MemLimitFile), []byte("max\n"), 0644))
+			},
+			expectedCfg: &ResourceConfig{
+				Memory: new(int64(-1)),
+			},
+		},
+		{
+			name:        "missing cgroup mount point returns error",
+			resource:    v1.ResourceCPU,
+			expectErr:   true,
+			mountPoints: map[string]string{"memory": ""},
+		},
+		{
+			name:        "unsupported resource returns error",
+			resource:    v1.ResourceStorage,
+			expectErr:   true,
+			mountPoints: map[string]string{"storage": ""},
+		},
+		{
+			name:     "malformed CPU quota integer returns error",
+			resource: v1.ResourceCPU,
+			setupFilesV1: func(t *testing.T, podDir string) {
+				require.NoError(t, os.WriteFile(filepath.Join(podDir, "cpu.cfs_quota_us"), []byte("invalid\n"), 0644))
+			},
+			setupFilesV2: func(t *testing.T, podDir string) {
+				require.NoError(t, os.WriteFile(filepath.Join(podDir, cgroupv2CpuMaxFile), []byte("invalid 100000\n"), 0644))
+			},
+			expectErr: true,
+		},
+		{
+			name:     "malformed cpu.max single token returns error under v2",
+			resource: v1.ResourceCPU,
+			setupFilesV2: func(t *testing.T, podDir string) {
+				require.NoError(t, os.WriteFile(filepath.Join(podDir, cgroupv2CpuMaxFile), []byte("50000\n"), 0644))
+			},
+			expectErr: true,
+		},
+		{
+			name:     "malformed cpu.max invalid period integer returns error under v2",
+			resource: v1.ResourceCPU,
+			setupFilesV2: func(t *testing.T, podDir string) {
+				require.NoError(t, os.WriteFile(filepath.Join(podDir, cgroupv2CpuMaxFile), []byte("50000 invalid\n"), 0644))
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runners := []struct {
+				version    string
+				setupFiles func(t *testing.T, podDir string)
+				manager    func(subsystems *CgroupSubsystems) CgroupManager
+			}{
+				{
+					version:    "v1",
+					setupFiles: tc.setupFilesV1,
+					manager: func(subsystems *CgroupSubsystems) CgroupManager {
+						return &cgroupV1impl{cgroupCommon: cgroupCommon{subsystems: subsystems}}
+					},
+				},
+				{
+					version:    "v2",
+					setupFiles: tc.setupFilesV2,
+					manager: func(subsystems *CgroupSubsystems) CgroupManager {
+						return &cgroupV2impl{cgroupCommon: cgroupCommon{subsystems: subsystems}}
+					},
+				},
+			}
+
+			for _, runner := range runners {
+				t.Run(runner.version, func(t *testing.T) {
+					tempDir := t.TempDir()
+					podDir := filepath.Join(tempDir, adaptedName)
+					require.NoError(t, os.MkdirAll(podDir, 0755))
+					if runner.setupFiles != nil {
+						runner.setupFiles(t, podDir)
+					}
+					mounts := map[string]string{"cpu": tempDir, "memory": tempDir}
+					if tc.mountPoints != nil {
+						mounts = make(map[string]string, len(tc.mountPoints))
+						for k := range tc.mountPoints {
+							mounts[k] = tempDir
+						}
+					}
+					m := runner.manager(&CgroupSubsystems{MountPoints: mounts})
+					cfg, err := m.GetCgroupConfig(cgroupName, tc.resource)
+					if tc.expectErr {
+						require.Errorf(t, err, "expected error for %s in %s", tc.name, runner.version)
+					} else {
+						require.NoErrorf(t, err, "unexpected error for %s in %s", tc.name, runner.version)
+						assert.Equalf(t, tc.expectedCfg, cfg, "mismatch for %s in %s", tc.name, runner.version)
+					}
+				})
+			}
+		})
 	}
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -40,6 +40,7 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/test/utils/ktesting"
 
+	apitest "k8s.io/cri-api/pkg/apis/testing"
 	kubelettypes "k8s.io/kubelet/pkg/types"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
@@ -1081,36 +1082,139 @@ func TestUpdateContainerResources(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	fakeRuntime, _, m, errCreate := createTestRuntimeManager(tCtx)
 	require.NoError(t, errCreate)
-	pod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			UID:       "12345678",
-			Name:      "bar",
-			Namespace: "new",
-		},
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
-				{
-					Name:            "foo",
-					Image:           "busybox",
-					ImagePullPolicy: v1.PullIfNotPresent,
+	m.cpuCFSQuota = true
+
+	tests := []struct {
+		name                   string
+		newResources           v1.ResourceRequirements
+		expectedLinuxResources *runtimeapi.LinuxContainerResources
+	}{
+		{
+			name: "Increase CPU and Memory limits and requests",
+			newResources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("200m"),
+					v1.ResourceMemory: resource.MustParse("200Mi"),
 				},
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("400m"),
+					v1.ResourceMemory: resource.MustParse("400Mi"),
+				},
+			},
+			expectedLinuxResources: &runtimeapi.LinuxContainerResources{
+				CpuPeriod:          100000,
+				CpuQuota:           40000,
+				CpuShares:          204,
+				MemoryLimitInBytes: 419430400,
+			},
+		},
+		{
+			name: "Request CPU only, no CPU limits",
+			newResources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("100m"),
+				},
+			},
+			expectedLinuxResources: &runtimeapi.LinuxContainerResources{
+				CpuPeriod:          100000,
+				CpuQuota:           0,
+				CpuShares:          102,
+				MemoryLimitInBytes: 0,
+			},
+		},
+		{
+			name: "Limit CPU only, requests default to limit",
+			newResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("200m"),
+				},
+			},
+			expectedLinuxResources: &runtimeapi.LinuxContainerResources{
+				CpuPeriod:          100000,
+				CpuQuota:           20000,
+				CpuShares:          204,
+				MemoryLimitInBytes: 0,
+			},
+		},
+		{
+			name: "Limit Memory only, no CPU limits/requests",
+			newResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("500Mi"),
+				},
+			},
+			expectedLinuxResources: &runtimeapi.LinuxContainerResources{
+				CpuPeriod:          100000,
+				CpuShares:          2,
+				MemoryLimitInBytes: 524288000,
 			},
 		},
 	}
 
-	// Create fake sandbox and container
-	_, fakeContainers := makeAndSetFakePod(tCtx, m, fakeRuntime, pod)
-	assert.Len(t, fakeContainers, 1)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "12345678",
+					Name:      "bar",
+					Namespace: "new",
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:            "foo",
+							Image:           "busybox",
+							ImagePullPolicy: v1.PullIfNotPresent,
+						},
+					},
+				},
+			}
 
-	runtimePod, err := m.GetPod(tCtx, pod.UID)
-	require.NoError(t, err)
-	cStatus, _, err := m.getPodContainerStatuses(tCtx, runtimePod, "")
-	require.NoError(t, err)
-	containerID := cStatus[0].ID
+			// Create fake sandbox and container
+			_, fakeContainers := makeAndSetFakePod(tCtx, m, fakeRuntime, pod)
+			require.Len(t, fakeContainers, 1)
+			t.Cleanup(func() {
+				fakeRuntime.Containers = make(map[string]*apitest.FakeContainer)
+				fakeRuntime.Sandboxes = make(map[string]*apitest.FakePodSandbox)
+			})
 
-	err = m.updateContainerResources(tCtx, pod, &pod.Spec.Containers[0], containerID)
-	assert.NoError(t, err)
+			runtimePod, err := m.GetPod(tCtx, pod.UID)
+			require.NoError(t, err)
+			cStatus, _, err := m.getPodContainerStatuses(tCtx, runtimePod, "")
+			require.NoError(t, err)
+			containerID := cStatus[0].ID
 
-	// Verify container is updated
-	assert.Contains(t, fakeRuntime.Called, "UpdateContainerResources")
+			// Perform resource update
+			container := pod.Spec.Containers[0].DeepCopy()
+			container.Resources = tc.newResources
+			err = m.updateContainerResources(tCtx, pod, container, containerID)
+			assert.NoError(t, err)
+
+			// Verify container config resources inside the fake runtime
+			c, ok := fakeRuntime.Containers[containerID.ID]
+			require.True(t, ok)
+			require.NotNil(t, c.LinuxResources)
+			type linuxResources struct {
+				CpuPeriod          int64
+				CpuQuota           int64
+				CpuShares          int64
+				MemoryLimitInBytes int64
+			}
+			expected := linuxResources{
+				CpuPeriod:          tc.expectedLinuxResources.CpuPeriod,
+				CpuQuota:           tc.expectedLinuxResources.CpuQuota,
+				CpuShares:          tc.expectedLinuxResources.CpuShares,
+				MemoryLimitInBytes: tc.expectedLinuxResources.MemoryLimitInBytes,
+			}
+			actual := linuxResources{
+				CpuPeriod:          c.LinuxResources.CpuPeriod,
+				CpuQuota:           c.LinuxResources.CpuQuota,
+				CpuShares:          c.LinuxResources.CpuShares,
+				MemoryLimitInBytes: c.LinuxResources.MemoryLimitInBytes,
+			}
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("Unexpected linux resources (-want +got):\n%s", diff)
+			}
+		})
+	}
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -40,6 +40,7 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/kubernetes/test/utils/ktesting"
 
+	apitest "k8s.io/cri-api/pkg/apis/testing"
 	kubelettypes "k8s.io/kubelet/pkg/types"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
@@ -1078,41 +1079,148 @@ func TestKillContainerGracePeriod(t *testing.T) {
 
 // TestUpdateContainerResources tests updating a container in a Pod.
 func TestUpdateContainerResources(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("in-place resize is only supported on Linux")
+	}
+
 	tCtx := ktesting.Init(t)
 	fakeRuntime, _, m, errCreate := createTestRuntimeManager(tCtx)
 	require.NoError(t, errCreate)
-	pod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			UID:       "12345678",
-			Name:      "bar",
-			Namespace: "new",
-		},
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
-				{
-					Name:            "foo",
-					Image:           "busybox",
-					ImagePullPolicy: v1.PullIfNotPresent,
+	m.cpuCFSQuota = true
+
+	tests := []struct {
+		name                   string
+		newResources           v1.ResourceRequirements
+		expectedLinuxResources *runtimeapi.LinuxContainerResources
+	}{
+		{
+			name: "Increase CPU and Memory limits and requests",
+			newResources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("200m"),
+					v1.ResourceMemory: resource.MustParse("200Mi"),
 				},
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("400m"),
+					v1.ResourceMemory: resource.MustParse("400Mi"),
+				},
+			},
+			expectedLinuxResources: &runtimeapi.LinuxContainerResources{
+				CpuPeriod:          100000,
+				CpuQuota:           40000,
+				CpuShares:          204,
+				MemoryLimitInBytes: 419430400,
+			},
+		},
+		{
+			name: "Request CPU only, no CPU limits",
+			newResources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("100m"),
+				},
+			},
+			expectedLinuxResources: &runtimeapi.LinuxContainerResources{
+				CpuPeriod:          100000,
+				CpuQuota:           0,
+				CpuShares:          102,
+				MemoryLimitInBytes: 0,
+			},
+		},
+		{
+			name: "Limit CPU only, requests default to limit",
+			newResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("200m"),
+				},
+			},
+			expectedLinuxResources: &runtimeapi.LinuxContainerResources{
+				CpuPeriod:          100000,
+				CpuQuota:           20000,
+				CpuShares:          204,
+				MemoryLimitInBytes: 0,
+			},
+		},
+		{
+			name: "Limit Memory only, no CPU limits/requests",
+			newResources: v1.ResourceRequirements{
+				Limits: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("500Mi"),
+				},
+			},
+			expectedLinuxResources: &runtimeapi.LinuxContainerResources{
+				CpuPeriod:          100000,
+				CpuShares:          2,
+				MemoryLimitInBytes: 524288000,
 			},
 		},
 	}
 
-	// Create fake sandbox and container
-	_, fakeContainers := makeAndSetFakePod(tCtx, m, fakeRuntime, pod)
-	assert.Len(t, fakeContainers, 1)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "12345678",
+					Name:      "bar",
+					Namespace: "new",
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:            "foo",
+							Image:           "busybox",
+							ImagePullPolicy: v1.PullIfNotPresent,
+						},
+					},
+				},
+			}
 
-	runtimePod, err := m.GetPod(tCtx, pod.UID)
-	require.NoError(t, err)
-	cStatus, _, err := m.getPodContainerStatuses(tCtx, runtimePod, "")
-	require.NoError(t, err)
-	containerID := cStatus[0].ID
+			// Create fake sandbox and container
+			_, fakeContainers := makeAndSetFakePod(tCtx, m, fakeRuntime, pod)
+			require.Len(t, fakeContainers, 1)
+			t.Cleanup(func() {
+				fakeRuntime.Containers = make(map[string]*apitest.FakeContainer)
+				fakeRuntime.Sandboxes = make(map[string]*apitest.FakePodSandbox)
+			})
 
-	err = m.updateContainerResources(tCtx, pod, &pod.Spec.Containers[0], containerID)
-	assert.NoError(t, err)
+			runtimePod, err := m.GetPod(tCtx, pod.UID)
+			require.NoError(t, err)
+			cStatus, _, err := m.getPodContainerStatuses(tCtx, runtimePod, "")
+			require.NoError(t, err)
+			containerID := cStatus[0].ID
 
-	// Verify container is updated
-	assert.Contains(t, fakeRuntime.Called, "UpdateContainerResources")
+			// Perform resource update
+			container := pod.Spec.Containers[0].DeepCopy()
+			container.Resources = tc.newResources
+			err = m.updateContainerResources(tCtx, pod, container, containerID)
+			require.NoError(t, err)
+
+			// Verify container config resources inside the fake runtime
+			c, ok := fakeRuntime.Containers[containerID.ID]
+			require.True(t, ok)
+			require.NotNil(t, c.LinuxResources)
+			type linuxResources struct {
+				CPUPeriod          int64
+				CPUQuota           int64
+				CPUShares          int64
+				MemoryLimitInBytes int64
+			}
+			expected := linuxResources{
+				CPUPeriod:          tc.expectedLinuxResources.CpuPeriod,
+				CPUQuota:           tc.expectedLinuxResources.CpuQuota,
+				CPUShares:          tc.expectedLinuxResources.CpuShares,
+				MemoryLimitInBytes: tc.expectedLinuxResources.MemoryLimitInBytes,
+			}
+			actual := linuxResources{
+				CPUPeriod:          c.LinuxResources.CpuPeriod,
+				CPUQuota:           c.LinuxResources.CpuQuota,
+				CPUShares:          c.LinuxResources.CpuShares,
+				MemoryLimitInBytes: c.LinuxResources.MemoryLimitInBytes,
+			}
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("Unexpected linux resources (-want +got):\n%s", diff)
+			}
+		})
+	}
 }
 
 func TestMakeMountsBindMountOptions(t *testing.T) {

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -29,6 +29,8 @@ import (
 	"time"
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -4030,9 +4032,16 @@ func TestUpdatePodContainerResources(t *testing.T) {
 		for _, allSideCarCtrs := range []bool{false, true} {
 			var containersToUpdate []containerToUpdateInfo
 			containerToUpdateInfo := func(container *v1.Container, idx int) containerToUpdateInfo {
+				var cid kubecontainer.ContainerID
+				for id, c := range fakeRuntime.Containers {
+					if c.Metadata.Name == container.Name {
+						cid = kubecontainer.ContainerID{Type: "testRuntime", ID: id}
+						break
+					}
+				}
 				return containerToUpdateInfo{
 					container:       container,
-					kubeContainerID: kubecontainer.ContainerID{},
+					kubeContainerID: cid,
 					desiredContainerResources: resourceRequirements{
 						memoryLimit:   tc.apiSpecResources[idx].Limits.Memory().Value(),
 						memoryRequest: tc.apiSpecResources[idx].Requests.Memory().Value(),
@@ -4072,6 +4081,15 @@ func TestUpdatePodContainerResources(t *testing.T) {
 
 			if tc.invokeUpdateResources {
 				assert.Contains(t, fakeRuntime.Called, "UpdateContainerResources", dsc)
+				for idx, cinfo := range containersToUpdate {
+					c, ok := fakeRuntime.Containers[cinfo.kubeContainerID.ID]
+					require.True(t, ok, "container not found on fakeRuntime: %s", dsc)
+					require.NotNil(t, c.LinuxResources, "container LinuxResources should be set: %s", dsc)
+					assert.Equal(t, tc.expectedCurrentLimits[idx].Cpu().MilliValue(), c.LinuxResources.CpuQuota/100, dsc)
+					assert.Equal(t, tc.expectedCurrentLimits[idx].Memory().Value(), c.LinuxResources.MemoryLimitInBytes, dsc)
+					expectedShares := cm.MilliCPUToShares(tc.expectedCurrentRequests[idx].Cpu().MilliValue())
+					assert.Equal(t, int64(expectedShares), c.LinuxResources.CpuShares, dsc)
+				}
 			}
 			for idx := range len(containersToUpdate) {
 				assert.Equal(t, tc.expectedCurrentLimits[idx].Memory().Value(), containersToUpdate[idx].currentContainerResources.memoryLimit, dsc)
@@ -4232,20 +4250,33 @@ func TestDoPodResizeAction(t *testing.T) {
 	metrics.PodResizeDurationMilliseconds.Reset()
 
 	for i, tc := range []struct {
-		testName                    string
-		currentResources            resourceRequirements
-		desiredResources            resourceRequirements
-		updatedResources            []v1.ResourceName
-		otherContainersHaveLimits   bool
-		runtimeErrors               map[string][]error
-		expectedError               string
-		expectedErrorMessage        string
-		expectPodCgroupUpdates      int
-		injectPodUpdateCgroupsError error
-		currentPodLevelResources    *resourceRequirements
-		desiredPodLevelResources    *resourceRequirements
-		updatedPodLevelResources    bool
-		enablePLR                   bool
+		// Metadata
+		testName string
+
+		// Container-level input state and resources
+		currentResources          resourceRequirements
+		desiredResources          resourceRequirements
+		updatedResources          []v1.ResourceName // resources triggered for update in this resize pass
+		otherContainersHaveLimits bool              // set to simulate sibling containers affecting pod cgroup calculations
+
+		// Pod-level resource state (used for InPlacePodLevelResourcesVerticalScaling feature)
+		currentPodLevelResources *resourceRequirements
+		desiredPodLevelResources *resourceRequirements
+		updatedPodLevelResources bool // indicates if pod-level resource specification changes
+		enablePLR                bool // enables InPlacePodLevelResourcesVerticalScaling feature gate
+
+		// Mock configuration and runtime error injection
+		runtimeErrors               map[string][]error // mock failures for CRI calls to verify error propagation
+		injectPodUpdateCgroupsError error              // mock failures for cgroup writes to verify rollback flow
+
+		// Expected overall test execution results
+		expectedError        string // overall Kubelet error type expected
+		expectedErrorMessage string // expected text of Kubelet error
+
+		// Expected actuation details to verify correctness
+		expectPodCgroupUpdates     int                // expected total calls to SetPodCgroupConfig
+		expectedPodLevelResources  *cm.ResourceConfig // exact pod-level cgroup settings expected after actuation
+		expectedContainerResources *cm.ResourceConfig // exact container cgroups written to fake runtime
 	}{
 		{
 			testName: "Increase cpu and memory requests and limits, with computed pod limits",
@@ -4260,6 +4291,16 @@ func TestDoPodResizeAction(t *testing.T) {
 			otherContainersHaveLimits: true,
 			updatedResources:          []v1.ResourceName{v1.ResourceCPU, v1.ResourceMemory},
 			expectPodCgroupUpdates:    3, // cpu req, cpu lim, mem lim
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](409),
+				CPUQuota:  ptr.To[int64](40000),
+				Memory:    ptr.To[int64](200000200),
+			},
+			expectedContainerResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](204),
+				CPUQuota:  ptr.To[int64](20000),
+				Memory:    ptr.To[int64](200),
+			},
 		},
 		{
 			testName: "Increase cpu and memory requests and limits, with computed pod limits and set a runtime error",
@@ -4277,6 +4318,11 @@ func TestDoPodResizeAction(t *testing.T) {
 			runtimeErrors:             map[string][]error{"UpdateContainerResources": {fmt.Errorf("error updating container resources")}},
 			expectedError:             "ResizePodInPlaceError",
 			expectedErrorMessage:      "error updating container resources",
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](409),
+				CPUQuota:  ptr.To[int64](40000),
+				Memory:    ptr.To[int64](200000200),
+			},
 		},
 		{
 			testName: "Increase cpu and memory requests and limits, without computed pod limits",
@@ -4292,6 +4338,14 @@ func TestDoPodResizeAction(t *testing.T) {
 			otherContainersHaveLimits: false,
 			updatedResources:          []v1.ResourceName{v1.ResourceCPU, v1.ResourceMemory},
 			expectPodCgroupUpdates:    1, // cpu req, cpu lim, mem lim
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](204),
+			},
+			expectedContainerResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](204),
+				CPUQuota:  ptr.To[int64](20000),
+				Memory:    ptr.To[int64](200),
+			},
 		},
 		{
 			testName: "Increase cpu and memory requests only",
@@ -4305,6 +4359,13 @@ func TestDoPodResizeAction(t *testing.T) {
 			},
 			updatedResources:       []v1.ResourceName{v1.ResourceCPU},
 			expectPodCgroupUpdates: 1, // cpu req
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](153),
+			},
+			expectedContainerResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](153),
+				CPUQuota:  ptr.To[int64](20000),
+			},
 		},
 		{
 			testName: "Resize memory request no limits",
@@ -4331,6 +4392,12 @@ func TestDoPodResizeAction(t *testing.T) {
 			},
 			updatedResources:       []v1.ResourceName{v1.ResourceCPU},
 			expectPodCgroupUpdates: 1, // cpu req
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](204),
+			},
+			expectedContainerResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](204),
+			},
 		},
 		{
 			testName: "Add limits",
@@ -4344,6 +4411,11 @@ func TestDoPodResizeAction(t *testing.T) {
 			},
 			updatedResources:       []v1.ResourceName{v1.ResourceCPU, v1.ResourceMemory},
 			expectPodCgroupUpdates: 0,
+			expectedContainerResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](102),
+				CPUQuota:  ptr.To[int64](10000),
+				Memory:    ptr.To[int64](100),
+			},
 		},
 		{
 			testName: "Add limits and pod limits",
@@ -4358,6 +4430,16 @@ func TestDoPodResizeAction(t *testing.T) {
 			otherContainersHaveLimits: true,
 			updatedResources:          []v1.ResourceName{v1.ResourceCPU, v1.ResourceMemory},
 			expectPodCgroupUpdates:    2, // cpu lim, memory lim
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](307),
+				CPUQuota:  ptr.To[int64](30000),
+				Memory:    ptr.To[int64](200000100),
+			},
+			expectedContainerResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](102),
+				CPUQuota:  ptr.To[int64](10000),
+				Memory:    ptr.To[int64](100),
+			},
 		},
 		{
 			testName: "Fail updatePodSandboxResources blocks resize",
@@ -4388,6 +4470,10 @@ func TestDoPodResizeAction(t *testing.T) {
 			injectPodUpdateCgroupsError: fmt.Errorf("cgroup update failed"),
 			expectedError:               "ResizePodInPlaceError",
 			expectedErrorMessage:        "cgroup update failed",
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](204),
+				CPUQuota:  ptr.To[int64](20000),
+			},
 		},
 		{
 			testName: "Ignore Unimplemented error from updatePodSandboxResources",
@@ -4406,6 +4492,14 @@ func TestDoPodResizeAction(t *testing.T) {
 			// No error expected because we swallow Unimplemented
 			expectedError:        "",
 			expectedErrorMessage: "",
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](204),
+				CPUQuota:  ptr.To[int64](20000),
+			},
+			expectedContainerResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](204),
+				CPUQuota:  ptr.To[int64](20000),
+			},
 		},
 		{
 			testName: "Ignore Unimplemented message from updatePodSandboxResources",
@@ -4424,6 +4518,14 @@ func TestDoPodResizeAction(t *testing.T) {
 			// No error expected because we swallow Unimplemented
 			expectedError:        "",
 			expectedErrorMessage: "",
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](204),
+				CPUQuota:  ptr.To[int64](20000),
+			},
+			expectedContainerResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](204),
+				CPUQuota:  ptr.To[int64](20000),
+			},
 		},
 		{
 			testName: "Resize pod-level memory request only (skips cgroup write, updates actuated)",
@@ -4469,6 +4571,11 @@ func TestDoPodResizeAction(t *testing.T) {
 			updatedResources:         []v1.ResourceName{},
 			expectPodCgroupUpdates:   1,
 			enablePLR:                true,
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](102),
+				CPUQuota:  ptr.To[int64](10000),
+				Memory:    ptr.To[int64](200),
+			},
 		},
 		{
 			testName: "Resize pod-level CPU request (updates cgroups and actuated)",
@@ -4488,6 +4595,10 @@ func TestDoPodResizeAction(t *testing.T) {
 			updatedResources:         []v1.ResourceName{},
 			expectPodCgroupUpdates:   1,
 			enablePLR:                true,
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](204),
+				CPUQuota:  ptr.To[int64](10000),
+			},
 		},
 		{
 			testName: "Resize pod-level CPU limit (updates cgroups and actuated)",
@@ -4507,6 +4618,10 @@ func TestDoPodResizeAction(t *testing.T) {
 			updatedResources:         []v1.ResourceName{},
 			expectPodCgroupUpdates:   1,
 			enablePLR:                true,
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](102),
+				CPUQuota:  ptr.To[int64](20000),
+			},
 		},
 		{
 			testName: "Resize pod-level CPU limit and container-level CPU limit (updates cgroups and actuated)",
@@ -4526,6 +4641,14 @@ func TestDoPodResizeAction(t *testing.T) {
 			updatedResources:         []v1.ResourceName{v1.ResourceCPU},
 			expectPodCgroupUpdates:   1, // Pod level cgroup update
 			enablePLR:                true,
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](102),
+				CPUQuota:  ptr.To[int64](30000),
+			},
+			expectedContainerResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](102),
+				CPUQuota:  ptr.To[int64](20000),
+			},
 		},
 		{
 			testName: "Resize pod-level memory request and container-level memory request (updates actuated)",
@@ -4545,6 +4668,9 @@ func TestDoPodResizeAction(t *testing.T) {
 			updatedResources:         []v1.ResourceName{v1.ResourceMemory},
 			expectPodCgroupUpdates:   0, // Memory request doesn't update cgroup
 			enablePLR:                true,
+			expectedContainerResources: &cm.ResourceConfig{
+				Memory: ptr.To[int64](200),
+			},
 		},
 		{
 			testName: "Resize pod-level CPU request and container-level CPU request (updates cgroups and actuated)",
@@ -4564,6 +4690,14 @@ func TestDoPodResizeAction(t *testing.T) {
 			updatedResources:         []v1.ResourceName{v1.ResourceCPU},
 			expectPodCgroupUpdates:   1, // Pod level cgroup update for cpu shares
 			enablePLR:                true,
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](204),
+				CPUQuota:  ptr.To[int64](20000),
+			},
+			expectedContainerResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](153),
+				CPUQuota:  ptr.To[int64](20000),
+			},
 		},
 		{
 			testName: "Resize pod-level memory limit and container-level memory limit (updates cgroups and actuated)",
@@ -4583,10 +4717,16 @@ func TestDoPodResizeAction(t *testing.T) {
 			updatedResources:         []v1.ResourceName{v1.ResourceMemory},
 			expectPodCgroupUpdates:   1, // Pod level cgroup update for memory limit
 			enablePLR:                true,
+			expectedPodLevelResources: &cm.ResourceConfig{
+				Memory: ptr.To[int64](300),
+			},
+			expectedContainerResources: &cm.ResourceConfig{
+				Memory: ptr.To[int64](250),
+			},
 		},
 	} {
 		t.Run(tc.testName, func(t *testing.T) {
-			_, _, m, err := createTestRuntimeManager(tCtx, withErrors(tc.runtimeErrors))
+			fakeRuntime, _, m, err := createTestRuntimeManager(tCtx, withErrors(tc.runtimeErrors))
 			require.NoError(t, err)
 			m.cpuCFSQuota = true // Enforce CPU Limits
 
@@ -4616,7 +4756,26 @@ func TestDoPodResizeAction(t *testing.T) {
 			}, nil).Maybe()
 			if tc.expectPodCgroupUpdates > 0 {
 				// TODO: Update to use proper logger once contextual logging migration is complete
-				call := mockPCM.EXPECT().SetPodCgroupConfig(klog.TODO(), mock.Anything, mock.Anything)
+				call := mockPCM.EXPECT().SetPodCgroupConfig(klog.TODO(), mock.Anything, mock.Anything).Run(func(logger klog.Logger, pod *v1.Pod, rc *cm.ResourceConfig) {
+					require.NotNil(t, rc, "ResourceConfig should not be nil")
+					require.False(t, rc.Memory == nil && rc.CPUShares == nil && rc.CPUQuota == nil, "SetPodCgroupConfig called with an empty ResourceConfig")
+					expected := &cm.ResourceConfig{}
+					if tc.expectedPodLevelResources != nil {
+						if rc.Memory != nil {
+							expected.Memory = tc.expectedPodLevelResources.Memory
+						}
+						if rc.CPUShares != nil {
+							expected.CPUShares = tc.expectedPodLevelResources.CPUShares
+						}
+						if rc.CPUQuota != nil {
+							expected.CPUQuota = tc.expectedPodLevelResources.CPUQuota
+							expected.CPUPeriod = rc.CPUPeriod // Ignore CPUPeriod in comparison
+						}
+					}
+					if diff := cmp.Diff(expected, rc, cmpopts.IgnoreFields(cm.ResourceConfig{}, "CPUSet")); diff != "" {
+						t.Errorf("Unexpected SetPodCgroupConfig resources (-want +got):\n%s", diff)
+					}
+				})
 				if tc.injectPodUpdateCgroupsError != nil {
 					call.Return(tc.injectPodUpdateCgroupsError).Times(1)
 				} else {
@@ -4625,6 +4784,10 @@ func TestDoPodResizeAction(t *testing.T) {
 			}
 
 			pod, kps := makeBasePodAndStatus()
+			_, fakeContainers := makeAndSetFakePod(tCtx, m, fakeRuntime, pod)
+			for idx, fc := range fakeContainers {
+				kps.ContainerStatuses[idx].ID = kubecontainer.ContainerID{Type: "testRuntime", ID: fc.Id}
+			}
 			if tc.desiredPodLevelResources != nil {
 				// pod spec and allocated resources are already updated as desired when doPodResizeAction() is called.
 				pod.Spec.Resources = &v1.ResourceRequirements{
@@ -4730,6 +4893,37 @@ func TestDoPodResizeAction(t *testing.T) {
 					} else {
 						assert.Equal(t, tc.currentPodLevelResources.memoryRequest, updatedActuated.Requests.Memory().Value(), tc.testName)
 						assert.Equal(t, tc.currentPodLevelResources.cpuRequest, updatedActuated.Requests.Cpu().MilliValue(), tc.testName)
+					}
+				}
+				if len(tc.updatedResources) > 0 {
+					c, ok := fakeRuntime.Containers[kps.ContainerStatuses[0].ID.ID]
+					require.True(t, ok, "Container should exist in fake runtime")
+					require.NotNil(t, c.LinuxResources, "LinuxResources should not be nil")
+
+					hasCPUUpdate := false
+					hasMemoryUpdate := false
+					for _, r := range tc.updatedResources {
+						if r == v1.ResourceCPU {
+							hasCPUUpdate = true
+						}
+						if r == v1.ResourceMemory {
+							hasMemoryUpdate = true
+						}
+					}
+
+					if hasCPUUpdate && tc.expectedContainerResources != nil {
+						if tc.expectedContainerResources.CPUShares != nil {
+							assert.Equal(t, int64(*tc.expectedContainerResources.CPUShares), c.LinuxResources.CpuShares, "Container CPU Shares did not match expected")
+						}
+						if tc.expectedContainerResources.CPUQuota != nil {
+							assert.Equal(t, *tc.expectedContainerResources.CPUQuota, c.LinuxResources.CpuQuota, "Container CPU Quota did not match expected")
+						}
+					}
+
+					if hasMemoryUpdate && tc.expectedContainerResources != nil {
+						if tc.expectedContainerResources.Memory != nil {
+							assert.Equal(t, *tc.expectedContainerResources.Memory, c.LinuxResources.MemoryLimitInBytes, "Container Memory Limit did not match expected")
+						}
 					}
 				}
 			}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -29,6 +29,8 @@ import (
 	"time"
 
 	cadvisorapi "github.com/google/cadvisor/lib/model"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -4196,10 +4198,15 @@ func TestComputePodResizeActionForOOMKilledSidecarContainer(t *testing.T) {
 }
 
 func TestUpdatePodContainerResources(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("in-place resize is only supported on Linux")
+	}
+
 	tCtx := ktesting.Init(t)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
 	fakeRuntime, _, m, err := createTestRuntimeManager(tCtx)
 	m.machineInfo.MemoryCapacity = 17179860387 // 16GB
+	m.cpuCFSQuota = true
 	assert.NoError(t, err)
 
 	cpu100m := resource.MustParse("100m")
@@ -4277,9 +4284,16 @@ func TestUpdatePodContainerResources(t *testing.T) {
 		for _, allSideCarCtrs := range []bool{false, true} {
 			var containersToUpdate []containerToUpdateInfo
 			containerToUpdateInfo := func(container *v1.Container, idx int) containerToUpdateInfo {
+				var cid kubecontainer.ContainerID
+				for id, c := range fakeRuntime.Containers {
+					if c.Metadata.Name == container.Name {
+						cid = kubecontainer.ContainerID{Type: "testRuntime", ID: id}
+						break
+					}
+				}
 				return containerToUpdateInfo{
 					container:       container,
-					kubeContainerID: kubecontainer.ContainerID{},
+					kubeContainerID: cid,
 					desiredContainerResources: resourceRequirements{
 						memoryLimit:   tc.apiSpecResources[idx].Limits.Memory().Value(),
 						memoryRequest: tc.apiSpecResources[idx].Requests.Memory().Value(),
@@ -4319,6 +4333,15 @@ func TestUpdatePodContainerResources(t *testing.T) {
 
 			if tc.invokeUpdateResources {
 				assert.Contains(t, fakeRuntime.Called, "UpdateContainerResources", dsc)
+				for idx, cinfo := range containersToUpdate {
+					c, ok := fakeRuntime.Containers[cinfo.kubeContainerID.ID]
+					require.True(t, ok, "container not found on fakeRuntime: %s", dsc)
+					require.NotNil(t, c.LinuxResources, "container LinuxResources should be set: %s", dsc)
+					assert.Equal(t, tc.expectedCurrentLimits[idx].Cpu().MilliValue(), c.LinuxResources.CpuQuota/100, dsc)
+					assert.Equal(t, tc.expectedCurrentLimits[idx].Memory().Value(), c.LinuxResources.MemoryLimitInBytes, dsc)
+					expectedShares := cm.MilliCPUToShares(tc.expectedCurrentRequests[idx].Cpu().MilliValue())
+					assert.Equal(t, int64(expectedShares), c.LinuxResources.CpuShares, dsc)
+				}
 			}
 			for idx := range len(containersToUpdate) {
 				assert.Equal(t, tc.expectedCurrentLimits[idx].Memory().Value(), containersToUpdate[idx].currentContainerResources.memoryLimit, dsc)
@@ -4473,26 +4496,40 @@ func TestDoPodResizeAction(t *testing.T) {
 		t.Skip("unsupported OS")
 	}
 
-	logger, tCtx := ktesting.NewTestContext(t)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
 	metrics.Register()
 	metrics.PodResizeDurationMilliseconds.Reset()
 
 	for i, tc := range []struct {
-		testName                    string
-		currentResources            resourceRequirements
-		desiredResources            resourceRequirements
-		updatedResources            []v1.ResourceName
-		otherContainersHaveLimits   bool
-		runtimeErrors               map[string][]error
-		expectedError               string
-		expectedErrorMessage        string
-		expectPodCgroupUpdates      int
-		injectPodUpdateCgroupsError error
-		currentPodLevelResources    *resourceRequirements
-		desiredPodLevelResources    *resourceRequirements
-		updatedPodLevelResources    bool
-		enablePLR                   bool
+		// Metadata
+		testName string
+
+		// Container-level input state and resources
+		currentResources          resourceRequirements
+		desiredResources          resourceRequirements
+		updatedResources          []v1.ResourceName // resources triggered for update in this resize pass
+		otherContainersHaveLimits bool              // set to simulate sibling containers affecting pod cgroup calculations
+
+		// Pod-level resource state (used for InPlacePodLevelResourcesVerticalScaling feature)
+		currentPodLevelResources *resourceRequirements
+		desiredPodLevelResources *resourceRequirements
+		updatedPodLevelResources bool // indicates if pod-level resource specification changes
+		enablePLR                bool // enables InPlacePodLevelResourcesVerticalScaling feature gate
+
+		// Mock configuration and runtime error injection
+		runtimeErrors               map[string][]error // mock failures for CRI calls to verify error propagation
+		injectPodUpdateCgroupsError error              // mock failures for cgroup writes to verify rollback flow
+
+		// Expected overall test execution results
+		expectedError        string // overall Kubelet error type expected
+		expectedErrorMessage string // expected text of Kubelet error
+
+		// Expected actuation details to verify correctness
+		expectPodCgroupUpdates     int                // expected total calls to SetPodCgroupConfig
+		expectedPodLevelResources  *cm.ResourceConfig // exact pod-level cgroup settings expected after actuation
+		expectedContainerResources *cm.ResourceConfig // exact container cgroups written to fake runtime
 	}{
 		{
 			testName: "Increase cpu and memory requests and limits, with computed pod limits",
@@ -4507,6 +4544,16 @@ func TestDoPodResizeAction(t *testing.T) {
 			otherContainersHaveLimits: true,
 			updatedResources:          []v1.ResourceName{v1.ResourceCPU, v1.ResourceMemory},
 			expectPodCgroupUpdates:    3, // cpu req, cpu lim, mem lim
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](409),
+				CPUQuota:  ptr.To[int64](40000),
+				Memory:    ptr.To[int64](200000200),
+			},
+			expectedContainerResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](204),
+				CPUQuota:  ptr.To[int64](20000),
+				Memory:    ptr.To[int64](200),
+			},
 		},
 		{
 			testName: "Increase cpu and memory requests and limits, with computed pod limits and set a runtime error",
@@ -4524,6 +4571,11 @@ func TestDoPodResizeAction(t *testing.T) {
 			runtimeErrors:             map[string][]error{"UpdateContainerResources": {fmt.Errorf("error updating container resources")}},
 			expectedError:             "ResizePodInPlaceError",
 			expectedErrorMessage:      "error updating container resources",
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](409),
+				CPUQuota:  ptr.To[int64](40000),
+				Memory:    ptr.To[int64](200000200),
+			},
 		},
 		{
 			testName: "Increase cpu and memory requests and limits, without computed pod limits",
@@ -4539,6 +4591,14 @@ func TestDoPodResizeAction(t *testing.T) {
 			otherContainersHaveLimits: false,
 			updatedResources:          []v1.ResourceName{v1.ResourceCPU, v1.ResourceMemory},
 			expectPodCgroupUpdates:    1, // cpu req, cpu lim, mem lim
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](204),
+			},
+			expectedContainerResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](204),
+				CPUQuota:  ptr.To[int64](20000),
+				Memory:    ptr.To[int64](200),
+			},
 		},
 		{
 			testName: "Increase cpu and memory requests only",
@@ -4552,6 +4612,13 @@ func TestDoPodResizeAction(t *testing.T) {
 			},
 			updatedResources:       []v1.ResourceName{v1.ResourceCPU},
 			expectPodCgroupUpdates: 1, // cpu req
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](153),
+			},
+			expectedContainerResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](153),
+				CPUQuota:  ptr.To[int64](20000),
+			},
 		},
 		{
 			testName: "Resize memory request no limits",
@@ -4578,6 +4645,12 @@ func TestDoPodResizeAction(t *testing.T) {
 			},
 			updatedResources:       []v1.ResourceName{v1.ResourceCPU},
 			expectPodCgroupUpdates: 1, // cpu req
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](204),
+			},
+			expectedContainerResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](204),
+			},
 		},
 		{
 			testName: "Add limits",
@@ -4591,6 +4664,11 @@ func TestDoPodResizeAction(t *testing.T) {
 			},
 			updatedResources:       []v1.ResourceName{v1.ResourceCPU, v1.ResourceMemory},
 			expectPodCgroupUpdates: 0,
+			expectedContainerResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](102),
+				CPUQuota:  ptr.To[int64](10000),
+				Memory:    ptr.To[int64](100),
+			},
 		},
 		{
 			testName: "Add limits and pod limits",
@@ -4605,6 +4683,16 @@ func TestDoPodResizeAction(t *testing.T) {
 			otherContainersHaveLimits: true,
 			updatedResources:          []v1.ResourceName{v1.ResourceCPU, v1.ResourceMemory},
 			expectPodCgroupUpdates:    2, // cpu lim, memory lim
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](307),
+				CPUQuota:  ptr.To[int64](30000),
+				Memory:    ptr.To[int64](200000100),
+			},
+			expectedContainerResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](102),
+				CPUQuota:  ptr.To[int64](10000),
+				Memory:    ptr.To[int64](100),
+			},
 		},
 		{
 			testName: "Fail updatePodSandboxResources blocks resize",
@@ -4635,6 +4723,10 @@ func TestDoPodResizeAction(t *testing.T) {
 			injectPodUpdateCgroupsError: fmt.Errorf("cgroup update failed"),
 			expectedError:               "ResizePodInPlaceError",
 			expectedErrorMessage:        "cgroup update failed",
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](204),
+				CPUQuota:  ptr.To[int64](20000),
+			},
 		},
 		{
 			testName: "Ignore Unimplemented error from updatePodSandboxResources",
@@ -4653,6 +4745,14 @@ func TestDoPodResizeAction(t *testing.T) {
 			// No error expected because we swallow Unimplemented
 			expectedError:        "",
 			expectedErrorMessage: "",
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](204),
+				CPUQuota:  ptr.To[int64](20000),
+			},
+			expectedContainerResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](204),
+				CPUQuota:  ptr.To[int64](20000),
+			},
 		},
 		{
 			testName: "Ignore Unimplemented message from updatePodSandboxResources",
@@ -4671,6 +4771,14 @@ func TestDoPodResizeAction(t *testing.T) {
 			// No error expected because we swallow Unimplemented
 			expectedError:        "",
 			expectedErrorMessage: "",
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](204),
+				CPUQuota:  ptr.To[int64](20000),
+			},
+			expectedContainerResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](204),
+				CPUQuota:  ptr.To[int64](20000),
+			},
 		},
 		{
 			testName: "Resize pod-level memory request only (skips cgroup write, updates actuated)",
@@ -4716,6 +4824,11 @@ func TestDoPodResizeAction(t *testing.T) {
 			updatedResources:         []v1.ResourceName{},
 			expectPodCgroupUpdates:   1,
 			enablePLR:                true,
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](102),
+				CPUQuota:  ptr.To[int64](10000),
+				Memory:    ptr.To[int64](200),
+			},
 		},
 		{
 			testName: "Resize pod-level CPU request (updates cgroups and actuated)",
@@ -4735,6 +4848,10 @@ func TestDoPodResizeAction(t *testing.T) {
 			updatedResources:         []v1.ResourceName{},
 			expectPodCgroupUpdates:   1,
 			enablePLR:                true,
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](204),
+				CPUQuota:  ptr.To[int64](10000),
+			},
 		},
 		{
 			testName: "Resize pod-level CPU limit (updates cgroups and actuated)",
@@ -4754,6 +4871,10 @@ func TestDoPodResizeAction(t *testing.T) {
 			updatedResources:         []v1.ResourceName{},
 			expectPodCgroupUpdates:   1,
 			enablePLR:                true,
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](102),
+				CPUQuota:  ptr.To[int64](20000),
+			},
 		},
 		{
 			testName: "Resize pod-level CPU limit and container-level CPU limit (updates cgroups and actuated)",
@@ -4773,6 +4894,14 @@ func TestDoPodResizeAction(t *testing.T) {
 			updatedResources:         []v1.ResourceName{v1.ResourceCPU},
 			expectPodCgroupUpdates:   1, // Pod level cgroup update
 			enablePLR:                true,
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](102),
+				CPUQuota:  ptr.To[int64](30000),
+			},
+			expectedContainerResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](102),
+				CPUQuota:  ptr.To[int64](20000),
+			},
 		},
 		{
 			testName: "Resize pod-level memory request and container-level memory request (updates actuated)",
@@ -4792,6 +4921,9 @@ func TestDoPodResizeAction(t *testing.T) {
 			updatedResources:         []v1.ResourceName{v1.ResourceMemory},
 			expectPodCgroupUpdates:   0, // Memory request doesn't update cgroup
 			enablePLR:                true,
+			expectedContainerResources: &cm.ResourceConfig{
+				Memory: ptr.To[int64](200),
+			},
 		},
 		{
 			testName: "Resize pod-level CPU request and container-level CPU request (updates cgroups and actuated)",
@@ -4811,6 +4943,14 @@ func TestDoPodResizeAction(t *testing.T) {
 			updatedResources:         []v1.ResourceName{v1.ResourceCPU},
 			expectPodCgroupUpdates:   1, // Pod level cgroup update for cpu shares
 			enablePLR:                true,
+			expectedPodLevelResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](204),
+				CPUQuota:  ptr.To[int64](20000),
+			},
+			expectedContainerResources: &cm.ResourceConfig{
+				CPUShares: ptr.To[uint64](153),
+				CPUQuota:  ptr.To[int64](20000),
+			},
 		},
 		{
 			testName: "Resize pod-level memory limit and container-level memory limit (updates cgroups and actuated)",
@@ -4830,10 +4970,16 @@ func TestDoPodResizeAction(t *testing.T) {
 			updatedResources:         []v1.ResourceName{v1.ResourceMemory},
 			expectPodCgroupUpdates:   1, // Pod level cgroup update for memory limit
 			enablePLR:                true,
+			expectedPodLevelResources: &cm.ResourceConfig{
+				Memory: ptr.To[int64](300),
+			},
+			expectedContainerResources: &cm.ResourceConfig{
+				Memory: ptr.To[int64](250),
+			},
 		},
 	} {
 		t.Run(tc.testName, func(t *testing.T) {
-			_, _, m, err := createTestRuntimeManager(tCtx, withErrors(tc.runtimeErrors))
+			fakeRuntime, _, m, err := createTestRuntimeManager(tCtx, withErrors(tc.runtimeErrors))
 			require.NoError(t, err)
 			m.cpuCFSQuota = true // Enforce CPU Limits
 
@@ -4863,7 +5009,25 @@ func TestDoPodResizeAction(t *testing.T) {
 			}, nil).Maybe()
 			if tc.expectPodCgroupUpdates > 0 {
 				// TODO: Update to use proper logger once contextual logging migration is complete
-				call := mockPCM.EXPECT().SetPodCgroupConfig(klog.TODO(), mock.Anything, mock.Anything)
+				call := mockPCM.EXPECT().SetPodCgroupConfig(klog.TODO(), mock.Anything, mock.Anything).Run(func(logger klog.Logger, pod *v1.Pod, rc *cm.ResourceConfig) {
+					require.NotNil(t, rc, "ResourceConfig should not be nil")
+					require.False(t, rc.Memory == nil && rc.CPUShares == nil && rc.CPUQuota == nil, "SetPodCgroupConfig called with an empty ResourceConfig")
+					expected := &cm.ResourceConfig{}
+					if tc.expectedPodLevelResources != nil {
+						if rc.Memory != nil {
+							expected.Memory = tc.expectedPodLevelResources.Memory
+						}
+						if rc.CPUShares != nil {
+							expected.CPUShares = tc.expectedPodLevelResources.CPUShares
+						}
+						if rc.CPUQuota != nil {
+							expected.CPUQuota = tc.expectedPodLevelResources.CPUQuota
+						}
+					}
+					if diff := cmp.Diff(expected, rc, cmpopts.IgnoreFields(cm.ResourceConfig{}, "CPUSet", "CPUPeriod")); diff != "" {
+						t.Errorf("Unexpected SetPodCgroupConfig resources (-want +got):\n%s", diff)
+					}
+				})
 				if tc.injectPodUpdateCgroupsError != nil {
 					call.Return(tc.injectPodUpdateCgroupsError).Times(1)
 				} else {
@@ -4872,6 +5036,10 @@ func TestDoPodResizeAction(t *testing.T) {
 			}
 
 			pod, kps := makeBasePodAndStatus()
+			_, fakeContainers := makeAndSetFakePod(tCtx, m, fakeRuntime, pod)
+			for idx, fc := range fakeContainers {
+				kps.ContainerStatuses[idx].ID = kubecontainer.ContainerID{Type: "testRuntime", ID: fc.Id}
+			}
 			if tc.desiredPodLevelResources != nil {
 				// pod spec and allocated resources are already updated as desired when doPodResizeAction() is called.
 				pod.Spec.Resources = &v1.ResourceRequirements{
@@ -4977,6 +5145,21 @@ func TestDoPodResizeAction(t *testing.T) {
 					} else {
 						assert.Equal(t, tc.currentPodLevelResources.memoryRequest, updatedActuated.Requests.Memory().Value(), tc.testName)
 						assert.Equal(t, tc.currentPodLevelResources.cpuRequest, updatedActuated.Requests.Cpu().MilliValue(), tc.testName)
+					}
+				}
+				if tc.expectedContainerResources != nil {
+					c, ok := fakeRuntime.Containers[kps.ContainerStatuses[0].ID.ID]
+					require.True(t, ok, "Container should exist in fake runtime")
+					require.NotNil(t, c.LinuxResources, "LinuxResources should not be nil")
+
+					if tc.expectedContainerResources.CPUShares != nil {
+						assert.Equal(t, int64(*tc.expectedContainerResources.CPUShares), c.LinuxResources.CpuShares, "Container CPU Shares did not match expected")
+					}
+					if tc.expectedContainerResources.CPUQuota != nil {
+						assert.Equal(t, *tc.expectedContainerResources.CPUQuota, c.LinuxResources.CpuQuota, "Container CPU Quota did not match expected")
+					}
+					if tc.expectedContainerResources.Memory != nil {
+						assert.Equal(t, *tc.expectedContainerResources.Memory, c.LinuxResources.MemoryLimitInBytes, "Container Memory Limit did not match expected")
 					}
 				}
 			}

--- a/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go
@@ -517,12 +517,28 @@ func (r *FakeRuntimeService) ContainerStatus(_ context.Context, containerID stri
 }
 
 // UpdateContainerResources returns the container resource in the FakeRuntimeService.
-func (r *FakeRuntimeService) UpdateContainerResources(context.Context, string, *runtimeapi.ContainerResources) error {
+func (r *FakeRuntimeService) UpdateContainerResources(_ context.Context, containerID string, resources *runtimeapi.ContainerResources) error {
 	r.Lock()
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "UpdateContainerResources")
-	return r.popError("UpdateContainerResources")
+	if err := r.popError("UpdateContainerResources"); err != nil {
+		return err
+	}
+
+	c, ok := r.Containers[containerID]
+	if !ok {
+		return fmt.Errorf("container %q not found", containerID)
+	}
+
+	if resources != nil {
+		if resources.Linux != nil {
+			c.LinuxResources = resources.Linux
+		}
+		c.Resources = resources
+	}
+
+	return nil
 }
 
 // ExecSync emulates the sync execution of a command in a container in the FakeRuntimeService.

--- a/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_runtime_service.go
@@ -531,12 +531,28 @@ func (r *FakeRuntimeService) ContainerStatus(_ context.Context, containerID stri
 }
 
 // UpdateContainerResources returns the container resource in the FakeRuntimeService.
-func (r *FakeRuntimeService) UpdateContainerResources(context.Context, string, *runtimeapi.ContainerResources) error {
+func (r *FakeRuntimeService) UpdateContainerResources(_ context.Context, containerID string, resources *runtimeapi.ContainerResources) error {
 	r.Lock()
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "UpdateContainerResources")
-	return r.popError("UpdateContainerResources")
+	if err := r.popError("UpdateContainerResources"); err != nil {
+		return err
+	}
+
+	c, ok := r.Containers[containerID]
+	if !ok {
+		return fmt.Errorf("container %q not found", containerID)
+	}
+
+	if resources != nil {
+		if resources.Linux != nil {
+			c.LinuxResources = resources.Linux
+		}
+		c.Resources = resources
+	}
+
+	return nil
 }
 
 // ExecSync emulates the sync execution of a command in a container in the FakeRuntimeService.


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
/area test

#### What this PR does / why we need it:

Add additional coverage for kubelet cgroup handling.
It will make me feel better about removing the cgroup coverage for e2e tests, as proposed in https://github.com/kubernetes/kubernetes/pull/139018. See https://github.com/kubernetes/kubernetes/pull/139018#pullrequestreview-4413428606 for further context.

#### Which issue(s) this PR is related to:

- https://github.com/kubernetes/kubernetes/pull/139018
- https://github.com/kubernetes/kubernetes/issues/135783

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig node

This PR was created with the assistance of Google Antigravity. 
