### PR TITLE
Fix CEL cost estimates for CRD metadata.name and metadata.generateName

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
@@ -11089,6 +11089,22 @@ func TestValidateCustomResourceDefinitionValidation(t *testing.T) {
 			},
 		},
 		{
+			// Validate that metadata.name and metadata.generateName are estimated against the cost limit of a 253 length string.
+			// This will fail with a cost limit exceeded error if either length is incorrectly assumed to be unbounded.
+			name: "x-kubernetes-validations rule referencing metadata.name and generateName is within estimated cost limit",
+			opts: validationOptions{requireStructuralSchema: true},
+			input: apiextensions.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+					Type: "object",
+					XValidations: apiextensions.ValidationRules{
+						{
+							Rule: "self.metadata.name.contains(self.metadata.name) && self.metadata.generateName.contains(self.metadata.generateName)",
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "x-kubernetes-validations rule invalidated by messageExpression exceeding per-CRD estimated cost limit",
 			opts: validationOptions{requireStructuralSchema: true},
 			input: apiextensions.CustomResourceValidation{

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/compilation_test.go
@@ -1938,3 +1938,49 @@ func fakeFunction(arg1 ref.Val) ref.Val {
 
 	return types.String(strings.ToUpper(arg))
 }
+
+// TestMetadataNameCostIsBounded verifies that CEL rules referencing
+// self.metadata.name are cost-estimated using the bounded object-name length
+// rather than the full request size.
+func TestMetadataNameCostIsBounded(t *testing.T) {
+	const boundedCeiling = 10000
+	cases := []struct {
+		name string
+		rule apiextensions.ValidationRule
+	}{
+		{name: "name rule", rule: apiextensions.ValidationRule{Rule: "self.metadata.name.contains('x')"}},
+		{name: "generateName rule", rule: apiextensions.ValidationRule{Rule: "self.metadata.generateName.contains('x')"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &schema.Structural{
+				Generic: schema.Generic{Type: "object"},
+				ValidationExtensions: schema.ValidationExtensions{
+					XValidations: apiextensions.ValidationRules{tc.rule},
+				},
+			}
+			results, err := Compile(
+				s,
+				model.SchemaDeclType(s, true),
+				celconfig.PerCallLimit,
+				environment.MustBaseEnvSet(environment.DefaultCompatibilityVersion()),
+				StoredExpressionsEnvLoader(),
+			)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(results) != 1 {
+				t.Fatalf("expected 1 compilation result, got %d", len(results))
+			}
+			if results[0].Error != nil {
+				t.Fatalf("unexpected compile error: %v", results[0].Error)
+			}
+			if results[0].MaxCost == 0 {
+				t.Errorf("%s: expected a non-zero cost", tc.name)
+			}
+			if results[0].MaxCost > boundedCeiling {
+				t.Errorf("%s MaxCost = %d, expected it bounded (<= %d); an unbounded name would cost far more", tc.name, results[0].MaxCost, boundedCeiling)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/model/schemas.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/model/schemas.go
@@ -17,6 +17,7 @@ limitations under the License.
 package model
 
 import (
+	apimachineryvalidation "k8s.io/apimachinery/pkg/util/validation"
 	apiservercel "k8s.io/apiserver/pkg/cel"
 	"k8s.io/apiserver/pkg/cel/common"
 
@@ -62,14 +63,32 @@ func WithTypeAndObjectMeta(s *schema.Structural) *schema.Structural {
 	stringType := schema.Structural{Generic: schema.Generic{Type: "string"}}
 	props["kind"] = stringType
 	props["apiVersion"] = stringType
+	metadataProps := s.Properties["metadata"].Properties
 	props["metadata"] = schema.Structural{
 		Generic: schema.Generic{Type: "object"},
 		Properties: map[string]schema.Structural{
-			"name":         stringType,
-			"generateName": stringType,
+			"name":         cappedLengthStringType(metadataProps["name"], nameMaxLength),
+			"generateName": cappedLengthStringType(metadataProps["generateName"], nameMaxLength-1), // The generated suffix is at least 1 byte
 		},
 	}
 	result.Properties = props
 
 	return result
+}
+
+// nameMaxLength is the default maxLength applied to metadata.name.
+const nameMaxLength = int64(apimachineryvalidation.DNS1123SubdomainMaxLength)
+
+// cappedLengthStringType returns a string type whose max length is capped at maxLength,
+// using the existing schema's maxLength instead when it is shorter.
+func cappedLengthStringType(existing schema.Structural, maxLength int64) schema.Structural {
+	if existing.ValueValidation != nil && existing.ValueValidation.MaxLength != nil {
+		if *existing.ValueValidation.MaxLength < maxLength {
+			maxLength = *existing.ValueValidation.MaxLength
+		}
+	}
+	return schema.Structural{
+		Generic:         schema.Generic{Type: "string"},
+		ValueValidation: &schema.ValueValidation{MaxLength: &maxLength},
+	}
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/model/schemas_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/model/schemas_test.go
@@ -132,6 +132,200 @@ func TestSchemaDeclTypes(t *testing.T) {
 	}
 }
 
+func TestWithTypeAndObjectMetaNameLength(t *testing.T) {
+	const (
+		defaultMax             = nameMaxLength
+		defaultGenerateNameMax = nameMaxLength - 1 // generated suffix is at least 1 byte
+	)
+
+	maxLengthOf := func(s *schema.Structural, field string) *int64 {
+		md, ok := s.Properties["metadata"]
+		if !ok || md.Properties == nil {
+			return nil
+		}
+		f, ok := md.Properties[field]
+		if !ok || f.ValueValidation == nil {
+			return nil
+		}
+		return f.ValueValidation.MaxLength
+	}
+
+	cases := []struct {
+		name             string
+		input            *schema.Structural
+		wantName         int64
+		wantGenerateName int64
+	}{
+		{
+			name:             "metadata absent, defaults applied to both fields",
+			input:            &schema.Structural{Generic: schema.Generic{Type: "object"}},
+			wantName:         defaultMax,
+			wantGenerateName: defaultGenerateNameMax,
+		},
+		{
+			name: "author maxLength on name preserved, generateName defaulted",
+			input: &schema.Structural{
+				Generic: schema.Generic{Type: "object"},
+				Properties: map[string]schema.Structural{
+					"metadata": {
+						Generic: schema.Generic{Type: "object"},
+						Properties: map[string]schema.Structural{
+							"name": {
+								Generic:         schema.Generic{Type: "string"},
+								ValueValidation: &schema.ValueValidation{MaxLength: ptr.To[int64](10)},
+							},
+						},
+					},
+				},
+			},
+			wantName:         10,
+			wantGenerateName: defaultGenerateNameMax,
+		},
+		{
+			name: "author maxLength on generateName smaller than default is preserved",
+			input: &schema.Structural{
+				Generic: schema.Generic{Type: "object"},
+				Properties: map[string]schema.Structural{
+					"metadata": {
+						Generic: schema.Generic{Type: "object"},
+						Properties: map[string]schema.Structural{
+							"generateName": {
+								Generic:         schema.Generic{Type: "string"},
+								ValueValidation: &schema.ValueValidation{MaxLength: ptr.To[int64](100)},
+							},
+						},
+					},
+				},
+			},
+			wantName:         defaultMax,
+			wantGenerateName: 100,
+		},
+		{
+			name: "author maxLength larger than default is capped to the default",
+			input: &schema.Structural{
+				Generic: schema.Generic{Type: "object"},
+				Properties: map[string]schema.Structural{
+					"metadata": {
+						Generic: schema.Generic{Type: "object"},
+						Properties: map[string]schema.Structural{
+							"name": {
+								Generic:         schema.Generic{Type: "string"},
+								ValueValidation: &schema.ValueValidation{MaxLength: ptr.To[int64](1000)},
+							},
+							"generateName": {
+								Generic:         schema.Generic{Type: "string"},
+								ValueValidation: &schema.ValueValidation{MaxLength: ptr.To[int64](1000)},
+							},
+						},
+					},
+				},
+			},
+			wantName:         defaultMax,
+			wantGenerateName: defaultGenerateNameMax,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := WithTypeAndObjectMeta(tc.input)
+			if ml := maxLengthOf(got, "name"); ml == nil || *ml != tc.wantName {
+				t.Errorf("metadata.name maxLength = %v, want %d", ml, tc.wantName)
+			}
+			if ml := maxLengthOf(got, "generateName"); ml == nil || *ml != tc.wantGenerateName {
+				t.Errorf("metadata.generateName maxLength = %v, want %d", ml, tc.wantGenerateName)
+			}
+
+			// The bound must flow into CEL cost estimation: the declType's
+			// MaxElements for name and generateName reflect the bounded length
+			// (4 bytes per rune), not the request size.
+			root := SchemaDeclType(tc.input, true)
+			meta, ok := root.FindField("metadata")
+			if !ok {
+				t.Fatalf("metadata field missing from declType")
+			}
+			for _, f := range []struct {
+				field string
+				want  int64
+			}{
+				{"name", tc.wantName},
+				{"generateName", tc.wantGenerateName},
+			} {
+				field, ok := meta.Type.FindField(f.field)
+				if !ok {
+					t.Fatalf("metadata.%s field missing from declType", f.field)
+				}
+				if got := field.Type.MaxElements; got != f.want*4 {
+					t.Errorf("metadata.%s declType MaxElements = %d, want %d", f.field, got, f.want*4)
+				}
+				if field.Type.MaxElements >= apiservercel.DefaultMaxRequestSizeBytes-2 {
+					t.Errorf("metadata.%s declType MaxElements = %d, expected it bounded well below the request size", f.field, field.Type.MaxElements)
+				}
+			}
+		})
+	}
+}
+
+// TestWithTypeAndObjectMetaIdempotent ensures re-applying WithTypeAndObjectMeta
+// (which happens when a schema is processed more than once) keeps the bounds stable.
+func TestWithTypeAndObjectMetaIdempotent(t *testing.T) {
+	once := WithTypeAndObjectMeta(&schema.Structural{Generic: schema.Generic{Type: "object"}})
+	twice := WithTypeAndObjectMeta(once)
+	if twice != once {
+		t.Errorf("expected the already-bounded schema to be returned unchanged")
+	}
+	for _, f := range []struct {
+		field string
+		want  int64
+	}{
+		{"name", nameMaxLength},
+		{"generateName", nameMaxLength - 1},
+	} {
+		ml := twice.Properties["metadata"].Properties[f.field].ValueValidation.MaxLength
+		if ml == nil || *ml != f.want {
+			t.Errorf("metadata.%s maxLength = %v, want %d", f.field, ml, f.want)
+		}
+	}
+}
+
+// TestWithTypeAndObjectMetaDoesNotMutateInput verifies the maxLength bound is applied
+// only to the returned (CEL-only) schema and never written back to the caller's schema.
+// The input schema is also used for pruning, defaulting, and to build the value
+// validator, none of which should gain a metadata.name maxLength constraint.
+func TestWithTypeAndObjectMetaDoesNotMutateInput(t *testing.T) {
+	input := &schema.Structural{
+		Generic: schema.Generic{Type: "object"},
+		Properties: map[string]schema.Structural{
+			"metadata": {
+				Generic: schema.Generic{Type: "object"},
+				Properties: map[string]schema.Structural{
+					"name": {
+						Generic:         schema.Generic{Type: "string"},
+						ValueValidation: &schema.ValueValidation{Format: "k8s-short-name"},
+					},
+				},
+			},
+		},
+	}
+
+	result := WithTypeAndObjectMeta(input)
+
+	// The author's metadata.name in the input is untouched: no maxLength was added and
+	// its format is preserved.
+	inName := input.Properties["metadata"].Properties["name"]
+	if inName.ValueValidation == nil || inName.ValueValidation.MaxLength != nil {
+		t.Errorf("input metadata.name must not gain a maxLength, got %+v", inName.ValueValidation)
+	}
+	if inName.ValueValidation == nil || inName.ValueValidation.Format != "k8s-short-name" {
+		t.Errorf("input metadata.name format must be preserved, got %+v", inName.ValueValidation)
+	}
+
+	// The returned schema, used only for CEL cost/type modeling, carries the bound.
+	outName := result.Properties["metadata"].Properties["name"]
+	if outName.ValueValidation == nil || outName.ValueValidation.MaxLength == nil || *outName.ValueValidation.MaxLength != nameMaxLength {
+		t.Errorf("result metadata.name maxLength = %+v, want %d", outName.ValueValidation, nameMaxLength)
+	}
+}
+
 func testSchema() *schema.Structural {
 	// Manual construction of a schema with the following definition:
 	//

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/validator_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/validator_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customresource
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsvalidation "k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// TestValidateCustomResourceName verifies that:
+//   - the DNS1123 subdomain name validation applies to every custom resource regardless
+//     of the schema an author declares for metadata.name (it cannot be relaxed),
+//   - an author-declared constraint on metadata.name is enforced in addition, and
+//   - the maxLength that WithTypeAndObjectMeta sets on metadata.name/generateName for CEL
+//     cost estimation is never enforced as a value constraint (a 253-char generateName,
+//     which exceeds the 252 cost bound, is still accepted).
+func TestValidateCustomResourceName(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Foo"}
+
+	// metadata.name uses a pattern that permits uppercase letters - more permissive than
+	// DNS1123 in that dimension - so we can show the DNS1123 baseline still applies.
+	props := &apiextensions.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]apiextensions.JSONSchemaProps{
+			"metadata": {
+				Type: "object",
+				Properties: map[string]apiextensions.JSONSchemaProps{
+					"name": {Type: "string", Pattern: "^[A-Za-z]+$"},
+				},
+			},
+		},
+	}
+	schemaValidator, _, err := apiextensionsvalidation.NewSchemaValidator(props)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Cluster-scoped so the test can focus on name validation without a namespace.
+	validator := customResourceValidator{namespaceScoped: false, kind: gvk, schemaValidator: schemaValidator}
+
+	newCR := func(meta map[string]interface{}) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "example.com/v1",
+			"kind":       "Foo",
+			"metadata":   meta,
+		}}
+	}
+
+	cases := []struct {
+		name        string
+		meta        map[string]interface{}
+		errContains string // "" means the resource is expected to validate
+	}{
+		{
+			name: "valid lowercase name accepted",
+			meta: map[string]interface{}{"name": "foo"},
+		},
+		{
+			// The author's pattern permits "Foo", but the DNS1123 baseline rejects uppercase.
+			name:        "uppercase name rejected by DNS1123 despite a permissive pattern",
+			meta:        map[string]interface{}{"name": "Foo"},
+			errContains: "RFC 1123 subdomain",
+		},
+		{
+			// DNS1123 permits "foo123", but the author's pattern rejects digits.
+			name:        "name rejected by the author's pattern",
+			meta:        map[string]interface{}{"name": "foo123"},
+			errContains: "should match",
+		},
+		{
+			// generateName up to 253 is valid per DNS1123; the 252 CEL cost bound must not reject it.
+			name: "253-char generateName accepted; CEL cost bound is not enforced",
+			meta: map[string]interface{}{"name": "foo", "generateName": strings.Repeat("a", 253)},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validator.Validate(context.TODO(), newCR(tc.meta), nil)
+			if tc.errContains == "" {
+				if len(errs) != 0 {
+					t.Fatalf("expected no validation error, got: %v", errs.ToAggregate())
+				}
+				return
+			}
+			if len(errs) == 0 {
+				t.Fatalf("expected a validation error containing %q, got none", tc.errContains)
+			}
+			if got := errs.ToAggregate().Error(); !strings.Contains(got, tc.errContains) {
+				t.Errorf("error %q does not contain %q", got, tc.errContains)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

In https://github.com/kubernetes-sigs/controller-tools/issues/1424 it was noticed that even though CRDs apply dns1123 style formats to metadata.name by default, CEL estimated cost assumes that metadata.name can be of unbounded length.

However, Kubernetes flavored DNS1123 validation (`NameIsDNSSubdomain`) is applied unconditionally to all custom resources. This means that there is always a 253 byte limit.  This fixes CRDs to communicate that fact to CEL such that estimated costs work as expected.

Note that is change is not visible beyond CEL (it is not visible to OpenAPI or elsewhere).

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

I consider this a estimated cost bug and so am not deferring the rollout across versions like done for many CEL related changes. Please let me know if you disagree.

#### Does this PR introduce a user-facing change?

```release-note
Fix CEL estimated cost of metadata.name and metadata.generateName for CRDs to match what the 253 limit that is validated by default unless the CRD author adds sets validations on the metadata fields.
```
