### PR TITLE
Improve kubelet exec probes and init CPU reuse

### DIFF
--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -675,32 +675,52 @@ func (p *staticPolicy) RemoveContainer(logger logr.Logger, s state.State, podUID
 func (p *staticPolicy) allocateCPUs(logger logr.Logger, s state.State, numCPUs int, numaAffinity bitmask.BitMask, reusableCPUs cpuset.CPUSet) (topology.Allocation, error) {
 	logger.Info("AllocateCPUs", "numCPUs", numCPUs, "socket", numaAffinity)
 
-	allocatableCPUs := p.GetAvailableCPUs(s).Union(reusableCPUs)
+	availableCPUs := p.GetAvailableCPUs(s)
+	allocatableCPUs := availableCPUs.Union(reusableCPUs)
+	if numCPUs > allocatableCPUs.Size() {
+		return topology.EmptyAllocation(), fmt.Errorf("not enough cpus available to satisfy request: requested=%d, available=%d", numCPUs, allocatableCPUs.Size())
+	}
 
-	// If there are aligned CPUs in numaAffinity, attempt to take those first.
 	result := topology.EmptyAllocation()
-	if numaAffinity != nil {
-		alignedCPUs := p.getAlignedCPUs(numaAffinity, allocatableCPUs)
-
-		numAlignedToAlloc := alignedCPUs.Size()
-		if numCPUs < numAlignedToAlloc {
-			numAlignedToAlloc = numCPUs
+	takeCPUs := func(candidates cpuset.CPUSet, numToTake int) error {
+		candidates = candidates.Difference(result.CPUs)
+		if numToTake > candidates.Size() {
+			numToTake = candidates.Size()
+		}
+		if numToTake <= 0 {
+			return nil
 		}
 
-		allocatedCPUs, err := p.takeByTopology(logger, alignedCPUs, numAlignedToAlloc)
+		allocatedCPUs, err := p.takeByTopology(logger, candidates, numToTake)
 		if err != nil {
+			return err
+		}
+		result.CPUs = result.CPUs.Union(allocatedCPUs)
+		return nil
+	}
+
+	if numaAffinity != nil {
+		alignedReusableCPUs := p.getAlignedCPUs(numaAffinity, reusableCPUs)
+		if err := takeCPUs(alignedReusableCPUs, numCPUs-result.CPUs.Size()); err != nil {
 			return topology.EmptyAllocation(), err
 		}
 
-		result.CPUs = result.CPUs.Union(allocatedCPUs)
+		alignedCPUs := p.getAlignedCPUs(numaAffinity, availableCPUs)
+		if err := takeCPUs(alignedCPUs, numCPUs-result.CPUs.Size()); err != nil {
+			return topology.EmptyAllocation(), err
+		}
 	}
 
-	// Get any remaining CPUs from what's leftover after attempting to grab aligned ones.
-	remainingCPUs, err := p.takeByTopology(logger, allocatableCPUs.Difference(result.CPUs), numCPUs-result.CPUs.Size())
-	if err != nil {
+	if err := takeCPUs(reusableCPUs, numCPUs-result.CPUs.Size()); err != nil {
 		return topology.EmptyAllocation(), err
 	}
-	result.CPUs = result.CPUs.Union(remainingCPUs)
+
+	if err := takeCPUs(availableCPUs, numCPUs-result.CPUs.Size()); err != nil {
+		return topology.EmptyAllocation(), err
+	}
+	if result.CPUs.Size() != numCPUs {
+		return topology.EmptyAllocation(), fmt.Errorf("failed to allocate cpus")
+	}
 	result.Aligned = p.topology.CheckAlignment(result.CPUs)
 
 	// Remove allocated CPUs from the shared CPUSet.

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -773,6 +773,48 @@ func TestStaticPolicyReuseCPUs(t *testing.T) {
 	}
 }
 
+func TestStaticPolicyPrefersReusableCPUs(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	policy, err := NewStaticPolicy(logger, topoSingleSocketHT, 1, cpuset.New(), topologymanager.NewFakeManager(), nil)
+	if err != nil {
+		t.Fatalf("NewStaticPolicy() failed: %v", err)
+	}
+
+	st := &mockState{
+		assignments:   state.ContainerCPUAssignments{},
+		defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+	}
+	pod := makeMultiContainerPod(
+		[]struct{ request, limit string }{
+			{"1000m", "1000m"}},
+		[]struct{ request, limit string }{
+			{"2000m", "2000m"}})
+
+	if err := policy.Allocate(logger, st, pod, &pod.Spec.InitContainers[0]); err != nil {
+		t.Fatalf("StaticPolicy Allocate() init container error: %v", err)
+	}
+	initCSet := st.assignments[string(pod.UID)][pod.Spec.InitContainers[0].Name]
+	if initCSet.Size() != 1 {
+		t.Fatalf("StaticPolicy Allocate() expected one init container CPU, got %s", initCSet)
+	}
+	defaultCPUSetAfterInit := st.defaultCPUSet.Clone()
+
+	if err := policy.Allocate(logger, st, pod, &pod.Spec.Containers[0]); err != nil {
+		t.Fatalf("StaticPolicy Allocate() app container error: %v", err)
+	}
+	appCSet := st.assignments[string(pod.UID)][pod.Spec.Containers[0].Name]
+	if appCSet.Size() != 2 {
+		t.Fatalf("StaticPolicy Allocate() expected two app container CPUs, got %s", appCSet)
+	}
+	if !initCSet.IsSubsetOf(appCSet) {
+		t.Errorf("StaticPolicy Allocate() expected app container cpuset %s to reuse init container cpuset %s", appCSet, initCSet)
+	}
+	freshCPUs := appCSet.Difference(initCSet)
+	if !st.defaultCPUSet.Equals(defaultCPUSetAfterInit.Difference(freshCPUs)) {
+		t.Errorf("StaticPolicy Allocate() default cpuset %s lost CPUs outside app fresh allocation %s", st.defaultCPUSet, freshCPUs)
+	}
+}
+
 func TestStaticPolicyDoNotReuseCPUs(t *testing.T) {
 	testCases := []struct {
 		staticPolicyTest

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"time"
 
+	"golang.org/x/sync/singleflight"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -47,6 +48,8 @@ type prober struct {
 	tcp    tcpprobe.Prober
 	grpc   grpcprobe.Prober
 	runner kubecontainer.CommandRunner
+
+	execProbeGroup singleflight.Group
 
 	recorder record.EventRecorderLogger
 }
@@ -155,7 +158,7 @@ func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe
 	case p.Exec != nil:
 		logger.V(4).Info("Exec-Probe runProbe", "pod", klog.KObj(pod), "containerName", container.Name, "execCommand", p.Exec.Command)
 		command := kubecontainer.ExpandContainerCommandOnlyStatic(p.Exec.Command, container.Env)
-		return pb.exec.Probe(pb.newExecInContainer(ctx, pod, container, containerID, command, timeout))
+		return pb.runExecProbe(ctx, pod, container, containerID, command, timeout)
 
 	case p.HTTPGet != nil:
 		req, err := httpprobe.NewRequestForHTTPGetAction(p.HTTPGet, &container, status.PodIP, "probe")
@@ -200,6 +203,29 @@ func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe
 		logger.V(4).Info("Failed to find probe builder for container", "containerName", container.Name)
 		return probe.Unknown, "", fmt.Errorf("missing probe handler for %s:%s", format.Pod(pod), container.Name)
 	}
+}
+
+type execProbeResult struct {
+	result probe.Result
+	output string
+}
+
+func execProbeKey(containerID kubecontainer.ContainerID, cmd []string, timeout time.Duration) string {
+	return fmt.Sprintf("%s\x00%s\x00%q", containerID.String(), timeout, cmd)
+}
+
+func (pb *prober) runExecProbe(ctx context.Context, pod *v1.Pod, container v1.Container, containerID kubecontainer.ContainerID, cmd []string, timeout time.Duration) (probe.Result, string, error) {
+	key := execProbeKey(containerID, cmd, timeout)
+	value, err, _ := pb.execProbeGroup.Do(key, func() (any, error) {
+		result, output, err := pb.exec.Probe(pb.newExecInContainer(ctx, pod, container, containerID, cmd, timeout))
+		return execProbeResult{result: result, output: output}, err
+	})
+	if value == nil {
+		return probe.Unknown, "", err
+	}
+
+	execResult := value.(execProbeResult)
+	return execResult.result, execResult.output, err
 }
 
 type execInContainer struct {

--- a/pkg/kubelet/prober/prober_test.go
+++ b/pkg/kubelet/prober/prober_test.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,6 +40,7 @@ import (
 	"k8s.io/kubernetes/pkg/probe"
 	execprobe "k8s.io/kubernetes/pkg/probe/exec"
 	"k8s.io/kubernetes/test/utils/ktesting"
+	"k8s.io/utils/exec"
 )
 
 func TestGetURLParts(t *testing.T) {
@@ -274,6 +277,82 @@ func TestProbe(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+type blockingExecProber struct {
+	calls   atomic.Int32
+	started chan struct{}
+	release <-chan struct{}
+	result  probe.Result
+	output  string
+	err     error
+}
+
+func (p *blockingExecProber) Probe(c exec.Cmd) (probe.Result, string, error) {
+	if p.calls.Add(1) == 1 {
+		close(p.started)
+	}
+	<-p.release
+	return p.result, p.output, p.err
+}
+
+func TestRunProbeCoalescesConcurrentExecProbes(t *testing.T) {
+	ctx := ktesting.Init(t)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	execProber := &blockingExecProber{
+		started: started,
+		release: release,
+		result:  probe.Success,
+		output:  "ok",
+	}
+	prober := &prober{
+		exec: execProber,
+	}
+	probeSpec := &v1.Probe{
+		ProbeHandler: v1.ProbeHandler{
+			Exec: &v1.ExecAction{Command: []string{"cat", "/tmp/healthy"}},
+		},
+		TimeoutSeconds: 1,
+	}
+	pod := &v1.Pod{}
+	container := v1.Container{Name: "container"}
+	containerID := kubecontainer.ContainerID{Type: "test", ID: "container"}
+
+	results := make(chan error, 2)
+	run := func(probeType probeType, ready chan<- struct{}) {
+		if ready != nil {
+			close(ready)
+		}
+		result, output, err := prober.runProbe(ctx, probeType, probeSpec, pod, v1.PodStatus{}, container, containerID)
+		if err != nil {
+			results <- err
+			return
+		}
+		if result != probe.Success || output != "ok" {
+			results <- fmt.Errorf("expected success with output ok, got result=%v output=%q", result, output)
+			return
+		}
+		results <- nil
+	}
+
+	go run(liveness, nil)
+	<-started
+	readinessStarted := make(chan struct{})
+	go run(readiness, readinessStarted)
+	<-readinessStarted
+	time.Sleep(100 * time.Millisecond)
+	if got := execProber.calls.Load(); got != 1 {
+		t.Fatalf("expected one in-flight exec probe call, got %d", got)
+	}
+	close(release)
+
+	for i := 0; i < 2; i++ {
+		require.NoError(t, <-results)
+	}
+	if got := execProber.calls.Load(); got != 1 {
+		t.Fatalf("expected one exec probe call, got %d", got)
 	}
 }
 

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -347,8 +347,9 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 
 	// Note, exec probe does NOT have access to pod environment variables or downward API
 	result, err := w.probeManager.prober.probe(ctx, w.probeType, w.pod, status, w.container, w.containerID)
-	if err != nil {
-		// Prober error, throw away the result.
+	if err != nil && result != results.Failure {
+		// The prober maps execution errors that should affect health to Failure.
+		// Other errors preserve the existing no-result behavior.
 		return true
 	}
 

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package prober
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -706,6 +707,38 @@ func TestOnHoldOnLivenessOrStartupCheckFailure(t *testing.T) {
 		} else if probeType == startup && !w.onHold {
 			t.Errorf("Prober should be on hold due to %s check success", probeType)
 		}
+	}
+}
+
+func TestLivenessProbeErrorCountsAsFailure(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	m := newTestManager()
+	w := newTestWorker(m, liveness, v1.Probe{SuccessThreshold: 1, FailureThreshold: 3})
+	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatus())
+
+	m.prober.exec = fakeExecProber{probe.Success, nil}
+	msg := "initial probe success"
+	expectContinue(t, w, w.doProbe(ctx), msg)
+	expectResult(t, w, results.Success, msg)
+
+	m.prober.exec = fakeExecProber{probe.Unknown, errors.New("exec probe failed")}
+	for i := 0; i < 2; i++ {
+		msg := fmt.Sprintf("%d probe error below threshold", i+1)
+		expectContinue(t, w, w.doProbe(ctx), msg)
+		expectResult(t, w, results.Success, msg)
+		if w.resultRun != i+1 {
+			t.Errorf("Prober resultRun should be %d, but %d", i+1, w.resultRun)
+		}
+	}
+
+	msg = "probe error reached threshold"
+	expectContinue(t, w, w.doProbe(ctx), msg)
+	expectResult(t, w, results.Failure, msg)
+	if !w.onHold {
+		t.Errorf("Prober should be on hold after liveness probe error reaches failure threshold")
+	}
+	if w.resultRun != 0 {
+		t.Errorf("Prober resultRun should be reset to 0, but %d", w.resultRun)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node

#### What this PR does / why we need it:

This combines three node fixes in one PR:

- Coalesces identical in-flight exec probes for the same container, expanded command, and timeout so overlapping readiness/liveness exec probes share one runtime exec call.
- Counts exec probe execution errors as liveness/startup failures once the prober maps them to `Failure`, so invalid liveness commands reach the existing threshold and restart path.
- Prefers reusable standard init-container CPU assignments before allocating fresh CPUs in the static CPU manager policy, preventing completed init CPUs from being stranded when app containers request more CPUs.

#### Which issue(s) this PR fixes:

Fixes #106682
Fixes #112228
Addresses #82440

#### Special notes for reviewers:

#112228 has an open WIP PR, #131764, with a broader reconcile-loop cleanup. This PR keeps that larger cleanup out of scope and implements the smaller allocation-order fix.

#### Does this PR introduce a user-facing change?

```release-note
Kubelet now counts errored exec liveness probes as failures after probe error mapping, coalesces identical in-flight exec probes, and prefers reusable init-container CPUs before allocating fresh CPUs in the static CPU manager policy.
```

#### Additional documentation e.g., KEPs:

None

#### Testing:

- `go test ./pkg/kubelet/prober -run 'Test(LivenessProbeErrorCountsAsFailure|RunProbeCoalescesConcurrentExecProbes)' -count=1`
- `go test ./pkg/kubelet/cm/cpumanager -run TestStaticPolicyPrefersReusableCPUs -count=1`
- `go test ./pkg/kubelet/prober -count=1`
- `go test ./pkg/kubelet/cm/cpumanager -count=1`