### PR TITLE
DRA kubeletplugin: use hashed registrar socket name for rolling updates

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
@@ -18,6 +18,8 @@ package kubeletplugin
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net"
@@ -49,7 +51,51 @@ const (
 	KubeletPluginsDir = "/var/lib/kubelet/plugins"
 	// KubeletRegistryDir is the default for [RegistrarDirectoryPath]
 	KubeletRegistryDir = "/var/lib/kubelet/plugins_registry"
+
+	// unixPathMax is the maximum length of an AF_UNIX socket path on Linux.
+	unixPathMax = 108
+
+	// rollingUpdateUIDHashBytes is how much of the SHA-256 digest of a pod UID
+	// is hex-encoded when the full UID does not fit in the registration socket
+	// path. 8 bytes (64 bits) is ample for node-local uniqueness during rolling
+	// updates.
+	rollingUpdateUIDHashBytes = 8
+
+	// rollingUpdateRegistrarSocketHashBytes is how much of the SHA-256 digest
+	// of (driver name, pod UID) is hex-encoded into the shortest rolling-update
+	// registration socket basename. 16 bytes (128 bits) is ample for
+	// node-local uniqueness while keeping AF_UNIX paths under typical limits.
+	rollingUpdateRegistrarSocketHashBytes = 16
 )
+
+// RollingUpdateRegistrarSocketFile returns a kubelet plugin registration socket
+// basename for rolling updates. The full path path.Join(registryDir, basename)
+// must fit within unixPathMax bytes.
+//
+// The basename is chosen in order of preference:
+//  1. <driver name>-<pod UID>-reg.sock
+//  2. <driver name>-<hex(SHA-256(pod UID))>-reg.sock
+//  3. dra-<hex(SHA-256(driver name, NUL, pod UID))>-reg.sock
+func RollingUpdateRegistrarSocketFile(registryDir, driverName string, podUID types.UID) string {
+	uid := string(podUID)
+	uidHash := sha256Sum(uid)
+	driverUIDHash := sha256Sum(driverName + "\x00" + uid)
+	candidates := []string{
+		driverName + "-" + uid + "-reg.sock",
+		driverName + "-" + hex.EncodeToString(uidHash[:rollingUpdateUIDHashBytes]) + "-reg.sock",
+		"dra-" + hex.EncodeToString(driverUIDHash[:rollingUpdateRegistrarSocketHashBytes]) + "-reg.sock",
+	}
+	for _, basename := range candidates {
+		if len(path.Join(registryDir, basename)) <= unixPathMax {
+			return basename
+		}
+	}
+	return candidates[len(candidates)-1]
+}
+
+func sha256Sum(data string) [32]byte {
+	return sha256.Sum256([]byte(data))
+}
 
 // DRAPlugin is the interface that needs to be implemented by a DRA driver to
 // use this helper package. The helper package then implements the gRPC
