### PR TITLE
apiserver: add ListerNotOlderThan to RunBenchmarkWriteThroughput

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_benchmarks.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_benchmarks.go
@@ -55,13 +55,14 @@ var (
 )
 
 const (
-	loadNone            = "None"
-	loadWatcher         = "Watcher"
-	loadLister          = "Lister"
-	loadListerExactRV   = "ListerExactRV"
-	loadWatchList       = "WatchList"
-	trafficDeleteCreate = "DeleteCreate"
-	trafficPatch        = "Patch"
+	loadNone               = "None"
+	loadWatcher            = "Watcher"
+	loadLister             = "Lister"
+	loadListerExactRV      = "ListerExactRV"
+	loadListerNotOlderThan = "ListerNotOlderThan"
+	loadWatchList          = "WatchList"
+	trafficDeleteCreate    = "DeleteCreate"
+	trafficPatch           = "Patch"
 )
 
 func RunBenchmarkWriteThroughput(ctx context.Context, b *testing.B, store storage.Interface, data BenchmarkData, hasIndex bool, tracker *WatchLatencyTracker) {
@@ -72,7 +73,7 @@ func RunBenchmarkWriteThroughput(ctx context.Context, b *testing.B, store storag
 		b.Run(fmt.Sprintf("Traffic=%s", trafficType), func(b *testing.B) {
 			for _, parallelism := range []int{25} {
 				b.Run(fmt.Sprintf("Parallelism=%d", parallelism), func(b *testing.B) {
-					for _, loadType := range []string{loadNone, loadWatcher, loadLister, loadListerExactRV, loadWatchList} {
+					for _, loadType := range []string{loadNone, loadWatcher, loadLister, loadListerExactRV, loadListerNotOlderThan, loadWatchList} {
 						useIndexOptions := []bool{false}
 						if hasIndex && loadType != loadNone {
 							useIndexOptions = []bool{false, true}
@@ -122,6 +123,8 @@ func runBenchmarkWriteThroughput(ctx context.Context, b *testing.B, store storag
 		startBackgroundListers(ctx, store, data, 1, readIndexed, &workersWg, stopBackgroundLoadCh, &listCalls, &listObjects, "", &latestRV)
 	case loadListerExactRV:
 		startBackgroundListers(ctx, store, data, 1, readIndexed, &workersWg, stopBackgroundLoadCh, &listCalls, &listObjects, metav1.ResourceVersionMatchExact, &latestRV)
+	case loadListerNotOlderThan:
+		startBackgroundListers(ctx, store, data, 1, readIndexed, &workersWg, stopBackgroundLoadCh, &listCalls, &listObjects, metav1.ResourceVersionMatchNotOlderThan, &latestRV)
 	case loadWatchList:
 		startBackgroundWatchListers(ctx, store, data, 1, readIndexed, &workersWg, stopBackgroundLoadCh, &listCalls, &listObjects)
 	default:
@@ -147,7 +150,7 @@ func runBenchmarkWriteThroughput(ctx context.Context, b *testing.B, store storag
 	switch loadType {
 	case loadWatcher:
 		b.ReportMetric(float64(watchEvents.Load())/elapsedSeconds, "watch-events/s")
-	case loadLister, loadListerExactRV, loadWatchList:
+	case loadLister, loadListerExactRV, loadListerNotOlderThan, loadWatchList:
 		b.ReportMetric(float64(listCalls.Load())/elapsedSeconds, "list-calls/s")
 		b.ReportMetric(float64(listObjects.Load())/elapsedSeconds, "list-objs/s")
 	}


### PR DESCRIPTION
Implement loadListerNotOlderThan in RunBenchmarkWriteThroughput to support benchmarking storage write throughput with background listers utilizing resource version match "NotOlderThan".

This matches the existing ListerExactRV scenario but uses ResourceVersionMatchNotOlderThan when calling GetList.

Comparative benchmark results (Lister vs ListerNotOlderThan):
```
                              Lister      ListerNotOlderThan
                              sec/op      sec/op       vs base
Traffic=Patch/UseIndex=false  124.6µ ±25%  110.6µ ±42%       ~ (p=0.240 n=6)
Traffic=Patch/UseIndex=true    82.53µ ±29%  77.62µ ±35%       ~ (p=0.937 n=6)

                           Lister        ListerNotOlderThan
                        list-calls/s  list-calls/s     vs base
Traffic=Patch/UseIndex=false  10.33 ±48%    8.58 ±27%        ~ (p=0.485 n=6)
Traffic=Patch/UseIndex=true   24.73 ±45%   92.04 ±63%  +272.18% (p=0.002 n=6)

                           Lister        ListerNotOlderThan
                         list-objs/s   list-objs/s     vs base
Traffic=Patch/UseIndex=false  1.549M ±48%   1.287M ±27%        ~ (p=0.485 n=6)
Traffic=Patch/UseIndex=true    544.1 ±45%   2025.0 ±63%  +272.14% (p=0.002 n=6)

                              Lister       ListerNotOlderThan
                           watch-lat-p99 watch-lat-p99  vs base
Traffic=Patch/UseIndex=false  403.9m ±233%  262.3m ±305%       ~ (p=0.937 n=6)
Traffic=Patch/UseIndex=true   518.6m ±101%  268.0m ±285%       ~ (p=0.818 n=6)

                              Lister      ListerNotOlderThan
                             writes/s     writes/s     vs base
Traffic=Patch/UseIndex=false  17.83k ±34%   14.95k ±70%       ~ (p=0.699 n=6)
Traffic=Patch/UseIndex=true   17.75k ±20%   16.30k ±23%       ~ (p=0.589 n=6)

                              Lister      ListerNotOlderThan
                               B/op        B/op        vs base
Traffic=Patch/UseIndex=false 154.0Ki ±32%  153.7Ki ±32%       ~ (p=0.937 n=6)
Traffic=Patch/UseIndex=true  93.66Ki ±11%  93.15Ki ±16%       ~ (p=1.000 n=6)

                              Lister      ListerNotOlderThan
                            allocs/op    allocs/op     vs base
Traffic=Patch/UseIndex=false   645.5 ± 8%   643.0 ± 5%       ~ (p=0.662 n=6)
Traffic=Patch/UseIndex=true    651.0 ± 2%   641.5 ± 4%       ~ (p=0.333 n=6)
```

/kind feature

```release-note
NONE
```

/cc @Jefftree @michaelasp 