### PR TITLE
TAS Monitoring Metrics for Placement Phases

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -6278,6 +6278,16 @@
   componentEndpoints:
   - component: kube-scheduler
     endpoint: /metrics
+- name: generated_placements_total
+  subsystem: scheduler
+  help: Number of candidate placements generated when scheduling pod groups.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - profile
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
 - name: get_node_hint_duration_seconds
   subsystem: scheduler
   help: Latency for getting a node hint.
@@ -6319,6 +6329,48 @@
   stabilityLevel: ALPHA
   labels:
   - call_type
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
+- name: placement_evaluation_duration_seconds
+  subsystem: scheduler
+  help: Latency in seconds of evaluating a single candidate placement when scheduling
+    pod groups, by result. 'feasible' means the pod group fit into the placement,
+    while 'infeasible' means it did not.
+  type: Histogram
+  stabilityLevel: ALPHA
+  labels:
+  - profile
+  - result
+  buckets:
+  - 0.001
+  - 0.002
+  - 0.004
+  - 0.008
+  - 0.016
+  - 0.032
+  - 0.064
+  - 0.128
+  - 0.256
+  - 0.512
+  - 1.024
+  - 2.048
+  - 4.096
+  - 8.192
+  - 16.384
+  componentEndpoints:
+  - component: kube-scheduler
+    endpoint: /metrics
+- name: placement_evaluations_total
+  subsystem: scheduler
+  help: Number of candidate placements evaluated when scheduling pod groups, by result.
+    'feasible' means the pod group fit into the placement, while 'infeasible' means
+    it did not.
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - profile
+  - result
   componentEndpoints:
   - component: kube-scheduler
     endpoint: /metrics

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -185,6 +185,12 @@ var (
 	podGroupScheduleAttempts           *metrics.CounterVec
 	podGroupSchedulingLatency          *metrics.HistogramVec
 	PodGroupSchedulingAlgorithmLatency *metrics.Histogram
+
+	// The below are only available when the TopologyAwareWorkloadScheduling feature gate is enabled.
+	GeneratedPlacementsTotal    *metrics.CounterVec
+	PlacementEvaluations        *metrics.CounterVec
+	PlacementEvaluationDuration *metrics.HistogramVec
+
 	// The below are only available when the DRADeviceBindingConditions feature gate is enabled.
 	DRABindingConditionsAllocationsTotal *metrics.CounterVec
 	DRABindingConditionsPreBindDuration  *metrics.HistogramVec
@@ -234,6 +240,13 @@ func Register() {
 				PreemptionEvaluationDuration,
 				PreemptionExecutionDuration,
 				PreemptionPDBViolations,
+			)
+		}
+		if utilfeature.DefaultFeatureGate.Enabled(features.TopologyAwareWorkloadScheduling) {
+			RegisterMetrics(
+				GeneratedPlacementsTotal,
+				PlacementEvaluations,
+				PlacementEvaluationDuration,
 			)
 		}
 		if utilfeature.DefaultFeatureGate.Enabled(features.DRADeviceBindingConditions) {
@@ -622,6 +635,30 @@ func InitMetrics() {
 			StabilityLevel: metrics.ALPHA,
 		}, []string{"preemptor"},
 	)
