### PR TITLE
scheduler: Add resourceVersion to Pod status patch

### DIFF
--- a/pkg/scheduler/framework/api_calls/pod_status_patch.go
+++ b/pkg/scheduler/framework/api_calls/pod_status_patch.go
@@ -111,7 +111,7 @@ func (psuc *PodStatusPatchCall) Execute(ctx context.Context, client clientset.In
 	}
 
 	// It's safe to run PatchPodStatus even on outdated pod object.
-	err := util.PatchPodStatus(ctx, client, psuc.podRef.Name, psuc.podRef.Namespace, psuc.podStatus, podStatusCopy)
+	err := util.PatchPodStatus(ctx, client, psuc.podRef.Name, psuc.podRef.Namespace, "", psuc.podStatus, podStatusCopy)
 	if err != nil {
 		logger.Error(err, "Failed to patch pod status", "pod", psuc.podRef)
 		return err

--- a/pkg/scheduler/framework/plugins/dynamicresources/extendeddynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/extendeddynamicresources.go
@@ -579,7 +579,7 @@ func (pl *DynamicResources) patchPodExtendedResourceClaimStatus(
 		RequestMappings:   cer,
 		ResourceClaimName: claim.Name,
 	}
-	err := schedutil.PatchPodStatus(ctx, pl.clientset, pod.Name, pod.Namespace, &pod.Status, podStatusCopy)
+	err := schedutil.PatchPodStatus(ctx, pl.clientset, pod.Name, pod.Namespace, "", &pod.Status, podStatusCopy)
 	if err != nil {
 		return fmt.Errorf("update pod %s/%s ExtendedResourceClaimStatus: %w", pod.Namespace, pod.Name, err)
 	}

--- a/pkg/scheduler/framework/plugins/dynamicresources/nodeallocatabledynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/nodeallocatabledynamicresources.go
@@ -423,7 +423,7 @@ func (pl *DynamicResources) patchNodeAllocatableResourceClaimStatus(ctx context.
 	targetStatus := pod.Status.DeepCopy()
 
 	targetStatus.NodeAllocatableResourceClaimStatuses = nodeAllocatableClaimStatus
-	if err := schedutil.PatchPodStatus(ctx, pl.clientset, pod.Name, pod.Namespace, baseStatus, targetStatus); err != nil {
+	if err := schedutil.PatchPodStatus(ctx, pl.clientset, pod.Name, pod.Namespace, "", baseStatus, targetStatus); err != nil {
 		return statusError(logger, fmt.Errorf("updating pod %s/%s NodeAllocatableResourceClaimStatuses: %w", pod.Namespace, pod.Name, err))
 	}
 	logger.V(5).Info("Patched pod status with NodeAllocatableResourceClaimStatuses", "pod", klog.KObj(pod), "status", targetStatus.NodeAllocatableResourceClaimStatuses)
@@ -438,7 +438,7 @@ func (pl *DynamicResources) clearNodeAllocatableResourceClaimStatus(ctx context.
 	targetStatus := pod.Status.DeepCopy()
 	targetStatus.NodeAllocatableResourceClaimStatuses = nil
 
-	if err := schedutil.PatchPodStatus(ctx, pl.clientset, pod.Name, pod.Namespace, &pod.Status, targetStatus); err != nil {
+	if err := schedutil.PatchPodStatus(ctx, pl.clientset, pod.Name, pod.Namespace, "", &pod.Status, targetStatus); err != nil {
 		logger.Error(err, "Failed to clear NodeAllocatableResourceClaimStatuses on Unreserve", "pod", klog.KObj(pod))
 	} else {
 		logger.V(5).Info("Cleared NodeAllocatableResourceClaimStatuses", "pod", klog.KObj(pod))

--- a/pkg/scheduler/framework/preemption/executor.go
+++ b/pkg/scheduler/framework/preemption/executor.go
@@ -132,7 +132,7 @@ func NewExecutor(fh fwk.Handle, fts feature.Features) *Executor {
 			newStatus := victim.Status.DeepCopy()
 			updated := apipod.UpdatePodCondition(newStatus, condition)
 			if updated {
-				if err := util.PatchPodStatus(ctx, fh.ClientSet(), victim.Name, victim.Namespace, &victim.Status, newStatus); err != nil {
+				if err := util.PatchPodStatus(ctx, fh.ClientSet(), victim.Name, victim.Namespace, "", &victim.Status, newStatus); err != nil {
 					if !apierrors.IsNotFound(err) {
 						logger.Error(err, "Could not add DisruptionTarget condition due to preemption", "preemptor", klog.KObj(preemptor), "victim", klog.KObj(victim))
 						return err
@@ -400,7 +400,7 @@ func clearNominatedNodeName(ctx context.Context, cs clientset.Interface, apiCach
 			}
 			podStatusCopy := p.Status.DeepCopy()
 			podStatusCopy.NominatedNodeName = ""
-			if err := util.PatchPodStatus(ctx, cs, p.Name, p.Namespace, &p.Status, podStatusCopy); err != nil {
+			if err := util.PatchPodStatus(ctx, cs, p.Name, p.Namespace, "", &p.Status, podStatusCopy); err != nil {
 				errs = append(errs, err)
 			}
 		}

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -1333,5 +1333,8 @@ func updatePod(ctx context.Context, client clientset.Interface, apiCacher fwk.AP
 	if nnnNeedsUpdate {
 		podStatusCopy.NominatedNodeName = nominatingInfo.NominatedNodeName
 	}
-	return util.PatchPodStatus(ctx, client, pod.Name, pod.Namespace, &pod.Status, podStatusCopy)
+	// Resource version is included here to prevent an update during binding
+	// setting the PodScheduled=False condition from overwriting a
+	// PodScheduled=True update if a subsequent retry succeeds first.
+	return util.PatchPodStatus(ctx, client, pod.Name, pod.Namespace, pod.ResourceVersion, &pod.Status, podStatusCopy)
 }

--- a/pkg/scheduler/util/utils.go
+++ b/pkg/scheduler/util/utils.go
@@ -116,8 +116,10 @@ func BindPod(ctx context.Context, cs kubernetes.Interface, binding *v1.Binding) 
 }
 
 // PatchPodStatus calculates the delta bytes change from <old.Status> to <newStatus>,
-// and then submit a request to API server to patch the pod changes.
-func PatchPodStatus(ctx context.Context, cs kubernetes.Interface, name string, namespace string, oldStatus *v1.PodStatus, newStatus *v1.PodStatus) error {
+// and then submit a request to API server to patch the pod changes. When
+// resourceVersion is not empty, it is included in the patch to detect
+// conflicts.
+func PatchPodStatus(ctx context.Context, cs kubernetes.Interface, name string, namespace string, resourceVersion string, oldStatus *v1.PodStatus, newStatus *v1.PodStatus) error {
 	if newStatus == nil {
 		return nil
 	}
@@ -131,7 +133,11 @@ func PatchPodStatus(ctx context.Context, cs kubernetes.Interface, name string, n
 		return err
 	}
 
-	newData, err := json.Marshal(v1.Pod{Status: *newStatus})
+	newPod := v1.Pod{Status: *newStatus}
+	if resourceVersion != "" {
+		newPod.ResourceVersion = resourceVersion
+	}
+	newData, err := json.Marshal(newPod)
 	if err != nil {
 		return err
 	}
@@ -149,7 +155,14 @@ func PatchPodStatus(ctx context.Context, cs kubernetes.Interface, name string, n
 		return err
 	}
 
-	return retry.OnError(retry.DefaultBackoff, RetriableWithConflict, patchFn)
+	retryFn := RetriableWithConflict
+	if resourceVersion != "" {
+		// A conflict probably means the Pod was updated in the meantime.
+		// Retrying with the same patch will continue to hit the same error.
+		// Return faster in that case so the caller can generate a different patch.
+		retryFn = Retriable
+	}
+	return retry.OnError(retry.DefaultBackoff, retryFn, patchFn)
 }
 
 // PatchPodGroupStatus calculates the delta bytes change from <old.Status> to <newStatus>,

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"syscall"
@@ -167,15 +168,44 @@ func TestMoreImportantPod(t *testing.T) {
 }
 
 func TestPatchPodStatus(t *testing.T) {
+	conflictCheckingClient := func() *clientsetfake.Clientset {
+		client := clientsetfake.NewClientset()
+
+		reqcount := 0
+		client.PrependReactor("patch", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+			defer func() { reqcount++ }()
+			if reqcount > 0 {
+				return true, nil, errors.New("request should not be retried")
+			}
+			patch := action.(clienttesting.PatchAction)
+			var patchPod v1.Pod
+			err := json.Unmarshal(patch.GetPatch(), &patchPod)
+			if err != nil {
+				return true, nil, err
+			}
+			existing, err := client.Tracker().Get(patch.GetResource(), patch.GetNamespace(), patch.GetName())
+			if err != nil {
+				return true, nil, err
+			}
+			if existing.(metav1.Object).GetResourceVersion() != patchPod.ResourceVersion {
+				return true, nil, apierrors.NewConflict(patch.GetResource().GroupResource(), patch.GetName(), fmt.Errorf("object is out of date"))
+			}
+			return false, nil, nil
+		})
+
+		return client
+	}
+
 	tests := []struct {
 		name   string
 		pod    v1.Pod
 		client *clientsetfake.Clientset
 		// validateErr checks if error returned from PatchPodStatus is expected one or not.
 		// (true means error is expected one.)
-		validateErr    func(goterr error) bool
-		statusToUpdate v1.PodStatus
-		nilOldStatus   bool
+		validateErr     func(goterr error) bool
+		statusToUpdate  v1.PodStatus
+		resourceVersion string
+		nilOldStatus    bool
 	}{
 		{
 			name:   "Should update pod conditions successfully",
@@ -321,6 +351,47 @@ func TestPatchPodStatus(t *testing.T) {
 			},
 			nilOldStatus: true,
 		},
+		{
+			name:   "up to date resource version succeeds",
+			client: conflictCheckingClient(),
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:       "ns",
+					Name:            "pod1",
+					ResourceVersion: "2",
+				},
+			},
+			resourceVersion: "2",
+			statusToUpdate: v1.PodStatus{
+				Conditions: []v1.PodCondition{
+					{
+						Type:   v1.PodScheduled,
+						Status: v1.ConditionFalse,
+					},
+				},
+			},
+		},
+		{
+			name:   "updated resource version produces conflict",
+			client: conflictCheckingClient(),
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:       "ns",
+					Name:            "pod1",
+					ResourceVersion: "2",
+				},
+			},
+			resourceVersion: "1",
+			statusToUpdate: v1.PodStatus{
+				Conditions: []v1.PodCondition{
+					{
+						Type:   v1.PodScheduled,
+						Status: v1.ConditionFalse,
+					},
+				},
+			},
+			validateErr: apierrors.IsConflict,
+		},
 	}
 
 	for _, tc := range tests {
@@ -330,7 +401,7 @@ func TestPatchPodStatus(t *testing.T) {
 			defer cancel()
 
 			client := tc.client
-			_, err := client.CoreV1().Pods(tc.pod.Namespace).Create(context.TODO(), &tc.pod, metav1.CreateOptions{})
+			_, err := client.CoreV1().Pods(tc.pod.Namespace).Create(ctx, &tc.pod, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -339,7 +410,7 @@ func TestPatchPodStatus(t *testing.T) {
 			if tc.nilOldStatus {
 				oldStatus = nil
 			}
-			err = PatchPodStatus(ctx, client, tc.pod.Name, tc.pod.Namespace, oldStatus, &tc.statusToUpdate)
+			err = PatchPodStatus(ctx, client, tc.pod.Name, tc.pod.Namespace, tc.resourceVersion, oldStatus, &tc.statusToUpdate)
 			if err != nil && tc.validateErr == nil {
 				// shouldn't be error
 				t.Fatal(err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When a Pod fails to asynchronously bind, a race occurs between the patch to add the `PodScheduled=False` condition and a subsequent binding attempt. If binding succeeds and adds `PodScheduled=True` before the `PodScheduled=False` condition is set, then the last update persists where the Pod is scheduled with a `spec.nodeName` but still has the `PodScheduled=False` condition.

This change adds the `metadata.resourceVersion` of the Pod to patches so these conflicts can be detected and handled appropriately.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
https://github.com/kubernetes/kubernetes/issues/139417

#### Special notes for your reviewer:

This bug primarily surfaces in the `TestDRA/all/PodGroup` integration tests as described in #139417, but theoretically affects all Pods. At least locally for me, this eliminates flakes in those tests:

Before:

    20m0s: 2581 runs so far, 9 failures (0.35%), 32 active

After:

    20m0s: 2568 runs so far, 0 failures, 32 active

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug where successfully scheduled Pods could be stuck with the `PodScheduled=False` condition.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
