### PR TITLE
On successful scheduling of podgroup, requeue remaining pods directly to active queue.

### DIFF
--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -108,7 +108,13 @@ type SchedulingQueue interface {
 	AddUnschedulablePodIfNotPresent(logger klog.Logger, pInfo *framework.QueuedPodInfo, podSchedulingCycle int64) error
 	// AddAttemptedPodGroupIfNeeded adds an attempted pod group back to scheduling queue.
 	// If there are no pending pods, it will not add the pod group back to the queue.
-	AddAttemptedPodGroupIfNeeded(logger klog.Logger, pgInfo *framework.QueuedPodGroupInfo, schedulingCycle int64) error
+	// Should be called synchronously to the pod group scheduling cycle.
+	// If the pod group scheduling succeeded, the remaining pods of the pod group will be
+	// requeued directly to the active queue instead of backoff.
+	// If there were unschedulable pods remaining, the pod group will preserve its timestamp,
+	// to trigger preemption immediately after the current cycle, unless a higher priority
+	// pod or pod group comes in between.
+	AddAttemptedPodGroupIfNeeded(logger klog.Logger, pgInfo *framework.QueuedPodGroupInfo, schedulingCycle int64, status *fwk.Status) error
 	// SchedulingCycle returns the current number of scheduling cycle which is
 	// cached by scheduling queue. Normally, incrementing this number whenever
 	// a pod is popped (e.g. called Pop()) is enough.
@@ -144,6 +150,7 @@ type SchedulingQueue interface {
 	PatchPodStatus(pod *v1.Pod, conditions []*v1.PodCondition, nominatingInfo *fwk.NominatingInfo) (<-chan error, error)
 
 	// The following functions are supposed to be used only for testing or debugging.
+	GetPodGroup(name, namespace string) (*framework.QueuedPodGroupInfo, bool)
 	GetPod(name, namespace string, schedulingGroup *v1.PodSchedulingGroup) (*framework.QueuedPodInfo, bool)
 	PendingPods() ([]*v1.Pod, string)
 	InFlightPods() []*v1.Pod
@@ -1097,7 +1104,12 @@ func (p *PriorityQueue) addUnschedulablePodGroupMember(logger klog.Logger, pInfo
 // AddAttemptedPodGroupIfNeeded adds an attempted pod group back to scheduling queue.
 // If there are no pending pods, it will not add the pod group back to the queue.
 // Should be called synchronously to the pod group scheduling cycle.
-func (p *PriorityQueue) AddAttemptedPodGroupIfNeeded(logger klog.Logger, pgInfo *framework.QueuedPodGroupInfo, schedulingCycle int64) error {
+// If the pod group scheduling succeeded, the remaining pods of the pod group will be
+// requeued directly to the active queue instead of backoff.
+// If there were unschedulable pods remaining, the pod group will preserve its timestamp,
+// to trigger preemption immediately after the current cycle, unless a higher priority
+// pod or pod group comes in between.
+func (p *PriorityQueue) AddAttemptedPodGroupIfNeeded(logger klog.Logger, pgInfo *framework.QueuedPodGroupInfo, schedulingCycle int64, status *fwk.Status) error {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -1119,6 +1131,8 @@ func (p *PriorityQueue) AddAttemptedPodGroupIfNeeded(logger klog.Logger, pgInfo 
 		// No pending pods, nothing to requeue.
 		return nil
 	}
+	// hadUnschedulableOrErrorPods is true if at least one pod of the pod group in this scheduling cycle was unschedulable or had an error.
+	hadUnschedulableOrErrorPods := hasIntersection(pgInfo.QueuedPodInfos, pendingPods)
 	pgInfo.SetPods(pendingPods)
 
 	podGroup, ok := p.workloadForest.getRootForPod(pendingPods[0].Pod)
@@ -1133,28 +1147,38 @@ func (p *PriorityQueue) AddAttemptedPodGroupIfNeeded(logger klog.Logger, pgInfo 
 	}
 	pgInfo.PodGroup = podGroup
 
-	hasErrorPods := false
-	pgInfo.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
-		if pInfo.UnschedulablePlugins.Len() == 0 && pInfo.PendingPlugins.Len() == 0 {
-			hasErrorPods = true
-			return false
-		}
-		return true
-	})
-	if hasErrorPods {
-		// This Pod group came back because of some unexpected errors (e.g., a network issue).
-		pgInfo.ConsecutiveErrorsCount++
-	} else {
-		// This Pod group is rejected by some plugins, not coming back due to unexpected errors (e.g., a network issue)
+	requeueWithoutBackoff := false
+	preserveTimestamp := false
+
+	if status.IsSuccess() {
+		// If the scheduling attempt of the pod group succeeded, requeue remaining pods directly to active queue.
+		requeueWithoutBackoff = true
+		// If there are remaining unschedulable or error pods, preserve timestamp, so that subsequent
+		// scheduling attempt triggers preemption immediately for the podgroup.
+		preserveTimestamp = hadUnschedulableOrErrorPods
+		// We should reset the error and unschedulable count, because the scheduling was successful.
+		pgInfo.ConsecutiveErrorsCount = 0
+		pgInfo.UnschedulableCount = 0
+	} else if status.IsRejected() {
+		// This Pod group is rejected by some plugins, not coming back due to unexpected errors (e.g., a network issue).
 		pgInfo.UnschedulableCount++
 		// We should reset the error count because the error is gone.
 		pgInfo.ConsecutiveErrorsCount = 0
+		// We changed ConsecutiveErrorsCount or UnschedulableCount plus Timestamp, and now
+		// the calculated backoff time should be different, removing the cached backoff time.
+		pgInfo.BackoffExpiration = time.Time{}
+	} else {
+		// This Pod group came back because of some unexpected errors (e.g., a network issue).
+		pgInfo.ConsecutiveErrorsCount++
+		// We changed ConsecutiveErrorsCount or UnschedulableCount plus Timestamp, and now
+		// the calculated backoff time should be different, removing the cached backoff time.
+		pgInfo.BackoffExpiration = time.Time{}
 	}
-	// Refresh the timestamp since the pod is re-added.
-	pgInfo.Timestamp = p.clock.Now()
-	// We changed ConsecutiveErrorsCount or UnschedulableCount plus Timestamp, and now the calculated backoff time should be different,
-	// removing the cached backoff time.
-	pgInfo.BackoffExpiration = time.Time{}
+
+	if !preserveTimestamp {
+		pgInfo.Timestamp = p.clock.Now()
+	}
+
 	// Clear the flush flag since the pod is returning to the queue after a scheduling attempt.
 	pgInfo.WasFlushedFromUnschedulable = false
 	pgInfo.FlushTimestamp = time.Time{}
@@ -1164,7 +1188,7 @@ func (p *PriorityQueue) AddAttemptedPodGroupIfNeeded(logger klog.Logger, pgInfo 
 	// Try to requeue this pod group to activeQ or backoffQ.
 	// If the PreEnqueue fails for this pod group, it will be moved to the unschedulableEntities.
 	queue := unschedulableQ
-	if p.backoffQ.isEntityBackingoff(pgInfo) {
+	if !requeueWithoutBackoff && p.backoffQ.isEntityBackingoff(pgInfo) {
 		if added := p.moveToBackoffQ(logger, pgInfo, framework.ScheduleAttemptFailure); added {
 			queue = backoffQ
 		}
@@ -1180,6 +1204,21 @@ func (p *PriorityQueue) AddAttemptedPodGroupIfNeeded(logger klog.Logger, pgInfo 
 	}
 
 	return nil
+}
+
+// hasIntersection returns true if any pod in sliceB is present in sliceA.
+func hasIntersection(sliceA, sliceB []*framework.QueuedPodInfo) bool {
+	uids := sets.New[types.UID]()
+	for _, pInfo := range sliceA {
+		uids.Insert(pInfo.Pod.UID)
+	}
+
+	for _, pInfo := range sliceB {
+		if uids.Has(pInfo.Pod.UID) {
+			return true
+		}
+	}
+	return false
 }
 
 // flushBackoffQCompleted Moves all pods from backoffQ which have completed backoff in to activeQ
@@ -1702,6 +1741,30 @@ func (p *PriorityQueue) GetPod(name, namespace string, schedulingGroup *v1.PodSc
 		pInfo = p.getPod(pod, unlockedActiveQ)
 	})
 	return pInfo, pInfo != nil
+}
+
+// GetPodGroup searches for a pod group in the activeQ, backoffQ, and unschedulableEntities.
+// This function is only used for testing.
+func (p *PriorityQueue) GetPodGroup(name, namespace string) (*framework.QueuedPodGroupInfo, bool) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	pgInfo := &framework.QueuedPodGroupInfo{
+		PodGroupInfo: &framework.PodGroupInfo{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	var foundPGInfo *framework.QueuedPodGroupInfo
+	p.activeQ.underRLock(func(unlockedActiveQ unlockedActiveQueueReader) {
+		entity := p.getEntityFromAnyQueue(unlockedActiveQ, pgInfo)
+		if entity != nil {
+			if pg, ok := entity.(*framework.QueuedPodGroupInfo); ok {
+				foundPGInfo = pg
+			}
+		}
+	})
+	return foundPGInfo, foundPGInfo != nil
 }
 
 func (p *PriorityQueue) getPod(podLookup *v1.Pod, unlockedActiveQ unlockedActiveQueueReader) *framework.QueuedPodInfo {

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -1075,7 +1075,7 @@ func Test_InFlightPods(t *testing.T) {
 							t.Fatalf("unexpected error from AddUnschedulablePodIfNotPresent: %v", err)
 						}
 					case action.podGroupAttempted != nil:
-						err := q.AddAttemptedPodGroupIfNeeded(logger, action.podGroupAttempted, q.SchedulingCycle())
+						err := q.AddAttemptedPodGroupIfNeeded(logger, action.podGroupAttempted, q.SchedulingCycle(), fwk.NewStatus(fwk.Error))
 						if err != nil {
 							t.Fatalf("unexpected error from AddAttemptedPodGroupIfNeeded: %v", err)
 						}
@@ -3728,6 +3728,7 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 		disableBackoff                  bool
 		blockOnPreEnqueue               bool
 		skipAddPodGroup                 bool
+		status                          *fwk.Status
 		expectedUnschedulableCount      int
 		expectedConsecutiveErrorsCount  int
 		expectedInActiveQ               bool
@@ -3735,6 +3736,7 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 		expectedInUnschedulableEntities bool
 		expectedInIncomplete            []*v1.Pod
 		expectedPodsInGroup             int
+		expectPreservedTimestamp        bool
 	}{
 		{
 			name: "No pending pods, pod group is not enqueued",
@@ -3744,53 +3746,43 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 			expectedPodsInGroup: 1,
 		},
 		{
-			name: "Pods present, no unschedulable plugins, pod group not backing off",
+			name: "Pods present, pod group scheduling had an error, and pod group not backing off",
 			setup: func(tCtx ktesting.TContext, q *PriorityQueue, pgInfo *framework.QueuedPodGroupInfo) {
 				pInfo1 := q.newQueuedPodInfo(tCtx, pod1)
 				pInfo2 := q.newQueuedPodInfo(tCtx, pod2)
 				q.pendingPodGroupPods.add(pInfo1)
 				q.pendingPodGroupPods.add(pInfo2)
 			},
+			status:                         fwk.NewStatus(fwk.Error),
 			disableBackoff:                 true,
 			expectedConsecutiveErrorsCount: 1,
 			expectedInActiveQ:              true,
 			expectedPodsInGroup:            2,
 		},
 		{
-			name: "Pods present, one with unschedulable plugins, pod group not backing off",
-			setup: func(tCtx ktesting.TContext, q *PriorityQueue, pgInfo *framework.QueuedPodGroupInfo) {
-				pInfo1 := q.newQueuedPodInfo(tCtx, pod1)
-				pInfo2 := q.newQueuedPodInfo(tCtx, pod2, "fakePlugin")
-				q.pendingPodGroupPods.add(pInfo1)
-				q.pendingPodGroupPods.add(pInfo2)
-			},
-			disableBackoff:                 true,
-			expectedConsecutiveErrorsCount: 1,
-			expectedInActiveQ:              true,
-			expectedPodsInGroup:            2,
-		},
-		{
-			name: "Pods present, with unschedulable plugins, pod group not backing off",
+			name: "Pods present, pod group scheduling result is unschedulable, and pod group not backing off",
 			setup: func(tCtx ktesting.TContext, q *PriorityQueue, pgInfo *framework.QueuedPodGroupInfo) {
 				pInfo1 := q.newQueuedPodInfo(tCtx, pod1, "fakePlugin")
-				pInfo2 := q.newQueuedPodInfo(tCtx, pod2, "fakePlugin")
+				pInfo2 := q.newQueuedPodInfo(tCtx, pod2)
 				q.pendingPodGroupPods.add(pInfo1)
 				q.pendingPodGroupPods.add(pInfo2)
 				pgInfo.ConsecutiveErrorsCount = 5 // Set to non-zero to verify reset
 			},
+			status:                     fwk.NewStatus(fwk.Unschedulable),
 			disableBackoff:             true,
 			expectedUnschedulableCount: 1,
 			expectedInActiveQ:          true,
 			expectedPodsInGroup:        2,
 		},
 		{
-			name: "Pods present, with unschedulable plugins, pod group not backing off, but blocked on PreEnqueue",
+			name: "Pods present, pod group scheduling result is unschedulable, and pod group not backing off, but blocked on PreEnqueue",
 			setup: func(tCtx ktesting.TContext, q *PriorityQueue, pgInfo *framework.QueuedPodGroupInfo) {
 				pInfo1 := q.newQueuedPodInfo(tCtx, pod1, "fakePlugin")
-				pInfo2 := q.newQueuedPodInfo(tCtx, pod2, "fakePlugin")
+				pInfo2 := q.newQueuedPodInfo(tCtx, pod2)
 				q.pendingPodGroupPods.add(pInfo1)
 				q.pendingPodGroupPods.add(pInfo2)
 			},
+			status:                          fwk.NewStatus(fwk.Unschedulable),
 			disableBackoff:                  true,
 			blockOnPreEnqueue:               true,
 			expectedUnschedulableCount:      1,
@@ -3798,50 +3790,41 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 			expectedPodsInGroup:             2,
 		},
 		{
-			name: "Pods present, no unschedulable plugins, pod group backing off",
+			name: "Pods present, pod group scheduling result is Error, and pod group backing off",
 			setup: func(tCtx ktesting.TContext, q *PriorityQueue, pgInfo *framework.QueuedPodGroupInfo) {
 				pInfo1 := q.newQueuedPodInfo(tCtx, pod1)
 				pInfo2 := q.newQueuedPodInfo(tCtx, pod2)
 				q.pendingPodGroupPods.add(pInfo1)
 				q.pendingPodGroupPods.add(pInfo2)
 			},
+			status:                         fwk.NewStatus(fwk.Error),
 			expectedConsecutiveErrorsCount: 1,
 			expectedInBackoffQ:             true,
 			expectedPodsInGroup:            2,
 		},
 		{
-			name: "Pods present, one with unschedulable plugin, pod group backing off",
-			setup: func(tCtx ktesting.TContext, q *PriorityQueue, pgInfo *framework.QueuedPodGroupInfo) {
-				pInfo1 := q.newQueuedPodInfo(tCtx, pod1)
-				pInfo2 := q.newQueuedPodInfo(tCtx, pod2, "fakePlugin")
-				q.pendingPodGroupPods.add(pInfo1)
-				q.pendingPodGroupPods.add(pInfo2)
-			},
-			expectedConsecutiveErrorsCount: 1,
-			expectedInBackoffQ:             true,
-			expectedPodsInGroup:            2,
-		},
-		{
-			name: "Pods present, with unschedulable plugins, pod group backing off",
+			name: "Pods present, pod group scheduling result is Unschedulable, and pod group backing off",
 			setup: func(tCtx ktesting.TContext, q *PriorityQueue, pgInfo *framework.QueuedPodGroupInfo) {
 				pInfo1 := q.newQueuedPodInfo(tCtx, pod1, "fakePlugin")
-				pInfo2 := q.newQueuedPodInfo(tCtx, pod2, "fakePlugin")
+				pInfo2 := q.newQueuedPodInfo(tCtx, pod2)
 				q.pendingPodGroupPods.add(pInfo1)
 				q.pendingPodGroupPods.add(pInfo2)
 				pgInfo.ConsecutiveErrorsCount = 5 // Set to non-zero to verify reset
 			},
+			status:                     fwk.NewStatus(fwk.Unschedulable),
 			expectedUnschedulableCount: 1,
 			expectedInBackoffQ:         true,
 			expectedPodsInGroup:        2,
 		},
 		{
-			name: "Pods present, with unschedulable plugins, pod group backing off, but blocked on PreEnqueue",
+			name: "Pods present, pod group scheduling result is Error, and pod group backing off, but blocked on PreEnqueue",
 			setup: func(tCtx ktesting.TContext, q *PriorityQueue, pgInfo *framework.QueuedPodGroupInfo) {
 				pInfo1 := q.newQueuedPodInfo(tCtx, pod1)
 				pInfo2 := q.newQueuedPodInfo(tCtx, pod2)
 				q.pendingPodGroupPods.add(pInfo1)
 				q.pendingPodGroupPods.add(pInfo2)
 			},
+			status:                          fwk.NewStatus(fwk.Error),
 			blockOnPreEnqueue:               true,
 			expectedConsecutiveErrorsCount:  1,
 			expectedInUnschedulableEntities: true,
@@ -3855,9 +3838,32 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 				q.pendingPodGroupPods.add(pInfo1)
 				q.pendingPodGroupPods.add(pInfo2)
 			},
+			status:               fwk.NewStatus(fwk.Error),
 			skipAddPodGroup:      true,
 			expectedInIncomplete: []*v1.Pod{pod1, pod2},
 			expectedPodsInGroup:  2,
+		},
+		{
+			name: "Unschedulable pods are present but pod group scheduling was successful, requeue to active queue directly and preserve timestamp",
+			setup: func(tCtx ktesting.TContext, q *PriorityQueue, pgInfo *framework.QueuedPodGroupInfo) {
+				pInfo1 := q.newQueuedPodInfo(tCtx, pod1, "fakePlugin")
+				pInfo2 := q.newQueuedPodInfo(tCtx, pod2)
+				q.pendingPodGroupPods.add(pInfo1)
+				q.pendingPodGroupPods.add(pInfo2)
+			},
+			expectedInActiveQ:        true,
+			expectedPodsInGroup:      2,
+			expectPreservedTimestamp: true,
+		},
+		{
+			name: "New pods only are present and pod group scheduling was successful, requeue to active queue directly with new timestamp",
+			setup: func(tCtx ktesting.TContext, q *PriorityQueue, pgInfo *framework.QueuedPodGroupInfo) {
+				pInfo2 := q.newQueuedPodInfo(tCtx, pod2)
+				q.pendingPodGroupPods.add(pInfo2)
+			},
+			expectedInActiveQ:        true,
+			expectedPodsInGroup:      1,
+			expectPreservedTimestamp: false,
 		},
 	}
 
@@ -3885,14 +3891,22 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 			}
 
 			pgInfo := q.newQueuedPodGroupInfo(q.newQueuedPodInfo(tCtx, pod1), podGroup)
+			oldTimestamp := pgInfo.Timestamp
 
 			test.setup(tCtx, q, pgInfo)
+			c.Step(time.Second)
 
-			err := q.AddAttemptedPodGroupIfNeeded(tCtx.Logger(), pgInfo, q.SchedulingCycle())
+			err := q.AddAttemptedPodGroupIfNeeded(tCtx.Logger(), pgInfo, q.SchedulingCycle(), test.status)
 			if err != nil {
 				tCtx.Fatalf("Unexpected error from AddAttemptedPodGroupIfNeeded: %v", err)
 			}
 
+			if test.expectPreservedTimestamp && !pgInfo.Timestamp.Equal(oldTimestamp) {
+				tCtx.Errorf("Expected timestamp to be preserved (%v), but got %v", oldTimestamp, pgInfo.Timestamp)
+			}
+			if !test.expectPreservedTimestamp && (test.expectedInActiveQ || test.expectedInBackoffQ || test.expectedInUnschedulableEntities) && pgInfo.Timestamp != c.Now() {
+				tCtx.Errorf("Expected timestamp to be %v, but got %v", c.Now(), pgInfo.Timestamp)
+			}
 			if pgInfo.UnschedulableCount != test.expectedUnschedulableCount {
 				tCtx.Errorf("Expected UnschedulableCount to be %v, got %v", test.expectedUnschedulableCount, pgInfo.UnschedulableCount)
 			}

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -110,7 +110,7 @@ func (sched *Scheduler) handlePodGroupFailureBeforeScheduling(ctx context.Contex
 			Message: err.Error(),
 		})
 	}
-	err = sched.SchedulingQueue.AddAttemptedPodGroupIfNeeded(logger, podGroupInfo, sched.SchedulingQueue.SchedulingCycle())
+	err = sched.SchedulingQueue.AddAttemptedPodGroupIfNeeded(logger, podGroupInfo, sched.SchedulingQueue.SchedulingCycle(), fwk.AsStatus(err))
 	if err != nil {
 		utilruntime.HandleErrorWithContext(ctx, err, "Failed to add pod group back to scheduling queue", "podGroup", klog.KObj(podGroupInfo))
 	}
@@ -598,7 +598,7 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 	}
 	sched.updatePodGroupCondition(ctx, podGroupInfo, condition)
 
