### PR TITLE
kubelet: identify workload in PLEG container finished log

### DIFF
--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -381,8 +381,9 @@ func (g *GenericPLEG) reconcilePodRecord(ctx context.Context, pid types.UID) {
 	// Update the internal storage and send out the events.
 	g.podRecords.update(pid)
 
-	// Map from containerId to exit code; used as a temporary cache for lookup
-	containerExitCode := make(map[string]int)
+	// Map from containerID to container status; used as a temporary cache to look
+	// up the name and exit code of finished containers.
+	containerStatuses := make(map[string]*kubecontainer.Status)
 
 	for i := range events {
 		// Filter out events that are not reliable and no other components use yet.
@@ -397,17 +398,20 @@ func (g *GenericPLEG) reconcilePodRecord(ctx context.Context, pid types.UID) {
 		}
 		// Log exit code of containers when they finished in a particular event
 		if events[i].Type == ContainerDied {
-			// Fill up containerExitCode map for ContainerDied event when first time appeared
-			if len(containerExitCode) == 0 && pod != nil {
-				if err == nil {
-					for _, containerStatus := range status.ContainerStatuses {
-						containerExitCode[containerStatus.ID.ID] = containerStatus.ExitCode
-					}
+			// Fill up containerStatuses map for ContainerDied event when first time appeared
+			if len(containerStatuses) == 0 && pod != nil && err == nil {
+				for _, containerStatus := range status.ContainerStatuses {
+					containerStatuses[containerStatus.ID.ID] = containerStatus
 				}
 			}
 			if containerID, ok := events[i].Data.(string); ok {
-				if exitCode, ok := containerExitCode[containerID]; ok && pod != nil {
-					logger.V(2).Info("Generic (PLEG): container finished", "podID", pod.ID, "containerID", containerID, "exitCode", exitCode)
+				if containerStatus, ok := containerStatuses[containerID]; ok && pod != nil {
+					logger.V(2).Info("Generic (PLEG): container finished",
+						"pod", klog.KRef(pod.Namespace, pod.Name),
+						"podUID", pod.ID,
+						"containerName", containerStatus.Name,
+						"containerID", containerID,
+						"exitCode", containerStatus.ExitCode)
 				}
 			}
 		}

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -398,14 +398,14 @@ func (g *GenericPLEG) reconcilePodRecord(ctx context.Context, pid types.UID) {
 		}
 		// Log exit code of containers when they finished in a particular event
 		if events[i].Type == ContainerDied {
-			// Fill up containerStatuses map for ContainerDied event when first time appeared
-			if len(containerStatuses) == 0 && pod != nil && err == nil {
+			// Fill up containerStatuses map for ContainerDied event when first time appeared.
+			if len(containerStatuses) == 0 && pod != nil {
 				for _, containerStatus := range status.ContainerStatuses {
 					containerStatuses[containerStatus.ID.ID] = containerStatus
 				}
 			}
 			if containerID, ok := events[i].Data.(string); ok {
-				if containerStatus, ok := containerStatuses[containerID]; ok && pod != nil {
+				if containerStatus, ok := containerStatuses[containerID]; ok {
 					logger.V(2).Info("Generic (PLEG): container finished",
 						"pod", klog.KRef(pod.Namespace, pod.Name),
 						"podUID", pod.ID,

--- a/pkg/kubelet/pleg/generic_test.go
+++ b/pkg/kubelet/pleg/generic_test.go
@@ -36,6 +36,8 @@ import (
 	"k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/component-base/metrics/testutil"
+	"k8s.io/klog/v2"
+	klogtesting "k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
@@ -414,6 +416,51 @@ func TestRelistWithCache(t *testing.T) {
 	}
 	// Now that we are able to query status for pods[1], pleg should generate an event.
 	assert.Exactly(t, []*PodLifecycleEvent{events[1]}, actualEvents)
+}
+
+func TestContainerFinishedLog(t *testing.T) {
+	logger := klogtesting.NewLogger(t, klogtesting.NewConfig(klogtesting.Verbosity(2), klogtesting.BufferLogs(true)))
+	tCtx := klog.NewContext(context.Background(), logger)
+
+	runtimeMock := containertest.NewMockRuntime(t)
+	pleg := newTestGenericPLEGWithRuntimeMock(runtimeMock)
+
+	container := createTestContainer("c0", kubecontainer.ContainerStateExited)
+	pod := &kubecontainer.Pod{
+		ID:         "test-pod-uid",
+		Name:       "my-pod",
+		Namespace:  "my-namespace",
+		Containers: []*kubecontainer.Container{container},
+	}
+	status := &kubecontainer.PodStatus{
+		ID:        pod.ID,
+		Name:      pod.Name,
+		Namespace: pod.Namespace,
+		ContainerStatuses: []*kubecontainer.Status{{
+			ID:       container.ID,
+			Name:     "my-container",
+			State:    kubecontainer.ContainerStateExited,
+			ExitCode: 137,
+		}},
+	}
+	runtimeMock.EXPECT().GetPods(mock.Anything, true).Return([]*kubecontainer.Pod{pod}, nil).Times(1)
+	runtimeMock.EXPECT().GetPodStatus(mock.Anything, pod).Return(status, nil).Times(1)
+
+	pleg.Relist(tCtx)
+
+	underlier, ok := logger.GetSink().(klogtesting.Underlier)
+	require.True(t, ok, "Should have had a ktesting LogSink, got %T", logger.GetSink())
+	logs := underlier.GetBuffer().String()
+	for _, want := range []string{
+		"container finished",
+		`pod="my-namespace/my-pod"`,
+		"podUID=",
+		"test-pod-uid",
+		`containerName="my-container"`,
+		"exitCode=137",
+	} {
+		assert.Contains(t, logs, want)
+	}
 }
 
 func TestRemoveCacheEntry(t *testing.T) {

--- a/pkg/kubelet/pleg/generic_test.go
+++ b/pkg/kubelet/pleg/generic_test.go
@@ -454,8 +454,7 @@ func TestContainerFinishedLog(t *testing.T) {
 	for _, want := range []string{
 		"container finished",
 		`pod="my-namespace/my-pod"`,
-		"podUID=",
-		"test-pod-uid",
+		`podUID="test-pod-uid"`,
 		`containerName="my-container"`,
 		"exitCode=137",
 	} {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/sig node

**What this PR does / why we need it:**

The `"Generic (PLEG): container finished"` log message is the primary signal for container kill events (e.g. `exitCode=137` for SIGKILL), but it only included the pod UID and container ID:

    generic.go:410] "Generic (PLEG): container finished" podID="0137706b-..." containerID="79923472..." exitCode=137

Attributing such an event to a workload required a separate lookup from pod UID to pod name, which makes log-based metrics and alerting on SIGKILL/OOM events unnecessarily difficult.

This PR adds the pod namespace/name and the container name to the message:

    generic.go:412] "Generic (PLEG): container finished" pod="my-namespace/my-pod" podUID="0137706b-..." containerName="my-container" containerID="79923472..." exitCode=137

Notes:
- The container statuses were already fetched during relisting; the lookup map
  now caches the full status instead of just the exit code, so there is no
  additional runtime cost.
- The message string and the `exitCode` key are unchanged, so existing
  log filters keep working.
- The `podID` key was renamed to `podUID` to match the structured logging
  conventions used elsewhere in the kubelet.

**Which issue(s) this PR fixes:**

Fixes #139496

Related: #125785, #96725

**Special notes for your reviewer:**

The kubelet never sends SIGKILL itself (the runtime escalates after the grace period, or the kernel OOM killer acts directly), so the issue's secondary request for an explicit "SIGKILL sent" log is intentionally not implemented.

The kubelet-initiated kill path already logs "Killing container with a grace period" with full workload identity; this PR closes the gap on the observation side.

**Does this PR introduce a user-facing change?**


```release-note
kubelet: the "Generic (PLEG): container finished" log message now includes the pod namespace/name and the container name. The `podID` key was renamed to `podUID`.
```