### PR TITLE
refactor: use AddEventHandlerWithOptions in storageversion controllers

### DIFF
--- a/pkg/controller/storageversiongc/gc_controller.go
+++ b/pkg/controller/storageversiongc/gc_controller.go
@@ -73,20 +73,22 @@ func NewStorageVersionGC(ctx context.Context, clientset kubernetes.Interface, le
 		),
 	}
 	logger := klog.FromContext(ctx)
-	leaseInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := leaseInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: func(obj interface{}) {
 			c.onDeleteLease(logger, obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
+	utilruntime.Must(err)
 	// use the default resync period from the informer
-	storageVersionInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = storageVersionInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			c.onAddStorageVersion(logger, obj)
 		},
 		UpdateFunc: func(old, newObj interface{}) {
 			c.onUpdateStorageVersion(logger, old, newObj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
+	utilruntime.Must(err)
 
 	return c
 }

--- a/pkg/controller/storageversionmigrator/migrationrunner.go
+++ b/pkg/controller/storageversionmigrator/migrationrunner.go
@@ -80,7 +80,7 @@ func NewCustomResourceController(
 		),
 	}
 
-	_, _ = svmInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := svmInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			crController.addSVM(logger, obj)
 		},
@@ -90,7 +90,8 @@ func NewCustomResourceController(
 		DeleteFunc: func(obj interface{}) {
 			crController.deleteSVM(logger, obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
+	utilruntime.Must(err)
 
 	return crController
 }

--- a/pkg/controller/storageversionmigrator/resourceversion.go
+++ b/pkg/controller/storageversionmigrator/resourceversion.go
@@ -90,14 +90,15 @@ func NewResourceVersionController(
 		),
 	}
 
-	_, _ = svmInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := svmInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			rvController.addSVM(logger, obj)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			rvController.updateSVM(logger, oldObj, newObj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
+	utilruntime.Must(err)
 
 	return rvController
 }

--- a/pkg/controller/storageversionmigrator/storageversionmigrator.go
+++ b/pkg/controller/storageversionmigrator/storageversionmigrator.go
@@ -96,14 +96,15 @@ func NewSVMController(
 		rateLimiter: rateLimiter,
 	}
 
-	_, _ = svmInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := svmInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			svmController.addSVM(logger, obj)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			svmController.updateSVM(logger, oldObj, newObj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
+	utilruntime.Must(err)
 
 	return svmController
 }


### PR DESCRIPTION
Migrate plain `AddEventHandler` calls in `pkg/controller/storageversiongc` and
`pkg/controller/storageversionmigrator` to `AddEventHandlerWithOptions` with
`cache.HandlerOptions{Logger: &logger}`, so the contextual logger is propagated
into the informer handler goroutines.

The logger is already in scope at each call site (`klog.FromContext(ctx)`) and
the handler functions already accept a `klog.Logger` argument, so this is a pure
API migration with no behaviour change.

**Files changed (4):**
- `pkg/controller/storageversiongc/gc_controller.go` (2 call sites)
- `pkg/controller/storageversionmigrator/migrationrunner.go` (1 call site)
- `pkg/controller/storageversionmigrator/resourceversion.go` (1 call site)
- `pkg/controller/storageversionmigrator/storageversionmigrator.go` (1 call site)

Fixes: https://github.com/kubernetes/kubernetes/issues/126379

```release-note
NONE
```