-	err := sched.SchedulingQueue.AddAttemptedPodGroupIfNeeded(logger, podGroupInfo, sched.SchedulingQueue.SchedulingCycle())
+	err := sched.SchedulingQueue.AddAttemptedPodGroupIfNeeded(logger, podGroupInfo, sched.SchedulingQueue.SchedulingCycle(), podGroupResult.status)
 	if err != nil {
 		utilruntime.HandleErrorWithContext(ctx, err, "Failed to add attempted pod group to scheduling queue", "podGroup", klog.KObj(podGroupInfo))
 	}

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -1177,37 +1177,27 @@ func (p *orderedPlacementPlugin) GeneratePlacements(ctx context.Context, state f
 }
 
 func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
+
 	testNode := st.MakeNode().Name("node1").UID("node1").Obj()
 
-	p1 := st.MakePod().Name("p1").UID("p1").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
-	p2 := st.MakePod().Name("p2").UID("p2").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
-	p3 := st.MakePod().Name("p3").UID("p3").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
-
-	qInfo1 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p1}}
-	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
-	qInfo3 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p3}}
+	p1 := st.MakePod().Name("p1").Namespace("default").UID("p1").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
+	p2 := st.MakePod().Name("p2").Namespace("default").UID("p2").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
+	p3 := st.MakePod().Name("p3").Namespace("default").UID("p3").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
 
 	testPodGroup := &schedulingv1alpha3.PodGroup{
 		ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
 	}
 
