### PR TITLE
apiserver: exercise ConcurrentWatchObjectDecode on/off in BenchmarkCacherInit

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_init_bench_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_init_bench_test.go
@@ -65,26 +65,30 @@ func BenchmarkCacherInit(b *testing.B) {
 	}
 
 	for _, rangeStream := range []bool{false, true} {
-		b.Run(fmt.Sprintf("RangeStream=%v", rangeStream), func(b *testing.B) {
-			featuregatetesting.SetFeatureGateDuringTest(b, utilfeature.DefaultFeatureGate, features.EtcdRangeStream, rangeStream)
+		for _, concurrentDecode := range []bool{false, true} {
+			name := fmt.Sprintf("RangeStream=%v/ConcurrentDecode=%v", rangeStream, concurrentDecode)
+			b.Run(name, func(b *testing.B) {
+				featuregatetesting.SetFeatureGateDuringTest(b, utilfeature.DefaultFeatureGate, features.EtcdRangeStream, rangeStream)
+				featuregatetesting.SetFeatureGateDuringTest(b, utilfeature.DefaultFeatureGate, features.ConcurrentWatchObjectDecode, concurrentDecode)
 
-			b.ResetTimer()
-			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
-				cacher, err := NewCacherFromConfig(config)
-				if err != nil {
-					b.Fatal(err)
+				b.ResetTimer()
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					cacher, err := NewCacherFromConfig(config)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if err := cacher.Wait(ctx); err != nil {
+						b.Fatal(err)
+					}
+					b.StopTimer()
+					cacher.Stop()
+					etcd3.TestOnlyResetResourceSizeEstimator(etcdStorage)
+					b.StartTimer()
 				}
-				if err := cacher.Wait(ctx); err != nil {
-					b.Fatal(err)
-				}
-				b.StopTimer()
-				cacher.Stop()
-				etcd3.TestOnlyResetResourceSizeEstimator(etcdStorage)
-				b.StartTimer()
-			}
-			b.ReportMetric(float64(pods), "pods/cache")
-		})
+				b.ReportMetric(float64(pods), "pods/cache")
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`BenchmarkCacherInit` already sweeps `EtcdRangeStream` on and off. This extends it to the full cross product of `EtcdRangeStream` and `ConcurrentWatchObjectDecode`.

benchstat over 10 runs, 150k pods.

Outer column header is `EtcdRangeStream`, inner is `ConcurrentWatchObjectDecode`, base is both off. **Both gates on cuts init time ~55% (2.2x), concurrent decode alone ~40%.**

ConcurrentWatchObjectDecode improves perf better than RangeStream but has its own tradeoffs that will be investigated separately but this is just intended to show the effects on the watch cache init. 

```
              │                    rs=false                        │                                rs=true                                    │
              │  cwod=false  │            cwod=true                │            cwod=false               │            cwod=true                │
              │    sec/op    │   sec/op     vs base                │   sec/op     vs base                │   sec/op     vs base                │
CacherInit-12   6.109 ± 101%   3.691 ± 26%  -39.57% (p=0.000 n=10)   4.938 ± 24%  -19.16% (p=0.023 n=10)   2.740 ± 23%  -55.15% (p=0.000 n=10)

              │                     false                     │                                    true                                     │
              │    false     │              true              │                false                 │                 true                 │
              │     B/op     │     B/op      vs base          │     B/op      vs base                │     B/op      vs base                │
CacherInit-12   11.76Gi ± 3%   11.79Gi ± 2%  ~ (p=0.436 n=10)   10.56Gi ± 0%  -10.27% (p=0.000 n=10)   10.58Gi ± 0%  -10.05% (p=0.000 n=10)

              │                      false                       │                                  true                                   │
              │    false    │                true                │               false                │                true                │
              │  allocs/op  │  allocs/op   vs base               │  allocs/op   vs base               │  allocs/op   vs base               │
CacherInit-12   64.58M ± 0%   65.33M ± 0%  +1.16% (p=0.000 n=10)   64.62M ± 0%  +0.06% (p=0.000 n=10)   65.37M ± 0%  +1.22% (p=0.000 n=10)
```

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
