### PR TITLE
Fix/cpumanager preserve numa affinity

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_assignment.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment.go
@@ -889,7 +889,12 @@ func takeByTopologyNUMAPacked(logger klog.Logger, topo *topology.CPUTopology, av
 // of size 'cpuGroupSize' according to the algorithm described above. This is
 // important, for example, to ensure that all CPUs (i.e. all hyperthreads) from
 // a single core are allocated together.
-func takeByTopologyNUMADistributed(logger klog.Logger, topo *topology.CPUTopology, availableCPUs cpuset.CPUSet, numCPUs int, cpuGroupSize int, cpuSortingStrategy CPUSortingStrategy, alignBySocket bool) (cpuset.CPUSet, error) {
+//
+// minNUMAsFromHint is the NUMA node count from the TopologyManager's topology
+// hint. When non-zero, it raises the minimum NUMA node count for distribution,
+// ensuring CPU allocation stays aligned with device topology (e.g., GPUs, NICs).
+// Pass 0 to use the default behavior (minimum NUMAs needed to satisfy the request).
+func takeByTopologyNUMADistributed(logger klog.Logger, topo *topology.CPUTopology, availableCPUs cpuset.CPUSet, numCPUs int, cpuGroupSize int, cpuSortingStrategy CPUSortingStrategy, alignBySocket bool, minNUMAsFromHint int) (cpuset.CPUSet, error) {
 	// If the number of CPUs requested cannot be handed out in chunks of
 	// 'cpuGroupSize', then we just call out the packing algorithm since we
 	// can't distribute CPUs in this chunk size.
@@ -915,6 +920,18 @@ func takeByTopologyNUMADistributed(logger klog.Logger, topo *topology.CPUTopolog
 	// could satisfy this request. This is used to optimize how many iterations
 	// of the loop we need to go through below.
 	minNUMAs, maxNUMAs := acc.rangeNUMANodesNeededToSatisfy(cpuGroupSize)
+
+	// If the TopologyManager selected a specific NUMA affinity, honor it by
+	// ensuring we distribute across at least that many NUMA nodes. This
+	// prevents CPUManager from shrinking a multi-NUMA affinity back to fewer
+	// nodes than what TopologyManager intended (e.g., for GPU/NIC alignment).
+	if minNUMAsFromHint > 0 {
+		if minNUMAsFromHint > minNUMAs && minNUMAsFromHint <= maxNUMAs {
+			minNUMAs = minNUMAsFromHint
+		} else if minNUMAsFromHint > maxNUMAs {
+			logger.V(4).Info("NUMA affinity hint exceeds maximum feasible NUMA count, ignoring", "minNUMAsFromHint", minNUMAsFromHint, "maxNUMAs", maxNUMAs)
+		}
+	}
 
 	// Try combinations of 1,2,3,... NUMA nodes until we find a combination
 	// where we can evenly distribute CPUs across them. To optimize things, we

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment.go
@@ -656,7 +656,12 @@ func (a *cpuAccumulator) takeRemainingCPUs() {
 // rangeNUMANodesNeededToSatisfy returns minimum and maximum (in this order) number of NUMA nodes
 // needed to satisfy the cpuAccumulator's goal of accumulating `a.numCPUsNeeded` CPUs, assuming that
 // CPU groups have size given by the `cpuGroupSize` argument.
-func (a *cpuAccumulator) rangeNUMANodesNeededToSatisfy(cpuGroupSize int) (minNumNUMAs, maxNumNUMAs int) {
+//
+// When minNumNUMAsFromHint is greater than 0, it raises the minimum NUMA node count
+// to honor the TopologyManager's topology hint. This ensures CPU allocation alignes with device
+// topology (e.g., GPUs, NICs that span multiple NUMA nodes). If the hint exceeds the maximum feasible NUMA count,
+// minNumNUMAsFromHint is ignored.
+func (a *cpuAccumulator) rangeNUMANodesNeededToSatisfy(cpuGroupSize int, minNumNUMAsFromHint int) (minNumNUMAs, maxNumNUMAs int) {
 	// Get the total number of NUMA nodes in the system.
 	numNUMANodes := a.topo.CPUDetails.NUMANodes().Size()
 
@@ -683,6 +688,17 @@ func (a *cpuAccumulator) rangeNUMANodesNeededToSatisfy(cpuGroupSize int) (minNum
 	// Calculate the maximum number of numa nodes required to satisfy the allocation.
 	maxNumNUMAs = min(numCPUGroupsNeeded, numNUMANodesAvailable)
 
+	// If the TopologyManager selected a specific NUMA affinity, honor it by
+	// ensuring we distribute across at least that many NUMA nodes. This
+	// prevents CPUManager from shrinking a multi-NUMA affinity back to fewer
+	// nodes than what TopologyManager intended (e.g., for GPU/NIC alignment).
+	if minNumNUMAsFromHint > 0 {
+		if minNumNUMAsFromHint > minNumNUMAs && minNumNUMAsFromHint <= maxNumNUMAs {
+			minNumNUMAs = minNumNUMAsFromHint
+		} else if minNumNUMAsFromHint > maxNumNUMAs {
+			a.logger.V(4).Info("NUMA affinity hint exceeds maximum feasible NUMA count, ignoring", "minNumNUMAsFromHint", minNumNUMAsFromHint, "maxNumNUMAs", maxNumNUMAs)
+		}
+	}
 	return
 }
 
@@ -896,7 +912,12 @@ func takeByTopologyNUMAPacked(logger klog.Logger, topo *topology.CPUTopology, av
 // of size 'cpuGroupSize' according to the algorithm described above. This is
 // important, for example, to ensure that all CPUs (i.e. all hyperthreads) from
 // a single core are allocated together.
-func takeByTopologyNUMADistributed(logger klog.Logger, topo *topology.CPUTopology, availableCPUs cpuset.CPUSet, numCPUs int, cpuGroupSize int, cpuSortingStrategy CPUSortingStrategy, alignBySocket bool) (cpuset.CPUSet, error) {
+//
+// minNUMAsFromHint is the NUMA node count from the TopologyManager's topology
+// hint. When non-zero, it raises the minimum NUMA node count for distribution,
+// ensuring CPU allocation stays aligned with device topology (e.g., GPUs, NICs).
+// Pass 0 to use the default behavior (minimum NUMAs needed to satisfy the request).
+func takeByTopologyNUMADistributed(logger klog.Logger, topo *topology.CPUTopology, availableCPUs cpuset.CPUSet, numCPUs int, cpuGroupSize int, cpuSortingStrategy CPUSortingStrategy, alignBySocket bool, minNUMAsFromHint int) (cpuset.CPUSet, error) {
 	// If the number of CPUs requested cannot be handed out in chunks of
 	// 'cpuGroupSize', then we just call out the packing algorithm since we
 	// can't distribute CPUs in this chunk size.
@@ -921,7 +942,7 @@ func takeByTopologyNUMADistributed(logger klog.Logger, topo *topology.CPUTopolog
 	// Calculate the minimum and maximum possible number of NUMA nodes that
 	// could satisfy this request. This is used to optimize how many iterations
 	// of the loop we need to go through below.
-	minNUMAs, maxNUMAs := acc.rangeNUMANodesNeededToSatisfy(cpuGroupSize)
+	minNUMAs, maxNUMAs := acc.rangeNUMANodesNeededToSatisfy(cpuGroupSize, minNUMAsFromHint)
 
 	// Try combinations of 1,2,3,... NUMA nodes until we find a combination
 	// where we can evenly distribute CPUs across them. To optimize things, we

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
@@ -1063,7 +1063,7 @@ func TestTakeByTopologyNUMADistributed(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			result, err := takeByTopologyNUMADistributed(logger, tc.topo, tc.availableCPUs, tc.numCPUs, tc.cpuGroupSize, CPUSortingStrategyPacked, false)
+			result, err := takeByTopologyNUMADistributed(logger, tc.topo, tc.availableCPUs, tc.numCPUs, tc.cpuGroupSize, CPUSortingStrategyPacked, false, 0)
 			if err != nil {
 				if tc.expErr == "" {
 					t.Errorf("unexpected error [%v]", err)
@@ -1086,4 +1086,169 @@ func mustParseCPUSet(t *testing.T, s string) cpuset.CPUSet {
 		t.Errorf("parsing %q: %v", s, err)
 	}
 	return cpus
+}
+
+func TestTakeByTopologyNUMADistributedWithMinNUMAHint(t *testing.T) {
+	// This test verifies the fix for https://github.com/kubernetes/kubernetes/issues/139430
+	// When TopologyManager selects a 4-NUMA affinity (e.g., for GPU alignment),
+	// CPUManager should not shrink the allocation to fewer NUMA nodes even if
+	// fewer nodes could satisfy the CPU count.
+	logger, _ := ktesting.NewTestContext(t)
+
+	testCases := []struct {
+		description      string
+		topo             *topology.CPUTopology
+		availableCPUs    cpuset.CPUSet
+		numCPUs          int
+		cpuGroupSize     int
+		alignBySocket    bool
+		minNUMAsFromHint int
+		expNUMAs         int // expected number of NUMA nodes in result
+	}{
+		{
+			// 4 NUMA nodes, 20 CPUs each (80 total). Request 30 CPUs.
+			// Without hint: minNUMAs=2 (30 fits in 2 NUMAs of 20 each)
+			// With hint=4: must use all 4 NUMAs
+			description:      "30 CPUs with 4-NUMA hint should distribute across all 4 NUMAs",
+			topo:             topoDualSocketMultiNumaPerSocketHT,
+			availableCPUs:    mustParseCPUSet(t, "0-79"),
+			numCPUs:          30,
+			cpuGroupSize:     1,
+			minNUMAsFromHint: 4,
+			expNUMAs:         4,
+		},
+		{
+			// Same topology, no hint (0) → should use minimum NUMAs (2)
+			description:      "30 CPUs without hint should pack into minimum NUMAs",
+			topo:             topoDualSocketMultiNumaPerSocketHT,
+			availableCPUs:    mustParseCPUSet(t, "0-79"),
+			numCPUs:          30,
+			cpuGroupSize:     1,
+			minNUMAsFromHint: 0,
+			expNUMAs:         2,
+		},
+		{
+			// 4 NUMA hint but only need 10 CPUs (fits in 1 NUMA)
+			// hint=4 should still force 4-NUMA distribution
+			description:      "10 CPUs with 4-NUMA hint should distribute across all 4 NUMAs",
+			topo:             topoDualSocketMultiNumaPerSocketHT,
+			availableCPUs:    mustParseCPUSet(t, "0-79"),
+			numCPUs:          10,
+			cpuGroupSize:     1,
+			minNUMAsFromHint: 4,
+			expNUMAs:         4,
+		},
+		{
+			// Regression guard: hint exceeds available NUMA nodes (8 > 4).
+			// Should gracefully fall back to the original algorithm behavior
+			// (minimum NUMAs needed) without panicking or erroring.
+			description:      "hint exceeds max NUMAs should fallback to minimum (regression guard)",
+			topo:             topoDualSocketMultiNumaPerSocketHT,
+			availableCPUs:    mustParseCPUSet(t, "0-79"),
+			numCPUs:          30,
+			cpuGroupSize:     1,
+			minNUMAsFromHint: 8,
+			expNUMAs:         2,
+		},
+		{
+			// Regression guard: hint smaller than computed minNUMAs.
+			// 30 CPUs on 4x20 topology → minNUMAs=2. hint=1 is below that.
+			// Should NOT reduce below the computed minimum; keeps original behavior.
+			description:      "hint smaller than minNUMAs should not reduce distribution (regression guard)",
+			topo:             topoDualSocketMultiNumaPerSocketHT,
+			availableCPUs:    mustParseCPUSet(t, "0-79"),
+			numCPUs:          30,
+			cpuGroupSize:     1,
+			minNUMAsFromHint: 1,
+			expNUMAs:         2,
+		},
+		{
+			// cpuGroupSize=2 with 4-NUMA hint: verifies that CPU grouping
+			// constraint is compatible with NUMA hint enforcement.
+			// 20 CPUs with groups of 2 across 4 NUMAs → 5 CPUs per NUMA (valid).
+			description:      "cpuGroupSize=2 with 4-NUMA hint should distribute respecting group size",
+			topo:             topoDualSocketMultiNumaPerSocketHT,
+			availableCPUs:    mustParseCPUSet(t, "0-79"),
+			numCPUs:          20,
+			cpuGroupSize:     2,
+			minNUMAsFromHint: 4,
+			expNUMAs:         4,
+		},
+		{
+			// cpuGroupSize=2 without hint: should use minimum NUMAs.
+			// 20 CPUs with groups of 2 on 4x20 topology → fits in 1 NUMA.
+			description:      "cpuGroupSize=2 without hint should pack into minimum NUMAs",
+			topo:             topoDualSocketMultiNumaPerSocketHT,
+			availableCPUs:    mustParseCPUSet(t, "0-79"),
+			numCPUs:          20,
+			cpuGroupSize:     2,
+			minNUMAsFromHint: 0,
+			expNUMAs:         1,
+		},
+		{
+			// alignBySocket=true with 4-NUMA hint: verifies that socket alignment
+			// is compatible with NUMA hint enforcement. Topology has 2 sockets
+			// with 2 NUMAs each; hint=4 means all NUMAs across both sockets.
+			description:      "alignBySocket=true with 4-NUMA hint should distribute across all NUMAs",
+			topo:             topoDualSocketMultiNumaPerSocketHT,
+			availableCPUs:    mustParseCPUSet(t, "0-79"),
+			numCPUs:          40,
+			cpuGroupSize:     1,
+			alignBySocket:    true,
+			minNUMAsFromHint: 4,
+			expNUMAs:         4,
+		},
+		{
+			// NUMA subset constraint: availableCPUs only contains CPUs from
+			// NUMA 1,2,3 (not NUMA 0). This simulates the real scenario where
+			// TopologyManager's alignedCPUs pre-filters the input pool to only
+			// the NUMA nodes selected by device affinity. With hint=3, the
+			// allocation should distribute across exactly 3 NUMAs (1,2,3) and
+			// must NOT allocate any CPU from NUMA 0 (which is not in the pool).
+			// This proves the NUMA-subset constraint is enforced by input
+			// filtering (alignedCPUs) rather than needing the full bitmask.
+			// Actual NUMA-CPU mapping for topoDualSocketMultiNumaPerSocketHT:
+			// NUMA 0: CPU 0-9, 40-49 (Socket 0)
+			// NUMA 1: CPU 10-19, 50-59 (Socket 0)
+			// NUMA 2: CPU 20-29, 60-69 (Socket 1)
+			// NUMA 3: CPU 30-39, 70-79 (Socket 1)
+			description:      "NUMA subset - hint=3 with CPUs only from NUMA 1,2,3 should not use NUMA 0",
+			topo:             topoDualSocketMultiNumaPerSocketHT,
+			availableCPUs:    mustParseCPUSet(t, "10-39,50-79"), // NUMA 1(10-19,50-59) + NUMA 2(20-29,60-69) + NUMA 3(30-39,70-79)
+			numCPUs:          15,
+			cpuGroupSize:     1,
+			minNUMAsFromHint: 3,
+			expNUMAs:         3,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := takeByTopologyNUMADistributed(logger, tc.topo, tc.availableCPUs, tc.numCPUs, tc.cpuGroupSize, CPUSortingStrategyPacked, tc.alignBySocket, tc.minNUMAsFromHint)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Count how many distinct NUMA nodes are represented in the result
+			numaNodes := make(map[int]bool)
+			for _, cpuID := range result.UnsortedList() {
+				numaNodes[tc.topo.CPUDetails[cpuID].NUMANodeID] = true
+			}
+
+			if len(numaNodes) != tc.expNUMAs {
+				t.Errorf("expected CPUs distributed across %d NUMA nodes, got %d (NUMAs: %v, result: %s)",
+					tc.expNUMAs, len(numaNodes), numaNodes, result)
+			}
+
+			// Additional assertion for NUMA subset test: verify no NUMA 0 CPUs which is filtered by getAlignedCPUsFilters
+			if tc.description == "NUMA subset - hint=3 with CPUs only from NUMA 1,2,3 should not use NUMA 0" {
+				for _, cpuID := range result.UnsortedList() {
+					if tc.topo.CPUDetails[cpuID].NUMANodeID == 0 {
+						t.Errorf("CPU %d belongs to NUMA 0 but should not be allocated (NUMA 0 is not in availableCPUs), result: %s",
+							cpuID, result)
+					}
+				}
+			}
+		})
+	}
 }

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
@@ -1298,7 +1298,7 @@ func TestTakeByTopologyNUMADistributed(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			result, err := takeByTopologyNUMADistributed(logger, tc.topo, tc.availableCPUs, tc.numCPUs, tc.cpuGroupSize, CPUSortingStrategyPacked, false)
+			result, err := takeByTopologyNUMADistributed(logger, tc.topo, tc.availableCPUs, tc.numCPUs, tc.cpuGroupSize, CPUSortingStrategyPacked, false, 0)
 			if err != nil {
 				if tc.expErr == "" {
 					t.Errorf("unexpected error [%v]", err)
@@ -1321,4 +1321,159 @@ func mustParseCPUSet(t *testing.T, s string) cpuset.CPUSet {
 		t.Errorf("parsing %q: %v", s, err)
 	}
 	return cpus
+}
+
+func TestTakeByTopologyNUMADistributedWithMinNUMAHint(t *testing.T) {
+	// This test verifies the fix for https://github.com/kubernetes/kubernetes/issues/139430
+	// When TopologyManager selects a 4-NUMA affinity (e.g., for GPU alignment),
+	// CPUManager should not shrink the allocation to fewer NUMA nodes even if
+	// fewer nodes could satisfy the CPU count.
+	logger, _ := ktesting.NewTestContext(t)
+
+	testCases := []struct {
+		description      string
+		topo             *topology.CPUTopology
+		availableCPUs    cpuset.CPUSet
+		numCPUs          int
+		cpuGroupSize     int
+		alignBySocket    bool
+		minNUMAsFromHint int
+		expNUMAs         cpuset.CPUSet // expected set of NUMA node IDs in result
+	}{
+		{
+			// 4 NUMA nodes, 20 CPUs each (80 total). Request 30 CPUs.
+			// Without hint: minNUMAs=2 (30 fits in 2 NUMAs of 20 each)
+			// With hint=4: must use all 4 NUMAs
+			description:      "30 CPUs with 4-NUMA hint should distribute across all 4 NUMAs",
+			topo:             topoDualSocketMultiNumaPerSocketHT,
+			availableCPUs:    mustParseCPUSet(t, "0-79"),
+			numCPUs:          30,
+			cpuGroupSize:     1,
+			minNUMAsFromHint: 4,
+			expNUMAs:         cpuset.New(0, 1, 2, 3),
+		},
+		{
+			// Same topology, no hint (0) → should use minimum NUMAs (2)
+			description:      "30 CPUs without hint should pack into minimum NUMAs",
+			topo:             topoDualSocketMultiNumaPerSocketHT,
+			availableCPUs:    mustParseCPUSet(t, "0-79"),
+			numCPUs:          30,
+			cpuGroupSize:     1,
+			minNUMAsFromHint: 0,
+			expNUMAs:         cpuset.New(0, 1),
+		},
+		{
+			// 4 NUMA hint but only need 10 CPUs (fits in 1 NUMA)
+			// hint=4 should still force 4-NUMA distribution
+			description:      "10 CPUs with 4-NUMA hint should distribute across all 4 NUMAs",
+			topo:             topoDualSocketMultiNumaPerSocketHT,
+			availableCPUs:    mustParseCPUSet(t, "0-79"),
+			numCPUs:          10,
+			cpuGroupSize:     1,
+			minNUMAsFromHint: 4,
+			expNUMAs:         cpuset.New(0, 1, 2, 3),
+		},
+		{
+			// Regression guard: hint exceeds available NUMA nodes (8 > 4).
+			// Should gracefully fall back to the original algorithm behavior
+			// (minimum NUMAs needed) without panicking or erroring.
+			description:      "hint exceeds max NUMAs should fallback to minimum (regression guard)",
+			topo:             topoDualSocketMultiNumaPerSocketHT,
+			availableCPUs:    mustParseCPUSet(t, "0-79"),
+			numCPUs:          30,
+			cpuGroupSize:     1,
+			minNUMAsFromHint: 8,
+			expNUMAs:         cpuset.New(0, 1),
+		},
+		{
+			// Regression guard: hint smaller than computed minNUMAs.
+			// 30 CPUs on 4x20 topology → minNUMAs=2. hint=1 is below that.
+			// Should NOT reduce below the computed minimum; keeps original behavior.
+			description:      "hint smaller than minNUMAs should not reduce distribution (regression guard)",
+			topo:             topoDualSocketMultiNumaPerSocketHT,
+			availableCPUs:    mustParseCPUSet(t, "0-79"),
+			numCPUs:          30,
+			cpuGroupSize:     1,
+			minNUMAsFromHint: 1,
+			expNUMAs:         cpuset.New(0, 1),
+		},
+		{
+			// cpuGroupSize=2 with 4-NUMA hint: verifies that CPU grouping
+			// constraint is compatible with NUMA hint enforcement.
+			// 20 CPUs with groups of 2 across 4 NUMAs → 5 CPUs per NUMA (valid).
+			description:      "cpuGroupSize=2 with 4-NUMA hint should distribute respecting group size",
+			topo:             topoDualSocketMultiNumaPerSocketHT,
+			availableCPUs:    mustParseCPUSet(t, "0-79"),
+			numCPUs:          20,
+			cpuGroupSize:     2,
+			minNUMAsFromHint: 4,
+			expNUMAs:         cpuset.New(0, 1, 2, 3),
+		},
+		{
+			// cpuGroupSize=2 without hint: should use minimum NUMAs.
+			// 20 CPUs with groups of 2 on 4x20 topology → fits in 1 NUMA.
+			description:      "cpuGroupSize=2 without hint should pack into minimum NUMAs",
+			topo:             topoDualSocketMultiNumaPerSocketHT,
+			availableCPUs:    mustParseCPUSet(t, "0-79"),
+			numCPUs:          20,
+			cpuGroupSize:     2,
+			minNUMAsFromHint: 0,
+			expNUMAs:         cpuset.New(0),
+		},
+		{
+			// alignBySocket=true with 4-NUMA hint: verifies that socket alignment
+			// is compatible with NUMA hint enforcement. Topology has 2 sockets
+			// with 2 NUMAs each; hint=4 means all NUMAs across both sockets.
+			description:      "alignBySocket=true with 4-NUMA hint should distribute across all NUMAs",
+			topo:             topoDualSocketMultiNumaPerSocketHT,
+			availableCPUs:    mustParseCPUSet(t, "0-79"),
+			numCPUs:          40,
+			cpuGroupSize:     1,
+			alignBySocket:    true,
+			minNUMAsFromHint: 4,
+			expNUMAs:         cpuset.New(0, 1, 2, 3),
+		},
+		{
+			// NUMA subset constraint: availableCPUs only contains CPUs from
+			// NUMA 1,2,3 (not NUMA 0). This simulates the real scenario where
+			// TopologyManager's alignedCPUs pre-filters the input pool to only
+			// the NUMA nodes selected by device affinity. With hint=3, the
+			// allocation should distribute across exactly NUMA 1, 2, 3 and
+			// must NOT allocate any CPU from NUMA 0 (which is not in the pool).
+			// This proves the NUMA-subset constraint is enforced by input
+			// filtering (alignedCPUs) rather than needing the full bitmask.
+			// Actual NUMA-CPU mapping for topoDualSocketMultiNumaPerSocketHT:
+			// NUMA 0: CPU 0-9, 40-49 (Socket 0)
+			// NUMA 1: CPU 10-19, 50-59 (Socket 0)
+			// NUMA 2: CPU 20-29, 60-69 (Socket 1)
+			// NUMA 3: CPU 30-39, 70-79 (Socket 1)
+			description:      "NUMA subset - hint=3 with CPUs only from NUMA 1,2,3 should not use NUMA 0",
+			topo:             topoDualSocketMultiNumaPerSocketHT,
+			availableCPUs:    mustParseCPUSet(t, "10-39,50-79"), // NUMA 1(10-19,50-59) + NUMA 2(20-29,60-69) + NUMA 3(30-39,70-79)
+			numCPUs:          15,
+			cpuGroupSize:     1,
+			minNUMAsFromHint: 3,
+			expNUMAs:         cpuset.New(1, 2, 3),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := takeByTopologyNUMADistributed(logger, tc.topo, tc.availableCPUs, tc.numCPUs, tc.cpuGroupSize, CPUSortingStrategyPacked, tc.alignBySocket, tc.minNUMAsFromHint)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Collect the set of NUMA node IDs represented in the result.
+			numaNodesBuilder := cpuset.New()
+			for _, cpuID := range result.UnsortedList() {
+				numaNodesBuilder = numaNodesBuilder.Union(cpuset.New(tc.topo.CPUDetails[cpuID].NUMANodeID))
+			}
+
+			if !numaNodesBuilder.Equals(tc.expNUMAs) {
+				t.Errorf("expected NUMA nodes %s, got %s (result CPUs: %s)",
+					tc.expNUMAs, numaNodesBuilder, result)
+			}
+		})
+	}
 }

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -166,7 +166,7 @@ func NewStaticPolicy(logger klog.Logger, topology *topology.CPUTopology, numRese
 		//
 		// For example: Given a system with 8 CPUs available and HT enabled,
 		// if numReservedCPUs=2, then reserved={0,4}
-		reserved, _ = policy.takeByTopology(logger, allCPUs, numReservedCPUs)
+		reserved, _ = policy.takeByTopology(logger, allCPUs, numReservedCPUs, 0)
 	}
 
 	if reserved.Size() != numReservedCPUs {
@@ -450,7 +450,7 @@ func (p *staticPolicy) allocatePodForAdd(logger klog.Logger, s state.State, pod 
 			// The pool available for this init container is the entire pod allocation
 			// minus what's already taken by sidecars.
 			runnablePool := podAllocation.CPUs.Difference(sidecarCPUs)
-			cset, err := p.takeByTopology(logger, runnablePool, numCPUs)
+			cset, err := p.takeByTopology(logger, runnablePool, numCPUs, 0)
 			if err != nil {
 				return err
 			}
@@ -483,7 +483,7 @@ func (p *staticPolicy) allocatePodForAdd(logger klog.Logger, s state.State, pod 
 	for _, c := range pod.Spec.Containers {
 		if numCPUs := p.guaranteedCPUs(logger, pod, &c); numCPUs > 0 {
 			metrics.CPUManagerPinningRequestsTotal.Inc()
-			cset, err := p.takeByTopology(logger, podSharedPool, numCPUs)
+			cset, err := p.takeByTopology(logger, podSharedPool, numCPUs, 0)
 			if err != nil {
 				return err
 			}
@@ -708,7 +708,7 @@ func (p *staticPolicy) allocateCPUs(logger klog.Logger, s state.State, numCPUs i
 			numAlignedToAlloc = numCPUs
 		}
 
-		allocatedCPUs, err := p.takeByTopology(logger, alignedCPUs, numAlignedToAlloc)
+		allocatedCPUs, err := p.takeByTopology(logger, alignedCPUs, numAlignedToAlloc, numaAffinity.Count())
 		if err != nil {
 			return topology.EmptyAllocation(), err
 		}
@@ -717,7 +717,7 @@ func (p *staticPolicy) allocateCPUs(logger klog.Logger, s state.State, numCPUs i
 	}
 
 	// Get any remaining CPUs from what's leftover after attempting to grab aligned ones.
-	remainingCPUs, err := p.takeByTopology(logger, allocatableCPUs.Difference(result.CPUs), numCPUs-result.CPUs.Size())
+	remainingCPUs, err := p.takeByTopology(logger, allocatableCPUs.Difference(result.CPUs), numCPUs-result.CPUs.Size(), 0)
 	if err != nil {
 		return topology.EmptyAllocation(), err
 	}
@@ -815,7 +815,7 @@ func (p *staticPolicy) podGuaranteedCPUs(logger klog.Logger, pod *v1.Pod) int {
 	return requestedByLongRunningContainers
 }
 
-func (p *staticPolicy) takeByTopology(logger klog.Logger, availableCPUs cpuset.CPUSet, numCPUs int) (cpuset.CPUSet, error) {
+func (p *staticPolicy) takeByTopology(logger klog.Logger, availableCPUs cpuset.CPUSet, numCPUs int, minNUMAsFromHint int) (cpuset.CPUSet, error) {
 	cpuSortingStrategy := CPUSortingStrategyPacked
 	if p.options.DistributeCPUsAcrossCores {
 		cpuSortingStrategy = CPUSortingStrategySpread
@@ -826,7 +826,7 @@ func (p *staticPolicy) takeByTopology(logger klog.Logger, availableCPUs cpuset.C
 		if p.options.FullPhysicalCPUsOnly {
 			cpuGroupSize = p.cpuGroupSize
 		}
-		return takeByTopologyNUMADistributed(logger, p.topology, availableCPUs, numCPUs, cpuGroupSize, cpuSortingStrategy, p.options.AlignBySocket)
+		return takeByTopologyNUMADistributed(logger, p.topology, availableCPUs, numCPUs, cpuGroupSize, cpuSortingStrategy, p.options.AlignBySocket, minNUMAsFromHint)
 	}
 
 	return takeByTopologyNUMAPacked(logger, p.topology, availableCPUs, numCPUs, cpuSortingStrategy, p.options.PreferAlignByUncoreCacheOption)

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -171,7 +171,7 @@ func NewStaticPolicy(logger klog.Logger, topology *topology.CPUTopology, numRese
 		//
 		// For example: Given a system with 8 CPUs available and HT enabled,
 		// if numReservedCPUs=2, then reserved={0,4}
-		reserved, _ = policy.takeByTopology(logger, allCPUs, numReservedCPUs)
+		reserved, _ = policy.takeByTopology(logger, allCPUs, numReservedCPUs, 0)
 	}
 
 	if reserved.Size() != numReservedCPUs {
@@ -433,6 +433,10 @@ func (p *staticPolicy) allocatePodForAdd(logger klog.Logger, s state.State, pod 
 
 	// 4. Allocate the entire CPU "bubble" for the pod using the hint from the Topology Manager.
 	hint := p.affinity.GetAffinity(logger, podUID, append(pod.Spec.InitContainers, pod.Spec.Containers...)[0].Name)
+	numaHintCount := 0
+	if hint.NUMANodeAffinity != nil {
+		numaHintCount = hint.NUMANodeAffinity.Count()
+	}
 	podAllocation, err := p.allocateCPUs(logger, s, totalPodCPUs, hint.NUMANodeAffinity, cpuset.New())
 	if err != nil {
 		logger.Error(err, "Unable to allocate CPUs for pod", "totalPodCPUs", totalPodCPUs)
@@ -469,7 +473,7 @@ func (p *staticPolicy) allocatePodForAdd(logger klog.Logger, s state.State, pod 
 			// The pool available for this init container is the entire pod allocation
 			// minus what's already taken by sidecars.
 			runnablePool := podAllocation.CPUs.Difference(sidecarCPUs)
-			cset, err := p.takeByTopology(logger, runnablePool, numCPUs)
+			cset, err := p.takeByTopology(logger, runnablePool, numCPUs, numaHintCount)
 			if err != nil {
 				return err
 			}
@@ -502,7 +506,7 @@ func (p *staticPolicy) allocatePodForAdd(logger klog.Logger, s state.State, pod 
 	for _, c := range pod.Spec.Containers {
 		if numCPUs := p.guaranteedCPUs(logger, pod, &c); numCPUs > 0 {
 			metrics.CPUManagerPinningRequestsTotal.Inc()
-			cset, err := p.takeByTopology(logger, podSharedPool, numCPUs)
+			cset, err := p.takeByTopology(logger, podSharedPool, numCPUs, numaHintCount)
 			if err != nil {
 				return err
 			}
@@ -740,7 +744,7 @@ func (p *staticPolicy) allocateCPUs(logger klog.Logger, s state.State, numCPUs i
 			numAlignedToAlloc = numCPUs
 		}
 
-		allocatedCPUs, err := p.takeByTopology(logger, alignedCPUs, numAlignedToAlloc)
+		allocatedCPUs, err := p.takeByTopology(logger, alignedCPUs, numAlignedToAlloc, numaAffinity.Count())
 		if err != nil {
 			return topology.EmptyAllocation(), err
 		}
@@ -749,7 +753,7 @@ func (p *staticPolicy) allocateCPUs(logger klog.Logger, s state.State, numCPUs i
 	}
 
 	// Get any remaining CPUs from what's leftover after attempting to grab aligned ones.
-	remainingCPUs, err := p.takeByTopology(logger, allocatableCPUs.Difference(result.CPUs), numCPUs-result.CPUs.Size())
+	remainingCPUs, err := p.takeByTopology(logger, allocatableCPUs.Difference(result.CPUs), numCPUs-result.CPUs.Size(), 0)
 	if err != nil {
 		return topology.EmptyAllocation(), err
 	}
@@ -847,7 +851,7 @@ func (p *staticPolicy) podGuaranteedCPUs(logger klog.Logger, pod *v1.Pod) int {
 	return requestedByLongRunningContainers
 }
 
-func (p *staticPolicy) takeByTopology(logger klog.Logger, availableCPUs cpuset.CPUSet, numCPUs int) (cpuset.CPUSet, error) {
+func (p *staticPolicy) takeByTopology(logger klog.Logger, availableCPUs cpuset.CPUSet, numCPUs int, minNUMAsFromHint int) (cpuset.CPUSet, error) {
 	cpuSortingStrategy := CPUSortingStrategyPacked
 	if p.options.DistributeCPUsAcrossCores {
 		cpuSortingStrategy = CPUSortingStrategySpread
@@ -858,7 +862,7 @@ func (p *staticPolicy) takeByTopology(logger klog.Logger, availableCPUs cpuset.C
 		if p.options.FullPhysicalCPUsOnly {
 			cpuGroupSize = p.cpuGroupSize
 		}
-		return takeByTopologyNUMADistributed(logger, p.topology, availableCPUs, numCPUs, cpuGroupSize, cpuSortingStrategy, p.options.AlignBySocket)
+		return takeByTopologyNUMADistributed(logger, p.topology, availableCPUs, numCPUs, cpuGroupSize, cpuSortingStrategy, p.options.AlignBySocket, minNUMAsFromHint)
 	}
 
 	return takeByTopologyNUMAPacked(logger, p.topology, availableCPUs, numCPUs, cpuSortingStrategy, p.options.PreferAlignByUncoreCacheOption)

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -2731,6 +2731,64 @@ func TestStaticPolicyAllocatePod(t *testing.T) {
 				expPodSharedPoolAssignments: 0,
 			},
 		},
+		{
+			description: "scope: pod, DistributeCPUsAcrossNUMA with multi-NUMA hint should distribute container CPUs across all hinted NUMA nodes",
+			topo:        topoDualSocketHT,
+			options: map[string]string{
+				DistributeCPUsAcrossNUMAOption: "true",
+			},
+			numReservedCPUs: 2,
+			reservedCPUs:    cpuset.New(0, 1),
+			stAssignments:   state.ContainerCPUAssignments{},
+			stDefaultCPUSet: cpuset.New(2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			pod:             makePodWithPodLevelResources("pod-single-container-distributed", "4", "4", "workload", "4", "4"),
+			topologyHint:    topologymanager.TopologyHint{NUMANodeAffinity: newNUMAAffinity(0, 1), Preferred: true},
+			expErr:          nil,
+			expPodAssignments: state.ContainerCPUAssignments{
+				"pod-single-container-distributed": map[string]cpuset.CPUSet{
+					"workload": cpuset.New(2, 3, 8, 9),
+				},
+			},
+			expDefaultCPUSet:                cpuset.New(4, 5, 6, 7, 10, 11),
+			podLevelResourcesEnabled:        true,
+			podLevelResourceManagersEnabled: true,
+			requiredMetrics: requiredMetrics{
+				expTotalAllocs:              1,
+				expExclusiveAssignments:     1,
+				expPodSharedPoolAssignments: 0,
+			},
+		},
+		{
+			description: "scope: pod, DistributeCPUsAcrossNUMA with multi-NUMA hint should distribute multiple containers across all hinted NUMA nodes",
+			topo:        topoDualSocketHT,
+			options: map[string]string{
+				DistributeCPUsAcrossNUMAOption: "true",
+			},
+			numReservedCPUs: 2,
+			reservedCPUs:    cpuset.New(0, 1),
+			stAssignments:   state.ContainerCPUAssignments{},
+			stDefaultCPUSet: cpuset.New(2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			pod: makePodWithContainersAndPodLevelResources("pod-multi-container-distributed", "6", "6", []containerSpec{}, []containerSpec{
+				{name: "workload", request: "4", limit: "4"},
+				{name: "sidecar", request: "2", limit: "2"},
+			}),
+			topologyHint: topologymanager.TopologyHint{NUMANodeAffinity: newNUMAAffinity(0, 1), Preferred: true},
+			expErr:       nil,
+			expPodAssignments: state.ContainerCPUAssignments{
+				"pod-multi-container-distributed": map[string]cpuset.CPUSet{
+					"workload": cpuset.New(2, 3, 8, 9),
+					"sidecar":  cpuset.New(6, 7),
+				},
+			},
+			expDefaultCPUSet:                cpuset.New(4, 5, 10, 11),
+			podLevelResourcesEnabled:        true,
+			podLevelResourceManagersEnabled: true,
+			requiredMetrics: requiredMetrics{
+				expTotalAllocs:              2,
+				expExclusiveAssignments:     2,
+				expPodSharedPoolAssignments: 0,
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -2743,7 +2801,7 @@ func TestStaticPolicyAllocatePod(t *testing.T) {
 			metrics.ResourceManagerAllocationErrorsTotal.Reset()
 			metrics.ResourceManagerContainerAssignments.Reset()
 
-			policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, testCase.reservedCPUs, topologymanager.NewFakeManager(logger), testCase.options)
+			policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, testCase.reservedCPUs, topologymanager.NewFakeManagerWithHint(logger, &testCase.topologyHint), testCase.options)
 			if err != nil {
 				t.Fatalf("NewStaticPolicy() failed: %v", err)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
When `distribute-cpus-across-numa` policy option is enabled, CPUManager's  `takeByTopologyNUMADistributed` function finds the **minimum** number of NUMA  nodes needed to satisfy a CPU request and distributes evenly across them.   However, when TopologyManager has explicitly selected a multi-NUMA affinity   (e.g., all 4 NUMA nodes because GPUs/NICs span them all), CPUManager ignores  this intent and shrinks the allocation back to fewer NUMA nodes.
     This PR ensures CPUManager honors the TopologyManager's NUMA affinity as a minimum constraint for distribution, preserving device topology alignment

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #139430 

#### Special notes for your reviewer:
1. `allocateCPUs()` now passes `numaAffinity.Count()` (number of NUMA nodes in the TopologyManager hint) through to `takeByTopologyNUMADistributed()`
2. `takeByTopologyNUMADistributed()` uses this as a floor for `minNUMAs`, the loop variable that controls the minimum combination size to try

The fix is conservative:
- Only applies when `distribute-cpus-across-numa` is enabled
- Only when a valid NUMA affinity hint exists (`numaAffinity != nil`)
- Falls back to original behavior if hint count exceeds available NUMA nodes
- Passes `0` (no constraint) for non-aligned allocation paths
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
CPUManager now preserves TopologyManager's multi-NUMA affinity when using the
distribute-cpus-across-numa policy option, ensuring CPU allocation stays
aligned with device topology (e.g., GPUs, NICs) across NUMA nodes.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
