### PR TITLE
informer-gen: fix pluralization and factory godoc bugs

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factory.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factory.go
@@ -334,19 +334,19 @@ var sharedInformerFactoryInterface = `
 //	defer factory.Shutdown()    // Returns immediately if nothing was started.
 //	genericInformer := factory.ForResource(resource)
 //	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	handle, err := typeInformer.Informer().AddEventHandler(...)
+//	handle, err := typedInformer.Informer().AddEventHandler(...)
 //	if err != nil {
 //	    return fmt.Errorf("register event handler: %v", err)
 //	}
-//	defer typeInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
+//	defer typedInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
 //	factory.StartWithContext(ctx)                            // Start processing these informers.
 //	synced := factory.WaitForCacheSyncWithContext(ctx)
 //	if err := synced.AsError(); err != nil {
 //	    return err
 //	}
-//	for v := range synced {
+//	for informerType, wasSynced := range synced.Synced {
 //	    // Only if desired log some information similar to this.
-//	    fmt.Fprintf(os.Stdout, "cache synced: %s", v)
+//	    fmt.Fprintf(os.Stdout, "cache synced: %s=%v", informerType, wasSynced)
 //	}
 //
 //	// Also make sure that all of the initial cache events have been delivered.

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/informer.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/informer.go
@@ -44,6 +44,7 @@ type informerGenerator struct {
 	clientSetPackage          string
 	listersPackage            string
 	internalInterfacesPackage string
+	pluralExceptions          map[string]string
 }
 
 var _ generator.Generator = &informerGenerator{}
@@ -111,7 +112,7 @@ func (g *informerGenerator) GenerateType(c *generator.Context, t *types.Type, w 
 		"namespaceAll":                                c.Universe.Type(metav1NamespaceAll),
 		"namespaced":                                  !tags.NonNamespaced,
 		"newLister":                                   c.Universe.Function(types.Name{Package: listerPackage, Name: "New" + t.Name.Name + "Lister"}),
-		"resourceName":                                strings.ToLower(t.Name.Name) + "s",
+		"resourceName":                                namer.NewAllLowercasePluralNamer(g.pluralExceptions).Name(t),
 		"runtimeObject":                               c.Universe.Type(runtimeObject),
 		"schemaGroupVersionResource":                  c.Universe.Type(schemaGroupVersionResource),
 		"timeDuration":                                c.Universe.Type(timeDuration),

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/targets.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/targets.go
@@ -214,14 +214,16 @@ func GetTargets(context *generator.Context, args *args.Args) []generator.Target 
 					internalVersionOutputDir, internalVersionOutputPkg,
 					groupPackageName, gv, groupGoNames[groupPackageName],
 					boilerplate, typesToGenerate,
-					args.InternalClientSetPackage, args.ListersPackage))
+					args.InternalClientSetPackage, args.ListersPackage,
+					genutil.PluralExceptionListToMapOrDie(args.PluralExceptions)))
 		} else {
 			targetList = append(targetList,
 				versionTarget(
 					externalVersionOutputDir, externalVersionOutputPkg,
 					groupPackageName, gv, groupGoNames[groupPackageName],
 					boilerplate, typesToGenerate,
-					args.VersionedClientSetPackage, args.ListersPackage))
+					args.VersionedClientSetPackage, args.ListersPackage,
+					genutil.PluralExceptionListToMapOrDie(args.PluralExceptions)))
 		}
 	}
 
@@ -348,7 +350,7 @@ func groupTarget(outputDirBase, outputPackageBase string, groupVersions clientge
 	}
 }
 
-func versionTarget(outputDirBase, outputPkgBase string, groupPkgName string, gv clientgentypes.GroupVersion, groupGoName string, boilerplate []byte, typesToGenerate []*types.Type, clientSetPackage, listersPackage string) generator.Target {
+func versionTarget(outputDirBase, outputPkgBase string, groupPkgName string, gv clientgentypes.GroupVersion, groupGoName string, boilerplate []byte, typesToGenerate []*types.Type, clientSetPackage, listersPackage string, pluralExceptions map[string]string) generator.Target {
 	subdir := []string{groupPkgName, strings.ToLower(gv.Version.NonEmpty())}
 	outputDir := filepath.Join(outputDirBase, filepath.Join(subdir...))
 	outputPkg := path.Join(outputPkgBase, path.Join(subdir...))
@@ -383,6 +385,7 @@ func versionTarget(outputDirBase, outputPkgBase string, groupPkgName string, gv 
 					clientSetPackage:          clientSetPackage,
 					listersPackage:            listersPackage,
 					internalInterfacesPackage: path.Join(outputPkgBase, subdirForInternalInterfaces),
+					pluralExceptions:          pluralExceptions,
 				})
 			}
 			return generators


### PR DESCRIPTION
## What this PR does / why we need it

Fixes two independent bugs in `staging/src/k8s.io/code-generator/cmd/informer-gen/generators/`.

### Bug 1: Naive pluralization of GVR Resource field

The `WithInformerName` code path in `informer.go` computed the GVR
`Resource` field using `strings.ToLower(t.Name.Name) + "s"`, which
produces incorrect API resource names for types whose plural is not a
simple `+s` suffix. For example:

- `BlockAffinity` → `blockaffinitys` ❌ (should be `blockaffinities`)
- `GlobalNetworkPolicy` → `globalnetworkpolicys` ❌ (should be `globalnetworkpolicies`)

`generic.go` in the same package already uses the exception-aware
`namer.NewAllLowercasePluralNamer` fed by the `--plural-exceptions`
flag. This PR threads the exceptions map through `versionTarget` and
`informerGenerator`, and uses the same namer for consistency.

### Bug 2: Godoc bugs in `SharedInformerFactory` template

Three mistakes in the usage example in `factory.go`:

1. Variable name typo: `typeInformer` used twice where it should be
   `typedInformer` (the variable defined one line above)
2. Invalid range expression: `for v := range synced` tries to range
   over a `cache.SyncResult` struct value. Go only supports ranging
   over arrays, slices, maps, channels, and integers. Fixed to
   `for informerType, wasSynced := range synced.Synced` (the `Synced`
   field is `map[reflect.Type]bool`)

## Which issue(s) this PR fixes

Fixes #139383

## Tests

- `go build ./cmd/informer-gen/...` — passes
- `go test ./...` in `staging/src/k8s.io/code-generator/` — all pass
- `gofmt -l` on changed files — no output (no formatting changes needed)

## Does this PR introduce a user-facing change?

Yes. Users who run `informer-gen` against types with irregular plurals
(e.g. via `--plural-exceptions`) will now get the correct GVR
`Resource` string in the generated `WithInformerName` code path.