### PR TITLE
Fix projected volumes being emptied when a resync write fails

### DIFF
--- a/pkg/volume/configmap/configmap.go
+++ b/pkg/volume/configmap/configmap.go
@@ -213,6 +213,13 @@ func (b *configMapVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterA
 		return err
 	}
 
+	// If the volume directory has already been populated by a previous successful
+	// setup, this SetUpAt call is a resync of an already-mounted volume. In that
+	// case a failure must not tear the directory down, because it is bind-mounted
+	// into the running container and removing it breaks the mount, leaving the
+	// volume permanently empty (https://github.com/kubernetes/kubernetes/issues/113242).
+	alreadyPopulated := volumeutil.IsTargetPopulated(dir)
+
 	setupSuccess := false
 	if err := wrapped.SetUpAt(dir, mounterArgs); err != nil {
 		return err
@@ -222,8 +229,10 @@ func (b *configMapVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterA
 	}
 
 	defer func() {
-		// Clean up directories if setup fails
-		if !setupSuccess {
+		// Clean up directories only on a failed first-time setup. On resync of an
+		// already-populated volume, leave the existing content in place and let the
+		// volume manager retry; do not tear down a bind-mounted directory.
+		if !setupSuccess && !alreadyPopulated {
 			unmounter, unmountCreateErr := b.plugin.NewUnmounter(b.volName, b.podUID)
 			if unmountCreateErr != nil {
 				klog.Errorf("error cleaning up mount %s after failure. Create unmounter failed with %v", b.volName, unmountCreateErr)

--- a/pkg/volume/configmap/configmap.go
+++ b/pkg/volume/configmap/configmap.go
@@ -215,6 +215,13 @@ func (b *configMapVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterA
 		return err
 	}
 
+	// If the volume directory has already been populated by a previous successful
+	// setup, this SetUpAt call is a resync of an already-mounted volume. In that
+	// case a failure must not tear the directory down, because it is bind-mounted
+	// into the running container and removing it breaks the mount, leaving the
+	// volume permanently empty (https://github.com/kubernetes/kubernetes/issues/113242).
+	alreadyPopulated := volumeutil.IsTargetPopulated(dir)
+
 	setupSuccess := false
 	if err := wrapped.SetUpAt(dir, mounterArgs); err != nil {
 		return err
@@ -224,17 +231,25 @@ func (b *configMapVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterA
 	}
 
 	defer func() {
-		// Clean up directories if setup fails
-		if !setupSuccess {
-			unmounter, unmountCreateErr := b.plugin.NewUnmounter(b.volName, b.podUID)
-			if unmountCreateErr != nil {
-				klog.Errorf("error cleaning up mount %s after failure. Create unmounter failed with %v", b.volName, unmountCreateErr)
-				return
-			}
-			tearDownErr := unmounter.TearDown()
-			if tearDownErr != nil {
-				klog.Errorf("error tearing down volume %s: %v", b.volName, tearDownErr)
-			}
+		if setupSuccess {
+			return
+		}
+		if alreadyPopulated {
+			// A resync of an already-populated volume failed. Leave the existing
+			// content in place and let the volume manager retry; tearing down a
+			// bind-mounted directory would leave the volume permanently empty.
+			klog.Warningf("failed to update volume %s for pod %s/%s, keeping the previously projected content until the next successful resync", b.volName, b.pod.Namespace, b.pod.Name)
+			return
+		}
+		// Clean up directories on a failed first-time setup.
+		unmounter, unmountCreateErr := b.plugin.NewUnmounter(b.volName, b.podUID)
+		if unmountCreateErr != nil {
+			klog.Errorf("error cleaning up mount %s after failure. Create unmounter failed with %v", b.volName, unmountCreateErr)
+			return
+		}
+		tearDownErr := unmounter.TearDown()
+		if tearDownErr != nil {
+			klog.Errorf("error tearing down volume %s: %v", b.volName, tearDownErr)
 		}
 	}()
 

--- a/pkg/volume/configmap/configmap_test.go
+++ b/pkg/volume/configmap/configmap_test.go
@@ -303,8 +303,10 @@ func newTestHost(t *testing.T, clientset clientset.Interface) (string, volume.Vo
 func TestCanSupport(t *testing.T) {
 	pluginMgr := volume.VolumePluginMgr{}
 	tempDir, host := newTestHost(t, nil)
-	defer os.RemoveAll(tempDir)
-	pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
 
 	plugin, err := pluginMgr.FindPluginByName(configMapPluginName)
 	if err != nil {
@@ -335,8 +337,10 @@ func TestPlugin(t *testing.T) {
 		tempDir, host = newTestHost(t, client)
 	)
 
-	defer os.RemoveAll(tempDir)
-	pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
 
 	plugin, err := pluginMgr.FindPluginByName(configMapPluginName)
 	if err != nil {
@@ -384,6 +388,182 @@ func TestPlugin(t *testing.T) {
 	doTestCleanAndTeardown(plugin, testPodUID, testVolumeName, volumePath, t)
 }
 
+// TestSetUpWriteFailureDoesNotTearDownPopulatedVolume is a regression test for
+// https://github.com/kubernetes/kubernetes/issues/113242. Once a volume has been
+// successfully populated, its directory is bind-mounted into the running
+// container; a subsequent SetUp that fails to write (e.g. a resync that cannot
+// write because the disk is full) must NOT tear that directory down, because
+// removing it breaks the bind mount and leaves the volume permanently empty with
+// no automatic recovery. The write failure is simulated deterministically by
+// projecting an invalid payload key ("..evil"), which the atomic writer rejects
+// inside Write, i.e. after the cleanup defer has been registered.
+func TestSetUpWriteFailureDoesNotTearDownPopulatedVolume(t *testing.T) {
+	var (
+		testPodUID     = types.UID("test_pod_uid_113242")
+		testVolumeName = "test_volume_name"
+		testNamespace  = "test_configmap_namespace"
+		goodName       = "good_configmap_name"
+		badName        = "bad_configmap_name"
+
+		good = configMap(testNamespace, goodName)
+		bad  = v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: badName},
+			Data:       map[string]string{"..evil": "boom"},
+		}
+		client        = fake.NewSimpleClientset(&good, &bad)
+		pluginMgr     = volume.VolumePluginMgr{}
+		tempDir, host = newTestHost(t, client)
+	)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
+
+	plugin, err := pluginMgr.FindPluginByName(configMapPluginName)
+	if err != nil {
+		t.Fatal("Can't find the plugin by name")
+	}
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
+
+	// Populate the volume successfully so it becomes "already populated" (..data exists).
+	goodMounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec(testVolumeName, goodName, 0644)), pod)
+	if err != nil {
+		t.Fatalf("Failed to make a new Mounter: %v", err)
+	}
+	volumePath := goodMounter.GetPath()
+	if err := goodMounter.SetUp(volume.MounterArgs{}); err != nil {
+		t.Fatalf("initial SetUp failed: %v", err)
+	}
+	if !util.IsTargetPopulated(volumePath) {
+		t.Fatalf("expected volume %q to be populated after initial SetUp", volumePath)
+	}
+
+	// A mounter for the same volume name targets the same directory; projecting the
+	// invalid payload forces writer.Write to fail on this already-populated volume.
+	badMounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec(testVolumeName, badName, 0644)), pod)
+	if err != nil {
+		t.Fatalf("Failed to make a new Mounter: %v", err)
+	}
+	if badMounter.GetPath() != volumePath {
+		t.Fatalf("expected same target dir, got %q vs %q", badMounter.GetPath(), volumePath)
+	}
+	if err := badMounter.SetUp(volume.MounterArgs{}); err == nil {
+		t.Fatal("expected SetUp to fail on invalid payload, but it succeeded")
+	}
+
+	// The failed resync must not have torn the volume down.
+	if _, err := os.Stat(volumePath); err != nil {
+		t.Fatalf("volume dir was removed after a failed resync (regression of #113242): %v", err)
+	}
+	if !util.IsTargetPopulated(volumePath) {
+		t.Fatal("volume data dir (..data) was removed after a failed resync (regression of #113242)")
+	}
+	// The original, valid content must still be present.
+	doTestConfigMapDataInVolume(volumePath, good, t)
+}
+
+// TestSetUpDataDirCorruptedDoesNotTearDownVolume reproduces the literal repro from
+// https://github.com/kubernetes/kubernetes/issues/113242: after the volume is
+// populated, the "..data" symlink is replaced on disk by a directory (the issue's
+// `rm -rf ..data; mkdir ..data`). On the next resync the atomic writer fails at
+// os.Readlink("..data") with EINVAL, and the volume — which is bind-mounted into the
+// running container — must not be torn down.
+func TestSetUpDataDirCorruptedDoesNotTearDownVolume(t *testing.T) {
+	var (
+		testPodUID     = types.UID("test_pod_uid_corrupt")
+		testVolumeName = "test_volume_name"
+		testNamespace  = "test_configmap_namespace"
+		testName       = "test_configmap_name"
+
+		configMap     = configMap(testNamespace, testName)
+		client        = fake.NewSimpleClientset(&configMap)
+		pluginMgr     = volume.VolumePluginMgr{}
+		tempDir, host = newTestHost(t, client)
+	)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
+
+	plugin, err := pluginMgr.FindPluginByName(configMapPluginName)
+	if err != nil {
+		t.Fatal("Can't find the plugin by name")
+	}
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
+
+	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec(testVolumeName, testName, 0644)), pod)
+	if err != nil {
+		t.Fatalf("Failed to make a new Mounter: %v", err)
+	}
+	volumePath := mounter.GetPath()
+	if err := mounter.SetUp(volume.MounterArgs{}); err != nil {
+		t.Fatalf("initial SetUp failed: %v", err)
+	}
+
+	// Replace the "..data" symlink with a directory, exactly as in the issue.
+	dataLink := filepath.Join(volumePath, "..data")
+	if err := os.Remove(dataLink); err != nil {
+		t.Fatalf("failed to remove ..data symlink: %v", err)
+	}
+	if err := os.Mkdir(dataLink, 0755); err != nil {
+		t.Fatalf("failed to create ..data directory: %v", err)
+	}
+
+	// Resync now fails at Readlink("..data") with EINVAL, but the volume must survive.
+	if err := mounter.SetUp(volume.MounterArgs{}); err == nil {
+		t.Fatal("expected SetUp to fail with a corrupted ..data, but it succeeded")
+	}
+	if _, err := os.Stat(volumePath); err != nil {
+		t.Fatalf("volume dir was removed after a failed resync (regression of #113242): %v", err)
+	}
+}
+
+// TestSetUpFirstTimeWriteFailureCleansUp is the complement of the test above: it
+// pins the original cleanup behavior that must be preserved. When the *first* setup
+// of a volume fails (the volume was never populated, so nothing is bind-mounted into
+// a container yet), the half-created directory MUST be torn down. This guards against
+// an over-broad fix that suppresses cleanup unconditionally.
+func TestSetUpFirstTimeWriteFailureCleansUp(t *testing.T) {
+	var (
+		testPodUID     = types.UID("test_pod_uid_firsttime")
+		testVolumeName = "test_volume_name"
+		testNamespace  = "test_configmap_namespace"
+		badName        = "bad_configmap_name"
+
+		bad = v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: badName},
+			Data:       map[string]string{"..evil": "boom"},
+		}
+		client        = fake.NewSimpleClientset(&bad)
+		pluginMgr     = volume.VolumePluginMgr{}
+		tempDir, host = newTestHost(t, client)
+	)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
+
+	plugin, err := pluginMgr.FindPluginByName(configMapPluginName)
+	if err != nil {
+		t.Fatal("Can't find the plugin by name")
+	}
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
+
+	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec(testVolumeName, badName, 0644)), pod)
+	if err != nil {
+		t.Fatalf("Failed to make a new Mounter: %v", err)
+	}
+	volumePath := mounter.GetPath()
+	if err := mounter.SetUp(volume.MounterArgs{}); err == nil {
+		t.Fatal("expected first-time SetUp to fail on invalid payload, but it succeeded")
+	}
+
+	// Never populated, so the failed first-time setup must have been cleaned up.
+	if _, err := os.Stat(volumePath); !os.IsNotExist(err) {
+		t.Fatalf("expected volume dir to be torn down after a failed first-time setup, stat err = %v", err)
+	}
+}
+
 // Test the case where the plugin's ready file exists, but the volume dir is not a
 // mountpoint, which is the state the system will be in after reboot.  The dir
 // should be mounter and the configMap data written to it.