-	podGroupInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: []*framework.QueuedPodInfo{qInfo1, qInfo2, qInfo3},
-		PodGroupInfo: &framework.PodGroupInfo{
-			Name:            "pg",
-			Namespace:       "default",
-			UnscheduledPods: []*v1.Pod{p1, p2, p3},
-		},
-	}
-
 	tests := []struct {
-		name             string
-		existingPodGroup *schedulingv1alpha3.PodGroup
-		algorithmResult  podGroupAlgorithmResult
-		expectBound      sets.Set[string]
-		expectPreempting sets.Set[string]
-		expectFailed     sets.Set[string]
-		expectCondition  *metav1.Condition
+		name                    string
+		existingPodGroup        *schedulingv1alpha3.PodGroup
+		algorithmResult         podGroupAlgorithmResult
+		expectBound             sets.Set[string]
+		expectPreempting        sets.Set[string]
+		expectFailed            sets.Set[string]
+		expectCondition         *metav1.Condition
+		expectPodsInActiveQueue sets.Set[string]
 	}{
 		{
 			name: "All pods feasible",
@@ -1276,6 +1266,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				Status: metav1.ConditionTrue,
 				Reason: "Scheduled",
 			},
+			expectPodsInActiveQueue: sets.New("p2"),
 		},
 		{
 			name: "All pods require preemption",
@@ -1385,7 +1376,6 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 					status:         fwk.NewStatus(fwk.Unschedulable),
 				}},
 			},
