### PR TITLE
Setup ObjectMeta test suite and wire it for AdmissionRegistration API group

### DIFF
--- a/pkg/api/testing/validation.go
+++ b/pkg/api/testing/validation.go
@@ -24,7 +24,6 @@ import (
 	"strconv"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	runtimetest "k8s.io/apimachinery/pkg/runtime/testing"
@@ -295,11 +294,7 @@ func VerifyValidationEquivalence(t *testing.T, ctx context.Context, obj runtime.
 	}
 
 	verifyValidationEquivalence(t, expectedErrs, func(c context.Context) field.ErrorList {
-		errs := strategy.Validate(c, obj)
-		if dv, ok := strategy.(rest.DeclarativeValidationStrategy); ok {
-			errs = dv.ValidateDeclaratively(c, obj, nil, errs, operation.Create, dv.DeclarativeValidationConfig(c, obj, nil))
-		}
-		return errs
+		return rest.ValidateCreate(c, obj, strategy)
 	}, ctx, opts, obj)
 	VerifyVersionedValidationEquivalence(t, obj, nil, testConfigs...)
 }
@@ -327,11 +322,7 @@ func VerifyUpdateValidationEquivalence(t *testing.T, ctx context.Context, obj, o
 	}
 
 	verifyValidationEquivalence(t, expectedErrs, func(c context.Context) field.ErrorList {
-		errs := strategy.ValidateUpdate(c, obj, old)
-		if dv, ok := strategy.(rest.DeclarativeValidationStrategy); ok {
-			errs = dv.ValidateDeclaratively(c, obj, old, errs, operation.Update, dv.DeclarativeValidationConfig(c, obj, old))
-		}
-		return errs
+		return rest.ValidateUpdate(c, obj, old, strategy)
 	}, ctx, opts, obj)
 	VerifyVersionedValidationEquivalence(t, obj, old, testConfigs...)
 }

