### PR TITLE
[release-1.34] Bugfix: DeleteOptions decode errors should return 400 instead of 500

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete.go
@@ -103,11 +103,13 @@ func DeleteResource(r rest.GracefulDeleter, allowsOptions bool, scope *RequestSc
 				defaultGVK := scope.MetaGroupVersion.WithKind("DeleteOptions")
 				obj, gvk, err := apihelpers.GetMetaInternalVersionCodecs().DecoderToVersion(s.Serializer, defaultGVK.GroupVersion()).Decode(body, &defaultGVK, options)
 				if err != nil {
+					err = errors.NewBadRequest(err.Error())
 					scope.err(err, w, req)
 					return
 				}
 				if obj != options {
-					scope.err(fmt.Errorf("decoded object cannot be converted to DeleteOptions"), w, req)
+					err = errors.NewBadRequest("decoded object cannot be converted to DeleteOptions")
+					scope.err(err, w, req)
 					return
 				}
 				span.AddEvent("Decoded delete options")
@@ -278,11 +280,13 @@ func DeleteCollection(r rest.CollectionDeleter, checkBody bool, scope *RequestSc
 				defaultGVK := scope.MetaGroupVersion.WithKind("DeleteOptions")
 				obj, gvk, err := apihelpers.GetMetaInternalVersionCodecs().DecoderToVersion(s.Serializer, defaultGVK.GroupVersion()).Decode(body, &defaultGVK, options)
 				if err != nil {
+					err = errors.NewBadRequest(err.Error())
 					scope.err(err, w, req)
 					return
 				}
 				if obj != options {
-					scope.err(fmt.Errorf("decoded object cannot be converted to DeleteOptions"), w, req)
+					err = errors.NewBadRequest("decoded object cannot be converted to DeleteOptions")
+					scope.err(err, w, req)
 					return
 				}
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apiserver/pkg/admission"
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
 	"k8s.io/apiserver/pkg/audit"
@@ -41,7 +42,6 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/handlers/negotiation"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
-
 	"k8s.io/utils/ptr"
 )
 
@@ -147,6 +147,98 @@ func TestDeleteResourceAuditLogRequestObject(t *testing.T) {
 	}
 }
 