-			expectBound:  sets.New[string](),
 			expectFailed: sets.New("p1", "p2", "p3"),
 			expectCondition: &metav1.Condition{
 				Type:    schedulingapi.PodGroupInitiallyScheduled,
@@ -1409,7 +1399,6 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 					status:         fwk.NewStatus(fwk.Unschedulable),
 				}},
 			},
-			expectBound:  sets.New[string](),
 			expectFailed: sets.New("p1", "p2", "p3"),
 			expectCondition: &metav1.Condition{
 				Type:    schedulingapi.PodGroupInitiallyScheduled,
@@ -1433,7 +1422,6 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 					status:         fwk.NewStatus(fwk.Unschedulable),
 				}},
 			},
-			expectBound:  sets.New[string](),
 			expectFailed: sets.New("p1", "p2", "p3"),
 			expectCondition: &metav1.Condition{
 				Type:    schedulingapi.PodGroupInitiallyScheduled,
@@ -1457,7 +1445,6 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 					status:         fwk.NewStatus(fwk.Error, "plugin returned error"),
 				}},
 			},
-			expectBound:  sets.New[string](),
 			expectFailed: sets.New("p1", "p2", "p3"),
 			expectCondition: &metav1.Condition{
 				Type:    schedulingapi.PodGroupInitiallyScheduled,
@@ -1485,7 +1472,6 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 					status:         fwk.NewStatus(fwk.Error, "internal failure"),
 				}},
 			},
