### PR TITLE
Promote agnhost e2e test image to 2.64.0

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -83,7 +83,7 @@ dependencies:
 
   # agnhost - E2E test image
   - name: "agnhost"
-    version: 2.63.0
+    version: 2.64.0
     refPaths:
     - path: test/utils/image/manifest.go
       match: configs\[Agnhost\] = Config{list\.PromoterE2eRegistry, "agnhost", "\d+\.\d+\.\d+"}

--- a/hack/testdata/pod-with-large-name.yaml
+++ b/hack/testdata/pod-with-large-name.yaml
@@ -8,5 +8,5 @@ metadata:
 spec:
   containers:
   - name: kubernetes-serve-hostname
-    image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+    image: registry.k8s.io/e2e-test-images/agnhost:2.64.0
     command: ["/agnhost", "serve-hostname"]

--- a/test/e2e/dra/test-driver/deploy/example/pod-external-toleration.yaml
+++ b/test/e2e/dra/test-driver/deploy/example/pod-external-toleration.yaml
@@ -28,13 +28,13 @@ spec:
   restartPolicy: Never
   containers:
   - name: with-resource
-    image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+    image: registry.k8s.io/e2e-test-images/agnhost:2.64.0
     command: ["sh", "-c", "set && mount && ls -la /dev/ && /agnhost pause"]
     resources:
       claims:
       - name: resource
   - name: without-resource
-    image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+    image: registry.k8s.io/e2e-test-images/agnhost:2.64.0
     command: ["sh", "-c", "set && mount && ls -la /dev/ && /agnhost pause"]
   resourceClaims:
   - name: resource

--- a/test/e2e/dra/test-driver/deploy/example/pod-external.yaml
+++ b/test/e2e/dra/test-driver/deploy/example/pod-external.yaml
@@ -24,13 +24,13 @@ spec:
   restartPolicy: Never
   containers:
   - name: with-resource
-    image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+    image: registry.k8s.io/e2e-test-images/agnhost:2.64.0
     command: ["sh", "-c", "set && mount && ls -la /dev/ && /agnhost pause"]
     resources:
       claims:
       - name: resource
   - name: without-resource
-    image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+    image: registry.k8s.io/e2e-test-images/agnhost:2.64.0
     command: ["sh", "-c", "set && mount && ls -la /dev/ && /agnhost pause"]
   resourceClaims:
   - name: resource

--- a/test/e2e/dra/test-driver/deploy/example/pod-inline.yaml
+++ b/test/e2e/dra/test-driver/deploy/example/pod-inline.yaml
@@ -29,13 +29,13 @@ spec:
   restartPolicy: Never
   containers:
   - name: with-resource
-    image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+    image: registry.k8s.io/e2e-test-images/agnhost:2.64.0
     command: ["sh", "-c", "set && mount && ls -la /dev/ && /agnhost pause"]
     resources:
       claims:
       - name: resource
   - name: without-resource
-    image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+    image: registry.k8s.io/e2e-test-images/agnhost:2.64.0
     command: ["sh", "-c", "set && mount && ls -la /dev/ && /agnhost pause"]
   terminationGracePeriodSeconds: 0 # Shut down immediately.
   resourceClaims:

--- a/test/e2e/testing-manifests/kubectl/agnhost-primary-pod.yaml
+++ b/test/e2e/testing-manifests/kubectl/agnhost-primary-pod.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
     - name: primary
-      image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+      image: registry.k8s.io/e2e-test-images/agnhost:2.64.0
       env:
         - name: PRIMARY
           value: "true"
@@ -21,7 +21,7 @@ spec:
         - mountPath: /agnhost-primary-data
           name: data
     - name: sentinel
-      image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+      image: registry.k8s.io/e2e-test-images/agnhost:2.64.0
       env:
         - name: SENTINEL
           value: "true"

--- a/test/e2e/testing-manifests/serviceloadbalancer/netexecrc.yaml
+++ b/test/e2e/testing-manifests/serviceloadbalancer/netexecrc.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: netexec
-        image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+        image: registry.k8s.io/e2e-test-images/agnhost:2.64.0
         command: ["/agnhost", "netexec"]
         ports:
         - containerPort: 8080

--- a/test/fixtures/doc-yaml/user-guide/multi-pod.yaml
+++ b/test/fixtures/doc-yaml/user-guide/multi-pod.yaml
@@ -42,7 +42,7 @@ metadata:
 spec:
   containers:
   - name: kubernetes-serve-hostname
