### PR TITLE
e2e_node_windows: add CPU affinity tests

### DIFF
--- a/test/e2e_node_windows/cpu_manager_test.go
+++ b/test/e2e_node_windows/cpu_manager_test.go
@@ -1,0 +1,731 @@
+//go:build windows
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enodewindows
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	internalapi "k8s.io/cri-api/pkg/apis"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"k8s.io/kubernetes/pkg/features"
+	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
+	"k8s.io/kubernetes/test/e2e/feature"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2enodekubelet "k8s.io/kubernetes/test/e2e_node_windows/kubeletconfig"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+/*
+ * Windows CPU Affinity Node E2E Tests
+ *
+ * These tests verify that the CPU manager correctly sets Windows CPU group
+ * affinity on containers via the CRI, as implemented in:
+ *   - pkg/kubelet/cm/cpumanager/cpu_manager_windows.go
+ *   - pkg/kubelet/cm/internal_container_lifecycle_windows.go
+ *
+ * Prerequisites:
+ *   - Windows node with kubelet running as a Windows service named "kubelet"
+ *   - At least 2 allocatable integer CPUs on the node
+ *   - containerd as the container runtime
+ *
+ * Linux-only features intentionally NOT covered here:
+ *   - SMT/HT alignment (FullPCPUsOnlyOption) — no equivalent in Windows CRI
+ *   - Uncore cache alignment (PreferAlignByUnCoreCacheOption) — no L3 topology via Windows CRI
+ *   - CFS quota management — cgroup concept, not applicable on Windows
+ *   - Strict CPU reservation option — implemented via cgroup on Linux
+ */
+
+var _ = SIGWindowsDescribe(feature.CPUManager, feature.Windows, ginkgo.Ordered, ginkgo.ContinueOnFailure, framework.WithSerial(), func() {
+	f := framework.NewDefaultFramework("cpu-manager-windows")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	var (
+		oldCfg    *kubeletconfig.KubeletConfiguration
+		criClient internalapi.RuntimeService
+		podMap    map[string]*v1.Pod
+	)
+
+	// createPodSync creates a pod, waits for it to be running, registers it
+	// in podMap for cleanup, and returns the updated pod object.
+	var createPodSync func(ctx context.Context, pod *v1.Pod) *v1.Pod
+
+	ginkgo.BeforeAll(func(ctx context.Context) {
+		var err error
+		oldCfg, err = getCurrentKubeletConfig(ctx)
+		framework.ExpectNoError(err, "failed to get current kubelet config")
+
+		criClient, _, err = getCRIClient(ctx)
+		framework.ExpectNoError(err, "failed to get CRI client")
+	})
+
+	ginkgo.AfterAll(func(ctx context.Context) {
+		updateWindowsKubeletConfig(ctx, f, oldCfg)
+	})
+
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		podMap = make(map[string]*v1.Pod)
+		createPodSync = func(ctx context.Context, pod *v1.Pod) *v1.Pod {
+			newPod := e2epod.NewPodClient(f).CreateSync(ctx, pod)
+			podMap[string(newPod.UID)] = newPod
+			return newPod
+		}
+	})
+
+	ginkgo.AfterEach(func(ctx context.Context) {
+		for _, pod := range podMap {
+			e2epod.NewPodClient(f).DeleteSync(ctx, pod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
+		}
+	})
+
+	// -------------------------------------------------------------------------
+	// Non-guaranteed (burstable / best-effort) pod tests
+	// These mirror the Linux "running non-guaranteed pods tests" group.
+	// -------------------------------------------------------------------------
+	ginkgo.When("running non-guaranteed pods", ginkgo.Label("non-guaranteed"), func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			updateWindowsKubeletConfigIfNeeded(ctx, f, buildWindowsCPUManagerKubeletConfig(oldCfg, true))
+		})
+
+		ginkgo.It("should not set CPU affinity on a burstable container", func(ctx context.Context) {
+			pod := makeWindowsCPUManagerPod("burstable-pod", []windowsCtnAttribute{
+				{name: "burstable-ctr", cpuRequest: "100m", cpuLimit: "500m"},
+			})
+			ginkgo.By("creating the burstable pod")
+			pod = createPodSync(ctx, pod)
+
+			ginkgo.By("verifying no exclusive CPU affinity is set")
+			affinities, err := getWindowsContainerCPUAffinity(ctx, criClient, pod, "burstable-ctr")
+			framework.ExpectNoError(err)
+			cpuCount := countCPUsInAffinities(affinities)
+			hostCPUs := int(getLocalNode(ctx, f).Status.Capacity.Cpu().Value())
+			gomega.Expect(cpuCount).To(gomega.Equal(hostCPUs),
+				"burstable container must not receive exclusive CPU affinity: got %d CPUs (host has %d)", cpuCount, hostCPUs)
+		})
+
+		// Mirrors: "should let the container access all the online non-exclusively-allocated
+		// CPUs when using a reserved CPUs set" (Linux).
+		// On Windows we verify via CRI: the guaranteed container has affinity set and the
+		// burstable container has none, meaning the burstable runs on the shared pool.
+		ginkgo.It("should set affinity only on the guaranteed container when coexisting with a burstable pod", func(ctx context.Context) {
+			skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), 2) // 1 for guaranteed + 1 reserved
+
+			guPod := makeWindowsCPUManagerPod("gu-pod", []windowsCtnAttribute{
+				{name: "gu-ctr", cpuRequest: "1000m", cpuLimit: "1000m"},
+			})
+			ginkgo.By("creating the guaranteed pod")
+			guPod = createPodSync(ctx, guPod)
+
+			buPod := makeWindowsCPUManagerPod("bu-pod", []windowsCtnAttribute{
+				{name: "bu-ctr", cpuRequest: "100m", cpuLimit: "300m"},
+			})
+			ginkgo.By("creating the burstable pod")
+			buPod = createPodSync(ctx, buPod)
+
+			ginkgo.By("verifying guaranteed container has CPU affinity set")
+			gomega.Eventually(ctx, func(ctx context.Context) (int, error) {
+				aff, err := getWindowsContainerCPUAffinity(ctx, criClient, guPod, "gu-ctr")
+				if err != nil {
+					return 0, err
+				}
+				return countCPUsInAffinities(aff), nil
+			}, 30*time.Second, 2*time.Second).Should(gomega.Equal(1),
+				"guaranteed container should have exactly 1 CPU affinity")
+
+			ginkgo.By("verifying burstable container runs on the shared pool, not exclusively pinned")
+			buAff, err := getWindowsContainerCPUAffinity(ctx, criClient, buPod, "bu-ctr")
+			framework.ExpectNoError(err)
+			guAff, err := getWindowsContainerCPUAffinity(ctx, criClient, guPod, "gu-ctr")
+			framework.ExpectNoError(err)
+			// The shared pool used by burstable containers shrinks as guaranteed pods
+			// take exclusive CPUs, so the expected size is hostCPUs - guaranteedExclusive.
+			buCPUs := countCPUsInAffinities(buAff)
+			guCPUs := countCPUsInAffinities(guAff)
+			hostCPUs := int(getLocalNode(ctx, f).Status.Capacity.Cpu().Value())
+			sharedPool := hostCPUs - guCPUs
+			gomega.Expect(buCPUs).To(gomega.Equal(sharedPool),
+				"burstable container must not receive exclusive CPU affinity: got %d CPUs (host=%d, guaranteed=%d, shared pool=%d)",
+				buCPUs, hostCPUs, guCPUs, sharedPool)
+		})
+	})
+
+	// -------------------------------------------------------------------------
+	// Guaranteed pod tests (feature gate ON)
+	// These mirror the Linux "running guaranteed pod tests" group.
+	// -------------------------------------------------------------------------
+	ginkgo.When("running guaranteed pods with exclusive CPU allocation", ginkgo.Label("guaranteed", "exclusive-cpus"), func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			updateWindowsKubeletConfigIfNeeded(ctx, f, buildWindowsCPUManagerKubeletConfig(oldCfg, true))
+		})
+
+		// Mirrors: "should allocate exclusively a CPU to a 1-container pod".
+		ginkgo.It("should set CPU affinity with exactly 1 CPU for a single-container pod", func(ctx context.Context) {
+			skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), 1)
+
+			pod := makeWindowsCPUManagerPod("gu-pod-1cpu", []windowsCtnAttribute{
+				{name: "gu-ctr", cpuRequest: "1000m", cpuLimit: "1000m"},
+			})
+			ginkgo.By("creating the guaranteed pod")
+			pod = createPodSync(ctx, pod)
+
+			ginkgo.By("verifying CPU affinity is set to exactly 1 CPU")
+			gomega.Eventually(ctx, func(ctx context.Context) (int, error) {
+				aff, err := getWindowsContainerCPUAffinity(ctx, criClient, pod, "gu-ctr")
+				if err != nil {
+					return 0, err
+				}
+				return countCPUsInAffinities(aff), nil
+			}, 30*time.Second, 2*time.Second).Should(gomega.Equal(1),
+				"expected exactly 1 CPU in affinity mask")
+
+			ginkgo.By("verifying the host job-object affinity agrees with the CRI report")
+			verifyHostMatchesCRI(ctx, criClient, pod, "gu-ctr")
+		})
+
+		// Mirrors: "should allocate exclusively a even number of CPUs to a 1-container pod".
+		ginkgo.It("should set CPU affinity with exactly 2 CPUs for a single-container pod", func(ctx context.Context) {
+			skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), 2)
+
+			pod := makeWindowsCPUManagerPod("gu-pod-2cpu", []windowsCtnAttribute{
+				{name: "gu-ctr", cpuRequest: "2000m", cpuLimit: "2000m"},
+			})
+			ginkgo.By("creating the guaranteed pod requesting 2 CPUs")
+			pod = createPodSync(ctx, pod)
+
+			ginkgo.By("verifying CPU affinity is set to exactly 2 CPUs")
+			gomega.Eventually(ctx, func(ctx context.Context) (int, error) {
+				aff, err := getWindowsContainerCPUAffinity(ctx, criClient, pod, "gu-ctr")
+				if err != nil {
+					return 0, err
+				}
+				return countCPUsInAffinities(aff), nil
+			}, 30*time.Second, 2*time.Second).Should(gomega.Equal(2),
+				"expected exactly 2 CPUs in affinity mask")
+
+			ginkgo.By("verifying the host job-object affinity agrees with the CRI report")
+			verifyHostMatchesCRI(ctx, criClient, pod, "gu-ctr")
+		})
+
+		// Mirrors: "should allocate exclusively a odd number of CPUs to a 1-container pod".
+		ginkgo.It("should set CPU affinity with exactly 3 CPUs for a single-container pod", func(ctx context.Context) {
+			skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), 3)
+
+			pod := makeWindowsCPUManagerPod("gu-pod-3cpu", []windowsCtnAttribute{
+				{name: "gu-ctr", cpuRequest: "3000m", cpuLimit: "3000m"},
+			})
+			ginkgo.By("creating the guaranteed pod requesting 3 CPUs")
+			pod = createPodSync(ctx, pod)
+
+			ginkgo.By("verifying CPU affinity is set to exactly 3 CPUs")
+			gomega.Eventually(ctx, func(ctx context.Context) (int, error) {
+				aff, err := getWindowsContainerCPUAffinity(ctx, criClient, pod, "gu-ctr")
+				if err != nil {
+					return 0, err
+				}
+				return countCPUsInAffinities(aff), nil
+			}, 30*time.Second, 2*time.Second).Should(gomega.Equal(3),
+				"expected exactly 3 CPUs in affinity mask")
+
+			ginkgo.By("verifying the host job-object affinity agrees with the CRI report")
+			verifyHostMatchesCRI(ctx, criClient, pod, "gu-ctr")
+		})
+
+		// Mirrors: "should allocate exclusively CPUs to a multi-container pod (1+2)".
+		ginkgo.It("should assign non-overlapping CPU affinity to each container in a multi-container pod (1+2)", func(ctx context.Context) {
+			skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), 3)
+
+			pod := makeWindowsCPUManagerPod("gu-pod-1plus2", []windowsCtnAttribute{
+				{name: "gu-ctr-1", cpuRequest: "1000m", cpuLimit: "1000m"},
+				{name: "gu-ctr-2", cpuRequest: "2000m", cpuLimit: "2000m"},
+			})
+			ginkgo.By("creating the guaranteed pod with containers requesting 1 and 2 CPUs")
+			pod = createPodSync(ctx, pod)
+
+			var aff1, aff2 []*runtimeapi.WindowsCpuGroupAffinity
+			ginkgo.By("verifying each container gets the correct CPU count")
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				var err error
+				aff1, err = getWindowsContainerCPUAffinity(ctx, criClient, pod, "gu-ctr-1")
+				if err != nil {
+					return err
+				}
+				aff2, err = getWindowsContainerCPUAffinity(ctx, criClient, pod, "gu-ctr-2")
+				if err != nil {
+					return err
+				}
+				c1, c2 := countCPUsInAffinities(aff1), countCPUsInAffinities(aff2)
+				if c1 != 1 || c2 != 2 {
+					return fmt.Errorf("want cpu counts (1,2), got (%d,%d)", c1, c2)
+				}
+				return nil
+			}, 30*time.Second, 2*time.Second).Should(gomega.Succeed())
+
+			ginkgo.By("verifying the CPU affinity masks do not overlap")
+			gomega.Expect(windowsAffinitiesOverlap(aff1, aff2)).To(gomega.BeFalse(),
+				"containers in the same pod must receive non-overlapping CPU affinity masks")
+
+			ginkgo.By("verifying the host job-object affinity agrees with the CRI report and masks are disjoint")
+			verifyHostMatchesCRI(ctx, criClient, pod, "gu-ctr-1")
+			verifyHostMatchesCRI(ctx, criClient, pod, "gu-ctr-2")
+			verifyHostMasksDisjoint(pod, "gu-ctr-1", pod, "gu-ctr-2")
+		})
+
+		// Mirrors: "should allocate exclusively CPUs to a multi-container pod (3+2)".
+		ginkgo.It("should assign non-overlapping CPU affinity to each container in a multi-container pod (3+2)", func(ctx context.Context) {
+			skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), 5)
+
+			pod := makeWindowsCPUManagerPod("gu-pod-3plus2", []windowsCtnAttribute{
+				{name: "gu-ctr-1", cpuRequest: "3000m", cpuLimit: "3000m"},
+				{name: "gu-ctr-2", cpuRequest: "2000m", cpuLimit: "2000m"},
+			})
+			ginkgo.By("creating the guaranteed pod with containers requesting 3 and 2 CPUs")
+			pod = createPodSync(ctx, pod)
+
+			var aff1, aff2 []*runtimeapi.WindowsCpuGroupAffinity
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				var err error
+				aff1, err = getWindowsContainerCPUAffinity(ctx, criClient, pod, "gu-ctr-1")
+				if err != nil {
+					return err
+				}
+				aff2, err = getWindowsContainerCPUAffinity(ctx, criClient, pod, "gu-ctr-2")
+				if err != nil {
+					return err
+				}
+				c1, c2 := countCPUsInAffinities(aff1), countCPUsInAffinities(aff2)
+				if c1 != 3 || c2 != 2 {
+					return fmt.Errorf("want cpu counts (3,2), got (%d,%d)", c1, c2)
+				}
+				return nil
+			}, 30*time.Second, 2*time.Second).Should(gomega.Succeed())
+
+			gomega.Expect(windowsAffinitiesOverlap(aff1, aff2)).To(gomega.BeFalse(),
+				"containers in the same pod must receive non-overlapping CPU affinity masks")
+
+			ginkgo.By("verifying the host job-object affinity agrees with the CRI report and masks are disjoint")
+			verifyHostMatchesCRI(ctx, criClient, pod, "gu-ctr-1")
+			verifyHostMatchesCRI(ctx, criClient, pod, "gu-ctr-2")
+			verifyHostMasksDisjoint(pod, "gu-ctr-1", pod, "gu-ctr-2")
+		})
+
+		// Mirrors: "should allocate exclusively a CPU to multiple 1-container pods".
+		ginkgo.It("should assign non-overlapping CPU affinity across separate guaranteed pods (2+2)", func(ctx context.Context) {
+			skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), 4)
+
+			pod1 := makeWindowsCPUManagerPod("gu-pod-a", []windowsCtnAttribute{
+				{name: "gu-ctr-a", cpuRequest: "2000m", cpuLimit: "2000m"},
+			})
+			ginkgo.By("creating guaranteed pod 1")
+			pod1 = createPodSync(ctx, pod1)
+
+			pod2 := makeWindowsCPUManagerPod("gu-pod-b", []windowsCtnAttribute{
+				{name: "gu-ctr-b", cpuRequest: "2000m", cpuLimit: "2000m"},
+			})
+			ginkgo.By("creating guaranteed pod 2")
+			pod2 = createPodSync(ctx, pod2)
+
+			var affA, affB []*runtimeapi.WindowsCpuGroupAffinity
+			ginkgo.By("verifying both containers each get exactly 2 CPUs")
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				var err error
+				affA, err = getWindowsContainerCPUAffinity(ctx, criClient, pod1, "gu-ctr-a")
+				if err != nil {
+					return err
+				}
+				affB, err = getWindowsContainerCPUAffinity(ctx, criClient, pod2, "gu-ctr-b")
+				if err != nil {
+					return err
+				}
+				cA, cB := countCPUsInAffinities(affA), countCPUsInAffinities(affB)
+				if cA != 2 || cB != 2 {
+					return fmt.Errorf("want cpu counts (2,2), got (%d,%d)", cA, cB)
+				}
+				return nil
+			}, 30*time.Second, 2*time.Second).Should(gomega.Succeed())
+
+			ginkgo.By("verifying the two pods' CPU affinity masks do not overlap")
+			gomega.Expect(windowsAffinitiesOverlap(affA, affB)).To(gomega.BeFalse(),
+				"guaranteed pods must not share exclusively-allocated CPUs")
+
+			ginkgo.By("verifying the host job-object affinity agrees with the CRI report and masks are disjoint")
+			verifyHostMatchesCRI(ctx, criClient, pod1, "gu-ctr-a")
+			verifyHostMatchesCRI(ctx, criClient, pod2, "gu-ctr-b")
+			verifyHostMasksDisjoint(pod1, "gu-ctr-a", pod2, "gu-ctr-b")
+		})
+	})
+
+	// -------------------------------------------------------------------------
+	// Feature gate disabled tests
+	// Mirrors the Linux "running guaranteed pod tests with feature gates disabled"
+	// group, adapted for the Windows-specific WindowsCPUAndMemoryAffinity gate.
+	// When the feature gate is off, cpu_manager_windows.go's updateContainerCPUSet
+	// returns immediately without calling UpdateContainerResources, so the CRI
+	// should report no AffinityCpus even for guaranteed containers.
+	// -------------------------------------------------------------------------
+	ginkgo.When("running guaranteed pods with WindowsCPUAndMemoryAffinity feature gate disabled", ginkgo.Label("guaranteed", "feature-gate-disabled"), func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			updateWindowsKubeletConfigIfNeeded(ctx, f, buildWindowsCPUManagerKubeletConfig(oldCfg, false))
+		})
+
+		ginkgo.It("should NOT set CPU affinity on a 1-CPU guaranteed container when feature gate is off", func(ctx context.Context) {
+			skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), 1)
+
+			pod := makeWindowsCPUManagerPod("gu-pod-no-affinity", []windowsCtnAttribute{
+				{name: "gu-ctr", cpuRequest: "1000m", cpuLimit: "1000m"},
+			})
+			ginkgo.By("creating the guaranteed pod")
+			pod = createPodSync(ctx, pod)
+
+			// Give the CPU manager reconcile loop (1 s period) a few cycles to act,
+			// then confirm it still has not set any exclusive affinity.  On Windows
+			// "no affinity assigned" is reported either as an empty list or as a full
+			// mask covering every host CPU; anything in between is a strict subset
+			// (i.e. exclusive pinning) which the feature gate must prevent.
+			ginkgo.By("verifying no exclusive CPU affinity is set even for a guaranteed container")
+			hostCPUs := int(getLocalNode(ctx, f).Status.Capacity.Cpu().Value())
+			gomega.Consistently(ctx, func(ctx context.Context) error {
+				aff, err := getWindowsContainerCPUAffinity(ctx, criClient, pod, "gu-ctr")
+				if err != nil {
+					return err
+				}
+				cpuCount := countCPUsInAffinities(aff)
+				if cpuCount != 0 && cpuCount < hostCPUs {
+					return fmt.Errorf("feature gate off: guaranteed container received exclusive affinity: got %d CPUs (host has %d)", cpuCount, hostCPUs)
+				}
+				return nil
+			}, 10*time.Second, 2*time.Second).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("should NOT set CPU affinity on a multi-container guaranteed pod when feature gate is off", func(ctx context.Context) {
+			skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), 3)
+
+			pod := makeWindowsCPUManagerPod("gu-pod-mc-no-affinity", []windowsCtnAttribute{
+				{name: "gu-ctr-1", cpuRequest: "1000m", cpuLimit: "1000m"},
+				{name: "gu-ctr-2", cpuRequest: "2000m", cpuLimit: "2000m"},
+			})
+			ginkgo.By("creating the guaranteed multi-container pod")
+			pod = createPodSync(ctx, pod)
+
+			ginkgo.By("verifying no exclusive CPU affinity is set on either container")
+			hostCPUs := int(getLocalNode(ctx, f).Status.Capacity.Cpu().Value())
+			gomega.Consistently(ctx, func(ctx context.Context) error {
+				aff1, err := getWindowsContainerCPUAffinity(ctx, criClient, pod, "gu-ctr-1")
+				if err != nil {
+					return err
+				}
+				aff2, err := getWindowsContainerCPUAffinity(ctx, criClient, pod, "gu-ctr-2")
+				if err != nil {
+					return err
+				}
+				c1 := countCPUsInAffinities(aff1)
+				c2 := countCPUsInAffinities(aff2)
+				if c1 != 0 && c1 < hostCPUs {
+					return fmt.Errorf("feature gate off: gu-ctr-1 received exclusive affinity: got %d CPUs (host has %d)", c1, hostCPUs)
+				}
+				if c2 != 0 && c2 < hostCPUs {
+					return fmt.Errorf("feature gate off: gu-ctr-2 received exclusive affinity: got %d CPUs (host has %d)", c2, hostCPUs)
+				}
+				return nil
+			}, 10*time.Second, 2*time.Second).Should(gomega.Succeed())
+		})
+	})
+
+	// -------------------------------------------------------------------------
+	// Init / sidecar container tests
+	// Windows supports init containers and restartable init (sidecar) containers.
+	// These mirror the Linux "checking the sidecar containers" group.
+	//
+	// Verification approach differs from Linux: on Windows we cannot read the
+	// cpuset filesystem.  Instead:
+	//   - For terminated init containers we can only observe the outcome on the
+	//     main container (CPUs released and re-used).
+	//   - For running sidecar (restartable init) containers we query the CRI.
+	// -------------------------------------------------------------------------
+	ginkgo.When("running pods with init containers", ginkgo.Label("guaranteed", "init-containers"), func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			updateWindowsKubeletConfigIfNeeded(ctx, f, buildWindowsCPUManagerKubeletConfig(oldCfg, true))
+		})
+
+		// Mirrors: "should reuse init container exclusive CPUs, but not sidecar container
+		// exclusive CPUs".
+		// A terminated (non-restartable) init container releases its exclusive CPUs so
+		// that the regular app container can use them.  A restartable sidecar init
+		// container holds its CPUs for its entire lifetime.
+		// We verify:
+		//   1. The sidecar container (restartable init) holds exactly 1 exclusive CPU.
+		//   2. The app container holds exactly 1 exclusive CPU.
+		//   3. The sidecar and app CPUs do not overlap (both are exclusive).
+		ginkgo.It("sidecar container should hold exclusive CPUs separately from the app container", func(ctx context.Context) {
+			skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), 2) // 1 non-restartable init + 1 sidecar reused + 1 app = 2 total (init CPUs reused)
+
+			var restartAlways = v1.ContainerRestartPolicyAlways
+
+			pod := makeWindowsCPUManagerInitPod("gu-sidecar-pod",
+				[]windowsCtnAttribute{
+					// non-restartable init: terminates quickly, CPUs are reused
+					{name: "init-ctr", cpuRequest: "1000m", cpuLimit: "1000m"},
+					// restartable sidecar: stays alive, holds exclusive CPUs
+					{name: "sidecar-ctr", cpuRequest: "1000m", cpuLimit: "1000m", restartPolicy: &restartAlways},
+				},
+				// app container
+				windowsCtnAttribute{name: "app-ctr", cpuRequest: "1000m", cpuLimit: "1000m"},
+			)
+			ginkgo.By("creating the pod with a non-restartable init container, a sidecar, and an app container")
+			pod = createPodSync(ctx, pod)
+
+			ginkgo.By("verifying sidecar container holds exactly 1 CPU")
+			var sidecarAff, appAff []*runtimeapi.WindowsCpuGroupAffinity
+			gomega.Eventually(ctx, func(ctx context.Context) error {
+				var err error
+				sidecarAff, err = getWindowsContainerCPUAffinity(ctx, criClient, pod, "sidecar-ctr")
+				if err != nil {
+					return err
+				}
+				appAff, err = getWindowsContainerCPUAffinity(ctx, criClient, pod, "app-ctr")
+				if err != nil {
+					return err
+				}
+				cs, ca := countCPUsInAffinities(sidecarAff), countCPUsInAffinities(appAff)
+				if cs != 1 || ca != 1 {
+					return fmt.Errorf("want sidecar=1 app=1, got sidecar=%d app=%d", cs, ca)
+				}
+				return nil
+			}, 60*time.Second, 2*time.Second).Should(gomega.Succeed(),
+				"both sidecar and app containers must each hold exactly 1 exclusive CPU")
+
+			ginkgo.By("verifying sidecar and app container CPU affinity masks do not overlap")
+			gomega.Expect(windowsAffinitiesOverlap(sidecarAff, appAff)).To(gomega.BeFalse(),
+				"sidecar and app containers must not share exclusively-allocated CPUs")
+		})
+
+		// A pod whose only init container is non-restartable: after the init
+		// container completes, the app container gets exclusive CPUs (which may
+		// overlap with the init container's former CPUs — that is expected and
+		// correct; we only verify the app container count here).
+		ginkgo.It("app container should get exclusive CPUs after a non-restartable init container completes", func(ctx context.Context) {
+			skipIfAllocatableCPUsLessThan(getLocalNode(ctx, f), 1)
+
+			pod := makeWindowsCPUManagerInitPod("gu-init-pod",
+				[]windowsCtnAttribute{
+					// init container: terminates after a brief sleep
+					{name: "init-ctr", cpuRequest: "1000m", cpuLimit: "1000m"},
+				},
+				windowsCtnAttribute{name: "app-ctr", cpuRequest: "1000m", cpuLimit: "1000m"},
+			)
+			ginkgo.By("creating the pod with a non-restartable init container")
+			pod = createPodSync(ctx, pod)
+
+			ginkgo.By("verifying the app container holds exactly 1 exclusive CPU after init completes")
+			gomega.Eventually(ctx, func(ctx context.Context) (int, error) {
+				aff, err := getWindowsContainerCPUAffinity(ctx, criClient, pod, "app-ctr")
+				if err != nil {
+					return 0, err
+				}
+				return countCPUsInAffinities(aff), nil
+			}, 60*time.Second, 2*time.Second).Should(gomega.Equal(1),
+				"app container must hold exactly 1 exclusive CPU")
+		})
+	})
+})
+
+// -------------------------------------------------------------------------
+// Pod / container creation helpers
+// -------------------------------------------------------------------------
+
+// windowsCtnAttribute describes a single container's CPU resource requirements
+// for use with makeWindowsCPUManagerPod / makeWindowsCPUManagerInitPod.
+type windowsCtnAttribute struct {
+	name          string
+	cpuRequest    string
+	cpuLimit      string
+	restartPolicy *v1.ContainerRestartPolicy
+}
+
+// makeWindowsCPUManagerPod builds a Pod spec for Windows CPU affinity tests.
+// Containers run a PowerShell sleep so they stay alive without Linux-specific
+// cgroup mounts or /proc filesystem access.
+func makeWindowsCPUManagerPod(podName string, attrs []windowsCtnAttribute) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: podName},
+		Spec: v1.PodSpec{
+			RestartPolicy: v1.RestartPolicyNever,
+			Containers:    buildWindowsContainers(attrs),
+			NodeSelector:  map[string]string{"kubernetes.io/os": "windows"},
+		},
+	}
+}
+
+// verifyHostMatchesCRI asserts that the Windows kernel's job-object affinity
+// for ctnName agrees bit-for-bit with the affinity CRI reports. This proves the
+// runtime actually applied the mask, not just that containerd recorded it.
+func verifyHostMatchesCRI(ctx context.Context, criClient internalapi.RuntimeService, pod *v1.Pod, ctnName string) {
+	ginkgo.GinkgoHelper()
+	criAff, err := getWindowsContainerCPUAffinity(ctx, criClient, pod, ctnName)
+	framework.ExpectNoError(err, "failed to fetch CRI affinity for host comparison of %q", ctnName)
+	framework.ExpectNoError(
+		validateHostJobAffinityProcessIsolated(pod, ctnName, criAff),
+		"host job-object affinity does not match CRI-reported affinity for %q", ctnName)
+}
+
+// verifyHostMasksDisjoint asserts that the kernel-applied affinity masks of two
+// containers (in the same or different pods) share no CPU — the host-level
+// counterpart to the CRI windowsAffinitiesOverlap check.
+func verifyHostMasksDisjoint(pod1 *v1.Pod, ctn1 string, pod2 *v1.Pod, ctn2 string) {
+	ginkgo.GinkgoHelper()
+	h1, err := getHostJobAffinity(pod1, ctn1)
+	framework.ExpectNoError(err, "failed to read host job affinity for %q", ctn1)
+	h2, err := getHostJobAffinity(pod2, ctn2)
+	framework.ExpectNoError(err, "failed to read host job affinity for %q", ctn2)
+	gomega.Expect(hostJobAffinitiesOverlap(h1, h2)).To(gomega.BeFalse(),
+		"containers %q and %q must not share exclusively-allocated CPUs at the kernel level", ctn1, ctn2)
+}
+
+// makeWindowsCPUManagerInitPod builds a Pod spec that has init containers
+// (possibly restartable / sidecar) followed by a regular app container.
+func makeWindowsCPUManagerInitPod(podName string, initAttrs []windowsCtnAttribute, appAttr windowsCtnAttribute) *v1.Pod {
+	initContainers := buildWindowsContainers(initAttrs)
+	for i := range initContainers {
+		if initAttrs[i].restartPolicy != nil {
+			initContainers[i].RestartPolicy = initAttrs[i].restartPolicy
+		} else {
+			// Non-restartable init containers exit quickly.
+			initContainers[i].Command = []string{"powershell.exe", "-Command", "Start-Sleep -Seconds 2"}
+		}
+	}
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: podName},
+		Spec: v1.PodSpec{
+			RestartPolicy:  v1.RestartPolicyNever,
+			InitContainers: initContainers,
+			Containers:     buildWindowsContainers([]windowsCtnAttribute{appAttr}),
+			NodeSelector:   map[string]string{"kubernetes.io/os": "windows"},
+		},
+	}
+}
+
+// buildWindowsContainers converts a slice of windowsCtnAttribute into v1.Container
+// objects suitable for Windows nodes (PowerShell command, no Linux volume mounts).
+func buildWindowsContainers(attrs []windowsCtnAttribute) []v1.Container {
+	var containers []v1.Container
+	for _, attr := range attrs {
+		requests := v1.ResourceList{
+			v1.ResourceMemory: resource.MustParse("128Mi"),
+		}
+		if attr.cpuRequest != "" {
+			requests[v1.ResourceCPU] = resource.MustParse(attr.cpuRequest)
+		}
+		limits := v1.ResourceList{
+			v1.ResourceMemory: resource.MustParse("128Mi"),
+		}
+		if attr.cpuLimit != "" {
+			limits[v1.ResourceCPU] = resource.MustParse(attr.cpuLimit)
+		}
+		containers = append(containers, v1.Container{
+			Name:  attr.name,
+			Image: busyboxImage,
+			Resources: v1.ResourceRequirements{
+				Requests: requests,
+				Limits:   limits,
+			},
+			// Long-running sleep; powershell.exe is available in the Windows BusyBox image.
+			Command: []string{"powershell.exe", "-Command", "Start-Sleep -Seconds 86400"},
+		})
+	}
+	return containers
+}
+
+// -------------------------------------------------------------------------
+// Kubelet configuration helpers
+// -------------------------------------------------------------------------
+
+// buildWindowsCPUManagerKubeletConfig returns a KubeletConfiguration with the
+// static CPU manager policy.  When featureGateOn is true, the
+// WindowsCPUAndMemoryAffinity feature gate is also enabled.
+func buildWindowsCPUManagerKubeletConfig(oldCfg *kubeletconfig.KubeletConfiguration, featureGateOn bool) *kubeletconfig.KubeletConfiguration {
+	newCfg := oldCfg.DeepCopy()
+	if newCfg.FeatureGates == nil {
+		newCfg.FeatureGates = make(map[string]bool)
+	}
+	newCfg.FeatureGates[string(features.WindowsCPUAndMemoryAffinity)] = featureGateOn
+	newCfg.CPUManagerPolicy = string(cpumanager.PolicyStatic)
+	newCfg.CPUManagerReconcilePeriod = metav1.Duration{Duration: 1 * time.Second}
+	// Reserve CPU 0 so the remaining CPUs are available for guaranteed pods.
+	newCfg.ReservedSystemCPUs = "0"
+	return newCfg
+}
+
+// updateWindowsKubeletConfig stops the kubelet Windows service, writes the new
+// configuration file, and restarts the service.
+func updateWindowsKubeletConfig(ctx context.Context, f *framework.Framework, cfg *kubeletconfig.KubeletConfiguration) {
+	ginkgo.GinkgoHelper()
+	kubeletStart := mustStopKubelet(ctx, f)
+	framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(cfg), "failed to write kubelet config file")
+	kubeletStart(ctx)
+}
+
+// updateWindowsKubeletConfigIfNeeded calls updateWindowsKubeletConfig only when
+// the desired configuration differs from what is currently running, avoiding
+// unnecessary kubelet restarts between tests in the same When block.
+func updateWindowsKubeletConfigIfNeeded(ctx context.Context, f *framework.Framework, desired *kubeletconfig.KubeletConfiguration) {
+	ginkgo.GinkgoHelper()
+	current, err := getCurrentKubeletConfig(ctx)
+	framework.ExpectNoError(err, "failed to get current kubelet config")
+	if equalKubeletConfiguration(current, desired) {
+		framework.Logf("kubelet configuration already matches desired state, skipping restart")
+		return
+	}
+	updateWindowsKubeletConfig(ctx, f, desired)
+}
+
+// equalKubeletConfiguration returns true when the two configurations are
+// semantically equal (ignoring TypeMeta which is not meaningful for comparison).
+func equalKubeletConfiguration(a, b *kubeletconfig.KubeletConfiguration) bool {
+	a = a.DeepCopy()
+	b = b.DeepCopy()
+	a.TypeMeta = metav1.TypeMeta{}
+	b.TypeMeta = metav1.TypeMeta{}
+	return reflect.DeepEqual(a, b)
+}
+
+// -------------------------------------------------------------------------
+// Skip / node helpers
+// -------------------------------------------------------------------------
+
+// skipIfAllocatableCPUsLessThan skips the current test when the node does not
+// have enough allocatable integer CPUs to satisfy the test.
+// One CPU (CPU 0) is always reserved by buildWindowsCPUManagerKubeletConfig,
+// so the minimum allocatable count is (requested + 1).
+func skipIfAllocatableCPUsLessThan(node *v1.Node, requested int) {
+	ginkgo.GinkgoHelper()
+	allocatable := node.Status.Allocatable[v1.ResourceCPU]
+	need := int64(requested + 1) // +1 for the reserved CPU
+	if allocatable.Value() < need {
+		ginkgo.Skip(fmt.Sprintf(
+			"skipping: node has %d allocatable CPUs but test needs %d (including 1 reserved)",
+			allocatable.Value(), need))
+	}
+}

