### PR TITLE
Fix TestClassifyLBError test case for nil error

### DIFF
--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -2690,9 +2690,9 @@ func TestClassifyLBError(t *testing.T) {
 		expected lbErrorType
 	}{
 		{
-			name:     "nil error returns other",
+			name:     "nil error returns none",
 			err:      nil,
-			expected: lbErrOther,
+			expected: lbErrNone,
 		},
 		{
 			name:     "generic error returns other",
@@ -2757,6 +2757,7 @@ func TestLBErrorTypeConstants(t *testing.T) {
 		lbErrNotImplemented,
 		lbErrInvalidIP,
 		lbErrOther,
+		lbErrNone,
 	}
 	seen := make(map[lbErrorType]bool)
 	for _, et := range errTypes {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:

Fix TestClassifyLBError test case for nil error introduced by https://github.com/kubernetes/kubernetes/pull/137767
    
The classifyLBError function returns lbErrNone when err is nil, but the test was incorrectly expecting lbErrOther.
  
#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/issues/139635

failing unit test on Windows:
```
[sig-network] k8s.io/kubernetes/pkg/proxy: winkernel expand_less	0s
{Failed  === RUN   TestClassifyLBError/nil_error_returns_other
    proxier_test.go:2730: 
        	Error Trace:	C:/kubernetes/pkg/proxy/winkernel/proxier_test.go:2730
        	Error:      	Not equal: 
        	            	expected: "other"
        	            	actual  : "none"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,2 +1,2 @@
        	            	-(winkernel.lbErrorType) (len=5) "other"
        	            	+(winkernel.lbErrorType) (len=4) "none"
        	            	 
        	Test:       	TestClassifyLBError/nil_error_returns_other
--- FAIL: TestClassifyLBError/nil_error_returns_other (0.00s)

=== RUN   TestClassifyLBError
--- FAIL: TestClassifyLBError (0.00s)
}
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
