### PR TITLE
Fix Quantity.String dropping magnitude for large DecimalSI values

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -451,7 +451,14 @@ func (q *Quantity) CanonicalizeBytes(out []byte) (result, suffix []byte) {
 	switch format {
 	case DecimalExponent, DecimalSI:
 		number, exponent := q.AsCanonicalBytes(out)
-		suffix, _ := quantitySuffixer.constructBytes(10, exponent, format)
+		suffix, ok := quantitySuffixer.constructBytes(10, exponent, format)
+		if !ok {
+			// DecimalSI only has suffixes for exponents in the range [-9, 18]
+			// (n through E). Larger or smaller exponents have no SI suffix, so
+			// fall back to DecimalExponent, which can represent any exponent and
+			// thus avoids silently dropping the magnitude of the value.
+			suffix, _ = quantitySuffixer.constructBytes(10, exponent, DecimalExponent)
+		}
 		return number, suffix
 	default:
 		// format must be BinarySI

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -801,6 +801,13 @@ func TestQuantityParseEmit(t *testing.T) {
 		{".000001Ki", "1024u"},
 		{".000000001Ki", "1024n"},
 		{".000000000001Ki", "2n"},
+		// DecimalSI only has suffixes up to "E" (10^18). Values whose canonical
+		// exponent exceeds that range must fall back to DecimalExponent rather
+		// than silently dropping the suffix (and thus the magnitude). See
+		// CanonicalizeBytes.
+		{"1000000000000000000000", "1e21"},
+		{"1234000000000000000000", "1234E"},
+		{"5000000000000000000000000", "5e24"},
 	}
 
 	for _, item := range table {
@@ -811,6 +818,13 @@ func TestQuantityParseEmit(t *testing.T) {
 		}
 		if e, a := item.expect, q.String(); e != a {
 			t.Errorf("%#v: expected %v, got %v", item.in, e, a)
+		}
+		// The emitted canonical string must round-trip back to the same value.
+		r, err := ParseQuantity(q.String())
+		if err != nil {
+			t.Errorf("%#v: couldn't re-parse emitted %q: %v", item.in, q.String(), err)
+		} else if q.Cmp(r) != 0 {
+			t.Errorf("%#v: value changed across String/Parse: %v != %v", item.in, q.AsDec(), r.AsDec())
 		}
 	}
 	for _, item := range table {


### PR DESCRIPTION
/kind bug
/sig api-machinery

#### What this PR does / why we need it:

`DecimalSI` only defines suffixes up to `E` (10^18). For a `Quantity` in `DecimalSI` format whose canonical base-10 exponent exceeds that range (e.g. 10^21), `quantitySuffixer.constructBytes` returns `ok=false`, but `CanonicalizeBytes` discarded that result and emitted only the mantissa.

As a result a quantity such as `"1000000000000000000000"` (10^21) was serialized by `String()` (and therefore `MarshalJSON()` / `ToUnstructured()`) as `"1"`, silently losing 21 orders of magnitude, and the emitted string no longer round-tripped back to the original value.

This falls back to `DecimalExponent` (which can represent any exponent as `eNN`) when the `DecimalSI` suffix lookup fails, mirroring the existing `BinarySI -> DecimalSI` fallback in the same function. Values within the SI suffix range are unchanged. Added round-trip coverage to `TestQuantityParseEmit`.

#### Which issue(s) this PR fixes:

(none — self-reported)

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where resource.Quantity values in DecimalSI format larger than the "E" (10^18) suffix range were serialized to a string that dropped their magnitude (e.g. 10^21 emitted as "1"). Such values now serialize using the decimal exponent form and round-trip correctly.
```
