### PR TITLE
use %w verb when wrapping errors in pkg/kubelet/apis package

### DIFF
--- a/pkg/kubelet/apis/podresources/client.go
+++ b/pkg/kubelet/apis/podresources/client.go
@@ -47,7 +47,7 @@ func GetV1alpha1Client(socket string, connectionTimeout time.Duration, maxMsgSiz
 		grpc.WithContextDialer(dialer),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
 	if err != nil {
-		return nil, nil, fmt.Errorf("error dialing socket %s: %v", socket, err)
+		return nil, nil, fmt.Errorf("error dialing socket %s: %w", socket, err)
 	}
 	return v1alpha1.NewPodResourcesListerClient(conn), conn, nil
 }
@@ -66,7 +66,7 @@ func GetV1Client(socket string, connectionTimeout time.Duration, maxMsgSize int)
 		grpc.WithContextDialer(dialer),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
 	if err != nil {
-		return nil, nil, fmt.Errorf("error dialing socket %s: %v", socket, err)
+		return nil, nil, fmt.Errorf("error dialing socket %s: %w", socket, err)
 	}
 	return v1.NewPodResourcesListerClient(conn), conn, nil
 }

--- a/pkg/kubelet/apis/podresources/server_v1_test.go
+++ b/pkg/kubelet/apis/podresources/server_v1_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package podresources
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"testing"
@@ -1055,7 +1056,7 @@ func TestGetPodResourcesV1(t *testing.T) {
 					t.Errorf("want exit = %v, got %v", tc.err, err)
 				}
 			} else {
-				if err != tc.err {
+				if !errors.Is(err, tc.err) {
 					t.Errorf("want exit = %v, got %v", tc.err, err)
 				} else {
 					if tc.expectedResponse.String() != resp.String() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
part of https://github.com/kubernetes/kubernetes/pull/139209
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
the Consumers of `GetV1alpha1Client` and `GetV1Client` in their project.  Added  release-note for this pr.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
 use `%w` verb when wrapping errors with `fmt.Errorf`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
