### PR TITLE
[WIP] Reuse a pooled allocator when serializing non-watch responses

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -109,6 +109,14 @@ func SerializeObject(mediaType string, encoder runtime.Encoder, hw http.Response
 		ctx:             ctx,
 	}
 
+	// Reuse a pooled buffer for this encode instead of allocating fresh memory per
+	// item, releasing it once the encode finishes. Parity with the watch path (watch.go).
+	if encoderWithAllocator, supportsAllocator := encoder.(runtime.EncoderWithAllocator); supportsAllocator {
+		memoryAllocator := runtime.AllocatorPool.Get().(*runtime.Allocator)
+		defer runtime.AllocatorPool.Put(memoryAllocator)
+		encoder = runtime.NewEncoderWithAllocator(encoderWithAllocator, memoryAllocator)
+	}
+
 	err := encoder.Encode(object, w)
 	if err == nil {
 		err = w.Close()


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Pool the encode allocator in `SerializeObject`, matching the watch path, so per-response marshal buffers are reused instead of allocated per item.

Theory is that scalability tests are driven by GC pressure on lists and this reduces it by a sizable amount.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```