### PR TITLE
proxy/nftables: skip ListAll on incremental sync

### DIFF
--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -178,6 +178,11 @@ type Proxier struct {
 
 	// staleChains contains information about chains to be deleted later
 	staleChains map[string]time.Time
+	// activeChains and activeAffinitySets are the service-related chains and
+	// affinity sets that kube-proxy believes are committed in nftables after the
+	// previous successful sync. They allow incremental syncs to avoid ListAll.
+	activeChains       sets.Set[string]
+	activeAffinitySets sets.Set[string]
 
 	// serviceCIDRs is a comma separated list of ServiceCIDRs belonging to the IPFamily
 	// which proxier is operating on, can be directly consumed by knftables.
@@ -254,6 +259,8 @@ func NewProxier(ctx context.Context,
 		nodePortAddresses:   nodePortAddresses,
 		networkInterfacer:   proxyutil.RealNetwork{},
 		staleChains:         make(map[string]time.Time),
+		activeChains:        sets.New[string](),
+		activeAffinitySets:  sets.New[string](),
 		logger:              logger,
 		logRateLimiter:      rate.NewLimiter(rate.Every(24*time.Hour), 1),
 		clusterIPs:          newNFTElementStorage("set", clusterIPsSet),
@@ -1151,16 +1158,21 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 
 	var existingChains sets.Set[string]
 	var existingAffinitySets sets.Set[string]
-	if allObjects, err := proxier.nftables.ListAll(context.TODO()); err == nil {
-		existingChains = sets.New(allObjects["chain"]...)
-		existingAffinitySets = sets.New[string]()
-		for _, set := range allObjects["set"] {
-			if isAffinitySetName(set) {
-				existingAffinitySets.Insert(set)
+	if doFullSync {
+		if allObjects, err := proxier.nftables.ListAll(context.TODO()); err == nil {
+			existingChains = sets.New(allObjects["chain"]...)
+			existingAffinitySets = sets.New[string]()
+			for _, set := range allObjects["set"] {
+				if isAffinitySetName(set) {
+					existingAffinitySets.Insert(set)
+				}
 			}
+		} else {
+			proxier.logger.Error(err, "Failed to list existing nftables objects")
 		}
 	} else {
-		proxier.logger.Error(err, "Failed to list existing nftables objects")
+		existingChains = proxier.activeChains.Clone()
+		existingAffinitySets = proxier.activeAffinitySets.Clone()
 	}
 
 	// Accumulate service/endpoint chains and affinity sets to keep.
@@ -1726,6 +1738,8 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 	}
 	success = true
 	proxier.needFullSync = false
+	proxier.activeChains = activeChains
+	proxier.activeAffinitySets = activeAffinitySets
 
 	for name, lastChangeTriggerTimes := range endpointUpdateResult.LastChangeTriggerTimes {
 		for _, lastChangeTriggerTime := range lastChangeTriggerTimes {

--- a/pkg/proxy/nftables/proxier_test.go
+++ b/pkg/proxy/nftables/proxier_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package nftables
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"reflect"
@@ -128,6 +129,8 @@ func NewFakeProxier(ipFamily v1.IPFamily) (*knftables.Fake, *Proxier) {
 		nodePortAddresses:   proxyutil.NewNodePortAddresses(ipFamily, nodePortAddresses),
 		networkInterfacer:   networkInterfacer,
 		staleChains:         make(map[string]time.Time),
+		activeChains:        sets.New[string](),
+		activeAffinitySets:  sets.New[string](),
 		serviceCIDRs:        serviceCIDRs,
 		logRateLimiter:      rate.NewLimiter(rate.Every(24*time.Hour), 1),
 		clusterIPs:          newNFTElementStorage("set", clusterIPsSet),
@@ -3826,6 +3829,58 @@ func assertNumOperations(t *testing.T, nft *knftables.Fake, ops ...int) {
 	}
 	if nft.LastTransaction.NumOperations() != expectedOps {
 		t.Errorf("Expected transaction with %d operations, got %d", expectedOps, nft.LastTransaction.NumOperations())
+	}
+}
+
+type countingNFTables struct {
+	knftables.Interface
+	listAllCalls int
+}
+
+func (nft *countingNFTables) ListAll(ctx context.Context) (map[string][]string, error) {
+	nft.listAllCalls++
+	return nft.Interface.ListAll(ctx)
+}
+
+func TestSyncProxyRulesSkipsListAllOnIncrementalSync(t *testing.T) {
+	nft, fp := NewFakeProxier(v1.IPv4Protocol)
+	countingNFT := &countingNFTables{Interface: nft}
+	fp.nftables = countingNFT
+
+	makeServiceMap(fp,
+		makeTestService("ns1", "svc1", func(svc *v1.Service) {
+			svc.Spec.Type = v1.ServiceTypeClusterIP
+			svc.Spec.ClusterIP = "172.30.0.41"
+			svc.Spec.Ports = []v1.ServicePort{{
+				Name:     "p80",
+				Port:     80,
+				Protocol: v1.ProtocolTCP,
+			}}
+		}),
+	)
+	populateEndpointSlices(fp,
+		makeTestEndpointSlice("ns1", "svc1", 1, func(eps *discovery.EndpointSlice) {
+			eps.AddressType = discovery.AddressTypeIPv4
+			eps.Endpoints = []discovery.Endpoint{{
+				Addresses: []string{"10.0.1.1"},
+				NodeName:  ptr.To(testNodeName),
+			}}
+			eps.Ports = []discovery.EndpointPort{{
+				Name:     ptr.To("p80"),
+				Port:     ptr.To[int32](80),
+				Protocol: ptr.To(v1.ProtocolTCP),
+			}}
+		}),
+	)
+
+	fp.syncProxyRules()
+	if countingNFT.listAllCalls != 1 {
+		t.Fatalf("expected initial full sync to call ListAll once, got %d", countingNFT.listAllCalls)
+	}
+
+	fp.syncProxyRules()
+	if countingNFT.listAllCalls != 1 {
+		t.Fatalf("expected incremental sync to skip ListAll, got %d calls", countingNFT.listAllCalls)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Refs #139513

Issue #139513 reports that kube-proxy nftables incremental sync time grows super-linearly with Service count, and that at 44k Services the incremental sync is almost entirely spent in `nft --json --terse list table ip kube-proxy` via `ListAll`.

Root cause: `syncProxyRules` calls `ListAll` on every sync, including `fullSync=false` incremental syncs. The result is only needed to discover previously committed service chains and affinity sets for cleanup. kube-proxy already maintains map/set element state across successful syncs; this PR adds equivalent committed-state tracking for service chains and affinity sets so incremental syncs can avoid table-wide discovery.

Summary of changes:
- track committed service chains and affinity sets after successful syncs
- keep the full-sync reconciliation path using `ListAll`
- use the committed in-memory chain/set state for incremental sync cleanup
- add a focused fake nftables regression test that verifies an initial full sync calls `ListAll` once and a following incremental sync skips it

#### Which issue(s) this PR is related to:

Refs #139513

#### Special notes for your reviewer:

This is draft because local execution of Linux-tagged nftables tests was not possible on my macOS host. The package compiles for Linux locally, but the Linux test binary cannot be executed here without Docker/qemu.

Local reproduction/validation commands:

```console
# Inspected issue and linked PR state
gh issue view 139513 --repo kubernetes/kubernetes --json number,title,body,comments,labels,assignees,closedByPullRequestsReferences,url

# Reproduced root cause in code: pre-change syncProxyRules calls ListAll unconditionally before every sync.
rg -n "ListAll|doFullSync|activeChains|activeAffinitySets" pkg/proxy/nftables/proxier.go pkg/proxy/nftables/proxier_test.go

# Formatting / whitespace
gofmt -w pkg/proxy/nftables/proxier.go pkg/proxy/nftables/proxier_test.go
git diff --check

# Linux compile validation for the Linux-only nftables tests/package
GOOS=linux go test -c ./pkg/proxy/nftables -o /tmp/nftables.test

# Native macOS test attempt; expected to report no test files because proxier_test.go is linux-build-tagged
go test ./pkg/proxy/nftables -run TestSyncProxyRulesSkipsListAllOnIncrementalSync -count=1
# result: ? k8s.io/kubernetes/pkg/proxy/nftables [no test files]
```

Local test limitation:
- `GOOS=linux go test ./pkg/proxy/nftables -run TestSyncProxyRulesSkipsListAllOnIncrementalSync -count=1` produced `exec format error` on Darwin because it builds a Linux binary.
- `docker`, `podman`, `nerdctl`, `colima`, `lima`, and qemu runners were not available locally.

Rollout / rollback notes:
- Rollout risk is scoped to kube-proxy nftables mode incremental sync cleanup bookkeeping.
- Full sync still reconciles against the kernel with `ListAll`.
- If an incremental transaction fails, existing failure handling forces the next sync to be full, which refreshes state from nftables.
- Rollback is reverting this commit; kube-proxy returns to calling `ListAll` on every sync.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
