### PR TITLE
Fix spelling typos in apiextensions-apiserver comments

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go
@@ -246,7 +246,7 @@ func splitReplicasPath(replicasPath string) []string {
 	return strings.Split(strings.TrimPrefix(replicasPath, "."), ".")
 }
 
-// scaleFromCustomResource returns a scale subresource for a customresource and a bool signalling wether
+// scaleFromCustomResource returns a scale subresource for a customresource and a bool signalling whether
 // the specReplicas value was found.
 func scaleFromCustomResource(cr *unstructured.Unstructured, specReplicasPath, statusReplicasPath, labelSelectorPath string) (*autoscalingv1.Scale, bool, error) {
 	specReplicas, foundSpecReplicas, err := unstructured.NestedInt64(cr.UnstructuredContent(), splitReplicasPath(specReplicasPath)...)

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
@@ -222,7 +222,7 @@ func testStoragedVersionInCRDStatus(t *testing.T, ns string, noxuDefinition *api
 		t.Fatal(err)
 	}
 
-	// The storage version list should be initilized to storage version
+	// The storage version list should be initialized to storage version
 	crd, err := apiExtensionClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.TODO(), noxuDefinition.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Fixes two spelling typos in `apiextensions-apiserver` comments:

* `pkg/registry/customresource/etcd.go`: `wether` → `whether`
* `test/integration/versioning_test.go`: `initilized` → `initialized`

Comment-only; no functional change.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Neither is caught by `hack/verify-spelling.sh` — `wether` is a valid word, and `initilized` isn't in misspell's dictionary.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
