### PR TITLE
Generalize memorymanager checkpoint

### DIFF
--- a/pkg/kubelet/cm/memorymanager/state/checkpoint.go
+++ b/pkg/kubelet/cm/memorymanager/state/checkpoint.go
@@ -22,29 +22,56 @@ import (
 	"hash/fnv"
 	"strings"
 
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/checksum"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"
 	"k8s.io/utils/dump"
 )
 
+// MemoryManagerCheckpointV3 serializes checkpoint data to a string, following the
+// same approach used in the allocation manager (see pkg/kubelet/allocation/state/checkpoint.go).
+// The embedded V1 version is for keeping forward compatibility.
 var _ checkpointmanager.Checkpoint = &MemoryManagerCheckpointV1{}
 var _ checkpointmanager.Checkpoint = &MemoryManagerCheckpointV2{}
+var _ checkpointmanager.Checkpoint = &MemoryManagerCheckpointV3{}
 var _ checkpointmanager.Checkpoint = &MemoryManagerCheckpoint{}
 
-// MemoryManagerCheckpoint struct is used to store memory/pod assignments in a checkpoint in v2 format
+// MemoryManagerCheckpointData struct is used to store memory/pod assignments, which is part of a checkpoint in v3 format
+type MemoryManagerCheckpointData struct {
+	PolicyName   string                     `json:"policyName"`
+	MachineState NUMANodeMap                `json:"machineState"`
+	Entries      ContainerMemoryAssignments `json:"entries,omitempty"`
+	PodEntries   PodMemoryAssignments       `json:"podEntries,omitempty"`
+}
+
+// MemoryManagerCheckpoint represents a structure to store memory/pod assignments checkpoint data.
+// Dual-checksum format for backward compatibility.
+// The Data string with DataChecksum is the authoritative V3 payload.
 type MemoryManagerCheckpoint struct {
+	// Backward compatibility
+	// The embedded V1 checkpoint must not be enhanced and should be removed as soon as the oldest supported version understands V3.
+	MemoryManagerCheckpointV1 `json:",inline"`
+
+	// Data is a serialized MemoryManagerCheckpointData
+	Data string `json:"data"`
+	// DataChecksum is a checksum of Data string
+	DataChecksum checksum.Checksum `json:"dataChecksum"`
+
+	// CheckpointData holds actual data, not serialized directly
+	CheckpointData MemoryManagerCheckpointData `json:"-"`
+}
+
+// MemoryManagerCheckpointV3 struct is used to store memory/pod assignments in a checkpoint in v3 format
+type MemoryManagerCheckpointV3 = MemoryManagerCheckpoint
+
+// MemoryManagerCheckpointV2 struct is used to store memory/pod assignments in a checkpoint in v2 format
+type MemoryManagerCheckpointV2 struct {
 	PolicyName   string                     `json:"policyName"`
 	MachineState NUMANodeMap                `json:"machineState"`
 	Entries      ContainerMemoryAssignments `json:"entries,omitempty"`
 	PodEntries   PodMemoryAssignments       `json:"podEntries,omitempty"`
 	Checksum     checksum.Checksum          `json:"checksum"`
 }