+
+	// The below (GeneratedPlacementsTotal, PlacementEvaluations and PlacementEvaluationDuration) are only available when the TopologyAwareWorkloadScheduling feature gate is enabled.
+	GeneratedPlacementsTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      SchedulerSubsystem,
+			Name:           "generated_placements_total",
+			Help:           "Number of candidate placements generated when scheduling pod groups.",
+			StabilityLevel: metrics.ALPHA,
+		}, []string{"profile"})
+	PlacementEvaluations = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      SchedulerSubsystem,
+			Name:           "placement_evaluations_total",
+			Help:           "Number of candidate placements evaluated when scheduling pod groups, by result. 'feasible' means the pod group fit into the placement, while 'infeasible' means it did not.",
+			StabilityLevel: metrics.ALPHA,
+		}, []string{"result", "profile"})
+	PlacementEvaluationDuration = metrics.NewHistogramVec(
+		&metrics.HistogramOpts{
+			Subsystem:      SchedulerSubsystem,
+			Name:           "placement_evaluation_duration_seconds",
+			Help:           "Latency in seconds of evaluating a single candidate placement when scheduling pod groups, by result. 'feasible' means the pod group fit into the placement, while 'infeasible' means it did not.",
+			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
+			StabilityLevel: metrics.ALPHA,
+		}, []string{"result", "profile"})
 
 	metricsList = []metrics.Registerable{
 		scheduleAttempts,

--- a/pkg/scheduler/metrics/profile_metrics.go
+++ b/pkg/scheduler/metrics/profile_metrics.go
@@ -23,6 +23,8 @@ var (
 	UnschedulableResult       = "unschedulable"
 	WaitingOnPreemptionResult = "waiting_on_preemption"
 	ErrorResult               = "error"
+	FeasibleResult            = "feasible"
+	InfeasibleResult          = "infeasible"
 )
 
 // PodScheduled can records a successful scheduling attempt and the duration
@@ -75,4 +77,17 @@ func PodGroupScheduleError(profile string, duration float64) {
 func observePodGroupScheduleAttemptAndLatency(result, profile string, duration float64) {
 	podGroupSchedulingLatency.WithLabelValues(result, profile).Observe(duration)
 	podGroupScheduleAttempts.WithLabelValues(result, profile).Inc()
+}
+
+// RecordGeneratedPlacements records the number of candidate placements generated for a
+// pod group in a single scheduling cycle.
+func RecordGeneratedPlacements(profile string, count int) {
+	GeneratedPlacementsTotal.WithLabelValues(profile).Add(float64(count))
+}
+
+// ObservePlacementEvaluation records a single candidate placement evaluation and the
+// duration, by result.
+func ObservePlacementEvaluation(result, profile string, duration float64) {
+	PlacementEvaluations.WithLabelValues(result, profile).Inc()
+	PlacementEvaluationDuration.WithLabelValues(result, profile).Observe(duration)
 }

--- a/pkg/scheduler/metrics/profile_metrics_test.go
+++ b/pkg/scheduler/metrics/profile_metrics_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/testutil"
+)
+
+func TestRecordGeneratedPlacements(t *testing.T) {
+	InitMetrics()
+	registry := metrics.NewKubeRegistry()
+	registry.MustRegister(GeneratedPlacementsTotal)
+
+	RecordGeneratedPlacements("test-profile", 3)
+	RecordGeneratedPlacements("test-profile", 2)
+	RecordGeneratedPlacements("test-profile-2", 4)
+
+	want := `
+		# HELP scheduler_generated_placements_total [ALPHA] Number of candidate placements generated when scheduling pod groups.
+		# TYPE scheduler_generated_placements_total counter
+		scheduler_generated_placements_total{profile="test-profile"} 5
+		scheduler_generated_placements_total{profile="test-profile-2"} 4
+	`
+	if err := testutil.GatherAndCompare(registry, strings.NewReader(want), "scheduler_generated_placements_total"); err != nil {
+		t.Errorf("unexpected generated_placements_total metric output:\n%v", err)
+	}
+}
+
+func TestObservePlacementEvaluation(t *testing.T) {
+	InitMetrics()
+	registry := metrics.NewKubeRegistry()
+	registry.MustRegister(PlacementEvaluations)
+	registry.MustRegister(PlacementEvaluationDuration)
+
+	ObservePlacementEvaluation(FeasibleResult, "test-profile", 0.5)
+	ObservePlacementEvaluation(FeasibleResult, "test-profile", 0.5)
+	ObservePlacementEvaluation(InfeasibleResult, "test-profile", 0.1)
+	ObservePlacementEvaluation(FeasibleResult, "test-profile-2", 0.2)
+	ObservePlacementEvaluation(InfeasibleResult, "test-profile-2", 0.3)
+
+	wantCounter := `
+		# HELP scheduler_placement_evaluations_total [ALPHA] Number of candidate placements evaluated when scheduling pod groups, by result. 'feasible' means the pod group fit into the placement, while 'infeasible' means it did not.
+		# TYPE scheduler_placement_evaluations_total counter
+		scheduler_placement_evaluations_total{profile="test-profile",result="feasible"} 2
+		scheduler_placement_evaluations_total{profile="test-profile",result="infeasible"} 1
+		scheduler_placement_evaluations_total{profile="test-profile-2",result="feasible"} 1
+		scheduler_placement_evaluations_total{profile="test-profile-2",result="infeasible"} 1
+	`
+	if err := testutil.GatherAndCompare(registry, strings.NewReader(wantCounter), "scheduler_placement_evaluations_total"); err != nil {
+		t.Errorf("unexpected placement_evaluations_total metric output:\n%v", err)
+	}
+
+	// The duration histogram is recorded alongside the counter, so its sample
+	// count per profile/result must match the number of evaluations recorded above.
+	for _, tc := range []struct {
+		profile   string
+		result    string
+		wantCount uint64
+	}{
+		{"test-profile", FeasibleResult, 2},
+		{"test-profile", InfeasibleResult, 1},
+		{"test-profile-2", FeasibleResult, 1},
+		{"test-profile-2", InfeasibleResult, 1},
+	} {
+		gotCount, err := testutil.GetHistogramMetricCount(PlacementEvaluationDuration.WithLabelValues(tc.result, tc.profile))
+		if err != nil {
+			t.Errorf("Failed to get sample count for placement_evaluation_duration_seconds{profile=%q,result=%q}: %v", tc.profile, tc.result, err)
+			continue
+		}
+		if gotCount != tc.wantCount {
+			t.Errorf("placement_evaluation_duration_seconds{profile=%q,result=%q}: got %d samples, want %d", tc.profile, tc.result, gotCount, tc.wantCount)
+		}
+	}
+}

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -971,12 +971,14 @@ func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context
 			status:       status,
 		}
 	}
