### PR TITLE
kube-proxy: clear stale conntrack entries for UDP services with no endpoints

### DIFF
--- a/pkg/proxy/conntrack/cleanup.go
+++ b/pkg/proxy/conntrack/cleanup.go
@@ -86,10 +86,15 @@ func CleanStaleEntries(ct Interface, ipFamily v1.IPFamily,
 			}
 		}
 
-		// a Service without endpoints does not require to clean the conntrack entries associated.
-		if endpoints.Len() == 0 {
-			continue
-		}
+		// Note: a Service without any serving endpoints is processed too, with an
+		// empty endpoints set, so that all the existing entries directed to its
+		// frontends are removed. The REJECT (iptables) / reject (nftables) rule
+		// installed for a Service with no endpoints does not cover the previously
+		// established flows: those are DNATed to the (deleted) endpoint IP before
+		// the reject rule, which matches on the Service IP, can be evaluated.
+		// One-way UDP flows (e.g. statsd) refresh the conntrack entry timeout with
+		// every packet, so without this cleanup they keep sending traffic to the
+		// deleted endpoint IP indefinitely.
 
 		// we need to filter entries that are directed to a Service IP:Port frontend
 		// that does not have an Endpoint IP:Port backend as part of the serving endpoints
@@ -105,8 +110,13 @@ func CleanStaleEntries(ct Interface, ipFamily v1.IPFamily,
 			serviceIPEndpoints[net.JoinHostPort(externalIP.String(), portStr)] = endpoints
 		}
 		// we need to filter entries that are directed to a *:NodePort that does not have
