### PR TITLE
DRA: Update scheduler_perf integration test cases of ConsumableCapacity

### DIFF
--- a/test/integration/scheduler_perf/dra/consumablecapacity/performance-config.yaml
+++ b/test/integration/scheduler_perf/dra/consumablecapacity/performance-config.yaml
@@ -16,13 +16,15 @@
 #
 # Combining `performance` and `short` selects suitable workloads for a local
 # before/after comparisons with benchstat.
-
+#
 # ConsumableCapacity is a variant of
-# SchedulingWithResourceClaimTemplate. It creates a single ResourceSlice that have two devices, 
-# one preallocate device slice and one basic device. Both allows multiple allocations and contain consumable capacity.
-# And, it creates a resource claim template with two requests.
-# Each requests half of this capacity for two count.
-# The first request checks distinctAttribute which the other checks matchAttribute.
+# SchedulingWithResourceClaimTemplate. For each node, it creates one ResourceSlice with four
+# shareable devices, each providing 10Gb of consumable bandwidth capacity.
+# It also creates a ResourceClaimTemplate with one request for two devices.
+# Each allocation requests 2500Mb of bandwidth, and the constraint requires the
+# selected devices to have distinct values for dra.example.com/index.
+#
+# This means eight pods fit onto one node.
 - name: ConsumableCapacity
   featureGates:
     DynamicResourceAllocation: true
@@ -33,18 +35,23 @@
   - opcode: createNodes
     nodeTemplatePath: ../templates/node-with-dra-test-driver.yaml
     countParam: $nodesWithDRA
-  - opcode: createResourceDriver
-    driverName: test-driver.cdi.k8s.io
-    nodes: scheduler-perf-dra-*
-    maxClaimsPerNodeParam: $maxClaimsPerNode
   - opcode: createAny
+    # one ResourceSlice with four shareable devices of 10Gb bandwidth
     templatePath: ../templates/resourceslice-consumablecapacity.yaml
-    countParam: $resourceSlices
+    countParam: $nodesWithDRA
   - opcode: createAny
     templatePath: ../templates/deviceclass-consumablecapacity.yaml
   - opcode: createAny
+    # A request for two distinct devices of 2500Mb bandwidth
     templatePath: ../templates/resourceclaimtemplate-consumablecapacity.yaml
     namespace: test
+  - opcode: createAny
+    templatePath: ../templates/resourceclaimtemplate-consumablecapacity.yaml
+    namespace: init
+  - opcode: createPods
+    namespace: init
+    countParam: $initPods
+    podTemplatePath: ../templates/pod-with-claim-template.yaml
   - opcode: createPods
     namespace: test
     countParam: $measurePods
@@ -58,11 +65,10 @@
     params:
       nodesWithDRA: 1
       nodesWithoutDRA: 1
-      resourceSlices: 1
+      initPods: 0
       measurePods: 1
       steadyState: false
       duration: 0s # unused
-      maxClaimsPerNode: 2
   - name: fast_with_DRAPartitionableDevices
     featureGates:
       DRAPartitionableDevices: true
@@ -71,17 +77,77 @@
     params:
       nodesWithDRA: 1
       nodesWithoutDRA: 1
-      resourceSlices: 1
+      initPods: 0
       measurePods: 1
       steadyState: false
       duration: 0s # unused
-      maxClaimsPerNode: 2
-  - name: 2000pods_100nodes
+  - name: empty_100nodes
     params:
       nodesWithDRA: 100
       nodesWithoutDRA: 0
-      resourceSlices: 2000
-      measurePods: 2000
+      initPods: 0
+      measurePods: 10
       steadyState: true
       duration: 10s
-      maxClaimsPerNode: 20
+  - name: half_100nodes
+    params:
+      nodesWithDRA: 100
+      nodesWithoutDRA: 0
+      initPods: 400 # 50 nodes * 8 pods/node
+      measurePods: 10
+      steadyState: true
+      duration: 10s
+  - name: empty_500nodes
+    labels: [performance]
+    params:
+      nodesWithDRA: 500
+      nodesWithoutDRA: 0
+      initPods: 0
+      measurePods: 10
+      steadyState: true
+      duration: 10s
+  - name: half_500nodes
+    labels: [performance]
+    params:
+      nodesWithDRA: 500
+      nodesWithoutDRA: 0
+      initPods: 2000  # 250 nodes * 8 pods/node
+      measurePods: 10
+      steadyState: true
+      duration: 10s
+  - name: full_500nodes
+    labels: [performance]
+    params:
+      nodesWithDRA: 500
+      nodesWithoutDRA: 0
+      initPods: 3990  # 500 nodes * 8 pods/node - 10 pods
+      measurePods: 10
+      steadyState: true
+      duration: 10s
+  - name: empty_1000nodes
+    labels: [performance]
+    params:
+      nodesWithDRA: 1000
+      nodesWithoutDRA: 0
+      initPods: 0
+      measurePods: 10
+      steadyState: true
+      duration: 10s
+  - name: half_1000nodes
+    labels: [performance]
+    params:
+      nodesWithDRA: 1000
+      nodesWithoutDRA: 0
+      initPods: 4000 # 500 nodes * 8 pods/node
+      measurePods: 10
+      steadyState: true
+      duration: 10s
+  - name: full_1000nodes
+    labels: [performance]
+    params:
+      nodesWithDRA: 1000
+      nodesWithoutDRA: 0
+      initPods: 7990 # 1000 nodes * 8 pods/node - 10 pods
+      measurePods: 10
+      steadyState: true
+      duration: 10s