+	metrics.RecordGeneratedPlacements(schedFwk.ProfileName(), len(placements))
 
 	var anyResult *podGroupAlgorithmResult
 	successfulResults := make(map[*fwk.Placement]*podGroupAlgorithmResult)
 
 	for _, placement := range placements {
 		logger.V(4).Info("Assuming placement in snapshot", "placement", placement.Name)
+		evaluationStart := time.Now()
 		err := sched.nodeInfoSnapshot.AssumePlacement(placement)
 		if err != nil {
 			return &podGroupAlgorithmResult{
@@ -1002,9 +1004,14 @@ func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context
 			anyResult = result
 		}
 
+		// Errors are excluded by the early return above since they are internal
+		// faults, not feasibility results.
+		evaluationResult := metrics.InfeasibleResult
 		if result.status.IsSuccess() {
+			evaluationResult = metrics.FeasibleResult
 			successfulResults[placement] = result
 		}
+		metrics.ObservePlacementEvaluation(evaluationResult, schedFwk.ProfileName(), metrics.SinceInSeconds(evaluationStart))
 	}
 
 	if len(successfulResults) == 0 {

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -42,6 +42,8 @@ import (
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/events"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	componentmetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
 	fwk "k8s.io/kube-scheduler/framework"
@@ -58,6 +60,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/queuesort"
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
+	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	"k8s.io/kubernetes/pkg/scheduler/profile"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	tf "k8s.io/kubernetes/pkg/scheduler/testing/framework"
@@ -2187,11 +2190,35 @@ var statusCmpOpt = cmp.Comparer(func(s1 *fwk.Status, s2 *fwk.Status) bool {
 	return s1.Code() == s2.Code() && s1.Plugin() == s2.Plugin() && s1.Message() == s2.Message()
 })
 
+func assertCounterValueFromGatherer(t *testing.T, g componentmetrics.Gatherer, name, labelName, labelValue string, want int) {
+	t.Helper()
+	got := 0
+	if vals, err := testutil.GetCounterValuesFromGatherer(g, name, nil, labelName); err == nil {
+		got = int(vals[labelValue])
+	}
+	if got != want {
+		t.Errorf("unexpected %s{%s=%q}: got %d, want %d", name, labelName, labelValue, got, want)
+	}
+}
+
+func assertHistogramSampleCountFromGatherer(t *testing.T, g componentmetrics.Gatherer, name string, labels map[string]string, want int) {
+	t.Helper()
+	got := 0
+	if vec, err := testutil.GetHistogramVecFromGatherer(g, name, labels); err == nil {
+		got = int(vec.GetAggregatedSampleCount())
+	}
+	if got != want {
+		t.Errorf("unexpected %s%v sample count: got %d, want %d", name, labels, got, want)
+	}
+}
+
 func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
 		features.TopologyAwareWorkloadScheduling: true,
 		features.GenericWorkload:                 true,
 	})
+	testRegistry := componentmetrics.NewKubeRegistry()
+	testRegistry.MustRegister(metrics.GeneratedPlacementsTotal, metrics.PlacementEvaluations, metrics.PlacementEvaluationDuration)
 
 	nodes := []*v1.Node{
 		st.MakeNode().Name("node1").Obj(),
@@ -2208,11 +2235,16 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		placementPlugin           fakePlacementPlugin
-		placementFeasibleStatuses [][]fwk.Code
-		expectedResult            podGroupAlgorithmResult
+		placementPlugin               fakePlacementPlugin
+		placementFeasibleStatuses     [][]fwk.Code
+		expectedResult                podGroupAlgorithmResult
+		expectedGeneratedPlacements   int
+		expectedFeasibleEvaluations   int
+		expectedInfeasibleEvaluations int
 	}{
 		"respects higher score of placement1": {
+			expectedGeneratedPlacements: 2,
+			expectedFeasibleEvaluations: 2,
 			placementPlugin: fakePlacementPlugin{
 				generatePlacementsResult: map[string][]string{
 					"placement1": {nodes[0].Name},
@@ -2238,6 +2270,8 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			},
 		},
 		"respects higher score of placement2": {
+			expectedGeneratedPlacements: 2,
+			expectedFeasibleEvaluations: 2,
 			placementPlugin: fakePlacementPlugin{
 				generatePlacementsResult: map[string][]string{
 					"placement1": {nodes[0].Name},
@@ -2271,6 +2305,8 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			},
 		},
 		"when all placements are infeasible, returns unschedulable": {
+			expectedGeneratedPlacements:   2,
+			expectedInfeasibleEvaluations: 2,
 			placementPlugin: fakePlacementPlugin{
 				generatePlacementsResult: map[string][]string{
 					"placement1": {nodes[0].Name},
@@ -2304,6 +2340,8 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			},
 		},
 		"when all placements are infeasible, but pods are feasible, returns unschedulable": {
+			expectedGeneratedPlacements:   2,
+			expectedInfeasibleEvaluations: 2,
 			placementPlugin: fakePlacementPlugin{
 				generatePlacementsResult: map[string][]string{
 					"placement1": {nodes[0].Name},
@@ -2338,6 +2376,9 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			},
 		},
 		"filters out infeasible placements": {
+			expectedGeneratedPlacements:   2,
+			expectedFeasibleEvaluations:   1,
+			expectedInfeasibleEvaluations: 1,
 			placementPlugin: fakePlacementPlugin{
 				generatePlacementsResult: map[string][]string{
 					"placement1": {nodes[0].Name},
@@ -2365,6 +2406,9 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			},
 		},
 		"filters out infeasible placements with feasible pods": {
+			expectedGeneratedPlacements:   2,
+			expectedFeasibleEvaluations:   1,
+			expectedInfeasibleEvaluations: 1,
 			placementPlugin: fakePlacementPlugin{
 				generatePlacementsResult: map[string][]string{
 					"placement1": {nodes[0].Name},
@@ -2405,6 +2449,8 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			},
 		},
 		"when score plugin fails, returns error": {
+			expectedGeneratedPlacements: 2,
+			expectedFeasibleEvaluations: 2,
 			placementPlugin: fakePlacementPlugin{
 				generatePlacementsResult: map[string][]string{
 					"placement1": {nodes[0].Name},
@@ -2419,6 +2465,32 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			},
 			expectedResult: podGroupAlgorithmResult{
 				status: fwk.NewStatus(fwk.Error, "running PlacementScore plugins: plugin \"FakePlacementPlugin\" failed with: error for test").WithPlugin("FakePlacementPlugin"),
+			},
+		},
+		"when a placement evaluation errors, returns error": {
+			expectedGeneratedPlacements: 1,
+			placementPlugin: fakePlacementPlugin{
+				generatePlacementsResult: map[string][]string{
+					"placement1": {nodes[0].Name},
+				},
+				scorePlacementsResult: map[string]int64{
+					"placement1": 1,
+				},
+				filterStatus: map[string]*fwk.Status{
+					nodes[0].Name: fwk.NewStatus(fwk.Error, "error for test"),
+				},
+			},
+			expectedResult: podGroupAlgorithmResult{
+				podResults: []algorithmResult{
+					{
+						podInfo: podGroupPodInfo,
+						scheduleResult: ScheduleResult{
+							nominatingInfo: &fwk.NominatingInfo{NominatingMode: fwk.ModeOverride},
+						},
+						status: fwk.NewStatus(fwk.Error, "running \"FakePlacementPlugin\" filter plugin: error for test"),
+					},
+				},
+				status: fwk.NewStatus(fwk.Error, "failed to schedule other pod from a pod group: running \"FakePlacementPlugin\" filter plugin: error for test"),
 			},
 		},
 	}
@@ -2498,6 +2570,10 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 				},
 			}
 
+			metrics.GeneratedPlacementsTotal.Reset()
+			metrics.PlacementEvaluations.Reset()
+			metrics.PlacementEvaluationDuration.Reset()
+
 			resultsMap := sched.runRootSchedulingAlgorithm(ctx, schedFwk, framework.NewCycleState(), pgInfo)
 			result := resultsMap[pgKey(pgInfo.PodGroupInfo)]
 
@@ -2529,6 +2605,14 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			if diff := cmp.Diff(tt.expectedResult, *result, opts...); diff != "" {
 				t.Fatalf("Unexpected algorithm result (-want,+got):\n%s", diff)
 			}
+
+			feasibleLabels := map[string]string{"profile": "test-scheduler", "result": metrics.FeasibleResult}
+			infeasibleLabels := map[string]string{"profile": "test-scheduler", "result": metrics.InfeasibleResult}
+			assertCounterValueFromGatherer(t, testRegistry, "scheduler_generated_placements_total", "profile", "test-scheduler", tt.expectedGeneratedPlacements)
+			assertCounterValueFromGatherer(t, testRegistry, "scheduler_placement_evaluations_total", "result", metrics.FeasibleResult, tt.expectedFeasibleEvaluations)
+			assertCounterValueFromGatherer(t, testRegistry, "scheduler_placement_evaluations_total", "result", metrics.InfeasibleResult, tt.expectedInfeasibleEvaluations)
+			assertHistogramSampleCountFromGatherer(t, testRegistry, "scheduler_placement_evaluation_duration_seconds", feasibleLabels, tt.expectedFeasibleEvaluations)
+			assertHistogramSampleCountFromGatherer(t, testRegistry, "scheduler_placement_evaluation_duration_seconds", infeasibleLabels, tt.expectedInfeasibleEvaluations)
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds Prometheus metrics for topology-aware scheduling (TAS) pod group placement, so the volume and latency of the placement evaluation phase can be observed.

3 alpha metrics are introduced, gated on the beta `TopologyAwareWorkloadScheduling` feature gate by default off (since they are only registered when TAS is enabled). Metrics are defined in [KEP-5732](https://github.com/kubernetes/enhancements/issues/5732):

- `scheduler_generated_placements_total` counter of candidate placements generated when scheduling pod groups.
- `scheduler_placement_evaluations_total` counter of candidate placements evaluated when scheduling pod groups, split by `feasible`/`infeasible` result.
- `scheduler_placement_evaluation_duration_seconds` latency of evaluating a single candidate placement, split by `feasible`/`infeasible` result.

The TAS pod group placement algorithm phases:
1. generation: generate candidate placements 
2. evaluation: per placement loop try to fit each candidate
3. scoring: pick the best among feasible placements (only if there are more than 1 feasible placement)

The placement generation and scoring phases are intentionally not given dedicated metrics, since they are already covered by `scheduler_framework_extension_point_duration_seconds` with the [`PlacementGenerate`](https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/framework/runtime/framework.go#L2076) and [`PlacementScore`](https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/framework/runtime/framework.go#L1493) extension points. 
There is also existing `podgroup_scheduling_algorithm_duration_seconds` which measures the overall pod group scheduling cycle, so this PR focuses on the per-placement evaluation.

#### Which issue(s) this PR is related to:
Fixes [#139347](https://github.com/kubernetes/kubernetes/issues/139347)

#### Special notes for your reviewer:
Updated KEP metric names https://github.com/kubernetes/enhancements/pull/6234#event-27926380968

Output:
```
# HELP scheduler_generated_placements_total [ALPHA] Number of candidate placements generated when scheduling pod groups.
# TYPE scheduler_generated_placements_total counter
scheduler_generated_placements_total{profile="default-scheduler"} 5

# HELP scheduler_placement_evaluations_total [ALPHA] Number of candidate placements evaluated... 'feasible'... 'infeasible'...
# TYPE scheduler_placement_evaluations_total counter
scheduler_placement_evaluations_total{profile="default-scheduler",result="feasible"} 2
scheduler_placement_evaluations_total{profile="default-scheduler",result="infeasible"} 3

# HELP scheduler_placement_evaluation_duration_seconds [ALPHA] Latency in seconds...
# TYPE scheduler_placement_evaluation_duration_seconds histogram
scheduler_placement_evaluation_duration_seconds_bucket{...,result="feasible",le="0.001"} 1
...
scheduler_placement_evaluation_duration_seconds_sum{...,result="feasible"} 0.0127
scheduler_placement_evaluation_duration_seconds_count{...,result="feasible"} 2
```

#### Does this PR introduce a user-facing change?

```release-note
Scheduler metrics for the topology-aware scheduling (TAS) placement phases available when the TopologyAwareWorkloadScheduling feature gate is enabled: scheduler_generated_placements_total, scheduler_placement_evaluations_total, and scheduler_placement_evaluation_duration_seconds.
```