### PR TITLE
[WIP] leaderelection: release lease only after OnStartedLeading returns

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -217,8 +217,28 @@ func (le *LeaderElector) Run(ctx context.Context) {
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	go le.config.Callbacks.OnStartedLeading(ctx)
+
+	finishedLeading := make(chan struct{})
+	go func() {
+		defer close(finishedLeading)
+		le.config.Callbacks.OnStartedLeading(ctx)
+	}()
+
 	le.renew(ctx)
+
+	if le.config.ReleaseOnCancel {
+		// Release only after OnStartedLeading returns, so we never give up the lease
+		// while guarded work still runs and break mutual exclusion. Bound the wait by
+		// LeaseDuration so a stuck callback cannot block shutdown.
+		cancel()
+		timer := le.clock.NewTimer(le.config.LeaseDuration)
+		defer timer.Stop()
+		select {
+		case <-finishedLeading:
+		case <-timer.C():
+		}
+		le.release(klog.FromContext(ctx))
+	}
 }
 
 // RunOrDie starts a client with the provided config or panics if the config
@@ -304,11 +324,6 @@ func (le *LeaderElector) renew(ctx context.Context) {
 		logger.Info("Failed to renew lease", "lock", desc, "err", err)
 		cancel()
 	}, le.config.RetryPeriod)
-
-	// if we hold the lease, give it up
-	if le.config.ReleaseOnCancel {
-		le.release(logger)
-	}
 }
 
 // release attempts to release the leader lease if we have acquired it.

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
@@ -977,6 +977,103 @@ func testReleaseOnCancellation(t *testing.T, objectType string) {
 	}
 }
 