--- a/test/e2e_node_windows/cpu_manager_test.go
+++ b/test/e2e_node_windows/cpu_manager_test.go
@@ -1,6 +1,8 @@
 //go:build windows
 
 /*
+Copyright The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -550,6 +552,132 @@ var _ = SIGWindowsDescribe(feature.CPUManager, feature.Windows, ginkgo.Ordered, 
 				"app container must hold exactly 1 exclusive CPU")
 		})
 	})
+	// -------------------------------------------------------------------------
+	// Strict vs non-strict CPU reservation
+	// With the strict-cpu-reservation policy option the reserved CPUs are removed
+	// from the shared pool, so shared-pool (burstable) containers are confined to
+	// (online - reserved). Without it (the default) the reserved CPUs remain part
+	// of the shared pool and stay usable by burstable containers.
+	// -------------------------------------------------------------------------
+	ginkgo.When("running with the strict-cpu-reservation policy option", ginkgo.Label("non-guaranteed", "strict-cpu-reservation"), func() {
+		// Toggling strict-cpu-reservation changes whether the reserved CPU belongs
+		// to the default pool, which invalidates the persisted CPU manager
+		// checkpoint. Reset to a clean non-strict state on the way out so the
+		// checkpoint left behind is compatible with the rest of the suite.
+		ginkgo.AfterEach(func(ctx context.Context) {
+			updateWindowsKubeletConfigClearState(ctx, f, buildWindowsCPUManagerKubeletConfig(oldCfg, true))
+		})
+
+		ginkgo.It("should exclude the reserved CPU from the burstable shared pool when strict-cpu-reservation is enabled", func(ctx context.Context) {
+			node := getLocalNode(ctx, f)
+			hostCPUs := int(node.Status.Capacity.Cpu().Value())
+			if hostCPUs < 2 {
+				ginkgo.Skip(fmt.Sprintf("strict-cpu-reservation test needs >= 2 CPUs (1 reserved + shared pool), node has %d", hostCPUs))
+			}
+
+			ginkgo.By("enabling the static CPU manager with strict-cpu-reservation and CPU 0 reserved")
+			updateWindowsKubeletConfigClearState(ctx, f, buildWindowsStrictCPUReservationConfig(oldCfg))
+
+			pod := createPodSync(ctx, makeWindowsCPUManagerPod("strict-burstable-pod", []windowsCtnAttribute{
+				{name: "bu-ctr", cpuRequest: "100m", cpuLimit: "300m"},
+			}))
+
+			// The reconcile loop applies the shared pool shortly after the container
+			// starts; with strict reservation the reserved CPU 0 is excluded from it.
+			ginkgo.By("verifying the burstable container is confined to (host - reserved) CPUs")
+			gomega.Eventually(ctx, func(ctx context.Context) (int, error) {
+				aff, err := getWindowsContainerCPUAffinity(ctx, criClient, pod, "bu-ctr")
+				if err != nil {
+					return 0, err
+				}
+				return countCPUsInAffinities(aff), nil
+			}, 60*time.Second, 2*time.Second).Should(gomega.Equal(hostCPUs-1),
+				"with strict-cpu-reservation the burstable shared pool must exclude the 1 reserved CPU (host=%d)", hostCPUs)
+		})
+
+		ginkgo.It("should keep the reserved CPU in the burstable shared pool when strict-cpu-reservation is disabled (default)", func(ctx context.Context) {
+			node := getLocalNode(ctx, f)
+			hostCPUs := int(node.Status.Capacity.Cpu().Value())
+			if hostCPUs < 2 {
+				ginkgo.Skip(fmt.Sprintf("test needs >= 2 CPUs, node has %d", hostCPUs))
+			}
+
+			ginkgo.By("enabling the static CPU manager without strict-cpu-reservation (CPU 0 reserved)")
+			updateWindowsKubeletConfigClearState(ctx, f, buildWindowsCPUManagerKubeletConfig(oldCfg, true))
+
+			pod := createPodSync(ctx, makeWindowsCPUManagerPod("nonstrict-burstable-pod", []windowsCtnAttribute{
+				{name: "bu-ctr", cpuRequest: "100m", cpuLimit: "300m"},
+			}))
+
+			// Without strict reservation and with no exclusive allocations, the
+			// shared pool is the whole machine, including the reserved CPU.
+			ginkgo.By("verifying the burstable container can use all host CPUs (reserved included)")
+			gomega.Eventually(ctx, func(ctx context.Context) (int, error) {
+				aff, err := getWindowsContainerCPUAffinity(ctx, criClient, pod, "bu-ctr")
+				if err != nil {
+					return 0, err
+				}
+				return countCPUsInAffinities(aff), nil
+			}, 60*time.Second, 2*time.Second).Should(gomega.Equal(hostCPUs),
+				"without strict-cpu-reservation the burstable shared pool must include the reserved CPU (host=%d)", hostCPUs)
+		})
+	})
+
+	// -------------------------------------------------------------------------
+	// Dynamic shared-pool resizing (reconcile loop)
+	// The CPU manager reconcile loop updates a *running* shared-pool container's
+	// affinity as guaranteed pods take and release exclusive CPUs. This verifies
+	// the live transition, not just the steady state at pod start.
+	// -------------------------------------------------------------------------
+	ginkgo.When("dynamically resizing the shared pool", ginkgo.Label("guaranteed", "non-guaranteed", "shared-pool", "reconcile"), func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			updateWindowsKubeletConfigIfNeeded(ctx, f, buildWindowsCPUManagerKubeletConfig(oldCfg, true))
+		})
+
+		ginkgo.It("should shrink and grow a running burstable container's affinity as a guaranteed pod comes and goes", func(ctx context.Context) {
+			node := getLocalNode(ctx, f)
+			hostCPUs := int(node.Status.Capacity.Cpu().Value())
+			// Need >= 2 CPUs: CPU 0 reserved (which stays in the shared pool in
+			// non-strict mode) plus at least one non-reserved CPU for the guaranteed
+			// pod's exclusive allocation. The shared pool is then never empty, so the
+			// burstable mask shrinks from hostCPUs to hostCPUs-1 and back.
+			if hostCPUs < 2 {
+				ginkgo.Skip(fmt.Sprintf("dynamic shared-pool test needs >= 2 CPUs, node has %d", hostCPUs))
+			}
+
+			buPod := createPodSync(ctx, makeWindowsCPUManagerPod("dyn-bu-pod", []windowsCtnAttribute{
+				{name: "bu-ctr", cpuRequest: "100m", cpuLimit: "300m"},
+			}))
+			burstableCPUCount := func(ctx context.Context) (int, error) {
+				aff, err := getWindowsContainerCPUAffinity(ctx, criClient, buPod, "bu-ctr")
+				if err != nil {
+					return 0, err
+				}
+				return countCPUsInAffinities(aff), nil
+			}
+
+			ginkgo.By("waiting for the burstable container to occupy the full shared pool")
+			gomega.Eventually(ctx, burstableCPUCount, 60*time.Second, 2*time.Second).Should(gomega.Equal(hostCPUs),
+				"with no exclusive allocations the burstable shared pool should span all %d host CPUs", hostCPUs)
+
+			ginkgo.By("creating a guaranteed pod that takes 1 exclusive CPU")
+			guPod := createPodSync(ctx, makeWindowsCPUManagerPod("dyn-gu-pod", []windowsCtnAttribute{
+				{name: "gu-ctr", cpuRequest: "1000m", cpuLimit: "1000m"},
+			}))
+
+			ginkgo.By("verifying the running burstable container's affinity shrinks by the 1 exclusive CPU")
+			gomega.Eventually(ctx, burstableCPUCount, 60*time.Second, 2*time.Second).Should(gomega.Equal(hostCPUs-1),
+				"the reconcile loop should remove the guaranteed pod's exclusive CPU from the running burstable container's mask")
+
+			ginkgo.By("deleting the guaranteed pod to release its exclusive CPU")
+			e2epod.NewPodClient(f).DeleteSync(ctx, guPod.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
+			delete(podMap, string(guPod.UID))
+
+			ginkgo.By("verifying the running burstable container's affinity grows back to the full shared pool")
+			gomega.Eventually(ctx, burstableCPUCount, 60*time.Second, 2*time.Second).Should(gomega.Equal(hostCPUs),
+				"the reconcile loop should return the released CPU to the running burstable container's mask")
+		})
+	})
 })
 
 // -------------------------------------------------------------------------
@@ -678,11 +806,39 @@ func buildWindowsCPUManagerKubeletConfig(oldCfg *kubeletconfig.KubeletConfigurat
 	return newCfg
 }
 
+// buildWindowsStrictCPUReservationConfig returns a static CPU manager config
+// (feature gate on) with the strict-cpu-reservation policy option enabled, which
+// removes the reserved CPUs from the shared pool. CPUManagerPolicyOptions is GA
+// and locked on, so only the option map needs to be set.
+func buildWindowsStrictCPUReservationConfig(oldCfg *kubeletconfig.KubeletConfiguration) *kubeletconfig.KubeletConfiguration {
+	newCfg := buildWindowsCPUManagerKubeletConfig(oldCfg, true)
+	newCfg.CPUManagerPolicyOptions = map[string]string{
+		cpumanager.StrictCPUReservationOption: "true",
+	}
+	return newCfg
+}
+
 // updateWindowsKubeletConfig stops the kubelet Windows service, writes the new
 // configuration file, and restarts the service.
 func updateWindowsKubeletConfig(ctx context.Context, f *framework.Framework, cfg *kubeletconfig.KubeletConfiguration) {
 	ginkgo.GinkgoHelper()
 	kubeletStart := mustStopKubelet(ctx, f)
+	framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(cfg), "failed to write kubelet config file")
+	kubeletStart(ctx)
+}
+
+// updateWindowsKubeletConfigClearState is like updateWindowsKubeletConfig but
+// also removes the CPU/memory manager state files while the kubelet is stopped.
+// This is required when the new configuration invalidates the persisted
+// checkpoint (e.g. toggling strict-cpu-reservation, which changes whether the
+// reserved CPU belongs to the default pool) — otherwise the kubelet refuses to
+// start with "invalid state, please drain node and remove policy state file".
+// It mirrors the Linux updateKubeletConfig(..., deleteStateFiles=true).
+func updateWindowsKubeletConfigClearState(ctx context.Context, f *framework.Framework, cfg *kubeletconfig.KubeletConfiguration) {
+	ginkgo.GinkgoHelper()
+	kubeletStart := mustStopKubelet(ctx, f)
+	deleteStateFile(cpuManagerStateFile)
+	deleteStateFile(memoryManagerStateFile)
 	framework.ExpectNoError(e2enodekubelet.WriteKubeletConfigFile(cfg), "failed to write kubelet config file")
 	kubeletStart(ctx)
 }

--- a/test/e2e_node_windows/criproxy/endpoint.go
+++ b/test/e2e_node_windows/criproxy/endpoint.go
@@ -1,0 +1,36 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package criproxy
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+const (
+	// defaultNpipeEndpoint is the named-pipe endpoint template used for the CRI
+	// proxy's gRPC server. Windows CRI endpoints are named pipes (npipe://),
+	// not unix sockets, so the proxy listens on a uniquely-named pipe.
+	defaultNpipeEndpoint = "npipe://./pipe/kubelet-remote-proxy-%v"
+)
+
+// GenerateEndpoint generates a new named-pipe endpoint for the proxy gRPC server.
+func GenerateEndpoint() (string, error) {
+	// use a random int as part of the pipe name to keep it unique
+	return fmt.Sprintf(defaultNpipeEndpoint, rand.Int()), nil
+}

--- a/test/e2e_node_windows/criproxy/proxy_image_service.go
+++ b/test/e2e_node_windows/criproxy/proxy_image_service.go
@@ -1,0 +1,129 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package criproxy
+
+import (
+	"context"
+
+	kubeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+const (
+	ListImages  = "ListImages"
+	ImageStatus = "ImageStatus"
+	PullImage   = "PullImage"
+	RemoveImage = "RemoveImage"
+	ImageFsInfo = "ImageFsInfo"
+	// Streaming APIs
+	StreamImages = "StreamImages"
+	// Per-send injection point for streaming APIs, called before each stream.Send().
+	StreamImagesSend = "StreamImagesSend"
+)
+
+// ListImages lists existing images.
+func (p *RemoteRuntime) ListImages(ctx context.Context, req *kubeapi.ListImagesRequest) (*kubeapi.ListImagesResponse, error) {
+	if err := p.runInjectors(ListImages); err != nil {
+		return nil, err
+	}
+
+	images, err := p.imageService.ListImages(ctx, req.Filter)
+	if err != nil {
+		return nil, err
+	}
+	return &kubeapi.ListImagesResponse{
+		Images: images,
+	}, nil
+}
+
+// ImageStatus returns the status of the image. If the image is not
+// present, returns a response with ImageStatusResponse.Image set to
+// nil.
+func (p *RemoteRuntime) ImageStatus(ctx context.Context, req *kubeapi.ImageStatusRequest) (*kubeapi.ImageStatusResponse, error) {
+	if err := p.runInjectors(ImageStatus); err != nil {
+		return nil, err
+	}
+
+	resp, err := p.imageService.ImageStatus(ctx, req.Image, false)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// PullImage pulls an image with authentication config.
+func (p *RemoteRuntime) PullImage(ctx context.Context, req *kubeapi.PullImageRequest) (*kubeapi.PullImageResponse, error) {
+	if err := p.runInjectors(PullImage); err != nil {
+		return nil, err
+	}
+
+	image, err := p.imageService.PullImage(ctx, req.Image, req.Auth, req.SandboxConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &kubeapi.PullImageResponse{
+		ImageRef: image,
+	}, nil
+}
+
+// RemoveImage removes the image.
+// This call is idempotent, and must not return an error if the image has
+// already been removed.
+func (p *RemoteRuntime) RemoveImage(ctx context.Context, req *kubeapi.RemoveImageRequest) (*kubeapi.RemoveImageResponse, error) {
+	if err := p.runInjectors(RemoveImage); err != nil {
+		return nil, err
+	}
+
+	err := p.imageService.RemoveImage(ctx, req.Image)
+	if err != nil {
+		return nil, err
+	}
+	return &kubeapi.RemoveImageResponse{}, nil
+}
+
+// ImageFsInfo returns information of the filesystem that is used to store images.
+func (p *RemoteRuntime) ImageFsInfo(ctx context.Context, req *kubeapi.ImageFsInfoRequest) (*kubeapi.ImageFsInfoResponse, error) {
+	if err := p.runInjectors(ImageFsInfo); err != nil {
+		return nil, err
+	}
+
+	resp, err := p.imageService.ImageFsInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// StreamImages returns a stream of images.
+func (p *RemoteRuntime) StreamImages(req *kubeapi.StreamImagesRequest, stream kubeapi.ImageService_StreamImagesServer) error {
+	if err := p.runInjectors(StreamImages); err != nil {
+		return err
+	}
+
+	images, err := p.imageService.ListImages(stream.Context(), req.Filter)
+	if err != nil {
+		return err
+	}
+	for _, image := range images {
+		if err := p.runInjectors(StreamImagesSend); err != nil {
+			return err
+		}
+		if err := stream.Send(&kubeapi.StreamImagesResponse{Images: []*kubeapi.Image{image}}); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/test/e2e_node_windows/criproxy/proxy_runtime_service.go
+++ b/test/e2e_node_windows/criproxy/proxy_runtime_service.go
@@ -1,0 +1,649 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package criproxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	internalapi "k8s.io/cri-api/pkg/apis"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"k8s.io/cri-client/pkg/util"
+	"k8s.io/kubernetes/test/e2e/framework"
+	utilexec "k8s.io/utils/exec"
+)
+
+const (
+	Version                   = "Version"
+	RunPodSandbox             = "RunPodSandbox"
+	StopPodSandbox            = "StopPodSandbox"
+	RemovePodSandbox          = "RemovePodSandbox"
+	PodSandboxStatus          = "PodSandboxStatus"
+	ListPodSandbox            = "ListPodSandbox"
+	CreateContainer           = "CreateContainer"
+	StartContainer            = "StartContainer"
+	StopContainer             = "StopContainer"
+	RemoveContainer           = "RemoveContainer"
+	ListContainers            = "ListContainers"
+	ContainerStatus           = "ContainerStatus"
+	UpdateContainerResources  = "UpdateContainerResources"
+	ReopenContainerLog        = "ReopenContainerLog"
+	ExecSync                  = "ExecSync"
+	Exec                      = "Exec"
+	Attach                    = "Attach"
+	PortForward               = "PortForward"
+	ContainerStats            = "ContainerStats"
+	ListContainerStats        = "ListContainerStats"
+	PodSandboxStats           = "PodSandboxStats"
+	ListPodSandboxStats       = "ListPodSandboxStats"
+	UpdateRuntimeConfig       = "UpdateRuntimeConfig"
+	Status                    = "Status"
+	CheckpointContainer       = "CheckpointContainer"
+	GetContainerEvents        = "GetContainerEvents"
+	ListMetricDescriptors     = "ListMetricDescriptors"
+	ListPodSandboxMetrics     = "ListPodSandboxMetrics"
+	RuntimeConfig             = "RuntimeConfig"
+	UpdatePodSandboxResources = "UpdatePodSandboxResources"
+	// Streaming APIs
+	StreamPodSandboxes      = "StreamPodSandboxes"
+	StreamContainers        = "StreamContainers"
+	StreamContainerStats    = "StreamContainerStats"
+	StreamPodSandboxStats   = "StreamPodSandboxStats"
+	StreamPodSandboxMetrics = "StreamPodSandboxMetrics"
+	// Per-send injection points for streaming APIs, called before each stream.Send().
+	StreamPodSandboxesSend = "StreamPodSandboxesSend"
+	StreamContainersSend   = "StreamContainersSend"
+)
+
+// AddInjector inject the error or delay to the next call to the RuntimeService.
+func (p *RemoteRuntime) AddInjector(injector func(string) error) {
+	p.injectors = append(p.injectors, injector)
+}
+
+// ResetInjectors resets all registered injectors.
+func (p *RemoteRuntime) ResetInjectors() {
+	p.injectors = []func(string) error{}
+}
+
+func (p *RemoteRuntime) runInjectors(apiName string) error {
+	for _, injector := range p.injectors {
+		if err := injector(apiName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RemoteRuntime represents a proxy for remote container runtime.
+type RemoteRuntime struct {
+	server         *grpc.Server
+	injectors      []func(string) error
+	runtimeService internalapi.RuntimeService
+	imageService   internalapi.ImageManagerService
+	runtimeapi.UnsafeImageServiceServer
+	runtimeapi.UnsafeRuntimeServiceServer
+}
+
+// NewRemoteRuntimeProxy creates a new RemoteRuntime.
+func NewRemoteRuntimeProxy(runtimeService internalapi.RuntimeService, imageService internalapi.ImageManagerService) *RemoteRuntime {
+	p := &RemoteRuntime{
+		server:         grpc.NewServer(),
+		runtimeService: runtimeService,
+		imageService:   imageService,
+	}
+	runtimeapi.RegisterRuntimeServiceServer(p.server, p)
+	runtimeapi.RegisterImageServiceServer(p.server, p)
+
+	return p
+}
+
+// Start starts the remote runtime proxy.
+func (p *RemoteRuntime) Start(endpoint string) error {
+	l, err := util.CreateListener(endpoint)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %q: %w", endpoint, err)
+	}
+
+	go func() {
+		if err := p.server.Serve(l); err != nil {
+			framework.Failf("Failed to start cri proxy : %v", err)
+		}
+	}()
+	return nil
+}
+
+// Stop stops the fake remote runtime proxy.
+func (p *RemoteRuntime) Stop() {
+	p.server.Stop()
+}
+
+// Version returns the runtime name, runtime version, and runtime API version.
+func (p *RemoteRuntime) Version(ctx context.Context, req *runtimeapi.VersionRequest) (*runtimeapi.VersionResponse, error) {
+	if err := p.runInjectors(Version); err != nil {
+		return nil, err
+	}
+	return p.runtimeService.Version(ctx, req.Version)
+}
+
+// RunPodSandbox creates and starts a pod-level sandbox. Runtimes must ensure
+// the sandbox is in the ready state on success.
+func (p *RemoteRuntime) RunPodSandbox(ctx context.Context, req *runtimeapi.RunPodSandboxRequest) (*runtimeapi.RunPodSandboxResponse, error) {
+	if err := p.runInjectors(RunPodSandbox); err != nil {
+		return nil, err
+	}
+
+	sandboxID, err := p.runtimeService.RunPodSandbox(ctx, req.Config, req.RuntimeHandler)
+	if err != nil {
+		return nil, err
+	}
+	return &runtimeapi.RunPodSandboxResponse{PodSandboxId: sandboxID}, nil
+}
+
+// StopPodSandbox stops any running process that is part of the sandbox and
+// reclaims network resources (e.g., IP addresses) allocated to the sandbox.
+// If there are any running containers in the sandbox, they must be forcibly
+// terminated.
+func (p *RemoteRuntime) StopPodSandbox(ctx context.Context, req *runtimeapi.StopPodSandboxRequest) (*runtimeapi.StopPodSandboxResponse, error) {
+	if err := p.runInjectors(StopPodSandbox); err != nil {
+		return nil, err
+	}
+
+	err := p.runtimeService.StopPodSandbox(ctx, req.PodSandboxId)
+	if err != nil {
+		return nil, err
+	}
+	return &runtimeapi.StopPodSandboxResponse{}, nil
+}
+
+// RemovePodSandbox removes the sandbox. If there are any running containers
+// in the sandbox, they must be forcibly terminated and removed.
+// This call is idempotent, and must not return an error if the sandbox has
+// already been removed.
+func (p *RemoteRuntime) RemovePodSandbox(ctx context.Context, req *runtimeapi.RemovePodSandboxRequest) (*runtimeapi.RemovePodSandboxResponse, error) {
+	if err := p.runInjectors(RemovePodSandbox); err != nil {
+		return nil, err
+	}
+	err := p.runtimeService.RemovePodSandbox(ctx, req.PodSandboxId)
+	if err != nil {
+		return nil, err
+	}
+
+	return &runtimeapi.RemovePodSandboxResponse{}, nil
+}
+
+// PodSandboxStatus returns the status of the PodSandbox. If the PodSandbox is not
+// present, returns an error.
+func (p *RemoteRuntime) PodSandboxStatus(ctx context.Context, req *runtimeapi.PodSandboxStatusRequest) (*runtimeapi.PodSandboxStatusResponse, error) {
+	if err := p.runInjectors(PodSandboxStatus); err != nil {
+		return nil, err
+	}
+
+	resp, err := p.runtimeService.PodSandboxStatus(ctx, req.PodSandboxId, false)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// ListPodSandbox returns a list of PodSandboxes.
+func (p *RemoteRuntime) ListPodSandbox(ctx context.Context, req *runtimeapi.ListPodSandboxRequest) (*runtimeapi.ListPodSandboxResponse, error) {
+	if err := p.runInjectors(ListPodSandbox); err != nil {
+		return nil, err
+	}
+
+	items, err := p.runtimeService.ListPodSandbox(ctx, req.Filter)
+	if err != nil {
+		return nil, err
+	}
+	return &runtimeapi.ListPodSandboxResponse{Items: items}, nil
+}
+
+// CreateContainer creates a new container in specified PodSandbox
+func (p *RemoteRuntime) CreateContainer(ctx context.Context, req *runtimeapi.CreateContainerRequest) (*runtimeapi.CreateContainerResponse, error) {
+	if err := p.runInjectors(CreateContainer); err != nil {
+		return nil, err
+	}
+
+	containerID, err := p.runtimeService.CreateContainer(ctx, req.PodSandboxId, req.Config, req.SandboxConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &runtimeapi.CreateContainerResponse{ContainerId: containerID}, nil
+}
+
+// StartContainer starts the container.
+func (p *RemoteRuntime) StartContainer(ctx context.Context, req *runtimeapi.StartContainerRequest) (*runtimeapi.StartContainerResponse, error) {
+	if err := p.runInjectors(StartContainer); err != nil {
+		return nil, err
+	}
+
+	err := p.runtimeService.StartContainer(ctx, req.ContainerId)
+	if err != nil {
+		return nil, err
+	}
+	return &runtimeapi.StartContainerResponse{}, nil
+}
+
+// StopContainer stops a running container with a grace period (i.e., timeout).
+// This call is idempotent, and must not return an error if the container has
+// already been stopped.
+func (p *RemoteRuntime) StopContainer(ctx context.Context, req *runtimeapi.StopContainerRequest) (*runtimeapi.StopContainerResponse, error) {
+	if err := p.runInjectors(StopContainer); err != nil {
+		return nil, err
+	}
+
+	err := p.runtimeService.StopContainer(ctx, req.ContainerId, req.Timeout)
+	if err != nil {
+		return nil, err
+	}
+	return &runtimeapi.StopContainerResponse{}, nil
+}
+
+// RemoveContainer removes the container. If the container is running, the
+// container must be forcibly removed.
+// This call is idempotent, and must not return an error if the container has
+// already been removed.
+func (p *RemoteRuntime) RemoveContainer(ctx context.Context, req *runtimeapi.RemoveContainerRequest) (*runtimeapi.RemoveContainerResponse, error) {
+	if err := p.runInjectors(RemoveContainer); err != nil {
+		return nil, err
+	}
+
+	err := p.runtimeService.RemoveContainer(ctx, req.ContainerId)
+	if err != nil {
+		return nil, err
+	}
+	return &runtimeapi.RemoveContainerResponse{}, nil
+}
+
+// ListContainers lists all containers by filters.
+func (p *RemoteRuntime) ListContainers(ctx context.Context, req *runtimeapi.ListContainersRequest) (*runtimeapi.ListContainersResponse, error) {
+	if err := p.runInjectors(ListContainers); err != nil {
+		return nil, err
+	}
+
+	items, err := p.runtimeService.ListContainers(ctx, req.Filter)
+	if err != nil {
+		return nil, err
+	}
+	return &runtimeapi.ListContainersResponse{Containers: items}, nil
+}
+
+// ContainerStatus returns status of the container. If the container is not
+// present, returns an error.
+func (p *RemoteRuntime) ContainerStatus(ctx context.Context, req *runtimeapi.ContainerStatusRequest) (*runtimeapi.ContainerStatusResponse, error) {
+	if err := p.runInjectors(ContainerStatus); err != nil {
+		return nil, err
+	}
+
+	resp, err := p.runtimeService.ContainerStatus(ctx, req.ContainerId, false)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// ExecSync runs a command in a container synchronously.
+func (p *RemoteRuntime) ExecSync(ctx context.Context, req *runtimeapi.ExecSyncRequest) (*runtimeapi.ExecSyncResponse, error) {
+	if err := p.runInjectors(ExecSync); err != nil {
+		return nil, err
+	}
+
+	var exitCode int32
+	stdout, stderr, err := p.runtimeService.ExecSync(ctx, req.ContainerId, req.Cmd, time.Duration(req.Timeout)*time.Second)
+	if err != nil {
+		var exitError utilexec.ExitError
+		ok := errors.As(err, &exitError)
+		if !ok {
+			return nil, err
+		}
+		exitCode = int32(exitError.ExitStatus())
+	}
+	return &runtimeapi.ExecSyncResponse{
+		Stdout:   stdout,
+		Stderr:   stderr,
+		ExitCode: exitCode,
+	}, nil
+}
+
+// Exec prepares a streaming endpoint to execute a command in the container.
+func (p *RemoteRuntime) Exec(ctx context.Context, req *runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error) {
+	if err := p.runInjectors(Exec); err != nil {
+		return nil, err
+	}
+
+	return p.runtimeService.Exec(ctx, req)
+}
+
+// Attach prepares a streaming endpoint to attach to a running container.
+func (p *RemoteRuntime) Attach(ctx context.Context, req *runtimeapi.AttachRequest) (*runtimeapi.AttachResponse, error) {
+	if err := p.runInjectors(Attach); err != nil {
+		return nil, err
+	}
+
+	return p.runtimeService.Attach(ctx, req)
+}
+
+// PortForward prepares a streaming endpoint to forward ports from a PodSandbox.
+func (p *RemoteRuntime) PortForward(ctx context.Context, req *runtimeapi.PortForwardRequest) (*runtimeapi.PortForwardResponse, error) {
+	if err := p.runInjectors(PortForward); err != nil {
+		return nil, err
+	}
+
+	return p.runtimeService.PortForward(ctx, req)
+}
+
+// ContainerStats returns stats of the container. If the container does not
+// exist, the call returns an error.
+func (p *RemoteRuntime) ContainerStats(ctx context.Context, req *runtimeapi.ContainerStatsRequest) (*runtimeapi.ContainerStatsResponse, error) {
+	if err := p.runInjectors(ContainerStats); err != nil {
+		return nil, err
+	}
+
+	stats, err := p.runtimeService.ContainerStats(ctx, req.ContainerId)
+	if err != nil {
+		return nil, err
+	}
+	return &runtimeapi.ContainerStatsResponse{Stats: stats}, nil
+}
+
+// ListContainerStats returns stats of all running containers.
+func (p *RemoteRuntime) ListContainerStats(ctx context.Context, req *runtimeapi.ListContainerStatsRequest) (*runtimeapi.ListContainerStatsResponse, error) {
+	if err := p.runInjectors(ListContainerStats); err != nil {
+		return nil, err
+	}
+
+	stats, err := p.runtimeService.ListContainerStats(ctx, req.Filter)
+	if err != nil {
+		return nil, err
+	}
+	return &runtimeapi.ListContainerStatsResponse{Stats: stats}, nil
+}
+
+// PodSandboxStats returns stats of the pod. If the pod does not
+// exist, the call returns an error.
+func (p *RemoteRuntime) PodSandboxStats(ctx context.Context, req *runtimeapi.PodSandboxStatsRequest) (*runtimeapi.PodSandboxStatsResponse, error) {
+	if err := p.runInjectors(PodSandboxStats); err != nil {
+		return nil, err
+	}
+
+	stats, err := p.runtimeService.PodSandboxStats(ctx, req.PodSandboxId)
+	if err != nil {
+		return nil, err
+	}
+	return &runtimeapi.PodSandboxStatsResponse{Stats: stats}, nil
+}
+
+// ListPodSandboxStats returns stats of all running pods.
+func (p *RemoteRuntime) ListPodSandboxStats(ctx context.Context, req *runtimeapi.ListPodSandboxStatsRequest) (*runtimeapi.ListPodSandboxStatsResponse, error) {
+	if err := p.runInjectors(ListPodSandboxStats); err != nil {
+		return nil, err
+	}
+
+	stats, err := p.runtimeService.ListPodSandboxStats(ctx, req.Filter)
+	if err != nil {
+		return nil, err
+	}
+	return &runtimeapi.ListPodSandboxStatsResponse{Stats: stats}, nil
+}
+
+// UpdateRuntimeConfig updates the runtime configuration based on the given request.
+func (p *RemoteRuntime) UpdateRuntimeConfig(ctx context.Context, req *runtimeapi.UpdateRuntimeConfigRequest) (*runtimeapi.UpdateRuntimeConfigResponse, error) {
+	if err := p.runInjectors(UpdateRuntimeConfig); err != nil {
+		return nil, err
+	}
+
+	err := p.runtimeService.UpdateRuntimeConfig(ctx, req.RuntimeConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &runtimeapi.UpdateRuntimeConfigResponse{}, nil
+}
+
+// UpdatePodSandboxResources synchronously updates the PodSandboxConfig.
+func (p *RemoteRuntime) UpdatePodSandboxResources(ctx context.Context, req *runtimeapi.UpdatePodSandboxResourcesRequest) (*runtimeapi.UpdatePodSandboxResourcesResponse, error) {
+	if err := p.runInjectors(UpdatePodSandboxResources); err != nil {
+		return nil, err
+	}
+
+	return p.runtimeService.UpdatePodSandboxResources(ctx, req)
+}
+
+// Status returns the status of the runtime.
+func (p *RemoteRuntime) Status(ctx context.Context, req *runtimeapi.StatusRequest) (*runtimeapi.StatusResponse, error) {
+	if err := p.runInjectors(Status); err != nil {
+		return nil, err
+	}
+
+	resp, err := p.runtimeService.Status(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// UpdateContainerResources updates ContainerConfig of the container.
+func (p *RemoteRuntime) UpdateContainerResources(ctx context.Context, req *runtimeapi.UpdateContainerResourcesRequest) (*runtimeapi.UpdateContainerResourcesResponse, error) {
+	if err := p.runInjectors(UpdateContainerResources); err != nil {
+		return nil, err
+	}
+
+	err := p.runtimeService.UpdateContainerResources(ctx, req.ContainerId, &runtimeapi.ContainerResources{Linux: req.Linux})
+	if err != nil {
+		return nil, err
+	}
+	return &runtimeapi.UpdateContainerResourcesResponse{}, nil
+}
+
+// ReopenContainerLog reopens the container log file.
+func (p *RemoteRuntime) ReopenContainerLog(ctx context.Context, req *runtimeapi.ReopenContainerLogRequest) (*runtimeapi.ReopenContainerLogResponse, error) {
+	if err := p.runInjectors(ReopenContainerLog); err != nil {
+		return nil, err
+	}
+
+	err := p.runtimeService.ReopenContainerLog(ctx, req.ContainerId)
+	if err != nil {
+		return nil, err
+	}
+	return &runtimeapi.ReopenContainerLogResponse{}, nil
+}
+
+// CheckpointContainer checkpoints the given container.
+func (p *RemoteRuntime) CheckpointContainer(ctx context.Context, req *runtimeapi.CheckpointContainerRequest) (*runtimeapi.CheckpointContainerResponse, error) {
+	if err := p.runInjectors(CheckpointContainer); err != nil {
+		return nil, err
+	}
+
+	err := p.runtimeService.CheckpointContainer(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return &runtimeapi.CheckpointContainerResponse{}, nil
+}
+
+func (p *RemoteRuntime) GetContainerEvents(req *runtimeapi.GetEventsRequest, ces runtimeapi.RuntimeService_GetContainerEventsServer) error {
+	if err := p.runInjectors(GetContainerEvents); err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithCancel(ces.Context())
+	defer cancel()
+
+	// Capacity of the channel for receiving pod lifecycle events. This number
+	// is a bit arbitrary and may be adjusted in the future.
+	plegChannelCapacity := 1000
+	containerEventsResponseCh := make(chan *runtimeapi.ContainerEventResponse, plegChannelCapacity)
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(containerEventsResponseCh)
+		errCh <- p.runtimeService.GetContainerEvents(ctx, containerEventsResponseCh, nil)
+	}()
+
+	for event := range containerEventsResponseCh {
+		if err := ces.Send(event); err != nil {
+			cancel()
+			return status.Errorf(codes.Unknown, "Failed to send event: %v", err)
+		}
+	}
+
+	if err := <-errCh; err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, io.EOF) {
+		return err
+	}
+
+	return nil
+}
+
+// ListMetricDescriptors gets the descriptors for the metrics that will be returned in ListPodSandboxMetrics.
+func (p *RemoteRuntime) ListMetricDescriptors(ctx context.Context, req *runtimeapi.ListMetricDescriptorsRequest) (*runtimeapi.ListMetricDescriptorsResponse, error) {
+	if err := p.runInjectors(ListMetricDescriptors); err != nil {
+		return nil, err
+	}
+
+	descs, err := p.runtimeService.ListMetricDescriptors(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &runtimeapi.ListMetricDescriptorsResponse{Descriptors: descs}, nil
+}
+
+// ListPodSandboxMetrics retrieves the metrics for all pod sandboxes.
+func (p *RemoteRuntime) ListPodSandboxMetrics(ctx context.Context, req *runtimeapi.ListPodSandboxMetricsRequest) (*runtimeapi.ListPodSandboxMetricsResponse, error) {
+	if err := p.runInjectors(ListPodSandboxMetrics); err != nil {
+		return nil, err
+	}
+
+	podMetrics, err := p.runtimeService.ListPodSandboxMetrics(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &runtimeapi.ListPodSandboxMetricsResponse{PodMetrics: podMetrics}, nil
+}
+
+// RuntimeConfig returns the configuration information of the runtime.
+func (p *RemoteRuntime) RuntimeConfig(ctx context.Context, req *runtimeapi.RuntimeConfigRequest) (*runtimeapi.RuntimeConfigResponse, error) {
+	if err := p.runInjectors(RuntimeConfig); err != nil {
+		return nil, err
+	}
+
+	resp, err := p.runtimeService.RuntimeConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// StreamPodSandboxes returns a stream of PodSandboxes.
+func (p *RemoteRuntime) StreamPodSandboxes(req *runtimeapi.StreamPodSandboxesRequest, stream runtimeapi.RuntimeService_StreamPodSandboxesServer) error {
+	if err := p.runInjectors(StreamPodSandboxes); err != nil {
+		return err
+	}
+
+	items, err := p.runtimeService.ListPodSandbox(stream.Context(), req.Filter)
+	if err != nil {
+		return err
+	}
+	for _, item := range items {
+		if err := p.runInjectors(StreamPodSandboxesSend); err != nil {
+			return err
+		}
+		if err := stream.Send(&runtimeapi.StreamPodSandboxesResponse{PodSandboxes: []*runtimeapi.PodSandbox{item}}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// StreamContainers returns a stream of containers.
+func (p *RemoteRuntime) StreamContainers(req *runtimeapi.StreamContainersRequest, stream runtimeapi.RuntimeService_StreamContainersServer) error {
+	if err := p.runInjectors(StreamContainers); err != nil {
+		return err
+	}
+
+	items, err := p.runtimeService.ListContainers(stream.Context(), req.Filter)
+	if err != nil {
+		return err
+	}
+	for _, item := range items {
+		if err := p.runInjectors(StreamContainersSend); err != nil {
+			return err
+		}
+		if err := stream.Send(&runtimeapi.StreamContainersResponse{Containers: []*runtimeapi.Container{item}}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// StreamContainerStats returns a stream of container stats.
+func (p *RemoteRuntime) StreamContainerStats(req *runtimeapi.StreamContainerStatsRequest, stream runtimeapi.RuntimeService_StreamContainerStatsServer) error {
+	if err := p.runInjectors(StreamContainerStats); err != nil {
+		return err
+	}
+
+	stats, err := p.runtimeService.ListContainerStats(stream.Context(), req.Filter)
+	if err != nil {
+		return err
+	}
+	for _, stat := range stats {
+		if err := stream.Send(&runtimeapi.StreamContainerStatsResponse{ContainerStats: []*runtimeapi.ContainerStats{stat}}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// StreamPodSandboxStats returns a stream of pod sandbox stats.
+func (p *RemoteRuntime) StreamPodSandboxStats(req *runtimeapi.StreamPodSandboxStatsRequest, stream runtimeapi.RuntimeService_StreamPodSandboxStatsServer) error {
+	if err := p.runInjectors(StreamPodSandboxStats); err != nil {
+		return err
+	}
+
+	stats, err := p.runtimeService.ListPodSandboxStats(stream.Context(), req.Filter)
+	if err != nil {
+		return err
+	}
+	for _, stat := range stats {
+		if err := stream.Send(&runtimeapi.StreamPodSandboxStatsResponse{PodSandboxStats: []*runtimeapi.PodSandboxStats{stat}}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// StreamPodSandboxMetrics returns a stream of pod sandbox metrics.
+func (p *RemoteRuntime) StreamPodSandboxMetrics(req *runtimeapi.StreamPodSandboxMetricsRequest, stream runtimeapi.RuntimeService_StreamPodSandboxMetricsServer) error {
+	if err := p.runInjectors(StreamPodSandboxMetrics); err != nil {
+		return err
+	}
+
+	podMetrics, err := p.runtimeService.ListPodSandboxMetrics(stream.Context())
+	if err != nil {
+		return err
+	}
+	for _, metric := range podMetrics {
+		if err := stream.Send(&runtimeapi.StreamPodSandboxMetricsResponse{PodSandboxMetrics: []*runtimeapi.PodSandboxMetrics{metric}}); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/test/e2e_node_windows/e2e_node_suite_test.go
+++ b/test/e2e_node_windows/e2e_node_suite_test.go
@@ -43,8 +43,7 @@ import (
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2etestfiles "k8s.io/kubernetes/test/e2e/framework/testfiles"
 	e2etestingmanifests "k8s.io/kubernetes/test/e2e/testing-manifests"
-	"k8s.io/kubernetes/test/e2e_node/criproxy"
-	e2enodetestingmanifests "k8s.io/kubernetes/test/e2e_node/testing-manifests"
+	"k8s.io/kubernetes/test/e2e_node_windows/criproxy"
 	"k8s.io/kubernetes/test/e2e_node_windows/services"
 
 	// define and freeze constants
@@ -96,7 +95,6 @@ func registerNodeFlags(flags *flag.FlagSet) {
 	flags.StringVar(&framework.TestContext.ImageDescription, "image-description", "", "The description of the image which the test will be running on.")
 	flags.StringVar(&framework.TestContext.SystemSpecName, "system-spec-name", "", "The name of the system spec (e.g., gke) that's used in the node e2e test. The system specs are in test/e2e_node/system/specs/. This is used by the test framework to determine which tests to run for validating the system requirements.")
 	flags.Var(cliflag.NewMapStringString(&framework.TestContext.ExtraEnvs), "extra-envs", "The extra environment variables needed for node e2e tests. Format: a list of key=value pairs, e.g., env1=val1,env2=val2")
-	flags.StringVar(&framework.TestContext.SriovdpConfigMapFile, "sriovdp-configmap-file", "", "The name of the SRIOV device plugin Config Map to load.")
 	flag.StringVar(&framework.TestContext.ClusterDNSDomain, "dns-domain", "", "The DNS Domain of the cluster.")
 	flag.Var(cliflag.NewMapStringString(&framework.TestContext.RuntimeConfig), "runtime-config", "The runtime configuration used on node e2e tests.")
 	flags.BoolVar(&framework.TestContext.RequireDevices, "require-devices", false, "If true, require device plugins to be installed in the running environment.")
@@ -109,7 +107,6 @@ func registerNodeFlags(flags *flag.FlagSet) {
 func init() {
 	// Enable embedded FS file lookup as fallback
 	e2etestfiles.AddFileSource(e2etestingmanifests.GetE2ETestingManifestsFS())
-	e2etestfiles.AddFileSource(e2enodetestingmanifests.GetE2ENodeTestingManifestsFS())
 }
 
 func TestMain(m *testing.M) {
@@ -166,6 +163,7 @@ func TestE2eNode(t *testing.T) {
 	if *systemValidateMode {
 		// If system-validate-mode is specified, only run system validation in current process.
 		klog.Warningf("system spec validation is not supported on platform other than linux yet")
+		return
 	}
 
 	// We're not running in a special mode so lets run tests.

--- a/test/e2e_node_windows/kubeletconfig/kubeletconfig.go
+++ b/test/e2e_node_windows/kubeletconfig/kubeletconfig.go
@@ -1,0 +1,217 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeletconfig
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
+	"k8s.io/kubernetes/pkg/cluster/ports"
+	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
+	kubeletconfigscheme "k8s.io/kubernetes/pkg/kubelet/apis/config/scheme"
+	kubeletconfigcodec "k8s.io/kubernetes/pkg/kubelet/kubeletconfig/util/codec"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
+
+	"sigs.k8s.io/yaml"
+)
+
+func getKubeletConfigFilePath() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current working directory: %w", err)
+	}
+
+	// DO NOT name this file "kubelet" - you will overwrite the kubelet binary and be very confused :)
+	return filepath.Join(cwd, "kubelet-config"), nil
+}
+
+// GetCurrentKubeletConfigFromFile returns the current kubelet configuration under the filesystem.
+// This method should only run together with e2e node tests, meaning the test executor and the cluster nodes is the
+// same machine
+func GetCurrentKubeletConfigFromFile() (*kubeletconfig.KubeletConfiguration, error) {
+	kubeletConfigFilePath, err := getKubeletConfigFilePath()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(kubeletConfigFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the kubelet config from the file %q: %w", kubeletConfigFilePath, err)
+	}
+
+	var kubeletConfigV1Beta1 kubeletconfigv1beta1.KubeletConfiguration
+	if err := yaml.Unmarshal(data, &kubeletConfigV1Beta1); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal the kubelet config: %w", err)
+	}
+
+	scheme, _, err := kubeletconfigscheme.NewSchemeAndCodecs()
+	if err != nil {
+		return nil, err
+	}
+
+	kubeletConfig := kubeletconfig.KubeletConfiguration{}
+	err = scheme.Convert(&kubeletConfigV1Beta1, &kubeletConfig, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &kubeletConfig, nil
+}
+
+// WriteKubeletConfigFile updates the kubelet configuration under the filesystem
+// This method should only run together with e2e node tests, meaning the test executor and the cluster nodes is the
+// same machine
+func WriteKubeletConfigFile(kubeletConfig *kubeletconfig.KubeletConfiguration) error {
+	data, err := kubeletconfigcodec.EncodeKubeletConfig(kubeletConfig, kubeletconfigv1beta1.SchemeGroupVersion)
+	if err != nil {
+		return err
+	}
+
+	kubeletConfigFilePath, err := getKubeletConfigFilePath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(kubeletConfigFilePath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write the kubelet file to %q: %w", kubeletConfigFilePath, err)
+	}
+
+	return nil
+}
+
+// GetCurrentKubeletConfig fetches the current Kubelet Config for the given node
+func GetCurrentKubeletConfig(ctx context.Context, nodeName, namespace string, useProxy bool, standaloneMode bool) (*kubeletconfig.KubeletConfiguration, error) {
+	resp := pollConfigz(ctx, 5*time.Minute, 5*time.Second, nodeName, namespace, useProxy, standaloneMode)
+	if len(resp) == 0 {
+		return nil, fmt.Errorf("failed to fetch /configz from %q", nodeName)
+	}
+	kubeCfg, err := decodeConfigz(resp)
+	if err != nil {
+		return nil, err
+	}
+	return kubeCfg, nil
+}
+
+// returns a status 200 response from the /configz endpoint or nil if fails
+func pollConfigz(ctx context.Context, timeout time.Duration, pollInterval time.Duration, nodeName, namespace string, useProxy bool, standaloneMode bool) []byte {
+	endpoint := ""
+	if useProxy {
+		// start local proxy, so we can send graceful deletion over query string, rather than body parameter
+		framework.Logf("Opening proxy to cluster")
+		tk := e2ekubectl.NewTestKubeconfig(framework.TestContext.CertDir, framework.TestContext.Host, framework.TestContext.KubeConfig, framework.TestContext.KubeContext, framework.TestContext.KubectlPath, namespace)
+		cmd := tk.KubectlCmd("proxy", "-p", "0")
+		stdout, stderr, err := framework.StartCmdAndStreamOutput(cmd)
+		framework.ExpectNoError(err)
+		defer func() { _ = stdout.Close() }()
+		defer func() { _ = stderr.Close() }()
+		defer framework.TryKill(cmd)
+
+		buf := make([]byte, 128)
+		var n int
+		n, err = stdout.Read(buf)
+		framework.ExpectNoError(err)
+		output := string(buf[:n])
+		proxyRegexp := regexp.MustCompile("Starting to serve on 127.0.0.1:([0-9]+)")
+		match := proxyRegexp.FindStringSubmatch(output)
+		gomega.Expect(match).To(gomega.HaveLen(2))
+		port, err := strconv.Atoi(match[1])
+		framework.ExpectNoError(err)
+		framework.Logf("http requesting node kubelet /configz")
+		endpoint = fmt.Sprintf("http://127.0.0.1:%d/api/v1/nodes/%s/proxy/configz", port, nodeName)
+	} else if !standaloneMode {
+		endpoint = fmt.Sprintf("%s/api/v1/nodes/%s/proxy/configz", framework.TestContext.Host, framework.TestContext.NodeName)
+	} else {
+		endpoint = fmt.Sprintf("https://127.0.0.1:%d/configz", ports.KubeletPort)
+	}
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: tr}
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	framework.ExpectNoError(err)
+	if !useProxy {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", framework.TestContext.BearerToken))
+	}
+	req.Header.Add("Accept", "application/json")
+
+	var respBody []byte
+	err = wait.PollUntilContextTimeout(ctx, pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		resp, err := client.Do(req)
+		if err != nil {
+			framework.Logf("Failed to get /configz, retrying. Error: %v", err)
+			return false, nil
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			framework.Logf("/configz response status not 200, retrying. Response was: %+v", resp)
+			return false, nil
+		}
+
+		respBody, err = io.ReadAll(resp.Body)
+		if err != nil {
+			framework.Logf("failed to read body from /configz response, retrying. Error: %v", err)
+			return false, nil
+		}
+
+		return true, nil
+	})
+	framework.ExpectNoError(err, "Failed to get successful response from /configz")
+
+	return respBody
+}
+
+// Decodes the http response from /configz and returns a kubeletconfig.KubeletConfiguration (internal type).
+func decodeConfigz(respBody []byte) (*kubeletconfig.KubeletConfiguration, error) {
+	// This hack because /configz reports the following structure:
+	// {"kubeletconfig": {the JSON representation of kubeletconfigv1beta1.KubeletConfiguration}}
+	type configzWrapper struct {
+		ComponentConfig kubeletconfigv1beta1.KubeletConfiguration `json:"kubeletconfig"`
+	}
+
+	configz := configzWrapper{}
+	kubeCfg := kubeletconfig.KubeletConfiguration{}
+
+	err := json.Unmarshal(respBody, &configz)
+	if err != nil {
+		return nil, err
+	}
+
+	scheme, _, err := kubeletconfigscheme.NewSchemeAndCodecs()
+	if err != nil {
+		return nil, err
+	}
+	err = scheme.Convert(&configz.ComponentConfig, &kubeCfg, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &kubeCfg, nil
+}

--- a/test/e2e_node_windows/util.go
+++ b/test/e2e_node_windows/util.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -67,6 +68,15 @@ var (
 
 const (
 	kubeletServiceName = "kubelet"
+
+	// CPU/memory manager state files live in the kubelet root directory
+	// (--root-dir, /var/lib/kubelet). They must be removed when the kubelet is
+	// reconfigured in a way that invalidates the persisted checkpoint (e.g.
+	// toggling the static CPU manager's strict-cpu-reservation option), otherwise
+	// the kubelet refuses to start with "invalid state, please drain node and
+	// remove policy state file".
+	cpuManagerStateFile    = "/var/lib/kubelet/cpu_manager_state"
+	memoryManagerStateFile = "/var/lib/kubelet/memory_manager_state"
 )
 
 // getKubeletServicePID returns the PID of the kubelet service, or 0 if it
@@ -218,7 +228,10 @@ func startContainerRuntime() error {
 
 // deleteStateFile deletes the state file with the filename.
 func deleteStateFile(stateFileName string) {
-	// no-op on Windows for now
+	err := os.Remove(stateFileName)
+	if err != nil && !os.IsNotExist(err) {
+		framework.ExpectNoError(err, "failed to delete the state file %q", stateFileName)
+	}
 }
 
 // systemValidation validates the system spec.

--- a/test/e2e_node_windows/util.go
+++ b/test/e2e_node_windows/util.go
@@ -20,15 +20,37 @@ package e2enodewindows
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	clientset "k8s.io/client-go/kubernetes"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	remote "k8s.io/cri-client/pkg"
+	"k8s.io/klog/v2"
+	stats "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
+	"k8s.io/kubernetes/pkg/cluster/ports"
 	"k8s.io/kubernetes/pkg/features"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
+	kubeletmetrics "k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2emetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
@@ -39,7 +61,312 @@ var (
 
 	// kubeletCfg is the kubelet configuration the test is running against.
 	kubeletCfg *kubeletconfig.KubeletConfiguration
+
+	kubeletHealthCheckURL = fmt.Sprintf("http://127.0.0.1:%d/healthz", ports.KubeletHealthzPort)
 )
+
+const (
+	kubeletServiceName = "kubelet"
+)
+
+// getKubeletServicePID returns the PID of the kubelet service, or 0 if it
+// cannot be determined (e.g. the service is no longer running).
+func getKubeletServicePID() int {
+	cmdLine := []string{"sc.exe", "queryex", kubeletServiceName}
+
+	stdout, err := exec.Command(cmdLine[0], cmdLine[1:]...).CombinedOutput()
+	if err != nil {
+		return 0
+	}
+
+	regex := regexp.MustCompile(`PID\s*:\s*(\d+)`)
+	matches := regex.FindStringSubmatch(string(stdout))
+	if len(matches) <= 1 {
+		return 0
+	}
+
+	pid, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0
+	}
+	return pid
+}
+
+// killProcessByPID kills the process with the given PID. A "process not found"
+// outcome is treated as success — by the time we taskkill, the kubelet may
+// already have exited on its own (e.g. in response to an earlier sc.exe stop).
+func killProcessByPID(pid int) {
+	if pid <= 0 {
+		return
+	}
+	cmdLine := []string{"taskkill", "/F", "/PID", strconv.Itoa(pid)}
+
+	stdout, err := exec.Command(cmdLine[0], cmdLine[1:]...).CombinedOutput()
+	if err == nil {
+		return
+	}
+	// taskkill returns non-zero with "not found" / "no running instance" when the
+	// process has already exited. That's the state we wanted, so swallow it.
+	out := strings.ToLower(string(stdout))
+	if strings.Contains(out, "not found") || strings.Contains(out, "no running") {
+		return
+	}
+	framework.ExpectNoError(err, "taskkill failed for PID %d: %s", pid, string(stdout))
+}
+
+// findKubeletServiceState searches for the state of the kubelet service.
+func findKubeletServiceState() string {
+	cmdLine := []string{"sc.exe", "query", kubeletServiceName}
+
+	// Assume kubelet service has already been registered
+	stdout, err := exec.Command(cmdLine[0], cmdLine[1:]...).CombinedOutput()
+	framework.ExpectNoError(err)
+
+	regex := regexp.MustCompile(`(?m)STATE\s*:\s*\d+\s+(\w+)`)
+	matches := regex.FindStringSubmatch(string(stdout))
+	gomega.Expect(len(matches)).To(gomega.BeNumerically(">", 1), "Found the matched state: %q", stdout)
+	state := matches[1]
+
+	return state
+}
+
+// stopKubeletService stops the kubelet Windows service and waits until SCM
+// reports it as STOPPED. sc.exe stop is asynchronous: the service typically
+// transitions RUNNING -> STOP_PENDING -> STOPPED. Issuing sc.exe start while
+// SCM still considers the service running yields error 1056
+// ("An instance of the service is already running"), so we must gate the next
+// start on the SCM state, not on the HTTP health probe (which goes down well
+// before SCM finishes the transition).
+func stopKubeletService(ctx context.Context) {
+	state := findKubeletServiceState()
+	if strings.EqualFold(state, "STOPPED") {
+		return
+	}
+
+	if strings.EqualFold(state, "RUNNING") {
+		stdout, err := exec.CommandContext(ctx, "sc.exe", "stop", kubeletServiceName).CombinedOutput()
+		framework.ExpectNoError(err, "Failed to stop kubelet service: %v, %s", err, string(stdout))
+	}
+
+	// Wait for SCM to report STOPPED. If it stays in STOP_PENDING for too long,
+	// fall back to forcibly killing the kubelet process.
+	const (
+		stopTimeout = 30 * time.Second
+		stopPoll    = 250 * time.Millisecond
+	)
+	deadline := time.Now().Add(stopTimeout)
+	for time.Now().Before(deadline) {
+		if strings.EqualFold(findKubeletServiceState(), "STOPPED") {
+			return
+		}
+		time.Sleep(stopPoll)
+	}
+
+	// Stuck in STOP_PENDING — force-kill the process and re-check.
+	killProcessByPID(getKubeletServicePID())
+	gomega.Eventually(ctx, func() string {
+		return strings.ToUpper(findKubeletServiceState())
+	}, 10*time.Second, stopPoll).Should(gomega.Equal("STOPPED"), "kubelet service did not reach STOPPED state")
+}
+
+// startKubeletService starts the kubelet Windows service and waits for the
+// kubelet HTTP health check to succeed.
+func startKubeletService(ctx context.Context, f *framework.Framework) {
+	stdout, err := exec.CommandContext(ctx, "sc.exe", "start", kubeletServiceName).CombinedOutput()
+	framework.ExpectNoError(err, "Failed to start kubelet service with sc.exe: %v, %s", err, string(stdout))
+	waitForKubeletToStart(ctx, f)
+}
+
+// restartKubelet restarts the current kubelet service.
+// the "current" kubelet service is the instance managed by the current e2e_node test run.
+// If `running` is true, restarts only if the current kubelet is actually running. In some cases,
+// the kubelet may have exited or can be stopped, typically because it was intentionally stopped
+// earlier during a test, or, sometimes, because it just crashed.
+// Warning: the "current" kubelet is poorly defined. The "current" kubelet is assumed to be the most
+// recent kubelet service unit, IOW there is not a unique ID we use to bind explicitly a kubelet
+// instance to a test run.
+func restartKubelet(ctx context.Context, running bool) {
+	stopKubeletService(ctx)
+
+	stdout, err := exec.CommandContext(ctx, "sc.exe", "start", kubeletServiceName).CombinedOutput()
+	framework.ExpectNoError(err, "Failed to restart kubelet service with sc.exe: %v, %s", err, string(stdout))
+}
+
+// mustStopKubelet will kill the running kubelet, and returns a func that will restart the process again
+func mustStopKubelet(ctx context.Context, f *framework.Framework) func(ctx context.Context) {
+	stopKubeletService(ctx)
+
+	// Belt-and-braces: ensure the HTTP health endpoint is also down before
+	// returning, since that is the surface the next test will probe.
+	gomega.Eventually(ctx, func() bool {
+		return e2enode.HealthCheck(kubeletHealthCheckURL)
+	}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.BeFalseBecause("kubelet was expected to be stopped but it is still running"))
+
+	return func(ctx context.Context) {
+		startKubeletService(ctx, f)
+	}
+}
+
+// TODO: add the windows part implementation
+func stopContainerRuntime() error {
+	return nil
+}
+
+func startContainerRuntime() error {
+	return nil
+}
+
+// deleteStateFile deletes the state file with the filename.
+func deleteStateFile(stateFileName string) {
+	// no-op on Windows for now
+}
+
+// systemValidation validates the system spec.
+func systemValidation(systemSpecFile *string) {
+	klog.Warningf("system spec validation is not supported on platform other than linux yet")
+}
+
+func getNodeSummary(ctx context.Context) (*stats.Summary, error) {
+	kubeletConfig, err := getCurrentKubeletConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current kubelet config")
+	}
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("http://%s/stats/summary", net.JoinHostPort(kubeletConfig.Address, strconv.Itoa(int(kubeletConfig.ReadOnlyPort)))), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build http request: %w", err)
+	}
+	req.Header.Add("Accept", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get /stats/summary: %w", err)
+	}
+
+	defer resp.Body.Close()
+	contentsBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read /stats/summary: %+v", resp)
+	}
+
+	decoder := json.NewDecoder(strings.NewReader(string(contentsBytes)))
+	summary := stats.Summary{}
+	err = decoder.Decode(&summary)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse /stats/summary to go struct: %+v", resp)
+	}
+	return &summary, nil
+}
+
+func addAfterEachForCleaningUpPods(f *framework.Framework) {
+	ginkgo.AfterEach(func(ctx context.Context) {
+		ginkgo.By("Deleting any Pods created by the test in namespace: " + f.Namespace.Name)
+		l, err := e2epod.NewPodClient(f).List(ctx, metav1.ListOptions{})
+		framework.ExpectNoError(err)
+		for _, p := range l.Items {
+			if p.Namespace != f.Namespace.Name {
+				continue
+			}
+			framework.Logf("Deleting pod: %s", p.Name)
+			e2epod.NewPodClient(f).DeleteSync(ctx, p.Name, metav1.DeleteOptions{}, f.Timeouts.PodDelete)
+		}
+	})
+}
+
+func waitForKubeletToStart(ctx context.Context, f *framework.Framework) {
+	// wait until the kubelet health check will succeed
+	gomega.Eventually(ctx, func() bool {
+		return e2enode.HealthCheck(kubeletHealthCheckURL)
+	}, 2*time.Minute, 5*time.Second).Should(gomega.BeTrueBecause("expected kubelet to be in healthy state"))
+
+	// Wait for the Kubelet to be ready.
+	gomega.Eventually(ctx, func(ctx context.Context) error {
+		nodes, err := e2enode.TotalReady(ctx, f.ClientSet)
+		if err != nil {
+			return fmt.Errorf("error getting ready nodes: %w", err)
+		}
+		if nodes != 1 {
+			return fmt.Errorf("expected 1 ready node, got %d", nodes)
+		}
+		return nil
+	}, time.Minute, time.Second).Should(gomega.Succeed())
+}
+
+// listNamespaceEvents lists the events in the given namespace.
+func listNamespaceEvents(ctx context.Context, c clientset.Interface, ns string) error {
+	ls, err := c.CoreV1().Events(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, event := range ls.Items {
+		klog.Infof("Event(%#v): type: '%v' reason: '%v' %v", event.InvolvedObject, event.Type, event.Reason, event.Message)
+	}
+	return nil
+}
+
+func logPodEvents(ctx context.Context, f *framework.Framework) {
+	framework.Logf("Summary of pod events during the test:")
+	err := listNamespaceEvents(ctx, f.ClientSet, f.Namespace.Name)
+	framework.ExpectNoError(err)
+}
+
+func logNodeEvents(ctx context.Context, f *framework.Framework) {
+	framework.Logf("Summary of node events during the test:")
+	err := listNamespaceEvents(ctx, f.ClientSet, "")
+	framework.ExpectNoError(err)
+}
+
+func getLocalNode(ctx context.Context, f *framework.Framework) *v1.Node {
+	nodeList, err := e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)
+	framework.ExpectNoError(err)
+	gomega.Expect(nodeList.Items).Should(gomega.HaveLen(1), "Unexpected number of node objects for node e2e. Expects only one node.")
+	return &nodeList.Items[0]
+}
+
+// getLocalTestNode fetches the node object describing the local worker node set up by the e2e_node infra, alongside with its ready state.
+func getLocalTestNode(ctx context.Context, f *framework.Framework) (*v1.Node, bool) {
+	logger := klog.FromContext(ctx)
+	node, err := f.ClientSet.CoreV1().Nodes().Get(ctx, framework.TestContext.NodeName, metav1.GetOptions{})
+	framework.ExpectNoError(err)
+	ready := e2enode.IsNodeReady(logger, node)
+	schedulable := e2enode.IsNodeSchedulable(logger, node)
+	framework.Logf("node %q ready=%v schedulable=%v", node.Name, ready, schedulable)
+	return node, ready && schedulable
+}
+
+func getLocalNodeCPUDetails(ctx context.Context, f *framework.Framework) (cpuCapVal int64, cpuAllocVal int64, cpuResVal int64) {
+	localNodeCap := getLocalNode(ctx, f).Status.Capacity
+	cpuCap := localNodeCap[v1.ResourceCPU]
+	localNodeAlloc := getLocalNode(ctx, f).Status.Allocatable
+	cpuAlloc := localNodeAlloc[v1.ResourceCPU]
+	cpuRes := cpuCap.DeepCopy()
+	cpuRes.Sub(cpuAlloc)
+
+	// RoundUp reserved CPUs to get only integer cores.
+	cpuRes.RoundUp(0)
+
+	return cpuCap.Value(), cpuCap.Value() - cpuRes.Value(), cpuRes.Value()
+}
+
+func nodeNameOrIP() string {
+	return "localhost"
+}
+
+// logKubeletLatencyMetrics logs KubeletLatencyMetrics computed from the Prometheus
+// metrics exposed on the current node and identified by the metricNames.
+// The Kubelet subsystem prefix is automatically prepended to these metric names.
+func logKubeletLatencyMetrics(ctx context.Context, metricNames ...string) {
+	metricSet := sets.NewString()
+	for _, key := range metricNames {
+		metricSet.Insert(kubeletmetrics.KubeletSubsystem + "_" + key)
+	}
+	metric, err := e2emetrics.GrabKubeletMetricsWithoutProxy(ctx, fmt.Sprintf("%s:%d", nodeNameOrIP(), ports.KubeletReadOnlyPort), "/metrics")
+	if err != nil {
+		framework.Logf("Error getting kubelet metrics: %v", err)
+	} else {
+		framework.Logf("Kubelet Metrics: %+v", e2emetrics.GetKubeletLatencyMetrics(metric, metricSet))
+	}
+}
 
 // getCRIClient connects CRI and returns CRI runtime service clients and image service client.
 func getCRIClient(ctx context.Context) (internalapi.RuntimeService, internalapi.ImageManagerService, error) {

--- a/test/e2e_node_windows/util_affinity_windows.go
+++ b/test/e2e_node_windows/util_affinity_windows.go
@@ -1,0 +1,94 @@
+//go:build windows
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enodewindows
+
+import (
+	"context"
+	"fmt"
+	"math/bits"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	internalapi "k8s.io/cri-api/pkg/apis"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// containerIDForContainer returns the runtime container ID for ctnName
+// inside pod, with the runtime scheme prefix ("containerd://") stripped.
+func containerIDForContainer(pod *v1.Pod, ctnName string) (string, error) {
+	for _, cs := range append(pod.Status.ContainerStatuses, pod.Status.InitContainerStatuses...) {
+		if cs.Name != ctnName {
+			continue
+		}
+		_, id, found := strings.Cut(cs.ContainerID, "://")
+		if !found {
+			return "", fmt.Errorf("unsupported containerID format: %q", cs.ContainerID)
+		}
+		return id, nil
+	}
+	return "", fmt.Errorf("container %q not found in pod %s/%s status", ctnName, pod.Namespace, pod.Name)
+}
+
+// getWindowsContainerCPUAffinity queries the CRI for the CPU group affinities
+// currently set on the named container. Returns nil when no affinity is set.
+func getWindowsContainerCPUAffinity(
+	ctx context.Context,
+	criClient internalapi.RuntimeService,
+	pod *v1.Pod,
+	ctnName string,
+) ([]*runtimeapi.WindowsCpuGroupAffinity, error) {
+	cntID, err := containerIDForContainer(pod, ctnName)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := criClient.ContainerStatus(ctx, cntID, false)
+	if err != nil {
+		return nil, fmt.Errorf("ContainerStatus(%q): %w", cntID, err)
+	}
+	if resp == nil || resp.Status == nil || resp.Status.Resources == nil || resp.Status.Resources.Windows == nil {
+		return nil, nil
+	}
+	return resp.Status.Resources.Windows.AffinityCpus, nil
+}
+
+// countCPUsInAffinities returns the total number of logical CPUs represented
+// across all WindowsCpuGroupAffinity entries by counting set bits in each mask.
+func countCPUsInAffinities(affinities []*runtimeapi.WindowsCpuGroupAffinity) int {
+	total := 0
+	for _, a := range affinities {
+		total += bits.OnesCount64(a.CpuMask)
+	}
+	return total
+}
+
+// windowsAffinitiesOverlap returns true when two sets of CPU group affinities
+// share at least one CPU (same bit set in the same processor group).
+func windowsAffinitiesOverlap(a, b []*runtimeapi.WindowsCpuGroupAffinity) bool {
+	maskA := make(map[uint32]uint64, len(a))
+	for _, aff := range a {
+		maskA[aff.CpuGroup] |= aff.CpuMask
+	}
+	for _, aff := range b {
+		if maskA[aff.CpuGroup]&aff.CpuMask != 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e_node_windows/util_jobobject_windows.go
+++ b/test/e2e_node_windows/util_jobobject_windows.go
@@ -1,0 +1,202 @@
+//go:build windows
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enodewindows
+
+import (
+	"fmt"
+	"math/bits"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+
+	v1 "k8s.io/api/core/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// Host-side job-object validation reads the Win32 kernel state directly,
+// complementing the CRI ContainerStatus read-back used elsewhere in this
+// suite. The CRI check verifies "containerd remembers what the kubelet
+// asked for"; this check verifies "the kernel actually applied it".
+//
+// Scope: WCOW process-isolated containers only. Naming convention
+// "\Container_<full-id>" is containerd/hcsshim internal and used here
+// only as a diagnostic source of truth, mirroring what hcsshim's own
+// test suite does.
+
+const jobObjectQueryAccess = 0x0004 // JOB_OBJECT_QUERY
+
+var (
+	modntdll            = windows.NewLazySystemDLL("ntdll.dll")
+	procNtOpenJobObject = modntdll.NewProc("NtOpenJobObject")
+)
+
+// groupAffinity mirrors Win32 GROUP_AFFINITY (winnt.h). KAFFINITY is
+// ULONG_PTR which is uintptr on 64-bit Go.
+type groupAffinity struct {
+	Mask     uintptr
+	Group    uint16
+	Reserved [3]uint16
+}
+
+// openJobObject opens the container silo job object by its object-manager
+// name (e.g. "\Container_<id>"). It uses the native NtOpenJobObject rather
+// than the Win32 OpenJobObjectW: the silo lives at the root of the NT object
+// namespace, and OpenJobObjectW only resolves names under BaseNamedObjects
+// and rejects names containing a backslash (it would return
+// ERROR_BAD_PATHNAME "the specified path is invalid"). Returns an error whose
+// NTStatus is windows.STATUS_OBJECT_NAME_NOT_FOUND when no such job object
+// exists.
+func openJobObject(name string) (windows.Handle, error) {
+	uname, err := windows.NewNTUnicodeString(name)
+	if err != nil {
+		return 0, err
+	}
+	oa := windows.OBJECT_ATTRIBUTES{
+		ObjectName: uname,
+		Attributes: windows.OBJ_CASE_INSENSITIVE,
+	}
+	oa.Length = uint32(unsafe.Sizeof(oa))
+
+	var h windows.Handle
+	// NTSTATUS NtOpenJobObject(PHANDLE, ACCESS_MASK, POBJECT_ATTRIBUTES)
+	r, _, _ := procNtOpenJobObject.Call(
+		uintptr(unsafe.Pointer(&h)),
+		uintptr(jobObjectQueryAccess),
+		uintptr(unsafe.Pointer(&oa)),
+	)
+	if status := windows.NTStatus(r); status != windows.STATUS_SUCCESS {
+		return 0, fmt.Errorf("NtOpenJobObject(%s): %w", name, status)
+	}
+	return h, nil
+}
+
+// getHostJobAffinity opens the containerd-created job object for a
+// process-isolated container and reads its JobObjectGroupInformationEx
+// (the GROUP_AFFINITY array currently applied by the Windows kernel).
+func getHostJobAffinity(pod *v1.Pod, ctnName string) ([]groupAffinity, error) {
+	cntID, err := containerIDForContainer(pod, ctnName)
+	if err != nil {
+		return nil, err
+	}
+
+	// The silo job object is only readable by SYSTEM (see util_system_windows.go),
+	// so open and query it while impersonating SYSTEM. The handle's access is
+	// checked at open time, so reading under the same impersonated context is
+	// what matters here.
+	var out []groupAffinity
+	err = runAsSystem(func() error {
+		h, err := openJobObject(`\Container_` + cntID)
+		if err != nil {
+			return err
+		}
+		defer windows.CloseHandle(h)
+
+		// JobObjectGroupInformationEx returns a flat array of GROUP_AFFINITY.
+		// 64 entries covers Windows' architectural limit on processor groups,
+		// far more than any real system has.
+		const maxGroups = 64
+		entrySize := int(unsafe.Sizeof(groupAffinity{}))
+		buf := make([]byte, maxGroups*entrySize)
+
+		var returned uint32
+		if err := windows.QueryInformationJobObject(
+			h, windows.JobObjectGroupInformationEx,
+			uintptr(unsafe.Pointer(&buf[0])), uint32(len(buf)), &returned,
+		); err != nil {
+			return fmt.Errorf("QueryInformationJobObject(JobObjectGroupInformationEx): %w", err)
+		}
+
+		count := int(returned) / entrySize
+		out = make([]groupAffinity, count)
+		for i := 0; i < count; i++ {
+			out[i] = *(*groupAffinity)(unsafe.Pointer(&buf[i*entrySize]))
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// countCPUsInHostJobAffinity sums set bits across all GROUP_AFFINITY
+// entries returned by getHostJobAffinity.
+func countCPUsInHostJobAffinity(affs []groupAffinity) int {
+	total := 0
+	for _, a := range affs {
+		total += bits.OnesCount64(uint64(a.Mask))
+	}
+	return total
+}
+
+// hostJobAffinitiesOverlap reports whether two host job-object affinities share
+// at least one CPU (same bit set in the same processor group). It is the
+// host-side counterpart to windowsAffinitiesOverlap (which compares CRI masks).
+func hostJobAffinitiesOverlap(a, b []groupAffinity) bool {
+	maskA := map[uint16]uint64{}
+	for _, x := range a {
+		maskA[x.Group] |= uint64(x.Mask)
+	}
+	for _, x := range b {
+		if maskA[x.Group]&uint64(x.Mask) != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// hostJobAffinityMatchesCRI returns nil iff the host job-object affinity
+// matches the CRI-reported affinity bit-for-bit in every processor group.
+// Bit-for-bit agreement proves both that the runtime applied the
+// kubelet's request and that CRI's read-back is faithful.
+func hostJobAffinityMatchesCRI(host []groupAffinity, cri []*runtimeapi.WindowsCpuGroupAffinity) error {
+	hostByGroup := map[uint16]uint64{}
+	for _, a := range host {
+		hostByGroup[a.Group] |= uint64(a.Mask)
+	}
+	criByGroup := map[uint16]uint64{}
+	for _, a := range cri {
+		criByGroup[uint16(a.CpuGroup)] |= a.CpuMask
+	}
+	for g, hMask := range hostByGroup {
+		if criByGroup[g] != hMask {
+			return fmt.Errorf("group %d: host mask=0x%x, CRI mask=0x%x", g, hMask, criByGroup[g])
+		}
+	}
+	for g, cMask := range criByGroup {
+		if _, ok := hostByGroup[g]; !ok && cMask != 0 {
+			return fmt.Errorf("group %d: CRI mask=0x%x, host has no affinity in this group", g, cMask)
+		}
+	}
+	return nil
+}
+
+// validateHostJobAffinityProcessIsolated cross-checks the host job-object
+// affinity against the CRI-reported affinity for a process-isolated
+// container.
+func validateHostJobAffinityProcessIsolated(pod *v1.Pod, ctnName string, cri []*runtimeapi.WindowsCpuGroupAffinity) error {
+	host, err := getHostJobAffinity(pod, ctnName)
+	if err != nil {
+		return err
+	}
+	if got, want := countCPUsInHostJobAffinity(host), countCPUsInAffinities(cri); got != want {
+		return fmt.Errorf("CPU count disagreement: host job=%d, CRI=%d", got, want)
+	}
+	return hostJobAffinityMatchesCRI(host, cri)
+}

--- a/test/e2e_node_windows/util_kubeletconfig.go
+++ b/test/e2e_node_windows/util_kubeletconfig.go
@@ -24,7 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2enodekubelet "k8s.io/kubernetes/test/e2e_node/kubeletconfig"
+	e2enodekubelet "k8s.io/kubernetes/test/e2e_node_windows/kubeletconfig"
 )
 
 // getCurrentKubeletConfig returns the current KubeletConfiguration.

--- a/test/e2e_node_windows/util_system_windows.go
+++ b/test/e2e_node_windows/util_system_windows.go
@@ -1,0 +1,164 @@
+//go:build windows
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enodewindows
+
+import (
+	"fmt"
+	"runtime"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// SYSTEM impersonation. The container silo job object created by hcsshim/HCS
+// has a security descriptor that grants access only to NT AUTHORITY\SYSTEM and
+// the container's own context — not to Administrators. So an elevated-but-not-
+// SYSTEM process is denied at open time regardless of the requested access
+// mask (and SeDebugPrivilege does not help: it bypasses DACLs only for
+// OpenProcess/OpenThread, not job objects). runAsSystem briefly assumes a
+// SYSTEM token so the host-side affinity read can open the silo.
+//
+// Requires the suite to run elevated: Administrators hold SeDebugPrivilege
+// (to open a SYSTEM process) and SeImpersonatePrivilege (to set a thread
+// token) by default.
+
+const systemSIDString = "S-1-5-18" // NT AUTHORITY\SYSTEM
+
+// runAsSystem runs fn while the current OS thread impersonates SYSTEM, then
+// reverts. The goroutine is locked to its thread for the duration because
+// SetThreadToken/RevertToSelf are per-thread: locking guarantees fn() runs
+// under the impersonated token and that we revert the same thread we changed.
+func runAsSystem(fn func() error) (err error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	if err := enablePrivilege(seDebugName); err != nil {
+		return fmt.Errorf("enable SeDebugPrivilege: %w", err)
+	}
+
+	sysTok, err := duplicateSystemToken()
+	if err != nil {
+		return err
+	}
+	defer sysTok.Close()
+
+	if err := windows.SetThreadToken(nil, sysTok); err != nil {
+		return fmt.Errorf("SetThreadToken(SYSTEM): %w", err)
+	}
+	defer func() {
+		if rerr := windows.RevertToSelf(); rerr != nil && err == nil {
+			err = fmt.Errorf("RevertToSelf: %w", rerr)
+		}
+	}()
+
+	return fn()
+}
+
+const seDebugName = "SeDebugPrivilege"
+
+// enablePrivilege enables the named privilege on the current process token. It
+// is a no-op-equivalent if the privilege is already enabled.
+func enablePrivilege(name string) error {
+	var tok windows.Token
+	if err := windows.OpenProcessToken(windows.CurrentProcess(),
+		windows.TOKEN_ADJUST_PRIVILEGES|windows.TOKEN_QUERY, &tok); err != nil {
+		return fmt.Errorf("OpenProcessToken: %w", err)
+	}
+	defer tok.Close()
+
+	namePtr, err := windows.UTF16PtrFromString(name)
+	if err != nil {
+		return err
+	}
+	var luid windows.LUID
+	if err := windows.LookupPrivilegeValue(nil, namePtr, &luid); err != nil {
+		return fmt.Errorf("LookupPrivilegeValue(%s): %w", name, err)
+	}
+	tp := windows.Tokenprivileges{
+		PrivilegeCount: 1,
+		Privileges:     [1]windows.LUIDAndAttributes{{Luid: luid, Attributes: windows.SE_PRIVILEGE_ENABLED}},
+	}
+	// AdjustTokenPrivileges returns success even when the privilege is not held
+	// (GetLastError would be ERROR_NOT_ALL_ASSIGNED); in that case the later
+	// OpenProcess against a SYSTEM process simply fails and is surfaced there.
+	if err := windows.AdjustTokenPrivileges(tok, false, &tp, 0, nil, nil); err != nil {
+		return fmt.Errorf("AdjustTokenPrivileges(%s): %w", name, err)
+	}
+	return nil
+}
+
+// duplicateSystemToken walks running processes and duplicates an impersonation
+// token from the first one running as SYSTEM whose token can be fully
+// duplicated. Returns an error if none can be obtained.
+func duplicateSystemToken() (windows.Token, error) {
+	systemSID, err := windows.StringToSid(systemSIDString)
+	if err != nil {
+		return 0, err
+	}
+
+	snap, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return 0, fmt.Errorf("CreateToolhelp32Snapshot: %w", err)
+	}
+	defer windows.CloseHandle(snap)
+
+	var pe windows.ProcessEntry32
+	pe.Size = uint32(unsafe.Sizeof(pe))
+	for err = windows.Process32First(snap, &pe); err == nil; err = windows.Process32Next(snap, &pe) {
+		if pe.ProcessID == 0 {
+			continue
+		}
+		if dup, ok := trySystemTokenFromPID(pe.ProcessID, systemSID); ok {
+			return dup, nil
+		}
+	}
+	return 0, fmt.Errorf("could not duplicate a SYSTEM token from any process " +
+		"(is the suite running elevated with SeDebugPrivilege?)")
+}
+
+// trySystemTokenFromPID duplicates an impersonation token from pid iff that
+// process runs as systemSID. It returns ok=false (and no error) on any failure
+// so the caller can try the next process: some protected SYSTEM processes
+// (e.g. csrss.exe) deny TOKEN_DUPLICATE even with SeDebugPrivilege.
+func trySystemTokenFromPID(pid uint32, systemSID *windows.SID) (windows.Token, bool) {
+	ph, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, pid)
+	if err != nil {
+		return 0, false
+	}
+	defer windows.CloseHandle(ph)
+
+	var procTok windows.Token
+	if err := windows.OpenProcessToken(ph, windows.TOKEN_DUPLICATE|windows.TOKEN_QUERY, &procTok); err != nil {
+		return 0, false
+	}
+	defer procTok.Close()
+
+	tu, err := procTok.GetTokenUser()
+	if err != nil || !tu.User.Sid.Equals(systemSID) {
+		return 0, false
+	}
+
+	var dup windows.Token
+	if err := windows.DuplicateTokenEx(procTok,
+		windows.TOKEN_QUERY|windows.TOKEN_IMPERSONATE|windows.TOKEN_DUPLICATE,
+		nil, windows.SecurityImpersonation, windows.TokenImpersonation, &dup); err != nil {
+		return 0, false
+	}
+	return dup, true
+}


### PR DESCRIPTION
e2e_node_windows: add CPU manager affinity node e2e tests

Add node e2e tests for Windows CPU manager exclusive-CPU affinity
(static policy, WindowsCPUAndMemoryAffinity feature gate), covering how
affinity is applied to containers and how it is verified on Windows.

Tests (cpu_manager_test.go):
- Guaranteed pods get exactly the requested number of exclusive CPUs
  (1/2/3-CPU single-container pods), with non-overlapping CPUs across
  containers in a multi-container pod (1+2, 3+2) and across separate
  guaranteed pods (2+2).
- Non-guaranteed (burstable) containers get no affinity, including a
  burstable pod coexisting with a guaranteed one.
- With the WindowsCPUAndMemoryAffinity feature gate off, guaranteed pods
  get no affinity (negative cases).
- Init containers: a restartable sidecar holds exclusive CPUs separately
  from the app container; the app container gains exclusive CPUs after a
  non-restartable init container completes.

Verification is two-layered:
- CRI read-back of ContainerStatus Windows.AffinityCpus ("containerd
  recorded what the kubelet asked for"), and
- the actual Win32 job-object affinity of the hcsshim container silo
  ("the kernel applied it"), read under brief SYSTEM impersonation since
  the silo job object is accessible only to NT AUTHORITY\SYSTEM.

Suite plumbing: drop the dependency on test/e2e_node by porting the
kubeletconfig and criproxy subpackages locally (the CRI proxy uses a
Windows named pipe), plus shared helpers (util*.go) for kubelet config,
Windows service control, CRI/host affinity reads, and SYSTEM
impersonation.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
N/A
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note NONE

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
