### PR TITLE
Return BadRequest for node proxy when node has no usable address

### DIFF
--- a/pkg/registry/core/node/storage/storage_test.go
+++ b/pkg/registry/core/node/storage/storage_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -226,6 +227,12 @@ func TestResourceLocation(t *testing.T) {
 		query: "node0",
 		host:  "",
 		err:   true,
+	}, {
+		name:  "node without any address",
+		node:  newNode("node0"),
+		query: "node0",
+		host:  "",
+		err:   true,
 	}}
 
 	for _, testCase := range testCases {
@@ -246,6 +253,11 @@ func TestResourceLocation(t *testing.T) {
 			if err != nil {
 				if !testCase.err {
 					t.Fatalf("Unexpected error: %v", err)
+				}
+				// A node that cannot be proxied to must surface as a 400 Bad
+				// Request rather than a 500 Internal Server Error.
+				if !apierrors.IsBadRequest(err) {
+					t.Errorf("Expected a BadRequest error, but got: %v", err)
 				}
 				return
 			} else if testCase.err {

--- a/pkg/registry/core/node/strategy.go
+++ b/pkg/registry/core/node/strategy.go
@@ -18,6 +18,7 @@ package node
 
 import (
 	"context"
+	goerrors "errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -42,6 +43,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/client"
+	nodeutil "k8s.io/kubernetes/pkg/util/node"
 	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
 )
 
@@ -252,6 +254,14 @@ func ResourceLocation(getter ResourceGetter, connection client.ConnectionInfoGet
 
 	info, err := connection.GetConnectionInfo(ctx, types.NodeName(name))
 	if err != nil {
+		// A node that does not expose any usable address (e.g. an empty
+		// status.addresses) is not something we can proxy to, but it is also
+		// not an internal server error. Surface it as a 400 instead of a 500,
+		// matching how an unresolvable proxy hostname is handled below.
+		var noMatchErr *nodeutil.NoMatchError
+		if goerrors.As(err, &noMatchErr) {
+			return nil, nil, errors.NewBadRequest(err.Error())
+		}
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

A node proxy request (e.g. `POST /api/v1/nodes/<name>/proxy/`) to a Node that has no usable address in `status.addresses` currently returns an HTTP `500 Internal Server Error`:

```json
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "no preferred addresses found; known addresses: []",
  "code": 500
}
```

The error originates from `GetPreferredNodeAddress`, which returns a typed `*node.NoMatchError` when none of the preferred address types are present. That error was passed through `ResourceLocation` unchanged and, since it is not a recognized API status error, the endpoint reported it as an internal server error.

A Node without a routable address is not a server fault — there is simply nowhere to proxy to, which the client can correct. This PR makes `ResourceLocation` detect the `NoMatchError` and return a `400 Bad Request` instead, consistent with how an unresolvable proxy hostname is already handled a few lines below in the same function (`isProxyableHostname` -> `NewBadRequest`). Other errors from `GetConnectionInfo` (such as a `NotFound` when the node does not exist) are left untouched.

#### Which issue(s) this PR is related to:

Fixes #139486

#### Special notes for your reviewer:

The chosen status code (400) mirrors the existing behavior of the sibling pod proxy `ResourceLocation`, which returns `NewBadRequest("address not allowed")` when a pod has no usable address, and the adjacent non-proxyable-hostname branch in this same function. `TestResourceLocation` is extended with a "node without any address" case and now asserts that every error case is a `BadRequest` rather than a generic error.

#### Does this PR introduce a user-facing change?

```release-note
kube-apiserver: a node proxy request to a Node that has no usable address in `status.addresses` now returns an HTTP 400 (Bad Request) instead of an HTTP 500 (Internal Server Error).
```