### PR TITLE
Run etcd3 watcher initial-events tests with EtcdRangeStream on and off

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -115,23 +115,28 @@ func TestWatch(t *testing.T) {
 		ctx, store, _ := testSetup(t)
 		storagetesting.RunSendInitialEventsBackwardCompatibility(ctx, t, store)
 	})
-	t.Run("WatchSemantics", func(t *testing.T) {
-		ctx, store, _ := testSetup(t)
-		storagetesting.RunWatchSemantics(ctx, t, store)
-	})
-	t.Run("WatchSemanticsWithConcurrentDecode", func(t *testing.T) {
-		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ConcurrentWatchObjectDecode, true)
-		ctx, store, _ := testSetup(t)
-		storagetesting.RunWatchSemantics(ctx, t, store)
-	})
-	t.Run("WatchSemanticInitialEventsExtended", func(t *testing.T) {
-		ctx, store, _ := testSetup(t)
-		storagetesting.RunWatchSemanticInitialEventsExtended(ctx, t, store)
-	})
-	t.Run("WatchListMatchSingle", func(t *testing.T) {
-		ctx, store, _ := testSetup(t)
-		storagetesting.RunWatchListMatchSingle(ctx, t, store)
-	})
+	for _, rangeStream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("RangeStream=%v", rangeStream), func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EtcdRangeStream, rangeStream)
+			t.Run("WatchSemantics", func(t *testing.T) {
+				ctx, store, _ := testSetup(t)
+				storagetesting.RunWatchSemantics(ctx, t, store)
+			})
+			t.Run("WatchSemanticsWithConcurrentDecode", func(t *testing.T) {
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ConcurrentWatchObjectDecode, true)
+				ctx, store, _ := testSetup(t)
+				storagetesting.RunWatchSemantics(ctx, t, store)
+			})
+			t.Run("WatchSemanticInitialEventsExtended", func(t *testing.T) {
+				ctx, store, _ := testSetup(t)
+				storagetesting.RunWatchSemanticInitialEventsExtended(ctx, t, store)
+			})
+			t.Run("WatchListMatchSingle", func(t *testing.T) {
+				ctx, store, _ := testSetup(t)
+				storagetesting.RunWatchListMatchSingle(ctx, t, store)
+			})
+		})
+	}
 	t.Run("WatchErrorEventIsBlockingFurtherEvent", func(t *testing.T) {
 		ctx, store, _ := testSetup(t)
 		storagetesting.RunWatchErrorIsBlockingFurtherEvents(ctx, t, &storeWithPrefixTransformer{store})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Run etcd3 watcher initial-events tests with EtcdRangeStream on and off.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
