### PR TITLE
scheduler: respect NominatedNodeName in TAS placement selection

### DIFF
--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -966,10 +966,11 @@ func (sched *Scheduler) updatePodGroupCondition(ctx context.Context,
 // podGroupSchedulingPlacementAlgorithm tries several different combinations for scheduling the pod group and selects the best one.
 // First it runs placement generator plugins to create a list of placements.
 // Placement is a set of nodes that will be considered when scheduling a pod group.
-// Then for each placement it tries to schedule the pod group through podGroupSchedulingDefaultAlgorithm.
-// Finally, it runs placement scorer plugins to select the best placement.
+// For a standalone PodGroup it evaluates the placement matching the pods' NominatedNodeName first
+// and uses it if the gang is feasible there, short-circuiting the rest. Otherwise (or for a
+// PodGroup that is part of a CompositePodGroup) it tries every placement through
+// podGroupSchedulingDefaultAlgorithm and runs placement scorer plugins to select the best one.
 func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, podGroupInfo *framework.PodGroupInfo, queuedPodGroupInfo *framework.QueuedPodGroupInfo) (finalResult *podGroupAlgorithmResult, revertFns revertFns) {
-	logger := klog.FromContext(ctx)
 	allNodes, err := sched.nodeInfoSnapshot.ListNodesInPlacement()
 	if err != nil {
 		return &podGroupAlgorithmResult{
@@ -1002,43 +1003,68 @@ func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context
 		}
 	}()
 
-	for _, placement := range placements {
-		logger.V(4).Info("Assuming placement in snapshot", "placement", placement.Name)
-		evaluationStart := time.Now()
-		err := sched.nodeInfoSnapshot.AssumePlacement(placement)
-		if err != nil {
-			return &podGroupAlgorithmResult{
-				podGroupInfo: podGroupInfo,
-				status:       fwk.AsStatus(fmt.Errorf("failed to assume pod group placement: %w", err)),
-			}, nil
-		}
-		placementCycleState := framework.NewCycleState()
-		placementCycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
-		result, placementRevertFns := sched.podGroupSchedulingDefaultAlgorithm(ctx, schedFwk, placementCycleState, podGroupInfo, queuedPodGroupInfo)
-		placementRevertFns.revert()
-
+	// Try the placement matching the pods' NominatedNodeName first, mirroring pod-by-pod
+	// scheduling, which evaluates the nominated node before all others. A nominated node is
+	// usually set by a previous preemption cycle and is the placement the pod group is
+	// expected to land on, so if the gang is feasible there we use it and skip the rest.
+	//
+	// This fast path is limited to standalone PodGroups. A PodGroup that is part of a
+	// CompositePodGroup defers its feasibility verdict to the CPG root, where a Success status
+	// with nothing scheduled is still meaningful. Short-circuiting on it (or dropping it) here
+	// could wrongly report the whole CPG Unschedulable and stop sibling groups from being
+	// evaluated, so CPG children evaluate every placement as before.
+	// TODO(kubernetes/kubernetes#140863): extend NNN support to CompositePodGroups.
+	nominatedFeasible := false
+	var nominated *fwk.Placement
+	if queuedPodGroupInfo.GetType() == fwk.PodGroupKeyType {
+		nominated = nominatedPlacement(placements, podGroupInfo, queuedPodGroupInfo)
+	}
+	if nominated != nil {
+		result := sched.evaluatePlacement(ctx, schedFwk, podGroupCycleState, podGroupInfo, queuedPodGroupInfo, nominated)
 		if result.status.IsError() {
 			return result, nil
 		}
-
-		if anyResult == nil {
-			anyResult = result
+		anyResult = result
+		// Honoring the nominated placement matters more than fitting more pods elsewhere: the NNN
+		// was typically set by a prior preemption cycle. This mirrors pod-by-pod NNN, which can
+		// pick a non-optimal node because it skips scoring. The tradeoff: when minCount < len(pods)
+		// we may prefer the nominated placement over one that fits the whole gang. For a standalone
+		// PodGroup a Success status implies at least minCount pods were placed. The anyScheduled
+		// check prevents short-circuiting when the placement is feasible only because minCount pods
+		// were already scheduled in previous cycles (for example minCount=3 with 3 pods already
+		// running), but we failed to place any newly arriving pods on the nominated placement.
+		if result.status.IsSuccess() && result.anyScheduled {
+			successfulResults[nominated] = result
+			nominatedFeasible = true
 		}
+	}
 
-		// Errors are excluded by the early return above since they are internal
-		// faults, not feasibility results.
-		evaluationResult := metrics.InfeasibleResult
-		if result.status.IsSuccess() {
-			evaluationResult = metrics.FeasibleResult
-			successfulResults[placement] = result
+	// Only evaluate the remaining placements when the nominated one wasn't feasible.
+	if !nominatedFeasible {
+		for _, placement := range placements {
+			if placement == nominated {
+				continue
+			}
+			result := sched.evaluatePlacement(ctx, schedFwk, podGroupCycleState, podGroupInfo, queuedPodGroupInfo, placement)
+			if result.status.IsError() {
+				return result, nil
+			}
+
+			if anyResult == nil {
+				anyResult = result
+			}
+
+			if result.status.IsSuccess() {
+				successfulResults[placement] = result
+			}
 		}
-		metrics.ObservePlacementEvaluation(evaluationResult, schedFwk.ProfileName(), metrics.SinceInSeconds(evaluationStart))
 	}
 
 	if len(successfulResults) == 0 {
 		// We need to send events and set the status for pods in case all simulations were infeasible.
-		// The selection of which simulation we report is arbitrary for now, but may change in the future.
-		anyResult.status = fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("0/%d placements are available, first placement status: %v", len(placements), anyResult.status.AsError())).WithError(errPodGroupUnschedulable)
+		// anyResult is the nominated placement's result when one was evaluated, otherwise the first
+		// placement tried. Which one we report is otherwise arbitrary and may change in the future.
+		anyResult.status = fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("0/%d placements are available, reported placement status: %v", len(placements), anyResult.status.AsError())).WithError(errPodGroupUnschedulable)
 		return anyResult, nil
 	}
 
@@ -1190,6 +1216,75 @@ func (sched *Scheduler) findBestCompositePodGroupPlacement(ctx context.Context, 
 
 	placementPodGroupAssignments, placementStates := makeCompositePodGroupAssignments(podGroupInfo, successfulResults)
 	return sched.findBestPlacement(ctx, schedFwk, podGroupCycleState, podGroupInfo, placementPodGroupAssignments, placementStates)
+}
+
+// evaluatePlacement runs the pod group scheduling algorithm within a single placement,
+// assuming the placement in the snapshot for the duration of the simulation.
+func (sched *Scheduler) evaluatePlacement(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, podGroupInfo *framework.PodGroupInfo, queuedPodGroupInfo *framework.QueuedPodGroupInfo, placement *fwk.Placement) *podGroupAlgorithmResult {
+	klog.FromContext(ctx).V(4).Info("Assuming placement in snapshot", "placement", placement.Name)
+	evaluationStart := time.Now()
+	if err := sched.nodeInfoSnapshot.AssumePlacement(placement); err != nil {
+		return &podGroupAlgorithmResult{
+			podGroupInfo: podGroupInfo,
+			status:       fwk.AsStatus(fmt.Errorf("failed to assume pod group placement: %w", err)),
+		}
+	}
+	placementCycleState := framework.NewCycleState()
+	placementCycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
+	result, placementRevertFns := sched.podGroupSchedulingDefaultAlgorithm(ctx, schedFwk, placementCycleState, podGroupInfo, queuedPodGroupInfo)
+	placementRevertFns.revert()
+
+	if result.status.IsError() {
+		// Error results are internal faults, not feasibility verdicts, and callers early-return
+		// on them, so skip the feasible/infeasible evaluation metric.
+		return result
+	}
+
+	evaluationResult := metrics.InfeasibleResult
+	if result.status.IsSuccess() {
+		evaluationResult = metrics.FeasibleResult
+	}
+	metrics.ObservePlacementEvaluation(evaluationResult, schedFwk.ProfileName(), metrics.SinceInSeconds(evaluationStart))
+	return result
+}
+
+// nominatedPlacement returns the placement that should be evaluated first because it best
+// matches the pods' NominatedNodeName, or nil when no placement holds any nominated node.
+// A nominated node is typically set by a previous preemption cycle, so preferring its
+// placement mirrors pod-by-pod scheduling, which tries the nominated node before all others.
+// When nominations span placements, the one honoring the most pods' nominations is chosen.
+func nominatedPlacement(placements []*fwk.Placement, podGroupInfo *framework.PodGroupInfo, queuedPodGroupInfo *framework.QueuedPodGroupInfo) *fwk.Placement {
+	// Count nominated nodes across the pods of the currently evaluated pod group node
+	// (podGroupInfo), which for CPG TAS is the CPG or PG carrying the TAS constraints, not the
+	// whole hierarchy rooted at queuedPodGroupInfo.
+	//
+	// We count instead of using a set because pods in the group can carry different
+	// NominatedNodeNames when preemption nominated them independently. Counting lets us pick the
+	// placement covering the most nominated pods; a set would drop those tallies and couldn't rank
+	// placements that only partially overlap the nominated nodes.
+	nominatedNodeCounts := make(map[string]int)
+	for _, podInfo := range queuedPodGroupInfo.QueuedPodInfos[pgKey(podGroupInfo)] {
+		if nnn := podInfo.Pod.Status.NominatedNodeName; nnn != "" {
+			nominatedNodeCounts[nnn]++
+		}
+	}
+	if len(nominatedNodeCounts) == 0 {
+		return nil
+	}
+
+	var best *fwk.Placement
+	bestCount := 0
+	for _, placement := range placements {
+		count := 0
+		for _, node := range placement.Nodes {
+			count += nominatedNodeCounts[node.Node().Name]
+		}
+		if count > bestCount {
+			bestCount = count
+			best = placement
+		}
+	}
+	return best
 }
 
 // findBestPlacement uses PlacementScore plugins to determine the best placement based on the scheduling results.

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
@@ -1150,43 +1151,43 @@ func (sched *Scheduler) evaluatePlacement(ctx context.Context, schedFwk framewor
 	return result
 }
 
-// nominatedPlacement returns the placement that should be evaluated first because it best
-// matches the pods' NominatedNodeName, or nil when no placement holds any nominated node.
-// A nominated node is typically set by a previous preemption cycle, so preferring its
-// placement mirrors pod-by-pod scheduling, which tries the nominated node before all others.
-// When nominations span placements, the one honoring the most pods' nominations is chosen.
+// nominatedPlacement returns the placement to evaluate first because it holds the pods'
+// NominatedNodeName, or nil when zero or more than one placement matches. A nominated node is
+// typically set by a previous preemption cycle, so preferring its placement mirrors pod-by-pod
+// scheduling, which tries the nominated node before all others.
+//
+// The framework contract permits overlapping placements, so a nominated node can appear in more
+// than one. NNN alone can't tell which placement WAP picked last cycle, so we only take the fast
+// path when exactly one placement matches; otherwise the caller scores every placement, which is
+// deterministic regardless of the order the generator returned them.
 func nominatedPlacement(placements []*fwk.Placement, podGroupInfo *framework.PodGroupInfo, queuedPodGroupInfo *framework.QueuedPodGroupInfo) *fwk.Placement {
-	// Count nominated nodes across the pods of the currently evaluated pod group node
+	// Collect nominated nodes across the pods of the currently evaluated pod group node
 	// (podGroupInfo), which for CPG TAS is the CPG or PG carrying the TAS constraints, not the
 	// whole hierarchy rooted at queuedPodGroupInfo.
-	//
-	// We count instead of using a set because pods in the group can carry different
-	// NominatedNodeNames when preemption nominated them independently. Counting lets us pick the
-	// placement covering the most nominated pods; a set would drop those tallies and couldn't rank
-	// placements that only partially overlap the nominated nodes.
-	nominatedNodeCounts := make(map[string]int)
+	nominatedNodes := sets.New[string]()
 	for _, podInfo := range queuedPodGroupInfo.QueuedPodInfos[podGroupInfo.GetKey()] {
 		if nnn := podInfo.Pod.Status.NominatedNodeName; nnn != "" {
-			nominatedNodeCounts[nnn]++
+			nominatedNodes.Insert(nnn)
 		}
 	}
-	if len(nominatedNodeCounts) == 0 {
+	if nominatedNodes.Len() == 0 {
 		return nil
 	}
 
-	var best *fwk.Placement
-	bestCount := 0
+	var matched *fwk.Placement
 	for _, placement := range placements {
-		count := 0
 		for _, node := range placement.Nodes {
-			count += nominatedNodeCounts[node.Node().Name]
-		}
-		if count > bestCount {
-			bestCount = count
-			best = placement
+			if nominatedNodes.Has(node.Node().Name) {
+				if matched != nil {
+					// Overlap: fall back to scoring all placements.
+					return nil
+				}
+				matched = placement
+				break
+			}
 		}
 	}
-	return best
+	return matched
 }
 
 // findBestPlacement uses PlacementScore plugins to determine the best placement based on the scheduling results.

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -856,10 +856,11 @@ func (sched *Scheduler) updatePodGroupCondition(ctx context.Context,
 // podGroupSchedulingPlacementAlgorithm tries several different combinations for scheduling the pod group and selects the best one.
 // First it runs placement generator plugins to create a list of placements.
 // Placement is a set of nodes that will be considered when scheduling a pod group.
-// Then for each placement it tries to schedule the pod group through podGroupSchedulingDefaultAlgorithm.
-// Finally, it runs placement scorer plugins to select the best placement.
+// For a standalone PodGroup it evaluates the placement matching the pods' NominatedNodeName first
+// and uses it if the gang is feasible there, short-circuiting the rest. Otherwise (or for a
+// PodGroup that is part of a CompositePodGroup) it tries every placement through
+// podGroupSchedulingDefaultAlgorithm and runs placement scorer plugins to select the best one.
 func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, podGroupInfo *framework.PodGroupInfo, queuedPodGroupInfo *framework.QueuedPodGroupInfo) (finalResult *podGroupAlgorithmResult, revertFns revertFns) {
-	logger := klog.FromContext(ctx)
 	allNodes, err := sched.nodeInfoSnapshot.ListNodesInPlacement()
 	if err != nil {
 		return &podGroupAlgorithmResult{
@@ -892,42 +893,67 @@ func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context
 		}
 	}()
 
-	for _, placement := range placements {
-		logger.V(4).Info("Assuming placement in snapshot", "placement", placement.Name)
-		evaluationStart := time.Now()
-		err := sched.nodeInfoSnapshot.AssumePlacement(placement)
-		if err != nil {
-			return &podGroupAlgorithmResult{
-				podGroupInfo: podGroupInfo,
-				status:       fwk.AsStatus(fmt.Errorf("failed to assume pod group placement: %w", err)),
-			}, nil
-		}
-		placementCycleState := framework.NewCycleState()
-		placementCycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
-		result, placementRevertFns := sched.podGroupSchedulingDefaultAlgorithm(ctx, schedFwk, placementCycleState, podGroupInfo, queuedPodGroupInfo)
-		placementRevertFns.revert()
-
+	// Try the placement matching the pods' NominatedNodeName first, mirroring pod-by-pod
+	// scheduling, which evaluates the nominated node before all others. A nominated node is
+	// usually set by a previous preemption cycle and is the placement the pod group is
+	// expected to land on, so if the gang is feasible there we use it and skip the rest.
+	//
+	// This fast path is limited to standalone PodGroups. A PodGroup that is part of a
+	// CompositePodGroup defers its feasibility verdict to the CPG root, where a Success status
+	// with nothing scheduled is still meaningful. Short-circuiting on it (or dropping it) here
+	// could wrongly report the whole CPG Unschedulable and stop sibling groups from being
+	// evaluated, so CPG children evaluate every placement as before.
+	// TODO(kubernetes/kubernetes#140863): extend NNN support to CompositePodGroups.
+	nominatedFeasible := false
+	var nominated *fwk.Placement
+	if queuedPodGroupInfo.GetType() == fwk.PodGroupKeyType {
+		nominated = nominatedPlacement(placements, podGroupInfo, queuedPodGroupInfo)
+	}
+	if nominated != nil {
+		result := sched.evaluatePlacement(ctx, schedFwk, podGroupCycleState, podGroupInfo, queuedPodGroupInfo, nominated)
 		if result.status.IsError() {
 			return result, nil
 		}
-
-		if anyResult == nil {
-			anyResult = result
+		anyResult = result
+		// Honoring the nominated placement matters more than fitting more pods elsewhere: the NNN
+		// was typically set by a prior preemption cycle. This mirrors pod-by-pod NNN, which can
+		// pick a non-optimal node because it skips scoring. The tradeoff: when minCount < len(pods)
+		// we may prefer the nominated placement over one that fits the whole gang. For a standalone
+		// PodGroup a Success status implies at least minCount pods were placed. The anyScheduled
+		// check prevents short-circuiting when the placement is feasible only because minCount pods
+		// were already scheduled in previous cycles (for example minCount=3 with 3 pods already
+		// running), but we failed to place any newly arriving pods on the nominated placement.
+		if result.status.IsSuccess() && result.anyScheduled {
+			successfulResults[nominated] = result
+			nominatedFeasible = true
 		}
+	}
 
-		// Errors are excluded by the early return above since they are internal
-		// faults, not feasibility results.
-		evaluationResult := metrics.InfeasibleResult
-		if result.status.IsSuccess() {
-			evaluationResult = metrics.FeasibleResult
-			successfulResults[placement] = result
+	// Only evaluate the remaining placements when the nominated one wasn't feasible.
+	if !nominatedFeasible {
+		for _, placement := range placements {
+			if placement == nominated {
+				continue
+			}
+			result := sched.evaluatePlacement(ctx, schedFwk, podGroupCycleState, podGroupInfo, queuedPodGroupInfo, placement)
+			if result.status.IsError() {
+				return result, nil
+			}
+
+			if anyResult == nil {
+				anyResult = result
+			}
+
+			if result.status.IsSuccess() {
+				successfulResults[placement] = result
+			}
 		}
-		metrics.ObservePlacementEvaluation(evaluationResult, schedFwk.ProfileName(), metrics.SinceInSeconds(evaluationStart))
 	}
 
 	if len(successfulResults) == 0 {
 		// We need to send events and set the status for pods in case all simulations were infeasible.
-		// The selection of which simulation we report is arbitrary for now, but may change in the future.
+		// anyResult is the nominated placement's result when one was evaluated, otherwise the first
+		// placement tried. Which one we report is otherwise arbitrary and may change in the future.
 		fitError := newPodGroupPlacementFitError(anyResult.status, len(placements))
 		anyResult.status = fwk.NewStatus(fwk.Unschedulable).WithError(fitError)
 		return anyResult, nil
@@ -1086,6 +1112,75 @@ func (sched *Scheduler) findBestCompositePodGroupPlacement(ctx context.Context, 
 
 	placementPodGroupAssignments, placementStates := makeCompositePodGroupAssignments(podGroupInfo, successfulResults)
 	return sched.findBestPlacement(ctx, schedFwk, podGroupCycleState, podGroupInfo, placementPodGroupAssignments, placementStates)
+}
+
+// evaluatePlacement runs the pod group scheduling algorithm within a single placement,
+// assuming the placement in the snapshot for the duration of the simulation.
+func (sched *Scheduler) evaluatePlacement(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, podGroupInfo *framework.PodGroupInfo, queuedPodGroupInfo *framework.QueuedPodGroupInfo, placement *fwk.Placement) *podGroupAlgorithmResult {
+	klog.FromContext(ctx).V(4).Info("Assuming placement in snapshot", "placement", placement.Name)
+	evaluationStart := time.Now()
+	if err := sched.nodeInfoSnapshot.AssumePlacement(placement); err != nil {
+		return &podGroupAlgorithmResult{
+			podGroupInfo: podGroupInfo,
+			status:       fwk.AsStatus(fmt.Errorf("failed to assume pod group placement: %w", err)),
+		}
+	}
+	placementCycleState := framework.NewCycleState()
+	placementCycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
+	result, placementRevertFns := sched.podGroupSchedulingDefaultAlgorithm(ctx, schedFwk, placementCycleState, podGroupInfo, queuedPodGroupInfo)
+	placementRevertFns.revert()
+
+	if result.status.IsError() {
+		// Error results are internal faults, not feasibility verdicts, and callers early-return
+		// on them, so skip the feasible/infeasible evaluation metric.
+		return result
+	}
+
+	evaluationResult := metrics.InfeasibleResult
+	if result.status.IsSuccess() {
+		evaluationResult = metrics.FeasibleResult
+	}
+	metrics.ObservePlacementEvaluation(evaluationResult, schedFwk.ProfileName(), metrics.SinceInSeconds(evaluationStart))
+	return result
+}
+
+// nominatedPlacement returns the placement that should be evaluated first because it best
+// matches the pods' NominatedNodeName, or nil when no placement holds any nominated node.
+// A nominated node is typically set by a previous preemption cycle, so preferring its
+// placement mirrors pod-by-pod scheduling, which tries the nominated node before all others.
+// When nominations span placements, the one honoring the most pods' nominations is chosen.
+func nominatedPlacement(placements []*fwk.Placement, podGroupInfo *framework.PodGroupInfo, queuedPodGroupInfo *framework.QueuedPodGroupInfo) *fwk.Placement {
+	// Count nominated nodes across the pods of the currently evaluated pod group node
+	// (podGroupInfo), which for CPG TAS is the CPG or PG carrying the TAS constraints, not the
+	// whole hierarchy rooted at queuedPodGroupInfo.
+	//
+	// We count instead of using a set because pods in the group can carry different
+	// NominatedNodeNames when preemption nominated them independently. Counting lets us pick the
+	// placement covering the most nominated pods; a set would drop those tallies and couldn't rank
+	// placements that only partially overlap the nominated nodes.
+	nominatedNodeCounts := make(map[string]int)
+	for _, podInfo := range queuedPodGroupInfo.QueuedPodInfos[podGroupInfo.GetKey()] {
+		if nnn := podInfo.Pod.Status.NominatedNodeName; nnn != "" {
+			nominatedNodeCounts[nnn]++
+		}
+	}
+	if len(nominatedNodeCounts) == 0 {
+		return nil
+	}
+
+	var best *fwk.Placement
+	bestCount := 0
+	for _, placement := range placements {
+		count := 0
+		for _, node := range placement.Nodes {
+			count += nominatedNodeCounts[node.Node().Name]
+		}
+		if count > bestCount {
+			bestCount = count
+			best = placement
+		}
+	}
+	return best
 }
 
 // findBestPlacement uses PlacementScore plugins to determine the best placement based on the scheduling results.

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -954,7 +954,13 @@ func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context
 		// We need to send events and set the status for pods in case all simulations were infeasible.
 		// anyResult is the nominated placement's result when one was evaluated, otherwise the first
 		// placement tried. Which one we report is otherwise arbitrary and may change in the future.
-		fitError := newPodGroupPlacementFitError(anyResult.status, len(placements))
+		// A feasible nominated placement that scheduled no new pod leaves anyResult with a Success
+		// status and no message; report an actionable reason rather than an empty one.
+		reportStatus := anyResult.status
+		if reportStatus.IsSuccess() {
+			reportStatus = fwk.NewStatus(fwk.Unschedulable, "nominated placement is feasible but no pending pod was scheduled")
+		}
+		fitError := newPodGroupPlacementFitError(reportStatus, len(placements))
 		anyResult.status = fwk.NewStatus(fwk.Unschedulable).WithError(fitError)
 		return anyResult, nil
 	}

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -2611,7 +2611,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 						status: fwk.NewStatus(fwk.Unschedulable, "0/1 nodes are available:"),
 					},
 				},
-				status: fwk.NewStatus(fwk.Unschedulable, "0/2 placements are available, first placement status: injected placementFeasible status").WithError(errPodGroupUnschedulable),
+				status: fwk.NewStatus(fwk.Unschedulable, "0/2 placements are available, reported placement status: injected placementFeasible status").WithError(errPodGroupUnschedulable),
 			},
 		},
 		"when all placements are infeasible, but pods are feasible, returns unschedulable": {
@@ -2651,7 +2651,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 						status: nil,
 					},
 				},
-				status: fwk.NewStatus(fwk.Unschedulable, "0/2 placements are available, first placement status: injected placementFeasible status").WithError(errPodGroupUnschedulable),
+				status: fwk.NewStatus(fwk.Unschedulable, "0/2 placements are available, reported placement status: injected placementFeasible status").WithError(errPodGroupUnschedulable),
 			},
 		},
 		"filters out infeasible placements": {
@@ -2911,6 +2911,334 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 				assertHistogramSampleCountFromGatherer(t, testRegistry, "scheduler_placement_evaluation_duration_seconds", infeasibleLabels, tt.expectedInfeasibleEvaluations)
 			})
 		}
