### PR TITLE
apiserver/endpoints/handlers/responsewriters: move gzip writer pool constructor to compression.go

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/compression.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/compression.go
@@ -17,13 +17,35 @@ limitations under the License.
 package responsewriters
 
 import (
+	"compress/gzip"
 	"net/http"
 	"strings"
+	"sync"
 
 	"k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/featuregate"
 )
+
+const (
+	// gzipContentEncodingLevel is set to 1 which uses least CPU compared to higher levels, yet offers
+	// similar compression ratios (off by at most 1.5x, but typically within 1.1x-1.3x). For further details see -
+	// https://github.com/kubernetes/kubernetes/issues/112296
+	gzipContentEncodingLevel = 1
+)
+
+// NewGzipWriterPoolOrDie returns a sync.Pool of gzip.Writers configured with gzipContentEncodingLevel.
+func NewGzipWriterPoolOrDie() *sync.Pool {
+	return &sync.Pool{
+		New: func() interface{} {
+			gw, err := gzip.NewWriterLevel(nil, gzipContentEncodingLevel)
+			if err != nil {
+				panic(err)
+			}
+			return gw
+		},
+	}
+}
 
 // responseContentEncodingSupported returns a supported client-requested content encoding for the
 // provided request. It will return the empty string if no supported content encoding was

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"net/http"
 	"strconv"
-	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -137,21 +136,9 @@ func SerializeObject(mediaType string, encoder runtime.Encoder, hw http.Response
 	w.Close()
 }
 
-var gzipPool = &sync.Pool{
-	New: func() interface{} {
-		gw, err := gzip.NewWriterLevel(nil, defaultGzipContentEncodingLevel)
-		if err != nil {
-			panic(err)
-		}
-		return gw
-	},
-}
+var gzipPool = NewGzipWriterPoolOrDie()
 
 const (
-	// defaultGzipContentEncodingLevel is set to 1 which uses least CPU compared to higher levels, yet offers
-	// similar compression ratios (off by at most 1.5x, but typically within 1.1x-1.3x). For further details see -
-	// https://github.com/kubernetes/kubernetes/issues/112296
-	defaultGzipContentEncodingLevel = 1
 	// defaultGzipThresholdBytes is compared to the size of the first write from the stream
 	// (usually the entire object), and if the size is smaller no gzipping will be performed
 	// if the client requests it.

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
@@ -252,7 +252,7 @@ func TestSerializeObject(t *testing.T) {
 				"Content-Encoding": []string{"gzip"},
 				"Vary":             []string{"Accept-Encoding"},
 			},
-			wantBody: gzipContent(largePayload, defaultGzipContentEncodingLevel),
+			wantBody: gzipContent(largePayload, gzipContentEncodingLevel),
 		},
 
 		{
@@ -290,7 +290,7 @@ func TestSerializeObject(t *testing.T) {
 				"Content-Encoding": []string{"gzip"},
 				"Vary":             []string{"Accept-Encoding"},
 			},
-			wantBody: gzipContent(largePayload, defaultGzipContentEncodingLevel),
+			wantBody: gzipContent(largePayload, gzipContentEncodingLevel),
 		},
 
 		{
@@ -348,7 +348,7 @@ func TestSerializeObject(t *testing.T) {
 				"Content-Encoding": []string{"gzip"},
 				"Vary":             []string{"Accept-Encoding"},
 			},
-			wantBody: gzipContent([]byte(": "+string(largePayload)), defaultGzipContentEncodingLevel),
+			wantBody: gzipContent([]byte(": "+string(largePayload)), gzipContentEncodingLevel),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Moves the `gzip writer pool constructor` and the `gzipContentEncodingLevel` constant from `writers.go` to `compression.go`, and exports it as `NewGzipWriterPoolOrDie`.

This allows reuse for the upcoming `WatchListCompression` feature gate, enabling `watch.go` to call `responsewriters.NewGzipWriterPoolOrDie()` to create its own gzip writer pool.

xref: https://github.com/kubernetes/kubernetes/pull/139482
xref: https://github.com/kubernetes/kubernetes/pull/139308
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