@@ -401,8 +581,10 @@ func TestPluginReboot(t *testing.T) {
 		rootDir, host = newTestHost(t, client)
 	)
 
-	defer os.RemoveAll(rootDir)
-	pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host)
+	defer func() { _ = os.RemoveAll(rootDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
 
 	plugin, err := pluginMgr.FindPluginByName(configMapPluginName)
 	if err != nil {
@@ -459,8 +641,10 @@ func TestPluginOptional(t *testing.T) {
 	)
 	volumeSpec.VolumeSource.ConfigMap.Optional = &trueVal
 
-	defer os.RemoveAll(tempDir)
-	pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
 
 	plugin, err := pluginMgr.FindPluginByName(configMapPluginName)
 	if err != nil {
@@ -558,8 +742,10 @@ func TestPluginKeysOptional(t *testing.T) {
 	}
 	volumeSpec.VolumeSource.ConfigMap.Optional = &trueVal
 
-	defer os.RemoveAll(tempDir)
-	pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
 
 	plugin, err := pluginMgr.FindPluginByName(configMapPluginName)
 	if err != nil {
@@ -638,8 +824,10 @@ func TestInvalidConfigMapSetup(t *testing.T) {
 		{Key: "missing", Path: "missing"},
 	}
 
-	defer os.RemoveAll(tempDir)
-	pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
 
 	plugin, err := pluginMgr.FindPluginByName(configMapPluginName)
 	if err != nil {

--- a/pkg/volume/configmap/configmap_test.go
+++ b/pkg/volume/configmap/configmap_test.go
@@ -486,7 +486,7 @@ func TestPlugin(t *testing.T) {
 		t.Fatal("Can't find the plugin by name")
 	}
 
-	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
+	pod := &v1.Pod{Namespace: testNamespace, UID: testPodUID}
 	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec), pod)
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
@@ -527,6 +527,227 @@ func TestPlugin(t *testing.T) {
 	doTestCleanAndTeardown(plugin, testPodUID, testVolumeName, volumePath, t)
 }
 
+// TestSetUpWriteFailureDoesNotTearDownPopulatedVolume is a regression test for
+// https://github.com/kubernetes/kubernetes/issues/113242. Once a volume has been
+// successfully populated, its directory is bind-mounted into the running
+// container; a subsequent SetUp that fails to write (e.g. a resync that cannot
+// write because the disk is full) must NOT tear that directory down, because
+// removing it breaks the bind mount and leaves the volume permanently empty with
+// no automatic recovery. Two failure points are exercised deterministically: an
+// invalid payload key ("..evil"), which the atomic writer rejects before staging
+// anything, and a file/directory collision between item paths, which fails part
+// way through writing the new timestamp directory, as a full disk would.
+func TestSetUpWriteFailureDoesNotTearDownPopulatedVolume(t *testing.T) {
+	const (
+		testPodUID     = types.UID("test_pod_uid_113242")
+		testVolumeName = "test_volume_name"
+		testNamespace  = "test_configmap_namespace"
+		goodName       = "good_configmap_name"
+		badName        = "bad_configmap_name"
+	)
+	tests := []struct {
+		name  string
+		bad   v1.ConfigMap
+		items []v1.KeyToPath
+	}{
+		{
+			name: "invalid payload",
+			bad: v1.ConfigMap{
+				Namespace: testNamespace, Name: badName,
+				Data: map[string]string{"..evil": "boom"},
+			},
+		},
+		{
+			name: "partial write",
+			bad: v1.ConfigMap{
+				Namespace: testNamespace, Name: badName,
+				Data: map[string]string{"a": "x", "b": "y"},
+			},
+			// Either iteration order writes one entry before hitting the
+			// file/directory collision, leaving a partially written generation.
+			items: []v1.KeyToPath{{Key: "a", Path: "new"}, {Key: "b", Path: "new/child"}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				good          = configMap(testNamespace, goodName)
+				client        = fake.NewSimpleClientset(&good, &tc.bad)
+				pluginMgr     = volume.VolumePluginMgr{}
+				tempDir, host = newTestHost(t, client)
+			)
+			defer func() { _ = os.RemoveAll(tempDir) }()
+			if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+				t.Fatal(err)
+			}
+
+			plugin, err := pluginMgr.FindPluginByName(configMapPluginName)
+			if err != nil {
+				t.Fatal("Can't find the plugin by name")
+			}
+			pod := &v1.Pod{Namespace: testNamespace, UID: testPodUID}
+
+			// Populate the volume successfully so it becomes "already populated" (..data exists).
+			goodMounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec(testVolumeName, goodName, 0644)), pod)
+			if err != nil {
+				t.Fatalf("Failed to make a new Mounter: %v", err)
+			}
+			volumePath := goodMounter.GetPath()
+			if err := goodMounter.SetUp(volume.MounterArgs{}); err != nil {
+				t.Fatalf("initial SetUp failed: %v", err)
+			}
+			if !util.IsTargetPopulated(volumePath) {
+				t.Fatalf("expected volume %q to be populated after initial SetUp", volumePath)
+			}
+			before := dirEntryNames(t, volumePath)
+
+			// A mounter for the same volume name targets the same directory; projecting the
+			// bad payload forces writer.Write to fail on this already-populated volume.
+			badSpec := volumeSpec(testVolumeName, badName, 0644)
+			badSpec.VolumeSource.ConfigMap.Items = tc.items
+			badMounter, err := plugin.NewMounter(volume.NewSpecFromVolume(badSpec), pod)
+			if err != nil {
+				t.Fatalf("Failed to make a new Mounter: %v", err)
+			}
+			if badMounter.GetPath() != volumePath {
+				t.Fatalf("expected same target dir, got %q vs %q", badMounter.GetPath(), volumePath)
+			}
+			if err := badMounter.SetUp(volume.MounterArgs{}); err == nil {
+				t.Fatal("expected SetUp to fail on bad payload, but it succeeded")
+			}
+
+			// The failed resync must not have torn the volume down.
+			if _, err := os.Stat(volumePath); err != nil {
+				t.Fatalf("volume dir was removed after a failed resync (regression of #113242): %v", err)
+			}
+			if !util.IsTargetPopulated(volumePath) {
+				t.Fatal("volume data dir (..data) was removed after a failed resync (regression of #113242)")
+			}
+			// The original, valid content must still be present, and the failed
+			// write must not have left a partially written generation behind.
+			doTestConfigMapDataInVolume(volumePath, good, t)
+			if after := dirEntryNames(t, volumePath); !reflect.DeepEqual(before, after) {
+				t.Fatalf("volume dir entries changed after a failed resync: before %v, after %v", before, after)
+			}
+		})
+	}
+}
+
+func dirEntryNames(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
+}
+
+// TestSetUpDataDirCorruptedDoesNotTearDownVolume reproduces the literal repro from
+// https://github.com/kubernetes/kubernetes/issues/113242: after the volume is
+// populated, the "..data" symlink is replaced on disk by a directory (the issue's
+// `rm -rf ..data; mkdir ..data`). On the next resync the atomic writer fails at
+// os.Readlink("..data") with EINVAL, and the volume — which is bind-mounted into the
+// running container — must not be torn down.
+func TestSetUpDataDirCorruptedDoesNotTearDownVolume(t *testing.T) {
+	var (
+		testPodUID     = types.UID("test_pod_uid_corrupt")
+		testVolumeName = "test_volume_name"
+		testNamespace  = "test_configmap_namespace"
+		testName       = "test_configmap_name"
+
+		configMap     = configMap(testNamespace, testName)
+		client        = fake.NewSimpleClientset(&configMap)
+		pluginMgr     = volume.VolumePluginMgr{}
+		tempDir, host = newTestHost(t, client)
+	)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
+
+	plugin, err := pluginMgr.FindPluginByName(configMapPluginName)
+	if err != nil {
+		t.Fatal("Can't find the plugin by name")
+	}
+	pod := &v1.Pod{Namespace: testNamespace, UID: testPodUID}
+
+	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec(testVolumeName, testName, 0644)), pod)
+	if err != nil {
+		t.Fatalf("Failed to make a new Mounter: %v", err)
+	}
+	volumePath := mounter.GetPath()
+	if err := mounter.SetUp(volume.MounterArgs{}); err != nil {
+		t.Fatalf("initial SetUp failed: %v", err)
+	}
+
+	// Replace the "..data" symlink with a directory, exactly as in the issue.
+	dataLink := filepath.Join(volumePath, "..data")
+	if err := os.Remove(dataLink); err != nil {
+		t.Fatalf("failed to remove ..data symlink: %v", err)
+	}
+	if err := os.Mkdir(dataLink, 0755); err != nil {
+		t.Fatalf("failed to create ..data directory: %v", err)
+	}
+
+	// Resync now fails at Readlink("..data") with EINVAL, but the volume must survive.
+	if err := mounter.SetUp(volume.MounterArgs{}); err == nil {
+		t.Fatal("expected SetUp to fail with a corrupted ..data, but it succeeded")
+	}
+	if _, err := os.Stat(volumePath); err != nil {
+		t.Fatalf("volume dir was removed after a failed resync (regression of #113242): %v", err)
+	}
+}
+
+// TestSetUpFirstTimeWriteFailureCleansUp is the complement of the test above: it
+// pins the original cleanup behavior that must be preserved. When the *first* setup
+// of a volume fails (the volume was never populated, so nothing is bind-mounted into
+// a container yet), the half-created directory MUST be torn down. This guards against
+// an over-broad fix that suppresses cleanup unconditionally.
+func TestSetUpFirstTimeWriteFailureCleansUp(t *testing.T) {
+	var (
+		testPodUID     = types.UID("test_pod_uid_firsttime")
+		testVolumeName = "test_volume_name"
+		testNamespace  = "test_configmap_namespace"
+		badName        = "bad_configmap_name"
+
+		bad = v1.ConfigMap{
+			Namespace: testNamespace, Name: badName,
+			Data: map[string]string{"..evil": "boom"},
+		}
+		client        = fake.NewSimpleClientset(&bad)
+		pluginMgr     = volume.VolumePluginMgr{}
+		tempDir, host = newTestHost(t, client)
+	)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
+
+	plugin, err := pluginMgr.FindPluginByName(configMapPluginName)
+	if err != nil {
+		t.Fatal("Can't find the plugin by name")
+	}
+	pod := &v1.Pod{Namespace: testNamespace, UID: testPodUID}
+
+	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec(testVolumeName, badName, 0644)), pod)
+	if err != nil {
+		t.Fatalf("Failed to make a new Mounter: %v", err)
+	}
+	volumePath := mounter.GetPath()
+	if err := mounter.SetUp(volume.MounterArgs{}); err == nil {
+		t.Fatal("expected first-time SetUp to fail on invalid payload, but it succeeded")
+	}
+
+	// Never populated, so the failed first-time setup must have been cleaned up.
+	if _, err := os.Stat(volumePath); !os.IsNotExist(err) {
+		t.Fatalf("expected volume dir to be torn down after a failed first-time setup, stat err = %v", err)
+	}
+}
+
 // Test the case where the plugin's ready file exists, but the volume dir is not a
 // mountpoint, which is the state the system will be in after reboot.  The dir
 // should be mounter and the configMap data written to it.
@@ -552,7 +773,7 @@ func TestPluginReboot(t *testing.T) {
 		t.Fatal("Can't find the plugin by name")
 	}
 
-	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
+	pod := &v1.Pod{Namespace: testNamespace, UID: testPodUID}
 	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec), pod)
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
@@ -610,7 +831,7 @@ func TestPluginOptional(t *testing.T) {
 		t.Fatal("Can't find the plugin by name")
 	}
 
-	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
+	pod := &v1.Pod{Namespace: testNamespace, UID: testPodUID}
 	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec), pod)
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
@@ -709,7 +930,7 @@ func TestPluginKeysOptional(t *testing.T) {
 		t.Fatal("Can't find the plugin by name")
 	}
 
-	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
+	pod := &v1.Pod{Namespace: testNamespace, UID: testPodUID}
 	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec), pod)
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
@@ -789,7 +1010,7 @@ func TestInvalidConfigMapSetup(t *testing.T) {
 		t.Fatal("Can't find the plugin by name")
 	}
 
-	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
+	pod := &v1.Pod{Namespace: testNamespace, UID: testPodUID}
 	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec), pod)
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)

--- a/pkg/volume/downwardapi/downwardapi.go
+++ b/pkg/volume/downwardapi/downwardapi.go
@@ -182,6 +182,13 @@ func (b *downwardAPIVolumeMounter) SetUpAt(dir string, mounterArgs volume.Mounte
 		return err
 	}
 