+	}
+}
+
+func placementWithNodes(name string, nodeNames ...string) *fwk.Placement {
+	nodes := make([]fwk.NodeInfo, 0, len(nodeNames))
+	for _, n := range nodeNames {
+		ni := framework.NewNodeInfo()
+		ni.SetNode(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: n}})
+		nodes = append(nodes, ni)
+	}
+	return &fwk.Placement{Name: name, Nodes: nodes}
+}
+
+func podGroupWithNominations(nominated ...string) *framework.QueuedPodGroupInfo {
+	pgi := &framework.QueuedPodGroupInfo{PodGroupInfo: &framework.PodGroupInfo{}}
+	infos := make([]*framework.QueuedPodInfo, 0, len(nominated))
+	for i, nnn := range nominated {
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: string(rune('a' + i))},
+			Status:     v1.PodStatus{NominatedNodeName: nnn},
+		}
+		infos = append(infos, &framework.QueuedPodInfo{
+			PodInfo: &framework.PodInfo{Pod: pod},
+		})
+	}
+	pgi.QueuedPodInfos = map[fwk.EntityKey][]*framework.QueuedPodInfo{
+		pgKey(pgi.PodGroupInfo): infos,
+	}
+	return pgi
+}
+
+func TestNominatedPlacement(t *testing.T) {
+	rack1 := placementWithNodes("rack-1", "node-1")
+	rack2 := placementWithNodes("rack-2", "node-2")
+	rack12 := placementWithNodes("rack-12", "node-1", "node-2")
+	rack23 := placementWithNodes("rack-23", "node-2", "node-3")
+
+	tests := []struct {
+		name       string
+		placements []*fwk.Placement
+		podGroup   *framework.QueuedPodGroupInfo
+		want       *fwk.Placement
+	}{
+		{
+			name:       "no nominations returns nil",
+			placements: []*fwk.Placement{rack1, rack2},
+			podGroup:   podGroupWithNominations("", ""),
+			want:       nil,
+		},
+		{
+			name:       "nominated node not in any placement returns nil",
+			placements: []*fwk.Placement{rack1, rack2},
+			podGroup:   podGroupWithNominations("node-3"),
+			want:       nil,
+		},
+		{
+			name:       "single placement holds the nominated node",
+			placements: []*fwk.Placement{rack1, rack2},
+			podGroup:   podGroupWithNominations("node-2", ""),
+			want:       rack2,
+		},
+		{
+			name:       "placement holding the most nominated nodes wins",
+			placements: []*fwk.Placement{rack1, rack12},
+			podGroup:   podGroupWithNominations("node-1", "node-2"),
+			want:       rack12,
+		},
+		{
+			name:       "placement honoring the most pods wins over one holding more nominated nodes",
+			placements: []*fwk.Placement{rack1, rack23},
+			podGroup:   podGroupWithNominations("node-1", "node-1", "node-1", "node-2", "node-3"),
+			want:       rack1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := nominatedPlacement(tt.placements, tt.podGroup.PodGroupInfo, tt.podGroup); got != tt.want {
+				t.Errorf("nominatedPlacement() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPodGroupSchedulingPlacementAlgorithm_NominatedNode covers the NominatedNodeName path:
+// the placement matching the pods' NNN is evaluated first, short-circuits scoring when the
+// gang is feasible there, and otherwise falls through to normal score-based selection.
+func TestPodGroupSchedulingPlacementAlgorithm_NominatedNode(t *testing.T) {
+	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+		features.TopologyAwareWorkloadScheduling: true,
+		features.GenericWorkload:                 true,
+	})
+
+	nodes := []*v1.Node{
+		st.MakeNode().Name("node1").Obj(),
+		st.MakeNode().Name("node2").Obj(),
+	}
+
+	podGroupKey := "podgroup/default/pg"
+	tests := map[string]struct {
+		placementPlugin           fakePlacementPlugin
+		placementFeasibleStatuses [][]fwk.Code
+		// nominatedNodeName is written to the pod's status before scheduling.
+		nominatedNodeName string
+		// rootIsCPG makes the scheduling root a CompositePodGroup, which gates off the NNN fast path.
+		rootIsCPG bool
+		// expectedHost is the node the gang should land on. Empty means unschedulable.
+		expectedHost string
+		expectError  bool
+	}{
+		"nominated placement short-circuits scoring even with a lower score": {
+			placementPlugin: fakePlacementPlugin{
+				generatePlacementsResult: map[string]map[string][]string{
+					podGroupKey: {
+						"placement1": {nodes[0].Name},
+						"placement2": {nodes[1].Name},
+					},
+				},
+				// placement1 scores higher, so without the NNN short-circuit the gang would
+				// land on node1. The nomination points at node2, which must win instead.
+				scorePlacementsResult: map[string]map[string]int64{
+					podGroupKey: {
+						"placement1": 2,
+						"placement2": 1,
+					},
+				},
+			},
+			nominatedNodeName: nodes[1].Name,
+			expectedHost:      nodes[1].Name,
+		},
+		"infeasible nominated placement falls back to scoring": {
+			placementPlugin: fakePlacementPlugin{
+				generatePlacementsResult: map[string]map[string][]string{
+					podGroupKey: {
+						"placement1": {nodes[0].Name},
+						"placement2": {nodes[1].Name},
+					},
+				},
+				scorePlacementsResult: map[string]map[string]int64{
+					podGroupKey: {
+						"placement1": 1,
+					},
+				},
+				// The nominated node is infeasible, so its placement can't short-circuit and
+				// the gang falls back to the only feasible placement.
+				filterStatus: map[string]*fwk.Status{
+					nodes[1].Name: fwk.NewStatus(fwk.Unschedulable),
+				},
+			},
+			placementFeasibleStatuses: [][]fwk.Code{{fwk.Unschedulable}, {fwk.Success}},
+			nominatedNodeName:         nodes[1].Name,
+			expectedHost:              nodes[0].Name,
+		},
+		"error on the nominated placement propagates": {
+			placementPlugin: fakePlacementPlugin{
+				generatePlacementsResult: map[string]map[string][]string{
+					podGroupKey: {
+						"placement1": {nodes[0].Name},
+						"placement2": {nodes[1].Name},
+					},
+				},
+				scorePlacementsResult: map[string]map[string]int64{
+					podGroupKey: {
+						"placement1": 1,
+					},
+				},
+				filterStatus: map[string]*fwk.Status{
+					nodes[1].Name: fwk.NewStatus(fwk.Error, "injected filter error"),
+				},
+			},
+			nominatedNodeName: nodes[1].Name,
+			expectError:       true,
+		},
+		"CPG root skips the nominated fast path and scores every placement": {
+			placementPlugin: fakePlacementPlugin{
+				generatePlacementsResult: map[string]map[string][]string{
+					podGroupKey: {
+						"placement1": {nodes[0].Name},
+						"placement2": {nodes[1].Name},
+					},
+				},
+				// Same setup as the short-circuit case: placement1 scores higher and the
+				// nomination points at node2. Because the root is a CompositePodGroup, the NNN
+				// fast path is disabled and the higher-scored placement1 (node1) must win.
+				scorePlacementsResult: map[string]map[string]int64{
+					podGroupKey: {
+						"placement1": 2,
+						"placement2": 1,
+					},
+				},
+			},
+			nominatedNodeName: nodes[1].Name,
+			rootIsCPG:         true,
+			expectedHost:      nodes[0].Name,
+		},
+		"feasible nominated placement that schedules no new pod does not short-circuit": {
+			placementPlugin: fakePlacementPlugin{
+				generatePlacementsResult: map[string]map[string][]string{
+					podGroupKey: {
+						"placement1": {nodes[0].Name},
+						"placement2": {nodes[1].Name},
+					},
+				},
+				// The nominated placement2 even scores higher, so nothing but the anyScheduled
+				// guard keeps it from winning.
+				scorePlacementsResult: map[string]map[string]int64{
+					podGroupKey: {
+						"placement1": 1,
+						"placement2": 2,
+					},
+				},
+				// The pod can't be placed on the nominated node, so no new pod is scheduled on
+				// placement2. PlacementFeasible still reports Success there (as it would when
+				// minCount is already met by pods scheduled in previous cycles). Without the
+				// anyScheduled guard the nominated placement would short-circuit and the gang
+				// would land nowhere; the guard makes it fall back to placement1 (node1).
+				filterStatus: map[string]*fwk.Status{
+					nodes[1].Name: fwk.NewStatus(fwk.Unschedulable),
+				},
+			},
+			placementFeasibleStatuses: [][]fwk.Code{{fwk.Success}, {fwk.Success}},
+			nominatedNodeName:         nodes[1].Name,
+			expectedHost:              nodes[0].Name,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+
+			informerFactory := informers.NewSharedInformerFactory(clientsetfake.NewClientset(), 0)
+			queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
+
+			tt.placementPlugin.name = "FakePlacementPlugin"
+			orderedPlacementGeneratePlugin := &orderedPlacementPlugin{&tt.placementPlugin}
+			placementFeasiblePlugin := &fakePlacementFeasiblePlugin{
+				placementFeasibleStatuses: tt.placementFeasibleStatuses,
+			}
+
+			registry := []tf.RegisterPluginFunc{
+				tf.RegisterPlacementGeneratePlugin(orderedPlacementGeneratePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+					return orderedPlacementGeneratePlugin, nil
+				}),
+				tf.RegisterPlacementScorePlugin(tt.placementPlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+					return &tt.placementPlugin, nil
+				}, 1),
+				tf.RegisterFilterPlugin(tt.placementPlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+					return &tt.placementPlugin, nil
+				}),
+				tf.RegisterPermitPlugin(placementFeasiblePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+					return placementFeasiblePlugin, nil
+				}),
+			}
+
+			snapshot := internalcache.NewEmptySnapshot()
+
+			schedFwk, err := tf.NewFramework(ctx,
+				append(registry,
+					tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+					tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				),
+				"test-scheduler",
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithPodNominator(queue),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create new framework: %v", err)
+			}
+
+			cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
+			for _, node := range nodes {
+				cache.AddNode(logger, node)
+			}
+			testPodGroup := &schedulingv1beta1.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
+			}
+			cache.AddPodGroup(testPodGroup)
+
+			sched := &Scheduler{
+				Cache:            cache,
+				nodeInfoSnapshot: snapshot,
+				SchedulingQueue:  queue,
+				Profiles:         profile.Map{"test-scheduler": schedFwk},
+			}
+			sched.SchedulePod = sched.schedulePod
+
+			if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
+				t.Fatalf("Failed to update snapshot: %v", err)
+			}
+
+			pod := st.MakePod().Name("foo").UID("foo").PodGroupName("pg").NominatedNodeName(tt.nominatedNodeName).Obj()
+			queuedPodInfos := []*framework.QueuedPodInfo{{PodInfo: &framework.PodInfo{Pod: pod}}}
+			childPodGroupInfo := &framework.PodGroupInfo{
+				Name:            "pg",
+				Namespace:       "default",
+				Type:            fwk.PodGroupKeyType,
+				PodGroup:        testPodGroup,
+				UnscheduledPods: []*v1.Pod{pod},
+			}
+			// The root is normally the pod group itself, but for the CPG case it is a separate
+			// CompositePodGroup wrapping the child, which is what gates off the NNN fast path.
+			rootPodGroupInfo := childPodGroupInfo
+			if tt.rootIsCPG {
+				rootPodGroupInfo = &framework.PodGroupInfo{
+					Name:      "pg",
+					Namespace: "default",
+					Type:      fwk.CompositePodGroupKeyType,
+				}
+			}
+			pgInfo := &framework.QueuedPodGroupInfo{
+				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): queuedPodInfos},
+				PodGroupInfo:   rootPodGroupInfo,
+			}
+
+			result, _ := sched.podGroupSchedulingPlacementAlgorithm(ctx, schedFwk, framework.NewCycleState(), childPodGroupInfo, pgInfo)
+
+			if tt.expectError {
+				if result.status == nil || !result.status.IsError() {
+					t.Fatalf("expected an error status, got %v", result.status)
+				}
+				return
+			}
+			if result.status != nil && !result.status.IsSuccess() {
+				t.Fatalf("expected the gang to be scheduled, got status %v", result.status)
+			}
+			if got := result.podResults[0].scheduleResult.SuggestedHost; got != tt.expectedHost {
+				t.Fatalf("gang landed on %q, want %q", got, tt.expectedHost)
+			}
+		})
 	}
 }
 

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -2930,6 +2930,338 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 	}
 }
 
