### PR TITLE
refactor: use AddEventHandlerWithOptions in cronjob and certificates

### DIFF
--- a/pkg/controller/certificates/certificate_controller.go
+++ b/pkg/controller/certificates/certificate_controller.go
@@ -78,7 +78,7 @@ func NewCertificateController(
 	}
 
 	// Manage the addition/update of certificate requests
-	csrInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := csrInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			csr := obj.(*certificates.CertificateSigningRequest)
 			logger.V(4).Info("Adding certificate request", "csr", csr.Name)
@@ -106,7 +106,8 @@ func NewCertificateController(
 			logger.V(4).Info("Deleting certificate request", "csr", csr.Name)
 			cc.enqueueCertificateRequest(obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
+	utilruntime.Must(err)
 	cc.csrLister = csrInformer.Lister()
 	cc.csrsSynced = csrInformer.Informer().HasSynced
 	return cc

--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -114,13 +114,14 @@ func NewControllerV2(ctx context.Context, jobInformer batchv1informers.JobInform
 		now: time.Now,
 	}
 
-	jobInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := jobInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    jm.addJob,
 		UpdateFunc: jm.updateJob,
 		DeleteFunc: jm.deleteJob,
-	})
+	}, cache.HandlerOptions{Logger: &logger})
+	utilruntime.Must(err)
 
-	cronJobsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = cronJobsInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			jm.enqueueController(obj)
 		},
@@ -130,9 +131,10 @@ func NewControllerV2(ctx context.Context, jobInformer batchv1informers.JobInform
 		DeleteFunc: func(obj interface{}) {
 			jm.enqueueController(obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
+	utilruntime.Must(err)
 
-	err := jobInformer.Informer().AddIndexers(cache.Indexers{
+	err = jobInformer.Informer().AddIndexers(cache.Indexers{
 		jobControllerUIDIndex: func(obj interface{}) ([]string, error) {
 			job, ok := obj.(*batchv1.Job)
 			if !ok {


### PR DESCRIPTION
Migrate plain `AddEventHandler` calls in `pkg/controller/cronjob` and `pkg/controller/certificates` to `AddEventHandlerWithOptions` with `cache.HandlerOptions{Logger: &logger}`, so the contextual logger is propagated into the informer handler goroutines.

The logger is already in scope at each call site (`klog.FromContext(ctx)`) so this is a pure API migration with no behaviour change.

**Files changed (2):**
- `pkg/controller/cronjob/cronjob_controllerv2.go` (2 call sites)
- `pkg/controller/certificates/certificate_controller.go` (1 call site)

Fixes: https://github.com/kubernetes/kubernetes/issues/126379

```release-note
NONE
```