### PR TITLE
apiserver: return 422 instead of 500 when runtimeClassName is empty

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -352,6 +352,10 @@ var ValidatePodGroupName = apimachineryvalidation.NameIsDNSSubdomain
 // trailing dashes are allowed.
 func ValidateRuntimeClassName(name string, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
+	if len(name) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath, "runtimeClassName must not be empty"))
+		return allErrs
+	}
 	for _, msg := range apimachineryvalidation.NameIsDNSSubdomain(name, false) {
 		allErrs = append(allErrs, field.Invalid(fldPath, name, msg))
 	}

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -10665,6 +10665,14 @@ func TestValidatePodSpec(t *testing.T) {
 		"bad RuntimeClassName": {pod: *podtest.MakePod("",
 			podtest.SetRuntimeClassName("invalid/sandbox"),
 		)},
+		"empty string RuntimeClassName": {
+    			pod: *podtest.MakePod("",
+        			podtest.SetRuntimeClassName(""),
+    			),
+			expectedErrors: field.ErrorList{        			
+				field.Required(field.NewPath("field").Child("runtimeClassName"), "runtimeClassName must not be empty"					),
+    				},
+		},
 		"bad empty fsGroupchangepolicy": {pod: *podtest.MakePod("",
 			podtest.SetSecurityContext(&core.PodSecurityContext{
 				FSGroupChangePolicy: &badfsGroupChangePolicy2,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When spec.runtimeClassName is set to an empty string (""), the API server returns HTTP 500 instead of a proper validation error. The empty string passes the nil pointer check but then fails deep in apimachinery name validation, causing an unhandled 500.

Added an explicit len(name) == 0 guard in ValidateRuntimeClassName to return a proper field.Required error (HTTP 422) instead.

#### Which issue(s) this PR is related to:
Fixes #139462

#### Special notes for your reviewer:
The fix is in pkg/apis/core/validation/validation.go in the ValidateRuntimeClassName function. Added a unit test case "empty string RuntimeClassName" in validation_test.go.

#### Does this PR introduce a user-facing change:
Fixed a bug where setting pod `spec.runtimeClassName` to an empty string returned HTTP 500 instead of a proper 422 validation error.

#### Additional documentation
