### PR TITLE
Reduce conflicts in benchmark between PATCH requests by making them sequential

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_benchmarks.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_benchmarks.go
@@ -103,6 +103,7 @@ func runBenchmarkWriteThroughput(ctx context.Context, b *testing.B, store storag
 	var watchEvents atomic.Uint64
 	var listCalls atomic.Uint64
 	var listObjects atomic.Uint64
+	var index atomic.Uint64
 
 	switch loadType {
 	case loadNone:
@@ -123,7 +124,8 @@ func runBenchmarkWriteThroughput(ctx context.Context, b *testing.B, store storag
 	start := time.Now()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			writes.Add(runTraffic(ctx, b, store, data, trafficType))
+			i := int(index.Add(1)) % len(data.PodKeys)
+			writes.Add(runTraffic(ctx, b, store, data, trafficType, i))
 		}
 	})
 	end := time.Now()
@@ -160,41 +162,30 @@ func waitForConsistent(ctx context.Context, store storage.Interface) error {
 	return nil
 }
 
-func runTraffic(ctx context.Context, b *testing.B, store storage.Interface, data BenchmarkData, trafficType string) (writes uint64) {
+func runTraffic(ctx context.Context, b *testing.B, store storage.Interface, data BenchmarkData, trafficType string, index int) (writes uint64) {
 	var podOut *example.Pod
 	switch trafficType {
 	case trafficDeleteCreate:
-		i := rand.Intn(len(data.PodKeys))
 		podOut = &example.Pod{}
-		err := store.Delete(ctx, data.PodKeys[i], podOut, nil, storage.ValidateAllObjectFunc, nil, storage.DeleteOptions{})
+		err := store.Delete(ctx, data.PodKeys[index], podOut, nil, storage.ValidateAllObjectFunc, nil, storage.DeleteOptions{})
 		if err == nil {
 			writes += 1
 		} else if !storage.IsNotFound(err) {
-			panic(fmt.Sprintf("Unexpected error on Delete %q: %v", data.PodKeys[i], err))
+			panic(fmt.Sprintf("Unexpected error on Delete %q: %v", data.PodKeys[index], err))
 		}
-		pod := data.Pods[i]
+		pod := data.Pods[index]
 		podOut = &example.Pod{}
-		err = store.Create(ctx, data.PodKeys[i], pod, podOut, 0)
+		err = store.Create(ctx, data.PodKeys[index], pod, podOut, 0)
 		if err == nil {
 			writes += 1
 		} else if !storage.IsExist(err) {
-			panic(fmt.Sprintf("Unexpected error on Create %q: %v", data.PodKeys[i], err))
+			panic(fmt.Sprintf("Unexpected error on Create %q: %v", data.PodKeys[index], err))
 		}
 	case trafficPatch:
-		i := rand.Intn(len(data.PodKeys))
 		podOut = &example.Pod{}
-		err := store.GuaranteedUpdate(ctx, data.PodKeys[i], podOut, false, nil, patchFunc(i), nil)
+		err := store.GuaranteedUpdate(ctx, data.PodKeys[index], podOut, false, nil, patchFunc(index), nil)
 		if err != nil {
-			panic(fmt.Sprintf("Unexpected error on Patch %q: %v", data.PodKeys[i], err))
-		} else {
-			writes += 1
-		}
-		// Execute patch second time to match 2 operations.
-		j := rand.Intn(len(data.PodKeys))
-		podOut = &example.Pod{}
-		err = store.GuaranteedUpdate(ctx, data.PodKeys[j], podOut, false, nil, patchFunc(j), nil)
-		if err != nil {
-			panic(fmt.Sprintf("Unexpected error on Patch %q: %v", data.PodKeys[j], err))
+			panic(fmt.Sprintf("Unexpected error on Patch %q: %v", data.PodKeys[index], err))
 		} else {
 			writes += 1
 		}


### PR DESCRIPTION
/kind feature

Patch throughput in benchmark was bottlenecked by conflicts. By changing how we pick keys in traffic generation this PR eliminates conflicts and almost doubles write throughput in some scenarios. Goal of this change is to make benchmark more accurate and reflective to real load.

* **87.15% Throughput Increase:** The write throughput increased from 31.95k to 59.79k writes/s for Patch requests with no background traffic.

Benchstat results.
```
goos: linux
goarch: amd64
pkg: k8s.io/apiserver/pkg/storage/cacher
cpu: AMD Ryzen Threadripper PRO 3945WX 12-Cores

                                              │ before_all_results.txt │         after_all_results.txt         │
                                              │         sec/op         │    sec/op      vs base                │
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=None/UseIndex=false-24                  91.28µ ± 49%   18.93µ ± 396%  -79.27% (p=0.026 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=Watcher/UseIndex=false-24               52.13µ ± 25%   20.13µ ±  13%  -61.38% (p=0.002 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=Watcher/UseIndex=true-24                29.93µ ±  2%   13.84µ ±   4%  -53.76% (p=0.002 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=Lister/UseIndex=false-24                35.93µ ± 70%   16.74µ ±  18%  -53.43% (p=0.002 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=Lister/UseIndex=true-24                 29.35µ ±  9%   13.66µ ±   3%  -53.46% (p=0.002 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=WatchList/UseIndex=false-24             32.98µ ± 11%   14.85µ ±   4%  -54.97% (p=0.002 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=WatchList/UseIndex=true-24              30.42µ ± 11%   13.78µ ±   3%  -54.69% (p=0.002 n=6)
geomean                                                   39.52µ         15.81µ         -60.00%

                                              │ before_all_results.txt │         after_all_results.txt         │
                                              │     seconds-delay      │ seconds-delay  vs base                │
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=None/UseIndex=false-24                 159.0m ± 386%   258.7m ± 413%        ~ (p=0.937 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=Watcher/UseIndex=false-24              38.16m ± 175%   27.62m ±  75%        ~ (p=0.240 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=Watcher/UseIndex=true-24               25.26m ±   4%   22.18m ± 199%        ~ (p=0.394 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=Lister/UseIndex=false-24               25.38m ± 177%   22.20m ± 149%        ~ (p=0.093 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=Lister/UseIndex=true-24                27.15m ± 109%   22.63m ±   5%  -16.63% (p=0.002 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=WatchList/UseIndex=false-24            29.00m ±  14%   24.88m ± 129%        ~ (p=0.180 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=WatchList/UseIndex=true-24             27.19m ±   6%   22.19m ±   8%  -18.39% (p=0.002 n=6)
geomean                                                  36.31m          33.15m          -8.72%

                                              │ before_all_results.txt │         after_all_results.txt         │
                                              │        writes/s        │   writes/s     vs base                │
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=None/UseIndex=false-24                  31.86k ± 37%   63.86k ± 55%        ~ (p=0.065 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=Watcher/UseIndex=false-24               41.20k ± 24%   50.88k ±  9%  +23.48% (p=0.002 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=Watcher/UseIndex=true-24                68.39k ±  2%   75.16k ±  5%   +9.91% (p=0.002 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=Lister/UseIndex=false-24                64.23k ± 11%   69.45k ±  6%        ~ (p=0.093 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=Lister/UseIndex=true-24                 69.65k ±  5%   74.71k ±  3%   +7.27% (p=0.002 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=WatchList/UseIndex=false-24             62.23k ± 10%   69.94k ±  5%  +12.40% (p=0.004 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=WatchList/UseIndex=true-24              67.87k ± 11%   74.06k ±  3%   +9.12% (p=0.002 n=6)
geomean                                                   55.85k         67.77k        +21.33%

                                              │ before_all_results.txt │         after_all_results.txt         │
                                              │     watch-events/s     │ watch-events/s  vs base               │
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=Watcher/UseIndex=false-24             965.8k ± 63%    1439.1k ±  8%        ~ (p=0.310 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=Watcher/UseIndex=true-24               295.6 ±  5%      275.3 ± 11%   -6.88% (p=0.009 n=6)
geomean                                                 16.90k           19.90k        +17.79%

                                              │ before_all_results.txt │         after_all_results.txt         │
                                              │      list-calls/s      │ list-calls/s   vs base                │
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=Lister/UseIndex=false-24                6.979 ± 155%     8.736 ± 22%         ~ (p=0.485 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=Lister/UseIndex=true-24                 89.34 ±   2%     93.88 ±  1%    +5.08% (p=0.002 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=WatchList/UseIndex=false-24            956.8m ±   8%   1920.0m ± 13%  +100.66% (p=0.002 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=WatchList/UseIndex=true-24              5.450 ±  14%     7.342 ± 12%   +34.73% (p=0.002 n=6)
geomean                                                   7.551            10.37         +37.32%

                                              │ before_all_results.txt │         after_all_results.txt         │
                                              │      list-objs/s       │  list-objs/s   vs base                │
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=Lister/UseIndex=false-24               1.047M ± 155%   1.310M ± 22%        ~ (p=0.485 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=Lister/UseIndex=true-24                2.859k ±   2%   2.348k ±  1%  -17.89% (p=0.002 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=WatchList/UseIndex=false-24            211.7k ±   9%   291.4k ±  4%  +37.68% (p=0.002 n=6)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallel
ism=25/Background=WatchList/UseIndex=true-24              194.7 ±   4%    187.1 ±  7%        ~ (p=0.240 n=6)
geomean                                                  18.74k          20.24k         +7.98%

```

```release-note
NONE
```
/cc @Jefftree 