### PR TITLE
Fix spelling typo in kubectl cp comment

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/filespec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/filespec.go
@@ -34,7 +34,7 @@ type pathSpec interface {
 
 // localPath represents a client-native path, which will differ based
 // on the client OS, its methods will use path/filepath package which
-// is OS dependant
+// is OS dependent
 type localPath struct {
 	file string
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Corrects a spelling typo in a code comment:

* `dependant` → `dependent`

Comment-only change; no functional impact.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

`dependent` is the standard spelling used in technical documentation and throughout the Kubernetes codebase.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