+func placementWithNodes(name string, nodeNames ...string) *fwk.Placement {
+	nodes := make([]fwk.NodeInfo, 0, len(nodeNames))
+	for _, n := range nodeNames {
+		ni := framework.NewNodeInfo()
+		ni.SetNode(&v1.Node{Name: n})
+		nodes = append(nodes, ni)
+	}
+	return &fwk.Placement{Name: name, Nodes: nodes}
+}
+
+func podGroupWithNominations(nominated ...string) *framework.QueuedPodGroupInfo {
+	pgi := &framework.QueuedPodGroupInfo{PodGroupInfo: &framework.PodGroupInfo{
+		GenericPodGroup: fwk.NewGenericPodGroup(&schedulingv1beta1.PodGroup{
+			Name:      "pg",
+			Namespace: "default",
+		}),
+	}}
+	infos := make([]*framework.QueuedPodInfo, 0, len(nominated))
+	for i, nnn := range nominated {
+		pod := &v1.Pod{
+			Name:   string(rune('a' + i)),
+			Status: v1.PodStatus{NominatedNodeName: nnn},
+		}
+		infos = append(infos, &framework.QueuedPodInfo{
+			PodInfo: &framework.PodInfo{Pod: pod},
+		})
+	}
+	pgi.QueuedPodInfos = map[fwk.EntityKey][]*framework.QueuedPodInfo{
+		pgi.PodGroupInfo.GetKey(): infos,
+	}
+	return pgi
+}
+
+func TestNominatedPlacement(t *testing.T) {
+	rack1 := placementWithNodes("rack-1", "node-1")
+	rack2 := placementWithNodes("rack-2", "node-2")
+	rack12 := placementWithNodes("rack-12", "node-1", "node-2")
+	rack23 := placementWithNodes("rack-23", "node-2", "node-3")
+
+	tests := []struct {
+		name       string
+		placements []*fwk.Placement
+		podGroup   *framework.QueuedPodGroupInfo
+		want       *fwk.Placement
+	}{
+		{
+			name:       "no nominations returns nil",
+			placements: []*fwk.Placement{rack1, rack2},
+			podGroup:   podGroupWithNominations("", ""),
+			want:       nil,
+		},
+		{
+			name:       "nominated node not in any placement returns nil",
+			placements: []*fwk.Placement{rack1, rack2},
+			podGroup:   podGroupWithNominations("node-3"),
+			want:       nil,
+		},
+		{
+			name:       "single placement holds the nominated node",
+			placements: []*fwk.Placement{rack1, rack2},
+			podGroup:   podGroupWithNominations("node-2", ""),
+			want:       rack2,
+		},
+		{
+			name:       "placement holding the most nominated nodes wins",
+			placements: []*fwk.Placement{rack1, rack12},
+			podGroup:   podGroupWithNominations("node-1", "node-2"),
+			want:       rack12,
+		},
+		{
+			name:       "placement honoring the most pods wins over one holding more nominated nodes",
+			placements: []*fwk.Placement{rack1, rack23},
+			podGroup:   podGroupWithNominations("node-1", "node-1", "node-1", "node-2", "node-3"),
+			want:       rack1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := nominatedPlacement(tt.placements, tt.podGroup.PodGroupInfo, tt.podGroup); got != tt.want {
+				t.Errorf("nominatedPlacement() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPodGroupSchedulingPlacementAlgorithm_NominatedNode covers the NominatedNodeName path:
+// the placement matching the pods' NNN is evaluated first, short-circuits scoring when the
+// gang is feasible there, and otherwise falls through to normal score-based selection.
+func TestPodGroupSchedulingPlacementAlgorithm_NominatedNode(t *testing.T) {
+	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+		features.TopologyAwareWorkloadScheduling: true,
+		features.GenericWorkload:                 true,
+	})
+
+	nodes := []*v1.Node{
+		st.MakeNode().Name("node1").Obj(),
+		st.MakeNode().Name("node2").Obj(),
+	}
+
+	podGroupKey := fwk.PodGroupKey("default", "pg")
+	tests := map[string]struct {
+		placementPlugin           fakePlacementPlugin
+		placementFeasibleStatuses [][]fwk.Code
+		// nominatedNodeName is written to the pod's status before scheduling.
+		nominatedNodeName string
+		// rootIsCPG makes the scheduling root a CompositePodGroup, which gates off the NNN fast path.
+		rootIsCPG bool
+		// expectedHost is the node the gang should land on. Empty means unschedulable.
+		expectedHost string
+		expectError  bool
+	}{
+		"nominated placement short-circuits scoring even with a lower score": {
+			placementPlugin: fakePlacementPlugin{
+				generatePlacementsResult: map[fwk.EntityKey]map[string][]string{
+					podGroupKey: {
+						"placement1": {nodes[0].Name},
+						"placement2": {nodes[1].Name},
+					},
+				},
+				// placement1 scores higher, so without the NNN short-circuit the gang would
+				// land on node1. The nomination points at node2, which must win instead.
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
+					podGroupKey: {
+						"placement1": 2,
+						"placement2": 1,
+					},
+				},
+			},
+			nominatedNodeName: nodes[1].Name,
+			expectedHost:      nodes[1].Name,
+		},
+		"infeasible nominated placement falls back to scoring": {
+			placementPlugin: fakePlacementPlugin{
+				generatePlacementsResult: map[fwk.EntityKey]map[string][]string{
+					podGroupKey: {
+						"placement1": {nodes[0].Name},
+						"placement2": {nodes[1].Name},
+					},
+				},
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
+					podGroupKey: {
+						"placement1": 1,
+					},
+				},
+				// The nominated node is infeasible, so its placement can't short-circuit and
+				// the gang falls back to the only feasible placement.
+				filterStatus: map[string]*fwk.Status{
+					nodes[1].Name: fwk.NewStatus(fwk.Unschedulable),
+				},
+			},
+			placementFeasibleStatuses: [][]fwk.Code{{fwk.Unschedulable}, {fwk.Success}},
+			nominatedNodeName:         nodes[1].Name,
+			expectedHost:              nodes[0].Name,
+		},
+		"error on the nominated placement propagates": {
+			placementPlugin: fakePlacementPlugin{
+				generatePlacementsResult: map[fwk.EntityKey]map[string][]string{
+					podGroupKey: {
+						"placement1": {nodes[0].Name},
+						"placement2": {nodes[1].Name},
+					},
+				},
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
+					podGroupKey: {
+						"placement1": 1,
+					},
+				},
+				filterStatus: map[string]*fwk.Status{
+					nodes[1].Name: fwk.NewStatus(fwk.Error, "injected filter error"),
+				},
+			},
+			nominatedNodeName: nodes[1].Name,
+			expectError:       true,
+		},
+		"CPG root skips the nominated fast path and scores every placement": {
+			placementPlugin: fakePlacementPlugin{
+				generatePlacementsResult: map[fwk.EntityKey]map[string][]string{
+					podGroupKey: {
+						"placement1": {nodes[0].Name},
+						"placement2": {nodes[1].Name},
+					},
+				},
+				// Same setup as the short-circuit case: placement1 scores higher and the
+				// nomination points at node2. Because the root is a CompositePodGroup, the NNN
+				// fast path is disabled and the higher-scored placement1 (node1) must win.
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
+					podGroupKey: {
+						"placement1": 2,
+						"placement2": 1,
+					},
+				},
+			},
+			nominatedNodeName: nodes[1].Name,
+			rootIsCPG:         true,
+			expectedHost:      nodes[0].Name,
+		},
+		"feasible nominated placement that schedules no new pod does not short-circuit": {
+			placementPlugin: fakePlacementPlugin{
+				generatePlacementsResult: map[fwk.EntityKey]map[string][]string{
+					podGroupKey: {
+						"placement1": {nodes[0].Name},
+						"placement2": {nodes[1].Name},
+					},
+				},
+				// The nominated placement2 even scores higher, so nothing but the anyScheduled
+				// guard keeps it from winning.
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
+					podGroupKey: {
+						"placement1": 1,
+						"placement2": 2,
+					},
+				},
+				// The pod can't be placed on the nominated node, so no new pod is scheduled on
+				// placement2. PlacementFeasible still reports Success there (as it would when
+				// minCount is already met by pods scheduled in previous cycles). Without the
+				// anyScheduled guard the nominated placement would short-circuit and the gang
+				// would land nowhere; the guard makes it fall back to placement1 (node1).
+				filterStatus: map[string]*fwk.Status{
+					nodes[1].Name: fwk.NewStatus(fwk.Unschedulable),
+				},
+			},
+			placementFeasibleStatuses: [][]fwk.Code{{fwk.Success}, {fwk.Success}},
+			nominatedNodeName:         nodes[1].Name,
+			expectedHost:              nodes[0].Name,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+
+			informerFactory := informers.NewSharedInformerFactory(clientsetfake.NewClientset(), 0)
+			queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
+
+			tt.placementPlugin.name = "FakePlacementPlugin"
+			orderedPlacementGeneratePlugin := &orderedPlacementPlugin{&tt.placementPlugin}
+			placementFeasiblePlugin := &fakePlacementFeasiblePlugin{
+				placementFeasibleStatuses: tt.placementFeasibleStatuses,
+			}
+
+			registry := []tf.RegisterPluginFunc{
+				tf.RegisterPlacementGeneratePlugin(orderedPlacementGeneratePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+					return orderedPlacementGeneratePlugin, nil
+				}),
+				tf.RegisterPlacementScorePlugin(tt.placementPlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+					return &tt.placementPlugin, nil
+				}, 1),
+				tf.RegisterFilterPlugin(tt.placementPlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+					return &tt.placementPlugin, nil
+				}),
+				tf.RegisterPermitPlugin(placementFeasiblePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+					return placementFeasiblePlugin, nil
+				}),
+			}
+
+			snapshot := internalcache.NewEmptySnapshot()
+
+			schedFwk, err := tf.NewFramework(ctx,
+				append(registry,
+					tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+					tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				),
+				"test-scheduler",
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithPodNominator(queue),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create new framework: %v", err)
+			}
+
+			cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
+			for _, node := range nodes {
+				cache.AddNode(logger, node)
+			}
+			testPodGroup := &schedulingv1beta1.PodGroup{
+				Name:      "pg",
+				Namespace: "default",
+			}
+			cache.AddGenericPodGroup(fwk.NewGenericPodGroup(testPodGroup))
+
+			sched := &Scheduler{
+				Cache:            cache,
+				nodeInfoSnapshot: snapshot,
+				SchedulingQueue:  queue,
+				Profiles:         profile.Map{"test-scheduler": schedFwk},
+			}
+			sched.initAlgorithm()
+			sched.SchedulePod = sched.algorithm.SchedulePod
+
+			if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
+				t.Fatalf("Failed to update snapshot: %v", err)
+			}
+
+			pod := st.MakePod().Name("foo").UID("foo").PodGroupName("pg").NominatedNodeName(tt.nominatedNodeName).Obj()
+			queuedPodInfos := []*framework.QueuedPodInfo{{PodInfo: &framework.PodInfo{Pod: pod}}}
+			childPodGroupInfo := &framework.PodGroupInfo{
+				GenericPodGroup: fwk.NewGenericPodGroup(testPodGroup),
+				UnscheduledPods: []*v1.Pod{pod},
+			}
+			// The root is normally the pod group itself, but for the CPG case it is a separate
+			// CompositePodGroup wrapping the child, which is what gates off the NNN fast path.
+			rootPodGroupInfo := childPodGroupInfo
+			if tt.rootIsCPG {
+				rootPodGroupInfo = &framework.PodGroupInfo{
+					GenericPodGroup: fwk.NewGenericCompositePodGroup(
+						st.MakeCompositePodGroup().Name("pg").Namespace("default").Obj(),
+					),
+				}
+			}
+			pgInfo := &framework.QueuedPodGroupInfo{
+				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): queuedPodInfos},
+				PodGroupInfo:   rootPodGroupInfo,
+			}
+
+			result, _ := sched.podGroupSchedulingPlacementAlgorithm(ctx, schedFwk, framework.NewCycleState(), childPodGroupInfo, pgInfo)
+
+			if tt.expectError {
+				if result.status == nil || !result.status.IsError() {
+					t.Fatalf("expected an error status, got %v", result.status)
+				}
+				return
+			}
+			if result.status != nil && !result.status.IsSuccess() {
+				t.Fatalf("expected the gang to be scheduled, got status %v", result.status)
+			}
+			if got := result.podResults[0].scheduleResult.SuggestedHost; got != tt.expectedHost {
+				t.Fatalf("gang landed on %q, want %q", got, tt.expectedHost)
+			}
+		})
+	}
+}
+
 func TestPodGroupSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
 		features.TopologyAwareWorkloadScheduling: true,

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -2994,16 +2994,22 @@ func TestNominatedPlacement(t *testing.T) {
 			want:       rack2,
 		},
 		{
-			name:       "placement holding the most nominated nodes wins",
-			placements: []*fwk.Placement{rack1, rack12},
-			podGroup:   podGroupWithNominations("node-1", "node-2"),
-			want:       rack12,
+			name:       "single placement matching several nominated nodes wins",
+			placements: []*fwk.Placement{rack1, rack23},
+			podGroup:   podGroupWithNominations("node-2", "node-3"),
+			want:       rack23,
 		},
 		{
-			name:       "placement honoring the most pods wins over one holding more nominated nodes",
-			placements: []*fwk.Placement{rack1, rack23},
-			podGroup:   podGroupWithNominations("node-1", "node-1", "node-1", "node-2", "node-3"),
-			want:       rack1,
+			name:       "overlapping placements sharing a nominated node returns nil",
+			placements: []*fwk.Placement{rack12, rack23},
+			podGroup:   podGroupWithNominations("node-2"),
+			want:       nil,
+		},
+		{
+			name:       "distinct placements each holding a nominated node returns nil",
+			placements: []*fwk.Placement{rack1, rack2},
+			podGroup:   podGroupWithNominations("node-1", "node-2"),
+			want:       nil,
 		},
 	}
 	for _, tt := range tests {
@@ -3012,6 +3018,21 @@ func TestNominatedPlacement(t *testing.T) {
 				t.Errorf("nominatedPlacement() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestNominatedPlacementOrderIndependent asserts that when nominated nodes fall into overlapping
+// placements the fallback (nil) is returned regardless of the order the generator returned them,
+// so placement selection can't depend on slice order.
+func TestNominatedPlacementOrderIndependent(t *testing.T) {
+	rack12 := placementWithNodes("rack-12", "node-1", "node-2")
+	rack23 := placementWithNodes("rack-23", "node-2", "node-3")
+	pg := podGroupWithNominations("node-2")
+
+	forward := nominatedPlacement([]*fwk.Placement{rack12, rack23}, pg.PodGroupInfo, pg)
+	reverse := nominatedPlacement([]*fwk.Placement{rack23, rack12}, pg.PodGroupInfo, pg)
+	if forward != nil || reverse != nil {
+		t.Errorf("nominatedPlacement() = %v (forward), %v (reverse), want nil for both", forward, reverse)
 	}
 }
 

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -3038,8 +3038,9 @@ func TestPodGroupSchedulingPlacementAlgorithm_NominatedNode(t *testing.T) {
 		// rootIsCPG makes the scheduling root a CompositePodGroup, which gates off the NNN fast path.
 		rootIsCPG bool
 		// expectedHost is the node the gang should land on. Empty means unschedulable.
-		expectedHost string
-		expectError  bool
+		expectedHost   string
+		expectedStatus *fwk.Status
+		expectError    bool
 	}{
 		"nominated placement short-circuits scoring even with a lower score": {
 			placementPlugin: fakePlacementPlugin{
@@ -3155,6 +3156,24 @@ func TestPodGroupSchedulingPlacementAlgorithm_NominatedNode(t *testing.T) {
 			nominatedNodeName:         nodes[1].Name,
 			expectedHost:              nodes[0].Name,
 		},
+		"feasible nominated placement that schedules no new pod reports an actionable reason": {
+			placementPlugin: fakePlacementPlugin{
+				generatePlacementsResult: map[fwk.EntityKey]map[string][]string{
+					podGroupKey: {
+						"placement2": {nodes[1].Name},
+					},
+				},
+				filterStatus: map[string]*fwk.Status{
+					nodes[1].Name: fwk.NewStatus(fwk.Unschedulable),
+				},
+			},
+			placementFeasibleStatuses: [][]fwk.Code{{fwk.Success}},
+			nominatedNodeName:         nodes[1].Name,
+			expectedStatus: fwk.NewStatus(
+				fwk.Unschedulable,
+				"0/1 placements are available, first placement status: nominated placement is feasible but no pending pod was scheduled",
+			),
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -3249,6 +3268,12 @@ func TestPodGroupSchedulingPlacementAlgorithm_NominatedNode(t *testing.T) {
 			if tt.expectError {
 				if result.status == nil || !result.status.IsError() {
 					t.Fatalf("expected an error status, got %v", result.status)
+				}
+				return
+			}
+			if tt.expectedStatus != nil {
+				if diff := cmp.Diff(tt.expectedStatus, result.status, statusCmpOpt); diff != "" {
+					t.Fatalf("unexpected status (-want,+got):\n%s", diff)
 				}
 				return
 			}

--- a/test/integration/scheduler/podgroup/stepsframework/stepsframework.go
+++ b/test/integration/scheduler/podgroup/stepsframework/stepsframework.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/scheduler/backend/queue"
 	testutils "k8s.io/kubernetes/test/integration/util"
@@ -154,6 +155,14 @@ type Step struct {
 	DeletePods []string
 	// UpdatePod is used to mutate any field of the pod.
 	UpdatePod *UpdatePod
+	// UpdatePodStatus is used to mutate the status subresource of the pod,
+	// such as NominatedNodeName, which UpdatePod cannot touch.
+	UpdatePodStatus *UpdatePod
+	// WaitForPodsNominated waits until the named pods carry the expected
+	// NominatedNodeName in the scheduling queue. Keyed by pod name. This is a
+	// queue-level barrier so a following step can rely on the scheduler reading
+	// the nominated node during the placement cycle.
+	WaitForPodsNominated map[string]string
 	// WaitForPodsInActiveQ is used to check if the pods are present in ActiveQ.
 	WaitForPodsInActiveQ []string
 	// WaitForPodsInUnschedulableEntities is use to wait for pods to be in unschedulableEntities.
@@ -463,6 +472,45 @@ func updatePod(testCtx *testutils.TestContext, ns string, update *UpdatePod) err
 	return nil
 }
 
+func updatePodStatus(testCtx *testutils.TestContext, ns string, update *UpdatePod) error {
+	cs := testCtx.ClientSet
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		p, err := cs.CoreV1().Pods(ns).Get(testCtx.Ctx, update.PodName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get pod %s for status update: %w", update.PodName, err)
+		}
+		update.ModifyFn(p)
+		_, err = cs.CoreV1().Pods(ns).UpdateStatus(testCtx.Ctx, p, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to update status of pod %s: %w", update.PodName, err)
+		}
+		return nil
+	})
+}
+
+func waitForPodsNominated(testCtx *testutils.TestContext, nominated map[string]string) error {
+	err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
+		func(_ context.Context) (bool, error) {
+			pods, _ := testCtx.Scheduler.SchedulingQueue.PendingPods()
+			matched := 0
+			for _, p := range pods {
+				want, ok := nominated[p.Name]
+				if !ok {
+					continue
+				}
+				if p.Status.NominatedNodeName != want {
+					return false, nil
+				}
+				matched++
+			}
+			return matched == len(nominated), nil
+		})
+	if err != nil {
+		return fmt.Errorf("failed to wait for pods %v to be nominated in the scheduling queue: %w", nominated, err)
+	}
+	return nil
+}
+
 func waitForPodsInActiveQ(testCtx *testutils.TestContext, podNames []string) error {
 	for _, podName := range podNames {
 		err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 10*time.Second, false, func(ctx context.Context) (bool, error) {
@@ -695,6 +743,10 @@ func RunSteps(testCtx *testutils.TestContext, t *testing.T, ns string, steps []S
 			err = deletePods(testCtx, ns, step.DeletePods)
 		case step.UpdatePod != nil:
 			err = updatePod(testCtx, ns, step.UpdatePod)
+		case step.UpdatePodStatus != nil:
+			err = updatePodStatus(testCtx, ns, step.UpdatePodStatus)
+		case step.WaitForPodsNominated != nil:
+			err = waitForPodsNominated(testCtx, step.WaitForPodsNominated)
 		case step.WaitForPodsInActiveQ != nil:
 			err = waitForPodsInActiveQ(testCtx, step.WaitForPodsInActiveQ)
 		case step.WaitForPodsInUnschedulableEntities != nil:

--- a/test/integration/scheduler/podgroup/topology_aware_scheduling/tas_test.go
+++ b/test/integration/scheduler/podgroup/topology_aware_scheduling/tas_test.go
@@ -1580,6 +1580,153 @@ func TestTopologyAwareSchedulingWithBasicPolicy(t *testing.T) {
 	}
 }
 
+func TestTopologyAwareSchedulingNominatedNode(t *testing.T) {
+	tests := []scenario{
+		{
+			name: "gang prefers the rack matching the pods' nominated node",
+			steps: []stepsframework.Step{
+				{
+					Name: "Create one node per rack. rack-1's node is smaller so MostAllocated scores it higher; rack-2 (nominated) fits the gang but scores lower, so without the NNN fix the gang deterministically lands on rack-1",
+					CreateNodes: []*v1.Node{
+						makeNode("node-rack1", "rack-1", "zone-1"),
+						st.MakeNode().Name("node-rack2").Label("rack", "rack-2").Label("zone", "zone-1").
+							Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Obj(),
+					},
+				},
+				{
+					Name: "Create the gang pods before the PodGroup, so they wait gated in the queue",
+					CreatePods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+					},
+				},
+				{
+					Name: "Nominate rack-2 for p1 via its status",
+					UpdatePodStatus: &stepsframework.UpdatePod{
+						PodName:  "p1",
+						ModifyFn: func(p *v1.Pod) { p.Status.NominatedNodeName = "node-rack2" },
+					},
+				},
+				{
+					Name: "Nominate rack-2 for p2 via its status",
+					UpdatePodStatus: &stepsframework.UpdatePod{
+						PodName:  "p2",
+						ModifyFn: func(p *v1.Pod) { p.Status.NominatedNodeName = "node-rack2" },
+					},
+				},
+				{
+					Name: "Wait until the queued pods carry the nominated node before opening the gate",
+					WaitForPodsNominated: map[string]string{
+						"p1": "node-rack2",
+						"p2": "node-rack2",
+					},
+				},
+				{
+					Name:           "Create the PodGroup (gang, minCount=2), opening the gate",
+					CreatePodGroup: makeGangPodGroup("pg1", "rack", 2),
+				},
+				{
+					Name:                 "Verify the gang is scheduled",
+					WaitForPodsScheduled: []string{"p1", "p2"},
+				},
+				{
+					Name: "Verify the gang landed on rack-2, the nominated rack",
+					VerifyAssignments: &stepsframework.VerifyAssignments{
+						Pods:  []string{"p1", "p2"},
+						Nodes: sets.New("node-rack2"),
+					},
+				},
+			},
+		},
+		{
+			name: "pod falls back when its nominated placement is full after minCount was met",
+			steps: []stepsframework.Step{
+				{
+					Name: "Create a one-CPU node in rack-1 and a four-CPU node in rack-2",
+					CreateNodes: []*v1.Node{
+						st.MakeNode().Name("node-rack1").Label("rack", "rack-1").Label("zone", "zone-1").
+							Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
+						st.MakeNode().Name("node-rack2").Label("rack", "rack-2").Label("zone", "zone-1").
+							Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Obj(),
+					},
+				},
+				{
+					Name:       "Fill rack-1 with an unrelated assigned pod",
+					CreatePods: []*v1.Pod{makeAssignedPod("existing", "node-rack1", "1")},
+				},
+				{
+					Name:           "Create the gang with minCount=2",
+					CreatePodGroup: makeGangPodGroup("pg1", "rack", 2),
+				},
+				{
+					Name: "Create the first two pods",
+					CreatePods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+					},
+				},
+				{
+					Name:                 "Wait for minCount to be satisfied",
+					WaitForPodsScheduled: []string{"p1", "p2"},
+				},
+				{
+					Name: "Verify the first two pods satisfied minCount on rack-2",
+					VerifyAssignments: &stepsframework.VerifyAssignments{
+						Pods:  []string{"p1", "p2"},
+						Nodes: sets.New("node-rack2"),
+					},
+				},
+				{
+					Name:           "Delete the PodGroup so a new pod remains gated",
+					DeletePodGroup: "pg1",
+				},
+				{
+					Name:       "Create a third pod while the PodGroup is absent",
+					CreatePods: []*v1.Pod{makePod("p3", "pg1")},
+				},
+				{
+					Name:                                "Wait for the third pod to be gated on the missing PodGroup",
+					WaitForPodsInIncompletePodGroupPods: []string{"p3"},
+				},
+				{
+					Name: "Nominate the full node in rack-1 for the third pod",
+					UpdatePodStatus: &stepsframework.UpdatePod{
+						PodName:  "p3",
+						ModifyFn: func(p *v1.Pod) { p.Status.NominatedNodeName = "node-rack1" },
+					},
+				},
+				{
+					Name: "Wait until the gated pod carries the nominated node",
+					WaitForPodsNominated: map[string]string{
+						"p3": "node-rack1",
+					},
+				},
+				{
+					Name:           "Re-create the PodGroup to move the third pod to the active queue",
+					CreatePodGroup: makeGangPodGroup("pg1", "rack", 2),
+				},
+				{
+					Name:                 "Verify the third pod falls back and schedules",
+					WaitForPodsScheduled: []string{"p3"},
+				},
+				{
+					Name: "Verify the third pod landed on rack-2 instead of the full nominated node",
+					VerifyAssignments: &stepsframework.VerifyAssignments{
+						Pods:  []string{"p3"},
+						Nodes: sets.New("node-rack2"),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runTestScenario(t, tt, false)
+		})
+	}
+}
+
 func runTestScenario(t *testing.T, tt scenario, cpgEnabled bool) {
 	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
 		features.CompositePodGroup:               cpgEnabled,

--- a/test/integration/scheduler/podgroup/topology_aware_scheduling/tas_test.go
+++ b/test/integration/scheduler/podgroup/topology_aware_scheduling/tas_test.go
@@ -1639,7 +1639,7 @@ func TestTopologyAwareSchedulingNominatedNode(t *testing.T) {
 			},
 		},
 		{
-			name: "pod falls back when its nominated placement is full after minCount was met",
+			name: "NNN outside the selected TAS domain does not prevent scheduling",
 			steps: []stepsframework.Step{
 				{
 					Name: "Create a one-CPU node in rack-1 and a four-CPU node in rack-2",
@@ -1706,11 +1706,11 @@ func TestTopologyAwareSchedulingNominatedNode(t *testing.T) {
 					CreatePodGroup: makeGangPodGroup("pg1", "rack", 2),
 				},
 				{
-					Name:                 "Verify the third pod falls back and schedules",
+					Name:                 "Verify the third pod schedules in the selected TAS domain",
 					WaitForPodsScheduled: []string{"p3"},
 				},
 				{
-					Name: "Verify the third pod landed on rack-2 instead of the full nominated node",
+					Name: "Verify the third pod landed on rack-2; its rack-1 NNN was outside the generated placement",
 					VerifyAssignments: &stepsframework.VerifyAssignments{
 						Pods:  []string{"p3"},
 						Nodes: sets.New("node-rack2"),


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Makes Topology-Aware Workload Scheduling (TAS) respect `NominatedNodeName` (NNN) when picking a placement for a PodGroup. Today TAS ranks placements by score and a random tiebreak, ignoring NNN, so a gang nominated to specific nodes can land elsewhere. Pod-by-pod scheduling already tries the nominated node first; this closes the gap at the placement level.

The core scheduler now evaluates the placement matching the pods' NNN before any other. If the gang is feasible there, it uses that placement and skips the rest. Otherwise it falls back to the normal score-based selection across all placements.

#### Which issue(s) this PR is related to:

Fixes #139348
KEP: https://github.com/kubernetes/enhancements/issues/5732

#### Special notes for your reviewer:

- Nominated placement first: mirrors pod-by-pod scheduling, which tries the nominated node before all others. A nominated node is usually set by a prior preemption cycle, so it's the placement the gang is expected to land on.
- Short-circuit only when the gang is feasible on the nominated placement now, not via preemption. If it isn't, the nominated placement competes with the rest under normal scoring, so NNN never schedules fewer pods.
- When nominations span more than one placement, no single placement clearly matches, so we skip the shortcut and fall back to normal scoring. This keeps the result independent of the order plugins hand us placements.
- Test plumbing: steps framework gained `UpdatePodStatus` and a `WaitForPodsNominated` barrier so the integration test sets NNN before the gang's cycle without racing.

#### Does this PR introduce a user-facing change?

```release-note
kube-scheduler: TAS placement selection now respects NominatedNodeName. This does not yet apply to PodGroups belonging to a CompositePodGroup; see https://github.com/kubernetes/kubernetes/issues/140863.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/5732
```


