### PR TITLE
apiserver/endpoints/handlers: move content encoding negotiation to handlers/internal

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/compression.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/compression.go
@@ -1,0 +1,60 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package responsewriters
+
+import (
+	"net/http"
+	"strings"
+
+	"k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/component-base/featuregate"
+)
+
+// responseContentEncodingSupported returns a supported client-requested content encoding for the
+// provided request. It will return the empty string if no supported content encoding was
+// found or if the APIResponseCompression feature gate is disabled.
+func responseContentEncodingSupported(req *http.Request) string {
+	return ContentEncodingSupported(req, features.APIResponseCompression)
+}
+
+// ContentEncodingSupported returns a supported client-requested content encoding for the
+// provided request. It will return the empty string if no supported content encoding was
+// found or if the provided feature gate is disabled.
+func ContentEncodingSupported(req *http.Request, feature featuregate.Feature) string {
+	encoding := req.Header.Get("Accept-Encoding")
+	if len(encoding) == 0 {
+		return ""
+	}
+	if !utilfeature.DefaultFeatureGate.Enabled(feature) {
+		return ""
+	}
+	for len(encoding) > 0 {
+		var token string
+		if next := strings.Index(encoding, ","); next != -1 {
+			token = encoding[:next]
+			encoding = encoding[next+1:]
+		} else {
+			token = encoding
+			encoding = ""
+		}
+		if strings.TrimSpace(token) == "gzip" {
+			return "gzip"
+		}
+	}
+	return ""
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/compression_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/compression_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package responsewriters
+
+import (
+	"net/http"
+	"testing"
+
+	"k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/component-base/featuregate"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+)
+
+func TestContentEncodingSupported(t *testing.T) {
+	scenarios := []struct {
+		name              string
+		acceptEncoding    string
+		featureGate       featuregate.Feature
+		enableFeatureGate bool
+		expectedEncoding  string
+	}{
+		{
+			name:              "no Accept-Encoding header",
+			acceptEncoding:    "",
+			featureGate:       features.APIResponseCompression,
+			enableFeatureGate: true,
+			expectedEncoding:  "",
+		},
+		{
+			name:              "gzip accepted, compression enabled",
+			acceptEncoding:    "gzip",
+			featureGate:       features.APIResponseCompression,
+			enableFeatureGate: true,
+			expectedEncoding:  "gzip",
+		},
+		{
+			name:             "gzip accepted, compression disabled",
+			acceptEncoding:   "gzip",
+			featureGate:      features.APIResponseCompression,
+			expectedEncoding: "",
+		},
+		{
+			name:              "multiple encodings with gzip",
+			acceptEncoding:    "deflate, gzip",
+			featureGate:       features.APIResponseCompression,
+			enableFeatureGate: true,
+			expectedEncoding:  "gzip",
+		},
+		{
+			name:              "unsupported encoding only",
+			acceptEncoding:    "deflate",
+			featureGate:       features.APIResponseCompression,
+			enableFeatureGate: true,
+			expectedEncoding:  "",
+		},
+		{
+			name:              "gzip with whitespace",
+			acceptEncoding:    " gzip ",
+			featureGate:       features.APIResponseCompression,
+			enableFeatureGate: true,
+			expectedEncoding:  "gzip",
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, scenario.featureGate, scenario.enableFeatureGate)
+
+			req, _ := http.NewRequest(http.MethodGet, "/", nil)
+			if scenario.acceptEncoding != "" {
+				req.Header.Set("Accept-Encoding", scenario.acceptEncoding)
+			}
+
+			got := ContentEncodingSupported(req, scenario.featureGate)
+			if got != scenario.expectedEncoding {
+				t.Errorf("contentEncodingSupported returned: %q, want: %q", got, scenario.expectedEncoding)
+			}
+		})
+	}
+}
+
+func TestResponseContentEncodingSupported(t *testing.T) {
+	scenarios := []struct {
+		name                          string
+		acceptEncoding                string
+		apiResponseCompressionEnabled bool
+		expectedEncoding              string
+	}{
+		{
+			name:                          "gzip accepted, APIResponseCompression enabled",
+			acceptEncoding:                "gzip",
+			apiResponseCompressionEnabled: true,
+			expectedEncoding:              "gzip",
+		},
+		{
+			name:                          "gzip accepted, APIResponseCompression disabled",
+			acceptEncoding:                "gzip",
+			apiResponseCompressionEnabled: false,
+			expectedEncoding:              "",
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.APIResponseCompression, scenario.apiResponseCompressionEnabled)
+
+			req, _ := http.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("Accept-Encoding", scenario.acceptEncoding)
+
+			got := responseContentEncodingSupported(req)
+			if got != scenario.expectedEncoding {
+				t.Errorf("ResponseContentEncodingSupported returned: %q, want: %q", got, scenario.expectedEncoding)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"net/http"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -104,7 +103,7 @@ func SerializeObject(mediaType string, encoder runtime.Encoder, hw http.Response
 	w := &deferredResponseWriter{
 		mediaType:       mediaType,
 		statusCode:      statusCode,
-		contentEncoding: negotiateContentEncoding(req),
+		contentEncoding: responseContentEncodingSupported(req),
 		hw:              hw,
 		ctx:             ctx,
 	}
@@ -161,34 +160,6 @@ const (
 	// When streaming JSON first write is "{", while Kubernetes protobuf starts unique 4 byte header.
 	firstWriteStreamingThresholdBytes = 4
 )
-
-// negotiateContentEncoding returns a supported client-requested content encoding for the
-// provided request. It will return the empty string if no supported content encoding was
-// found or if response compression is disabled.
-func negotiateContentEncoding(req *http.Request) string {
-	encoding := req.Header.Get("Accept-Encoding")
-	if len(encoding) == 0 {
-		return ""
-	}
-	if !utilfeature.DefaultFeatureGate.Enabled(features.APIResponseCompression) {
-		return ""
-	}
-	for len(encoding) > 0 {
-		var token string
-		if next := strings.Index(encoding, ","); next != -1 {
-			token = encoding[:next]
-			encoding = encoding[next+1:]
-		} else {
-			token = encoding
-			encoding = ""
-		}
-		switch strings.TrimSpace(token) {
-		case "gzip":
-			return "gzip"
-		}
-	}
-	return ""
-}
 
 type deferredResponseWriter struct {
 	mediaType       string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Refactors negotiateContentEncoding in the responsewriters package to accept a featuregate parameter and exports it as ContentEncodingSupported.

This allows reuse for both APIResponseCompression and the upcoming WatchListCompression feature gate, enabling watch.go to call responsewriters.ContentEncodingSupported(req, features.WatchListCompression).

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
xref: https://github.com/kubernetes/kubernetes/pull/139308

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
