### PR TITLE
DRA: Wire DRAListTypeAttributes gate into ResourceSlice update tests

### DIFF
--- a/pkg/registry/resource/resourceslice/strategy_test.go
+++ b/pkg/registry/resource/resourceslice/strategy_test.go
@@ -820,7 +820,22 @@ func TestResourceSliceStrategyUpdate(t *testing.T) {
 			listTypeAttributes:    false,
 			expectValidationError: true,
 		},
-		"keep-list-type-attributes": {
+		"keep-fields-list-type-attributes": {
+			oldObj: slice.DeepCopy(),
+			newObj: func() *resource.ResourceSlice {
+				obj := sliceWithListTypeAttributes.DeepCopy()
+				obj.ResourceVersion = "4"
+				return obj
+			}(),
+			listTypeAttributes: true,
+			expectObj: func() *resource.ResourceSlice {
+				obj := sliceWithListTypeAttributes.DeepCopy()
+				obj.ResourceVersion = "4"
+				obj.Generation = 1
+				return obj
+			}(),
+		},
+		"keep-existing-fields-list-type-attributes": {
 			oldObj: sliceWithListTypeAttributes,
 			newObj: func() *resource.ResourceSlice {
 				obj := sliceWithListTypeAttributes.DeepCopy()
@@ -858,6 +873,7 @@ func TestResourceSliceStrategyUpdate(t *testing.T) {
 				features.DRADeviceBindingConditions:   tc.bindingConditions,
 				features.DRAResourceClaimDeviceStatus: tc.deviceStatus,
 				features.DRAConsumableCapacity:        tc.consumableCapacity,
+				features.DRAListTypeAttributes:        tc.listTypeAttributes,
 			})
 
 			oldObj := tc.oldObj.DeepCopy()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR wires the existing `listTypeAttributes` test-case field into `TestResourceSliceStrategyUpdate`'s feature-gate override map.
 
The update strategy test table already has `listTypeAttributes` cases, but the per-test `FeatureOverrides` map was not applying that field. This makes the update tests exercise the intended `DRAListTypeAttributes` gate state, matching the create strategy test.

As `DRAListTypeAttributes` is still alpha/default-off, the three tests (`drop-list-type-attributes`, `keep-existing-list-type-attributes-without-featuregate-enabled` and `keep-list-type-attributes`) were using default false value as per-case override was omitted before this PR. `keep-list-type-attributes` test also passes without the override because its old object already uses list-typed attributes, so the ratcheting path preserves them even with the gate off. The other two tests set the override as false - same as default.

The issue this PR is solving is futureproofing: when `DRAListTypeAttributes` graduates to beta/default-on, the existing disabled-path update case would inherit the default-on gate unless this per-case override is wired. As a result, without this PR, 2 of these tests will start failing with beta. This PR makes the update-test honor its existing `listTypeAttributes` table field, matching the create-test.

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/5491-dra-list-types-for-attributes
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
This is a test-only cleanup for `ResourceSlice` strategy coverage. It does not change runtime behavior.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
