### PR TITLE
Handling syscall failures when hns is not running.

### DIFF
--- a/pkg/proxy/winkernel/hns.go
+++ b/pkg/proxy/winkernel/hns.go
@@ -42,6 +42,7 @@ type HostNetworkService interface {
 	deleteEndpoint(hnsID string) error
 	getLoadBalancer(endpoints []endpointInfo, flags loadBalancerFlags, sourceVip string, vip string, protocol uint16, internalPort uint16, externalPort uint16, previousLoadBalancers map[loadBalancerIdentifier]*loadBalancerInfo) (*loadBalancerInfo, error)
 	getAllLoadBalancers() (map[loadBalancerIdentifier]*loadBalancerInfo, error)
+	createLoadbalancerWithRetry(proposedLB *hcn.HostComputeLoadBalancer, existingLBs map[loadBalancerIdentifier]*loadBalancerInfo) (*hcn.HostComputeLoadBalancer, error)
 	updateLoadBalancer(hnsID string, sourceVip, vip string, endpoints []endpointInfo, flags loadBalancerFlags, protocol, internalPort, externalPort uint16, previousLoadBalancers map[loadBalancerIdentifier]*loadBalancerInfo) (*loadBalancerInfo, error)
 	deleteLoadBalancer(hnsID string) error
 }
@@ -56,6 +57,45 @@ var (
 	// LoadBalancerPortMappingFlagsVipExternalIP enables VipExternalIP.
 	LoadBalancerPortMappingFlagsVipExternalIP hcn.LoadBalancerPortMappingFlags = 16
 )
