### PR TITLE
Access latest snapshot locklessly instead of reading from locking store

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -3178,6 +3178,9 @@ func (f *fakeSnapshotter) RemoveLess(rv uint64)                       {}
 func (f *fakeSnapshotter) Len() int {
 	return 0
 }
+func (f *fakeSnapshotter) Latest() (store.OrderedLister, bool) {
+	return nil, false
+}
 
 // --- Sharding unit tests for filterWithAttrsAndPrefixFunction ---
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_btree.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_btree.go
@@ -440,6 +440,7 @@ var _ Snapshotter = (*storeSnapshotter)(nil)
 type Snapshotter interface {
 	Reset()
 	GetLessOrEqual(rv uint64) (OrderedLister, bool)
+	Latest() (OrderedLister, bool)
 	Add(rv uint64, indexer OrderedLister)
 	RemoveLess(rv uint64)
 	Len() int
@@ -474,6 +475,17 @@ func (s *storeSnapshotter) GetLessOrEqual(rv uint64) (OrderedLister, bool) {
 		return nil, false
 	}
 	return result.snapshot, true
+}
+
+func (s *storeSnapshotter) Latest() (OrderedLister, bool) {
+	s.mux.RLock()
+	defer s.mux.RUnlock()
+
+	max, ok := s.snapshots.Max()
+	if !ok {
+		return nil, false
+	}
+	return max.snapshot, true
 }
 
 func (s *storeSnapshotter) Add(rv uint64, indexer OrderedLister) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_btree_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/store_btree_test.go
@@ -151,6 +151,9 @@ func (f *fakeSnapshotter) GetLessOrEqual(rv uint64) (OrderedLister, bool) {
 	}
 	return f.getLessOrEqual(rv)
 }
