### PR TITLE
kubelet: coalesce identical in-flight exec probes

### DIFF
--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"time"
 
+	"golang.org/x/sync/singleflight"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -47,6 +48,8 @@ type prober struct {
 	tcp    tcpprobe.Prober
 	grpc   grpcprobe.Prober
 	runner kubecontainer.CommandRunner
+
+	execProbeGroup singleflight.Group
 
 	recorder record.EventRecorderLogger
 }
@@ -155,7 +158,7 @@ func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe
 	case p.Exec != nil:
 		logger.V(4).Info("Exec-Probe runProbe", "pod", klog.KObj(pod), "containerName", container.Name, "execCommand", p.Exec.Command)
 		command := kubecontainer.ExpandContainerCommandOnlyStatic(p.Exec.Command, container.Env)
-		return pb.exec.Probe(pb.newExecInContainer(ctx, pod, container, containerID, command, timeout))
+		return pb.runExecProbe(ctx, pod, container, containerID, command, timeout)
 
 	case p.HTTPGet != nil:
 		req, err := httpprobe.NewRequestForHTTPGetAction(p.HTTPGet, &container, status.PodIP, "probe")
@@ -200,6 +203,29 @@ func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe
 		logger.V(4).Info("Failed to find probe builder for container", "containerName", container.Name)
 		return probe.Unknown, "", fmt.Errorf("missing probe handler for %s:%s", format.Pod(pod), container.Name)
 	}
+}
+
+type execProbeResult struct {
+	result probe.Result
+	output string
+}
+
+func execProbeKey(containerID kubecontainer.ContainerID, cmd []string, timeout time.Duration) string {
+	return fmt.Sprintf("%s\x00%s\x00%q", containerID.String(), timeout, cmd)
+}
+
+func (pb *prober) runExecProbe(ctx context.Context, pod *v1.Pod, container v1.Container, containerID kubecontainer.ContainerID, cmd []string, timeout time.Duration) (probe.Result, string, error) {
+	key := execProbeKey(containerID, cmd, timeout)
+	value, err, _ := pb.execProbeGroup.Do(key, func() (any, error) {
+		result, output, err := pb.exec.Probe(pb.newExecInContainer(ctx, pod, container, containerID, cmd, timeout))
+		return execProbeResult{result: result, output: output}, err
+	})
+	if value == nil {
+		return probe.Unknown, "", err
+	}
+
+	execResult := value.(execProbeResult)
+	return execResult.result, execResult.output, err
 }
 
 type execInContainer struct {

--- a/pkg/kubelet/prober/prober_test.go
+++ b/pkg/kubelet/prober/prober_test.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,6 +40,7 @@ import (
 	"k8s.io/kubernetes/pkg/probe"
 	execprobe "k8s.io/kubernetes/pkg/probe/exec"
 	"k8s.io/kubernetes/test/utils/ktesting"
+	"k8s.io/utils/exec"
 )
 
 func TestGetURLParts(t *testing.T) {
@@ -274,6 +277,82 @@ func TestProbe(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+type blockingExecProber struct {
+	calls   atomic.Int32
+	started chan struct{}
+	release <-chan struct{}
+	result  probe.Result
+	output  string
+	err     error
+}
+
+func (p *blockingExecProber) Probe(c exec.Cmd) (probe.Result, string, error) {
+	if p.calls.Add(1) == 1 {
+		close(p.started)
+	}
+	<-p.release
+	return p.result, p.output, p.err
+}
+
+func TestRunProbeCoalescesConcurrentExecProbes(t *testing.T) {
+	ctx := ktesting.Init(t)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	execProber := &blockingExecProber{
+		started: started,
+		release: release,
+		result:  probe.Success,
+		output:  "ok",
+	}
+	prober := &prober{
+		exec: execProber,
+	}
+	probeSpec := &v1.Probe{
+		ProbeHandler: v1.ProbeHandler{
+			Exec: &v1.ExecAction{Command: []string{"cat", "/tmp/healthy"}},
+		},
+		TimeoutSeconds: 1,
+	}
+	pod := &v1.Pod{}
+	container := v1.Container{Name: "container"}
+	containerID := kubecontainer.ContainerID{Type: "test", ID: "container"}
+
+	results := make(chan error, 2)
+	run := func(probeType probeType, ready chan<- struct{}) {
+		if ready != nil {
+			close(ready)
+		}
+		result, output, err := prober.runProbe(ctx, probeType, probeSpec, pod, v1.PodStatus{}, container, containerID)
+		if err != nil {
+			results <- err
+			return
+		}
+		if result != probe.Success || output != "ok" {
+			results <- fmt.Errorf("expected success with output ok, got result=%v output=%q", result, output)
+			return
+		}
+		results <- nil
+	}
+
+	go run(liveness, nil)
+	<-started
+	readinessStarted := make(chan struct{})
+	go run(readiness, readinessStarted)
+	<-readinessStarted
+	time.Sleep(100 * time.Millisecond)
+	if got := execProber.calls.Load(); got != 1 {
+		t.Fatalf("expected one in-flight exec probe call, got %d", got)
+	}
+	close(release)
+
+	for i := 0; i < 2; i++ {
+		require.NoError(t, <-results)
+	}
+	if got := execProber.calls.Load(); got != 1 {
+		t.Fatalf("expected one exec probe call, got %d", got)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node

#### What this PR does / why we need it:

Kubelet creates separate workers for readiness, liveness, and startup probes. If multiple exec probes for the same container overlap and use the same expanded command and timeout, they currently issue duplicate runtime exec requests.

This adds in-flight coalescing for identical exec probes keyed by container ID, expanded command, and timeout. It only shares concurrent calls; it does not cache probe results after the runtime call completes.

#### Which issue(s) this PR fixes:

Addresses #82440

#### Special notes for reviewers:

Split out from #139544 after reviewer feedback to keep each PR focused.

#### Does this PR introduce a user-facing change?

```release-note
Kubelet now coalesces identical in-flight exec probes for the same container command and timeout.
```

#### Additional documentation e.g., KEPs:

None

#### Testing:

- `go test ./pkg/kubelet/prober -count=1`