-			expectBound:  sets.New[string](),
 			expectFailed: sets.New("p1", "p2", "p3"),
 			expectCondition: &metav1.Condition{
 				Type:    schedulingapi.PodGroupInitiallyScheduled,
@@ -1590,7 +1576,6 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 					status:         fwk.NewStatus(fwk.Error),
 				}},
 			},
-			expectBound:  sets.New[string](),
 			expectFailed: sets.New("p1", "p2", "p3"),
 			expectCondition: &metav1.Condition{
 				Type:    schedulingapi.PodGroupInitiallyScheduled,
@@ -1608,7 +1593,6 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 					status:         nil,
 				}},
 			},
-			expectBound:  sets.New[string](),
 			expectFailed: sets.New("p1", "p2", "p3"),
 			expectCondition: &metav1.Condition{
 				Type:    schedulingapi.PodGroupInitiallyScheduled,
@@ -1621,7 +1605,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
+			logger, ctx := ktesting.NewTestContext(t)
 
 			var lock sync.Mutex
 			boundPods := sets.New[string]()
@@ -1632,7 +1616,6 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			if tt.existingPodGroup != nil {
 				pg = tt.existingPodGroup
 			}
-			podGroupInfo.PodGroupInfo.PodGroup = pg
 			client := clientsetfake.NewClientset(testNode, pg)
 			client.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
 				if action.GetSubresource() != "binding" {
@@ -1673,17 +1656,18 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			}
 
 			cache := internalcache.New(ctx, nil, true)
-			cache.AddNode(klog.FromContext(ctx), testNode)
+			cache.AddNode(logger, testNode)
 
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			informerFactory.Start(ctx.Done())
 			informerFactory.WaitForCacheSync(ctx.Done())
 
+			schedulingQueue := internalqueue.NewTestQueue(ctx, schedFwk.QueueSortFunc())
 			sched := &Scheduler{
 				client:          client,
 				Cache:           cache,
 				Profiles:        profile.Map{"test-scheduler": schedFwk},
-				SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
+				SchedulingQueue: schedulingQueue,
 				FailureHandler: func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
 					lock.Lock()
 					if ni != nil && ni.NominatedNodeName != "" {
@@ -1692,8 +1676,24 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 						failedPods.Insert(p.Pod.Name)
 					}
 					lock.Unlock()
+					if err := schedulingQueue.AddUnschedulablePodIfNotPresent(logger, p, schedulingQueue.SchedulingCycle()); err != nil {
+						t.Fatalf("Unexpected error when adding an unschedulable pod %q to queue: %v", p.Pod.Name, err)
+					}
 				},
 			}
