### PR TITLE
kubelet/images: coalesce concurrent EnsureImageExists for the same image

### DIFF
--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -18,7 +18,10 @@ package images
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"hash/fnv"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -41,6 +44,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/images/pullmanager"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
+	hashutil "k8s.io/kubernetes/pkg/util/hash"
 	"k8s.io/kubernetes/pkg/util/parsers"
 	"k8s.io/utils/ptr"
 )
@@ -67,6 +71,14 @@ type imageManager struct {
 	nodeKeyring credentialprovider.DockerKeyring
 
 	podPullingTimeRecorder ImagePodPullingTimeRecorder
+
+	// pullCoalescers coalesces concurrent EnsureImageExists calls for the
+	// same ImageSpec: the first arrival becomes the leader and runs the
+	// pull; the rest wait on the chan, then re-run the precheck so they
+	// honor their own credentials (KEP-2535) instead of piggy-backing on
+	// the leader's authorization.
+	pullCoalescersLock sync.Mutex
+	pullCoalescers     map[uint64]chan struct{}
 }
 
 var _ ImageManager = &imageManager{}
@@ -101,6 +113,7 @@ func NewImageManager(
 		backOff:                imageBackOff,
 		puller:                 puller,
 		podPullingTimeRecorder: podPullingTimeRecorder,
+		pullCoalescers:         make(map[uint64]chan struct{}),
 	}
 }
 
