### PR TITLE
Clear stale event slots in watchCache.Replace to reduce peak memory use

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -756,6 +756,9 @@ func (w *watchCache) Replace(objs []interface{}, resourceVersion string) error {
 	// Empty the cyclic buffer, ensuring startIndex doesn't decrease.
 	w.startIndex = w.endIndex
 	w.removedEventSinceRelist = false
+	// Clear out the stale cache so it don't hold old objects
+	// in memory until overwritten.
+	clear(w.cache)
 
 	if err := w.store.Replace(toReplace, resourceVersion); err != nil {
 		return err


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This reduces peak memory during relist operations.

`Replace()` resets `startIndex`/`endIndex` to empty the ring buffer, but ignores `*watchCacheEvent`.
Each stale slot holds a stale object version (plus its label and field sets) until it eventually gets overwritten.

In the worst case a full buffer retains `~capacity * object-size` stale objects. E.g. for 100k pods, this could  be as much as 1GB.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
