### PR TITLE
kubelet: prefer reusable init container CPUs

### DIFF
--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -676,32 +676,52 @@ func (p *staticPolicy) RemoveContainer(logger logr.Logger, s state.State, podUID
 func (p *staticPolicy) allocateCPUs(logger logr.Logger, s state.State, numCPUs int, numaAffinity bitmask.BitMask, reusableCPUs cpuset.CPUSet) (topology.Allocation, error) {
 	logger.Info("AllocateCPUs", "numCPUs", numCPUs, "socket", numaAffinity)
 
-	allocatableCPUs := p.GetAvailableCPUs(s).Union(reusableCPUs)
+	availableCPUs := p.GetAvailableCPUs(s)
+	allocatableCPUs := availableCPUs.Union(reusableCPUs)
+	if numCPUs > allocatableCPUs.Size() {
+		return topology.EmptyAllocation(), fmt.Errorf("not enough cpus available to satisfy request: requested=%d, available=%d", numCPUs, allocatableCPUs.Size())
+	}
 
-	// If there are aligned CPUs in numaAffinity, attempt to take those first.
 	result := topology.EmptyAllocation()
-	if numaAffinity != nil {
-		alignedCPUs := p.getAlignedCPUs(numaAffinity, allocatableCPUs)
-
-		numAlignedToAlloc := alignedCPUs.Size()
-		if numCPUs < numAlignedToAlloc {
-			numAlignedToAlloc = numCPUs
+	takeCPUs := func(candidates cpuset.CPUSet, numToTake int) error {
+		candidates = candidates.Difference(result.CPUs)
+		if numToTake > candidates.Size() {
+			numToTake = candidates.Size()
+		}
+		if numToTake <= 0 {
+			return nil
 		}
 
-		allocatedCPUs, err := p.takeByTopology(logger, alignedCPUs, numAlignedToAlloc)
+		allocatedCPUs, err := p.takeByTopology(logger, candidates, numToTake)
 		if err != nil {
+			return err
+		}
+		result.CPUs = result.CPUs.Union(allocatedCPUs)
+		return nil
+	}
+
+	if numaAffinity != nil {
+		alignedReusableCPUs := p.getAlignedCPUs(numaAffinity, reusableCPUs)
+		if err := takeCPUs(alignedReusableCPUs, numCPUs-result.CPUs.Size()); err != nil {
 			return topology.EmptyAllocation(), err
 		}
 
-		result.CPUs = result.CPUs.Union(allocatedCPUs)
+		alignedCPUs := p.getAlignedCPUs(numaAffinity, availableCPUs)
+		if err := takeCPUs(alignedCPUs, numCPUs-result.CPUs.Size()); err != nil {
+			return topology.EmptyAllocation(), err
+		}
 	}
 
-	// Get any remaining CPUs from what's leftover after attempting to grab aligned ones.
-	remainingCPUs, err := p.takeByTopology(logger, allocatableCPUs.Difference(result.CPUs), numCPUs-result.CPUs.Size())
-	if err != nil {
+	if err := takeCPUs(reusableCPUs, numCPUs-result.CPUs.Size()); err != nil {
 		return topology.EmptyAllocation(), err
 	}
-	result.CPUs = result.CPUs.Union(remainingCPUs)
+
+	if err := takeCPUs(availableCPUs, numCPUs-result.CPUs.Size()); err != nil {
+		return topology.EmptyAllocation(), err
+	}
+	if result.CPUs.Size() != numCPUs {
+		return topology.EmptyAllocation(), fmt.Errorf("failed to allocate cpus")
+	}
 	result.Aligned = p.topology.CheckAlignment(result.CPUs)
 
 	// Remove allocated CPUs from the shared CPUSet.

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -809,6 +809,48 @@ func TestStaticPolicyReuseCPUs(t *testing.T) {
 	}
 }
 
+func TestStaticPolicyPrefersReusableCPUs(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	policy, err := NewStaticPolicy(logger, topoSingleSocketHT, 1, cpuset.New(), topologymanager.NewFakeManager(), nil)
+	if err != nil {
+		t.Fatalf("NewStaticPolicy() failed: %v", err)
+	}
+
+	st := &mockState{
+		assignments:   state.ContainerCPUAssignments{},
+		defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+	}
+	pod := makeMultiContainerPod(
+		[]struct{ request, limit string }{
+			{"1000m", "1000m"}},
+		[]struct{ request, limit string }{
+			{"2000m", "2000m"}})
+
+	if err := policy.Allocate(logger, st, pod, &pod.Spec.InitContainers[0]); err != nil {
+		t.Fatalf("StaticPolicy Allocate() init container error: %v", err)
+	}
+	initCSet := st.assignments[string(pod.UID)][pod.Spec.InitContainers[0].Name]
+	if initCSet.Size() != 1 {
+		t.Fatalf("StaticPolicy Allocate() expected one init container CPU, got %s", initCSet)
+	}
+	defaultCPUSetAfterInit := st.defaultCPUSet.Clone()
+
+	if err := policy.Allocate(logger, st, pod, &pod.Spec.Containers[0]); err != nil {
+		t.Fatalf("StaticPolicy Allocate() app container error: %v", err)
+	}
+	appCSet := st.assignments[string(pod.UID)][pod.Spec.Containers[0].Name]
+	if appCSet.Size() != 2 {
+		t.Fatalf("StaticPolicy Allocate() expected two app container CPUs, got %s", appCSet)
+	}
+	if !initCSet.IsSubsetOf(appCSet) {
+		t.Errorf("StaticPolicy Allocate() expected app container cpuset %s to reuse init container cpuset %s", appCSet, initCSet)
+	}
+	freshCPUs := appCSet.Difference(initCSet)
+	if !st.defaultCPUSet.Equals(defaultCPUSetAfterInit.Difference(freshCPUs)) {
+		t.Errorf("StaticPolicy Allocate() default cpuset %s lost CPUs outside app fresh allocation %s", st.defaultCPUSet, freshCPUs)
+	}
+}
+
 func TestStaticPolicyDoNotReuseCPUs(t *testing.T) {
 	testCases := []struct {
 		staticPolicyTest


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node

#### What this PR does / why we need it:

The static CPU manager tracks CPUs assigned to standard init containers as reusable for later app containers in the same pod. Allocation currently considers reusable and fresh CPUs together, so topology selection can choose fresh CPUs while leaving completed init CPUs stranded.

This prefers reusable init-container CPUs before allocating fresh CPUs, while still using the existing topology-aware selection for each candidate set.

#### Which issue(s) this PR fixes:

Fixes #112228

#### Special notes for reviewers:

Split out from #139544 after reviewer feedback to keep each PR focused.

This is the narrow allocation-order approach related to the closed #131966 discussion. It is intentionally separate from the broader open WIP reconcile-loop cleanup in #131764.

#### Does this PR introduce a user-facing change?

```release-note
Kubelet static CPU manager policy now prefers reusable init-container CPU assignments before allocating fresh CPUs for app containers in the same pod.
```

#### Additional documentation e.g., KEPs:

None

#### Testing:

- `go test ./pkg/kubelet/cm/cpumanager -count=1`