### PR TITLE
apiserver proxy: fix flaky metrics assertions in streamtranslator tests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/streamtranslator_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/streamtranslator_test.go
@@ -140,14 +140,20 @@ func TestStreamTranslator_LoopbackStdinToStdout(t *testing.T) {
 		t.Errorf("unexpected data received: %d sent: %d", len(data), len(randomData))
 	}
 	// Validate the streamtranslator metrics; should be one 200 success.
+	// Use polling to wait for the metric to be updated asynchronously.
 	metricNames := []string{"apiserver_stream_translator_requests_total"}
 	expected := `
 # HELP apiserver_stream_translator_requests_total [ALPHA] Total number of requests that were handled by the StreamTranslatorProxy, which processes streaming RemoteCommand/V5
 # TYPE apiserver_stream_translator_requests_total counter
 apiserver_stream_translator_requests_total{code="200"} 1
 `
-	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expected), metricNames...); err != nil {
-		t.Fatal(err)
+	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+		if testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expected), metricNames...) == nil {
+			return true, nil
+		}
+		return false, nil
+	}); err != nil {
+		t.Fatalf("Failed to observe metric after waiting 2 seconds: %v", err)
 	}
 }
 
@@ -240,14 +246,20 @@ func TestStreamTranslator_LoopbackStdinToStderr(t *testing.T) {
 		t.Errorf("unexpected data received: %d sent: %d", len(data), len(randomData))
 	}
 	// Validate the streamtranslator metrics; should be one 200 success.
+	// Use polling to wait for the metric to be updated asynchronously.
 	metricNames := []string{"apiserver_stream_translator_requests_total"}
 	expected := `
 # HELP apiserver_stream_translator_requests_total [ALPHA] Total number of requests that were handled by the StreamTranslatorProxy, which processes streaming RemoteCommand/V5
 # TYPE apiserver_stream_translator_requests_total counter
 apiserver_stream_translator_requests_total{code="200"} 1
 `
-	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expected), metricNames...); err != nil {
-		t.Fatal(err)
+	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+		if testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expected), metricNames...) == nil {
+			return true, nil
+		}
+		return false, nil
+	}); err != nil {
+		t.Fatalf("Failed to observe metric after waiting 2 seconds: %v", err)
 	}
 }
 
@@ -355,14 +367,20 @@ func TestStreamTranslator_ErrorStream(t *testing.T) {
 		}
 	}
 	// Validate the streamtranslator metrics; an exit code error is considered 200 success.
+	// Use polling to wait for the metric to be updated asynchronously.
 	metricNames := []string{"apiserver_stream_translator_requests_total"}
 	expected := `
 # HELP apiserver_stream_translator_requests_total [ALPHA] Total number of requests that were handled by the StreamTranslatorProxy, which processes streaming RemoteCommand/V5
 # TYPE apiserver_stream_translator_requests_total counter
 apiserver_stream_translator_requests_total{code="200"} 1
 `
-	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expected), metricNames...); err != nil {
-		t.Fatal(err)
+	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+		if testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expected), metricNames...) == nil {
+			return true, nil
+		}
+		return false, nil
+	}); err != nil {
+		t.Fatalf("Failed to observe metric after waiting 2 seconds: %v", err)
 	}
 }
 
@@ -464,14 +482,20 @@ func TestStreamTranslator_MultipleReadChannels(t *testing.T) {
 		t.Errorf("unexpected data received: %d sent: %d", len(stderrBytes), len(randomData))
 	}
 	// Validate the streamtranslator metrics; should have one 200 success.
+	// Use polling to wait for the metric to be updated asynchronously.
 	metricNames := []string{"apiserver_stream_translator_requests_total"}
 	expected := `
 # HELP apiserver_stream_translator_requests_total [ALPHA] Total number of requests that were handled by the StreamTranslatorProxy, which processes streaming RemoteCommand/V5
 # TYPE apiserver_stream_translator_requests_total counter
 apiserver_stream_translator_requests_total{code="200"} 1
 `
-	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expected), metricNames...); err != nil {
-		t.Fatal(err)
+	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+		if testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expected), metricNames...) == nil {
+			return true, nil
+		}
+		return false, nil
+	}); err != nil {
+		t.Fatalf("Failed to observe metric after waiting 2 seconds: %v", err)
 	}
 }
 
@@ -693,14 +717,20 @@ func TestStreamTranslator_TTYResizeChannel(t *testing.T) {
 		}
 	}
 	// Validate the streamtranslator metrics; should have one 200 success.
+	// Use polling to wait for the metric to be updated asynchronously.
 	metricNames := []string{"apiserver_stream_translator_requests_total"}
 	expected := `
 # HELP apiserver_stream_translator_requests_total [ALPHA] Total number of requests that were handled by the StreamTranslatorProxy, which processes streaming RemoteCommand/V5
 # TYPE apiserver_stream_translator_requests_total counter
 apiserver_stream_translator_requests_total{code="200"} 1
 `
-	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expected), metricNames...); err != nil {
-		t.Fatal(err)
+	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+		if testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expected), metricNames...) == nil {
+			return true, nil
+		}
+		return false, nil
+	}); err != nil {
+		t.Fatalf("Failed to observe metric after waiting 2 seconds: %v", err)
 	}
 }
 
@@ -838,14 +868,20 @@ func TestStreamTranslator_BlockRedirects(t *testing.T) {
 				}
 			}
 			// Validate the streamtranslator metrics; should have one 500 failure each loop.
+			// Use polling to wait for the metric to be updated asynchronously.
 			metricNames := []string{"apiserver_stream_translator_requests_total"}
 			expected := `
 # HELP apiserver_stream_translator_requests_total [ALPHA] Total number of requests that were handled by the StreamTranslatorProxy, which processes streaming RemoteCommand/V5
 # TYPE apiserver_stream_translator_requests_total counter
 apiserver_stream_translator_requests_total{code="500"} 1
 `
-			if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expected), metricNames...); err != nil {
-				t.Fatal(err)
+			if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+				if testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expected), metricNames...) == nil {
+					return true, nil
+				}
+				return false, nil
+			}); err != nil {
+				t.Fatalf("Failed to observe metric after waiting 2 seconds: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:
All streamtranslator tests that assert on the apiserver_stream_translator_requests_total metric suffer from a race condition where the test checks the metric before it has been asynchronously updated by the server-side handler.

This manifests as intermittent test failures like:
```
    === RUN   TestStreamTranslator_TTYResizeChannel
        streamtranslator_test.go:703:  # HELP apiserver_stream_translator_requests_total [ALPHA]
             # TYPE apiserver_stream_translator_requests_total counter
             apiserver_stream_translator_requests_total{code="200"} 1
            -apiserver_stream_translator_requests_total{code="400"} 1

    --- FAIL: TestStreamTranslator_TTYResizeChannel (0.78s)
```
The metric assertion races with the metric update because metrics are incremented asynchronously after the streaming completes. The test immediately checks the metric without waiting for the update to propagate.

This fix applies wait.PollUntilContextTimeout to all 6 tests that check streamtranslator metrics, following the pattern established in PR #133193 (commit f07dcd443d7) which fixed the same issue in TestStreamTranslator_WebSocketServerErrors.

Tests updated:
- TestStreamTranslator_LoopbackStdinToStdout
- TestStreamTranslator_LoopbackStdinToStderr
- TestStreamTranslator_ErrorStream
- TestStreamTranslator_MultipleReadChannels
- TestStreamTranslator_TTYResizeChannel
- TestStreamTranslator_BlockRedirects (subtests)
- 
#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
