### PR TITLE
fix: race in watchcache list snapshot processing

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -626,13 +626,15 @@ func (w *watchCache) waitAndListConsistent(ctx context.Context, key, continueKey
 }
 
 func (w *watchCache) waitAndListLatestRV(ctx context.Context, minResourceVersion uint64, key, continueKey string, matchValues []storage.MatchValue) (resp listResp, index string, err error) {
-	snap, resourceVersion, index, err := w.waitAndGetLatestSnapshot(ctx, minResourceVersion, key, continueKey, matchValues)
+	snap, items, resourceVersion, index, err := w.waitAndGetLatestSnapshot(ctx, minResourceVersion, key, continueKey, matchValues)
 	if err != nil {
 		return listResp{}, "", err
 	}
-	items, err := snap.OrderedListPrefix(key, continueKey)
-	if err != nil {
-		return listResp{}, "", err
+	if snap != nil {
+		items, err = snap.OrderedListPrefix(key, continueKey)
+		if err != nil {
+			return listResp{}, "", err
+		}
 	}
 	return listResp{
 		Items:           items,
@@ -640,13 +642,13 @@ func (w *watchCache) waitAndListLatestRV(ctx context.Context, minResourceVersion
 	}, index, nil
 }
 
-func (w *watchCache) waitAndGetLatestSnapshot(ctx context.Context, minResourceVersion uint64, key, continueKey string, matchValues []storage.MatchValue) (snap store.Snapshot, resourceVersion uint64, index string, err error) {
+func (w *watchCache) waitAndGetLatestSnapshot(ctx context.Context, minResourceVersion uint64, key, continueKey string, matchValues []storage.MatchValue) (snap store.Snapshot, items []interface{}, resourceVersion uint64, index string, err error) {
 	consistentReadSupported := delegator.ConsistentReadSupported()
 	w.RLock()
 	defer w.RUnlock()
 	err = w.waitUntilFreshLocked(ctx, consistentReadSupported, minResourceVersion)
 	if err != nil {
-		return nil, 0, "", err
+		return nil, nil, 0, "", err
 	}
 	// This isn't the place where we do "final filtering" - only some "prefiltering" is happening here. So the only
 	// requirement here is to NOT miss anything that should be returned. We can return as many non-matching items as we
@@ -654,16 +656,18 @@ func (w *watchCache) waitAndGetLatestSnapshot(ctx context.Context, minResourceVe
 	// TODO: if multiple indexes match, return the one with the fewest items, so as to do as much filtering as possible.
 	for _, matchValue := range matchValues {
 		if result, err := w.store.ByIndex(matchValue.IndexName, matchValue.Value); err == nil {
-			return listSnapshot{Items: result}, w.resourceVersion, matchValue.IndexName, nil
+			items, err := listSnapshot{Items: result}.OrderedListPrefix(key, continueKey)
+			return nil, items, w.resourceVersion, matchValue.IndexName, err
 		}
 	}
 	if w.snapshots != nil {
 		snap, ok := w.snapshots.Latest()
 		if ok {
-			return snap, w.resourceVersion, "", nil
+			return snap, nil, w.resourceVersion, "", nil
 		}
 	}
-	return w.store, w.resourceVersion, "", nil
+	items, err = w.store.OrderedListPrefix(key, continueKey)
+	return nil, items, w.resourceVersion, "", err
 }
 
 type listSnapshot struct {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1412,4 +1413,96 @@ func TestCacheSnapshots(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, elements, 1)
 	assert.Equal(t, makeTestPod("foo", 600), elements[0].(*store.Element).Object)
+}
+
+func TestWatchCacheListSnapshotRace(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ListFromCacheSnapshot, true)
+
+	store := newTestWatchCache(100, DefaultEventFreshDuration, &cache.Indexers{
+		"spec.nodeName": func(obj interface{}) ([]string, error) {
+			pod, ok := obj.(*v1.Pod)
+			if !ok {
+				return nil, fmt.Errorf("not a pod")
+			}
+			return []string{pod.Spec.NodeName}, nil
+		},
+	})
+	defer store.Stop()
+
+	// Add initial pods
+	for i := 0; i < 50; i++ {
+		pod := makeTestPod(fmt.Sprintf("pod-%d", i), uint64(100+i))
+		pod.Spec.NodeName = "node-1"
+		require.NoError(t, store.Add(pod))
+	}
+
+	stopCh := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Start concurrent writers
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		rv := uint64(200)
+		for {
+			select {
+			case <-stopCh:
+				return
+			default:
+				// Delete and recreate pod-0
+				pod := makeTestPod("pod-0", rv)
+				pod.Spec.NodeName = "node-1"
+				_ = store.Delete(pod)
+
+				rv++
+				pod = makeTestPod("pod-0", rv)
+				pod.Spec.NodeName = "node-1"
+				_ = store.Add(pod)
+				rv++
+			}
+		}
+	}()
+
+	// Start concurrent readers using index matching
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stopCh:
+					return
+				default:
+					pred := storage.SelectionPredicate{
+						Label: labels.Everything(),
+						Field: fields.OneTermEqualSelector("spec.nodeName", "node-1"),
+						GetAttrs: func(obj runtime.Object) (labels.Set, fields.Set, error) {
+							pod, ok := obj.(*v1.Pod)
+							if !ok {
+								return nil, nil, fmt.Errorf("not a pod")
+							}
+							return labels.Set(pod.Labels), fields.Set{"spec.nodeName": pod.Spec.NodeName}, nil
+						},
+						IndexFields: []string{"spec.nodeName"},
+					}
+					opts := storage.ListOptions{
+						Recursive: true,
+						Predicate: pred,
+						// Use ResourceVersion "0" to exercise waitAndListLatestRV directly and
+						// avoid the test-only race in mock getCurrentRV used by waitAndListConsistent.
+						ResourceVersion: "0",
+					}
+					_, _, err := store.WaitUntilFreshAndGetList(context.Background(), "/prefix/default", opts)
+					if err != nil {
+						t.Errorf("unexpected error on list: %v", err)
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	close(stopCh)
+	wg.Wait()
 }


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:

 This PR fixes a data race in `watchCache` when the `ListFromCacheSnapshot` feature gate is enabled.

 In #139595, `OrderedListPrefix` execution was moved outside of `watchCache.   RLock` to reduce lock contention. However, this is only safe when the returned   snapshot is an immutable COW snapshot. For non-COW paths (such as the index-matching path and the active store fallback path), the returned `listSnapshot`  wraps slice pointers referencing the mutable active store. Without lock protection,  concurrent write operations during list filtering outside the lock lead to a data race.

 To resolve this, we wrap `OrderedListPrefix` execution with `RLock` specifically for these non-snapshot paths (by calling it inside `waitAndGetLatestSnapshot`  while the lock is held), while keeping the COW snapshot path lock-free.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
