### PR TITLE
Align DeviceTaintRule informer API version with handlers

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
@@ -25,7 +25,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
-	resourcealphaapi "k8s.io/api/resource/v1alpha3"
+	resourcebetaapi "k8s.io/api/resource/v1beta2"
 	labels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/diff"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -395,15 +395,15 @@ func sliceDriverPoolDeviceIndexFunc(obj any) ([]string, error) {
 	return indexValues, nil
 }
 
-func driverPoolDeviceIndexPatchKey(patch *resourcealphaapi.DeviceTaintRule) string {
-	deviceSelector := ptr.Deref(patch.Spec.DeviceSelector, resourcealphaapi.DeviceTaintSelector{})
+func driverPoolDeviceIndexPatchKey(patch *resourcebetaapi.DeviceTaintRule) string {
+	deviceSelector := ptr.Deref(patch.Spec.DeviceSelector, resourcebetaapi.DeviceTaintSelector{})
 	driverKey := ptr.Deref(deviceSelector.Driver, anyDriver)
 	poolKey := ptr.Deref(deviceSelector.Pool, anyPool)
 	deviceKey := ptr.Deref(deviceSelector.Device, anyDevice)
 	return deviceID(driverKey, poolKey, deviceKey)
 }
 
-func (t *Tracker) sliceNamesForPatch(ctx context.Context, patch *resourcealphaapi.DeviceTaintRule) []string {
+func (t *Tracker) sliceNamesForPatch(ctx context.Context, patch *resourcebetaapi.DeviceTaintRule) []string {
 	patchKey := driverPoolDeviceIndexPatchKey(patch)
 	sliceNames, err := t.resourceSlices.GetIndexer().IndexKeys(driverPoolDeviceIndexName, patchKey)
 	if err != nil {
@@ -469,7 +469,7 @@ func (t *Tracker) resourceSliceDelete(ctx context.Context) func(obj any) {
 func (t *Tracker) deviceTaintAdd(ctx context.Context) func(obj any) {
 	logger := klog.FromContext(ctx)
 	return func(obj any) {
-		rule, ok := obj.(*resourcealphaapi.DeviceTaintRule)
+		rule, ok := obj.(*resourcebetaapi.DeviceTaintRule)
 		if !ok {
 			return
 		}
@@ -487,11 +487,11 @@ func (t *Tracker) deviceTaintAdd(ctx context.Context) func(obj any) {
 func (t *Tracker) deviceTaintUpdate(ctx context.Context) func(oldObj, newObj any) {
 	logger := klog.FromContext(ctx)
 	return func(oldObj, newObj any) {
-		oldRule, ok := oldObj.(*resourcealphaapi.DeviceTaintRule)
+		oldRule, ok := oldObj.(*resourcebetaapi.DeviceTaintRule)
 		if !ok {
 			return
 		}
-		newRule, ok := newObj.(*resourcealphaapi.DeviceTaintRule)
+		newRule, ok := newObj.(*resourcebetaapi.DeviceTaintRule)
 		if !ok {
 			return
 		}
@@ -519,7 +519,7 @@ func (t *Tracker) deviceTaintDelete(ctx context.Context) func(obj any) {
 		if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 			obj = tombstone.Obj
 		}
-		patch, ok := obj.(*resourcealphaapi.DeviceTaintRule)
+		patch, ok := obj.(*resourcebetaapi.DeviceTaintRule)
 		if !ok {
 			return
 		}
@@ -631,7 +631,7 @@ func (t *Tracker) syncSlice(ctx context.Context, name string, sendEvent bool) {
 		return
 	}
 
-	patches := typedSlice[*resourcealphaapi.DeviceTaintRule](t.deviceTaints.GetIndexer().List())
+	patches := typedSlice[*resourcebetaapi.DeviceTaintRule](t.deviceTaints.GetIndexer().List())
 	patchedSlice, err := t.applyPatches(ctx, slice, patches)
 	if err != nil {
 		t.handleError(ctx, err, "failed to apply patches to ResourceSlice", "resourceslice", klog.KObj(slice))
@@ -666,7 +666,7 @@ func (t *Tracker) syncSlice(ctx context.Context, name string, sendEvent bool) {
 	}
 }
 
-func (t *Tracker) applyPatches(ctx context.Context, slice *resourceapi.ResourceSlice, taintRules []*resourcealphaapi.DeviceTaintRule) (*resourceapi.ResourceSlice, error) {
+func (t *Tracker) applyPatches(ctx context.Context, slice *resourceapi.ResourceSlice, taintRules []*resourcebetaapi.DeviceTaintRule) (*resourceapi.ResourceSlice, error) {
 	logger := klog.FromContext(ctx)
 
 	// slice will be DeepCopied just-in-time, only when necessary.

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
-	resourcealphaapi "k8s.io/api/resource/v1alpha3"
+	resourcebetaapi "k8s.io/api/resource/v1beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
@@ -116,7 +116,7 @@ func applyEventPair(tCtx *testContext, event any) {
 			require.NoError(tCtx, err)
 			tCtx.resourceSliceAdd(tCtx.Context)(pair[1])
 		}
-	case [2]*resourcealphaapi.DeviceTaintRule:
+	case [2]*resourcebetaapi.DeviceTaintRule:
 		store := tCtx.deviceTaints.GetStore()
 		switch {
 		case pair[0] != nil && pair[1] != nil:
@@ -279,39 +279,39 @@ var (
 	slice2               = sliceWithDevices(slice2NoDevices, devices2)
 	slice2Tainted        = sliceWithDevices(slice2, taintedDevices2)
 
-	alphaDeviceTaint = func(taint resourceapi.DeviceTaint) resourcealphaapi.DeviceTaint {
-		return resourcealphaapi.DeviceTaint{
+	alphaDeviceTaint = func(taint resourceapi.DeviceTaint) resourcebetaapi.DeviceTaint {
+		return resourcebetaapi.DeviceTaint{
 			Key:       taint.Key,
 			Value:     taint.Value,
-			Effect:    resourcealphaapi.DeviceTaintEffect(taint.Effect),
+			Effect:    resourcebetaapi.DeviceTaintEffect(taint.Effect),
 			TimeAdded: taint.TimeAdded,
 		}
 	}
-	taintAllDevicesRule = &resourcealphaapi.DeviceTaintRule{
+	taintAllDevicesRule = &resourcebetaapi.DeviceTaintRule{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "rule",
 		},
-		Spec: resourcealphaapi.DeviceTaintRuleSpec{
+		Spec: resourcebetaapi.DeviceTaintRuleSpec{
 			Taint: alphaDeviceTaint(deviceTaint1),
 		},
 	}
-	taintPoolDevicesRule = func(rule *resourcealphaapi.DeviceTaintRule, pool string) *resourcealphaapi.DeviceTaintRule {
+	taintPoolDevicesRule = func(rule *resourcebetaapi.DeviceTaintRule, pool string) *resourcebetaapi.DeviceTaintRule {
 		rule = rule.DeepCopy()
-		rule.Spec.DeviceSelector = &resourcealphaapi.DeviceTaintSelector{
+		rule.Spec.DeviceSelector = &resourcebetaapi.DeviceTaintSelector{
 			Pool: &pool,
 		}
 		return rule
 	}
-	taintDriverDevicesRule = func(rule *resourcealphaapi.DeviceTaintRule, driver string) *resourcealphaapi.DeviceTaintRule {
+	taintDriverDevicesRule = func(rule *resourcebetaapi.DeviceTaintRule, driver string) *resourcebetaapi.DeviceTaintRule {
 		rule = rule.DeepCopy()
-		rule.Spec.DeviceSelector = &resourcealphaapi.DeviceTaintSelector{
+		rule.Spec.DeviceSelector = &resourcebetaapi.DeviceTaintSelector{
 			Driver: &driver,
 		}
 		return rule
 	}
-	taintNamedDevicesRule = func(rule *resourcealphaapi.DeviceTaintRule, name string) *resourcealphaapi.DeviceTaintRule {
+	taintNamedDevicesRule = func(rule *resourcebetaapi.DeviceTaintRule, name string) *resourcebetaapi.DeviceTaintRule {
 		rule = rule.DeepCopy()
-		rule.Spec.DeviceSelector = &resourcealphaapi.DeviceTaintSelector{
+		rule.Spec.DeviceSelector = &resourcebetaapi.DeviceTaintSelector{
 			Device: &name,
 		}
 		return rule
@@ -720,8 +720,8 @@ func BenchmarkEventHandlers(b *testing.B) {
 	now := time.Now()
 	benchmarks := map[string]struct {
 		resourceSlices []*resourceapi.ResourceSlice
-		taintRules     []*resourcealphaapi.DeviceTaintRule
-		loop           func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, taintRules []*resourcealphaapi.DeviceTaintRule, i int)
+		taintRules     []*resourcebetaapi.DeviceTaintRule
+		loop           func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, taintRules []*resourcebetaapi.DeviceTaintRule, i int)
 	}{
 		"resource-slice-add-no-taint-rules": {
 			resourceSlices: func() []*resourceapi.ResourceSlice {
@@ -738,7 +738,7 @@ func BenchmarkEventHandlers(b *testing.B) {
 				}
 				return resourceSlices
 			}(),
-			loop: func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, _ []*resourcealphaapi.DeviceTaintRule, i int) {
+			loop: func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, _ []*resourcebetaapi.DeviceTaintRule, i int) {
 				tracker.resourceSliceAdd(ctx)(resourceSlices[i%len(resourceSlices)])
 			},
 		},
@@ -757,23 +757,23 @@ func BenchmarkEventHandlers(b *testing.B) {
 				}
 				return resourceSlices
 			}(),
-			taintRules: []*resourcealphaapi.DeviceTaintRule{
+			taintRules: []*resourcebetaapi.DeviceTaintRule{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "taintRule",
 					},
-					Spec: resourcealphaapi.DeviceTaintRuleSpec{
+					Spec: resourcebetaapi.DeviceTaintRuleSpec{
 						DeviceSelector: nil, // all slices
-						Taint: resourcealphaapi.DeviceTaint{
+						Taint: resourcebetaapi.DeviceTaint{
 							Key:       "example.com/taint",
 							Value:     "tainted",
-							Effect:    resourcealphaapi.DeviceTaintEffectNoExecute,
+							Effect:    resourcebetaapi.DeviceTaintEffectNoExecute,
 							TimeAdded: &metav1.Time{Time: now},
 						},
 					},
 				},
 			},
-			loop: func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, taintRules []*resourcealphaapi.DeviceTaintRule, i int) {
+			loop: func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, taintRules []*resourcebetaapi.DeviceTaintRule, i int) {
 				tracker.deviceTaintAdd(ctx)(taintRules[i%len(taintRules)])
 			},
 		},
@@ -792,23 +792,23 @@ func BenchmarkEventHandlers(b *testing.B) {
 				}
 				return resourceSlices
 			}(),
-			taintRules: []*resourcealphaapi.DeviceTaintRule{
+			taintRules: []*resourcebetaapi.DeviceTaintRule{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "taintRule",
 					},
-					Spec: resourcealphaapi.DeviceTaintRuleSpec{
+					Spec: resourcebetaapi.DeviceTaintRuleSpec{
 						DeviceSelector: nil, // all slices
-						Taint: resourcealphaapi.DeviceTaint{
+						Taint: resourcebetaapi.DeviceTaint{
 							Key:       "example.com/taint",
 							Value:     "tainted",
-							Effect:    resourcealphaapi.DeviceTaintEffectNoExecute,
+							Effect:    resourcebetaapi.DeviceTaintEffectNoExecute,
 							TimeAdded: &metav1.Time{Time: now},
 						},
 					},
 				},
 			},
-			loop: func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, _ []*resourcealphaapi.DeviceTaintRule, i int) {
+			loop: func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, _ []*resourcebetaapi.DeviceTaintRule, i int) {
 				tracker.resourceSliceAdd(ctx)(resourceSlices[i%len(resourceSlices)])
 			},
 		},
@@ -841,25 +841,25 @@ func BenchmarkEventHandlers(b *testing.B) {
 				resourceSlices[nSlices/2].Spec.Devices[nDevices/2].Name = "patchme"
 				return resourceSlices
 			}(),
-			taintRules: []*resourcealphaapi.DeviceTaintRule{
+			taintRules: []*resourcebetaapi.DeviceTaintRule{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "taintRule",
 					},
-					Spec: resourcealphaapi.DeviceTaintRuleSpec{
-						DeviceSelector: &resourcealphaapi.DeviceTaintSelector{
+					Spec: resourcebetaapi.DeviceTaintRuleSpec{
+						DeviceSelector: &resourcebetaapi.DeviceTaintSelector{
 							Device: ptr.To("patchme"),
 						},
-						Taint: resourcealphaapi.DeviceTaint{
+						Taint: resourcebetaapi.DeviceTaint{
 							Key:       "example.com/taint",
 							Value:     "tainted",
-							Effect:    resourcealphaapi.DeviceTaintEffectNoExecute,
+							Effect:    resourcebetaapi.DeviceTaintEffectNoExecute,
 							TimeAdded: &metav1.Time{Time: now},
 						},
 					},
 				},
 			},
-			loop: func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, taintRules []*resourcealphaapi.DeviceTaintRule, i int) {
+			loop: func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, taintRules []*resourcebetaapi.DeviceTaintRule, i int) {
 				tracker.deviceTaintAdd(ctx)(taintRules[i%len(taintRules)])
 			},
 		},
@@ -886,26 +886,26 @@ func BenchmarkEventHandlers(b *testing.B) {
 				}
 				return resourceSlices
 			}(),
-			taintRules: []*resourcealphaapi.DeviceTaintRule{
+			taintRules: []*resourcebetaapi.DeviceTaintRule{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "patch",
 					},
-					Spec: resourcealphaapi.DeviceTaintRuleSpec{
-						DeviceSelector: &resourcealphaapi.DeviceTaintSelector{
+					Spec: resourcebetaapi.DeviceTaintRuleSpec{
+						DeviceSelector: &resourcebetaapi.DeviceTaintSelector{
 							Pool:   ptr.To("pool-250"),
 							Device: ptr.To("patchme"),
 						},
-						Taint: resourcealphaapi.DeviceTaint{
+						Taint: resourcebetaapi.DeviceTaint{
 							Key:       "example.com/taint",
 							Value:     "tainted",
-							Effect:    resourcealphaapi.DeviceTaintEffectNoExecute,
+							Effect:    resourcebetaapi.DeviceTaintEffectNoExecute,
 							TimeAdded: &metav1.Time{Time: now},
 						},
 					},
 				},
 			},
-			loop: func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, patches []*resourcealphaapi.DeviceTaintRule, i int) {
+			loop: func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, patches []*resourcebetaapi.DeviceTaintRule, i int) {
 				tracker.resourceSliceAdd(ctx)(resourceSlices[250]) // the slice affected by the patch
 			},
 		},
@@ -927,21 +927,21 @@ func BenchmarkEventHandlers(b *testing.B) {
 				}
 				return resourceSlices
 			}(),
-			taintRules: func() []*resourcealphaapi.DeviceTaintRule {
-				patches := make([]*resourcealphaapi.DeviceTaintRule, 500)
+			taintRules: func() []*resourcebetaapi.DeviceTaintRule {
+				patches := make([]*resourcebetaapi.DeviceTaintRule, 500)
 				for i := range patches {
-					patches[i] = &resourcealphaapi.DeviceTaintRule{
+					patches[i] = &resourcebetaapi.DeviceTaintRule{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "taint-rule-" + strconv.Itoa(i),
 						},
-						Spec: resourcealphaapi.DeviceTaintRuleSpec{
-							DeviceSelector: &resourcealphaapi.DeviceTaintSelector{
+						Spec: resourcebetaapi.DeviceTaintRuleSpec{
+							DeviceSelector: &resourcebetaapi.DeviceTaintSelector{
 								Pool: ptr.To("pool-" + strconv.Itoa(i)),
 							},
-							Taint: resourcealphaapi.DeviceTaint{
+							Taint: resourcebetaapi.DeviceTaint{
 								Key:       "example.com/taint",
 								Value:     "tainted",
-								Effect:    resourcealphaapi.DeviceTaintEffectNoExecute,
+								Effect:    resourcebetaapi.DeviceTaintEffectNoExecute,
 								TimeAdded: &metav1.Time{Time: now},
 							},
 						},
@@ -949,7 +949,7 @@ func BenchmarkEventHandlers(b *testing.B) {
 				}
 				return patches
 			}(),
-			loop: func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, taintRules []*resourcealphaapi.DeviceTaintRule, i int) {
+			loop: func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, taintRules []*resourcebetaapi.DeviceTaintRule, i int) {
 				tracker.deviceTaintAdd(ctx)(taintRules[i%len(taintRules)])
 			},
 		},

--- a/test/integration/dra/device_taints.go
+++ b/test/integration/dra/device_taints.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/controller/devicetainteviction"
 	"k8s.io/kubernetes/pkg/features"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	"k8s.io/kubernetes/test/utils/client-go/ktesting"
 	"k8s.io/utils/ptr"
 )
@@ -402,4 +403,95 @@ func testEvictCluster(tCtx ktesting.TContext, useRule useRuleMode) {
 				"Message": gomega.Equal(fmt.Sprintf("%d pods evicted since starting the controller.", numPods)),
 			}))))
 	}
+}
+
+func testNoScheduleRule(tCtx ktesting.TContext, useRule useRuleMode) {
+	tCtx.Parallel()
+
+	startScheduler(tCtx)
+
+	namespace := createTestNamespace(tCtx, nil)
+	class, driverName := createTestClass(tCtx, namespace)
+	slice := st.MakeResourceSlice("worker-0", driverName).Devices(device1)
+
+	taintKey := "testing"
+	ruleName := "rule-" + namespace
+	switch useRule {
+	case useV1alpha3Rule:
+		rule := &resourcealpha.DeviceTaintRule{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ruleName,
+			},
+			Spec: resourcealpha.DeviceTaintRuleSpec{
+				DeviceSelector: &resourcealpha.DeviceTaintSelector{
+					Driver: &driverName,
+				},
+				Taint: resourcealpha.DeviceTaint{
+					Key:    taintKey,
+					Effect: resourcealpha.DeviceTaintEffectNoSchedule,
+				},
+			},
+		}
+		_ = must(tCtx, tCtx.Client().ResourceV1alpha3().DeviceTaintRules().Create, rule, metav1.CreateOptions{})
+		tCtx.CleanupCtx(func(tCtx ktesting.TContext) {
+			err := tCtx.Client().ResourceV1alpha3().DeviceTaintRules().Delete(tCtx, ruleName, metav1.DeleteOptions{})
+			if apierrors.IsNotFound(err) {
+				return
+			}
+			tCtx.ExpectNoError(err)
+		})
+	case useV1beta2Rule:
+		rule := &resourcebeta.DeviceTaintRule{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ruleName,
+			},
+			Spec: resourcebeta.DeviceTaintRuleSpec{
+				DeviceSelector: &resourcebeta.DeviceTaintSelector{
+					Driver: &driverName,
+				},
+				Taint: resourcebeta.DeviceTaint{
+					Key:    taintKey,
+					Effect: resourcebeta.DeviceTaintEffectNoSchedule,
+				},
+			},
+		}
+		_ = must(tCtx, tCtx.Client().ResourceV1beta2().DeviceTaintRules().Create, rule, metav1.CreateOptions{})
+		tCtx.CleanupCtx(func(tCtx ktesting.TContext) {
+			err := tCtx.Client().ResourceV1beta2().DeviceTaintRules().Delete(tCtx, ruleName, metav1.DeleteOptions{})
+			if apierrors.IsNotFound(err) {
+				return
+			}
+			tCtx.ExpectNoError(err)
+		})
+	case useNoRule:
+		slice.Spec.Devices[0].Taints = []resourceapi.DeviceTaint{
+			{
+				Key:    taintKey,
+				Effect: resourceapi.DeviceTaintEffectNoSchedule,
+			},
+		}
+	}
+
+	// Creating the ResourceSlice after the DeviceTaintRule exercises additional
+	// code paths in the ResourceSlice tracker.
+	_ = createSlice(tCtx, slice.Obj())
+
+	pod := st.MakePod().Name(podName).Namespace(namespace).
+		Container("my-container").
+		Obj()
+
+	untoleratingClaim := createClaim(tCtx, namespace, "-untolerating", class, claim)
+	untoleratingPod := createPod(tCtx, namespace, "-untolerating", pod, untoleratingClaim)
+	expectPodUnschedulable(tCtx, untoleratingPod, "cannot allocate all claims")
+
+	toleratingClaim := claim.DeepCopy()
+	toleratingClaim.Spec.Devices.Requests[0].Exactly.Tolerations = []resourceapi.DeviceToleration{
+		{
+			Key:    taintKey,
+			Effect: resourceapi.DeviceTaintEffectNoSchedule,
+		},
+	}
+	_ = createClaim(tCtx, namespace, "-tolerating", class, toleratingClaim)
+	toleratingPod := createPod(tCtx, namespace, "-tolerating", pod)
+	waitForPodScheduled(tCtx, namespace, toleratingPod.Name)
 }

--- a/test/integration/dra/dra.go
+++ b/test/integration/dra/dra.go
@@ -134,6 +134,7 @@ func run(tCtx ktesting.TContext, whatRE string) {
 			f: func(tCtx ktesting.TContext) {
 				runSubTest(tCtx, "Pod", func(tCtx ktesting.TContext) { testPod(tCtx, true) })
 				runSubTest(tCtx, "EvictClusterWithSlices", func(tCtx ktesting.TContext) { testEvictCluster(tCtx, useNoRule) })
+				runSubTest(tCtx, "NoScheduleWithSlices", func(tCtx ktesting.TContext) { testNoScheduleRule(tCtx, useNoRule) })
 				// Number of devices per slice is chosen so that Filter takes a few seconds:
 				// without a timeout, the test doesn't run too long, but long enough that a short timeout triggers.
 				runSubTest(tCtx, "FilterTimeout", func(tCtx ktesting.TContext) { testFilterTimeout(tCtx, 21) })
@@ -249,6 +250,9 @@ func run(tCtx ktesting.TContext, whatRE string) {
 				runSubTest(tCtx, "EvictClusterWithV1alpha3Rule", func(tCtx ktesting.TContext) { testEvictCluster(tCtx, useV1alpha3Rule) })
 				runSubTest(tCtx, "EvictClusterWithV1beta2Rule", func(tCtx ktesting.TContext) { testEvictCluster(tCtx, useV1beta2Rule) })
 				runSubTest(tCtx, "EvictClusterWithSlices", func(tCtx ktesting.TContext) { testEvictCluster(tCtx, useNoRule) })
+				runSubTest(tCtx, "NoScheduleWithV1alpha3Rule", func(tCtx ktesting.TContext) { testNoScheduleRule(tCtx, useV1alpha3Rule) })
+				runSubTest(tCtx, "NoScheduleWithV1beta2Rule", func(tCtx ktesting.TContext) { testNoScheduleRule(tCtx, useV1beta2Rule) })
+				runSubTest(tCtx, "NoScheduleWithSlices", func(tCtx ktesting.TContext) { testNoScheduleRule(tCtx, useNoRule) })
 				runSubTest(tCtx, "InvalidResourceSlices", testInvalidResourceSlices)
 				// Number of devices per slice is chosen so that Filter takes a few seconds: The allocator
 				// in the experimental channel has an improvement that requires a higher number here than


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The [ci-dra-integration](https://testgrid.k8s.io/sig-node-dynamic-resource-allocation#ci-dra-integration) job is currently failing since the v1.37.0-alpha.1 tag was published which moves the DRA upgrade/downgrade test baseline version from 1.35 to 1.36. Between 1.35 and 1.36, the ResourceSlice tracker used by kube-scheduler updated its DeviceTaintRule API version from v1alpha3 to v1beta2, but the event handlers in the tracker continued to expect v1alpha3. The upgrade/downgrade tests follow code paths not exercised by the e2e tests which induce a panic in kube-scheduler that appears to be the root cause of the failure:
```
E0611 12:22:26.198231   60568 iface.go:275] "Observed a panic" panic="interface conversion: interface {} is *v1beta2.DeviceTaintRule, not *v1alpha3.DeviceTaintRule" panicGoValue="&runtime.TypeAssertionError{_interface:(*abi.Type)(0x1bd9b20), concrete:(*abi.Type)(0x1fef720), asserted:(*abi.Type)(0x1fedc20), missingMethod:\"\"}" stacktrace=<
	goroutine 364 [running]:
	k8s.io/apimachinery/pkg/util/runtime.logPanic({0x2155bd0, 0xec45a6bf5f0}, {0x1c442e0, 0xec45a6bf500})
		k8s.io/apimachinery/pkg/util/runtime/runtime.go:134 +0xbc
	k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x2155bd0, 0xec45a6bf560}, {0x1c442e0, 0xec45a6bf500}, {0x0, 0x0, 0xec45a94a828?})
		k8s.io/apimachinery/pkg/util/runtime/runtime.go:109 +0x116
	k8s.io/apimachinery/pkg/util/runtime.HandleCrashWithLogger({{0x2160508?, 0xec45a248fc0?}, 0xec45a2c1dc0?}, {0x0, 0x0, 0x0})
		k8s.io/apimachinery/pkg/util/runtime/runtime.go:93 +0x10f
	panic({0x1c442e0?, 0xec45a6bf500?})
		runtime/panic.go:860 +0x13a
	k8s.io/dynamic-resource-allocation/resourceslice/tracker.typedSlice[...](...)
		k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go:739
	k8s.io/dynamic-resource-allocation/resourceslice/tracker.(*Tracker).syncSlice(0xec45a2c1cc0, {0x2155c08, 0xec45a30b950}, {0xec45a36e000, 0x3e}, 0x1)
		k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go:634 +0x1357
	k8s.io/dynamic-resource-allocation/resourceslice/tracker.(*Tracker).resourceSliceAdd.func1({0x1fe22a0?, 0xec45ac42000})
		k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go:428 +0x2df
	k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnAdd(...)
		k8s.io/client-go/tools/cache/controller.go:301
	k8s.io/client-go/tools/cache.(*processorListener).run.func1(0xec45a94af5f, 0xec45a7f0270, {0x1d54580?, 0xec45a7be0f0?})
		k8s.io/client-go/tools/cache/shared_informer.go:1360 +0x2ca
	k8s.io/client-go/tools/cache.(*processorListener).run(0xec45a7f0270)
		k8s.io/client-go/tools/cache/shared_informer.go:1370 +0x3c
	k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
		k8s.io/apimachinery/pkg/util/wait/wait.go:72 +0x4c
	created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 355
		k8s.io/apimachinery/pkg/util/wait/wait.go:70 +0x73
 >
panic: interface conversion: interface {} is *v1beta2.DeviceTaintRule, not *v1alpha3.DeviceTaintRule [recovered, repanicked]
```

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug when the DRADeviceTaintRules feature is enabled that caused kube-scheduler to panic when DeviceTaintRules exist and ResourceSlices are changed or to ignore new changes to DeviceTaintRules.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
