### PR TITLE
proxy/nftables: chunk cold-start transactions to avoid long netlink locks

### DIFF
--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -1133,18 +1133,178 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		}
 	}
 
-	// Now start the actual syncing transaction
-	tx := proxier.nftables.NewTransaction()
-	if doFullSync {
-		proxier.setupNFTables(tx)
-	}
-
 	// We need to use, eg, "ip daddr" for IPv4 but "ip6 daddr" for IPv6
 	ipX := "ip"
 	ipvX_addr := "ipv4_addr" //nolint:staticcheck // var name intentionally resembles value
 	if proxier.ipFamily == v1.IPv6Protocol {
 		ipX = "ip6"
 		ipvX_addr = "ipv6_addr"
+	}
+
+	// Now start the actual syncing transaction.
+	//
+	// On a full sync we split the work into multiple sequential transactions:
+	//   txInit:   initializes the table, base chains, and global sets/maps.
+	//   chunks:   creates endpoint chains/affinity sets and service chains in small batches.
+	//   tx:       populates rules into every chain and elements into every set/map.
+	//
+	// Submitting one giant transaction at scale (thousands of services) causes the
+	// kernel to hold a netlink lock for the entire duration, stalling traffic
+	// forwarding on a newly joined node.  Splitting into smaller chunked transactions
+	// keeps each individual kernel operation shorter.
+	//
+	// On an incremental (warm) sync doFullSync is false, so chainTx == tx and
+	// everything goes into a single transaction exactly as before.
+	tx := proxier.nftables.NewTransaction()
+	// chainTx is the transaction used for ensureChain calls in the rules loop.
+	// In the full-sync path it is intentionally nil: all ensureChain calls below
+	// pass doFullSync=true as skipCreation, so chainTx is never dereferenced.
+	var chainTx *knftables.Transaction
+	if !doFullSync {
+		chainTx = tx
+	} else {
+		// Initialize the table, base chains, and global sets/maps.
+		txInit := proxier.nftables.NewTransaction()
+		proxier.setupNFTables(txInit)
+		if err := proxier.nftables.Run(context.TODO(), txInit); err != nil {
+			proxier.logger.Error(err, "nftables table initialization failed")
+			metrics.NFTablesSyncFailuresTotal.WithLabelValues(string(proxier.ipFamily)).Inc()
+			clear(proxier.staleChains)
+			proxier.logFailure(txInit)
+			return err
+		}
+
+		// Collect all endpoint chains, affinity sets, and service chains that need to be created.
+		neededEndpointChains := sets.New[string]()
+		neededAffinitySets := make(map[string]time.Duration)
+		neededServiceChains := sets.New[string]()
+
+		for svcName, svc := range proxier.svcPortMap {
+			svcInfo, ok := svc.(*servicePortInfo)
+			if !ok {
+				continue
+			}
+
+			allEndpoints := proxier.endpointsMap[svcName]
+			clusterEndpoints, localEndpoints, allLocallyReachableEndpoints, _ := proxy.CategorizeEndpoints(allEndpoints, svcInfo, proxier.nodeName, proxier.topologyLabels)
+
+			serviceUsesAffinity := svcInfo.SessionAffinityType() == v1.ServiceAffinityClientIP
+
+			for _, ep := range allLocallyReachableEndpoints {
+				epInfo, ok := ep.(*endpointInfo)
+				if !ok {
+					continue
+				}
+				if serviceUsesAffinity {
+					neededEndpointChains.Insert(epInfo.chainName)
+					neededAffinitySets[epInfo.affinitySetName] = time.Duration(svcInfo.StickyMaxAgeSeconds()) * time.Second
+				}
+			}
+
+			if len(clusterEndpoints) > 0 && svcInfo.UsesClusterEndpoints() {
+				neededServiceChains.Insert(svcInfo.clusterPolicyChainName)
+			}
+			if len(localEndpoints) > 0 && svcInfo.UsesLocalEndpoints() {
+				neededServiceChains.Insert(svcInfo.localPolicyChainName)
+			}
+			if len(allEndpoints) > 0 && svcInfo.ExternallyAccessible() {
+				neededServiceChains.Insert(svcInfo.externalChainName)
+			}
+			if len(svcInfo.LoadBalancerVIPs()) > 0 && len(svcInfo.LoadBalancerSourceRanges()) > 0 {
+				neededServiceChains.Insert(svcInfo.firewallChainName)
+			}
+		}
+
+		// Batch create endpoint chains and affinity sets
+		currentTx := proxier.nftables.NewTransaction()
+		opsInCurrentTx := 0
+		const maxOpsPerTx = 1000
+
+		for _, chain := range neededEndpointChains.UnsortedList() {
+			if opsInCurrentTx >= maxOpsPerTx {
+				if err := proxier.nftables.Run(context.TODO(), currentTx); err != nil {
+					proxier.logger.Error(err, "failed to run chunked endpoint chains transaction")
+					metrics.NFTablesSyncFailuresTotal.WithLabelValues(string(proxier.ipFamily)).Inc()
+					clear(proxier.staleChains)
+					proxier.logFailure(currentTx)
+					return err
+				}
+				currentTx = proxier.nftables.NewTransaction()
+				opsInCurrentTx = 0
+			}
+			currentTx.Add(&knftables.Chain{
+				Name: chain,
+			})
+			currentTx.Flush(&knftables.Chain{
+				Name: chain,
+			})
+			opsInCurrentTx += 2
+		}
+
+		for name, timeout := range neededAffinitySets {
+			if opsInCurrentTx >= maxOpsPerTx {
+				if err := proxier.nftables.Run(context.TODO(), currentTx); err != nil {
+					proxier.logger.Error(err, "failed to run chunked affinity sets transaction")
+					metrics.NFTablesSyncFailuresTotal.WithLabelValues(string(proxier.ipFamily)).Inc()
+					clear(proxier.staleChains)
+					proxier.logFailure(currentTx)
+					return err
+				}
+				currentTx = proxier.nftables.NewTransaction()
+				opsInCurrentTx = 0
+			}
+			currentTx.Add(&knftables.Set{
+				Name:    name,
+				Type:    ipvX_addr,
+				Flags:   []knftables.SetFlag{knftables.DynamicFlag, knftables.TimeoutFlag},
+				Timeout: ptr.To(timeout),
+			})
+			opsInCurrentTx++
+		}
+
+		if opsInCurrentTx > 0 {
+			if err := proxier.nftables.Run(context.TODO(), currentTx); err != nil {
+				proxier.logger.Error(err, "failed to run chunked endpoint chains/affinity sets transaction")
+				metrics.NFTablesSyncFailuresTotal.WithLabelValues(string(proxier.ipFamily)).Inc()
+				clear(proxier.staleChains)
+				proxier.logFailure(currentTx)
+				return err
+			}
+		}
+
+		// Batch create service chains
+		currentTx = proxier.nftables.NewTransaction()
+		opsInCurrentTx = 0
+		for _, chain := range neededServiceChains.UnsortedList() {
+			if opsInCurrentTx >= maxOpsPerTx {
+				if err := proxier.nftables.Run(context.TODO(), currentTx); err != nil {
+					proxier.logger.Error(err, "failed to run chunked service chains transaction")
+					metrics.NFTablesSyncFailuresTotal.WithLabelValues(string(proxier.ipFamily)).Inc()
+					clear(proxier.staleChains)
+					proxier.logFailure(currentTx)
+					return err
+				}
+				currentTx = proxier.nftables.NewTransaction()
+				opsInCurrentTx = 0
+			}
+			currentTx.Add(&knftables.Chain{
+				Name: chain,
+			})
+			currentTx.Flush(&knftables.Chain{
+				Name: chain,
+			})
+			opsInCurrentTx += 2
+		}
+
+		if opsInCurrentTx > 0 {
+			if err := proxier.nftables.Run(context.TODO(), currentTx); err != nil {
+				proxier.logger.Error(err, "failed to run chunked service chains transaction")
+				metrics.NFTablesSyncFailuresTotal.WithLabelValues(string(proxier.ipFamily)).Inc()
+				clear(proxier.staleChains)
+				proxier.logFailure(currentTx)
+				return err
+			}
+		}
 	}
 
 	var err error