+// For issues https://github.com/kubernetes/kubernetes/issues/132359 and https://github.com/kubernetes/kubernetes/issues/139491
+func TestDeleteResourceDeleteOptions(t *testing.T) {
+	ctx := t.Context()
+	fakeDeleterFn := func(ctx context.Context, _ rest.ValidateObjectFunc, _ *metav1.DeleteOptions) (runtime.Object, bool, error) {
+		return nil, false, nil
+	}
+	js := jsonserializer.NewSerializerWithOptions(jsonserializer.DefaultMetaFactory, nil, nil, jsonserializer.SerializerOptions{})
+	scope := &RequestScope{
+		Namer: &mockNamer{},
+		Serializer: &fakeSerializer{
+			serializer: runtime.NewCodec(js, js),
+		},
+	}
+	handler := DeleteResource(fakeDeleterFunc(fakeDeleterFn), true, scope, nil)
+
+	tests := []struct {
+		name       string
+		body       string
+		expectCode int
+	}{
+		{
+			name:       "valid delete options",
+			body:       "{}",
+			expectCode: 200,
+		},
+		{
+			name:       "gracePeriodSeconds invalid type",
+			body:       `{"gracePeriodSeconds":"true"}`,
+			expectCode: 400,
+		},
+		{
+			name:       "ignoreStoreReadErrorWithClusterBreakingPotential invalid type",
+			body:       `{"ignoreStoreReadErrorWithClusterBreakingPotential":1}`,
+			expectCode: 400,
+		},
+		{
+			name:       "orphanDependents invalid Go type",
+			body:       `{"orphanDependents": "randomString"}`,
+			expectCode: 400,
+		},
+		{
+			name:       "orphanDependents invalid type int",
+			body:       `{"orphanDependents":1}`,
+			expectCode: 400,
+		},
+		{
+			name:       "propagationPolicy invalid type",
+			body:       `{"propagationPolicy":1}`,
+			expectCode: 400,
+		},
+		{
+			name:       "preconditions invalid type",
+			body:       `{"preconditions":"fix"}`,
+			expectCode: 400,
+		},
+		{
+			name:       "apiVersion/kind mismatch",
+			body:       `{ "apiVersion": "v1", "kind": "APIResourceList" }`,
+			expectCode: 400,
+		},
+		{
+			name:       "apiVersion invalid type",
+			body:       `{ "apiVersion": false, "kind": "DeleteOptions" }`,
+			expectCode: 400,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req, err := http.NewRequestWithContext(ctx, request.MethodDelete, "/api/v1/namespaces/default/pods/testpod", strings.NewReader(test.body))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Accept", "*/*")
+
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, req)
+			gotCode := recorder.Code
+			if gotCode != test.expectCode {
+				t.Fatalf("expected status %v but got %v", test.expectCode, gotCode)
+			}
+		})
+	}
+}
+
+type fakeDeleterFunc func(ctx context.Context, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error)
+
+func (f fakeDeleterFunc) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
+	return f(ctx, deleteValidation, options)
+}
+
 func TestDeleteCollection(t *testing.T) {
 	req := &http.Request{
 		Header: http.Header{},
@@ -211,6 +303,92 @@ func TestDeleteCollection(t *testing.T) {
 				if !strings.Contains(err.Error(), test.expectErr) {
 					t.Fatalf("expect %s but got %s", test.expectErr, err.Error())
 				}
+			}
+		})
+	}
+}
+
+// For issues https://github.com/kubernetes/kubernetes/issues/132359 and https://github.com/kubernetes/kubernetes/issues/139491
+func TestDeleteCollectionDeleteOptions(t *testing.T) {
+	ctx := t.Context()
+	fakeDeleterFn := func(ctx context.Context, _ rest.ValidateObjectFunc, _ *metav1.DeleteOptions, _ *metainternalversion.ListOptions) (runtime.Object, error) {
+		return nil, nil
+	}
+	js := jsonserializer.NewSerializerWithOptions(jsonserializer.DefaultMetaFactory, nil, nil, jsonserializer.SerializerOptions{})
+	scope := &RequestScope{
+		Namer: &mockNamer{},
+		Serializer: &fakeSerializer{
+			serializer: runtime.NewCodec(js, js),
+		},
+	}
+	handler := DeleteCollection(fakeCollectionDeleterFunc(fakeDeleterFn), true, scope, nil)
+
+	tests := []struct {
+		name       string
+		body       string
+		expectCode int
+	}{
+		{
+			name:       "valid delete options",
+			body:       "{}",
+			expectCode: 200,
+		},
+		{
+			name:       "gracePeriodSeconds invalid type",
+			body:       `{"gracePeriodSeconds":"true"}`,
+			expectCode: 400,
+		},
+		{
+			name:       "ignoreStoreReadErrorWithClusterBreakingPotential invalid type",
+			body:       `{"ignoreStoreReadErrorWithClusterBreakingPotential":1}`,
+			expectCode: 400,
+		},
+		{
+			name:       "orphanDependents invalid Go type",
+			body:       `{"orphanDependents": "randomString"}`,
+			expectCode: 400,
+		},
+		{
+			name:       "orphanDependents invalid type int",
+			body:       `{"orphanDependents":1}`,
+			expectCode: 400,
+		},
+		{
+			name:       "propagationPolicy invalid type",
+			body:       `{"propagationPolicy":1}`,
+			expectCode: 400,
+		},
+		{
+			name:       "preconditions invalid type",
+			body:       `{"preconditions":"fix"}`,
+			expectCode: 400,
+		},
+		{
+			name:       "apiVersion/kind mismatch",
+			body:       `{ "apiVersion": "v1", "kind": "APIResourceList" }`,
+			expectCode: 400,
+		},
+		{
+			name:       "apiVersion invalid type",
+			body:       `{ "apiVersion": false, "kind": "DeleteOptions" }`,
+			expectCode: 400,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req, err := http.NewRequestWithContext(ctx, request.MethodDelete, "/api/v1/namespaces/default/pods/testpod", strings.NewReader(test.body))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Accept", "*/*")
+
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, req)
+			gotCode := recorder.Code
+			if gotCode != test.expectCode {
+				t.Fatalf("expected status %v but got %v", test.expectCode, gotCode)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Backport of #132359 to release-1.34.

When DELETE requests include a DeleteOptions body with invalid JSON field types, the apiserver returns HTTP 400 instead of HTTP 500.

#### Which issue(s) this PR is related to:

Fixes #139491

- #132359

#### Special notes for your reviewer:

Cherry-pick style backport of the fix from #132359, with additional test coverage for all repro cases from #139491.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where the API server returned HTTP 500 instead of HTTP 400 when DELETE requests contained DeleteOptions with invalid JSON field types.
```

/sig api-machinery
/area apiserver