### PR TITLE
fix(apiserver): return 400 instead of 500 for invalid resourceVersion in API Request

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -522,7 +522,7 @@ func (c *Cacher) Watch(ctx context.Context, key string, opts storage.ListOptions
 	pred := opts.Predicate
 	requestedWatchRV, err := c.versioner.ParseResourceVersion(opts.ResourceVersion)
 	if err != nil {
-		return nil, err
+		return nil, errors.NewBadRequest(fmt.Sprintf("invalid resourceVersion: %v", err))
 	}
 
 	readyGeneration, downtime, err := c.ready.checkAndReadGeneration()
@@ -691,7 +691,7 @@ func (c *Cacher) Get(ctx context.Context, key string, opts storage.GetOptions, o
 	}
 	getRV, err := c.versioner.ParseResourceVersion(opts.ResourceVersion)
 	if err != nil {
-		return err
+		return errors.NewBadRequest(fmt.Sprintf("invalid resourceVersion: %v", err))
 	}
 
 	objVal, err := conversion.EnforcePtr(objPtr)
@@ -744,9 +744,9 @@ func (c *Cacher) GetList(ctx context.Context, key string, opts storage.ListOptio
 	if err != nil {
 		return err
 	}
-	_, err = c.versioner.ParseResourceVersion(opts.ResourceVersion)
-	if err != nil {
-		return err
+
+	if _, err := c.versioner.ParseResourceVersion(opts.ResourceVersion); err != nil {
+		return errors.NewBadRequest(fmt.Sprintf("invalid resourceVersion: %v", err))
 	}
 
 	ctx, span := tracing.Start(ctx, "cacher.GetList",
@@ -1168,7 +1168,7 @@ func (c *Cacher) isStopped() bool {
 func (c *Cacher) Compact(resourceVersion string) error {
 	rv, err := c.versioner.ParseResourceVersion(resourceVersion)
 	if err != nil {
-		return err
+		return errors.NewBadRequest(fmt.Sprintf("invalid resourceVersion: %v", err))
 	}
 	c.watchCache.Compact(rv)
 	return nil
@@ -1391,7 +1391,7 @@ func (c *Cacher) ShouldDelegateExactRV(resourceVersion string, recursive bool) (
 	}
 	listRV, err := c.versioner.ParseResourceVersion(resourceVersion)
 	if err != nil {
-		return delegator.Result{}, err
+		return delegator.Result{}, errors.NewBadRequest(fmt.Sprintf("invalid resourceVersion: %v", err))
 	}
 	return c.shouldDelegateExactRV(listRV)
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
@@ -18,6 +18,7 @@ package cacher
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -134,7 +135,7 @@ func (c *CacheDelegator) Get(ctx context.Context, key string, opts storage.GetOp
 	// It's guaranteed that the returned value is at least that
 	// fresh as the given resourceVersion.
 	if _, err := c.cacher.versioner.ParseResourceVersion(opts.ResourceVersion); err != nil {
-		return err
+		return errors.NewBadRequest(fmt.Sprintf("invalid resourceVersion: %v", err))
 	}
 	span.AddEvent("About to fetch object from cache")
 	return c.cacher.Get(ctx, key, opts, objPtr)
@@ -154,7 +155,7 @@ func (c *CacheDelegator) GetList(ctx context.Context, key string, opts storage.L
 	}
 
 	if _, err := c.cacher.versioner.ParseResourceVersion(opts.ResourceVersion); err != nil {
-		return err
+		return errors.NewBadRequest(fmt.Sprintf("invalid resourceVersion: %v", err))
 	}
 
 	if !c.cacher.Ready() && shouldDelegateListOnNotReadyCache(opts) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -520,7 +520,7 @@ func (c *watchCache) waitUntilFreshAndGetList(ctx context.Context, key string, o
 	} else {
 		listRV, err = c.versioner.ParseResourceVersion(opts.ResourceVersion)
 		if err != nil {
-			return listResp{}, "", err
+			return listResp{}, "", errors.NewBadRequest(fmt.Sprintf("invalid resourceVersion: %v", err))
 		}
 	}
 	obj, exists, readResourceVersion, err := c.WaitUntilFreshAndGet(ctx, listRV, key)
@@ -556,7 +556,7 @@ func (w *watchCache) WaitUntilFreshAndGetKeys(ctx context.Context, resourceVersi
 func (w *watchCache) waitUntilFreshAndList(ctx context.Context, key string, opts storage.ListOptions) (resp listResp, index string, err error) {
 	listRV, err := w.versioner.ParseResourceVersion(opts.ResourceVersion)
 	if err != nil {
-		return listResp{}, "", err
+		return listResp{}, "", errors.NewBadRequest(fmt.Sprintf("invalid resourceVersion: %v", err))
 	}
 	switch opts.ResourceVersionMatch {
 	case metav1.ResourceVersionMatchExact:
@@ -726,7 +726,7 @@ func (w *watchCache) GetByKey(key string) (interface{}, bool, error) {
 func (w *watchCache) Replace(objs []interface{}, resourceVersion string) error {
 	version, err := w.versioner.ParseResourceVersion(resourceVersion)
 	if err != nil {
-		return err
+		return errors.NewBadRequest(fmt.Sprintf("invalid resourceVersion: %v", err))
 	}
 
 	toReplace := make([]interface{}, 0, len(objs))

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -969,7 +969,7 @@ func (s *store) Watch(ctx context.Context, key string, opts storage.ListOptions)
 	}
 	rev, err := s.versioner.ParseResourceVersion(opts.ResourceVersion)
 	if err != nil {
-		return nil, err
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("invalid resource version: %v", err))
 	}
 	return s.watcher.Watch(s.watchContext(ctx), preparedKey, int64(rev), opts)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The apiserver was returning HTTP 500 (InternalError) when a client supplied an invalid `resourceVersion` in list/watch requests. An invalid `resourceVersion` is a client input error, not a server fault, so it should surface as HTTP 400 (BadRequest). This PR maps `resourceVersion` parse failures to `StatusBadRequest`, allowing clients to distinguish malformed requests from genuine server errors and avoid spurious retries against the apiserver.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #139485

#### Special notes for your reviewer:
The change is scoped to the error mapping path for `resourceVersion` parsing; existing valid-input behavior is unchanged. Please confirm the new status code does not regress any client retry/backoff logic that may have been (incorrectly) keying off the 500 response.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-apiserver now returns HTTP 400 (BadRequest) instead of HTTP 500 (InternalError) when a list or watch request specifies an invalid `resourceVersion`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```