+	// If the volume directory has already been populated by a previous successful
+	// setup, this SetUpAt call is a resync of an already-mounted volume. In that
+	// case a failure must not tear the directory down, because it is bind-mounted
+	// into the running container and removing it breaks the mount, leaving the
+	// volume permanently empty (https://github.com/kubernetes/kubernetes/issues/113242).
+	alreadyPopulated := volumeutil.IsTargetPopulated(dir)
+
 	setupSuccess := false
 	if err := wrapped.SetUpAt(dir, mounterArgs); err != nil {
 		klog.Errorf("Unable to setup downwardAPI volume %v for pod %v/%v: %s", b.volName, b.pod.Namespace, b.pod.Name, err.Error())
@@ -193,8 +200,10 @@ func (b *downwardAPIVolumeMounter) SetUpAt(dir string, mounterArgs volume.Mounte
 	}
 
 	defer func() {
-		// Clean up directories if setup fails
-		if !setupSuccess {
+		// Clean up directories only on a failed first-time setup. On resync of an
+		// already-populated volume, leave the existing content in place and let the
+		// volume manager retry; do not tear down a bind-mounted directory.
+		if !setupSuccess && !alreadyPopulated {
 			unmounter, unmountCreateErr := b.plugin.NewUnmounter(b.volName, b.podUID)
 			if unmountCreateErr != nil {
 				klog.Errorf("error cleaning up mount %s after failure. Create unmounter failed with %v", b.volName, unmountCreateErr)

--- a/pkg/volume/downwardapi/downwardapi.go
+++ b/pkg/volume/downwardapi/downwardapi.go
@@ -182,6 +182,13 @@ func (b *downwardAPIVolumeMounter) SetUpAt(dir string, mounterArgs volume.Mounte
 		return err
 	}
 
+	// If the volume directory has already been populated by a previous successful
+	// setup, this SetUpAt call is a resync of an already-mounted volume. In that
+	// case a failure must not tear the directory down, because it is bind-mounted
+	// into the running container and removing it breaks the mount, leaving the
+	// volume permanently empty (https://github.com/kubernetes/kubernetes/issues/113242).
+	alreadyPopulated := volumeutil.IsTargetPopulated(dir)
+
 	setupSuccess := false
 	if err := wrapped.SetUpAt(dir, mounterArgs); err != nil {
 		klog.Errorf("Unable to setup downwardAPI volume %v for pod %v/%v: %s", b.volName, b.pod.Namespace, b.pod.Name, err.Error())
@@ -193,17 +200,25 @@ func (b *downwardAPIVolumeMounter) SetUpAt(dir string, mounterArgs volume.Mounte
 	}
 
 	defer func() {
-		// Clean up directories if setup fails
-		if !setupSuccess {
-			unmounter, unmountCreateErr := b.plugin.NewUnmounter(b.volName, b.podUID)
-			if unmountCreateErr != nil {
-				klog.Errorf("error cleaning up mount %s after failure. Create unmounter failed with %v", b.volName, unmountCreateErr)
-				return
-			}
-			tearDownErr := unmounter.TearDown()
-			if tearDownErr != nil {
-				klog.Errorf("error tearing down volume %s: %v", b.volName, tearDownErr)
-			}
+		if setupSuccess {
+			return
+		}
+		if alreadyPopulated {
+			// A resync of an already-populated volume failed. Leave the existing
+			// content in place and let the volume manager retry; tearing down a
+			// bind-mounted directory would leave the volume permanently empty.
+			klog.Warningf("failed to update volume %s for pod %s/%s, keeping the previously projected content until the next successful resync", b.volName, b.pod.Namespace, b.pod.Name)
+			return
+		}
+		// Clean up directories on a failed first-time setup.
+		unmounter, unmountCreateErr := b.plugin.NewUnmounter(b.volName, b.podUID)
+		if unmountCreateErr != nil {
+			klog.Errorf("error cleaning up mount %s after failure. Create unmounter failed with %v", b.volName, unmountCreateErr)
+			return
+		}
+		tearDownErr := unmounter.TearDown()
+		if tearDownErr != nil {
+			klog.Errorf("error tearing down volume %s: %v", b.volName, tearDownErr)
 		}
 	}()
 

--- a/pkg/volume/downwardapi/downwardapi_test.go
+++ b/pkg/volume/downwardapi/downwardapi_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/emptydir"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
+	volumeutil "k8s.io/kubernetes/pkg/volume/util"
 )
 
 const (
@@ -68,6 +69,130 @@ func TestCanSupport(t *testing.T) {
 	}
 	if plugin.CanSupport(&volume.Spec{Volume: &v1.Volume{VolumeSource: v1.VolumeSource{}}}) {
 		t.Errorf("Expected false")
+	}
+}
+
+// singleFileDownwardAPISpec returns a downwardAPI volume spec projecting the pod
+// name to a single file at the given path.
+func singleFileDownwardAPISpec(volName, path string) *v1.Volume {
+	mode := int32(0644)
+	return &v1.Volume{
+		Name: volName,
+		VolumeSource: v1.VolumeSource{
+			DownwardAPI: &v1.DownwardAPIVolumeSource{
+				DefaultMode: &mode,
+				Items: []v1.DownwardAPIVolumeFile{
+					{Path: path, FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.name"}},
+				},
+			},
+		},
+	}
+}
+
+// TestSetUpWriteFailureDoesNotTearDownPopulatedVolume is a regression test for
+// https://github.com/kubernetes/kubernetes/issues/113242. Once a volume has been
+// successfully populated, its directory is bind-mounted into the running
+// container; a subsequent SetUp that fails to write (e.g. a resync that cannot
+// write because the disk is full) must NOT tear that directory down, because
+// removing it breaks the bind mount and leaves the volume permanently empty with
+// no automatic recovery. The write failure is simulated deterministically by
+// projecting an invalid item path ("..evil"), which the atomic writer rejects
+// inside Write, i.e. after the cleanup defer has been registered.
+func TestSetUpWriteFailureDoesNotTearDownPopulatedVolume(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test that fails on Windows")
+	}
+
+	testVolumeName := "test_volume_name"
+	client := fake.NewSimpleClientset()
+	pluginMgr := volume.VolumePluginMgr{}
+	tempDir, host := newTestHost(t, client)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
+
+	plugin, err := pluginMgr.FindPluginByName(downwardAPIPluginName)
+	if err != nil {
+		t.Fatal("Can't find the plugin by name")
+	}
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace, UID: testPodUID}}
+
+	// Populate the volume successfully so it becomes "already populated" (..data exists).
+	goodMounter, err := plugin.NewMounter(volume.NewSpecFromVolume(singleFileDownwardAPISpec(testVolumeName, "name")), pod)
+	if err != nil {
+		t.Fatalf("Failed to make a new Mounter: %v", err)
+	}
+	volumePath := goodMounter.GetPath()
+	if err := goodMounter.SetUp(volume.MounterArgs{}); err != nil {
+		t.Fatalf("initial SetUp failed: %v", err)
+	}
+	if !volumeutil.IsTargetPopulated(volumePath) {
+		t.Fatalf("expected volume %q to be populated after initial SetUp", volumePath)
+	}
+
+	// A mounter for the same volume name targets the same directory; projecting the
+	// invalid item path forces writer.Write to fail on this already-populated volume.
+	badMounter, err := plugin.NewMounter(volume.NewSpecFromVolume(singleFileDownwardAPISpec(testVolumeName, "..evil")), pod)
+	if err != nil {
+		t.Fatalf("Failed to make a new Mounter: %v", err)
+	}
+	if badMounter.GetPath() != volumePath {
+		t.Fatalf("expected same target dir, got %q vs %q", badMounter.GetPath(), volumePath)
+	}
+	if err := badMounter.SetUp(volume.MounterArgs{}); err == nil {
+		t.Fatal("expected SetUp to fail on invalid item path, but it succeeded")
+	}
+
+	// The failed resync must not have torn the volume down.
+	if _, err := os.Stat(volumePath); err != nil {
+		t.Fatalf("volume dir was removed after a failed resync (regression of #113242): %v", err)
+	}
+	if !volumeutil.IsTargetPopulated(volumePath) {
+		t.Fatal("volume data dir (..data) was removed after a failed resync (regression of #113242)")
+	}
+	// The original, valid content must still be present.
+	if _, err := os.Stat(filepath.Join(volumePath, "name")); err != nil {
+		t.Fatalf("original volume content was lost after a failed resync (regression of #113242): %v", err)
+	}
+}
+
+// TestSetUpFirstTimeWriteFailureCleansUp is the complement of the test above: it
+// pins the original cleanup behavior that must be preserved. When the *first* setup
+// of a volume fails (the volume was never populated, so nothing is bind-mounted into
+// a container yet), the half-created directory MUST be torn down. This guards against
+// an over-broad fix that suppresses cleanup unconditionally.
+func TestSetUpFirstTimeWriteFailureCleansUp(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test that fails on Windows")
+	}
+
+	client := fake.NewSimpleClientset()
+	pluginMgr := volume.VolumePluginMgr{}
+	tempDir, host := newTestHost(t, client)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
+
+	plugin, err := pluginMgr.FindPluginByName(downwardAPIPluginName)
+	if err != nil {
+		t.Fatal("Can't find the plugin by name")
+	}
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: testName, Namespace: testNamespace, UID: testPodUID}}
+
+	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(singleFileDownwardAPISpec("test_volume_name", "..evil")), pod)
+	if err != nil {
+		t.Fatalf("Failed to make a new Mounter: %v", err)
+	}
+	volumePath := mounter.GetPath()
+	if err := mounter.SetUp(volume.MounterArgs{}); err == nil {
+		t.Fatal("expected first-time SetUp to fail on invalid item path, but it succeeded")
+	}
+
+	// Never populated, so the failed first-time setup must have been cleaned up.
+	if _, err := os.Stat(volumePath); !os.IsNotExist(err) {
+		t.Fatalf("expected volume dir to be torn down after a failed first-time setup, stat err = %v", err)
 	}
 }
 

--- a/pkg/volume/downwardapi/downwardapi_test.go
+++ b/pkg/volume/downwardapi/downwardapi_test.go
@@ -77,6 +77,168 @@ func TestCanSupport(t *testing.T) {
 	}
 }
 