--- a/pkg/api/testing/validation_test.go
+++ b/pkg/api/testing/validation_test.go
@@ -106,8 +106,8 @@ func TestVersionedValidationByFuzzing(t *testing.T) {
 					if subresource != "" {
 						opts = append(opts, WithSubResources(subresource))
 					}
-					// extensions/v1beta1 is unserved and no longer carries
-					// declarative validation;
+					// extensions/v1beta1 is unserved and does not carry declarative validation,
+					// so skip it from the versioned validation equivalence sweep.
 					opts = append(opts, WithSkipGroupVersions("extensions/v1beta1"))
 					VerifyVersionedValidationEquivalence(t, obj, nil, opts...)
 

--- a/pkg/api/testing/validation_test.go
+++ b/pkg/api/testing/validation_test.go
@@ -106,7 +106,9 @@ func TestVersionedValidationByFuzzing(t *testing.T) {
 					if subresource != "" {
 						opts = append(opts, WithSubResources(subresource))
 					}
-
+					// extensions/v1beta1 is unserved and no longer carries
+					// declarative validation;
+					opts = append(opts, WithSkipGroupVersions("extensions/v1beta1"))
 					VerifyVersionedValidationEquivalence(t, obj, nil, opts...)
 
 					old, err := legacyscheme.Scheme.New(gv.WithKind(kind))

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/create.go
@@ -144,25 +144,26 @@ func BeforeCreate(strategy RESTCreateStrategy, ctx context.Context, obj runtime.
 // ValidateCreate performs common and strategy-specific validation for a create operation.
 func ValidateCreate(ctx context.Context, obj runtime.Object, strategy RESTCreateStrategy) field.ErrorList {
 	errs := strategy.Validate(ctx, obj)
+
+	if len(errs) == 0 {
+		objectMeta, err := meta.Accessor(obj)
+		if err != nil {
+			return append(errs, field.InternalError(field.NewPath("metadata"), fmt.Errorf("failed to get object metadata: %v", err)))
+		}
+
+		// TODO: Replace this check with the ObjectMeta name validation (validatePathSegment) once we are sure that all other validations are covered by strategy.Validate and strategy.ValidateDeclaratively.
+
+		// Custom validation (including name validation) passed
+		// Now run common validation on object meta
+		// Do this *after* custom validation so that specific error messages are shown whenever possible
+		errs = append(errs, genericvalidation.ValidateObjectMetaAccessor(objectMeta, strategy.NamespaceScoped(), validatePathSegment, field.NewPath("metadata"))...)
+	}
+
 	if dv, ok := strategy.(DeclarativeValidationStrategy); ok {
 		errs = dv.ValidateDeclaratively(ctx, obj, nil, errs, operation.Create, dv.DeclarativeValidationConfig(ctx, obj, nil))
 	}
 
-	if len(errs) > 0 {
-		return errs
-	}
-
-	objectMeta, err := meta.Accessor(obj)
-	if err != nil {
-		return append(errs, field.InternalError(field.NewPath("metadata"), fmt.Errorf("failed to get object metadata: %w", err)))
-	}
-
-	// TODO: Replace this check with the ObjectMeta name validation (validatePathSegment) once we are sure that all other validations are covered by strategy.Validate and strategy.ValidateDeclaratively.
-
-	// Custom validation (including name validation) passed
-	// Now run common validation on object meta
-	// Do this *after* custom validation so that specific error messages are shown whenever possible
-	return genericvalidation.ValidateObjectMetaAccessor(objectMeta, strategy.NamespaceScoped(), validatePathSegment, field.NewPath("metadata"))
+	return errs
 }
 
 // CheckGeneratedNameError checks whether an error that occurred creating a resource is due

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/create.go
@@ -148,7 +148,7 @@ func ValidateCreate(ctx context.Context, obj runtime.Object, strategy RESTCreate
 	if len(errs) == 0 {
 		objectMeta, err := meta.Accessor(obj)
 		if err != nil {
-			return append(errs, field.InternalError(field.NewPath("metadata"), fmt.Errorf("failed to get object metadata: %v", err)))
+			return append(errs, field.InternalError(field.NewPath("metadata"), fmt.Errorf("failed to get object metadata: %w", err)))
 		}
 
 		// TODO: Replace this check with the ObjectMeta name validation (validatePathSegment) once we are sure that all other validations are covered by strategy.Validate and strategy.ValidateDeclaratively.

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/create.go
@@ -154,7 +154,7 @@ func ValidateCreate(ctx context.Context, obj runtime.Object, strategy RESTCreate
 
 	objectMeta, err := meta.Accessor(obj)
 	if err != nil {
-		return append(errs, field.InternalError(field.NewPath("metadata"), fmt.Errorf("failed to get object metadata: %v", err)))
+		return append(errs, field.InternalError(field.NewPath("metadata"), fmt.Errorf("failed to get object metadata: %w", err)))
 	}
 
 	// TODO: Replace this check with the ObjectMeta name validation (validatePathSegment) once we are sure that all other validations are covered by strategy.Validate and strategy.ValidateDeclaratively.

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/create.go
@@ -127,18 +127,8 @@ func BeforeCreate(strategy RESTCreateStrategy, ctx context.Context, obj runtime.
 
 	strategy.PrepareForCreate(ctx, obj)
 
-	errs := strategy.Validate(ctx, obj)
-	if dv, ok := strategy.(DeclarativeValidationStrategy); ok {
-		errs = dv.ValidateDeclaratively(ctx, obj, nil, errs, operation.Create, dv.DeclarativeValidationConfig(ctx, obj, nil))
-	}
-	if len(errs) > 0 {
-		return errors.NewInvalid(kind.GroupKind(), objectMeta.GetName(), errs)
-	}
-
-	// Custom validation (including name validation) passed
-	// Now run common validation on object meta
-	// Do this *after* custom validation so that specific error messages are shown whenever possible
-	if errs := genericvalidation.ValidateObjectMetaAccessor(objectMeta, strategy.NamespaceScoped(), validatePathSegment, field.NewPath("metadata")); len(errs) > 0 {
+	errs := ValidateCreate(ctx, obj, strategy)
+	if len(errs) != 0 {
 		return errors.NewInvalid(kind.GroupKind(), objectMeta.GetName(), errs)
 	}
 
@@ -149,6 +139,30 @@ func BeforeCreate(strategy RESTCreateStrategy, ctx context.Context, obj runtime.
 	strategy.Canonicalize(obj)
 
 	return nil
+}
+
+// ValidateCreate performs common and strategy-specific validation for a create operation.
+func ValidateCreate(ctx context.Context, obj runtime.Object, strategy RESTCreateStrategy) field.ErrorList {
+	errs := strategy.Validate(ctx, obj)
+	if dv, ok := strategy.(DeclarativeValidationStrategy); ok {
+		errs = dv.ValidateDeclaratively(ctx, obj, nil, errs, operation.Create, dv.DeclarativeValidationConfig(ctx, obj, nil))
+	}
+
+	if len(errs) > 0 {
+		return errs
+	}
+
+	objectMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return append(errs, field.InternalError(field.NewPath("metadata"), fmt.Errorf("failed to get object metadata: %v", err)))
+	}
+
+	// TODO: Replace this check with the ObjectMeta name validation (validatePathSegment) once we are sure that all other validations are covered by strategy.Validate and strategy.ValidateDeclaratively.
+
+	// Custom validation (including name validation) passed
+	// Now run common validation on object meta
+	// Do this *after* custom validation so that specific error messages are shown whenever possible
+	return genericvalidation.ValidateObjectMetaAccessor(objectMeta, strategy.NamespaceScoped(), validatePathSegment, field.NewPath("metadata"))
 }
 
 // CheckGeneratedNameError checks whether an error that occurred creating a resource is due

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
@@ -151,7 +151,6 @@ func BeforeUpdate(strategy RESTUpdateStrategy, ctx context.Context, obj, old run
 	if oldMeta.GetDeletionGracePeriodSeconds() != nil && objectMeta.GetDeletionGracePeriodSeconds() == nil {
 		objectMeta.SetDeletionGracePeriodSeconds(oldMeta.GetDeletionGracePeriodSeconds())
 	}
-	// Ensure some common fields, like UID, are validated for all resources.
 	errs := ValidateUpdate(ctx, obj, old, strategy)
 	if len(errs) > 0 {
 		RecordDuplicateValidationErrors(ctx, kind.GroupKind(), errs)
@@ -171,6 +170,7 @@ func BeforeUpdate(strategy RESTUpdateStrategy, ctx context.Context, obj, old run
 func ValidateUpdate(ctx context.Context, obj runtime.Object, old runtime.Object, strategy RESTUpdateStrategy) field.ErrorList {
 
 	// TODO: Replace this check with the ObjectMeta name validation (validatePathSegment) once we are sure that all other validations are covered by strategy.Validate and strategy.ValidateDeclaratively.
+	// Ensure some common fields, like UID, are validated for all resources.
 	errs := validateCommonFields(obj, old, strategy)
 
 	errs = append(errs, strategy.ValidateUpdate(ctx, obj, old)...)

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
@@ -89,20 +89,22 @@ type RESTUpdateStrategy interface {
 }
 
 // TODO: add other common fields that require global validation.
-func validateCommonFields(obj, old runtime.Object, strategy RESTUpdateStrategy) (field.ErrorList, error) {
+func validateCommonFields(obj, old runtime.Object, strategy RESTUpdateStrategy) field.ErrorList {
 	allErrs := field.ErrorList{}
 	objectMeta, err := meta.Accessor(obj)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get new object metadata: %v", err)
+		allErrs = append(allErrs, field.InternalError(field.NewPath("metadata"), fmt.Errorf("failed to get new object metadata: %v", err)))
+		return allErrs
 	}
 	oldObjectMeta, err := meta.Accessor(old)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get old object metadata: %v", err)
+		allErrs = append(allErrs, field.InternalError(field.NewPath("metadata"), fmt.Errorf("failed to get old object metadata: %v", err)))
+		return allErrs
 	}
 	allErrs = append(allErrs, genericvalidation.ValidateObjectMetaAccessor(objectMeta, strategy.NamespaceScoped(), validatePathSegment, field.NewPath("metadata"))...)
 	allErrs = append(allErrs, genericvalidation.ValidateObjectMetaAccessorUpdate(objectMeta, oldObjectMeta, field.NewPath("metadata"))...)
 
-	return allErrs, nil
+	return allErrs
 }
 
 // BeforeUpdate ensures that common operations for all resources are performed on update. It only returns
@@ -149,17 +151,8 @@ func BeforeUpdate(strategy RESTUpdateStrategy, ctx context.Context, obj, old run
 	if oldMeta.GetDeletionGracePeriodSeconds() != nil && objectMeta.GetDeletionGracePeriodSeconds() == nil {
 		objectMeta.SetDeletionGracePeriodSeconds(oldMeta.GetDeletionGracePeriodSeconds())
 	}
-
 	// Ensure some common fields, like UID, are validated for all resources.
-	errs, err := validateCommonFields(obj, old, strategy)
-	if err != nil {
-		return errors.NewInternalError(err)
-	}
-
-	errs = append(errs, strategy.ValidateUpdate(ctx, obj, old)...)
-	if dv, ok := strategy.(DeclarativeValidationStrategy); ok {
-		errs = dv.ValidateDeclaratively(ctx, obj, old, errs, operation.Update, dv.DeclarativeValidationConfig(ctx, obj, old))
-	}
+	errs := ValidateUpdate(ctx, obj, old, strategy)
 	if len(errs) > 0 {
 		RecordDuplicateValidationErrors(ctx, kind.GroupKind(), errs)
 		return errors.NewInvalid(kind.GroupKind(), objectMeta.GetName(), errs)
@@ -172,6 +165,19 @@ func BeforeUpdate(strategy RESTUpdateStrategy, ctx context.Context, obj, old run
 	strategy.Canonicalize(obj)
 
 	return nil
+}
+
+// ValidateUpdate performs common and strategy-specific validation for an update operation.
+func ValidateUpdate(ctx context.Context, obj runtime.Object, old runtime.Object, strategy RESTUpdateStrategy) field.ErrorList {
+
+	// TODO: Replace this check with the ObjectMeta name validation (validatePathSegment) once we are sure that all other validations are covered by strategy.Validate and strategy.ValidateDeclaratively.
+	errs := validateCommonFields(obj, old, strategy)
+
+	errs = append(errs, strategy.ValidateUpdate(ctx, obj, old)...)
+	if dv, ok := strategy.(DeclarativeValidationStrategy); ok {
+		errs = dv.ValidateDeclaratively(ctx, obj, old, errs, operation.Update, dv.DeclarativeValidationConfig(ctx, obj, old))
+	}
+	return errs
 }
 
 // TransformFunc is a function to transform and return newObj

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
@@ -93,12 +93,12 @@ func validateCommonFields(obj, old runtime.Object, strategy RESTUpdateStrategy) 
 	allErrs := field.ErrorList{}
 	objectMeta, err := meta.Accessor(obj)
 	if err != nil {
-		allErrs = append(allErrs, field.InternalError(field.NewPath("metadata"), fmt.Errorf("failed to get new object metadata: %v", err)))
+		allErrs = append(allErrs, field.InternalError(field.NewPath("metadata"), fmt.Errorf("failed to get new object metadata: %w", err)))
 		return allErrs
 	}
 	oldObjectMeta, err := meta.Accessor(old)
 	if err != nil {
-		allErrs = append(allErrs, field.InternalError(field.NewPath("metadata"), fmt.Errorf("failed to get old object metadata: %v", err)))
+		allErrs = append(allErrs, field.InternalError(field.NewPath("metadata"), fmt.Errorf("failed to get old object metadata: %w", err)))
 		return allErrs
 	}
 	allErrs = append(allErrs, genericvalidation.ValidateObjectMetaAccessor(objectMeta, strategy.NamespaceScoped(), validatePathSegment, field.NewPath("metadata"))...)

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/declarative_validation_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/declarative_validation_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/declarative_validation_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/declarative_validation_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Kubernetes Authors.
+Copyright 2025 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,52 +14,31 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package validatingadmissionpolicy
+package mutatingadmissionpolicy
 
 import (
-	"testing"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
-	"k8s.io/kubernetes/pkg/apis/admissionregistration"
-	registry "k8s.io/kubernetes/pkg/registry/admissionregistration/validatingadmissionpolicy"
+	admissionregistration "k8s.io/kubernetes/pkg/apis/admissionregistration"
+	_ "k8s.io/kubernetes/pkg/apis/admissionregistration/install"
+	registry "k8s.io/kubernetes/pkg/registry/admissionregistration/mutatingadmissionpolicy"
 	"k8s.io/kubernetes/test/declarative_validation/meta"
+	"testing"
 )
 
-func TestDeclarativeValidateStatusUpdate(t *testing.T) {
-	for _, apiVersion := range apiVersions {
-		t.Run(apiVersion, func(t *testing.T) {
-			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-				APIGroup:    "admissionregistration.k8s.io",
-				APIVersion:  apiVersion,
-				Resource:    "validatingadmissionpolicies",
-				Subresource: "status",
-			})
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1", "v1alpha1", "v1beta1"}
 
-			strategy := registry.NewStatusStrategy(registry.NewStrategy(nil, nil))
-			meta.RunConditionTestCases(t, ctx, field.NewPath("status", "conditions"), &admissionregistration.ValidatingAdmissionPolicy{}, strategy, func(obj *admissionregistration.ValidatingAdmissionPolicy, c []metav1.Condition) {
-				*obj = admissionregistration.ValidatingAdmissionPolicy{
-					ObjectMeta: metav1.ObjectMeta{Name: "valid-policy", ResourceVersion: "1"},
-					Spec:       admissionregistration.ValidatingAdmissionPolicySpec{},
-					Status: admissionregistration.ValidatingAdmissionPolicyStatus{
-						Conditions: c,
-					},
-				}
-			})
-		})
-	}
-}
-
-// Helper function to create a baseline valid ValidatingAdmissionPolicy with optional tweaks
-func mkValidatingAdmissionPolicy(tweaks ...func(*admissionregistration.ValidatingAdmissionPolicy)) admissionregistration.ValidatingAdmissionPolicy {
+// Helper function to create a baseline valid MutatingAdmissionPolicy with optional tweaks
+func mkMutatingAdmissionPolicy(tweaks ...func(*admissionregistration.MutatingAdmissionPolicy)) admissionregistration.MutatingAdmissionPolicy {
 	fp := admissionregistration.Fail
+	rp := admissionregistration.NeverReinvocationPolicy
 	mp := admissionregistration.Equivalent
-	obj := admissionregistration.ValidatingAdmissionPolicy{
+	obj := admissionregistration.MutatingAdmissionPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "valid-resource-name",
 		},
-		Spec: admissionregistration.ValidatingAdmissionPolicySpec{
+		Spec: admissionregistration.MutatingAdmissionPolicySpec{
 			FailurePolicy: &fp,
 			MatchConstraints: &admissionregistration.MatchResources{
 				MatchPolicy:       &mp,
@@ -80,11 +59,15 @@ func mkValidatingAdmissionPolicy(tweaks ...func(*admissionregistration.Validatin
 					},
 				},
 			},
-			Validations: []admissionregistration.Validation{
+			Mutations: []admissionregistration.Mutation{
 				{
-					Expression: "true",
+					PatchType: admissionregistration.PatchTypeJSONPatch,
+					JSONPatch: &admissionregistration.JSONPatch{
+						Expression: `[JSONPatch{op: "add", path: "/spec/replicas", value: 3}]`,
+					},
 				},
 			},
+			ReinvocationPolicy: rp,
 		},
 	}
 	for _, tweak := range tweaks {
@@ -104,12 +87,12 @@ func TestDeclarativeValidate(t *testing.T) {
 			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
 				APIGroup:          "admissionregistration.k8s.io",
 				APIVersion:        apiVersion,
-				Resource:          "validatingadmissionpolicies",
+				Resource:          "mutatingadmissionpolicies",
 				Namespace:         namespace,
 				IsResourceRequest: true,
 				Verb:              "create",
 			})
-			obj := mkValidatingAdmissionPolicy(func(o *admissionregistration.ValidatingAdmissionPolicy) {
+			obj := mkMutatingAdmissionPolicy(func(o *admissionregistration.MutatingAdmissionPolicy) {
 				o.Namespace = namespace
 			})
 			meta.RunObjectMetaTestCases(t, ctx, &obj, strategy)
@@ -128,12 +111,12 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
 				APIGroup:          "admissionregistration.k8s.io",
 				APIVersion:        apiVersion,
-				Resource:          "validatingadmissionpolicies",
+				Resource:          "mutatingadmissionpolicies",
 				Namespace:         namespace,
 				IsResourceRequest: true,
 				Verb:              "update",
 			})
-			obj := mkValidatingAdmissionPolicy(func(o *admissionregistration.ValidatingAdmissionPolicy) {
+			obj := mkMutatingAdmissionPolicy(func(o *admissionregistration.MutatingAdmissionPolicy) {
 				o.Namespace = namespace
 			})
 			meta.RunObjectMetaUpdateTestCases(t, ctx, &obj, strategy)

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/declarative_validation_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/declarative_validation_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutatingadmissionpolicybinding
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	admissionregistration "k8s.io/kubernetes/pkg/apis/admissionregistration"
+	_ "k8s.io/kubernetes/pkg/apis/admissionregistration/install"
+	registry "k8s.io/kubernetes/pkg/registry/admissionregistration/mutatingadmissionpolicybinding"
+	"k8s.io/kubernetes/pkg/registry/admissionregistration/resolver"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+	"testing"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1", "v1alpha1", "v1beta1"}
+
+// Helper function to create a baseline valid MutatingAdmissionPolicyBinding with optional tweaks
+func mkMutatingAdmissionPolicyBinding(tweaks ...func(*admissionregistration.MutatingAdmissionPolicyBinding)) admissionregistration.MutatingAdmissionPolicyBinding {
+	obj := admissionregistration.MutatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "valid-resource-name",
+		},
+		Spec: admissionregistration.MutatingAdmissionPolicyBindingSpec{
+			PolicyName: "some-policy",
+		},
+	}
+	for _, tweak := range tweaks {
+		tweak(&obj)
+	}
+	return obj
+}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			strategy := registry.NewStrategy(nil, nil, resolver.ResourceResolverFunc(func(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {
+				return schema.GroupVersionResource{}, nil
+			}))
+			var namespace string
+			if strategy.NamespaceScoped() {
+				namespace = metav1.NamespaceDefault
+			}
+			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+				APIGroup:          "admissionregistration.k8s.io",
+				APIVersion:        apiVersion,
+				Resource:          "mutatingadmissionpolicybindings",
+				Namespace:         namespace,
+				IsResourceRequest: true,
+				Verb:              "create",
+			})
+			obj := mkMutatingAdmissionPolicyBinding(func(o *admissionregistration.MutatingAdmissionPolicyBinding) {
+				o.Namespace = namespace
+			})
+			meta.RunObjectMetaTestCases(t, ctx, &obj, strategy)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			strategy := registry.NewStrategy(nil, nil, resolver.ResourceResolverFunc(func(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {
+				return schema.GroupVersionResource{}, nil
+			}))
+			var namespace string
+			if strategy.NamespaceScoped() {
+				namespace = metav1.NamespaceDefault
+			}
+			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+				APIGroup:          "admissionregistration.k8s.io",
+				APIVersion:        apiVersion,
+				Resource:          "mutatingadmissionpolicybindings",
+				Namespace:         namespace,
+				IsResourceRequest: true,
+				Verb:              "update",
+			})
+			obj := mkMutatingAdmissionPolicyBinding(func(o *admissionregistration.MutatingAdmissionPolicyBinding) {
+				o.Namespace = namespace
+			})
+			meta.RunObjectMetaUpdateTestCases(t, ctx, &obj, strategy)
+		})
+	}
+}

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/declarative_validation_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/declarative_validation_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ limitations under the License.
 package mutatingadmissionpolicybinding
 
 import (
+	"testing"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
@@ -25,7 +27,6 @@ import (
 	registry "k8s.io/kubernetes/pkg/registry/admissionregistration/mutatingadmissionpolicybinding"
 	"k8s.io/kubernetes/pkg/registry/admissionregistration/resolver"
 	"k8s.io/kubernetes/test/declarative_validation/meta"
-	"testing"
 )
 
 // TODO: remove this apiVersions variable once coverage tests are generated for this package.

--- a/test/declarative_validation/admissionregistration/mutatingwebhookconfiguration/declarative_validation_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingwebhookconfiguration/declarative_validation_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutatingwebhookconfiguration
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	admissionregistration "k8s.io/kubernetes/pkg/apis/admissionregistration"
+	_ "k8s.io/kubernetes/pkg/apis/admissionregistration/install"
+	registry "k8s.io/kubernetes/pkg/registry/admissionregistration/mutatingwebhookconfiguration"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+	"testing"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1", "v1beta1"}
+
+// Helper function to create a baseline valid MutatingWebhookConfiguration with optional tweaks
+func mkMutatingWebhookConfiguration(tweaks ...func(*admissionregistration.MutatingWebhookConfiguration)) admissionregistration.MutatingWebhookConfiguration {
+	obj := admissionregistration.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "valid-resource-name",
+		},
+	}
+	for _, tweak := range tweaks {
+		tweak(&obj)
+	}
+	return obj
+}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			strategy := registry.Strategy
+			var namespace string
+			if strategy.NamespaceScoped() {
+				namespace = metav1.NamespaceDefault
+			}
+			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+				APIGroup:          "admissionregistration.k8s.io",
+				APIVersion:        apiVersion,
+				Resource:          "mutatingwebhookconfigurations",
+				Namespace:         namespace,
+				IsResourceRequest: true,
+				Verb:              "create",
+			})
+			obj := mkMutatingWebhookConfiguration(func(o *admissionregistration.MutatingWebhookConfiguration) {
+				o.Namespace = namespace
+			})
+			meta.RunObjectMetaTestCases(t, ctx, &obj, strategy)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			strategy := registry.Strategy
+			var namespace string
+			if strategy.NamespaceScoped() {
+				namespace = metav1.NamespaceDefault
+			}
+			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+				APIGroup:          "admissionregistration.k8s.io",
+				APIVersion:        apiVersion,
+				Resource:          "mutatingwebhookconfigurations",
+				Namespace:         namespace,
+				IsResourceRequest: true,
+				Verb:              "update",
+			})
+			obj := mkMutatingWebhookConfiguration(func(o *admissionregistration.MutatingWebhookConfiguration) {
+				o.Namespace = namespace
+			})
+			meta.RunObjectMetaUpdateTestCases(t, ctx, &obj, strategy)
+		})
+	}
+}

