### PR TITLE
Add retries to get CRD updated

### DIFF
--- a/test/integration/apiserver/crd_validation_expressions_test.go
+++ b/test/integration/apiserver/crd_validation_expressions_test.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"testing"
 
+	"time"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -30,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/client-go/dynamic"
 	apiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
@@ -712,14 +715,26 @@ func TestCustomResourceValidatorsWithSchemaConversion(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Make an unrelated update to the previous persisted CR instance to make sure CRD handler doesn't panic
-	oldCR, err := crClient.Get(context.TODO(), name1, metav1.GetOptions{})
+	// It may take some time for the CRD schema update to be processed by the API Server's internal validation cache.
+	var lastErr error
+	err = wait.PollUntilContextTimeout(context.TODO(), 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+		oldCR, err := crClient.Get(ctx, name1, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		oldCR.Object["metadata"].(map[string]interface{})["labels"] = map[string]interface{}{"key": "value"}
+		_, err = crClient.Update(ctx, oldCR, metav1.UpdateOptions{})
+		lastErr = err
+
+		if err != nil && strings.Contains(err.Error(), "rule compiler initialization error: failed to convert to declType for CEL validation rules") {
+			return true, nil
+		}
+
+		return false, nil
+	})
 	if err != nil {
-		t.Fatal(err)
-	}
-	oldCR.Object["metadata"].(map[string]interface{})["labels"] = map[string]interface{}{"key": "value"}
-	_, err = crClient.Update(context.TODO(), oldCR, metav1.UpdateOptions{})
-	if err == nil || !strings.Contains(err.Error(), "rule compiler initialization error: failed to convert to declType for CEL validation rules") {
-		t.Fatalf("expect error to contain \rule compiler initialization error: failed to convert to declType for CEL validation rules\" but get: %v", err)
+		t.Fatalf("expect error to contain \"rule compiler initialization error: failed to convert to declType for CEL validation rules\" but get: %v", lastErr)
 	}
 	// Create another CR instance with an array and be rejected
 	name2 := names.SimpleNameGenerator.GenerateName("cr-2")


### PR DESCRIPTION

#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

This PR fixes a flaky test `TestCustomResourceValidatorsWithSchemaConversion` in the `apiserver` integration tests. 

The test updates a CRD schema and then makes an unrelated update to an existing CR instance, expecting a specific `rule compiler initialization error`. However, the API server cache for CRDs can take some time to update. Due to this delay, the expected error might not be hit immediately if the API server evaluates the CR update against the old, cached schema.

To resolve this, this PR adds a `wait.PollUntilContextTimeout` loop to retry the CR update until the API server's cache catches up and successfully returns the expected CEL validation compilation error.


This is can validated by introducing artificial delay in  CRD informer cache flow.

```
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -479,6 +479,12 @@ func (r *crdHandler) updateCustomResourceDefinition(oldObj, newObj interface{})
 	oldCRD := oldObj.(*apiextensionsv1.CustomResourceDefinition)
 	newCRD := newObj.(*apiextensionsv1.CustomResourceDefinition)

+	// INTENTIONAL DELAY TO SIMULATE FLAKE: Wait 3 seconds before processing the update in the cache.
+	// This will cause subsequent requests to still use the old cache for 3 seconds.
+	if newCRD.Name != "" && strings.Contains(newCRD.Name, "structural") {
+		time.Sleep(5 * time.Millisecond)
+	}
+
 	r.customStorageLock.Lock()
 	defer r.customStorageLock.Unlock()

```
#### Which issue(s) this PR is related to:

Fixes #139614

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