-    image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+    image: registry.k8s.io/e2e-test-images/agnhost:2.64.0
     command: ["/agnhost", "serve-hostname"]
     resources:
       limits:

--- a/test/fixtures/pkg/kubectl/cmd/auth/rbac-resource-plus.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/auth/rbac-resource-plus.yaml
@@ -30,7 +30,7 @@ items:
   spec:
     containers:
     - name: kubernetes-serve-hostname
-      image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+      image: registry.k8s.io/e2e-test-images/agnhost:2.64.0
       command: ["/agnhost", "serve-hostname"]
       resources:
         limits:

--- a/test/images/kitten/BASEIMAGE
+++ b/test/images/kitten/BASEIMAGE
@@ -1,7 +1,7 @@
-linux/amd64=REGISTRY/agnhost:2.63.0-linux-amd64
-linux/arm64=REGISTRY/agnhost:2.63.0-linux-arm64
-linux/ppc64le=REGISTRY/agnhost:2.63.0-linux-ppc64le
-linux/s390x=REGISTRY/agnhost:2.63.0-linux-s390x
-windows/amd64/1809=REGISTRY/agnhost:2.63.0-windows-amd64-1809
-windows/amd64/ltsc2022=REGISTRY/agnhost:2.63.0-windows-amd64-ltsc2022
-windows/amd64/ltsc2025=REGISTRY/agnhost:2.63.0-windows-amd64-ltsc2025
+linux/amd64=REGISTRY/agnhost:2.64.0-linux-amd64
+linux/arm64=REGISTRY/agnhost:2.64.0-linux-arm64
+linux/ppc64le=REGISTRY/agnhost:2.64.0-linux-ppc64le
+linux/s390x=REGISTRY/agnhost:2.64.0-linux-s390x
+windows/amd64/1809=REGISTRY/agnhost:2.64.0-windows-amd64-1809
+windows/amd64/ltsc2022=REGISTRY/agnhost:2.64.0-windows-amd64-ltsc2022
+windows/amd64/ltsc2025=REGISTRY/agnhost:2.64.0-windows-amd64-ltsc2025

--- a/test/images/nautilus/BASEIMAGE
+++ b/test/images/nautilus/BASEIMAGE
@@ -1,7 +1,7 @@
-linux/amd64=REGISTRY/agnhost:2.63.0-linux-amd64
-linux/arm64=REGISTRY/agnhost:2.63.0-linux-arm64
-linux/ppc64le=REGISTRY/agnhost:2.63.0-linux-ppc64le
-linux/s390x=REGISTRY/agnhost:2.63.0-linux-s390x
-windows/amd64/1809=REGISTRY/agnhost:2.63.0-windows-amd64-1809
-windows/amd64/ltsc2022=REGISTRY/agnhost:2.63.0-windows-amd64-ltsc2022
-windows/amd64/ltsc2025=REGISTRY/agnhost:2.63.0-windows-amd64-ltsc2025
+linux/amd64=REGISTRY/agnhost:2.64.0-linux-amd64
+linux/arm64=REGISTRY/agnhost:2.64.0-linux-arm64
+linux/ppc64le=REGISTRY/agnhost:2.64.0-linux-ppc64le
+linux/s390x=REGISTRY/agnhost:2.64.0-linux-s390x
+windows/amd64/1809=REGISTRY/agnhost:2.64.0-windows-amd64-1809
+windows/amd64/ltsc2022=REGISTRY/agnhost:2.64.0-windows-amd64-ltsc2022
+windows/amd64/ltsc2025=REGISTRY/agnhost:2.64.0-windows-amd64-ltsc2025

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -209,7 +209,7 @@ const (
 func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config) {
 	configs := map[ImageID]Config{}
 	configs[AgnhostPrev] = Config{list.PromoterE2eRegistry, "agnhost", "2.55"}
-	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.63.0"}
+	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.64.0"}
 	configs[AgnhostPrivate] = Config{list.PrivateRegistry, "agnhost", "2.6"}
 	configs[APIServer] = Config{list.PromoterE2eRegistry, "sample-apiserver", "1.29.2"}
 	configs[AppArmorLoader] = Config{list.PromoterE2eRegistry, "apparmor-loader", "1.4"}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/sig testing
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Bumps the agnhost e2e test image from 2.63.0 to 2.64.0. The new version includes the `h2c-server` subcommand for HTTP/2 cleartext probe testing.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A
#### Special notes for your reviewer:
Depends on image promotion: https://github.com/kubernetes/k8s.io/pull/#9582
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```