--- a/test/declarative_validation/admissionregistration/mutatingwebhookconfiguration/declarative_validation_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingwebhookconfiguration/declarative_validation_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,13 +17,14 @@ limitations under the License.
 package mutatingwebhookconfiguration
 
 import (
+	"testing"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	admissionregistration "k8s.io/kubernetes/pkg/apis/admissionregistration"
 	_ "k8s.io/kubernetes/pkg/apis/admissionregistration/install"
 	registry "k8s.io/kubernetes/pkg/registry/admissionregistration/mutatingwebhookconfiguration"
 	"k8s.io/kubernetes/test/declarative_validation/meta"
-	"testing"
 )
 
 // TODO: remove this apiVersions variable once coverage tests are generated for this package.

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/declarative_validation_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/declarative_validation_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/declarative_validation_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/declarative_validation_test.go
@@ -25,6 +25,7 @@ import (
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/apis/admissionregistration"
 	registry "k8s.io/kubernetes/pkg/registry/admissionregistration/validatingadmissionpolicybinding"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
 )
 
 func TestDeclarativeValidate(t *testing.T) {
@@ -70,6 +71,9 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, &registry.Strategy, tc.expectedErrs)
 		})
 	}
+	obj := mkValidBinding()
+	meta.RunObjectMetaTestCases(t, ctx, &obj, &registry.Strategy)
+
 }
 
 func TestDeclarativeValidateUpdate(t *testing.T) {
@@ -81,6 +85,13 @@ func TestDeclarativeValidateUpdate(t *testing.T) {
 }
 
 func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
+	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+		APIGroup:          "admissionregistration.k8s.io",
+		APIVersion:        apiVersion,
+		Resource:          "validatingadmissionpolicybindings",
+		IsResourceRequest: true,
+		Verb:              "update",
+	})
 	testCases := map[string]struct {
 		oldObj       admissionregistration.ValidatingAdmissionPolicyBinding
 		updateObj    admissionregistration.ValidatingAdmissionPolicyBinding
@@ -108,18 +119,11 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 	}
 	for k, tc := range testCases {
 		t.Run(k, func(t *testing.T) {
-			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
-				APIPrefix:         "apis",
-				APIGroup:          "admissionregistration.k8s.io",
-				APIVersion:        apiVersion,
-				Resource:          "validatingadmissionpolicybindings",
-				Name:              "valid-binding",
-				IsResourceRequest: true,
-				Verb:              "update",
-			})
 			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, &registry.Strategy, tc.expectedErrs)
 		})
 	}
