### PR TITLE
apiserver: exercise RangeStream on/off in BenchmarkCacherInit

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_init_bench_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_init_bench_test.go
@@ -30,8 +30,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/etcd3"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/clock"
 )
 
@@ -61,22 +64,28 @@ func BenchmarkCacherInit(b *testing.B) {
 		Clock:        clock.RealClock{},
 	}
 
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		cacher, err := NewCacherFromConfig(config)
-		if err != nil {
-			b.Fatal(err)
-		}
-		if err := cacher.Wait(ctx); err != nil {
-			b.Fatal(err)
-		}
-		b.StopTimer()
-		cacher.Stop()
-		etcd3.TestOnlyResetResourceSizeEstimator(etcdStorage)
-		b.StartTimer()
+	for _, rangeStream := range []bool{false, true} {
+		b.Run(fmt.Sprintf("RangeStream=%v", rangeStream), func(b *testing.B) {
+			featuregatetesting.SetFeatureGateDuringTest(b, utilfeature.DefaultFeatureGate, features.EtcdRangeStream, rangeStream)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				cacher, err := NewCacherFromConfig(config)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if err := cacher.Wait(ctx); err != nil {
+					b.Fatal(err)
+				}
+				b.StopTimer()
+				cacher.Stop()
+				etcd3.TestOnlyResetResourceSizeEstimator(etcdStorage)
+				b.StartTimer()
+			}
+			b.ReportMetric(float64(pods), "pods/cache")
+		})
 	}
-	b.ReportMetric(float64(pods), "pods/cache")
 }
 
 func loadExemplarPod(b *testing.B) *corev1.Pod {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_testing_utils_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_testing_utils_test.go
@@ -61,7 +61,7 @@ func init() {
 	utilruntime.Must(metav1.AddMetaToScheme(scheme))
 	scheme.AddUnversionedTypes(corev1.SchemeGroupVersion, &metav1.Status{})
 	pb := protobuf.NewSerializer(scheme, scheme)
-	corev1ProtoCodec = codecs.CodecForVersions(pb, pb, schema.GroupVersions{corev1.SchemeGroupVersion}, nil)
+	corev1ProtoCodec = codecs.CodecForVersions(pb, pb, schema.GroupVersions{corev1.SchemeGroupVersion}, schema.GroupVersions{corev1.SchemeGroupVersion})
 	examplev1ProtoCodec = codecs.CodecForVersions(pb, pb, schema.GroupVersions{examplev1.SchemeGroupVersion}, nil)
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Compare paginated vs RangeStream watch-cache init in BenchmarkCacherInit.

```
              │ rs-off.txt │             rs-on.txt              │
              │   sec/op   │   sec/op     vs base               │
CacherInit-12   6.173 ± 16%  4.343 ± 11%  -29.65% (p=0.002 n=6)

              │ rs-off.txt  │             rs-on.txt             │
              │    B/op     │    B/op       vs base             │
CacherInit-12  11.55Gi ± 1%  10.53Gi ± 0%   -8.85% (p=0.002 n=6)

              │ rs-off.txt │             rs-on.txt             │
              │  allocs/op │  allocs/op   vs base              │
CacherInit-12   64.56M ± 0%  64.66M ± 0%   +0.15% (p=0.002 n=6)
```

#### Which issue(s) this PR is related to:

Related to https://github.com/kubernetes/kubernetes/issues/138815

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
