### PR TITLE
WIP: add cacher watch-cache init benchmark for ConcurrentWatchObjectDecode

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_init_bench_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_init_bench_test.go
@@ -20,12 +20,17 @@ import (
 	"context"
 	"fmt"
 	"os"
+	goruntime "runtime"
+	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 	"sigs.k8s.io/yaml"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
@@ -33,6 +38,9 @@ import (
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/etcd3"
+	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
+	"k8s.io/apiserver/pkg/storage/etcd3/testserver"
+	"k8s.io/apiserver/pkg/storage/value/encrypt/identity"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/clock"
@@ -146,5 +154,201 @@ func seedCorev1PodsParallel(b *testing.B, ctx context.Context, etcdStorage stora
 
 	if err := g.Wait(); err != nil {
 		b.Fatalf("seed: %v", err)
+	}
+}
+
+const (
+	crGroup    = "example.com"
+	crVersion  = "v1"
+	crKind     = "Widget"
+	crResource = "widgets"
+
+	crAPIVersion = crGroup + "/" + crVersion
+	crKeyPrefix  = "/" + crResource + "/"
+)
+
+func rusageSeconds(ru syscall.Rusage) float64 {
+	cpu := func(t syscall.Timeval) float64 { return float64(t.Sec) + float64(t.Usec)/1e6 }
+	return cpu(ru.Utime) + cpu(ru.Stime)
+}
+
+// makeCR builds a generic unstructured custom resource of groups x fields padded
+// entries. The default weights mirror the kueue Workload that motivated the gate
+// (kubernetes#136950).
+func makeCR(idx, groups, fields int) *unstructured.Unstructured {
+	items := make([]any, 0, groups)
+	for g := range groups {
+		entries := make([]any, 0, fields)
+		for f := range fields {
+			entries = append(entries, map[string]any{
+				"name":  fmt.Sprintf("k%d_%d", g, f),
+				"value": strings.Repeat("x", 100),
+			})
+		}
+		items = append(items, map[string]any{"name": fmt.Sprintf("g%d", g), "entries": entries})
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": crAPIVersion,
+		"kind":       crKind,
+		"metadata":   map[string]any{"name": fmt.Sprintf("cr-%d", idx), "namespace": "default"},
+		"spec":       map[string]any{"groups": items},
+	}}
+}
+
+func seedCRsParallel(b *testing.B, ctx context.Context, etcdStorage storage.Interface, count, groups, fields, workers int) {
+	eg, gctx := errgroup.WithContext(ctx)
+	idxCh := make(chan int, workers*4)
+
+	for range workers {
+		eg.Go(func() error {
+			out := &unstructured.Unstructured{}
+			for idx := range idxCh {
+				w := makeCR(idx, groups, fields)
+				key := crKeyPrefix + "default/" + w.GetName()
+				if err := etcdStorage.Create(gctx, key, w, out, 0); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+
+	eg.Go(func() error {
+		defer close(idxCh)
+		for i := range count {
+			select {
+			case idxCh <- i:
+			case <-gctx.Done():
+				return gctx.Err()
+			}
+		}
+		return nil
+	})
+
+	if err := eg.Wait(); err != nil {
+		b.Fatalf("seed: %v", err)
+	}
+}
+
+// BenchmarkCacherInitConcurrentDecode measures cold watch-cache init for a
+// JSON/unstructured custom resource with ConcurrentWatchObjectDecode off vs on.
+// JSON decode is heavy enough (unlike protobuf Pods) to show the gate's effect.
+func BenchmarkCacherInitConcurrentDecode(b *testing.B) {
+	ctx := context.Background()
+	codec := unstructured.UnstructuredJSONScheme
+	versioner := storage.APIObjectVersioner{}
+	gr := schema.GroupResource{Group: crGroup, Resource: crResource}
+	newFunc := func() runtime.Object {
+		u := &unstructured.Unstructured{}
+		u.SetAPIVersion(crAPIVersion)
+		u.SetKind(crKind)
+		return u
+	}
+	newListFunc := func() runtime.Object {
+		u := &unstructured.UnstructuredList{}
+		u.SetAPIVersion(crAPIVersion)
+		u.SetKind(crKind + "List")
+		return u
+	}
+
+	cases := []struct {
+		name                  string
+		count, groups, fields int
+	}{
+		{"weight=medium/n=10k", 10_000, 10, 10}, // ~14 KB each
+		{"weight=heavy/n=10k", 10_000, 60, 20},  // ~160 KB each (kueue Workload weight)
+		{"weight=medium/n=50k", 50_000, 10, 10}, // more items
+	}
+
+	for _, tc := range cases {
+		cfg := testserver.NewTestConfig(b)
+		cfg.QuotaBackendBytes = 8 << 30 // headroom for heavy multi-GB seeds
+		server := &etcd3testing.EtcdTestServer{V3Client: testserver.RunEtcd(b, cfg)}
+		compactor := etcd3.NewCompactor(server.V3Client.Client, 0, clock.RealClock{}, nil)
+		etcdStorage, err := etcd3.New(
+			server.V3Client, compactor, codec, newFunc, newListFunc,
+			etcd3testing.PathPrefix(), crKeyPrefix, gr,
+			identity.NewEncryptCheckTransformer(), etcd3.NewDefaultLeaseManagerConfig(),
+			etcd3.NewDefaultDecoder(codec, versioner), versioner)
+		if err != nil {
+			b.Fatal(err)
+		}
+		seedCRsParallel(b, ctx, etcdStorage, tc.count, tc.groups, tc.fields, 32)
+
+		config := Config{
+			Storage:             etcdStorage,
+			Versioner:           versioner,
+			GroupResource:       gr,
+			EventsHistoryWindow: DefaultEventFreshDuration,
+			ResourcePrefix:      crKeyPrefix,
+			KeyFunc: func(obj runtime.Object) (string, error) {
+				return storage.NamespaceKeyFunc(crKeyPrefix, obj)
+			},
+			GetAttrsFunc: storage.DefaultNamespaceScopedAttr,
+			NewFunc:      newFunc,
+			NewListFunc:  newListFunc,
+			Codec:        codec,
+			Clock:        clock.RealClock{},
+		}
+
+		for _, concurrent := range []bool{false, true} {
+			b.Run(fmt.Sprintf("%s/Concurrent=%v", tc.name, concurrent), func(b *testing.B) {
+				featuregatetesting.SetFeatureGateDuringTest(b, utilfeature.DefaultFeatureGate, features.ConcurrentWatchObjectDecode, concurrent)
+
+				b.ResetTimer()
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					// Peak heap + CPU during init. ReadMemStats sampling adds fixed
+					// overhead to sec/op equally for both arms; the delta is unaffected.
+					var peak uint64
+					stop, done := make(chan struct{}), make(chan struct{})
+					go func() {
+						defer close(done)
+						var m goruntime.MemStats
+						tk := time.NewTicker(50 * time.Millisecond)
+						defer tk.Stop()
+						for {
+							select {
+							case <-stop:
+								return
+							case <-tk.C:
+								goruntime.ReadMemStats(&m)
+								if m.HeapInuse > peak {
+									peak = m.HeapInuse
+								}
+							}
+						}
+					}()
+					var ru0, ru1 syscall.Rusage
+					_ = syscall.Getrusage(syscall.RUSAGE_SELF, &ru0)
+					wallStart := time.Now()
+
+					cacher, err := NewCacherFromConfig(config)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if err := cacher.Wait(ctx); err != nil {
+						b.Fatal(err)
+					}
+
+					wall := time.Since(wallStart)
+					_ = syscall.Getrusage(syscall.RUSAGE_SELF, &ru1)
+					close(stop)
+					<-done
+
+					b.StopTimer()
+					b.ReportMetric(float64(peak)/(1<<20), "peakHeapMB")
+					b.ReportMetric((rusageSeconds(ru1)-rusageSeconds(ru0))/wall.Seconds(), "cpu-cores")
+					cacher.Stop()
+					etcd3.TestOnlyResetResourceSizeEstimator(etcdStorage)
+					b.StartTimer()
+				}
+				b.ReportMetric(float64(tc.count), "objs/cache")
+			})
+		}
+
+		etcdStorage.Close()
+		compactor.Stop()
+		server.Terminate(b)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add BenchmarkCacherInitConcurrentDecode measuring cold watch-cache init for JSON custom resources with ConcurrentWatchObjectDecode off vs on.

benchstat (gate off -> on, n=6):

```
goos: darwin
goarch: arm64
pkg: k8s.io/apiserver/pkg/storage/cacher
                                                  │     false     │                true                 │
                                                  │    sec/op     │    sec/op     vs base               │
CacherInitConcurrentDecode/weight=medium/n=10k-12   1603.7m ±  1%   379.4m ±  9%  -76.34% (p=0.002 n=6)
CacherInitConcurrentDecode/weight=heavy/n=10k-12     21.537 ±  6%    6.306 ± 24%  -70.72% (p=0.002 n=6)
CacherInitConcurrentDecode/weight=medium/n=50k-12     7.953 ± 10%    1.890 ±  7%  -76.24% (p=0.002 n=6)
geomean                                               6.500          1.654        -74.56%

                                                  │    false    │                true                 │
                                                  │  cpu-cores  │  cpu-cores   vs base                │
CacherInitConcurrentDecode/weight=medium/n=10k-12   1.223 ±  3%   5.527 ±  8%  +352.11% (p=0.002 n=6)
CacherInitConcurrentDecode/weight=heavy/n=10k-12    1.123 ± 11%   5.043 ± 14%  +349.31% (p=0.002 n=6)
CacherInitConcurrentDecode/weight=medium/n=50k-12   1.252 ±  8%   5.829 ±  2%  +365.76% (p=0.002 n=6)
geomean                                             1.198         5.457        +355.67%

                                                  │  peakHeapMB  │      peakHeapMB vs base           │
CacherInitConcurrentDecode/weight=medium/n=10k-12   1.060k ±  3%   1.032k ±  2%       ~ (p=0.089 n=6)
CacherInitConcurrentDecode/weight=heavy/n=10k-12    11.18k ± 15%   11.23k ± 19%       ~ (p=0.121 n=6)
CacherInitConcurrentDecode/weight=medium/n=50k-12   5.356k ±  8%   5.402k ±  6%       ~ (p=0.699 n=6)

                                                  │     B/op     │      B/op     vs base             │
CacherInitConcurrentDecode/weight=medium/n=10k-12   1.205Gi ± 0%   1.207Gi ± 0%  +0.18% (p=0.002 n=6)
CacherInitConcurrentDecode/weight=heavy/n=10k-12    13.81Gi ± 0%   13.81Gi ± 0%  +0.01% (p=0.002 n=6)
CacherInitConcurrentDecode/weight=medium/n=50k-12   5.293Gi ± 3%   5.354Gi ± 3%       ~ (p=0.180 n=6)

                                                  │  allocs/op  │     allocs/op vs base             │
CacherInitConcurrentDecode/weight=medium/n=10k-12   9.952M ± 0%   10.002M ± 0%  +0.50% (p=0.002 n=6)
CacherInitConcurrentDecode/weight=heavy/n=10k-12    104.9M ± 0%    104.9M ± 0%  +0.04% (p=0.002 n=6)
CacherInitConcurrentDecode/weight=medium/n=50k-12   49.63M ± 0%    49.88M ± 0%  +0.51% (p=0.002 n=6)
```

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