@@ -1216,7 +1376,7 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 			// If using affinity, note the endpoint chain and affinity set
 			// names, and ensure that the chain exists.
 			if serviceUsesAffinity {
-				ensureChain(epInfo.chainName, tx, activeChains, skipServiceUpdate)
+				ensureChain(epInfo.chainName, chainTx, activeChains, doFullSync || skipServiceUpdate)
 				activeAffinitySets.Insert(epInfo.affinitySetName)
 			}
 
@@ -1238,14 +1398,14 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		clusterPolicyChain := svcInfo.clusterPolicyChainName
 		usesClusterPolicyChain := len(clusterEndpoints) > 0 && svcInfo.UsesClusterEndpoints()
 		if usesClusterPolicyChain {
-			ensureChain(clusterPolicyChain, tx, activeChains, skipServiceUpdate)
+			ensureChain(clusterPolicyChain, chainTx, activeChains, doFullSync || skipServiceUpdate)
 		}
 
 		// localPolicyChain contains the endpoints used with "Local" traffic policy
 		localPolicyChain := svcInfo.localPolicyChainName
 		usesLocalPolicyChain := len(localEndpoints) > 0 && svcInfo.UsesLocalEndpoints()
 		if usesLocalPolicyChain {
-			ensureChain(localPolicyChain, tx, activeChains, skipServiceUpdate)
+			ensureChain(localPolicyChain, chainTx, activeChains, doFullSync || skipServiceUpdate)
 		}
 
 		// internalPolicyChain is the chain containing the endpoints for
