### PR TITLE
Reduce times lock is aquired in watch cache during reads

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -1305,13 +1305,20 @@ func (c *Cacher) waitUntilWatchCacheFreshAndForceAllEvents(ctx context.Context, 
 		//
 		// In this very rare scenario, the worst case will be that this
 		// request will wait for 3 seconds before it fails.
-		if etcdfeature.DefaultFeatureSupportChecker.Supports(storage.RequestWatchProgress) && c.watchCache.notFresh(requestedWatchRV) {
-			c.watchCache.waitingUntilFresh.Add()
-			defer c.watchCache.waitingUntilFresh.Remove()
-		}
-		err := c.watchCache.waitUntilFreshAndBlock(ctx, requestedWatchRV)
+		consistentReadSupported := delegator.ConsistentReadSupported()
+		c.watchCache.RLock()
 		defer c.watchCache.RUnlock()
-		return err
+		if requestedWatchRV > 0 && requestedWatchRV > c.watchCache.resourceVersion {
+			if consistentReadSupported {
+				c.watchCache.waitingUntilFresh.Add()
+				err := c.watchCache.waitUntilFreshLocked(ctx, requestedWatchRV)
+				c.watchCache.waitingUntilFresh.Remove()
+				return err
+			} else {
+				return c.watchCache.waitUntilFreshLocked(ctx, requestedWatchRV)
+			}
+		}
+		return nil
 	}
 	return nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_testing_utils_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_testing_utils_test.go
@@ -160,12 +160,12 @@ func compactWatch(c *CacheDelegator, client *clientv3.Client) storagetesting.Com
 			t.Fatal(err)
 		}
 
-		err = c.cacher.watchCache.waitUntilFreshAndBlock(context.TODO(), rv)
+		c.cacher.watchCache.RLock()
+		err = c.cacher.watchCache.waitUntilFreshLocked(context.TODO(), rv)
+		c.cacher.watchCache.RUnlock()
 		if err != nil {
 			t.Fatalf("WatchCache didn't caught up to RV: %v", rv)
 		}
-		c.cacher.watchCache.RUnlock()
-
 		c.cacher.watchCache.Lock()
 		defer c.cacher.watchCache.Unlock()
 		c.cacher.Lock()

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -441,10 +441,12 @@ func (w *watchCache) List() []interface{} {
 	return w.store.List()
 }
 
