### PR TITLE
scheduler: fix pending pods metric accounting for entities with size > 1

### DIFF
--- a/pkg/scheduler/backend/heap/heap.go
+++ b/pkg/scheduler/backend/heap/heap.go
@@ -122,6 +122,10 @@ type Heap[T Item] struct {
 func (h *Heap[T]) AddOrUpdate(obj T) {
 	key := h.data.keyFunc(obj)
 	if idx, exists := h.data.keyIndex[key]; exists {
+		if h.metricRecorder != nil {
+			// The new object might have a different size than the stored one.
+			h.metricRecorder.Add(obj.Size() - h.data.queue[idx].obj.Size())
+		}
 		h.data.queue[idx].obj = obj
 		heap.Fix(h.data, idx)
 	} else {
@@ -138,7 +142,9 @@ func (h *Heap[T]) Delete(obj T) T {
 	if idx, ok := h.data.keyIndex[key]; ok {
 		removed := heap.Remove(h.data, idx).(T)
 		if h.metricRecorder != nil {
-			h.metricRecorder.Add(-obj.Size())
+			// Use the size of the removed object, because the passed obj might be
+			// a lookup object whose size doesn't match the stored one.
+			h.metricRecorder.Add(-removed.Size())
 		}
 		return removed
 	}

--- a/pkg/scheduler/backend/heap/heap_test.go
+++ b/pkg/scheduler/backend/heap/heap_test.go
@@ -745,6 +745,18 @@ func TestHeapWithRecorder(t *testing.T) {
 	if *metricRecorder != 7 {
 		t.Errorf("expected count to be 7 (3+4) but got %d", *metricRecorder)
 	}
+	// Update an existing item with a different size.
+	h.AddOrUpdate(mkHeapObj("baz", 100, 5))
+	if *metricRecorder != 9 {
+		t.Errorf("expected count to be 9 (5+4) but got %d", *metricRecorder)
+	}
+	// Delete an item using a lookup object whose size doesn't match the stored one.
+	if obj := h.Delete(mkHeapObj("baz", 100, 0)); obj.name == "" {
+		t.Fatalf("Failed to delete item")
+	}
+	if *metricRecorder != 4 {
+		t.Errorf("expected count to be 4 but got %d", *metricRecorder)
+	}
 
 	h.metricRecorder.Clear()
 	if *metricRecorder != 0 {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`Heap.Delete` decrements the metric recorder by the size of the passed object. But the passed object may be just a lookup object, whose size doesn't match the stored one.

The scheduling queue deletes entities from the activeQ/backoffQ heaps using such lookups. For pod groups (added in #138567), the lookup built by `newQueuedPodGroupInfoForLookup` has no member pods, so its `Size()` is 0, while the stored group has `Size() == N`. Whenever a queued pod group is deleted via a lookup (a new member pod joins a queued group, a member pod is deleted, the group is activated out of the backoffQ), the `scheduler_pending_pods` gauge is decremented by 0 after having been incremented by N, so it stays inflated forever. For example, adding 3 pods of the same group one by one leaves the gauge at 6 instead of 3.

Fixed by decrementing by the size of the removed object instead. Also adjust the metric by the size delta in `AddOrUpdate` when an update replaces the stored object - same kind of problem, though currently a no-op since no caller changes the size on update.

Individual pods always have `Size() == 1`, so they are not affected.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