+
+const (
+	errorCodeHnsNotRunning     = "0x6b5"
+	errorCodeFileAlreadyExists = "0xb7"
+)
+
+// isHnsNotRunningError checks if the error is due to HNS service not running by looking for the specific error code in the error message.
+func isHnsNotRunningError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), errorCodeHnsNotRunning)
+}
+
+// isFileAlreadyExistsError checks if the error is due to an entity already existing by looking for the specific error code in the error message.
+func isFileAlreadyExistsError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), errorCodeFileAlreadyExists)
+}
+
+// findExistingLBIdByFrontend finds the ID of an existing load balancer that matches the frontend configuration of the proposed load balancer.
+func findExistingLBIdByFrontend(proposedLB *hcn.HostComputeLoadBalancer, existingLBs map[loadBalancerIdentifier]*loadBalancerInfo) string {
+	if len(proposedLB.PortMappings) == 0 {
+		return ""
+	}
+	lbID, matchingLbIDsCount := "", 0
+	frontEndVIP, isProposedLbIPv6 := "", (proposedLB.Flags&LoadBalancerFlagsIPv6) == LoadBalancerFlagsIPv6
+	if len(proposedLB.FrontendVIPs) != 0 {
+		frontEndVIP = proposedLB.FrontendVIPs[0]
+	}
+	for id, lbInfo := range existingLBs {
+		if id.vip == frontEndVIP && id.protocol == uint16(proposedLB.PortMappings[0].Protocol) && id.internalPort == proposedLB.PortMappings[0].InternalPort && id.externalPort == proposedLB.PortMappings[0].ExternalPort && id.isIPv6 == isProposedLbIPv6 {
+			lbID = lbInfo.hnsID
+			matchingLbIDsCount++
+		}
+	}
+	if matchingLbIDsCount == 1 {
+		klog.V(1).InfoS("Found existing load balancer with matching frontend configuration", "lbID", lbID, "frontendVIP", frontEndVIP, "protocol", proposedLB.PortMappings[0].Protocol, "internalPort", proposedLB.PortMappings[0].InternalPort, "externalPort", proposedLB.PortMappings[0].ExternalPort, "isIPv6", isProposedLbIPv6)
+		return lbID
+	}
+	klog.V(1).InfoS("Did not find a unique existing load balancer with matching frontend configuration", "matchingLbIDsCount", matchingLbIDsCount, "frontendVIP", frontEndVIP, "protocol", proposedLB.PortMappings[0].Protocol, "internalPort", proposedLB.PortMappings[0].InternalPort, "externalPort", proposedLB.PortMappings[0].ExternalPort, "isIPv6", isProposedLbIPv6)
+	return ""
+}
 
 func getLoadBalancerPolicyFlags(flags loadBalancerFlags) (lbPortMappingFlags hcn.LoadBalancerPortMappingFlags, lbFlags hcn.LoadBalancerFlags) {
 	lbPortMappingFlags = hcn.LoadBalancerPortMappingFlagsNone
@@ -369,6 +409,29 @@ func (hns hns) getAllLoadBalancers() (map[loadBalancerIdentifier]*loadBalancerIn
 	return loadBalancers, nil
 }
 
+func (hns hns) createLoadbalancerWithRetry(proposedLB *hcn.HostComputeLoadBalancer, existingLBs map[loadBalancerIdentifier]*loadBalancerInfo) (*hcn.HostComputeLoadBalancer, error) {
+	lb, err := hns.hcn.CreateLoadBalancer(proposedLB)
+	if isFileAlreadyExistsError(err) && len(proposedLB.PortMappings) > 0 {
+		frontEndVIP := ""
+		if len(proposedLB.FrontendVIPs) != 0 {
+			frontEndVIP = proposedLB.FrontendVIPs[0]
+		}
+		existingLbID := findExistingLBIdByFrontend(proposedLB, existingLBs)
+		if existingLbID != "" {
+			klog.V(1).InfoS("Retrying create load balancer again", "frontendVIP", frontEndVIP, "protocol", proposedLB.PortMappings[0].Protocol, "internalPort", proposedLB.PortMappings[0].InternalPort, "externalPort", proposedLB.PortMappings[0].ExternalPort)
+			err = hns.deleteLoadBalancer(existingLbID)
+			if err != nil {
+				klog.V(1).InfoS("Failed to delete existing load balancer", "lbID", existingLbID, "error", err)
+				return nil, err
+			}
+			lb, err = hns.hcn.CreateLoadBalancer(proposedLB)
+		} else {
+			klog.V(1).InfoS("Did not find a unique existing load balancer with matching frontend configuration", "frontendVIP", frontEndVIP, "protocol", proposedLB.PortMappings[0].Protocol, "internalPort", proposedLB.PortMappings[0].InternalPort, "externalPort", proposedLB.PortMappings[0].ExternalPort)
+		}
+	}
+	return lb, err
+}
+
 func (hns hns) getLoadBalancer(endpoints []endpointInfo, flags loadBalancerFlags, sourceVip string, vip string, protocol uint16, internalPort uint16, externalPort uint16, previousLoadBalancers map[loadBalancerIdentifier]*loadBalancerInfo) (*loadBalancerInfo, error) {
 	var id loadBalancerIdentifier
 	vips := []string{}
@@ -450,9 +513,10 @@ func (hns hns) getLoadBalancer(endpoints []endpointInfo, flags loadBalancerFlags
 		loadBalancer.HostComputeEndpoints = append(loadBalancer.HostComputeEndpoints, ep.hnsID)
 	}
 
-	lb, err := hns.hcn.CreateLoadBalancer(loadBalancer)
+	lb, err := hns.createLoadbalancerWithRetry(loadBalancer, previousLoadBalancers)
 
 	if err != nil {
+		klog.V(2).ErrorS(err, "Error creating Hns loadbalancer policy resource", "error", err, "endpoints", endpoints)
 		return nil, err
 	}
 
@@ -546,8 +610,17 @@ func (hns hns) updateLoadBalancer(hnsID string,
 func (hns hns) deleteLoadBalancer(hnsID string) error {
 	lb, err := hns.hcn.GetLoadBalancerByID(hnsID)
 	if err != nil {
-		// Return silently
-		return nil
+		if hcn.IsNotFoundError(err) {
+			klog.V(1).InfoS("LoadBalancer policy resource not found, may have already been deleted", "lbID", hnsID)
+			// Return silently
+			return nil
+		}
+		if isHnsNotRunningError(err) {
+			klog.V(1).ErrorS(err, "HNS is not running, skipping delete loadbalancer", "lbID", hnsID)
+			return err
+		}
+		klog.V(2).ErrorS(err, "Error getting Hns loadbalancer policy resource by ID", "lbID", hnsID)
+		return err
 	}
 
 	err = hns.hcn.DeleteLoadBalancer(lb)

--- a/pkg/proxy/winkernel/hns.go
+++ b/pkg/proxy/winkernel/hns.go
@@ -59,7 +59,15 @@ var (
 )
 
 const (
-	errorCodeHnsNotRunning     = "0x6b5"
+
+	// 0x6b5 is a standard Win32 RPC error (RPC_S_UNKNOWN_IF).
+	// It is returned by the RPC runtime when the target service's
+	// RPC interface is not registered. In this context, it typically
+	// indicates that the HNS service is not running or not yet initialized.
+	errorCodeHnsNotRunning = "0x6b5"
+
+	// 0xb7 (ERROR_ALREADY_EXISTS): Object already exists.
+	// Returned when attempting to create a resource that already exists.
 	errorCodeFileAlreadyExists = "0xb7"
 )
 
@@ -418,7 +426,7 @@ func (hns hns) createLoadbalancerWithRetry(proposedLB *hcn.HostComputeLoadBalanc
 		}
 		existingLbID := findExistingLBIdByFrontend(proposedLB, existingLBs)
 		if existingLbID != "" {
-			klog.V(1).InfoS("Retrying create load balancer again", "frontendVIP", frontEndVIP, "protocol", proposedLB.PortMappings[0].Protocol, "internalPort", proposedLB.PortMappings[0].InternalPort, "externalPort", proposedLB.PortMappings[0].ExternalPort)
+			klog.V(1).InfoS("Deleting matching load balancer and retrying create load balancer again", "existingLBID", existingLbID, "frontendVIP", frontEndVIP, "protocol", proposedLB.PortMappings[0].Protocol, "internalPort", proposedLB.PortMappings[0].InternalPort, "externalPort", proposedLB.PortMappings[0].ExternalPort)
 			err = hns.deleteLoadBalancer(existingLbID)
 			if err != nil {
 				klog.V(1).InfoS("Failed to delete existing load balancer", "lbID", existingLbID, "error", err)

--- a/pkg/proxy/winkernel/hns.go
+++ b/pkg/proxy/winkernel/hns.go
@@ -42,7 +42,7 @@ type HostNetworkService interface {
 	deleteEndpoint(hnsID string) error
 	getLoadBalancer(endpoints []endpointInfo, flags loadBalancerFlags, sourceVip string, vip string, protocol uint16, internalPort uint16, externalPort uint16, previousLoadBalancers map[loadBalancerIdentifier]*loadBalancerInfo) (*loadBalancerInfo, error)
 	getAllLoadBalancers() (map[loadBalancerIdentifier]*loadBalancerInfo, error)
-	createLoadbalancerWithRetry(proposedLB *hcn.HostComputeLoadBalancer, existingLBs map[loadBalancerIdentifier]*loadBalancerInfo) (*hcn.HostComputeLoadBalancer, error)
+	createOrReplaceLoadbalancer(proposedLB *hcn.HostComputeLoadBalancer, existingLBs map[loadBalancerIdentifier]*loadBalancerInfo) (*hcn.HostComputeLoadBalancer, error)
 	updateLoadBalancer(hnsID string, sourceVip, vip string, endpoints []endpointInfo, flags loadBalancerFlags, protocol, internalPort, externalPort uint16, previousLoadBalancers map[loadBalancerIdentifier]*loadBalancerInfo) (*loadBalancerInfo, error)
 	deleteLoadBalancer(hnsID string) error
 }
@@ -71,8 +71,8 @@ const (
 	errorCodeFileAlreadyExists = "0xb7"
 )
 
-// isHnsNotRunningError checks if the error is due to HNS service not running by looking for the specific error code in the error message.
-func isHnsNotRunningError(err error) bool {
+// IsHnsNotRunningError checks if the error is due to HNS service not running by looking for the specific error code in the error message.
+func IsHnsNotRunningError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), errorCodeHnsNotRunning)
 }
 
@@ -91,23 +91,23 @@ func findExistingLBIdByFrontend(proposedLB *hcn.HostComputeLoadBalancer, existin
 	if len(proposedLB.PortMappings) == 0 {
 		return ""
 	}
-	lbID, matchingLbIDsCount := "", 0
+	lbID := ""
 	frontEndVIP, isProposedLbIPv6 := "", (proposedLB.Flags&LoadBalancerFlagsIPv6) == LoadBalancerFlagsIPv6
 	if len(proposedLB.FrontendVIPs) != 0 {
 		frontEndVIP = proposedLB.FrontendVIPs[0]
 	}
 	for id, lbInfo := range existingLBs {
 		if id.vip == frontEndVIP && id.protocol == uint16(proposedLB.PortMappings[0].Protocol) && id.internalPort == proposedLB.PortMappings[0].InternalPort && id.externalPort == proposedLB.PortMappings[0].ExternalPort && id.isIPv6 == isProposedLbIPv6 {
+			if lbID != "" {
+				// More than 1 existing LB has the same frontend configuration, return no match to avoid deleting any of them
+				klog.Warning("More than 1 existing lb has matching frontend, will not delete any existing lbs", "existingLBID1", lbID, "existingLBID2", lbInfo.hnsID, "frontendVIP", frontEndVIP, "protocol", proposedLB.PortMappings[0].Protocol, "internalPort", proposedLB.PortMappings[0].InternalPort, "externalPort", proposedLB.PortMappings[0].ExternalPort, "isIPv6", isProposedLbIPv6)
+				return ""
+			}
 			lbID = lbInfo.hnsID
-			matchingLbIDsCount++
 		}
 	}
-	if matchingLbIDsCount == 1 {
-		klog.V(1).InfoS("Found existing load balancer with matching frontend configuration", "lbID", lbID, "frontendVIP", frontEndVIP, "protocol", proposedLB.PortMappings[0].Protocol, "internalPort", proposedLB.PortMappings[0].InternalPort, "externalPort", proposedLB.PortMappings[0].ExternalPort, "isIPv6", isProposedLbIPv6)
-		return lbID
-	}
-	klog.V(1).InfoS("Did not find a unique existing load balancer with matching frontend configuration", "matchingLbIDsCount", matchingLbIDsCount, "frontendVIP", frontEndVIP, "protocol", proposedLB.PortMappings[0].Protocol, "internalPort", proposedLB.PortMappings[0].InternalPort, "externalPort", proposedLB.PortMappings[0].ExternalPort, "isIPv6", isProposedLbIPv6)
-	return ""
+	klog.V(4).InfoS("Search for existing lb with matching frontend completed", "lbID", lbID, "frontendVIP", frontEndVIP, "protocol", proposedLB.PortMappings[0].Protocol, "internalPort", proposedLB.PortMappings[0].InternalPort, "externalPort", proposedLB.PortMappings[0].ExternalPort, "isIPv6", isProposedLbIPv6)
+	return lbID
 }
 
 func getLoadBalancerPolicyFlags(flags loadBalancerFlags) (lbPortMappingFlags hcn.LoadBalancerPortMappingFlags, lbFlags hcn.LoadBalancerFlags) {
@@ -422,7 +422,7 @@ func (hns hns) getAllLoadBalancers() (map[loadBalancerIdentifier]*loadBalancerIn
 	return loadBalancers, nil
 }
 
-func (hns hns) createLoadbalancerWithRetry(proposedLB *hcn.HostComputeLoadBalancer, existingLBs map[loadBalancerIdentifier]*loadBalancerInfo) (*hcn.HostComputeLoadBalancer, error) {
+func (hns hns) createOrReplaceLoadbalancer(proposedLB *hcn.HostComputeLoadBalancer, existingLBs map[loadBalancerIdentifier]*loadBalancerInfo) (*hcn.HostComputeLoadBalancer, error) {
 	lb, err := hns.hcn.CreateLoadBalancer(proposedLB)
 	if IsPolicyAlreadyExists(err) && len(proposedLB.PortMappings) > 0 {
 		frontEndVIP := ""
@@ -431,7 +431,7 @@ func (hns hns) createLoadbalancerWithRetry(proposedLB *hcn.HostComputeLoadBalanc
 		}
 		existingLbID := findExistingLBIdByFrontend(proposedLB, existingLBs)
 		if existingLbID != "" {
-			klog.V(1).InfoS("Deleting matching load balancer and retrying create load balancer again", "existingLBID", existingLbID, "frontendVIP", frontEndVIP, "protocol", proposedLB.PortMappings[0].Protocol, "internalPort", proposedLB.PortMappings[0].InternalPort, "externalPort", proposedLB.PortMappings[0].ExternalPort)
+			klog.V(4).InfoS("Deleting matching load balancer and retrying create load balancer again", "existingLBID", existingLbID, "frontendVIP", frontEndVIP, "protocol", proposedLB.PortMappings[0].Protocol, "internalPort", proposedLB.PortMappings[0].InternalPort, "externalPort", proposedLB.PortMappings[0].ExternalPort)
 			err = hns.deleteLoadBalancer(existingLbID)
 			if err != nil {
 				klog.V(1).InfoS("Failed to delete existing load balancer", "lbID", existingLbID, "error", err)
@@ -439,7 +439,7 @@ func (hns hns) createLoadbalancerWithRetry(proposedLB *hcn.HostComputeLoadBalanc
 			}
 			lb, err = hns.hcn.CreateLoadBalancer(proposedLB)
 		} else {
-			klog.V(1).InfoS("Did not find a unique existing load balancer with matching frontend configuration", "frontendVIP", frontEndVIP, "protocol", proposedLB.PortMappings[0].Protocol, "internalPort", proposedLB.PortMappings[0].InternalPort, "externalPort", proposedLB.PortMappings[0].ExternalPort)
+			klog.V(4).InfoS("Did not find a unique existing load balancer with matching frontend configuration", "frontendVIP", frontEndVIP, "protocol", proposedLB.PortMappings[0].Protocol, "internalPort", proposedLB.PortMappings[0].InternalPort, "externalPort", proposedLB.PortMappings[0].ExternalPort)
 		}
 	}
 	return lb, err
@@ -526,7 +526,7 @@ func (hns hns) getLoadBalancer(endpoints []endpointInfo, flags loadBalancerFlags
 		loadBalancer.HostComputeEndpoints = append(loadBalancer.HostComputeEndpoints, ep.hnsID)
 	}
 
-	lb, err := hns.createLoadbalancerWithRetry(loadBalancer, previousLoadBalancers)
+	lb, err := hns.createOrReplaceLoadbalancer(loadBalancer, previousLoadBalancers)
 
 	if err != nil {
 		klog.V(2).ErrorS(err, "Error creating Hns loadbalancer policy resource", "error", err, "endpoints", endpoints)
@@ -628,7 +628,7 @@ func (hns hns) deleteLoadBalancer(hnsID string) error {
 			// Return silently
 			return nil
 		}
-		if isHnsNotRunningError(err) {
+		if IsHnsNotRunningError(err) {
 			klog.V(1).ErrorS(err, "HNS is not running, skipping delete loadbalancer", "lbID", hnsID)
 			return err
 		}

--- a/pkg/proxy/winkernel/hns.go
+++ b/pkg/proxy/winkernel/hns.go
@@ -76,9 +76,14 @@ func isHnsNotRunningError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), errorCodeHnsNotRunning)
 }
 
-// isFileAlreadyExistsError checks if the error is due to an entity already existing by looking for the specific error code in the error message.
-func isFileAlreadyExistsError(err error) bool {
-	return err != nil && strings.Contains(err.Error(), errorCodeFileAlreadyExists)
+// IsPolicyAlreadyExists checks if the error is due to a load balancer policy already existing with
+// the same frontend configuration by checking for specific error conditions, including the presence
+// of a specific error code or message indicating a resource already exists.
+func IsPolicyAlreadyExists(err error) bool {
+	if err == nil {
+		return false
+	}
+	return hcn.IsPortAlreadyExistsError(err) || strings.Contains(err.Error(), errorCodeFileAlreadyExists)
 }
 
 // findExistingLBIdByFrontend finds the ID of an existing load balancer that matches the frontend configuration of the proposed load balancer.
@@ -419,7 +424,7 @@ func (hns hns) getAllLoadBalancers() (map[loadBalancerIdentifier]*loadBalancerIn
 
 func (hns hns) createLoadbalancerWithRetry(proposedLB *hcn.HostComputeLoadBalancer, existingLBs map[loadBalancerIdentifier]*loadBalancerInfo) (*hcn.HostComputeLoadBalancer, error) {
 	lb, err := hns.hcn.CreateLoadBalancer(proposedLB)
-	if isFileAlreadyExistsError(err) && len(proposedLB.PortMappings) > 0 {
+	if IsPolicyAlreadyExists(err) && len(proposedLB.PortMappings) > 0 {
 		frontEndVIP := ""
 		if len(proposedLB.FrontendVIPs) != 0 {
 			frontEndVIP = proposedLB.FrontendVIPs[0]

--- a/pkg/proxy/winkernel/hns_test.go
+++ b/pkg/proxy/winkernel/hns_test.go
@@ -20,6 +20,7 @@ package winkernel
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -723,4 +724,310 @@ func createTestNetwork() (*hcn.HostComputeNetwork, error) {
 	network.Ipams[0].Subnets[0].Policies = append(network.Ipams[0].Subnets[0].Policies, spJson)
 
 	return network.Create()
+}
+
+func TestIsHnsNotRunningError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "HNS not running error during enumerate endpoints",
+			err:      fmt.Errorf("hcnEnumerateEndpoints failed in Win32: The interface is unknown. (0x6b5)"),
+			expected: true,
+		},
+		{
+			name:     "HNS not running error during enumerate networks",
+			err:      fmt.Errorf("hcnEnumerateNetworks failed in Win32: The interface is unknown. (0x6b5)"),
+			expected: true,
+		},
+		{
+			name:     "unrelated error",
+			err:      fmt.Errorf("some other error"),
+			expected: false,
+		},
+		{
+			name:     "error containing 0xb7 but not 0x6b5",
+			err:      fmt.Errorf("file already exists: 0xb7"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isHnsNotRunningError(tt.err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsFileAlreadyExistsError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "file already exists error",
+			err:      fmt.Errorf("HNS error: 0xb7 - The specified port already exists."),
+			expected: true,
+		},
+		{
+			name:     "unrelated error",
+			err:      fmt.Errorf("some other error"),
+			expected: false,
+		},
+		{
+			name:     "HNS not running error (not file exists)",
+			err:      fmt.Errorf("HNS call failed: 0x6b5"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isFileAlreadyExistsError(tt.err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFindExistingLBIdByFrontend(t *testing.T) {
+	tests := []struct {
+		name        string
+		proposedLB  *hcn.HostComputeLoadBalancer
+		existingLBs map[loadBalancerIdentifier]*loadBalancerInfo
+		expectedID  string
+	}{
+		{
+			name: "single matching LB found",
+			proposedLB: &hcn.HostComputeLoadBalancer{
+				FrontendVIPs: []string{serviceVip},
+				PortMappings: []hcn.LoadBalancerPortMapping{
+					{Protocol: protocol, InternalPort: internalPort, ExternalPort: externalPort},
+				},
+				Flags: hcn.LoadBalancerFlagsNone,
+			},
+			existingLBs: map[loadBalancerIdentifier]*loadBalancerInfo{
+				{vip: serviceVip, protocol: protocol, internalPort: internalPort, externalPort: externalPort, isIPv6: false}: {hnsID: "lb-123"},
+			},
+			expectedID: "lb-123",
+		},
+		{
+			name: "no matching LB",
+			proposedLB: &hcn.HostComputeLoadBalancer{
+				FrontendVIPs: []string{serviceVip},
+				PortMappings: []hcn.LoadBalancerPortMapping{
+					{Protocol: protocol, InternalPort: internalPort, ExternalPort: externalPort},
+				},
+				Flags: hcn.LoadBalancerFlagsNone,
+			},
+			existingLBs: map[loadBalancerIdentifier]*loadBalancerInfo{
+				{vip: "10.0.0.99", protocol: protocol, internalPort: internalPort, externalPort: externalPort, isIPv6: false}: {hnsID: "lb-999"},
+			},
+			expectedID: "",
+		},
+		{
+			name: "multiple matching LBs returns empty (ambiguous)",
+			proposedLB: &hcn.HostComputeLoadBalancer{
+				FrontendVIPs: []string{serviceVip},
+				PortMappings: []hcn.LoadBalancerPortMapping{
+					{Protocol: protocol, InternalPort: internalPort, ExternalPort: externalPort},
+				},
+				Flags: hcn.LoadBalancerFlagsNone,
+			},
+			existingLBs: map[loadBalancerIdentifier]*loadBalancerInfo{
+				{vip: serviceVip, protocol: protocol, internalPort: internalPort, externalPort: externalPort, isIPv6: false}:                             {hnsID: "lb-1"},
+				{vip: serviceVip, protocol: protocol, internalPort: internalPort, externalPort: externalPort, isIPv6: false, endpointsHash: [20]byte{1}}: {hnsID: "lb-2"},
+			},
+			expectedID: "",
+		},
+		{
+			name: "empty existing LBs map",
+			proposedLB: &hcn.HostComputeLoadBalancer{
+				FrontendVIPs: []string{serviceVip},
+				PortMappings: []hcn.LoadBalancerPortMapping{
+					{Protocol: protocol, InternalPort: internalPort, ExternalPort: externalPort},
+				},
+				Flags: hcn.LoadBalancerFlagsNone,
+			},
+			existingLBs: map[loadBalancerIdentifier]*loadBalancerInfo{},
+			expectedID:  "",
+		},
+		{
+			name: "IPv6 LB matches only IPv6 entry",
+			proposedLB: &hcn.HostComputeLoadBalancer{
+				FrontendVIPs: []string{"fd00::1"},
+				PortMappings: []hcn.LoadBalancerPortMapping{
+					{Protocol: protocol, InternalPort: internalPort, ExternalPort: externalPort},
+				},
+				Flags: LoadBalancerFlagsIPv6,
+			},
+			existingLBs: map[loadBalancerIdentifier]*loadBalancerInfo{
+				{vip: "fd00::1", protocol: protocol, internalPort: internalPort, externalPort: externalPort, isIPv6: true}:  {hnsID: "lb-v6"},
+				{vip: "fd00::1", protocol: protocol, internalPort: internalPort, externalPort: externalPort, isIPv6: false}: {hnsID: "lb-v4"},
+			},
+			expectedID: "lb-v6",
+		},
+		{
+			name: "proposed LB with empty FrontendVIPs matches empty vip entry",
+			proposedLB: &hcn.HostComputeLoadBalancer{
+				FrontendVIPs: []string{},
+				PortMappings: []hcn.LoadBalancerPortMapping{
+					{Protocol: protocol, InternalPort: internalPort, ExternalPort: externalPort},
+				},
+				Flags: hcn.LoadBalancerFlagsNone,
+			},
+			existingLBs: map[loadBalancerIdentifier]*loadBalancerInfo{
+				{vip: "", protocol: protocol, internalPort: internalPort, externalPort: externalPort, isIPv6: false}: {hnsID: "lb-nodeport"},
+			},
+			expectedID: "lb-nodeport",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := findExistingLBIdByFrontend(tt.proposedLB, tt.existingLBs)
+			assert.Equal(t, tt.expectedID, result)
+		})
+	}
+}
+
+func TestCreateLoadbalancerWithRetry_Success(t *testing.T) {
+	hcnMock := getHcnMock("L2Bridge")
+	hns := hns{hcn: hcnMock}
+
+	proposedLB := &hcn.HostComputeLoadBalancer{
+		FrontendVIPs: []string{serviceVip},
+		PortMappings: []hcn.LoadBalancerPortMapping{
+			{Protocol: protocol, InternalPort: internalPort, ExternalPort: externalPort},
+		},
+		Flags: hcn.LoadBalancerFlagsNone,
+	}
+	existingLBs := map[loadBalancerIdentifier]*loadBalancerInfo{}
+
+	lb, err := hns.createLoadbalancerWithRetry(proposedLB, existingLBs)
+	assert.NoError(t, err)
+	assert.NotNil(t, lb)
+	assert.NotEmpty(t, lb.Id)
+}
+
+func TestCreateLoadbalancerWithRetry_FileAlreadyExistsAndRetrySucceeds(t *testing.T) {
+	hcnMock := getHcnMock("L2Bridge")
+	hns := hns{hcn: hcnMock}
+
+	// Create an existing LB that will conflict
+	existingLB := &hcn.HostComputeLoadBalancer{
+		FrontendVIPs: []string{serviceVip},
+		PortMappings: []hcn.LoadBalancerPortMapping{
+			{Protocol: protocol, InternalPort: internalPort, ExternalPort: externalPort},
+		},
+		Flags: hcn.LoadBalancerFlagsNone,
+	}
+	createdLB, err := hcnMock.CreateLoadBalancer(existingLB)
+	assert.NoError(t, err)
+
+	// Build the existingLBs map that the retry logic uses to find the conflicting LB
+	existingLBs := map[loadBalancerIdentifier]*loadBalancerInfo{
+		{vip: serviceVip, protocol: protocol, internalPort: internalPort, externalPort: externalPort, isIPv6: false}: {hnsID: createdLB.Id},
+	}
+
+	// Now attempt to create a duplicate — should get 0xb7, find existing, delete it, and retry
+	proposedLB := &hcn.HostComputeLoadBalancer{
+		FrontendVIPs: []string{serviceVip},
+		PortMappings: []hcn.LoadBalancerPortMapping{
+			{Protocol: protocol, InternalPort: internalPort, ExternalPort: externalPort},
+		},
+		Flags: hcn.LoadBalancerFlagsNone,
+	}
+
+	lb, err := hns.createLoadbalancerWithRetry(proposedLB, existingLBs)
+	assert.NoError(t, err)
+	assert.NotNil(t, lb)
+	assert.NotEqual(t, createdLB.Id, lb.Id, "should have created a new LB after deleting the old one")
+}
+
+func TestCreateLoadbalancerWithRetry_FileAlreadyExistsNoMatchingLB(t *testing.T) {
+	hcnMock := getHcnMock("L2Bridge")
+	hns := hns{hcn: hcnMock}
+
+	// Create an existing LB that will conflict at HCN level
+	existingLB := &hcn.HostComputeLoadBalancer{
+		FrontendVIPs: []string{serviceVip},
+		PortMappings: []hcn.LoadBalancerPortMapping{
+			{Protocol: protocol, InternalPort: internalPort, ExternalPort: externalPort},
+		},
+		Flags: hcn.LoadBalancerFlagsNone,
+	}
+	_, err := hcnMock.CreateLoadBalancer(existingLB)
+	assert.NoError(t, err)
+
+	// existingLBs doesn't contain the conflicting LB — can't find it by frontend
+	existingLBs := map[loadBalancerIdentifier]*loadBalancerInfo{}
+
+	proposedLB := &hcn.HostComputeLoadBalancer{
+		FrontendVIPs: []string{serviceVip},
+		PortMappings: []hcn.LoadBalancerPortMapping{
+			{Protocol: protocol, InternalPort: internalPort, ExternalPort: externalPort},
+		},
+		Flags: hcn.LoadBalancerFlagsNone,
+	}
+
+	lb, err := hns.createLoadbalancerWithRetry(proposedLB, existingLBs)
+	assert.Error(t, err, "should return the original 0xb7 error since no matching LB was found to delete")
+	assert.Nil(t, lb)
+}
+
+func TestDeleteLoadBalancer_NotFound(t *testing.T) {
+	hcnMock := getHcnMock("L2Bridge")
+	hns := hns{hcn: hcnMock}
+
+	// Deleting a non-existent LB should return nil (silently)
+	err := hns.deleteLoadBalancer("non-existent-lb-id")
+	assert.NoError(t, err, "deleteLoadBalancer should return nil for not-found errors")
+}
+
+func TestDeleteLoadBalancer_HnsNotRunning(t *testing.T) {
+	hcnMock := getHcnMock("L2Bridge")
+	hcnMock.ShouldReturnHnsNotRunning = true
+	hns := hns{hcn: hcnMock}
+
+	err := hns.deleteLoadBalancer("any-lb-id")
+	assert.Error(t, err, "deleteLoadBalancer should return error when HNS is not running")
+	assert.True(t, isHnsNotRunningError(err))
+}
+
+func TestDeleteLoadBalancer_Success(t *testing.T) {
+	hcnMock := getHcnMock("L2Bridge")
+	hns := hns{hcn: hcnMock}
+
+	// Create a LB first
+	lb := &hcn.HostComputeLoadBalancer{
+		FrontendVIPs: []string{serviceVip},
+		PortMappings: []hcn.LoadBalancerPortMapping{
+			{Protocol: protocol, InternalPort: internalPort, ExternalPort: externalPort},
+		},
+		Flags: hcn.LoadBalancerFlagsNone,
+	}
+	createdLB, err := hcnMock.CreateLoadBalancer(lb)
+	assert.NoError(t, err)
+
+	// Delete it
+	err = hns.deleteLoadBalancer(createdLB.Id)
+	assert.NoError(t, err)
+
+	// Verify it's gone
+	_, err = hcnMock.GetLoadBalancerByID(createdLB.Id)
+	assert.Error(t, err, "LB should have been deleted")
 }

--- a/pkg/proxy/winkernel/hns_test.go
+++ b/pkg/proxy/winkernel/hns_test.go
@@ -761,13 +761,13 @@ func TestIsHnsNotRunningError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := isHnsNotRunningError(tt.err)
+			result := IsHnsNotRunningError(tt.err)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
 }
 
-func TestIsFileAlreadyExistsError(t *testing.T) {
+func TestIsPolicyAlreadyExists(t *testing.T) {
 	tests := []struct {
 		name     string
 		err      error
@@ -797,7 +797,7 @@ func TestIsFileAlreadyExistsError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := isFileAlreadyExistsError(tt.err)
+			result := IsPolicyAlreadyExists(tt.err)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -1005,7 +1005,7 @@ func TestDeleteLoadBalancer_HnsNotRunning(t *testing.T) {
 
 	err := hns.deleteLoadBalancer("any-lb-id")
 	assert.Error(t, err, "deleteLoadBalancer should return error when HNS is not running")
-	assert.True(t, isHnsNotRunningError(err))
+	assert.True(t, IsHnsNotRunningError(err))
 }
 
 func TestDeleteLoadBalancer_Success(t *testing.T) {

--- a/pkg/proxy/winkernel/hns_test.go
+++ b/pkg/proxy/winkernel/hns_test.go
@@ -904,7 +904,7 @@ func TestFindExistingLBIdByFrontend(t *testing.T) {
 	}
 }
 
-func TestCreateLoadbalancerWithRetry_Success(t *testing.T) {
+func TestCreateOrReplaceLoadbalancer_Success(t *testing.T) {
 	hcnMock := getHcnMock("L2Bridge")
 	hns := hns{hcn: hcnMock}
 
@@ -917,13 +917,13 @@ func TestCreateLoadbalancerWithRetry_Success(t *testing.T) {
 	}
 	existingLBs := map[loadBalancerIdentifier]*loadBalancerInfo{}
 
-	lb, err := hns.createLoadbalancerWithRetry(proposedLB, existingLBs)
+	lb, err := hns.createOrReplaceLoadbalancer(proposedLB, existingLBs)
 	assert.NoError(t, err)
 	assert.NotNil(t, lb)
 	assert.NotEmpty(t, lb.Id)
 }
 
-func TestCreateLoadbalancerWithRetry_FileAlreadyExistsAndRetrySucceeds(t *testing.T) {
+func TestCreateOrReplaceLoadbalancer_FileAlreadyExistsAndRetrySucceeds(t *testing.T) {
 	hcnMock := getHcnMock("L2Bridge")
 	hns := hns{hcn: hcnMock}
 
@@ -952,13 +952,13 @@ func TestCreateLoadbalancerWithRetry_FileAlreadyExistsAndRetrySucceeds(t *testin
 		Flags: hcn.LoadBalancerFlagsNone,
 	}
 
-	lb, err := hns.createLoadbalancerWithRetry(proposedLB, existingLBs)
+	lb, err := hns.createOrReplaceLoadbalancer(proposedLB, existingLBs)
 	assert.NoError(t, err)
 	assert.NotNil(t, lb)
 	assert.NotEqual(t, createdLB.Id, lb.Id, "should have created a new LB after deleting the old one")
 }
 
-func TestCreateLoadbalancerWithRetry_FileAlreadyExistsNoMatchingLB(t *testing.T) {
+func TestCreateOrReplaceLoadbalancer_FileAlreadyExistsNoMatchingLB(t *testing.T) {
 	hcnMock := getHcnMock("L2Bridge")
 	hns := hns{hcn: hcnMock}
 
@@ -984,7 +984,7 @@ func TestCreateLoadbalancerWithRetry_FileAlreadyExistsNoMatchingLB(t *testing.T)
 		Flags: hcn.LoadBalancerFlagsNone,
 	}
 
-	lb, err := hns.createLoadbalancerWithRetry(proposedLB, existingLBs)
+	lb, err := hns.createOrReplaceLoadbalancer(proposedLB, existingLBs)
 	assert.Error(t, err, "should return the original 0xb7 error since no matching LB was found to delete")
 	assert.Nil(t, lb)
 }

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -1212,7 +1212,7 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 
 	prevNetworkID := proxier.network.id
 	updatedNetwork, err := hns.getNetworkByName(hnsNetworkName)
-	if isHnsNotRunningError(err) {
+	if IsHnsNotRunningError(err) {
 		klog.V(1).ErrorS(err, "HNS is not running. Unable to read network. Skipping sync", "hnsNetworkName", hnsNetworkName)
 		return
 	}

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -912,6 +912,7 @@ func (svcInfo *serviceInfo) cleanupAllPolicies(endpoints []proxy.Endpoint, mapSt
 func (svcInfo *serviceInfo) deleteLoadBalancerPolicy(mapStaleLoadbalancer map[string]loadBalancerType, ipFamilyStr string) {
 	// Remove the Hns Policy corresponding to this service
 	hns := svcInfo.hns
+	klog.V(3).InfoS("Loadbalancer Hns LoadBalancer delete triggered for clusterip loadbalancer resources in cleanup", "clusterIPLoadbalancerID", svcInfo.hnsID)
 	if err := hns.deleteLoadBalancer(svcInfo.hnsID); err != nil {
 		mapStaleLoadbalancer[svcInfo.hnsID] = lbTypeClusterIP
 		klog.V(1).ErrorS(err, "Error deleting Hns loadbalancer policy resource.", "hnsID", svcInfo.hnsID, "ClusterIP", svcInfo.ClusterIP())
@@ -921,6 +922,7 @@ func (svcInfo *serviceInfo) deleteLoadBalancerPolicy(mapStaleLoadbalancer map[st
 		svcInfo.hnsID = ""
 	}
 
+	klog.V(3).InfoS("Loadbalancer Hns LoadBalancer delete triggered for nodeport loadbalancer resources in cleanup", "nodePortLoadbalancerID", svcInfo.nodePorthnsID)
 	if err := hns.deleteLoadBalancer(svcInfo.nodePorthnsID); err != nil {
 		mapStaleLoadbalancer[svcInfo.nodePorthnsID] = lbTypeNodePort
 		klog.V(1).ErrorS(err, "Error deleting Hns NodePort policy resource.", "hnsID", svcInfo.nodePorthnsID, "NodePort", svcInfo.NodePort())
@@ -1199,6 +1201,11 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 
 	prevNetworkID := proxier.network.id
 	updatedNetwork, err := hns.getNetworkByName(hnsNetworkName)
+	if isHnsNotRunningError(err) {
+		klog.V(1).ErrorS(err, "HNS is not running. Unable to read network. Skipping sync", "hnsNetworkName", hnsNetworkName)
+		return
+	}
+
 	if updatedNetwork == nil || updatedNetwork.id != prevNetworkID || isNetworkNotFoundError(err) {
 		klog.InfoS("The HNS network is not present or has changed since the last sync, please check the CNI deployment", "hnsNetworkName", hnsNetworkName)
 		proxier.cleanupAllPolicies()

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -912,30 +912,38 @@ func (svcInfo *serviceInfo) cleanupAllPolicies(endpoints []proxy.Endpoint, mapSt
 func (svcInfo *serviceInfo) deleteLoadBalancerPolicy(mapStaleLoadbalancer map[string]loadBalancerType, ipFamilyStr string) {
 	// Remove the Hns Policy corresponding to this service
 	hns := svcInfo.hns
-	klog.V(3).InfoS("Loadbalancer Hns LoadBalancer delete triggered for clusterip loadbalancer resources in cleanup", "clusterIPLoadbalancerID", svcInfo.hnsID)
-	if err := hns.deleteLoadBalancer(svcInfo.hnsID); err != nil {
-		mapStaleLoadbalancer[svcInfo.hnsID] = lbTypeClusterIP
-		klog.V(1).ErrorS(err, "Error deleting Hns loadbalancer policy resource.", "hnsID", svcInfo.hnsID, "ClusterIP", svcInfo.ClusterIP())
-		metrics.WinKernelLBDeleteFailure.WithLabelValues(ipFamilyStr, string(lbTypeClusterIP), string(classifyLBError(err))).Inc()
-	} else {
-		// On successful delete, remove hnsId
-		svcInfo.hnsID = ""
+	if svcInfo.hnsID != "" {
+		klog.V(3).InfoS("Deleting ClusterIP LB during cleanup", "clusterIPLBID", svcInfo.hnsID, "ClusterIP", svcInfo.ClusterIP())
+		if err := hns.deleteLoadBalancer(svcInfo.hnsID); err != nil {
+			mapStaleLoadbalancer[svcInfo.hnsID] = lbTypeClusterIP
+			klog.V(1).ErrorS(err, "Error deleting ClusterIP LB during cleanup.", "hnsID", svcInfo.hnsID, "ClusterIP", svcInfo.ClusterIP())
+			metrics.WinKernelLBDeleteFailure.WithLabelValues(ipFamilyStr, string(lbTypeClusterIP), string(classifyLBError(err))).Inc()
+		} else {
+			// On successful delete, remove hnsId
+			svcInfo.hnsID = ""
+		}
 	}
 
-	klog.V(3).InfoS("Loadbalancer Hns LoadBalancer delete triggered for nodeport loadbalancer resources in cleanup", "nodePortLoadbalancerID", svcInfo.nodePorthnsID)
-	if err := hns.deleteLoadBalancer(svcInfo.nodePorthnsID); err != nil {
-		mapStaleLoadbalancer[svcInfo.nodePorthnsID] = lbTypeNodePort
-		klog.V(1).ErrorS(err, "Error deleting Hns NodePort policy resource.", "hnsID", svcInfo.nodePorthnsID, "NodePort", svcInfo.NodePort())
-		metrics.WinKernelLBDeleteFailure.WithLabelValues(ipFamilyStr, string(lbTypeNodePort), string(classifyLBError(err))).Inc()
-	} else {
-		// On successful delete, remove hnsId
-		svcInfo.nodePorthnsID = ""
+	if svcInfo.nodePorthnsID != "" {
+		klog.V(3).InfoS("Deleting NodePort LB during cleanup", "nodePortLBID", svcInfo.nodePorthnsID, "NodePort", svcInfo.NodePort())
+		if err := hns.deleteLoadBalancer(svcInfo.nodePorthnsID); err != nil {
+			mapStaleLoadbalancer[svcInfo.nodePorthnsID] = lbTypeNodePort
+			klog.V(1).ErrorS(err, "Error deleting NodePort LB during cleanup.", "hnsID", svcInfo.nodePorthnsID, "NodePort", svcInfo.NodePort())
+			metrics.WinKernelLBDeleteFailure.WithLabelValues(ipFamilyStr, string(lbTypeNodePort), string(classifyLBError(err))).Inc()
+		} else {
+			// On successful delete, remove hnsId
+			svcInfo.nodePorthnsID = ""
+		}
 	}
 
 	for _, externalIP := range svcInfo.externalIPs {
+		if externalIP.hnsID == "" {
+			continue
+		}
+		klog.V(3).InfoS("Deleting ExternalIP LB during cleanup", "externalIPLBID", externalIP.hnsID, "ExternalIP", externalIP.ip)
 		if err := hns.deleteLoadBalancer(externalIP.hnsID); err != nil {
 			mapStaleLoadbalancer[externalIP.hnsID] = lbTypeExternalIP
-			klog.V(1).ErrorS(err, "Error deleting Hns ExternalIP policy resource.", "hnsID", externalIP.hnsID, "IP", externalIP.ip)
+			klog.V(1).ErrorS(err, "Error deleting ExternalIP LB during cleanup.", "hnsID", externalIP.hnsID, "ExternalIP", externalIP.ip)
 			metrics.WinKernelLBDeleteFailure.WithLabelValues(ipFamilyStr, string(lbTypeExternalIP), string(classifyLBError(err))).Inc()
 		} else {
 			// On successful delete, remove hnsId
@@ -943,20 +951,23 @@ func (svcInfo *serviceInfo) deleteLoadBalancerPolicy(mapStaleLoadbalancer map[st
 		}
 	}
 	for _, lbIngressIP := range svcInfo.loadBalancerIngressIPs {
-		klog.V(3).InfoS("Loadbalancer Hns LoadBalancer delete triggered for loadBalancer Ingress resources in cleanup", "lbIngressIP", lbIngressIP)
-		if err := hns.deleteLoadBalancer(lbIngressIP.hnsID); err != nil {
-			mapStaleLoadbalancer[lbIngressIP.hnsID] = lbTypeIngressIP
-			klog.V(1).ErrorS(err, "Error deleting Hns IngressIP policy resource.", "hnsID", lbIngressIP.hnsID, "IP", lbIngressIP.ip)
-			metrics.WinKernelLBDeleteFailure.WithLabelValues(ipFamilyStr, string(lbTypeIngressIP), string(classifyLBError(err))).Inc()
-		} else {
-			// On successful delete, remove hnsId
-			lbIngressIP.hnsID = ""
+		if lbIngressIP.hnsID != "" {
+			klog.V(3).InfoS("Deleting Ingress LB during cleanup", "ingressLBID", lbIngressIP.hnsID, "IngressIP", lbIngressIP.ip)
+			if err := hns.deleteLoadBalancer(lbIngressIP.hnsID); err != nil {
+				mapStaleLoadbalancer[lbIngressIP.hnsID] = lbTypeIngressIP
+				klog.V(1).ErrorS(err, "Error deleting Ingress LB during cleanup.", "hnsID", lbIngressIP.hnsID, "IngressIP", lbIngressIP.ip)
+				metrics.WinKernelLBDeleteFailure.WithLabelValues(ipFamilyStr, string(lbTypeIngressIP), string(classifyLBError(err))).Inc()
+			} else {
+				// On successful delete, remove hnsId
+				lbIngressIP.hnsID = ""
+			}
 		}
 
 		if lbIngressIP.healthCheckHnsID != "" {
+			klog.V(3).InfoS("Deleting Ingress LB HealthCheck during cleanup", "ingressLBHealthCheckID", lbIngressIP.healthCheckHnsID, "IngressIP", lbIngressIP.ip)
 			if err := hns.deleteLoadBalancer(lbIngressIP.healthCheckHnsID); err != nil {
 				mapStaleLoadbalancer[lbIngressIP.healthCheckHnsID] = lbTypeHealthCheck
-				klog.V(1).ErrorS(err, "Error deleting Hns IngressIP HealthCheck policy resource.", "hnsID", lbIngressIP.healthCheckHnsID, "IP", lbIngressIP.ip)
+				klog.V(1).ErrorS(err, "Error deleting Ingress LB HealthCheck during cleanup.", "hnsID", lbIngressIP.healthCheckHnsID, "IngressIP", lbIngressIP.ip)
 				metrics.WinKernelLBDeleteFailure.WithLabelValues(ipFamilyStr, string(lbTypeHealthCheck), string(classifyLBError(err))).Inc()
 			} else {
 				// On successful delete, remove hnsId
@@ -1469,7 +1480,7 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		if len(hnsEndpoints) == 0 {
 			if svcInfo.winProxyOptimization {
 				// Deleting loadbalancers when there are no endpoints to serve.
-				klog.V(3).InfoS("Cleanup existing ", "endpointInfo", hnsEndpoints, "serviceName", svcName)
+				klog.V(3).InfoS("Cleanup existing", "endpointInfo", hnsEndpoints, "serviceName", svcName)
 				svcInfo.deleteLoadBalancerPolicy(proxier.mapStaleLoadbalancers, ipFamilyStr)
 			}
 			klog.ErrorS(nil, "Endpoint information not available for service, not applying any policy", "serviceName", svcName)

--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -2817,3 +2817,77 @@ func TestLBMetricEmission(t *testing.T) {
 		})
 	}
 }
+
+// TestCreateServiceWhereFrontEndSameAsExistingLB validates service creation scenarios
+// where the frontend IP and port match those of an existing load balancer.
+// When a match is detected, the existing load balancer is expected to be deleted
+// and recreated with new configuration to ensure it is correctly associated with the new service.
+func TestCreateServiceWhereFrontEndSameAsExistingLB(t *testing.T) {
+	proxier := NewFakeProxier(t, "testhost", netutils.ParseIPSloppy("10.0.0.1"), NETWORK_TYPE_L2BRIDGE, true)
+	if proxier == nil {
+		t.Fatal("Failed to create proxier")
+	}
+
+	svcIP := "10.20.30.41"
+	lbIP := "14.0.0.14"
+	svcPort := 80
+	svcPortName := proxy.ServicePortName{
+		NamespacedName: makeNSN("ns1", "svc1"),
+		Port:           "p80",
+		Protocol:       v1.ProtocolTCP,
+	}
+
+	makeServiceMap(proxier,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+			svc.Spec.Type = v1.ServiceTypeLoadBalancer
+			svc.Spec.ClusterIP = svcIP
+			svc.Spec.LoadBalancerIP = lbIP
+			svc.Spec.Ports = []v1.ServicePort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: v1.ProtocolTCP,
+			}}
+		}),
+	)
+
+	populateEndpointSlices(proxier,
+		makeTestEndpointSlice(svcPortName.Namespace, svcPortName.Name, 1, func(eps *discovery.EndpointSlice) {
+			eps.AddressType = discovery.AddressTypeIPv4
+			eps.Endpoints = []discovery.Endpoint{
+				{
+					Addresses: []string{epIpAddressLocal1}, // Local Endpoint 1
+				},
+			}
+			eps.Ports = []discovery.EndpointPort{{
+				Name:     ptr.To(svcPortName.Port),
+				Port:     ptr.To(int32(svcPort)),
+				Protocol: ptr.To(v1.ProtocolTCP),
+			}}
+		}),
+	)
+
+	hcn := (proxier.hcn).(*fakehcn.HcnMock)
+	// Populating the endpoint to the cache, since it's a local endpoint and local endpoints are managed by CNI and not KubeProxy
+	// Populating here marks the endpoint to local
+	hcn.PopulateQueriedEndpoints(endpointLocal1, networkId, epIpAddressLocal1, macAddressLocal1, prefixLen)
+	hcn.PopulateQueriedLoadbalancers(loadbalancerGuid2, svcIP, 6, uint16(svcPort), uint16(svcPort), false, endpointLocal2)
+
+	proxier.setInitialized(true)
+
+	// Test 1: When a local endpoint is added to the service, the service should continue to use the local endpoints and existing loadbalancer.
+	// If no existing loadbalancer is present, a new loadbalancer should be created.
+	proxier.syncProxyRules()
+
+	ep := proxier.endpointsMap[svcPortName][0]
+	epInfo, ok := ep.(*endpointInfo)
+	assert.True(t, ok, fmt.Sprintf("Failed to cast endpointInfo %q", svcPortName.String()))
+	assert.NotEmpty(t, epInfo.hnsID, fmt.Sprintf("Expected HNS ID to be set for endpoint %s, but got empty value", epIpAddressRemote))
+
+	svc := proxier.svcPortMap[svcPortName]
+	svcInfo, ok := svc.(*serviceInfo)
+	assert.True(t, ok, "Failed to cast serviceInfo %q", svcPortName.String())
+	assert.Equal(t, svcInfo.hnsID, loadbalancerGuid1, fmt.Sprintf("%v does not match %v", svcInfo.hnsID, loadbalancerGuid1))
+	lb, err := proxier.hcn.GetLoadBalancerByID(loadbalancerGuid1)
+	assert.Equal(t, nil, err, fmt.Sprintf("Failed to fetch loadbalancer: %s. Error: %v", loadbalancerGuid1, err))
+	assert.NotNil(t, lb, "Loadbalancer object should not be nil")
+}

--- a/pkg/proxy/winkernel/testing/hcnutils_mock.go
+++ b/pkg/proxy/winkernel/testing/hcnutils_mock.go
@@ -36,6 +36,8 @@ type HcnMock struct {
 	supportedFeatures            hcn.SupportedFeatures
 	network                      *hcn.HostComputeNetwork
 	ShouldFailDeleteLoadBalancer bool
+	ShouldReturnHnsNotRunning    bool
+	CreateLoadBalancerError      error
 }
 
 func (hcnObj HcnMock) generateEndpointGuid() (endpointId string, endpointName string) {
@@ -94,6 +96,34 @@ func (hcnObj HcnMock) PopulateQueriedEndpoints(epId, hnsId, ipAddress, mac strin
 
 	endpointMap[endpoint.Id] = endpoint
 	endpointMap[endpoint.Name] = endpoint
+}
+
+func (hcnObj HcnMock) PopulateQueriedLoadbalancers(lbID, vip string, protocol uint16, internalPort, externalPort uint16, isIPv6 bool, endpointIDs ...string) {
+	if lb, ok := loadbalancerMap[lbID]; ok {
+		lb.HostComputeEndpoints = append(lb.HostComputeEndpoints, endpointIDs...)
+		return
+	}
+
+	lb := &hcn.HostComputeLoadBalancer{
+		Id:                   lbID,
+		HostComputeEndpoints: append([]string(nil), endpointIDs...),
+		PortMappings: []hcn.LoadBalancerPortMapping{
+			{
+				Protocol:     uint32(protocol),
+				InternalPort: internalPort,
+				ExternalPort: externalPort,
+			},
+		},
+	}
+
+	if vip != "" {
+		lb.FrontendVIPs = []string{vip}
+	}
+	if isIPv6 {
+		lb.Flags |= hcn.LoadBalancerFlagsIPv6
+	}
+
+	loadbalancerMap[lbID] = lb
 }
 
 func (hcnObj HcnMock) GetNetworkByName(networkName string) (*hcn.HostComputeNetwork, error) {
@@ -177,6 +207,9 @@ func (hcnObj HcnMock) ListLoadBalancers() ([]hcn.HostComputeLoadBalancer, error)
 }
 
 func (hcnObj HcnMock) GetLoadBalancerByID(loadBalancerId string) (*hcn.HostComputeLoadBalancer, error) {
+	if hcnObj.ShouldReturnHnsNotRunning {
+		return nil, fmt.Errorf("HNS error: 0x6b5")
+	}
 	if lb, ok := loadbalancerMap[loadBalancerId]; ok {
 		return lb, nil
 	}
@@ -185,6 +218,9 @@ func (hcnObj HcnMock) GetLoadBalancerByID(loadBalancerId string) (*hcn.HostCompu
 }
 
 func (hcnObj HcnMock) CreateLoadBalancer(loadBalancer *hcn.HostComputeLoadBalancer) (*hcn.HostComputeLoadBalancer, error) {
+	if hcnObj.CreateLoadBalancerError != nil {
+		return nil, hcnObj.CreateLoadBalancerError
+	}
 	if _, ok := loadbalancerMap[loadBalancer.Id]; ok {
 		return nil, fmt.Errorf("LoadBalancer id %s Already Present", loadBalancer.Id)
 	}
@@ -193,10 +229,10 @@ func (hcnObj HcnMock) CreateLoadBalancer(loadBalancer *hcn.HostComputeLoadBalanc
 		portMappingMatched = portMappingMatched && (lb.PortMappings[0].InternalPort == loadBalancer.PortMappings[0].InternalPort)
 		portMappingMatched = portMappingMatched && len(lb.FrontendVIPs) != 0 && len(loadBalancer.FrontendVIPs) != 0 && lb.FrontendVIPs[0] == loadBalancer.FrontendVIPs[0]
 		if portMappingMatched && ((lb.Flags & hcn.LoadBalancerFlagsIPv6) == (loadBalancer.Flags & hcn.LoadBalancerFlagsIPv6)) {
-			return nil, fmt.Errorf("The specified port already exists.")
+			return nil, fmt.Errorf("HNS error: 0xb7 - The specified port already exists.")
 		}
 		if portMappingMatched && lb.PortMappings[0].Flags&hcn.LoadBalancerPortMappingFlagsLocalRoutedVIP == 0 && lb.FrontendVIPs[0] == loadBalancer.FrontendVIPs[0] {
-			return nil, fmt.Errorf("The specified port already exists.")
+			return nil, fmt.Errorf("HNS error: 0xb7 - The specified port already exists.")
 		}
 	}
 	loadBalancer.Id = hcnObj.generateLoadbalancerGuid()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR improves Windows kube-proxy resiliency during transient HNS downtime scenarios.
Currently, when HNS is temporarily unavailable (for example during HNS restart/recovery), syscall failures from HNS APIs such as GetLoadBalancer are interpreted by kube-proxy as the LoadBalancer being absent. As a result, kube-proxy resets the internal LoadBalancer state/ID and later attempts to recreate the same LoadBalancer.
However, the original HNS LoadBalancer objects may still exist and can later be restored via the HNS rehydration mechanism. This leads to duplicate create attempts failing with:

``` hcnCreateLoadBalancer failed in Win32: Cannot create a file when that file already exists. (0xb7) ```

This PR ensures transient HNS syscall failures are handled correctly and are no longer treated as definitive "LoadBalancer not found" conditions. This prevents kube-proxy from unnecessarily resetting LoadBalancer state during temporary HNS outages.

The fix improves:

- kube-proxy resiliency during HNS restart/recovery
- Windows node networking stability
- LoadBalancer reconciliation correctness under stress/restart scenarios

#### Which issue(s) this PR is related to:

Fixes #139519

#### Special notes for your reviewer:

The issue can be reproduced reliably by:

- Restarting HNS continuously in a loop
- Simultaneously scaling service backend pods up/down rapidly

The core issue is a race between:

- kube-proxy SyncProxyRules execution, and
- temporary HNS unavailability during restart

This PR specifically changes the handling of syscall failures when HNS is unavailable so that kube-proxy does not incorrectly assume that the HNS LoadBalancer object has been deleted.
Validation performed:

- HNS restart stress testing
- Rapid pod scaling during HNS restart
- Verification that duplicate LoadBalancer create failures no longer occur

#### Does this PR introduce a user-facing change?

```release-note
Fixed a Windows kube-proxy issue where transient HNS downtime during restart/recovery could cause incorrect LoadBalancer state reconciliation, resulting in duplicate LoadBalancer creation failures with "Cannot create a file when that file already exists. (0xb7)" errors.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```


/sig windows
/area kube-proxy