### PR TITLE
kubelet: count probe errors mapped to failure

### DIFF
--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -347,8 +347,9 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 
 	// Note, exec probe does NOT have access to pod environment variables or downward API
 	result, err := w.probeManager.prober.probe(ctx, w.probeType, w.pod, status, w.container, w.containerID)
-	if err != nil {
-		// Prober error, throw away the result.
+	if err != nil && result != results.Failure {
+		// The prober maps execution errors that should affect health to Failure.
+		// Other errors preserve the existing no-result behavior.
 		return true
 	}
 

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package prober
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -706,6 +707,38 @@ func TestOnHoldOnLivenessOrStartupCheckFailure(t *testing.T) {
 		} else if probeType == startup && !w.onHold {
 			t.Errorf("Prober should be on hold due to %s check success", probeType)
 		}
+	}
+}
+
+func TestLivenessProbeErrorCountsAsFailure(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	m := newTestManager()
+	w := newTestWorker(m, liveness, v1.Probe{SuccessThreshold: 1, FailureThreshold: 3})
+	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatus())
+
+	m.prober.exec = fakeExecProber{probe.Success, nil}
+	msg := "initial probe success"
+	expectContinue(t, w, w.doProbe(ctx), msg)
+	expectResult(t, w, results.Success, msg)
+
+	m.prober.exec = fakeExecProber{probe.Unknown, errors.New("exec probe failed")}
+	for i := 0; i < 2; i++ {
+		msg := fmt.Sprintf("%d probe error below threshold", i+1)
+		expectContinue(t, w, w.doProbe(ctx), msg)
+		expectResult(t, w, results.Success, msg)
+		if w.resultRun != i+1 {
+			t.Errorf("Prober resultRun should be %d, but %d", i+1, w.resultRun)
+		}
+	}
+
+	msg = "probe error reached threshold"
+	expectContinue(t, w, w.doProbe(ctx), msg)
+	expectResult(t, w, results.Failure, msg)
+	if !w.onHold {
+		t.Errorf("Prober should be on hold after liveness probe error reaches failure threshold")
+	}
+	if w.resultRun != 0 {
+		t.Errorf("Prober resultRun should be reset to 0, but %d", w.resultRun)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node

#### What this PR does / why we need it:

Exec probe execution errors are mapped by the kubelet prober to `Failure`, but the worker dropped all errored results before applying thresholds. That meant an invalid exec liveness command could keep reporting probe errors without reaching the liveness restart path.

This lets errored results that the prober already mapped to `Failure` flow through the existing worker metrics, threshold, result cache, and liveness/startup hold logic.

#### Which issue(s) this PR fixes:

Fixes #106682

#### Special notes for reviewers:

Split out from #139544 after reviewer feedback to keep each PR focused.

#### Does this PR introduce a user-facing change?

```release-note
Kubelet now counts exec probe errors that are mapped to failure toward liveness and startup probe failure thresholds.
```

#### Additional documentation e.g., KEPs:

None

#### Testing:

- `go test ./pkg/kubelet/prober -count=1`