+	updateObj := mkValidBinding()
+	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, &registry.Strategy)
 }
 
 func mkValidBinding(tweaks ...func(obj *admissionregistration.ValidatingAdmissionPolicyBinding)) admissionregistration.ValidatingAdmissionPolicyBinding {

--- a/test/declarative_validation/admissionregistration/validatingwebhookconfiguration/declarative_validation_test.go
+++ b/test/declarative_validation/admissionregistration/validatingwebhookconfiguration/declarative_validation_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validatingwebhookconfiguration
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	admissionregistration "k8s.io/kubernetes/pkg/apis/admissionregistration"
+	_ "k8s.io/kubernetes/pkg/apis/admissionregistration/install"
+	registry "k8s.io/kubernetes/pkg/registry/admissionregistration/validatingwebhookconfiguration"
+	"k8s.io/kubernetes/test/declarative_validation/meta"
+	"testing"
+)
+
+// TODO: remove this apiVersions variable once coverage tests are generated for this package.
+var apiVersions = []string{"v1", "v1beta1"}
+
+// Helper function to create a baseline valid ValidatingWebhookConfiguration with optional tweaks
+func mkValidatingWebhookConfiguration(tweaks ...func(*admissionregistration.ValidatingWebhookConfiguration)) admissionregistration.ValidatingWebhookConfiguration {
+	obj := admissionregistration.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "valid-resource-name",
+		},
+	}
+	for _, tweak := range tweaks {
+		tweak(&obj)
+	}
+	return obj
+}
+
+func TestDeclarativeValidate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			strategy := registry.Strategy
+			var namespace string
+			if strategy.NamespaceScoped() {
+				namespace = metav1.NamespaceDefault
+			}
+			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+				APIGroup:          "admissionregistration.k8s.io",
+				APIVersion:        apiVersion,
+				Resource:          "validatingwebhookconfigurations",
+				Namespace:         namespace,
+				IsResourceRequest: true,
+				Verb:              "create",
+			})
+			obj := mkValidatingWebhookConfiguration(func(o *admissionregistration.ValidatingWebhookConfiguration) {
+				o.Namespace = namespace
+			})
+			meta.RunObjectMetaTestCases(t, ctx, &obj, strategy)
+		})
+	}
+}
+
+func TestDeclarativeValidateUpdate(t *testing.T) {
+	for _, apiVersion := range apiVersions {
+		t.Run(apiVersion, func(t *testing.T) {
+			strategy := registry.Strategy
+			var namespace string
+			if strategy.NamespaceScoped() {
+				namespace = metav1.NamespaceDefault
+			}
+			ctx := genericapirequest.WithRequestInfo(genericapirequest.NewDefaultContext(), &genericapirequest.RequestInfo{
+				APIGroup:          "admissionregistration.k8s.io",
+				APIVersion:        apiVersion,
+				Resource:          "validatingwebhookconfigurations",
+				Namespace:         namespace,
+				IsResourceRequest: true,
+				Verb:              "update",
+			})
+			obj := mkValidatingWebhookConfiguration(func(o *admissionregistration.ValidatingWebhookConfiguration) {
+				o.Namespace = namespace
+			})
+			meta.RunObjectMetaUpdateTestCases(t, ctx, &obj, strategy)
+		})
+	}
+}