+// leaseHolder returns a function reporting the current holder identity of the
+// lease backing c ("" if unset).
+func leaseHolder(c *fake.Clientset) func() string {
+	return func() string {
+		l, err := c.CoordinationV1().Leases("foo").Get(context.Background(), "bar", metav1.GetOptions{})
+		if err != nil || l.Spec.HolderIdentity == nil {
+			return ""
+		}
+		return *l.Spec.HolderIdentity
+	}
+}
+
+// startReleaseElector starts a ReleaseOnCancel elector backed by c whose
+// OnStartedLeading blocks on drain after the context is cancelled, and returns a
+// holder getter once the lease is held.
+func startReleaseElector(t *testing.T, ctx context.Context, c *fake.Clientset, leaseDuration time.Duration, drain <-chan struct{}) func() string {
+	t.Helper()
+	lock, err := rl.New("leases", "foo", "bar", c.CoreV1(), c.CoordinationV1(),
+		rl.ResourceLockConfig{Identity: "baz", EventRecorder: record.NewFakeRecorder(100)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	elector, err := NewLeaderElector(LeaderElectionConfig{
+		Lock: lock, LeaseDuration: leaseDuration, RenewDeadline: leaseDuration / 2, RetryPeriod: leaseDuration / 4,
+		ReleaseOnCancel: true,
+		Callbacks: LeaderCallbacks{
+			OnStartedLeading: func(cbCtx context.Context) {
+				<-cbCtx.Done()
+				<-drain
+			},
+			OnStoppedLeading: func() {},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	go elector.Run(ctx)
+
+	holder := leaseHolder(c)
+	if err := wait.PollUntilContextTimeout(context.Background(), 50*time.Millisecond, 10*time.Second, true, func(context.Context) (bool, error) {
+		return holder() == "baz", nil
+	}); err != nil {
+		t.Fatalf("failed to acquire lease: %v", err)
+	}
+	return holder
+}
+
+// TestReleaseWaitsForOnStartedLeading verifies the lock is not released until the
+// OnStartedLeading callback returns, so the lease is never given up while guarded
+// work is still running (which would break mutual exclusion).
+func TestReleaseWaitsForOnStartedLeading(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	c := fake.NewSimpleClientset()
+	resume := make(chan struct{})
+	holder := startReleaseElector(t, ctx, c, 15*time.Second, resume)
+
+	// Shutdown begins while the callback is still draining, so the lease must stay held.
+	cancel()
+	time.Sleep(2 * time.Second)
+	if got := holder(); got != "baz" {
+		t.Fatalf("lock released before OnStartedLeading returned: holder=%q", got)
+	}
+
+	// Once the callback returns, the lock is released.
+	close(resume)
+	if err := wait.PollUntilContextTimeout(context.Background(), 50*time.Millisecond, 10*time.Second, true, func(context.Context) (bool, error) {
+		return holder() == "", nil
+	}); err != nil {
+		t.Fatalf("lock not released after OnStartedLeading returned: %v", err)
+	}
+}
+
+// TestReleaseBoundedWhenOnStartedLeadingStuck verifies the wait before releasing
+// is bounded by LeaseDuration: a callback that ignores cancellation must not block
+// release forever.
+func TestReleaseBoundedWhenOnStartedLeadingStuck(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	c := fake.NewSimpleClientset()
+	unblock := make(chan struct{})
+	t.Cleanup(func() { close(unblock) })
+	holder := startReleaseElector(t, ctx, c, 2*time.Second, unblock)
+
+	// The callback never returns, but the bounded wait must still release the lock.
+	cancel()
+	if err := wait.PollUntilContextTimeout(context.Background(), 50*time.Millisecond, 10*time.Second, true, func(context.Context) (bool, error) {
+		return holder() == "", nil
+	}); err != nil {
+		t.Fatalf("lock not released within the bounded wait: %v", err)
+	}
+}
+
 func TestLeaderElectionConfigValidation(t *testing.T) {
 	resourceLockConfig := rl.ResourceLockConfig{
 		Identity: "baz",

--- a/test/integration/controllermanager/leader_election_release_test.go
+++ b/test/integration/controllermanager/leader_election_release_test.go
@@ -27,6 +27,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/tools/record"
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	kubecontrollermanagertesting "k8s.io/kubernetes/cmd/kube-controller-manager/app/testing"
 	"k8s.io/kubernetes/test/integration/framework"
@@ -107,4 +110,76 @@ func TestLeaderElectionReleaseOnCancel(t *testing.T) {
 		t.Fatalf("expected lease holder to be cleared after shutdown, but got %q: %v", holder, err)
 	}
 	t.Log("lease holder cleared after shutdown")
+}
+
+// TestLeaderElectionReleaseWaitsForControllers verifies, against a real API server,
+// that with ReleaseOnCancel the leader lease is held until the OnStartedLeading
+// callback (the controllers) returns. Releasing earlier would let a standby acquire
+// the freed lease while this instance is still writing, breaking mutual exclusion.
+func TestLeaderElectionReleaseWaitsForControllers(t *testing.T) {
+	apiServer := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
+	t.Cleanup(apiServer.TearDownFn)
+
+	client, err := kubernetes.NewForConfig(apiServer.ClientConfig)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	const leaseName, identity = "test-release-wait", "instance-A"
+	lock, err := resourcelock.NewFromKubeconfig(resourcelock.LeasesResourceLock, metav1.NamespaceSystem, leaseName,
+		resourcelock.ResourceLockConfig{Identity: identity, EventRecorder: record.NewFakeRecorder(100)},
+		apiServer.ClientConfig, 5*time.Second)
+	if err != nil {
+		t.Fatalf("failed to create resource lock: %v", err)
+	}
+
+	// holder returns the lease's current holder identity ("" if unset/missing).
+	holder := func() string {
+		lease, err := client.CoordinationV1().Leases(metav1.NamespaceSystem).Get(context.Background(), leaseName, metav1.GetOptions{})
+		if err != nil || lease.Spec.HolderIdentity == nil {
+			return ""
+		}
+		return *lease.Spec.HolderIdentity
+	}
+
+	resume := make(chan struct{}) // closed when the test lets the controller finish draining
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
+		Lock:            lock,
+		LeaseDuration:   15 * time.Second,
+		RenewDeadline:   10 * time.Second,
+		RetryPeriod:     2 * time.Second,
+		ReleaseOnCancel: true,
+		Name:            leaseName,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(cctx context.Context) {
+				<-cctx.Done()
+				<-resume // simulate a slow controller drain
+			},
+			OnStoppedLeading: func() {},
+		},
+	})
+
+	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true, func(context.Context) (bool, error) {
+		return holder() == identity, nil
+	}); err != nil {
+		t.Fatalf("lease never acquired by %q: %v", identity, err)
+	}
+
+	// Shutdown begins while the controller is still draining, so the lease must stay held.
+	cancel()
+	time.Sleep(2 * time.Second)
+	if got := holder(); got != identity {
+		t.Fatalf("lease released while controller was still draining: holder=%q", got)
+	}
+
+	// Let the controller finish, then the lease may be released.
+	close(resume)
+	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true, func(context.Context) (bool, error) {
+		return holder() == "", nil
+	}); err != nil {
+		t.Fatalf("lease not released after controller drained: %v", err)
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Hold the leader lease until the OnStartedLeading callback returns (bounded by LeaseDuration) when ReleaseOnCancel is set, so a shutting-down leader does not give up the lease while lease-guarded work is still draining and let a standby acquire it.

#### Which issue(s) this PR is related to:

KEP-5366 Graceful Leader Transition: https://github.com/kubernetes/enhancements/blob/4a9fa726eb16365c1c1295ea0335bc777b47796c/keps/sig-api-machinery/5366-graceful-leader-transition/README.md

#### Does this PR introduce a user-facing change?

```release-note
With ReleaseOnCancel enabled, leader election now releases the lease only after the OnStartedLeading callback returns (bounded by LeaseDuration).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```