### PR TITLE
test: move autoscaling resource-consumer onto agnhost

### DIFF
--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -953,7 +953,7 @@ func runServiceAndWorkloadForResourceConsumer(ctx context.Context, c clientset.I
 
 	rcConfig := testutils.RCConfig{
 		Client:               c,
-		Image:                imageutils.GetE2EImage(imageutils.ResourceConsumer),
+		Image:                imageutils.GetE2EImage(imageutils.Agnhost),
 		Name:                 name,
 		Namespace:            ns,
 		Timeout:              timeoutRC,
@@ -964,6 +964,7 @@ func runServiceAndWorkloadForResourceConsumer(ctx context.Context, c clientset.I
 		MemLimit:             memLimitMb * 1024 * 1024,
 		Annotations:          podAnnotations,
 		AdditionalContainers: additionalContainers,
+		Command:              []string{"/agnhost", "resource-consumer"},
 	}
 	if podResources != nil {
 		rcConfig.PodResources = podResources.DeepCopy()

--- a/test/images/agnhost/README.md
+++ b/test/images/agnhost/README.md
@@ -692,6 +692,28 @@ Usage:
         [--port <port>] [--consumer-port <port>] [--consumer-service-name <service-name>] [--consumer-service-namespace <namespace>]
 ```
 
+### resource-consumer
+
+This subcommand starts the resource-consumer HTTP server used by autoscaling tests.
+
+The subcommand can accept the following flags:
+
+- `port` (default: 8080): The port number to listen to.
+
+It exposes the same endpoints as the standalone `test/images/resource-consumer` image:
+
+- `POST /ConsumeCPU`
+- `POST /ConsumeMem`
+- `POST /BumpMetric`
+- `POST /GetCurrentStatus`
+- `GET /metrics`
+
+Usage:
+
+```console
+    kubectl exec test-agnhost -- /agnhost resource-consumer [--port <port>]
+```
+
 
 ### serve-hostname
 

--- a/test/images/agnhost/agnhost.go
+++ b/test/images/agnhost/agnhost.go
@@ -50,6 +50,7 @@ import (
 	"k8s.io/kubernetes/test/images/agnhost/podcertificatesigner"
 	portforwardtester "k8s.io/kubernetes/test/images/agnhost/port-forward-tester"
 	"k8s.io/kubernetes/test/images/agnhost/porter"
+	resourceconsumer "k8s.io/kubernetes/test/images/agnhost/resource-consumer"
 	resconsumerctrl "k8s.io/kubernetes/test/images/agnhost/resource-consumer-controller"
 	servehostname "k8s.io/kubernetes/test/images/agnhost/serve-hostname"
 	tcpreset "k8s.io/kubernetes/test/images/agnhost/tcp-reset"
@@ -88,6 +89,7 @@ func main() {
 	rootCmd.AddCommand(pause.CmdPause)
 	rootCmd.AddCommand(porter.CmdPorter)
 	rootCmd.AddCommand(portforwardtester.CmdPortForwardTester)
+	rootCmd.AddCommand(resourceconsumer.CmdResourceConsumer)
 	rootCmd.AddCommand(resconsumerctrl.CmdResourceConsumerController)
 	rootCmd.AddCommand(servehostname.CmdServeHostname)
 	rootCmd.AddCommand(testwebserver.CmdTestWebserver)

--- a/test/images/agnhost/resource-consumer/common.go
+++ b/test/images/agnhost/resource-consumer/common.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourceconsumer
+
+import (
+	"math"
+	"time"
+)
+
+const sleep = 10 * time.Millisecond
+
+func doSomething() {
+	for i := 1; i < 10000000; i++ {
+		x := float64(0)
+		x += math.Sqrt(0)
+	}
+}

--- a/test/images/agnhost/resource-consumer/cpu.go
+++ b/test/images/agnhost/resource-consumer/cpu.go
@@ -1,0 +1,43 @@
+//go:build !windows
+
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourceconsumer
+
+import (
+	"log"
+	"time"
+
+	"bitbucket.org/bertimus9/systemstat"
+)
+
+// ConsumeCPU consumes a given number of millicores for the specified duration.
+func ConsumeCPU(millicores int, durationSec int) {
+	log.Printf("ConsumeCPU millicores: %v, durationSec: %v", millicores, durationSec)
+	millicoresPct := float64(millicores) / 10
+	duration := time.Duration(durationSec) * time.Second
+	start := time.Now()
+	first := systemstat.GetProcCPUSample()
+	for time.Since(start) < duration {
+		cpu := systemstat.GetProcCPUAverage(first, systemstat.GetProcCPUSample(), systemstat.GetUptime().Uptime)
+		if cpu.TotalPct < millicoresPct {
+			doSomething()
+		} else {
+			time.Sleep(sleep)
+		}
+	}
+}

--- a/test/images/agnhost/resource-consumer/cpu_windows.go
+++ b/test/images/agnhost/resource-consumer/cpu_windows.go
@@ -1,0 +1,75 @@
+//go:build windows
+
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourceconsumer
+
+import (
+	"log"
+	"syscall"
+	"time"
+
+	syswin "golang.org/x/sys/windows"
+)
+
+type procCPUStats struct {
+	User   int64
+	System int64
+	Time   time.Time
+	Total  int64
+}
+
+func statsNow(handle syscall.Handle) (s procCPUStats) {
+	var processInfo syscall.Rusage
+	syscall.GetProcessTimes(handle, &processInfo.CreationTime, &processInfo.ExitTime, &processInfo.KernelTime, &processInfo.UserTime)
+	s.Time = time.Now()
+	s.User = processInfo.UserTime.Nanoseconds()
+	s.System = processInfo.KernelTime.Nanoseconds()
+	s.Total = s.User + s.System
+	return s
+}
+
+func usageNow(first procCPUStats, second procCPUStats) int64 {
+	dT := second.Time.Sub(first.Time).Nanoseconds()
+	dUsage := second.Total - first.Total
+	if dT == 0 {
+		return 0
+	}
+	return 1000 * dUsage / dT
+}
+
+// ConsumeCPU consumes a given number of millicores for the specified duration.
+func ConsumeCPU(millicores int, durationSec int) {
+	log.Printf("ConsumeCPU millicores: %v, durationSec: %v", millicores, durationSec)
+	phandle, err := syswin.GetCurrentProcess()
+	if err != nil {
+		panic(err)
+	}
+	handle := syscall.Handle(phandle)
+
+	duration := time.Duration(durationSec) * time.Second
+	start := time.Now()
+	first := statsNow(handle)
+	for time.Since(start) < duration {
+		currentMillicores := usageNow(first, statsNow(handle))
+		if currentMillicores < int64(millicores) {
+			doSomething()
+		} else {
+			time.Sleep(sleep)
+		}
+	}
+}

--- a/test/images/agnhost/resource-consumer/resource_consumer.go
+++ b/test/images/agnhost/resource-consumer/resource_consumer.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourceconsumer
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/spf13/cobra"
+)
+
+// CmdResourceConsumer is used by agnhost Cobra.
+var CmdResourceConsumer = &cobra.Command{
+	Use:   "resource-consumer",
+	Short: "Starts a HTTP server for consuming CPU, memory, and custom metrics",
+	Args:  cobra.MaximumNArgs(0),
+	Run:   runResourceConsumer,
+}
+
+var port int
+
+func init() {
+	CmdResourceConsumer.Flags().IntVar(&port, "port", 8080, "Port number.")
+}
+
+func runResourceConsumer(cmd *cobra.Command, args []string) {
+	handler := NewResourceConsumerHandler()
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), handler))
+}

--- a/test/images/agnhost/resource-consumer/resource_consumer_handler.go
+++ b/test/images/agnhost/resource-consumer/resource_consumer_handler.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourceconsumer
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"time"
+
+	"k8s.io/kubernetes/test/images/resource-consumer/common"
+)
+
+// ResourceConsumerHandler holds metrics for a resource consumer.
+type ResourceConsumerHandler struct {
+	metrics     map[string]float64
+	metricsLock sync.Mutex
+}
+
+// NewResourceConsumerHandler creates and initializes a ResourceConsumerHandler to defaults.
+func NewResourceConsumerHandler() *ResourceConsumerHandler {
+	return &ResourceConsumerHandler{metrics: map[string]float64{}}
+}
+
+func (handler *ResourceConsumerHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if req.URL.Path == common.MetricsAddress {
+		handler.handleMetrics(w)
+		return
+	}
+	if req.Method != "POST" {
+		http.Error(w, common.BadRequest, http.StatusBadRequest)
+		return
+	}
+	if err := req.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.URL.Path == common.ConsumeCPUAddress {
+		handler.handleConsumeCPU(w, req.Form)
+		return
+	}
+	if req.URL.Path == common.ConsumeMemAddress {
+		handler.handleConsumeMem(w, req.Form)
+		return
+	}
+	if req.URL.Path == common.GetCurrentStatusAddress {
+		handler.handleGetCurrentStatus(w)
+		return
+	}
+	if req.URL.Path == common.BumpMetricAddress {
+		handler.handleBumpMetric(w, req.Form)
+		return
+	}
+	http.Error(w, fmt.Sprintf("%s: %s", common.UnknownFunction, req.URL.Path), http.StatusNotFound)
+}
+
+func (handler *ResourceConsumerHandler) handleConsumeCPU(w http.ResponseWriter, query url.Values) {
+	durationSecString := query.Get(common.DurationSecQuery)
+	millicoresString := query.Get(common.MillicoresQuery)
+	if durationSecString == "" || millicoresString == "" {
+		http.Error(w, common.NotGivenFunctionArgument, http.StatusBadRequest)
+		return
+	}
+
+	durationSec, durationSecError := strconv.Atoi(durationSecString)
+	millicores, millicoresError := strconv.Atoi(millicoresString)
+	if durationSecError != nil || millicoresError != nil {
+		http.Error(w, common.IncorrectFunctionArgument, http.StatusBadRequest)
+		return
+	}
+
+	go ConsumeCPU(millicores, durationSec)
+	fmt.Fprintln(w, common.ConsumeCPUAddress[1:])
+	fmt.Fprintln(w, millicores, common.MillicoresQuery)
+	fmt.Fprintln(w, durationSec, common.DurationSecQuery)
+}
+
+func (handler *ResourceConsumerHandler) handleConsumeMem(w http.ResponseWriter, query url.Values) {
+	durationSecString := query.Get(common.DurationSecQuery)
+	megabytesString := query.Get(common.MegabytesQuery)
+	if durationSecString == "" || megabytesString == "" {
+		http.Error(w, common.NotGivenFunctionArgument, http.StatusBadRequest)
+		return
+	}
+
+	durationSec, durationSecError := strconv.Atoi(durationSecString)
+	megabytes, megabytesError := strconv.Atoi(megabytesString)
+	if durationSecError != nil || megabytesError != nil {
+		http.Error(w, common.IncorrectFunctionArgument, http.StatusBadRequest)
+		return
+	}
+
+	go ConsumeMem(megabytes, durationSec)
+	fmt.Fprintln(w, common.ConsumeMemAddress[1:])
+	fmt.Fprintln(w, megabytes, common.MegabytesQuery)
+	fmt.Fprintln(w, durationSec, common.DurationSecQuery)
+}
+
+func (handler *ResourceConsumerHandler) handleGetCurrentStatus(w http.ResponseWriter) {
+	GetCurrentStatus()
+	fmt.Fprintln(w, "Warning: not implemented!")
+	fmt.Fprint(w, common.GetCurrentStatusAddress[1:])
+}
+
+func (handler *ResourceConsumerHandler) handleMetrics(w http.ResponseWriter) {
+	handler.metricsLock.Lock()
+	defer handler.metricsLock.Unlock()
+	for k, v := range handler.metrics {
+		fmt.Fprintf(w, "# HELP %s info message.\n", k)
+		fmt.Fprintf(w, "# TYPE %s gauge\n", k)
+		fmt.Fprintf(w, "%s %f\n", k, v)
+	}
+}
+
+func (handler *ResourceConsumerHandler) bumpMetric(metric string, delta float64, duration time.Duration) {
+	handler.metricsLock.Lock()
+	if _, ok := handler.metrics[metric]; ok {
+		handler.metrics[metric] += delta
+	} else {
+		handler.metrics[metric] = delta
+	}
+	handler.metricsLock.Unlock()
+
+	time.Sleep(duration)
+
+	handler.metricsLock.Lock()
+	handler.metrics[metric] -= delta
+	handler.metricsLock.Unlock()
+}
+
+func (handler *ResourceConsumerHandler) handleBumpMetric(w http.ResponseWriter, query url.Values) {
+	metric := query.Get(common.MetricNameQuery)
+	deltaString := query.Get(common.DeltaQuery)
+	durationSecString := query.Get(common.DurationSecQuery)
+	if durationSecString == "" || metric == "" || deltaString == "" {
+		http.Error(w, common.NotGivenFunctionArgument, http.StatusBadRequest)
+		return
+	}
+
+	durationSec, durationSecError := strconv.Atoi(durationSecString)
+	delta, deltaError := strconv.ParseFloat(deltaString, 64)
+	if durationSecError != nil || deltaError != nil {
+		http.Error(w, common.IncorrectFunctionArgument, http.StatusBadRequest)
+		return
+	}
+
+	go handler.bumpMetric(metric, delta, time.Duration(durationSec)*time.Second)
+	fmt.Fprintln(w, common.BumpMetricAddress[1:])
+	fmt.Fprintln(w, metric, common.MetricNameQuery)
+	fmt.Fprintln(w, delta, common.DeltaQuery)
+	fmt.Fprintln(w, durationSec, common.DurationSecQuery)
+}

--- a/test/images/agnhost/resource-consumer/utils.go
+++ b/test/images/agnhost/resource-consumer/utils.go
@@ -1,0 +1,38 @@
+//go:build !windows
+
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourceconsumer
+
+import (
+	"log"
+	"os/exec"
+	"strconv"
+)
+
+var consumeMemBinary = "stress"
+
+// ConsumeMem consumes a given number of megabytes for the specified duration.
+func ConsumeMem(megabytes int, durationSec int) {
+	log.Printf("ConsumeMem megabytes: %v, durationSec: %v", megabytes, durationSec)
+	megabytesString := strconv.Itoa(megabytes) + "M"
+	durationSecString := strconv.Itoa(durationSec)
+	consumeMem := exec.Command(consumeMemBinary, "-m", "1", "--vm-bytes", megabytesString, "--vm-hang", "0", "-t", durationSecString)
+	if err := consumeMem.Run(); err != nil {
+		log.Printf("Error while consuming memory: %v", err)
+	}
+}

--- a/test/images/agnhost/resource-consumer/utils_common.go
+++ b/test/images/agnhost/resource-consumer/utils_common.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourceconsumer
+
+import "log"
+
+// GetCurrentStatus prints out a no-op.
+func GetCurrentStatus() {
+	log.Printf("GetCurrentStatus")
+}

--- a/test/images/agnhost/resource-consumer/utils_windows.go
+++ b/test/images/agnhost/resource-consumer/utils_windows.go
@@ -1,0 +1,46 @@
+//go:build windows
+
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourceconsumer
+
+import (
+	"log"
+	"os/exec"
+	"strconv"
+	"time"
+)
+
+var consumeMemBinary = "testlimit.exe"
+
+// ConsumeMem consumes a given number of megabytes for the specified duration.
+func ConsumeMem(megabytes int, durationSec int) {
+	log.Printf("ConsumeMem megabytes: %v, durationSec: %v", megabytes, durationSec)
+	megabytesString := strconv.Itoa(megabytes)
+	durationSecString := strconv.Itoa(durationSec)
+	consumeMem := exec.Command(consumeMemBinary, "-accepteula", "-d", megabytesString, "-e", "0", durationSecString, "-c", "1")
+	if err := consumeMem.Start(); err != nil {
+		log.Printf("Error while consuming memory: %v", err)
+		return
+	}
+
+	time.AfterFunc(time.Duration(durationSec)*time.Second, func() {
+		if err := consumeMem.Process.Kill(); err != nil {
+			log.Printf("Could not kill testlimit process! Error: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This is a partial fix for #131893.

It reduces one remaining non-agnhost image usage in autoscaling e2e by moving the autoscaling resource-consumer workload from the standalone `resource-consumer` image onto a new `agnhost resource-consumer` subcommand.

That keeps the existing autoscaling behavior while moving this test path toward the project's preferred consolidation on `agnhost`.

Windows-specific `resource-consumer` usage in `test/e2e/windows/eviction.go` is intentionally left unchanged in this PR because it depends on `testlimit.exe`.

#### Which issue(s) this PR fixes:
Partial fix for #131893

#### Special notes for your reviewer:
This PR copies the existing standalone resource-consumer behavior into `agnhost` and switches the autoscaling e2e framework to invoke it via `command: ["/agnhost", "resource-consumer"]`.

Focused verification:
- `go test ./test/images/agnhost/resource-consumer`
- `go test ./test/images/agnhost -run ^`
- `go test ./test/e2e/framework/autoscaling -run ^`

#### Does this PR introduce a user-facing change?
```release-note
NONE
```