### PR TITLE
refactor: use realistic exemplar Pod data in protobuf update and watch benchmarks

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -20,11 +20,11 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -39,9 +39,10 @@ import (
 	"github.com/emicklei/go-restful/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/apitesting"
-	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -59,13 +60,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/managedfields"
 	"k8s.io/apimachinery/pkg/util/net"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/admission"
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
 	"k8s.io/apiserver/pkg/apis/example"
-	examplefuzzer "k8s.io/apiserver/pkg/apis/example/fuzzer"
 	examplev1 "k8s.io/apiserver/pkg/apis/example/v1"
 	"k8s.io/apiserver/pkg/audit"
 	auditpolicy "k8s.io/apiserver/pkg/audit/policy"
@@ -110,6 +111,11 @@ var newGroupVersion = schema.GroupVersion{Group: testAPIGroup, Version: "version
 var testGroup2Version = schema.GroupVersion{Group: testAPIGroup2, Version: "version"}
 var testInternalGroup2Version = schema.GroupVersion{Group: testAPIGroup2, Version: runtime.APIVersionInternal}
 var prefix = "apis"
+
+//go:embed handlers/responsewriters/testdata/exemplar_pod.yaml
+var benchmarkExemplarPodYAML []byte
+
+const benchmarkSeed int64 = 100
 
 var grouplessGroupVersion = schema.GroupVersion{Group: "", Version: "v1"}
 var grouplessInternalGroupVersion = schema.GroupVersion{Group: "", Version: runtime.APIVersionInternal}
@@ -4563,12 +4569,13 @@ func BenchmarkUpdateProtobuf(b *testing.B) {
 	simpleStorage := &SimpleRESTStorage{}
 	handler := handle(map[string]rest.Storage{"simples": simpleStorage})
 	server := httptest.NewServer(handler)
-	defer server.Close()
+	b.Cleanup(server.Close)
 	client := http.Client{}
 
 	dest, _ := url.Parse(server.URL)
 	dest.Path = "/" + prefix + "/" + newGroupVersion.Group + "/" + newGroupVersion.Version + "/namespaces/foo/simples/bar"
 	dest.RawQuery = ""
+	url := dest.String()
 
 	info, _ := runtime.SerializerInfoForMediaType(codecs.SupportedMediaTypes(), "application/vnd.kubernetes.protobuf")
 	e := codecs.EncoderForVersion(info.Serializer, newGroupVersion)
@@ -4577,29 +4584,33 @@ func BenchmarkUpdateProtobuf(b *testing.B) {
 		b.Fatal(err)
 	}
 
+	b.ReportAllocs()
+	benchmarkUpdateProtobuf(b, ctx, &client, url, data)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		// Use a closure to execute defers before continuing
-		func() {
-			request, err := http.NewRequestWithContext(ctx, request.MethodPut, dest.String(), bytes.NewReader(data))
-			if err != nil {
-				b.Fatalf("unexpected error: %v", err)
-			}
-			request.Header.Set("Accept", "application/vnd.kubernetes.protobuf")
-			request.Header.Set("Content-Type", "application/vnd.kubernetes.protobuf")
-			response, err := client.Do(request)
-			if err != nil {
-				b.Fatalf("unexpected error: %v", err)
-			}
-			defer apitesting.Close(b, response.Body)
-			if response.StatusCode != http.StatusBadRequest {
-				body, _ := io.ReadAll(response.Body)
-				b.Fatalf("Unexpected response %#v\n%s", response, body)
-			}
-			_, _ = io.ReadAll(response.Body)
-		}()
+	for b.Loop() {
+		benchmarkUpdateProtobuf(b, ctx, &client, url, data)
 	}
 	b.StopTimer()
+}
+
+func benchmarkUpdateProtobuf(b *testing.B, ctx context.Context, client *http.Client, url string, data []byte) {
+	request, err := http.NewRequestWithContext(ctx, request.MethodPut, url, bytes.NewReader(data))
+	if err != nil {
+		b.Fatalf("unexpected error: %v", err)
+	}
+	request.Header.Set("Accept", "application/vnd.kubernetes.protobuf")
+	request.Header.Set("Content-Type", "application/vnd.kubernetes.protobuf")
+
+	response, err := client.Do(request)
+	if err != nil {
+		b.Fatalf("unexpected error: %v", err)
+	}
+	defer apitesting.Close(b, response.Body)
+	if response.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(response.Body)
+		b.Fatalf("Unexpected response %#v\n%s", response, body)
+	}
+	_, _ = io.ReadAll(response.Body)
 }
 
 func newTestServer(handler http.Handler) *httptest.Server {
@@ -4614,13 +4625,79 @@ func newTestRequestInfoResolver() *request.RequestInfoFactory {
 	}
 }
 
-const benchmarkSeed = 100
-
 func benchmarkItems(b *testing.B) []example.Pod {
-	clientapiObjectFuzzer := fuzzer.FuzzerFor(examplefuzzer.Funcs, rand.NewSource(benchmarkSeed), codecs)
+	b.Helper()
+	exemplar := loadExemplarPod(b)
+	utilrand.Seed(benchmarkSeed)
+
+	nodeNames := make([]string, 5)
+	for i := range nodeNames {
+		nodeNames[i] = utilrand.String(10)
+	}
 	items := make([]example.Pod, 3)
 	for i := range items {
-		clientapiObjectFuzzer.Fill(&items[i])
+		namespace := utilrand.String(10)
+		nodeName := nodeNames[utilrand.Intn(len(nodeNames))]
+		items[i] = *exemplar.DeepCopy()
+		randomizePod(&items[i], namespace, nodeName)
 	}
 	return items
+}
+
+func loadExemplarPod(b *testing.B) *example.Pod {
+	b.Helper()
+
+	if len(benchmarkExemplarPodYAML) == 0 {
+		b.Fatal("benchmark exemplar pod is empty")
+	}
+	var src corev1.Pod
+	if err := yaml.UnmarshalStrict(benchmarkExemplarPodYAML, &src); err != nil {
+		b.Fatalf("decode benchmark exemplar pod: %v", err)
+	}
+	pod := &example.Pod{
+		TypeMeta:   src.TypeMeta,
+		ObjectMeta: src.ObjectMeta,
+		Spec: example.PodSpec{
+			RestartPolicy:                 example.RestartPolicy(src.Spec.RestartPolicy),
+			TerminationGracePeriodSeconds: src.Spec.TerminationGracePeriodSeconds,
+			ActiveDeadlineSeconds:         src.Spec.ActiveDeadlineSeconds,
+			NodeSelector:                  src.Spec.NodeSelector,
+			ServiceAccountName:            src.Spec.ServiceAccountName,
+			NodeName:                      src.Spec.NodeName,
+			Hostname:                      src.Spec.Hostname,
+			Subdomain:                     src.Spec.Subdomain,
+			SchedulerName:                 src.Spec.SchedulerName,
+		},
+		Status: example.PodStatus{
+			Phase:     example.PodPhase(src.Status.Phase),
+			Message:   src.Status.Message,
+			Reason:    src.Status.Reason,
+			HostIP:    src.Status.HostIP,
+			PodIP:     src.Status.PodIP,
+			StartTime: src.Status.StartTime,
+		},
+	}
+	for _, c := range src.Status.Conditions {
+		pod.Status.Conditions = append(pod.Status.Conditions, example.PodCondition{
+			Type:               example.PodConditionType(c.Type),
+			Status:             example.ConditionStatus(c.Status),
+			LastProbeTime:      c.LastProbeTime,
+			LastTransitionTime: c.LastTransitionTime,
+			Reason:             c.Reason,
+			Message:            c.Message,
+		})
+	}
+	return pod
+}
+
+func randomizePod(pod *example.Pod, ns string, nodeName string) {
+	pod.Namespace = ns
+	if pod.GenerateName != "" {
+		pod.Name = pod.GenerateName + utilrand.String(10)
+	} else {
+		pod.Name = "benchmark-pod-" + utilrand.String(10)
+	}
+	pod.UID = types.UID(utilrand.String(36))
+	pod.ResourceVersion = ""
+	pod.Spec.NodeName = nodeName
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR updates the shared benchmark input setup in `staging/src/k8s.io/apiserver/pkg/endpoints` to use an exemplar Pod fixture instead of fuzzer-generated benchmark Pods.

- reuses the existing exemplar Pod fixture from `handlers/responsewriters/testdata/exemplar_pod.yaml`
- updates the shared `benchmarkItems()` helper in `apiserver_test.go`

Because `watch_test.go` reuses the same shared benchmark helper, this change affects both `BenchmarkUpdateProtobuf` and the related watch benchmarks.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:


Summary:

```text
                              │             old.txt             │             new.txt             │
                              │             sec/op              │    sec/op     vs base           │
UpdateProtobuf-14                                   84.53µ ± 1%   97.49µ ± 14%   +15.34% (p=0.000 n=10)
WatchHTTP-14                                        19.49µ ± 0%   66.90µ ±  2%  +243.19% (p=0.000 n=10)
WatchHTTP_UTF8-14                                   19.61µ ± 1%   66.19µ ±  4%  +237.57% (p=0.000 n=10)
WatchWebsocket-14                                   20.71µ ± 5%   74.20µ ±  1%  +258.36% (p=0.000 n=10)
WatchProtobuf-14                                    12.84µ ± 3%   25.10µ ±  1%   +95.58% (p=0.000 n=10)
WatchCachingObjectJSON-14                           11.85µ ± 1%   23.31µ ±  4%   +96.70% (p=0.000 n=10)
WatchCachingObjectProtobuf-14                       11.96µ ± 3%   22.37µ ±  1%   +87.12% (p=0.000 n=10)
geomean                                             19.86µ        45.75µ        +130.40%

                              │              B/op               │     B/op       vs base          │
UpdateProtobuf-14                                  31.17Ki ± 0%    64.53Ki ± 0%  +107.00% (p=0.000 n=10)
WatchHTTP-14                                       1.016Ki ± 0%    2.619Ki ± 0%  +157.88% (p=0.000 n=10)
WatchHTTP_UTF8-14                                  1.016Ki ± 0%    2.619Ki ± 0%  +157.84% (p=0.000 n=10)
WatchWebsocket-14                                  4.021Ki ± 0%   18.931Ki ± 0%  +370.86% (p=0.000 n=10)
WatchProtobuf-14                                     752.0 ± 0%     1098.0 ± 0%   +46.01% (p=0.000 n=10)
WatchCachingObjectJSON-14                            56.00 ± 0%      57.00 ± 0%    +1.79% (p=0.000 n=10)
WatchCachingObjectProtobuf-14                        56.00 ± 0%      65.00 ± 0%   +16.07% (p=0.000 n=10)
geomean                                              855.4         1.639Ki        +96.17%

                              │            allocs/op            │  allocs/op   vs base            │
UpdateProtobuf-14                                    284.0 ± 0%    371.0 ± 0%   +30.63% (p=0.000 n=10)
WatchHTTP-14                                         22.00 ± 0%    69.00 ± 0%  +213.64% (p=0.000 n=10)
WatchHTTP_UTF8-14                                    22.00 ± 0%    69.00 ± 0%  +213.64% (p=0.000 n=10)
WatchWebsocket-14                                    31.00 ± 0%    78.00 ± 0%  +151.61% (p=0.000 n=10)
WatchProtobuf-14                                     7.000 ± 0%   10.000 ± 0%   +42.86% (p=0.000 n=10)
WatchCachingObjectJSON-14                            2.000 ± 0%    2.000 ± 0%         ~ (p=1.000 n=10) ¹
WatchCachingObjectProtobuf-14                        2.000 ± 0%    3.000 ± 0%   +50.00% (p=0.000 n=10)
geomean                                              14.25         26.11        +83.21%
¹ all samples are equal

```


#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```