### PR TITLE
kubelet: defer mirror pod reconciliation to postSync to avoid blocking static pod updates

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -240,6 +240,16 @@ const (
 
 	// instrumentationScope is the name of OpenTelemetry instrumentation scope
 	instrumentationScope = "k8s.io/kubernetes/pkg/kubelet"
+
+	// mirrorPodAPITimeout bounds API calls made during mirror pod
+	// reconciliation (create and delete). On single-master clusters where
+	// etcd runs as a static pod, an etcd manifest change causes a circular
+	// dependency: the API server can't respond because etcd is restarting,
+	// and the new etcd can't start because SyncPod is blocked waiting for
+	// the API server. This timeout breaks that deadlock. Reconciliation is
+	// retried on every subsequent SyncPod cycle, so a transient timeout is
+	// harmless.
+	mirrorPodAPITimeout = 10 * time.Second
 )
 
 var (
@@ -3507,8 +3517,17 @@ func (kl *Kubelet) UnprepareDynamicResources(ctx context.Context, pod *v1.Pod) e
 	return kl.containerManager.UnprepareDynamicResources(ctx, pod)
 }
 
-// Ensure Mirror Pod for Static Pod exists and matches the current pod definition.
-// The function logs and ignores any errors.
+// tryReconcileMirrorPods ensures the mirror pod for a static pod exists and
+// matches the current pod definition. When the mirror pod is outdated or
+// missing, it is deleted and/or recreated.
+//
+// All API server calls (create/delete) are bounded by mirrorPodAPITimeout.
+// On single-master clusters where etcd runs as a static pod, an etcd manifest
+// change creates a circular dependency: the API server needs etcd, but etcd
+// can't start until SyncPod finishes, which is waiting for the API server.
+// The timeout breaks the deadlock. Reconciliation is retried on every
+// subsequent SyncPod cycle, so a transient timeout only delays mirror pod
+// visibility — it does not affect the static pod container itself.
 func (kl *Kubelet) tryReconcileMirrorPods(ctx context.Context, staticPod, mirrorPod *v1.Pod) {
 	logger := klog.FromContext(ctx)
 	if !kubetypes.IsStaticPod(staticPod) {
@@ -3521,10 +3540,7 @@ func (kl *Kubelet) tryReconcileMirrorPods(ctx context.Context, staticPod, mirror
 			// it. The mirror pod will get recreated later.
 			logger.Info("Trying to delete pod", "pod", klog.KObj(mirrorPod), "podUID", mirrorPod.UID)
 			podFullName := kubecontainer.GetPodFullName(staticPod)
-			// Use a bounded timeout so mirror pod deletion doesn't block
-			// indefinitely if the API server is unreachable (e.g. during
-			// etcd restarts). Reconciliation will be retried on the next sync.
-			deleteCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			deleteCtx, cancel := context.WithTimeout(ctx, mirrorPodAPITimeout)
 			if ok, err := kl.mirrorPodClient.DeleteMirrorPod(deleteCtx, podFullName, &mirrorPod.UID); err != nil {
 				logger.Error(err, "Failed deleting mirror pod", "pod", klog.KObj(mirrorPod))
 			} else if ok {
@@ -3542,9 +3558,11 @@ func (kl *Kubelet) tryReconcileMirrorPods(ctx context.Context, staticPod, mirror
 			logger.Info("No need to create a mirror pod, since node has been removed from the cluster", "node", klog.KRef("", string(kl.nodeName)))
 		} else {
 			logger.Info("Creating a mirror pod for static pod", "pod", klog.KObj(staticPod))
-			if err := kl.mirrorPodClient.CreateMirrorPod(ctx, staticPod); err != nil {
+			createCtx, cancel := context.WithTimeout(ctx, mirrorPodAPITimeout)
+			if err := kl.mirrorPodClient.CreateMirrorPod(createCtx, staticPod); err != nil {
 				logger.Error(err, "Failed creating a mirror pod", "pod", klog.KObj(staticPod))
 			}
+			cancel()
 		}
 	}
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2204,14 +2204,15 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 		}
 	}
 
-	// Create Mirror Pod for Static Pod if it doesn't already exist
-	kl.tryReconcileMirrorPods(ctx, pod, mirrorPod)
+	reconcileMirrorPod := func() {
+		kl.tryReconcileMirrorPods(ctx, pod, mirrorPod)
+	}
 
 	// Make data directories for the pod
 	if err := kl.makePodDataDirs(pod); err != nil {
 		kl.recorder.WithLogger(logger).Eventf(pod, v1.EventTypeWarning, events.FailedToMakePodDataDirectories, "error making pod data directories: %v", err)
 		logger.Error(err, "Unable to make pod data directories for pod", "pod", klog.KObj(pod))
-		return false, nil, err
+		return false, reconcileMirrorPod, err
 	}
 
 	// Wait for volumes to attach/mount
@@ -2220,13 +2221,13 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 		if errors.As(err, &volumeAttachLimitErr) {
 			kl.rejectPod(ctx, pod, volumemanager.VolumeAttachmentLimitExceededReason, volumeAttachLimitErr.Error())
 			recordAdmissionRejection(volumemanager.VolumeAttachmentLimitExceededReason)
-			return true, nil, nil
+			return true, reconcileMirrorPod, nil
 		}
 		if !wait.Interrupted(err) {
 			kl.recorder.WithLogger(logger).Eventf(pod, v1.EventTypeWarning, events.FailedMountVolume, "Unable to attach or mount volumes: %v", err)
 			logger.Error(err, "Unable to attach or mount volumes for pod; skipping pod", "pod", klog.KObj(pod))
 		}
-		return false, nil, err
+		return false, reconcileMirrorPod, err
 	}
 
 	// Fetch the pull secrets for the pod
@@ -2308,7 +2309,10 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	if len(result.SyncResults) > 0 && err == nil {
 		postSync = func() {
 			kl.RequestPodRelist(klog.FromContext(ctx), pod.UID)
+			reconcileMirrorPod()
 		}
+	} else {
+		postSync = reconcileMirrorPod
 	}
 
 	return false, postSync, err
@@ -3517,12 +3521,17 @@ func (kl *Kubelet) tryReconcileMirrorPods(ctx context.Context, staticPod, mirror
 			// it. The mirror pod will get recreated later.
 			logger.Info("Trying to delete pod", "pod", klog.KObj(mirrorPod), "podUID", mirrorPod.UID)
 			podFullName := kubecontainer.GetPodFullName(staticPod)
-			if ok, err := kl.mirrorPodClient.DeleteMirrorPod(ctx, podFullName, &mirrorPod.UID); err != nil {
+			// Use a bounded timeout so mirror pod deletion doesn't block
+			// indefinitely if the API server is unreachable (e.g. during
+			// etcd restarts). Reconciliation will be retried on the next sync.
+			deleteCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			if ok, err := kl.mirrorPodClient.DeleteMirrorPod(deleteCtx, podFullName, &mirrorPod.UID); err != nil {
 				logger.Error(err, "Failed deleting mirror pod", "pod", klog.KObj(mirrorPod))
 			} else if ok {
 				deleted = ok
 				logger.Info("Deleted mirror pod as it didn't match the static Pod", "pod", klog.KObj(mirrorPod))
 			}
+			cancel()
 		}
 	}
 	if mirrorPod == nil || deleted {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1622,6 +1622,68 @@ func TestCreateMirrorPodWithEarlySyncPodReturn(t *testing.T) {
 	assert.True(t, manager.HasPod(podFullName), "Expected mirror pod %q to be created", podFullName)
 }
 
+func TestMirrorPodDeletionTimeout(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+
+	kl := testKubelet.kubelet
+	manager := testKubelet.fakeMirrorClient
+
+	// Simulate an unreachable API server (e.g. etcd down on single-master).
+	manager.DeleteDelay = 30 * time.Second
+
+	pod := podWithUIDNameNsSpec("12345678", "foo", "ns", v1.PodSpec{
+		Containers: []v1.Container{
+			{Name: "1234", Image: "foo"},
+		},
+	})
+	pod.Annotations[kubetypes.ConfigSourceAnnotationKey] = "file"
+
+	// Mirror pod has an outdated spec — triggers delete+recreate.
+	mirrorPod := podWithUIDNameNsSpec("11111111", "foo", "ns", v1.PodSpec{
+		Containers: []v1.Container{
+			{Name: "1234", Image: "bar"},
+		},
+	})
+	mirrorPod.Annotations[kubetypes.ConfigSourceAnnotationKey] = "api"
+	mirrorPod.Annotations[kubetypes.ConfigMirrorAnnotationKey] = "mirror"
+
+	pods := []*v1.Pod{pod, mirrorPod}
+	kl.podManager.SetPods(pods)
+	isTerminal, postSync, err := kl.SyncPod(tCtx, kubetypes.SyncPodUpdate, pod, mirrorPod, &kubecontainer.PodStatus{})
+	require.NoError(t, err)
+	if isTerminal {
+		t.Fatalf("pod should not be terminal: %#v", pod)
+	}
+	require.NotNil(t, postSync, "postSync must not be nil for static pods")
+
+	// postSync should complete within mirrorPodAPITimeout, not hang for
+	// the full 30s DeleteDelay.
+	done := make(chan struct{})
+	go func() {
+		postSync()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// OK — postSync returned within the timeout.
+	case <-time.After(mirrorPodAPITimeout + 2*time.Second):
+		t.Fatal("postSync blocked longer than mirrorPodAPITimeout; timeout did not cap the API call")
+	}
+
+	// Delete timed out, so the old mirror pod was not removed. But the
+	// function should still attempt to create a new mirror pod on the
+	// next sync. In this run the delete failed, so no create was issued.
+	podFullName := kubecontainer.GetPodFullName(pod)
+	creates, deletes := manager.GetCounts(podFullName)
+	// Delete was called but timed out (counted by fake), create was not
+	// reached because delete didn't succeed.
+	assert.Equal(t, 0, creates, "expected 0 creates since delete timed out")
+	assert.Equal(t, 0, deletes, "expected 0 completed deletes since the call timed out")
+}
+
 func TestDeleteOutdatedMirrorPod(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -871,7 +871,7 @@ func TestVolumeAttachLimitExceededCleanup(t *testing.T) {
 		func(ctx context.Context) (bool, error) {
 			for _, p := range pods {
 				st, ok := kl.statusManager.GetPodStatus(p.UID)
-				if !ok || st.Phase != v1.PodFailed && st.Reason != "VolumeAttachmentLimitExceeded" {
+				if !ok || st.Phase != v1.PodFailed || st.Reason != "VolumeAttachmentLimitExceeded" {
 					return false, nil
 				}
 			}
@@ -1550,16 +1550,76 @@ func TestCreateMirrorPod(t *testing.T) {
 			pod.Annotations[kubetypes.ConfigSourceAnnotationKey] = "file"
 			pods := []*v1.Pod{pod}
 			kl.podManager.SetPods(pods)
-			isTerminal, _, err := kl.SyncPod(tCtx, tt.updateType, pod, nil, &kubecontainer.PodStatus{})
+			isTerminal, postSync, err := kl.SyncPod(tCtx, tt.updateType, pod, nil, &kubecontainer.PodStatus{})
 			assert.NoError(t, err)
 			if isTerminal {
 				t.Fatalf("pod should not be terminal: %#v", pod)
+			}
+			if postSync != nil {
+				postSync()
 			}
 			podFullName := kubecontainer.GetPodFullName(pod)
 			assert.True(t, manager.HasPod(podFullName), "Expected mirror pod %q to be created", podFullName)
 			assert.Equal(t, 1, manager.NumOfPods(), "Expected only 1 mirror pod %q, got %+v", podFullName, manager.GetPods())
 		})
 	}
+}
+
+func TestCreateMirrorPodWithRuntimePostSync(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+
+	kl := testKubelet.kubelet
+	manager := testKubelet.fakeMirrorClient
+	testKubelet.fakeRuntime.SyncResults = &kubecontainer.PodSyncResult{
+		SyncResults: []*kubecontainer.SyncResult{{
+			Action: kubecontainer.StartContainer,
+			Target: "container",
+		}},
+	}
+
+	pod := podWithUIDNameNs("12345678", "bar", "foo")
+	pod.Annotations[kubetypes.ConfigSourceAnnotationKey] = "file"
+	kl.podManager.SetPods([]*v1.Pod{pod})
+
+	isTerminal, postSync, err := kl.SyncPod(tCtx, kubetypes.SyncPodUpdate, pod, nil, &kubecontainer.PodStatus{})
+	require.NoError(t, err)
+	if isTerminal {
+		t.Fatalf("pod should not be terminal: %#v", pod)
+	}
+	require.NotNil(t, postSync)
+
+	postSync()
+
+	podFullName := kubecontainer.GetPodFullName(pod)
+	assert.True(t, manager.HasPod(podFullName), "Expected mirror pod %q to be created", podFullName)
+}
+
+func TestCreateMirrorPodWithEarlySyncPodReturn(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+
+	kl := testKubelet.kubelet
+	manager := testKubelet.fakeMirrorClient
+	kl.volumeManager = kubeletvolume.NewFakeVolumeManager(nil, 0, nil, true /* volumeAttachLimitExceeded */)
+
+	pod := podWithUIDNameNs("12345678", "bar", "foo")
+	pod.Annotations[kubetypes.ConfigSourceAnnotationKey] = "file"
+	kl.podManager.SetPods([]*v1.Pod{pod})
+
+	isTerminal, postSync, err := kl.SyncPod(tCtx, kubetypes.SyncPodUpdate, pod, nil, &kubecontainer.PodStatus{})
+	require.NoError(t, err)
+	if !isTerminal {
+		t.Fatalf("pod should be terminal after admission rejection: %#v", pod)
+	}
+	require.NotNil(t, postSync)
+
+	postSync()
+
+	podFullName := kubecontainer.GetPodFullName(pod)
+	assert.True(t, manager.HasPod(podFullName), "Expected mirror pod %q to be created", podFullName)
 }
 
 func TestDeleteOutdatedMirrorPod(t *testing.T) {
@@ -1587,10 +1647,13 @@ func TestDeleteOutdatedMirrorPod(t *testing.T) {
 
 	pods := []*v1.Pod{pod, mirrorPod}
 	kl.podManager.SetPods(pods)
-	isTerminal, _, err := kl.SyncPod(tCtx, kubetypes.SyncPodUpdate, pod, mirrorPod, &kubecontainer.PodStatus{})
+	isTerminal, postSync, err := kl.SyncPod(tCtx, kubetypes.SyncPodUpdate, pod, mirrorPod, &kubecontainer.PodStatus{})
 	assert.NoError(t, err)
 	if isTerminal {
 		t.Fatalf("pod should not be terminal: %#v", pod)
+	}
+	if postSync != nil {
+		postSync()
 	}
 	name := kubecontainer.GetPodFullName(pod)
 	creates, deletes := manager.GetCounts(name)

--- a/pkg/kubelet/pod/testing/fake_mirror_client.go
+++ b/pkg/kubelet/pod/testing/fake_mirror_client.go
@@ -19,6 +19,7 @@ package testing
 import (
 	"context"
 	"sync"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -33,6 +34,10 @@ type FakeMirrorClient struct {
 	mirrorPods   sets.Set[string]
 	createCounts map[string]int
 	deleteCounts map[string]int
+	// DeleteDelay simulates a slow API server. When non-zero,
+	// DeleteMirrorPod blocks for this duration unless the context
+	// expires first, in which case it returns the context error.
+	DeleteDelay time.Duration
 }
 
 func NewFakeMirrorClient() *FakeMirrorClient {
@@ -53,7 +58,14 @@ func (fmc *FakeMirrorClient) CreateMirrorPod(_ context.Context, pod *v1.Pod) err
 }
 
 // TODO (Robert Krawitz): Implement UID checking
-func (fmc *FakeMirrorClient) DeleteMirrorPod(_ context.Context, podFullName string, _ *types.UID) (bool, error) {
+func (fmc *FakeMirrorClient) DeleteMirrorPod(ctx context.Context, podFullName string, _ *types.UID) (bool, error) {
+	if fmc.DeleteDelay > 0 {
+		select {
+		case <-time.After(fmc.DeleteDelay):
+		case <-ctx.Done():
+			return false, ctx.Err()
+		}
+	}
 	fmc.mirrorPodLock.Lock()
 	defer fmc.mirrorPodLock.Unlock()
 	fmc.mirrorPods.Delete(podFullName)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:
On single-master clusters utilizing a local etcd, updating the etcd static pod manifest triggers a 30+ second cluster downtime. 
When a static pod manifest update occurs, the kubelet attempts to delete the old mirror pod synchronously within `SyncPod`. However, because the old etcd container has already been stopped, the API server goes offline. The synchronous deletion call blocks while trying to contact the unavailable API server, postponing the startup of the new etcd container until the HTTP client call eventually times out.
To solve this, this PR:
1. Defers mirror pod reconciliation (`tryReconcileMirrorPods`) into a `postSync` callback. This allows the container runtime to launch the new etcd container first (restoring API server access) before mirror pod bookkeeping occurs.
2. Implements a bounded 10-second timeout on the mirror pod delete API server request (`DeleteMirrorPod`) to prevent the post-sync goroutine from hanging indefinitely if the API server is unreachable for other reasons.
#### Which issue(s) this PR is related to:
Fixes #139502
#### Special notes:
Unit tests in `pkg/kubelet/kubelet_test.go` (`TestSyncPod` and `TestDeleteOutdatedMirrorPod`) have been updated to explicitly invoke the returned `postSync` callback so that the deferred mirror pod updates are executed and asserted on.
#### Does this PR introduce a user-facing change?
```release-note
kubelet: Fixed an issue where static mirror pod reconciliation could block indefinitely if the API server was unreachable (e.g., during etcd restarts). A 10-second timeout is now applied to mirror pod deletion, and mirror pod reconciliation is deferred until after pod startup to prevent delays.
```