### PR TITLE
Fix CEL cost estimation for CRD fields bounded only via allOf

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
@@ -11105,6 +11105,30 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			},
 		},
 		{
+			// reproducer from https://github.com/kubernetes/kubernetes/issues/134029
+			name: "x-kubernetes-validations rule on a string field bounded only via allOf maxLength should be within estimated cost limit",
+			opts: validationOptions{requireStructuralSchema: true},
+			input: apiextensions.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+					Type: "object",
+					Properties: map[string]apiextensions.JSONSchemaProps{
+						"text": {
+							Type: "string",
+							AllOf: []apiextensions.JSONSchemaProps{
+								{MaxLength: ptr.To[int64](10)},
+								{MaxLength: ptr.To[int64](20)},
+							},
+							XValidations: apiextensions.ValidationRules{
+								{
+									Rule: "true && self.contains(self)",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "x-kubernetes-validations rule invalidated by messageExpression exceeding per-CRD estimated cost limit",
 			opts: validationOptions{requireStructuralSchema: true},
 			input: apiextensions.CustomResourceValidation{

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation_test.go
@@ -1081,6 +1081,52 @@ func genStringWithRule(rule string) func(maxLength *int64) *schema.Structural {
 	}
 }
 
+// genWithAllOfMaxLength wraps a schema generator so that the maxLength bound is declared inside
+// an allOf member instead of directly on the schema, as emitted by tools like controller-gen.
+// See https://github.com/kubernetes/kubernetes/issues/134029.
+func genWithAllOfMaxLength(gen func(maxLength *int64) *schema.Structural) func(maxLength *int64) *schema.Structural {
+	return func(maxLength *int64) *schema.Structural {
+		s := gen(nil)
+		if s.ValueValidation == nil {
+			s.ValueValidation = &schema.ValueValidation{}
+		}
+		s.ValueValidation.AllOf = append(s.ValueValidation.AllOf, schema.NestedValueValidation{
+			ValueValidation: schema.ValueValidation{MaxLength: maxLength},
+		})
+		return s
+	}
+}
+
+// genWithAllOfMaxItems wraps a schema generator so that the maxItems bound is declared inside
+// an allOf member instead of directly on the schema.
+func genWithAllOfMaxItems(gen func(maxItems *int64) *schema.Structural) func(maxItems *int64) *schema.Structural {
+	return func(maxItems *int64) *schema.Structural {
+		s := gen(nil)
+		if s.ValueValidation == nil {
+			s.ValueValidation = &schema.ValueValidation{}
+		}
+		s.ValueValidation.AllOf = append(s.ValueValidation.AllOf, schema.NestedValueValidation{
+			ValueValidation: schema.ValueValidation{MaxItems: maxItems},
+		})
+		return s
+	}
+}
+
+// genWithAllOfMaxProperties wraps a schema generator so that the maxProperties bound is declared
+// inside an allOf member instead of directly on the schema.
+func genWithAllOfMaxProperties(gen func(maxProperties *int64) *schema.Structural) func(maxProperties *int64) *schema.Structural {
+	return func(maxProperties *int64) *schema.Structural {
+		s := gen(nil)
+		if s.ValueValidation == nil {
+			s.ValueValidation = &schema.ValueValidation{}
+		}
+		s.ValueValidation.AllOf = append(s.ValueValidation.AllOf, schema.NestedValueValidation{
+			ValueValidation: schema.ValueValidation{MaxProperties: maxProperties},
+		})
+		return s
+	}
+}
+
 // genEnumWithRuleAndValues creates a function that accepts an optional maxLength
 // with given validation rule and a set of enum values, following the convention of existing tests.
 // The test has two checks, first with maxLength unset to check if maxLength can be concluded from enums,
@@ -1878,6 +1924,126 @@ func TestCostEstimation(t *testing.T) {
 				intOrString := intOrStringType()
 				intOrString = withRule(intOrString, "isQuantity(self)")
 				intOrString = withMaxLength(intOrString, max)
+				return &intOrString
+			},
+			expectedCalcCost: 314574,
+			setMaxElements:   20,
+			expectedSetCost:  9,
+		},
+		// The following cases verify that bounds declared only inside allOf members drive cost
+		// estimation the same way directly attached bounds do.
+		// See https://github.com/kubernetes/kubernetes/issues/134029.
+		{
+			name:             "string with contains and allOf maxLength",
+			schemaGenerator:  genWithAllOfMaxLength(genStringWithRule("self.contains('test')")),
+			expectedCalcCost: 314574,
+			setMaxElements:   10,
+			expectedSetCost:  5,
+		},
+		{
+			name: "string with contains and multiple allOf maxLengths",
+			schemaGenerator: func(maxLength *int64) *schema.Structural {
+				s := genStringWithRule("self.contains('test')")(nil)
+				var looser *int64
+				if maxLength != nil {
+					looser = new(*maxLength * 3)
+				}
+				s.ValueValidation.AllOf = []schema.NestedValueValidation{
+					{ValueValidation: schema.ValueValidation{MaxLength: looser}},
+					{ValueValidation: schema.ValueValidation{MaxLength: maxLength}},
+				}
+				return s
+			},
+			expectedCalcCost: 314574,
+			setMaxElements:   10,
+			expectedSetCost:  5,
+		},
+		{
+			name: "string with contains and nested allOf maxLength",
+			schemaGenerator: func(maxLength *int64) *schema.Structural {
+				s := genStringWithRule("self.contains('test')")(nil)
+				s.ValueValidation.AllOf = []schema.NestedValueValidation{
+					{ValueValidation: schema.ValueValidation{AllOf: []schema.NestedValueValidation{
+						{ValueValidation: schema.ValueValidation{MaxLength: maxLength}},
+					}}},
+				}
+				return s
+			},
+			expectedCalcCost: 314574,
+			setMaxElements:   10,
+			expectedSetCost:  5,
+		},
+		{
+			name: "string with contains and allOf maxLength tighter than direct maxLength",
+			schemaGenerator: func(maxLength *int64) *schema.Structural {
+				var looser *int64
+				if maxLength != nil {
+					looser = new(*maxLength * 5)
+				}
+				s := genStringWithRule("self.contains('test')")(looser)
+				s.ValueValidation.AllOf = []schema.NestedValueValidation{
+					{ValueValidation: schema.ValueValidation{MaxLength: maxLength}},
+				}
+				return s
+			},
+			expectedCalcCost: 314574,
+			setMaxElements:   10,
+			expectedSetCost:  5,
+		},
+		{
+			name: "string with contains and direct maxLength tighter than allOf maxLength",
+			schemaGenerator: func(maxLength *int64) *schema.Structural {
+				s := genStringWithRule("self.contains('test')")(maxLength)
+				var looser *int64
+				if maxLength != nil {
+					looser = new(*maxLength * 5)
+				}
+				s.ValueValidation.AllOf = []schema.NestedValueValidation{
+					{ValueValidation: schema.ValueValidation{MaxLength: looser}},
+				}
+				return s
+			},
+			expectedCalcCost: 314574,
+			setMaxElements:   10,
+			expectedSetCost:  5,
+		},
+		{
+			name: "string with contains and allOf maxItems not applied to strings",
+			schemaGenerator: func(maxItems *int64) *schema.Structural {
+				s := genStringWithRule("self.contains('test')")(nil)
+				s.ValueValidation.AllOf = []schema.NestedValueValidation{
+					{ValueValidation: schema.ValueValidation{MaxItems: maxItems}},
+				}
+				return s
+			},
+			expectedCalcCost: 314574,
+			setMaxElements:   10,
+			expectedSetCost:  314574,
+		},
+		{
+			name:             "number array with all and allOf maxItems",
+			schemaGenerator:  genWithAllOfMaxItems(genArrayWithRule("number", "self.all(x, true)")),
+			expectedCalcCost: 4718591,
+			setMaxElements:   10,
+			expectedSetCost:  32,
+		},
+		{
+			name:             "map of numbers with all and allOf maxProperties",
+			schemaGenerator:  genWithAllOfMaxProperties(genMapWithRule("number", "self.all(x, true)")),
+			expectedCalcCost: 1348169,
+			setMaxElements:   10,
+			expectedSetCost:  32,
+		},
+		{
+			name: "IntOrString type with quantity rule and allOf maxLength",
+			schemaGenerator: func(maxLength *int64) *schema.Structural {
+				intOrString := intOrStringType()
+				intOrString = withRule(intOrString, "isQuantity(self)")
+				intOrString.ValueValidation = &schema.ValueValidation{
+					AllOf: []schema.NestedValueValidation{
+						{ValueValidation: schema.ValueValidation{MaxLength: maxLength}},
+					},
+				}
 				return &intOrString
 			},
 			expectedCalcCost: 314574,

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/model/schemas.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/model/schemas.go
@@ -17,6 +17,8 @@ limitations under the License.
 package model
 
 import (
+	"maps"
+
 	apimachineryvalidation "k8s.io/apimachinery/pkg/util/validation"
 	apiservercel "k8s.io/apiserver/pkg/cel"
 	"k8s.io/apiserver/pkg/cel/common"
@@ -34,7 +36,118 @@ import (
 //
 // The CEL declaration for objects with XPreserveUnknownFields does not expose unknown fields.
 func SchemaDeclType(s *schema.Structural, isResourceRoot bool) *apiservercel.DeclType {
-	return common.SchemaDeclType(&Structural{Structural: s}, isResourceRoot)
+	return common.SchemaDeclType(&Structural{Structural: foldAllOfBounds(s)}, isResourceRoot)
+}
+
+// foldAllOfBounds returns a schema where, on every node, the maxLength, maxItems and
+// maxProperties bounds declared inside allOf members (including allOf members nested in other
+// allOf members) are folded into the bounds declared directly on the node, keeping the tightest
+// bound of each kind. Tools like controller-gen declare bounds inside allOf when multiple
+// validation markers apply to a single field, and the CEL cost estimator only consults the
+// bounds attached directly to a node, so without folding such fields are cost estimated as
+// unbounded (https://github.com/kubernetes/kubernetes/issues/134029).
+//
+// Bounds are only folded for the node types they constrain: maxLength for strings and
+// x-kubernetes-int-or-string nodes, maxItems for arrays and maxProperties for objects.
+// Bounds declared for descendant paths inside allOf members (items, properties and
+// additionalProperties of a member) are not folded.
+//
+// Only allOf members are folded: because every allOf member must hold, the tightest member
+// bound is guaranteed to bound the value, so folding it can never under-estimate cost.
+// anyOf, oneOf and not members provide no such guarantee for any individual member and are
+// deliberately ignored.
+//
+// The input schema is shared and must not be mutated, so folding is copy on write: the
+// original pointer is returned whenever no folding is needed.
+func foldAllOfBounds(s *schema.Structural) *schema.Structural {
+	if s == nil {
+		return nil
+	}
+
+	out := s
+	copyOnWrite := func() {
+		if out == s {
+			shallow := *s
+			out = &shallow
+		}
+	}
+
+	if items := foldAllOfBounds(s.Items); items != s.Items {
+		copyOnWrite()
+		out.Items = items
+	}
+	if s.AdditionalProperties != nil && s.AdditionalProperties.Structural != nil {
+		if folded := foldAllOfBounds(s.AdditionalProperties.Structural); folded != s.AdditionalProperties.Structural {
+			copyOnWrite()
+			out.AdditionalProperties = &schema.StructuralOrBool{Structural: folded, Bool: s.AdditionalProperties.Bool}
+		}
+	}
+	// foldedProps is cloned from the full Properties map when the first property needs
+	// folding, then the folded properties overwrite their clones; it stays nil if no
+	// property needs folding.
+	var foldedProps map[string]schema.Structural
+	for name := range s.Properties {
+		prop := s.Properties[name]
+		if folded := foldAllOfBounds(&prop); folded != &prop {
+			if foldedProps == nil {
+				foldedProps = maps.Clone(s.Properties)
+			}
+			foldedProps[name] = *folded
+		}
+	}
+	if foldedProps != nil {
+		copyOnWrite()
+		out.Properties = foldedProps
+	}
+
+	if s.ValueValidation == nil || len(s.ValueValidation.AllOf) == 0 {
+		return out
+	}
+
+	var get func(*schema.ValueValidation) *int64
+	var set func(*schema.ValueValidation, *int64)
+	switch {
+	case s.Type == "string" || s.XIntOrString:
+		get = func(vv *schema.ValueValidation) *int64 { return vv.MaxLength }
+		set = func(vv *schema.ValueValidation, bound *int64) { vv.MaxLength = bound }
+	case s.Type == "array":
+		get = func(vv *schema.ValueValidation) *int64 { return vv.MaxItems }
+		set = func(vv *schema.ValueValidation, bound *int64) { vv.MaxItems = bound }
+	case s.Type == "object":
+		get = func(vv *schema.ValueValidation) *int64 { return vv.MaxProperties }
+		set = func(vv *schema.ValueValidation, bound *int64) { vv.MaxProperties = bound }
+	default:
+		return out
+	}
+
+	direct := get(s.ValueValidation)
+	tightest := tightestAllOfBound(get, s.ValueValidation.AllOf)
+	if tightest == nil || (direct != nil && *direct <= *tightest) {
+		return out
+	}
+
+	copyOnWrite()
+	vv := *out.ValueValidation
+	set(&vv, new(*tightest))
+	out.ValueValidation = &vv
+	return out
+}
+
+// tightestAllOfBound returns the smallest bound selected by get that is declared across the
+// given allOf members, recursing into allOf members nested inside other allOf members, or nil
+// if no member declares one.
+func tightestAllOfBound(get func(*schema.ValueValidation) *int64, allOf []schema.NestedValueValidation) *int64 {
+	var tightest *int64
+	for i := range allOf {
+		member := &allOf[i]
+		if bound := get(&member.ValueValidation); bound != nil && (tightest == nil || *bound < *tightest) {
+			tightest = bound
+		}
+		if bound := tightestAllOfBound(get, member.AllOf); bound != nil && (tightest == nil || *bound < *tightest) {
+			tightest = bound
+		}
+	}
+	return tightest
 }
 
 // WithTypeAndObjectMeta ensures the kind, apiVersion and

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/model/schemas_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/model/schemas_test.go
@@ -819,3 +819,263 @@ func BenchmarkDeeplyNestedSchemaDeclType(b *testing.B) {
 		SchemaDeclType(benchmarkSchema, false)
 	}
 }
+
+func TestFoldAllOfBounds(t *testing.T) {
+	cases := []struct {
+		name   string
+		schema *schema.Structural
+		// want is the expected folded schema; nil means no folding is expected and the
+		// original schema pointer must be returned unchanged
+		want *schema.Structural
+	}{
+		{
+			name:   "no allOf",
+			schema: stringSchema(withMaxLength(10)),
+		},
+		{
+			name:   "allOf without max bounds",
+			schema: stringSchema(withAllOf(nestedVV(func(vv *schema.ValueValidation) { vv.MinLength = ptr.To[int64](5) }))),
+		},
+		{
+			name:   "maxLength from single allOf member",
+			schema: stringSchema(withAllOf(nestedMaxLength(10))),
+			want:   stringSchema(withAllOf(nestedMaxLength(10)), withMaxLength(10)),
+		},
+		{
+			name:   "tightest of multiple allOf maxLengths",
+			schema: stringSchema(withAllOf(nestedMaxLength(20), nestedMaxLength(10), nestedMaxLength(30))),
+			want:   stringSchema(withAllOf(nestedMaxLength(20), nestedMaxLength(10), nestedMaxLength(30)), withMaxLength(10)),
+		},
+		{
+			name: "maxLength nested in allOf inside allOf",
+			schema: stringSchema(withAllOf(nestedVV(func(vv *schema.ValueValidation) {
+				vv.AllOf = []schema.NestedValueValidation{*nestedMaxLength(5)}
+			}))),
+			want: stringSchema(withAllOf(nestedVV(func(vv *schema.ValueValidation) {
+				vv.AllOf = []schema.NestedValueValidation{*nestedMaxLength(5)}
+			})), withMaxLength(5)),
+		},
+		{
+			name:   "direct maxLength tighter than allOf",
+			schema: stringSchema(withAllOf(nestedMaxLength(20)), withMaxLength(10)),
+		},
+		{
+			name:   "allOf maxLength tighter than direct",
+			schema: stringSchema(withAllOf(nestedMaxLength(20)), withMaxLength(50)),
+			want:   stringSchema(withAllOf(nestedMaxLength(20)), withMaxLength(20)),
+		},
+		{
+			name: "maxLength in allOf not applied to array",
+			schema: &schema.Structural{
+				Generic: schema.Generic{Type: "array"},
+				Items:   stringSchema(),
+				ValueValidation: &schema.ValueValidation{
+					AllOf: []schema.NestedValueValidation{*nestedMaxLength(10)},
+				},
+			},
+		},
+		{
+			name: "maxItems from allOf member",
+			schema: &schema.Structural{
+				Generic: schema.Generic{Type: "array"},
+				Items:   stringSchema(),
+				ValueValidation: &schema.ValueValidation{
+					AllOf: []schema.NestedValueValidation{*nestedVV(func(vv *schema.ValueValidation) { vv.MaxItems = ptr.To[int64](5) })},
+				},
+			},
+			want: &schema.Structural{
+				Generic: schema.Generic{Type: "array"},
+				Items:   stringSchema(),
+				ValueValidation: &schema.ValueValidation{
+					MaxItems: ptr.To[int64](5),
+					AllOf:    []schema.NestedValueValidation{*nestedVV(func(vv *schema.ValueValidation) { vv.MaxItems = ptr.To[int64](5) })},
+				},
+			},
+		},
+		{
+			name: "maxProperties from allOf member",
+			schema: &schema.Structural{
+				Generic:              schema.Generic{Type: "object"},
+				AdditionalProperties: &schema.StructuralOrBool{Structural: stringSchema()},
+				ValueValidation: &schema.ValueValidation{
+					AllOf: []schema.NestedValueValidation{*nestedVV(func(vv *schema.ValueValidation) { vv.MaxProperties = ptr.To[int64](7) })},
+				},
+			},
+			want: &schema.Structural{
+				Generic:              schema.Generic{Type: "object"},
+				AdditionalProperties: &schema.StructuralOrBool{Structural: stringSchema()},
+				ValueValidation: &schema.ValueValidation{
+					MaxProperties: ptr.To[int64](7),
+					AllOf:         []schema.NestedValueValidation{*nestedVV(func(vv *schema.ValueValidation) { vv.MaxProperties = ptr.To[int64](7) })},
+				},
+			},
+		},
+		{
+			name: "maxLength from allOf member on int-or-string node",
+			schema: &schema.Structural{
+				Extensions: schema.Extensions{XIntOrString: true},
+				ValueValidation: &schema.ValueValidation{
+					AllOf: []schema.NestedValueValidation{*nestedMaxLength(10)},
+				},
+			},
+			want: &schema.Structural{
+				Extensions: schema.Extensions{XIntOrString: true},
+				ValueValidation: &schema.ValueValidation{
+					MaxLength: ptr.To[int64](10),
+					AllOf:     []schema.NestedValueValidation{*nestedMaxLength(10)},
+				},
+			},
+		},
+		{
+			name: "bound folded on nested property",
+			schema: &schema.Structural{
+				Generic: schema.Generic{Type: "object"},
+				Properties: map[string]schema.Structural{
+					"a": *stringSchema(withAllOf(nestedMaxLength(10))),
+					"b": *stringSchema(),
+				},
+			},
+			want: &schema.Structural{
+				Generic: schema.Generic{Type: "object"},
+				Properties: map[string]schema.Structural{
+					"a": *stringSchema(withAllOf(nestedMaxLength(10)), withMaxLength(10)),
+					"b": *stringSchema(),
+				},
+			},
+		},
+		{
+			name: "bound folded on array items",
+			schema: &schema.Structural{
+				Generic: schema.Generic{Type: "array"},
+				Items:   stringSchema(withAllOf(nestedMaxLength(10))),
+			},
+			want: &schema.Structural{
+				Generic: schema.Generic{Type: "array"},
+				Items:   stringSchema(withAllOf(nestedMaxLength(10)), withMaxLength(10)),
+			},
+		},
+		{
+			name: "bound folded on additionalProperties",
+			schema: &schema.Structural{
+				Generic:              schema.Generic{Type: "object"},
+				AdditionalProperties: &schema.StructuralOrBool{Structural: stringSchema(withAllOf(nestedMaxLength(10)))},
+			},
+			want: &schema.Structural{
+				Generic:              schema.Generic{Type: "object"},
+				AdditionalProperties: &schema.StructuralOrBool{Structural: stringSchema(withAllOf(nestedMaxLength(10)), withMaxLength(10))},
+			},
+		},
+		{
+			name: "descendant bounds inside allOf members are not folded",
+			schema: &schema.Structural{
+				Generic: schema.Generic{Type: "object"},
+				Properties: map[string]schema.Structural{
+					"a": *stringSchema(),
+				},
+				ValueValidation: &schema.ValueValidation{
+					AllOf: []schema.NestedValueValidation{
+						{Properties: map[string]schema.NestedValueValidation{"a": *nestedMaxLength(10)}},
+					},
+				},
+			},
+		},
+		{
+			name: "bounds inside anyOf and oneOf members are not folded",
+			schema: stringSchema(func(s *schema.Structural) {
+				s.ValueValidation = &schema.ValueValidation{
+					AnyOf: []schema.NestedValueValidation{*nestedMaxLength(10)},
+					OneOf: []schema.NestedValueValidation{*nestedMaxLength(20)},
+				}
+			}),
+		},
+		{
+			name: "bounds inside anyOf and oneOf members nested in allOf members are not folded",
+			schema: stringSchema(withAllOf(
+				nestedVV(func(vv *schema.ValueValidation) {
+					vv.AnyOf = []schema.NestedValueValidation{*nestedMaxLength(10)}
+				}),
+				nestedVV(func(vv *schema.ValueValidation) {
+					vv.OneOf = []schema.NestedValueValidation{*nestedMaxLength(20)}
+				}),
+			)),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			original := tc.schema.DeepCopy()
+			got := foldAllOfBounds(tc.schema)
+			if !reflect.DeepEqual(original, tc.schema) {
+				t.Errorf("input schema was mutated")
+			}
+			if tc.want == nil {
+				if got != tc.schema {
+					t.Errorf("expected the original schema pointer when no folding is needed, got a copy")
+				}
+				return
+			}
+			if got == tc.schema {
+				t.Errorf("expected a copy when folding is needed, got the original schema pointer")
+			}
+			if !reflect.DeepEqual(tc.want, got) {
+				t.Errorf("unexpected folded schema, want:\n%#v\ngot:\n%#v", tc.want, got)
+			}
+		})
+	}
+}
+
+// TestSchemaDeclTypeFoldsAllOfBounds verifies that bounds declared only inside allOf members
+// are reflected in DeclType.MaxElements, which drives CEL cost estimation.
+// See https://github.com/kubernetes/kubernetes/issues/134029.
+func TestSchemaDeclTypeFoldsAllOfBounds(t *testing.T) {
+	stringBounded := stringSchema(withAllOf(nestedMaxLength(10)))
+	if declType := SchemaDeclType(stringBounded, false); declType.MaxElements != 40 {
+		t.Errorf("expected MaxElements 40 (maxLength 10 in runes, 4 bytes per rune), got %d", declType.MaxElements)
+	}
+	intOrStringBounded := &schema.Structural{
+		Extensions: schema.Extensions{XIntOrString: true},
+		ValueValidation: &schema.ValueValidation{
+			AllOf: []schema.NestedValueValidation{*nestedMaxLength(10)},
+		},
+	}
+	if declType := SchemaDeclType(intOrStringBounded, false); declType.MaxElements != 40 {
+		t.Errorf("expected MaxElements 40 (maxLength 10 in runes, 4 bytes per rune), got %d", declType.MaxElements)
+	}
+}
+
+func stringSchema(opts ...func(*schema.Structural)) *schema.Structural {
+	result := &schema.Structural{Generic: schema.Generic{Type: "string"}}
+	for _, opt := range opts {
+		opt(result)
+	}
+	return result
+}
+
+func withMaxLength(maxLength int64) func(*schema.Structural) {
+	return func(s *schema.Structural) {
+		if s.ValueValidation == nil {
+			s.ValueValidation = &schema.ValueValidation{}
+		}
+		s.ValueValidation.MaxLength = new(maxLength)
+	}
+}
+
+func withAllOf(members ...*schema.NestedValueValidation) func(*schema.Structural) {
+	return func(s *schema.Structural) {
+		if s.ValueValidation == nil {
+			s.ValueValidation = &schema.ValueValidation{}
+		}
+		for _, member := range members {
+			s.ValueValidation.AllOf = append(s.ValueValidation.AllOf, *member)
+		}
+	}
+}
+
+func nestedMaxLength(maxLength int64) *schema.NestedValueValidation {
+	return nestedVV(func(vv *schema.ValueValidation) { vv.MaxLength = new(maxLength) })
+}
+
+func nestedVV(mutate func(*schema.ValueValidation)) *schema.NestedValueValidation {
+	result := &schema.NestedValueValidation{}
+	mutate(&result.ValueValidation)
+	return result
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation_test.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"fmt"
 	"math"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -5027,6 +5028,71 @@ func BenchmarkCELValidationWithAndWithoutOldSelfReference(b *testing.B) {
 			}
 		})
 	}
+}
+
+// TestNewValidatorAllOfBoundedCost verifies that x-kubernetes-validations rules on a field whose
+// maxLength is declared only inside allOf members are cost estimated using that bound, exactly as
+// if the bound was declared directly on the field, and that NewValidator does not mutate the
+// input schema while folding the bounds.
+// Reproducer from https://github.com/kubernetes/kubernetes/issues/134029.
+func TestNewValidatorAllOfBoundedCost(t *testing.T) {
+	rule := "true && self.contains(self)"
+
+	allOfBounded := objectTypePtr(map[string]schema.Structural{
+		"text": withRule(schema.Structural{
+			Generic: schema.Generic{Type: "string"},
+			ValueValidation: &schema.ValueValidation{
+				AllOf: []schema.NestedValueValidation{
+					{ValueValidation: schema.ValueValidation{MaxLength: ptr.To[int64](10)}},
+					{ValueValidation: schema.ValueValidation{MaxLength: ptr.To[int64](20)}},
+				},
+			},
+		}, rule),
+	})
+	directBounded := objectTypePtr(map[string]schema.Structural{
+		"text": withRule(withMaxLength(stringType, ptr.To[int64](10)), rule),
+	})
+
+	original := allOfBounded.DeepCopy()
+
+	allOfCost := compiledRuleCost(t, allOfBounded)
+	directCost := compiledRuleCost(t, directBounded)
+
+	if allOfCost != directCost {
+		t.Errorf("estimated cost with maxLength inside allOf: %d, want the same as with maxLength directly on the field: %d", allOfCost, directCost)
+	}
+	// the per expression cost limit enforced at CRD write time is 10000000 (StaticEstimatedCostLimit
+	// in k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation); the reproducer rule must
+	// fit it once the allOf bound is taken into account
+	const perExpressionCostLimit = 10000000
+	if allOfCost > perExpressionCostLimit {
+		t.Errorf("estimated cost %d exceeds the per expression cost limit %d", allOfCost, perExpressionCostLimit)
+	}
+	if !reflect.DeepEqual(original, allOfBounded) {
+		t.Errorf("NewValidator must not mutate the input schema")
+	}
+}
+
+// compiledRuleCost returns the estimated cost of the single compiled rule on the "text" property
+// of the given root schema.
+func compiledRuleCost(t *testing.T, s *schema.Structural) uint64 {
+	t.Helper()
+	v := NewValidator(s, true, celconfig.PerCallLimit)
+	if v == nil {
+		t.Fatal("expected non nil validator")
+	}
+	fieldValidator, ok := v.Properties["text"]
+	if !ok {
+		t.Fatal("expected a validator for property text")
+	}
+	if len(fieldValidator.compiledRules) != 1 {
+		t.Fatalf("expected one compiled rule, got %d", len(fieldValidator.compiledRules))
+	}
+	result := fieldValidator.compiledRules[0]
+	if result.Error != nil {
+		t.Fatalf("expected no compilation error, got %v", result.Error)
+	}
+	return result.MaxCost
 }
 
 func primitiveType(typ, format string) schema.Structural {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig api-machinery

**What this PR does / why we need it:**

A CRD string field bounded only via `allOf: [{maxLength: 10}, {maxLength: 20}]`, which is exactly what controller-gen emits when multiple kubebuilder validation markers apply to a field, is treated by the CEL cost estimator as an effectively unbounded string (about 3MB), so `x-kubernetes-validations` rules on it are rejected with "estimated rule cost exceeds budget" at CRD write time.

The estimate is driven entirely by `DeclType.MaxElements`, which `model.SchemaDeclType` builds only from bounds attached directly to the schema node. Measured on master for the same string field with the same `maxLength: 10` constraint and the rule `self.contains('x')`:

| constraint location | `DeclType.MaxElements` | estimated rule cost |
| --- | --- | --- |
| `maxLength` directly on the field | 40 | 5 |
| `maxLength` only inside `allOf` | 3145726 | 314574 |

This PR folds the tightest `maxLength`/`maxItems`/`maxProperties` found in `allOf` members (recursing into `allOf` members nested in other `allOf` members) into each node before the DeclType is built. The fold is a copy on write transform inside `model.SchemaDeclType`, so it covers all three call sites that build cost-relevant DeclTypes (the CRD write time cost budget check in `defaultConverter`, `NewValidator`, and the unescapable property name fallback) and never mutates the shared structural schema (original pointer returned when nothing changes; pinned by tests).

#### Soundness

Only `allOf` members are folded. Every `allOf` member must hold, so the tightest member bound is guaranteed to bound the value and folding can never under-estimate cost. `anyOf`/`oneOf`/`not` provide no such guarantee for any individual member and are deliberately ignored (also pinned by tests).

Type gating: `maxLength` applies to strings and `x-kubernetes-int-or-string` nodes, `maxItems` to arrays, `maxProperties` to objects.

Before this change, the issue reproducer (rule `true && self.contains(self)` on a field with `allOf: [{maxLength: 10}, {maxLength: 20}]`) was estimated at cost 98956172331 against a per expression limit of 10000000 and rejected with:

```
spec.validation.openAPIV3Schema.properties[text].x-kubernetes-validations[0].rule: Forbidden: estimated rule cost exceeds budget by factor of more than 100x (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared)
```

After this change the same rule is estimated at cost 18, identical to declaring `maxLength: 10` directly on the field, and the CRD is accepted.

**Which issue(s) this PR fixes:**

Fixes #134029

**Special notes for your reviewer:**

- **Prior attempt:**
#134212 by @itzPranshul merged `allOf` constraints into the compilation schema inside `validator()`. That merge happens after the DeclType driving the cost estimate was already built in `NewValidator`, so the estimated cost does not change (verified empirically: compiling with the merged schema but the original DeclType still yields cost 314574 instead of 5). This PR reuses the idea of min-merging `allOf` constraints, with attribution; the cost estimate is fixed by folding before the DeclType is built.
- **Why before DeclType construction:**
The size estimator in `compilation.go` returns `SizeEstimate{Min: 0, Max: uint64(currentNode.MaxElements)}`, so only the DeclType matters for cost.
- **Scope:**
Same node bounds plus `allOf` nested in `allOf`. Bounds declared for descendant paths inside `allOf` members (`items`/`properties`/`additionalProperties` of a member) are not folded; possible follow-up.
- **Related, deliberately out of scope:**
`extractMaxElements` in `apis/apiextensions/validation/cel_validation.go` (the `MaxCardinality` multiplier from parent arrays/maps) also ignores `allOf` bounds. Same bug class at a different layer; candidate follow-up.
- **Version skew:**
A CRD accepted by a fixed apiserver may be rejected on rollback to an older apiserver (the older estimator still sees the field as unbounded). This only affects CRD create/update, where cost budgets are enforced; established CRDs are unaffected.
- **Performance:**
The fold walks the subtree once per `model.SchemaDeclType` call with a fast path returning the original pointer untouched. `NewValidator` runs on CRD writes, not the request path.

**Does this PR introduce a user-facing change?**

```release-note
Fixed CEL validation rule cost estimation for CRD schema fields that declare `maxLength`, `maxItems` or `maxProperties` inside `allOf`, so such rules are no longer rejected with overestimated cost.
```