+
+			// Create the pod group and add the pods to queue and pop the group to set up internal queue state correctly.
+			schedulingQueue.AddPodGroup(logger, pg)
+			schedulingQueue.Add(ctx, p1)
+			schedulingQueue.Add(ctx, p2)
+			schedulingQueue.Add(ctx, p3)
+			entity, err := schedulingQueue.Pop(logger)
+			if err != nil {
+				t.Fatalf("Failed to pop pod group: %v", err)
+			}
+			podGroupInfo := entity.(*framework.QueuedPodGroupInfo)
+			podGroupInfo.PodGroup = pg
+			oldTimestamp := podGroupInfo.Timestamp
 
 			podGroupCycleState := framework.NewCycleState()
 
@@ -1705,12 +1705,13 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				tt.algorithmResult.podResults[i].podCtx = podCtx
 			}
 
+			podGroupPodCount := len(podGroupInfo.QueuedPodInfos)
 			sched.submitPodGroupAlgorithmResult(ctx, schedFwk, podGroupCycleState, podGroupInfo, tt.algorithmResult, time.Now())
 
 			if err := wait.PollUntilContextTimeout(ctx, time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 				lock.Lock()
 				defer lock.Unlock()
-				return len(boundPods)+len(preemptingPods)+len(failedPods) == len(podGroupInfo.QueuedPodInfos), nil
+				return len(boundPods)+len(preemptingPods)+len(failedPods) == podGroupPodCount, nil
 			}); err != nil {
 				t.Errorf("Failed waiting for all pods to be either bound or failed")
 			}
@@ -1723,6 +1724,25 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			}
 			if !tt.expectFailed.Equal(failedPods) {
 				t.Errorf("Expected failed pods: %v, but got: %v", tt.expectFailed, failedPods)
+			}
+
+			activePods := sched.SchedulingQueue.PodsInActiveQ()
+			activePodNames := sets.New[string]()
+			for _, pod := range activePods {
+				activePodNames.Insert(pod.Name)
+			}
+			if diff := cmp.Diff(tt.expectPodsInActiveQueue, activePodNames, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Unexpected pods in active queue (-want, +got):\n%s", diff)
+			}
+
+			// If there were any remaining pods of the podgroup requeued into the active queue, they must preserve their timestamp.
+			if tt.expectPodsInActiveQueue.Len() > 0 {
+				queuedPGInfo, ok := sched.SchedulingQueue.GetPodGroup("pg", "default")
+				if !ok {
+					t.Errorf("Expected pod group pg to be requeued, but it was not found in the scheduling queue")
+				} else if !queuedPGInfo.Timestamp.Equal(oldTimestamp) {
+					t.Errorf("Expected timestamp to be preserved exactly for pod group. Original: %v, Requeued: %v", oldTimestamp, queuedPGInfo.Timestamp)
+				}
 			}
 
 			updatedPodGroup, err := client.SchedulingV1alpha3().PodGroups("default").Get(ctx, "pg", metav1.GetOptions{})