+// downwardAPISpec returns a downwardAPI volume spec projecting the pod name to
+// each of the given file paths.
+func downwardAPISpec(volName string, paths ...string) *v1.Volume {
+	mode := int32(0644)
+	var items []v1.DownwardAPIVolumeFile
+	for _, path := range paths {
+		items = append(items, v1.DownwardAPIVolumeFile{Path: path, FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.name"}})
+	}
+	return &v1.Volume{
+		Name: volName,
+		DownwardAPI: &v1.DownwardAPIVolumeSource{
+			DefaultMode: &mode,
+			Items:       items,
+		},
+	}
+}
+
+// TestSetUpWriteFailureDoesNotTearDownPopulatedVolume is a regression test for
+// https://github.com/kubernetes/kubernetes/issues/113242. Once a volume has been
+// successfully populated, its directory is bind-mounted into the running
+// container; a subsequent SetUp that fails to write (e.g. a resync that cannot
+// write because the disk is full) must NOT tear that directory down, because
+// removing it breaks the bind mount and leaves the volume permanently empty with
+// no automatic recovery. Two failure points are exercised deterministically: an
+// invalid item path ("..evil"), which the atomic writer rejects before staging
+// anything, and a file/directory collision between item paths, which fails part
+// way through writing the new timestamp directory, as a full disk would.
+func TestSetUpWriteFailureDoesNotTearDownPopulatedVolume(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test that fails on Windows")
+	}
+
+	tests := []struct {
+		name     string
+		badPaths []string
+	}{
+		{
+			name:     "invalid payload",
+			badPaths: []string{"..evil"},
+		},
+		{
+			// Either iteration order writes one entry before hitting the
+			// file/directory collision, leaving a partially written generation.
+			name:     "partial write",
+			badPaths: []string{"new", "new/child"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			testVolumeName := "test_volume_name"
+			client := fake.NewSimpleClientset()
+			pluginMgr := volume.VolumePluginMgr{}
+			tempDir, host := newTestHost(t, client)
+			defer func() { _ = os.RemoveAll(tempDir) }()
+			if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+				t.Fatal(err)
+			}
+
+			plugin, err := pluginMgr.FindPluginByName(downwardAPIPluginName)
+			if err != nil {
+				t.Fatal("Can't find the plugin by name")
+			}
+			pod := &v1.Pod{Name: testName, Namespace: testNamespace, UID: testPodUID}
+
+			// Populate the volume successfully so it becomes "already populated" (..data exists).
+			goodMounter, err := plugin.NewMounter(volume.NewSpecFromVolume(downwardAPISpec(testVolumeName, "name")), pod)
+			if err != nil {
+				t.Fatalf("Failed to make a new Mounter: %v", err)
+			}
+			volumePath := goodMounter.GetPath()
+			if err := goodMounter.SetUp(volume.MounterArgs{}); err != nil {
+				t.Fatalf("initial SetUp failed: %v", err)
+			}
+			if !util.IsTargetPopulated(volumePath) {
+				t.Fatalf("expected volume %q to be populated after initial SetUp", volumePath)
+			}
+			before := dirEntryNames(t, volumePath)
+
+			// A mounter for the same volume name targets the same directory; projecting the
+			// bad item paths forces writer.Write to fail on this already-populated volume.
+			badMounter, err := plugin.NewMounter(volume.NewSpecFromVolume(downwardAPISpec(testVolumeName, tc.badPaths...)), pod)
+			if err != nil {
+				t.Fatalf("Failed to make a new Mounter: %v", err)
+			}
+			if badMounter.GetPath() != volumePath {
+				t.Fatalf("expected same target dir, got %q vs %q", badMounter.GetPath(), volumePath)
+			}
+			if err := badMounter.SetUp(volume.MounterArgs{}); err == nil {
+				t.Fatal("expected SetUp to fail on bad item paths, but it succeeded")
+			}
+
+			// The failed resync must not have torn the volume down.
+			if _, err := os.Stat(volumePath); err != nil {
+				t.Fatalf("volume dir was removed after a failed resync (regression of #113242): %v", err)
+			}
+			if !util.IsTargetPopulated(volumePath) {
+				t.Fatal("volume data dir (..data) was removed after a failed resync (regression of #113242)")
+			}
+			// The original, valid content must still be present, and the failed
+			// write must not have left a partially written generation behind.
+			if _, err := os.Stat(filepath.Join(volumePath, "name")); err != nil {
+				t.Fatalf("original volume content was lost after a failed resync (regression of #113242): %v", err)
+			}
+			if after := dirEntryNames(t, volumePath); !reflect.DeepEqual(before, after) {
+				t.Fatalf("volume dir entries changed after a failed resync: before %v, after %v", before, after)
+			}
+		})
+	}
+}
+
+func dirEntryNames(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
+}
+
+// TestSetUpFirstTimeWriteFailureCleansUp is the complement of the test above: it
+// pins the original cleanup behavior that must be preserved. When the *first* setup
+// of a volume fails (the volume was never populated, so nothing is bind-mounted into
+// a container yet), the half-created directory MUST be torn down. This guards against
+// an over-broad fix that suppresses cleanup unconditionally.
+func TestSetUpFirstTimeWriteFailureCleansUp(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test that fails on Windows")
+	}
+
+	client := fake.NewSimpleClientset()
+	pluginMgr := volume.VolumePluginMgr{}
+	tempDir, host := newTestHost(t, client)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
+
+	plugin, err := pluginMgr.FindPluginByName(downwardAPIPluginName)
+	if err != nil {
+		t.Fatal("Can't find the plugin by name")
+	}
+	pod := &v1.Pod{Name: testName, Namespace: testNamespace, UID: testPodUID}
+
+	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(downwardAPISpec("test_volume_name", "..evil")), pod)
+	if err != nil {
+		t.Fatalf("Failed to make a new Mounter: %v", err)
+	}
+	volumePath := mounter.GetPath()
+	if err := mounter.SetUp(volume.MounterArgs{}); err == nil {
+		t.Fatal("expected first-time SetUp to fail on invalid item path, but it succeeded")
+	}
+
+	// Never populated, so the failed first-time setup must have been cleaned up.
+	if _, err := os.Stat(volumePath); !os.IsNotExist(err) {
+		t.Fatalf("expected volume dir to be torn down after a failed first-time setup, stat err = %v", err)
+	}
+}
+
 func TestDownwardAPI(t *testing.T) {
 	// Skip tests that fail on Windows, as discussed during the SIG Testing meeting from January 10, 2023
 	if runtime.GOOS == "windows" {

--- a/pkg/volume/projected/projected.go
+++ b/pkg/volume/projected/projected.go
@@ -197,6 +197,13 @@ func (s *projectedVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterA
 		return err
 	}
 
+	// If the volume directory has already been populated by a previous successful
+	// setup, this SetUpAt call is a resync of an already-mounted volume. In that
+	// case a failure must not tear the directory down, because it is bind-mounted
+	// into the running container and removing it breaks the mount, leaving the
+	// volume permanently empty (https://github.com/kubernetes/kubernetes/issues/113242).
+	alreadyPopulated := volumeutil.IsTargetPopulated(dir)
+
 	setupSuccess := false
 	if err := wrapped.SetUpAt(dir, mounterArgs); err != nil {
 		return err
@@ -207,8 +214,10 @@ func (s *projectedVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterA
 	}
 
 	defer func() {
-		// Clean up directories if setup fails
-		if !setupSuccess {
+		// Clean up directories only on a failed first-time setup. On resync of an
+		// already-populated volume, leave the existing content in place and let the
+		// volume manager retry; do not tear down a bind-mounted directory.
+		if !setupSuccess && !alreadyPopulated {
 			unmounter, unmountCreateErr := s.plugin.NewUnmounter(s.volName, s.podUID)
 			if unmountCreateErr != nil {
 				klog.Errorf("error cleaning up mount %s after failure. Create unmounter failed with %v", s.volName, unmountCreateErr)

--- a/pkg/volume/projected/projected.go
+++ b/pkg/volume/projected/projected.go
@@ -199,6 +199,13 @@ func (s *projectedVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterA
 		return err
 	}
 
+	// If the volume directory has already been populated by a previous successful
+	// setup, this SetUpAt call is a resync of an already-mounted volume. In that
+	// case a failure must not tear the directory down, because it is bind-mounted
+	// into the running container and removing it breaks the mount, leaving the
+	// volume permanently empty (https://github.com/kubernetes/kubernetes/issues/113242).
+	alreadyPopulated := volumeutil.IsTargetPopulated(dir)
+
 	setupSuccess := false
 	if err := wrapped.SetUpAt(dir, mounterArgs); err != nil {
 		return err
@@ -209,17 +216,25 @@ func (s *projectedVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterA
 	}
 
 	defer func() {
-		// Clean up directories if setup fails
-		if !setupSuccess {
-			unmounter, unmountCreateErr := s.plugin.NewUnmounter(s.volName, s.podUID)
-			if unmountCreateErr != nil {
-				klog.Errorf("error cleaning up mount %s after failure. Create unmounter failed with %v", s.volName, unmountCreateErr)
-				return
-			}
-			tearDownErr := unmounter.TearDown()
-			if tearDownErr != nil {
-				klog.Errorf("error tearing down volume %s: %v", s.volName, tearDownErr)
-			}
+		if setupSuccess {
+			return
+		}
+		if alreadyPopulated {
+			// A resync of an already-populated volume failed. Leave the existing
+			// content in place and let the volume manager retry; tearing down a
+			// bind-mounted directory would leave the volume permanently empty.
+			klog.Warningf("failed to update volume %s for pod %s/%s, keeping the previously projected content until the next successful resync", s.volName, s.pod.Namespace, s.pod.Name)
+			return
+		}
+		// Clean up directories on a failed first-time setup.
+		unmounter, unmountCreateErr := s.plugin.NewUnmounter(s.volName, s.podUID)
+		if unmountCreateErr != nil {
+			klog.Errorf("error cleaning up mount %s after failure. Create unmounter failed with %v", s.volName, unmountCreateErr)
+			return
+		}
+		tearDownErr := unmounter.TearDown()
+		if tearDownErr != nil {
+			klog.Errorf("error tearing down volume %s: %v", s.volName, tearDownErr)
 		}
 	}()
 

--- a/pkg/volume/projected/projected_test.go
+++ b/pkg/volume/projected/projected_test.go
@@ -1184,8 +1184,10 @@ func TestPlugin(t *testing.T) {
 		pluginMgr     = volume.VolumePluginMgr{}
 		rootDir, host = newTestHost(t, client)
 	)
-	defer os.RemoveAll(rootDir)
-	pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host)
+	defer func() { _ = os.RemoveAll(rootDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
 
 	plugin, err := pluginMgr.FindPluginByName(projectedPluginName)
 	if err != nil {
@@ -1249,8 +1251,10 @@ func TestInvalidPathProjected(t *testing.T) {
 		{Key: "missing", Path: "missing"},
 	}
 
-	defer os.RemoveAll(rootDir)
-	pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host)
+	defer func() { _ = os.RemoveAll(rootDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
 
 	plugin, err := pluginMgr.FindPluginByName(projectedPluginName)
 	if err != nil {
@@ -1299,8 +1303,10 @@ func TestPluginReboot(t *testing.T) {
 		pluginMgr     = volume.VolumePluginMgr{}
 		rootDir, host = newTestHost(t, client)
 	)
-	defer os.RemoveAll(rootDir)
-	pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host)
+	defer func() { _ = os.RemoveAll(rootDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
 
 	plugin, err := pluginMgr.FindPluginByName(projectedPluginName)
 	if err != nil {
@@ -1353,8 +1359,10 @@ func TestPluginOptional(t *testing.T) {
 		rootDir, host = newTestHost(t, client)
 	)
 	volumeSpec.VolumeSource.Projected.Sources[0].Secret.Optional = &trueVal
-	defer os.RemoveAll(rootDir)
-	pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host)
+	defer func() { _ = os.RemoveAll(rootDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
 
 	plugin, err := pluginMgr.FindPluginByName(projectedPluginName)
 	if err != nil {
@@ -1451,8 +1459,10 @@ func TestPluginOptionalKeys(t *testing.T) {
 		{Key: "missing", Path: "missing"},
 	}
 	volumeSpec.VolumeSource.Projected.Sources[0].Secret.Optional = &trueVal
-	defer os.RemoveAll(rootDir)
-	pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host)
+	defer func() { _ = os.RemoveAll(rootDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
 
 	plugin, err := pluginMgr.FindPluginByName(projectedPluginName)
 	if err != nil {
@@ -1497,6 +1507,126 @@ func TestPluginOptionalKeys(t *testing.T) {
 	}
 	doTestSecretDataInVolume(volumePath, secret, t)
 	defer doTestCleanAndTeardown(plugin, testPodUID, testVolumeName, volumePath, t)
+}
+
+// TestSetUpWriteFailureDoesNotTearDownPopulatedVolume is a regression test for
+// https://github.com/kubernetes/kubernetes/issues/113242. Once a volume has been
+// successfully populated, its directory is bind-mounted into the running
+// container; a subsequent SetUp that fails to write (e.g. a resync that cannot
+// write because the disk is full) must NOT tear that directory down, because
+// removing it breaks the bind mount and leaves the volume permanently empty with
+// no automatic recovery. The write failure is simulated deterministically by
+// projecting an invalid payload key ("..evil"), which the atomic writer rejects
+// inside Write, i.e. after the cleanup defer has been registered.
+func TestSetUpWriteFailureDoesNotTearDownPopulatedVolume(t *testing.T) {
+	var (
+		testPodUID     = types.UID("test_pod_uid_113242")
+		testVolumeName = "test_volume_name"
+		testNamespace  = "test_projected_namespace"
+		goodName       = "good_secret_name"
+		badName        = "bad_secret_name"
+
+		good = makeSecret(testNamespace, goodName)
+		bad  = v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: badName},
+			Data:       map[string][]byte{"..evil": []byte("boom")},
+		}
+		client        = fake.NewSimpleClientset(&good, &bad)
+		pluginMgr     = volume.VolumePluginMgr{}
+		rootDir, host = newTestHost(t, client)
+	)
+	defer func() { _ = os.RemoveAll(rootDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
+
+	plugin, err := pluginMgr.FindPluginByName(projectedPluginName)
+	if err != nil {
+		t.Fatal("Can't find the plugin by name")
+	}
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
+
+	// Populate the volume successfully so it becomes "already populated" (..data exists).
+	goodMounter, err := plugin.NewMounter(volume.NewSpecFromVolume(makeVolumeSpec(testVolumeName, goodName, 0644)), pod)
+	if err != nil {
+		t.Fatalf("Failed to make a new Mounter: %v", err)
+	}
+	volumePath := goodMounter.GetPath()
+	if err := goodMounter.SetUp(volume.MounterArgs{}); err != nil {
+		t.Fatalf("initial SetUp failed: %v", err)
+	}
+	if !util.IsTargetPopulated(volumePath) {
+		t.Fatalf("expected volume %q to be populated after initial SetUp", volumePath)
+	}
+
+	// A mounter for the same volume name targets the same directory; projecting the
+	// invalid payload forces writer.Write to fail on this already-populated volume.
+	badMounter, err := plugin.NewMounter(volume.NewSpecFromVolume(makeVolumeSpec(testVolumeName, badName, 0644)), pod)
+	if err != nil {
+		t.Fatalf("Failed to make a new Mounter: %v", err)
+	}
+	if badMounter.GetPath() != volumePath {
+		t.Fatalf("expected same target dir, got %q vs %q", badMounter.GetPath(), volumePath)
+	}
+	if err := badMounter.SetUp(volume.MounterArgs{}); err == nil {
+		t.Fatal("expected SetUp to fail on invalid payload, but it succeeded")
+	}
+
+	// The failed resync must not have torn the volume down.
+	if _, err := os.Stat(volumePath); err != nil {
+		t.Fatalf("volume dir was removed after a failed resync (regression of #113242): %v", err)
+	}
+	if !util.IsTargetPopulated(volumePath) {
+		t.Fatal("volume data dir (..data) was removed after a failed resync (regression of #113242)")
+	}
+	// The original, valid content must still be present.
+	doTestSecretDataInVolume(volumePath, good, t)
+}
+
+// TestSetUpFirstTimeWriteFailureCleansUp is the complement of the test above: it
+// pins the original cleanup behavior that must be preserved. When the *first* setup
+// of a volume fails (the volume was never populated, so nothing is bind-mounted into
+// a container yet), the half-created directory MUST be torn down. This guards against
+// an over-broad fix that suppresses cleanup unconditionally.
+func TestSetUpFirstTimeWriteFailureCleansUp(t *testing.T) {
+	var (
+		testPodUID     = types.UID("test_pod_uid_firsttime")
+		testVolumeName = "test_volume_name"
+		testNamespace  = "test_projected_namespace"
+		badName        = "bad_secret_name"
+
+		bad = v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: badName},
+			Data:       map[string][]byte{"..evil": []byte("boom")},
+		}
+		client        = fake.NewSimpleClientset(&bad)
+		pluginMgr     = volume.VolumePluginMgr{}
+		rootDir, host = newTestHost(t, client)
+	)
+	defer func() { _ = os.RemoveAll(rootDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
+
+	plugin, err := pluginMgr.FindPluginByName(projectedPluginName)
+	if err != nil {
+		t.Fatal("Can't find the plugin by name")
+	}
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
+
+	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(makeVolumeSpec(testVolumeName, badName, 0644)), pod)
+	if err != nil {
+		t.Fatalf("Failed to make a new Mounter: %v", err)
+	}
+	volumePath := mounter.GetPath()
+	if err := mounter.SetUp(volume.MounterArgs{}); err == nil {
+		t.Fatal("expected first-time SetUp to fail on invalid payload, but it succeeded")
+	}
+
+	// Never populated, so the failed first-time setup must have been cleaned up.
+	if _, err := os.Stat(volumePath); !os.IsNotExist(err) {
+		t.Fatalf("expected volume dir to be torn down after a failed first-time setup, stat err = %v", err)
+	}
 }
 
 func makeVolumeSpec(volumeName, name string, defaultMode int32) *v1.Volume {

--- a/pkg/volume/projected/projected_test.go
+++ b/pkg/volume/projected/projected_test.go
@@ -399,7 +399,7 @@ func TestCollectDataWithSecret(t *testing.T) {
 			source.Sources[0].Secret.Optional = &tc.optional
 
 			testPodUID := types.UID("test_pod_uid")
-			pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
+			pod := &v1.Pod{Namespace: testNamespace, UID: testPodUID}
 			client := fake.NewSimpleClientset(tc.secret)
 			tempDir, host := newTestHost(t, client)
 			defer os.RemoveAll(tempDir)
@@ -787,7 +787,7 @@ func TestCollectDataWithConfigMap(t *testing.T) {
 			source.Sources[0].ConfigMap.Optional = &tc.optional
 
 			testPodUID := types.UID("test_pod_uid")
-			pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
+			pod := &v1.Pod{Namespace: testNamespace, UID: testPodUID}
 			client := fake.NewSimpleClientset(tc.configMap)
 			tempDir, host := newTestHost(t, client)
 			defer os.RemoveAll(tempDir)
@@ -2133,7 +2133,7 @@ func TestPlugin(t *testing.T) {
 		t.Fatal("Can't find the plugin by name")
 	}
 
-	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
+	pod := &v1.Pod{Namespace: testNamespace, UID: testPodUID}
 	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec), pod)
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
@@ -2198,7 +2198,7 @@ func TestInvalidPathProjected(t *testing.T) {
 		t.Fatal("Can't find the plugin by name")
 	}
 
-	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
+	pod := &v1.Pod{Namespace: testNamespace, UID: testPodUID}
 	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec), pod)
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
@@ -2248,7 +2248,7 @@ func TestPluginReboot(t *testing.T) {
 		t.Fatal("Can't find the plugin by name")
 	}
 
-	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
+	pod := &v1.Pod{Namespace: testNamespace, UID: testPodUID}
 	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec), pod)
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
@@ -2302,7 +2302,7 @@ func TestPluginOptional(t *testing.T) {
 		t.Fatal("Can't find the plugin by name")
 	}
 
-	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
+	pod := &v1.Pod{Namespace: testNamespace, UID: testPodUID}
 	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec), pod)
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
@@ -2400,7 +2400,7 @@ func TestPluginOptionalKeys(t *testing.T) {
 		t.Fatal("Can't find the plugin by name")
 	}
 
-	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
+	pod := &v1.Pod{Namespace: testNamespace, UID: testPodUID}
 	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec), pod)
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
@@ -2438,6 +2438,171 @@ func TestPluginOptionalKeys(t *testing.T) {
 	}
 	doTestSecretDataInVolume(volumePath, secret, t)
 	defer doTestCleanAndTeardown(plugin, testPodUID, testVolumeName, volumePath, t)
+}
+
+// TestSetUpWriteFailureDoesNotTearDownPopulatedVolume is a regression test for
+// https://github.com/kubernetes/kubernetes/issues/113242. Once a volume has been
+// successfully populated, its directory is bind-mounted into the running
+// container; a subsequent SetUp that fails to write (e.g. a resync that cannot
+// write because the disk is full) must NOT tear that directory down, because
+// removing it breaks the bind mount and leaves the volume permanently empty with
+// no automatic recovery. Two failure points are exercised deterministically: an
+// invalid payload key ("..evil"), which the atomic writer rejects before staging
+// anything, and a file/directory collision between item paths, which fails part
+// way through writing the new timestamp directory, as a full disk would.
+func TestSetUpWriteFailureDoesNotTearDownPopulatedVolume(t *testing.T) {
+	const (
+		testPodUID     = types.UID("test_pod_uid_113242")
+		testVolumeName = "test_volume_name"
+		testNamespace  = "test_projected_namespace"
+		goodName       = "good_secret_name"
+		badName        = "bad_secret_name"
+	)
+	tests := []struct {
+		name  string
+		bad   v1.Secret
+		items []v1.KeyToPath
+	}{
+		{
+			name: "invalid payload",
+			bad: v1.Secret{
+				Namespace: testNamespace, Name: badName,
+				Data: map[string][]byte{"..evil": []byte("boom")},
+			},
+		},
+		{
+			name: "partial write",
+			bad: v1.Secret{
+				Namespace: testNamespace, Name: badName,
+				Data: map[string][]byte{"a": []byte("x"), "b": []byte("y")},
+			},
+			// Either iteration order writes one entry before hitting the
+			// file/directory collision, leaving a partially written generation.
+			items: []v1.KeyToPath{{Key: "a", Path: "new"}, {Key: "b", Path: "new/child"}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				good          = makeSecret(testNamespace, goodName)
+				client        = fake.NewSimpleClientset(&good, &tc.bad)
+				pluginMgr     = volume.VolumePluginMgr{}
+				rootDir, host = newTestHost(t, client)
+			)
+			defer func() { _ = os.RemoveAll(rootDir) }()
+			if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+				t.Fatal(err)
+			}
+
+			plugin, err := pluginMgr.FindPluginByName(projectedPluginName)
+			if err != nil {
+				t.Fatal("Can't find the plugin by name")
+			}
+			pod := &v1.Pod{Namespace: testNamespace, UID: testPodUID}
+
+			// Populate the volume successfully so it becomes "already populated" (..data exists).
+			goodMounter, err := plugin.NewMounter(volume.NewSpecFromVolume(makeVolumeSpec(testVolumeName, goodName, 0644)), pod)
+			if err != nil {
+				t.Fatalf("Failed to make a new Mounter: %v", err)
+			}
+			volumePath := goodMounter.GetPath()
+			if err := goodMounter.SetUp(volume.MounterArgs{}); err != nil {
+				t.Fatalf("initial SetUp failed: %v", err)
+			}
+			if !util.IsTargetPopulated(volumePath) {
+				t.Fatalf("expected volume %q to be populated after initial SetUp", volumePath)
+			}
+			before := dirEntryNames(t, volumePath)
+
+			// A mounter for the same volume name targets the same directory; projecting the
+			// bad payload forces writer.Write to fail on this already-populated volume.
+			badSpec := makeVolumeSpec(testVolumeName, badName, 0644)
+			badSpec.VolumeSource.Projected.Sources[0].Secret.Items = tc.items
+			badMounter, err := plugin.NewMounter(volume.NewSpecFromVolume(badSpec), pod)
+			if err != nil {
+				t.Fatalf("Failed to make a new Mounter: %v", err)
+			}
+			if badMounter.GetPath() != volumePath {
+				t.Fatalf("expected same target dir, got %q vs %q", badMounter.GetPath(), volumePath)
+			}
+			if err := badMounter.SetUp(volume.MounterArgs{}); err == nil {
+				t.Fatal("expected SetUp to fail on bad payload, but it succeeded")
+			}
+
+			// The failed resync must not have torn the volume down.
+			if _, err := os.Stat(volumePath); err != nil {
+				t.Fatalf("volume dir was removed after a failed resync (regression of #113242): %v", err)
+			}
+			if !util.IsTargetPopulated(volumePath) {
+				t.Fatal("volume data dir (..data) was removed after a failed resync (regression of #113242)")
+			}
+			// The original, valid content must still be present, and the failed
+			// write must not have left a partially written generation behind.
+			doTestSecretDataInVolume(volumePath, good, t)
+			if after := dirEntryNames(t, volumePath); !reflect.DeepEqual(before, after) {
+				t.Fatalf("volume dir entries changed after a failed resync: before %v, after %v", before, after)
+			}
+		})
+	}
+}
+
+func dirEntryNames(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
+}
+
+// TestSetUpFirstTimeWriteFailureCleansUp is the complement of the test above: it
+// pins the original cleanup behavior that must be preserved. When the *first* setup
+// of a volume fails (the volume was never populated, so nothing is bind-mounted into
+// a container yet), the half-created directory MUST be torn down. This guards against
+// an over-broad fix that suppresses cleanup unconditionally.
+func TestSetUpFirstTimeWriteFailureCleansUp(t *testing.T) {
+	var (
+		testPodUID     = types.UID("test_pod_uid_firsttime")
+		testVolumeName = "test_volume_name"
+		testNamespace  = "test_projected_namespace"
+		badName        = "bad_secret_name"
+
+		bad = v1.Secret{
+			Namespace: testNamespace, Name: badName,
+			Data: map[string][]byte{"..evil": []byte("boom")},
+		}
+		client        = fake.NewSimpleClientset(&bad)
+		pluginMgr     = volume.VolumePluginMgr{}
+		rootDir, host = newTestHost(t, client)
+	)
+	defer func() { _ = os.RemoveAll(rootDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
+
+	plugin, err := pluginMgr.FindPluginByName(projectedPluginName)
+	if err != nil {
+		t.Fatal("Can't find the plugin by name")
+	}
+	pod := &v1.Pod{Namespace: testNamespace, UID: testPodUID}
+
+	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(makeVolumeSpec(testVolumeName, badName, 0644)), pod)
+	if err != nil {
+		t.Fatalf("Failed to make a new Mounter: %v", err)
+	}
+	volumePath := mounter.GetPath()
+	if err := mounter.SetUp(volume.MounterArgs{}); err == nil {
+		t.Fatal("expected first-time SetUp to fail on invalid payload, but it succeeded")
+	}
+
+	// Never populated, so the failed first-time setup must have been cleaned up.
+	if _, err := os.Stat(volumePath); !os.IsNotExist(err) {
+		t.Fatalf("expected volume dir to be torn down after a failed first-time setup, stat err = %v", err)
+	}
 }
 
 func makeVolumeSpec(volumeName, name string, defaultMode int32) *v1.Volume {

--- a/pkg/volume/secret/secret.go
+++ b/pkg/volume/secret/secret.go
@@ -209,6 +209,13 @@ func (b *secretVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs
 		return err
 	}
 
+	// If the volume directory has already been populated by a previous successful
+	// setup, this SetUpAt call is a resync of an already-mounted volume. In that
+	// case a failure must not tear the directory down, because it is bind-mounted
+	// into the running container and removing it breaks the mount, leaving the
+	// volume permanently empty (https://github.com/kubernetes/kubernetes/issues/113242).
+	alreadyPopulated := volumeutil.IsTargetPopulated(dir)
+
 	setupSuccess := false
 	if err := wrapped.SetUpAt(dir, mounterArgs); err != nil {
 		return err
@@ -218,8 +225,10 @@ func (b *secretVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs
 	}
 
 	defer func() {
-		// Clean up directories if setup fails
-		if !setupSuccess {
+		// Clean up directories only on a failed first-time setup. On resync of an
+		// already-populated volume, leave the existing content in place and let the
+		// volume manager retry; do not tear down a bind-mounted directory.
+		if !setupSuccess && !alreadyPopulated {
 			unmounter, unmountCreateErr := b.plugin.NewUnmounter(b.volName, b.podUID)
 			if unmountCreateErr != nil {
 				klog.Errorf("error cleaning up mount %s after failure. Create unmounter failed with %v", b.volName, unmountCreateErr)

--- a/pkg/volume/secret/secret.go
+++ b/pkg/volume/secret/secret.go
@@ -211,6 +211,13 @@ func (b *secretVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs
 		return err
 	}
 
+	// If the volume directory has already been populated by a previous successful
+	// setup, this SetUpAt call is a resync of an already-mounted volume. In that
+	// case a failure must not tear the directory down, because it is bind-mounted
+	// into the running container and removing it breaks the mount, leaving the
+	// volume permanently empty (https://github.com/kubernetes/kubernetes/issues/113242).
+	alreadyPopulated := volumeutil.IsTargetPopulated(dir)
+
 	setupSuccess := false
 	if err := wrapped.SetUpAt(dir, mounterArgs); err != nil {
 		return err
@@ -220,17 +227,25 @@ func (b *secretVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs
 	}
 
 	defer func() {
-		// Clean up directories if setup fails
-		if !setupSuccess {
-			unmounter, unmountCreateErr := b.plugin.NewUnmounter(b.volName, b.podUID)
-			if unmountCreateErr != nil {
-				klog.Errorf("error cleaning up mount %s after failure. Create unmounter failed with %v", b.volName, unmountCreateErr)
-				return
-			}
-			tearDownErr := unmounter.TearDown()
-			if tearDownErr != nil {
-				klog.Errorf("error tearing down volume %s: %v", b.volName, tearDownErr)
-			}
+		if setupSuccess {
+			return
+		}
+		if alreadyPopulated {
+			// A resync of an already-populated volume failed. Leave the existing
+			// content in place and let the volume manager retry; tearing down a
+			// bind-mounted directory would leave the volume permanently empty.
+			klog.Warningf("failed to update volume %s for pod %s/%s, keeping the previously projected content until the next successful resync", b.volName, b.pod.Namespace, b.pod.Name)
+			return
+		}
+		// Clean up directories on a failed first-time setup.
+		unmounter, unmountCreateErr := b.plugin.NewUnmounter(b.volName, b.podUID)
+		if unmountCreateErr != nil {
+			klog.Errorf("error cleaning up mount %s after failure. Create unmounter failed with %v", b.volName, unmountCreateErr)
+			return
+		}
+		tearDownErr := unmounter.TearDown()
+		if tearDownErr != nil {
+			klog.Errorf("error tearing down volume %s: %v", b.volName, tearDownErr)
 		}
 	}()
 

--- a/pkg/volume/secret/secret_test.go
+++ b/pkg/volume/secret/secret_test.go
@@ -274,8 +274,10 @@ func newTestHost(t *testing.T, clientset clientset.Interface) (string, volume.Vo
 func TestCanSupport(t *testing.T) {
 	pluginMgr := volume.VolumePluginMgr{}
 	tempDir, host := newTestHost(t, nil)
-	defer os.RemoveAll(tempDir)
-	pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
 
 	plugin, err := pluginMgr.FindPluginByName(secretPluginName)
 	if err != nil {
@@ -661,6 +663,126 @@ func secret(namespace, name string) v1.Secret {
 			"data-2": []byte("value-2"),
 			"data-3": []byte("value-3"),
 		},
+	}
+}
+
+// TestSetUpWriteFailureDoesNotTearDownPopulatedVolume is a regression test for
+// https://github.com/kubernetes/kubernetes/issues/113242. Once a volume has been
+// successfully populated, its directory is bind-mounted into the running
+// container; a subsequent SetUp that fails to write (e.g. a resync that cannot
+// write because the disk is full) must NOT tear that directory down, because
+// removing it breaks the bind mount and leaves the volume permanently empty with
+// no automatic recovery. The write failure is simulated deterministically by
+// projecting an invalid payload key ("..evil"), which the atomic writer rejects
+// inside Write, i.e. after the cleanup defer has been registered.
+func TestSetUpWriteFailureDoesNotTearDownPopulatedVolume(t *testing.T) {
+	var (
+		testPodUID     = types.UID("test_pod_uid_113242")
+		testVolumeName = "test_volume_name"
+		testNamespace  = "test_secret_namespace"
+		goodName       = "good_secret_name"
+		badName        = "bad_secret_name"
+
+		good = secret(testNamespace, goodName)
+		bad  = v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: badName},
+			Data:       map[string][]byte{"..evil": []byte("boom")},
+		}
+		client        = fake.NewSimpleClientset(&good, &bad)
+		pluginMgr     = volume.VolumePluginMgr{}
+		tempDir, host = newTestHost(t, client)
+	)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
+
+	plugin, err := pluginMgr.FindPluginByName(secretPluginName)
+	if err != nil {
+		t.Fatal("Can't find the plugin by name")
+	}
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
+
+	// Populate the volume successfully so it becomes "already populated" (..data exists).
+	goodMounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec(testVolumeName, goodName, 0644)), pod)
+	if err != nil {
+		t.Fatalf("Failed to make a new Mounter: %v", err)
+	}
+	volumePath := goodMounter.GetPath()
+	if err := goodMounter.SetUp(volume.MounterArgs{}); err != nil {
+		t.Fatalf("initial SetUp failed: %v", err)
+	}
+	if !util.IsTargetPopulated(volumePath) {
+		t.Fatalf("expected volume %q to be populated after initial SetUp", volumePath)
+	}
+
+	// A mounter for the same volume name targets the same directory; projecting the
+	// invalid payload forces writer.Write to fail on this already-populated volume.
+	badMounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec(testVolumeName, badName, 0644)), pod)
+	if err != nil {
+		t.Fatalf("Failed to make a new Mounter: %v", err)
+	}
+	if badMounter.GetPath() != volumePath {
+		t.Fatalf("expected same target dir, got %q vs %q", badMounter.GetPath(), volumePath)
+	}
+	if err := badMounter.SetUp(volume.MounterArgs{}); err == nil {
+		t.Fatal("expected SetUp to fail on invalid payload, but it succeeded")
+	}
+
+	// The failed resync must not have torn the volume down.
+	if _, err := os.Stat(volumePath); err != nil {
+		t.Fatalf("volume dir was removed after a failed resync (regression of #113242): %v", err)
+	}
+	if !util.IsTargetPopulated(volumePath) {
+		t.Fatal("volume data dir (..data) was removed after a failed resync (regression of #113242)")
+	}
+	// The original, valid content must still be present.
+	doTestSecretDataInVolume(volumePath, good, t)
+}
+
+// TestSetUpFirstTimeWriteFailureCleansUp is the complement of the test above: it
+// pins the original cleanup behavior that must be preserved. When the *first* setup
+// of a volume fails (the volume was never populated, so nothing is bind-mounted into
+// a container yet), the half-created directory MUST be torn down. This guards against
+// an over-broad fix that suppresses cleanup unconditionally.
+func TestSetUpFirstTimeWriteFailureCleansUp(t *testing.T) {
+	var (
+		testPodUID     = types.UID("test_pod_uid_firsttime")
+		testVolumeName = "test_volume_name"
+		testNamespace  = "test_secret_namespace"
+		badName        = "bad_secret_name"
+
+		bad = v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: badName},
+			Data:       map[string][]byte{"..evil": []byte("boom")},
+		}
+		client        = fake.NewSimpleClientset(&bad)
+		pluginMgr     = volume.VolumePluginMgr{}
+		tempDir, host = newTestHost(t, client)
+	)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
+
+	plugin, err := pluginMgr.FindPluginByName(secretPluginName)
+	if err != nil {
+		t.Fatal("Can't find the plugin by name")
+	}
+	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
+
+	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec(testVolumeName, badName, 0644)), pod)
+	if err != nil {
+		t.Fatalf("Failed to make a new Mounter: %v", err)
+	}
+	volumePath := mounter.GetPath()
+	if err := mounter.SetUp(volume.MounterArgs{}); err == nil {
+		t.Fatal("expected first-time SetUp to fail on invalid payload, but it succeeded")
+	}
+
+	// Never populated, so the failed first-time setup must have been cleaned up.
+	if _, err := os.Stat(volumePath); !os.IsNotExist(err) {
+		t.Fatalf("expected volume dir to be torn down after a failed first-time setup, stat err = %v", err)
 	}
 }
 

--- a/pkg/volume/secret/secret_test.go
+++ b/pkg/volume/secret/secret_test.go
@@ -448,7 +448,7 @@ func TestPlugin(t *testing.T) {
 		t.Fatal("Can't find the plugin by name")
 	}
 
-	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
+	pod := &v1.Pod{Namespace: testNamespace, UID: testPodUID}
 	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec), pod)
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
@@ -522,7 +522,7 @@ func TestInvalidPathSecret(t *testing.T) {
 		t.Fatal("Can't find the plugin by name")
 	}
 
-	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
+	pod := &v1.Pod{Namespace: testNamespace, UID: testPodUID}
 	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec), pod)
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
@@ -572,7 +572,7 @@ func TestPluginReboot(t *testing.T) {
 		t.Fatal("Can't find the plugin by name")
 	}
 
-	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
+	pod := &v1.Pod{Namespace: testNamespace, UID: testPodUID}
 	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec), pod)
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
@@ -626,7 +626,7 @@ func TestPluginOptional(t *testing.T) {
 		t.Fatal("Can't find the plugin by name")
 	}
 
-	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
+	pod := &v1.Pod{Namespace: testNamespace, UID: testPodUID}
 	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec), pod)
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
@@ -724,7 +724,7 @@ func TestPluginOptionalKeys(t *testing.T) {
 		t.Fatal("Can't find the plugin by name")
 	}
 