-
-// MemoryManagerCheckpointV2 struct is used to store memory/pod assignments in a checkpoint in v2 format
-type MemoryManagerCheckpointV2 = MemoryManagerCheckpoint
 
 // MemoryManagerCheckpointV1 struct is used to store memory/pod assignments in a checkpoint in v1 format
 type MemoryManagerCheckpointV1 struct {
@@ -57,7 +84,7 @@ type MemoryManagerCheckpointV1 struct {
 // NewMemoryManagerCheckpoint returns an instance of Checkpoint
 func newMemoryManagerCheckpoint() *MemoryManagerCheckpoint {
 	//nolint:staticcheck // unexported-type-in-api user-facing error message
-	return newMemoryManagerCheckpointV2()
+	return newMemoryManagerCheckpointV3()
 }
 
 func newMemoryManagerCheckpointV1() *MemoryManagerCheckpointV1 {
@@ -75,12 +102,26 @@ func newMemoryManagerCheckpointV2() *MemoryManagerCheckpointV2 {
 	}
 }
 
+func newMemoryManagerCheckpointV3() *MemoryManagerCheckpointV3 {
+	return &MemoryManagerCheckpoint{
+		MemoryManagerCheckpointV1: MemoryManagerCheckpointV1{
+			Entries:      ContainerMemoryAssignments{},
+			MachineState: NUMANodeMap{},
+		},
+		CheckpointData: MemoryManagerCheckpointData{
+			Entries:      ContainerMemoryAssignments{},
+			PodEntries:   PodMemoryAssignments{},
+			MachineState: NUMANodeMap{},
+		},
+	}
+}
+
 // MarshalCheckpoint returns marshalled checkpoint in v1 format
 func (mp *MemoryManagerCheckpointV1) MarshalCheckpoint() ([]byte, error) {
 	// make sure checksum wasn't set before so it doesn't affect output checksum
 	mp.Checksum = 0
 
-	// In order to preserve rollback compatibility when the feature gate is disabled,
+	// In order to preserve rollback compatibility,
 	// we must generate a checksum using the legacy struct name "MemoryManagerCheckpoint"
 	// instead of "MemoryManagerCheckpointV1". Older Kubelets do not have the string
 	// replacement logic and expect the original struct name.
@@ -97,7 +138,40 @@ func (mp *MemoryManagerCheckpointV1) MarshalCheckpoint() ([]byte, error) {
 func (mp *MemoryManagerCheckpointV2) MarshalCheckpoint() ([]byte, error) {
 	// make sure checksum wasn't set before so it doesn't affect output checksum
 	mp.Checksum = 0
-	mp.Checksum = checksum.New(mp)
+
+	// In order to preserve rollback compatibility,
+	// we must generate a checksum using the legacy struct name "MemoryManagerCheckpoint"
+	// instead of "MemoryManagerCheckpointV2". Older Kubelets do not have the string
+	// replacement logic and expect the original struct name.
+	object := dump.ForHash(mp)
+	object = strings.Replace(object, "MemoryManagerCheckpointV2", "MemoryManagerCheckpoint", 1)
+	hash := fnv.New32a()
+	_, _ = fmt.Fprintf(hash, "%v", object)
+	mp.Checksum = checksum.Checksum(hash.Sum32())
+
+	return json.Marshal(*mp)
+}
+
+// MarshalCheckpoint returns marshalled checkpoint in v3 format
+func (mp *MemoryManagerCheckpointV3) MarshalCheckpoint() ([]byte, error) {
+	data, err := json.Marshal(mp.CheckpointData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize memory manager checkpoint data: %w", err)
+	}
+	mp.Data = string(data)
+	mp.DataChecksum = checksum.New(mp.Data)
+
+	mp.PolicyName = mp.CheckpointData.PolicyName
+	mp.MachineState = mp.CheckpointData.MachineState
+	mp.Entries = mp.CheckpointData.Entries
+
+	mp.Checksum = 0
+	object := dump.ForHash(&mp.MemoryManagerCheckpointV1)
+	object = strings.Replace(object, "MemoryManagerCheckpointV1", "MemoryManagerCheckpoint", 1)
+	hash := fnv.New32a()
+	_, _ = fmt.Fprintf(hash, "%v", object)
+	mp.Checksum = checksum.Checksum(hash.Sum32())
+
 	return json.Marshal(*mp)
 }
 
@@ -111,6 +185,17 @@ func (mp *MemoryManagerCheckpointV2) UnmarshalCheckpoint(blob []byte) error {
 	return json.Unmarshal(blob, mp)
 }
 
+// UnmarshalCheckpoint tries to unmarshal passed bytes to checkpoint in v3 format
+func (mp *MemoryManagerCheckpointV3) UnmarshalCheckpoint(blob []byte) error {
+	if err := json.Unmarshal(blob, mp); err != nil {
+		return fmt.Errorf("failed to deserialize memory manager checkpoint: %w", err)
+	}
+	if err := json.Unmarshal([]byte(mp.Data), &mp.CheckpointData); err != nil {
+		return fmt.Errorf("failed to deserialize memory manager checkpoint data: %w", err)
+	}
+	return nil
+}
+
 // VerifyChecksum verifies that current checksum of checkpoint is valid in v1 format
 func (mp *MemoryManagerCheckpointV1) VerifyChecksum() error {
 	if mp.Checksum == 0 {
@@ -120,17 +205,6 @@ func (mp *MemoryManagerCheckpointV1) VerifyChecksum() error {
 
 	ck := mp.Checksum
 	mp.Checksum = 0
-
-	if !utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) {
-		err := ck.Verify(mp)
-		if err == nil {
-			mp.Checksum = ck
-			return nil
-		}
-		// If the standard verification failed, it could be a legacy checkpoint.
-		// Fallback to the legacy verification method, when V2 is latest.
-	}
-
 	object := dump.ForHash(mp)
 	object = strings.Replace(object, "MemoryManagerCheckpointV1", "MemoryManagerCheckpoint", 1)
 	mp.Checksum = ck
@@ -149,10 +223,33 @@ func (mp *MemoryManagerCheckpointV1) VerifyChecksum() error {
 }
 
 // VerifyChecksum verifies that current checksum of checkpoint is valid in v2 format
-func (mp *MemoryManagerCheckpoint) VerifyChecksum() error {
+func (mp *MemoryManagerCheckpointV2) VerifyChecksum() error {
+	if mp.Checksum == 0 {
+		// accept empty checksum for compatibility with old file backend
+		return nil
+	}
+
 	ck := mp.Checksum
 	mp.Checksum = 0
-	err := ck.Verify(mp)
+	object := dump.ForHash(mp)
+	object = strings.Replace(object, "MemoryManagerCheckpointV2", "MemoryManagerCheckpoint", 1)
 	mp.Checksum = ck
-	return err
+
+	hash := fnv.New32a()
+	_, _ = fmt.Fprintf(hash, "%v", object)
+	actualCS := checksum.Checksum(hash.Sum32())
+	if mp.Checksum != actualCS {
+		return &errors.CorruptCheckpointError{
+			ActualCS:   uint64(actualCS),
+			ExpectedCS: uint64(mp.Checksum),
+		}
+	}
+
+	return nil
+}
+
+// VerifyChecksum verifies that current checksum of checkpoint is valid in v3 format.
+// DataChecksum is the authoritative checksum over Data.
+func (mp *MemoryManagerCheckpoint) VerifyChecksum() error {
+	return mp.DataChecksum.Verify(mp.Data)
 }

--- a/pkg/kubelet/cm/memorymanager/state/checkpoint.go
+++ b/pkg/kubelet/cm/memorymanager/state/checkpoint.go
@@ -224,11 +224,6 @@ func (mp *MemoryManagerCheckpointV1) VerifyChecksum() error {
 
 // VerifyChecksum verifies that current checksum of checkpoint is valid in v2 format
 func (mp *MemoryManagerCheckpointV2) VerifyChecksum() error {
-	if mp.Checksum == 0 {
-		// accept empty checksum for compatibility with old file backend
-		return nil
-	}
-
 	ck := mp.Checksum
 	mp.Checksum = 0
 	object := dump.ForHash(mp)

--- a/pkg/kubelet/cm/memorymanager/state/state.go
+++ b/pkg/kubelet/cm/memorymanager/state/state.go
@@ -103,6 +103,17 @@ func (as ContainerMemoryAssignments) Clone() ContainerMemoryAssignments {
 // PodMemoryAssignments stores memory assignments of pods
 type PodMemoryAssignments map[string]PodEntry
 
+// Clone returns a copy of PodMemoryAssignments
+func (as PodMemoryAssignments) Clone() PodMemoryAssignments {
+	clone := make(PodMemoryAssignments)
+	for pod, entry := range as {
+		clone[pod] = PodEntry{
+			MemoryBlocks: append([]Block{}, entry.MemoryBlocks...),
+		}
+	}
+	return clone
+}
+
 // PodEntry represents pod-level memory assignments for a pod
 type PodEntry struct {
 	MemoryBlocks []Block `json:"memoryBlocks,omitempty"`

--- a/pkg/kubelet/cm/memorymanager/state/state_checkpoint.go
+++ b/pkg/kubelet/cm/memorymanager/state/state_checkpoint.go
@@ -19,7 +19,6 @@ package state
 import (
 	"errors"
 	"fmt"
-	"maps"
 	"path/filepath"
 	"sync"
 
@@ -67,31 +66,24 @@ func NewCheckpointState(logger klog.Logger, stateDir, checkpointName, policyName
 
 // migrateV1CheckpointToV2Checkpoint converts checkpoints from the v1 format to the v2 format
 func (sc *stateCheckpoint) migrateV1CheckpointToV2Checkpoint(src *MemoryManagerCheckpointV1, dst *MemoryManagerCheckpointV2) {
-	if src.PolicyName != "" {
-		dst.PolicyName = src.PolicyName
-	}
-	if src.MachineState != nil {
-		dst.MachineState = src.MachineState.Clone()
-	}
-	if len(src.Entries) > 0 {
-		dst.Entries = src.Entries.Clone()
-	}
+	dst.PolicyName = src.PolicyName
+	dst.MachineState = src.MachineState.Clone()
+	dst.Entries = src.Entries.Clone()
+}
+
+// migrateV2CheckpointToV3Checkpoint converts checkpoints from the v2 format to the v3 format
+func (sc *stateCheckpoint) migrateV2CheckpointToV3Checkpoint(src *MemoryManagerCheckpointV2, dst *MemoryManagerCheckpointV3) {
+	dst.CheckpointData.PolicyName = src.PolicyName
+	dst.CheckpointData.MachineState = src.MachineState.Clone()
+	dst.CheckpointData.Entries = src.Entries.Clone()
+	dst.CheckpointData.PodEntries = src.PodEntries.Clone()
 }
 
 // restores state from a checkpoint and creates it if it doesn't exist
 func (sc *stateCheckpoint) restoreState() error {
 	sc.Lock()
 	defer sc.Unlock()
-
-	var checkpoint any
-	var err error
-
-	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) {
-		checkpoint, err = sc.loadAndMigrateCheckpointV2()
-	} else {
-		checkpoint, err = sc.loadCheckpointV1()
-	}
-
+	cp, err := sc.loadAndMigrateCheckpointV3()
 	if err != nil {
 		if errors.Is(err, cperrors.ErrCheckpointNotFound) {
 			return sc.storeState()
@@ -99,22 +91,13 @@ func (sc *stateCheckpoint) restoreState() error {
 		return err
 	}
 
-	switch cp := checkpoint.(type) {
-	case *MemoryManagerCheckpointV2:
-		if sc.policyName != cp.PolicyName {
-			return fmt.Errorf("[memorymanager] configured policy %q differs from state checkpoint policy %q", sc.policyName, cp.PolicyName)
-		}
-		sc.cache.SetMachineState(cp.MachineState)
-		sc.cache.SetMemoryAssignments(cp.Entries)
-		sc.cache.SetPodMemoryAssignments(cp.PodEntries)
-	case *MemoryManagerCheckpointV1:
-		if sc.policyName != cp.PolicyName {
-			return fmt.Errorf("[memorymanager] configured policy %q differs from state checkpoint policy %q", sc.policyName, cp.PolicyName)
-		}
-		sc.cache.SetMachineState(cp.MachineState)
-		sc.cache.SetMemoryAssignments(cp.Entries)
-	default:
-		return fmt.Errorf("unknown checkpoint type: %T", cp)
+	if sc.policyName != cp.CheckpointData.PolicyName {
+		return fmt.Errorf("[memorymanager] configured policy %q differs from state checkpoint policy %q", sc.policyName, cp.CheckpointData.PolicyName)
+	}
+	sc.cache.SetMachineState(cp.CheckpointData.MachineState)
+	sc.cache.SetMemoryAssignments(cp.CheckpointData.Entries)
+	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) {
+		sc.cache.SetPodMemoryAssignments(cp.CheckpointData.PodEntries)
 	}
 
 	sc.logger.V(2).Info("State checkpoint: restored state from checkpoint")
@@ -122,16 +105,51 @@ func (sc *stateCheckpoint) restoreState() error {
 	return nil
 }
 
-// loadAndMigrateCheckpointV2 loads the latest checkpoint and migrates it from older versions if needed.
+// loadAndMigrateCheckpointV3 loads the latest checkpoint and migrates it from older versions if needed.
+func (sc *stateCheckpoint) loadAndMigrateCheckpointV3() (*MemoryManagerCheckpointV3, error) {
+	// Try to load as V3.
+	checkpointV3 := newMemoryManagerCheckpointV3()
+	err := sc.checkpointManager.GetCheckpoint(sc.checkpointName, checkpointV3)
+	if err == nil {
+		return checkpointV3, nil
+	}
+	if errors.Is(err, cperrors.ErrCheckpointNotFound) {
+		return nil, err
+	}
+
+	if len(checkpointV3.Data) > 0 || checkpointV3.DataChecksum != 0 {
+		// This is a corrupted V3 checkpoint version. Don't fall back to previous versions, but return error.
+		err = fmt.Errorf("could not load v3 checkpoint: %w", err)
+		sc.logger.Error(err, "not falling back to previous versions")
+		return nil, err
+	}
+
+	// Log the V3 load error and fall back to V2.
+	sc.logger.Info("could not load v3 checkpoint for memory manager, falling back to v2", "err", err)
+
+	// Try to load as V2.
+	checkpointV2, err := sc.loadAndMigrateCheckpointV2()
+	if err != nil {
+		return nil, err
+	}
+
+	// Reset V3 (as it might contain some remaining data from previous load attempt)
+	checkpointV3 = newMemoryManagerCheckpointV3()
+
+	// Loaded V2, now migrate to V3.
+	sc.logger.Info("migrating memory manager checkpoint from v2 to v3")
+	sc.migrateV2CheckpointToV3Checkpoint(checkpointV2, checkpointV3)
+
+	return checkpointV3, nil
+}
+
+// loadAndMigrateCheckpointV2 loads the checkpoint in V2 and migrates it from older versions if needed.
 func (sc *stateCheckpoint) loadAndMigrateCheckpointV2() (*MemoryManagerCheckpointV2, error) {
 	// Try to load as V2.
 	checkpointV2 := newMemoryManagerCheckpointV2()
 	err := sc.checkpointManager.GetCheckpoint(sc.checkpointName, checkpointV2)
 	if err == nil {
 		return checkpointV2, nil
-	}
-	if errors.Is(err, cperrors.ErrCheckpointNotFound) {
-		return nil, err
 	}
 
 	// Log the V2 load error and fall back to V1.
@@ -169,34 +187,14 @@ func (sc *stateCheckpoint) loadCheckpointV1() (*MemoryManagerCheckpointV1, error
 
 // saves state to a checkpoint, caller is responsible for locking
 func (sc *stateCheckpoint) storeState() error {
-	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) {
-		return sc.storeStateV2()
-	}
-	return sc.storeStateV1()
-}
-
-func (sc *stateCheckpoint) storeStateV2() error {
 	checkpoint := newMemoryManagerCheckpoint()
-	checkpoint.PolicyName = sc.policyName
-	checkpoint.MachineState = sc.cache.GetMachineState()
-	checkpoint.Entries = sc.cache.GetMemoryAssignments()
+	checkpoint.CheckpointData.PolicyName = sc.policyName
+	checkpoint.CheckpointData.MachineState = sc.cache.GetMachineState()
+	checkpoint.CheckpointData.Entries = sc.cache.GetMemoryAssignments()
 
-	podAssignments := sc.cache.GetPodMemoryAssignments()
-	maps.Copy(checkpoint.PodEntries, podAssignments)
-
-	err := sc.checkpointManager.CreateCheckpoint(sc.checkpointName, checkpoint)
-	if err != nil {
-		sc.logger.Error(err, "Could not save checkpoint")
-		return err
+	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) {
+		checkpoint.CheckpointData.PodEntries = sc.cache.GetPodMemoryAssignments()
 	}
-	return nil
-}
-
-func (sc *stateCheckpoint) storeStateV1() error {
-	checkpoint := newMemoryManagerCheckpointV1()
-	checkpoint.PolicyName = sc.policyName
-	checkpoint.MachineState = sc.cache.GetMachineState()
-	checkpoint.Entries = sc.cache.GetMemoryAssignments()
 
 	err := sc.checkpointManager.CreateCheckpoint(sc.checkpointName, checkpoint)
 	if err != nil {

--- a/pkg/kubelet/cm/memorymanager/state/state_checkpoint.go
+++ b/pkg/kubelet/cm/memorymanager/state/state_checkpoint.go
@@ -148,6 +148,9 @@ func (sc *stateCheckpoint) loadAndMigrateCheckpointV2() (*MemoryManagerCheckpoin
 		return nil, err
 	}
 
+	// Reset V2 (as it might contain some remaining data from previous load attempt)
+	checkpointV2 = newMemoryManagerCheckpointV2()
+
 	// Loaded V1, now migrate to V2.
 	sc.logger.Info("migrating memory manager checkpoint from v1 to v2")
 	sc.migrateV1CheckpointToV2Checkpoint(checkpointV1, checkpointV2)

--- a/pkg/kubelet/cm/memorymanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/memorymanager/state/state_checkpoint_test.go
@@ -18,15 +18,18 @@ package state
 
 import (
 	"encoding/json"
+	"fmt"
+	"maps"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/core/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/component-base/featuregate"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
@@ -37,41 +40,125 @@ import (
 
 const testingCheckpoint = "memorymanager_checkpoint_test"
 
+type FeatureGateCombination map[featuregate.Feature]bool
+
+// allFeatureGateCombinations generates all combinations of provided feature gates.
+// Each combination is represented as a map of feature name to its state (enabled/disabled).
+// Combinations are constructed:
+//   - starting with single empty combination
+//   - then for each feature gate all combinations are appended twice to new slice
+//     (once with feature disabled and once with feature enabled)
+//   - combination list is replaced with new slice
+//
+// For example, given two features A and B, allFeatureGateCombinations will build combinations:
+// * Initial: `[{}]`
+// * After A: `[{A: false}, {A: true}]`
+// * After B: `[{A: false, B: false}, {A: false, B: true}, {A: true, B: false}, {A: true, B: true}]`
+func allFeatureGateCombinations(gates []featuregate.Feature) []FeatureGateCombination {
+	combinations := []FeatureGateCombination{make(FeatureGateCombination)}
+	for _, gate := range gates {
+		var newCombinations []FeatureGateCombination
+		for _, combination := range combinations {
+			// Append combination copy with the feature disabled
+			disabled := maps.Clone(combination)
+			disabled[gate] = false
+			newCombinations = append(newCombinations, disabled)
+
+			// Append combination with the feature enabled
+			combination[gate] = true
+			newCombinations = append(newCombinations, combination)
+		}
+		combinations = newCombinations
+	}
+	return combinations
+}
+
+func describe(comb FeatureGateCombination) string {
+	keys := slices.Sorted(maps.Keys(comb))
+	if len(keys) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%s=%v", keys[0], comb[keys[0]])
+	for _, key := range keys[1:] {
+		fmt.Fprintf(&sb, ",%s=%v", key, comb[key])
+	}
+	return sb.String()
+}
+
 // assertStateEqual marks provided test as failed if provided states differ
 func assertStateEqual(t *testing.T, restoredState, expectedState State) {
 	expectedMachineState := expectedState.GetMachineState()
 	restoredMachineState := restoredState.GetMachineState()
-	assert.Equal(t, expectedMachineState, restoredMachineState, "expected MachineState does not equal to restored one")
+	require.Equal(t, expectedMachineState, restoredMachineState, "expected MachineState does not equal to restored one")
 
 	expectedMemoryAssignments := expectedState.GetMemoryAssignments()
 	restoredMemoryAssignments := restoredState.GetMemoryAssignments()
-	assert.Equal(t, expectedMemoryAssignments, restoredMemoryAssignments, "state memory assignments mismatch")
+	require.Equal(t, expectedMemoryAssignments, restoredMemoryAssignments, "state memory assignments mismatch")
+
+	expectedPodMemoryAssignments := expectedState.GetPodMemoryAssignments()
+	restoredPodMemoryAssignments := restoredState.GetPodMemoryAssignments()
+	require.Equal(t, expectedPodMemoryAssignments, restoredPodMemoryAssignments, "state memory pod assignments mismatch")
 }
 
 func TestCheckpointStateRestore(t *testing.T) {
-	logger, _ := ktesting.NewTestContext(t)
 	testCases := []struct {
-		description                     string
-		checkpointContent               string
-		expectedError                   string
-		expectedState                   *stateMemory
-		podLevelResourceManagersEnabled bool
+		description       string
+		fgRequirements    FeatureGateCombination
+		checkpointContent string
+		policyName        string
+		expectedError     string
+		expectedState     *stateMemory
 	}{
 		{
 			"Restore non-existing checkpoint",
+			nil,
 			"",
+			"none",
 			"",
 			&stateMemory{},
-			false,
 		},
 		{
-			"Restore valid checkpoint",
+			"Fail to restore checkpoint without data section",
+			nil,
 			`{
 				"policyName":"static",
 				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
 				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
-				"checksum": 4215593881
+				"checksum": 4215593881,
+				"dataChecksum": 1234
 			}`,
+			"none",
+			"could not load v3 checkpoint: failed to deserialize memory manager checkpoint data: unexpected end of JSON input",
+			&stateMemory{},
+		},
+		{
+			"Fail to restore checkpoint without dataChecksum section",
+			nil,
+			`{
+				"policyName":"static",
+				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
+				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
+				"checksum": 4215593881,
+				"data": "{\"policyName\":\"static\",\"machineState\":{\"0\":{\"numberOfAssignments\":0,\"memoryMap\":{\"memory\":{\"total\":2048,\"systemReserved\":512,\"allocatable\":1536,\"reserved\":512,\"free\":1024}},\"cells\":[]}},\"entries\":{\"pod\":{\"container1\":[{\"numaAffinity\":[0],\"type\":\"memory\",\"size\":512}]}}}"
+			}`,
+			"none",
+			"could not load v3 checkpoint: checkpoint is corrupted",
+			&stateMemory{},
+		},
+		// In below testcase V2 part of checkpoint is intentionally corrupted to verify that it is not used.
+		{
+			"Restore valid checkpoint",
+			nil,
+			`{
+				"policyName":"other",
+				"machineState":{"0":{"numberOfAssignments":5,"memoryMap":{"memory":{"total":1024,"systemReserved":256,"allocatable":768,"reserved":256,"free":512}},"cells":[]}},
+				"entries":{"pod":{"containerX":[{"numaAffinity":[0],"type":"memory","size":128}]}},
+				"checksum": 1234,
+				"data": "{\"policyName\":\"static\",\"machineState\":{\"0\":{\"numberOfAssignments\":0,\"memoryMap\":{\"memory\":{\"total\":2048,\"systemReserved\":512,\"allocatable\":1536,\"reserved\":512,\"free\":1024}},\"cells\":[]}},\"entries\":{\"pod\":{\"container1\":[{\"numaAffinity\":[0],\"type\":\"memory\",\"size\":512}]}}}",
+				"dataChecksum": 1849615440
+			}`,
+			"static",
 			"",
 			&stateMemory{
 				assignments: ContainerMemoryAssignments{
@@ -99,218 +186,479 @@ func TestCheckpointStateRestore(t *testing.T) {
 					},
 				},
 			},
-			false,
 		},
 		{
-			"Restore checkpoint with invalid checksum",
+			"Fail to restore checkpoint with invalid dataChecksum",
+			nil,
+			`{
+				"policyName":"static",
+				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
+				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
+				"checksum": 4215593881,
+				"data": "{\"policyName\":\"static\",\"machineState\":{\"0\":{\"numberOfAssignments\":0,\"memoryMap\":{\"memory\":{\"total\":2048,\"systemReserved\":512,\"allocatable\":1536,\"reserved\":512,\"free\":1024}},\"cells\":[]}},\"entries\":{\"pod\":{\"container1\":[{\"numaAffinity\":[0],\"type\":\"memory\",\"size\":512}]}}}",
+				"dataChecksum": 1234
+			}`,
+			"none",
+			"could not load v3 checkpoint: checkpoint is corrupted",
+			&stateMemory{},
+		},
+		{
+			"Fail to restore checkpoint with invalid data JSON",
+			nil,
+			`{
+				"policyName":"static",
+				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
+				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
+				"checksum": 4215593881,
+				"data": "{",
+				"dataChecksum": 1234
+			}`,
+			"none",
+			"could not load v3 checkpoint: failed to deserialize memory manager checkpoint data: unexpected end of JSON input",
+			&stateMemory{},
+		},
+		{
+			"Fail to restore checkpoint with invalid JSON",
+			nil,
+			`{`,
+			"none",
+			"unexpected end of JSON input",
+			&stateMemory{},
+		},
+		// In below testcase V2 part of checkpoint is intentionally corrupted to verify that it is not used.
+		{
+			"Fail to restore checkpoint with invalid policy name",
+			nil,
+			`{
+				"policyName":"other",
+				"machineState":{"0":{"numberOfAssignments":5,"memoryMap":{"memory":{"total":1024,"systemReserved":256,"allocatable":768,"reserved":256,"free":512}},"cells":[]}},
+				"entries":{"pod":{"containerX":[{"numaAffinity":[0],"type":"memory","size":128}]}},
+				"checksum": 1234,
+				"data": "{\"policyName\":\"static\",\"machineState\":{\"0\":{\"numberOfAssignments\":0,\"memoryMap\":{\"memory\":{\"total\":2048,\"systemReserved\":512,\"allocatable\":1536,\"reserved\":512,\"free\":1024}},\"cells\":[]}},\"entries\":{\"pod\":{\"container1\":[{\"numaAffinity\":[0],\"type\":\"memory\",\"size\":512}]}}}",
+				"dataChecksum": 1849615440
+			}`,
+			"none",
+			`[memorymanager] configured policy "none" differs from state checkpoint policy "static"`,
+			&stateMemory{},
+		},
+		// In below testcase V2 part of checkpoint is intentionally corrupted to verify that it is not used.
+		{
+			"Restore checkpoint ignoring unknown fields in data section",
+			nil,
+			`{
+				"policyName":"other",
+				"machineState":{"0":{"numberOfAssignments":5,"memoryMap":{"memory":{"total":1024,"systemReserved":256,"allocatable":768,"reserved":256,"free":512}},"cells":[]}},
+				"entries":{"pod":{"containerX":[{"numaAffinity":[0],"type":"memory","size":128}]}},
+				"checksum": 1234,
+				"data": "{\"unknownField\":\"value\",\"policyName\":\"static\",\"machineState\":{\"0\":{\"numberOfAssignments\":0,\"memoryMap\":{\"memory\":{\"total\":2048,\"systemReserved\":512,\"allocatable\":1536,\"reserved\":512,\"free\":1024}},\"cells\":[]}},\"entries\":{\"pod\":{\"container1\":[{\"numaAffinity\":[0],\"type\":\"memory\",\"size\":512}]}}}",
+				"dataChecksum": 2100279793
+			}`,
+			"static",
+			"",
+			&stateMemory{
+				assignments: ContainerMemoryAssignments{
+					"pod": map[string][]Block{
+						"container1": {
+							{
+								NUMAAffinity: []int{0},
+								Type:         v1.ResourceMemory,
+								Size:         512,
+							},
+						},
+					},
+				},
+				machineState: NUMANodeMap{
+					0: &NUMANodeState{
+						MemoryMap: map[v1.ResourceName]*MemoryTable{
+							v1.ResourceMemory: {
+								Allocatable:    1536,
+								Free:           1024,
+								Reserved:       512,
+								SystemReserved: 512,
+								TotalMemSize:   2048,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"Restore checkpoint from v1 (migration)",
+			nil,
+			`{
+				"policyName":"static",
+				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
+				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
+				"checksum": 4215593881
+			}`,
+			"static",
+			"",
+			&stateMemory{
+				assignments: ContainerMemoryAssignments{
+					"pod": map[string][]Block{
+						"container1": {
+							{
+								NUMAAffinity: []int{0},
+								Type:         v1.ResourceMemory,
+								Size:         512,
+							},
+						},
+					},
+				},
+				machineState: NUMANodeMap{
+					0: &NUMANodeState{
+						MemoryMap: map[v1.ResourceName]*MemoryTable{
+							v1.ResourceMemory: {
+								Allocatable:    1536,
+								Free:           1024,
+								Reserved:       512,
+								SystemReserved: 512,
+								TotalMemSize:   2048,
+							},
+						},
+					},
+				},
+			},
+		},
+		// In below testcase podEntries is intentionally corrupted so loading v2 will fail and fallback to v1.
+		{
+			"Restore checkpoint from v1 (migration) with checksum zeroed",
+			nil,
+			`{
+				"policyName":"static",
+				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
+				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
+				"podEntries":{"pod":3},
+				"checksum": 0
+			}`,
+			"static",
+			"",
+			&stateMemory{
+				assignments: ContainerMemoryAssignments{
+					"pod": map[string][]Block{
+						"container1": {
+							{
+								NUMAAffinity: []int{0},
+								Type:         v1.ResourceMemory,
+								Size:         512,
+							},
+						},
+					},
+				},
+				machineState: NUMANodeMap{
+					0: &NUMANodeState{
+						MemoryMap: map[v1.ResourceName]*MemoryTable{
+							v1.ResourceMemory: {
+								Allocatable:    1536,
+								Free:           1024,
+								Reserved:       512,
+								SystemReserved: 512,
+								TotalMemSize:   2048,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"Fail to restore checkpoint from v1 with invalid checksum",
+			nil,
 			`{
 				"policyName":"static",
 				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
 				"entries":{"pod":{"container1":[{"affinity":[0],"type":"memory","size":512}]}},
 				"checksum": 101010
 			}`,
+			"static",
 			"checkpoint is corrupted",
 			&stateMemory{},
-			false,
-		},
-		{
-			"Restore checkpoint with invalid JSON",
-			`{`,
-			"unexpected end of JSON input",
-			&stateMemory{},
-			false,
-		},
-		{
-			"Restore checkpoint from v1 (migration) with PodLevelResourceManagers enabled",
-			`{
-				"policyName":"static",
-				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
-				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
-				"checksum": 4215593881
-			}`,
-			"",
-			&stateMemory{
-				assignments: ContainerMemoryAssignments{
-					"pod": map[string][]Block{
-						"container1": {
-							{
-								NUMAAffinity: []int{0},
-								Type:         v1.ResourceMemory,
-								Size:         512,
-							},
-						},
-					},
-				},
-				machineState: NUMANodeMap{
-					0: &NUMANodeState{
-						MemoryMap: map[v1.ResourceName]*MemoryTable{
-							v1.ResourceMemory: {
-								Allocatable:    1536,
-								Free:           1024,
-								Reserved:       512,
-								SystemReserved: 512,
-								TotalMemSize:   2048,
-							},
-						},
-					},
-				},
-			},
-			true,
-		},
-		{
-			"Restore checkpoint from v1 (migration) with PodLevelResourceManagers disabled",
-			`{
-				"policyName":"static",
-				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
-				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
-				"checksum": 4215593881
-			}`,
-			"",
-			&stateMemory{
-				assignments: ContainerMemoryAssignments{
-					"pod": map[string][]Block{
-						"container1": {
-							{
-								NUMAAffinity: []int{0},
-								Type:         v1.ResourceMemory,
-								Size:         512,
-							},
-						},
-					},
-				},
-				machineState: NUMANodeMap{
-					0: &NUMANodeState{
-						MemoryMap: map[v1.ResourceName]*MemoryTable{
-							v1.ResourceMemory: {
-								Allocatable:    1536,
-								Free:           1024,
-								Reserved:       512,
-								SystemReserved: 512,
-								TotalMemSize:   2048,
-							},
-						},
-					},
-				},
-			},
-			false,
 		},
 		{
 			"Restore checkpoint from v2 with PodLevelResourceManagers enabled",
-			`{
-					"policyName":"static",
-					"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
-					"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
-					"podEntries":{"pod":{"memoryBlocks":[{"numaAffinity":[0],"type":"memory","size":512}]}},
-					"checksum": 1278640530
-        }`,
-			"",
-			&stateMemory{
-				assignments: ContainerMemoryAssignments{
-					"pod": map[string][]Block{
-						"container1": {
-							{
-								NUMAAffinity: []int{0},
-								Type:         v1.ResourceMemory,
-								Size:         512,
-							},
-						},
-					},
-				},
-				podAssignments: PodMemoryAssignments{
-					"pod": PodEntry{
-						MemoryBlocks: []Block{
-							{
-								NUMAAffinity: []int{0},
-								Type:         v1.ResourceMemory,
-								Size:         512,
-							},
-						},
-					},
-				},
-				machineState: NUMANodeMap{
-					0: &NUMANodeState{
-						MemoryMap: map[v1.ResourceName]*MemoryTable{
-							v1.ResourceMemory: {
-								Allocatable:    1536,
-								Free:           1024,
-								Reserved:       512,
-								SystemReserved: 512,
-								TotalMemSize:   2048,
-							},
-						},
-					},
-				},
-			},
-			true,
-		},
-		{
-			"Restore checkpoint from v2 with PodLevelResourceManagers disabled",
-			`{
-					"policyName":"static",
-					"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
-					"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
-					"podEntries":{"pod":{"memoryBlocks":[{"numaAffinity":[0],"type":"memory","size":512}]}},
-					"checksum": 1278640530
-        }`,
-			"checkpoint is corrupted, please drain this node and delete the memory manager checkpoint file",
-			&stateMemory{
-				assignments: ContainerMemoryAssignments{
-					"pod": map[string][]Block{
-						"container1": {
-							{
-								NUMAAffinity: []int{0},
-								Type:         v1.ResourceMemory,
-								Size:         512,
-							},
-						},
-					},
-				},
-				podAssignments: PodMemoryAssignments{
-					"pod": PodEntry{
-						MemoryBlocks: []Block{
-							{
-								NUMAAffinity: []int{0},
-								Type:         v1.ResourceMemory,
-								Size:         512,
-							},
-						},
-					},
-				},
-				machineState: NUMANodeMap{
-					0: &NUMANodeState{
-						MemoryMap: map[v1.ResourceName]*MemoryTable{
-							v1.ResourceMemory: {
-								Allocatable:    1536,
-								Free:           1024,
-								Reserved:       512,
-								SystemReserved: 512,
-								TotalMemSize:   2048,
-							},
-						},
-					},
-				},
-			},
-			false,
-		},
-		{
-			"Restore non-existing checkpoint with PodLevelResourceManagers enabled",
-			"",
-			"",
-			&stateMemory{},
-			true,
-		},
-		{
-			"Restore corrupt checkpoint with PodLevelResourceManagers enabled",
+			FeatureGateCombination{features.PodLevelResourceManagers: true},
 			`{
 				"policyName":"static",
 				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
-				"entries":{},
-				"podEntries":{},
-				"checksum": 12345
+				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
+				"podEntries":{"pod":{"memoryBlocks":[{"numaAffinity":[0],"type":"memory","size":512}]}},
+				"checksum": 1278640530
 			}`,
+			"static",
+			"",
+			&stateMemory{
+				assignments: ContainerMemoryAssignments{
+					"pod": map[string][]Block{
+						"container1": {
+							{
+								NUMAAffinity: []int{0},
+								Type:         v1.ResourceMemory,
+								Size:         512,
+							},
+						},
+					},
+				},
+				podAssignments: PodMemoryAssignments{
+					"pod": PodEntry{
+						MemoryBlocks: []Block{
+							{
+								NUMAAffinity: []int{0},
+								Type:         v1.ResourceMemory,
+								Size:         512,
+							},
+						},
+					},
+				},
+				machineState: NUMANodeMap{
+					0: &NUMANodeState{
+						MemoryMap: map[v1.ResourceName]*MemoryTable{
+							v1.ResourceMemory: {
+								Allocatable:    1536,
+								Free:           1024,
+								Reserved:       512,
+								SystemReserved: 512,
+								TotalMemSize:   2048,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"Restore checkpoint from v2 with PodLevelResourceManagers disabled",
+			FeatureGateCombination{features.PodLevelResourceManagers: false},
+			`{
+				"policyName":"static",
+				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
+				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
+				"podEntries":{"pod":{"memoryBlocks":[{"numaAffinity":[0],"type":"memory","size":512}]}},
+				"checksum": 1278640530
+			}`,
+			"static",
+			"",
+			&stateMemory{
+				assignments: ContainerMemoryAssignments{
+					"pod": map[string][]Block{
+						"container1": {
+							{
+								NUMAAffinity: []int{0},
+								Type:         v1.ResourceMemory,
+								Size:         512,
+							},
+						},
+					},
+				},
+				machineState: NUMANodeMap{
+					0: &NUMANodeState{
+						MemoryMap: map[v1.ResourceName]*MemoryTable{
+							v1.ResourceMemory: {
+								Allocatable:    1536,
+								Free:           1024,
+								Reserved:       512,
+								SystemReserved: 512,
+								TotalMemSize:   2048,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"Restore checkpoint from v2 with zeroed checksum and with PodLevelResourceManagers enabled",
+			FeatureGateCombination{features.PodLevelResourceManagers: true},
+			`{
+				"policyName":"static",
+				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
+				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
+				"podEntries":{"pod":{"memoryBlocks":[{"numaAffinity":[0],"type":"memory","size":512}]}},
+				"checksum": 0
+			}`,
+			"static",
+			"",
+			&stateMemory{
+				assignments: ContainerMemoryAssignments{
+					"pod": map[string][]Block{
+						"container1": {
+							{
+								NUMAAffinity: []int{0},
+								Type:         v1.ResourceMemory,
+								Size:         512,
+							},
+						},
+					},
+				},
+				podAssignments: PodMemoryAssignments{
+					"pod": PodEntry{
+						MemoryBlocks: []Block{
+							{
+								NUMAAffinity: []int{0},
+								Type:         v1.ResourceMemory,
+								Size:         512,
+							},
+						},
+					},
+				},
+				machineState: NUMANodeMap{
+					0: &NUMANodeState{
+						MemoryMap: map[v1.ResourceName]*MemoryTable{
+							v1.ResourceMemory: {
+								Allocatable:    1536,
+								Free:           1024,
+								Reserved:       512,
+								SystemReserved: 512,
+								TotalMemSize:   2048,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"Restore checkpoint from v2 with zeroed checksum and with PodLevelResourceManagers disabled",
+			FeatureGateCombination{features.PodLevelResourceManagers: false},
+			`{
+				"policyName":"static",
+				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
+				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
+				"podEntries":{"pod":{"memoryBlocks":[{"numaAffinity":[0],"type":"memory","size":512}]}},
+				"checksum": 0
+			}`,
+			"static",
+			"",
+			&stateMemory{
+				assignments: ContainerMemoryAssignments{
+					"pod": map[string][]Block{
+						"container1": {
+							{
+								NUMAAffinity: []int{0},
+								Type:         v1.ResourceMemory,
+								Size:         512,
+							},
+						},
+					},
+				},
+				machineState: NUMANodeMap{
+					0: &NUMANodeState{
+						MemoryMap: map[v1.ResourceName]*MemoryTable{
+							v1.ResourceMemory: {
+								Allocatable:    1536,
+								Free:           1024,
+								Reserved:       512,
+								SystemReserved: 512,
+								TotalMemSize:   2048,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"Fail to restore checkpoint from v2 with invalid checksum",
+			nil,
+			`{
+				"policyName":"static",
+				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
+				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
+				"podEntries":{"pod":{"memoryBlocks":[{"numaAffinity":[0],"type":"memory","size":512}]}},
+				"checksum": 101010
+			}`,
+			"static",
 			"checkpoint is corrupted",
 			&stateMemory{},
-			true,
+		},
+		// In below testcase V2 part of checkpoint is intentionally corrupted to verify that it is not used.
+		{
+			"Restore checkpoint from v3 with PodLevelResourceManagers enabled",
+			FeatureGateCombination{features.PodLevelResourceManagers: true},
+			`{
+				"policyName":"other",
+				"machineState":{"0":{"numberOfAssignments":5,"memoryMap":{"memory":{"total":1024,"systemReserved":256,"allocatable":768,"reserved":256,"free":512}},"cells":[]}},
+				"entries":{"pod":{"containerX":[{"numaAffinity":[0],"type":"memory","size":128}]}},
+				"podEntries":{"podY":{"memoryBlocks":[{"numaAffinity":[0],"type":"memory","size":64}]}},
+				"checksum": 1234,
+				"data": "{\"policyName\":\"static\",\"machineState\":{\"0\":{\"numberOfAssignments\":0,\"memoryMap\":{\"memory\":{\"total\":2048,\"systemReserved\":512,\"allocatable\":1536,\"reserved\":512,\"free\":1024}},\"cells\":[]}},\"entries\":{\"pod\":{\"container1\":[{\"numaAffinity\":[0],\"type\":\"memory\",\"size\":512}]}},\"podEntries\":{\"pod\":{\"memoryBlocks\":[{\"numaAffinity\":[0],\"type\":\"memory\",\"size\":512}]}}}",
+				"dataChecksum": 637296054
+			}`,
+			"static",
+			"",
+			&stateMemory{
+				assignments: ContainerMemoryAssignments{
+					"pod": map[string][]Block{
+						"container1": {
+							{
+								NUMAAffinity: []int{0},
+								Type:         v1.ResourceMemory,
+								Size:         512,
+							},
+						},
+					},
+				},
+				podAssignments: PodMemoryAssignments{
+					"pod": PodEntry{
+						MemoryBlocks: []Block{
+							{
+								NUMAAffinity: []int{0},
+								Type:         v1.ResourceMemory,
+								Size:         512,
+							},
+						},
+					},
+				},
+				machineState: NUMANodeMap{
+					0: &NUMANodeState{
+						MemoryMap: map[v1.ResourceName]*MemoryTable{
+							v1.ResourceMemory: {
+								Allocatable:    1536,
+								Free:           1024,
+								Reserved:       512,
+								SystemReserved: 512,
+								TotalMemSize:   2048,
+							},
+						},
+					},
+				},
+			},
+		},
+		// In below testcase V2 part of checkpoint is intentionally corrupted to verify that it is not used.
+		{
+			"Restore checkpoint from v3 with PodLevelResourceManagers disabled",
+			FeatureGateCombination{features.PodLevelResourceManagers: false},
+			`{
+				"policyName":"other",
+				"machineState":{"0":{"numberOfAssignments":5,"memoryMap":{"memory":{"total":1024,"systemReserved":256,"allocatable":768,"reserved":256,"free":512}},"cells":[]}},
+				"entries":{"pod":{"containerX":[{"numaAffinity":[0],"type":"memory","size":128}]}},
+				"podEntries":{"podY":{"memoryBlocks":[{"numaAffinity":[0],"type":"memory","size":64}]}},
+				"checksum": 1234,
+				"data": "{\"policyName\":\"static\",\"machineState\":{\"0\":{\"numberOfAssignments\":0,\"memoryMap\":{\"memory\":{\"total\":2048,\"systemReserved\":512,\"allocatable\":1536,\"reserved\":512,\"free\":1024}},\"cells\":[]}},\"entries\":{\"pod\":{\"container1\":[{\"numaAffinity\":[0],\"type\":\"memory\",\"size\":512}]}},\"podEntries\":{\"pod\":{\"memoryBlocks\":[{\"numaAffinity\":[0],\"type\":\"memory\",\"size\":512}]}}}",
+				"dataChecksum": 637296054
+			}`,
+			"static",
+			"",
+			&stateMemory{
+				assignments: ContainerMemoryAssignments{
+					"pod": map[string][]Block{
+						"container1": {
+							{
+								NUMAAffinity: []int{0},
+								Type:         v1.ResourceMemory,
+								Size:         512,
+							},
+						},
+					},
+				},
+				machineState: NUMANodeMap{
+					0: &NUMANodeState{
+						MemoryMap: map[v1.ResourceName]*MemoryTable{
+							v1.ResourceMemory: {
+								Allocatable:    1536,
+								Free:           1024,
+								Reserved:       512,
+								SystemReserved: 512,
+								TotalMemSize:   2048,
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -325,32 +673,54 @@ func TestCheckpointStateRestore(t *testing.T) {
 
 	// create checkpoint manager for testing
 	cpm, err := checkpointmanager.NewCheckpointManager(testingDir)
-	assert.NoError(t, err, "could not create testing checkpoint manager")
+	require.NoError(t, err, "could not create testing checkpoint manager")
 
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			if tc.podLevelResourceManagersEnabled {
-				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResources, true)
-				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResourceManagers, true)
+	// list of all features verified in this test
+	featureGateList := []featuregate.Feature{
+		features.PodLevelResourceManagers,
+	}
+	// iterate over all possible enabled/disabled feature combinations
+	for _, fgComb := range allFeatureGateCombinations(featureGateList) {
+		// run all testcases for current feature combination
+		t.Run(describe(fgComb), func(t *testing.T) {
+			for _, key := range slices.Sorted(maps.Keys(fgComb)) {
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, key, fgComb[key])
 			}
 
-			// ensure there is no previous checkpoint
-			assert.NoError(t, cpm.RemoveCheckpoint(testingCheckpoint), "could not remove testing checkpoint")
+			for _, tc := range testCases {
+				// verify feature gate requirements for testcase
+				skip := false
+				for fg, requiredState := range tc.fgRequirements {
+					state, exist := fgComb[fg]
+					if !exist || requiredState != state {
+						skip = true
+					}
+				}
+				if skip {
+					continue
+				}
 
-			// prepare checkpoint for testing
-			if strings.TrimSpace(tc.checkpointContent) != "" {
-				checkpoint := &testutil.MockCheckpoint{Content: tc.checkpointContent}
-				assert.NoError(t, cpm.CreateCheckpoint(testingCheckpoint, checkpoint), "could not create testing checkpoint")
-			}
+				t.Run(tc.description, func(t *testing.T) {
+					// ensure there is no previous checkpoint
+					require.NoError(t, cpm.RemoveCheckpoint(testingCheckpoint), "could not remove testing checkpoint")
 
-			restoredState, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "static")
-			if strings.TrimSpace(tc.expectedError) != "" {
-				assert.Error(t, err)
-				assert.ErrorContains(t, err, "could not restore state from checkpoint: "+tc.expectedError)
-			} else {
-				require.NoError(t, err, "unexpected error while creating checkpointState")
-				// compare state after restoration with the one expected
-				assertStateEqual(t, restoredState, tc.expectedState)
+					// prepare checkpoint for testing
+					if strings.TrimSpace(tc.checkpointContent) != "" {
+						checkpoint := &testutil.MockCheckpoint{Content: tc.checkpointContent}
+						require.NoError(t, cpm.CreateCheckpoint(testingCheckpoint, checkpoint), "could not create testing checkpoint")
+					}
+
+					logger, _ := ktesting.NewTestContext(t)
+					restoredState, err := NewCheckpointState(logger, testingDir, testingCheckpoint, tc.policyName)
+					if strings.TrimSpace(tc.expectedError) != "" {
+						require.Error(t, err)
+						require.ErrorContains(t, err, "could not restore state from checkpoint: "+tc.expectedError)
+					} else {
+						require.NoError(t, err, "unexpected error while creating checkpointState")
+						// compare state after restoration with the one expected
+						assertStateEqual(t, restoredState, tc.expectedState)
+					}
+				})
 			}
 		})
 	}
@@ -395,12 +765,12 @@ func TestCheckpointStateStore(t *testing.T) {
 	})
 
 	cpm, err := checkpointmanager.NewCheckpointManager(testingDir)
-	assert.NoError(t, err, "could not create testing checkpoint manager")
+	require.NoError(t, err, "could not create testing checkpoint manager")
 
-	assert.NoError(t, cpm.RemoveCheckpoint(testingCheckpoint), "could not remove testing checkpoint")
+	require.NoError(t, cpm.RemoveCheckpoint(testingCheckpoint), "could not remove testing checkpoint")
 
 	cs1, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "static")
-	assert.NoError(t, err, "could not create testing checkpointState instance")
+	require.NoError(t, err, "could not create testing checkpointState instance")
 
 	// set values of cs1 instance so they are stored in checkpoint and can be read by cs2
 	cs1.SetMachineState(expectedState.machineState)
@@ -408,7 +778,77 @@ func TestCheckpointStateStore(t *testing.T) {
 
 	// restore checkpoint with previously stored values
 	cs2, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "static")
-	assert.NoError(t, err, "could not create testing checkpointState instance")
+	require.NoError(t, err, "could not create testing checkpointState instance")
+
+	assertStateEqual(t, cs2, expectedState)
+}
+
+func TestCheckpointStateStore_WithPodLevelResourceManagersEnabled(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResourceManagers, true)
+	expectedState := &stateMemory{
+		assignments: ContainerMemoryAssignments{
+			"pod": map[string][]Block{
+				"container1": {
+					{
+						NUMAAffinity: []int{0},
+						Type:         v1.ResourceMemory,
+						Size:         1024,
+					},
+				},
+			},
+		},
+		podAssignments: PodMemoryAssignments{
+			"pod": PodEntry{
+				MemoryBlocks: []Block{
+					{
+						NUMAAffinity: []int{0},
+						Type:         v1.ResourceMemory,
+						Size:         512,
+					},
+				},
+			},
+		},
+		machineState: NUMANodeMap{
+			0: &NUMANodeState{
+				MemoryMap: map[v1.ResourceName]*MemoryTable{
+					v1.ResourceMemory: {
+						Allocatable:    1536,
+						Free:           512,
+						Reserved:       1024,
+						SystemReserved: 512,
+						TotalMemSize:   2048,
+					},
+				},
+			},
+		},
+	}
+
+	// create temp dir
+	testingDir, err := os.MkdirTemp("", "memorymanager_state_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		require.NoErrorf(t, os.RemoveAll(testingDir), "unable to remove dir %s", testingDir)
+	})
+
+	cpm, err := checkpointmanager.NewCheckpointManager(testingDir)
+	require.NoError(t, err, "could not create testing checkpoint manager")
+
+	require.NoError(t, cpm.RemoveCheckpoint(testingCheckpoint), "could not remove testing checkpoint")
+
+	cs1, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "static")
+	require.NoError(t, err, "could not create testing checkpointState instance")
+
+	// set values of cs1 instance so they are stored in checkpoint and can be read by cs2
+	cs1.SetMachineState(expectedState.machineState)
+	cs1.SetMemoryAssignments(expectedState.assignments)
+	cs1.SetPodMemoryAssignments(expectedState.podAssignments)
+
+	// restore checkpoint with previously stored values
+	cs2, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "static")
+	require.NoError(t, err, "could not create testing checkpointState instance")
 
 	assertStateEqual(t, cs2, expectedState)
 }
@@ -517,26 +957,26 @@ func TestCheckpointStateHelpers(t *testing.T) {
 	})
 
 	cpm, err := checkpointmanager.NewCheckpointManager(testingDir)
-	assert.NoError(t, err, "could not create testing checkpoint manager")
+	require.NoError(t, err, "could not create testing checkpoint manager")
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			// ensure there is no previous checkpoint
-			assert.NoError(t, cpm.RemoveCheckpoint(testingCheckpoint), "could not remove testing checkpoint")
+			require.NoError(t, cpm.RemoveCheckpoint(testingCheckpoint), "could not remove testing checkpoint")
 
 			state, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "static")
-			assert.NoError(t, err, "could not create testing checkpoint manager")
+			require.NoError(t, err, "could not create testing checkpoint manager")
 
 			state.SetMachineState(tc.machineState)
-			assert.Equal(t, tc.machineState, state.GetMachineState(), "machine state inconsistent")
+			require.Equal(t, tc.machineState, state.GetMachineState(), "machine state inconsistent")
 
 			for pod := range tc.assignments {
 				for container, blocks := range tc.assignments[pod] {
 					state.SetMemoryBlocks(pod, container, blocks)
-					assert.Equal(t, blocks, state.GetMemoryBlocks(pod, container), "memory block inconsistent")
+					require.Equal(t, blocks, state.GetMemoryBlocks(pod, container), "memory block inconsistent")
 
 					state.Delete(pod, container)
-					assert.Nil(t, state.GetMemoryBlocks(pod, container), "deleted container still existing in state")
+					require.Nil(t, state.GetMemoryBlocks(pod, container), "deleted container still existing in state")
 				}
 			}
 		})
@@ -591,64 +1031,408 @@ func TestCheckpointStateClear(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			state, err := NewCheckpointState(logger, testingDir, testingCheckpoint, "static")
-			assert.NoError(t, err, "could not create testing checkpoint manager")
+			require.NoError(t, err, "could not create testing checkpoint manager")
 
 			state.SetMachineState(tc.machineState)
 			state.SetMemoryAssignments(tc.assignments)
 
 			state.ClearState()
-			assert.Equal(t, NUMANodeMap{}, state.GetMachineState(), "cleared state with non-empty machine state")
-			assert.Equal(t, ContainerMemoryAssignments{}, state.GetMemoryAssignments(), "cleared state with non-empty memory assignments")
+			require.Equal(t, NUMANodeMap{}, state.GetMachineState(), "cleared state with non-empty machine state")
+			require.Equal(t, ContainerMemoryAssignments{}, state.GetMemoryAssignments(), "cleared state with non-empty memory assignments")
 		})
 	}
 }
 
-func TestMemoryManagerCheckpointV1_MarshalCheckpoint_ForwardCompatibility(t *testing.T) {
-	// 1. Create a V1 checkpoint using the struct defined in the current codebase (1.36+)
-	currentCheckpoint := &MemoryManagerCheckpointV1{
-		PolicyName:   "none",
-		MachineState: NUMANodeMap{},
-		Entries:      ContainerMemoryAssignments{},
+func TestMemoryManagerCheckpoint_MarshalCheckpoint_HashCompatibility(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		currentCheckpoint      any
+		expectedLegacyChecksum func() checksum.Checksum
+	}{
+		{
+			name: "V1 checkpoint",
+			currentCheckpoint: &MemoryManagerCheckpointV1{
+				PolicyName: "none",
+				MachineState: NUMANodeMap{
+					0: &NUMANodeState{
+						MemoryMap: map[v1.ResourceName]*MemoryTable{
+							v1.ResourceMemory: {
+								Allocatable:    1536,
+								Free:           512,
+								Reserved:       1024,
+								SystemReserved: 512,
+								TotalMemSize:   2048,
+							},
+						},
+					},
+				},
+				Entries: ContainerMemoryAssignments{},
+			},
+			expectedLegacyChecksum: func() checksum.Checksum {
+				type MemoryManagerCheckpoint struct {
+					PolicyName   string                     `json:"policyName"`
+					MachineState NUMANodeMap                `json:"machineState"`
+					Entries      ContainerMemoryAssignments `json:"entries,omitempty"`
+					Checksum     checksum.Checksum          `json:"checksum"`
+				}
+
+				return checksum.New(&MemoryManagerCheckpoint{
+					PolicyName: "none",
+					MachineState: NUMANodeMap{
+						0: &NUMANodeState{
+							MemoryMap: map[v1.ResourceName]*MemoryTable{
+								v1.ResourceMemory: {
+									Allocatable:    1536,
+									Free:           512,
+									Reserved:       1024,
+									SystemReserved: 512,
+									TotalMemSize:   2048,
+								},
+							},
+						},
+					},
+					Entries: ContainerMemoryAssignments{},
+				})
+			},
+		},
+		{
+			name: "V2 checkpoint",
+			currentCheckpoint: &MemoryManagerCheckpointV2{
+				PolicyName: "none",
+				MachineState: NUMANodeMap{
+					0: &NUMANodeState{
+						MemoryMap: map[v1.ResourceName]*MemoryTable{
+							v1.ResourceMemory: {
+								Allocatable:    1536,
+								Free:           512,
+								Reserved:       1024,
+								SystemReserved: 512,
+								TotalMemSize:   2048,
+							},
+						},
+					},
+				},
+				Entries:    ContainerMemoryAssignments{},
+				PodEntries: PodMemoryAssignments{},
+			},
+			expectedLegacyChecksum: func() checksum.Checksum {
+				type MemoryManagerCheckpoint struct {
+					PolicyName   string                     `json:"policyName"`
+					MachineState NUMANodeMap                `json:"machineState"`
+					Entries      ContainerMemoryAssignments `json:"entries,omitempty"`
+					PodEntries   PodMemoryAssignments       `json:"podEntries,omitempty"`
+					Checksum     checksum.Checksum          `json:"checksum"`
+				}
+
+				return checksum.New(&MemoryManagerCheckpoint{
+					PolicyName: "none",
+					MachineState: NUMANodeMap{
+						0: &NUMANodeState{
+							MemoryMap: map[v1.ResourceName]*MemoryTable{
+								v1.ResourceMemory: {
+									Allocatable:    1536,
+									Free:           512,
+									Reserved:       1024,
+									SystemReserved: 512,
+									TotalMemSize:   2048,
+								},
+							},
+						},
+					},
+					Entries:    ContainerMemoryAssignments{},
+					PodEntries: PodMemoryAssignments{},
+				})
+			},
+		},
+		{
+			name: "V3 checkpoint",
+			currentCheckpoint: &MemoryManagerCheckpointV3{
+				MemoryManagerCheckpointV1: MemoryManagerCheckpointV1{
+					PolicyName: "none",
+					MachineState: NUMANodeMap{
+						0: &NUMANodeState{
+							MemoryMap: map[v1.ResourceName]*MemoryTable{
+								v1.ResourceMemory: {
+									Allocatable:    1536,
+									Free:           512,
+									Reserved:       1024,
+									SystemReserved: 512,
+									TotalMemSize:   2048,
+								},
+							},
+						},
+					},
+					Entries: ContainerMemoryAssignments{},
+				},
+				CheckpointData: MemoryManagerCheckpointData{
+					PolicyName: "none",
+					MachineState: NUMANodeMap{
+						0: &NUMANodeState{
+							MemoryMap: map[v1.ResourceName]*MemoryTable{
+								v1.ResourceMemory: {
+									Allocatable:    1536,
+									Free:           512,
+									Reserved:       1024,
+									SystemReserved: 512,
+									TotalMemSize:   2048,
+								},
+							},
+						},
+					},
+					Entries:    ContainerMemoryAssignments{},
+					PodEntries: PodMemoryAssignments{},
+				},
+			},
+			expectedLegacyChecksum: func() checksum.Checksum {
+				type MemoryManagerCheckpoint struct {
+					PolicyName   string                     `json:"policyName"`
+					MachineState NUMANodeMap                `json:"machineState"`
+					Entries      ContainerMemoryAssignments `json:"entries,omitempty"`
+					Checksum     checksum.Checksum          `json:"checksum"`
+				}
+
+				return checksum.New(&MemoryManagerCheckpoint{
+					PolicyName: "none",
+					MachineState: NUMANodeMap{
+						0: &NUMANodeState{
+							MemoryMap: map[v1.ResourceName]*MemoryTable{
+								v1.ResourceMemory: {
+									Allocatable:    1536,
+									Free:           512,
+									Reserved:       1024,
+									SystemReserved: 512,
+									TotalMemSize:   2048,
+								},
+							},
+						},
+					},
+					Entries: ContainerMemoryAssignments{},
+				})
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// 1. Marshal the checkpoint using the logic that forces the "MemoryManagerCheckpoint" name
+			data, err := tc.currentCheckpoint.(interface{ MarshalCheckpoint() ([]byte, error) }).MarshalCheckpoint()
+			if err != nil {
+				t.Fatalf("Failed to marshal checkpoint: %v", err)
+			}
+
+			// 2. Unmarshal the raw JSON to extract the checksum that was actually written to the file
+			var result map[string]interface{}
+			if err := json.Unmarshal(data, &result); err != nil {
+				t.Fatalf("Failed to unmarshal JSON: %v", err)
+			}
+
+			actualChecksumFloat, ok := result["checksum"].(float64)
+			if !ok {
+				t.Fatalf("Checksum field missing or invalid type")
+			}
+			writtenChecksum := checksum.Checksum(uint64(actualChecksumFloat))
+
+			// 3. Compute the expected legacy checksum
+			expectedLegacyChecksum := tc.expectedLegacyChecksum()
+
+			// 4. Assert that the checksum written by our 1.37+ code matches
+			// what an older Kubelet would expect to see.
+			if writtenChecksum != expectedLegacyChecksum {
+				t.Errorf("Written Checksum %d does not match legacy calculation %d. Forward compatibility broken.", writtenChecksum, expectedLegacyChecksum)
+			}
+		})
+	}
+}
+
+func TestMemoryManagerCheckpoint_RoundTrip(t *testing.T) {
+	testCases := []struct {
+		name     string
+		original checkpointmanager.Checkpoint
+		restored checkpointmanager.Checkpoint
+		verify   func(t *testing.T, original, restored checkpointmanager.Checkpoint)
+	}{
+		{
+			name: "V1 checkpoint",
+			original: &MemoryManagerCheckpointV1{
+				PolicyName: "static",
+				MachineState: NUMANodeMap{
+					0: &NUMANodeState{
+						MemoryMap: map[v1.ResourceName]*MemoryTable{
+							v1.ResourceMemory: {
+								Allocatable:    1536,
+								Free:           512,
+								Reserved:       1024,
+								SystemReserved: 512,
+								TotalMemSize:   2048,
+							},
+						},
+					},
+				},
+				Entries: ContainerMemoryAssignments{
+					"pod": map[string][]Block{
+						"container1": {
+							{
+								NUMAAffinity: []int{0},
+								Type:         v1.ResourceMemory,
+								Size:         1024,
+							},
+						},
+					},
+				},
+			},
+			restored: newMemoryManagerCheckpointV1(),
+			verify: func(t *testing.T, original, restored checkpointmanager.Checkpoint) {
+				o := original.(*MemoryManagerCheckpointV1)
+				r := restored.(*MemoryManagerCheckpointV1)
+				require.Equal(t, o.PolicyName, r.PolicyName)
+				require.Equal(t, o.MachineState, r.MachineState)
+				require.Equal(t, o.Entries, r.Entries)
+			},
+		},
+		{
+			name: "V2 checkpoint",
+			original: &MemoryManagerCheckpointV2{
+				PolicyName: "static",
+				MachineState: NUMANodeMap{
+					0: &NUMANodeState{
+						MemoryMap: map[v1.ResourceName]*MemoryTable{
+							v1.ResourceMemory: {
+								Allocatable:    1536,
+								Free:           512,
+								Reserved:       1024,
+								SystemReserved: 512,
+								TotalMemSize:   2048,
+							},
+						},
+					},
+				},
+				Entries: ContainerMemoryAssignments{
+					"pod": map[string][]Block{
+						"container1": {
+							{
+								NUMAAffinity: []int{0},
+								Type:         v1.ResourceMemory,
+								Size:         1024,
+							},
+						},
+					},
+				},
+				PodEntries: PodMemoryAssignments{
+					"pod": PodEntry{
+						MemoryBlocks: []Block{
+							{
+								NUMAAffinity: []int{0},
+								Type:         v1.ResourceMemory,
+								Size:         512,
+							},
+						},
+					},
+				},
+			},
+			restored: newMemoryManagerCheckpointV2(),
+			verify: func(t *testing.T, original, restored checkpointmanager.Checkpoint) {
+				o := original.(*MemoryManagerCheckpointV2)
+				r := restored.(*MemoryManagerCheckpointV2)
+				require.Equal(t, o.PolicyName, r.PolicyName)
+				require.Equal(t, o.MachineState, r.MachineState)
+				require.Equal(t, o.Entries, r.Entries)
+				require.Equal(t, o.PodEntries, r.PodEntries)
+			},
+		},
+		{
+			name: "V3 checkpoint",
+			original: &MemoryManagerCheckpointV3{
+				MemoryManagerCheckpointV1: MemoryManagerCheckpointV1{
+					PolicyName: "static",
+					MachineState: NUMANodeMap{
+						0: &NUMANodeState{
+							MemoryMap: map[v1.ResourceName]*MemoryTable{
+								v1.ResourceMemory: {
+									Allocatable:    1536,
+									Free:           512,
+									Reserved:       1024,
+									SystemReserved: 512,
+									TotalMemSize:   2048,
+								},
+							},
+						},
+					},
+					Entries: ContainerMemoryAssignments{
+						"pod": map[string][]Block{
+							"container1": {
+								{
+									NUMAAffinity: []int{0},
+									Type:         v1.ResourceMemory,
+									Size:         1024,
+								},
+							},
+						},
+					},
+				},
+				CheckpointData: MemoryManagerCheckpointData{
+					PolicyName: "static",
+					MachineState: NUMANodeMap{
+						0: &NUMANodeState{
+							MemoryMap: map[v1.ResourceName]*MemoryTable{
+								v1.ResourceMemory: {
+									Allocatable:    1536,
+									Free:           512,
+									Reserved:       1024,
+									SystemReserved: 512,
+									TotalMemSize:   2048,
+								},
+							},
+						},
+					},
+					Entries: ContainerMemoryAssignments{
+						"pod": map[string][]Block{
+							"container1": {
+								{
+									NUMAAffinity: []int{0},
+									Type:         v1.ResourceMemory,
+									Size:         1024,
+								},
+							},
+						},
+					},
+					PodEntries: PodMemoryAssignments{
+						"pod": PodEntry{
+							MemoryBlocks: []Block{
+								{
+									NUMAAffinity: []int{0},
+									Type:         v1.ResourceMemory,
+									Size:         512,
+								},
+							},
+						},
+					},
+				},
+			},
+			restored: newMemoryManagerCheckpointV3(),
+			verify: func(t *testing.T, original, restored checkpointmanager.Checkpoint) {
+				o := original.(*MemoryManagerCheckpointV3)
+				r := restored.(*MemoryManagerCheckpointV3)
+				// embedded V2 part
+				require.Equal(t, o.PolicyName, r.PolicyName)
+				require.Equal(t, o.MachineState, r.MachineState)
+				require.Equal(t, o.Entries, r.Entries)
+				// V4 part
+				require.Equal(t, o.CheckpointData.PolicyName, r.CheckpointData.PolicyName)
+				require.Equal(t, o.CheckpointData.MachineState, r.CheckpointData.MachineState)
+				require.Equal(t, o.CheckpointData.Entries, r.CheckpointData.Entries)
+				require.Equal(t, o.CheckpointData.PodEntries, r.CheckpointData.PodEntries)
+			},
+		},
 	}
 
-	// Marshal it using the logic that forces the "MemoryManagerCheckpoint" name
-	data, err := currentCheckpoint.MarshalCheckpoint()
-	if err != nil {
-		t.Fatalf("Failed to marshal checkpoint: %v", err)
-	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := tc.original.MarshalCheckpoint()
+			require.NoError(t, err)
 
-	// 2. Unmarshal the raw JSON to extract the checksum that was actually written to the file
-	var result map[string]interface{}
-	if err := json.Unmarshal(data, &result); err != nil {
-		t.Fatalf("Failed to unmarshal JSON: %v", err)
-	}
+			require.NoError(t, tc.restored.UnmarshalCheckpoint(data))
+			require.NoError(t, tc.restored.VerifyChecksum())
 
-	actualChecksumFloat, ok := result["checksum"].(float64)
-	if !ok {
-		t.Fatalf("Checksum field missing or invalid type")
-	}
-	writtenChecksum := checksum.Checksum(uint64(actualChecksumFloat))
-
-	// 3. Reconstruct how versions 1.35 and earlier would calculate the checksum
-	// by defining a struct with the exact legacy name and fields.
-	type MemoryManagerCheckpoint struct {
-		PolicyName   string                     `json:"policyName"`
-		MachineState NUMANodeMap                `json:"machineState"`
-		Entries      ContainerMemoryAssignments `json:"entries,omitempty"`
-		Checksum     checksum.Checksum          `json:"checksum"`
-	}
-
-	legacyCheckpoint := &MemoryManagerCheckpoint{
-		PolicyName:   currentCheckpoint.PolicyName,
-		MachineState: currentCheckpoint.MachineState,
-		Entries:      currentCheckpoint.Entries,
-	}
-
-	expectedLegacyChecksum := checksum.New(legacyCheckpoint)
-
-	// 4. Assert that the checksum written by our 1.36+ code matches
-	// what a 1.35 Kubelet would expect to see.
-	if writtenChecksum != expectedLegacyChecksum {
-		t.Errorf("Written Checksum %d does not match legacy calculation %d. Forward compatibility broken.", writtenChecksum, expectedLegacyChecksum)
+			tc.verify(t, tc.original, tc.restored)
+		})
 	}
 }

--- a/pkg/kubelet/cm/memorymanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/memorymanager/state/state_checkpoint_test.go
@@ -319,7 +319,9 @@ func TestCheckpointStateRestore(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(testingDir)
+	t.Cleanup(func() {
+		require.NoErrorf(t, os.RemoveAll(testingDir), "unable to remove dir %s", testingDir)
+	})
 
 	// create checkpoint manager for testing
 	cpm, err := checkpointmanager.NewCheckpointManager(testingDir)
@@ -388,7 +390,9 @@ func TestCheckpointStateStore(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(testingDir)
+	t.Cleanup(func() {
+		require.NoErrorf(t, os.RemoveAll(testingDir), "unable to remove dir %s", testingDir)
+	})
 
 	cpm, err := checkpointmanager.NewCheckpointManager(testingDir)
 	assert.NoError(t, err, "could not create testing checkpoint manager")
@@ -508,7 +512,9 @@ func TestCheckpointStateHelpers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(testingDir)
+	t.Cleanup(func() {
+		require.NoErrorf(t, os.RemoveAll(testingDir), "unable to remove dir %s", testingDir)
+	})
 
 	cpm, err := checkpointmanager.NewCheckpointManager(testingDir)
 	assert.NoError(t, err, "could not create testing checkpoint manager")
@@ -578,7 +584,9 @@ func TestCheckpointStateClear(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(testingDir)
+	t.Cleanup(func() {
+		require.NoErrorf(t, os.RemoveAll(testingDir), "unable to remove dir %s", testingDir)
+	})
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {

--- a/pkg/kubelet/cm/memorymanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/memorymanager/state/state_checkpoint_test.go
@@ -111,46 +111,46 @@ func TestCheckpointStateRestore(t *testing.T) {
 		expectedState     *stateMemory
 	}{
 		{
-			"Restore non-existing checkpoint",
-			nil,
-			"",
-			"none",
-			"",
-			&stateMemory{},
+			description:       "Restore non-existing checkpoint",
+			fgRequirements:    nil,
+			checkpointContent: "",
+			policyName:        "none",
+			expectedError:     "",
+			expectedState:     &stateMemory{},
 		},
 		{
-			"Fail to restore checkpoint without data section",
-			nil,
-			`{
+			description:    "Fail to restore checkpoint without data section",
+			fgRequirements: nil,
+			checkpointContent: `{
 				"policyName":"static",
 				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
 				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
 				"checksum": 4215593881,
 				"dataChecksum": 1234
 			}`,
-			"none",
-			"could not load v3 checkpoint: failed to deserialize memory manager checkpoint data: unexpected end of JSON input",
-			&stateMemory{},
+			policyName:    "none",
+			expectedError: "could not load v3 checkpoint: failed to deserialize memory manager checkpoint data: unexpected end of JSON input",
+			expectedState: &stateMemory{},
 		},
 		{
-			"Fail to restore checkpoint without dataChecksum section",
-			nil,
-			`{
+			description:    "Fail to restore checkpoint without dataChecksum section",
+			fgRequirements: nil,
+			checkpointContent: `{
 				"policyName":"static",
 				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
 				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
 				"checksum": 4215593881,
 				"data": "{\"policyName\":\"static\",\"machineState\":{\"0\":{\"numberOfAssignments\":0,\"memoryMap\":{\"memory\":{\"total\":2048,\"systemReserved\":512,\"allocatable\":1536,\"reserved\":512,\"free\":1024}},\"cells\":[]}},\"entries\":{\"pod\":{\"container1\":[{\"numaAffinity\":[0],\"type\":\"memory\",\"size\":512}]}}}"
 			}`,
-			"none",
-			"could not load v3 checkpoint: checkpoint is corrupted",
-			&stateMemory{},
+			policyName:    "none",
+			expectedError: "could not load v3 checkpoint: checkpoint is corrupted",
+			expectedState: &stateMemory{},
 		},
 		// In below testcase V2 part of checkpoint is intentionally corrupted to verify that it is not used.
 		{
-			"Restore valid checkpoint",
-			nil,
-			`{
+			description:    "Restore valid checkpoint",
+			fgRequirements: nil,
+			checkpointContent: `{
 				"policyName":"other",
 				"machineState":{"0":{"numberOfAssignments":5,"memoryMap":{"memory":{"total":1024,"systemReserved":256,"allocatable":768,"reserved":256,"free":512}},"cells":[]}},
 				"entries":{"pod":{"containerX":[{"numaAffinity":[0],"type":"memory","size":128}]}},
@@ -158,9 +158,9 @@ func TestCheckpointStateRestore(t *testing.T) {
 				"data": "{\"policyName\":\"static\",\"machineState\":{\"0\":{\"numberOfAssignments\":0,\"memoryMap\":{\"memory\":{\"total\":2048,\"systemReserved\":512,\"allocatable\":1536,\"reserved\":512,\"free\":1024}},\"cells\":[]}},\"entries\":{\"pod\":{\"container1\":[{\"numaAffinity\":[0],\"type\":\"memory\",\"size\":512}]}}}",
 				"dataChecksum": 1849615440
 			}`,
-			"static",
-			"",
-			&stateMemory{
+			policyName:    "static",
+			expectedError: "",
+			expectedState: &stateMemory{
 				assignments: ContainerMemoryAssignments{
 					"pod": map[string][]Block{
 						"container1": {
@@ -188,9 +188,9 @@ func TestCheckpointStateRestore(t *testing.T) {
 			},
 		},
 		{
-			"Fail to restore checkpoint with invalid dataChecksum",
-			nil,
-			`{
+			description:    "Fail to restore checkpoint with invalid dataChecksum",
+			fgRequirements: nil,
+			checkpointContent: `{
 				"policyName":"static",
 				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
 				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
@@ -198,14 +198,14 @@ func TestCheckpointStateRestore(t *testing.T) {
 				"data": "{\"policyName\":\"static\",\"machineState\":{\"0\":{\"numberOfAssignments\":0,\"memoryMap\":{\"memory\":{\"total\":2048,\"systemReserved\":512,\"allocatable\":1536,\"reserved\":512,\"free\":1024}},\"cells\":[]}},\"entries\":{\"pod\":{\"container1\":[{\"numaAffinity\":[0],\"type\":\"memory\",\"size\":512}]}}}",
 				"dataChecksum": 1234
 			}`,
-			"none",
-			"could not load v3 checkpoint: checkpoint is corrupted",
-			&stateMemory{},
+			policyName:    "none",
+			expectedError: "could not load v3 checkpoint: checkpoint is corrupted",
+			expectedState: &stateMemory{},
 		},
 		{
-			"Fail to restore checkpoint with invalid data JSON",
-			nil,
-			`{
+			description:    "Fail to restore checkpoint with invalid data JSON",
+			fgRequirements: nil,
+			checkpointContent: `{
 				"policyName":"static",
 				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
 				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
@@ -213,23 +213,23 @@ func TestCheckpointStateRestore(t *testing.T) {
 				"data": "{",
 				"dataChecksum": 1234
 			}`,
-			"none",
-			"could not load v3 checkpoint: failed to deserialize memory manager checkpoint data: unexpected end of JSON input",
-			&stateMemory{},
+			policyName:    "none",
+			expectedError: "could not load v3 checkpoint: failed to deserialize memory manager checkpoint data: unexpected end of JSON input",
+			expectedState: &stateMemory{},
 		},
 		{
-			"Fail to restore checkpoint with invalid JSON",
-			nil,
-			`{`,
-			"none",
-			"unexpected end of JSON input",
-			&stateMemory{},
+			description:       "Fail to restore checkpoint with invalid JSON",
+			fgRequirements:    nil,
+			checkpointContent: `{`,
+			policyName:        "none",
+			expectedError:     "unexpected end of JSON input",
+			expectedState:     &stateMemory{},
 		},
 		// In below testcase V2 part of checkpoint is intentionally corrupted to verify that it is not used.
 		{
-			"Fail to restore checkpoint with invalid policy name",
-			nil,
-			`{
+			description:    "Fail to restore checkpoint with invalid policy name",
+			fgRequirements: nil,
+			checkpointContent: `{
 				"policyName":"other",
 				"machineState":{"0":{"numberOfAssignments":5,"memoryMap":{"memory":{"total":1024,"systemReserved":256,"allocatable":768,"reserved":256,"free":512}},"cells":[]}},
 				"entries":{"pod":{"containerX":[{"numaAffinity":[0],"type":"memory","size":128}]}},
@@ -237,15 +237,15 @@ func TestCheckpointStateRestore(t *testing.T) {
 				"data": "{\"policyName\":\"static\",\"machineState\":{\"0\":{\"numberOfAssignments\":0,\"memoryMap\":{\"memory\":{\"total\":2048,\"systemReserved\":512,\"allocatable\":1536,\"reserved\":512,\"free\":1024}},\"cells\":[]}},\"entries\":{\"pod\":{\"container1\":[{\"numaAffinity\":[0],\"type\":\"memory\",\"size\":512}]}}}",
 				"dataChecksum": 1849615440
 			}`,
-			"none",
-			`[memorymanager] configured policy "none" differs from state checkpoint policy "static"`,
-			&stateMemory{},
+			policyName:    "none",
+			expectedError: `[memorymanager] configured policy "none" differs from state checkpoint policy "static"`,
+			expectedState: &stateMemory{},
 		},
 		// In below testcase V2 part of checkpoint is intentionally corrupted to verify that it is not used.
 		{
-			"Restore checkpoint ignoring unknown fields in data section",
-			nil,
-			`{
+			description:    "Restore checkpoint ignoring unknown fields in data section",
+			fgRequirements: nil,
+			checkpointContent: `{
 				"policyName":"other",
 				"machineState":{"0":{"numberOfAssignments":5,"memoryMap":{"memory":{"total":1024,"systemReserved":256,"allocatable":768,"reserved":256,"free":512}},"cells":[]}},
 				"entries":{"pod":{"containerX":[{"numaAffinity":[0],"type":"memory","size":128}]}},
@@ -253,9 +253,9 @@ func TestCheckpointStateRestore(t *testing.T) {
 				"data": "{\"unknownField\":\"value\",\"policyName\":\"static\",\"machineState\":{\"0\":{\"numberOfAssignments\":0,\"memoryMap\":{\"memory\":{\"total\":2048,\"systemReserved\":512,\"allocatable\":1536,\"reserved\":512,\"free\":1024}},\"cells\":[]}},\"entries\":{\"pod\":{\"container1\":[{\"numaAffinity\":[0],\"type\":\"memory\",\"size\":512}]}}}",
 				"dataChecksum": 2100279793
 			}`,
-			"static",
-			"",
-			&stateMemory{
+			policyName:    "static",
+			expectedError: "",
+			expectedState: &stateMemory{
 				assignments: ContainerMemoryAssignments{
 					"pod": map[string][]Block{
 						"container1": {
@@ -283,17 +283,17 @@ func TestCheckpointStateRestore(t *testing.T) {
 			},
 		},
 		{
-			"Restore checkpoint from v1 (migration)",
-			nil,
-			`{
+			description:    "Restore checkpoint from v1 (migration)",
+			fgRequirements: nil,
+			checkpointContent: `{
 				"policyName":"static",
 				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
 				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
 				"checksum": 4215593881
 			}`,
-			"static",
-			"",
-			&stateMemory{
+			policyName:    "static",
+			expectedError: "",
+			expectedState: &stateMemory{
 				assignments: ContainerMemoryAssignments{
 					"pod": map[string][]Block{
 						"container1": {
@@ -322,18 +322,18 @@ func TestCheckpointStateRestore(t *testing.T) {
 		},
 		// In below testcase podEntries is intentionally corrupted so loading v2 will fail and fallback to v1.
 		{
-			"Restore checkpoint from v1 (migration) with checksum zeroed",
-			nil,
-			`{
+			description:    "Restore checkpoint from v1 (migration) with checksum zeroed",
+			fgRequirements: nil,
+			checkpointContent: `{
 				"policyName":"static",
 				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
 				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
 				"podEntries":{"pod":3},
 				"checksum": 0
 			}`,
-			"static",
-			"",
-			&stateMemory{
+			policyName:    "static",
+			expectedError: "",
+			expectedState: &stateMemory{
 				assignments: ContainerMemoryAssignments{
 					"pod": map[string][]Block{
 						"container1": {
@@ -361,31 +361,31 @@ func TestCheckpointStateRestore(t *testing.T) {
 			},
 		},
 		{
-			"Fail to restore checkpoint from v1 with invalid checksum",
-			nil,
-			`{
+			description:    "Fail to restore checkpoint from v1 with invalid checksum",
+			fgRequirements: nil,
+			checkpointContent: `{
 				"policyName":"static",
 				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
 				"entries":{"pod":{"container1":[{"affinity":[0],"type":"memory","size":512}]}},
 				"checksum": 101010
 			}`,
-			"static",
-			"checkpoint is corrupted",
-			&stateMemory{},
+			policyName:    "static",
+			expectedError: "checkpoint is corrupted",
+			expectedState: &stateMemory{},
 		},
 		{
-			"Restore checkpoint from v2 with PodLevelResourceManagers enabled",
-			FeatureGateCombination{features.PodLevelResourceManagers: true},
-			`{
+			description:    "Restore checkpoint from v2 with PodLevelResourceManagers enabled",
+			fgRequirements: FeatureGateCombination{features.PodLevelResourceManagers: true},
+			checkpointContent: `{
 				"policyName":"static",
 				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
 				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
 				"podEntries":{"pod":{"memoryBlocks":[{"numaAffinity":[0],"type":"memory","size":512}]}},
 				"checksum": 1278640530
 			}`,
-			"static",
-			"",
-			&stateMemory{
+			policyName:    "static",
+			expectedError: "",
+			expectedState: &stateMemory{
 				assignments: ContainerMemoryAssignments{
 					"pod": map[string][]Block{
 						"container1": {
@@ -424,18 +424,18 @@ func TestCheckpointStateRestore(t *testing.T) {
 			},
 		},
 		{
-			"Restore checkpoint from v2 with PodLevelResourceManagers disabled",
-			FeatureGateCombination{features.PodLevelResourceManagers: false},
-			`{
+			description:    "Restore checkpoint from v2 with PodLevelResourceManagers disabled",
+			fgRequirements: FeatureGateCombination{features.PodLevelResourceManagers: false},
+			checkpointContent: `{
 				"policyName":"static",
 				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
 				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
 				"podEntries":{"pod":{"memoryBlocks":[{"numaAffinity":[0],"type":"memory","size":512}]}},
 				"checksum": 1278640530
 			}`,
-			"static",
-			"",
-			&stateMemory{
+			policyName:    "static",
+			expectedError: "",
+			expectedState: &stateMemory{
 				assignments: ContainerMemoryAssignments{
 					"pod": map[string][]Block{
 						"container1": {
@@ -463,18 +463,18 @@ func TestCheckpointStateRestore(t *testing.T) {
 			},
 		},
 		{
-			"Restore checkpoint from v2 with zeroed checksum and with PodLevelResourceManagers enabled",
-			FeatureGateCombination{features.PodLevelResourceManagers: true},
-			`{
+			description:    "Restore checkpoint from v2 with zeroed checksum and with PodLevelResourceManagers enabled",
+			fgRequirements: FeatureGateCombination{features.PodLevelResourceManagers: true},
+			checkpointContent: `{
 				"policyName":"static",
 				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
 				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
 				"podEntries":{"pod":{"memoryBlocks":[{"numaAffinity":[0],"type":"memory","size":512}]}},
 				"checksum": 0
 			}`,
-			"static",
-			"",
-			&stateMemory{
+			policyName:    "static",
+			expectedError: "",
+			expectedState: &stateMemory{
 				assignments: ContainerMemoryAssignments{
 					"pod": map[string][]Block{
 						"container1": {
@@ -513,18 +513,18 @@ func TestCheckpointStateRestore(t *testing.T) {
 			},
 		},
 		{
-			"Restore checkpoint from v2 with zeroed checksum and with PodLevelResourceManagers disabled",
-			FeatureGateCombination{features.PodLevelResourceManagers: false},
-			`{
+			description:    "Restore checkpoint from v2 with zeroed checksum and with PodLevelResourceManagers disabled",
+			fgRequirements: FeatureGateCombination{features.PodLevelResourceManagers: false},
+			checkpointContent: `{
 				"policyName":"static",
 				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
 				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
 				"podEntries":{"pod":{"memoryBlocks":[{"numaAffinity":[0],"type":"memory","size":512}]}},
 				"checksum": 0
 			}`,
-			"static",
-			"",
-			&stateMemory{
+			policyName:    "static",
+			expectedError: "",
+			expectedState: &stateMemory{
 				assignments: ContainerMemoryAssignments{
 					"pod": map[string][]Block{
 						"container1": {
@@ -552,24 +552,24 @@ func TestCheckpointStateRestore(t *testing.T) {
 			},
 		},
 		{
-			"Fail to restore checkpoint from v2 with invalid checksum",
-			nil,
-			`{
+			description:    "Fail to restore checkpoint from v2 with invalid checksum",
+			fgRequirements: nil,
+			checkpointContent: `{
 				"policyName":"static",
 				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
 				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
 				"podEntries":{"pod":{"memoryBlocks":[{"numaAffinity":[0],"type":"memory","size":512}]}},
 				"checksum": 101010
 			}`,
-			"static",
-			"checkpoint is corrupted",
-			&stateMemory{},
+			policyName:    "static",
+			expectedError: "checkpoint is corrupted",
+			expectedState: &stateMemory{},
 		},
 		// In below testcase V2 part of checkpoint is intentionally corrupted to verify that it is not used.
 		{
-			"Restore checkpoint from v3 with PodLevelResourceManagers enabled",
-			FeatureGateCombination{features.PodLevelResourceManagers: true},
-			`{
+			description:    "Restore checkpoint from v3 with PodLevelResourceManagers enabled",
+			fgRequirements: FeatureGateCombination{features.PodLevelResourceManagers: true},
+			checkpointContent: `{
 				"policyName":"other",
 				"machineState":{"0":{"numberOfAssignments":5,"memoryMap":{"memory":{"total":1024,"systemReserved":256,"allocatable":768,"reserved":256,"free":512}},"cells":[]}},
 				"entries":{"pod":{"containerX":[{"numaAffinity":[0],"type":"memory","size":128}]}},
@@ -578,9 +578,9 @@ func TestCheckpointStateRestore(t *testing.T) {
 				"data": "{\"policyName\":\"static\",\"machineState\":{\"0\":{\"numberOfAssignments\":0,\"memoryMap\":{\"memory\":{\"total\":2048,\"systemReserved\":512,\"allocatable\":1536,\"reserved\":512,\"free\":1024}},\"cells\":[]}},\"entries\":{\"pod\":{\"container1\":[{\"numaAffinity\":[0],\"type\":\"memory\",\"size\":512}]}},\"podEntries\":{\"pod\":{\"memoryBlocks\":[{\"numaAffinity\":[0],\"type\":\"memory\",\"size\":512}]}}}",
 				"dataChecksum": 637296054
 			}`,
-			"static",
-			"",
-			&stateMemory{
+			policyName:    "static",
+			expectedError: "",
+			expectedState: &stateMemory{
 				assignments: ContainerMemoryAssignments{
 					"pod": map[string][]Block{
 						"container1": {
@@ -620,9 +620,9 @@ func TestCheckpointStateRestore(t *testing.T) {
 		},
 		// In below testcase V2 part of checkpoint is intentionally corrupted to verify that it is not used.
 		{
-			"Restore checkpoint from v3 with PodLevelResourceManagers disabled",
-			FeatureGateCombination{features.PodLevelResourceManagers: false},
-			`{
+			description:    "Restore checkpoint from v3 with PodLevelResourceManagers disabled",
+			fgRequirements: FeatureGateCombination{features.PodLevelResourceManagers: false},
+			checkpointContent: `{
 				"policyName":"other",
 				"machineState":{"0":{"numberOfAssignments":5,"memoryMap":{"memory":{"total":1024,"systemReserved":256,"allocatable":768,"reserved":256,"free":512}},"cells":[]}},
 				"entries":{"pod":{"containerX":[{"numaAffinity":[0],"type":"memory","size":128}]}},
@@ -631,9 +631,9 @@ func TestCheckpointStateRestore(t *testing.T) {
 				"data": "{\"policyName\":\"static\",\"machineState\":{\"0\":{\"numberOfAssignments\":0,\"memoryMap\":{\"memory\":{\"total\":2048,\"systemReserved\":512,\"allocatable\":1536,\"reserved\":512,\"free\":1024}},\"cells\":[]}},\"entries\":{\"pod\":{\"container1\":[{\"numaAffinity\":[0],\"type\":\"memory\",\"size\":512}]}},\"podEntries\":{\"pod\":{\"memoryBlocks\":[{\"numaAffinity\":[0],\"type\":\"memory\",\"size\":512}]}}}",
 				"dataChecksum": 637296054
 			}`,
-			"static",
-			"",
-			&stateMemory{
+			policyName:    "static",
+			expectedError: "",
+			expectedState: &stateMemory{
 				assignments: ContainerMemoryAssignments{
 					"pod": map[string][]Block{
 						"container1": {

--- a/pkg/kubelet/cm/memorymanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/memorymanager/state/state_checkpoint_test.go
@@ -320,7 +320,6 @@ func TestCheckpointStateRestore(t *testing.T) {
 				},
 			},
 		},
-		// In below testcase podEntries is intentionally corrupted so loading v2 will fail and fallback to v1.
 		{
 			description:    "Restore checkpoint from v1 (migration) with checksum zeroed",
 			fgRequirements: nil,
@@ -328,7 +327,6 @@ func TestCheckpointStateRestore(t *testing.T) {
 				"policyName":"static",
 				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
 				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
-				"podEntries":{"pod":3},
 				"checksum": 0
 			}`,
 			policyName:    "static",
@@ -439,56 +437,6 @@ func TestCheckpointStateRestore(t *testing.T) {
 				assignments: ContainerMemoryAssignments{
 					"pod": map[string][]Block{
 						"container1": {
-							{
-								NUMAAffinity: []int{0},
-								Type:         v1.ResourceMemory,
-								Size:         512,
-							},
-						},
-					},
-				},
-				machineState: NUMANodeMap{
-					0: &NUMANodeState{
-						MemoryMap: map[v1.ResourceName]*MemoryTable{
-							v1.ResourceMemory: {
-								Allocatable:    1536,
-								Free:           1024,
-								Reserved:       512,
-								SystemReserved: 512,
-								TotalMemSize:   2048,
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			description:    "Restore checkpoint from v2 with zeroed checksum and with PodLevelResourceManagers enabled",
-			fgRequirements: FeatureGateCombination{features.PodLevelResourceManagers: true},
-			checkpointContent: `{
-				"policyName":"static",
-				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"cells":[]}},
-				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
-				"podEntries":{"pod":{"memoryBlocks":[{"numaAffinity":[0],"type":"memory","size":512}]}},
-				"checksum": 0
-			}`,
-			policyName:    "static",
-			expectedError: "",
-			expectedState: &stateMemory{
-				assignments: ContainerMemoryAssignments{
-					"pod": map[string][]Block{
-						"container1": {
-							{
-								NUMAAffinity: []int{0},
-								Type:         v1.ResourceMemory,
-								Size:         512,
-							},
-						},
-					},
-				},
-				podAssignments: PodMemoryAssignments{
-					"pod": PodEntry{
-						MemoryBlocks: []Block{
 							{
 								NUMAAffinity: []int{0},
 								Type:         v1.ResourceMemory,

--- a/pkg/kubelet/cm/memorymanager/state/state_mem.go
+++ b/pkg/kubelet/cm/memorymanager/state/state_mem.go
@@ -17,7 +17,6 @@ limitations under the License.
 package state
 
 import (
-	"maps"
 	"sync"
 
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -98,9 +97,7 @@ func (s *stateMemory) GetPodMemoryAssignments() PodMemoryAssignments {
 	s.RLock()
 	defer s.RUnlock()
 
-	clone := make(PodMemoryAssignments)
-	maps.Copy(clone, s.podAssignments)
-	return clone
+	return s.podAssignments.Clone()
 }
 
 // SetMachineState stores NUMANodeMap in State
@@ -139,8 +136,7 @@ func (s *stateMemory) SetPodMemoryAssignments(assignments PodMemoryAssignments) 
 	s.Lock()
 	defer s.Unlock()
 
-	s.podAssignments = make(PodMemoryAssignments)
-	maps.Copy(s.podAssignments, assignments)
+	s.podAssignments = assignments.Clone()
 	s.logger.V(5).Info("Updated Pod Memory assignments", "assignments", assignments)
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

##### Why

Latest introduction of PodLevelResourceManagers feature gate to memory manager (and CPU manager) checkpoints, has made future enhancements of checkpoint structure barely possible.

Depending if PodLevelResourceManagers is enabled or not V1 or V2 versions of checkpoints are used.
So new feature X that would like to modify checkpoint is blocked. It would require 4 versions to be possible: when both of features (X and PodLevelResourceManagers) are enabled, when only one is, and when none is.

Because PodLevelResourceManagers was already merged and is part of 1.36 Kubernetes release,
this change needs to introduce new version V3 and provide smooth migration from old versions

##### What it does

This PR generalizes the memory manager checkpoint functionality by keeping data serialized to a string, which is a pattern used in DRA checkpoints. and applied already to CPU manager (https://github.com/kubernetes/kubernetes/pull/139102)

Instead of directly serializing the checkpoint struct, the actual checkpoint data is now stored in a separate struct which gets serialized to a string. The main checkpoint struct now contains this serialized data and a checksum of it.

This approach provides better forward/backward compatibility as the data structure can evolve without breaking existing checkpoints. It also allows for more robust error handling as deserialization issues can be caught and handled more gracefully.

The checksum is now calculated on the serialized data string rather than the struct itself, making it more reliable and consistent. File consistency is still kept as the checksum verification ensures data integrity.

Generalized checkpoint serialization is used regardless of feature gate settings. This allows future development of the checkpoint structure and enhancements for future features possible.

Additionally, V1 structure is embedded inline for forward compatibility - allowing older kubelet versions (using V1) to read newer V3 checkpoint files.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
