### PR TITLE
apiserver: add configurable HTTP/2 write and read-idle timeouts

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -1408,6 +1408,16 @@
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
+- name: http2_server_errors_total
+  subsystem: apiserver
+  help: Number of HTTP/2 server errors by error type.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - type
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: attempts_duration_seconds
   subsystem: impersonation
   namespace: apiserver

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -167,6 +167,18 @@ var (
 			StabilityLevel: compbasemetrics.ALPHA,
 		},
 	)
+	// HTTP2ServerErrors counts HTTP/2 server errors by type, as reported by the
+	// golang.org/x/net/http2 CountError hook. Useful for tracking ping timeouts
+	// and protocol violations that cause connection closes.
+	HTTP2ServerErrors = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Subsystem:      APIServerComponent,
+			Name:           "http2_server_errors_total",
+			Help:           "Number of HTTP/2 server errors by error type.",
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"type"},
+	)
 	WatchEvents = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
 			Subsystem:      APIServerComponent,
@@ -304,6 +316,7 @@ var (
 		fieldValidationRequestLatencies,
 		responseSizes,
 		TLSHandshakeErrors,
+		HTTP2ServerErrors,
 		WatchEvents,
 		WatchEventsSizes,
 		currentInflightRequests,

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -377,6 +377,15 @@ type SecureServingInfo struct {
 	// A value of zero means to use the default provided by golang's HTTP/2 support.
 	HTTP2MaxStreamsPerConnection int
 
+	// HTTP2WriteByteTimeout specifies the timeout after which a connection will be closed
+	// if no bytes can be written to it. A value of 0 disables the timeout.
+	HTTP2WriteByteTimeout time.Duration
+
+	// HTTP2ReadIdleTimeout specifies the timeout after which a health check using a ping
+	// frame will be carried out if no frame is received on the connection.
+	// A value of 0 disables the keepalive ping.
+	HTTP2ReadIdleTimeout time.Duration
+
 	// DisableHTTP2 indicates that http2 should not be enabled.
 	DisableHTTP2 bool
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
@@ -79,6 +80,15 @@ type SecureServingOptions struct {
 	// HTTP2MaxStreamsPerConnection is the limit that the api server imposes on each client.
 	// A value of zero means to use the default provided by golang's HTTP/2 support.
 	HTTP2MaxStreamsPerConnection int
+
+	// HTTP2WriteByteTimeout is the timeout after which a connection will be closed if no
+	// data can be written to it. A value of 0 disables the timeout.
+	HTTP2WriteByteTimeout time.Duration
+
+	// HTTP2ReadIdleTimeout is the timeout after which a health check using a ping frame
+	// will be carried out if no frame is received on the connection.
+	// A value of 0 disables the keepalive ping.
+	HTTP2ReadIdleTimeout time.Duration
 
 	// PermitPortSharing controls if SO_REUSEPORT is used when binding the port, which allows
 	// more than one instance to bind on the same address and port.
@@ -227,6 +237,15 @@ func (s *SecureServingOptions) AddFlags(fs *pflag.FlagSet) {
 		"the maximum number of streams in an HTTP/2 connection. "+
 		"Zero means to use golang's default.")
 
+	fs.DurationVar(&s.HTTP2WriteByteTimeout, "http2-write-byte-timeout", s.HTTP2WriteByteTimeout, ""+
+		"The timeout after which a connection will be closed if no data can be written to it. "+
+		"This bounds the duration that a misbehaving client can hold an HTTP/2 connection "+
+		"open while not reading the response body. Zero means no timeout.")
+
+	fs.DurationVar(&s.HTTP2ReadIdleTimeout, "http2-read-idle-timeout", s.HTTP2ReadIdleTimeout, ""+
+		"The timeout after which a health check using a ping frame will be carried out "+
+		"if no frame is received on the HTTP/2 connection. Zero means no keepalive ping.")
+
 	fs.BoolVar(&s.PermitPortSharing, "permit-port-sharing", s.PermitPortSharing,
 		"If true, SO_REUSEPORT will be used when binding the port, which allows "+
 			"more than one instance to bind on the same address and port. [default=false]")
@@ -278,6 +297,8 @@ func (s *SecureServingOptions) ApplyTo(config **server.SecureServingInfo) error 
 	*config = &server.SecureServingInfo{
 		Listener:                     s.Listener,
 		HTTP2MaxStreamsPerConnection: s.HTTP2MaxStreamsPerConnection,
+		HTTP2WriteByteTimeout:        s.HTTP2WriteByteTimeout,
+		HTTP2ReadIdleTimeout:         s.HTTP2ReadIdleTimeout,
 		DisableHTTP2:                 s.DisableHTTP2Serving,
 	}
 	c := *config

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
@@ -38,6 +38,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/pflag"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/version"
@@ -381,6 +383,65 @@ func TestServerRunWithSNI(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSecureServingOptionsHTTP2Timeouts verifies that the HTTP/2 write-byte and
+// read-idle timeout options default to disabled, are parsed from their flags, and
+// are propagated to the SecureServingInfo by ApplyTo.
+func TestSecureServingOptionsHTTP2Timeouts(t *testing.T) {
+	t.Run("defaults are disabled", func(t *testing.T) {
+		o := NewSecureServingOptions()
+		if o.HTTP2WriteByteTimeout != 0 {
+			t.Errorf("expected --http2-write-byte-timeout to default to 0 (disabled), got %s", o.HTTP2WriteByteTimeout)
+		}
+		if o.HTTP2ReadIdleTimeout != 0 {
+			t.Errorf("expected --http2-read-idle-timeout to default to 0 (disabled), got %s", o.HTTP2ReadIdleTimeout)
+		}
+	})
+
+	t.Run("flags are parsed", func(t *testing.T) {
+		o := NewSecureServingOptions()
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		o.AddFlags(fs)
+		if err := fs.Parse([]string{"--http2-write-byte-timeout=1m", "--http2-read-idle-timeout=30s"}); err != nil {
+			t.Fatalf("failed to parse flags: %v", err)
+		}
+		if want := time.Minute; o.HTTP2WriteByteTimeout != want {
+			t.Errorf("expected HTTP2WriteByteTimeout %s, got %s", want, o.HTTP2WriteByteTimeout)
+		}
+		if want := 30 * time.Second; o.HTTP2ReadIdleTimeout != want {
+			t.Errorf("expected HTTP2ReadIdleTimeout %s, got %s", want, o.HTTP2ReadIdleTimeout)
+		}
+	})
+
+	t.Run("ApplyTo propagates to SecureServingInfo", func(t *testing.T) {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("failed to listen: %v", err)
+		}
+		defer func() {
+			_ = ln.Close()
+		}()
+
+		o := NewSecureServingOptions()
+		o.Listener = ln
+		o.HTTP2WriteByteTimeout = time.Minute
+		o.HTTP2ReadIdleTimeout = 30 * time.Second
+
+		var info *server.SecureServingInfo
+		if err := o.ApplyTo(&info); err != nil {
+			t.Fatalf("failed applying the SecureServingOptions: %v", err)
+		}
+		if info == nil {
+			t.Fatal("expected a non-nil SecureServingInfo")
+		}
+		if want := time.Minute; info.HTTP2WriteByteTimeout != want {
+			t.Errorf("expected HTTP2WriteByteTimeout %s, got %s", want, info.HTTP2WriteByteTimeout)
+		}
+		if want := 30 * time.Second; info.HTTP2ReadIdleTimeout != want {
+			t.Errorf("expected HTTP2ReadIdleTimeout %s, got %s", want, info.HTTP2ReadIdleTimeout)
+		}
+	})
 }
 
 func parseIPList(ips []string) []net.IP {

--- a/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
@@ -186,6 +186,11 @@ func (s *SecureServingInfo) Serve(handler http.Handler, shutdownTimeout time.Dur
 			// shrink the per-stream buffer and max framesize from the 1MB default while still accommodating most API POST requests in a single frame
 			MaxUploadBufferPerStream: resourceBody99Percentile,
 			MaxReadFrameSize:         resourceBody99Percentile,
+			WriteByteTimeout:         s.HTTP2WriteByteTimeout,
+			ReadIdleTimeout:          s.HTTP2ReadIdleTimeout,
+			CountError: func(errType string) {
+				metrics.HTTP2ServerErrors.WithLabelValues(errType).Inc()
+			},
 		}
 
 		// use the overridden concurrent streams setting or make the default of 250 explicit so we can size MaxUploadBufferPerConnection appropriately

--- a/staging/src/k8s.io/apiserver/pkg/server/secure_serving_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/secure_serving_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"golang.org/x/net/http2"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/server/dynamiccertificates"
+	"k8s.io/client-go/util/cert"
+	netutils "k8s.io/utils/net"
+)
+
+// TestSecureServingWriteByteTimeoutDoesNotAffectStreamingResponses verifies that
+// configuring HTTP2WriteByteTimeout does not break a watch-like streaming response
+// whose bytes keep flowing. The write-byte timeout only runs while a write is
+// actively blocked on the socket; periods with no pending write - the common case
+// for a quiet watch - must not trip it. Here the handler streams several chunks
+// separated by idle gaps that are deliberately longer than the timeout, and the
+// client reads each chunk as it arrives, so every individual write completes well
+// within the timeout. The connection must survive and deliver all chunks.
+//
+// This exercises the real SecureServingInfo.Serve path (and therefore the
+// http2.Server wiring in secure_serving.go) rather than an httptest server, which
+// would bypass that configuration.
+func TestSecureServingWriteByteTimeoutDoesNotAffectStreamingResponses(t *testing.T) {
+	const (
+		writeByteTimeout = 250 * time.Millisecond
+		// idle gap between chunks, larger than the timeout to prove that an idle
+		// connection with no in-flight write is not closed.
+		idleGap = 3 * writeByteTimeout
+		chunks  = 3
+	)
+
+	certPEM, keyPEM, err := cert.GenerateSelfSignedCertKey("127.0.0.1", []net.IP{netutils.ParseIPSloppy("127.0.0.1")}, nil)
+	if err != nil {
+		t.Fatalf("failed to generate self-signed cert: %v", err)
+	}
+	servingCert, err := dynamiccertificates.NewStaticCertKeyContent("serving-cert", certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("failed to load serving cert: %v", err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+
+	info := &SecureServingInfo{
+		Listener:              ln,
+		Cert:                  servingCert,
+		HTTP2WriteByteTimeout: writeByteTimeout,
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Errorf("expected the ResponseWriter to implement http.Flusher")
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+		for i := range chunks {
+			if i > 0 {
+				time.Sleep(idleGap)
+			}
+			if _, err := fmt.Fprintf(w, "chunk-%d\n", i); err != nil {
+				t.Errorf("unexpected error writing chunk %d: %v", i, err)
+				return
+			}
+			flusher.Flush()
+		}
+	})
+
+	stopCh := make(chan struct{})
+	stoppedCh, _, err := info.Serve(handler, 10*time.Second, stopCh)
+	if err != nil {
+		t.Fatalf("failed to start serving: %v", err)
+	}
+	defer func() {
+		close(stopCh)
+		<-stoppedCh
+	}()
+
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(certPEM) {
+		t.Fatal("failed to add serving cert to the client trust pool")
+	}
+	transport := &http.Transport{TLSClientConfig: &tls.Config{RootCAs: roots}}
+	if err := http2.ConfigureTransport(transport); err != nil {
+		t.Fatalf("failed to configure http/2 transport: %v", err)
+	}
+	client := &http.Client{Transport: transport}
+
+	// A generous overall deadline (far above chunks*idleGap) keeps the test
+	// flake-free under CI load while still failing fast if the stream stalls.
+	ctx, cancel := context.WithTimeout(context.Background(), wait.ForeverTestTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://%s/watch", ln.Addr().String()), nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.ProtoMajor != 2 {
+		t.Errorf("expected an HTTP/2 response, got %s", resp.Proto)
+	}
+
+	// Reading every chunk to completion confirms the connection was not closed
+	// by the write-byte timeout while the stream was idle between writes.
+	scanner := bufio.NewScanner(resp.Body)
+	got := 0
+	for scanner.Scan() {
+		got++
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("unexpected error reading the streamed response: %v", err)
+	}
+	if got != chunks {
+		t.Errorf("expected to read %d streamed chunks, got %d", chunks, got)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Right now kube-apiserver has no connection-level write timeout. If an HTTP/2
client stops reading the response (its receive buffer fills up and stays full),
the server's `writeDataFromHandler` goroutine just parks in a `select` waiting
for flow-control credit that never comes. There's no `<-ctx.Done()` case in that
select, so the 60s cancellation from the `WithTimeoutForNonLongRunningRequests`
filter never gets observed. The goroutine holds onto its APF seat until the TCP
connection finally dies on its own, which can take a long time.

This is the server side of #111886. It isn't really client specific either, any
HTTP/2 client whose body reader can stall will do it (slow consumer, killed
process, a thread that's blocked on something else).

So this adds two flags:

| Flag | Default | What it does |
|---|---|---|
| `--http2-write-byte-timeout` | `0` (disabled) | Close the connection if no bytes can be written to it for this long |
| `--http2-read-idle-timeout` | `0` (disabled) | Send a PING after this much idle time, close if there's no PONG |

It also hooks up `http2.Server.CountError` to a new counter
`apiserver_http2_server_errors_total{type}`, mostly so ping timeouts and protocol
violations are actually visible somewhere instead of silently closing conns.

How it behaves:

- Stalled LIST/GET (client recv buffer full): server closes the connection after
  `--http2-write-byte-timeout`, the handler goroutine wakes up and the APF seat
  gets released.
- Normal watch (events flowing, or just quiet): the write timeout doesn't fire.
  `WriteByteTimeout` only runs the timer while a write is actually blocked, and it
  resets as soon as any bytes go out, so an idle watch with nothing pending is
  fine.
- Dead peer (`--http2-read-idle-timeout`): PING goes out after the idle interval,
  and the conn is closed if no PONG comes back within `PingTimeout` (15s default).

Both default to `0`, so nothing changes on an existing cluster unless you opt in.
If you do turn the write timeout on, 60s is a reasonable starting point.

A couple of "why not X" notes since they come up:

`http.Server.WriteTimeout` won't work here. That one is a total per-request write
deadline, so it would kill every watch the moment they hit it.
`http2.Server.WriteByteTimeout` is a different thing, the timer only runs while a
write is in progress and resets on any bytes written, so idle watches aren't
touched.

KEP-4460 (per-request deadline through `ResponseController`) was the other option.
That was tried in #114189 and hit a nil pointer panic in
`net/http.(*http2pipe).CloseWithError`. The underlying Go bug
(golang/go#65526, the HTTP/1.x handler hang with `SetWriteDeadline`) has been open
since early 2024 with no movement. `WriteByteTimeout` sits at the connection layer
underneath `ResponseController` so it sidesteps that whole thing.

#### Which issue(s) this PR is related to:

Fixes #111886

#### Special notes for your reviewer:

Tests added:

- `TestSecureServingOptionsHTTP2Timeouts` (`pkg/server/options/serving_test.go`):
  checks the two flags default to `0`, parse, and make it through `ApplyTo` into
  `SecureServingInfo`.
- `TestSecureServingWriteByteTimeoutDoesNotAffectStreamingResponses`
  (`pkg/server/secure_serving_test.go`): runs the real `SecureServingInfo.Serve`
  path with `HTTP2WriteByteTimeout` set, and checks that a watch-style streaming
  response with idle gaps longer than the timeout doesn't get closed. Basically
  the "we didn't break watches" guarantee.

One thing I left out on purpose: there's no test asserting the timeout actually
fires on a stalled reader, and none for the read-idle ping timeout. To trigger
either of those deterministically you need a hand-rolled `http2.Framer` client
that advertises a big flow-control window but then stops draining the socket (for
the write timeout) or ignores PINGs (for read-idle), and you end up racing real
kernel socket buffers. x/net/http2 only tests these with its own internal fake
clock, which we can't get at from here. So those tests would be flaky and would
mostly be re-testing x/net behavior rather than anything this PR does. Can add
them if you'd rather have them, just didn't want to ship something flaky.

#### Does this PR introduce a user-facing change?

```release-note
kube-apiserver: added two new flags, `--http2-write-byte-timeout` and `--http2-read-idle-timeout`, to configure server-side HTTP/2 connection timeouts. `--http2-write-byte-timeout` closes a connection when the server has been unable to write response bytes for the configured duration (for example, a stalled client whose receive buffer is full), which releases the API Priority and Fairness seat held by the blocked request handler. `--http2-read-idle-timeout` sends an HTTP/2 PING after the configured period with no incoming frames and closes the connection if no response is received. Both flags default to `0` (disabled), so there is no change in behavior unless they are set. A new metric `apiserver_http2_server_errors_total` was also added to make HTTP/2 server errors and ping timeouts observable.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
