### PR TITLE
apimachinery: wrap json parse error in MetaFactory.Interpret

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/meta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/meta.go
@@ -53,7 +53,7 @@ func (SimpleMetaFactory) Interpret(data []byte) (*schema.GroupVersionKind, error
 		Kind string `json:"kind,omitempty"`
 	}{}
 	if err := json.Unmarshal(data, &findKind); err != nil {
-		return nil, fmt.Errorf("couldn't get version/kind; json parse error: %v", err)
+		return nil, fmt.Errorf("couldn't get version/kind; json parse error: %w", err)
 	}
 	gv, err := schema.ParseGroupVersion(findKind.APIVersion)
 	if err != nil {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/meta_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/meta_test.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package json
 
-import "testing"
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
 
 func TestSimpleMetaFactoryInterpret(t *testing.T) {
 	factory := SimpleMetaFactory{}
@@ -41,5 +45,19 @@ func TestSimpleMetaFactoryInterpret(t *testing.T) {
 	_, err = factory.Interpret([]byte(`{`))
 	if err == nil {
 		t.Errorf("unexpected non-error")
+	}
+}
+
+func TestSimpleMetaFactoryInterpretInvalidKindType(t *testing.T) {
+	factory := SimpleMetaFactory{}
+	_, err := factory.Interpret([]byte(`{"kind":true}`))
+	if err == nil {
+		t.Fatalf("expected an error for invalid kind type, got nil")
+	}
+	// The underlying json error must be recoverable via errors.As so that
+	// callers can classify it as a client (4xx) error instead of a 500.
+	var typeErr *json.UnmarshalTypeError
+	if !errors.As(err, &typeErr) {
+		t.Errorf("expected wrapped *json.UnmarshalTypeError, got %T: %v", err, err)
 	}
 }


### PR DESCRIPTION
### type
#### / why we need it:
`SimpleMetaFactory.Interpret` flattens the underlying JSON unmarshal
error into an opaque string via `%v`, discarding the typed
`*json.UnmarshalTypeError`. As a result, callers cannot inspect the
error to distinguish a malformed client request (e.g. a `kind` field
with a non-string type) from a genuine internal error.

This PR switches the wrap to `%w` so callers can recover the underlying
`json` error via `errors.As`. The error message is byte-for-byte
unchanged, so this is backward compatible.

This is a foundational change: it makes the error classifiable. Wiring
specific callers (e.g. status mapping in the apiserver) to use this and
return a 4xx is intended as a follow-up.

#### Which issue(s) this PR fixes:

Refs #139461

#### Does this PR introduce a user-facing change?

```release-note
NONE
```