--- a/test/integration/scheduler/podgroup/queueing/queueing_test.go
+++ b/test/integration/scheduler/podgroup/queueing/queueing_test.go
@@ -74,7 +74,7 @@ func (p *podInjectorPlugin) PreFilter(ctx context.Context, state fwk.CycleState,
 		}
 		err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 10*time.Second, false, func(ctx context.Context) (bool, error) {
 			for _, p := range p.schedulingQueue.PendingPodGroupPods() {
-				if p.Name == pod.Name {
+				if p.Name == p3.Name {
 					return true, nil
 				}
 			}
@@ -995,6 +995,260 @@ func TestPodGroupSequentialQueueing(t *testing.T) {
 				{
 					Name:        "Create initial node",
 					CreateNodes: []*v1.Node{node},
+				},
+			}, tt.steps...)
+
+			if err := stepsframework.RunSteps(testCtx, t, ns, steps); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestPodGroupRequeueRemainingOnSchedulingSuccess(t *testing.T) {
+	type podInjector struct {
+		watchPod    string
+		podToInject *v1.Pod
+	}
+
+	node1 := st.MakeNode().Name("node").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Obj()
+	node2 := st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Obj()
+	node3 := st.MakeNode().Name("node3").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Obj()
+
+	pg := st.MakePodGroup().Name("pg").BasicPolicy().Obj()
+	pgP1 := st.MakePod().Name("pg-p1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").Priority(0).PodGroupName("pg").Obj()
+	pgP2 := st.MakePod().Name("pg-p2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").Priority(0).PodGroupName("pg").Obj()
+	pgP3 := st.MakePod().Name("pg-p3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").Priority(0).PodGroupName("pg").Obj()
+
+	highPriorityPod := st.MakePod().Name("high-priority-pod").Req(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Container("image").Priority(1000).Obj()
+	normalPriorityPod := st.MakePod().Name("normal-priority-pod").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").Priority(0).Obj()
+
+	tests := []struct {
+		name        string
+		podInjector *podInjector
+		steps       []stepsframework.Step
+	}{
+		{
+			name: "After successfully scheduling a podgroup and requeuing a remaining unscheduled pod, the next scheduling attempt prioritizes the higher priority pod",
+			steps: []stepsframework.Step{
+				{
+					Name:           "Create PodGroup pg",
+					CreatePodGroup: pg,
+				},
+				{
+					Name:       "Create member pods pg-p1, pg-p2 and pg-p3",
+					CreatePods: []*v1.Pod{pgP1, pgP2, pgP3},
+				},
+				{
+					Name:                 "Verify member pods are in active queue",
+					WaitForPodsInActiveQ: []string{"pg-p1", "pg-p2", "pg-p3"},
+				},
+				{
+					Name:           "Run scheduling attempt",
+					RunScheduleOne: true,
+				},
+				{
+					Name:                 "Verify pg-p1 and pg-p2 are scheduled",
+					WaitForPodsScheduled: []string{"pg-p1", "pg-p2"},
+				},
+				{
+					Name:                     "Verify pg-p3 is unschedulable",
+					WaitForPodsUnschedulable: []string{"pg-p3"},
+				},
+				{
+					Name:                 "Verify pg-p3 is back in active queue",
+					WaitForPodsInActiveQ: []string{"pg-p3"},
+				},
+				{
+					Name:       "Create individual pod with higher priority",
+					CreatePods: []*v1.Pod{highPriorityPod},
+				},
+				{
+					Name:                 "Verify high priority pod is in active queue",
+					WaitForPodsInActiveQ: []string{"high-priority-pod"},
+				},
+				{
+					Name:        "Add node2 to expand capacity",
+					CreateNodes: []*v1.Node{node2},
+				},
+				{
+					Name:           "Run scheduling attempt",
+					RunScheduleOne: true,
+				},
+				{
+					Name:                 "Verify high priority pod is scheduled",
+					WaitForPodsScheduled: []string{"high-priority-pod"},
+				},
+				{
+					Name:                 "Verify pg-p3 is still in active queue",
+					WaitForPodsInActiveQ: []string{"pg-p3"},
+				},
+			},
+		},
+		{
+			name: "After successfully scheduling a podgroup and requeuing a remaining unscheduled pod, the next scheduling attempt prioritizes the old pod if priorities are equal",
+			steps: []stepsframework.Step{
+				{
+					Name:           "Create PodGroup pg",
+					CreatePodGroup: pg,
+				},
+				{
+					Name:       "Create member pods pg-p1, pg-p2 and pg-p3",
+					CreatePods: []*v1.Pod{pgP1, pgP2, pgP3},
+				},
+				{
+					Name:                 "Verify member pods are in active queue",
+					WaitForPodsInActiveQ: []string{"pg-p1", "pg-p2", "pg-p3"},
+				},
+				{
+					Name:       "Create an individual pod with the same priority",
+					CreatePods: []*v1.Pod{normalPriorityPod},
+				},
+				{
+					Name:                 "Verify normal-priority-pod is in active queue",
+					WaitForPodsInActiveQ: []string{"normal-priority-pod"},
+				},
+				{
+					Name:           "Run scheduling attempt",
+					RunScheduleOne: true,
+				},
+				{
+					Name:                 "Verify pg-p1 and pg-p2 are scheduled",
+					WaitForPodsScheduled: []string{"pg-p1", "pg-p2"},
+				},
+				{
+					Name:                     "Verify pg-p3 is unschedulable",
+					WaitForPodsUnschedulable: []string{"pg-p3"},
+				},
+				{
+					Name:                 "Verify pg-p3 is back in active queue with preserved older timestamp",
+					WaitForPodsInActiveQ: []string{"pg-p3"},
+				},
+				{
+					Name:        "Add node3 to expand capacity",
+					CreateNodes: []*v1.Node{node3},
+				},
+				{
+					Name:           "Run scheduling attempt",
+					RunScheduleOne: true,
+				},
+				{
+					Name:                 "Verify pg-p3 is scheduled",
+					WaitForPodsScheduled: []string{"pg-p3"},
+				},
+				{
+					Name:           "Run scheduling attempt",
+					RunScheduleOne: true,
+				},
+				{
+					Name:                     "Verify normal-priority-pod remains unschedulable",
+					WaitForPodsUnschedulable: []string{"normal-priority-pod"},
+				},
+			},
+		},
+		{
+			name: "After successfully scheduling a podgroup with a new pending pod added mid-cycle, an older individual pod in queue is prioritized if priorities are equal",
+			podInjector: &podInjector{
+				watchPod:    "pg-p1",
+				podToInject: pgP3,
+			},
+			steps: []stepsframework.Step{
+				{
+					Name:           "Create PodGroup pg",
+					CreatePodGroup: pg,
+				},
+				{
+					Name:       "Create member pods pg-p1 and pg-p2",
+					CreatePods: []*v1.Pod{pgP1, pgP2},
+				},
+				{
+					Name:                 "Verify member pods are in active queue",
+					WaitForPodsInActiveQ: []string{"pg-p1", "pg-p2"},
+				},
+				{
+					Name:       "Create an individual pod with the same priority",
+					CreatePods: []*v1.Pod{normalPriorityPod},
+				},
+				{
+					Name:                 "Verify normal-priority-pod is in active queue",
+					WaitForPodsInActiveQ: []string{"normal-priority-pod"},
+				},
+				{
+					Name:           "Run scheduling attempt for podgroup (injects pg-p3 mid-cycle)",
+					RunScheduleOne: true,
+				},
+				{
+					Name:                 "Verify pg-p1 and pg-p2 are scheduled",
+					WaitForPodsScheduled: []string{"pg-p1", "pg-p2"},
+				},
+				{
+					Name:                 "Verify pg-p3 is in active queue with new timestamp",
+					WaitForPodsInActiveQ: []string{"pg-p3"},
+				},
+				{
+					Name:        "Add node3 to expand capacity",
+					CreateNodes: []*v1.Node{node3},
+				},
+				{
+					Name:           "Run scheduling attempt",
+					RunScheduleOne: true,
+				},
+				{
+					Name:                 "Verify normal-priority-pod is scheduled before pg-p3 due to older timestamp",
+					WaitForPodsScheduled: []string{"normal-priority-pod"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
+			var piPlugin *podInjectorPlugin
+			var opts []scheduler.Option
+			if tt.podInjector != nil {
+				registry := frameworkruntime.Registry{
+					"PodInjectorPlugin": func(ctx context.Context, obj runtime.Object, handle fwk.Handle) (fwk.Plugin, error) {
+						piPlugin = newPodInjectorPlugin(handle, tt.podInjector.watchPod, tt.podInjector.podToInject)
+						return piPlugin, nil
+					},
+				}
+				plugins := configv1.Plugins{
+					PreFilter: configv1.PluginSet{
+						Enabled: []configv1.Plugin{{Name: "PodInjectorPlugin"}},
+					},
+				}
+				cfg := configtesting.V1ToInternalWithDefaults(t, configv1.KubeSchedulerConfiguration{
+					Profiles: []configv1.KubeSchedulerProfile{{
+						SchedulerName: ptr.To(v1.DefaultSchedulerName),
+						Plugins:       &plugins,
+					}},
+				})
+				opts = append(opts,
+					scheduler.WithFrameworkOutOfTreeRegistry(registry),
+					scheduler.WithProfiles(cfg.Profiles...),
+				)
+			}
+			opts = append(opts,
+				scheduler.WithPodInitialBackoffSeconds(10),
+				scheduler.WithPodMaxBackoffSeconds(20),
+			)
+			testCtx := testutils.InitTestSchedulerWithOptions(
+				t,
+				testutils.InitTestAPIServer(t, "podgroup-ordering", nil),
+				0,
+				opts...,
+			)
+			if piPlugin != nil {
+				piPlugin.schedulingQueue = testCtx.Scheduler.SchedulingQueue
+			}
+			testutils.SyncSchedulerInformerFactory(testCtx)
+			ns := testCtx.NS.Name
+
+			steps := append([]stepsframework.Step{
+				{
+					Name:        "Create initial node",
+					CreateNodes: []*v1.Node{node1},
 				},
 			}, tt.steps...)
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
/sig-scheduling

#### What this PR does / why we need it:

When a podgroup is successfully scheduled, we want to requeue the remaining unscheduled pods of such a podgroup directly into active queue using their old timestamp, this will attempt scheduling and preemption immediately in the next scheduling cycle, unless a higher priority pod or podgroup comes in between.

KEP context:
https://github.com/kubernetes/enhancements/blob/15ecef0909db27c649cdc3dc4d4e927354108dd1/keps/sig-scheduling/4671-gang-scheduling/README.md?plain=1#L1197-L1207

#### Which issue(s) this PR is related to:
N/A

#### Does this PR introduce a user-facing change?
```release-note
After successful scheduling of a podgroup, its remaining unscheduled pods are requeued directly to active queue rather than backoff queue. These pods preserve their old timestamp so they have precedence in scheduling unless a higher priority entity comes in between.
```