### PR TITLE
Add scheduler failure cache for same-spec Pod fast-fail

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -692,6 +692,11 @@ const (
 	// Enables opportunistic batching in the scheduler.
 	OpportunisticBatching featuregate.Feature = "OpportunisticBatching"
 
+	// Enables signature-based scheduling failure cache for same-spec Pods.
+	// When a Pod fails scheduling, subsequent Pods with the same scheduling
+	// signature skip the full scheduling cycle and fail immediately.
+	SchedulerFailureCache featuregate.Feature = "SchedulerFailureCache"
+
 	// owner: @tallclair
 	//
 	// Enables relisting individual pods on-demand.
@@ -1663,6 +1668,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.35"), Default: true, PreRelease: featuregate.Beta},
 	},
 
+	SchedulerFailureCache: {
+		{Version: version.MustParse("1.35"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
 	PLEGOnDemandRelist: {
 		{Version: version.MustParse("1.36"), Default: true, PreRelease: featuregate.Beta},
 	},
@@ -2423,6 +2432,10 @@ var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]feature
 	NominatedNodeNameForExpectation: {},
 
 	OpportunisticBatching: {},
+
+	SchedulerFailureCache: {
+		OpportunisticBatching,
+	},
 
 	PLEGOnDemandRelist: {},
 

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -148,6 +148,14 @@ type SchedulingQueue interface {
 	UnschedulablePods() []*v1.Pod
 	// PendingPodGroupPods returns all the pending pods waiting for their pod groups.
 	PendingPodGroupPods() []*v1.Pod
+
+	// CheckFailureCache returns a cached scheduling failure if a pod with the same
+	// scheduling signature previously failed and the cache is still valid.
+	// Returns nil if no cached failure exists or the pod should not fast-fail.
+	CheckFailureCache(podInfo *framework.QueuedPodInfo) error
+	// CacheFailure stores a scheduling failure keyed by pod scheduling signature
+	// for future fast-fail of same-signature pods.
+	CacheFailure(signature fwk.PodSignature, fitError *framework.FitError)
 }
 
 // NewSchedulingQueue initializes a priority queue as a new scheduling queue.
@@ -214,6 +222,10 @@ type PriorityQueue struct {
 	isGenericWorkloadEnabled bool
 	// isOpportunisticBatchingEnabled indicates whether the OpportunisticBatching feature gate is enabled.
 	isOpportunisticBatchingEnabled bool
+	// isFailureCacheEnabled indicates whether the SchedulerFailureCache feature gate is enabled.
+	isFailureCacheEnabled bool
+	// failureCache caches scheduling failures keyed by PodSignature for fast-failing same-spec Pods.
+	failureCache map[string]*failureCacheEntry
 }
 
 // QueueingHintFunction is the wrapper of QueueingHintFn that has PluginName.
@@ -229,6 +241,13 @@ type clusterEvent struct {
 	oldObj interface{}
 	// newObj is the object that involved this event.
 	newObj interface{}
+}
+
+// failureCacheEntry holds information about a scheduling failure for a specific PodSignature.
+type failureCacheEntry struct {
+	unschedulablePlugins sets.Set[string]
+	message              string
+	numAllNodes          int
 }
 
 type priorityQueueOptions struct {
@@ -385,6 +404,7 @@ func NewPriorityQueue(
 	isPopFromBackoffQEnabled := utilfeature.DefaultFeatureGate.Enabled(features.SchedulerPopFromBackoffQ)
 	isGenericWorkloadEnabled := utilfeature.DefaultFeatureGate.Enabled(features.GenericWorkload)
 	isOpportunisticBatchingEnabled := utilfeature.DefaultFeatureGate.Enabled(features.OpportunisticBatching)
+	isFailureCacheEnabled := utilfeature.DefaultFeatureGate.Enabled(features.SchedulerFailureCache)
 	lessConverted := convertLessFn(lessFn)
 
 	backoffQ := newBackoffQueue(options.clock, options.podInitialBackoffDuration, options.podMaxBackoffDuration, lessConverted, isPopFromBackoffQEnabled)
@@ -405,6 +425,8 @@ func NewPriorityQueue(
 		isPopFromBackoffQEnabled:          isPopFromBackoffQEnabled,
 		isGenericWorkloadEnabled:          isGenericWorkloadEnabled,
 		isOpportunisticBatchingEnabled:    isOpportunisticBatchingEnabled,
+		isFailureCacheEnabled:             isFailureCacheEnabled,
+		failureCache:                      make(map[string]*failureCacheEntry),
 	}
 	var backoffQPopper backoffQPopper
 	if isPopFromBackoffQEnabled {
@@ -1404,6 +1426,8 @@ func (p *PriorityQueue) AssignedPodUpdated(logger klog.Logger, oldPod, newPod *v
 // if Pop() is waiting for an entity, it receives the signal after all the pods are in the
 // queue and the head is the highest priority pod.
 func (p *PriorityQueue) moveAllToActiveOrBackoffQueue(logger klog.Logger, event fwk.ClusterEvent, oldObj, newObj interface{}, preCheck PreEnqueueCheck) {
+	p.invalidateFailureCache(event)
+
 	if !p.isEventOfInterest(logger, event) {
 		// No plugin is interested in this event.
 		// Return early before iterating all entities in unschedulableEntities for preCheck.
@@ -1779,4 +1803,84 @@ func (p *PriorityQueue) newQueuedPodGroupInfo(podInfo *framework.QueuedPodInfo) 
 // queuedEntityKeyFunc returns a unique key for a queued entity based on its type, namespace, and name.
 func queuedEntityKeyFunc(obj framework.QueuedEntityInfo) string {
 	return fmt.Sprintf("%s/%s/%s", obj.Type(), obj.GetNamespace(), obj.GetName())
+}
+
+// CheckFailureCache returns a cached FitError if a pod with the same scheduling
+// signature previously failed scheduling and no relevant cluster events have
+// invalidated the cache entry since then.
+func (p *PriorityQueue) CheckFailureCache(podInfo *framework.QueuedPodInfo) error {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	if !p.isFailureCacheEnabled {
+		return nil
+	}
+	if podInfo.PodSignature == nil {
+		return nil
+	}
+	if len(podInfo.Pod.Status.NominatedNodeName) > 0 {
+		return nil
+	}
+
+	entry, ok := p.failureCache[string(podInfo.PodSignature)]
+	if !ok {
+		return nil
+	}
+
+	return &framework.FitError{
+		Pod:         podInfo.Pod,
+		NumAllNodes: entry.numAllNodes,
+		Diagnosis: framework.Diagnosis{
+			UnschedulablePlugins: entry.unschedulablePlugins,
+			PreFilterMsg:         entry.message,
+		},
+	}
+}
+
+// CacheFailure stores a scheduling failure keyed by pod scheduling signature.
+// Subsequent pods with the same signature will fast-fail without running the
+// full scheduling cycle, until a relevant cluster event invalidates the cache.
+func (p *PriorityQueue) CacheFailure(signature fwk.PodSignature, fitError *framework.FitError) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if !p.isFailureCacheEnabled || len(signature) == 0 {
+		return
+	}
+
+	key := string(signature)
+	if _, ok := p.failureCache[key]; ok {
+		return
+	}
+
+	p.failureCache[key] = &failureCacheEntry{
+		unschedulablePlugins: fitError.Diagnosis.UnschedulablePlugins,
+		message:              fitError.Diagnosis.PreFilterMsg,
+		numAllNodes:          fitError.NumAllNodes,
+	}
+}
+
+// invalidateFailureCache removes cached failures whose rejecting plugins are
+// interested in the given cluster event. Wildcard events clear the entire cache.
+func (p *PriorityQueue) invalidateFailureCache(event fwk.ClusterEvent) {
+	if !p.isFailureCacheEnabled || len(p.failureCache) == 0 {
+		return
+	}
+
+	if framework.ClusterEventIsWildCard(event) {
+		p.failureCache = make(map[string]*failureCacheEntry)
+		return
+	}
+
+	for sig, entry := range p.failureCache {
+		for pluginName := range entry.unschedulablePlugins {
+			for _, pluginEvent := range p.pluginToEventsMap[pluginName] {
+				if framework.MatchClusterEvents(pluginEvent, event) {
+					delete(p.failureCache, sig)
+					goto nextEntry
+				}
+			}
+		}
+	nextEntry:
+	}
 }

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -7207,3 +7207,351 @@ func TestAddUnschedulablePodIfNotPresentPodGroupMember(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckFailureCache(t *testing.T) {
+	sig := fwk.PodSignature("test-signature")
+
+	tests := []struct {
+		name            string
+		enableFG        bool
+		podSignature    fwk.PodSignature
+		nominatedNode   string
+		cacheEntry      *failureCacheEntry
+		expectFitError  bool
+	}{
+		{
+			name:         "feature gate disabled",
+			enableFG:     false,
+			podSignature: sig,
+			cacheEntry: &failureCacheEntry{
+				unschedulablePlugins: sets.New("NodeResourcesFit"),
+			},
+		},
+		{
+			name:         "nil signature (unsignable pod)",
+			enableFG:     true,
+			podSignature: nil,
+			cacheEntry: &failureCacheEntry{
+				unschedulablePlugins: sets.New("NodeResourcesFit"),
+			},
+		},
+		{
+			name:          "pod has nominated node",
+			enableFG:      true,
+			podSignature:  sig,
+			nominatedNode: "node-1",
+			cacheEntry: &failureCacheEntry{
+				unschedulablePlugins: sets.New("NodeResourcesFit"),
+			},
+		},
+		{
+			name:         "no cache entry for signature",
+			enableFG:     true,
+			podSignature: sig,
+		},
+		{
+			name:         "cache hit returns FitError",
+			enableFG:     true,
+			podSignature: sig,
+			cacheEntry: &failureCacheEntry{
+				unschedulablePlugins: sets.New("NodeResourcesFit"),
+				message:              "node(s) didn't satisfy resource requirements",
+				numAllNodes:          10,
+			},
+			expectFitError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerFailureCache, tt.enableFG)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.OpportunisticBatching, true)
+
+			clientset := fake.NewSimpleClientset()
+			informerFactory := informers.NewSharedInformerFactory(clientset, 0)
+			q := NewPriorityQueue(newDefaultQueueSort(), informerFactory)
+
+			if tt.cacheEntry != nil {
+				q.failureCache[string(sig)] = tt.cacheEntry
+			}
+
+			pod := st.MakePod().Name("pod2").Obj()
+			if tt.nominatedNode != "" {
+				pod.Status.NominatedNodeName = tt.nominatedNode
+			}
+			podInfo := &framework.QueuedPodInfo{
+				PodInfo:     &framework.PodInfo{Pod: pod},
+				PodSignature: tt.podSignature,
+			}
+
+			err := q.CheckFailureCache(podInfo)
+			if tt.expectFitError {
+				if err == nil {
+					t.Fatal("Expected FitError, got nil")
+				}
+				fitErr, ok := err.(*framework.FitError)
+				if !ok {
+					t.Fatalf("Expected *framework.FitError, got %T", err)
+				}
+				if fitErr.NumAllNodes != tt.cacheEntry.numAllNodes {
+					t.Errorf("Expected NumAllNodes %d, got %d", tt.cacheEntry.numAllNodes, fitErr.NumAllNodes)
+				}
+				if fitErr.Diagnosis.PreFilterMsg != tt.cacheEntry.message {
+					t.Errorf("Expected PreFilterMsg %q, got %q", tt.cacheEntry.message, fitErr.Diagnosis.PreFilterMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected nil error, got %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestCacheFailure(t *testing.T) {
+	tests := []struct {
+		name          string
+		enableFG      bool
+		signature     fwk.PodSignature
+		fitError      *framework.FitError
+		expectCached  bool
+	}{
+		{
+			name:      "feature gate disabled",
+			enableFG:  false,
+			signature: fwk.PodSignature("sig"),
+			fitError: &framework.FitError{
+				NumAllNodes: 5,
+				Diagnosis: framework.Diagnosis{
+					UnschedulablePlugins: sets.New("NodeResourcesFit"),
+				},
+			},
+		},
+		{
+			name:      "empty signature",
+			enableFG:  true,
+			signature: nil,
+			fitError: &framework.FitError{
+				NumAllNodes: 5,
+				Diagnosis: framework.Diagnosis{
+					UnschedulablePlugins: sets.New("NodeResourcesFit"),
+				},
+			},
+		},
+		{
+			name:      "caches failure entry",
+			enableFG:  true,
+			signature: fwk.PodSignature("sig-1"),
+			fitError: &framework.FitError{
+				NumAllNodes: 10,
+				Diagnosis: framework.Diagnosis{
+					UnschedulablePlugins: sets.New("NodeResourcesFit", "TaintToleration"),
+					PreFilterMsg:         "pod failed prefilter",
+				},
+			},
+			expectCached: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerFailureCache, tt.enableFG)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.OpportunisticBatching, true)
+
+			clientset := fake.NewSimpleClientset()
+			informerFactory := informers.NewSharedInformerFactory(clientset, 0)
+			q := NewPriorityQueue(newDefaultQueueSort(), informerFactory)
+
+			q.CacheFailure(tt.signature, tt.fitError)
+
+			if tt.expectCached {
+				entry, ok := q.failureCache[string(tt.signature)]
+				if !ok {
+					t.Fatal("Expected cache entry to exist")
+				}
+				if !entry.unschedulablePlugins.Equal(tt.fitError.Diagnosis.UnschedulablePlugins) {
+					t.Errorf("Expected UnschedulablePlugins %v, got %v", tt.fitError.Diagnosis.UnschedulablePlugins, entry.unschedulablePlugins)
+				}
+				if entry.message != tt.fitError.Diagnosis.PreFilterMsg {
+					t.Errorf("Expected message %q, got %q", tt.fitError.Diagnosis.PreFilterMsg, entry.message)
+				}
+				if entry.numAllNodes != tt.fitError.NumAllNodes {
+					t.Errorf("Expected NumAllNodes %d, got %d", tt.fitError.NumAllNodes, entry.numAllNodes)
+				}
+			} else {
+				if len(q.failureCache) > 0 {
+					t.Errorf("Expected empty cache, got %d entries", len(q.failureCache))
+				}
+			}
+		})
+	}
+}
+
+func TestInvalidateFailureCache(t *testing.T) {
+	tests := []struct {
+		name                      string
+		event                     fwk.ClusterEvent
+		setupEntry                *failureCacheEntry
+		setupPluginToEvents       map[string][]fwk.ClusterEvent
+		expectCacheCleared        bool
+		expectSpecificEvicted     bool
+	}{
+		{
+			name: "wildcard event clears entire cache",
+			event: fwk.ClusterEvent{
+				Resource:  fwk.WildCard,
+				ActionType: fwk.All,
+			},
+			setupEntry: &failureCacheEntry{
+				unschedulablePlugins: sets.New("NodeResourcesFit"),
+			},
+			expectCacheCleared: true,
+		},
+		{
+			name: "matching plugin event evicts entry",
+			event: fwk.ClusterEvent{
+				Resource:  fwk.Node,
+				ActionType: fwk.Add,
+			},
+			setupEntry: &failureCacheEntry{
+				unschedulablePlugins: sets.New("NodeResourcesFit"),
+			},
+			setupPluginToEvents: map[string][]fwk.ClusterEvent{
+				"NodeResourcesFit": {
+					{Resource: fwk.Node, ActionType: fwk.Add},
+				},
+			},
+			expectSpecificEvicted: true,
+		},
+		{
+			name: "non-matching plugin event keeps entry",
+			event: fwk.ClusterEvent{
+				Resource:  fwk.AssignedPod,
+				ActionType: fwk.Delete,
+			},
+			setupEntry: &failureCacheEntry{
+				unschedulablePlugins: sets.New("NodeResourcesFit"),
+			},
+			setupPluginToEvents: map[string][]fwk.ClusterEvent{
+				"NodeResourcesFit": {
+					{Resource: fwk.Node, ActionType: fwk.Add},
+				},
+			},
+		},
+		{
+			name: "event matches one plugin, entry with multiple plugins evicted",
+			event: fwk.ClusterEvent{
+				Resource:  fwk.Node,
+				ActionType: fwk.Add,
+			},
+			setupEntry: &failureCacheEntry{
+				unschedulablePlugins: sets.New("NodeResourcesFit", "TaintToleration"),
+			},
+			setupPluginToEvents: map[string][]fwk.ClusterEvent{
+				"NodeResourcesFit": {
+					{Resource: fwk.Node, ActionType: fwk.Add},
+				},
+				"TaintToleration": {
+					{Resource: fwk.Node, ActionType: fwk.UpdateNodeTaint},
+				},
+			},
+			expectSpecificEvicted: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerFailureCache, true)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.OpportunisticBatching, true)
+
+			clientset := fake.NewSimpleClientset()
+			informerFactory := informers.NewSharedInformerFactory(clientset, 0)
+			q := NewPriorityQueue(newDefaultQueueSort(), informerFactory)
+
+			if tt.setupPluginToEvents != nil {
+				q.pluginToEventsMap = tt.setupPluginToEvents
+			}
+
+			sig := fwk.PodSignature("sig")
+			q.failureCache[string(sig)] = tt.setupEntry
+
+			q.invalidateFailureCache(tt.event)
+
+			if tt.expectCacheCleared {
+				if len(q.failureCache) != 0 {
+					t.Errorf("Expected empty cache, got %d entries", len(q.failureCache))
+				}
+			} else if tt.expectSpecificEvicted {
+				if len(q.failureCache) != 0 {
+					t.Errorf("Expected entry to be evicted, but cache has %d entries", len(q.failureCache))
+				}
+			} else {
+				if len(q.failureCache) != 1 {
+					t.Errorf("Expected entry to remain, but cache has %d entries", len(q.failureCache))
+				}
+			}
+		})
+	}
+}
+
+func TestFailureCacheIntegration(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.SchedulerFailureCache, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.OpportunisticBatching, true)
+
+	clientset := fake.NewSimpleClientset()
+	informerFactory := informers.NewSharedInformerFactory(clientset, 0)
+	q := NewPriorityQueue(newDefaultQueueSort(), informerFactory)
+
+	// Set up plugin event mapping for invalidation
+	q.pluginToEventsMap = map[string][]fwk.ClusterEvent{
+		"NodeResourcesFit": {
+			{Resource: fwk.Node, ActionType: fwk.Add},
+		},
+	}
+
+	sig := fwk.PodSignature("integration-sig")
+	fitErr := &framework.FitError{
+		Pod:         st.MakePod().Name("pod1").Obj(),
+		NumAllNodes: 5,
+		Diagnosis: framework.Diagnosis{
+			UnschedulablePlugins: sets.New("NodeResourcesFit"),
+			PreFilterMsg:         "node(s) didn't satisfy resource requirements",
+		},
+	}
+
+	// Step 1: Cache the failure
+	q.CacheFailure(sig, fitErr)
+	if len(q.failureCache) != 1 {
+		t.Fatalf("Expected 1 cache entry after CacheFailure, got %d", len(q.failureCache))
+	}
+
+	// Step 2: Check cache hit
+	pod := st.MakePod().Name("pod2").Obj()
+	podInfo := &framework.QueuedPodInfo{
+		PodInfo:      &framework.PodInfo{Pod: pod},
+		PodSignature: sig,
+	}
+	err := q.CheckFailureCache(podInfo)
+	if err == nil {
+		t.Fatal("Expected cached FitError, got nil")
+	}
+	cachedErr, ok := err.(*framework.FitError)
+	if !ok {
+		t.Fatalf("Expected *framework.FitError, got %T", err)
+	}
+	if cachedErr.NumAllNodes != 5 {
+		t.Errorf("Expected NumAllNodes=5, got %d", cachedErr.NumAllNodes)
+	}
+
+	// Step 3: Invalidate with matching event (Node Add)
+	q.invalidateFailureCache(fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add})
+	if len(q.failureCache) != 0 {
+		t.Errorf("Expected cache to be invalidated, got %d entries", len(q.failureCache))
+	}
+
+	// Step 4: Verify cache miss after invalidation
+	err = q.CheckFailureCache(podInfo)
+	if err != nil {
+		t.Errorf("Expected nil after invalidation, got %v", err)
+	}
+}

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -174,6 +174,10 @@ func (sched *Scheduler) schedulingCycle(
 	start time.Time,
 	podsToActivate *framework.PodsToActivate,
 ) (ScheduleResult, *framework.QueuedPodInfo, *fwk.Status) {
+	if err := sched.SchedulingQueue.CheckFailureCache(podInfo); err != nil {
+		return ScheduleResult{nominatingInfo: clearNominatedNode}, podInfo, fwk.AsStatus(err)
+	}
+
 	if err := sched.Cache.UpdateSnapshot(klog.FromContext(ctx), sched.nodeInfoSnapshot); err != nil {
 		return ScheduleResult{nominatingInfo: clearNominatedNode}, podInfo, fwk.AsStatus(err)
 	}
@@ -1230,6 +1234,11 @@ func (sched *Scheduler) handleSchedulingFailure(ctx context.Context, podFwk fram
 	} else if fitError, ok := err.(*framework.FitError); ok { // Inject UnschedulablePlugins to PodInfo, which will be used later for moving Pods between queues efficiently.
 		podInfo.UnschedulablePlugins = fitError.Diagnosis.UnschedulablePlugins
 		podInfo.PendingPlugins = fitError.Diagnosis.PendingPlugins
+		// Cache the failure for same-spec pods to fast-fail future scheduling attempts.
+		// Don't cache if preemption nominated a node (pod expected to schedule after eviction).
+		if nominatingInfo == nil || nominatingInfo.NominatedNodeName == "" {
+			sched.SchedulingQueue.CacheFailure(podInfo.PodSignature, fitError)
+		}
 		logger.V(2).Info("Unable to schedule pod; no fit; waiting", "pod", klog.KObj(pod), "err", errMsg)
 	} else if errors.Is(err, errPodGroupUnschedulable) {
 		logger.V(2).Info("Unable to schedule pod belonging to a pod group; waiting", "pod", klog.KObj(pod), "err", errMsg)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When a workload controller (Deployment, Job, etc.) creates many Pods from the same PodTemplate and the first Pod fails scheduling with a FitError, every subsequent identical Pod independently re-runs the fullPreFilter→Filter→Score→PostFilter cycle only to arrive at the same conclusion. With N identical pending Pods and M nodes, this wastes O(N×M) Filter evaluations.

This PR introduces a failure cache keyed by PodSignature (from KEP-5598 Opportunistic Batching). When a Pod fails scheduling, the cache stores (signature → rejecting plugins). Subsequent Pods with the same signature
skip the scheduling cycle entirely and fail immediately with the cached FitError, reducing the work to O(1+M).

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/issues/139369 
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

Design:
- Write: In handleSchedulingFailure, when a signable Pod gets a FitError without preemption, cache (signature → rejecting plugins).
- Read: At the start of schedulingCycle, if the Pod's signature matchesa cache entry and the Pod has no NominatedNodeName, return the cached FitError directly — no PreFilter/Filter/Score executed.
- Invalidation: In MoveAllToActiveOrBackoffQueue, if a ClusterEvent matches EventsToRegister() of any plugin in a cached entry, the entry is deleted. Wildcard events clear the entire cache.
    
Safety:
- Unsignable Pods (PodSignature==nil, e.g. InterPodAffinity, TopologySpreadConstraints, profiles with extenders) are never cached.
- Pods with NominatedNodeName set bypass the cache (they target a specific nominated node).
- Pods where preemption was triggered are not cached.
- Invalidation is conservative: we only risk extra invalidations, never incorrect fast-fails.
    
Feature gate: SchedulerFailureCache (Alpha, default=false), with a dependency on OpportunisticBatching.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added SchedulerFailureCache feature gate (Alpha, default=false), which enables signature-based scheduling failure caching for same-spec Pods. When enabled, if a Pod fails scheduling, subsequent Pods with the same scheduling signature skip the full scheduling cycle and fail immediately until a relevant cluster event invalidates the cache. This significantly reduces scheduler CPU waste in workloads with many identical unschedulable Pods. Requires OpportunisticBatching to be enabled.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: 
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/5598
```
