### PR TITLE
cleanup: remove deprecated kubelet CSR feature gate code branches

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -1192,11 +1192,13 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	AllowDNSOnlyNodeCSR: {
 		{Version: version.MustParse("1.0"), Default: true, PreRelease: featuregate.GA},
 		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Deprecated},
+		{Version: version.MustParse("1.35"), Default: false, PreRelease: featuregate.Deprecated, LockToDefault: true}, // remove in 1.38
 	},
 
 	AllowInsecureKubeletCertificateSigningRequests: {
 		{Version: version.MustParse("1.0"), Default: true, PreRelease: featuregate.GA},
 		{Version: version.MustParse("1.31"), Default: false, PreRelease: featuregate.Deprecated},
+		{Version: version.MustParse("1.35"), Default: false, PreRelease: featuregate.Deprecated, LockToDefault: true}, // remove in 1.38
 	},
 
 	AllowOverwriteTerminationGracePeriodSeconds: {

--- a/pkg/kubelet/certificate/kubelet.go
+++ b/pkg/kubelet/certificate/kubelet.go
@@ -32,13 +32,11 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/server/dynamiccertificates"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/certificate"
 	compbasemetrics "k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/pkg/features"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	netutils "k8s.io/utils/net"
@@ -49,11 +47,6 @@ func newGetTemplateFn(nodeName types.NodeName, getAddresses func() []v1.NodeAddr
 		hostnames, ips := addressesToHostnamesAndIPs(getAddresses())
 		// by default, require at least one IP before requesting a serving certificate
 		hasRequiredAddresses := len(ips) > 0
-
-		// optionally allow requesting a serving certificate with just a DNS name
-		if utilfeature.DefaultFeatureGate.Enabled(features.AllowDNSOnlyNodeCSR) {
-			hasRequiredAddresses = hasRequiredAddresses || len(hostnames) > 0
-		}
 
 		// don't return a template if we have no addresses to request for
 		if !hasRequiredAddresses {

--- a/pkg/kubelet/certificate/kubelet_test.go
+++ b/pkg/kubelet/certificate/kubelet_test.go
@@ -32,10 +32,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/util/cert"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/test/utils/client-go/ktesting"
 	netutils "k8s.io/utils/net"
 )
@@ -277,45 +274,21 @@ func TestNewCertificateManagerConfigGetTemplate(t *testing.T) {
 		name          string
 		nodeAddresses []v1.NodeAddress
 		want          *x509.CertificateRequest
-		featuregate   bool
 	}{
 		{
-			name:        "node addresses or hostnames and gate enabled",
-			featuregate: true,
+			name: "no addresses",
 		},
 		{
-			name:        "node addresses or hostnames and gate disabled",
-			featuregate: false,
-		},
-		{
-			name: "only hostnames and gate enabled",
+			name: "only hostnames",
 			nodeAddresses: []v1.NodeAddress{
 				{
 					Type:    v1.NodeHostName,
 					Address: nodeName,
 				},
 			},
-			want: &x509.CertificateRequest{
-				Subject: pkix.Name{
-					CommonName:   fmt.Sprintf("system:node:%s", nodeName),
-					Organization: []string{"system:nodes"},
-				},
-				DNSNames: []string{nodeName},
-			},
-			featuregate: true,
 		},
 		{
-			name: "only hostnames and gate disabled",
-			nodeAddresses: []v1.NodeAddress{
-				{
-					Type:    v1.NodeHostName,
-					Address: nodeName,
-				},
-			},
-			featuregate: false,
-		},
-		{
-			name: "only IP addresses and gate enabled",
+			name: "only IP addresses",
 			nodeAddresses: []v1.NodeAddress{
 				{
 					Type:    v1.NodeInternalIP,
@@ -329,27 +302,9 @@ func TestNewCertificateManagerConfigGetTemplate(t *testing.T) {
 				},
 				IPAddresses: []net.IP{nodeIP},
 			},
-			featuregate: true,
 		},
 		{
-			name: "only IP addresses and gate disabled",
-			nodeAddresses: []v1.NodeAddress{
-				{
-					Type:    v1.NodeInternalIP,
-					Address: nodeIP.String(),
-				},
-			},
-			want: &x509.CertificateRequest{
-				Subject: pkix.Name{
-					CommonName:   fmt.Sprintf("system:node:%s", nodeName),
-					Organization: []string{"system:nodes"},
-				},
-				IPAddresses: []net.IP{nodeIP},
-			},
-			featuregate: false,
-		},
-		{
-			name: "IP addresses and hostnames and gate enabled",
+			name: "IP addresses and hostnames",
 			nodeAddresses: []v1.NodeAddress{
 				{
 					Type:    v1.NodeHostName,
@@ -368,34 +323,10 @@ func TestNewCertificateManagerConfigGetTemplate(t *testing.T) {
 				DNSNames:    []string{nodeName},
 				IPAddresses: []net.IP{nodeIP},
 			},
-			featuregate: true,
-		},
-		{
-			name: "IP addresses and hostnames and gate disabled",
-			nodeAddresses: []v1.NodeAddress{
-				{
-					Type:    v1.NodeHostName,
-					Address: nodeName,
-				},
-				{
-					Type:    v1.NodeInternalIP,
-					Address: nodeIP.String(),
-				},
-			},
-			want: &x509.CertificateRequest{
-				Subject: pkix.Name{
-					CommonName:   fmt.Sprintf("system:node:%s", nodeName),
-					Organization: []string{"system:nodes"},
-				},
-				DNSNames:    []string{nodeName},
-				IPAddresses: []net.IP{nodeIP},
-			},
-			featuregate: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AllowDNSOnlyNodeCSR, tt.featuregate)
 			getAddresses := func() []v1.NodeAddress {
 				return tt.nodeAddresses
 			}

--- a/plugin/pkg/admission/noderestriction/admission.go
+++ b/plugin/pkg/admission/noderestriction/admission.go
@@ -91,7 +91,6 @@ type Plugin struct {
 	inspectedFeatureGates                          bool
 	expansionRecoveryEnabled                       bool
 	dynamicResourceAllocationEnabled               bool
-	allowInsecureKubeletCertificateSigningRequests bool
 	serviceAccountNodeAudienceRestriction          bool
 	podCertificateRequestsEnabled                  bool
 }
@@ -107,7 +106,6 @@ var (
 func (p *Plugin) InspectFeatureGates(featureGates featuregate.FeatureGate) {
 	p.expansionRecoveryEnabled = featureGates.Enabled(features.RecoverVolumeExpansionFailure)
 	p.dynamicResourceAllocationEnabled = featureGates.Enabled(features.DynamicResourceAllocation)
-	p.allowInsecureKubeletCertificateSigningRequests = featureGates.Enabled(features.AllowInsecureKubeletCertificateSigningRequests)
 	p.serviceAccountNodeAudienceRestriction = featureGates.Enabled(features.ServiceAccountNodeAudienceRestriction)
 	p.podCertificateRequestsEnabled = featureGates.Enabled(features.PodCertificateRequest)
 	p.inspectedFeatureGates = true
@@ -238,9 +236,6 @@ func (p *Plugin) Admit(ctx context.Context, a admission.Attributes, o admission.
 		return p.admitResourceSlice(nodeName, a)
 
 	case csrResource:
-		if p.allowInsecureKubeletCertificateSigningRequests {
-			return nil
-		}
 		return p.admitCSR(nodeName, a)
 	default:
 		return nil

--- a/plugin/pkg/admission/noderestriction/admission_test.go
+++ b/plugin/pkg/admission/noderestriction/admission_test.go
@@ -1829,16 +1829,6 @@ func Test_nodePlugin_Admit(t *testing.T) {
 			err:        "forbidden: can only create a node CSR with CN=system:node:mynode",
 		},
 		{
-			name:       "allow CSR create incorrect node with feature gate disabled",
-			attributes: createCSRAttributes("system:node:othernode", certificatesapi.KubeletServingSignerName, true, privKey, mynode),
-			err:        "",
-			features:   feature.DefaultFeatureGate,
-			setupFunc: func(t *testing.T) {
-				t.Helper()
-				featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.AllowInsecureKubeletCertificateSigningRequests, true)
-			},
-		},
-		{
 			name:       "deny CSR create invalid",
 			attributes: createCSRAttributes("system:node:mynode", certificatesapi.KubeletServingSignerName, false, privKey, mynode),
 			err:        "unable to parse csr: asn1: syntax error: sequence truncated",


### PR DESCRIPTION
## What this PR does

Removes dead code guarded by two deprecated feature gates that have been
locked to false since v1.35:

- `AllowDNSOnlyNodeCSR` — allowed kubelet to serve CSRs using DNS names only, without Node IPs
- `AllowInsecureKubeletCertificateSigningRequests` — disabled strict NodeRestriction validation for kubelet CSR signers

Both gates were introduced in v1.31 as temporary compatibility switches.

## Changes

- `pkg/kubelet/certificate/kubelet.go` — remove DNS-only compatibility branch
- `plugin/pkg/admission/noderestriction/admission.go` — remove insecure CSR admission bypass, struct field, and feature gate assignment
- Remove tests that tested the now-removed behavior
- Remove unused imports

## Testing

- `go test ./pkg/kubelet/...` ✅ all pass
- `go test ./plugin/pkg/admission/noderestriction/...` ✅ pass

Fixes #139410

kind/cleanup 
area/kubelet
sig/auth
sig/node

## Manual verification on local cluster

Verified gate is locked:
$ ./_output/bin/kubelet --feature-gates=AllowDNSOnlyNodeCSR=true
Error: cannot set feature gate AllowDNSOnlyNodeCSR to true, feature is locked to false

Verified kubelet CSR now always requires IP address:
$ kubectl get csr csr-lbg8d -o jsonpath='{.spec.request}' | base64 -d | openssl req -noout -text | grep -A2 "Subject Alternative"
X509v3 Subject Alternative Name:
    IP Address:127.0.0.1
    



```release-note
NONE
```