### PR TITLE
scheduler: log error alert for missing GangScheduling plugin under GenericWorkload

### DIFF
--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -496,6 +496,8 @@ func NewFramework(ctx context.Context, r Registry, profile *config.KubeScheduler
 			} else {
 				return nil, fmt.Errorf("GenericWorkload is enabled, but GangScheduling plugin does not fulfill PlacementFeasiblePlugin interface")
 			}
+		} else {
+			logger.Error(nil, "GenericWorkload is enabled, but GangScheduling plugin is not set. Gang scheduling using PodGroups may not work as expected.")
 		}
 	}
 


### PR DESCRIPTION
 

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Under  GenericWorkload=true , PodGroup scheduling correctness strictly depends on  GangScheduling  plugin, which serves as the sole  interface.go implementation

Issue :  
kube-scheduler  starts with feature gate  GenericWorkload=true  enabled, but  GangScheduling  plugin is omitted from active  scheduler profiles.
Scheduler starts successfully. However,  minCount  constraints fail silently. PodGroups get scheduled as regular Pods, violating gang  scheduling invariants.

Expected Behavior: Scheduler fails startup with explicit configuration validation error.
 
 

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
