### PR TITLE
staging: support external etcd in storage write benchmarks

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -20,12 +20,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/grpclog"
 
 	"k8s.io/apimachinery/pkg/api/apitesting"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -573,9 +575,14 @@ type setupOptions struct {
 	clock          clock.WithTicker
 	codec          runtime.Codec
 	transformer    value.Transformer
+	useExternalEtcd bool
 }
 
 type setupOption func(*setupOptions)
+
+func withExternalEtcd(options *setupOptions) {
+	options.useExternalEtcd = true
+}
 
 func withDefaults(options *setupOptions) {
 	prefix := "/pods/"
@@ -640,10 +647,10 @@ func testSetupWithEtcdServer(t testing.TB, opts ...setupOption) (context.Context
 		opt(&setupOpts)
 	}
 
-	server, etcdStorage := newEtcdTestStorageWithOptions(t, etcd3testing.PathPrefix(), setupOpts.codec, setupOpts.transformer)
+	server, etcdStorage := newEtcdTestStorageWithOptions(t, etcd3testing.PathPrefix(), setupOpts.codec, setupOpts.transformer, setupOpts.useExternalEtcd)
 	// Inject one list error to make sure we test the relist case.
 	listErrors := 1
-	if clientfeatures.FeatureGates().Enabled(clientfeatures.WatchListClient) {
+	if clientfeatures.FeatureGates().Enabled(clientfeatures.WatchListClient) || setupOpts.useExternalEtcd {
 		// The WatchListClient feature changes the reflector to use WATCH
 		// instead of LIST, therefore we don't expect any errors
 		listErrors = 0
@@ -676,8 +683,10 @@ func testSetupWithEtcdServer(t testing.TB, opts ...setupOption) (context.Context
 
 	// Since some tests depend on the fact that GetList shouldn't fail,
 	// we wait until the error from the underlying storage is consumed.
-	if err := wait.PollInfinite(100*time.Millisecond, wrappedStorage.ErrorsConsumed); err != nil {
-		t.Fatalf("Failed to inject list errors: %v", err)
+	if listErrors > 0 {
+		if err := wait.PollInfinite(100*time.Millisecond, wrappedStorage.ErrorsConsumed); err != nil {
+			t.Fatalf("Failed to inject list errors: %v", err)
+		}
 	}
 
 	// The tests assume that Get/GetList/Watch calls shouldn't fail.
@@ -727,11 +736,17 @@ func (c *createWrapper) Create(ctx context.Context, key string, obj, out runtime
 }
 func BenchmarkStoreWriteThroughput(b *testing.B) {
 	klog.SetLogger(logr.Discard())
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, io.Discard))
 	dimensions := []struct {
 		namespaceCount       int
 		podPerNamespaceCount int
 		nodeCount            int
 	}{
+		{
+			namespaceCount:       50,
+			podPerNamespaceCount: 300,
+			nodeCount:            500,
+		},
 		{
 			namespaceCount:       50,
 			podPerNamespaceCount: 3_000,
@@ -740,7 +755,7 @@ func BenchmarkStoreWriteThroughput(b *testing.B) {
 	}
 	for _, dims := range dimensions {
 		b.Run(fmt.Sprintf("Namespaces=%d/Pods=%d/Nodes=%d", dims.namespaceCount, dims.namespaceCount*dims.podPerNamespaceCount, dims.nodeCount), func(b *testing.B) {
-			opts := []setupOption{withNodeNameAndNamespaceIndex}
+			opts := []setupOption{withNodeNameAndNamespaceIndex, withExternalEtcd}
 			ctx, cacher, _, terminate := testSetupWithEtcdServer(b, opts...)
 			b.Cleanup(terminate)
 			data := storagetesting.PrepareBenchmarkData(dims.namespaceCount, dims.podPerNamespaceCount, dims.nodeCount)
@@ -787,7 +802,7 @@ func BenchmarkStoreList(b *testing.B) {
 	for _, dims := range dimensions {
 		b.Run(fmt.Sprintf("Namespaces=%d/Pods=%d/Nodes=%d", dims.namespaceCount, dims.namespaceCount*dims.podPerNamespaceCount, dims.nodeCount), func(b *testing.B) {
 			data := storagetesting.PrepareBenchmarkData(dims.namespaceCount, dims.podPerNamespaceCount, dims.nodeCount)
-			ctx, cacher, _, terminate := testSetupWithEtcdServer(b, withNodeNameAndNamespaceIndex)
+			ctx, cacher, _, terminate := testSetupWithEtcdServer(b, withNodeNameAndNamespaceIndex, withExternalEtcd)
 			b.Cleanup(terminate)
 			require.NoError(b, storagetesting.PrecreateBenchmarkPods(ctx, cacher, data))
 			for _, useIndex := range []bool{true, false} {
@@ -802,7 +817,7 @@ func BenchmarkStoreList(b *testing.B) {
 func BenchmarkStoreStats(b *testing.B) {
 	klog.SetLogger(logr.Discard())
 	data := storagetesting.PrepareBenchmarkData(50, 3_000, 5_000)
-	ctx, cacher, _, terminate := testSetupWithEtcdServer(b)
+	ctx, cacher, _, terminate := testSetupWithEtcdServer(b, withExternalEtcd)
 	b.Cleanup(terminate)
 	var out example.Pod
 	for _, pod := range data.Pods {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_testing_utils_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_testing_utils_test.go
@@ -78,11 +78,11 @@ func newEtcdTestStorage(t testing.TB, prefix string) (*etcd3testing.EtcdTestServ
 }
 
 func newEtcdTestStorageWithCodec(t testing.TB, prefix string, codec runtime.Codec) (*etcd3testing.EtcdTestServer, storage.Interface) {
-	return newEtcdTestStorageWithOptions(t, prefix, codec, identity.NewEncryptCheckTransformer())
+	return newEtcdTestStorageWithOptions(t, prefix, codec, identity.NewEncryptCheckTransformer(), false)
 }
 
-func newEtcdTestStorageWithOptions(t testing.TB, prefix string, codec runtime.Codec, transformer value.Transformer) (*etcd3testing.EtcdTestServer, storage.Interface) {
-	server, _ := etcd3testing.NewUnsecuredEtcd3TestClientServer(t)
+func newEtcdTestStorageWithOptions(t testing.TB, prefix string, codec runtime.Codec, transformer value.Transformer, useExternalEtcd bool) (*etcd3testing.EtcdTestServer, storage.Interface) {
+	server, _ := etcd3testing.NewUnsecuredEtcd3TestClientServerWithOptions(t, useExternalEtcd)
 	versioner := storage.APIObjectVersioner{}
 	compactor := etcd3.NewCompactor(server.V3Client.Client, 0, clock.RealClock{}, nil)
 	t.Cleanup(compactor.Stop)

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -749,6 +749,12 @@ func withDefaults(options *setupOptions) {
 	options.leaseConfig = newTestLeaseManagerConfig()
 }
 
+func withExternalEtcd(options *setupOptions) {
+	options.client = func(t testing.TB) *kubernetes.Client {
+		return testserver.RunExternalEtcd(t)
+	}
+}
+
 var _ setupOption = withDefaults
 
 func testSetup(t testing.TB, opts ...setupOption) (context.Context, *store, *kubernetes.Client) {
@@ -1026,6 +1032,7 @@ func BenchmarkStore_GetList(b *testing.B) {
 
 func BenchmarkStoreWriteThroughput(b *testing.B) {
 	klog.SetLogger(logr.Discard())
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, io.Discard))
 	dimensions := []struct {
 		namespaceCount       int
 		podPerNamespaceCount int
@@ -1039,7 +1046,7 @@ func BenchmarkStoreWriteThroughput(b *testing.B) {
 	}
 	for _, dims := range dimensions {
 		b.Run(fmt.Sprintf("Namespaces=%d/Pods=%d/Nodes=%d", dims.namespaceCount, dims.namespaceCount*dims.podPerNamespaceCount, dims.nodeCount), func(b *testing.B) {
-			ctx, store, _ := testSetup(b)
+			ctx, store, _ := testSetup(b, withExternalEtcd)
 			data := storagetesting.PrepareBenchmarkData(dims.namespaceCount, dims.podPerNamespaceCount, dims.nodeCount)
 			b.ResetTimer()
 			storagetesting.RunBenchmarkWriteThroughput(ctx, b, store, data, false, nil)
@@ -1076,7 +1083,7 @@ func BenchmarkStoreList(b *testing.B) {
 			featuregatetesting.SetFeatureGateDuringTest(b, utilfeature.DefaultFeatureGate, features.SizeBasedListCostEstimate, sizeBasedEnabled)
 			b.Run(fmt.Sprintf("SizeBasedListCostEstimate=%v/Namespaces=%d/Pods=%d/Nodes=%d", sizeBasedEnabled, dims.namespaceCount, dims.namespaceCount*dims.podPerNamespaceCount, dims.nodeCount), func(b *testing.B) {
 				data := storagetesting.PrepareBenchmarkData(dims.namespaceCount, dims.podPerNamespaceCount, dims.nodeCount)
-				ctx, store, _ := testSetup(b)
+				ctx, store, _ := testSetup(b, withExternalEtcd)
 				require.NoError(b, storagetesting.PrecreateBenchmarkPods(ctx, store, data))
 				storagetesting.RunBenchmarkStoreList(ctx, b, store, data, false)
 			})
@@ -1137,7 +1144,7 @@ func TestGetCurrentResourceVersion(t *testing.T) {
 func BenchmarkStoreStats(b *testing.B) {
 	klog.SetLogger(logr.Discard())
 	data := storagetesting.PrepareBenchmarkData(50, 3_000, 5_000)
-	ctx, store, _ := testSetup(b)
+	ctx, store, _ := testSetup(b, withExternalEtcd)
 	require.NoError(b, storagetesting.PrecreateBenchmarkPods(ctx, store, data))
 	storagetesting.RunBenchmarkStoreStats(ctx, b, store)
 }
@@ -1148,7 +1155,7 @@ func BenchmarkStatsCacheCleanKeys(b *testing.B) {
 	namespaceCount := 50
 	podPerNamespaceCount := 3_000
 	data := storagetesting.PrepareBenchmarkData(namespaceCount, podPerNamespaceCount, 5_000)
-	ctx, store, _ := testSetup(b)
+	ctx, store, _ := testSetup(b, withExternalEtcd)
 	require.NoError(b, storagetesting.PrecreateBenchmarkPods(ctx, store, data))
 	// List to fetch object sizes for statsCache.
 	listOut := &example.PodList{}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testing/test_server.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testing/test_server.go
@@ -36,8 +36,17 @@ func (e *EtcdTestServer) Terminate(t testing.TB) {
 
 // NewUnsecuredEtcd3TestClientServer creates a new client and server for testing
 func NewUnsecuredEtcd3TestClientServer(t testing.TB) (*EtcdTestServer, *storagebackend.Config) {
+	return NewUnsecuredEtcd3TestClientServerWithOptions(t, false)
+}
+
+// NewUnsecuredEtcd3TestClientServerWithOptions creates a new client and server for testing with optional external etcd
+func NewUnsecuredEtcd3TestClientServerWithOptions(t testing.TB, useExternalEtcd bool) (*EtcdTestServer, *storagebackend.Config) {
 	server := &EtcdTestServer{}
-	server.V3Client = testserver.RunEtcd(t, nil)
+	if useExternalEtcd {
+		server.V3Client = testserver.RunExternalEtcd(t)
+	} else {
+		server.V3Client = testserver.RunEtcd(t, nil)
+	}
 	config := &storagebackend.Config{
 		Type:   "etcd3",
 		Prefix: PathPrefix(),

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testserver/test_server.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testserver/test_server.go
@@ -18,9 +18,11 @@ package testserver
 
 import (
 	"fmt"
+	"io"
 	"net"
 	"net/url"
 	"os"
+	"os/exec"
 	"strconv"
 	"sync"
 	"testing"
@@ -119,12 +121,79 @@ func RunEtcd(t testing.TB, cfg *embed.Config) *kubernetes.Client {
 		t.Fatal(err)
 	}
 
-	client, err := kubernetes.New(clientv3.Config{
-		TLS:         tlsConfig,
-		Endpoints:   e.Server.Cluster().ClientURLs(),
-		DialTimeout: 10 * time.Second,
-		Logger:      zaptest.NewLogger(t, zaptest.Level(zapcore.ErrorLevel)).Named("etcd-client"),
+	return newTestClient(t, clientv3.Config{
+		TLS:       tlsConfig,
+		Endpoints: e.Server.Cluster().ClientURLs(),
 	})
+}
+
+// RunExternalEtcd starts an external etcd subprocess and returns a client connected to the server.
+// The external etcd process is terminated when the test ends.
+func RunExternalEtcd(t testing.TB) *kubernetes.Client {
+	t.Helper()
+	ports, err := getAvailablePorts(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientPort := ports[0]
+	peerPort := ports[1]
+
+	clientURL := fmt.Sprintf("http://127.0.0.1:%d", clientPort)
+	peerURL := fmt.Sprintf("http://127.0.0.1:%d", peerPort)
+
+	dir := t.TempDir()
+
+	cmd := exec.Command("etcd",
+		"--data-dir", dir,
+		"--listen-client-urls", clientURL,
+		"--advertise-client-urls", clientURL,
+		"--listen-peer-urls", peerURL,
+		"--initial-advertise-peer-urls", peerURL,
+		"--initial-cluster", fmt.Sprintf("default=%s", peerURL),
+		"--quota-backend-bytes", strconv.FormatInt(8*1024*1024*1024, 10),
+		"--log-level", "warn",
+	)
+
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start external etcd: %v", err)
+	}
+
+	ready := false
+	for i := 0; i < 50; i++ {
+		conn, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(clientPort)), 100*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			ready = true
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !ready {
+		cmd.Process.Kill()
+		t.Fatal("external etcd failed to start")
+	}
+
+	t.Cleanup(func() {
+		cmd.Process.Kill()
+		cmd.Wait()
+	})
+
+	return newTestClient(t, clientv3.Config{
+		Endpoints: []string{clientURL},
+	})
+}
+
+func newTestClient(t testing.TB, config clientv3.Config) *kubernetes.Client {
+	if config.Logger == nil {
+		config.Logger = zaptest.NewLogger(t, zaptest.Level(zapcore.ErrorLevel)).Named("etcd-client")
+	}
+	if config.DialTimeout == 0 {
+		config.DialTimeout = 10 * time.Second
+	}
+	client, err := kubernetes.New(config)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Configure the write throughput benchmarks to launch and run directly against an external etcd process. This facilitates scheduling and process boundary isolation testing.

Also, silence etcd client and gRPC logs during run execution to prevent interleaved logs from corrupting benchmark stdout lines.

Pivoted Cacher Benchstat Results (n=6 samples, 15k Pods scale):
  - FsyncEnabled vs FsyncDisabled write throughput: -7.52% (statistically insignificant)
  - ExternalEtcd vs FsyncDisabled write throughput: -6.91% (statistically insignificant)
  - ExternalEtcd vs FsyncDisabled watch p99 latency: -64.46% (statistically significant)

Pivoted Store (Raw) Benchstat Results (n=6 samples, 15k Pods scale):
  - FsyncEnabled vs FsyncDisabled write throughput: +4.68% (statistically insignificant)
  - ExternalEtcd vs FsyncDisabled write throughput: -0.18% (statistically insignificant)

/kind feature

```release-note
NONE
```

/cc @Jefftree @michaelasp 