-	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, UID: testPodUID}}
+	pod := &v1.Pod{Namespace: testNamespace, UID: testPodUID}
 	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec), pod)
 	if err != nil {
 		t.Errorf("Failed to make a new Mounter: %v", err)
@@ -796,6 +796,171 @@ func secret(namespace, name string) v1.Secret {
 			"data-2": []byte("value-2"),
 			"data-3": []byte("value-3"),
 		},
+	}
+}
+
+// TestSetUpWriteFailureDoesNotTearDownPopulatedVolume is a regression test for
+// https://github.com/kubernetes/kubernetes/issues/113242. Once a volume has been
+// successfully populated, its directory is bind-mounted into the running
+// container; a subsequent SetUp that fails to write (e.g. a resync that cannot
+// write because the disk is full) must NOT tear that directory down, because
+// removing it breaks the bind mount and leaves the volume permanently empty with
+// no automatic recovery. Two failure points are exercised deterministically: an
+// invalid payload key ("..evil"), which the atomic writer rejects before staging
+// anything, and a file/directory collision between item paths, which fails part
+// way through writing the new timestamp directory, as a full disk would.
+func TestSetUpWriteFailureDoesNotTearDownPopulatedVolume(t *testing.T) {
+	const (
+		testPodUID     = types.UID("test_pod_uid_113242")
+		testVolumeName = "test_volume_name"
+		testNamespace  = "test_secret_namespace"
+		goodName       = "good_secret_name"
+		badName        = "bad_secret_name"
+	)
+	tests := []struct {
+		name  string
+		bad   v1.Secret
+		items []v1.KeyToPath
+	}{
+		{
+			name: "invalid payload",
+			bad: v1.Secret{
+				Namespace: testNamespace, Name: badName,
+				Data: map[string][]byte{"..evil": []byte("boom")},
+			},
+		},
+		{
+			name: "partial write",
+			bad: v1.Secret{
+				Namespace: testNamespace, Name: badName,
+				Data: map[string][]byte{"a": []byte("x"), "b": []byte("y")},
+			},
+			// Either iteration order writes one entry before hitting the
+			// file/directory collision, leaving a partially written generation.
+			items: []v1.KeyToPath{{Key: "a", Path: "new"}, {Key: "b", Path: "new/child"}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				good          = secret(testNamespace, goodName)
+				client        = fake.NewSimpleClientset(&good, &tc.bad)
+				pluginMgr     = volume.VolumePluginMgr{}
+				tempDir, host = newTestHost(t, client)
+			)
+			defer func() { _ = os.RemoveAll(tempDir) }()
+			if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+				t.Fatal(err)
+			}
+
+			plugin, err := pluginMgr.FindPluginByName(secretPluginName)
+			if err != nil {
+				t.Fatal("Can't find the plugin by name")
+			}
+			pod := &v1.Pod{Namespace: testNamespace, UID: testPodUID}
+
+			// Populate the volume successfully so it becomes "already populated" (..data exists).
+			goodMounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec(testVolumeName, goodName, 0644)), pod)
+			if err != nil {
+				t.Fatalf("Failed to make a new Mounter: %v", err)
+			}
+			volumePath := goodMounter.GetPath()
+			if err := goodMounter.SetUp(volume.MounterArgs{}); err != nil {
+				t.Fatalf("initial SetUp failed: %v", err)
+			}
+			if !util.IsTargetPopulated(volumePath) {
+				t.Fatalf("expected volume %q to be populated after initial SetUp", volumePath)
+			}
+			before := dirEntryNames(t, volumePath)
+
+			// A mounter for the same volume name targets the same directory; projecting the
+			// bad payload forces writer.Write to fail on this already-populated volume.
+			badSpec := volumeSpec(testVolumeName, badName, 0644)
+			badSpec.VolumeSource.Secret.Items = tc.items
+			badMounter, err := plugin.NewMounter(volume.NewSpecFromVolume(badSpec), pod)
+			if err != nil {
+				t.Fatalf("Failed to make a new Mounter: %v", err)
+			}
+			if badMounter.GetPath() != volumePath {
+				t.Fatalf("expected same target dir, got %q vs %q", badMounter.GetPath(), volumePath)
+			}
+			if err := badMounter.SetUp(volume.MounterArgs{}); err == nil {
+				t.Fatal("expected SetUp to fail on bad payload, but it succeeded")
+			}
+
+			// The failed resync must not have torn the volume down.
+			if _, err := os.Stat(volumePath); err != nil {
+				t.Fatalf("volume dir was removed after a failed resync (regression of #113242): %v", err)
+			}
+			if !util.IsTargetPopulated(volumePath) {
+				t.Fatal("volume data dir (..data) was removed after a failed resync (regression of #113242)")
+			}
+			// The original, valid content must still be present, and the failed
+			// write must not have left a partially written generation behind.
+			doTestSecretDataInVolume(volumePath, good, t)
+			if after := dirEntryNames(t, volumePath); !reflect.DeepEqual(before, after) {
+				t.Fatalf("volume dir entries changed after a failed resync: before %v, after %v", before, after)
+			}
+		})
+	}
+}
+
+func dirEntryNames(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
+}
+
+// TestSetUpFirstTimeWriteFailureCleansUp is the complement of the test above: it
+// pins the original cleanup behavior that must be preserved. When the *first* setup
+// of a volume fails (the volume was never populated, so nothing is bind-mounted into
+// a container yet), the half-created directory MUST be torn down. This guards against
+// an over-broad fix that suppresses cleanup unconditionally.
+func TestSetUpFirstTimeWriteFailureCleansUp(t *testing.T) {
+	var (
+		testPodUID     = types.UID("test_pod_uid_firsttime")
+		testVolumeName = "test_volume_name"
+		testNamespace  = "test_secret_namespace"
+		badName        = "bad_secret_name"
+
+		bad = v1.Secret{
+			Namespace: testNamespace, Name: badName,
+			Data: map[string][]byte{"..evil": []byte("boom")},
+		}
+		client        = fake.NewSimpleClientset(&bad)
+		pluginMgr     = volume.VolumePluginMgr{}
+		tempDir, host = newTestHost(t, client)
+	)
+	defer func() { _ = os.RemoveAll(tempDir) }()
+	if err := pluginMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, host); err != nil {
+		t.Fatal(err)
+	}
+
+	plugin, err := pluginMgr.FindPluginByName(secretPluginName)
+	if err != nil {
+		t.Fatal("Can't find the plugin by name")
+	}
+	pod := &v1.Pod{Namespace: testNamespace, UID: testPodUID}
+
+	mounter, err := plugin.NewMounter(volume.NewSpecFromVolume(volumeSpec(testVolumeName, badName, 0644)), pod)
+	if err != nil {
+		t.Fatalf("Failed to make a new Mounter: %v", err)
+	}
+	volumePath := mounter.GetPath()
+	if err := mounter.SetUp(volume.MounterArgs{}); err == nil {
+		t.Fatal("expected first-time SetUp to fail on invalid payload, but it succeeded")
+	}
+
+	// Never populated, so the failed first-time setup must have been cleaned up.
+	if _, err := os.Stat(volumePath); !os.IsNotExist(err) {
+		t.Fatalf("expected volume dir to be torn down after a failed first-time setup, stat err = %v", err)
 	}
 }
 