--- a/test/declarative_validation/admissionregistration/validatingwebhookconfiguration/declarative_validation_test.go
+++ b/test/declarative_validation/admissionregistration/validatingwebhookconfiguration/declarative_validation_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,13 +17,14 @@ limitations under the License.
 package validatingwebhookconfiguration
 
 import (
+	"testing"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	admissionregistration "k8s.io/kubernetes/pkg/apis/admissionregistration"
 	_ "k8s.io/kubernetes/pkg/apis/admissionregistration/install"
 	registry "k8s.io/kubernetes/pkg/registry/admissionregistration/validatingwebhookconfiguration"
 	"k8s.io/kubernetes/test/declarative_validation/meta"
-	"testing"
 )
 
 // TODO: remove this apiVersions variable once coverage tests are generated for this package.

--- a/test/declarative_validation/meta/objectmeta.go
+++ b/test/declarative_validation/meta/objectmeta.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package meta
+
+import (
+	"context"
+	"testing"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/rest"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+)
+
+func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context, baseObj T, strategy rest.RESTCreateStrategy, options ...apitesting.ValidationTestConfig) {
+	t.Helper()
+	fldPath := field.NewPath("metadata")
+
+	testCases := []struct {
+		Name         string
+		Modify       func(metav1.Object)
+		ExpectedErrs field.ErrorList
+	}{
+		{
+			Name: "annotations: invalid key",
+			Modify: func(meta metav1.Object) {
+				meta.SetAnnotations(map[string]string{
+					"invalid/key/format": "value",
+				})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("annotations"), "", "").WithOrigin("format=k8s-label-key").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "annotations: too long",
+			Modify: func(meta metav1.Object) {
+				meta.SetAnnotations(map[string]string{
+					"a": string(make([]byte, apivalidation.TotalAnnotationSizeLimitB)),
+				})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.TooLong(fldPath.Child("annotations"), "", apivalidation.TotalAnnotationSizeLimitB).MarkFromImperative(),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("objectmeta: "+tc.Name, func(t *testing.T) {
+			obj := baseObj.DeepCopyObject().(T)
+			if accessor, err := apimeta.Accessor(obj); err == nil {
+				tc.Modify(accessor)
+			} else {
+				t.Fatalf("failed to get accessor: %v", err)
+			}
+			apitesting.VerifyValidationEquivalence(t, ctx, obj, strategy, tc.ExpectedErrs, options...)
+		})
+	}
+}
+
+func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Context, baseObj T, strategy rest.RESTUpdateStrategy, options ...apitesting.ValidationTestConfig) {
+	t.Helper()
+	fldPath := field.NewPath("metadata")
+
+	testCases := []struct {
+		Name         string
+		Modify       func(old, new metav1.Object)
+		ExpectedErrs field.ErrorList
+	}{
+		{
+			Name: "update: annotations: invalid key",
+			Modify: func(old, new metav1.Object) {
+				old.SetResourceVersion("1")
+				new.SetResourceVersion("2")
+				new.SetAnnotations(map[string]string{
+					"invalid/key/format": "value",
+				})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("annotations"), "", "").WithOrigin("format=k8s-label-key").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "update: annotations: too long",
+			Modify: func(old, new metav1.Object) {
+				old.SetResourceVersion("1")
+				new.SetResourceVersion("2")
+				new.SetAnnotations(map[string]string{
+					"a": string(make([]byte, apivalidation.TotalAnnotationSizeLimitB)),
+				})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.TooLong(fldPath.Child("annotations"), "", 0).MarkFromImperative(),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+
+		t.Run("objectmeta: "+tc.Name, func(t *testing.T) {
+			currOld := baseObj.DeepCopyObject().(T)
+			currNew := baseObj.DeepCopyObject().(T)
+			newAcc, _ := apimeta.Accessor(currNew)
+			oldAcc, _ := apimeta.Accessor(currOld)
+			tc.Modify(oldAcc, newAcc)
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, currNew, currOld, strategy, tc.ExpectedErrs, options...)
+		})
+	}
+}

--- a/test/declarative_validation/meta/objectmeta.go
+++ b/test/declarative_validation/meta/objectmeta.go
@@ -18,12 +18,15 @@ package meta
 
 import (
 	"context"
+	"strings"
 	"testing"
+	"time"
 
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/rest"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
@@ -32,6 +35,7 @@ import (
 func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context, baseObj T, strategy rest.RESTCreateStrategy, options ...apitesting.ValidationTestConfig) {
 	t.Helper()
 	fldPath := field.NewPath("metadata")
+	trueVar := true
 
 	// TODO: Remove MarkFromImperative from expected errors after adding corresponding declarative validation tags on ObjectMeta.
 	testCases := []struct {
@@ -61,6 +65,247 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 				field.TooLong(fldPath.Child("annotations"), "", apivalidation.TotalAnnotationSizeLimitB).MarkFromImperative(),
 			},
 		},
+		{
+			Name: "generation: negative",
+			Modify: func(meta metav1.Object) {
+				meta.SetGeneration(-1)
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("generation"), "", "").WithOrigin("minimum").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "ownerReferences: empty apiVersion",
+			Modify: func(meta metav1.Object) {
+				meta.SetOwnerReferences([]metav1.OwnerReference{
+					mkOwnerReference(tweakAPIVersion("")),
+				})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("ownerReferences").Child("apiVersion"), "", "version must not be empty").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "ownerReferences: empty kind",
+			Modify: func(meta metav1.Object) {
+				meta.SetOwnerReferences([]metav1.OwnerReference{
+					mkOwnerReference(tweakKind("")),
+				})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("ownerReferences").Child("kind"), "", "must not be empty").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "ownerReferences: empty name",
+			Modify: func(meta metav1.Object) {
+				meta.SetOwnerReferences([]metav1.OwnerReference{
+					mkOwnerReference(tweakName("")),
+				})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("ownerReferences").Child("name"), "", "must not be empty").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "ownerReferences: empty uid",
+			Modify: func(meta metav1.Object) {
+				meta.SetOwnerReferences([]metav1.OwnerReference{
+					mkOwnerReference(tweakUID("")),
+				})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("ownerReferences").Child("uid"), "", "must not be empty").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "ownerReferences: event is disallowed",
+			Modify: func(meta metav1.Object) {
+				meta.SetOwnerReferences([]metav1.OwnerReference{
+					mkOwnerReference(tweakKind("Event")),
+				})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("ownerReferences"), "", "v1, Kind=Event is disallowed from being an owner").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "ownerReferences: multiple controllers",
+			Modify: func(meta metav1.Object) {
+				meta.SetOwnerReferences([]metav1.OwnerReference{
+					mkOwnerReference(tweakName("name1"), tweakController(&trueVar)),
+					mkOwnerReference(tweakName("name2"), tweakUID("uid-2"), tweakController(&trueVar)),
+				})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("ownerReferences"), "", "Only one reference can have Controller set to true. Found \"true\" in references for Pod/name1 and Pod/name2").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "finalizers: conflicting",
+			Modify: func(meta metav1.Object) {
+				meta.SetFinalizers([]string{metav1.FinalizerOrphanDependents, metav1.FinalizerDeleteDependents})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("finalizers"), "", "finalizer orphan and foregroundDeletion cannot be both set").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "finalizers: invalid format",
+			Modify: func(meta metav1.Object) {
+				meta.SetFinalizers([]string{"invalid/format/slash"})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("finalizers"), "", "").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "managedFields: invalid operation",
+			Modify: func(meta metav1.Object) {
+				meta.SetManagedFields([]metav1.ManagedFieldsEntry{
+					mkManagedFieldsEntry(tweakOperation("Invalid")),
+				})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("managedFields").Index(0).Child("operation"), "", "must be `Apply` or `Update`").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "managedFields: invalid fieldsType",
+			Modify: func(meta metav1.Object) {
+				meta.SetManagedFields([]metav1.ManagedFieldsEntry{
+					mkManagedFieldsEntry(tweakFieldsType("Invalid")),
+				})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("managedFields").Index(0).Child("fieldsType"), "", "must be `FieldsV1`").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "managedFields: manager too long",
+			Modify: func(meta metav1.Object) {
+				meta.SetManagedFields([]metav1.ManagedFieldsEntry{
+					mkManagedFieldsEntry(tweakManager(strings.Repeat("a", 129))),
+				})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.TooLong(fldPath.Child("managedFields").Index(0).Child("manager"), "", 128).MarkFromImperative(),
+			},
+		},
+		{
+			Name: "managedFields: subresource too long",
+			Modify: func(meta metav1.Object) {
+				meta.SetManagedFields([]metav1.ManagedFieldsEntry{
+					mkManagedFieldsEntry(tweakSubresource(strings.Repeat("a", 257))),
+				})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.TooLong(fldPath.Child("managedFields").Index(0).Child("subresource"), "", 0).MarkFromImperative(),
+			},
+		},
+		{
+			Name: "labels: invalid key format",
+			Modify: func(meta metav1.Object) {
+				meta.SetLabels(map[string]string{
+					"a/b/c": "value",
+				})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-key").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "labels: key too long",
+			Modify: func(meta metav1.Object) {
+				meta.SetLabels(map[string]string{
+					strings.Repeat("a", 317): "value",
+				})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-key").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "labels: invalid value format",
+			Modify: func(meta metav1.Object) {
+				meta.SetLabels(map[string]string{
+					"key": "a!",
+				})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-value").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "labels: value too long",
+			Modify: func(meta metav1.Object) {
+				meta.SetLabels(map[string]string{
+					"key": strings.Repeat("a", 64),
+				})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-value").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "finalizers: name too long",
+			Modify: func(meta metav1.Object) {
+				meta.SetFinalizers([]string{strings.Repeat("a", 317)})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("finalizers"), "", "").MarkFromImperative(),
+			},
+		},
+	}
+
+	if strategy.NamespaceScoped() {
+		testCases = append(testCases, []struct {
+			Name         string
+			Modify       func(metav1.Object)
+			ExpectedErrs field.ErrorList
+		}{
+			{
+				Name: "namespace: empty",
+				Modify: func(meta metav1.Object) {
+					meta.SetNamespace("")
+				},
+				ExpectedErrs: field.ErrorList{
+					field.Required(fldPath.Child("namespace"), "").MarkFromImperative(),
+				},
+			},
+			{
+				Name: "namespace: invalid dns label format",
+				Modify: func(meta metav1.Object) {
+					meta.SetNamespace("foo.bar")
+				},
+				ExpectedErrs: field.ErrorList{
+					field.Invalid(fldPath.Child("namespace"), "", "").MarkFromImperative(),
+				},
+			},
+			{
+				Name: "namespace: too long",
+				Modify: func(meta metav1.Object) {
+					meta.SetNamespace(strings.Repeat("a", 64))
+				},
+				ExpectedErrs: field.ErrorList{
+					field.Invalid(fldPath.Child("namespace"), "", "").MarkFromImperative(),
+				},
+			},
+		}...)
+	} else {
+		testCases = append(testCases, struct {
+			Name         string
+			Modify       func(metav1.Object)
+			ExpectedErrs field.ErrorList
+		}{
+			Name: "namespace: forbidden",
+			Modify: func(meta metav1.Object) {
+				meta.SetNamespace("default")
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Forbidden(fldPath.Child("namespace"), "not allowed on this type").MarkFromImperative(),
+			},
+		})
 	}
 
 	for _, tc := range testCases {
@@ -79,6 +324,8 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Context, baseObj T, strategy rest.RESTUpdateStrategy, options ...apitesting.ValidationTestConfig) {
 	t.Helper()
 	fldPath := field.NewPath("metadata")
+	t1 := metav1.NewTime(time.Unix(1000, 0).UTC())
+	t2 := metav1.NewTime(time.Unix(2000, 0).UTC())
 
 	// TODO: Remove MarkFromImperative from expected errors after adding corresponding declarative validation tags on ObjectMeta.
 	testCases := []struct {
@@ -89,8 +336,6 @@ func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Co
 		{
 			Name: "update: annotations: invalid key",
 			Modify: func(old, new metav1.Object) {
-				old.SetResourceVersion("1")
-				new.SetResourceVersion("2")
 				new.SetAnnotations(map[string]string{
 					"invalid/key/format": "value",
 				})
@@ -102,8 +347,6 @@ func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Co
 		{
 			Name: "update: annotations: too long",
 			Modify: func(old, new metav1.Object) {
-				old.SetResourceVersion("1")
-				new.SetResourceVersion("2")
 				new.SetAnnotations(map[string]string{
 					"a": string(make([]byte, apivalidation.TotalAnnotationSizeLimitB)),
 				})
@@ -112,17 +355,254 @@ func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Co
 				field.TooLong(fldPath.Child("annotations"), "", 0).MarkFromImperative(),
 			},
 		},
+		{
+			Name: "update: resourceVersion: missing",
+			Modify: func(old, new metav1.Object) {
+				new.SetResourceVersion("")
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("resourceVersion"), "", "must be specified for an update").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "update: generation: decremented",
+			Modify: func(old, new metav1.Object) {
+				old.SetGeneration(5)
+				new.SetGeneration(4)
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("generation"), "", "must not be decremented").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "update: uid: immutable",
+			Modify: func(old, new metav1.Object) {
+				old.SetUID("uid-1")
+				new.SetUID("uid-2")
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("uid"), "", "field is immutable").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "update: creationTimestamp: immutable",
+			Modify: func(old, new metav1.Object) {
+				old.SetCreationTimestamp(t1)
+				new.SetCreationTimestamp(t2)
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("creationTimestamp"), "", "field is immutable").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "update: deletionTimestamp: immutable",
+			Modify: func(old, new metav1.Object) {
+				old.SetDeletionTimestamp(nil)
+				new.SetDeletionTimestamp(&t2)
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("deletionTimestamp"), "", "field is immutable").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "update: deletionGracePeriodSeconds: immutable",
+			Modify: func(old, new metav1.Object) {
+				g1 := int64(30)
+				g2 := int64(40)
+				old.SetDeletionGracePeriodSeconds(&g1)
+				new.SetDeletionGracePeriodSeconds(&g2)
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("deletionGracePeriodSeconds"), "", "field is immutable").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "update: finalizers: no new finalizers if deleted",
+			Modify: func(old, new metav1.Object) {
+				old.SetResourceVersion("1")
+				new.SetResourceVersion("2")
+				old.SetDeletionTimestamp(&t1)
+				new.SetDeletionTimestamp(&t1)
+				old.SetFinalizers([]string{"example.com/a"})
+				new.SetFinalizers([]string{"example.com/a", "example.com/b"})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Forbidden(fldPath.Child("finalizers"), "no new finalizers can be added if the object is being deleted, found new finalizers []string{\"example.com/b\"}").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "update: managedFields: subresource too long",
+			Modify: func(old, new metav1.Object) {
+				new.SetManagedFields([]metav1.ManagedFieldsEntry{
+					mkManagedFieldsEntry(tweakSubresource(strings.Repeat("a", 257))),
+				})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.TooLong(fldPath.Child("managedFields").Index(0).Child("subresource"), "", 0).MarkFromImperative(),
+			},
+		},
+		{
+			Name: "update: labels: invalid key format",
+			Modify: func(old, new metav1.Object) {
+				new.SetLabels(map[string]string{
+					"a/b/c": "value",
+				})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-key").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "update: labels: key too long",
+			Modify: func(old, new metav1.Object) {
+				new.SetLabels(map[string]string{
+					strings.Repeat("a", 317): "value",
+				})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-key").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "update: labels: invalid value format",
+			Modify: func(old, new metav1.Object) {
+				new.SetLabels(map[string]string{
+					"key": "a!",
+				})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-value").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "update: labels: value too long",
+			Modify: func(old, new metav1.Object) {
+				new.SetLabels(map[string]string{
+					"key": strings.Repeat("a", 64),
+				})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-value").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "update: finalizers: name too long",
+			Modify: func(old, new metav1.Object) {
+				new.SetFinalizers([]string{strings.Repeat("a", 317)})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("finalizers"), "", "").MarkFromImperative(),
+			},
+		},
+	}
+
+	if strategy.NamespaceScoped() {
+		testCases = append(testCases, struct {
+			Name         string
+			Modify       func(old, new metav1.Object)
+			ExpectedErrs field.ErrorList
+		}{
+			Name: "update: namespace: immutable",
+			Modify: func(old, new metav1.Object) {
+				old.SetResourceVersion("1")
+				new.SetResourceVersion("2")
+				old.SetNamespace("ns-one")
+				new.SetNamespace("ns-two")
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("namespace"), "", "field is immutable").MarkFromImperative(),
+			},
+		})
 	}
 
 	for _, tc := range testCases {
-
 		t.Run("objectmeta: "+tc.Name, func(t *testing.T) {
 			currOld := baseObj.DeepCopyObject().(T)
 			currNew := baseObj.DeepCopyObject().(T)
 			newAcc, _ := apimeta.Accessor(currNew)
 			oldAcc, _ := apimeta.Accessor(currOld)
+			oldAcc.SetResourceVersion("1")
+			newAcc.SetResourceVersion("2")
 			tc.Modify(oldAcc, newAcc)
 			apitesting.VerifyUpdateValidationEquivalence(t, ctx, currNew, currOld, strategy, tc.ExpectedErrs, options...)
 		})
+	}
+}
+
+func mkOwnerReference(tweaks ...func(*metav1.OwnerReference)) metav1.OwnerReference {
+	ref := metav1.OwnerReference{
+		APIVersion: "v1",
+		Kind:       "Pod",
+		Name:       "name",
+		UID:        "uid-1",
+	}
+	for _, tweak := range tweaks {
+		tweak(&ref)
+	}
+	return ref
+}
+
+func mkManagedFieldsEntry(tweaks ...func(*metav1.ManagedFieldsEntry)) metav1.ManagedFieldsEntry {
+	entry := metav1.ManagedFieldsEntry{
+		Operation:  "Update",
+		FieldsType: "FieldsV1",
+	}
+	for _, tweak := range tweaks {
+		tweak(&entry)
+	}
+	return entry
+}
+
+func tweakAPIVersion(v string) func(*metav1.OwnerReference) {
+	return func(r *metav1.OwnerReference) {
+		r.APIVersion = v
+	}
+}
+
+func tweakKind(k string) func(*metav1.OwnerReference) {
+	return func(r *metav1.OwnerReference) {
+		r.Kind = k
+	}
+}
+
+func tweakName(n string) func(*metav1.OwnerReference) {
+	return func(r *metav1.OwnerReference) {
+		r.Name = n
+	}
+}
+
+func tweakUID(u types.UID) func(*metav1.OwnerReference) {
+	return func(r *metav1.OwnerReference) {
+		r.UID = u
+	}
+}
+
+func tweakController(c *bool) func(*metav1.OwnerReference) {
+	return func(r *metav1.OwnerReference) {
+		r.Controller = c
+	}
+}
+
+func tweakOperation(op metav1.ManagedFieldsOperationType) func(*metav1.ManagedFieldsEntry) {
+	return func(m *metav1.ManagedFieldsEntry) {
+		m.Operation = op
+	}
+}
+
+func tweakFieldsType(ft string) func(*metav1.ManagedFieldsEntry) {
+	return func(m *metav1.ManagedFieldsEntry) {
+		m.FieldsType = ft
+	}
+}
+
+func tweakManager(mng string) func(*metav1.ManagedFieldsEntry) {
+	return func(m *metav1.ManagedFieldsEntry) {
+		m.Manager = mng
+	}
+}
+
+func tweakSubresource(sub string) func(*metav1.ManagedFieldsEntry) {
+	return func(m *metav1.ManagedFieldsEntry) {
+		m.Subresource = sub
 	}
 }

--- a/test/declarative_validation/meta/objectmeta.go
+++ b/test/declarative_validation/meta/objectmeta.go
@@ -44,6 +44,11 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 		ExpectedErrs field.ErrorList
 	}{
 		{
+			Name:         "valid: baseline",
+			Modify:       func(meta metav1.Object) {},
+			ExpectedErrs: field.ErrorList{},
+		},
+		{
 			Name: "annotations: invalid key",
 			Modify: func(meta metav1.Object) {
 				meta.SetAnnotations(map[string]string{
@@ -66,6 +71,15 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 			},
 		},
 		{
+			Name: "valid: annotations: at total size limit",
+			Modify: func(meta metav1.Object) {
+				meta.SetAnnotations(map[string]string{
+					"a": string(make([]byte, apivalidation.TotalAnnotationSizeLimitB-1)),
+				})
+			},
+			ExpectedErrs: field.ErrorList{},
+		},
+		{
 			Name: "generation: negative",
 			Modify: func(meta metav1.Object) {
 				meta.SetGeneration(-1)
@@ -73,6 +87,13 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 			ExpectedErrs: field.ErrorList{
 				field.Invalid(fldPath.Child("generation"), "", "").WithOrigin("minimum").MarkFromImperative(),
 			},
+		},
+		{
+			Name: "valid: generation: zero",
+			Modify: func(meta metav1.Object) {
+				meta.SetGeneration(0)
+			},
+			ExpectedErrs: field.ErrorList{},
 		},
 		{
 			Name: "ownerReferences: empty apiVersion",
@@ -160,6 +181,15 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 			},
 		},
 		{
+			Name: "finalizers: name too long",
+			Modify: func(meta metav1.Object) {
+				meta.SetFinalizers([]string{strings.Repeat("a", 317)})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("finalizers"), "", "").MarkFromImperative(),
+			},
+		},
+		{
 			Name: "managedFields: invalid operation",
 			Modify: func(meta metav1.Object) {
 				meta.SetManagedFields([]metav1.ManagedFieldsEntry{
@@ -193,6 +223,15 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 			},
 		},
 		{
+			Name: "valid: managedFields: manager at max length",
+			Modify: func(meta metav1.Object) {
+				meta.SetManagedFields([]metav1.ManagedFieldsEntry{
+					mkManagedFieldsEntry(tweakManager(strings.Repeat("a", 128))),
+				})
+			},
+			ExpectedErrs: field.ErrorList{},
+		},
+		{
 			Name: "managedFields: subresource too long",
 			Modify: func(meta metav1.Object) {
 				meta.SetManagedFields([]metav1.ManagedFieldsEntry{
@@ -202,6 +241,15 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 			ExpectedErrs: field.ErrorList{
 				field.TooLong(fldPath.Child("managedFields").Index(0).Child("subresource"), "", 0).MarkFromImperative(),
 			},
+		},
+		{
+			Name: "valid: managedFields: subresource at max length",
+			Modify: func(meta metav1.Object) {
+				meta.SetManagedFields([]metav1.ManagedFieldsEntry{
+					mkManagedFieldsEntry(tweakSubresource(strings.Repeat("a", 256))),
+				})
+			},
+			ExpectedErrs: field.ErrorList{},
 		},
 		{
 			Name: "labels: invalid key format",
@@ -248,13 +296,13 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 			},
 		},
 		{
-			Name: "finalizers: name too long",
+			Name: "valid: labels: value at max length",
 			Modify: func(meta metav1.Object) {
-				meta.SetFinalizers([]string{strings.Repeat("a", 317)})
+				meta.SetLabels(map[string]string{
+					"key": strings.Repeat("a", 63),
+				})
 			},
-			ExpectedErrs: field.ErrorList{
-				field.Invalid(fldPath.Child("finalizers"), "", "").MarkFromImperative(),
-			},
+			ExpectedErrs: field.ErrorList{},
 		},
 	}
 
@@ -334,6 +382,11 @@ func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Co
 		ExpectedErrs field.ErrorList
 	}{
 		{
+			Name:         "update: valid: baseline",
+			Modify:       func(old, new metav1.Object) {},
+			ExpectedErrs: field.ErrorList{},
+		},
+		{
 			Name: "update: annotations: invalid key",
 			Modify: func(old, new metav1.Object) {
 				new.SetAnnotations(map[string]string{
@@ -356,15 +409,6 @@ func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Co
 			},
 		},
 		{
-			Name: "update: resourceVersion: missing",
-			Modify: func(old, new metav1.Object) {
-				new.SetResourceVersion("")
-			},
-			ExpectedErrs: field.ErrorList{
-				field.Invalid(fldPath.Child("resourceVersion"), "", "must be specified for an update").MarkFromImperative(),
-			},
-		},
-		{
 			Name: "update: generation: decremented",
 			Modify: func(old, new metav1.Object) {
 				old.SetGeneration(5)
@@ -372,6 +416,15 @@ func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Co
 			},
 			ExpectedErrs: field.ErrorList{
 				field.Invalid(fldPath.Child("generation"), "", "must not be decremented").MarkFromImperative(),
+			},
+		},
+		{
+			Name: "update: resourceVersion: missing",
+			Modify: func(old, new metav1.Object) {
+				new.SetResourceVersion("")
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("resourceVersion"), "", "must be specified for an update").MarkFromImperative(),
 			},
 		},
 		{
@@ -431,6 +484,15 @@ func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Co
 			},
 		},
 		{
+			Name: "update: finalizers: name too long",
+			Modify: func(old, new metav1.Object) {
+				new.SetFinalizers([]string{strings.Repeat("a", 317)})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("finalizers"), "", "").MarkFromImperative(),
+			},
+		},
+		{
 			Name: "update: managedFields: subresource too long",
 			Modify: func(old, new metav1.Object) {
 				new.SetManagedFields([]metav1.ManagedFieldsEntry{
@@ -483,15 +545,6 @@ func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Co
 			},
 			ExpectedErrs: field.ErrorList{
 				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-value").MarkFromImperative(),
-			},
-		},
-		{
-			Name: "update: finalizers: name too long",
-			Modify: func(old, new metav1.Object) {
-				new.SetFinalizers([]string{strings.Repeat("a", 317)})
-			},
-			ExpectedErrs: field.ErrorList{
-				field.Invalid(fldPath.Child("finalizers"), "", "").MarkFromImperative(),
 			},
 		},
 	}

--- a/test/declarative_validation/meta/objectmeta.go
+++ b/test/declarative_validation/meta/objectmeta.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 	t.Helper()
 	fldPath := field.NewPath("metadata")
 
+	// TODO: Remove MarkFromImperative from expected errors after adding corresponding declarative validation tags on ObjectMeta.
 	testCases := []struct {
 		Name         string
 		Modify       func(metav1.Object)
@@ -79,6 +80,7 @@ func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Co
 	t.Helper()
 	fldPath := field.NewPath("metadata")
 
+	// TODO: Remove MarkFromImperative from expected errors after adding corresponding declarative validation tags on ObjectMeta.
 	testCases := []struct {
 		Name         string
 		Modify       func(old, new metav1.Object)

--- a/test/declarative_validation/storage/volumeattachment/declarative_validation_test.go
+++ b/test/declarative_validation/storage/volumeattachment/declarative_validation_test.go
@@ -122,6 +122,8 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			tc.oldInput.ObjectMeta.ResourceVersion = "1"
+			tc.newInput.ObjectMeta.ResourceVersion = "2"
 			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.newInput, &tc.oldInput, registry.Strategy, tc.expectedErrs)
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
The purpose of this PR is to get consensus on the approach and set up the template for `objectMeta` declarative validation test cases. 

Follow-up PRs (such as #139505) will use this template to wire the `objectMeta` test cases into the declarative validation tests for the remaining API groups. 

Test cases need to be wired for all types for two reasons:
1. To give confidence in the validation logic.
2. Declarative Validation (DV) coverage guard rails also need it.

Once all kinds are wired, we will enable Declarative validation for the `objectMeta`. The test cases in  objectMeta.go will be modified accordingly.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
This PR establishes the template. PR #139505 and subsequent PRs will be follow-ups to this one, applying the same pattern until all types(>60) are wired.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
```