-// waitUntilFreshAndBlock waits until cache is at least as fresh as given <resourceVersion>.
-// NOTE: This function acquired lock and doesn't release it.
-// You HAVE TO explicitly call w.RUnlock() after this function.
-func (w *watchCache) waitUntilFreshAndBlock(ctx context.Context, resourceVersion uint64) error {
+// waitUntilFreshLocked waits until cache is at least as fresh as given resourceVersion.
+func (w *watchCache) waitUntilFreshLocked(ctx context.Context, resourceVersion uint64) error {
+	if resourceVersion == 0 || resourceVersion <= w.resourceVersion {
+		return nil
+	}
+
 	startTime := w.clock.Now()
 	defer func() {
 		if resourceVersion > 0 {
@@ -473,7 +475,6 @@ func (w *watchCache) waitUntilFreshAndBlock(ctx context.Context, resourceVersion
 		}()
 	}
 
-	w.RLock()
 	span := tracing.SpanFromContext(ctx)
 	span.AddEvent("watchCache locked acquired")
 	for w.resourceVersion < resourceVersion {
@@ -536,15 +537,18 @@ func (c *watchCache) waitUntilFreshAndGetList(ctx context.Context, key string, o
 // WaitUntilFreshAndList returns list of pointers to `storeElement` objects along
 // with their ResourceVersion and the name of the index, if any, that was used.
 func (w *watchCache) WaitUntilFreshAndGetKeys(ctx context.Context, resourceVersion uint64) (keys []string, err error) {
-	if delegator.ConsistentReadSupported() && w.notFresh(resourceVersion) {
-		w.waitingUntilFresh.Add()
-		err = w.waitUntilFreshAndBlock(ctx, resourceVersion)
-		w.waitingUntilFresh.Remove()
-	} else {
-		err = w.waitUntilFreshAndBlock(ctx, resourceVersion)
-	}
-
+	consistentReadSupported := delegator.ConsistentReadSupported()
+	w.RLock()
 	defer w.RUnlock()
+	if resourceVersion > 0 && resourceVersion > w.resourceVersion {
+		if consistentReadSupported {
+			w.waitingUntilFresh.Add()
+			err = w.waitUntilFreshLocked(ctx, resourceVersion)
+			w.waitingUntilFresh.Remove()
+		} else {
+			err = w.waitUntilFreshLocked(ctx, resourceVersion)
+		}
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -588,14 +592,18 @@ func (w *watchCache) waitUntilFreshAndList(ctx context.Context, key string, opts
 }
 
 func (w *watchCache) waitAndListExactRV(ctx context.Context, key, continueKey string, resourceVersion uint64) (resp listResp, index string, err error) {
-	if delegator.ConsistentReadSupported() && w.notFresh(resourceVersion) {
-		w.waitingUntilFresh.Add()
-		err = w.waitUntilFreshAndBlock(ctx, resourceVersion)
-		w.waitingUntilFresh.Remove()
-	} else {
-		err = w.waitUntilFreshAndBlock(ctx, resourceVersion)
-	}
+	consistentReadSupported := delegator.ConsistentReadSupported()
+	w.RLock()
 	defer w.RUnlock()
+	if resourceVersion > 0 && resourceVersion > w.resourceVersion {
+		if consistentReadSupported {
+			w.waitingUntilFresh.Add()
+			err = w.waitUntilFreshLocked(ctx, resourceVersion)
+			w.waitingUntilFresh.Remove()
+		} else {
+			err = w.waitUntilFreshLocked(ctx, resourceVersion)
+		}
+	}
 	if err != nil {
 		return listResp{}, "", err
 	}
@@ -623,14 +631,18 @@ func (w *watchCache) waitAndListConsistent(ctx context.Context, key, continueKey
 }
 
 func (w *watchCache) waitAndListLatestRV(ctx context.Context, resourceVersion uint64, key, continueKey string, matchValues []storage.MatchValue) (resp listResp, index string, err error) {
-	if delegator.ConsistentReadSupported() && w.notFresh(resourceVersion) {
-		w.waitingUntilFresh.Add()
-		err = w.waitUntilFreshAndBlock(ctx, resourceVersion)
-		w.waitingUntilFresh.Remove()
-	} else {
-		err = w.waitUntilFreshAndBlock(ctx, resourceVersion)
-	}
+	consistentReadSupported := delegator.ConsistentReadSupported()
+	w.RLock()
 	defer w.RUnlock()
+	if resourceVersion > 0 && resourceVersion > w.resourceVersion {
+		if consistentReadSupported {
+			w.waitingUntilFresh.Add()
+			err = w.waitUntilFreshLocked(ctx, resourceVersion)
+			w.waitingUntilFresh.Remove()
+		} else {
+			err = w.waitUntilFreshLocked(ctx, resourceVersion)
+		}
+	}
 	if err != nil {
 		return listResp{}, "", err
 	}
@@ -683,14 +695,18 @@ func (w *watchCache) notFresh(resourceVersion uint64) bool {
 // WaitUntilFreshAndGet returns a pointers to <storeElement> object.
 func (w *watchCache) WaitUntilFreshAndGet(ctx context.Context, resourceVersion uint64, key string) (interface{}, bool, uint64, error) {
 	var err error
-	if delegator.ConsistentReadSupported() && w.notFresh(resourceVersion) {
-		w.waitingUntilFresh.Add()
-		err = w.waitUntilFreshAndBlock(ctx, resourceVersion)
-		w.waitingUntilFresh.Remove()
-	} else {
-		err = w.waitUntilFreshAndBlock(ctx, resourceVersion)
-	}
+	consistentReadSupported := delegator.ConsistentReadSupported()
+	w.RLock()
 	defer w.RUnlock()
+	if resourceVersion > 0 && resourceVersion > w.resourceVersion {
+		if consistentReadSupported {
+			w.waitingUntilFresh.Add()
+			err = w.waitUntilFreshLocked(ctx, resourceVersion)
+			w.waitingUntilFresh.Remove()
+		} else {
+			err = w.waitUntilFreshLocked(ctx, resourceVersion)
+		}
+	}
 	if err != nil {
 		return nil, false, 0, err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
@@ -1231,59 +1231,77 @@ func TestHistogramCacheReadWait(t *testing.T) {
 	testedMetrics := "apiserver_watch_cache_read_wait_seconds"
 	store := newTestWatchCache(2, DefaultEventFreshDuration, &cache.Indexers{})
 	defer store.Stop()
-
-	// In background, update the store.
-	go func() {
-		if err := store.Add(makeTestPod("foo", 2)); err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if err := store.Add(makeTestPod("bar", 5)); err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-	}()
+	fakeClock := store.clock.(*testingclock.FakeClock)
 
 	testCases := []struct {
 		desc            string
 		resourceVersion uint64
+		run             func(t *testing.T)
 		want            string
 	}{
 		{
 			desc:            "resourceVersion is non-zero",
 			resourceVersion: 5,
+			run: func(t *testing.T) {
+				if err := store.Add(makeTestPod("foo", 2)); err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+
+				getCompleted := make(chan struct{})
+				go func() {
+					defer close(getCompleted)
+					if _, _, _, err := store.WaitUntilFreshAndGet(ctx, 5, "prefix/ns/bar"); err != nil {
+						t.Errorf("unexpected error: %v", err)
+					}
+				}()
+
+				time.Sleep(10 * time.Millisecond)
+
+				fakeClock.Step(1 * time.Second)
+
+				if err := store.Add(makeTestPod("bar", 5)); err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+
+				<-getCompleted
+			},
 			want: `
-		# HELP apiserver_watch_cache_read_wait_seconds [ALPHA] Histogram of time spent waiting for a watch cache to become fresh.
-    # TYPE apiserver_watch_cache_read_wait_seconds histogram
-	    apiserver_watch_cache_read_wait_seconds_bucket{group="",resource="pods",le="0.005"} 1
-        apiserver_watch_cache_read_wait_seconds_bucket{group="",resource="pods",le="0.025"} 1
-        apiserver_watch_cache_read_wait_seconds_bucket{group="",resource="pods",le="0.05"} 1
-        apiserver_watch_cache_read_wait_seconds_bucket{group="",resource="pods",le="0.1"} 1
-        apiserver_watch_cache_read_wait_seconds_bucket{group="",resource="pods",le="0.2"} 1
-        apiserver_watch_cache_read_wait_seconds_bucket{group="",resource="pods",le="0.4"} 1
-        apiserver_watch_cache_read_wait_seconds_bucket{group="",resource="pods",le="0.6"} 1
-        apiserver_watch_cache_read_wait_seconds_bucket{group="",resource="pods",le="0.8"} 1
+		    # HELP apiserver_watch_cache_read_wait_seconds [ALPHA] Histogram of time spent waiting for a watch cache to become fresh.
+        # TYPE apiserver_watch_cache_read_wait_seconds histogram
+	      apiserver_watch_cache_read_wait_seconds_bucket{group="",resource="pods",le="0.005"} 0
+        apiserver_watch_cache_read_wait_seconds_bucket{group="",resource="pods",le="0.025"} 0
+        apiserver_watch_cache_read_wait_seconds_bucket{group="",resource="pods",le="0.05"} 0
+        apiserver_watch_cache_read_wait_seconds_bucket{group="",resource="pods",le="0.1"} 0
+        apiserver_watch_cache_read_wait_seconds_bucket{group="",resource="pods",le="0.2"} 0
+        apiserver_watch_cache_read_wait_seconds_bucket{group="",resource="pods",le="0.4"} 0
+        apiserver_watch_cache_read_wait_seconds_bucket{group="",resource="pods",le="0.6"} 0
+        apiserver_watch_cache_read_wait_seconds_bucket{group="",resource="pods",le="0.8"} 0
         apiserver_watch_cache_read_wait_seconds_bucket{group="",resource="pods",le="1"} 1
         apiserver_watch_cache_read_wait_seconds_bucket{group="",resource="pods",le="1.25"} 1
         apiserver_watch_cache_read_wait_seconds_bucket{group="",resource="pods",le="1.5"} 1
         apiserver_watch_cache_read_wait_seconds_bucket{group="",resource="pods",le="2"} 1
         apiserver_watch_cache_read_wait_seconds_bucket{group="",resource="pods",le="3"} 1
         apiserver_watch_cache_read_wait_seconds_bucket{group="",resource="pods",le="+Inf"} 1
-        apiserver_watch_cache_read_wait_seconds_sum{group="",resource="pods"} 0
+        apiserver_watch_cache_read_wait_seconds_sum{group="",resource="pods"} 1
         apiserver_watch_cache_read_wait_seconds_count{group="",resource="pods"} 1
 `,
 		},
 		{
 			desc:            "resourceVersion is 0",
 			resourceVersion: 0,
-			want:            ``,
+			run: func(t *testing.T) {
+				if _, _, _, err := store.WaitUntilFreshAndGet(ctx, 0, "prefix/ns/bar"); err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			},
+			want: ``,
 		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
 			defer registry.Reset()
-			if _, _, _, err := store.WaitUntilFreshAndGet(ctx, test.resourceVersion, "prefix/ns/bar"); err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
+			test.run(t)
 			if err := testutil.GatherAndCompare(registry, strings.NewReader(test.want), testedMetrics); err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}


### PR DESCRIPTION
/kind feature

The optimization reduces the number of watch cache RLock acquisitions on read paths (List/Get) from 2 to 1.

* **Smaller Scale (1,000 pods)**: Shows a ~44% to 49% reduction in latency and ~2x increase in throughput (both read list-calls/s and write throughput under read load).
* **Full Scale (150,000 pods):** In steady-state runs (using perflock and 10s benchtime to eliminate thermal and startup noise), the optimization yields a statistically significant 2.5% to 5.6% reduction in listing latency. Under concurrent backlog-catching workloads, it prevents lock queue buildup yielding up to +78% throughput increase.

**Proposal:** This change simplifies the locking pattern, reduces lock acquisitions, and yields clear benefits in contention-heavy scenarios without any regressions.

1. Smaller scale (1,000 pods)
``` 
goos: linux
goarch: amd64
pkg: k8s.io/apiserver/pkg/storage/cacher
cpu: AMD Ryzen Threadripper PRO 3945WX 12-Cores     
                                                                                            │ baseline_quick.txt │         optimized_quick.txt          │
                                                                                            │       sec/op       │   sec/op     vs base                 │
StoreWriteThroughput/Namespaces=5/Pods=1000/Nodes=50/Traffic=Patch/Parallelism=25/Background=Lister/UseIndex=true-24       61.55µ ±  7%     31.23µ ± 6%  -49.27% (p=0.002 n=6)
StoreList/Namespaces=5/Pods=1000/Nodes=50/Indexed=true/RV=/Scope=Namespace/Paginate=0-24                                   76.51µ ±  7%     42.74µ ± 8%  -44.14% (p=0.002 n=6)
StoreList/Namespaces=5/Pods=1000/Nodes=50/Indexed=true/RV=Exact/Scope=Namespace/Paginate=0-24                              47.18µ ± 13%     30.00µ ± 8%  -36.41% (p=0.002 n=6)
StoreList/Namespaces=5/Pods=1000/Nodes=50/Indexed=true/RV=NotOlderThan/Scope=Namespace/Paginate=0-24                       42.90µ ±  7%     38.83µ ± 5%   -9.49% (p=0.002 n=6)
geomean                                                                                                                    60.09µ           35.31µ       -36.45%

                                                                                            │ baseline_quick.txt │         optimized_quick.txt         │
                                                                                            │    list-calls/s    │ list-calls/s  vs base               │
StoreWriteThroughput/Namespaces=5/Pods=1000/Nodes=50/Traffic=Patch/Parallelism=25/Background=Lister/UseIndex=true-24          58.37 ± 10%     99.75 ± 2%  +70.90% (p=0.002 n=6)

                                                                                            │ baseline_quick.txt │        optimized_quick.txt         │
                                                                                            │    list-objs/s     │ list-objs/s  vs base               │
StoreWriteThroughput/Namespaces=5/Pods=1000/Nodes=50/Traffic=Patch/Parallelism=25/Background=Lister/UseIndex=true-24         1.167k ± 10%   2.195k ± 2%  +87.97% (p=0.002 n=6)

                                                                                            │ baseline_quick.txt │      optimized_quick.txt       │
                                                                                            │   seconds-delay    │ seconds-delay  vs base         │
StoreWriteThroughput/Namespaces=5/Pods=1000/Nodes=50/Traffic=Patch/Parallelism=25/Background=Lister/UseIndex=true-24         388.9µ ± 25%    305.8µ ± 35%  ~ (p=0.093 n=6)

                                                                                            │ baseline_quick.txt │        optimized_quick.txt         │
                                                                                            │      writes/s      │  writes/s    vs base               │
StoreWriteThroughput/Namespaces=5/Pods=1000/Nodes=50/Traffic=Patch/Parallelism=25/Background=Lister/UseIndex=true-24          32.51k ± 7%   64.07k ± 5%  +97.10% (p=0.002 n=6)

```
2.  Full Scale  without perflock
```
goos: linux
goarch: amd64
pkg: k8s.io/apiserver/pkg/storage/cacher
cpu: AMD Ryzen Threadripper PRO 3945WX 12-Cores
                                                                                            │ baseline_parallel_final.txt │    optimized_parallel_final.txt     │
                                                                                            │        list-calls/s         │ list-calls/s  vs base               │
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallelism=25/B...                   64.53 ± 37%    82.50 ±  9%  +27.85% (p=0.026 n=6)
                                                                                            │ baseline_parallel_final.txt │    optimized_parallel_final.txt     │
                                                                                            │         list-objs/s         │ list-objs/s   vs base               │
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallelism=25/B...                  1.807k ± 37%   3.218k ±  9%  +78.09% (p=0.002 n=6)
```


3. Full Scale with perflock (150,000 pods)
```
goos: linux
goarch: amd64
pkg: k8s.io/apiserver/pkg/storage/cacher
cpu: AMD Ryzen Threadripper PRO 3945WX 12-Cores
                                                                                            │ baseline_perflock_stable.txt │    optimized_perflock_stable.txt    │
                                                                                            │            sec/op            │    sec/op      vs base              │
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallelism=25/B...                   30.26µ ± 289%   29.88µ ± 316%       ~ (p=0.240 n=6)
StoreList/Namespaces=50/Pods=150000/Nodes=5000/Indexed=true/RV=/Scope=Namespace/Paginate=0-24                 395.5µ ±   4%   402.2µ ±   2%       ~ (p=0.589 n=6)
StoreList/Namespaces=50/Pods=150000/Nodes=5000/Indexed=true/RV=Exact/Scope=Namespace/Paginate=0-24            341.5µ ±   2%   332.9µ ±   4%  -2.52% (p=0.026 n=6)
StoreList/Namespaces=50/Pods=150000/Nodes=5000/Indexed=true/RV=NotOlderThan/Scope=Namespace/P...             398.1µ ±   1%   375.7µ ±   3%  -5.63% (p=0.002 n=6)
geomean                                                                                                       200.8µ          196.9µ         -1.96%

                                                                                            │ baseline_perflock_stable.txt │    optimized_perflock_stable.txt     │
                                                                                            │           writes/s           │   writes/s    vs base                │
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallelism=25/B...                   66.22k ± 59%   67.27k ± 62%  ~ (p=0.240 n=6)

```


```release-note
NONE
```