@@ -290,7 +336,9 @@ func RegistrarDirectoryPath(path string) Option {
 // of the helper code.
 //
 // The default is <driver name>-reg.sock. When rolling updates are enabled,
-// it is <driver name>-<uid>-reg.sock.
+// the basename is chosen so the full path under [RegistrarDirectoryPath]
+// fits within AF_UNIX length limits, preferring names that keep the driver
+// name visible (see [RollingUpdateRegistrarSocketFile]).
 //
 // This option and [RollingUpdate] are mutually exclusive.
 func RegistrarSocketFilename(name string) Option {
@@ -360,8 +408,10 @@ func PluginListener(listen func(ctx context.Context, path string) (net.Listener,
 // RollingUpdate can be used to enable support for running two plugin instances
 // in parallel while a newer instance replaces the older. When enabled, both
 // instances must share the same plugin data directory and driver name.
-// They create different sockets to allow the kubelet to connect to both at
-// the same time.
+// They create different registration sockets (and DRA gRPC sockets) so the
+// kubelet can connect to both at the same time. The default registration socket
+// basename is chosen to fit within AF_UNIX path limits (see
+// [RollingUpdateRegistrarSocketFile]).
 //
 // There is no guarantee which of the two instances are used by kubelet.
 // For example, it can happen that a claim gets prepared by one instance
@@ -688,7 +738,11 @@ func Start(ctx context.Context, plugin DRAPlugin, opts ...Option) (result *Helpe
 		uidPart = "-" + string(o.rollingUpdateUID)
 	}
 	if o.pluginRegistrationEndpoint.file == "" {
-		o.pluginRegistrationEndpoint.file = o.driverName + uidPart + "-reg.sock"
+		if o.rollingUpdateUID != "" {
+			o.pluginRegistrationEndpoint.file = RollingUpdateRegistrarSocketFile(o.pluginRegistrationEndpoint.dir, o.driverName, o.rollingUpdateUID)
+		} else {
+			o.pluginRegistrationEndpoint.file = o.driverName + "-reg.sock"
+		}
 	}
 	if o.pluginDataDirectoryPath == "" {
 		o.pluginDataDirectoryPath = path.Join(KubeletPluginsDir, o.driverName)

--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
@@ -19,7 +19,7 @@ package kubeletplugin
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/hex"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net"
@@ -56,13 +56,13 @@ const (
 	unixPathMax = 108
 
 	// rollingUpdateUIDHashBytes is how much of the SHA-256 digest of a pod UID
-	// is hex-encoded when the full UID does not fit in the registration socket
+	// is base64-encoded when the full UID does not fit in the registration socket
 	// path. 8 bytes (64 bits) is ample for node-local uniqueness during rolling
 	// updates.
 	rollingUpdateUIDHashBytes = 8
 
 	// rollingUpdateRegistrarSocketHashBytes is how much of the SHA-256 digest
-	// of (driver name, pod UID) is hex-encoded into the shortest rolling-update
+	// of (driver name, pod UID) is base64-encoded into the shortest rolling-update
 	// registration socket basename. 16 bytes (128 bits) is ample for
 	// node-local uniqueness while keeping AF_UNIX paths under typical limits.
 	rollingUpdateRegistrarSocketHashBytes = 16
@@ -74,16 +74,16 @@ const (
 //
 // The basename is chosen in order of preference:
 //  1. <driver name>-<pod UID>-reg.sock
-//  2. <driver name>-<hex(SHA-256(pod UID))>-reg.sock
-//  3. dra-<hex(SHA-256(driver name, NUL, pod UID))>-reg.sock
+//  2. <driver name>-<base64(SHA-256(pod UID)[:8])>-reg.sock
+//  3. dra-<base64(SHA-256(driver name, NUL, pod UID)[:16])>-reg.sock
 func RollingUpdateRegistrarSocketFile(registryDir, driverName string, podUID types.UID) string {
 	uid := string(podUID)
 	uidHash := sha256Sum(uid)
 	driverUIDHash := sha256Sum(driverName + "\x00" + uid)
 	candidates := []string{
 		driverName + "-" + uid + "-reg.sock",
-		driverName + "-" + hex.EncodeToString(uidHash[:rollingUpdateUIDHashBytes]) + "-reg.sock",
-		"dra-" + hex.EncodeToString(driverUIDHash[:rollingUpdateRegistrarSocketHashBytes]) + "-reg.sock",
+		driverName + "-" + base64.RawURLEncoding.EncodeToString(uidHash[:rollingUpdateUIDHashBytes]) + "-reg.sock",
+		"dra-" + base64.RawURLEncoding.EncodeToString(driverUIDHash[:rollingUpdateRegistrarSocketHashBytes]) + "-reg.sock",
 	}
 	for _, basename := range candidates {
 		if len(path.Join(registryDir, basename)) <= unixPathMax {

--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin_registration_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin_registration_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin_registration_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin_registration_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeletplugin
+
+import (
+	"path"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestRollingUpdateRegistrarSocketFile_lengthBound(t *testing.T) {
+	driver := "gpu.dra-example-driver.sigs.k8s.io"
+	podUID := types.UID("ad4af911-5bcd-47c5-a554-f35cea869472")
+	name := RollingUpdateRegistrarSocketFile(KubeletRegistryDir, driver, podUID)
+	full := path.Join(KubeletRegistryDir, name)
+	if len(full) > unixPathMax {
+		t.Fatalf("registration socket path len %d exceeds %d: %q", len(full), unixPathMax, full)
+	}
+}
+
+func TestRollingUpdateRegistrarSocketFile_prefersFullUID(t *testing.T) {
+	driver := "example.com/driver"
+	podUID := types.UID("11111111-2222-3333-4444-555555555555")
+	want := driver + "-" + string(podUID) + "-reg.sock"
+	got := RollingUpdateRegistrarSocketFile(KubeletRegistryDir, driver, podUID)
+	if got != want {
+		t.Fatalf("expected full UID basename %q, got %q", want, got)
+	}
+}
+
+func TestRollingUpdateRegistrarSocketFile_usesHashedUIDForLongDriverName(t *testing.T) {
+	driver := "gpu.dra-example-driver.sigs.k8s.io"
+	podUID := types.UID("ad4af911-5bcd-47c5-a554-f35cea869472")
+	got := RollingUpdateRegistrarSocketFile(KubeletRegistryDir, driver, podUID)
+
+	fullUID := driver + "-" + string(podUID) + "-reg.sock"
+	if got == fullUID {
+		t.Fatalf("expected hashed UID basename for long driver name, got full UID form %q", got)
+	}
+	if !strings.HasPrefix(got, driver+"-") || !strings.HasSuffix(got, "-reg.sock") {
+		t.Fatalf("expected driver name prefix and -reg.sock suffix, got %q", got)
+	}
+	if strings.Contains(got, string(podUID)) {
+		t.Fatalf("expected hashed UID, not full UID in %q", got)
+	}
+}
+
+func TestRollingUpdateRegistrarSocketFile_usesShortestFormForVeryLongDriverName(t *testing.T) {
+	driver := strings.Repeat("a", 100)
+	podUID := types.UID("ad4af911-5bcd-47c5-a554-f35cea869472")
+	got := RollingUpdateRegistrarSocketFile(KubeletRegistryDir, driver, podUID)
+	if !strings.HasPrefix(got, "dra-") || !strings.HasSuffix(got, "-reg.sock") {
+		t.Fatalf("expected shortest hashed basename, got %q", got)
+	}
+	if strings.Contains(got, driver) {
+		t.Fatalf("expected driver name to be omitted from shortest form, got %q", got)
+	}
+}
+
+func TestRollingUpdateRegistrarSocketFile_respectsCustomRegistryDir(t *testing.T) {
+	// A longer registry dir leaves less room for the driver name in the path.
+	registryDir := path.Join("/var/lib/kubelet", strings.Repeat("x", 20), "plugins_registry")
+	driver := "example.com/driver"
+	podUID := types.UID("11111111-2222-3333-4444-555555555555")
+
+	fullUID := driver + "-" + string(podUID) + "-reg.sock"
+	if len(path.Join(registryDir, fullUID)) <= unixPathMax {
+		t.Fatalf("test setup: expected full UID form to exceed limit with custom registry dir")
+	}
+
+	got := RollingUpdateRegistrarSocketFile(registryDir, driver, podUID)
+	if len(path.Join(registryDir, got)) > unixPathMax {
+		t.Fatalf("expected path within limit, got len %d: %q", len(path.Join(registryDir, got)), got)
+	}
+	if got == fullUID {
+		t.Fatalf("expected fallback from full UID form, got %q", got)
+	}
+}
+
+func TestRollingUpdateRegistrarSocketFile_deterministic(t *testing.T) {
+	driver := "example.com/driver"
+	podUID := types.UID("11111111-2222-3333-4444-555555555555")
+	a := RollingUpdateRegistrarSocketFile(KubeletRegistryDir, driver, podUID)
+	b := RollingUpdateRegistrarSocketFile(KubeletRegistryDir, driver, podUID)
+	if a != b {
+		t.Fatalf("expected stable name, got %q vs %q", a, b)
+	}
+}
+
+func TestRollingUpdateRegistrarSocketFile_distinctInputs(t *testing.T) {
+	uid := types.UID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	a := RollingUpdateRegistrarSocketFile(KubeletRegistryDir, "driver.one", uid)
+	b := RollingUpdateRegistrarSocketFile(KubeletRegistryDir, "driver.two", uid)
+	if a == b {
+		t.Fatalf("different driver names should not collide: %q", a)
+	}
+	c := RollingUpdateRegistrarSocketFile(KubeletRegistryDir, "driver.one", "ffffffff-ffff-ffff-ffff-ffffffffffff")
+	if a == c {
+		t.Fatalf("different pod UIDs should not collide: %q", a)
+	}
+}

--- a/test/e2e/dra/dra.go
+++ b/test/e2e/dra/dra.go
@@ -906,6 +906,44 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
 			framework.ExpectNoError(e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, pod.Name, pod.Namespace, f.Timeouts.PodDelete))
 		})
 
+		// Regression test for https://github.com/kubernetes/kubernetes/issues/139166:
+		// rolling-update registration sockets must stay within AF_UNIX path limits
+		// even when the driver name is longer than 28 characters.
+		f.It("rolling update with long driver name", f.WithKubeletMinVersion("1.33"), func(ctx context.Context) {
+			tCtx := f.TContext(ctx)
+			nodes := drautils.NewNodesNow(tCtx, 1, 1)
+
+			oldDriver := drautils.NewDriverInstance(tCtx)
+			oldDriver.Name = drautils.LongRollingUpdateDriverName
+			oldDriver.InstanceSuffix = "-old"
+			oldDriver.RollingUpdate = true
+			oldDriver.Run(tCtx, framework.TestContext.KubeletRootDir, nodes, drautils.DriverResourcesNow(nodes, 1))
+
+			getSlices := oldDriver.NewGetSlices()
+			tCtx.Eventually(getSlices).Should(gomega.HaveField("Items", gomega.HaveLen(len(nodes.NodeNames))))
+			initialSlices := getSlices(tCtx)
+
+			newDriver := drautils.NewDriverInstance(tCtx)
+			newDriver.Name = drautils.LongRollingUpdateDriverName
+			newDriver.InstanceSuffix = "-new"
+			newDriver.RollingUpdate = true
+			newDriver.Run(tCtx, framework.TestContext.KubeletRootDir, nodes, drautils.DriverResourcesNow(nodes, 1))
+
+			oldDriver.TearDown(tCtx)
+
+			b := drautils.NewBuilderNow(tCtx, oldDriver)
+			claim := b.ExternalClaim()
+			pod := b.PodExternal(claim.Name)
+			b.Create(tCtx, claim, pod)
+			b.TestPod(tCtx, pod)
+
+			finalSlices := getSlices(tCtx)
+			gomega.Expect(finalSlices.Items).Should(gomega.Equal(initialSlices.Items))
+
+			framework.ExpectNoError(f.ClientSet.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}))
+			framework.ExpectNoError(e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, pod.Name, pod.Namespace, f.Timeouts.PodDelete))
+		})
+
 		// Seamless upgrade support was added in Kubernetes 1.33.
 		f.It("failed update", f.WithKubeletMinVersion("1.33"), func(ctx context.Context) {
 			tCtx := f.TContext(ctx)

--- a/test/e2e/dra/utils/deploy.go
+++ b/test/e2e/dra/utils/deploy.go
@@ -19,7 +19,9 @@ package utils
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	_ "embed"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -268,6 +270,12 @@ const (
 	// is not managed by a driver. So any Pools and ResourceSlices will be published directly
 	// to the cluster, rather than through the driver.
 	multiHostDriverResources = "multi-host"
+
+	// LongRollingUpdateDriverName is a 30-character *.sigs.k8s.io-style driver name.
+	// With rolling updates, the legacy registration socket basename
+	// ({driver}-{pod UID}-reg.sock) exceeds common AF_UNIX path limits; see
+	// https://github.com/kubernetes/kubernetes/issues/139166.
+	LongRollingUpdateDriverName = "gpu.dra-example-driver.sigs.k8s.io"
 )
 
 // driverResourcesGenFunc defines the callback that will be invoked by the driver to generate the
@@ -407,6 +415,20 @@ func (d *Driver) SetNameSuffix(tCtx ktesting.TContext, suffix string) {
 	d.initName(tCtx)
 }
 
+// deploymentID returns an identifier for Kubernetes objects (ServiceAccount,
+// ClusterRole, etc.) derived from the driver name and instance suffix. The full
+// driver name is kept in d.Name for the API and kubelet plugin. When it is too
+// long for object name limits a short hashed form is used.
+func (d *Driver) deploymentID() string {
+	base := d.Name + d.InstanceSuffix
+	const maxLen = 40 // leaves room for "dra-kubelet-plugin-" and "-service-account"
+	if len(base) <= maxLen {
+		return base
+	}
+	sum := sha256.Sum256([]byte(base))
+	return "dra-" + hex.EncodeToString(sum[:8])
+}
+
 func (d *Driver) SetUp(tCtx ktesting.TContext, kubeletRootDir string, nodes *Nodes, driverResources map[string]resourceslice.DriverResources) {
 	tCtx.Logf("deploying driver %s on nodes %v", d.Name, nodes.NodeNames)
 	d.Nodes = make(map[string]KubeletPlugin)
@@ -472,12 +494,13 @@ func (d *Driver) SetUp(tCtx ktesting.TContext, kubeletRootDir string, nodes *Nod
 	}
 
 	// Create service account and corresponding RBAC rules.
-	d.serviceAccountName = "dra-kubelet-plugin-" + d.Name + d.InstanceSuffix + "-service-account"
+	deploymentID := d.deploymentID()
+	d.serviceAccountName = "dra-kubelet-plugin-" + deploymentID + "-service-account"
 	content := example.PluginPermissions
 
 	content = strings.ReplaceAll(content, "dra-kubelet-plugin-namespace", tCtx.Namespace())
 	content = strings.ReplaceAll(content, "dra-kubelet-plugin-driver-name", d.Name)
-	content = strings.ReplaceAll(content, "dra-kubelet-plugin", "dra-kubelet-plugin-"+d.Name+d.InstanceSuffix)
+	content = strings.ReplaceAll(content, "dra-kubelet-plugin", "dra-kubelet-plugin-"+deploymentID)
 	d.createFromYAML(tCtx, []byte(content), tCtx.Namespace())
 
 	// Figure out which hostpathplugin to use: basically the latest one


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When rolling updates are enabled, the DRA kubelet plugin helper names the plugin registration socket `{driver_name}-{pod_uid}-reg.sock`. With the default registry path (`/var/lib/kubelet/plugins_registry`) and a 36-character pod UID, only ~30 characters remain for the driver name to stay within the 108-byte AF_UNIX path limit on Linux.

Drivers using common `*.sigs.k8s.io` names (for example `gpu.dra-example-driver.sigs.k8s.io`, 34 characters) fail to start during rolling updates with:

```listen unix .../gpu.dra-example-driver.sigs.k8s.io-<uid>-reg.sock: bind: invalid argument```

This PR picks the rolling-update registration socket basename based on the full path length under the configured `RegistrarDirectoryPath`. It tries, in order:

1. `<driver name>-<pod UID>-reg.sock` - preferred when it fits (keeps full UID for debugging)
2. `<driver name>-<base64(SHA-256(pod UID)[:8])>-reg.sock` - keeps driver name, shortens the UID portion
3. `dra-<base64(SHA-256(driver name, NUL, pod UID)[:16])>-reg.sock` - shortest fallback for very long driver names

For #139166's 34-character driver at the default registry path, tier 2 is used so the driver name stays visible in the socket path.

Non-rolling-update behavior is unchanged (`<driver name>-reg.sock`). Explicit `RegistrarSocketFilename` and `RollingUpdate` remain mutually exclusive.


#### Which issue(s) this PR is related to:

Fixes #139166

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

- Change is limited to `k8s.io/dynamic-resource-allocation/kubeletplugin`, kubelet
  code is unchanged.
- DRA gRPC plugin sockets (`dra-<uid>.sock` under the per-driver plugin
  directory) are unchanged, only the registration socket basename in
  `plugins_registry` is affected.
- Path length is checked against the configured `RegistrarDirectoryPath`, not a hardcoded prefix. A ridiculously long registry directory can still exceed the limit that is operator error.
- E2E harness change in `deploy.go` hashes long driver names only for Kubernetes
  object names (ServiceAccount, etc.), `d.Name` passed to the plugin is still the full driver name.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug in the DRA kubelet plugin helper where drivers with names longer
than ~30 characters could not enable rolling updates because the plugin
registration socket path exceeded the AF_UNIX path length limit. Rolling-update
registration sockets now pick the shortest basename that fits under the
configured registry directory, preferring `<driver>-<pod UID>-reg.sock`,
then `<driver>-<hashed UID>-reg.sock`, then `dra-<hashed driver+UID>-reg.sock`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A

**Labels to add** (match the issue): `sig/node`, `wg/device-management`

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
