### PR TITLE
pkg/registry/core/pod/storage: return Invalid for bad Binding target

### DIFF
--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -186,7 +186,7 @@ func (r *BindingREST) Create(ctx context.Context, name string, obj runtime.Objec
 
 	// TODO: move me to a binding strategy
 	if errs := validation.ValidatePodBinding(binding); len(errs) != 0 {
-		return nil, errs.ToAggregate()
+		return nil, errors.NewInvalid(api.Kind("Binding"), name, errs)
 	}
 
 	if createValidation != nil {

--- a/pkg/registry/core/pod/storage/storage_test.go
+++ b/pkg/registry/core/pod/storage/storage_test.go
@@ -713,6 +713,34 @@ func TestEtcdCreateBindingNoPod(t *testing.T) {
 	}
 }
 
+func TestEtcdCreateBindingInvalidTarget(t *testing.T) {
+	storage, bindingStorage, _, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+	ctx := genericregistrytest.NewNamespaceScopeContext(storage.Store, metav1.NamespaceDefault)
+	if _, err := storage.Create(ctx, validNewPod(), rest.ValidateAllObjectFunc, &metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create pod: %v", err)
+	}
+	tests := []struct {
+		name   string
+		target api.ObjectReference
+	}{
+		{"unsupported target.kind, missing target.name", api.ObjectReference{Kind: "foo"}},
+		{"missing target.name", api.ObjectReference{}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := bindingStorage.Create(ctx, "foo", &api.Binding{
+				ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault, Name: "foo"},
+				Target:     tc.target,
+			}, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+			if !errors.IsInvalid(err) {
+				t.Errorf("expected Invalid (422), got %T: %v", err, err)
+			}
+		})
+	}
+}
+
 func TestEtcdCreateFailsWithoutNamespace(t *testing.T) {
 	storage, _, _, server := newStorage(t)
 	defer server.Terminate(t)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig api-machinery

**What this PR does / why we need it:**

When creating a Binding with invalid `target` fields (unsupported `target.kind`, missing `target.name`, etc.), `BindingREST.Create` returned `errs.ToAggregate()` from validation directly, producing a plain aggregate error. The REST framework defaults this to HTTP 500.

This change wraps the validation field error list in `errors.NewInvalid`, matching the pattern already used by `EvictionREST` and other registry handlers, so validation failures surface as the expected Invalid `StatusError` (HTTP 422).

Repro from the issue:

```bash
curl -X POST 'http://127.0.0.1:8001/api/v1/namespaces/default/bindings' \
  -H 'Content-Type: application/json' \
  --data-raw '{"target":{"kind":"foo"}}'
```

Before: `"code": 500`
After: `"code": 422` (Invalid)

**Which issue(s) this PR fixes:**

Fixes #139488

**Special notes for your reviewer:**

The fix is one line. Per review feedback, the regression coverage lives in the existing `TestEtcdCreateBinding` cases rather than in a separate test: `noName` and `badKind` (both reproductions from the issue) now assert `errors.IsInvalid` instead of just `err != nil`.

`badNameInURL` asserts `errors.IsBadRequest` instead — that case is rejected by the name-mismatch check before it reaches validation, so it returns 400 rather than 422.

**Does this PR introduce a user-facing change?**

```release-note
apiserver: Creating a Binding with invalid `target` fields now returns HTTP 422 (Invalid) instead of HTTP 500.
```