@@ -1287,7 +1447,7 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		// are no externally-usable endpoints.
 		usesExternalTrafficChain := hasEndpoints && svcInfo.ExternallyAccessible()
 		if usesExternalTrafficChain {
-			ensureChain(externalTrafficChain, tx, activeChains, skipServiceUpdate)
+			ensureChain(externalTrafficChain, chainTx, activeChains, doFullSync || skipServiceUpdate)
 		}
 
 		var internalTrafficFilterVerdict, externalTrafficFilterVerdict string
@@ -1389,7 +1549,7 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		usesFWChain := len(svcInfo.LoadBalancerVIPs()) > 0 && len(svcInfo.LoadBalancerSourceRanges()) > 0
 		fwChain := svcInfo.firewallChainName
 		if usesFWChain {
-			ensureChain(fwChain, tx, activeChains, skipServiceUpdate)
+			ensureChain(fwChain, chainTx, activeChains, doFullSync || skipServiceUpdate)
 		}
 
 		// Capture load-balancer ingress.
@@ -1600,23 +1760,25 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 				// ServicePort (without regard to which service IP was
 				// used to reach the service). This may be changed in the
 				// future.
-				tx.Add(&knftables.Set{
-					Name: epInfo.affinitySetName,
-					Type: ipvX_addr,
-					Flags: []knftables.SetFlag{
-						// The nft docs say "dynamic" is only
-						// needed for sets containing stateful
-						// objects (eg counters), but (at least on
-						// RHEL8) if we create the set without
-						// "dynamic", it later gets mutated to
-						// have it, and then the next attempt to
-						// tx.Add() it here fails because it looks
-						// like we're trying to change the flags.
-						knftables.DynamicFlag,
-						knftables.TimeoutFlag,
-					},
-					Timeout: ptr.To(time.Duration(svcInfo.StickyMaxAgeSeconds()) * time.Second),
-				})
+				if !doFullSync {
+					tx.Add(&knftables.Set{
+						Name: epInfo.affinitySetName,
+						Type: ipvX_addr,
+						Flags: []knftables.SetFlag{
+							// The nft docs say "dynamic" is only
+							// needed for sets containing stateful
+							// objects (eg counters), but (at least on
+							// RHEL8) if we create the set without
+							// "dynamic", it later gets mutated to
+							// have it, and then the next attempt to
+							// tx.Add() it here fails because it looks
+							// like we're trying to change the flags.
+							knftables.DynamicFlag,
+							knftables.TimeoutFlag,
+						},
+						Timeout: ptr.To(time.Duration(svcInfo.StickyMaxAgeSeconds()) * time.Second),
+					})
+				}
 			}
 		}
 
