### PR TITLE
apiserver: return 422 instead of 500 when runtimeClassName is empty

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -352,6 +352,10 @@ var ValidatePodGroupName = apimachineryvalidation.NameIsDNSSubdomain
 // trailing dashes are allowed.
 func ValidateRuntimeClassName(name string, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
+	if len(name) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath, "runtimeClassName must not be empty"))
+		return allErrs
+	}
 	for _, msg := range apimachineryvalidation.NameIsDNSSubdomain(name, false) {
 		allErrs = append(allErrs, field.Invalid(fldPath, name, msg))
 	}

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -10665,6 +10665,14 @@ func TestValidatePodSpec(t *testing.T) {
 		"bad RuntimeClassName": {pod: *podtest.MakePod("",
 			podtest.SetRuntimeClassName("invalid/sandbox"),
 		)},
+		"empty string RuntimeClassName": {
+    			pod: *podtest.MakePod("",
+        			podtest.SetRuntimeClassName(""),
+    			),
+			expectedErrors: field.ErrorList{        			
+				field.Required(field.NewPath("field").Child("runtimeClassName"), "runtimeClassName must not be empty"					),
+    				},
+		},
 		"bad empty fsGroupchangepolicy": {pod: *podtest.MakePod("",
 			podtest.SetSecurityContext(&core.PodSecurityContext{
 				FSGroupChangePolicy: &badfsGroupChangePolicy2,

--- a/plugin/pkg/admission/runtimeclass/admission.go
+++ b/plugin/pkg/admission/runtimeclass/admission.go
@@ -145,7 +145,7 @@ func (r *RuntimeClass) prepareObjects(ctx context.Context, attributes admission.
 		return nil, nil, apierrors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
 	}
 
-	if pod.Spec.RuntimeClassName == nil {
+	if pod.Spec.RuntimeClassName == nil || *pod.Spec.RuntimeClassName == "" {
 		return pod, nil, nil
 	}
 


### PR DESCRIPTION
What type of PR is this?

/kind bug
What this PR does / why we need it:

When spec.runtimeClassName is set to an empty string (""), the API server returns HTTP 500 instead of a proper validation error. The empty string passes the nil pointer check but then fails deep in apimachinery name validation, causing an unhandled 500.

Added an explicit len(name) == 0 guard in ValidateRuntimeClassName to return a proper field.Required error (HTTP 422) instead.
Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/139462
Special notes for your reviewer:

1. pkg/apis/core/validation/validation.go - Added explicit empty string 
   check in ValidateRuntimeClassName to return proper field.Required error (422).
2. plugin/pkg/admission/runtimeclass/admission.go - Added empty string 
   check in prepareObjects to skip RuntimeClass lookup when runtimeClassName 
   is "", preventing an unhandled 500 from client-go's Name() guard.
Unit test added in validation_test.go for the empty string case.