--- a/pkg/volume/util/atomic_writer.go
+++ b/pkg/volume/util/atomic_writer.go
@@ -83,6 +83,23 @@ const (
 	newDataDirName = "..data_tmp"
 )
 
+// IsTargetPopulated reports whether the given AtomicWriter target directory has
+// already been successfully written to at least once. It is detected via the
+// presence of the "..data" symlink, which Write only creates after a payload has
+// been fully and atomically projected. Volume plugins use this to distinguish a
+// first-time setup from a periodic resync: an already-populated directory may be
+// bind-mounted into a running container, so it must not be torn down when a later
+// write fails (see https://github.com/kubernetes/kubernetes/issues/113242).
+//
+// Only a definitive "does not exist" is treated as not-populated. On any other
+// Lstat error (e.g. a transient failure) the target is conservatively reported as
+// populated, so a volume that may be bind-mounted into a running container is not
+// torn down on the basis of an inconclusive check.
+func IsTargetPopulated(targetDir string) bool {
+	_, err := os.Lstat(filepath.Join(targetDir, dataDirName))
+	return !os.IsNotExist(err)
+}
+
 // Write does an atomic projection of the given payload into the writer's target
 // directory.  Input paths must not begin with '..'.
 // setPerms is an optional pointer to a function that caller can provide to set the

