### PR TITLE
Fix flaking e2e_node tests

### DIFF
--- a/test/e2e_node/container_lifecycle_test.go
+++ b/test/e2e_node/container_lifecycle_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -5220,7 +5221,13 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 				err = client.Delete(ctx, pod.Name, metav1.DeleteOptions{GracePeriodSeconds: &grace})
 				framework.ExpectNoError(err)
 				ginkgo.By("waiting for the pod to disappear")
-				err = e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, pod.Name, pod.Namespace, 120*time.Second)
+				err = framework.Gomega().Eventually(ctx, framework.HandleRetry(func(ctx context.Context) (*v1.Pod, error) {
+					pod, err := f.ClientSet.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+					if apierrors.IsNotFound(err) {
+						return nil, nil
+					}
+					return pod, err
+				})).WithTimeout(120 * time.Second).WithPolling(100 * time.Millisecond).Should(gomega.BeNil())
 				framework.ExpectNoError(err)
 
 				buffer := int64(2)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind flake
/sig node

#### What this PR does / why we need it:
This fixes a flaky e2e_node test for terminating a pod while it is still initializing restartable init containers.

The test deletes a pod with a 3 second grace period and asserts that the pod disappears in less than `grace + 2s`. It previously used `WaitForPodNotFoundInNamespace`, which uses the default e2e polling interval of 2 seconds. That polling interval is too coarse for a wall-clock assertion with only a 2 second buffer.

In the observed failure, kubelet did not hang waiting for restartable init containers that had not started. Kubelet removed the pod from etcd about 4.6 seconds after observing deletion, but the test reported about 6.1 seconds because it observed the final `NotFound` only on the next coarse poll.

This PR changes this specific test to wait for `NotFound` with a 100ms polling interval while preserving the existing 120 second timeout. The assertion now measures pod deletion latency instead of framework polling jitter.



#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #139493

#### Special notes for your reviewer:

Based on the kubelet logs from the failed test case: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-node-e2e-containerd/2062967865845223424 , the following results are obtained:


```
I0605 18:52:01.053155    2016 kubelet.go:2735] "SyncLoop DELETE" source="api" pods=["containers-lifecycle-test-3051/dont-hang-if-terminated-in-init"]
I0605 18:52:02.477923    2016 kuberuntime_container.go:909] "Killing container with a grace period" pod="containers-lifecycle-test-3051/dont-hang-if-terminated-in-init" podUID="a542c627-6a36-49cc-9237-2105a2ceb779" containerName="start-init" containerID="containerd://1885905099e01934462bcbcbc4528c82f9b7d0e545425d7c41f11a05a9efe89f" gracePeriod=3
I0605 18:52:05.641102    2016 status_manager.go:1222] "Pod fully terminated and removed from etcd" pod="containers-lifecycle-test-3051/dont-hang-if-terminated-in-init"
```
Kubelet-side deletion time:
```
18:52:05.641 - 18:52:01.053 = 4.588s
```
The test failure was:

```
[FAILED] should delete in < 5 seconds, took 6.067953
```

The extra time came from the test waiter's 2 second polling interval, not from kubelet waiting on non-started restartable init containers.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
