### PR TITLE
clientcmd: keep client behavior overrides fallback-neutral

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -652,6 +652,13 @@ func (config *inClusterClientConfig) ClientConfig() (*restclient.Config, error) 
 		if config.overrides.ClusterInfo.DisableCompression {
 			icc.DisableCompression = true
 		}
+		if len(config.overrides.ClusterInfo.ProxyURL) > 0 {
+			proxyURL, err := parseProxyURL(config.overrides.ClusterInfo.ProxyURL)
+			if err != nil {
+				return nil, err
+			}
+			icc.Proxy = http.ProxyURL(proxyURL)
+		}
 	}
 
 	return icc, nil

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -638,6 +638,20 @@ func (config *inClusterClientConfig) ClientConfig() (*restclient.Config, error) 
 		if certificateAuthorityFile := config.overrides.ClusterInfo.CertificateAuthority; len(certificateAuthorityFile) > 0 {
 			icc.TLSClientConfig.CAFile = certificateAuthorityFile
 		}
+
+		// Runtime client behavior overrides do not select the kubeconfig source,
+		// but once in-cluster configuration is selected, they still apply to the
+		// resulting REST client configuration.
+		if len(config.overrides.Timeout) > 0 {
+			timeout, err := ParseTimeout(config.overrides.Timeout)
+			if err != nil {
+				return nil, err
+			}
+			icc.Timeout = timeout
+		}
+		if config.overrides.ClusterInfo.DisableCompression {
+			icc.DisableCompression = true
+		}
 	}
 
 	return icc, nil

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -845,7 +846,9 @@ func TestCreateAuthConfigExecInstallHintCleanup(t *testing.T) {
 
 func TestInClusterClientConfigPrecedence(t *testing.T) {
 	tt := []struct {
-		overrides *ConfigOverrides
+		overrides                  *ConfigOverrides
+		expectedTimeout            time.Duration
+		expectedDisableCompression bool
 	}{
 		{
 			overrides: &ConfigOverrides{
@@ -934,6 +937,20 @@ func TestInClusterClientConfigPrecedence(t *testing.T) {
 		{
 			overrides: &ConfigOverrides{},
 		},
+		{
+			overrides: &ConfigOverrides{
+				Timeout: "30s",
+			},
+			expectedTimeout: 30 * time.Second,
+		},
+		{
+			overrides: &ConfigOverrides{
+				ClusterInfo: clientcmdapi.Cluster{
+					DisableCompression: true,
+				},
+			},
+			expectedDisableCompression: true,
+		},
 	}
 
 	for _, tc := range tt {
@@ -983,6 +1000,12 @@ func TestInClusterClientConfigPrecedence(t *testing.T) {
 		}
 		if clientConfig.TLSClientConfig.CAFile != expectedCAFile {
 			t.Errorf("Expected Certificate Authority %v, got %v", expectedCAFile, clientConfig.TLSClientConfig.CAFile)
+		}
+		if clientConfig.Timeout != tc.expectedTimeout {
+			t.Errorf("Expected timeout %v, got %v", tc.expectedTimeout, clientConfig.Timeout)
+		}
+		if clientConfig.DisableCompression != tc.expectedDisableCompression {
+			t.Errorf("Expected DisableCompression %v, got %v", tc.expectedDisableCompression, clientConfig.DisableCompression)
 		}
 	}
 }

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
@@ -849,6 +849,7 @@ func TestInClusterClientConfigPrecedence(t *testing.T) {
 		overrides                  *ConfigOverrides
 		expectedTimeout            time.Duration
 		expectedDisableCompression bool
+		expectedProxyURL           string
 	}{
 		{
 			overrides: &ConfigOverrides{
@@ -951,6 +952,14 @@ func TestInClusterClientConfigPrecedence(t *testing.T) {
 			},
 			expectedDisableCompression: true,
 		},
+		{
+			overrides: &ConfigOverrides{
+				ClusterInfo: clientcmdapi.Cluster{
+					ProxyURL: "http://proxy.example",
+				},
+			},
+			expectedProxyURL: "http://proxy.example",
+		},
 	}
 
 	for _, tc := range tt {
@@ -1006,6 +1015,22 @@ func TestInClusterClientConfigPrecedence(t *testing.T) {
 		}
 		if clientConfig.DisableCompression != tc.expectedDisableCompression {
 			t.Errorf("Expected DisableCompression %v, got %v", tc.expectedDisableCompression, clientConfig.DisableCompression)
+		}
+		if tc.expectedProxyURL == "" {
+			if clientConfig.Proxy != nil {
+				t.Errorf("Expected no proxy, got non-nil proxy")
+			}
+		} else {
+			if clientConfig.Proxy == nil {
+				t.Fatalf("Expected proxy %v, got nil", tc.expectedProxyURL)
+			}
+			proxyURL, err := clientConfig.Proxy(nil)
+			if err != nil {
+				t.Fatalf("Unexpected proxy error: %v", err)
+			}
+			if proxyURL.String() != tc.expectedProxyURL {
+				t.Errorf("Expected proxy %v, got %v", tc.expectedProxyURL, proxyURL.String())
+			}
 		}
 	}
 }

--- a/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder.go
@@ -151,6 +151,10 @@ func (config *DeferredLoadingClientConfig) isDefaultConfigForInClusterFallback(r
 		withoutFallbackNeutralOverrides.DisableCompression = false
 		changed = true
 	}
+	if len(config.overrides.ClusterInfo.ProxyURL) > 0 {
+		withoutFallbackNeutralOverrides.Proxy = nil
+		changed = true
+	}
 
 	return changed && config.loader.IsDefaultConfig(&withoutFallbackNeutralOverrides)
 }

--- a/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder.go
@@ -111,7 +111,7 @@ func (config *DeferredLoadingClientConfig) ClientConfig() (*restclient.Config, e
 	case mergedConfig != nil:
 		// the configuration is valid, but if this is equal to the defaults we should try
 		// in-cluster configuration
-		if !config.loader.IsDefaultConfig(mergedConfig) {
+		if !config.isDefaultConfigForInClusterFallback(mergedConfig) {
 			return mergedConfig, nil
 		}
 	}
@@ -125,6 +125,34 @@ func (config *DeferredLoadingClientConfig) ClientConfig() (*restclient.Config, e
 
 	// return the result of the merged client config
 	return mergedConfig, err
+}
+
+func (config *DeferredLoadingClientConfig) isDefaultConfigForInClusterFallback(restConfig *restclient.Config) bool {
+	if config.loader.IsDefaultConfig(restConfig) {
+		return true
+	}
+	if restConfig == nil || config.overrides == nil {
+		return false
+	}
+
+	// The legacy default rest.Config is used here as a source-selection sentinel:
+	// if the resolved config is still the default server/auth source, try
+	// in-cluster config before returning localhost:8080. Request/transport
+	// behavior overrides must not turn that sentinel into an explicit
+	// kubeconfig/source selection.
+	withoutFallbackNeutralOverrides := *restConfig
+	changed := false
+
+	if len(config.overrides.Timeout) > 0 {
+		withoutFallbackNeutralOverrides.Timeout = 0
+		changed = true
+	}
+	if config.overrides.ClusterInfo.DisableCompression {
+		withoutFallbackNeutralOverrides.DisableCompression = false
+		changed = true
+	}
+
+	return changed && config.loader.IsDefaultConfig(&withoutFallbackNeutralOverrides)
 }
 
 // Namespace implements KubeConfig

--- a/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder_test.go
@@ -18,6 +18,7 @@ package clientcmd
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
@@ -89,13 +90,22 @@ func TestInClusterConfig(t *testing.T) {
 	}
 	config2 := &restclient.Config{Host: "config2"}
 	err1 := fmt.Errorf("unique error")
+	proxyURL, err := parseProxyURL("http://proxy.example")
+	if err != nil {
+		t.Fatal(err)
+	}
 	configWithTimeout := *config1
 	configWithTimeout.Timeout = 30 * time.Second
 	configWithDisableCompression := *config1
 	configWithDisableCompression.DisableCompression = true
+	configWithProxy := *config1
+	configWithProxy.Proxy = http.ProxyURL(proxyURL)
 	configWithServerAndTimeout := *config1
 	configWithServerAndTimeout.Host = "https://explicit.example.com"
 	configWithServerAndTimeout.Timeout = 30 * time.Second
+	configWithServerAndProxy := *config1
+	configWithServerAndProxy.Host = "https://explicit.example.com"
+	configWithServerAndProxy.Proxy = http.ProxyURL(proxyURL)
 
 	testCases := map[string]struct {
 		clientConfig  *testClientConfig
@@ -235,6 +245,28 @@ func TestInClusterConfig(t *testing.T) {
 			err:        nil,
 		},
 
+		"in-cluster checked when config only differs from default by proxy url": {
+			defaultConfig: default1,
+			clientConfig:  &testClientConfig{config: &configWithProxy},
+			overrides:     &ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{ProxyURL: "http://proxy.example"}},
+			icc:           &testICC{},
+
+			checkedICC: true,
+			result:     &configWithProxy,
+			err:        nil,
+		},
+
+		"in-cluster returned when possible and config only differs from default by proxy url": {
+			defaultConfig: default1,
+			clientConfig:  &testClientConfig{config: &configWithProxy},
+			overrides:     &ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{ProxyURL: "http://proxy.example"}},
+			icc:           &testICC{possible: true, testClientConfig: testClientConfig{config: config2}},
+
+			checkedICC: true,
+			result:     config2,
+			err:        nil,
+		},
+
 		"in-cluster not checked when source selection differs from default even with request timeout": {
 			defaultConfig: default1,
 			clientConfig:  &testClientConfig{config: &configWithServerAndTimeout},
@@ -246,6 +278,22 @@ func TestInClusterConfig(t *testing.T) {
 
 			checkedICC: false,
 			result:     &configWithServerAndTimeout,
+			err:        nil,
+		},
+
+		"in-cluster not checked when source selection differs from default even with proxy url": {
+			defaultConfig: default1,
+			clientConfig:  &testClientConfig{config: &configWithServerAndProxy},
+			overrides: &ConfigOverrides{
+				ClusterInfo: clientcmdapi.Cluster{
+					Server:   "https://explicit.example.com",
+					ProxyURL: "http://proxy.example",
+				},
+			},
+			icc: &testICC{},
+
+			checkedICC: false,
+			result:     &configWithServerAndProxy,
 			err:        nil,
 		},
 	}

--- a/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder_test.go
@@ -19,6 +19,7 @@ package clientcmd
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	restclient "k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -88,11 +89,19 @@ func TestInClusterConfig(t *testing.T) {
 	}
 	config2 := &restclient.Config{Host: "config2"}
 	err1 := fmt.Errorf("unique error")
+	configWithTimeout := *config1
+	configWithTimeout.Timeout = 30 * time.Second
+	configWithDisableCompression := *config1
+	configWithDisableCompression.DisableCompression = true
+	configWithServerAndTimeout := *config1
+	configWithServerAndTimeout.Host = "https://explicit.example.com"
+	configWithServerAndTimeout.Timeout = 30 * time.Second
 
 	testCases := map[string]struct {
 		clientConfig  *testClientConfig
 		icc           *testICC
 		defaultConfig *DirectClientConfig
+		overrides     *ConfigOverrides
 
 		checkedICC bool
 		result     *restclient.Config
@@ -192,10 +201,57 @@ func TestInClusterConfig(t *testing.T) {
 			result:     config2,
 			err:        nil,
 		},
+
+		"in-cluster checked when config only differs from default by request timeout": {
+			defaultConfig: default1,
+			clientConfig:  &testClientConfig{config: &configWithTimeout},
+			overrides:     &ConfigOverrides{Timeout: "30s"},
+			icc:           &testICC{},
+
+			checkedICC: true,
+			result:     &configWithTimeout,
+			err:        nil,
+		},
+
+		"in-cluster returned when possible and config only differs from default by request timeout": {
+			defaultConfig: default1,
+			clientConfig:  &testClientConfig{config: &configWithTimeout},
+			overrides:     &ConfigOverrides{Timeout: "30s"},
+			icc:           &testICC{possible: true, testClientConfig: testClientConfig{config: config2}},
+
+			checkedICC: true,
+			result:     config2,
+			err:        nil,
+		},
+
+		"in-cluster checked when config only differs from default by disable compression": {
+			defaultConfig: default1,
+			clientConfig:  &testClientConfig{config: &configWithDisableCompression},
+			overrides:     &ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{DisableCompression: true}},
+			icc:           &testICC{},
+
+			checkedICC: true,
+			result:     &configWithDisableCompression,
+			err:        nil,
+		},
+
+		"in-cluster not checked when source selection differs from default even with request timeout": {
+			defaultConfig: default1,
+			clientConfig:  &testClientConfig{config: &configWithServerAndTimeout},
+			overrides: &ConfigOverrides{
+				Timeout:     "30s",
+				ClusterInfo: clientcmdapi.Cluster{Server: "https://explicit.example.com"},
+			},
+			icc: &testICC{},
+
+			checkedICC: false,
+			result:     &configWithServerAndTimeout,
+			err:        nil,
+		},
 	}
 
 	for name, test := range testCases {
-		c := &DeferredLoadingClientConfig{icc: test.icc}
+		c := &DeferredLoadingClientConfig{icc: test.icc, overrides: test.overrides}
 		c.loader = &ClientConfigLoadingRules{DefaultClientConfig: test.defaultConfig}
 		c.clientConfig = test.clientConfig
 


### PR DESCRIPTION
## Design note: scope of this fix

This PR fixes a specific class of config-loading bug: **client behavior overrides must not participate in kubeconfig source selection**.

The concrete issue reported in #93474 is `--request-timeout`: when kubectl runs inside a pod with no kubeconfig, adding `--request-timeout` changes the generated `rest.Config`, so the config no longer matches the default config sentinel. As a result, `DeferredLoadingClientConfig` returns the default `localhost:8080` config before trying in-cluster config.

That is the wrong boundary. `--request-timeout` changes how the client behaves after a server has been selected. It should not mean “the user selected a kubeconfig source”.

This PR intentionally keeps the change narrow. It does not try to redefine the behavior of every config flag. Instead, it handles the class we believe is safe to fix here:

> Client behavior overrides are fallback-neutral for source selection, but still apply to the final `rest.Config` after the source is selected.

## Config flag classification

While working on this bug, I used the following classification to avoid expanding the patch into unrelated precedence/security behavior.

### 1. Source selection overrides

These flags affect which kubeconfig source, context, cluster, user, or server should be used.

Examples:

- `--kubeconfig`
- `--server`
- `--context`
- `--cluster`
- `--user`

These are **not fallback-neutral**. If the user explicitly selects a source, context, cluster, user, or server, that should continue to affect whether in-cluster config is considered.

This PR does not change their precedence.

### 2. Client behavior overrides

These flags change request or transport behavior of the REST client, but do not identify a kubeconfig source.

Examples:

- `--request-timeout`
- `--disable-compression`
- `--proxy-url`, where used through `clientcmd` override APIs

These are the target scope of this PR.

They should not prevent in-cluster fallback when the only resolved config source is still the default `localhost:8080` sentinel. Once in-cluster config is selected, the behavior override should still be applied to the resulting `rest.Config`.

### 3. TLS / trust overrides

These flags change how the client authenticates or validates the server.

Examples:

- `--certificate-authority`
- `--insecure-skip-tls-verify`
- `--tls-server-name`

These are not handled as generic client behavior in this PR. They affect the trust boundary and can change security-sensitive behavior. Some existing in-cluster behavior already supports selected trust-related overrides, but this PR does not broaden that policy.

### 4. Identity / authentication overrides

These flags change who the client authenticates as.

Examples:

- `--token`
- `--client-certificate`
- `--client-key`
- `--username`
- `--password`
- auth-provider / exec-provider fields where used through `clientcmd`

These are out of scope for this PR. Applying them broadly to in-cluster config would be a larger authentication precedence change and should be reviewed separately.

### 5. Impersonation / authorization-view overrides

These flags change the user or groups the request is made as.

Examples:

- `--as`
- `--as-uid`
- `--as-group`
- `--as-user-extra`

These are also out of scope for this PR. They may be valid to apply after source selection, but that is a separate authorization behavior decision and should not be bundled with the `--request-timeout` regression fix.

### 6. View / namespace overrides

These flags affect request scope or presentation rather than REST server selection.

Examples:

- `--namespace`

Namespace handling already has its own path in `DeferredLoadingClientConfig.Namespace()`. This PR does not change that path.

### 7. Operational / discovery / cache options

Examples:

- `--cache-dir`
- discovery QPS/Burst settings
- warning printer behavior
- `WrapConfigFn`

These are not part of the `rest.Config` source-selection sentinel fixed here and are out of scope for this PR.

## Why not apply all overrides to in-cluster config?

A broader implementation could apply most or all `ConfigOverrides` to the in-cluster `rest.Config`. That would fix the `--request-timeout` symptom, but it would also change behavior for TLS, identity, authentication, impersonation, and possibly server precedence.

That would increase the blast radius of this bug fix.

For example, these are different product/API decisions:

- Should `--server` inside a pod mean “do not use in-cluster source”, or “use in-cluster credentials but replace the server URL”?
- Should `--token` inside a pod replace the service account token from in-cluster config?
- Should `--as` / impersonation flags apply to in-cluster config?
- Should TLS overrides be considered source-neutral, trust-boundary changes, or explicit source mutations?

Those questions are important, but they are not required to fix #93474.

This PR only addresses the safe and narrow rule needed for the reported bug:

> Request/transport behavior options should not make the default `localhost:8080` config look like an explicit kubeconfig source selection.

## Testing

- `go test ./staging/src/k8s.io/client-go/tools/clientcmd`