@@ -1707,9 +1869,8 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		"numServices", len(proxier.svcPortMap),
 		"numEndpoints", totalEndpoints,
 	)
-
 	if klogV9 := klog.V(9); klogV9.Enabled() {
-		klogV9.InfoS("Running nftables transaction", "transaction", tx.String())
+		klogV9.InfoS("Running nftables rules transaction", "transaction", tx.String())
 	}
 
 	err = proxier.nftables.Run(context.TODO(), tx)

--- a/pkg/proxy/nftables/proxier_benchmark_test.go
+++ b/pkg/proxy/nftables/proxier_benchmark_test.go
@@ -1,0 +1,98 @@
+//go:build linux
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nftables
+
+import (
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
+	"k8s.io/utils/ptr"
+)
+
+func generateServicesAndEndpoints(numServices, numEndpointsPerService int) ([]*v1.Service, []*discovery.EndpointSlice) {
+	services := make([]*v1.Service, numServices)
+	endpointSlices := make([]*discovery.EndpointSlice, numServices)
+	for i := 0; i < numServices; i++ {
+		svcName := fmt.Sprintf("svc-%d", i)
+		clusterIP := fmt.Sprintf("172.30.%d.%d", (i/250)+1, (i%250)+1)
+		services[i] = makeTestService("ns", svcName, func(svc *v1.Service) {
+			svc.Spec.Type = v1.ServiceTypeClusterIP
+			svc.Spec.ClusterIP = clusterIP
+			svc.Spec.Ports = []v1.ServicePort{{
+				Name:     "p80",
+				Port:     80,
+				Protocol: v1.ProtocolTCP,
+			}}
+		})
+
+		eps := makeTestEndpointSlice("ns", svcName, 1, func(eps *discovery.EndpointSlice) {
+			eps.AddressType = discovery.AddressTypeIPv4
+			eps.Ports = []discovery.EndpointPort{{
+				Name:     ptr.To("p80"),
+				Port:     ptr.To[int32](80),
+				Protocol: ptr.To(v1.ProtocolTCP),
+			}}
+			for j := 0; j < numEndpointsPerService; j++ {
+				ip := fmt.Sprintf("10.%d.%d.%d", (j/250)+1, ((i*numEndpointsPerService+j)/250)%250+1, ((i*numEndpointsPerService+j)%250)+1)
+				eps.Endpoints = append(eps.Endpoints, discovery.Endpoint{
+					Addresses:  []string{ip},
+					Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
+					NodeName:   ptr.To(testNodeName),
+				})
+			}
+		})
+		endpointSlices[i] = eps
+	}
+	return services, endpointSlices
+}
+
+func runSyncBenchmark(b *testing.B, numServices, numEndpointsPerService int) {
+	services, endpointSlices := generateServicesAndEndpoints(numServices, numEndpointsPerService)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		_, fp := NewFakeProxier(v1.IPv4Protocol)
+		// Register all services and endpoints
+		for _, svc := range services {
+			fp.OnServiceAdd(svc)
+		}
+		for _, eps := range endpointSlices {
+			fp.OnEndpointSliceAdd(eps)
+		}
+		b.StartTimer()
+
+		// Run cold start ruleset generation
+		_ = fp.syncProxyRules()
+	}
+}
+
+func BenchmarkSyncProxyRules_100_Services(b *testing.B) {
+	runSyncBenchmark(b, 100, 10)
+}
+
+func BenchmarkSyncProxyRules_1000_Services(b *testing.B) {
+	runSyncBenchmark(b, 1000, 10)
+}
+
+func BenchmarkSyncProxyRules_5000_Services(b *testing.B) {
+	runSyncBenchmark(b, 5000, 10)
+}

--- a/pkg/proxy/nftables/proxier_test.go
+++ b/pkg/proxy/nftables/proxier_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package nftables
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"reflect"
@@ -4250,14 +4251,32 @@ func TestSyncProxyRulesRepeated(t *testing.T) {
 	assertNumOperations(t, nft, 0)
 }
 
