### PR TITLE
Add cidr().isMask, clarify docs a bit

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/environment/base.go
@@ -137,11 +137,19 @@ var baseOpts = []VersionedOptions{
 			ext.Sets(),
 		},
 	},
+	// IP Library
 	{
 		IntroducedVersion: version.MajorMinor(1, 30),
 		EnvOptions: []cel.EnvOption{
 			UnversionedLib(library.IP),
-			UnversionedLib(library.CIDR),
+		},
+	},
+	// CIDR Library v0
+	{
+		IntroducedVersion: version.MajorMinor(1, 30),
+		RemovedVersion:    version.MajorMinor(1, 37),
+		EnvOptions: []cel.EnvOption{
+			library.CIDR(library.CIDRVersion(0)),
 		},
 	},
 	// Format Library
@@ -183,6 +191,13 @@ var baseOpts = []VersionedOptions{
 		IntroducedVersion: version.MajorMinor(1, 37),
 		EnvOptions: []cel.EnvOption{
 			library.Lists(library.ListsVersion(1)),
+		},
+	},
+	// CIDR Library v1
+	{
+		IntroducedVersion: version.MajorMinor(1, 37),
+		EnvOptions: []cel.EnvOption{
+			library.CIDR(library.CIDRVersion(1)),
 		},
 	},
 	StrictCostOpt,

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/cidr.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/cidr.go
@@ -18,6 +18,8 @@ package library
 
 import (
 	"fmt"
+	"maps"
+	"math"
 	"net/netip"
 
 	"github.com/google/cel-go/cel"
@@ -42,16 +44,22 @@ import (
 //
 //	cidr('192.168.0.0/16') // returns an IPv4 address with a CIDR mask
 //	cidr('::1/128') // returns an IPv6 address with a CIDR mask
+//	cidr('192.168.0.1/16') // returns an IPv4 address with a CIDR mask that is shorter than the address
 //	cidr('192.168.0.0/33') // error
 //	cidr('::1/129') // error
-//	cidr('192.168.0.1/16') // error, because there are non-0 bits after the prefix
 //
 // isCIDR
 //
-// Returns true if a string is a valid CIDR notation respresentation of a subnet with mask.
-// The CIDR must be an IPv4 or IPv6 subnet address with a mask.
+// Returns true if a string is a valid CIDR notation respresentation.
+// The CIDR must be an IPv4 or IPv6 IP or subnet address with a mask.
 // Leading zeros in IPv4 address octets are not allowed.
 // IPv4-mapped IPv6 addresses (e.g. ::ffff:1.2.3.4/24) are not allowed.
+//
+// Note that (unlike the apimachinery `IsValidCIDR` function), this accepts
+// both "subnet"/"mask"-style CIDR values ('192.168.0.0/16') and "interface
+// address"-style CIDR values ('192.168.0.1/16'). If you want to restrict the
+// value to valid subnets or masks, you should also call cidr().isMask() on
+// it.
 //
 //	isCIDR(<string>) <bool>
 //
@@ -59,10 +67,11 @@ import (
 //
 //	isCIDR('192.168.0.0/16') // returns true
 //	isCIDR('::1/128') // returns true
+//	isCIDR('192.168.0.1/16') // returns true
 //	isCIDR('192.168.0.0/33') // returns false
 //	isCIDR('::1/129') // returns false
 //
-// containsIP / containerCIDR / ip / masked / prefixLength
+// containsIP / containerCIDR / ip / isMask / masked / prefixLength
 //
 // - containsIP: Returns true if a the CIDR contains the given IP address.
 // The IP address must be an IPv4 or IPv6 address.
@@ -73,6 +82,9 @@ import (
 // May take either a string or CIDR as an argument.
 //
 // - ip: Returns the IP address representation of the CIDR.
+//
+// - isMask: Returns true if the CIDR is in mask/subnet form, with all of the bits
+// after the prefix length being 0. (Added in Kubernetes 1.37, CIDR library version 1.)
 //
 // - masked: Returns the CIDR representation of the network address with a masked prefix.
 // This can be used to return the canonical form of the CIDR network.
@@ -94,33 +106,55 @@ import (
 //	cidr('192.168.0.1/24').ip().family() // returns '4'
 //	cidr('::1/128').ip() // returns ipAddr('::1')
 //	cidr('::1/128').ip().family() // returns '6'
+//	cidr('192.168.0.0/24').isMask() // returns true
 //	cidr('192.168.0.0/24').masked() // returns cidr('192.168.0.0/24')
+//	cidr('192.168.0.1/24').isMask() // returns false
 //	cidr('192.168.0.1/24').masked() // returns cidr('192.168.0.0/24')
 //	cidr('192.168.0.0/24') == cidr('192.168.0.0/24').masked() // returns true, CIDR was already in canonical format
 //	cidr('192.168.0.1/24') == cidr('192.168.0.1/24').masked() // returns false, CIDR was not in canonical format
 //	cidr('192.168.0.0/16').prefixLength() // returns 16
 //	cidr('::1/128').prefixLength() // returns 128
-func CIDR() cel.EnvOption {
+func CIDR(options ...CIDROption) cel.EnvOption {
+	cidrsLib := &cidrs{}
+	for _, o := range options {
+		cidrsLib = o(cidrsLib)
+	}
 	return cel.Lib(cidrsLib)
 }
 
-var cidrsLib = &cidrs{}
+type CIDROption func(*cidrs) *cidrs
 
-type cidrs struct{}
+func CIDRVersion(version uint32) CIDROption {
+	return func(lib *cidrs) *cidrs {
+		lib.version = version
+		return lib
+	}
+}
+
+var cidrsLib = &cidrs{version: math.MaxUint32} // include all versions
+
+type cidrs struct {
+	version uint32
+}
 
 func (*cidrs) LibraryName() string {
 	return "kubernetes.net.cidr"
 }
 
-func (*cidrs) declarations() map[string][]cel.FunctionOpt {
-	return cidrLibraryDecls
+func (c *cidrs) declarations() map[string][]cel.FunctionOpt {
+	decls := map[string][]cel.FunctionOpt{}
+	maps.Copy(decls, cidrLibraryDeclsV0)
+	if c.version >= 1 {
+		maps.Copy(decls, cidrLibraryDeclsV1)
+	}
+	return decls
 }
 
 func (*cidrs) Types() []*cel.Type {
 	return []*cel.Type{apiservercel.CIDRType, apiservercel.IPType}
 }
 
-var cidrLibraryDecls = map[string][]cel.FunctionOpt{
+var cidrLibraryDeclsV0 = map[string][]cel.FunctionOpt{
 	"cidr": {
 		cel.Overload("string_to_cidr", []*cel.Type{cel.StringType}, apiservercel.CIDRType,
 			cel.UnaryBinding(stringToCIDR)),
@@ -159,9 +193,16 @@ var cidrLibraryDecls = map[string][]cel.FunctionOpt{
 	},
 }
 
-func (*cidrs) CompileOptions() []cel.EnvOption {
+var cidrLibraryDeclsV1 = map[string][]cel.FunctionOpt{
+	"isMask": {
+		cel.MemberOverload("cidr_is_mask", []*cel.Type{apiservercel.CIDRType}, cel.BoolType,
+			cel.UnaryBinding(isMask)),
+	},
+}
+
+func (c *cidrs) CompileOptions() []cel.EnvOption {
 	options := []cel.EnvOption{cel.Types(apiservercel.CIDRType)}
-	for name, overloads := range cidrLibraryDecls {
+	for name, overloads := range c.declarations() {
 		options = append(options, cel.Function(name, overloads...))
 	}
 	return options
@@ -260,6 +301,15 @@ func cidrToIP(arg ref.Val) ref.Val {
 	return apiservercel.IP{
 		Addr: cidr.Prefix.Addr(),
 	}
+}
+
+func isMask(arg ref.Val) ref.Val {
+	cidr, ok := arg.(apiservercel.CIDR)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(arg)
+	}
+
+	return types.Bool(cidr.Prefix == cidr.Prefix.Masked())
 }
 
 func masked(arg ref.Val) ref.Val {

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/cidr_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/cidr_test.go
@@ -30,10 +30,10 @@ import (
 	"k8s.io/apiserver/pkg/cel/library"
 )
 
-func testCIDR(t *testing.T, expr string, expectResult ref.Val, expectRuntimeErr string, expectCompileErrs []string) {
+func testCIDR(t *testing.T, expr string, version uint32, expectResult ref.Val, expectRuntimeErr string, expectCompileErrs []string) {
 	env, err := cel.NewEnv(
 		library.IP(),
-		library.CIDR(),
+		library.CIDR(library.CIDRVersion(version)),
 	)
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -101,9 +101,11 @@ func testCIDR(t *testing.T, expr string, expectResult ref.Val, expectRuntimeErr 
 
 func TestCIDR(t *testing.T) {
 	ipv4CIDR, _ := netip.ParsePrefix("192.168.0.0/24")
+	ipv4IfAddr, _ := netip.ParsePrefix("192.168.0.1/24")
 	ipv4Addr, _ := netip.ParseAddr("192.168.0.0")
 
 	ipv6CIDR, _ := netip.ParsePrefix("2001:db8::/32")
+	ipv6IfAddr, _ := netip.ParsePrefix("2001:db8::1/32")
 	ipv6Addr, _ := netip.ParseAddr("2001:db8::")
 
 	trueVal := types.Bool(true)
@@ -112,6 +114,7 @@ func TestCIDR(t *testing.T) {
 	cases := []struct {
 		name              string
 		expr              string
+		version           uint32
 		expectResult      ref.Val
 		expectRuntimeErr  string
 		expectCompileErrs []string
@@ -120,6 +123,11 @@ func TestCIDR(t *testing.T) {
 			name:         "parse ipv4",
 			expr:         `cidr("192.168.0.0/24")`,
 			expectResult: apiservercel.CIDR{Prefix: ipv4CIDR},
+		},
+		{
+			name:         "parse ipv4 ifaddr",
+			expr:         `cidr("192.168.0.1/24")`,
+			expectResult: apiservercel.CIDR{Prefix: ipv4IfAddr},
 		},
 		{
 			name:             "parse invalid ipv4",
@@ -182,14 +190,36 @@ func TestCIDR(t *testing.T) {
 			expectResult: apiservercel.IP{Addr: ipv4Addr},
 		},
 		{
-			name:         "masks masked ipv4",
+			name:         "ipv4 mask isMask",
+			expr:         `cidr("192.168.0.0/24").isMask()`,
+			version:      1,
+			expectResult: trueVal,
+		},
+		{
+			name:         "ipv4 mask can be masked",
 			expr:         `cidr("192.168.0.0/24").masked()`,
 			expectResult: apiservercel.CIDR{Prefix: netip.PrefixFrom(ipv4Addr, 24)},
 		},
 		{
-			name:         "masks unmasked ipv4",
+			name:         "ipv4 mask masks to itself",
+			expr:         `cidr("192.168.0.0/24").masked() == cidr("192.168.0.0/24")`,
+			expectResult: trueVal,
+		},
+		{
+			name:         "ipv4 address !isMask",
+			expr:         `cidr("192.168.0.1/24").isMask()`,
+			version:      1,
+			expectResult: falseVal,
+		},
+		{
+			name:         "ipv4 address can be masked",
 			expr:         `cidr("192.168.0.1/24").masked()`,
 			expectResult: apiservercel.CIDR{Prefix: netip.PrefixFrom(ipv4Addr, 24)},
+		},
+		{
+			name:         "ipv4 address does not mask to itself",
+			expr:         `cidr("192.168.0.1/24").masked() == cidr("192.168.0.1/24")`,
+			expectResult: falseVal,
 		},
 		{
 			name:         "returns prefix length ipv4",
@@ -200,6 +230,11 @@ func TestCIDR(t *testing.T) {
 			name:         "parse ipv6",
 			expr:         `cidr("2001:db8::/32")`,
 			expectResult: apiservercel.CIDR{Prefix: ipv6CIDR},
+		},
+		{
+			name:         "parse ipv6 ifaddr",
+			expr:         `cidr("2001:db8::1/32")`,
+			expectResult: apiservercel.CIDR{Prefix: ipv6IfAddr},
 		},
 		{
 			name:             "parse invalid ipv6",
@@ -252,19 +287,56 @@ func TestCIDR(t *testing.T) {
 			expectResult: apiservercel.IP{Addr: ipv6Addr},
 		},
 		{
-			name:         "masks masked ipv6",
+			name:         "ipv6 mask isMask",
+			expr:         `cidr("2001:db8::/32").isMask()`,
+			version:      1,
+			expectResult: trueVal,
+		},
+		{
+			name:         "ipv6 mask can be masked",
 			expr:         `cidr("2001:db8::/32").masked()`,
 			expectResult: apiservercel.CIDR{Prefix: netip.PrefixFrom(ipv6Addr, 32)},
 		},
 		{
-			name:         "masks unmasked ipv6",
+			name:         "ipv6 mask masks to itself",
+			expr:         `cidr("2001:db8::/32").masked() == cidr("2001:db8::/32")`,
+			expectResult: trueVal,
+		},
+		{
+			name:         "ipv6 address !isMask",
+			expr:         `cidr("2001:db8:1::/32").isMask()`,
+			version:      1,
+			expectResult: falseVal,
+		},
+		{
+			name:         "ipv6 address can be masked",
 			expr:         `cidr("2001:db8:1::/32").masked()`,
 			expectResult: apiservercel.CIDR{Prefix: netip.PrefixFrom(ipv6Addr, 32)},
+		},
+		{
+			name:         "ipv6 address does not mask to itself",
+			expr:         `cidr("2001:db8:1::/32").masked() == cidr("2001:db8:1::/32")`,
+			expectResult: falseVal,
 		},
 		{
 			name:         "returns prefix length ipv6",
 			expr:         `cidr("2001:db8::/32").prefixLength()`,
 			expectResult: types.Int(32),
+		},
+		{
+			name:         "ipv6 CIDR isCIDR",
+			expr:         `isCIDR("2001:db8::/32")`,
+			expectResult: trueVal,
+		},
+		{
+			name:         "ipv6 ifaddr isCIDR",
+			expr:         `isCIDR("2001:db8::1/32")`,
+			expectResult: trueVal,
+		},
+		{
+			name:         "cidr(ipv6IfAddr).masked() == cidr(ipv6CIDR)",
+			expr:         `cidr("2001:db8::1/32").masked() == cidr("2001:db8::/32")`,
+			expectResult: trueVal,
 		},
 		{
 			name:         "converting a CIDR to a string",
@@ -280,7 +352,7 @@ func TestCIDR(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			testCIDR(t, tc.expr, tc.expectResult, tc.expectRuntimeErr, tc.expectCompileErrs)
+			testCIDR(t, tc.expr, tc.version, tc.expectResult, tc.expectRuntimeErr, tc.expectCompileErrs)
 		})
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/cost.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/cost.go
@@ -161,7 +161,7 @@ func (l *CostEstimator) CallCost(function, overloadId string, args []ref.Val, re
 			cost := uint64(math.Ceil(float64(actualSize(args[0])) * 2 * common.StringTraversalCostFactor))
 			return &cost
 		}
-	case "masked", "prefixLength", "family", "isUnspecified", "isLoopback", "isLinkLocalMulticast", "isLinkLocalUnicast", "isGlobalUnicast":
+	case "masked", "isMask", "prefixLength", "family", "isUnspecified", "isLoopback", "isLinkLocalMulticast", "isLinkLocalUnicast", "isGlobalUnicast":
 		// IP and CIDR accessors are nominal cost.
 		cost := uint64(1)
 		return &cost
@@ -447,7 +447,7 @@ func (l *CostEstimator) EstimateCallCost(function, overloadId string, target *ch
 			// So we double the cost of parsing the string.
 			return &checker.CallEstimate{CostEstimate: sz.MultiplyByCostFactor(2 * common.StringTraversalCostFactor)}
 		}
-	case "masked", "prefixLength", "family", "isUnspecified", "isLoopback", "isLinkLocalMulticast", "isLinkLocalUnicast", "isGlobalUnicast":
+	case "masked", "isMask", "prefixLength", "family", "isUnspecified", "isLoopback", "isLinkLocalMulticast", "isLinkLocalUnicast", "isGlobalUnicast":
 		// IP and CIDR accessors are nominal cost.
 		return &checker.CallEstimate{CostEstimate: checker.CostEstimate{Min: 1, Max: 1}}
 	case "containsIP":

--- a/staging/src/k8s.io/apiserver/pkg/cel/library/library_compatibility_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/library/library_compatibility_test.go
@@ -61,6 +61,7 @@ func TestLibraryCompatibility(t *testing.T) {
 		"semver", "isSemver", "major", "minor", "patch",
 		// Kubernetes <1.37>:
 		"includes",
+		"isMask",
 		// Kubernetes <1.??>:
 	)
 
@@ -106,7 +107,7 @@ func TestTypeRegistration(t *testing.T) {
 		}
 		for _, lb := range lib.Types() {
 			registeredTypes.Insert(lb)
-			if !strings.HasPrefix(lb.TypeName(), "kubernetes.") && !legacyTypeNames.Has(lb.TypeName()) {
+			if !strings.HasPrefix(lb.TypeName(), "kubernetes.") && !upstreamTypeNames.Has(lb.TypeName()) {
 				t.Errorf("Expected all types in kubernetes CEL libraries to have a type name packaged with a 'kubernetes.' prefix but got %v", lb.TypeName())
 			}
 		}
@@ -117,5 +118,5 @@ func TestTypeRegistration(t *testing.T) {
 	}
 }
 
-// TODO: Consider renaming these to "kubernetes.net.IP" and "kubernetes.net.CIDR" if we decide not to promote them to cel-go
-var legacyTypeNames = sets.New[string]("net.IP", "net.CIDR")
+// We have our own implementation of these, but they are also cel-go types
+var upstreamTypeNames = sets.New[string]("net.IP", "net.CIDR")


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This syncs us to the version of the API in cel-go. (https://github.com/google/cel-go/pull/1238)

(I guess at some point we should adopt their implementation rather than having our own?)

#### Which issue(s) this PR is related to:
Fixes #134224

though ideally we still want some sort of CRD CEL linter that warns if it looks like you're using `isCIDR(val)` when you mean `isCIDR(val) && cidr(val).isMask()`

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @jpbetz 
/cc @JoelSpeed 