@@ -167,7 +180,29 @@ func (m *imageManager) imageNotPresentOnNeverPolicyError(logger klog.Logger, log
 
 // EnsureImageExists pulls the image for the specified pod and requestedImage, and returns
 // (imageRef, error message, error).
+//
+// Concurrent same-image arrivals are coalesced: only the first caller (the
+// leader) runs the full pull path; the rest wait for the leader to finish
+// and then re-enter, where imagePullPrecheck and (when KEP-2535 is on)
+// MustAttemptImagePull short-circuit them past PullImage. PullAlways opts
+// out — its contract is "always pull", not "share whoever is pulling".
 func (m *imageManager) EnsureImageExists(ctx context.Context, objRef *v1.ObjectReference, pod *v1.Pod, requestedImage string, pullSecrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig, podRuntimeHandler string, pullPolicy v1.PullPolicy) (imageRef, message string, err error) {
+	if pullPolicy != v1.PullAlways {
+		if key, ok := pullCoalesceKey(requestedImage, pod, podRuntimeHandler); ok {
+			done, leader := m.joinPullCoalesce(key)
+			if leader {
+				defer m.endPullCoalesce(key, done)
+			} else {
+				<-done
+			}
+		}
+	}
+	return m.ensureImageExistsLocked(ctx, objRef, pod, requestedImage, pullSecrets, podSandboxConfig, podRuntimeHandler, pullPolicy)
+}
+
+// ensureImageExistsLocked carries the original EnsureImageExists body,
+// unaware of pull coalescing.
+func (m *imageManager) ensureImageExistsLocked(ctx context.Context, objRef *v1.ObjectReference, pod *v1.Pod, requestedImage string, pullSecrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig, podRuntimeHandler string, pullPolicy v1.PullPolicy) (imageRef, message string, err error) {
 	logger := klog.FromContext(ctx)
 	logPrefix := fmt.Sprintf("%s/%s/%s", pod.Namespace, pod.Name, requestedImage)
 
@@ -436,6 +471,70 @@ func applyDefaultImageTag(image string) (string, error) {
 		image = image + ":" + tag
 	}
 	return image, nil
+}
+
+// pullCoalesceKey returns the hash key under which concurrent
+// EnsureImageExists calls for the same image should coalesce. Returns
+// ok=false when we can't form a stable key — in that case the wrapper
+// skips coalescing and lets the inner path report the original error.
+func pullCoalesceKey(requestedImage string, pod *v1.Pod, podRuntimeHandler string) (uint64, bool) {
+	image, err := applyDefaultImageTag(requestedImage)
+	if err != nil {
+		return 0, false
+	}
+	var podAnnotations []kubecontainer.Annotation
+	for k, v := range pod.GetAnnotations() {
+		podAnnotations = append(podAnnotations, kubecontainer.Annotation{Name: k, Value: v})
+	}
+	return imageSpecKey(kubecontainer.ImageSpec{
+		Image:          image,
+		Annotations:    podAnnotations,
+		RuntimeHandler: podRuntimeHandler,
+	}), true
+}
+
+// imageSpecKey hashes the full ImageSpec so two requests coalesce iff they
+// pull the same image — the kubelet cannot assume which fields the runtime
+// treats as identity-significant (e.g. containerd uses annotations for
+// snapshotter selection). Annotations come from a Go map range and must be
+// sorted for a stable hash. Collisions only cause an unrelated coalesce
+// (followers re-validate via precheck), not incorrect behavior.
+func imageSpecKey(spec kubecontainer.ImageSpec) uint64 {
+	if len(spec.Annotations) > 1 {
+		sorted := make([]kubecontainer.Annotation, len(spec.Annotations))
+		copy(sorted, spec.Annotations)
+		sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
+		spec.Annotations = sorted
+	}
+	hash := fnv.New32a()
+	specJson, _ := json.Marshal(spec)
+	hashutil.DeepHashObject(hash, specJson)
+	return uint64(hash.Sum32())
+}
+
+// joinPullCoalesce registers the caller as leader if no pull is in flight
+// for key, otherwise returns the existing leader's done chan. Followers
+// must <-done before calling imagePullPrecheck so they observe the
+// leader's outcome.
+func (m *imageManager) joinPullCoalesce(key uint64) (done chan struct{}, leader bool) {
+	m.pullCoalescersLock.Lock()
+	defer m.pullCoalescersLock.Unlock()
+	if existing, ok := m.pullCoalescers[key]; ok {
+		return existing, false
+	}
+	done = make(chan struct{})
+	m.pullCoalescers[key] = done
+	return done, true
+}
+
+// endPullCoalesce removes the leader's entry and wakes all waiters,
+// regardless of whether the pull succeeded — followers re-validate via
+// precheck and fall through if the image is still missing.
+func (m *imageManager) endPullCoalesce(key uint64, done chan struct{}) {
+	m.pullCoalescersLock.Lock()
+	delete(m.pullCoalescers, key)
+	m.pullCoalescersLock.Unlock()
+	close(done)
 }
 
 func trackedToImagePullCreds(trackedCreds *credentialprovider.TrackedAuthConfig) *kubeletconfiginternal.ImagePullCredentials {

--- a/pkg/kubelet/images/image_manager_test.go
+++ b/pkg/kubelet/images/image_manager_test.go
@@ -1197,6 +1197,73 @@ func TestMaxParallelImagePullsLimit(t *testing.T) {
 	fakeRuntime.AssertCallCounts("PullImage", 7)
 }
 
+// TestSameImageShortCircuitsFollowers checks that with PullIfNotPresent, only
+// the leader hits the runtime; followers re-run precheck after the leader
+// finishes and find the image already present, so they skip PullImage
+// entirely. PullAlways is excluded from this coordination so each pod still
+// validates its own credentials and refreshes mutable tags.
+func TestSameImageShortCircuitsFollowers(t *testing.T) {
+	ctx := ktesting.Init(t)
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test_pod",
+			Namespace:       "test-ns",
+			UID:             "bar",
+			ResourceVersion: "42",
+		}}
+	podSandboxConfig := &runtimeapi.PodSandboxConfig{
+		Metadata: &runtimeapi.PodSandboxMetadata{
+			Name:      pod.Name,
+			Namespace: pod.Namespace,
+			Uid:       string(pod.UID),
+		},
+	}
+
+	testCase := &pullerTestCase{
+		containerImage: "missing_image",
+		testName:       "same image short-circuits followers",
+		policy:         v1.PullIfNotPresent,
+		inspectErr:     nil,
+		pullerErr:      nil,
+		qps:            0.0,
+		burst:          0,
+	}
+
+	puller, fakeClock, fakeRuntime, _, _, _ := pullerTestEnv(t, *testCase, false, ptr.To(int32(2)))
+	fakeRuntime.BlockImagePulls = true
+	fakeRuntime.CalledFunctions = nil
+	fakeRuntime.ImageList = nil
+	fakeRuntime.T = t
+	fakeClock.Step(time.Second)
+
+	const followers = 5
+	const image = "missing_image"
+
+	// Leader races followers in goroutines so we exercise the inFlight wait,
+	// not just the post-leader fast path.
+	var wg sync.WaitGroup
+	for i := 0; i < followers+1; i++ {
+		wg.Add(1)
+		go func() {
+			_, _, err := puller.EnsureImageExists(ctx, nil, pod, image, testCase.pullSecrets, podSandboxConfig, "", testCase.policy)
+			assert.NoError(t, err)
+			wg.Done()
+		}()
+	}
+
+	// Wait long enough for everyone to register as leader-or-follower; only
+	// the leader should be blocked on PullImage now.
+	time.Sleep(500 * time.Millisecond)
+	fakeRuntime.AssertCallCounts("PullImage", 1)
+
+	fakeRuntime.UnblockImagePulls(1)
+	wg.Wait()
+
+	// Followers short-circuited via imagePullPrecheck after the leader
+	// populated ImageList, so PullImage was only called once.
+	fakeRuntime.AssertCallCounts("PullImage", 1)
+}
+
 func TestParallelPodPullingTimeRecorderWithErr(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	pod1 := &v1.Pod{
@@ -1231,6 +1298,11 @@ func TestParallelPodPullingTimeRecorderWithErr(t *testing.T) {
 
 	pods := [2]*v1.Pod{pod1, pod2}
 	podSandboxes := [2]*runtimeapi.PodSandboxConfig{pod1SandboxConfig, pod2SandboxConfig}
+	// Use distinct images so each pod is its own leader; otherwise the
+	// follower short-circuits past pullImage and never records start/finish
+	// metrics, which is exactly the path TestSameImageShortCircuitsFollowers
+	// covers.
+	images := [2]string{"missing_image_1", "missing_image_2"}
 
 	testCase := &pullerTestCase{
 		containerImage: "missing_image",
@@ -1246,7 +1318,7 @@ func TestParallelPodPullingTimeRecorderWithErr(t *testing.T) {
 	maxParallelImagePulls := 2
 	var wg sync.WaitGroup
 
-	puller, fakeClock, fakeRuntime, container, fakePodPullingTimeRecorder, _ := pullerTestEnv(t, *testCase, useSerializedEnv, ptr.To(int32(maxParallelImagePulls)))
+	puller, fakeClock, fakeRuntime, _, fakePodPullingTimeRecorder, _ := pullerTestEnv(t, *testCase, useSerializedEnv, ptr.To(int32(maxParallelImagePulls)))
 	fakeRuntime.BlockImagePulls = true
 	fakeRuntime.CalledFunctions = nil
 	fakeRuntime.T = t
@@ -1256,7 +1328,7 @@ func TestParallelPodPullingTimeRecorderWithErr(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		wg.Add(1)
 		go func(i int) {
-			_, _, _ = puller.EnsureImageExists(tCtx, nil, pods[i], container.Image, testCase.pullSecrets, podSandboxes[i], "", container.ImagePullPolicy)
+			_, _, _ = puller.EnsureImageExists(tCtx, nil, pods[i], images[i], testCase.pullSecrets, podSandboxes[i], "", testCase.policy)
 			wg.Done()
 		}(i)
 	}
@@ -1280,23 +1352,17 @@ func TestParallelPodPullingTimeRecorderWithErr(t *testing.T) {
 
 	wg.Wait()
 
-	// This time EnsureImageExists will return without pulling
-	for i := 0; i < 2; i++ {
-		wg.Add(1)
-		go func(i int) {
-			_, _, err := puller.EnsureImageExists(tCtx, nil, pods[i], container.Image, testCase.pullSecrets, podSandboxes[i], "", container.ImagePullPolicy)
-			assert.NoError(t, err)
-			wg.Done()
-		}(i)
+	// One pod won the unblock race, one got the error. Their identity is
+	// race-determined; what matters is that exactly one finished and exactly
+	// one is missing a finish record.
+	finished := 0
+	for _, pod := range pods {
+		if fakePodPullingTimeRecorder.finishedPullingRecorded[pod.UID] {
+			finished++
+		}
 	}
-	wg.Wait()
-
-	// Assert the number of PullImage calls is still 2
+	assert.Equal(t, 1, finished, "exactly one pod should have completed pulling")
 	fakeRuntime.AssertCallCounts("PullImage", 2)
-
-	// Both recorders should be finished
-	assert.True(t, fakePodPullingTimeRecorder.finishedPullingRecorded[pods[0].UID])
-	assert.True(t, fakePodPullingTimeRecorder.finishedPullingRecorded[pods[1].UID])
 }
 
 func TestEvalCRIPullErr(t *testing.T) {


### PR DESCRIPTION
 **What this PR does / why we need it**:

  When many pods on a node reference the same image, concurrent
  EnsureImageExists calls all fall through to PullImage even though
  container runtimes already deduplicate identical pulls. The followers
  burn maxParallelImagePulls slots and starve other images.

  This coalesces non-PullAlways callers per ImageSpec: the first arrival
  pulls, late arrivals wait on a chan and then re-run the precheck so each
  pod still verifies its own credentials (KEP-2535) and respects its own
  pull policy. PullAlways is left as-is so cred rotation and mutable-tag
  semantics are preserved.

  **Which issue(s) this PR fixes**:
  Related: #125164

  **Special notes for your reviewer**:
  - `puller.go` is unchanged; coordination lives entirely in `image_manager`.
  - Followers re-enter `ensureImageExistsLocked` after the leader finishes,
    so KEP-2535 per-pod credential verification still runs.

  **Does this PR introduce a user-facing change?**
  ```release-note
  kubelet: coalesce concurrent image pulls for the same image when pull policy is not Always, so a hot image referenced by many pods no longer starves other pulls of the maxParallelImagePulls budget.
  ```