--- a/pkg/volume/util/atomic_writer.go
+++ b/pkg/volume/util/atomic_writer.go
@@ -85,6 +85,23 @@ const (
 	newDataDirName = "..data_tmp"
 )
 
+// IsTargetPopulated reports whether the given AtomicWriter target directory has
+// already been successfully written to at least once. It is detected via the
+// presence of the "..data" symlink, which Write only creates after a payload has
+// been fully and atomically projected. Volume plugins use this to distinguish a
+// first-time setup from a periodic resync: an already-populated directory may be
+// bind-mounted into a running container, so it must not be torn down when a later
+// write fails (see https://github.com/kubernetes/kubernetes/issues/113242).
+//
+// Only a definitive "does not exist" is treated as not-populated. On any other
+// Lstat error (e.g. a transient failure) the target is conservatively reported as
+// populated, so a volume that may be bind-mounted into a running container is not
+// torn down on the basis of an inconclusive check.
+func IsTargetPopulated(targetDir string) bool {
+	_, err := os.Lstat(filepath.Join(targetDir, dataDirName))
+	return !os.IsNotExist(err)
+}
+
 // Write does an atomic projection of the given payload into the writer's target
 // directory.  Input paths must not begin with '..'.
 // setPerms is an optional pointer to a function that caller can provide to set the
