### PR TITLE
Split watchCache fields into two sub-structs: watch history and storage.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -1170,12 +1170,12 @@ func (c *Cacher) Compact(resourceVersion string) error {
 	if err != nil {
 		return err
 	}
-	c.watchCache.Compact(rv)
+	c.watchCache.storage.Compact(rv)
 	return nil
 }
 
 func (c *Cacher) MarkConsistent(consistent bool) {
-	c.watchCache.MarkConsistent(consistent)
+	c.watchCache.storage.MarkConsistent(consistent)
 }
 
 // Stop implements the graceful termination.
@@ -1383,7 +1383,7 @@ func newErrWatcher(err error) *errWatcher {
 
 func (c *Cacher) ShouldDelegateExactRV(resourceVersion string, recursive bool) (delegator.Result, error) {
 	// Not Recursive is not supported unitl exact RV is implemented for WaitUntilFreshAndGet.
-	if !recursive || c.watchCache.snapshots == nil {
+	if !recursive || c.watchCache.storage.snapshots == nil {
 		return delegator.Result{ShouldDelegate: true}, nil
 	}
 	listRV, err := c.versioner.ParseResourceVersion(resourceVersion)
@@ -1395,7 +1395,7 @@ func (c *Cacher) ShouldDelegateExactRV(resourceVersion string, recursive bool) (
 
 func (c *Cacher) ShouldDelegateContinue(continueToken string, recursive bool) (delegator.Result, error) {
 	// Not Recursive is not supported unitl exact RV is implemented for WaitUntilFreshAndGet.
-	if !recursive || c.watchCache.snapshots == nil {
+	if !recursive || c.watchCache.storage.snapshots == nil {
 		return delegator.Result{ShouldDelegate: true}, nil
 	}
 	_, continueRV, err := storage.DecodeContinue(continueToken, c.resourcePrefix)
@@ -1417,7 +1417,7 @@ func (c *Cacher) shouldDelegateExactRV(rv uint64) (delegator.Result, error) {
 			ShouldDelegate: !delegator.ConsistentReadSupported(),
 		}, nil
 	}
-	_, canServe := c.watchCache.snapshots.GetLessOrEqual(rv)
+	_, canServe := c.watchCache.storage.snapshots.GetLessOrEqual(rv)
 	return delegator.Result{
 		ShouldDelegate: !canServe,
 	}, nil

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -311,8 +311,8 @@ func TestMarkConsistent(t *testing.T) {
 	if len(etcdRequests) != 0 {
 		t.Errorf("Expected no requests to etcd, got: %+v", etcdRequests)
 	}
-	if cacher.cacher.watchCache.snapshots.Len() != 2 {
-		t.Errorf("Expected cache %d snapshots, got: %d", 2, cacher.cacher.watchCache.snapshots.Len())
+	if cacher.cacher.watchCache.storage.snapshots.Len() != 2 {
+		t.Errorf("Expected cache %d snapshots, got: %d", 2, cacher.cacher.watchCache.storage.snapshots.Len())
 	}
 
 	t.Log("Inconsistent cache clears old snapshots, list hits etcd")
@@ -326,8 +326,8 @@ func TestMarkConsistent(t *testing.T) {
 	if len(etcdRequests) != 1 {
 		t.Errorf("Expected request to etcd, got: %+v", etcdRequests)
 	}
-	if cacher.cacher.watchCache.snapshots.Len() != 0 {
-		t.Errorf("Expected cache %d snapshots, got: %d", 0, cacher.cacher.watchCache.snapshots.Len())
+	if cacher.cacher.watchCache.storage.snapshots.Len() != 0 {
+		t.Errorf("Expected cache %d snapshots, got: %d", 0, cacher.cacher.watchCache.storage.snapshots.Len())
 	}
 
 	t.Log("Inconsistent cache doesn't collect new snapshot, list hits etcd")
@@ -341,8 +341,8 @@ func TestMarkConsistent(t *testing.T) {
 	if len(etcdRequests) != 1 {
 		t.Errorf("Expected request to etcd, got: %+v", etcdRequests)
 	}
-	if cacher.cacher.watchCache.snapshots.Len() != 0 {
-		t.Errorf("Expected cache %d snapshots, got: %d", 0, cacher.cacher.watchCache.snapshots.Len())
+	if cacher.cacher.watchCache.storage.snapshots.Len() != 0 {
+		t.Errorf("Expected cache %d snapshots, got: %d", 0, cacher.cacher.watchCache.storage.snapshots.Len())
 	}
 
 	t.Log("Marking cache consistent allows it to collect new snapshots, list skips etcd")
@@ -357,8 +357,8 @@ func TestMarkConsistent(t *testing.T) {
 	if len(etcdRequests) != 0 {
 		t.Errorf("Expected no requests to etcd, got: %+v", etcdRequests)
 	}
-	if cacher.cacher.watchCache.snapshots.Len() != 1 {
-		t.Errorf("Expected cache %d snapshots, got: %d", 1, cacher.cacher.watchCache.snapshots.Len())
+	if cacher.cacher.watchCache.storage.snapshots.Len() != 1 {
+		t.Errorf("Expected cache %d snapshots, got: %d", 1, cacher.cacher.watchCache.storage.snapshots.Len())
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_testing_utils_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_testing_utils_test.go
@@ -182,15 +182,15 @@ func compactWatch(c *CacheDelegator, client *clientv3.Client) storagetesting.Com
 			t.Error("Open watchers are not supported during compaction")
 		}
 
-		for c.cacher.watchCache.startIndex < c.cacher.watchCache.endIndex {
-			index := c.cacher.watchCache.startIndex % c.cacher.watchCache.capacity
-			if c.cacher.watchCache.cache[index].ResourceVersion > rv {
+		for c.cacher.watchCache.history.startIndex < c.cacher.watchCache.history.endIndex {
+			index := c.cacher.watchCache.history.startIndex % c.cacher.watchCache.history.capacity
+			if c.cacher.watchCache.history.cache[index].ResourceVersion > rv {
 				break
 			}
 
-			c.cacher.watchCache.startIndex++
+			c.cacher.watchCache.history.startIndex++
 		}
-		c.cacher.watchCache.listResourceVersion = rv
+		c.cacher.watchCache.storage.listResourceVersion = rv
 		if _, err := client.Compact(ctx, int64(rv)); err != nil {
 			t.Fatalf("Could not compact: %v", err)
 		}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -263,7 +263,7 @@ func TestShouldDelegateList(t *testing.T) {
 			}
 			defer cacher.Stop()
 			if snapshotAvailable {
-				cacher.watchCache.snapshots.Add(uint64(mustAtoi(oldRV)), fakeIndexer{})
+				cacher.watchCache.storage.snapshots.Add(uint64(mustAtoi(oldRV)), fakeIndexer{})
 			}
 			result, err := delegator.ShouldDelegateList(toStorageOpts(opt), cacher)
 			if err != nil {
@@ -570,7 +570,7 @@ func TestMatchExactResourceVersionFallback(t *testing.T) {
 			defer cacher.Stop()
 			snapshotRequestCount := 0
 			cacher.watchCache.RWMutex.Lock()
-			cacher.watchCache.snapshots = &fakeSnapshotter{
+			cacher.watchCache.storage.snapshots = &fakeSnapshotter{
 				getLessOrEqual: func(rv uint64) (store.Snapshot, bool) {
 					snapshotAvailable := tc.snapshotsAvailable[snapshotRequestCount]
 					snapshotRequestCount++
@@ -2034,7 +2034,7 @@ func testCachingObjects(t *testing.T, watchersCount int) {
 			object = event.Object.(runtime.CacheableObject).GetObject()
 
 			if event.Type == watch.Deleted {
-				resourceVersion, err := cacher.versioner.ObjectResourceVersion(cacher.watchCache.cache[index].PrevObject)
+				resourceVersion, err := cacher.versioner.ObjectResourceVersion(cacher.watchCache.history.cache[index].PrevObject)
 				if err != nil {
 					t.Fatalf("Failed to parse resource version: %v", err)
 				}
@@ -2044,9 +2044,9 @@ func testCachingObjects(t *testing.T, watchersCount int) {
 			var e runtime.Object
 			switch event.Type {
 			case watch.Added, watch.Modified:
-				e = cacher.watchCache.cache[index].Object
+				e = cacher.watchCache.history.cache[index].Object
 			case watch.Deleted:
-				e = cacher.watchCache.cache[index].PrevObject
+				e = cacher.watchCache.history.cache[index].PrevObject
 			default:
 				t.Errorf("unexpected watch event: %#v", event)
 			}
@@ -2092,7 +2092,7 @@ func TestCacheIntervalInvalidationStopsWatch(t *testing.T) {
 	}
 	once := sync.Once{}
 	indexValidator := func(index int) bool {
-		isValid := valid && (index >= cacher.watchCache.startIndex)
+		isValid := valid && (index >= cacher.watchCache.history.startIndex)
 		once.Do(invalidateCacheInterval)
 		return isValid
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/compactor.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/compactor.go
@@ -72,7 +72,7 @@ func (c *compactor) compactIfNeeded() {
 	if rev <= c.compactRevision {
 		return
 	}
-	c.wc.Compact(uint64(rev))
+	c.wc.storage.Compact(uint64(rev))
 	c.compactRevision = rev
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -93,42 +93,17 @@ type watchCache struct {
 	// resource version.
 	cond *sync.Cond
 
-	// Maximum size of history window.
-	capacity int
+	// ResourceVersion up to which the watchCache is propagated.
+	resourceVersion uint64
 
-	// upper bound of capacity since event cache has a dynamic size.
-	upperBoundCapacity int
-
-	// lower bound of capacity since event cache has a dynamic size.
-	lowerBoundCapacity int
+	history watchCacheHistory
+	storage watchCacheStorage
 
 	// keyFunc is used to get a key in the underlying storage for a given object.
 	keyFunc func(runtime.Object) (string, error)
 
 	// getAttrsFunc is used to get labels and fields of an object.
 	getAttrsFunc func(runtime.Object) (labels.Set, fields.Set, error)
-
-	// cache is used a cyclic buffer - the "current" contents of it are
-	// stored in [start_index%capacity, end_index%capacity) - so the
-	// "current" contents have exactly end_index-start_index items.
-	cache      []*watchCacheEvent
-	startIndex int
-	endIndex   int
-	// removedEventSinceRelist holds the information whether any of the events
-	// were already removed from the `cache` cyclic buffer since the last relist
-	removedEventSinceRelist bool
-
-	// store will effectively support LIST operation from the "end of cache
-	// history" i.e. from the moment just after the newest cached watched event.
-	// It is necessary to effectively allow clients to start watching at now.
-	// NOTE: We assume that <store> is thread-safe.
-	store store.Indexer
-
-	// ResourceVersion up to which the watchCache is propagated.
-	resourceVersion uint64
-
-	// ResourceVersion of the last list result (populated via Replace() method).
-	listResourceVersion uint64
 
 	// This handler is run at the end of every successful Replace() method.
 	onReplace func()
@@ -139,9 +114,6 @@ type watchCache struct {
 
 	// for testing timeouts.
 	clock clock.Clock
-
-	// eventFreshDuration defines the minimum watch history watchcache will store.
-	eventFreshDuration time.Duration
 
 	// An underlying storage.Versioner.
 	versioner storage.Versioner
@@ -155,10 +127,6 @@ type watchCache struct {
 	// Requests progress notification if there are requests waiting for watch
 	// to be fresh
 	waitingUntilFresh *progress.ConditionalProgressRequester
-
-	// Stores previous snapshots of orderedLister to allow serving requests from previous revisions.
-	snapshots           store.Snapshotter
-	snapshottingEnabled atomic.Bool
 
 	getCurrentRV func(context.Context) (uint64, error)
 }
@@ -176,34 +144,77 @@ func newWatchCache(
 	getCurrentRV func(context.Context) (uint64, error),
 ) *watchCache {
 	wc := &watchCache{
-		capacity:            defaultLowerBoundCapacity,
-		keyFunc:             keyFunc,
-		getAttrsFunc:        getAttrsFunc,
-		cache:               make([]*watchCacheEvent, defaultLowerBoundCapacity),
-		lowerBoundCapacity:  defaultLowerBoundCapacity,
-		upperBoundCapacity:  capacityUpperBound(eventFreshDuration),
-		startIndex:          0,
-		endIndex:            0,
-		store:               store.NewIndexer(indexers),
-		resourceVersion:     0,
-		listResourceVersion: 0,
-		eventHandler:        eventHandler,
-		clock:               clock,
-		eventFreshDuration:  eventFreshDuration,
-		versioner:           versioner,
-		groupResource:       groupResource,
-		waitingUntilFresh:   progressRequester,
-		getCurrentRV:        getCurrentRV,
+		resourceVersion: 0,
+		history: watchCacheHistory{
+			capacity:           defaultLowerBoundCapacity,
+			cache:              make([]*watchCacheEvent, defaultLowerBoundCapacity),
+			lowerBoundCapacity: defaultLowerBoundCapacity,
+			upperBoundCapacity: capacityUpperBound(eventFreshDuration),
+			startIndex:         0,
+			endIndex:           0,
+			eventFreshDuration: eventFreshDuration,
+		},
+		storage: watchCacheStorage{
+			store:               store.NewIndexer(indexers),
+			listResourceVersion: 0,
+		},
+		keyFunc:           keyFunc,
+		getAttrsFunc:      getAttrsFunc,
+		eventHandler:      eventHandler,
+		clock:             clock,
+		versioner:         versioner,
+		groupResource:     groupResource,
+		waitingUntilFresh: progressRequester,
+		getCurrentRV:      getCurrentRV,
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
-		wc.snapshottingEnabled.Store(true)
-		wc.snapshots = store.NewSnapshotter()
+		wc.storage.snapshottingEnabled.Store(true)
+		wc.storage.snapshots = store.NewSnapshotter()
 	}
-	metrics.WatchCacheCapacity.WithLabelValues(groupResource.Group, groupResource.Resource).Set(float64(wc.capacity))
+	metrics.WatchCacheCapacity.WithLabelValues(groupResource.Group, groupResource.Resource).Set(float64(wc.history.capacity))
 	wc.cond = sync.NewCond(wc.RLocker())
 	wc.indexValidator = wc.isIndexValidLocked
 
 	return wc
+}
+
+type watchCacheHistory struct {
+	// Maximum size of history window.
+	capacity int
+
+	// upper bound of capacity since event cache has a dynamic size.
+	upperBoundCapacity int
+
+	// lower bound of capacity since event cache has a dynamic size.
+	lowerBoundCapacity int
+
+	// cache is used a cyclic buffer - the "current" contents of it are
+	// stored in [start_index%capacity, end_index%capacity) - so the
+	// "current" contents have exactly end_index-start_index items.
+	cache      []*watchCacheEvent
+	startIndex int
+	endIndex   int
+	// removedEventSinceRelist holds the information whether any of the events
+	// were already removed from the `cache` cyclic buffer since the last relist
+	removedEventSinceRelist bool
+
+	// eventFreshDuration defines the minimum watch history watchcache will store.
+	eventFreshDuration time.Duration
+}
+
+type watchCacheStorage struct {
+	// store will effectively support LIST operation from the "end of cache
+	// history" i.e. from the moment just after the newest cached watched event.
+	// It is necessary to effectively allow clients to start watching at now.
+	// NOTE: We assume that <store> is thread-safe.
+	store store.Indexer
+
+	// ResourceVersion of the last list result (populated via Replace() method).
+	listResourceVersion uint64
+
+	// Stores previous snapshots of orderedLister to allow serving requests from previous revisions.
+	snapshots           store.Snapshotter
+	snapshottingEnabled atomic.Bool
 }
 
 // capacityUpperBound denotes the maximum possible capacity of the watch cache
@@ -238,7 +249,7 @@ func (w *watchCache) Add(obj interface{}) error {
 	}
 	event := watch.Event{Type: watch.Added, Object: object}
 
-	f := func(elem *store.Element) error { return w.store.Add(elem) }
+	f := func(elem *store.Element) error { return w.storage.store.Add(elem) }
 	return w.processEvent(event, resourceVersion, f)
 }
 
@@ -250,7 +261,7 @@ func (w *watchCache) Update(obj interface{}) error {
 	}
 	event := watch.Event{Type: watch.Modified, Object: object}
 
-	f := func(elem *store.Element) error { return w.store.Update(elem) }
+	f := func(elem *store.Element) error { return w.storage.store.Update(elem) }
 	return w.processEvent(event, resourceVersion, f)
 }
 
@@ -262,7 +273,7 @@ func (w *watchCache) Delete(obj interface{}) error {
 	}
 	event := watch.Event{Type: watch.Deleted, Object: object}
 
-	f := func(elem *store.Element) error { return w.store.Delete(elem) }
+	f := func(elem *store.Element) error { return w.storage.store.Delete(elem) }
 	return w.processEvent(event, resourceVersion, f)
 }
 
@@ -303,12 +314,12 @@ func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64, upd
 		RecordTime:      w.clock.Now(),
 	}
 
-	// We can call w.store.Get() outside of a critical section,
-	// because the w.store itself is thread-safe and the only
-	// place where w.store is modified is below (via updateFunc)
+	// We can call w.storage.store.Get() outside of a critical section,
+	// because the w.storage.store itself is thread-safe and the only
+	// place where w.storage.store is modified is below (via updateFunc)
 	// and these calls are serialized because reflector is processing
 	// events one-by-one.
-	previous, exists, err := w.store.Get(elem)
+	previous, exists, err := w.storage.store.Get(elem)
 	if err != nil {
 		return err
 	}
@@ -323,7 +334,7 @@ func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64, upd
 		w.Lock()
 		defer w.Unlock()
 
-		w.updateCache(wcEvent)
+		w.history.updateCache(wcEvent, w.groupResource)
 		w.resourceVersion = resourceVersion
 		defer w.cond.Broadcast()
 
@@ -331,12 +342,12 @@ func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64, upd
 		if err != nil {
 			return err
 		}
-		if w.snapshots != nil && w.snapshottingEnabled.Load() {
-			if w.isCacheFullLocked() {
-				oldestRV := w.cache[w.startIndex%w.capacity].ResourceVersion
-				w.snapshots.RemoveLess(oldestRV)
+		if w.storage.snapshots != nil && w.storage.snapshottingEnabled.Load() {
+			if w.history.isCacheFullLocked() {
+				oldestRV := w.history.cache[w.history.startIndex%w.history.capacity].ResourceVersion
+				w.storage.snapshots.RemoveLess(oldestRV)
 			}
-			w.snapshots.Add(w.resourceVersion, w.store)
+			w.storage.snapshots.Add(w.resourceVersion, w.storage.store)
 		}
 		return err
 	}(); err != nil {
@@ -355,8 +366,8 @@ func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64, upd
 }
 
 // Assumes that lock is already held for write.
-func (w *watchCache) updateCache(event *watchCacheEvent) {
-	w.resizeCacheLocked(event.RecordTime)
+func (w *watchCacheHistory) updateCache(event *watchCacheEvent, groupResource schema.GroupResource) {
+	w.resizeCacheLocked(event.RecordTime, groupResource)
 	if w.isCacheFullLocked() {
 		// Cache is full - remove the oldest element.
 		w.startIndex++
@@ -369,18 +380,18 @@ func (w *watchCache) updateCache(event *watchCacheEvent) {
 // resizeCacheLocked resizes the cache if necessary:
 // - increases capacity by 2x if cache is full and all cached events occurred within last eventFreshDuration.
 // - decreases capacity by 2x when recent quarter of events occurred outside of eventFreshDuration(protect watchCache from flapping).
-func (w *watchCache) resizeCacheLocked(eventTime time.Time) {
+func (w *watchCacheHistory) resizeCacheLocked(eventTime time.Time, groupResource schema.GroupResource) {
 	if w.isCacheFullLocked() && eventTime.Sub(w.cache[w.startIndex%w.capacity].RecordTime) < w.eventFreshDuration {
 		capacity := min(w.capacity*2, w.upperBoundCapacity)
 		if capacity > w.capacity {
-			w.doCacheResizeLocked(capacity)
+			w.doCacheResizeLocked(capacity, groupResource)
 		}
 		return
 	}
 	if w.isCacheFullLocked() && eventTime.Sub(w.cache[(w.endIndex-w.capacity/4)%w.capacity].RecordTime) > w.eventFreshDuration {
 		capacity := max(w.capacity/2, w.lowerBoundCapacity)
 		if capacity < w.capacity {
-			w.doCacheResizeLocked(capacity)
+			w.doCacheResizeLocked(capacity, groupResource)
 		}
 		return
 	}
@@ -388,13 +399,13 @@ func (w *watchCache) resizeCacheLocked(eventTime time.Time) {
 
 // isCacheFullLocked used to judge whether watchCacheEvent is full.
 // Assumes that lock is already held for write.
-func (w *watchCache) isCacheFullLocked() bool {
+func (w *watchCacheHistory) isCacheFullLocked() bool {
 	return w.endIndex == w.startIndex+w.capacity
 }
 
 // doCacheResizeLocked resize watchCache's event array with different capacity.
 // Assumes that lock is already held for write.
-func (w *watchCache) doCacheResizeLocked(capacity int) {
+func (w *watchCacheHistory) doCacheResizeLocked(capacity int, groupResource schema.GroupResource) {
 	newCache := make([]*watchCacheEvent, capacity)
 	if capacity < w.capacity {
 		// adjust startIndex if cache capacity shrink.
@@ -404,7 +415,7 @@ func (w *watchCache) doCacheResizeLocked(capacity int) {
 		newCache[i%capacity] = w.cache[i%w.capacity]
 	}
 	w.cache = newCache
-	metrics.RecordsWatchCacheCapacityChange(w.groupResource, w.capacity, capacity)
+	metrics.RecordsWatchCacheCapacityChange(groupResource, w.capacity, capacity)
 	w.capacity = capacity
 }
 
@@ -438,7 +449,7 @@ func (w *watchCache) UpdateResourceVersion(resourceVersion string) {
 
 // List returns list of pointers to <store.Element> objects.
 func (w *watchCache) List() []interface{} {
-	return w.store.List()
+	return w.storage.store.List()
 }
 
 // waitUntilFreshLocked waits until cache is at least as fresh as given resourceVersion.
@@ -547,7 +558,7 @@ func (w *watchCache) WaitUntilFreshAndGetKeys(ctx context.Context, resourceVersi
 	if err != nil {
 		return nil, err
 	}
-	return w.store.ListKeys(), nil
+	return w.storage.store.ListKeys(), nil
 }
 
 // NOTICE: Structure follows the shouldDelegateList function in
@@ -607,10 +618,10 @@ func (w *watchCache) waitAndGetExactSnapshot(ctx context.Context, resourceVersio
 		return nil, err
 	}
 
-	if w.snapshots == nil {
+	if w.storage.snapshots == nil {
 		return nil, errors.NewResourceExpired(fmt.Sprintf("too old resource version: %d", resourceVersion))
 	}
-	store, ok := w.snapshots.GetLessOrEqual(resourceVersion)
+	store, ok := w.storage.snapshots.GetLessOrEqual(resourceVersion)
 	if !ok {
 		return nil, errors.NewResourceExpired(fmt.Sprintf("too old resource version: %d", resourceVersion))
 	}
@@ -653,17 +664,17 @@ func (w *watchCache) waitAndGetLatestSnapshot(ctx context.Context, minResourceVe
 	// want - they will be filtered out later. The fact that we return less things is only further performance improvement.
 	// TODO: if multiple indexes match, return the one with the fewest items, so as to do as much filtering as possible.
 	for _, matchValue := range matchValues {
-		if result, err := w.store.ByIndex(matchValue.IndexName, matchValue.Value); err == nil {
+		if result, err := w.storage.store.ByIndex(matchValue.IndexName, matchValue.Value); err == nil {
 			return listSnapshot{Items: result}, w.resourceVersion, matchValue.IndexName, nil
 		}
 	}
-	if w.snapshots != nil {
-		snap, ok := w.snapshots.Latest()
+	if w.storage.snapshots != nil {
+		snap, ok := w.storage.snapshots.Latest()
 		if ok {
 			return snap, w.resourceVersion, "", nil
 		}
 	}
-	return w.store, w.resourceVersion, "", nil
+	return w.storage.store, w.resourceVersion, "", nil
 }
 
 type listSnapshot struct {
@@ -706,12 +717,12 @@ func (w *watchCache) WaitUntilFreshAndGet(ctx context.Context, resourceVersion u
 	if err != nil {
 		return nil, false, 0, err
 	}
-	value, exists, err := w.store.GetByKey(key)
+	value, exists, err := w.storage.store.GetByKey(key)
 	return value, exists, w.resourceVersion, err
 }
 
 func (w *watchCache) ListKeys() []string {
-	return w.store.ListKeys()
+	return w.storage.store.ListKeys()
 }
 
 // Get takes runtime.Object as a parameter. However, it returns
@@ -726,12 +737,12 @@ func (w *watchCache) Get(obj interface{}) (interface{}, bool, error) {
 		return nil, false, fmt.Errorf("couldn't compute key: %v", err)
 	}
 
-	return w.store.Get(&store.Element{Key: key, Object: object})
+	return w.storage.store.Get(&store.Element{Key: key, Object: object})
 }
 
 // GetByKey returns pointer to <storeElement>.
 func (w *watchCache) GetByKey(key string) (interface{}, bool, error) {
-	return w.store.GetByKey(key)
+	return w.storage.store.GetByKey(key)
 }
 
 // Replace takes slice of runtime.Object as a parameter.
@@ -772,22 +783,22 @@ func (w *watchCache) Replace(objs []interface{}, resourceVersion string) error {
 	// content.
 
 	// Empty the cyclic buffer, ensuring startIndex doesn't decrease.
-	w.startIndex = w.endIndex
-	w.removedEventSinceRelist = false
+	w.history.startIndex = w.history.endIndex
+	w.history.removedEventSinceRelist = false
 	// Clear out the stale cache so it don't hold old objects
 	// in memory until overwritten.
-	clear(w.cache)
+	clear(w.history.cache)
 
-	if err := w.store.Replace(toReplace, resourceVersion); err != nil {
+	if err := w.storage.store.Replace(toReplace, resourceVersion); err != nil {
 		return err
 	}
-	if w.snapshots != nil {
-		w.snapshots.Reset()
-		if w.snapshottingEnabled.Load() {
-			w.snapshots.Add(version, w.store)
+	if w.storage.snapshots != nil {
+		w.storage.snapshots.Reset()
+		if w.storage.snapshottingEnabled.Load() {
+			w.storage.snapshots.Add(version, w.storage.store)
 		}
 	}
-	w.listResourceVersion = version
+	w.storage.listResourceVersion = version
 	w.resourceVersion = version
 	if w.onReplace != nil {
 		w.onReplace()
@@ -813,13 +824,13 @@ func (w *watchCache) Resync() error {
 func (w *watchCache) getListResourceVersion() uint64 {
 	w.RLock()
 	defer w.RUnlock()
-	return w.listResourceVersion
+	return w.storage.listResourceVersion
 }
 
 func (w *watchCache) currentCapacity() int {
 	w.RLock()
 	defer w.RUnlock()
-	return w.capacity
+	return w.history.capacity
 }
 
 const (
@@ -847,7 +858,7 @@ func (w *watchCache) suggestedWatchChannelSize(indexExists, triggerUsed bool) in
 	// We don't have an exact data, but given we store updates from
 	// the last <eventFreshDuration>, we approach it by dividing the
 	// capacity by the length of the history window.
-	chanSize := int(math.Ceil(float64(w.currentCapacity()) / w.eventFreshDuration.Seconds()))
+	chanSize := int(math.Ceil(float64(w.currentCapacity()) / w.history.eventFreshDuration.Seconds()))
 
 	// Finally we adjust the size to avoid ending with too low or
 	// to large values.
@@ -872,7 +883,7 @@ func (w *watchCache) suggestedWatchChannelSize(indexExists, triggerUsed bool) in
 // isIndexValidLocked checks if a given index is still valid.
 // This assumes that the lock is held.
 func (w *watchCache) isIndexValidLocked(index int) bool {
-	return index >= w.startIndex
+	return index >= w.history.startIndex
 }
 
 // getAllEventsSinceLocked returns a watchCacheInterval that can be used to
@@ -885,20 +896,20 @@ func (w *watchCache) getAllEventsSinceLocked(resourceVersion uint64, key string,
 		return w.getIntervalFromStoreLocked(key, matchesSingle)
 	}
 
-	size := w.endIndex - w.startIndex
+	size := w.history.endIndex - w.history.startIndex
 	var oldest uint64
 	switch {
-	case w.listResourceVersion > 0 && !w.removedEventSinceRelist:
+	case w.storage.listResourceVersion > 0 && !w.history.removedEventSinceRelist:
 		// If no event was removed from the buffer since last relist, the oldest watch
 		// event we can deliver is one greater than the resource version of the list.
-		oldest = w.listResourceVersion + 1
+		oldest = w.storage.listResourceVersion + 1
 	case size > 0:
 		// If the previous condition is not satisfied: either some event was already
 		// removed from the buffer or we've never completed a list (the latter can
 		// only happen in unit tests that populate the buffer without performing
 		// list/replace operations), the oldest watch event we can deliver is the first
 		// one in the buffer.
-		oldest = w.cache[w.startIndex%w.capacity].ResourceVersion
+		oldest = w.history.cache[w.history.startIndex%w.history.capacity].ResourceVersion
 	default:
 		return nil, fmt.Errorf("watch cache isn't correctly initialized")
 	}
@@ -924,13 +935,13 @@ func (w *watchCache) getAllEventsSinceLocked(resourceVersion uint64, key string,
 
 	// Binary search the smallest index at which resourceVersion is greater than the given one.
 	f := func(i int) bool {
-		return w.cache[(w.startIndex+i)%w.capacity].ResourceVersion > resourceVersion
+		return w.history.cache[(w.history.startIndex+i)%w.history.capacity].ResourceVersion > resourceVersion
 	}
 	first := sort.Search(size, f)
 	indexerFunc := func(i int) *watchCacheEvent {
-		return w.cache[i%w.capacity]
+		return w.history.cache[i%w.history.capacity]
 	}
-	ci := newCacheInterval(w.startIndex+first, w.endIndex, indexerFunc, w.indexValidator, resourceVersion, w.RWMutex.RLocker())
+	ci := newCacheInterval(w.history.startIndex+first, w.history.endIndex, indexerFunc, w.indexValidator, resourceVersion, w.RWMutex.RLocker())
 	return ci, nil
 }
 
@@ -938,21 +949,21 @@ func (w *watchCache) getAllEventsSinceLocked(resourceVersion uint64, key string,
 // that covers the entire storage state.
 // This function assumes to be called under the watchCache lock.
 func (w *watchCache) getIntervalFromStoreLocked(key string, matchesSingle bool) (*watchCacheInterval, error) {
-	ci, err := newCacheIntervalFromStore(w.resourceVersion, w.store, key, matchesSingle)
+	ci, err := newCacheIntervalFromStore(w.resourceVersion, w.storage.store, key, matchesSingle)
 	if err != nil {
 		return nil, err
 	}
 	return ci, nil
 }
 
-func (w *watchCache) Compact(rev uint64) {
+func (w *watchCacheStorage) Compact(rev uint64) {
 	if w.snapshots == nil {
 		return
 	}
 	w.snapshots.RemoveLess(rev)
 }
 
-func (w *watchCache) MarkConsistent(consistent bool) {
+func (w *watchCacheStorage) MarkConsistent(consistent bool) {
 	if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
 		w.snapshottingEnabled.Store(consistent)
 		if !consistent && w.snapshots != nil {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval_test.go
@@ -295,19 +295,19 @@ func TestCacheIntervalNextFromWatchCache(t *testing.T) {
 				wc.Add(makeTestPod(fmt.Sprintf("pod%d", i), uint64(i)))
 			}
 			indexerFunc := func(i int) *watchCacheEvent {
-				return wc.cache[i%wc.capacity]
+				return wc.history.cache[i%wc.history.capacity]
 			}
 
 			wci := newCacheInterval(
 				c.intervalStartIndex,
-				wc.endIndex,
+				wc.history.endIndex,
 				indexerFunc,
 				wc.isIndexValidLocked,
 				wc.resourceVersion,
 				&wc.RWMutex,
 			)
 
-			numExpectedEvents := wc.endIndex - c.intervalStartIndex
+			numExpectedEvents := wc.history.endIndex - c.intervalStartIndex
 			for i := 0; i < numExpectedEvents; i++ {
 				// Simulate and test interval invalidation iff
 				// the watchCache itself is not empty.
@@ -319,8 +319,8 @@ func TestCacheIntervalNextFromWatchCache(t *testing.T) {
 					// copying over events from the underlying watch cache,
 					// i.e. freshly filling in the interval buffer.
 					if i%bufferSize == 0 && i != c.eventsAddedToWatchcache {
-						originalCacheStartIndex := wc.startIndex
-						wc.startIndex = wci.startIndex + 1
+						originalCacheStartIndex := wc.history.startIndex
+						wc.history.startIndex = wci.startIndex + 1
 						event, err := wci.Next()
 						if err == nil {
 							t.Errorf("expected non-nil error")
@@ -329,7 +329,7 @@ func TestCacheIntervalNextFromWatchCache(t *testing.T) {
 							t.Errorf("expected nil event, got %v", *event)
 						}
 						// Restore startIndex.
-						wc.startIndex = originalCacheStartIndex
+						wc.history.startIndex = originalCacheStartIndex
 					}
 				}
 
@@ -350,8 +350,8 @@ func TestCacheIntervalNextFromWatchCache(t *testing.T) {
 					return
 				}
 
-				expectedIndex := (c.intervalStartIndex + i) % wc.capacity
-				expectedEvent := wc.cache[expectedIndex]
+				expectedIndex := (c.intervalStartIndex + i) % wc.history.capacity
+				expectedEvent := wc.history.cache[expectedIndex]
 				if err := verifyEvent(true, event, expectedEvent); err != nil {
 					t.Error(err)
 				}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
@@ -138,10 +138,10 @@ func newTestWatchCache(capacity int, eventFreshDuration time.Duration, indexers 
 	wc.watchCache = newWatchCache(keyFunc, mockHandler, getAttrsFunc, versioner, indexers, testingclock.NewFakeClock(time.Now()), eventFreshDuration, schema.GroupResource{Resource: "pods"}, pr, getCurrentRV)
 	// To preserve behavior of tests that assume a given capacity,
 	// resize it to th expected size.
-	wc.capacity = capacity
-	wc.cache = make([]*watchCacheEvent, capacity)
-	wc.lowerBoundCapacity = min(capacity, defaultLowerBoundCapacity)
-	wc.upperBoundCapacity = max(capacity, defaultUpperBoundCapacity)
+	wc.history.capacity = capacity
+	wc.history.cache = make([]*watchCacheEvent, capacity)
+	wc.history.lowerBoundCapacity = min(capacity, defaultLowerBoundCapacity)
+	wc.history.upperBoundCapacity = max(capacity, defaultUpperBoundCapacity)
 
 	return wc
 }
@@ -284,8 +284,8 @@ func TestEvents(t *testing.T) {
 	defer store.Stop()
 
 	// no dynamic-size cache to fit old tests.
-	store.lowerBoundCapacity = 5
-	store.upperBoundCapacity = 5
+	store.history.lowerBoundCapacity = 5
+	store.history.upperBoundCapacity = 5
 
 	store.Add(makeTestPod("pod", 3))
 
@@ -917,23 +917,23 @@ func TestDynamicCache(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			store := newTestWatchCache(test.cacheCapacity, DefaultEventFreshDuration, &cache.Indexers{})
 			defer store.Stop()
-			store.cache = make([]*watchCacheEvent, test.cacheCapacity)
-			store.startIndex = test.startIndex
-			store.lowerBoundCapacity = test.lowerBoundCapacity
-			store.upperBoundCapacity = test.upperBoundCapacity
+			store.history.cache = make([]*watchCacheEvent, test.cacheCapacity)
+			store.history.startIndex = test.startIndex
+			store.history.lowerBoundCapacity = test.lowerBoundCapacity
+			store.history.upperBoundCapacity = test.upperBoundCapacity
 			loadEventWithDuration(store, test.eventCount, test.interval)
 			nextInterval := store.clock.Now().Add(time.Duration(test.interval.Nanoseconds() * int64(test.eventCount)))
-			store.resizeCacheLocked(nextInterval)
-			if store.capacity != test.expectCapacity {
-				t.Errorf("expect capacity %d, but get %d", test.expectCapacity, store.capacity)
+			store.history.resizeCacheLocked(nextInterval, store.groupResource)
+			if store.history.capacity != test.expectCapacity {
+				t.Errorf("expect capacity %d, but get %d", test.expectCapacity, store.history.capacity)
 			}
 
 			// check cache's startIndex, endIndex and all elements.
-			if store.startIndex != test.expectStartIndex {
-				t.Errorf("expect startIndex %d, but get %d", test.expectStartIndex, store.startIndex)
+			if store.history.startIndex != test.expectStartIndex {
+				t.Errorf("expect startIndex %d, but get %d", test.expectStartIndex, store.history.startIndex)
 			}
-			if store.endIndex != test.startIndex+test.eventCount {
-				t.Errorf("expect endIndex %d get %d", test.startIndex+test.eventCount, store.endIndex)
+			if store.history.endIndex != test.startIndex+test.eventCount {
+				t.Errorf("expect endIndex %d get %d", test.startIndex+test.eventCount, store.history.endIndex)
 			}
 			if !checkCacheElements(store) {
 				t.Errorf("some elements locations in cache is wrong")
@@ -945,18 +945,18 @@ func TestDynamicCache(t *testing.T) {
 func loadEventWithDuration(cache *testWatchCache, count int, interval time.Duration) {
 	for i := 0; i < count; i++ {
 		event := &watchCacheEvent{
-			Key:        fmt.Sprintf("event-%d", i+cache.startIndex),
+			Key:        fmt.Sprintf("event-%d", i+cache.history.startIndex),
 			RecordTime: cache.clock.Now().Add(time.Duration(interval.Nanoseconds() * int64(i))),
 		}
-		cache.cache[(i+cache.startIndex)%cache.capacity] = event
+		cache.history.cache[(i+cache.history.startIndex)%cache.history.capacity] = event
 	}
-	cache.endIndex = cache.startIndex + count
+	cache.history.endIndex = cache.history.startIndex + count
 }
 
 func checkCacheElements(cache *testWatchCache) bool {
-	for i := cache.startIndex; i < cache.endIndex; i++ {
-		location := i % cache.capacity
-		if cache.cache[location].Key != fmt.Sprintf("event-%d", i) {
+	for i := cache.history.startIndex; i < cache.history.endIndex; i++ {
+		location := i % cache.history.capacity
+		if cache.history.cache[location].Key != fmt.Sprintf("event-%d", i) {
 			return false
 		}
 	}
@@ -974,7 +974,7 @@ func TestCacheIncreaseDoesNotBreakWatch(t *testing.T) {
 			ResourceVersion: rv,
 			RecordTime:      t,
 		}
-		store.updateCache(event)
+		store.history.updateCache(event, store.groupResource)
 	}
 
 	// Initial LIST comes from the moment of RV=10.
@@ -1209,8 +1209,8 @@ func TestCapacityUpperBound(t *testing.T) {
 func BenchmarkWatchCache_updateCache(b *testing.B) {
 	store := newTestWatchCache(defaultUpperBoundCapacity, DefaultEventFreshDuration, &cache.Indexers{})
 	defer store.Stop()
-	store.cache = store.cache[:0]
-	store.upperBoundCapacity = defaultUpperBoundCapacity
+	store.history.cache = store.history.cache[:0]
+	store.history.upperBoundCapacity = defaultUpperBoundCapacity
 	loadEventWithDuration(store, defaultUpperBoundCapacity, 0)
 	add := &watchCacheEvent{
 		Key:        fmt.Sprintf("event-%d", defaultUpperBoundCapacity),
@@ -1218,7 +1218,7 @@ func BenchmarkWatchCache_updateCache(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		store.updateCache(add)
+		store.history.updateCache(add, store.groupResource)
 	}
 }
 
@@ -1314,11 +1314,11 @@ func TestCacheSnapshots(t *testing.T) {
 
 	s := newTestWatchCache(3, DefaultEventFreshDuration, &cache.Indexers{})
 	defer s.Stop()
-	s.upperBoundCapacity = 3
-	s.lowerBoundCapacity = 1
+	s.history.upperBoundCapacity = 3
+	s.history.lowerBoundCapacity = 1
 	clock := s.clock.(*testingclock.FakeClock)
 
-	_, found := s.snapshots.GetLessOrEqual(100)
+	_, found := s.storage.snapshots.GetLessOrEqual(100)
 	assert.False(t, found, "Expected empty cache to not include any snapshots")
 
 	t.Log("Test cache on rev 100")
@@ -1328,9 +1328,9 @@ func TestCacheSnapshots(t *testing.T) {
 	require.NoError(t, s.Delete(makeTestPod("foo", 300)))
 
 	t.Log("Test cache on rev 100")
-	_, found = s.snapshots.GetLessOrEqual(99)
+	_, found = s.storage.snapshots.GetLessOrEqual(99)
 	assert.False(t, found, "Expected store to not include rev 99")
-	lister, found := s.snapshots.GetLessOrEqual(100)
+	lister, found := s.storage.snapshots.GetLessOrEqual(100)
 	assert.True(t, found, "Expected store to not include rev 100")
 	elements, err := lister.OrderedListPrefix("", "")
 	require.NoError(t, err)
@@ -1339,11 +1339,11 @@ func TestCacheSnapshots(t *testing.T) {
 
 	t.Log("Overflow cache to remove rev 100")
 	require.NoError(t, s.Add(makeTestPod("foo", 400)))
-	_, found = s.snapshots.GetLessOrEqual(100)
+	_, found = s.storage.snapshots.GetLessOrEqual(100)
 	assert.False(t, found, "Expected overfilled cache to delete oldest rev 100")
 
 	t.Log("Test cache on rev 200")
-	lister, found = s.snapshots.GetLessOrEqual(200)
+	lister, found = s.storage.snapshots.GetLessOrEqual(200)
 	assert.True(t, found, "Expected store to still keep rev 200")
 	elements, err = lister.OrderedListPrefix("", "")
 	require.NoError(t, err)
@@ -1351,14 +1351,14 @@ func TestCacheSnapshots(t *testing.T) {
 	assert.Equal(t, makeTestPod("foo", 200), elements[0].(*store.Element).Object)
 
 	t.Log("Test cache on rev 300")
-	lister, found = s.snapshots.GetLessOrEqual(300)
+	lister, found = s.storage.snapshots.GetLessOrEqual(300)
 	assert.True(t, found, "Expected store to still keep rev 300")
 	elements, err = lister.OrderedListPrefix("", "")
 	require.NoError(t, err)
 	assert.Empty(t, elements)
 
 	t.Log("Test cache on rev 400")
-	lister, found = s.snapshots.GetLessOrEqual(400)
+	lister, found = s.storage.snapshots.GetLessOrEqual(400)
 	assert.True(t, found, "Expected store to still keep rev 400")
 	elements, err = lister.OrderedListPrefix("", "")
 	require.NoError(t, err)
@@ -1366,16 +1366,16 @@ func TestCacheSnapshots(t *testing.T) {
 	assert.Equal(t, makeTestPod("foo", 400), elements[0].(*store.Element).Object)
 
 	t.Log("Add event outside the event fresh window to force cache capacity downsize")
-	assert.Equal(t, 3, s.capacity)
+	assert.Equal(t, 3, s.history.capacity)
 	clock.Step(DefaultEventFreshDuration + 1)
 	require.NoError(t, s.Update(makeTestPod("foo", 500)))
-	assert.Equal(t, 1, s.capacity)
-	assert.Equal(t, 1, s.snapshots.Len())
-	_, found = s.snapshots.GetLessOrEqual(499)
+	assert.Equal(t, 1, s.history.capacity)
+	assert.Equal(t, 1, s.storage.snapshots.Len())
+	_, found = s.storage.snapshots.GetLessOrEqual(499)
 	assert.False(t, found, "Expected overfilled cache to delete events below 500")
 
 	t.Log("Test cache on rev 500")
-	lister, found = s.snapshots.GetLessOrEqual(500)
+	lister, found = s.storage.snapshots.GetLessOrEqual(500)
 	assert.True(t, found, "Expected store to still keep rev 500")
 	elements, err = lister.OrderedListPrefix("", "")
 	require.NoError(t, err)
@@ -1384,11 +1384,11 @@ func TestCacheSnapshots(t *testing.T) {
 
 	t.Log("Add event to force capacity upsize")
 	require.NoError(t, s.Update(makeTestPod("foo", 600)))
-	assert.Equal(t, 2, s.capacity)
-	assert.Equal(t, 2, s.snapshots.Len())
+	assert.Equal(t, 2, s.history.capacity)
+	assert.Equal(t, 2, s.storage.snapshots.Len())
 
 	t.Log("Test cache on rev 600")
-	lister, found = s.snapshots.GetLessOrEqual(600)
+	lister, found = s.storage.snapshots.GetLessOrEqual(600)
 	assert.True(t, found, "Expected replace to be snapshotted")
 	elements, err = lister.OrderedListPrefix("", "")
 	require.NoError(t, err)
@@ -1396,17 +1396,17 @@ func TestCacheSnapshots(t *testing.T) {
 	assert.Equal(t, makeTestPod("foo", 600), elements[0].(*store.Element).Object)
 
 	t.Log("Replace cache to remove history")
-	_, found = s.snapshots.GetLessOrEqual(500)
+	_, found = s.storage.snapshots.GetLessOrEqual(500)
 	assert.True(t, found, "Confirm that cache stores history before replace")
 	err = s.Replace([]interface{}{makeTestPod("foo", 600)}, "700")
 	require.NoError(t, err)
-	_, found = s.snapshots.GetLessOrEqual(500)
+	_, found = s.storage.snapshots.GetLessOrEqual(500)
 	assert.False(t, found, "Expected replace to remove history")
-	_, found = s.snapshots.GetLessOrEqual(600)
+	_, found = s.storage.snapshots.GetLessOrEqual(600)
 	assert.False(t, found, "Expected replace to remove history")
 
 	t.Log("Test cache on rev 700")
-	lister, found = s.snapshots.GetLessOrEqual(700)
+	lister, found = s.storage.snapshots.GetLessOrEqual(700)
 	assert.True(t, found, "Expected replace to be snapshotted")
 	elements, err = lister.OrderedListPrefix("", "")
 	require.NoError(t, err)


### PR DESCRIPTION
Make it clear that watch cache is constructed from two subcomponents. Aligning codebase to follow structure closer to etcd cache where store and demux are separate substructs https://github.com/etcd-io/etcd/blob/main/cache/cache.go
/kind cleanup

```release-note
NONE
```

/cc @Jefftree @michaelasp @p0lyn0mial 