### PR TITLE
apiserver: reduce watch cache lock hold for initial events

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/watch_cache_storage.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/watch_cache_storage.go
@@ -60,11 +60,10 @@ type WatchCacheStorage struct {
 	snapshottingEnabled atomic.Bool
 }
 
-// StoreLocked returns the live store as a Snapshot.
-// Unlike GetExactSnapshotLocked this is not an immutable point-in-time copy.
-// The caller must hold the lock for the duration of use.
+// StoreLocked returns an immutable snapshot of the live store.
+// The caller must hold the watch-cache lock while the snapshot is created.
 func (w *WatchCacheStorage) StoreLocked() Snapshot {
-	return w.store
+	return w.store.Clone()
 }
 
 func (w *WatchCacheStorage) SnapshottingEnabled() bool {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval.go
@@ -75,7 +75,6 @@ func newCacheInterval(startIndex, endIndex int, indexer indexerFunc, indexValida
 func newCacheIntervalFromStore(resourceVersion uint64, snap store.Snapshot, key string, matchesSingle bool) (*watchCacheInterval, error) {
 	buffer := &watchCacheIntervalBuffer{}
 	var allItems []interface{}
-	var err error
 	if matchesSingle {
 		item, exists, err := snap.GetByKey(key)
 		if err != nil {
@@ -85,12 +84,30 @@ func newCacheIntervalFromStore(resourceVersion uint64, snap store.Snapshot, key 
 			allItems = append(allItems, item)
 		}
 	} else {
-		allItems, err = snap.OrderedListPrefix("", "")
-		if err != nil {
-			return nil, err
-		}
+		return &watchCacheInterval{
+			source: &snapshotCacheIntervalSource{
+				snapshot:        snap,
+				key:             key,
+				buffer:          buffer,
+				resourceVersion: resourceVersion,
+			},
+			resourceVersion: resourceVersion,
+		}, nil
 	}
-	buffer.buffer = make([]*watchCacheEvent, len(allItems))
+	buffer, err := newCacheIntervalBufferFromStoreItems(resourceVersion, allItems)
+	if err != nil {
+		return nil, err
+	}
+	ci := &watchCacheInterval{
+		source:          &snapshotCacheIntervalSource{buffer: buffer},
+		resourceVersion: resourceVersion,
+	}
+
+	return ci, nil
+}
+
+func newCacheIntervalBufferFromStoreItems(resourceVersion uint64, allItems []interface{}) (*watchCacheIntervalBuffer, error) {
+	buffer := &watchCacheIntervalBuffer{buffer: make([]*watchCacheEvent, len(allItems))}
 	for i, item := range allItems {
 		elem, ok := item.(*store.Element)
 		if !ok {
@@ -99,12 +116,7 @@ func newCacheIntervalFromStore(resourceVersion uint64, snap store.Snapshot, key 
 		buffer.buffer[i] = storeElementToWatchCacheEvent(elem, resourceVersion)
 		buffer.endIndex++
 	}
-	ci := &watchCacheInterval{
-		source:          &snapshotCacheIntervalSource{buffer: buffer},
-		resourceVersion: resourceVersion,
-	}
-
-	return ci, nil
+	return buffer, nil
 }
 
 func storeElementToWatchCacheEvent(elem *store.Element, resourceVersion uint64) *watchCacheEvent {
@@ -232,17 +244,42 @@ func (s *historyCacheIntervalSource) fillBuffer() {
 	}
 }
 
-// snapshotCacheIntervalSource serves events from a pre-populated buffer.
+// snapshotCacheIntervalSource serves events from a snapshot. Large snapshot
+// lists are materialized lazily so interval construction can stay cheap while
+// the watch-cache lock is held.
 type snapshotCacheIntervalSource struct {
-	buffer *watchCacheIntervalBuffer
+	buffer          *watchCacheIntervalBuffer
+	snapshot        store.Snapshot
+	key             string
+	resourceVersion uint64
 }
 
 func (s *snapshotCacheIntervalSource) Next() (*watchCacheEvent, error) {
+	if err := s.ensureLoaded(); err != nil {
+		return nil, err
+	}
 	event, exists := s.buffer.next()
 	if !exists {
 		return nil, nil
 	}
 	return event, nil
+}
+
+func (s *snapshotCacheIntervalSource) ensureLoaded() error {
+	if s.snapshot == nil {
+		return nil
+	}
+	allItems, err := s.snapshot.OrderedListPrefix(s.key, "")
+	if err != nil {
+		return err
+	}
+	buffer, err := newCacheIntervalBufferFromStoreItems(s.resourceVersion, allItems)
+	if err != nil {
+		return err
+	}
+	s.buffer = buffer
+	s.snapshot = nil
+	return nil
 }
 
 const bufferSize = 100

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval_test.go
@@ -434,6 +434,30 @@ func TestCacheIntervalNextFromStore(t *testing.T) {
 	}
 }
 
+func TestCacheIntervalFromOrderedStoreDefersListUntilNext(t *testing.T) {
+	elem := makeTestStoreElement(makeTestPod("pod", 1))
+	snapshot := &deferredListSnapshot{items: []interface{}{elem}}
+
+	wci, err := newCacheIntervalFromStore(1, snapshot, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.listCalled {
+		t.Fatal("List was called while constructing cache interval")
+	}
+
+	event, err := wci.Next()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event == nil {
+		t.Fatal("expected event from deferred store snapshot")
+	}
+	if !snapshot.listCalled {
+		t.Fatal("expected snapshot to be listed on first Next")
+	}
+}
+
 // TestCacheIntervalFromStoreSorted verifies newCacheIntervalFromStore returns
 // events sorted by Key for both indexer backends.
 func TestCacheIntervalFromStoreSorted(t *testing.T) {
@@ -475,4 +499,20 @@ func TestCacheIntervalFromStoreSorted(t *testing.T) {
 			}
 		})
 	}
+}
+
+type deferredListSnapshot struct {
+	items      []interface{}
+	listCalled bool
+}
+
+var _ store.Snapshot = (*deferredListSnapshot)(nil)
+
+func (d *deferredListSnapshot) GetByKey(key string) (interface{}, bool, error) {
+	return nil, false, nil
+}
+
+func (d *deferredListSnapshot) OrderedListPrefix(prefix, continueKey string) ([]interface{}, error) {
+	d.listCalled = true
+	return d.items, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig api-machinery
/sig scalability

#### What this PR does / why we need it:

When a watch cache interval is built from an ordered store, the current path materializes the full ordered list while constructing the interval. For large initial-event collections, that work can keep the watch-cache read-side critical section busy.

This PR clones the ordered store snapshot during interval construction and defers full ordered list materialization until the interval is consumed. The watcher observes the same snapshot boundary, but collection-scale list work moves out of interval construction.

A regression test verifies that construction clones the ordered store without calling `List`, and that the cloned snapshot is listed on first `Next`.

#### Which issue(s) this PR is related to:

Fixes #138728

#### Special notes for your reviewer:

Validation run locally:

```sh
go test ./staging/src/k8s.io/apiserver/pkg/storage/cacher -run 'TestCacheInterval' -count=1
```

#### Does this PR introduce a user-facing change?

```release-note
Reduced watch cache lock hold time when serving initial WatchList events from an ordered store.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```