+func (f *fakeSnapshotter) Latest() (OrderedLister, bool) {
+	return nil, false
+}
 func (f *fakeSnapshotter) Add(rv uint64, indexer OrderedLister) {}
 func (f *fakeSnapshotter) RemoveLess(rv uint64)                 {}
 func (f *fakeSnapshotter) Len() int {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -625,10 +625,10 @@ func (w *watchCache) waitAndListLatestRV(ctx context.Context, resourceVersion ui
 	if err != nil {
 		return listResp{}, "", err
 	}
-	return w.listLatestRV(key, continueKey, matchValues)
+	return w.listLatestRVLocked(key, continueKey, matchValues)
 }
 
-func (w *watchCache) listLatestRV(key, continueKey string, matchValues []storage.MatchValue) (resp listResp, index string, err error) {
+func (w *watchCache) listLatestRVLocked(key, continueKey string, matchValues []storage.MatchValue) (resp listResp, index string, err error) {
 	// This isn't the place where we do "final filtering" - only some "prefiltering" is happening here. So the only
 	// requirement here is to NOT miss anything that should be returned. We can return as many non-matching items as we
 	// want - they will be filtered out later. The fact that we return less things is only further performance improvement.
@@ -642,7 +642,14 @@ func (w *watchCache) listLatestRV(key, continueKey string, matchValues []storage
 			}, matchValue.IndexName, err
 		}
 	}
-	result := w.store.OrderedListPrefix(key, continueKey)
+	var store store.OrderedLister = w.store
+	if w.snapshots != nil {
+		snap, ok := w.snapshots.Latest()
+		if ok {
+			store = snap
+		}
+	}
+	result := store.OrderedListPrefix(key, continueKey)
 	return listResp{
 		Items:           result,
 		ResourceVersion: w.resourceVersion,


### PR DESCRIPTION
Evaluation results of the lockless snapshot optimization at a scale of 150k pods with 50 namespaces and 5000 nodes. Comparing the optimized approach against the baseline.

Benchmark results based on https://github.com/kubernetes/kubernetes/pull/139567

Store List Performance (RV=NotOlderThan):
```
Metric: sec/op
Benchmark                                                                          Base            Opt    Delta         p-value
------------------------------------------------------------------------   ------------   ------------   ------   -------------
StoreList/Indexed=true/RV=NotOlderThan/Scope=Cluster/Paginate=0-24         28.56m ± 25%   23.31m ± 16%        ~   (p=0.093 n=6)
StoreList/Indexed=true/RV=NotOlderThan/Scope=Cluster/Paginate=1000-24        2.253 ± 9%     2.219 ± 9%        ~   (p=0.818 n=6)
StoreList/Indexed=true/RV=NotOlderThan/Scope=Node/Paginate=0-24            8.141µ ± 12%   8.659µ ± 27%        ~   (p=0.394 n=6)
StoreList/Indexed=true/RV=NotOlderThan/Scope=Namespace/Paginate=0-24        548.9µ ± 8%   571.6µ ± 20%        ~   (p=0.589 n=6)
StoreList/Indexed=true/RV=NotOlderThan/Scope=Namespace/Paginate=1000-24    609.3µ ± 33%   593.2µ ± 17%        ~   (p=0.589 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Cluster/Paginate=0-24        27.64m ± 15%   30.21m ± 38%        ~   (p=0.818 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Cluster/Paginate=1000-24      2.309 ± 15%    2.175 ± 10%        ~   (p=0.699 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Node/Paginate=0-24           25.43m ± 21%   27.02m ± 29%        ~   (p=0.937 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Namespace/Paginate=0-24      481.8µ ± 13%   466.0µ ± 15%        ~   (p=0.937 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Namespace/Paginate=1000-24    535.5µ ± 8%   530.2µ ± 19%        ~   (p=0.699 n=6)
geomean                                                                          6.117m         6.059m   -0.95%

Metric: list-calls/s
Benchmark                                                                          Base            Opt    Delta         p-value
------------------------------------------------------------------------   ------------   ------------   ------   -------------
StoreList/Indexed=true/RV=NotOlderThan/Scope=Cluster/Paginate=0-24          35.12 ± 33%    43.36 ± 17%        ~   (p=0.093 n=6)
StoreList/Indexed=true/RV=NotOlderThan/Scope=Cluster/Paginate=1000-24        66.78 ± 9%     67.59 ± 9%        ~   (p=0.818 n=6)
StoreList/Indexed=true/RV=NotOlderThan/Scope=Node/Paginate=0-24            123.1k ± 13%   115.6k ± 21%        ~   (p=0.394 n=6)
StoreList/Indexed=true/RV=NotOlderThan/Scope=Namespace/Paginate=0-24        1.822k ± 8%   1.750k ± 18%        ~   (p=0.589 n=6)
StoreList/Indexed=true/RV=NotOlderThan/Scope=Namespace/Paginate=1000-24    4.936k ± 25%   5.059k ± 14%        ~   (p=0.589 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Cluster/Paginate=0-24         36.32 ± 16%    33.11 ± 62%        ~   (p=0.818 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Cluster/Paginate=1000-24      65.10 ± 17%     68.99 ± 9%        ~   (p=0.699 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Node/Paginate=0-24            39.76 ± 18%    37.02 ± 41%        ~   (p=0.937 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Namespace/Paginate=0-24      2.076k ± 15%   2.147k ± 13%        ~   (p=0.937 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Namespace/Paginate=1000-24    5.604k ± 8%   5.658k ± 23%        ~   (p=0.699 n=6)
geomean                                                                           556.3          560.9   +0.82%

Metric: list-objs/s
Benchmark                                                                          Base            Opt    Delta         p-value
------------------------------------------------------------------------   ------------   ------------   ------   -------------
StoreList/Indexed=true/RV=NotOlderThan/Scope=Cluster/Paginate=0-24         5.268M ± 33%   6.504M ± 17%        ~   (p=0.093 n=6)
StoreList/Indexed=true/RV=NotOlderThan/Scope=Cluster/Paginate=1000-24       66.78k ± 9%    67.59k ± 9%        ~   (p=0.818 n=6)
StoreList/Indexed=true/RV=NotOlderThan/Scope=Node/Paginate=0-24            3.693M ± 13%   3.468M ± 21%        ~   (p=0.394 n=6)
StoreList/Indexed=true/RV=NotOlderThan/Scope=Namespace/Paginate=0-24        5.466M ± 8%   5.249M ± 18%        ~   (p=0.589 n=6)
StoreList/Indexed=true/RV=NotOlderThan/Scope=Namespace/Paginate=1000-24    4.936M ± 25%   5.059M ± 14%        ~   (p=0.589 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Cluster/Paginate=0-24        5.448M ± 16%   4.966M ± 62%        ~   (p=0.818 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Cluster/Paginate=1000-24     65.11k ± 17%    68.99k ± 9%        ~   (p=0.699 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Node/Paginate=0-24           5.964M ± 18%   5.553M ± 41%        ~   (p=0.937 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Namespace/Paginate=0-24      6.229M ± 15%   6.441M ± 13%        ~   (p=0.937 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Namespace/Paginate=1000-24    5.604M ± 8%   5.658M ± 23%        ~   (p=0.699 n=6)
geomean                                                                          2.194M         2.212M   +0.82%

Metric: B/op
Benchmark                                                                          Base            Opt    Delta         p-value
------------------------------------------------------------------------   ------------   ------------   ------   -------------
StoreList/Indexed=true/RV=NotOlderThan/Scope=Cluster/Paginate=0-24         98.12Mi ± 0%   98.12Mi ± 0%   -0.00%   (p=0.026 n=6)
StoreList/Indexed=true/RV=NotOlderThan/Scope=Cluster/Paginate=1000-24      984.0Mi ± 0%   984.0Mi ± 0%        ~   (p=0.937 n=6)
StoreList/Indexed=true/RV=NotOlderThan/Scope=Node/Paginate=0-24            19.99Ki ± 0%   19.99Ki ± 0%   +0.02%   (p=0.002 n=6)
StoreList/Indexed=true/RV=NotOlderThan/Scope=Namespace/Paginate=0-24       1.772Mi ± 0%   1.772Mi ± 0%        ~   (p=0.848 n=6)
StoreList/Indexed=true/RV=NotOlderThan/Scope=Namespace/Paginate=1000-24    1.865Mi ± 0%   1.865Mi ± 0%        ~   (p=1.000 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Cluster/Paginate=0-24        98.12Mi ± 0%   98.12Mi ± 0%        ~   (p=0.093 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Cluster/Paginate=1000-24     984.0Mi ± 0%   984.0Mi ± 0%        ~   (p=0.818 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Node/Paginate=0-24           98.12Mi ± 0%   98.12Mi ± 0%        ~   (p=0.132 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Namespace/Paginate=0-24      1.725Mi ± 0%   1.725Mi ± 0%        ~   (p=0.184 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Namespace/Paginate=1000-24   1.818Mi ± 0%   1.818Mi ± 0%        ~   (p=0.916 n=6)
geomean                                                                         13.39Mi        13.39Mi   +0.00%

Metric: allocs/op
Benchmark                                                                         Base           Opt    Delta         p-value
------------------------------------------------------------------------   -----------   -----------   ------   -------------
StoreList/Indexed=true/RV=NotOlderThan/Scope=Cluster/Paginate=0-24          101.0 ± 1%    100.5 ± 1%        ~   (p=0.424 n=6)
StoreList/Indexed=true/RV=NotOlderThan/Scope=Cluster/Paginate=1000-24      16.32k ± 0%   16.31k ± 0%        ~   (p=0.729 n=6)
StoreList/Indexed=true/RV=NotOlderThan/Scope=Node/Paginate=0-24             51.00 ± 0%    51.00 ± 0%        ~   (p=1.000 n=6)
StoreList/Indexed=true/RV=NotOlderThan/Scope=Namespace/Paginate=0-24       71.00 ± 38%    71.00 ± 0%        ~   (p=1.000 n=6)
StoreList/Indexed=true/RV=NotOlderThan/Scope=Namespace/Paginate=1000-24     256.0 ± 0%    256.0 ± 0%        ~   (p=1.000 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Cluster/Paginate=0-24         101.0 ± 1%    100.0 ± 1%        ~   (p=0.177 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Cluster/Paginate=1000-24     16.30k ± 0%   16.32k ± 1%        ~   (p=1.000 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Node/Paginate=0-24            101.5 ± 1%    101.0 ± 1%        ~   (p=0.589 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Namespace/Paginate=0-24       65.00 ± 0%    65.00 ± 0%        ~   (p=1.000 n=6)
StoreList/Indexed=false/RV=NotOlderThan/Scope=Namespace/Paginate=1000-24   250.0 ± 12%    250.0 ± 0%        ~   (p=1.000 n=6)
geomean                                                                          289.6         289.0   -0.19%
```

Store Write Throughput Performance (Background=Lister/ListerNotOlderThan):
```
Metric: sec/op
Benchmark                                                                                                           Base            Opt    Delta         p-value
--------------------------------------------------------------------------------------------------------   -------------   ------------   ------   -------------
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=Lister/UseIndex=false-24                183.6µ ± 38%   234.6µ ± 47%        ~   (p=0.394 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=Lister/UseIndex=true-24                 208.3µ ± 48%   139.1µ ± 68%        ~   (p=0.485 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=ListerNotOlderThan/UseIndex=false-24    219.7µ ± 33%   194.3µ ± 76%        ~   (p=1.000 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=ListerNotOlderThan/UseIndex=true-24     168.2µ ± 30%   208.5µ ± 51%        ~   (p=0.699 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=Lister/UseIndex=false-24                       63.31µ ± 37%   48.91µ ± 46%        ~   (p=0.240 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=Lister/UseIndex=true-24                        29.45µ ± 27%   22.59µ ± 98%        ~   (p=0.240 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=ListerNotOlderThan/UseIndex=false-24          32.27µ ± 116%   39.01µ ± 32%        ~   (p=0.699 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=ListerNotOlderThan/UseIndex=true-24            23.86µ ± 53%   24.29µ ± 31%        ~   (p=0.937 n=6)
geomean                                                                                                           81.92µ         78.09µ   -4.68%

Metric: list-calls/s
Benchmark                                                                                                          Base            Opt    Delta         p-value
--------------------------------------------------------------------------------------------------------   ------------   ------------   ------   -------------
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=Lister/UseIndex=false-24                7.091 ± 60%    7.915 ± 69%        ~   (p=0.937 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=Lister/UseIndex=true-24                17.43 ± 104%    29.17 ± 58%        ~   (p=0.180 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=ListerNotOlderThan/UseIndex=false-24    8.893 ± 50%    8.769 ± 83%        ~   (p=0.937 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=ListerNotOlderThan/UseIndex=true-24    49.07 ± 100%   32.11 ± 204%        ~   (p=0.818 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=Lister/UseIndex=false-24                      7.400 ± 601%    7.354 ± 58%        ~   (p=0.699 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=Lister/UseIndex=true-24                        64.24 ± 15%    77.06 ± 26%        ~   (p=0.132 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=ListerNotOlderThan/UseIndex=false-24           7.375 ± 90%    6.919 ± 33%        ~   (p=0.699 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=ListerNotOlderThan/UseIndex=true-24             97.01 ± 9%    98.72 ± 11%        ~   (p=0.485 n=6)
geomean                                                                                                           19.18          19.96   +4.03%

Metric: list-objs/s
Benchmark                                                                                                           Base            Opt    Delta         p-value
--------------------------------------------------------------------------------------------------------   -------------   ------------   ------   -------------
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=Lister/UseIndex=false-24                1.062M ± 60%   1.185M ± 69%        ~   (p=0.937 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=Lister/UseIndex=true-24                 540.5 ± 104%    816.5 ± 58%        ~   (p=0.589 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=ListerNotOlderThan/UseIndex=false-24    1.332M ± 50%   1.313M ± 83%        ~   (p=0.937 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=ListerNotOlderThan/UseIndex=true-24    1521.0 ± 100%   899.0 ± 204%        ~   (p=0.699 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=Lister/UseIndex=false-24                      1.110M ± 601%   1.103M ± 58%        ~   (p=0.699 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=Lister/UseIndex=true-24                        1.992k ± 15%   2.158k ± 26%        ~   (p=0.937 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=ListerNotOlderThan/UseIndex=false-24           1.106M ± 90%   1.038M ± 33%        ~   (p=0.699 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=ListerNotOlderThan/UseIndex=true-24             3.007k ± 9%   2.765k ± 11%        ~   (p=0.084 n=6)
geomean                                                                                                           41.36k         40.88k   -1.14%

Metric: seconds-delay
Benchmark                                                                                                            Base               Opt     Delta         p-value
--------------------------------------------------------------------------------------------------------   --------------   ---------------   -------   -------------
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=Lister/UseIndex=false-24                408.6m ± 178%      756.0m ± 94%         ~   (p=0.589 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=Lister/UseIndex=true-24                  917.5m ± 97%     285.1m ± 238%         ~   (p=0.180 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=ListerNotOlderThan/UseIndex=false-24     504.9m ± 94%     287.0m ± 126%         ~   (p=0.699 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=ListerNotOlderThan/UseIndex=true-24      605.1m ± 94%      680.5m ± 96%         ~   (p=0.394 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=Lister/UseIndex=false-24                      38.53m ± 2710%   125.21m ± 1137%         ~   (p=0.589 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=Lister/UseIndex=true-24                       35.27m ± 1310%     36.84m ± 227%         ~   (p=0.818 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=ListerNotOlderThan/UseIndex=false-24            29.84m ± 17%     32.83m ± 870%         ~   (p=0.132 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=ListerNotOlderThan/UseIndex=true-24             29.10m ± 15%     77.39m ± 259%         ~   (p=0.310 n=6)
geomean                                                                                                            138.5m            162.8m   +17.56%

Metric: writes/s
Benchmark                                                                                                           Base            Opt    Delta         p-value
--------------------------------------------------------------------------------------------------------   -------------   ------------   ------   -------------
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=Lister/UseIndex=false-24                19.12k ± 20%   20.19k ± 26%        ~   (p=0.485 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=Lister/UseIndex=true-24                 19.74k ± 28%   18.75k ± 15%        ~   (p=0.310 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=ListerNotOlderThan/UseIndex=false-24    18.40k ± 33%   18.81k ± 18%        ~   (p=0.699 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=ListerNotOlderThan/UseIndex=true-24     17.48k ± 42%   21.84k ± 38%        ~   (p=0.485 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=Lister/UseIndex=false-24                      25.10k ± 203%   29.78k ± 42%        ~   (p=0.485 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=Lister/UseIndex=true-24                        35.00k ± 36%   46.23k ± 45%        ~   (p=0.240 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=ListerNotOlderThan/UseIndex=false-24           38.56k ± 30%   28.19k ± 45%        ~   (p=0.180 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=ListerNotOlderThan/UseIndex=true-24            43.28k ± 36%   47.62k ± 29%        ~   (p=0.485 n=6)
geomean                                                                                                           25.49k         27.06k   +6.18%

Metric: B/op
Benchmark                                                                                                           Base             Opt    Delta         p-value
--------------------------------------------------------------------------------------------------------   -------------   -------------   ------   -------------
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=Lister/UseIndex=false-24               207.5Ki ± 29%   212.3Ki ± 20%        ~   (p=0.699 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=Lister/UseIndex=true-24                118.1Ki ± 25%   134.1Ki ± 18%        ~   (p=0.937 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=ListerNotOlderThan/UseIndex=false-24   208.1Ki ± 46%   253.0Ki ± 24%        ~   (p=1.000 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=ListerNotOlderThan/UseIndex=true-24    126.0Ki ± 14%   123.7Ki ± 16%        ~   (p=0.937 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=Lister/UseIndex=false-24                      93.53Ki ± 45%   73.02Ki ± 20%        ~   (p=0.065 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=Lister/UseIndex=true-24                        36.85Ki ± 8%    36.04Ki ± 1%        ~   (p=0.394 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=ListerNotOlderThan/UseIndex=false-24          56.40Ki ± 54%   61.87Ki ± 17%        ~   (p=0.589 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=ListerNotOlderThan/UseIndex=true-24            35.94Ki ± 0%    36.00Ki ± 3%        ~   (p=0.699 n=6)
geomean                                                                                                          90.47Ki         92.20Ki   +1.92%

Metric: allocs/op
Benchmark                                                                                                         Base           Opt    Delta         p-value
--------------------------------------------------------------------------------------------------------   -----------   -----------   ------   -------------
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=Lister/UseIndex=false-24               1.108k ± 7%   1.135k ± 3%        ~   (p=0.329 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=Lister/UseIndex=true-24                1.149k ± 6%   1.117k ± 3%        ~   (p=0.329 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=ListerNotOlderThan/UseIndex=false-24   1.112k ± 3%   1.111k ± 1%        ~   (p=0.461 n=6)
StoreWriteThroughput/Traffic=DeleteCreate/Parallelism=25/Background=ListerNotOlderThan/UseIndex=true-24    1.117k ± 2%   1.127k ± 4%        ~   (p=0.234 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=Lister/UseIndex=false-24                      451.5 ± 28%   417.0 ± 20%        ~   (p=0.370 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=Lister/UseIndex=true-24                        377.5 ± 7%    373.0 ± 1%        ~   (p=0.697 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=ListerNotOlderThan/UseIndex=false-24           371.5 ± 0%    371.0 ± 5%        ~   (p=0.935 n=6)
StoreWriteThroughput/Traffic=Patch/Parallelism=25/Background=ListerNotOlderThan/UseIndex=true-24            371.5 ± 1%    373.0 ± 3%        ~   (p=0.195 n=6)
geomean                                                                                                          662.7         655.7   -1.06%
```

/kind feature

```release-note
NONE
```

/cc @Jefftree 