-		// an Endpoint IP:Port backend as part of the serving endpoints
-		if svc.NodePort() != 0 {
+		// an Endpoint IP:Port backend as part of the serving endpoints.
+		// NodePort entries are matched on the destination port only, so with an
+		// empty endpoints set every UDP flow towards that port number would be
+		// removed, including flows not owned by kube-proxy (e.g. traffic to an
+		// unrelated host on the same port). Skip NodePort cleanup for services
+		// without serving endpoints until the match can be restricted to node IPs.
+		if svc.NodePort() != 0 && endpoints.Len() > 0 {
 			// *:NodePort
 			serviceNodePortEndpoints[svc.NodePort()] = endpoints
 		}

--- a/pkg/proxy/conntrack/cleanup_test.go
+++ b/pkg/proxy/conntrack/cleanup_test.go
@@ -458,6 +458,7 @@ func TestServiceWithoutEndpoints(t *testing.T) {
 				{
 					Name:     "test-udp",
 					Port:     testServicePort,
+					NodePort: testServiceNodePort,
 					Protocol: v1.ProtocolUDP,
 				},
 			},
@@ -508,10 +509,38 @@ func TestServiceWithoutEndpoints(t *testing.T) {
 	_ = endpointsMap.Update(ect)
 
 	flows := []*netlink.ConntrackFlow{}
-	// 1 valid entry
-	flows = append(flows, generateConntrackEntry(testExternalIP, testServicePort, testServingEndpointIP, testEndpointPort, unix.IPPROTO_UDP))
-	// 1 stale entry
-	flows = append(flows, generateConntrackEntry(testExternalIP, testServicePort, testDeletedEndpointIP, testEndpointPort, unix.IPPROTO_UDP))
+	var entriesAfterCleanup []*netlink.ConntrackFlow
+
+	// All UDP entries directed to the frontends of a service without serving
+	// endpoints are stale and must be cleared, regardless of which (deleted)
+	// endpoint they are DNATed to: established flows bypass the REJECT rule
+	// installed for services with no endpoints and would otherwise keep
+	// blackholing traffic to the deleted endpoint IP indefinitely.
+	for _, origDest := range []string{testClusterIP, testLoadBalancerIP, testExternalIP} {
+		for _, dnatDest := range []string{testServingEndpointIP, testDeletedEndpointIP} {
+			flows = append(flows, generateConntrackEntry(origDest, testServicePort, dnatDest, testEndpointPort, unix.IPPROTO_UDP))
+		}
+	}
+
+	// UDP entries not directed to a service frontend are not owned by
+	// kube-proxy and must be preserved.
+	entry := generateConntrackEntry(testExternalIP, testNonServicePort, testDeletedEndpointIP, testEndpointPort, unix.IPPROTO_UDP)
+	flows = append(flows, entry)
+	entriesAfterCleanup = append(entriesAfterCleanup, entry)
+
+	// non-UDP entries must be preserved.
+	entry = generateConntrackEntry(testExternalIP, testServicePort, testDeletedEndpointIP, testEndpointPort, unix.IPPROTO_TCP)
+	flows = append(flows, entry)
+	entriesAfterCleanup = append(entriesAfterCleanup, entry)
+
+	// *:NodePort entries are matched on the destination port only, which with an
+	// empty endpoints set would also remove flows not owned by kube-proxy, so
+	// NodePort cleanup is skipped for services without serving endpoints and
+	// these entries must be preserved.
+	entry = generateConntrackEntry("", testServiceNodePort, testDeletedEndpointIP, testEndpointPort, unix.IPPROTO_UDP)
+	flows = append(flows, entry)
+	entriesAfterCleanup = append(entriesAfterCleanup, entry)
+
 	ct := newConntracker(
 		&fakeHandler{
 			entries: flows,
@@ -520,7 +549,19 @@ func TestServiceWithoutEndpoints(t *testing.T) {
 
 	CleanStaleEntries(ct, testIPFamily, svcPortMap, endpointsMap)
 	actualEntries, _ := ct.ListEntries(ipFamilyMap[testIPFamily])
-	if len(actualEntries) != 2 {
-		t.Errorf("unexpected number of entries, got %d expected %d", len(actualEntries), 2)
+
+	require.Len(t, actualEntries, len(entriesAfterCleanup))
+
+	// sort the actual flows before comparison
+	sort.Slice(actualEntries, func(i, j int) bool {
+		return actualEntries[i].String() < actualEntries[j].String()
+	})
+	// sort the expected flows before comparison
+	sort.Slice(entriesAfterCleanup, func(i, j int) bool {
+		return entriesAfterCleanup[i].String() < entriesAfterCleanup[j].String()
+	})
+
+	if diff := cmp.Diff(entriesAfterCleanup, actualEntries); len(diff) > 0 {
+		t.Errorf("unexpected entries after cleanup: %s", diff)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression
/sig network

#### What this PR does / why we need it:

The conntrack reconciler skips services without serving endpoints, so conntrack entries established while endpoints existed are never removed when a UDP service scales down to zero:

```go
// a Service without endpoints does not require to clean the conntrack entries associated.
if endpoints.Len() == 0 {
    continue
}
```

The REJECT (iptables) / reject (nftables) rule installed for such services does not cover those pre-existing flows: packets are DNATed to the deleted endpoint IP by conntrack before the rule, which matches on the service IP, is evaluated. One-way UDP senders (e.g. statsd clients, `[UNREPLIED]` entries) refresh the 30s conntrack timeout with every packet, so the stale flows blackhole traffic to the deleted pod IP indefinitely; recovery only happens when the service gets an endpoint again (the reconciler then processes the service and removes the entries, which is also why this bug is invisible in any N->M>0 transition).

This is a regression versus <=1.31, where the event-based cleanup (`DeletedUDPEndpoints`) cleared entries for every deleted UDP endpoint regardless of how many endpoints remained.

This PR processes such services with an empty endpoints set instead of skipping them, so every existing entry directed to their ClusterIP, LoadBalancer IP and ExternalIP frontends is treated as stale and deleted. New flows still cannot create entries (REJECT prevents conntrack confirmation), so there is nothing new to clean on subsequent syncs and no steady-state overhead beyond the one cleanup.

NodePort cleanup remains skipped for services without serving endpoints: NodePort entries are matched on the destination port only, and with an empty endpoints set that would also remove UDP flows not owned by kube-proxy (e.g. pod egress to an unrelated host on the same port number). This limitation is documented in the code and pinned by the updated test.

`TestServiceWithoutEndpoints` asserted the old behavior (entries preserved) and is updated to assert deletion of all entries directed to the service IP frontends, while preserving non-UDP entries, entries not directed to a service frontend, and *:NodePort entries. The updated test fails against the previous code (9 entries remain vs 3 expected).

Real-world impact observed (v1.33.5, statsd at ~64k pkt/s cluster-wide): after scaling the statsd-exporter service to 0, every sender kept DNAT-ing to the deleted pod IP for 13 hours; the traffic converged on the node owning the deleted pod IP and was dropped in NET_RX, holding one 8-core node at 60-73% softirq until the service was scaled back up. Verified with `kubeproxy_conntrack_reconciler_deleted_entries_total`: unchanged on the 1->0 sync, +1 (the stale entry) immediately on 0->1. Full analysis and reproduction steps in the linked issue.

#### Which issue(s) this PR fixes:

Fixes #139628

#### Special notes for your reviewer:

The skip originates from the #127318 review discussion, where the REJECT rule was considered sufficient protection for services without endpoints. That reasoning holds for new flows but not for previously established ones, which bypass the filter rule via early DNAT. iptables and nftables modes share this code path; IPVS is unaffected (`expire_nodest_conn=1`).

AI assistance disclosure: this fix was developed with AI assistance (Claude Code); the bug analysis, reproduction and the change were reviewed and verified by a human.

#### Does this PR introduce a user-facing change?

```release-note
kube-proxy now removes stale conntrack entries when a UDP service no longer has any serving endpoints (e.g. scaled down to zero), preventing previously established one-way UDP flows from being blackholed to deleted pod IPs indefinitely.
```
