### PR TITLE
use FeatureSupportChecker to detect etcd RangeStream support

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/etcd3/metrics"
+	etcdfeature "k8s.io/apiserver/pkg/storage/feature"
 	"k8s.io/apiserver/pkg/storage/value"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	utilflowcontrol "k8s.io/apiserver/pkg/util/flowcontrol"
@@ -291,8 +292,8 @@ func (wc *watchChan) RequestWatchProgress() error {
 // The revision to watch will be set to the revision in response.
 // All events sent will have isCreated=true
 func (wc *watchChan) sync() error {
-	// TODO(jefftree): detect RangeStream support via the etcd feature checker.
-	if wc.recursive && utilfeature.DefaultFeatureGate.Enabled(features.EtcdRangeStream) {
+	if wc.recursive && utilfeature.DefaultFeatureGate.Enabled(features.EtcdRangeStream) &&
+		etcdfeature.DefaultFeatureSupportChecker.Supports(storage.RangeStream) {
 		err := wc.syncStreamRecursive()
 		if err == nil {
 			return nil
@@ -374,6 +375,9 @@ func (wc *watchChan) syncStreamRecursive() error {
 	streamResp, err := wc.watcher.client.KV.GetStream(wc.ctx, wc.key, opts...)
 	metrics.RecordEtcdRequest("listStream", wc.watcher.groupResource, err, startTime)
 	if err != nil {
+		if grpcstatus.Code(err) == grpccodes.Unimplemented {
+			etcdfeature.DefaultFeatureSupportChecker.MarkUnsupported(storage.RangeStream)
+		}
 		return err
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/etcd3/testserver"
+	etcdfeature "k8s.io/apiserver/pkg/storage/feature"
 	storagetesting "k8s.io/apiserver/pkg/storage/testing"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -376,6 +377,10 @@ func TestWatchChanSyncStreamMatchesPaginated(t *testing.T) {
 func TestWatchChanSyncStreamFallsBackToPaginated(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EtcdRangeStream, true)
 
+	origChecker := etcdfeature.DefaultFeatureSupportChecker
+	etcdfeature.DefaultFeatureSupportChecker = etcdfeature.NewDefaultFeatureSupportChecker()
+	t.Cleanup(func() { etcdfeature.DefaultFeatureSupportChecker = origChecker })
+
 	origCtx, store, _ := testSetup(t)
 	initList, err := initStoreData(origCtx, store)
 	if err != nil {
@@ -397,6 +402,9 @@ func TestWatchChanSyncStreamFallsBackToPaginated(t *testing.T) {
 	}
 	if w.initialRev <= 0 {
 		t.Errorf("expected initialRev to be set by the paginated fallback, got %d", w.initialRev)
+	}
+	if etcdfeature.DefaultFeatureSupportChecker.Supports(storage.RangeStream) {
+		t.Error("expected RangeStream to be marked unsupported after the Unimplemented fallback")
 	}
 
 	close(w.incomingEventChan)

--- a/staging/src/k8s.io/apiserver/pkg/storage/feature/feature_support_checker.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/feature/feature_support_checker.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 )
 
@@ -41,14 +42,17 @@ var (
 	DefaultFeatureSupportChecker FeatureSupportChecker = newDefaultFeatureSupportChecker()
 )
 
+// rangeStreamRecheckInterval is how long RangeStream stays marked unsupported
+// before Supports reports it supported again. See storage.RangeStream.
+const rangeStreamRecheckInterval = 10 * time.Minute
+
 // FeatureSupportChecker to define Supports functions.
 type FeatureSupportChecker interface {
-	// Supports check if the feature is supported or not by checking internal cache.
-	// By default all calls to this function before calling CheckClient returns false.
-	// Returns true if all endpoints in etcd clients are supporting the feature.
-	// If client A supports and client B doesn't support the feature, the `Supports` will
-	// first return true at client A initializtion and then return false on client B
-	// initialzation, it can flip the support at runtime.
+	// Supports reports whether the etcd backend supports the given feature, from
+	// the result cached by CheckClient/MarkUnsupported. Before support is known it
+	// returns the feature's default, documented on the Feature constants (see
+	// storage.RequestWatchProgress and storage.RangeStream). Support can flip at
+	// runtime as endpoints are checked.
 	Supports(feature storage.Feature) bool
 	// CheckClient works with etcd client to recalcualte feature support and cache it internally.
 	// All etcd clients should support feature to cause `Supports` return true.
@@ -56,18 +60,31 @@ type FeatureSupportChecker interface {
 	// first return true at client A initializtion and then return false on client B
 	// initialzation, it can flip the support at runtime.
 	CheckClient(ctx context.Context, c client, feature storage.Feature)
+	// MarkUnsupported records that an etcd endpoint reported the feature
+	// unimplemented. See the Feature constants for per-feature recheck behavior
+	// (e.g. storage.RangeStream).
+	MarkUnsupported(feature storage.Feature)
 }
 
 type defaultFeatureSupportChecker struct {
-	lock                    sync.Mutex
-	progressNotifySupported *bool
-	checkingEndpoint        map[string]struct{}
+	lock                     sync.Mutex
+	progressNotifySupported  *bool
+	rangeStreamUnsupportedAt time.Time
+	clock                    clock.Clock
+	checkingEndpoint         map[string]struct{}
 }
 
 func newDefaultFeatureSupportChecker() *defaultFeatureSupportChecker {
 	return &defaultFeatureSupportChecker{
 		checkingEndpoint: make(map[string]struct{}),
+		clock:            clock.RealClock{},
 	}
+}
+
+// NewDefaultFeatureSupportChecker returns a new FeatureSupportChecker.
+// DefaultFeatureSupportChecker is the shared instance used by the storage layer.
+func NewDefaultFeatureSupportChecker() FeatureSupportChecker {
+	return newDefaultFeatureSupportChecker()
 }
 
 // Supports can check the featue from anywhere without storage if it was cached before.
@@ -78,6 +95,14 @@ func (f *defaultFeatureSupportChecker) Supports(feature storage.Feature) bool {
 		defer f.lock.Unlock()
 
 		return ptr.Deref(f.progressNotifySupported, false)
+	case storage.RangeStream:
+		f.lock.Lock()
+		defer f.lock.Unlock()
+
+		if f.rangeStreamUnsupportedAt.IsZero() {
+			return true
+		}
+		return f.clock.Since(f.rangeStreamUnsupportedAt) >= rangeStreamRecheckInterval
 	default:
 		runtime.HandleError(fmt.Errorf("feature %q is not implemented in DefaultFeatureSupportChecker", feature))
 		return false
@@ -89,6 +114,17 @@ func (f *defaultFeatureSupportChecker) CheckClient(ctx context.Context, c client
 	switch feature {
 	case storage.RequestWatchProgress:
 		f.checkClient(ctx, c)
+	default:
+		runtime.HandleError(fmt.Errorf("feature %q is not implemented in DefaultFeatureSupportChecker", feature))
+	}
+}
+
+func (f *defaultFeatureSupportChecker) MarkUnsupported(feature storage.Feature) {
+	switch feature {
+	case storage.RangeStream:
+		f.lock.Lock()
+		defer f.lock.Unlock()
+		f.rangeStreamUnsupportedAt = f.clock.Now()
 	default:
 		runtime.HandleError(fmt.Errorf("feature %q is not implemented in DefaultFeatureSupportChecker", feature))
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/feature/feature_support_checker_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/feature/feature_support_checker_test.go
@@ -20,10 +20,12 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"k8s.io/apiserver/pkg/storage"
+	testingclock "k8s.io/utils/clock/testing"
 )
 
 type mockEndpointVersion struct {
@@ -89,6 +91,11 @@ func TestSupports(t *testing.T) {
 			testName:       "Disabled - default",
 			featureName:    storage.RequestWatchProgress,
 			expectedResult: false,
+		},
+		{
+			testName:       "Enabled - RangeStream defaults to supported until proven otherwise",
+			featureName:    storage.RangeStream,
+			expectedResult: true,
 		},
 	}
 
@@ -266,4 +273,21 @@ func TestSupportsRequestWatchProgress(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMarkUnsupported(t *testing.T) {
+	f := newDefaultFeatureSupportChecker()
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	f.clock = fakeClock
+
+	assert.True(t, f.Supports(storage.RangeStream))
+
+	f.MarkUnsupported(storage.RangeStream)
+	assert.False(t, f.Supports(storage.RangeStream))
+
+	fakeClock.Step(rangeStreamRecheckInterval - time.Second)
+	assert.False(t, f.Supports(storage.RangeStream))
+
+	fakeClock.Step(2 * time.Second)
+	assert.True(t, f.Supports(storage.RangeStream))
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -34,8 +34,14 @@ import (
 // Feature is the name of each feature in storage that we check in feature_support_checker.
 type Feature = string
 
-// RequestWatchProgress is an etcd feature that may use to check if it supported or not.
+// RequestWatchProgress is an etcd feature for progress notification requests.
+// Default: false.
 var RequestWatchProgress Feature = "RequestWatchProgress"
+
+// RangeStream is an etcd feature (etcd 3.7+) for the streaming list RPC.
+// Default: true. MarkUnsupported flips it to false on an Unimplemented response,
+// reverting to true after a recheck interval.
+var RangeStream Feature = "RangeStream"
 
 // Versioner abstracts setting and retrieving metadata fields from database response
 // onto the object ot list. It is required to maintain storage invariants - updating an


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Gate the RangeStream streaming list (etcd 3.7+) at watch cache initialization via the FeatureSupportChecker. Clusters whose etcd lacks it fall back to a paginated list and stop re-attempting the streaming call on every init.

FeatureChecker is an async check. Each watch cache init must pick a RangeStream list or a paginated list, and the FeatureChecker probe may not be initialized. Three options:

1. **Block init on a feature check.** Correct, but adds probe latency to every init and stalls on slow etcd.
2. **Default unsupported until a check confirms.** Never fails a call, but caches that init before the check use paginated even when streaming is supported, silently losing the optimization.
3. **Default supported, attempt, fall back.** Try RangeStream, fall back to paginated on Unimplemented. Costs at most one failed RPC per recheck window on old etcd.

This PR takes option 3, since RangeStream falls back cleanly. `Supports(RangeStream)` defaults true, the watcher marks it unsupported on Unimplemented, and the mark expires after 10 minutes so a later init re-attempts streaming and picks up an etcd upgrade without a restart.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