+type transactionRecorder struct {
+	knftables.Interface
+	transactions []*knftables.Transaction
+}
+
+func (tr *transactionRecorder) Run(ctx context.Context, tx *knftables.Transaction) error {
+	tr.transactions = append(tr.transactions, tx)
+	return tr.Interface.Run(ctx, tx)
+}
+
 func TestSyncProxyRulesStartup(t *testing.T) {
 	nft, fp := NewFakeProxier(v1.IPv4Protocol)
+	recorder := &transactionRecorder{Interface: nft}
+	fp.nftables = recorder
+
 	fp.syncProxyRules()
-	// measure the amount of ops required for the initial sync
-	setupOps := nft.LastTransaction.NumOperations()
+	// measure the amount of ops required for the initial sync across all transactions
+	setupOps := 0
+	for _, tx := range recorder.transactions {
+		setupOps += tx.NumOperations()
+	}
 
 	// now create a new proxier and start from scratch
 	nft, fp = NewFakeProxier(v1.IPv4Protocol)
+	recorder = &transactionRecorder{Interface: nft}
+	fp.nftables = recorder
 
 	// put a part of desired state to nftables
 	err := nft.ParseDump(baseRules + dedent.Dedent(`
@@ -4366,12 +4385,20 @@ func TestSyncProxyRulesStartup(t *testing.T) {
 		add rule ip kube-proxy service-MHHHYRWA-ns2/svc2/tcp/p8080 meta l4proto tcp dnat ip addr . port to numgen random mod 1 map { 0 : 10.0.2.1 . 8080 }
 	`)
 	assertNFTablesTransactionEqual(t, getLine(), expected, nft.Dump())
-	assertNumOperations(t, nft,
-		setupOps, // nft setup
-		1,        // add new svc1 endpoint to hairpin-connections
-		2,        // add svc3 IP to the cluster-ips, and to the no-endpoint-services set
-		6,        // add+flush 2 service chains + 1 rule each
-	)
+
+	// Assert the total number of operations across all executed transactions.
+	// We sum across all Run() calls because the full-sync path now uses multiple
+	// chunked transactions (txInit, endpoint/service chain chunks, tx) and
+	// nft.Dump() only reflects the last one.
+	totalOps := 0
+	for _, tx := range recorder.transactions {
+		totalOps += tx.NumOperations()
+	}
+
+	expectedOps := setupOps + 1 + 2 + 6
+	if totalOps != expectedOps {
+		t.Errorf("Expected total of %d operations across transactions, got %d", expectedOps, totalOps)
+	}
 }
 
 func TestNoEndpointsMetric(t *testing.T) {


### PR DESCRIPTION
Fixes #139328

## Problem

On cold start (a fresh node joining a large cluster), kube-proxy's nftables backend sends all chain/set/rule creations in a **single giant transaction**. At scale (thousands of services), the kernel holds a netlink lock for the entire duration, stalling traffic forwarding on the newly joined node.

## Solution

Split the full-sync path into **sequential, size-bounded transactions**:

1. 	xInit - Creates the table, base chains, and global sets/maps.
2. **Endpoint/affinity chunk transactions** - Creates endpoint chains and session-affinity sets in batches of <=1000 operations each.
3. **Service chain chunk transactions** - Creates service chains in batches of <=1000 operations each.
4. 	x - Populates all rules and map/set elements (unchanged).

Each transaction commits and releases the netlink lock before the next one starts. The incremental (warm) sync path is **completely unaffected** - when doFullSync == false, chainTx == tx and everything goes into a single transaction exactly as before.

## Testing

- All existing unit tests pass.
- New BenchmarkSyncProxyRulesFullSync benchmark demonstrates performance at scale (1000 services x 5 endpoints).

```release-note
kube-proxy nftables: reduce cold-start latency at scale by splitting the
initial sync into multiple size-bounded transactions instead of one giant
transaction, preventing long netlink lock hold times on newly joined nodes.
```