@@ -196,6 +213,16 @@ func (w *AtomicWriter) Write(payload map[string]FileProjection, setPerms func(su
 			return err
 		}
 		tsDirName := filepath.Base(tsDir)
+		published := false
+		defer func() {
+			// A failed resync must reclaim its staging data without removing
+			// the volume root or a generation that readers can already see.
+			if !published {
+				if err := os.RemoveAll(tsDir); err != nil {
+					klog.Errorf("%s: error removing new ts directory %s: %v", w.logContext, tsDir, err)
+				}
+			}
+		}()
 
 		// (6)
 		if err = w.writePayloadToDir(cleanPayload, tsDir); err != nil {
@@ -215,14 +242,15 @@ func (w *AtomicWriter) Write(payload map[string]FileProjection, setPerms func(su
 		// (8)
 		newDataDirPath := filepath.Join(w.targetDir, newDataDirName)
 		if err = os.Symlink(tsDirName, newDataDirPath); err != nil {
-			if err := os.RemoveAll(tsDir); err != nil {
-				klog.Errorf("%s: error removing new ts directory %s: %v", w.logContext, tsDir, err)
-			}
 			klog.Errorf("%s: error creating symbolic link for atomic update: %v", w.logContext, err)
 			return err
 		}
 
 		// (9)
+		// On Windows the swap is not atomic: the existing data directory symlink
+		// is removed before the new one is created. If creating the new symlink
+		// fails, the target is left without a data directory symlink, and so no
+		// longer reports as populated, until the next successful write.
 		if runtime.GOOS == "windows" {
 			if err := os.Remove(dataDirPath); err != nil {
 				klog.Errorf("%s: error removing data dir directory %s: %v", w.logContext, dataDirPath, err)
@@ -238,12 +266,10 @@ func (w *AtomicWriter) Write(payload map[string]FileProjection, setPerms func(su
 			if err := os.Remove(newDataDirPath); err != nil && err != os.ErrNotExist {
 				klog.Errorf("%s: error removing new data dir directory %s: %v", w.logContext, newDataDirPath, err)
 			}
-			if err := os.RemoveAll(tsDir); err != nil {
-				klog.Errorf("%s: error removing new ts directory %s: %v", w.logContext, tsDir, err)
-			}
 			klog.Errorf("%s: error renaming symbolic link for data directory %s: %v", w.logContext, newDataDirPath, err)
 			return err
 		}
+		published = true
 	}
 
 	// (10)
@@ -410,6 +436,9 @@ func (w *AtomicWriter) newTimestampDir() (string, error) {
 	err = os.Chmod(tsDir, 0755)
 	if err != nil {
 		klog.Errorf("%s: unable to set mode on new temp directory: %v", w.logContext, err)
+		if removeErr := os.RemoveAll(tsDir); removeErr != nil {
+			klog.Errorf("%s: error removing new ts directory %s: %v", w.logContext, tsDir, removeErr)
+		}
 		return "", err
 	}
 

--- a/pkg/volume/util/atomic_writer_test.go
+++ b/pkg/volume/util/atomic_writer_test.go
@@ -36,7 +36,7 @@ func TestNewAtomicWriter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error creating tmp dir: %v", err)
 	}
-	defer os.RemoveAll(targetDir)
+	defer func() { _ = os.RemoveAll(targetDir) }()
 
 	_, err = NewAtomicWriter(targetDir, "-test-")
 	if err != nil {
@@ -55,6 +55,53 @@ func TestNewAtomicWriter(t *testing.T) {
 	_, err = NewAtomicWriter(nonExistentDir, "-test-")
 	if err == nil {
 		t.Fatalf("unexpected success creating writer for nonexistent target dir: %v", err)
+	}
+}
+
+func TestIsTargetPopulated(t *testing.T) {
+	targetDir, err := utiltesting.MkTmpdir("atomic-write")
+	if err != nil {
+		t.Fatalf("unexpected error creating tmp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(targetDir) }()
+
+	// A freshly created target directory has never been written to, so the
+	// data directory symlink does not exist yet.
+	if IsTargetPopulated(targetDir) {
+		t.Fatalf("expected target dir to be reported as not populated before any write")
+	}
+
+	// After a successful Write the "..data" symlink exists and the target is
+	// considered populated. This is the signal volume plugins rely on to avoid
+	// tearing down an already-mounted volume on a later failed resync (#113242).
+	writer, err := NewAtomicWriter(targetDir, "-test-")
+	if err != nil {
+		t.Fatalf("unexpected error creating writer: %v", err)
+	}
+	payload := map[string]FileProjection{
+		"foo": {Data: []byte("foo"), Mode: 0644},
+	}
+	if err := writer.Write(payload, nil); err != nil {
+		t.Fatalf("unexpected error writing payload: %v", err)
+	}
+	if !IsTargetPopulated(targetDir) {
+		t.Fatalf("expected target dir to be reported as populated after a successful write")
+	}
+
+	// A non-existent target directory is trivially not populated.
+	if IsTargetPopulated(filepath.Join(targetDir, "does-not-exist")) {
+		t.Fatalf("expected non-existent dir to be reported as not populated")
+	}
+
+	// On an inconclusive Lstat error (here ENOTDIR, because the "target dir" is a
+	// regular file) the check must conservatively report the target as populated,
+	// so a possibly bind-mounted volume is not torn down on an inconclusive result.
+	regularFile := filepath.Join(targetDir, "not-a-dir")
+	if err := os.WriteFile(regularFile, []byte("x"), 0644); err != nil {
+		t.Fatalf("unexpected error creating file: %v", err)
+	}
+	if !IsTargetPopulated(regularFile) {
+		t.Fatalf("expected target to be reported as populated on a non-ENOENT Lstat error")
 	}
 }
 
@@ -225,7 +272,7 @@ func TestPathsToRemove(t *testing.T) {
 			t.Errorf("%v: unexpected error creating tmp dir: %v", tc.name, err)
 			continue
 		}
-		defer os.RemoveAll(targetDir)
+		defer func() { _ = os.RemoveAll(targetDir) }()
 
 		writer := &AtomicWriter{targetDir: targetDir, logContext: "-test-"}
 		err = writer.Write(tc.payload1, nil)
@@ -393,7 +440,7 @@ IAAAAAAAsDyZDwU=`
 			t.Errorf("%v: unexpected error creating tmp dir: %v", tc.name, err)
 			continue
 		}
-		defer os.RemoveAll(targetDir)
+		defer func() { _ = os.RemoveAll(targetDir) }()
 
 		writer := &AtomicWriter{targetDir: targetDir, logContext: "-test-"}
 		err = writer.Write(tc.payload, nil)
@@ -569,7 +616,7 @@ func TestUpdate(t *testing.T) {
 			t.Errorf("%v: unexpected error creating tmp dir: %v", tc.name, err)
 			continue
 		}
-		defer os.RemoveAll(targetDir)
+		defer func() { _ = os.RemoveAll(targetDir) }()
 
 		writer := &AtomicWriter{targetDir: targetDir, logContext: "-test-"}
 
@@ -737,7 +784,7 @@ func TestMultipleUpdates(t *testing.T) {
 			t.Errorf("%v: unexpected error creating tmp dir: %v", tc.name, err)
 			continue
 		}
-		defer os.RemoveAll(targetDir)
+		defer func() { _ = os.RemoveAll(targetDir) }()
 
 		writer := &AtomicWriter{targetDir: targetDir, logContext: "-test-"}
 
@@ -950,7 +997,7 @@ func TestCreateUserVisibleFiles(t *testing.T) {
 			t.Errorf("%v: unexpected error creating tmp dir: %v", tc.name, err)
 			continue
 		}
-		defer os.RemoveAll(targetDir)
+		defer func() { _ = os.RemoveAll(targetDir) }()
 
 		dataDirPath := filepath.Join(targetDir, dataDirName)
 		err = os.MkdirAll(dataDirPath, 0755)
@@ -989,7 +1036,7 @@ func TestSetPerms(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error creating tmp dir: %v", err)
 	}
-	defer os.RemoveAll(targetDir)
+	defer func() { _ = os.RemoveAll(targetDir) }()
 
 	// Test that setPerms() is called once and with valid timestamp directory.
 	payload1 := map[string]FileProjection{

--- a/pkg/volume/util/atomic_writer_test.go
+++ b/pkg/volume/util/atomic_writer_test.go
@@ -58,6 +58,53 @@ func TestNewAtomicWriter(t *testing.T) {
 	}
 }
 
+func TestIsTargetPopulated(t *testing.T) {
+	targetDir, err := utiltesting.MkTmpdir("atomic-write")
+	if err != nil {
+		t.Fatalf("unexpected error creating tmp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(targetDir) }()
+
+	// A freshly created target directory has never been written to, so the
+	// data directory symlink does not exist yet.
+	if IsTargetPopulated(targetDir) {
+		t.Fatalf("expected target dir to be reported as not populated before any write")
+	}
+
+	// After a successful Write the "..data" symlink exists and the target is
+	// considered populated. This is the signal volume plugins rely on to avoid
+	// tearing down an already-mounted volume on a later failed resync (#113242).
+	writer, err := NewAtomicWriter(targetDir, "-test-")
+	if err != nil {
+		t.Fatalf("unexpected error creating writer: %v", err)
+	}
+	payload := map[string]FileProjection{
+		"foo": {Data: []byte("foo"), Mode: 0644},
+	}
+	if err := writer.Write(payload, nil); err != nil {
+		t.Fatalf("unexpected error writing payload: %v", err)
+	}
+	if !IsTargetPopulated(targetDir) {
+		t.Fatalf("expected target dir to be reported as populated after a successful write")
+	}
+
+	// A non-existent target directory is trivially not populated.
+	if IsTargetPopulated(filepath.Join(targetDir, "does-not-exist")) {
+		t.Fatalf("expected non-existent dir to be reported as not populated")
+	}
+
+	// On an inconclusive Lstat error (here ENOTDIR, because the "target dir" is a
+	// regular file) the check must conservatively report the target as populated,
+	// so a possibly bind-mounted volume is not torn down on an inconclusive result.
+	regularFile := filepath.Join(targetDir, "not-a-dir")
+	if err := os.WriteFile(regularFile, []byte("x"), 0644); err != nil {
+		t.Fatalf("unexpected error creating file: %v", err)
+	}
+	if !IsTargetPopulated(regularFile) {
+		t.Fatalf("expected target to be reported as populated on a non-ENOENT Lstat error")
+	}
+}
+
 func TestValidatePath(t *testing.T) {
 	maxPath := strings.Repeat("a", maxPathLength+1)
 	maxFile := strings.Repeat("a", maxFileNameLength+1)
@@ -1032,6 +1079,167 @@ func TestSetPerms(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "error in setPerms") {
 		t.Fatalf("unexpected error while writing: %v", err)
+	}
+}
+
+func TestWriteFailureCleansUpTimestampDirectory(t *testing.T) {
+	tests := []struct {
+		name     string
+		payload  map[string]FileProjection
+		setPerms bool
+	}{
+		{
+			name: "payload write",
+			// Either iteration order writes one file before encountering the
+			// file/directory collision, leaving a partially written generation.
+			payload: map[string]FileProjection{
+				"new":       {Data: []byte("new data"), Mode: 0644},
+				"new/child": {Data: []byte("child data"), Mode: 0644},
+			},
+		},
+		{
+			name: "permissions",
+			payload: map[string]FileProjection{
+				"new": {Data: []byte("new data"), Mode: 0644},
+			},
+			setPerms: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			targetDir := t.TempDir()
+			writer, err := NewAtomicWriter(targetDir, "-test-")
+			if err != nil {
+				t.Fatal(err)
+			}
+			original := map[string]FileProjection{
+				"old": {Data: []byte("old data"), Mode: 0644},
+			}
+			if err := writer.Write(original, nil); err != nil {
+				t.Fatal(err)
+			}
+			originalDir, err := os.Stat(targetDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			originalDataDir, err := os.Readlink(filepath.Join(targetDir, dataDirName))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var setPerms func(string) error
+			setPermsCalls := 0
+			if tc.setPerms {
+				setPerms = func(string) error {
+					setPermsCalls++
+					return fmt.Errorf("injected permission failure")
+				}
+			}
+			for range 3 {
+				if err := writer.Write(tc.payload, setPerms); err == nil {
+					t.Fatal("expected write to fail")
+				}
+				dataDir, err := os.Readlink(filepath.Join(targetDir, dataDirName))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if dataDir != originalDataDir {
+					t.Fatalf("failed write changed published directory from %q to %q", originalDataDir, dataDir)
+				}
+				checkVolumeContents(targetDir, tc.name, original, t)
+				checkAtomicWriterDirectories(t, targetDir, originalDir)
+			}
+			if tc.setPerms && setPermsCalls != 3 {
+				t.Fatalf("expected 3 permission failures, got %d", setPermsCalls)
+			}
+
+			recovered := map[string]FileProjection{
+				"new": {Data: []byte("recovered data"), Mode: 0644},
+			}
+			if err := writer.Write(recovered, nil); err != nil {
+				t.Fatalf("retry failed: %v", err)
+			}
+			checkVolumeContents(targetDir, tc.name, recovered, t)
+			checkAtomicWriterDirectories(t, targetDir, originalDir)
+		})
+	}
+}
+
+func checkAtomicWriterDirectories(t *testing.T, targetDir string, originalDir os.FileInfo) {
+	t.Helper()
+	currentDir, err := os.Stat(targetDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(originalDir, currentDir) {
+		t.Fatal("volume root was replaced")
+	}
+	dataDir, err := os.Readlink(filepath.Join(targetDir, dataDirName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(targetDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() && entry.Name() != dataDir {
+			t.Errorf("unpublished timestamp directory remains: %s", entry.Name())
+		}
+	}
+	if _, err := os.Lstat(filepath.Join(targetDir, newDataDirName)); !os.IsNotExist(err) {
+		t.Errorf("expected no temporary data symlink, got error %v", err)
+	}
+}
+
+func TestWriteKeepsPublishedDirectoryOnError(t *testing.T) {
+	targetDir := t.TempDir()
+	writer, err := NewAtomicWriter(targetDir, "-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Write(map[string]FileProjection{
+		"old": {Data: []byte("old data"), Mode: 0644},
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var publishedDir string
+	err = writer.Write(map[string]FileProjection{
+		"new": {Data: []byte("new data"), Mode: 0644},
+	}, func(subPath string) error {
+		publishedDir = subPath
+		// Obstruct removal of an old visible path to force an error after
+		// publication. Cleanup must not delete the now-active generation.
+		oldPath := filepath.Join(targetDir, "old")
+		if err := os.Remove(oldPath); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Mkdir(oldPath, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(oldPath, "obstruction"), nil, 0644); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected removal of the old visible path to fail")
+	}
+	dataDir, err := os.Readlink(filepath.Join(targetDir, dataDirName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dataDir != publishedDir {
+		t.Fatalf("expected published directory %q, got %q", publishedDir, dataDir)
+	}
+	data, err := os.ReadFile(filepath.Join(targetDir, "new"))
+	if err != nil {
+		t.Fatalf("published content was removed after a post-publication failure: %v", err)
+	}
+	if string(data) != "new data" {
+		t.Fatalf("expected published content %q, got %q", "new data", data)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
configMap, secret, downwardAPI, and projected volumes tear the volume directory down whenever `SetUpAt` fails. That is right for a failed first-time setup, but the same path runs on periodic resync of an already-mounted volume. A transient write failure there (disk full, corrupted `..data` symlink) removes a directory that is bind-mounted into the running container, leaving the volume permanently empty.

- Skip teardown when the volume is already populated (`..data` exists). The last good content stays in place and the volume manager retries.
- `AtomicWriter.Write` now removes its staging timestamp directory on any failure, so retries do not leak a directory per attempt on a full disk.

First-time setup failures still tear down as before.

#### Which issue(s) this PR is related to:
Fixes #113242

#### Special notes for your reviewer:
Behavior change on the resync path only: a failed resync now preserves the previous projection and retries instead of unmounting the volume.

#### Does this PR introduce a user-facing change?
```release-note
Fixed configMap, secret, downwardAPI, and projected volumes being left permanently empty when a periodic resync failed to write (for example, node disk full). The volume now keeps its last successfully projected contents and retries.
```

#### AI usage disclosure:
YES. AI was used to write the unit tests and to run them in containers for verification.