--- a/test/integration/scheduler_perf/dra/templates/node-with-dra-test-driver.yaml
+++ b/test/integration/scheduler_perf/dra/templates/node-with-dra-test-driver.yaml
@@ -2,9 +2,11 @@ apiVersion: v1
 kind: Node
 metadata:
   # The name is relevant for selecting whether the driver has resources for this node.
-  generateName: scheduler-perf-dra-
-  # The label is used by the node selector in ResourceSlices to scope devices to nodes
-  # that have DRA enabled.
+  # It's deterministic and can be matched with per-node ResourceSlices.
+  name: scheduler-perf-dra-{{.Index}}
+  # The label can used by the node selector in ResourceSlices to scope devices to nodes
+  # that have DRA enabled. Only use this for workloads which simulate network-attached
+  # devices, it wouldn't be realistic for node-local devices.
   labels:
     node-with-dra: "true"
 spec: {}

--- a/test/integration/scheduler_perf/dra/templates/resourceclaimtemplate-consumablecapacity.yaml
+++ b/test/integration/scheduler_perf/dra/templates/resourceclaimtemplate-consumablecapacity.yaml
@@ -1,4 +1,4 @@
-apiVersion: resource.k8s.io/v1beta2
+apiVersion: resource.k8s.io/v1
 kind: ResourceClaimTemplate
 metadata:
   name: test-claim-template
@@ -9,12 +9,11 @@ spec:
       - name: req-0
         exactly:
           deviceClassName: test-class
+          count: 2
           capacity:
             requests:
-              memory: 40Gi
-      - name: req-1
-        exactly:
-          deviceClassName: test-class
-          capacity:
-            requests:
-              memory: 40Gi
+              bandwidth: 2500M
+      constraints:
+      - requests:
+        - req-0
+        distinctAttribute: dra.example.com/index

--- a/test/integration/scheduler_perf/dra/templates/resourceslice-consumablecapacity.yaml
+++ b/test/integration/scheduler_perf/dra/templates/resourceslice-consumablecapacity.yaml
@@ -1,5 +1,5 @@
 kind: ResourceSlice
-apiVersion: resource.k8s.io/v1beta2
+apiVersion: resource.k8s.io/v1
 metadata:
   name: resourceslice-{{.Index}}
 spec:
@@ -8,20 +8,57 @@ spec:
     generation: 1
     resourceSliceCount: 1
   driver: test-driver.cdi.k8s.io
-  nodeSelector:
-    nodeSelectorTerms:
-    - matchExpressions:
-      - key: node-with-dra
-        operator: In
-        values:
-        - "true"
+  nodeName: scheduler-perf-dra-{{.Index}}
   devices:
-  - name: shareable-device
+  - name: shareable-device-0
     allowMultipleAllocations: true
+    attributes:
+      dra.example.com/index:
+        int: 0
     capacity:
-      memory:
-        value: 80Gi
+      bandwidth:
         requestPolicy:
-          default: 1Gi
+          default: 1M
           validRange:
-            min: 1Gi
+            min: 1M
+            step: 8
+        value: 10G
+  - name: shareable-device-1
+    allowMultipleAllocations: true
+    attributes:
+      dra.example.com/index:
+        int: 1
+    capacity:
+      bandwidth:
+        requestPolicy:
+          default: 1M
+          validRange:
+            min: 1M
+            step: 8
+        value: 10G
+  - name: shareable-device-2
+    allowMultipleAllocations: true
+    attributes:
+      dra.example.com/index:
+        int: 2
+    capacity:
+      bandwidth:
+        requestPolicy:
+          default: 1M
+          validRange:
+            min: 1M
+            step: 8
+        value: 10Gi
+  - name: shareable-device-3
+    allowMultipleAllocations: true
+    attributes:
+      dra.example.com/index:
+        int: 3
+    capacity:
+      bandwidth:
+        requestPolicy:
+          default: 1M
+          validRange:
+            min: 1M
+            step: 8
+        value: 10G


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This PR updates the scheduler_perf test config in integration test to realistic example.
The new test case is based on network use case where there are 4x10Gb bandwidth node shared to at most 8 claims which requests 2 distinct devices with 2500Mb bandwidth each.

In addition, to reduce performance influence from node selector, I also applied the patch from @pohly  (https://github.com/kubernetes/kubernetes/pull/138618#discussion_r3340487805) to use static count index instead of random generated name with node selector.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Address: https://github.com/kubernetes/kubernetes/pull/138618#discussion_r3304849278
KEP: https://github.com/kubernetes/enhancements/issues/5075

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]:  https://github.com/kubernetes/enhancements/issues/5075
```
