### PR TITLE
Test inline tags, match stdlib inline tag handling behavior

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
@@ -385,7 +385,10 @@ func fieldInfoFromField(structType reflect.Type, field int) *fieldInfo {
 	} else {
 		items := strings.Split(jsonTag, ",")
 		info.name = items[0]
-		if len(info.name) == 0 && !typeField.Anonymous {
+		if isInlinedFromTag(typeField, items[0], items[1:]) {
+			// match stdlib behavior when controlled by tag
+			info.name = ""
+		} else if len(info.name) == 0 && !typeField.Anonymous {
 			// match stdlib behavior for naming fields that don't specify a json tag name
 			info.name = typeField.Name
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
@@ -1028,21 +1028,21 @@ func TestOmitempty(t *testing.T) {
 
 type InlineTestPrimitive struct {
 	NoNameTagPrimitive          int64 `json:""`
-	NoNameTagInlinePrimitive    int64 `json:""`
+	NoNameTagInlinePrimitive    int64 `json:",inline"` // TODO: expect error when switching to json/v2
 	NoNameTagOmitemptyPrimitive int64 `json:",omitempty"`
 }
 type InlineTestAnonymous struct {
 	NoTag
 	NoNameTag          `json:""`
 	NameTag            `json:"nameTagEmbedded"`
-	NoNameTagInline    `json:""`
+	NoNameTagInline    `json:",inline"`
 	NoNameTagOmitempty `json:",omitempty"`
 }
 type InlineTestNamed struct {
 	NoTag              NoTag
 	NoNameTag          NoNameTag          `json:""`
 	NameTag            NameTag            `json:"nameTagEmbedded"`
-	NoNameTagInline    NoNameTagInline    `json:""`
+	NoNameTagInline    NoNameTagInline    `json:",inline"`
 	NoNameTagOmitempty NoNameTagOmitempty `json:",omitempty"`
 }
 type NoTag struct {
@@ -1113,13 +1113,20 @@ func TestInline(t *testing.T) {
 		{
 			name: "named-zero",
 			obj:  &InlineTestNamed{},
-			expect: map[string]any{
-				"NoTag":              map[string]any{"data0": int64(0)},
-				"nameTagEmbedded":    map[string]any{"data1": int64(0)},
-				"NoNameTag":          map[string]any{"data2": int64(0)},
-				"NoNameTagInline":    map[string]any{"data3": int64(0)},
-				"NoNameTagOmitempty": map[string]any{"data4": int64(0)},
-			},
+			expect: func() map[string]any {
+				m := map[string]any{
+					"NoTag":              map[string]any{"data0": int64(0)},
+					"nameTagEmbedded":    map[string]any{"data1": int64(0)},
+					"NoNameTag":          map[string]any{"data2": int64(0)},
+					"NoNameTagOmitempty": map[string]any{"data4": int64(0)},
+				}
+				if stdlibSupportsInlineTag {
+					m["data3"] = int64(0)
+				} else {
+					m["NoNameTagInline"] = map[string]any{"data3": int64(0)}
+				}
+				return m
+			}(),
 		},
 		{
 			name: "named-set",
@@ -1130,13 +1137,20 @@ func TestInline(t *testing.T) {
 				NoNameTagInline:    NoNameTagInline{Data3: 13},
 				NoNameTagOmitempty: NoNameTagOmitempty{Data4: 14},
 			},
-			expect: map[string]any{
-				"NoTag":              map[string]any{"data0": int64(10)},
-				"nameTagEmbedded":    map[string]any{"data1": int64(11)},
-				"NoNameTag":          map[string]any{"data2": int64(12)},
-				"NoNameTagInline":    map[string]any{"data3": int64(13)},
-				"NoNameTagOmitempty": map[string]any{"data4": int64(14)},
-			},
+			expect: func() map[string]any {
+				m := map[string]any{
+					"NoTag":              map[string]any{"data0": int64(10)},
+					"nameTagEmbedded":    map[string]any{"data1": int64(11)},
+					"NoNameTag":          map[string]any{"data2": int64(12)},
+					"NoNameTagOmitempty": map[string]any{"data4": int64(14)},
+				}
+				if stdlibSupportsInlineTag {
+					m["data3"] = int64(13)
+				} else {
+					m["NoNameTagInline"] = map[string]any{"data3": int64(13)}
+				}
+				return m
+			}(),
 		},
 	}
 	for _, tc := range testcases {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/fieldinfo_126.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/fieldinfo_126.go
@@ -1,0 +1,26 @@
+//go:build !go1.27
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import "reflect"
+
+func isInlinedFromTag(fieldType reflect.StructField, tagName string, tagDirectives []string) bool {
+	// go <1.27 doesn't honor ",inline"
+	return false
+}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/fieldinfo_126_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/fieldinfo_126_test.go
@@ -1,0 +1,21 @@
+//go:build !go1.27
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime_test
+
+const stdlibSupportsInlineTag = false

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/fieldinfo_127.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/fieldinfo_127.go
@@ -1,0 +1,33 @@
+//go:build go1.27
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"reflect"
+)
+
+func isInlinedFromTag(field reflect.StructField, tagName string, tagDirectives []string) bool {
+	fieldType := field.Type
+	if fieldType.Kind() == reflect.Pointer && fieldType.Name() == "" {
+		// optionally unwrap a single level
+		fieldType = fieldType.Elem()
+	}
+	// TODO: when switching to direct use of json/v2, error on non-struct inlining and use of inline with other directives
+	return fieldType.Kind() == reflect.Struct && tagName == "" && len(tagDirectives) == 1 && tagDirectives[0] == "inline"
+}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/fieldinfo_127_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/fieldinfo_127_test.go
@@ -1,0 +1,21 @@
+//go:build go1.27
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime_test
+
+const stdlibSupportsInlineTag = true


### PR DESCRIPTION
Restore unit tests of our structured conversion behavior around `inline` tags which make no sense (which I accidentally removed when removing inline tags that make no sense in https://github.com/kubernetes/kubernetes/pull/138260/changes/bed4a34ad8901d9a01efcb9594838f96ec9d4563#diff-85104e5f97bac2bef281a855d2b67f25f703d30e6adde3457095b462920acd24)

Flagged in https://github.com/golang/go/issues/79921#issuecomment-4664519509

/kind test
/assign @dims

```release-note
NONE
```