### PR TITLE
Avoid per-item output copy in JSON streaming list encoder

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections.go
@@ -17,6 +17,7 @@ limitations under the License.
 package json
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -35,14 +36,14 @@ import (
 func streamEncodeCollections(obj runtime.Object, w io.Writer) (bool, error) {
 	list, ok := obj.(*unstructured.UnstructuredList)
 	if ok {
-		return true, streamingEncodeUnstructuredList(w, list)
+		return true, newStreamEncoder(w).encodeUnstructuredList(list)
 	}
 	if _, ok := obj.(json.Marshaler); ok {
 		return false, nil
 	}
 	typeMeta, listMeta, items, err := getListMeta(obj)
 	if err == nil {
-		return true, streamingEncodeList(w, typeMeta, listMeta, items)
+		return true, newStreamEncoder(w).encodeList(typeMeta, listMeta, items)
 	}
 	return false, nil
 }
@@ -94,45 +95,59 @@ func getListMeta(list runtime.Object) (metav1.TypeMeta, metav1.ListMeta, []runti
 	return typeMeta, listMeta, items, nil
 }
 
-func streamingEncodeList(w io.Writer, typeMeta metav1.TypeMeta, listMeta metav1.ListMeta, items []runtime.Object) error {
+// streamEncoder encodes JSON values to w, reusing an internal buffer across
+// values to avoid the fresh output allocation json.Marshal makes per call.
+type streamEncoder struct {
+	w    io.Writer
+	buf  bytes.Buffer
+	json *json.Encoder
+}
+
+func newStreamEncoder(w io.Writer) *streamEncoder {
+	e := &streamEncoder{w: w}
+	e.json = json.NewEncoder(&e.buf)
+	return e
+}
+
+func (e *streamEncoder) encodeList(typeMeta metav1.TypeMeta, listMeta metav1.ListMeta, items []runtime.Object) error {
 	// Start
-	if _, err := w.Write([]byte(`{`)); err != nil {
+	if _, err := e.w.Write([]byte(`{`)); err != nil {
 		return err
 	}
 
 	// TypeMeta
 	if typeMeta.Kind != "" {
-		if err := encodeKeyValuePair(w, "kind", typeMeta.Kind, []byte(",")); err != nil {
+		if err := e.encodeKeyValuePair("kind", typeMeta.Kind, []byte(",")); err != nil {
 			return err
 		}
 	}
 	if typeMeta.APIVersion != "" {
-		if err := encodeKeyValuePair(w, "apiVersion", typeMeta.APIVersion, []byte(",")); err != nil {
+		if err := e.encodeKeyValuePair("apiVersion", typeMeta.APIVersion, []byte(",")); err != nil {
 			return err
 		}
 	}
 
 	// ListMeta
-	if err := encodeKeyValuePair(w, "metadata", listMeta, []byte(",")); err != nil {
+	if err := e.encodeKeyValuePair("metadata", listMeta, []byte(",")); err != nil {
 		return err
 	}
 
 	// Items
-	if err := encodeItemsObjectSlice(w, items); err != nil {
+	if err := e.encodeItemsObjectSlice(items); err != nil {
 		return err
 	}
 
 	// End
-	_, err := w.Write([]byte("}\n"))
+	_, err := e.w.Write([]byte("}\n"))
 	return err
 }
 
-func encodeItemsObjectSlice(w io.Writer, items []runtime.Object) (err error) {
+func (e *streamEncoder) encodeItemsObjectSlice(items []runtime.Object) (err error) {
 	if items == nil {
-		err := encodeKeyValuePair(w, "items", nil, nil)
+		err := e.encodeKeyValuePair("items", nil, nil)
 		return err
 	}
-	_, err = w.Write([]byte(`"items":[`))
+	_, err = e.w.Write([]byte(`"items":[`))
 	if err != nil {
 		return err
 	}
@@ -141,20 +156,20 @@ func encodeItemsObjectSlice(w io.Writer, items []runtime.Object) (err error) {
 		if i == len(items)-1 {
 			suffix = nil
 		}
-		err := encodeValue(w, item, suffix)
+		err := e.encodeValue(item, suffix)
 		if err != nil {
 			return err
 		}
 	}
-	_, err = w.Write([]byte("]"))
+	_, err = e.w.Write([]byte("]"))
 	if err != nil {
 		return err
 	}
 	return err
 }
 
-func streamingEncodeUnstructuredList(w io.Writer, list *unstructured.UnstructuredList) error {
-	_, err := w.Write([]byte(`{`))
+func (e *streamEncoder) encodeUnstructuredList(list *unstructured.UnstructuredList) error {
+	_, err := e.w.Write([]byte(`{`))
 	if err != nil {
 		return err
 	}
@@ -170,20 +185,20 @@ func streamingEncodeUnstructuredList(w io.Writer, list *unstructured.Unstructure
 			suffix = nil
 		}
 		if key == "items" {
-			err = encodeItemsUnstructuredSlice(w, list.Items, suffix)
+			err = e.encodeItemsUnstructuredSlice(list.Items, suffix)
 		} else {
-			err = encodeKeyValuePair(w, key, list.Object[key], suffix)
+			err = e.encodeKeyValuePair(key, list.Object[key], suffix)
 		}
 		if err != nil {
 			return err
 		}
 	}
-	_, err = w.Write([]byte("}\n"))
+	_, err = e.w.Write([]byte("}\n"))
 	return err
 }
 
-func encodeItemsUnstructuredSlice(w io.Writer, items []unstructured.Unstructured, suffix []byte) (err error) {
-	_, err = w.Write([]byte(`"items":[`))
+func (e *streamEncoder) encodeItemsUnstructuredSlice(items []unstructured.Unstructured, suffix []byte) (err error) {
+	_, err = e.w.Write([]byte(`"items":[`))
 	if err != nil {
 		return err
 	}
@@ -192,44 +207,42 @@ func encodeItemsUnstructuredSlice(w io.Writer, items []unstructured.Unstructured
 		if i == len(items)-1 {
 			comma = nil
 		}
-		err := encodeValue(w, item.Object, comma)
+		err := e.encodeValue(item.Object, comma)
 		if err != nil {
 			return err
 		}
 	}
-	_, err = w.Write([]byte("]"))
+	_, err = e.w.Write([]byte("]"))
 	if err != nil {
 		return err
 	}
 	if len(suffix) > 0 {
-		_, err = w.Write(suffix)
+		_, err = e.w.Write(suffix)
 	}
 	return err
 }
 
-func encodeKeyValuePair(w io.Writer, key string, value any, suffix []byte) (err error) {
-	err = encodeValue(w, key, []byte(":"))
+func (e *streamEncoder) encodeKeyValuePair(key string, value any, suffix []byte) (err error) {
+	err = e.encodeValue(key, []byte(":"))
 	if err != nil {
 		return err
 	}
-	err = encodeValue(w, value, suffix)
+	err = e.encodeValue(value, suffix)
 	if err != nil {
 		return err
 	}
 	return err
 }
 
-func encodeValue(w io.Writer, value any, suffix []byte) error {
-	data, err := json.Marshal(value)
-	if err != nil {
+func (e *streamEncoder) encodeValue(value any, suffix []byte) error {
+	e.buf.Reset()
+	if err := e.json.Encode(value); err != nil {
 		return err
 	}
-	_, err = w.Write(data)
-	if err != nil {
-		return err
-	}
-	if len(suffix) > 0 {
-		_, err = w.Write(suffix)
-	}
+	// Encode appends a newline after the value; replace it with the suffix to
+	// keep the output identical to json.Marshal's.
+	e.buf.Truncate(e.buf.Len() - 1)
+	e.buf.Write(suffix)
+	_, err := e.w.Write(e.buf.Bytes())
 	return err
 }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/collections_test.go
@@ -756,7 +756,7 @@ func TestFuzzCollectionsEncoding(t *testing.T) {
 	normalSerializer := NewSerializerWithOptions(DefaultMetaFactory, nil, nil, SerializerOptions{StreamingCollectionsEncoding: false})
 	normalBuffer := &bytes.Buffer{}
 	t.Run("CarpList", func(t *testing.T) {
-		for i := 0; i < 1000; i++ {
+		for range 1000 {
 			list := &testapigroupv1.CarpList{}
 			f.Fill(list)
 			streamingBuffer.Reset()
@@ -779,7 +779,7 @@ func TestFuzzCollectionsEncoding(t *testing.T) {
 		}
 	})
 	t.Run("UnstructuredList", func(t *testing.T) {
-		for i := 0; i < 1000; i++ {
+		for range 1000 {
 			list := &unstructured.UnstructuredList{}
 			f.Fill(list)
 			streamingBuffer.Reset()
@@ -798,6 +798,70 @@ func TestFuzzCollectionsEncoding(t *testing.T) {
 				t.Logf("normal: %s", normalBuffer.String())
 				t.Logf("streaming: %s", streamingBuffer.String())
 				t.Errorf("not matching:\n%s", diff)
+			}
+		}
+	})
+}
+
+func BenchmarkStreamEncodeCollections(b *testing.B) {
+	disableFuzzFieldsV1 := func(field *metav1.FieldsV1, c randfill.Continue) {}
+	fuzzMap := func(kvs map[string]interface{}, c randfill.Continue) {
+		kvs[c.String(0)] = c.Bool()
+		kvs[c.String(0)] = c.Uint64()
+		kvs[c.String(0)] = c.String(0)
+	}
+	f := randfill.New().Funcs(disableFuzzFieldsV1, fuzzMap)
+	carpList := &testapigroupv1.CarpList{}
+	carpList.Items = make([]testapigroupv1.Carp, 1000)
+	for i := range 1000 {
+		f.Fill(&carpList.Items[i])
+	}
+	carpList.Kind = "CarpList"
+	carpList.APIVersion = "testapigroup.k8s.io/v1"
+	carpList.ResourceVersion = "12345"
+	unstructuredList := &unstructured.UnstructuredList{}
+	unstructuredList.Object = map[string]interface{}{
+		"kind":       "List",
+		"apiVersion": "v1",
+		"metadata": map[string]interface{}{
+			"resourceVersion": "12345",
+		},
+	}
+	unstructuredList.Items = make([]unstructured.Unstructured, 1000)
+	for i := range 1000 {
+		unstrMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&carpList.Items[i])
+		if err != nil {
+			b.Fatalf("failed to convert carp to unstructured: %v", err)
+		}
+		unstructuredList.Items[i] = unstructured.Unstructured{Object: unstrMap}
+	}
+	b.Run("CarpList", func(b *testing.B) {
+		var buf bytes.Buffer
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			ok, err := streamEncodeCollections(carpList, &buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if !ok {
+				b.Fatal("not ok")
+			}
+		}
+	})
+	b.Run("UnstructuredList", func(b *testing.B) {
+		var buf bytes.Buffer
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			ok, err := streamEncodeCollections(unstructuredList, &buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if !ok {
+				b.Fatal("not ok")
 			}
 		}
 	})

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
@@ -926,3 +926,49 @@ func (b *writeCounter) Write(data []byte) (int, error) {
 	b.writeCount++
 	return b.Writer.Write(data)
 }
+
+func BenchmarkJSONStreaming(b *testing.B) {
+	scheme := runtime.NewScheme()
+	if err := v1.AddToScheme(scheme); err != nil {
+		b.Fatalf("failed to add v1 to scheme: %v", err)
+	}
+	typer := scheme
+	creater := scheme
+	serializerStreaming := jsonserializer.NewSerializerWithOptions(
+		jsonserializer.DefaultMetaFactory,
+		creater,
+		typer,
+		jsonserializer.SerializerOptions{StreamingCollectionsEncoding: true},
+	)
+	serializerNonStreaming := jsonserializer.NewSerializerWithOptions(
+		jsonserializer.DefaultMetaFactory,
+		creater,
+		typer,
+		jsonserializer.SerializerOptions{StreamingCollectionsEncoding: false},
+	)
+	podList := benchmarkItems(b, "testdata/exemplar_pod.yaml", 1000)
+	b.Run("Streaming", func(b *testing.B) {
+		var buf bytes.Buffer
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			err := serializerStreaming.Encode(podList, &buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("NonStreaming", func(b *testing.B) {
+		var buf bytes.Buffer
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			err := serializerNonStreaming.Encode(podList, &buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Reduce memory allocated when serving custom resource streaming list requests.

This fix is for all JSON streaming, but custom resources only support JSON so are the most directly impacted.

The streaming JSON collections encoder called `json.Marshal` for every list item (and every key/value pair). Marshal copies its internal buffer into a fresh exact-size []byte on each call, so encoding a streamed LIST response allocated garbage roughly equal to the entire response body, plus one allocation per item.

# Benchmarks

## Custom resources

```
goos: linux
goarch: amd64
pkg: k8s.io/apimachinery/pkg/runtime/serializer/json
cpu: AMD EPYC 7B12
                                           │ baseline_10.txt │             pr_10.txt             │
                                           │     sec/op      │     sec/op       vs base          │
StreamEncodeCollections/CarpList-8               33.04m ± 2%   31.37m ± 2%  -5.05% (p=0.000 n=10)
StreamEncodeCollections/UnstructuredList-8       60.98m ± 1%   59.22m ± 1%  -2.89% (p=0.002 n=10)
geomean                                          44.89m        43.10m       -3.98%

                                           │ baseline_10.txt │             pr_10.txt             │
                                           │      B/op       │      B/op        vs base          │
StreamEncodeCollections/CarpList-8              6.549Mi ± 1%   1.697Mi ± 2%  -74.08% (p=0.000 n=10)
StreamEncodeCollections/UnstructuredList-8      15.48Mi ± 0%   10.64Mi ± 0%  -31.25% (p=0.000 n=10)
geomean                                         10.07Mi        4.250Mi       -57.79%

                                           │ baseline_10.txt │             pr_10.txt             │
                                           │    allocs/op    │    allocs/op     vs base          │
StreamEncodeCollections/CarpList-8               43.88k ± 0%   43.21k ± 0%  -1.51% (p=0.000 n=10)
StreamEncodeCollections/UnstructuredList-8       308.2k ± 0%   309.7k ± 0%  +0.48% (p=0.000 n=10)
geomean                                          116.3k        115.7k       -0.52%
```

## Realistic pod

```
goos: linux
goarch: amd64
pkg: k8s.io/apiserver/pkg/endpoints/handlers/responsewriters
cpu: AMD EPYC 7B12
                             │ baseline_pod_10.txt │             pr_pod_10.txt             │
                             │       sec/op        │     sec/op       vs base              │
JSONStreaming/Streaming-8              91.40m ± 1%   86.52m ± 2%  -5.34% (p=0.000 n=10)
JSONStreaming/NonStreaming-8           87.95m ± 2%   85.23m ± 2%  -3.09% (p=0.009 n=10)
geomean                                89.66m        85.87m       -4.22%
                             │ baseline_pod_10.txt │             pr_pod_10.txt             │
                             │        B/op         │      B/op        vs base              │
JSONStreaming/Streaming-8             21.137Mi ± 0%   5.527Mi ±  0%  -73.85% (p=0.000 n=10)
JSONStreaming/NonStreaming-8           7.989Mi ± 5%   7.592Mi ± 47%        ~ (p=0.303 n=10)
geomean                                13.00Mi        6.478Mi        -50.15%
                             │ baseline_pod_10.txt │             pr_pod_10.txt             │
                             │      allocs/op      │    allocs/op     vs base              │
JSONStreaming/Streaming-8              94.02k ± 0%   93.02k ± 0%  -1.07% (p=0.000 n=10)
JSONStreaming/NonStreaming-8           93.00k ± 0%   93.00k ± 0%       ~ (p=0.628 n=10)
geomean                                93.51k        93.01k       -0.54%
```

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

