### PR TITLE
kubelet: unittests: use ktesting context

### DIFF
--- a/pkg/kubelet/certificate/kubelet_test.go
+++ b/pkg/kubelet/certificate/kubelet_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/client-go/util/cert"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/test/utils/client-go/ktesting"
 	netutils "k8s.io/utils/net"
 )
 
@@ -183,6 +184,7 @@ func createCertAndKeyFilesUsingRename(certDir string) (string, string, error) {
 }
 
 func TestKubeletServerCertificateFromFiles(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	// test two common ways of certificate file updates:
 	// 1. delete and write the cert and key files directly
 	// 2. create the cert and key files under a child dir and perform dir rename during update
@@ -239,7 +241,7 @@ func TestKubeletServerCertificateFromFiles(t *testing.T) {
 				t.Fatalf("got errors when rotating certificate files in the test: %v", err)
 			}
 
-			err = wait.PollUntilContextTimeout(context.Background(),
+			err = wait.PollUntilContextTimeout(tCtx,
 				100*time.Millisecond, 10*time.Second, true,
 				func(_ context.Context) (bool, error) {
 					c3 := m.Current()

--- a/pkg/kubelet/client/kubelet_client_test.go
+++ b/pkg/kubelet/client/kubelet_client_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apiserver/pkg/server/egressselector"
+	"k8s.io/kubernetes/test/utils/client-go/ktesting"
 )
 
 func kubeletTestCertHelper(valid bool) KubeletTLSConfig {
@@ -460,7 +461,7 @@ func TestGetConnectionInfo(t *testing.T) {
 				t.Fatalf("failed to create NodeConnectionInfoGetter: %v", err)
 			}
 
-			tCtx := context.Background()
+			tCtx := ktesting.Init(t)
 			connInfo, err := getter.GetConnectionInfo(tCtx, tt.nodeName)
 
 			if tt.expectError {

--- a/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager_test.go
+++ b/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager_test.go
@@ -114,8 +114,8 @@ func TestGetTrustAnchorsByName(t *testing.T) {
 }
 
 func testGetTrustAnchorsByName[T clusterTrustBundle](t *testing.T, b testingFunctionBundle[T]) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	tCtx := ktesting.Init(t)
+	ctx, cancel := context.WithTimeout(tCtx, 5*time.Second)
 	defer cancel()
 
 	ctb1Bundle := mustMakeRoot(t, "root1")
@@ -251,8 +251,8 @@ func TestGetTrustAnchorsBySignerName(t *testing.T) {
 }
 
 func testGetTrustAnchorsBySignerName[T clusterTrustBundle](t *testing.T, b testingFunctionBundle[T]) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	tCtx := ktesting.Init(t)
+	ctx, cancel := context.WithTimeout(tCtx, 5*time.Second)
 	defer cancel()
 
 	ctb1 := b.ctbConstructor("signer-a-label-a-1", "foo.bar/a", map[string]string{"label": "a"}, mustMakeRoot(t, "0"))

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -858,7 +858,7 @@ func TestReconcileState(t *testing.T) {
 		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WindowsCPUAndMemoryAffinity, true)
 	}
 
-	logger, _ := ktesting.NewTestContext(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 
 	testPolicy, _ := NewStaticPolicy(
 		logger,
@@ -1315,7 +1315,6 @@ func TestReconcileState(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		logger, _ := ktesting.NewTestContext(t)
 		mgr := &manager{
 			policy: testCase.policy,
 			state: &mockState{
@@ -1336,7 +1335,7 @@ func TestReconcileState(t *testing.T) {
 			},
 		}
 		mgr.sourcesReady = &sourcesReadyStub{}
-		success, failure := mgr.reconcileState(context.Background())
+		success, failure := mgr.reconcileState(tCtx)
 
 		if !reflect.DeepEqual(testCase.expectStAssignments, mgr.state.GetCPUAssignments()) {
 			t.Errorf("%v", testCase.description)

--- a/pkg/kubelet/cm/cpumanager/policy_static_restore_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_restore_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cpumanager
 
 import (
-	"context"
 	"runtime"
 	"testing"
 	"time"
@@ -101,7 +100,7 @@ func TestCPUManagerRestoreState(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.PodLevelResourceManagers, tc.podLevelResourceManagersEnabled)
 
 			sDir := t.TempDir()
-			logger, _ := ktesting.NewTestContext(t)
+			logger, tCtx := ktesting.NewTestContext(t)
 			mgr, err := NewManager(
 				logger,
 				"static",
@@ -140,7 +139,7 @@ func TestCPUManagerRestoreState(t *testing.T) {
 			pod.UID = types.UID("pod1")
 
 			// Start manager to initialize state and activePods
-			err = mgr.Start(context.Background(), func() []*v1.Pod { return []*v1.Pod{pod} }, &sourcesReadyStub{}, mockPodStatusProvider{}, mockRuntimeService{}, containermap.NewContainerMap())
+			err = mgr.Start(tCtx, func() []*v1.Pod { return []*v1.Pod{pod} }, &sourcesReadyStub{}, mockPodStatusProvider{}, mockRuntimeService{}, containermap.NewContainerMap())
 			if err != nil {
 				t.Fatalf("could not start manager: %v", err)
 			}
@@ -204,7 +203,7 @@ func TestCPUManagerRestoreState(t *testing.T) {
 				t.Fatalf("could not create manager 2: %v", err)
 			}
 
-			err = mgr2.Start(context.Background(), func() []*v1.Pod { return []*v1.Pod{pod} }, &sourcesReadyStub{}, mockPodStatusProvider{}, mockRuntimeService{}, containermap.NewContainerMap())
+			err = mgr2.Start(tCtx, func() []*v1.Pod { return []*v1.Pod{pod} }, &sourcesReadyStub{}, mockPodStatusProvider{}, mockRuntimeService{}, containermap.NewContainerMap())
 			if err != nil {
 				t.Fatalf("could not start manager 2: %v", err)
 			}

--- a/pkg/kubelet/cm/memorymanager/policy_static_restore_test.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static_restore_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package memorymanager
 
 import (
-	"context"
 	"runtime"
 	"testing"
 
@@ -39,6 +38,8 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Memory Manager static policy is not available on Windows")
 	}
+
+	tCtx := ktesting.Init(t)
 
 	testCases := []struct {
 		description                     string
@@ -129,7 +130,7 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 			pod := getPodWithContainersAndPodLevelResources("pod1", tc.podMemoryRequest, tc.podMemoryRequest, nil, tc.containers)
 
 			// Start manager to initialize state
-			err = mgr.Start(context.Background(), func() []*v1.Pod { return []*v1.Pod{pod} }, &sourcesReadyStub{}, mockPodStatusProvider{}, mockRuntimeService{}, containermap.NewContainerMap())
+			err = mgr.Start(tCtx, func() []*v1.Pod { return []*v1.Pod{pod} }, &sourcesReadyStub{}, mockPodStatusProvider{}, mockRuntimeService{}, containermap.NewContainerMap())
 			if err != nil {
 				t.Fatalf("could not start manager: %v", err)
 			}
@@ -166,7 +167,7 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 				t.Fatalf("could not create manager 2: %v", err)
 			}
 
-			err = mgr2.Start(context.Background(), func() []*v1.Pod { return []*v1.Pod{pod} }, &sourcesReadyStub{}, mockPodStatusProvider{}, mockRuntimeService{}, containermap.NewContainerMap())
+			err = mgr2.Start(tCtx, func() []*v1.Pod { return []*v1.Pod{pod} }, &sourcesReadyStub{}, mockPodStatusProvider{}, mockRuntimeService{}, containermap.NewContainerMap())
 			if err != nil {
 				t.Fatalf("could not start manager 2: %v", err)
 			}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -5152,6 +5152,7 @@ func generateCAAndCertKeyWithOptions(host string, alternateIPs []net.IP, alterna
 }
 
 func TestSyncPodRestartAllContainersRequeue(t *testing.T) {
+	logger, tCtx := ktesting.NewTestContext(t)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NodeDeclaredFeatures, true)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.RestartAllContainersOnContainerExits, true)
 
@@ -5173,7 +5174,6 @@ func TestSyncPodRestartAllContainersRequeue(t *testing.T) {
 	})
 	kubelet.podManager.SetPods([]*v1.Pod{pod})
 
-	logger := klog.FromContext(context.Background())
 	kubelet.statusManager.SetPodStatus(logger, pod, v1.PodStatus{
 		Phase: v1.PodRunning,
 		Conditions: []v1.PodCondition{
@@ -5215,7 +5215,7 @@ func TestSyncPodRestartAllContainersRequeue(t *testing.T) {
 		},
 	}
 
-	isTerminal, _, err := kubelet.SyncPod(context.Background(), kubetypes.SyncPodUpdate, pod, nil, podStatus)
+	isTerminal, _, err := kubelet.SyncPod(tCtx, kubetypes.SyncPodUpdate, pod, nil, podStatus)
 	require.False(t, isTerminal)
 	require.NoError(t, err)
 

--- a/pkg/kubelet/kubelet_volumes_test.go
+++ b/pkg/kubelet/kubelet_volumes_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -470,7 +471,7 @@ func TestVolumeUnmountAndDetachControllerDisabled(t *testing.T) {
 	kubelet.podWorkers.(*fakePodWorkers).setPodRuntimeBeRemoved(pod.UID)
 	kubelet.podManager.SetPods([]*v1.Pod{})
 
-	assert.NoError(t, kubelet.volumeManager.WaitForUnmount(tCtx, pod))
+	require.NoError(t, kubelet.volumeManager.WaitForUnmount(tCtx, pod))
 
 	// Verify volumes unmounted
 	hasMountedVolumes := kubelet.volumeManager.HasPossiblyMountedVolumesForPod(
@@ -550,7 +551,7 @@ func TestVolumeAttachAndMountControllerEnabled(t *testing.T) {
 		tCtx.Done(),
 		kubelet.volumeManager)
 
-	assert.NoError(t, kubelet.volumeManager.WaitForAttachAndMount(tCtx, pod))
+	require.NoError(t, kubelet.volumeManager.WaitForAttachAndMount(tCtx, pod))
 
 	podVolumes := kubelet.volumeManager.GetMountedVolumesForPod(
 		util.GetUniquePodName(pod))
@@ -637,7 +638,7 @@ func TestVolumeUnmountAndDetachControllerEnabled(t *testing.T) {
 		kubelet.volumeManager)
 
 	// Verify volumes attached
-	assert.NoError(t, kubelet.volumeManager.WaitForAttachAndMount(tCtx, pod))
+	require.NoError(t, kubelet.volumeManager.WaitForAttachAndMount(tCtx, pod))
 
 	podVolumes := kubelet.volumeManager.GetMountedVolumesForPod(
 		util.GetUniquePodName(pod))

--- a/pkg/kubelet/kubelet_volumes_test.go
+++ b/pkg/kubelet/kubelet_volumes_test.go
@@ -84,7 +84,7 @@ func TestListVolumesForPod(t *testing.T) {
 	go kubelet.volumeManager.Run(tCtx, kubelet.sourcesReady)
 
 	kubelet.podManager.SetPods([]*v1.Pod{pod})
-	err := kubelet.volumeManager.WaitForAttachAndMount(context.Background(), pod)
+	err := kubelet.volumeManager.WaitForAttachAndMount(tCtx, pod)
 	assert.NoError(t, err)
 
 	podName := util.GetUniquePodName(pod)
@@ -267,7 +267,7 @@ func TestPodVolumeDeadlineAttachAndMount(t *testing.T) {
 	for _, pod := range pods {
 		start := time.Now()
 		// ensure our context times out quickly
-		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(2*time.Second))
+		ctx, cancel := context.WithDeadline(tCtx, time.Now().Add(2*time.Second))
 		err := kubelet.volumeManager.WaitForAttachAndMount(ctx, pod)
 		delta := time.Since(start)
 		// the standard timeout is 2 minutes, so if it's just a few seconds we know that the context timeout was the cause
@@ -327,12 +327,12 @@ func TestPodVolumeDeadlineUnmount(t *testing.T) {
 
 	kubelet.podManager.SetPods(pods)
 	for i, pod := range pods {
-		if err := kubelet.volumeManager.WaitForAttachAndMount(context.Background(), pod); err != nil {
+		if err := kubelet.volumeManager.WaitForAttachAndMount(tCtx, pod); err != nil {
 			t.Fatalf("pod %d failed: %v", i, err)
 		}
 		start := time.Now()
 		// ensure our context times out quickly
-		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(2*time.Second))
+		ctx, cancel := context.WithDeadline(tCtx, time.Now().Add(2*time.Second))
 		err := kubelet.volumeManager.WaitForUnmount(ctx, pod)
 		delta := time.Since(start)
 		// the standard timeout is 2 minutes, so if it's just a few seconds we know that the context timeout was the cause
@@ -380,7 +380,7 @@ func TestVolumeAttachAndMountControllerDisabled(t *testing.T) {
 	go kubelet.volumeManager.Run(tCtx, kubelet.sourcesReady)
 
 	kubelet.podManager.SetPods([]*v1.Pod{pod})
-	err := kubelet.volumeManager.WaitForAttachAndMount(context.Background(), pod)
+	err := kubelet.volumeManager.WaitForAttachAndMount(tCtx, pod)
 	assert.NoError(t, err)
 
 	podVolumes := kubelet.volumeManager.GetMountedVolumesForPod(
@@ -443,7 +443,7 @@ func TestVolumeUnmountAndDetachControllerDisabled(t *testing.T) {
 	kubelet.podManager.SetPods([]*v1.Pod{pod})
 
 	// Verify volumes attached
-	err := kubelet.volumeManager.WaitForAttachAndMount(context.Background(), pod)
+	err := kubelet.volumeManager.WaitForAttachAndMount(tCtx, pod)
 	assert.NoError(t, err)
 
 	podVolumes := kubelet.volumeManager.GetMountedVolumesForPod(
@@ -470,7 +470,7 @@ func TestVolumeUnmountAndDetachControllerDisabled(t *testing.T) {
 	kubelet.podWorkers.(*fakePodWorkers).setPodRuntimeBeRemoved(pod.UID)
 	kubelet.podManager.SetPods([]*v1.Pod{})
 
-	assert.NoError(t, kubelet.volumeManager.WaitForUnmount(context.Background(), pod))
+	assert.NoError(t, kubelet.volumeManager.WaitForUnmount(tCtx, pod))
 
 	// Verify volumes unmounted
 	hasMountedVolumes := kubelet.volumeManager.HasPossiblyMountedVolumesForPod(
@@ -550,7 +550,7 @@ func TestVolumeAttachAndMountControllerEnabled(t *testing.T) {
 		tCtx.Done(),
 		kubelet.volumeManager)
 
-	assert.NoError(t, kubelet.volumeManager.WaitForAttachAndMount(context.Background(), pod))
+	assert.NoError(t, kubelet.volumeManager.WaitForAttachAndMount(tCtx, pod))
 
 	podVolumes := kubelet.volumeManager.GetMountedVolumesForPod(
 		util.GetUniquePodName(pod))
@@ -637,7 +637,7 @@ func TestVolumeUnmountAndDetachControllerEnabled(t *testing.T) {
 		kubelet.volumeManager)
 
 	// Verify volumes attached
-	assert.NoError(t, kubelet.volumeManager.WaitForAttachAndMount(context.Background(), pod))
+	assert.NoError(t, kubelet.volumeManager.WaitForAttachAndMount(tCtx, pod))
 
 	podVolumes := kubelet.volumeManager.GetMountedVolumesForPod(
 		util.GetUniquePodName(pod))

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -2962,8 +2962,7 @@ func TestComputePodActionsWithContainerRestartRules(t *testing.T) {
 		if test.mutateStatusFn != nil {
 			test.mutateStatusFn(status)
 		}
-		ctx := context.Background()
-		actions := m.computePodActions(ctx, pod, status, false)
+		actions := m.computePodActions(tCtx, pod, status, false)
 		verifyActions(t, &test.actions, &actions, desc)
 		if test.resetStatusFn != nil {
 			test.resetStatusFn(status)

--- a/pkg/kubelet/lifecycle/predicate_test.go
+++ b/pkg/kubelet/lifecycle/predicate_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodename"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeports"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/tainttoleration"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/ptr"
 )
 
@@ -293,6 +294,7 @@ func newPodWithPort(hostPorts ...int) *v1.Pod {
 }
 
 func TestGeneralPredicates(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	resourceTests := []struct {
 		pod        *v1.Pod
 		nodeInfo   *schedulerframework.NodeInfo
@@ -634,7 +636,7 @@ func TestGeneralPredicates(t *testing.T) {
 				}
 				return test.syncNode, nil
 			}}
-			reasons := w.generalFilter(context.Background(), test.pod, test.nodeInfo)
+			reasons := w.generalFilter(tCtx, test.pod, test.nodeInfo)
 			if diff := cmp.Diff(test.reasons, reasons); diff != "" {
 				t.Errorf("unexpected failure reasons (-want, +got):\n%s", diff)
 			}

--- a/pkg/kubelet/server/server_test.go
+++ b/pkg/kubelet/server/server_test.go
@@ -1741,7 +1741,7 @@ func TestWebsocketExecAttach(t *testing.T) {
 
 	errorChan := make(chan error)
 	go func() {
-		errorChan <- exec.StreamWithContext(context.Background(), *options)
+		errorChan <- exec.StreamWithContext(tCtx, *options)
 	}()
 
 	select {

--- a/pkg/kubelet/stats/cadvisor_stats_provider_test.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package stats
 
 import (
-	"context"
 	"runtime"
 	"testing"
 
@@ -118,8 +117,8 @@ func TestFilterTerminatedContainerInfoAndAssembleByPodCgroupKey(t *testing.T) {
 }
 
 func TestCadvisorListPodStats(t *testing.T) {
+	ctx := ktesting.Init(t).Context
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.KubeletPSI, true)
-	ctx := context.Background()
 	const (
 		namespace0 = "test0"
 		namespace2 = "test2"
@@ -644,7 +643,7 @@ func TestCadvisorListPodCPUAndMemoryStats(t *testing.T) {
 }
 
 func TestCadvisorImagesFsStatsKubeletSeparateDiskOff(t *testing.T) {
-	ctx := context.Background()
+	ctx := ktesting.Init(t).Context
 	var (
 		assert       = assert.New(t)
 		mockCadvisor = cadvisortest.NewMockInterface(t)
@@ -730,7 +729,7 @@ func TestImageFsStatsCustomResponse(t *testing.T) {
 			shouldErr:           false,
 		},
 	} {
-		ctx := context.Background()
+		ctx := ktesting.Init(t).Context
 		mockCadvisor := cadvisortest.NewMockInterface(t)
 		mockRuntime := containertest.NewMockRuntime(t)
 
@@ -754,7 +753,7 @@ func TestImageFsStatsCustomResponse(t *testing.T) {
 }
 
 func TestCadvisorImagesFsStats(t *testing.T) {
-	ctx := context.Background()
+	ctx := ktesting.Init(t).Context
 	var (
 		assert       = assert.New(t)
 		mockCadvisor = cadvisortest.NewMockInterface(t)
@@ -799,7 +798,7 @@ func TestCadvisorImagesFsStats(t *testing.T) {
 }
 
 func TestCadvisorSplitImagesFsStats(t *testing.T) {
-	ctx := context.Background()
+	ctx := ktesting.Init(t).Context
 	var (
 		assert       = assert.New(t)
 		mockCadvisor = cadvisortest.NewMockInterface(t)
@@ -852,7 +851,7 @@ func TestCadvisorSplitImagesFsStats(t *testing.T) {
 }
 
 func TestCadvisorSameDiskDifferentLocations(t *testing.T) {
-	ctx := context.Background()
+	ctx := ktesting.Init(t).Context
 	var (
 		assert       = assert.New(t)
 		mockCadvisor = cadvisortest.NewMockInterface(t)
@@ -905,7 +904,7 @@ func TestCadvisorSameDiskDifferentLocations(t *testing.T) {
 }
 
 func TestCadvisorListPodStatsWhenContainerLogFound(t *testing.T) {
-	ctx := context.Background()
+	ctx := ktesting.Init(t).Context
 	const (
 		namespace0 = "test0"
 	)

--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -2347,6 +2347,7 @@ func TestMergePodStatus(t *testing.T) {
 }
 
 func TestContainerTerminationMetric(t *testing.T) {
+	logger, tCtx := ktesting.NewTestContext(t)
 	metrics.Register()
 	manager := newTestManager(&fake.Clientset{})
 	pod := &v1.Pod{
@@ -2376,9 +2377,9 @@ func TestContainerTerminationMetric(t *testing.T) {
 			},
 		},
 	}
-	manager.SetPodStatus(klog.Background(), pod, initialStatus)
+	manager.SetPodStatus(logger, pod, initialStatus)
 
-	manager.testSyncBatch(context.Background())
+	manager.testSyncBatch(tCtx)
 
 	// Test successful termination (exit code 0)
 	successStatus := v1.PodStatus{
@@ -2395,8 +2396,8 @@ func TestContainerTerminationMetric(t *testing.T) {
 			},
 		},
 	}
-	manager.SetPodStatus(klog.Background(), pod, successStatus)
-	manager.testSyncBatch(context.Background())
+	manager.SetPodStatus(logger, pod, successStatus)
+	manager.testSyncBatch(tCtx)
 
 	count, err := testutil.GetCounterMetricValue(metrics.TerminatedContainersTotal.WithLabelValues(metrics.Container, "0", "Completed"))
 	require.NoError(t, err)
@@ -2431,8 +2432,8 @@ func TestContainerTerminationMetric(t *testing.T) {
 			},
 		},
 	}
-	manager.SetPodStatus(klog.Background(), errorPod, errorStatus)
-	manager.testSyncBatch(context.Background())
+	manager.SetPodStatus(logger, errorPod, errorStatus)
+	manager.testSyncBatch(tCtx)
 
 	count, err = testutil.GetCounterMetricValue(metrics.TerminatedContainersTotal.WithLabelValues(metrics.Container, "1", "Error"))
 	require.NoError(t, err)

--- a/pkg/kubelet/volume_host_test.go
+++ b/pkg/kubelet/volume_host_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/kubelet/podcertificate"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 type recordingPodCertificateManager struct {
@@ -55,13 +56,14 @@ func (f *recordingPodCertificateManager) MetricReport() *podcertificate.MetricRe
 // correct order.  Seems excessive, but we got here because I put the arguments
 // in the wrong order...
 func TestGetPodCertificateCredentialBundle(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	recorder := &recordingPodCertificateManager{}
 
 	kvh := &kubeletVolumeHost{
 		podCertificateManager: recorder,
 	}
 
-	_, _, err := kvh.GetPodCertificateCredentialBundle(context.Background(), "namespace", "pod-name", "pod-uid", "volume-name", 10)
+	_, _, err := kvh.GetPodCertificateCredentialBundle(tCtx, "namespace", "pod-name", "pod-uid", "volume-name", 10)
 	if err != nil {
 		t.Fatalf("Unexpected error calling GetPodCertificateCredentialBundle: %v", err)
 	}

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -327,7 +327,7 @@ func TestWaitForAttachAndMountVolumeAttachLimitExceededError(t *testing.T) {
 	go manager.Run(tCtx, sourcesReady)
 	podManager.SetPods([]*v1.Pod{pod})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(tCtx, 1*time.Second)
 	defer cancel()
 	err = manager.WaitForAttachAndMount(ctx, pod)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Use `ktesting.Init(t)` and `ktesting.NewTestContext(t)` instead of `context.Background()` so tests carry proper logging and cancellation tied to the test lifecycle.

#### Which issue(s) this PR is related to:

Ref: https://github.com/kubernetes/kubernetes/issues/130069

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```