### PR TITLE
Controller Robustness Test Framework

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -168,6 +168,14 @@ type ControllerExpectationsInterface interface {
 // ControllerExpectations is a cache mapping controllers to what they expect to see before being woken up for a sync.
 type ControllerExpectations struct {
 	cache.Store
+	clock clock.Clock
+}
+
+func (r *ControllerExpectations) getClock() clock.Clock {
+	if r.clock != nil {
+		return r.clock
+	}
+	return clock.RealClock{}
 }
 
 // GetExpectations returns the ControlleeExpectations of the given controller.
@@ -197,7 +205,7 @@ func (r *ControllerExpectations) SatisfiedExpectations(logger klog.Logger, contr
 		if exp.Fulfilled() {
 			logger.V(4).Info("Controller expectations fulfilled", "expectations", exp)
 			return true
-		} else if exp.isExpired() {
+		} else if exp.isExpired(r.getClock()) {
 			logger.V(4).Info("Controller expectations expired", "expectations", exp)
 			return true
 		} else {
@@ -219,16 +227,13 @@ func (r *ControllerExpectations) SatisfiedExpectations(logger klog.Logger, contr
 	return true
 }
 
-// TODO: Extend ExpirationCache to support explicit expiration.
-// TODO: Make this possible to disable in tests.
-// TODO: Support injection of clock.
-func (exp *ControlleeExpectations) isExpired() bool {
-	return clock.RealClock{}.Since(exp.timestamp) > ExpectationsTimeout
+func (exp *ControlleeExpectations) isExpired(clk clock.Clock) bool {
+	return clk.Since(exp.timestamp) > ExpectationsTimeout
 }
 
 // SetExpectations registers new expectations for the given controller. Forgets existing expectations.
 func (r *ControllerExpectations) SetExpectations(logger klog.Logger, controllerKey string, add, del int) error {
-	exp := &ControlleeExpectations{add: int64(add), del: int64(del), key: controllerKey, timestamp: clock.RealClock{}.Now()}
+	exp := &ControlleeExpectations{add: int64(add), del: int64(del), key: controllerKey, timestamp: r.getClock().Now()}
 	logger.V(4).Info("Setting expectations", "expectations", exp)
 	return r.Add(exp)
 }
@@ -310,9 +315,26 @@ func (e *ControlleeExpectations) MarshalLog() interface{} {
 	}
 }
 
+// ExpectationsClock is the default clock used for new controller expectations.
+// Can be overridden during testing to simulate timeouts without real-world sleep.
+//
+// CONCURRENCY WARNING: Mutating this global variable will affect all controllers
+// created in the same process. Tests that mutate this variable MUST NOT be run
+// in parallel with other tests (do not use t.Parallel()), as it will cause
+// unpredictable clock skews and test flakes.
+var ExpectationsClock clock.Clock = clock.RealClock{}
+
 // NewControllerExpectations returns a store for ControllerExpectations.
 func NewControllerExpectations() *ControllerExpectations {
-	return &ControllerExpectations{cache.NewStore(ExpKeyFunc)}
+	return NewControllerExpectationsWithClock(ExpectationsClock)
+}
+
+// NewControllerExpectationsWithClock returns a store for ControllerExpectations using the specified clock.
+func NewControllerExpectationsWithClock(clk clock.Clock) *ControllerExpectations {
+	return &ControllerExpectations{
+		Store: cache.NewStore(ExpKeyFunc),
+		clock: clk,
+	}
 }
 
 // UIDSetKeyFunc to parse out the key from a UIDSet.

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -168,6 +168,14 @@ type ControllerExpectationsInterface interface {
 // ControllerExpectations is a cache mapping controllers to what they expect to see before being woken up for a sync.
 type ControllerExpectations struct {
 	cache.Store
+	clock clock.Clock
+}
+
+func (r *ControllerExpectations) getClock() clock.Clock {
+	if r.clock != nil {
+		return r.clock
+	}
+	return clock.RealClock{}
 }
 
 // GetExpectations returns the ControlleeExpectations of the given controller.
@@ -197,7 +205,7 @@ func (r *ControllerExpectations) SatisfiedExpectations(logger klog.Logger, contr
 		if exp.Fulfilled() {
 			logger.V(4).Info("Controller expectations fulfilled", "expectations", exp)
 			return true
-		} else if exp.isExpired() {
+		} else if exp.isExpired(r.getClock()) {
 			logger.V(4).Info("Controller expectations expired", "expectations", exp)
 			return true
 		} else {
@@ -219,16 +227,13 @@ func (r *ControllerExpectations) SatisfiedExpectations(logger klog.Logger, contr
 	return true
 }
 
-// TODO: Extend ExpirationCache to support explicit expiration.
-// TODO: Make this possible to disable in tests.
-// TODO: Support injection of clock.
-func (exp *ControlleeExpectations) isExpired() bool {
-	return clock.RealClock{}.Since(exp.timestamp) > ExpectationsTimeout
+func (exp *ControlleeExpectations) isExpired(clk clock.Clock) bool {
+	return clk.Since(exp.timestamp) > ExpectationsTimeout
 }
 
 // SetExpectations registers new expectations for the given controller. Forgets existing expectations.
 func (r *ControllerExpectations) SetExpectations(logger klog.Logger, controllerKey string, add, del int) error {
-	exp := &ControlleeExpectations{add: int64(add), del: int64(del), key: controllerKey, timestamp: clock.RealClock{}.Now()}
+	exp := &ControlleeExpectations{add: int64(add), del: int64(del), key: controllerKey, timestamp: r.getClock().Now()}
 	logger.V(4).Info("Setting expectations", "expectations", exp)
 	return r.Add(exp)
 }
@@ -310,9 +315,21 @@ func (e *ControlleeExpectations) MarshalLog() interface{} {
 	}
 }
 
+// ExpectationsClock is the default clock used for new controller expectations.
+// Can be overridden during testing to simulate timeouts without real-world sleep.
+var ExpectationsClock clock.Clock = clock.RealClock{}
+
 // NewControllerExpectations returns a store for ControllerExpectations.
 func NewControllerExpectations() *ControllerExpectations {
-	return &ControllerExpectations{cache.NewStore(ExpKeyFunc)}
+	return NewControllerExpectationsWithClock(ExpectationsClock)
+}
+
+// NewControllerExpectationsWithClock returns a store for ControllerExpectations using the specified clock.
+func NewControllerExpectationsWithClock(clk clock.Clock) *ControllerExpectations {
+	return &ControllerExpectations{
+		Store: cache.NewStore(ExpKeyFunc),
+		clock: clk,
+	}
 }
 
 // UIDSetKeyFunc to parse out the key from a UIDSet.

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -317,6 +317,11 @@ func (e *ControlleeExpectations) MarshalLog() interface{} {
 
 // ExpectationsClock is the default clock used for new controller expectations.
 // Can be overridden during testing to simulate timeouts without real-world sleep.
+//
+// CONCURRENCY WARNING: Mutating this global variable will affect all controllers
+// created in the same process. Tests that mutate this variable MUST NOT be run
+// in parallel with other tests (do not use t.Parallel()), as it will cause
+// unpredictable clock skews and test flakes.
 var ExpectationsClock clock.Clock = clock.RealClock{}
 
 // NewControllerExpectations returns a store for ControllerExpectations.

--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -69,7 +69,7 @@ func NewFakeControllerExpectationsLookup(ttl time.Duration) (*ControllerExpectat
 	ttlPolicy := &cache.TTLPolicy{TTL: ttl, Clock: fakeClock}
 	ttlStore := cache.NewFakeExpirationStore(
 		ExpKeyFunc, nil, ttlPolicy, fakeClock)
-	return &ControllerExpectations{ttlStore}, fakeClock
+	return &ControllerExpectations{Store: ttlStore, clock: fakeClock}, fakeClock
 }
 
 func newReplicationController(replicas int) *v1.ReplicationController {

--- a/test/integration/daemonset/robustness_test.go
+++ b/test/integration/daemonset/robustness_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemonset
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/kubernetes/pkg/controller/daemon"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/test/utils/robustness"
+)
+
+func TestDaemonSetReconcileRobustnessMatrix(t *testing.T) {
+	dsName := "ds-1"
+
+	// The DaemonSet controller writes only the DaemonSet /status subresource (never
+	// the object itself), creates child Pods (POST pods) tracked in the wrapped
+	// "pod-cache" informer cache, and uses ControllerExpectations. The standard
+	// matrix derives all of its faults from these declarations.
+	suite := robustness.NewTestSuite(t, robustness.ControllerProfile{
+		Name: "daemonset",
+		Root: robustness.ResourceRef{
+			Group:     "apps",
+			Resource:  "daemonsets",
+			Namespace: "default",
+			Name:      dsName,
+		},
+		WritesRootStatus: true,
+		UsesExpectations: true,
+		Child: &robustness.ChildResource{
+			Resource:            "pods",
+			CacheName:           "pod-cache",
+			CreatedByController: true,
+		},
+	})
+
+	// The DaemonSet controller converges to a steady state, so check the final
+	// status deterministically once it settles (write-idle for 2s) rather than
+	// polling until it first holds.
+	suite.CheckWhenSettled(2 * time.Second)
+
+	// 1. Define the Controller Setup
+	suite.SetControllerSetup(func(fixture *robustness.RobustnessTestFixture) {
+		t.Logf("Feature StaleControllerConsistencyDaemonSet enabled: %v",
+			utilfeature.DefaultFeatureGate.Enabled(features.StaleControllerConsistencyDaemonSet))
+
+		// Start standard informers using the fixture client (0 resync - heals natively via events!)
+		informerFactory := informers.NewSharedInformerFactory(fixture.ClientSet(), 0)
+
+		// Wrap the Informers cleanly via fixture helper APIs, hiding all complexity from the test writer!
+		dsInformer := fixture.WrapDaemonSetInformer(informerFactory.Apps().V1().DaemonSets())
+		podInformer := fixture.WrapPodInformer(informerFactory.Core().V1().Pods())
+		nodeInformer := fixture.WrapNodeInformer(informerFactory.Core().V1().Nodes())
+
+		// Construct and start the DaemonSet controller
+		dc, err := daemon.NewDaemonSetsController(
+			fixture.Context(),
+			dsInformer,
+			informerFactory.Apps().V1().ControllerRevisions(),
+			podInformer,
+			nodeInformer,
+			fixture.ClientSet(),
+			flowcontrol.NewBackOff(100*time.Millisecond, 1*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Failed to create DaemonSet controller: %v", err)
+		}
+
+		informerFactory.Start(fixture.Context().Done())
+		informerFactory.WaitForCacheSync(fixture.Context().Done())
+
+		go dc.Run(fixture.Context(), 2)
+		t.Log("DaemonSet controller successfully started.")
+	})
+
+	// 2. Define the Action/Trigger: Create Node and DaemonSet
+	suite.SetScenarioAction(func(ctx context.Context, fixture *robustness.RobustnessTestFixture) error {
+		adminClient := fixture.AdminClientSet()
+
+		// Create Node target-node
+		node := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "target-node"},
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{Type: v1.NodeReady, Status: v1.ConditionTrue},
+				},
+			},
+		}
+		t.Log("Scenario Action: Creating target-node")
+		_, err := adminClient.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+
+		// Create DaemonSet ds-1
+		ds := &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: dsName, Namespace: "default"},
+			Spec: appsv1.DaemonSetSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "nginx"}},
+				Template: v1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "nginx"}},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{Name: "nginx", Image: "nginx"},
+						},
+					},
+				},
+			},
+		}
+		t.Log("Scenario Action: Creating DaemonSet")
+		_, err = adminClient.AppsV1().DaemonSets("default").Create(ctx, ds, metav1.CreateOptions{})
+		return err
+	})
+
+	// 3. Define Safety Invariant:
+	// We must NEVER have more than 1 Pod created for target-node.
+	suite.AddSafetyInvariant("MaxOnePodPerNode", robustness.CountAtMost(1, "Pod",
+		func(ctx context.Context, c clientset.Interface) (int, error) {
+			pods, err := c.CoreV1().Pods("default").List(ctx, metav1.ListOptions{})
+			if err != nil {
+				return 0, err
+			}
+			return len(pods.Items), nil
+		}))
+
+	// 4. Define Liveness Invariant:
+	// The DaemonSet status must eventually be updated to reflect exactly 1 scheduled pod.
+	suite.SetLivenessInvariant("DaemonSetStatusUpdated", robustness.ObjectSatisfies(
+		func(ctx context.Context, c clientset.Interface) (*appsv1.DaemonSet, error) {
+			return c.AppsV1().DaemonSets("default").Get(ctx, dsName, metav1.GetOptions{})
+		},
+		func(ds *appsv1.DaemonSet) error {
+			if ds.Status.CurrentNumberScheduled != 1 {
+				return fmt.Errorf("expected Status.CurrentNumberScheduled to be 1, got %d", ds.Status.CurrentNumberScheduled)
+			}
+			return nil
+		}), 30*time.Second)
+
+	// 5. Run the entire Robustness Chaos Matrix!
+	suite.Run()
+}

--- a/test/integration/daemonset/robustness_test.go
+++ b/test/integration/daemonset/robustness_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemonset
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/kubernetes/pkg/controller/daemon"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/test/utils/robustness"
+)
+
+func TestDaemonSetReconcileRobustnessMatrix(t *testing.T) {
+	dsName := "ds-1"
+
+	// The DaemonSet controller writes only the DaemonSet /status subresource (never
+	// the object itself), creates child Pods (POST pods) tracked in the wrapped
+	// "pod-cache" informer cache, and uses ControllerExpectations. The standard
+	// matrix derives all of its faults from these declarations.
+	suite := robustness.NewTestSuite(t, robustness.ControllerProfile{
+		Name: "daemonset",
+		Root: robustness.ResourceRef{
+			Group:     "apps",
+			Resource:  "daemonsets",
+			Namespace: "default",
+			Name:      dsName,
+		},
+		WritesRootStatus: true,
+		UsesExpectations: true,
+		Child: &robustness.ChildResource{
+			Resource:            "pods",
+			CreatedByController: true,
+		},
+	})
+
+	// The DaemonSet controller converges to a steady state, so check the final
+	// status deterministically once it settles (write-idle for 2s) rather than
+	// polling until it first holds.
+	suite.CheckWhenSettled(2 * time.Second)
+
+	// 1. Define the Controller Setup
+	suite.SetControllerSetup(func(fixture *robustness.RobustnessTestFixture) {
+		t.Logf("Feature StaleControllerConsistencyDaemonSet enabled: %v",
+			utilfeature.DefaultFeatureGate.Enabled(features.StaleControllerConsistencyDaemonSet))
+
+		// Start standard informers using the fixture client (0 resync - heals natively via events!)
+		informerFactory := informers.NewSharedInformerFactory(fixture.ClientSet(), 0)
+
+		// Wrap the Informers cleanly via fixture helper APIs, hiding all complexity from the test writer!
+		dsInformer := fixture.WrapDaemonSetInformer(informerFactory.Apps().V1().DaemonSets())
+		podInformer := fixture.WrapPodInformer(informerFactory.Core().V1().Pods())
+		nodeInformer := fixture.WrapNodeInformer(informerFactory.Core().V1().Nodes())
+
+		// Construct and start the DaemonSet controller
+		dc, err := daemon.NewDaemonSetsController(
+			fixture.Context(),
+			dsInformer,
+			informerFactory.Apps().V1().ControllerRevisions(),
+			podInformer,
+			nodeInformer,
+			fixture.ClientSet(),
+			flowcontrol.NewBackOff(100*time.Millisecond, 1*time.Second),
+		)
+		if err != nil {
+			t.Fatalf("Failed to create DaemonSet controller: %v", err)
+		}
+
+		fixture.StartInformers(informerFactory)
+
+		go dc.Run(fixture.Context(), 2)
+		t.Log("DaemonSet controller successfully started.")
+	})
+
+	// 2. Define the Action/Trigger: Create Node and DaemonSet
+	suite.SetScenarioAction(func(ctx context.Context, fixture *robustness.RobustnessTestFixture) error {
+		adminClient := fixture.AdminClientSet()
+
+		// Create Node target-node
+		node := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "target-node"},
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{Type: v1.NodeReady, Status: v1.ConditionTrue},
+				},
+			},
+		}
+		t.Log("Scenario Action: Creating target-node")
+		_, err := adminClient.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+
+		// Create DaemonSet ds-1
+		ds := &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: dsName, Namespace: "default"},
+			Spec: appsv1.DaemonSetSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "nginx"}},
+				Template: v1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "nginx"}},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{Name: "nginx", Image: "nginx"},
+						},
+					},
+				},
+			},
+		}
+		t.Log("Scenario Action: Creating DaemonSet")
+		_, err = adminClient.AppsV1().DaemonSets("default").Create(ctx, ds, metav1.CreateOptions{})
+		return err
+	})
+
+	// 3. Define Safety Invariant:
+	// We must NEVER have more than 1 Pod created for target-node.
+	suite.AddSafetyInvariant("MaxOnePodPerNode", robustness.CountAtMost(1, "Pod",
+		func(ctx context.Context, c clientset.Interface) (int, error) {
+			pods, err := c.CoreV1().Pods("default").List(ctx, metav1.ListOptions{})
+			if err != nil {
+				return 0, err
+			}
+			return len(pods.Items), nil
+		}))
+
+	// 4. Define Liveness Invariant:
+	// The DaemonSet status must eventually be updated to reflect exactly 1 scheduled pod.
+	suite.SetLivenessInvariant("DaemonSetStatusUpdated", robustness.ObjectSatisfies(
+		func(ctx context.Context, c clientset.Interface) (*appsv1.DaemonSet, error) {
+			return c.AppsV1().DaemonSets("default").Get(ctx, dsName, metav1.GetOptions{})
+		},
+		func(ds *appsv1.DaemonSet) error {
+			if ds.Status.CurrentNumberScheduled != 1 {
+				return fmt.Errorf("expected Status.CurrentNumberScheduled to be 1, got %d", ds.Status.CurrentNumberScheduled)
+			}
+			return nil
+		}), 30*time.Second)
+
+	// 5. Run the entire Robustness Chaos Matrix!
+	suite.Run()
+}

--- a/test/integration/node/robustness_test.go
+++ b/test/integration/node/robustness_test.go
@@ -1,0 +1,240 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	coordv1 "k8s.io/api/coordination/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/controller/nodelifecycle"
+	"k8s.io/kubernetes/test/utils/robustness"
+)
+
+func TestLeaseReconcileRobustnessMatrix(t *testing.T) {
+	nodeName := "target-node"
+	var scenarioStartTime time.Time // Track when the active scenario created its lease
+
+	// The renewal loop writes the Lease object itself (PUT leases), but never its
+	// /status subresource, creates no child objects, and uses no expectations.
+	suite := robustness.NewTestSuite(t, robustness.ControllerProfile{
+		Name: "lease-renewal",
+		Root: robustness.ResourceRef{
+			Group:     "coordination.k8s.io",
+			Resource:  "leases",
+			Namespace: v1.NamespaceNodeLease,
+			Name:      nodeName,
+		},
+		WritesRoot: true,
+	})
+
+	// 1. Define the Controller Setup: Start NodeLifecycleController
+	suite.SetControllerSetup(func(fixture *robustness.RobustnessTestFixture) {
+		// Start standard informers using the fixture client
+		informerFactory := informers.NewSharedInformerFactory(fixture.ClientSet(), 0)
+
+		// Wrap informers to support fault injection
+		nodeInformer := fixture.WrapNodeInformer(informerFactory.Core().V1().Nodes())
+		podInformer := fixture.WrapPodInformer(informerFactory.Core().V1().Pods())
+		leaseInformer := informerFactory.Coordination().V1().Leases()
+		dsInformer := fixture.WrapDaemonSetInformer(informerFactory.Apps().V1().DaemonSets())
+
+		// Construct and start the NodeLifecycleController
+		nc, err := nodelifecycle.NewNodeLifecycleController(
+			fixture.Context(),
+			leaseInformer,
+			podInformer,
+			nodeInformer,
+			dsInformer,
+			fixture.ClientSet(),
+			5*time.Second,        // Node monitor grace period
+			time.Minute,          // Node startup grace period
+			100*time.Millisecond, // Node monitor period
+			100,                  // Eviction limiter QPS
+			100,                  // Secondary eviction limiter QPS
+			50,                   // Large cluster threshold
+			0.55,                 // Unhealthy zone threshold
+		)
+		if err != nil {
+			t.Fatalf("Failed to create NodeLifecycle controller: %v", err)
+		}
+
+		informerFactory.Start(fixture.Context().Done())
+		informerFactory.WaitForCacheSync(fixture.Context().Done())
+
+		go nc.Run(fixture.Context())
+		t.Log("NodeLifecycle controller successfully started.")
+	})
+
+	// 2. Define the Action/Trigger: Create Node and Lease, then simulate background periodic renewals
+	suite.SetScenarioAction(func(ctx context.Context, fixture *robustness.RobustnessTestFixture) error {
+		adminClient := fixture.AdminClientSet()
+		wrappedClient := fixture.ClientSet()
+
+		// Create Node target-node (direct admin write)
+		node := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{
+						Type:               v1.NodeReady,
+						Status:             v1.ConditionTrue,
+						LastHeartbeatTime:  metav1.Now(),
+						LastTransitionTime: metav1.Now(),
+					},
+				},
+			},
+		}
+		t.Log("Scenario Action: Creating target-node")
+		_, err := adminClient.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+
+		// Pre-ensure lease namespace exists (direct admin write)
+		nsObj := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: v1.NamespaceNodeLease}}
+		_, err = adminClient.CoreV1().Namespaces().Create(ctx, nsObj, metav1.CreateOptions{})
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+
+		// Create the Lease object (direct admin write)
+		duration := int32(40)
+		testLease := &coordv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nodeName,
+				Namespace: v1.NamespaceNodeLease,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "v1",
+						Kind:       "Node",
+						Name:       nodeName,
+					},
+				},
+			},
+			Spec: coordv1.LeaseSpec{
+				HolderIdentity:       &nodeName,
+				LeaseDurationSeconds: &duration,
+				RenewTime:            &metav1.MicroTime{Time: time.Now()},
+			},
+		}
+
+		// Let's get the created node to have its UID
+		createdNode, err := adminClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		testLease.OwnerReferences[0].UID = createdNode.UID
+
+		t.Log("Trigger Action: Creating Lease")
+		createdLease, err := adminClient.CoordinationV1().Leases(v1.NamespaceNodeLease).Create(ctx, testLease, metav1.CreateOptions{})
+		if err != nil {
+			return err
+		}
+		if createdLease.Spec.RenewTime != nil {
+			scenarioStartTime = createdLease.Spec.RenewTime.Time
+		} else {
+			scenarioStartTime = time.Now()
+		}
+
+		// Periodic renewals subjected to injected faults (uses WRAPPED client!)
+		go func() {
+			ticker := time.NewTicker(200 * time.Millisecond)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					fmt.Printf("[Lease Renewal Loop] Context done, exiting\n")
+					return
+				case <-ticker.C:
+					fmt.Printf("[Lease Renewal Loop] Ticker ticked, performing Get...\n")
+					latest, err := wrappedClient.CoordinationV1().Leases(v1.NamespaceNodeLease).Get(ctx, nodeName, metav1.GetOptions{})
+					if err != nil {
+						fmt.Printf("[Lease Renewal Loop] Get failed: %v\n", err)
+						continue
+					}
+					latest.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
+					_, err = wrappedClient.CoordinationV1().Leases(v1.NamespaceNodeLease).Update(ctx, latest, metav1.UpdateOptions{})
+					if err != nil {
+						fmt.Printf("[Lease Renewal Loop] Update failed: %v\n", err)
+					} else {
+						fmt.Printf("[Lease Renewal Loop] Update succeeded\n")
+					}
+				}
+			}
+		}()
+
+		return nil
+	})
+
+	// 3. Safety Invariants
+
+	// Invariant A: Never more than one Lease
+	suite.AddSafetyInvariant("SingleLeaseObject", robustness.CountAtMost(1, "Lease",
+		func(ctx context.Context, c clientset.Interface) (int, error) {
+			leases, err := c.CoordinationV1().Leases(v1.NamespaceNodeLease).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				return 0, err
+			}
+			return len(leases.Items), nil
+		}))
+
+	// Invariant B: Node should never be marked unhealthy (NodeReady should remain True)
+	suite.AddSafetyInvariant("NodeAlwaysReady", func(ctx context.Context, c clientset.Interface) error {
+		node, err := c.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		for _, cond := range node.Status.Conditions {
+			if cond.Type == v1.NodeReady {
+				if cond.Status != v1.ConditionTrue {
+					return fmt.Errorf("node %q is not Ready: status=%v, reason=%v, message=%v", nodeName, cond.Status, cond.Reason, cond.Message)
+				}
+				return nil
+			}
+		}
+		return fmt.Errorf("node %q does not have NodeReady condition", nodeName)
+	})
+
+	// 4. Liveness Invariant: Lease is eventually renewed
+	suite.SetLivenessInvariant("LeaseEventuallyRenewed", robustness.ObjectSatisfies(
+		func(ctx context.Context, c clientset.Interface) (*coordv1.Lease, error) {
+			return c.CoordinationV1().Leases(v1.NamespaceNodeLease).Get(ctx, nodeName, metav1.GetOptions{})
+		},
+		func(latest *coordv1.Lease) error {
+			if latest.Spec.RenewTime == nil {
+				return fmt.Errorf("lease Spec.RenewTime is nil")
+			}
+			if !latest.Spec.RenewTime.After(scenarioStartTime) {
+				return fmt.Errorf("lease has not been renewed yet: renewTime=%v, scenarioStartTime=%v", latest.Spec.RenewTime.Time, scenarioStartTime)
+			}
+			return nil
+		}), 30*time.Second)
+
+	// 5. Run the entire Robustness Chaos Matrix!
+	suite.Run()
+}

--- a/test/integration/node/robustness_test.go
+++ b/test/integration/node/robustness_test.go
@@ -1,0 +1,238 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	coordv1 "k8s.io/api/coordination/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/controller/nodelifecycle"
+	"k8s.io/kubernetes/test/utils/robustness"
+)
+
+func TestLeaseReconcileRobustnessMatrix(t *testing.T) {
+	nodeName := "target-node"
+	var scenarioStartTime time.Time // Track when the active scenario created its lease
+
+	// The renewal loop writes the Lease object itself (PUT leases), but never its
+	// /status subresource, creates no child objects, and uses no expectations.
+	suite := robustness.NewTestSuite(t, robustness.ControllerProfile{
+		Name: "lease-renewal",
+		Root: robustness.ResourceRef{
+			Group:     "coordination.k8s.io",
+			Resource:  "leases",
+			Namespace: v1.NamespaceNodeLease,
+			Name:      nodeName,
+		},
+		WritesRoot: true,
+	})
+
+	// 1. Define the Controller Setup: Start NodeLifecycleController
+	suite.SetControllerSetup(func(fixture *robustness.RobustnessTestFixture) {
+		// Start standard informers using the fixture client
+		informerFactory := informers.NewSharedInformerFactory(fixture.ClientSet(), 0)
+
+		// Wrap informers to support fault injection
+		nodeInformer := fixture.WrapNodeInformer(informerFactory.Core().V1().Nodes())
+		podInformer := fixture.WrapPodInformer(informerFactory.Core().V1().Pods())
+		leaseInformer := informerFactory.Coordination().V1().Leases()
+		dsInformer := fixture.WrapDaemonSetInformer(informerFactory.Apps().V1().DaemonSets())
+
+		// Construct and start the NodeLifecycleController
+		nc, err := nodelifecycle.NewNodeLifecycleController(
+			fixture.Context(),
+			leaseInformer,
+			podInformer,
+			nodeInformer,
+			dsInformer,
+			fixture.ClientSet(),
+			5*time.Second,        // Node monitor grace period
+			time.Minute,          // Node startup grace period
+			100*time.Millisecond, // Node monitor period
+			100,                  // Eviction limiter QPS
+			100,                  // Secondary eviction limiter QPS
+			50,                   // Large cluster threshold
+			0.55,                 // Unhealthy zone threshold
+		)
+		if err != nil {
+			t.Fatalf("Failed to create NodeLifecycle controller: %v", err)
+		}
+		fixture.StartInformers(informerFactory)
+
+		go nc.Run(fixture.Context())
+		t.Log("NodeLifecycle controller successfully started.")
+	})
+
+	// 2. Define the Action/Trigger: Create Node and Lease, then simulate background periodic renewals
+	suite.SetScenarioAction(func(ctx context.Context, fixture *robustness.RobustnessTestFixture) error {
+		adminClient := fixture.AdminClientSet()
+		wrappedClient := fixture.ClientSet()
+
+		// Create Node target-node (direct admin write)
+		node := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{
+						Type:               v1.NodeReady,
+						Status:             v1.ConditionTrue,
+						LastHeartbeatTime:  metav1.Now(),
+						LastTransitionTime: metav1.Now(),
+					},
+				},
+			},
+		}
+		t.Log("Scenario Action: Creating target-node")
+		_, err := adminClient.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+
+		// Pre-ensure lease namespace exists (direct admin write)
+		nsObj := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: v1.NamespaceNodeLease}}
+		_, err = adminClient.CoreV1().Namespaces().Create(ctx, nsObj, metav1.CreateOptions{})
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+
+		// Create the Lease object (direct admin write)
+		duration := int32(40)
+		testLease := &coordv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nodeName,
+				Namespace: v1.NamespaceNodeLease,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "v1",
+						Kind:       "Node",
+						Name:       nodeName,
+					},
+				},
+			},
+			Spec: coordv1.LeaseSpec{
+				HolderIdentity:       &nodeName,
+				LeaseDurationSeconds: &duration,
+				RenewTime:            &metav1.MicroTime{Time: time.Now()},
+			},
+		}
+
+		// Let's get the created node to have its UID
+		createdNode, err := adminClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		testLease.OwnerReferences[0].UID = createdNode.UID
+
+		t.Log("Trigger Action: Creating Lease")
+		createdLease, err := adminClient.CoordinationV1().Leases(v1.NamespaceNodeLease).Create(ctx, testLease, metav1.CreateOptions{})
+		if err != nil {
+			return err
+		}
+		if createdLease.Spec.RenewTime != nil {
+			scenarioStartTime = createdLease.Spec.RenewTime.Time
+		} else {
+			scenarioStartTime = time.Now()
+		}
+
+		// Periodic renewals subjected to injected faults (uses WRAPPED client!)
+		go func() {
+			ticker := time.NewTicker(200 * time.Millisecond)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					fmt.Printf("[Lease Renewal Loop] Context done, exiting\n")
+					return
+				case <-ticker.C:
+					fmt.Printf("[Lease Renewal Loop] Ticker ticked, performing Get...\n")
+					latest, err := wrappedClient.CoordinationV1().Leases(v1.NamespaceNodeLease).Get(ctx, nodeName, metav1.GetOptions{})
+					if err != nil {
+						fmt.Printf("[Lease Renewal Loop] Get failed: %v\n", err)
+						continue
+					}
+					latest.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
+					_, err = wrappedClient.CoordinationV1().Leases(v1.NamespaceNodeLease).Update(ctx, latest, metav1.UpdateOptions{})
+					if err != nil {
+						fmt.Printf("[Lease Renewal Loop] Update failed: %v\n", err)
+					} else {
+						fmt.Printf("[Lease Renewal Loop] Update succeeded\n")
+					}
+				}
+			}
+		}()
+
+		return nil
+	})
+
+	// 3. Safety Invariants
+
+	// Invariant A: Never more than one Lease
+	suite.AddSafetyInvariant("SingleLeaseObject", robustness.CountAtMost(1, "Lease",
+		func(ctx context.Context, c clientset.Interface) (int, error) {
+			leases, err := c.CoordinationV1().Leases(v1.NamespaceNodeLease).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				return 0, err
+			}
+			return len(leases.Items), nil
+		}))
+
+	// Invariant B: Node should never be marked unhealthy (NodeReady should remain True)
+	suite.AddSafetyInvariant("NodeAlwaysReady", func(ctx context.Context, c clientset.Interface) error {
+		node, err := c.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		for _, cond := range node.Status.Conditions {
+			if cond.Type == v1.NodeReady {
+				if cond.Status != v1.ConditionTrue {
+					return fmt.Errorf("node %q is not Ready: status=%v, reason=%v, message=%v", nodeName, cond.Status, cond.Reason, cond.Message)
+				}
+				return nil
+			}
+		}
+		return fmt.Errorf("node %q does not have NodeReady condition", nodeName)
+	})
+
+	// 4. Liveness Invariant: Lease is eventually renewed
+	suite.SetLivenessInvariant("LeaseEventuallyRenewed", robustness.ObjectSatisfies(
+		func(ctx context.Context, c clientset.Interface) (*coordv1.Lease, error) {
+			return c.CoordinationV1().Leases(v1.NamespaceNodeLease).Get(ctx, nodeName, metav1.GetOptions{})
+		},
+		func(latest *coordv1.Lease) error {
+			if latest.Spec.RenewTime == nil {
+				return fmt.Errorf("lease Spec.RenewTime is nil")
+			}
+			if !latest.Spec.RenewTime.After(scenarioStartTime) {
+				return fmt.Errorf("lease has not been renewed yet: renewTime=%v, scenarioStartTime=%v", latest.Spec.RenewTime.Time, scenarioStartTime)
+			}
+			return nil
+		}), 30*time.Second)
+
+	// 5. Run the entire Robustness Chaos Matrix!
+	suite.Run()
+}

--- a/test/utils/robustness/clock.go
+++ b/test/utils/robustness/clock.go
@@ -1,0 +1,76 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package robustness
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/utils/clock"
+)
+
+// ShiftTime is a ClockFault that advances the wrapped clock by Offset. Valid only
+// at clock.* points.
+type ShiftTime struct {
+	Offset time.Duration
+}
+
+func (a ShiftTime) ApplyClock() ClockVerdict {
+	return ClockVerdict{Shift: a.Offset}
+}
+
+// FaultInjectingClock wraps k8s.io/utils/clock.Clock and intercepts Now() queries.
+type FaultInjectingClock struct {
+	clock.Clock
+	registry *FaultRegistry
+	name     string
+}
+
+// NewFaultInjectingClock creates a wrapped clock.Clock hooked to the registry.
+func NewFaultInjectingClock(realClock clock.Clock, registry *FaultRegistry, name string) clock.Clock {
+	return &FaultInjectingClock{
+		Clock:    realClock,
+		registry: registry,
+		name:     name,
+	}
+}
+
+func (c *FaultInjectingClock) Now() time.Time {
+	realNow := c.Clock.Now()
+	shift := c.registry.ResolveClock(context.Background(), ClockFacts{Clock: c.name})
+	return realNow.Add(shift)
+}
+
+func (c *FaultInjectingClock) Since(t time.Time) time.Duration {
+	return c.Now().Sub(t)
+}
+
+func (c *FaultInjectingClock) Sleep(d time.Duration) {
+	c.Clock.Sleep(d)
+}
+
+func (c *FaultInjectingClock) After(d time.Duration) <-chan time.Time {
+	return c.Clock.After(d)
+}
+
+func (c *FaultInjectingClock) NewTimer(d time.Duration) clock.Timer {
+	return c.Clock.NewTimer(d)
+}
+
+func (c *FaultInjectingClock) Tick(d time.Duration) <-chan time.Time {
+	return c.Clock.Tick(d)
+}

--- a/test/utils/robustness/doc.go
+++ b/test/utils/robustness/doc.go
@@ -1,0 +1,65 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package robustness is a fault-injection harness for controller reconciliation
+// loops: a controller author declares what their controller does and what must
+// hold true, and the framework runs the controller under a matrix of injected
+// failures, verifying the declared invariants throughout.
+//
+// The pieces, in the order a test author meets them:
+//
+//   - ControllerProfile (profile.go) declares what the controller does through
+//     the wrapped client: the root resource it reconciles, which writes it
+//     performs, whether it creates child objects, and whether it uses
+//     ControllerExpectations. Scenarios derive their faults from the profile,
+//     which is what makes the matrix reusable for any controller.
+//
+//   - RobustnessTestSuite (suite.go) orchestrates the matrix: for each scenario
+//     it builds a fresh fixture, starts the controller, injects the scenario's
+//     faults, runs the trigger action, and checks the invariants.
+//
+//   - Invariants (invariants.go) come in two flavors: safety invariants are
+//     checked continuously in the background ("never more than one Pod per
+//     node"), and the liveness invariant is the convergence target ("status
+//     eventually reports 1 scheduled"). Both run against the un-wrapped admin
+//     client. ObjectSatisfies and CountAtMost build common shapes.
+//
+//   - ChaosScenario (scenarios.go) is one cell of the matrix: a self-contained
+//     fault set derived from the profile. StandardChaosMatrix covers write
+//     conflicts, cache sync lag, flaky child creates, combined chaos, and
+//     expectations timeouts; AddScenario appends custom cells.
+//
+//   - FaultRegistry (registry.go) is the single source of truth for active
+//     faults. A FaultRule pairs a structured FaultMatch (ClientMatch,
+//     CacheMatch, ClockMatch, QueueMatch) with a FaultCondition (when to fire)
+//     and a FaultAction (what to do), validated against the match's injection
+//     domain at registration.
+//
+//   - Injection sites wrap the controller's dependencies and consult the
+//     registry: the REST transport (transport.go), informer caches
+//     (indexer.go, informers.go), the expectations clock (clock.go), and work
+//     queues (queue.go). The fixture (fixture.go) wires them together around an
+//     integration apiserver.
+//
+// Two guards keep a green run meaningful: every non-optional fault must have
+// matched a real injection site (AssertAllFaultsMatched), and every fault
+// declared ExpectTriggered must have actually fired
+// (AssertExpectedFaultsTriggered). A fault that silently injects nothing is a
+// test failure, not a pass.
+//
+// See test/integration/robustness for complete examples (lease renewal and the
+// DaemonSet controller).
+package robustness

--- a/test/utils/robustness/doc.go
+++ b/test/utils/robustness/doc.go
@@ -1,0 +1,65 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package robustness is a fault-injection harness for controller reconciliation
+// loops: a controller author declares what their controller does and what must
+// hold true, and the framework runs the controller under a matrix of injected
+// failures, verifying the declared invariants throughout.
+//
+// The pieces, in the order a test author meets them:
+//
+//   - ControllerProfile (profile.go) declares what the controller does through
+//     the wrapped client: the root resource it reconciles, which writes it
+//     performs, whether it creates child objects, and whether it uses
+//     ControllerExpectations. Scenarios derive their faults from the profile,
+//     which is what makes the matrix reusable for any controller.
+//
+//   - RobustnessTestSuite (suite.go) orchestrates the matrix: for each scenario
+//     it builds a fresh fixture, starts the controller, injects the scenario's
+//     faults, runs the trigger action, and checks the invariants.
+//
+//   - Invariants (invariants.go) come in two flavors: safety invariants are
+//     checked continuously in the background ("never more than one Pod per
+//     node"), and the liveness invariant is the convergence target ("status
+//     eventually reports 1 scheduled"). Both run against the un-wrapped admin
+//     client. ObjectSatisfies and CountAtMost build common shapes.
+//
+//   - ChaosScenario (scenarios.go) is one cell of the matrix: a self-contained
+//     fault set derived from the profile. StandardChaosMatrix covers write
+//     conflicts, cache sync lag, flaky child creates, combined chaos, and
+//     expectations timeouts; AddScenario appends custom cells.
+//
+//   - FaultRegistry (registry.go) is the single source of truth for active
+//     faults. A FaultRule pairs a structured FaultMatch (ClientMatch,
+//     CacheMatch, ClockMatch, QueueMatch) with a FaultCondition (when to fire)
+//     and a FaultAction (what to do), validated against the match's injection
+//     domain at registration.
+//
+//   - Injection sites wrap the controller's dependencies and consult the
+//     registry: the REST transport (transport.go), informer caches
+//     (indexer.go, informers.go), the expectations clock (clock.go), and work
+//     queues (queue.go). The fixture (fixture.go) wires them together around an
+//     integration apiserver.
+//
+// Two guards keep a green run meaningful: every non-optional fault must have
+// matched a real injection site (AssertAllFaultsMatched), and every fault
+// declared ExpectTriggered must have actually fired
+// (AssertExpectedFaultsTriggered). A fault that silently injects nothing is a
+// test failure, not a pass.
+//
+// See test/integration/daemonset and test/integration/node for complete
+// examples (the DaemonSet controller and lease renewal).
+package robustness

--- a/test/utils/robustness/fixture.go
+++ b/test/utils/robustness/fixture.go
@@ -18,6 +18,7 @@ package robustness
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -74,6 +75,11 @@ type RobustnessTestFixture struct {
 }
 
 // NewFixture creates a new test fixture, initializes the APIServer, and starts continuous invariant checks.
+//
+// CONCURRENCY WARNING: This fixture mutates the global controller.ExpectationsClock
+// to inject faults. Tests using this fixture MUST NOT run in parallel with other
+// tests in the same process (do not use t.Parallel()), as this will cause
+// unpredictable clock skews and flakes in concurrent tests.
 func NewFixture(t *testing.T, testName string) *RobustnessTestFixture {
 	// Initialize API Server
 	apiCtx := testutils.InitTestAPIServer(t, testName, nil)
@@ -138,8 +144,8 @@ func (f *RobustnessTestFixture) WrapIndexer(realIndexer cache.Indexer, name stri
 	return NewFaultInjectingIndexer(realIndexer, f.registry, name)
 }
 
-// WrapQueue wraps a workqueue.RateLimitingInterface with our fault injection hook.
-func (f *RobustnessTestFixture) WrapQueue(realQueue workqueue.RateLimitingInterface, name string) workqueue.RateLimitingInterface {
+// WrapQueue wraps a workqueue.TypedRateLimitingInterface[any] with our fault injection hook.
+func (f *RobustnessTestFixture) WrapQueue(realQueue workqueue.TypedRateLimitingInterface[any], name string) workqueue.TypedRateLimitingInterface[any] {
 	return NewFaultInjectingWorkQueue(realQueue, f.registry, name)
 }
 
@@ -171,7 +177,7 @@ func (f *RobustnessTestFixture) AssertEventually(name string, fn Invariant, time
 		invErr := f.invariantErr
 		f.mu.RUnlock()
 		if invErr != nil {
-			return false, fmt.Errorf("aborted: continuous invariant was violated: %v", invErr)
+			return false, fmt.Errorf("aborted: continuous invariant was violated: %w", invErr)
 		}
 
 		if err := fn(ctx, f.AdminClientSet()); err != nil {
@@ -198,7 +204,6 @@ func (f *RobustnessTestFixture) AssertEventually(name string, fn Invariant, time
 // controllers that converge without writing should use AssertEventually instead.
 func (f *RobustnessTestFixture) WaitUntilSettled(quietWindow, timeout time.Duration) bool {
 	f.t.Helper()
-	startMutations := f.activity.mutations.Load()
 	deadline := time.Now().Add(timeout)
 	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
@@ -217,9 +222,9 @@ func (f *RobustnessTestFixture) WaitUntilSettled(quietWindow, timeout time.Durat
 			if invErr != nil {
 				return false
 			}
-			// Require that the controller has acted since we began waiting, then
-			// that it has been idle for the full quiet window.
-			if f.activity.mutations.Load() <= startMutations {
+			// Require that the controller has acted since the fixture started,
+			// then that it has been idle for the full quiet window.
+			if f.activity.mutations.Load() == 0 {
 				continue
 			}
 			idle := time.Since(time.Unix(0, f.activity.lastMutation.Load()))
@@ -307,6 +312,10 @@ func (f *RobustnessTestFixture) startContinuousInvariantMonitor(pollInterval tim
 				}
 
 				if err := f.checkContinuousInvariants(); err != nil {
+					// If the context was cancelled during the check (e.g. tear down), ignore the error
+					if errors.Is(err, context.Canceled) || f.ctx.Err() != nil {
+						return
+					}
 					f.mu.Lock()
 					f.invariantErr = err
 					f.mu.Unlock()
@@ -324,7 +333,7 @@ func (f *RobustnessTestFixture) checkContinuousInvariants() error {
 	defer f.mu.RUnlock()
 	for _, inv := range f.continuousInvariants {
 		if err := inv.Fn(f.ctx, f.AdminClientSet()); err != nil {
-			return fmt.Errorf("safety invariant %q failed: %v", inv.Name, err)
+			return fmt.Errorf("safety invariant %q failed: %w", inv.Name, err)
 		}
 	}
 	return nil

--- a/test/utils/robustness/fixture.go
+++ b/test/utils/robustness/fixture.go
@@ -1,0 +1,336 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package robustness
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/kubernetes/pkg/controller"
+	testutils "k8s.io/kubernetes/test/integration/util"
+)
+
+// ExpectationsClockName is the registry name of the wrapped ControllerExpectations
+// clock installed by NewFixture. Target it with ClockMatch{Clock: ExpectationsClockName}.
+const ExpectationsClockName = "expectations"
+
+// activityTracker records mutating API traffic seen by the wrapped transport. It
+// is the signal used to detect that the controller has settled: it issued at
+// least one write and then gone idle. All methods are safe on a nil receiver
+// (the transport may be constructed without a tracker, e.g. in unit tests).
+type activityTracker struct {
+	mutations    atomic.Int64 // count of mutating requests observed
+	lastMutation atomic.Int64 // UnixNano of the most recent mutating request
+}
+
+// recordMutation notes that a mutating request (POST/PUT/PATCH/DELETE) was issued.
+func (a *activityTracker) recordMutation() {
+	if a == nil {
+		return
+	}
+	a.lastMutation.Store(time.Now().UnixNano())
+	a.mutations.Add(1)
+}
+
+// RobustnessTestFixture coordinates the integration API server lifecycle,
+// wrapped clients/queues, fault injection registry, and safety invariant monitoring.
+type RobustnessTestFixture struct {
+	t          *testing.T
+	registry   *FaultRegistry
+	testCtx    *testutils.TestContext
+	cancelCtx  context.CancelFunc
+	ctx        context.Context
+	tearDownFn func()
+
+	activity *activityTracker
+
+	mu                   sync.RWMutex
+	continuousInvariants []NamedInvariant
+	invariantErr         error
+}
+
+// NewFixture creates a new test fixture, initializes the APIServer, and starts continuous invariant checks.
+func NewFixture(t *testing.T, testName string) *RobustnessTestFixture {
+	// Initialize API Server
+	apiCtx := testutils.InitTestAPIServer(t, testName, nil)
+
+	ctx, cancel := context.WithCancel(apiCtx.Ctx)
+
+	f := &RobustnessTestFixture{
+		t:         t,
+		registry:  NewFaultRegistry(),
+		testCtx:   apiCtx,
+		ctx:       ctx,
+		cancelCtx: cancel,
+		activity:  &activityTracker{},
+	}
+
+	// Inject our fault-injecting expectations clock globally for this test run!
+	originalClock := controller.ExpectationsClock
+	controller.ExpectationsClock = NewFaultInjectingClock(originalClock, f.registry, ExpectationsClockName)
+
+	f.tearDownFn = func() {
+		// Restore the original expectations clock to avoid side effects on other tests
+		controller.ExpectationsClock = originalClock
+		cancel()
+	}
+
+	f.startContinuousInvariantMonitor(50 * time.Millisecond)
+	return f
+}
+
+// Context returns the test execution context (cancelled if any safety invariant is violated).
+func (f *RobustnessTestFixture) Context() context.Context {
+	return f.ctx
+}
+
+// Registry returns the FaultRegistry for declaring fault rules.
+func (f *RobustnessTestFixture) Registry() *FaultRegistry {
+	return f.registry
+}
+
+// KubeConfig returns the REST client configuration, wrapped with the dynamic fault interceptor.
+func (f *RobustnessTestFixture) KubeConfig() *restclient.Config {
+	config := restclient.CopyConfig(f.testCtx.KubeConfig)
+	config.QPS = -1 // Disable throttling for rapid test loops
+	config.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		return NewFaultInjectingTransport(rt, f.registry, f.activity)
+	})
+	return config
+}
+
+// ClientSet returns a client-go Clientset that is wrapped with the fault injection transport.
+func (f *RobustnessTestFixture) ClientSet() clientset.Interface {
+	return clientset.NewForConfigOrDie(f.KubeConfig())
+}
+
+// AdminClientSet returns an un-wrapped, direct API clientset (for arranging test state and verifying results).
+func (f *RobustnessTestFixture) AdminClientSet() clientset.Interface {
+	return f.testCtx.ClientSet
+}
+
+// WrapIndexer wraps a cache.Indexer with our fault injection hook.
+func (f *RobustnessTestFixture) WrapIndexer(realIndexer cache.Indexer, name string) cache.Indexer {
+	return NewFaultInjectingIndexer(realIndexer, f.registry, name)
+}
+
+// WrapQueue wraps a workqueue.RateLimitingInterface with our fault injection hook.
+func (f *RobustnessTestFixture) WrapQueue(realQueue workqueue.RateLimitingInterface, name string) workqueue.RateLimitingInterface {
+	return NewFaultInjectingWorkQueue(realQueue, f.registry, name)
+}
+
+// InjectFault registers a new fault rule in the central registry. It validates
+// that the rule's action can actually be served at its injection point, failing
+// the test immediately on a mis-targeted fault (e.g. a clock fault attached to a
+// transport point) rather than letting it silently misbehave at runtime.
+func (f *RobustnessTestFixture) InjectFault(rule FaultRule) {
+	f.t.Helper()
+	if err := validateFaultDomain(rule); err != nil {
+		f.t.Fatalf("InjectFault(%q): %v", rule.Name, err)
+	}
+	f.registry.Register(rule)
+}
+
+// AddContinuousInvariant registers a safety condition checked repeatedly in the background.
+func (f *RobustnessTestFixture) AddContinuousInvariant(name string, fn Invariant) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.continuousInvariants = append(f.continuousInvariants, NamedInvariant{Name: name, Fn: fn})
+}
+
+// AssertEventually blocks until the given liveness invariant passes, or times out.
+func (f *RobustnessTestFixture) AssertEventually(name string, fn Invariant, timeout time.Duration) {
+	f.t.Helper()
+	err := wait.PollUntilContextTimeout(f.ctx, 100*time.Millisecond, timeout, true, func(ctx context.Context) (bool, error) {
+		// Check for background continuous invariant failures first
+		f.mu.RLock()
+		invErr := f.invariantErr
+		f.mu.RUnlock()
+		if invErr != nil {
+			return false, fmt.Errorf("aborted: continuous invariant was violated: %v", invErr)
+		}
+
+		if err := fn(ctx, f.AdminClientSet()); err != nil {
+			f.t.Logf("[Wait] Invariant %q not met yet: %v", name, err)
+			return false, nil
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		f.t.Fatalf("Liveness invariant %q failed to converge within %v: %v", name, timeout, err)
+	}
+}
+
+// WaitUntilSettled blocks until the controller-under-test has settled, defined as:
+// it issued at least one mutating request through the wrapped client and then went
+// idle (no further mutating requests) for quietWindow. Returns true once settled,
+// or false if the timeout or a background safety violation is hit first.
+//
+// This is a controller-agnostic proxy for "end of reconciliation" — it needs no
+// access to the controller's work queue, and it naturally waits out retry storms
+// under fault injection (each retried write resets the idle window). It assumes
+// the controller performs at least one write on its way to convergence;
+// controllers that converge without writing should use AssertEventually instead.
+func (f *RobustnessTestFixture) WaitUntilSettled(quietWindow, timeout time.Duration) bool {
+	f.t.Helper()
+	startMutations := f.activity.mutations.Load()
+	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-f.ctx.Done():
+			return false
+		case <-ticker.C:
+			if time.Now().After(deadline) {
+				return false
+			}
+			f.mu.RLock()
+			invErr := f.invariantErr
+			f.mu.RUnlock()
+			if invErr != nil {
+				return false
+			}
+			// Require that the controller has acted since we began waiting, then
+			// that it has been idle for the full quiet window.
+			if f.activity.mutations.Load() <= startMutations {
+				continue
+			}
+			idle := time.Since(time.Unix(0, f.activity.lastMutation.Load()))
+			if idle >= quietWindow {
+				return true
+			}
+		}
+	}
+}
+
+// AssertWhenSettled waits for the controller to settle (see WaitUntilSettled), then
+// evaluates the invariant exactly once. Unlike AssertEventually (which retries
+// until the condition holds), this checks the final, steady state deterministically
+// — the right semantics for "X holds at the end of reconciliation". It fails if
+// the controller does not settle in time or if the invariant does not hold once
+// settled.
+func (f *RobustnessTestFixture) AssertWhenSettled(name string, fn Invariant, quietWindow, timeout time.Duration) {
+	f.t.Helper()
+	if !f.WaitUntilSettled(quietWindow, timeout) {
+		f.mu.RLock()
+		invErr := f.invariantErr
+		f.mu.RUnlock()
+		if invErr != nil {
+			f.t.Fatalf("Settle wait for %q aborted: continuous invariant was violated: %v", name, invErr)
+		}
+		f.t.Fatalf("Controller did not settle (a %v write-idle window) within %v while waiting to check %q", quietWindow, timeout, name)
+	}
+	if err := fn(f.ctx, f.AdminClientSet()); err != nil {
+		f.t.Errorf("Invariant %q failed once settled: %v", name, err)
+	}
+}
+
+// AssertFaultHitCount verifies that an injected fault was triggered the expected number of times.
+func (f *RobustnessTestFixture) AssertFaultHitCount(ruleName string, expected int) {
+	actual := f.registry.GetHitCount(ruleName)
+	if actual != expected {
+		f.t.Errorf("Fault verification failed for %q: expected %d hits, got %d", ruleName, expected, actual)
+	}
+}
+
+// AssertAllFaultsMatched fails the test if any registered non-optional fault rule
+// was never exercised. An unmatched rule means its Match never lined up with a
+// real injection site, so it injected nothing and the scenario silently asserted
+// nothing. Mark a rule Optional to exempt it (e.g. feature-gated faults).
+func (f *RobustnessTestFixture) AssertAllFaultsMatched() {
+	f.t.Helper()
+	if unmatched := f.registry.UnmatchedRules(); len(unmatched) > 0 {
+		f.t.Errorf("fault rule(s) registered but never matched any injection site (injected nothing): %v", unmatched)
+	}
+}
+
+// AssertExpectedFaultsTriggered fails the test if any fault rule registered with
+// ExpectTriggered never actually fired. Matching proves a rule lined up with a
+// real injection site (see AssertAllFaultsMatched); this proves the declared
+// faults were also delivered, without per-rule hit-count boilerplate.
+func (f *RobustnessTestFixture) AssertExpectedFaultsTriggered() {
+	f.t.Helper()
+	if silent := f.registry.ExpectedRulesNotTriggered(); len(silent) > 0 {
+		f.t.Errorf("fault rule(s) declared ExpectTriggered but never fired: %v", silent)
+	}
+}
+
+// AssertFaultHitCountGreaterThan verifies that an injected fault was triggered at least once (or more).
+func (f *RobustnessTestFixture) AssertFaultHitCountGreaterThan(ruleName string, min int) {
+	actual := f.registry.GetHitCount(ruleName)
+	if actual <= min {
+		f.t.Errorf("Fault verification failed for %q: expected > %d hits, got %d", ruleName, min, actual)
+	}
+}
+
+func (f *RobustnessTestFixture) startContinuousInvariantMonitor(pollInterval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(pollInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-f.ctx.Done():
+				return
+			case <-ticker.C:
+				// Non-blocking check: if the context was cancelled during sleep, exit immediately to prevent races
+				select {
+				case <-f.ctx.Done():
+					return
+				default:
+				}
+
+				if err := f.checkContinuousInvariants(); err != nil {
+					f.mu.Lock()
+					f.invariantErr = err
+					f.mu.Unlock()
+					f.t.Errorf("[Invariant Safety Violation] %v", err)
+					f.cancelCtx() // Cancel context to abort test immediately
+					return
+				}
+			}
+		}
+	}()
+}
+
+func (f *RobustnessTestFixture) checkContinuousInvariants() error {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	for _, inv := range f.continuousInvariants {
+		if err := inv.Fn(f.ctx, f.AdminClientSet()); err != nil {
+			return fmt.Errorf("safety invariant %q failed: %v", inv.Name, err)
+		}
+	}
+	return nil
+}
+
+// TearDown cancels context and shuts down the in-memory API server.
+func (f *RobustnessTestFixture) TearDown() {
+	f.tearDownFn()
+}

--- a/test/utils/robustness/fixture.go
+++ b/test/utils/robustness/fixture.go
@@ -1,0 +1,342 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package robustness
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/kubernetes/pkg/controller"
+	testutils "k8s.io/kubernetes/test/integration/util"
+)
+
+// ExpectationsClockName is the registry name of the wrapped ControllerExpectations
+// clock installed by NewFixture. Target it with ClockMatch{Clock: ExpectationsClockName}.
+const ExpectationsClockName = "expectations"
+
+// activityTracker records mutating API traffic seen by the wrapped transport. It
+// is the signal used to detect that the controller has settled: it issued at
+// least one write and then gone idle. All methods are safe on a nil receiver
+// (the transport may be constructed without a tracker, e.g. in unit tests).
+type activityTracker struct {
+	mutations    atomic.Int64 // count of mutating requests observed
+	lastMutation atomic.Int64 // UnixNano of the most recent mutating request
+}
+
+// recordMutation notes that a mutating request (POST/PUT/PATCH/DELETE) was issued.
+func (a *activityTracker) recordMutation() {
+	if a == nil {
+		return
+	}
+	a.lastMutation.Store(time.Now().UnixNano())
+	a.mutations.Add(1)
+}
+
+// RobustnessTestFixture coordinates the integration API server lifecycle,
+// wrapped clients/queues, fault injection registry, and safety invariant monitoring.
+type RobustnessTestFixture struct {
+	t          *testing.T
+	registry   *FaultRegistry
+	testCtx    *testutils.TestContext
+	cancelCtx  context.CancelFunc
+	ctx        context.Context
+	tearDownFn func()
+
+	activity *activityTracker
+
+	mu                   sync.RWMutex
+	continuousInvariants []NamedInvariant
+	invariantErr         error
+}
+
+// NewFixture creates a new test fixture, initializes the APIServer, and starts continuous invariant checks.
+//
+// CONCURRENCY WARNING: This fixture mutates the global controller.ExpectationsClock
+// to inject faults. Tests using this fixture MUST NOT run in parallel with other
+// tests in the same process (do not use t.Parallel()), as this will cause
+// unpredictable clock skews and flakes in concurrent tests.
+func NewFixture(t *testing.T, testName string) *RobustnessTestFixture {
+	// Initialize API Server
+	apiCtx := testutils.InitTestAPIServer(t, testName, nil)
+
+	ctx, cancel := context.WithCancel(apiCtx.Ctx)
+
+	f := &RobustnessTestFixture{
+		t:         t,
+		registry:  NewFaultRegistry(),
+		testCtx:   apiCtx,
+		ctx:       ctx,
+		cancelCtx: cancel,
+		activity:  &activityTracker{},
+	}
+
+	// Inject our fault-injecting expectations clock globally for this test run!
+	originalClock := controller.ExpectationsClock
+	controller.ExpectationsClock = NewFaultInjectingClock(originalClock, f.registry, ExpectationsClockName)
+
+	f.tearDownFn = func() {
+		// Restore the original expectations clock to avoid side effects on other tests
+		controller.ExpectationsClock = originalClock
+		cancel()
+	}
+
+	f.startContinuousInvariantMonitor(50 * time.Millisecond)
+	return f
+}
+
+// Context returns the test execution context (cancelled if any safety invariant is violated).
+func (f *RobustnessTestFixture) Context() context.Context {
+	return f.ctx
+}
+
+// Registry returns the FaultRegistry for declaring fault rules.
+func (f *RobustnessTestFixture) Registry() *FaultRegistry {
+	return f.registry
+}
+
+// KubeConfig returns the REST client configuration, wrapped with the dynamic fault interceptor.
+func (f *RobustnessTestFixture) KubeConfig() *restclient.Config {
+	config := restclient.CopyConfig(f.testCtx.KubeConfig)
+	config.QPS = -1 // Disable throttling for rapid test loops
+	config.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		return NewFaultInjectingTransport(rt, f.registry, f.activity)
+	})
+	return config
+}
+
+// ClientSet returns a client-go Clientset that is wrapped with the fault injection transport.
+func (f *RobustnessTestFixture) ClientSet() clientset.Interface {
+	return clientset.NewForConfigOrDie(f.KubeConfig())
+}
+
+// AdminClientSet returns an un-wrapped, direct API clientset (for arranging test state and verifying results).
+func (f *RobustnessTestFixture) AdminClientSet() clientset.Interface {
+	return f.testCtx.ClientSet
+}
+
+// WrapIndexer wraps a cache.Indexer with our fault injection hook.
+func (f *RobustnessTestFixture) WrapIndexer(realIndexer cache.Indexer, name string) cache.Indexer {
+	return NewFaultInjectingIndexer(realIndexer, f.registry, name)
+}
+
+// WrapQueue wraps a workqueue.TypedRateLimitingInterface[any] with our fault injection hook.
+func (f *RobustnessTestFixture) WrapQueue(realQueue workqueue.TypedRateLimitingInterface[any], name string) workqueue.TypedRateLimitingInterface[any] {
+	return NewFaultInjectingWorkQueue(realQueue, f.registry, name)
+}
+
+// StartInformers starts the given InformerFactory and blocks until all informer caches have synced.
+func (f *RobustnessTestFixture) StartInformers(factory informers.SharedInformerFactory) {
+	f.t.Helper()
+	factory.Start(f.ctx.Done())
+	synced := factory.WaitForCacheSync(f.ctx.Done())
+	for typ, ok := range synced {
+		if !ok {
+			f.t.Fatalf("failed to sync cache for informer: %v", typ)
+		}
+	}
+}
+
+// InjectFault registers a new fault rule in the central registry. It validates
+// that the rule's action can actually be served at its injection point, failing
+// the test immediately on a mis-targeted fault (e.g. a clock fault attached to a
+// transport point) rather than letting it silently misbehave at runtime.
+func (f *RobustnessTestFixture) InjectFault(rule FaultRule) {
+	f.t.Helper()
+	if err := validateFaultDomain(rule); err != nil {
+		f.t.Fatalf("InjectFault(%q): %v", rule.Name, err)
+	}
+	f.registry.Register(rule)
+}
+
+// AddContinuousInvariant registers a safety condition checked repeatedly in the background.
+func (f *RobustnessTestFixture) AddContinuousInvariant(name string, fn Invariant) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.continuousInvariants = append(f.continuousInvariants, NamedInvariant{Name: name, Fn: fn})
+}
+
+// AssertEventually blocks until the given liveness invariant passes, or times out.
+func (f *RobustnessTestFixture) AssertEventually(name string, fn Invariant, timeout time.Duration) {
+	f.t.Helper()
+	err := wait.PollUntilContextTimeout(f.ctx, 100*time.Millisecond, timeout, true, func(ctx context.Context) (bool, error) {
+		// Check for background continuous invariant failures first
+		f.mu.RLock()
+		invErr := f.invariantErr
+		f.mu.RUnlock()
+		if invErr != nil {
+			return false, fmt.Errorf("aborted: continuous invariant was violated: %w", invErr)
+		}
+
+		if err := fn(ctx, f.AdminClientSet()); err != nil {
+			f.t.Logf("[Wait] Invariant %q not met yet: %v", name, err)
+			return false, nil
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		f.t.Fatalf("Liveness invariant %q failed to converge within %v: %v", name, timeout, err)
+	}
+}
+
+// WaitUntilSettled blocks until the controller-under-test has settled, defined as:
+// it issued at least one mutating request through the wrapped client and then went
+// idle (no further mutating requests) for quietWindow. Returns true once settled,
+// or false if the timeout or a background safety violation is hit first.
+//
+// This is a controller-agnostic proxy for "end of reconciliation" — it needs no
+// access to the controller's work queue, and it naturally waits out retry storms
+// under fault injection (each retried write resets the idle window). It assumes
+// the controller performs at least one write on its way to convergence;
+// controllers that converge without writing should use AssertEventually instead.
+func (f *RobustnessTestFixture) WaitUntilSettled(quietWindow, timeout time.Duration) bool {
+	f.t.Helper()
+	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-f.ctx.Done():
+			return false
+		case <-ticker.C:
+			if time.Now().After(deadline) {
+				return false
+			}
+			f.mu.RLock()
+			invErr := f.invariantErr
+			f.mu.RUnlock()
+			if invErr != nil {
+				return false
+			}
+			// Require that the controller has acted since the fixture started,
+			// then that it has been idle for the full quiet window.
+			if f.activity.mutations.Load() == 0 {
+				continue
+			}
+			idle := time.Since(time.Unix(0, f.activity.lastMutation.Load()))
+			if idle >= quietWindow {
+				return true
+			}
+		}
+	}
+}
+
+// AssertWhenSettled waits for the controller to settle (see WaitUntilSettled), then
+// evaluates the invariant exactly once. Unlike AssertEventually (which retries
+// until the condition holds), this checks the final, steady state deterministically
+// — the right semantics for "X holds at the end of reconciliation". It fails if
+// the controller does not settle in time or if the invariant does not hold once
+// settled.
+func (f *RobustnessTestFixture) AssertWhenSettled(name string, fn Invariant, quietWindow, timeout time.Duration) {
+	f.t.Helper()
+	if !f.WaitUntilSettled(quietWindow, timeout) {
+		f.mu.RLock()
+		invErr := f.invariantErr
+		f.mu.RUnlock()
+		if invErr != nil {
+			f.t.Fatalf("Settle wait for %q aborted: continuous invariant was violated: %v", name, invErr)
+		}
+		f.t.Fatalf("Controller did not settle (a %v write-idle window) within %v while waiting to check %q", quietWindow, timeout, name)
+	}
+	if err := fn(f.ctx, f.AdminClientSet()); err != nil {
+		f.t.Errorf("Invariant %q failed once settled: %v", name, err)
+	}
+}
+
+// AssertAllFaultsMatched fails the test if any registered non-optional fault rule
+// was never exercised. An unmatched rule means its Match never lined up with a
+// real injection site, so it injected nothing and the scenario silently asserted
+// nothing. Mark a rule Optional to exempt it (e.g. feature-gated faults).
+func (f *RobustnessTestFixture) AssertAllFaultsMatched() {
+	f.t.Helper()
+	if unmatched := f.registry.UnmatchedRules(); len(unmatched) > 0 {
+		f.t.Errorf("fault rule(s) registered but never matched any injection site (injected nothing): %v", unmatched)
+	}
+}
+
+// AssertExpectedFaultsTriggered fails the test if any fault rule registered with
+// ExpectTriggered never actually fired. Matching proves a rule lined up with a
+// real injection site (see AssertAllFaultsMatched); this proves the declared
+// faults were also delivered, without per-rule hit-count boilerplate.
+func (f *RobustnessTestFixture) AssertExpectedFaultsTriggered() {
+	f.t.Helper()
+	if silent := f.registry.ExpectedRulesNotTriggered(); len(silent) > 0 {
+		f.t.Errorf("fault rule(s) declared ExpectTriggered but never fired: %v", silent)
+	}
+}
+
+func (f *RobustnessTestFixture) startContinuousInvariantMonitor(pollInterval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(pollInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-f.ctx.Done():
+				return
+			case <-ticker.C:
+				// Non-blocking check: if the context was cancelled during sleep, exit immediately to prevent races
+				select {
+				case <-f.ctx.Done():
+					return
+				default:
+				}
+
+				if err := f.checkContinuousInvariants(); err != nil {
+					// If the context was cancelled during the check (e.g. tear down), ignore the error
+					if errors.Is(err, context.Canceled) || f.ctx.Err() != nil {
+						return
+					}
+					f.mu.Lock()
+					f.invariantErr = err
+					f.mu.Unlock()
+					f.t.Errorf("[Invariant Safety Violation] %v", err)
+					f.cancelCtx() // Cancel context to abort test immediately
+					return
+				}
+			}
+		}
+	}()
+}
+
+func (f *RobustnessTestFixture) checkContinuousInvariants() error {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	for _, inv := range f.continuousInvariants {
+		if err := inv.Fn(f.ctx, f.AdminClientSet()); err != nil {
+			return fmt.Errorf("safety invariant %q failed: %w", inv.Name, err)
+		}
+	}
+	return nil
+}
+
+// TearDown cancels context and shuts down the in-memory API server.
+func (f *RobustnessTestFixture) TearDown() {
+	f.tearDownFn()
+}

--- a/test/utils/robustness/indexer.go
+++ b/test/utils/robustness/indexer.go
@@ -1,0 +1,125 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package robustness
+
+import (
+	"context"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+// Cache faults. Each implements CacheFault and is valid only at cache.* points.
+
+// StaleRead simulates cache sync lag: the lookup behaves as if the object is not
+// present yet (GetByKey -> missing, List/ByIndex -> empty, last-synced RV -> "1").
+type StaleRead struct{}
+
+func (StaleRead) ApplyCache() CacheVerdict { return CacheVerdict{Kind: CacheStaleRead} }
+
+// StaleObject returns a specific, out-of-date object from the cache.
+type StaleObject struct {
+	Obj interface{}
+}
+
+func (s StaleObject) ApplyCache() CacheVerdict {
+	return CacheVerdict{Kind: CacheStaleObject, Object: s.Obj}
+}
+
+// CacheError makes a cache lookup return an error (where the operation can).
+type CacheError struct {
+	Err error
+}
+
+func (e CacheError) ApplyCache() CacheVerdict {
+	return CacheVerdict{Kind: CacheReturnError, Err: e.Err}
+}
+
+// StaleRV makes LastStoreSyncResourceVersion report a specific (stale) version.
+type StaleRV struct {
+	RV string
+}
+
+func (s StaleRV) ApplyCache() CacheVerdict {
+	return CacheVerdict{Kind: CacheStaleRV, RV: s.RV}
+}
+
+// FaultInjectingIndexer wraps cache.Indexer and intercepts local cache lookups.
+type FaultInjectingIndexer struct {
+	cache.Indexer
+	registry *FaultRegistry
+	name     string // Optional cache identifier (e.g. "pod-informer")
+}
+
+// NewFaultInjectingIndexer creates a wrapped cache.Indexer hooked to the registry.
+func NewFaultInjectingIndexer(realIndexer cache.Indexer, registry *FaultRegistry, name string) cache.Indexer {
+	return &FaultInjectingIndexer{
+		Indexer:  realIndexer,
+		registry: registry,
+		name:     name,
+	}
+}
+
+func (i *FaultInjectingIndexer) GetByKey(key string) (interface{}, bool, error) {
+	v := i.registry.ResolveCache(context.Background(), CacheFacts{Cache: i.name, Op: "get", Key: key})
+	switch v.Kind {
+	case CacheStaleRead:
+		return nil, false, nil // simulate sync lag: object appears missing
+	case CacheStaleObject:
+		return v.Object, true, nil
+	case CacheReturnError:
+		return nil, false, v.Err
+	}
+	return i.Indexer.GetByKey(key)
+}
+
+func (i *FaultInjectingIndexer) Get(obj interface{}) (interface{}, bool, error) {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return nil, false, err
+	}
+	return i.GetByKey(key)
+}
+
+func (i *FaultInjectingIndexer) List() []interface{} {
+	v := i.registry.ResolveCache(context.Background(), CacheFacts{Cache: i.name, Op: "list"})
+	if v.Kind == CacheStaleRead {
+		return nil // empty list simulates stale cache lag
+	}
+	return i.Indexer.List()
+}
+
+func (i *FaultInjectingIndexer) ByIndex(indexName, indexedValue string) ([]interface{}, error) {
+	v := i.registry.ResolveCache(context.Background(), CacheFacts{Cache: i.name, Op: "by-index", Key: indexName + "/" + indexedValue})
+	switch v.Kind {
+	case CacheStaleRead:
+		return nil, nil // empty result simulates a stale index
+	case CacheReturnError:
+		return nil, v.Err
+	}
+	return i.Indexer.ByIndex(indexName, indexedValue)
+}
+
+func (i *FaultInjectingIndexer) LastStoreSyncResourceVersion() string {
+	v := i.registry.ResolveCache(context.Background(), CacheFacts{Cache: i.name, Op: "last-sync-rv"})
+	switch v.Kind {
+	case CacheStaleRV:
+		return v.RV
+	case CacheStaleRead:
+		return "1" // a valid but very old resource version
+	}
+	return i.Indexer.LastStoreSyncResourceVersion()
+}

--- a/test/utils/robustness/indexer.go
+++ b/test/utils/robustness/indexer.go
@@ -1,0 +1,87 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package robustness
+
+import (
+	"context"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+// Cache faults. Each implements CacheFault and is valid only at cache.* points.
+
+// StaleRead simulates cache sync lag: the lookup behaves as if the object is not
+// present yet (GetByKey -> missing, List/ByIndex -> empty, last-synced RV -> "1").
+type StaleRead struct{}
+
+func (StaleRead) ApplyCache() CacheVerdict { return CacheVerdict{Kind: CacheStaleRead} }
+
+// FaultInjectingIndexer wraps cache.Indexer and intercepts local cache lookups.
+type FaultInjectingIndexer struct {
+	cache.Indexer
+	registry *FaultRegistry
+	name     string // Optional cache identifier (e.g. "pod-informer")
+}
+
+// NewFaultInjectingIndexer creates a wrapped cache.Indexer hooked to the registry.
+func NewFaultInjectingIndexer(realIndexer cache.Indexer, registry *FaultRegistry, name string) cache.Indexer {
+	return &FaultInjectingIndexer{
+		Indexer:  realIndexer,
+		registry: registry,
+		name:     name,
+	}
+}
+
+func (i *FaultInjectingIndexer) GetByKey(key string) (interface{}, bool, error) {
+	v := i.registry.ResolveCache(context.Background(), CacheFacts{Cache: i.name, Op: "get", Key: key})
+	if v.Kind == CacheStaleRead {
+		return nil, false, nil // simulate sync lag: object appears missing
+	}
+	return i.Indexer.GetByKey(key)
+}
+
+func (i *FaultInjectingIndexer) Get(obj interface{}) (interface{}, bool, error) {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return nil, false, err
+	}
+	return i.GetByKey(key)
+}
+
+func (i *FaultInjectingIndexer) List() []interface{} {
+	v := i.registry.ResolveCache(context.Background(), CacheFacts{Cache: i.name, Op: "list"})
+	if v.Kind == CacheStaleRead {
+		return nil // empty list simulates stale cache lag
+	}
+	return i.Indexer.List()
+}
+
+func (i *FaultInjectingIndexer) ByIndex(indexName, indexedValue string) ([]interface{}, error) {
+	v := i.registry.ResolveCache(context.Background(), CacheFacts{Cache: i.name, Op: "by-index", Key: indexName + "/" + indexedValue})
+	if v.Kind == CacheStaleRead {
+		return nil, nil // empty result simulates a stale index
+	}
+	return i.Indexer.ByIndex(indexName, indexedValue)
+}
+
+func (i *FaultInjectingIndexer) LastStoreSyncResourceVersion() string {
+	v := i.registry.ResolveCache(context.Background(), CacheFacts{Cache: i.name, Op: "last-sync-rv"})
+	if v.Kind == CacheStaleRead {
+		return "1" // a valid but very old resource version
+	}
+	return i.Indexer.LastStoreSyncResourceVersion()
+}

--- a/test/utils/robustness/informers.go
+++ b/test/utils/robustness/informers.go
@@ -1,0 +1,131 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package robustness
+
+import (
+	"sync"
+
+	appsv1informers "k8s.io/client-go/informers/apps/v1"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	appsv1listers "k8s.io/client-go/listers/apps/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// wrappedSharedIndexInformer overrides GetIndexer() and GetStore() to return our wrapped indexer.
+type wrappedSharedIndexInformer struct {
+	cache.SharedIndexInformer
+	fixture *RobustnessTestFixture
+	name    string
+
+	mu             sync.Mutex
+	wrappedIndexer cache.Indexer
+}
+
+func (w *wrappedSharedIndexInformer) GetIndexer() cache.Indexer {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.wrappedIndexer == nil {
+		w.wrappedIndexer = w.fixture.WrapIndexer(w.SharedIndexInformer.GetIndexer(), w.name)
+	}
+	return w.wrappedIndexer
+}
+
+func (w *wrappedSharedIndexInformer) GetStore() cache.Store {
+	return w.GetIndexer()
+}
+
+// WrapPodInformer decorates a standard PodInformer to automatically use our fault-injecting indexer cache.
+func (f *RobustnessTestFixture) WrapPodInformer(realInformer coreinformers.PodInformer) coreinformers.PodInformer {
+	return &wrappedPodInformer{
+		PodInformer: realInformer,
+		inf: &wrappedSharedIndexInformer{
+			SharedIndexInformer: realInformer.Informer(),
+			fixture:             f,
+			name:                "pod-cache",
+		},
+		fixture: f,
+	}
+}
+
+type wrappedPodInformer struct {
+	coreinformers.PodInformer
+	inf     cache.SharedIndexInformer
+	fixture *RobustnessTestFixture
+}
+
+func (w *wrappedPodInformer) Informer() cache.SharedIndexInformer {
+	return w.inf
+}
+
+func (w *wrappedPodInformer) Lister() corelisters.PodLister {
+	return corelisters.NewPodLister(w.inf.GetIndexer())
+}
+
+// WrapNodeInformer decorates a standard NodeInformer to automatically use our fault-injecting indexer cache.
+func (f *RobustnessTestFixture) WrapNodeInformer(realInformer coreinformers.NodeInformer) coreinformers.NodeInformer {
+	return &wrappedNodeInformer{
+		NodeInformer: realInformer,
+		inf: &wrappedSharedIndexInformer{
+			SharedIndexInformer: realInformer.Informer(),
+			fixture:             f,
+			name:                "node-cache",
+		},
+		fixture: f,
+	}
+}
+
+type wrappedNodeInformer struct {
+	coreinformers.NodeInformer
+	inf     cache.SharedIndexInformer
+	fixture *RobustnessTestFixture
+}
+
+func (w *wrappedNodeInformer) Informer() cache.SharedIndexInformer {
+	return w.inf
+}
+
+func (w *wrappedNodeInformer) Lister() corelisters.NodeLister {
+	return corelisters.NewNodeLister(w.inf.GetIndexer())
+}
+
+// WrapDaemonSetInformer decorates a standard DaemonSetInformer to automatically use our fault-injecting indexer cache.
+func (f *RobustnessTestFixture) WrapDaemonSetInformer(realInformer appsv1informers.DaemonSetInformer) appsv1informers.DaemonSetInformer {
+	return &wrappedDSInformer{
+		DaemonSetInformer: realInformer,
+		inf: &wrappedSharedIndexInformer{
+			SharedIndexInformer: realInformer.Informer(),
+			fixture:             f,
+			name:                "daemonset-cache",
+		},
+		fixture: f,
+	}
+}
+
+type wrappedDSInformer struct {
+	appsv1informers.DaemonSetInformer
+	inf     cache.SharedIndexInformer
+	fixture *RobustnessTestFixture
+}
+
+func (w *wrappedDSInformer) Informer() cache.SharedIndexInformer {
+	return w.inf
+}
+
+func (w *wrappedDSInformer) Lister() appsv1listers.DaemonSetLister {
+	return appsv1listers.NewDaemonSetLister(w.inf.GetIndexer())
+}

--- a/test/utils/robustness/informers.go
+++ b/test/utils/robustness/informers.go
@@ -1,0 +1,122 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package robustness
+
+import (
+	"sync"
+
+	appsv1informers "k8s.io/client-go/informers/apps/v1"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	appsv1listers "k8s.io/client-go/listers/apps/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// wrappedSharedIndexInformer overrides GetIndexer() and GetStore() to return our wrapped indexer.
+type wrappedSharedIndexInformer struct {
+	cache.SharedIndexInformer
+	fixture *RobustnessTestFixture
+	name    string
+
+	mu             sync.Mutex
+	wrappedIndexer cache.Indexer
+}
+
+func (w *wrappedSharedIndexInformer) GetIndexer() cache.Indexer {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.wrappedIndexer == nil {
+		w.wrappedIndexer = w.fixture.WrapIndexer(w.SharedIndexInformer.GetIndexer(), w.name)
+	}
+	return w.wrappedIndexer
+}
+
+func (w *wrappedSharedIndexInformer) GetStore() cache.Store {
+	return w.GetIndexer()
+}
+
+// WrapSharedIndexInformer decorates any cache.SharedIndexInformer to route its indexer lookups through the fault registry.
+func (f *RobustnessTestFixture) WrapSharedIndexInformer(realInformer cache.SharedIndexInformer, name string) cache.SharedIndexInformer {
+	return &wrappedSharedIndexInformer{
+		SharedIndexInformer: realInformer,
+		fixture:             f,
+		name:                name,
+	}
+}
+
+// WrapPodInformer decorates a standard PodInformer to automatically use our fault-injecting indexer cache.
+func (f *RobustnessTestFixture) WrapPodInformer(realInformer coreinformers.PodInformer) coreinformers.PodInformer {
+	return &wrappedPodInformer{
+		PodInformer: realInformer,
+		inf:         f.WrapSharedIndexInformer(realInformer.Informer(), "pods"),
+	}
+}
+
+type wrappedPodInformer struct {
+	coreinformers.PodInformer
+	inf cache.SharedIndexInformer
+}
+
+func (w *wrappedPodInformer) Informer() cache.SharedIndexInformer {
+	return w.inf
+}
+
+func (w *wrappedPodInformer) Lister() corelisters.PodLister {
+	return corelisters.NewPodLister(w.inf.GetIndexer())
+}
+
+// WrapNodeInformer decorates a standard NodeInformer to automatically use our fault-injecting indexer cache.
+func (f *RobustnessTestFixture) WrapNodeInformer(realInformer coreinformers.NodeInformer) coreinformers.NodeInformer {
+	return &wrappedNodeInformer{
+		NodeInformer: realInformer,
+		inf:          f.WrapSharedIndexInformer(realInformer.Informer(), "nodes"),
+	}
+}
+
+type wrappedNodeInformer struct {
+	coreinformers.NodeInformer
+	inf cache.SharedIndexInformer
+}
+
+func (w *wrappedNodeInformer) Informer() cache.SharedIndexInformer {
+	return w.inf
+}
+
+func (w *wrappedNodeInformer) Lister() corelisters.NodeLister {
+	return corelisters.NewNodeLister(w.inf.GetIndexer())
+}
+
+// WrapDaemonSetInformer decorates a standard DaemonSetInformer to automatically use our fault-injecting indexer cache.
+func (f *RobustnessTestFixture) WrapDaemonSetInformer(realInformer appsv1informers.DaemonSetInformer) appsv1informers.DaemonSetInformer {
+	return &wrappedDSInformer{
+		DaemonSetInformer: realInformer,
+		inf:               f.WrapSharedIndexInformer(realInformer.Informer(), "daemonsets"),
+	}
+}
+
+type wrappedDSInformer struct {
+	appsv1informers.DaemonSetInformer
+	inf cache.SharedIndexInformer
+}
+
+func (w *wrappedDSInformer) Informer() cache.SharedIndexInformer {
+	return w.inf
+}
+
+func (w *wrappedDSInformer) Lister() appsv1listers.DaemonSetLister {
+	return appsv1listers.NewDaemonSetLister(w.inf.GetIndexer())
+}

--- a/test/utils/robustness/invariants.go
+++ b/test/utils/robustness/invariants.go
@@ -1,0 +1,78 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package robustness
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+// Invariant defines a predicate that must hold true under evaluation. It is
+// always evaluated against the un-wrapped admin client, so fault injection
+// never distorts what the invariant observes.
+type Invariant func(ctx context.Context, c clientset.Interface) error
+
+// NamedInvariant pairs an invariant with a human-readable name for reporting.
+type NamedInvariant struct {
+	Name string
+	Fn   Invariant
+}
+
+// ObjectSatisfies builds an Invariant from a typed getter and a check on the
+// fetched object, separating "how to fetch" from "what must hold":
+//
+//	robustness.ObjectSatisfies(
+//	    func(ctx context.Context, c clientset.Interface) (*appsv1.DaemonSet, error) {
+//	        return c.AppsV1().DaemonSets("default").Get(ctx, "ds-1", metav1.GetOptions{})
+//	    },
+//	    func(ds *appsv1.DaemonSet) error {
+//	        if ds.Status.CurrentNumberScheduled != 1 {
+//	            return fmt.Errorf("want 1 scheduled, got %d", ds.Status.CurrentNumberScheduled)
+//	        }
+//	        return nil
+//	    })
+func ObjectSatisfies[T any](get func(ctx context.Context, c clientset.Interface) (T, error), check func(obj T) error) Invariant {
+	return func(ctx context.Context, c clientset.Interface) error {
+		obj, err := get(ctx, c)
+		if err != nil {
+			return err
+		}
+		return check(obj)
+	}
+}
+
+// CountAtMost builds a safety Invariant enforcing an upper bound on an object
+// count (e.g. "never more than one Pod per node"). NotFound from the counter is
+// treated as zero, since an absent collection cannot violate an upper bound.
+func CountAtMost(limit int, what string, count func(ctx context.Context, c clientset.Interface) (int, error)) Invariant {
+	return func(ctx context.Context, c clientset.Interface) error {
+		n, err := count(ctx, c)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		if n > limit {
+			return fmt.Errorf("safety violation: detected %d %s objects, maximum allowed is %d", n, what, limit)
+		}
+		return nil
+	}
+}

--- a/test/utils/robustness/invariants.go
+++ b/test/utils/robustness/invariants.go
@@ -1,0 +1,91 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package robustness
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+// Invariant defines a predicate that must hold true under evaluation. It is
+// always evaluated against the un-wrapped admin client, so fault injection
+// never distorts what the invariant observes.
+type Invariant func(ctx context.Context, c clientset.Interface) error
+
+// NamedInvariant pairs an invariant with a human-readable name for reporting.
+type NamedInvariant struct {
+	Name string
+	Fn   Invariant
+}
+
+// ObjectSatisfies builds an Invariant from a typed getter and a check on the
+// fetched object, separating "how to fetch" from "what must hold":
+//
+//	robustness.ObjectSatisfies(
+//	    func(ctx context.Context, c clientset.Interface) (*appsv1.DaemonSet, error) {
+//	        return c.AppsV1().DaemonSets("default").Get(ctx, "ds-1", metav1.GetOptions{})
+//	    },
+//	    func(ds *appsv1.DaemonSet) error {
+//	        if ds.Status.CurrentNumberScheduled != 1 {
+//	            return fmt.Errorf("want 1 scheduled, got %d", ds.Status.CurrentNumberScheduled)
+//	        }
+//	        return nil
+//	    })
+func ObjectSatisfies[T any](get func(ctx context.Context, c clientset.Interface) (T, error), check func(obj T) error) Invariant {
+	return func(ctx context.Context, c clientset.Interface) error {
+		obj, err := get(ctx, c)
+		if err != nil {
+			return err
+		}
+		return check(obj)
+	}
+}
+
+// CountAtMost builds a safety Invariant enforcing an upper bound on an object
+// count (e.g. "never more than one Pod per node"). NotFound from the counter is
+// treated as zero, since an absent collection cannot violate an upper bound.
+func CountAtMost(limit int, what string, count func(ctx context.Context, c clientset.Interface) (int, error)) Invariant {
+	return func(ctx context.Context, c clientset.Interface) error {
+		n, err := count(ctx, c)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		if n > limit {
+			return fmt.Errorf("safety violation: detected %d %s objects, maximum allowed is %d", n, what, limit)
+		}
+		return nil
+	}
+}
+
+// AllOf combines multiple invariants into a single Invariant that succeeds
+// only if all constituent invariants pass.
+func AllOf(invariants ...Invariant) Invariant {
+	return func(ctx context.Context, c clientset.Interface) error {
+		for _, inv := range invariants {
+			if err := inv(ctx, c); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}

--- a/test/utils/robustness/profile.go
+++ b/test/utils/robustness/profile.go
@@ -1,0 +1,132 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package robustness
+
+import "fmt"
+
+// ResourceRef identifies an API resource — and optionally a single instance of it
+// — the way the apiserver's RequestInfo reports it: by API group and plural
+// resource name. Namespace and Name narrow the reference to one object; left
+// empty they match any instance.
+type ResourceRef struct {
+	Group     string // API group, e.g. "apps" ("" for the core group)
+	Resource  string // plural resource name, e.g. "daemonsets"
+	Namespace string // optional; "" matches any namespace
+	Name      string // optional; "" matches any instance
+}
+
+// ChildResource describes the dependent resource a controller manages on behalf
+// of its root object (e.g. the Pods a DaemonSet controller creates).
+type ChildResource struct {
+	Group    string // API group of the child ("" for the core group)
+	Resource string // plural resource name, e.g. "pods"
+
+	// CacheName is the name under which the child's informer cache is wrapped
+	// (see RobustnessTestFixture.WrapIndexer and the informer helpers). Leave it
+	// empty if the cache is not wrapped; cache-lag scenarios are then skipped.
+	CacheName string
+
+	// CreatedByController is true when the controller POSTs child objects itself
+	// through the wrapped client, enabling write-failure faults on the
+	// child-create path.
+	CreatedByController bool
+}
+
+// ControllerProfile declares what the controller-under-test does through the
+// wrapped client. Scenarios consult the profile to inject faults only at sites
+// the controller actually exercises; combined with the unmatched-fault guard
+// (AssertAllFaultsMatched) this keeps the chaos matrix honest for any
+// controller: a fault is either injected where it can really land, or not
+// registered at all — never a silent no-op.
+//
+// The declarations are promises: if the profile says WritesRootStatus, the
+// matrix will require the corresponding conflict fault to actually fire.
+type ControllerProfile struct {
+	// Name identifies the controller in logs.
+	Name string
+
+	// Root is the object whose reconciliation is under test.
+	Root ResourceRef
+
+	// WritesRoot is true when the controller PUTs the root object itself.
+	WritesRoot bool
+
+	// WritesRootStatus is true when the controller PUTs the root object's
+	// /status subresource.
+	WritesRootStatus bool
+
+	// Child, if non-nil, is the dependent resource the controller manages.
+	Child *ChildResource
+
+	// UsesExpectations is true when the controller tracks in-flight creates and
+	// deletes with ControllerExpectations, enabling expectations-timeout faults
+	// on the wrapped expectations clock.
+	UsesExpectations bool
+}
+
+func (p ControllerProfile) validate() error {
+	if p.Root.Resource == "" {
+		return fmt.Errorf("ControllerProfile.Root.Resource must be set to the plural resource name (e.g. %q)", "daemonsets")
+	}
+	if p.Child != nil && p.Child.Resource == "" {
+		return fmt.Errorf("ControllerProfile.Child.Resource must be set to the plural resource name (e.g. %q)", "pods")
+	}
+	return nil
+}
+
+// HasChildCache reports whether the controller has a child resource with a
+// wrapped informer cache, i.e. whether cache faults can target it.
+func (p ControllerProfile) HasChildCache() bool {
+	return p.Child != nil && p.Child.CacheName != ""
+}
+
+// CreatesChildren reports whether the controller creates child objects itself.
+func (p ControllerProfile) CreatesChildren() bool {
+	return p.Child != nil && p.Child.CreatedByController
+}
+
+// RootWriteMatch selects the controller's PUTs of the root object itself
+// (Subresource is exact-matched, so this never bleeds into /status).
+func (p ControllerProfile) RootWriteMatch() ClientMatch {
+	return ClientMatch{
+		Verb:      "PUT",
+		Group:     p.Root.Group,
+		Resource:  p.Root.Resource,
+		Namespace: p.Root.Namespace,
+		Name:      p.Root.Name,
+	}
+}
+
+// RootStatusWriteMatch selects the controller's PUTs of the root object's
+// /status subresource.
+func (p ControllerProfile) RootStatusWriteMatch() ClientMatch {
+	m := p.RootWriteMatch()
+	m.Subresource = "status"
+	return m
+}
+
+// ChildCreateMatch selects the controller's POSTs of child objects. Child must
+// be set (see CreatesChildren).
+func (p ControllerProfile) ChildCreateMatch() ClientMatch {
+	return ClientMatch{Verb: "POST", Group: p.Child.Group, Resource: p.Child.Resource}
+}
+
+// ChildCacheMatch selects lookups in the child's wrapped informer cache. Child
+// must be set with a CacheName (see HasChildCache).
+func (p ControllerProfile) ChildCacheMatch() CacheMatch {
+	return CacheMatch{Cache: p.Child.CacheName}
+}

--- a/test/utils/robustness/profile.go
+++ b/test/utils/robustness/profile.go
@@ -1,0 +1,138 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package robustness
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ResourceRef identifies an API resource — and optionally a single instance of it
+// — the way the apiserver's RequestInfo reports it: by API group and plural
+// resource name. Namespace and Name narrow the reference to one object; left
+// empty they match any instance.
+type ResourceRef struct {
+	Group     string // API group, e.g. "apps" ("" for the core group)
+	Resource  string // plural resource name, e.g. "daemonsets"
+	Namespace string // optional; "" matches any namespace
+	Name      string // optional; "" matches any instance
+}
+
+// ChildResource describes the dependent resource a controller manages on behalf
+// of its root object (e.g. the Pods a DaemonSet controller creates).
+type ChildResource struct {
+	Group    string // API group of the child ("" for the core group)
+	Resource string // plural resource name, e.g. "pods"
+
+	// CreatedByController is true when the controller POSTs child objects itself
+	// through the wrapped client, enabling write-failure faults on the
+	// child-create path.
+	CreatedByController bool
+}
+
+// ControllerProfile declares what the controller-under-test does through the
+// wrapped client. Scenarios consult the profile to inject faults only at sites
+// the controller actually exercises; combined with the unmatched-fault guard
+// (AssertAllFaultsMatched) this keeps the chaos matrix honest for any
+// controller: a fault is either injected where it can really land, or not
+// registered at all — never a silent no-op.
+//
+// The declarations are promises: if the profile says WritesRootStatus, the
+// matrix will require the corresponding conflict fault to actually fire.
+type ControllerProfile struct {
+	// Name identifies the controller in logs.
+	Name string
+
+	// Root is the object whose reconciliation is under test.
+	Root ResourceRef
+
+	// WritesRoot is true when the controller PUTs the root object itself.
+	WritesRoot bool
+
+	// WritesRootStatus is true when the controller PUTs the root object's
+	// /status subresource.
+	WritesRootStatus bool
+
+	// Child, if non-nil, is the dependent resource the controller manages.
+	Child *ChildResource
+
+	// UsesExpectations is true when the controller tracks in-flight creates and
+	// deletes with ControllerExpectations, enabling expectations-timeout faults
+	// on the wrapped expectations clock.
+	UsesExpectations bool
+}
+
+func (p ControllerProfile) validate() error {
+	if p.Root.Resource == "" {
+		return fmt.Errorf("ControllerProfile.Root.Resource must be set to the plural resource name (e.g. %q)", "daemonsets")
+	}
+	if strings.Contains(p.Root.Group, "/") {
+		return fmt.Errorf("ControllerProfile.Root.Group must be the API group without version (e.g. %q, not %q)", strings.Split(p.Root.Group, "/")[0], p.Root.Group)
+	}
+	if p.Child != nil {
+		if p.Child.Resource == "" {
+			return fmt.Errorf("ControllerProfile.Child.Resource must be set to the plural resource name (e.g. %q)", "pods")
+		}
+		if strings.Contains(p.Child.Group, "/") {
+			return fmt.Errorf("ControllerProfile.Child.Group must be the API group without version (e.g. %q, not %q)", strings.Split(p.Child.Group, "/")[0], p.Child.Group)
+		}
+	}
+	return nil
+}
+
+// HasChildCache reports whether the controller has a child resource with a
+// wrapped informer cache, i.e. whether cache faults can target it.
+func (p ControllerProfile) HasChildCache() bool {
+	return p.Child != nil && p.Child.Resource != ""
+}
+
+// CreatesChildren reports whether the controller creates child objects itself.
+func (p ControllerProfile) CreatesChildren() bool {
+	return p.Child != nil && p.Child.CreatedByController
+}
+
+// RootWriteMatch selects the controller's PUTs of the root object itself
+// (Subresource is exact-matched, so this never bleeds into /status).
+func (p ControllerProfile) RootWriteMatch() ClientMatch {
+	return ClientMatch{
+		Verb:      "PUT",
+		Group:     p.Root.Group,
+		Resource:  p.Root.Resource,
+		Namespace: p.Root.Namespace,
+		Name:      p.Root.Name,
+	}
+}
+
+// RootStatusWriteMatch selects the controller's PUTs of the root object's
+// /status subresource.
+func (p ControllerProfile) RootStatusWriteMatch() ClientMatch {
+	m := p.RootWriteMatch()
+	m.Subresource = "status"
+	return m
+}
+
+// ChildCreateMatch selects the controller's POSTs of child objects. Child must
+// be set (see CreatesChildren).
+func (p ControllerProfile) ChildCreateMatch() ClientMatch {
+	return ClientMatch{Verb: "POST", Group: p.Child.Group, Resource: p.Child.Resource}
+}
+
+// ChildCacheMatch selects lookups in the child's wrapped informer cache. Child
+// must be set (see HasChildCache).
+func (p ControllerProfile) ChildCacheMatch() CacheMatch {
+	return CacheMatch{Cache: p.Child.Resource}
+}

--- a/test/utils/robustness/queue.go
+++ b/test/utils/robustness/queue.go
@@ -22,29 +22,29 @@ import (
 	"k8s.io/client-go/util/workqueue"
 )
 
-// FaultInjectingWorkQueue wraps workqueue.RateLimitingInterface to control reconciler trigger events.
+// FaultInjectingWorkQueue wraps workqueue.TypedRateLimitingInterface[any] to control reconciler trigger events.
 type FaultInjectingWorkQueue struct {
-	workqueue.RateLimitingInterface
+	workqueue.TypedRateLimitingInterface[any]
 	registry *FaultRegistry
 	name     string
 }
 
-// NewFaultInjectingWorkQueue creates a wrapped RateLimitingInterface.
-func NewFaultInjectingWorkQueue(realQueue workqueue.RateLimitingInterface, registry *FaultRegistry, name string) workqueue.RateLimitingInterface {
+// NewFaultInjectingWorkQueue creates a wrapped TypedRateLimitingInterface[any].
+func NewFaultInjectingWorkQueue(realQueue workqueue.TypedRateLimitingInterface[any], registry *FaultRegistry, name string) workqueue.TypedRateLimitingInterface[any] {
 	return &FaultInjectingWorkQueue{
-		RateLimitingInterface: realQueue,
-		registry:              registry,
-		name:                  name,
+		TypedRateLimitingInterface: realQueue,
+		registry:                   registry,
+		name:                       name,
 	}
 }
 
 func (q *FaultInjectingWorkQueue) Get() (item interface{}, shutdown bool) {
 	// Runs any blocking faults registered on this queue's get operation.
 	q.registry.ResolveQueue(context.Background(), QueueFacts{Queue: q.name, Op: "get"})
-	return q.RateLimitingInterface.Get()
+	return q.TypedRateLimitingInterface.Get()
 }
 
 func (q *FaultInjectingWorkQueue) Add(item interface{}) {
 	q.registry.ResolveQueue(context.Background(), QueueFacts{Queue: q.name, Op: "add"})
-	q.RateLimitingInterface.Add(item)
+	q.TypedRateLimitingInterface.Add(item)
 }

--- a/test/utils/robustness/queue.go
+++ b/test/utils/robustness/queue.go
@@ -1,0 +1,50 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package robustness
+
+import (
+	"context"
+
+	"k8s.io/client-go/util/workqueue"
+)
+
+// FaultInjectingWorkQueue wraps workqueue.RateLimitingInterface to control reconciler trigger events.
+type FaultInjectingWorkQueue struct {
+	workqueue.RateLimitingInterface
+	registry *FaultRegistry
+	name     string
+}
+
+// NewFaultInjectingWorkQueue creates a wrapped RateLimitingInterface.
+func NewFaultInjectingWorkQueue(realQueue workqueue.RateLimitingInterface, registry *FaultRegistry, name string) workqueue.RateLimitingInterface {
+	return &FaultInjectingWorkQueue{
+		RateLimitingInterface: realQueue,
+		registry:              registry,
+		name:                  name,
+	}
+}
+
+func (q *FaultInjectingWorkQueue) Get() (item interface{}, shutdown bool) {
+	// Runs any blocking faults registered on this queue's get operation.
+	q.registry.ResolveQueue(context.Background(), QueueFacts{Queue: q.name, Op: "get"})
+	return q.RateLimitingInterface.Get()
+}
+
+func (q *FaultInjectingWorkQueue) Add(item interface{}) {
+	q.registry.ResolveQueue(context.Background(), QueueFacts{Queue: q.name, Op: "add"})
+	q.RateLimitingInterface.Add(item)
+}

--- a/test/utils/robustness/queue.go
+++ b/test/utils/robustness/queue.go
@@ -1,0 +1,61 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package robustness
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/client-go/util/workqueue"
+)
+
+// FaultInjectingWorkQueue wraps workqueue.TypedRateLimitingInterface[any] to control reconciler trigger events.
+type FaultInjectingWorkQueue struct {
+	workqueue.TypedRateLimitingInterface[any]
+	registry *FaultRegistry
+	name     string
+}
+
+// NewFaultInjectingWorkQueue creates a wrapped TypedRateLimitingInterface[any].
+func NewFaultInjectingWorkQueue(realQueue workqueue.TypedRateLimitingInterface[any], registry *FaultRegistry, name string) workqueue.TypedRateLimitingInterface[any] {
+	return &FaultInjectingWorkQueue{
+		TypedRateLimitingInterface: realQueue,
+		registry:                   registry,
+		name:                       name,
+	}
+}
+
+func (q *FaultInjectingWorkQueue) Get() (item interface{}, shutdown bool) {
+	// Runs any blocking faults registered on this queue's get operation.
+	q.registry.ResolveQueue(context.Background(), QueueFacts{Queue: q.name, Op: "get"})
+	return q.TypedRateLimitingInterface.Get()
+}
+
+func (q *FaultInjectingWorkQueue) Add(item interface{}) {
+	q.registry.ResolveQueue(context.Background(), QueueFacts{Queue: q.name, Op: "add"})
+	q.TypedRateLimitingInterface.Add(item)
+}
+
+func (q *FaultInjectingWorkQueue) AddRateLimited(item interface{}) {
+	q.registry.ResolveQueue(context.Background(), QueueFacts{Queue: q.name, Op: "add"})
+	q.TypedRateLimitingInterface.AddRateLimited(item)
+}
+
+func (q *FaultInjectingWorkQueue) AddAfter(item interface{}, duration time.Duration) {
+	q.registry.ResolveQueue(context.Background(), QueueFacts{Queue: q.name, Op: "add"})
+	q.TypedRateLimitingInterface.AddAfter(item, duration)
+}

--- a/test/utils/robustness/registry.go
+++ b/test/utils/robustness/registry.go
@@ -1,0 +1,565 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package robustness
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// FaultCondition evaluates whether a matched hook point should execute the fault action.
+// matchCount represents how many times this specific rule's matcher has fired.
+type FaultCondition func(matchCount int) bool
+
+// Standard Conditions
+
+// TriggerOnOccurrence triggers the fault only on the N-th match (1-indexed).
+func TriggerOnOccurrence(n int) FaultCondition {
+	return func(matchCount int) bool {
+		return matchCount == n
+	}
+}
+
+// TriggerRange triggers the fault between the start and end match counts (inclusive).
+func TriggerRange(start, end int) FaultCondition {
+	return func(matchCount int) bool {
+		return matchCount >= start && matchCount <= end
+	}
+}
+
+// TriggerProbability triggers the fault randomly with a probability between 0.0 and 1.0.
+func TriggerProbability(prob float64) FaultCondition {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var mu sync.Mutex
+	return func(matchCount int) bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return r.Float64() < prob
+	}
+}
+
+// TriggerAlways triggers the fault on every match.
+func TriggerAlways() FaultCondition {
+	return func(matchCount int) bool {
+		return true
+	}
+}
+
+// TriggerAfterSignal triggers a fault only once the named signal has been raised at
+// least once (see FaultRegistry.Signal). Used to gate faults on a phase of the test,
+// e.g. "only after the trigger action has completed".
+func TriggerAfterSignal(registry *FaultRegistry, signalName string) FaultCondition {
+	return func(matchCount int) bool {
+		return registry.SignalCount(signalName) > 0
+	}
+}
+
+// TriggerWindowAfterRuleHit triggers a fault during a fixed time window that
+// opens when the named rule first fires. Pair it with a sensor rule (a rule
+// with a nil Action and TriggerAlways) to sequence one fault relative to
+// another injection site, e.g. "the child cache goes stale for one second
+// starting at the controller's first child create" — the interleaving behind
+// classic stale-read bugs, which occurrence-based conditions cannot express
+// because they count from the start of the test.
+func TriggerWindowAfterRuleHit(registry *FaultRegistry, ruleName string, window time.Duration) FaultCondition {
+	var mu sync.Mutex
+	var start time.Time
+	return func(matchCount int) bool {
+		if registry.GetHitCount(ruleName) == 0 {
+			return false
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		if start.IsZero() {
+			start = time.Now()
+		}
+		return time.Since(start) < window
+	}
+}
+
+// faultDomain identifies which injection site a fault targets. The domain is
+// carried by the FaultMatch (no string parsing), which makes registration-time
+// validation and dispatch unambiguous.
+type faultDomain int
+
+const (
+	domainUnknown faultDomain = iota
+	domainTransport
+	domainCache
+	domainClock
+	domainQueue
+)
+
+// --- Structured matching. A FaultMatch selects the injection sites a rule applies
+// to, by typed fields rather than a flattened string key. Empty string fields are
+// wildcards ("match any"), except ClientMatch.Subresource which is matched exactly
+// ("" means the main resource, not "any subresource"). ---
+
+// FaultMatch is the structured selector for a fault rule. Each concrete match type
+// belongs to exactly one injection domain.
+type FaultMatch interface {
+	domain() faultDomain
+}
+
+func wildcard(matcher, fact string) bool { return matcher == "" || matcher == fact }
+
+// ClientFacts describes a REST request seen by the transport.
+type ClientFacts struct {
+	Verb        string // HTTP method, e.g. "PUT", "POST"
+	Group       string // API group, e.g. "apps" ("" for the core group)
+	Resource    string // plural resource, e.g. "daemonsets"
+	Subresource string // e.g. "status" ("" for the main resource)
+	Namespace   string
+	Name        string
+}
+
+// ClientMatch matches REST requests. Empty fields are wildcards, except
+// Subresource which is matched exactly ("" = main resource only).
+type ClientMatch struct {
+	Verb        string
+	Group       string
+	Resource    string
+	Subresource string
+	Namespace   string
+	Name        string
+}
+
+func (ClientMatch) domain() faultDomain { return domainTransport }
+
+func (m ClientMatch) matches(f ClientFacts) bool {
+	return wildcard(m.Verb, f.Verb) &&
+		wildcard(m.Group, f.Group) &&
+		wildcard(m.Resource, f.Resource) &&
+		m.Subresource == f.Subresource &&
+		wildcard(m.Namespace, f.Namespace) &&
+		wildcard(m.Name, f.Name)
+}
+
+// CacheFacts describes an informer cache lookup.
+type CacheFacts struct {
+	Cache string // cache name, e.g. "pod-cache"
+	Op    string // "get", "list", "by-index", "last-sync-rv"
+	Key   string // object key for get/by-index
+}
+
+// CacheMatch matches informer cache lookups. Empty fields are wildcards.
+type CacheMatch struct {
+	Cache string
+	Op    string
+	Key   string
+}
+
+func (CacheMatch) domain() faultDomain { return domainCache }
+
+func (m CacheMatch) matches(f CacheFacts) bool {
+	return wildcard(m.Cache, f.Cache) && wildcard(m.Op, f.Op) && wildcard(m.Key, f.Key)
+}
+
+// ClockFacts describes a clock read.
+type ClockFacts struct {
+	Clock string // clock name, e.g. "expectations"
+}
+
+// ClockMatch matches clock reads. An empty Clock matches any clock.
+type ClockMatch struct {
+	Clock string
+}
+
+func (ClockMatch) domain() faultDomain { return domainClock }
+
+func (m ClockMatch) matches(f ClockFacts) bool { return wildcard(m.Clock, f.Clock) }
+
+// QueueFacts describes a work queue operation.
+type QueueFacts struct {
+	Queue string // queue name
+	Op    string // "get", "add"
+}
+
+// QueueMatch matches work queue operations. Empty fields are wildcards.
+type QueueMatch struct {
+	Queue string
+	Op    string
+}
+
+func (QueueMatch) domain() faultDomain { return domainQueue }
+
+func (m QueueMatch) matches(f QueueFacts) bool {
+	return wildcard(m.Queue, f.Queue) && wildcard(m.Op, f.Op)
+}
+
+// --- Typed verdicts: what an injection site should do when a fault fires. ---
+//
+// Each injection domain has its own verdict type rather than overloading a shared
+// error return. This keeps every site self-contained and makes a mis-targeted
+// fault (e.g. a clock fault attached to a transport match) a registration error
+// instead of a silent, nonsensical side effect (see validateFaultDomain).
+
+// TransportVerdict tells FaultInjectingTransport how to handle a request.
+// The zero value means "pass through to the real transport".
+type TransportVerdict struct {
+	// Respond, if non-nil, is returned as a synthetic API response instead of
+	// forwarding the request to the real transport.
+	Respond *HTTPStatusError
+	// ConnErr, if non-nil, is returned as a transport-level error (nil response),
+	// simulating a refused or dropped connection.
+	ConnErr error
+}
+
+func (v TransportVerdict) isPass() bool { return v.Respond == nil && v.ConnErr == nil }
+
+// CacheVerdictKind enumerates how a cache lookup should be perturbed.
+type CacheVerdictKind int
+
+const (
+	CachePass        CacheVerdictKind = iota // no fault; use the real result
+	CacheStaleRead                           // behave as if the cache is empty / lagging
+	CacheStaleObject                         // return a specific (stale) object
+	CacheReturnError                         // return an error
+	CacheStaleRV                             // return a specific last-synced resource version
+)
+
+// CacheVerdict tells FaultInjectingIndexer how to perturb a lookup. Each indexer
+// operation interprets Kind as appropriate for its own return signature.
+type CacheVerdict struct {
+	Kind   CacheVerdictKind
+	Object interface{} // for CacheStaleObject
+	Err    error       // for CacheReturnError
+	RV     string      // for CacheStaleRV
+}
+
+// ClockVerdict tells FaultInjectingClock how to skew time. The zero value is no skew.
+type ClockVerdict struct {
+	Shift time.Duration // added to the real Now()
+}
+
+// --- Domain fault interfaces. A concrete action implements the interface(s) for
+// the site(s) it targets; validateFaultDomain rejects an action attached to a
+// match whose site it cannot serve. ---
+
+// TransportFault produces a verdict for the REST client transport.
+type TransportFault interface{ ApplyTransport() TransportVerdict }
+
+// CacheFault produces a verdict for an informer indexer lookup.
+type CacheFault interface{ ApplyCache() CacheVerdict }
+
+// ClockFault produces a verdict for a wrapped clock.
+type ClockFault interface{ ApplyClock() ClockVerdict }
+
+// BlockingFault blocks the calling goroutine (a delay or until a signal). It is
+// valid at ANY site and does not change the site's return value.
+type BlockingFault interface{ Block(ctx context.Context) }
+
+// FaultAction is a marker for fault behaviors. A concrete action implements one or
+// more of the domain interfaces above and/or BlockingFault, and is validated
+// against its match's domain at registration (see validateFaultDomain). A nil
+// Action is permitted (e.g. a rule used only to count matches).
+type FaultAction interface{}
+
+// InjectDelay blocks the calling goroutine for a fixed duration (or until ctx is
+// cancelled). Valid at any injection site.
+type InjectDelay struct {
+	Duration time.Duration
+}
+
+func (a InjectDelay) Block(ctx context.Context) {
+	select {
+	case <-ctx.Done():
+	case <-time.After(a.Duration):
+	}
+}
+
+// BlockUntil blocks the calling goroutine until the channel is closed (or ctx is
+// cancelled). Valid at any injection site.
+type BlockUntil struct {
+	Until <-chan struct{}
+}
+
+func (a BlockUntil) Block(ctx context.Context) {
+	select {
+	case <-ctx.Done():
+	case <-a.Until:
+	}
+}
+
+// FaultRule declares a fault condition and side effect bound to a set of injection
+// sites selected by Match.
+type FaultRule struct {
+	Name      string
+	Match     FaultMatch
+	Condition FaultCondition
+	Action    FaultAction
+
+	// Optional, when true, exempts this rule from the "every fault must match an
+	// injection site" check (see FaultRegistry.UnmatchedRules). Use it for faults
+	// that are only conditionally reachable (e.g. gated behind a feature flag).
+	// Leave it false for real faults so a mis-targeted Match surfaces as a test
+	// failure instead of a silent no-op.
+	Optional bool
+
+	// ExpectTriggered, when true, declares that this fault must actually fire
+	// (condition satisfied, action applied) at least once during the scenario,
+	// not merely match a site. The suite verifies this after convergence (see
+	// FaultRegistry.ExpectedRulesNotTriggered), replacing hand-written per-rule
+	// hit-count assertions. Leave it false for probabilistic faults that may
+	// legitimately never fire.
+	ExpectTriggered bool
+
+	// Track matching metrics atomically
+	matchCount int32
+	hitCount   int32
+}
+
+// FaultRegistry manages active fault rules and orchestrates trigger evaluations.
+type FaultRegistry struct {
+	mu    sync.RWMutex
+	rules map[faultDomain][]*FaultRule
+
+	signalsMu sync.Mutex
+	signals   map[string]int
+}
+
+// NewFaultRegistry creates a thread-safe FaultRegistry.
+func NewFaultRegistry() *FaultRegistry {
+	return &FaultRegistry{
+		rules:   make(map[faultDomain][]*FaultRule),
+		signals: make(map[string]int),
+	}
+}
+
+// Register adds a new FaultRule to the registry, bucketed by its match domain.
+func (r *FaultRegistry) Register(rule FaultRule) {
+	d := domainUnknown
+	if rule.Match != nil {
+		d = rule.Match.domain()
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.rules[d] = append(r.rules[d], &rule)
+}
+
+// Signal raises a named signal, incrementing its count. Used together with
+// TriggerAfterSignal to gate faults on a test phase.
+func (r *FaultRegistry) Signal(name string) {
+	r.signalsMu.Lock()
+	defer r.signalsMu.Unlock()
+	r.signals[name]++
+}
+
+// SignalCount returns how many times the named signal has been raised.
+func (r *FaultRegistry) SignalCount(name string) int {
+	r.signalsMu.Lock()
+	defer r.signalsMu.Unlock()
+	return r.signals[name]
+}
+
+// fire evaluates every rule in the given domain whose match accepts the facts
+// (via pred): it increments the rule's match counter, checks its condition, and
+// for a triggered rule runs any blocking effect and then invokes apply with the
+// action so the caller can extract a domain verdict. apply may be nil for
+// side-effect-only sites (the work queue).
+func (r *FaultRegistry) fire(ctx context.Context, domain faultDomain, pred func(FaultMatch) bool, apply func(action FaultAction)) {
+	r.mu.RLock()
+	rules := r.rules[domain]
+	r.mu.RUnlock()
+
+	for _, rule := range rules {
+		if !pred(rule.Match) {
+			continue
+		}
+		match := atomic.AddInt32(&rule.matchCount, 1)
+		if rule.Condition == nil || !rule.Condition(int(match)) {
+			continue
+		}
+		atomic.AddInt32(&rule.hitCount, 1)
+		if rule.Action == nil {
+			continue
+		}
+		if b, ok := rule.Action.(BlockingFault); ok {
+			b.Block(ctx)
+		}
+		if apply != nil {
+			apply(rule.Action)
+		}
+	}
+}
+
+// ResolveTransport returns the verdict of the first triggered TransportFault that
+// matches facts. The zero value means "pass through to the real transport".
+func (r *FaultRegistry) ResolveTransport(ctx context.Context, facts ClientFacts) TransportVerdict {
+	var v TransportVerdict
+	r.fire(ctx, domainTransport, func(m FaultMatch) bool {
+		cm, ok := m.(ClientMatch)
+		return ok && cm.matches(facts)
+	}, func(action FaultAction) {
+		if !v.isPass() {
+			return
+		}
+		if tf, ok := action.(TransportFault); ok {
+			v = tf.ApplyTransport()
+		}
+	})
+	return v
+}
+
+// ResolveCache returns the verdict of the first triggered CacheFault that matches
+// facts. CachePass means "use the real result".
+func (r *FaultRegistry) ResolveCache(ctx context.Context, facts CacheFacts) CacheVerdict {
+	v := CacheVerdict{Kind: CachePass}
+	r.fire(ctx, domainCache, func(m FaultMatch) bool {
+		cm, ok := m.(CacheMatch)
+		return ok && cm.matches(facts)
+	}, func(action FaultAction) {
+		if v.Kind != CachePass {
+			return
+		}
+		if cf, ok := action.(CacheFault); ok {
+			v = cf.ApplyCache()
+		}
+	})
+	return v
+}
+
+// ResolveClock returns the total time shift contributed by all triggered
+// ClockFaults that match facts.
+func (r *FaultRegistry) ResolveClock(ctx context.Context, facts ClockFacts) time.Duration {
+	var shift time.Duration
+	r.fire(ctx, domainClock, func(m FaultMatch) bool {
+		cm, ok := m.(ClockMatch)
+		return ok && cm.matches(facts)
+	}, func(action FaultAction) {
+		if cf, ok := action.(ClockFault); ok {
+			shift += cf.ApplyClock().Shift
+		}
+	})
+	return shift
+}
+
+// ResolveQueue fires any blocking faults registered on work queue operations that
+// match facts. Work queue faults have no verdict; they only delay or block.
+func (r *FaultRegistry) ResolveQueue(ctx context.Context, facts QueueFacts) {
+	r.fire(ctx, domainQueue, func(m FaultMatch) bool {
+		qm, ok := m.(QueueMatch)
+		return ok && qm.matches(facts)
+	}, nil)
+}
+
+// GetHitCount returns the total number of times faults with the specified ruleName were executed.
+func (r *FaultRegistry) GetHitCount(ruleName string) int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var total int
+	for _, ruleList := range r.rules {
+		for _, rule := range ruleList {
+			if rule.Name == ruleName {
+				total += int(atomic.LoadInt32(&rule.hitCount))
+			}
+		}
+	}
+	return total
+}
+
+// UnmatchedRules returns the names of all registered non-optional rules whose
+// match never accepted a real injection site (matchCount == 0).
+//
+// A rule that never matches injects nothing: the test goes green while asserting
+// nothing, which is the most dangerous failure mode for a fault-injection
+// harness. The usual cause is a Match that doesn't line up with a real injection
+// site (a mis-pluralized resource, a subresource that is never written, or
+// traffic that flows through an un-wrapped client). Callers should treat a
+// non-empty result as a test failure. Rules marked Optional are skipped.
+//
+// Note this checks matchCount, not hitCount: a probabilistic fault whose site was
+// exercised but whose Condition happened not to fire is still considered matched.
+func (r *FaultRegistry) UnmatchedRules() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var unmatched []string
+	for _, ruleList := range r.rules {
+		for _, rule := range ruleList {
+			if rule.Optional {
+				continue
+			}
+			if atomic.LoadInt32(&rule.matchCount) == 0 {
+				unmatched = append(unmatched, rule.Name)
+			}
+		}
+	}
+	return unmatched
+}
+
+// ExpectedRulesNotTriggered returns the names of all rules registered with
+// ExpectTriggered whose action never actually fired (hitCount == 0).
+//
+// This complements UnmatchedRules: matching proves the rule lined up with a real
+// injection site, while this proves the fault was actually delivered. A scenario
+// that declares ExpectTriggered on a rule gets its hit-count assertion for free.
+func (r *FaultRegistry) ExpectedRulesNotTriggered() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var silent []string
+	for _, ruleList := range r.rules {
+		for _, rule := range ruleList {
+			if !rule.ExpectTriggered {
+				continue
+			}
+			if atomic.LoadInt32(&rule.hitCount) == 0 {
+				silent = append(silent, rule.Name)
+			}
+		}
+	}
+	return silent
+}
+
+// validateFaultDomain checks that a rule's action can actually be served at the
+// injection site its match selects, so a mis-targeted fault (e.g. a clock fault on
+// a transport match) fails loudly at registration instead of silently doing
+// nothing useful. A nil action and BlockingFault actions are valid for any match.
+func validateFaultDomain(rule FaultRule) error {
+	if rule.Match == nil {
+		return fmt.Errorf("fault rule %q has no Match", rule.Name)
+	}
+	if rule.Action == nil {
+		return nil
+	}
+	if _, ok := rule.Action.(BlockingFault); ok {
+		return nil // blocking faults are valid at any site
+	}
+	switch rule.Match.domain() {
+	case domainTransport:
+		if _, ok := rule.Action.(TransportFault); !ok {
+			return fmt.Errorf("ClientMatch targets the REST transport but action %T is not a TransportFault", rule.Action)
+		}
+	case domainCache:
+		if _, ok := rule.Action.(CacheFault); !ok {
+			return fmt.Errorf("CacheMatch targets an informer cache but action %T is not a CacheFault", rule.Action)
+		}
+	case domainClock:
+		if _, ok := rule.Action.(ClockFault); !ok {
+			return fmt.Errorf("ClockMatch targets a clock but action %T is not a ClockFault", rule.Action)
+		}
+	case domainQueue:
+		return fmt.Errorf("QueueMatch only supports BlockingFault actions, but got %T", rule.Action)
+	}
+	return nil
+}

--- a/test/utils/robustness/registry.go
+++ b/test/utils/robustness/registry.go
@@ -80,16 +80,10 @@ func TriggerAfterSignal(registry *FaultRegistry, signalName string) FaultConditi
 // classic stale-read bugs, which occurrence-based conditions cannot express
 // because they count from the start of the test.
 func TriggerWindowAfterRuleHit(registry *FaultRegistry, ruleName string, window time.Duration) FaultCondition {
-	var mu sync.Mutex
-	var start time.Time
 	return func(matchCount int) bool {
-		if registry.GetHitCount(ruleName) == 0 {
-			return false
-		}
-		mu.Lock()
-		defer mu.Unlock()
+		start := registry.GetFirstHitTime(ruleName)
 		if start.IsZero() {
-			start = time.Now()
+			return false
 		}
 		return time.Since(start) < window
 	}
@@ -325,6 +319,7 @@ type FaultRule struct {
 	// Track matching metrics atomically
 	matchCount int32
 	hitCount   int32
+	firstHit   int64 // Unix nanoseconds, 0 means not hit
 }
 
 // FaultRegistry manages active fault rules and orchestrates trigger evaluations.
@@ -388,6 +383,7 @@ func (r *FaultRegistry) fire(ctx context.Context, domain faultDomain, pred func(
 		if rule.Condition == nil || !rule.Condition(int(match)) {
 			continue
 		}
+		atomic.CompareAndSwapInt64(&rule.firstHit, 0, time.Now().UnixNano())
 		atomic.AddInt32(&rule.hitCount, 1)
 		if rule.Action == nil {
 			continue
@@ -475,6 +471,29 @@ func (r *FaultRegistry) GetHitCount(ruleName string) int {
 		}
 	}
 	return total
+}
+
+// GetFirstHitTime returns the timestamp of the first time a rule with the given name triggered.
+// Returns the zero time if the rule has not triggered.
+func (r *FaultRegistry) GetFirstHitTime(ruleName string) time.Time {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var earliest int64
+	for _, ruleList := range r.rules {
+		for _, rule := range ruleList {
+			if rule.Name == ruleName {
+				hit := atomic.LoadInt64(&rule.firstHit)
+				if hit > 0 && (earliest == 0 || hit < earliest) {
+					earliest = hit
+				}
+			}
+		}
+	}
+	if earliest == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, earliest)
 }
 
 // UnmatchedRules returns the names of all registered non-optional rules whose

--- a/test/utils/robustness/registry.go
+++ b/test/utils/robustness/registry.go
@@ -1,0 +1,565 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package robustness
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// FaultCondition evaluates whether a matched hook point should execute the fault action.
+// matchCount represents how many times this specific rule's matcher has fired.
+type FaultCondition func(matchCount int) bool
+
+// Standard Conditions
+
+// TriggerOnOccurrence triggers the fault only on the N-th match (1-indexed).
+func TriggerOnOccurrence(n int) FaultCondition {
+	return func(matchCount int) bool {
+		return matchCount == n
+	}
+}
+
+// TriggerRange triggers the fault between the start and end match counts (inclusive).
+func TriggerRange(start, end int) FaultCondition {
+	return func(matchCount int) bool {
+		return matchCount >= start && matchCount <= end
+	}
+}
+
+// TriggerProbability triggers the fault randomly with a probability between 0.0 and 1.0.
+func TriggerProbability(prob float64) FaultCondition {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	var mu sync.Mutex
+	return func(matchCount int) bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return r.Float64() < prob
+	}
+}
+
+// TriggerAlways triggers the fault on every match.
+func TriggerAlways() FaultCondition {
+	return func(matchCount int) bool {
+		return true
+	}
+}
+
+// TriggerAfterSignal triggers a fault only once the named signal has been raised at
+// least once (see FaultRegistry.Signal). Used to gate faults on a phase of the test,
+// e.g. "only after the trigger action has completed".
+func TriggerAfterSignal(registry *FaultRegistry, signalName string) FaultCondition {
+	return func(matchCount int) bool {
+		return registry.SignalCount(signalName) > 0
+	}
+}
+
+// TriggerWindowAfterRuleHit triggers a fault during a fixed time window that
+// opens when the named rule first fires. Pair it with a sensor rule (a rule
+// with a nil Action and TriggerAlways) to sequence one fault relative to
+// another injection site, e.g. "the child cache goes stale for one second
+// starting at the controller's first child create" — the interleaving behind
+// classic stale-read bugs, which occurrence-based conditions cannot express
+// because they count from the start of the test.
+func TriggerWindowAfterRuleHit(registry *FaultRegistry, ruleName string, window time.Duration) FaultCondition {
+	return func(matchCount int) bool {
+		start := registry.GetFirstHitTime(ruleName)
+		if start.IsZero() {
+			return false
+		}
+		return time.Since(start) < window
+	}
+}
+
+// faultDomain identifies which injection site a fault targets. The domain is
+// carried by the FaultMatch (no string parsing), which makes registration-time
+// validation and dispatch unambiguous.
+type faultDomain int
+
+const (
+	domainUnknown faultDomain = iota
+	domainTransport
+	domainCache
+	domainClock
+	domainQueue
+)
+
+// --- Structured matching. A FaultMatch selects the injection sites a rule applies
+// to, by typed fields rather than a flattened string key. Empty string fields are
+// wildcards ("match any"), except ClientMatch.Subresource which is matched exactly
+// ("" means the main resource, not "any subresource"). ---
+
+// FaultMatch is the structured selector for a fault rule. Each concrete match type
+// belongs to exactly one injection domain.
+type FaultMatch interface {
+	domain() faultDomain
+}
+
+func wildcard(matcher, fact string) bool { return matcher == "" || matcher == fact }
+
+// ClientFacts describes a REST request seen by the transport.
+type ClientFacts struct {
+	Verb        string // HTTP method, e.g. "PUT", "POST"
+	Group       string // API group, e.g. "apps" ("" for the core group)
+	Resource    string // plural resource, e.g. "daemonsets"
+	Subresource string // e.g. "status" ("" for the main resource)
+	Namespace   string
+	Name        string
+}
+
+// ClientMatch matches REST requests. Empty fields are wildcards, except
+// Subresource which is matched exactly ("" = main resource only).
+type ClientMatch struct {
+	Verb        string
+	Group       string
+	Resource    string
+	Subresource string
+	Namespace   string
+	Name        string
+}
+
+func (ClientMatch) domain() faultDomain { return domainTransport }
+
+func (m ClientMatch) matches(f ClientFacts) bool {
+	return wildcard(m.Verb, f.Verb) &&
+		wildcard(m.Group, f.Group) &&
+		wildcard(m.Resource, f.Resource) &&
+		m.Subresource == f.Subresource &&
+		wildcard(m.Namespace, f.Namespace) &&
+		wildcard(m.Name, f.Name)
+}
+
+// CacheFacts describes an informer cache lookup.
+type CacheFacts struct {
+	Cache string // cache name, e.g. "pod-cache"
+	Op    string // "get", "list", "by-index", "last-sync-rv"
+	Key   string // object key for get/by-index
+}
+
+// CacheMatch matches informer cache lookups. Empty fields are wildcards.
+type CacheMatch struct {
+	Cache string
+	Op    string
+	Key   string
+}
+
+func (CacheMatch) domain() faultDomain { return domainCache }
+
+func (m CacheMatch) matches(f CacheFacts) bool {
+	return wildcard(m.Cache, f.Cache) && wildcard(m.Op, f.Op) && wildcard(m.Key, f.Key)
+}
+
+// ClockFacts describes a clock read.
+type ClockFacts struct {
+	Clock string // clock name, e.g. "expectations"
+}
+
+// ClockMatch matches clock reads. An empty Clock matches any clock.
+type ClockMatch struct {
+	Clock string
+}
+
+func (ClockMatch) domain() faultDomain { return domainClock }
+
+func (m ClockMatch) matches(f ClockFacts) bool { return wildcard(m.Clock, f.Clock) }
+
+// QueueFacts describes a work queue operation.
+type QueueFacts struct {
+	Queue string // queue name
+	Op    string // "get", "add"
+}
+
+// QueueMatch matches work queue operations. Empty fields are wildcards.
+type QueueMatch struct {
+	Queue string
+	Op    string
+}
+
+func (QueueMatch) domain() faultDomain { return domainQueue }
+
+func (m QueueMatch) matches(f QueueFacts) bool {
+	return wildcard(m.Queue, f.Queue) && wildcard(m.Op, f.Op)
+}
+
+// --- Typed verdicts: what an injection site should do when a fault fires. ---
+//
+// Each injection domain has its own verdict type rather than overloading a shared
+// error return. This keeps every site self-contained and makes a mis-targeted
+// fault (e.g. a clock fault attached to a transport match) a registration error
+// instead of a silent, nonsensical side effect (see validateFaultDomain).
+
+// TransportVerdict tells FaultInjectingTransport how to handle a request.
+// The zero value means "pass through to the real transport".
+type TransportVerdict struct {
+	// Respond, if non-nil, is returned as a synthetic API response instead of
+	// forwarding the request to the real transport.
+	Respond *HTTPStatusError
+}
+
+func (v TransportVerdict) isPass() bool { return v.Respond == nil }
+
+// CacheVerdictKind enumerates how a cache lookup should be perturbed.
+type CacheVerdictKind int
+
+const (
+	CachePass      CacheVerdictKind = iota // no fault; use the real result
+	CacheStaleRead                         // behave as if the cache is empty / lagging
+)
+
+// CacheVerdict tells FaultInjectingIndexer how to perturb a lookup.
+type CacheVerdict struct {
+	Kind CacheVerdictKind
+}
+
+// ClockVerdict tells FaultInjectingClock how to skew time. The zero value is no skew.
+type ClockVerdict struct {
+	Shift time.Duration // added to the real Now()
+}
+
+// --- Domain fault interfaces. A concrete action implements the interface(s) for
+// the site(s) it targets; validateFaultDomain rejects an action attached to a
+// match whose site it cannot serve. ---
+
+// TransportFault produces a verdict for the REST client transport.
+type TransportFault interface{ ApplyTransport() TransportVerdict }
+
+// CacheFault produces a verdict for an informer indexer lookup.
+type CacheFault interface{ ApplyCache() CacheVerdict }
+
+// ClockFault produces a verdict for a wrapped clock.
+type ClockFault interface{ ApplyClock() ClockVerdict }
+
+// BlockingFault blocks the calling goroutine (a delay or until a signal). It is
+// valid at ANY site and does not change the site's return value.
+type BlockingFault interface{ Block(ctx context.Context) }
+
+// FaultAction is a marker for fault behaviors. A concrete action implements one or
+// more of the domain interfaces above and/or BlockingFault, and is validated
+// against its match's domain at registration (see validateFaultDomain). A nil
+// Action is permitted (e.g. a rule used only to count matches).
+type FaultAction interface{}
+
+// InjectDelay blocks the calling goroutine for a fixed duration (or until ctx is
+// cancelled). Valid at any injection site.
+type InjectDelay struct {
+	Duration time.Duration
+}
+
+func (a InjectDelay) Block(ctx context.Context) {
+	select {
+	case <-ctx.Done():
+	case <-time.After(a.Duration):
+	}
+}
+
+// FaultRule declares a fault condition and side effect bound to a set of injection
+// sites selected by Match.
+type FaultRule struct {
+	Name      string
+	Match     FaultMatch
+	Condition FaultCondition
+	Action    FaultAction
+
+	// Optional, when true, exempts this rule from the "every fault must match an
+	// injection site" check (see FaultRegistry.UnmatchedRules). Use it for faults
+	// that are only conditionally reachable (e.g. gated behind a feature flag).
+	// Leave it false for real faults so a mis-targeted Match surfaces as a test
+	// failure instead of a silent no-op.
+	Optional bool
+
+	// ExpectTriggered, when true, declares that this fault must actually fire
+	// (condition satisfied, action applied) at least once during the scenario,
+	// not merely match a site. The suite verifies this after convergence (see
+	// FaultRegistry.ExpectedRulesNotTriggered), replacing hand-written per-rule
+	// hit-count assertions. Leave it false for probabilistic faults that may
+	// legitimately never fire.
+	ExpectTriggered bool
+}
+
+// activeRule tracks a registered rule and its runtime execution metrics atomically.
+type activeRule struct {
+	rule FaultRule
+
+	matchCount atomic.Int32
+	hitCount   atomic.Int32
+	firstHit   atomic.Int64 // Unix nanoseconds, 0 means not hit
+}
+
+// FaultRegistry manages active fault rules and orchestrates trigger evaluations.
+type FaultRegistry struct {
+	mu    sync.RWMutex
+	rules map[faultDomain][]*activeRule
+
+	signalsMu sync.Mutex
+	signals   map[string]int
+}
+
+// NewFaultRegistry creates a thread-safe FaultRegistry.
+func NewFaultRegistry() *FaultRegistry {
+	return &FaultRegistry{
+		rules:   make(map[faultDomain][]*activeRule),
+		signals: make(map[string]int),
+	}
+}
+
+// Register adds a new FaultRule to the registry, bucketed by its match domain.
+func (r *FaultRegistry) Register(rule FaultRule) {
+	d := domainUnknown
+	if rule.Match != nil {
+		d = rule.Match.domain()
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.rules[d] = append(r.rules[d], &activeRule{rule: rule})
+}
+
+// Signal raises a named signal, incrementing its count. Used together with
+// TriggerAfterSignal to gate faults on a test phase.
+func (r *FaultRegistry) Signal(name string) {
+	r.signalsMu.Lock()
+	defer r.signalsMu.Unlock()
+	r.signals[name]++
+}
+
+// SignalCount returns how many times the named signal has been raised.
+func (r *FaultRegistry) SignalCount(name string) int {
+	r.signalsMu.Lock()
+	defer r.signalsMu.Unlock()
+	return r.signals[name]
+}
+
+// fire evaluates every rule in the given domain whose match accepts the facts
+// (via pred): it increments the rule's match counter, checks its condition, and
+// for a triggered rule runs any blocking effect and then invokes apply with the
+// action so the caller can extract a domain verdict. apply may be nil for
+// side-effect-only sites (the work queue).
+func (r *FaultRegistry) fire(ctx context.Context, domain faultDomain, pred func(FaultMatch) bool, apply func(action FaultAction)) {
+	r.mu.RLock()
+	rules := r.rules[domain]
+	r.mu.RUnlock()
+
+	for _, ar := range rules {
+		if !pred(ar.rule.Match) {
+			continue
+		}
+		match := ar.matchCount.Add(1)
+		if ar.rule.Condition == nil || !ar.rule.Condition(int(match)) {
+			continue
+		}
+		ar.firstHit.CompareAndSwap(0, time.Now().UnixNano())
+		ar.hitCount.Add(1)
+		if ar.rule.Action == nil {
+			continue
+		}
+		if b, ok := ar.rule.Action.(BlockingFault); ok {
+			b.Block(ctx)
+		}
+		if apply != nil {
+			apply(ar.rule.Action)
+		}
+	}
+}
+
+// ResolveTransport returns the verdict of the first triggered TransportFault that
+// matches facts. The zero value means "pass through to the real transport".
+func (r *FaultRegistry) ResolveTransport(ctx context.Context, facts ClientFacts) TransportVerdict {
+	var v TransportVerdict
+	r.fire(ctx, domainTransport, func(m FaultMatch) bool {
+		cm, ok := m.(ClientMatch)
+		return ok && cm.matches(facts)
+	}, func(action FaultAction) {
+		if !v.isPass() {
+			return
+		}
+		if tf, ok := action.(TransportFault); ok {
+			v = tf.ApplyTransport()
+		}
+	})
+	return v
+}
+
+// ResolveCache returns the verdict of the first triggered CacheFault that matches
+// facts. CachePass means "use the real result".
+func (r *FaultRegistry) ResolveCache(ctx context.Context, facts CacheFacts) CacheVerdict {
+	v := CacheVerdict{Kind: CachePass}
+	r.fire(ctx, domainCache, func(m FaultMatch) bool {
+		cm, ok := m.(CacheMatch)
+		return ok && cm.matches(facts)
+	}, func(action FaultAction) {
+		if v.Kind != CachePass {
+			return
+		}
+		if cf, ok := action.(CacheFault); ok {
+			v = cf.ApplyCache()
+		}
+	})
+	return v
+}
+
+// ResolveClock returns the total time shift contributed by all triggered
+// ClockFaults that match facts.
+func (r *FaultRegistry) ResolveClock(ctx context.Context, facts ClockFacts) time.Duration {
+	var shift time.Duration
+	r.fire(ctx, domainClock, func(m FaultMatch) bool {
+		cm, ok := m.(ClockMatch)
+		return ok && cm.matches(facts)
+	}, func(action FaultAction) {
+		if cf, ok := action.(ClockFault); ok {
+			shift += cf.ApplyClock().Shift
+		}
+	})
+	return shift
+}
+
+// ResolveQueue fires any blocking faults registered on work queue operations that
+// match facts. Work queue faults have no verdict; they only delay or block.
+func (r *FaultRegistry) ResolveQueue(ctx context.Context, facts QueueFacts) {
+	r.fire(ctx, domainQueue, func(m FaultMatch) bool {
+		qm, ok := m.(QueueMatch)
+		return ok && qm.matches(facts)
+	}, nil)
+}
+
+// GetHitCount returns the total number of times faults with the specified ruleName were executed.
+func (r *FaultRegistry) GetHitCount(ruleName string) int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var total int
+	for _, ruleList := range r.rules {
+		for _, ar := range ruleList {
+			if ar.rule.Name == ruleName {
+				total += int(ar.hitCount.Load())
+			}
+		}
+	}
+	return total
+}
+
+// GetFirstHitTime returns the timestamp of the first time a rule with the given name triggered.
+// Returns the zero time if the rule has not triggered.
+func (r *FaultRegistry) GetFirstHitTime(ruleName string) time.Time {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var earliest int64
+	for _, ruleList := range r.rules {
+		for _, ar := range ruleList {
+			if ar.rule.Name == ruleName {
+				hit := ar.firstHit.Load()
+				if hit > 0 && (earliest == 0 || hit < earliest) {
+					earliest = hit
+				}
+			}
+		}
+	}
+	if earliest == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, earliest)
+}
+
+// UnmatchedRules returns the names of all registered non-optional rules whose
+// match never accepted a real injection site (matchCount == 0).
+//
+// A rule that never matches injects nothing: the test goes green while asserting
+// nothing, which is the most dangerous failure mode for a fault-injection
+// harness. The usual cause is a Match that doesn't line up with a real injection
+// site (a mis-pluralized resource, a subresource that is never written, or
+// traffic that flows through an un-wrapped client). Callers should treat a
+// non-empty result as a test failure. Rules marked Optional are skipped.
+//
+// Note this checks matchCount, not hitCount: a probabilistic fault whose site was
+// exercised but whose Condition happened not to fire is still considered matched.
+func (r *FaultRegistry) UnmatchedRules() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var unmatched []string
+	for _, ruleList := range r.rules {
+		for _, ar := range ruleList {
+			if ar.rule.Optional {
+				continue
+			}
+			if ar.matchCount.Load() == 0 {
+				unmatched = append(unmatched, ar.rule.Name)
+			}
+		}
+	}
+	return unmatched
+}
+
+// ExpectedRulesNotTriggered returns the names of all rules registered with
+// ExpectTriggered whose action never actually fired (hitCount == 0).
+//
+// This complements UnmatchedRules: matching proves the rule lined up with a real
+// injection site, while this proves the fault was actually delivered. A scenario
+// that declares ExpectTriggered on a rule gets its hit-count assertion for free.
+func (r *FaultRegistry) ExpectedRulesNotTriggered() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var silent []string
+	for _, ruleList := range r.rules {
+		for _, ar := range ruleList {
+			if !ar.rule.ExpectTriggered {
+				continue
+			}
+			if ar.hitCount.Load() == 0 {
+				silent = append(silent, ar.rule.Name)
+			}
+		}
+	}
+	return silent
+}
+
+// validateFaultDomain checks that a rule's action can actually be served at the
+// injection site its match selects, so a mis-targeted fault (e.g. a clock fault on
+// a transport match) fails loudly at registration instead of silently doing
+// nothing useful. A nil action and BlockingFault actions are valid for any match.
+func validateFaultDomain(rule FaultRule) error {
+	if rule.Match == nil {
+		return fmt.Errorf("fault rule %q has no Match", rule.Name)
+	}
+	if rule.Action == nil {
+		return nil
+	}
+	if _, ok := rule.Action.(BlockingFault); ok {
+		return nil // blocking faults are valid at any site
+	}
+	switch rule.Match.domain() {
+	case domainTransport:
+		if _, ok := rule.Action.(TransportFault); !ok {
+			return fmt.Errorf("ClientMatch targets the REST transport but action %T is not a TransportFault", rule.Action)
+		}
+	case domainCache:
+		if _, ok := rule.Action.(CacheFault); !ok {
+			return fmt.Errorf("CacheMatch targets an informer cache but action %T is not a CacheFault", rule.Action)
+		}
+	case domainClock:
+		if _, ok := rule.Action.(ClockFault); !ok {
+			return fmt.Errorf("ClockMatch targets a clock but action %T is not a ClockFault", rule.Action)
+		}
+	case domainQueue:
+		return fmt.Errorf("QueueMatch only supports BlockingFault actions, but got %T", rule.Action)
+	}
+	return nil
+}

--- a/test/utils/robustness/robustness_unit_test.go
+++ b/test/utils/robustness/robustness_unit_test.go
@@ -18,6 +18,7 @@ package robustness
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -201,7 +202,7 @@ func TestSyntheticErrorResponseContentType(t *testing.T) {
 	})
 
 	rt := NewFaultInjectingTransport(&recordingTransport{t: t}, reg, nil)
-	req, err := http.NewRequest("PUT", "https://example.test/apis/coordination.k8s.io/v1/namespaces/kube-node-lease/leases/target-node", nil)
+	req, err := http.NewRequest(http.MethodPut, "https://example.test/apis/coordination.k8s.io/v1/namespaces/kube-node-lease/leases/target-node", nil)
 	if err != nil {
 		t.Fatalf("failed to build request: %v", err)
 	}
@@ -247,8 +248,8 @@ func TestInjectedConflictIsClassified(t *testing.T) {
 		t.Errorf("apierrors.IsConflict(err) = false, want true; err = %v (%T)", err, err)
 	}
 	// The decoded Status payload only survives when Content-Type is set.
-	se, ok := err.(*apierrors.StatusError)
-	if !ok {
+	var se *apierrors.StatusError
+	if !errors.As(err, &se) {
 		t.Fatalf("err = %v (%T), want *apierrors.StatusError", err, err)
 	}
 	if got := se.ErrStatus.Message; got != "object was modified" {

--- a/test/utils/robustness/robustness_unit_test.go
+++ b/test/utils/robustness/robustness_unit_test.go
@@ -1,0 +1,257 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package robustness
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	coordv1 "k8s.io/api/coordination/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+)
+
+// recordingTransport is a base RoundTripper that fails the test if it is ever
+// reached. A short-circuiting fault must never fall through to the real transport.
+type recordingTransport struct {
+	t      *testing.T
+	called bool
+}
+
+func (rt *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.called = true
+	rt.t.Errorf("real transport was reached for %s %s; the injected fault should have short-circuited it", req.Method, req.URL.Path)
+	return nil, http.ErrServerClosed
+}
+
+// TestUnmatchedRules verifies a loud no-op guard: a registered fault whose
+// match never accepted a real injection site must be reported, while matched
+// rules and Optional rules must not be.
+func TestUnmatchedRules(t *testing.T) {
+	reg := NewFaultRegistry()
+
+	reg.Register(FaultRule{Name: "matched", Match: ClientMatch{Verb: "GET", Resource: "pods"}})
+	reg.Register(FaultRule{Name: "never-matched", Match: ClientMatch{Verb: "GET", Resource: "daemonsets"}})
+	reg.Register(FaultRule{Name: "optional-unmatched", Match: ClientMatch{Verb: "GET", Resource: "leases"}, Optional: true})
+
+	// Exercise only the "matched" rule's site.
+	reg.ResolveTransport(context.Background(), ClientFacts{Verb: "GET", Resource: "pods"})
+
+	unmatched := reg.UnmatchedRules()
+	if len(unmatched) != 1 || unmatched[0] != "never-matched" {
+		t.Fatalf("UnmatchedRules() = %v, want exactly [never-matched]", unmatched)
+	}
+}
+
+// TestExpectedRulesNotTriggered verifies the delivery guard: a rule declared
+// ExpectTriggered must actually fire, not merely match a site.
+func TestExpectedRulesNotTriggered(t *testing.T) {
+	reg := NewFaultRegistry()
+
+	reg.Register(FaultRule{Name: "fired", Match: ClientMatch{Verb: "GET"}, Condition: TriggerAlways(), ExpectTriggered: true})
+	reg.Register(FaultRule{Name: "matched-never-fired", Match: ClientMatch{Verb: "GET"}, Condition: TriggerOnOccurrence(99), ExpectTriggered: true})
+	reg.Register(FaultRule{Name: "not-expected", Match: ClientMatch{Verb: "GET"}, Condition: TriggerOnOccurrence(99)})
+
+	reg.ResolveTransport(context.Background(), ClientFacts{Verb: "GET", Resource: "pods"})
+
+	silent := reg.ExpectedRulesNotTriggered()
+	if len(silent) != 1 || silent[0] != "matched-never-fired" {
+		t.Fatalf("ExpectedRulesNotTriggered() = %v, want exactly [matched-never-fired]", silent)
+	}
+}
+
+// TestStandardChaosMatrixHonorsProfile verifies that every scenario derives its
+// faults from the controller profile: a minimal profile yields no faults for
+// sites the controller does not exercise, a full profile yields rules for all of
+// them, and every produced rule passes registration-time domain validation.
+func TestStandardChaosMatrixHonorsProfile(t *testing.T) {
+	minimal := ControllerProfile{
+		Root:       ResourceRef{Resource: "leases", Name: "n"},
+		WritesRoot: true,
+	}
+	full := ControllerProfile{
+		Root:             ResourceRef{Group: "apps", Resource: "daemonsets", Name: "ds-1"},
+		WritesRootStatus: true,
+		UsesExpectations: true,
+		Child:            &ChildResource{Resource: "pods", CacheName: "pod-cache", CreatedByController: true},
+	}
+
+	for _, p := range []struct {
+		name    string
+		profile ControllerProfile
+	}{{"minimal", minimal}, {"full", full}} {
+		t.Run(p.name, func(t *testing.T) {
+			reg := NewFaultRegistry()
+			for _, scenario := range StandardChaosMatrix() {
+				if scenario.Faults == nil {
+					continue
+				}
+				for _, rule := range scenario.Faults(p.profile, reg) {
+					if err := validateFaultDomain(rule); err != nil {
+						t.Errorf("scenario %q produced an invalid rule %q: %v", scenario.Name, rule.Name, err)
+					}
+					switch rule.Name {
+					case "ChildCacheSyncLag", "ChildCacheLagCombined", "StaleCacheWatchDeath", "FlakyWrites":
+						if p.profile.Child == nil {
+							t.Errorf("scenario %q produced child fault %q for a profile with no child resource", scenario.Name, rule.Name)
+						}
+					case "ShiftExpectationsClock":
+						if !p.profile.UsesExpectations {
+							t.Errorf("scenario %q produced %q for a profile without expectations", scenario.Name, rule.Name)
+						}
+					case "RootStatusConflict":
+						if !p.profile.WritesRootStatus {
+							t.Errorf("scenario %q produced %q for a profile that never writes /status", scenario.Name, rule.Name)
+						}
+					case "RootConflict":
+						if !p.profile.WritesRoot {
+							t.Errorf("scenario %q produced %q for a profile that never writes the root object", scenario.Name, rule.Name)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestValidateFaultDomain verifies the typed-verdict guard: an action may only
+// be attached to a point whose injection site it can actually serve. A
+// mis-targeted fault is rejected at registration; blocking faults and nil
+// signals are accepted anywhere.
+func TestValidateFaultDomain(t *testing.T) {
+	tests := []struct {
+		name    string
+		rule    FaultRule
+		wantErr bool
+	}{
+		{
+			name: "transport fault on client match",
+			rule: FaultRule{Match: ClientMatch{Verb: "PUT", Resource: "leases"}, Action: NewHTTPStatusError(409, metav1.StatusReasonConflict, "x")},
+		},
+		{
+			name:    "clock fault on client match is rejected",
+			rule:    FaultRule{Match: ClientMatch{Verb: "PUT", Resource: "leases"}, Action: ShiftTime{Offset: time.Minute}},
+			wantErr: true,
+		},
+		{
+			name: "cache fault on cache match",
+			rule: FaultRule{Match: CacheMatch{Cache: "pod-cache"}, Action: StaleRead{}},
+		},
+		{
+			name:    "transport fault on cache match is rejected",
+			rule:    FaultRule{Match: CacheMatch{Cache: "pod-cache"}, Action: NewHTTPStatusError(500, metav1.StatusReasonInternalError, "x")},
+			wantErr: true,
+		},
+		{
+			name: "clock fault on clock match",
+			rule: FaultRule{Match: ClockMatch{Clock: "expectations"}, Action: ShiftTime{Offset: time.Minute}},
+		},
+		{
+			name: "blocking fault is valid anywhere",
+			rule: FaultRule{Match: ClientMatch{Verb: "PUT", Resource: "leases"}, Action: InjectDelay{Duration: time.Millisecond}},
+		},
+		{
+			name: "nil action is valid",
+			rule: FaultRule{Match: ClientMatch{Verb: "PUT", Resource: "leases"}, Action: nil},
+		},
+		{
+			name:    "nil match is rejected",
+			rule:    FaultRule{Action: StaleRead{}},
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateFaultDomain(tc.rule)
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("validateFaultDomain() error = %v, wantErr = %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestSyntheticErrorResponseContentType verifies the transport directly sets a
+// JSON Content-Type and the expected status code on the synthetic response.
+func TestSyntheticErrorResponseContentType(t *testing.T) {
+	reg := NewFaultRegistry()
+	reg.Register(FaultRule{
+		Name:      "conflict",
+		Match:     ClientMatch{Verb: "PUT", Resource: "leases", Name: "target-node"},
+		Condition: TriggerAlways(),
+		Action:    NewHTTPStatusError(http.StatusConflict, metav1.StatusReasonConflict, "object was modified"),
+	})
+
+	rt := NewFaultInjectingTransport(&recordingTransport{t: t}, reg, nil)
+	req, err := http.NewRequest("PUT", "https://example.test/apis/coordination.k8s.io/v1/namespaces/kube-node-lease/leases/target-node", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip returned error: %v", err)
+	}
+	if resp.StatusCode != http.StatusConflict {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusConflict)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json (without it client-go cannot decode the Status)", got)
+	}
+}
+
+// TestInjectedConflictIsClassified is the end-to-end check for a real client-go
+// clientset wrapped with the fault transport surfaces the injected 409 as a
+// properly classified *apierrors.StatusError.
+func TestInjectedConflictIsClassified(t *testing.T) {
+	reg := NewFaultRegistry()
+	reg.Register(FaultRule{
+		Name:      "conflict",
+		Match:     ClientMatch{Verb: "PUT", Resource: "leases", Name: "target-node"},
+		Condition: TriggerAlways(),
+		Action:    NewHTTPStatusError(http.StatusConflict, metav1.StatusReasonConflict, "object was modified"),
+	})
+
+	cfg := &restclient.Config{Host: "https://example.test"}
+	cfg.Wrap(func(base http.RoundTripper) http.RoundTripper {
+		return NewFaultInjectingTransport(&recordingTransport{t: t}, reg, nil)
+	})
+	cs := clientset.NewForConfigOrDie(cfg)
+
+	lease := &coordv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{Name: "target-node", Namespace: v1.NamespaceNodeLease},
+	}
+	_, err := cs.CoordinationV1().Leases(v1.NamespaceNodeLease).Update(context.Background(), lease, metav1.UpdateOptions{})
+	if err == nil {
+		t.Fatal("expected an error from the injected conflict fault, got nil")
+	}
+	if !apierrors.IsConflict(err) {
+		t.Errorf("apierrors.IsConflict(err) = false, want true; err = %v (%T)", err, err)
+	}
+	// The decoded Status payload only survives when Content-Type is set.
+	se, ok := err.(*apierrors.StatusError)
+	if !ok {
+		t.Fatalf("err = %v (%T), want *apierrors.StatusError", err, err)
+	}
+	if got := se.ErrStatus.Message; got != "object was modified" {
+		t.Errorf("decoded Status.Message = %q, want %q (the Status body was not decoded; is Content-Type set on the synthetic response?)", got, "object was modified")
+	}
+}

--- a/test/utils/robustness/robustness_unit_test.go
+++ b/test/utils/robustness/robustness_unit_test.go
@@ -1,0 +1,373 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package robustness
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	coordv1 "k8s.io/api/coordination/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/util/workqueue"
+)
+
+// recordingTransport is a base RoundTripper that fails the test if it is ever
+// reached. A short-circuiting fault must never fall through to the real transport.
+type recordingTransport struct {
+	t      *testing.T
+	called bool
+}
+
+func (rt *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.called = true
+	rt.t.Errorf("real transport was reached for %s %s; the injected fault should have short-circuited it", req.Method, req.URL.Path)
+	return nil, http.ErrServerClosed
+}
+
+// TestUnmatchedRules verifies a loud no-op guard: a registered fault whose
+// match never accepted a real injection site must be reported, while matched
+// rules and Optional rules must not be.
+func TestUnmatchedRules(t *testing.T) {
+	reg := NewFaultRegistry()
+
+	reg.Register(FaultRule{Name: "matched", Match: ClientMatch{Verb: "GET", Resource: "pods"}})
+	reg.Register(FaultRule{Name: "never-matched", Match: ClientMatch{Verb: "GET", Resource: "daemonsets"}})
+	reg.Register(FaultRule{Name: "optional-unmatched", Match: ClientMatch{Verb: "GET", Resource: "leases"}, Optional: true})
+
+	// Exercise only the "matched" rule's site.
+	reg.ResolveTransport(context.Background(), ClientFacts{Verb: "GET", Resource: "pods"})
+
+	unmatched := reg.UnmatchedRules()
+	if len(unmatched) != 1 || unmatched[0] != "never-matched" {
+		t.Fatalf("UnmatchedRules() = %v, want exactly [never-matched]", unmatched)
+	}
+}
+
+// TestExpectedRulesNotTriggered verifies the delivery guard: a rule declared
+// ExpectTriggered must actually fire, not merely match a site.
+func TestExpectedRulesNotTriggered(t *testing.T) {
+	reg := NewFaultRegistry()
+
+	reg.Register(FaultRule{Name: "fired", Match: ClientMatch{Verb: "GET"}, Condition: TriggerAlways(), ExpectTriggered: true})
+	reg.Register(FaultRule{Name: "matched-never-fired", Match: ClientMatch{Verb: "GET"}, Condition: TriggerOnOccurrence(99), ExpectTriggered: true})
+	reg.Register(FaultRule{Name: "not-expected", Match: ClientMatch{Verb: "GET"}, Condition: TriggerOnOccurrence(99)})
+
+	reg.ResolveTransport(context.Background(), ClientFacts{Verb: "GET", Resource: "pods"})
+
+	silent := reg.ExpectedRulesNotTriggered()
+	if len(silent) != 1 || silent[0] != "matched-never-fired" {
+		t.Fatalf("ExpectedRulesNotTriggered() = %v, want exactly [matched-never-fired]", silent)
+	}
+}
+
+// TestStandardChaosMatrixHonorsProfile verifies that every scenario derives its
+// faults from the controller profile: a minimal profile yields no faults for
+// sites the controller does not exercise, a full profile yields rules for all of
+// them, and every produced rule passes registration-time domain validation.
+func TestStandardChaosMatrixHonorsProfile(t *testing.T) {
+	minimal := ControllerProfile{
+		Root:       ResourceRef{Resource: "leases", Name: "n"},
+		WritesRoot: true,
+	}
+	full := ControllerProfile{
+		Root:             ResourceRef{Group: "apps", Resource: "daemonsets", Name: "ds-1"},
+		WritesRootStatus: true,
+		UsesExpectations: true,
+		Child:            &ChildResource{Resource: "pods", CreatedByController: true},
+	}
+
+	for _, p := range []struct {
+		name    string
+		profile ControllerProfile
+	}{{"minimal", minimal}, {"full", full}} {
+		t.Run(p.name, func(t *testing.T) {
+			reg := NewFaultRegistry()
+			for _, scenario := range StandardChaosMatrix() {
+				if scenario.Faults == nil {
+					continue
+				}
+				for _, rule := range scenario.Faults(p.profile, reg) {
+					if err := validateFaultDomain(rule); err != nil {
+						t.Errorf("scenario %q produced an invalid rule %q: %v", scenario.Name, rule.Name, err)
+					}
+					switch rule.Name {
+					case "ChildCacheSyncLag", "ChildCacheLagCombined", "StaleCacheWatchDeath", "FlakyChildWrites":
+						if p.profile.Child == nil {
+							t.Errorf("scenario %q produced child fault %q for a profile with no child resource", scenario.Name, rule.Name)
+						}
+					case "ShiftExpectationsClock":
+						if !p.profile.UsesExpectations {
+							t.Errorf("scenario %q produced %q for a profile without expectations", scenario.Name, rule.Name)
+						}
+					case "RootStatusConflict", "FlakyRootStatusWrites":
+						if !p.profile.WritesRootStatus {
+							t.Errorf("scenario %q produced %q for a profile that never writes /status", scenario.Name, rule.Name)
+						}
+					case "RootConflict", "FlakyRootWrites":
+						if !p.profile.WritesRoot {
+							t.Errorf("scenario %q produced %q for a profile that never writes the root object", scenario.Name, rule.Name)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestFaultInjectingWorkQueue verifies that Add, AddRateLimited, AddAfter, and Get trigger queue faults.
+func TestFaultInjectingWorkQueue(t *testing.T) {
+	reg := NewFaultRegistry()
+	reg.Register(FaultRule{
+		Name:      "queue-add-delay",
+		Match:     QueueMatch{Queue: "test-queue", Op: "add"},
+		Condition: TriggerAlways(),
+		Action:    InjectDelay{Duration: time.Millisecond},
+	})
+	reg.Register(FaultRule{
+		Name:      "queue-get-delay",
+		Match:     QueueMatch{Queue: "test-queue", Op: "get"},
+		Condition: TriggerAlways(),
+		Action:    InjectDelay{Duration: time.Millisecond},
+	})
+
+	baseQueue := workqueue.NewTypedRateLimitingQueue[any](workqueue.DefaultTypedItemBasedRateLimiter[any]())
+	defer baseQueue.ShutDown()
+	wrappedQueue := NewFaultInjectingWorkQueue(baseQueue, reg, "test-queue")
+
+	wrappedQueue.Add("item1")
+	wrappedQueue.AddRateLimited("item2")
+	wrappedQueue.AddAfter("item3", time.Millisecond)
+
+	if hits := reg.GetHitCount("queue-add-delay"); hits != 3 {
+		t.Fatalf("expected 3 hits for queue-add-delay, got %d", hits)
+	}
+
+	item, _ := wrappedQueue.Get()
+	if item != "item1" {
+		t.Fatalf("expected item1, got %v", item)
+	}
+	if hits := reg.GetHitCount("queue-get-delay"); hits != 1 {
+		t.Fatalf("expected 1 hit for queue-get-delay, got %d", hits)
+	}
+}
+
+// TestProfileValidation verifies that invalid profiles (missing resource, version in group) fail validation.
+func TestProfileValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile ControllerProfile
+		wantErr bool
+	}{
+		{
+			name: "valid profile",
+			profile: ControllerProfile{
+				Root: ResourceRef{Group: "apps", Resource: "daemonsets"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing root resource",
+			profile: ControllerProfile{
+				Root: ResourceRef{Group: "apps"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "group with version in root is rejected",
+			profile: ControllerProfile{
+				Root: ResourceRef{Group: "apps/v1", Resource: "daemonsets"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "group with version in child is rejected",
+			profile: ControllerProfile{
+				Root:  ResourceRef{Group: "apps", Resource: "daemonsets"},
+				Child: &ChildResource{Group: "core/v1", Resource: "pods"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "child with missing resource is rejected",
+			profile: ControllerProfile{
+				Root:  ResourceRef{Group: "apps", Resource: "daemonsets"},
+				Child: &ChildResource{Group: "apps"},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.profile.validate()
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("validate() error = %v, wantErr = %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestAllOfInvariant verifies that AllOf evaluates each invariant and fails if any fail.
+func TestAllOfInvariant(t *testing.T) {
+	var called1, called2 bool
+	inv1 := func(ctx context.Context, c clientset.Interface) error {
+		called1 = true
+		return nil
+	}
+	inv2 := func(ctx context.Context, c clientset.Interface) error {
+		called2 = true
+		return errors.New("failed invariant 2")
+	}
+
+	composite := AllOf(inv1, inv2)
+	err := composite(context.Background(), nil)
+	if err == nil || err.Error() != "failed invariant 2" {
+		t.Fatalf("expected error from invariant 2, got %v", err)
+	}
+	if !called1 || !called2 {
+		t.Fatalf("expected both invariants to be called, got called1=%v called2=%v", called1, called2)
+	}
+}
+
+// TestValidateFaultDomain verifies the typed-verdict guard: an action may only
+// be attached to a point whose injection site it can actually serve. A
+// mis-targeted fault is rejected at registration; blocking faults and nil
+// signals are accepted anywhere.
+func TestValidateFaultDomain(t *testing.T) {
+	tests := []struct {
+		name    string
+		rule    FaultRule
+		wantErr bool
+	}{
+		{
+			name: "transport fault on client match",
+			rule: FaultRule{Match: ClientMatch{Verb: "PUT", Resource: "leases"}, Action: NewHTTPStatusError(409, metav1.StatusReasonConflict, "x")},
+		},
+		{
+			name:    "clock fault on client match is rejected",
+			rule:    FaultRule{Match: ClientMatch{Verb: "PUT", Resource: "leases"}, Action: ShiftTime{Offset: time.Minute}},
+			wantErr: true,
+		},
+		{
+			name: "cache fault on cache match",
+			rule: FaultRule{Match: CacheMatch{Cache: "pod-cache"}, Action: StaleRead{}},
+		},
+		{
+			name:    "transport fault on cache match is rejected",
+			rule:    FaultRule{Match: CacheMatch{Cache: "pod-cache"}, Action: NewHTTPStatusError(500, metav1.StatusReasonInternalError, "x")},
+			wantErr: true,
+		},
+		{
+			name: "clock fault on clock match",
+			rule: FaultRule{Match: ClockMatch{Clock: "expectations"}, Action: ShiftTime{Offset: time.Minute}},
+		},
+		{
+			name: "blocking fault is valid anywhere",
+			rule: FaultRule{Match: ClientMatch{Verb: "PUT", Resource: "leases"}, Action: InjectDelay{Duration: time.Millisecond}},
+		},
+		{
+			name: "nil action is valid",
+			rule: FaultRule{Match: ClientMatch{Verb: "PUT", Resource: "leases"}, Action: nil},
+		},
+		{
+			name:    "nil match is rejected",
+			rule:    FaultRule{Action: StaleRead{}},
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateFaultDomain(tc.rule)
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("validateFaultDomain() error = %v, wantErr = %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestSyntheticErrorResponseContentType verifies the transport directly sets a
+// JSON Content-Type and the expected status code on the synthetic response.
+func TestSyntheticErrorResponseContentType(t *testing.T) {
+	reg := NewFaultRegistry()
+	reg.Register(FaultRule{
+		Name:      "conflict",
+		Match:     ClientMatch{Verb: "PUT", Resource: "leases", Name: "target-node"},
+		Condition: TriggerAlways(),
+		Action:    NewHTTPStatusError(http.StatusConflict, metav1.StatusReasonConflict, "object was modified"),
+	})
+
+	rt := NewFaultInjectingTransport(&recordingTransport{t: t}, reg, nil)
+	req, err := http.NewRequest(http.MethodPut, "https://example.test/apis/coordination.k8s.io/v1/namespaces/kube-node-lease/leases/target-node", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip returned error: %v", err)
+	}
+	if resp.StatusCode != http.StatusConflict {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusConflict)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json (without it client-go cannot decode the Status)", got)
+	}
+}
+
+// TestInjectedConflictIsClassified is the end-to-end check for a real client-go
+// clientset wrapped with the fault transport surfaces the injected 409 as a
+// properly classified *apierrors.StatusError.
+func TestInjectedConflictIsClassified(t *testing.T) {
+	reg := NewFaultRegistry()
+	reg.Register(FaultRule{
+		Name:      "conflict",
+		Match:     ClientMatch{Verb: "PUT", Resource: "leases", Name: "target-node"},
+		Condition: TriggerAlways(),
+		Action:    NewHTTPStatusError(http.StatusConflict, metav1.StatusReasonConflict, "object was modified"),
+	})
+
+	cfg := &restclient.Config{Host: "https://example.test"}
+	cfg.Wrap(func(base http.RoundTripper) http.RoundTripper {
+		return NewFaultInjectingTransport(&recordingTransport{t: t}, reg, nil)
+	})
+	cs := clientset.NewForConfigOrDie(cfg)
+
+	lease := &coordv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{Name: "target-node", Namespace: v1.NamespaceNodeLease},
+	}
+	_, err := cs.CoordinationV1().Leases(v1.NamespaceNodeLease).Update(context.Background(), lease, metav1.UpdateOptions{})
+	if err == nil {
+		t.Fatal("expected an error from the injected conflict fault, got nil")
+	}
+	if !apierrors.IsConflict(err) {
+		t.Errorf("apierrors.IsConflict(err) = false, want true; err = %v (%T)", err, err)
+	}
+	// The decoded Status payload only survives when Content-Type is set.
+	var se *apierrors.StatusError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v (%T), want *apierrors.StatusError", err, err)
+	}
+	if got := se.ErrStatus.Message; got != "object was modified" {
+		t.Errorf("decoded Status.Message = %q, want %q (the Status body was not decoded; is Content-Type set on the synthetic response?)", got, "object was modified")
+	}
+}

--- a/test/utils/robustness/scenarios.go
+++ b/test/utils/robustness/scenarios.go
@@ -1,0 +1,202 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package robustness
+
+import (
+	"net/http"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// SignalTriggerComplete is raised by the suite once the scenario's trigger
+// action has run. Custom scenarios can gate faults on it via TriggerAfterSignal
+// so a fault only fires once reconciliation is actually underway.
+const SignalTriggerComplete = "trigger.action.completed"
+
+// ChaosScenario is one cell of the chaos matrix: a named set of faults injected
+// while the controller reconciles, plus optional extra verification.
+//
+// A scenario is self-contained: Faults builds every rule the scenario needs,
+// consulting the profile so rules are only produced for sites the controller
+// actually exercises. Rules that must demonstrably fire set ExpectTriggered and
+// are verified by the suite automatically; Verify is only for assertions beyond
+// that (and may be nil).
+type ChaosScenario struct {
+	Name string
+
+	// Faults returns the fault rules to inject for this scenario. It may return
+	// nil when the profile exposes no applicable injection site, in which case
+	// the scenario degenerates to a baseline run. The registry is provided for
+	// signal-gated conditions (see TriggerAfterSignal).
+	Faults func(profile ControllerProfile, registry *FaultRegistry) []FaultRule
+
+	// Verify, if non-nil, runs after convergence for assertions beyond the
+	// automatic ExpectTriggered / AssertAllFaultsMatched checks.
+	Verify func(profile ControllerProfile, fixture *RobustnessTestFixture)
+}
+
+// StandardChaosMatrix returns the default controller-agnostic scenario set. The
+// returned slice is fresh on each call, so callers may append custom scenarios
+// without affecting other suites (see RobustnessTestSuite.AddScenario).
+func StandardChaosMatrix() []ChaosScenario {
+	return []ChaosScenario{
+		{
+			// No faults: verifies the invariants hold under a clean run before
+			// trusting them under chaos.
+			Name: "BaselineNoFaults",
+		},
+		{
+			Name: "WriteConflicts",
+			Faults: func(p ControllerProfile, _ *FaultRegistry) []FaultRule {
+				return rootWriteConflicts(p, TriggerRange(1, 2))
+			},
+		},
+		{
+			Name: "CacheSyncLag",
+			Faults: func(p ControllerProfile, _ *FaultRegistry) []FaultRule {
+				if !p.HasChildCache() {
+					return nil
+				}
+				return []FaultRule{{
+					Name:            "ChildCacheSyncLag",
+					Match:           p.ChildCacheMatch(),
+					Condition:       TriggerOnOccurrence(1), // lag only the first lookup
+					Action:          StaleRead{},
+					ExpectTriggered: true,
+				}}
+			},
+		},
+		{
+			Name: "FlakyAPIServer",
+			Faults: func(p ControllerProfile, _ *FaultRegistry) []FaultRule {
+				// Target the child-create path: the root object is typically
+				// created by the test via the un-wrapped admin client, so POSTs
+				// through the wrapped client are the controller's child creations.
+				if !p.CreatesChildren() {
+					return nil
+				}
+				return []FaultRule{{
+					Name:      "FlakyWrites",
+					Match:     p.ChildCreateMatch(),
+					Condition: TriggerProbability(0.30),
+					Action:    NewHTTPStatusError(http.StatusInternalServerError, metav1.StatusReasonInternalError, "Internal Server Error: storage write failed"),
+					// Not ExpectTriggered: with few creates the 30% coin may
+					// legitimately never land. The site itself is still covered
+					// by the unmatched-fault guard.
+				}}
+			},
+		},
+		{
+			Name: "CombinedChaos",
+			Faults: func(p ControllerProfile, _ *FaultRegistry) []FaultRule {
+				rules := rootWriteConflicts(p, TriggerOnOccurrence(1))
+				if p.HasChildCache() {
+					rules = append(rules, FaultRule{
+						Name:            "ChildCacheLagCombined",
+						Match:           p.ChildCacheMatch(),
+						Condition:       TriggerOnOccurrence(1),
+						Action:          StaleRead{},
+						ExpectTriggered: true,
+					})
+				}
+				return rules
+			},
+		},
+		{
+			Name: "ExpectationsTimeout",
+			Faults: func(p ControllerProfile, reg *FaultRegistry) []FaultRule {
+				var rules []FaultRule
+				if p.UsesExpectations {
+					// Shift the expectations clock, but only after the trigger
+					// action completes, so creation-time expectations are set
+					// against real time and then appear expired.
+					rules = append(rules, FaultRule{
+						Name:            "ShiftExpectationsClock",
+						Match:           ClockMatch{Clock: ExpectationsClockName},
+						Condition:       TriggerAfterSignal(reg, SignalTriggerComplete),
+						Action:          ShiftTime{Offset: 6 * time.Minute},
+						ExpectTriggered: true,
+					})
+				}
+				switch {
+				case p.HasChildCache() && p.CreatesChildren():
+					// Simulate the child informer's watch dying immediately after
+					// the controller's create: every cache read (including the
+					// last-synced resource version) goes stale for a window
+					// starting at the first child POST. Pre-create staleness is
+					// harmless — this post-create interleaving is the one that
+					// produces duplicate children when the controller acts on the
+					// stale view.
+					rules = append(rules,
+						FaultRule{
+							Name:            "ChildCreateObserved",
+							Match:           p.ChildCreateMatch(),
+							Condition:       TriggerAlways(),
+							Action:          nil, // sensor only: opens the window below
+							ExpectTriggered: true,
+						},
+						FaultRule{
+							Name:            "StaleCacheWatchDeath",
+							Match:           p.ChildCacheMatch(),
+							Condition:       TriggerWindowAfterRuleHit(reg, "ChildCreateObserved", time.Second),
+							Action:          StaleRead{},
+							ExpectTriggered: true,
+						})
+				case p.HasChildCache():
+					// No child creates to key off; fall back to lagging the
+					// earliest lookups.
+					rules = append(rules, FaultRule{
+						Name:            "StaleCacheWatchDeath",
+						Match:           p.ChildCacheMatch(),
+						Condition:       TriggerRange(1, 3),
+						Action:          StaleRead{},
+						ExpectTriggered: true,
+					})
+				}
+				return rules
+			},
+		},
+	}
+}
+
+// rootWriteConflicts builds 409-conflict rules for the controller's writes to
+// the root object and/or its /status subresource, per the profile's write
+// declarations. Each produced rule sets ExpectTriggered: the profile promised
+// the write happens, so the conflict must demonstrably land.
+func rootWriteConflicts(p ControllerProfile, cond FaultCondition) []FaultRule {
+	var rules []FaultRule
+	if p.WritesRootStatus {
+		rules = append(rules, FaultRule{
+			Name:            "RootStatusConflict",
+			Match:           p.RootStatusWriteMatch(),
+			Condition:       cond,
+			Action:          NewHTTPStatusError(http.StatusConflict, metav1.StatusReasonConflict, "Conflict: object status was modified"),
+			ExpectTriggered: true,
+		})
+	}
+	if p.WritesRoot {
+		rules = append(rules, FaultRule{
+			Name:            "RootConflict",
+			Match:           p.RootWriteMatch(),
+			Condition:       cond,
+			Action:          NewHTTPStatusError(http.StatusConflict, metav1.StatusReasonConflict, "Conflict: object was modified"),
+			ExpectTriggered: true,
+		})
+	}
+	return rules
+}

--- a/test/utils/robustness/scenarios.go
+++ b/test/utils/robustness/scenarios.go
@@ -1,0 +1,215 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package robustness
+
+import (
+	"net/http"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// SignalTriggerComplete is raised by the suite once the scenario's trigger
+// action has run. Custom scenarios can gate faults on it via TriggerAfterSignal
+// so a fault only fires once reconciliation is actually underway.
+const SignalTriggerComplete = "trigger.action.completed"
+
+// ChaosScenario is one cell of the chaos matrix: a named set of faults injected
+// while the controller reconciles, plus optional extra verification.
+//
+// A scenario is self-contained: Faults builds every rule the scenario needs,
+// consulting the profile so rules are only produced for sites the controller
+// actually exercises. Rules that must demonstrably fire set ExpectTriggered and
+// are verified by the suite automatically; Verify is only for assertions beyond
+// that (and may be nil).
+type ChaosScenario struct {
+	Name string
+
+	// Faults returns the fault rules to inject for this scenario. It may return
+	// nil when the profile exposes no applicable injection site, in which case
+	// the scenario degenerates to a baseline run. The registry is provided for
+	// signal-gated conditions (see TriggerAfterSignal).
+	Faults func(profile ControllerProfile, registry *FaultRegistry) []FaultRule
+
+	// Verify, if non-nil, runs after convergence for assertions beyond the
+	// automatic ExpectTriggered / AssertAllFaultsMatched checks.
+	Verify func(profile ControllerProfile, fixture *RobustnessTestFixture)
+}
+
+// StandardChaosMatrix returns the default controller-agnostic scenario set. The
+// returned slice is fresh on each call, so callers may append custom scenarios
+// without affecting other suites (see RobustnessTestSuite.AddScenario).
+func StandardChaosMatrix() []ChaosScenario {
+	return []ChaosScenario{
+		{
+			// No faults: verifies the invariants hold under a clean run before
+			// trusting them under chaos.
+			Name: "BaselineNoFaults",
+		},
+		{
+			Name: "WriteConflicts",
+			Faults: func(p ControllerProfile, _ *FaultRegistry) []FaultRule {
+				return rootWriteConflicts(p, TriggerRange(1, 2))
+			},
+		},
+		{
+			Name: "CacheSyncLag",
+			Faults: func(p ControllerProfile, _ *FaultRegistry) []FaultRule {
+				if !p.HasChildCache() {
+					return nil
+				}
+				return []FaultRule{{
+					Name:            "ChildCacheSyncLag",
+					Match:           p.ChildCacheMatch(),
+					Condition:       TriggerOnOccurrence(1), // lag only the first lookup
+					Action:          StaleRead{},
+					ExpectTriggered: true,
+				}}
+			},
+		},
+		{
+			Name: "FlakyAPIServer",
+			Faults: func(p ControllerProfile, _ *FaultRegistry) []FaultRule {
+				// Target writes through the wrapped client with probabilistic 500s.
+				// For controllers that create children, target child creation;
+				// otherwise target root / root-status updates.
+				switch {
+				case p.CreatesChildren():
+					return []FaultRule{{
+						Name:      "FlakyChildWrites",
+						Match:     p.ChildCreateMatch(),
+						Condition: TriggerProbability(0.30),
+						Action:    NewHTTPStatusError(http.StatusInternalServerError, metav1.StatusReasonInternalError, "Internal Server Error: storage write failed"),
+					}}
+				case p.WritesRootStatus:
+					return []FaultRule{{
+						Name:      "FlakyRootStatusWrites",
+						Match:     p.RootStatusWriteMatch(),
+						Condition: TriggerProbability(0.30),
+						Action:    NewHTTPStatusError(http.StatusInternalServerError, metav1.StatusReasonInternalError, "Internal Server Error: status write failed"),
+					}}
+				case p.WritesRoot:
+					return []FaultRule{{
+						Name:      "FlakyRootWrites",
+						Match:     p.RootWriteMatch(),
+						Condition: TriggerProbability(0.30),
+						Action:    NewHTTPStatusError(http.StatusInternalServerError, metav1.StatusReasonInternalError, "Internal Server Error: object write failed"),
+					}}
+				default:
+					return nil
+				}
+			},
+		},
+		{
+			Name: "CombinedChaos",
+			Faults: func(p ControllerProfile, _ *FaultRegistry) []FaultRule {
+				rules := rootWriteConflicts(p, TriggerOnOccurrence(1))
+				if p.HasChildCache() {
+					rules = append(rules, FaultRule{
+						Name:            "ChildCacheLagCombined",
+						Match:           p.ChildCacheMatch(),
+						Condition:       TriggerOnOccurrence(1),
+						Action:          StaleRead{},
+						ExpectTriggered: true,
+					})
+				}
+				return rules
+			},
+		},
+		{
+			Name: "ExpectationsTimeout",
+			Faults: func(p ControllerProfile, reg *FaultRegistry) []FaultRule {
+				var rules []FaultRule
+				if p.UsesExpectations {
+					// Shift the expectations clock, but only after the trigger
+					// action completes, so creation-time expectations are set
+					// against real time and then appear expired.
+					rules = append(rules, FaultRule{
+						Name:            "ShiftExpectationsClock",
+						Match:           ClockMatch{Clock: ExpectationsClockName},
+						Condition:       TriggerAfterSignal(reg, SignalTriggerComplete),
+						Action:          ShiftTime{Offset: 6 * time.Minute},
+						ExpectTriggered: true,
+					})
+				}
+				switch {
+				case p.HasChildCache() && p.CreatesChildren():
+					// Simulate the child informer's watch dying immediately after
+					// the controller's create: every cache read (including the
+					// last-synced resource version) goes stale for a window
+					// starting at the first child POST. Pre-create staleness is
+					// harmless — this post-create interleaving is the one that
+					// produces duplicate children when the controller acts on the
+					// stale view.
+					rules = append(rules,
+						FaultRule{
+							Name:            "ChildCreateObserved",
+							Match:           p.ChildCreateMatch(),
+							Condition:       TriggerAlways(),
+							Action:          nil, // sensor only: opens the window below
+							ExpectTriggered: true,
+						},
+						FaultRule{
+							Name:            "StaleCacheWatchDeath",
+							Match:           p.ChildCacheMatch(),
+							Condition:       TriggerWindowAfterRuleHit(reg, "ChildCreateObserved", time.Second),
+							Action:          StaleRead{},
+							ExpectTriggered: true,
+						})
+				case p.HasChildCache():
+					// No child creates to key off; fall back to lagging the
+					// earliest lookups.
+					rules = append(rules, FaultRule{
+						Name:            "StaleCacheWatchDeath",
+						Match:           p.ChildCacheMatch(),
+						Condition:       TriggerRange(1, 3),
+						Action:          StaleRead{},
+						ExpectTriggered: true,
+					})
+				}
+				return rules
+			},
+		},
+	}
+}
+
+// rootWriteConflicts builds 409-conflict rules for the controller's writes to
+// the root object and/or its /status subresource, per the profile's write
+// declarations. Each produced rule sets ExpectTriggered: the profile promised
+// the write happens, so the conflict must demonstrably land.
+func rootWriteConflicts(p ControllerProfile, cond FaultCondition) []FaultRule {
+	var rules []FaultRule
+	if p.WritesRootStatus {
+		rules = append(rules, FaultRule{
+			Name:            "RootStatusConflict",
+			Match:           p.RootStatusWriteMatch(),
+			Condition:       cond,
+			Action:          NewHTTPStatusError(http.StatusConflict, metav1.StatusReasonConflict, "Conflict: object status was modified"),
+			ExpectTriggered: true,
+		})
+	}
+	if p.WritesRoot {
+		rules = append(rules, FaultRule{
+			Name:            "RootConflict",
+			Match:           p.RootWriteMatch(),
+			Condition:       cond,
+			Action:          NewHTTPStatusError(http.StatusConflict, metav1.StatusReasonConflict, "Conflict: object was modified"),
+			ExpectTriggered: true,
+		})
+	}
+	return rules
+}

--- a/test/utils/robustness/suite.go
+++ b/test/utils/robustness/suite.go
@@ -1,0 +1,207 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package robustness
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ControllerSetupFn initializes and runs the controller under test, using the fixture's wrapped clients.
+type ControllerSetupFn func(fixture *RobustnessTestFixture)
+
+// ScenarioActionFn executes the action that triggers reconciliation, using direct or wrapped clients from the fixture.
+type ScenarioActionFn func(ctx context.Context, fixture *RobustnessTestFixture) error
+
+// RobustnessTestSuite runs a controller's trigger action and invariants under
+// every scenario of a chaos matrix. The controller is described declaratively
+// by a ControllerProfile; scenarios derive their faults from it, so the same
+// matrix applies to any controller without modification.
+type RobustnessTestSuite struct {
+	t       *testing.T
+	profile ControllerProfile
+	matrix  []ChaosScenario
+
+	controllerSetup      ControllerSetupFn
+	scenarioAction       ScenarioActionFn
+	continuousInvariants []NamedInvariant
+	livenessInvariant    NamedInvariant
+	livenessTimeout      time.Duration
+
+	// Settled-state configuration. When checkWhenSettled is set, the liveness
+	// invariant is checked once after the controller settles (write-idle for
+	// quietWindow) rather than polled until it first holds. This gives
+	// deterministic "end of reconciliation" semantics for convergent controllers.
+	checkWhenSettled bool
+	quietWindow      time.Duration
+
+	scenarioCustomizers map[string]func(fixture *RobustnessTestFixture)
+}
+
+// NewTestSuite creates a chaos-matrix runner for the controller described by
+// profile, preloaded with the standard scenario matrix.
+func NewTestSuite(t *testing.T, profile ControllerProfile) *RobustnessTestSuite {
+	if err := profile.validate(); err != nil {
+		t.Fatalf("invalid ControllerProfile: %v", err)
+	}
+	return &RobustnessTestSuite{
+		t:       t,
+		profile: profile,
+		matrix:  StandardChaosMatrix(),
+		// Generous default ceiling: PollUntilContextTimeout returns as soon as the
+		// invariant holds, so a higher timeout only affects how long we wait before
+		// declaring failure — it does not slow the passing path. Integration
+		// convergence under load (fresh apiserver per subtest, shared etcd) can
+		// exceed 10s, which made tight ceilings flaky.
+		livenessTimeout:     30 * time.Second,
+		scenarioCustomizers: make(map[string]func(fixture *RobustnessTestFixture)),
+	}
+}
+
+// Profile returns the declared controller profile.
+func (s *RobustnessTestSuite) Profile() ControllerProfile {
+	return s.profile
+}
+
+// AddScenario appends a custom scenario to the matrix, after the standard ones.
+func (s *RobustnessTestSuite) AddScenario(scenario ChaosScenario) {
+	s.matrix = append(s.matrix, scenario)
+}
+
+// SetControllerSetup registers the setup callback for starting the controller.
+func (s *RobustnessTestSuite) SetControllerSetup(fn ControllerSetupFn) {
+	s.controllerSetup = fn
+}
+
+// SetScenarioAction registers the action that triggers reconciliation.
+func (s *RobustnessTestSuite) SetScenarioAction(fn ScenarioActionFn) {
+	s.scenarioAction = fn
+}
+
+// AddSafetyInvariant registers a safety condition checked continuously in the background.
+func (s *RobustnessTestSuite) AddSafetyInvariant(name string, fn Invariant) {
+	s.continuousInvariants = append(s.continuousInvariants, NamedInvariant{Name: name, Fn: fn})
+}
+
+// SetLivenessInvariant registers the target convergence state of the system.
+func (s *RobustnessTestSuite) SetLivenessInvariant(name string, fn Invariant, timeout time.Duration) {
+	s.livenessInvariant = NamedInvariant{Name: name, Fn: fn}
+	s.livenessTimeout = timeout
+}
+
+// CheckWhenSettled opts into deterministic end-of-reconciliation checking: instead
+// of polling the liveness invariant until it first holds, the suite waits for the
+// controller to settle (no mutating requests for quietWindow) and then evaluates
+// the invariant exactly once. Use this for convergent controllers; leave it unset
+// for controllers that write continuously (e.g. periodic lease renewal), which
+// should keep the polling AssertEventually behavior.
+func (s *RobustnessTestSuite) CheckWhenSettled(quietWindow time.Duration) {
+	s.checkWhenSettled = true
+	s.quietWindow = quietWindow
+}
+
+// ConfigureScenario registers a custom fault-injection decorator for a specific
+// scenario in the matrix, run after the scenario's own faults are injected.
+func (s *RobustnessTestSuite) ConfigureScenario(scenarioName string, fn func(fixture *RobustnessTestFixture)) {
+	s.scenarioCustomizers[scenarioName] = fn
+}
+
+// Run executes the trigger action against the controller under every scenario in the matrix.
+func (s *RobustnessTestSuite) Run() {
+	if s.controllerSetup == nil {
+		s.t.Fatal("Setup error: ControllerSetupFn must be set before calling Run()")
+	}
+	if s.scenarioAction == nil {
+		s.t.Fatal("Setup error: ScenarioActionFn must be set before calling Run()")
+	}
+	if s.livenessInvariant.Fn == nil {
+		s.t.Fatal("Setup error: LivenessInvariant must be set before calling Run()")
+	}
+
+	for _, scenario := range s.matrix {
+		scenario := scenario // Capture variable
+		s.t.Run(scenario.Name, func(t *testing.T) {
+			t.Logf("=== Robustness scenario %q for controller %q ===", scenario.Name, s.profile.Name)
+
+			// 1. Fresh test environment with a namespace-safe prefix (max 20 chars).
+			prefix := strings.ToLower(fmt.Sprintf("r-%s", scenario.Name))
+			if len(prefix) > 20 {
+				prefix = prefix[:20]
+			}
+			fixture := NewFixture(t, prefix)
+			defer fixture.TearDown()
+			ctx := fixture.Context()
+
+			// 2. Register continuous safety invariants.
+			for _, inv := range s.continuousInvariants {
+				fixture.AddContinuousInvariant(inv.Name, inv.Fn)
+			}
+
+			// 3. Start the controller under test.
+			s.controllerSetup(fixture)
+
+			// 4. Inject the scenario's faults, derived from the controller profile.
+			if scenario.Faults != nil {
+				for _, rule := range scenario.Faults(s.profile, fixture.Registry()) {
+					fixture.InjectFault(rule)
+				}
+			}
+
+			// 5. Run user-defined scenario customization if registered.
+			if customizer, ok := s.scenarioCustomizers[scenario.Name]; ok {
+				customizer(fixture)
+			}
+
+			// 6. Execute the trigger action, then signal completion so
+			// phase-gated faults (TriggerAfterSignal) can begin firing.
+			t.Logf("Executing scenario trigger action...")
+			if err := s.scenarioAction(ctx, fixture); err != nil {
+				t.Fatalf("Scenario trigger action failed: %v", err)
+			}
+			fixture.Registry().Signal(SignalTriggerComplete)
+
+			// 7. Assert convergence (liveness), while safety invariants check in
+			// the background. When settled-state checking is enabled, wait for
+			// the controller to settle and check the final state once; otherwise
+			// poll until the invariant first holds.
+			if s.checkWhenSettled {
+				t.Logf("Waiting for the controller to settle, then checking liveness (%s)...", s.livenessInvariant.Name)
+				fixture.AssertWhenSettled(s.livenessInvariant.Name, s.livenessInvariant.Fn, s.quietWindow, s.livenessTimeout)
+			} else {
+				t.Logf("Waiting for liveness convergence under faults (%s)...", s.livenessInvariant.Name)
+				fixture.AssertEventually(s.livenessInvariant.Name, s.livenessInvariant.Fn, s.livenessTimeout)
+			}
+
+			// 8. Scenario-specific extra assertions, if any.
+			if scenario.Verify != nil {
+				scenario.Verify(s.profile, fixture)
+			}
+
+			// 9. Guard against silent no-op faults: every non-optional fault must
+			// have matched a real injection site, and every fault declared
+			// ExpectTriggered must have actually fired. A green result without
+			// these checks would be meaningless.
+			fixture.AssertAllFaultsMatched()
+			fixture.AssertExpectedFaultsTriggered()
+
+			t.Logf("Scenario %q completed successfully!", scenario.Name)
+		})
+	}
+}

--- a/test/utils/robustness/suite.go
+++ b/test/utils/robustness/suite.go
@@ -136,7 +136,6 @@ func (s *RobustnessTestSuite) Run() {
 	}
 
 	for _, scenario := range s.matrix {
-		scenario := scenario // Capture variable
 		s.t.Run(scenario.Name, func(t *testing.T) {
 			t.Logf("=== Robustness scenario %q for controller %q ===", scenario.Name, s.profile.Name)
 

--- a/test/utils/robustness/suite.go
+++ b/test/utils/robustness/suite.go
@@ -1,0 +1,220 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package robustness
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+// ControllerSetupFn initializes and runs the controller under test, using the fixture's wrapped clients.
+type ControllerSetupFn func(fixture *RobustnessTestFixture)
+
+// ScenarioActionFn executes the action that triggers reconciliation, using direct or wrapped clients from the fixture.
+type ScenarioActionFn func(ctx context.Context, fixture *RobustnessTestFixture) error
+
+// RobustnessTestSuite runs a controller's trigger action and invariants under
+// every scenario of a chaos matrix. The controller is described declaratively
+// by a ControllerProfile; scenarios derive their faults from it, so the same
+// matrix applies to any controller without modification.
+type RobustnessTestSuite struct {
+	t       *testing.T
+	profile ControllerProfile
+	matrix  []ChaosScenario
+
+	controllerSetup      ControllerSetupFn
+	scenarioAction       ScenarioActionFn
+	continuousInvariants []NamedInvariant
+	livenessInvariants   []NamedInvariant
+	livenessTimeout      time.Duration
+
+	// Settled-state configuration. When checkWhenSettled is set, the liveness
+	// invariant is checked once after the controller settles (write-idle for
+	// quietWindow) rather than polled until it first holds. This gives
+	// deterministic "end of reconciliation" semantics for convergent controllers.
+	checkWhenSettled bool
+	quietWindow      time.Duration
+}
+
+// NewTestSuite creates a chaos-matrix runner for the controller described by
+// profile, preloaded with the standard scenario matrix.
+func NewTestSuite(t *testing.T, profile ControllerProfile) *RobustnessTestSuite {
+	if err := profile.validate(); err != nil {
+		t.Fatalf("invalid ControllerProfile: %v", err)
+	}
+	return &RobustnessTestSuite{
+		t:       t,
+		profile: profile,
+		matrix:  StandardChaosMatrix(),
+		// Generous default ceiling: PollUntilContextTimeout returns as soon as the
+		// invariant holds, so a higher timeout only affects how long we wait before
+		// declaring failure — it does not slow the passing path. Integration
+		// convergence under load (fresh apiserver per subtest, shared etcd) can
+		// exceed 10s, which made tight ceilings flaky.
+		livenessTimeout: 30 * time.Second,
+	}
+}
+
+// Profile returns the declared controller profile.
+func (s *RobustnessTestSuite) Profile() ControllerProfile {
+	return s.profile
+}
+
+// AddScenario appends a custom scenario to the matrix, after the standard ones.
+func (s *RobustnessTestSuite) AddScenario(scenario ChaosScenario) {
+	s.matrix = append(s.matrix, scenario)
+}
+
+// SetControllerSetup registers the setup callback for starting the controller.
+func (s *RobustnessTestSuite) SetControllerSetup(fn ControllerSetupFn) {
+	s.controllerSetup = fn
+}
+
+// SetScenarioAction registers the action that triggers reconciliation.
+func (s *RobustnessTestSuite) SetScenarioAction(fn ScenarioActionFn) {
+	s.scenarioAction = fn
+}
+
+// AddSafetyInvariant registers a safety condition checked continuously in the background.
+func (s *RobustnessTestSuite) AddSafetyInvariant(name string, fn Invariant) {
+	s.continuousInvariants = append(s.continuousInvariants, NamedInvariant{Name: name, Fn: fn})
+}
+
+// AddLivenessInvariant registers a target convergence condition. Multiple liveness
+// invariants can be registered; all must hold upon convergence.
+func (s *RobustnessTestSuite) AddLivenessInvariant(name string, fn Invariant) {
+	s.livenessInvariants = append(s.livenessInvariants, NamedInvariant{Name: name, Fn: fn})
+}
+
+// SetLivenessInvariant registers a single target convergence state (replacing any existing ones)
+// and sets the convergence timeout ceiling.
+func (s *RobustnessTestSuite) SetLivenessInvariant(name string, fn Invariant, timeout time.Duration) {
+	s.livenessInvariants = []NamedInvariant{{Name: name, Fn: fn}}
+	s.livenessTimeout = timeout
+}
+
+// SetLivenessTimeout sets the convergence timeout ceiling for liveness checks.
+func (s *RobustnessTestSuite) SetLivenessTimeout(timeout time.Duration) {
+	s.livenessTimeout = timeout
+}
+
+// CheckWhenSettled opts into deterministic end-of-reconciliation checking: instead
+// of polling the liveness invariant until it first holds, the suite waits for the
+// controller to settle (no mutating requests for quietWindow) and then evaluates
+// the invariant exactly once. Use this for convergent controllers; leave it unset
+// for controllers that write continuously (e.g. periodic lease renewal), which
+// should keep the polling AssertEventually behavior.
+func (s *RobustnessTestSuite) CheckWhenSettled(quietWindow time.Duration) {
+	s.checkWhenSettled = true
+	s.quietWindow = quietWindow
+}
+
+// Run executes the trigger action against the controller under every scenario in the matrix.
+func (s *RobustnessTestSuite) Run() {
+	if s.controllerSetup == nil {
+		s.t.Fatal("Setup error: ControllerSetupFn must be set before calling Run()")
+	}
+	if s.scenarioAction == nil {
+		s.t.Fatal("Setup error: ScenarioActionFn must be set before calling Run()")
+	}
+	if len(s.livenessInvariants) == 0 {
+		s.t.Fatal("Setup error: at least one LivenessInvariant must be set before calling Run()")
+	}
+
+	for _, scenario := range s.matrix {
+		s.t.Run(scenario.Name, func(t *testing.T) {
+			t.Logf("=== Robustness scenario %q for controller %q ===", scenario.Name, s.profile.Name)
+
+			// 1. Fresh test environment with a namespace-safe prefix (max 20 chars).
+			prefix := strings.ToLower(fmt.Sprintf("r-%s", scenario.Name))
+			if len(prefix) > 20 {
+				prefix = prefix[:20]
+			}
+			fixture := NewFixture(t, prefix)
+			defer fixture.TearDown()
+			ctx := fixture.Context()
+
+			// 2. Register continuous safety invariants.
+			for _, inv := range s.continuousInvariants {
+				fixture.AddContinuousInvariant(inv.Name, inv.Fn)
+			}
+
+			// 3. Start the controller under test.
+			s.controllerSetup(fixture)
+
+			// 4. Inject the scenario's faults, derived from the controller profile.
+			if scenario.Faults != nil {
+				for _, rule := range scenario.Faults(s.profile, fixture.Registry()) {
+					fixture.InjectFault(rule)
+				}
+			}
+
+			// 5. Execute the trigger action, then signal completion so
+			// phase-gated faults (TriggerAfterSignal) can begin firing.
+			t.Logf("Executing scenario trigger action...")
+			if err := s.scenarioAction(ctx, fixture); err != nil {
+				t.Fatalf("Scenario trigger action failed: %v", err)
+			}
+			fixture.Registry().Signal(SignalTriggerComplete)
+
+			// 6. Assert convergence (liveness), while safety invariants check in
+			// the background. When settled-state checking is enabled, wait for
+			// the controller to settle and check the final state once; otherwise
+			// poll until the invariant first holds.
+			var livenessNames []string
+			for _, inv := range s.livenessInvariants {
+				livenessNames = append(livenessNames, inv.Name)
+			}
+			allLiveness := strings.Join(livenessNames, ", ")
+			compositeLiveness := func(ctx context.Context, c clientset.Interface) error {
+				for _, inv := range s.livenessInvariants {
+					if err := inv.Fn(ctx, c); err != nil {
+						return fmt.Errorf("liveness invariant %q: %w", inv.Name, err)
+					}
+				}
+				return nil
+			}
+
+			if s.checkWhenSettled {
+				t.Logf("Waiting for the controller to settle, then checking liveness (%s)...", allLiveness)
+				fixture.AssertWhenSettled(allLiveness, compositeLiveness, s.quietWindow, s.livenessTimeout)
+			} else {
+				t.Logf("Waiting for liveness convergence under faults (%s)...", allLiveness)
+				fixture.AssertEventually(allLiveness, compositeLiveness, s.livenessTimeout)
+			}
+
+			// 8. Scenario-specific extra assertions, if any.
+			if scenario.Verify != nil {
+				scenario.Verify(s.profile, fixture)
+			}
+
+			// 9. Guard against silent no-op faults: every non-optional fault must
+			// have matched a real injection site, and every fault declared
+			// ExpectTriggered must have actually fired. A green result without
+			// these checks would be meaningless.
+			fixture.AssertAllFaultsMatched()
+			fixture.AssertExpectedFaultsTriggered()
+
+			t.Logf("Scenario %q completed successfully!", scenario.Name)
+		})
+	}
+}

--- a/test/utils/robustness/transport.go
+++ b/test/utils/robustness/transport.go
@@ -1,0 +1,169 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package robustness
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+// HTTPStatusError represents a structured API error status that should be converted
+// into a valid HTTP response with the given status code and serializable metav1.Status payload.
+type HTTPStatusError struct {
+	StatusCode int
+	Status     metav1.Status
+}
+
+func (e HTTPStatusError) Error() string {
+	return fmt.Sprintf("HTTP Status Error %d: %s", e.StatusCode, e.Status.Message)
+}
+
+// ApplyTransport implements TransportFault: the request is answered with a
+// synthetic API error response instead of being forwarded.
+func (e HTTPStatusError) ApplyTransport() TransportVerdict {
+	return TransportVerdict{Respond: &e}
+}
+
+// ConnectionError is a TransportFault that makes RoundTrip fail at the transport
+// level (nil response), simulating a refused or dropped connection.
+type ConnectionError struct {
+	Err error
+}
+
+func (e ConnectionError) Error() string { return e.Err.Error() }
+
+func (e ConnectionError) ApplyTransport() TransportVerdict {
+	return TransportVerdict{ConnErr: e.Err}
+}
+
+// NewHTTPStatusError creates an HTTPStatusError representing common API server failures.
+func NewHTTPStatusError(statusCode int, reason metav1.StatusReason, message string) HTTPStatusError {
+	return HTTPStatusError{
+		StatusCode: statusCode,
+		Status: metav1.Status{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Status",
+				APIVersion: "v1",
+			},
+			Status:  metav1.StatusFailure,
+			Message: message,
+			Reason:  reason,
+			Code:    int32(statusCode),
+		},
+	}
+}
+
+// FaultInjectingTransport wraps http.RoundTripper and triggers faults on matching REST API calls.
+type FaultInjectingTransport struct {
+	realTransport http.RoundTripper
+	registry      *FaultRegistry
+	activity      *activityTracker // may be nil; records mutating traffic for settle detection
+	resolver      *request.RequestInfoFactory
+}
+
+// NewFaultInjectingTransport creates a wrapped http.RoundTripper that routes request
+// hooks to the registry. activity may be nil when settle detection is not needed.
+func NewFaultInjectingTransport(realTransport http.RoundTripper, registry *FaultRegistry, activity *activityTracker) http.RoundTripper {
+	return &FaultInjectingTransport{
+		realTransport: realTransport,
+		registry:      registry,
+		activity:      activity,
+		resolver: &request.RequestInfoFactory{
+			APIPrefixes:          sets.NewString("api", "apis"),
+			GrouplessAPIPrefixes: sets.NewString("api"),
+		},
+	}
+}
+
+func (t *FaultInjectingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	info, _ := t.resolver.NewRequestInfo(req)
+	if info == nil || !info.IsResourceRequest {
+		return t.realTransport.RoundTrip(req)
+	}
+
+	// Record mutating traffic (the attempt, before any injected failure) so the
+	// fixture can detect when the controller has stopped writing (it has settled).
+	switch req.Method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		t.activity.recordMutation()
+	}
+
+	v := t.registry.ResolveTransport(req.Context(), ClientFacts{
+		Verb:        req.Method,
+		Group:       info.APIGroup,
+		Resource:    info.Resource,
+		Subresource: info.Subresource,
+		Namespace:   info.Namespace,
+		Name:        info.Name,
+	})
+	switch {
+	case v.Respond != nil:
+		return synthesizeResponse(*v.Respond)
+	case v.ConnErr != nil:
+		return nil, v.ConnErr
+	}
+
+	return t.realTransport.RoundTrip(req)
+}
+
+// synthesizeResponse builds an *http.Response carrying a serialized metav1.Status,
+// as the real apiserver would return for an error.
+func synthesizeResponse(httpErr HTTPStatusError) (*http.Response, error) {
+	// Ensure the payload is a well-formed Status object. client-go decodes error
+	// bodies (using the response Content-Type) into the returned
+	// *apierrors.StatusError. If TypeMeta is missing the body may not round-trip,
+	// so backfill it.
+	status := httpErr.Status
+	if status.Kind == "" {
+		status.Kind = "Status"
+	}
+	if status.APIVersion == "" {
+		status.APIVersion = "v1"
+	}
+	bodyBytes, jsonErr := json.Marshal(status)
+	if jsonErr != nil {
+		return nil, fmt.Errorf("failed to marshal injected status error: %v", jsonErr)
+	}
+
+	// Set Content-Type so client-go decodes the Status body. Note client-go
+	// already maps the HTTP status code to a Reason (409 -> Conflict) when it
+	// can't decode the body, so IsConflict/IsTooManyRequests still work without
+	// this. What the header buys is the actual Status *payload* — Message and
+	// Details (e.g. Details.RetryAfterSeconds, used for client backoff via
+	// apierrors.SuggestsClientDelay) — so the injected fault behaves like a real
+	// apiserver response rather than a generic stub.
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	return &http.Response{
+		StatusCode:    httpErr.StatusCode,
+		Status:        fmt.Sprintf("%d %s", httpErr.StatusCode, http.StatusText(httpErr.StatusCode)),
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Body:          io.NopCloser(bytes.NewReader(bodyBytes)),
+		ContentLength: int64(len(bodyBytes)),
+		Header:        header,
+	}, nil
+}

--- a/test/utils/robustness/transport.go
+++ b/test/utils/robustness/transport.go
@@ -143,7 +143,7 @@ func synthesizeResponse(httpErr HTTPStatusError) (*http.Response, error) {
 	}
 	bodyBytes, jsonErr := json.Marshal(status)
 	if jsonErr != nil {
-		return nil, fmt.Errorf("failed to marshal injected status error: %v", jsonErr)
+		return nil, fmt.Errorf("failed to marshal injected status error: %w", jsonErr)
 	}
 
 	// Set Content-Type so client-go decodes the Status body. Note client-go

--- a/test/utils/robustness/transport.go
+++ b/test/utils/robustness/transport.go
@@ -1,0 +1,154 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package robustness
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+// HTTPStatusError represents a structured API error status that should be converted
+// into a valid HTTP response with the given status code and serializable metav1.Status payload.
+type HTTPStatusError struct {
+	StatusCode int
+	Status     metav1.Status
+}
+
+func (e HTTPStatusError) Error() string {
+	return fmt.Sprintf("HTTP Status Error %d: %s", e.StatusCode, e.Status.Message)
+}
+
+// ApplyTransport implements TransportFault: the request is answered with a
+// synthetic API error response instead of being forwarded.
+func (e HTTPStatusError) ApplyTransport() TransportVerdict {
+	return TransportVerdict{Respond: &e}
+}
+
+// NewHTTPStatusError creates an HTTPStatusError representing common API server failures.
+func NewHTTPStatusError(statusCode int, reason metav1.StatusReason, message string) HTTPStatusError {
+	return HTTPStatusError{
+		StatusCode: statusCode,
+		Status: metav1.Status{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Status",
+				APIVersion: "v1",
+			},
+			Status:  metav1.StatusFailure,
+			Message: message,
+			Reason:  reason,
+			Code:    int32(statusCode),
+		},
+	}
+}
+
+// FaultInjectingTransport wraps http.RoundTripper and triggers faults on matching REST API calls.
+type FaultInjectingTransport struct {
+	realTransport http.RoundTripper
+	registry      *FaultRegistry
+	activity      *activityTracker // may be nil; records mutating traffic for settle detection
+	resolver      *request.RequestInfoFactory
+}
+
+// NewFaultInjectingTransport creates a wrapped http.RoundTripper that routes request
+// hooks to the registry. activity may be nil when settle detection is not needed.
+func NewFaultInjectingTransport(realTransport http.RoundTripper, registry *FaultRegistry, activity *activityTracker) http.RoundTripper {
+	return &FaultInjectingTransport{
+		realTransport: realTransport,
+		registry:      registry,
+		activity:      activity,
+		resolver: &request.RequestInfoFactory{
+			APIPrefixes:          sets.NewString("api", "apis"),
+			GrouplessAPIPrefixes: sets.NewString("api"),
+		},
+	}
+}
+
+func (t *FaultInjectingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	info, _ := t.resolver.NewRequestInfo(req)
+	if info == nil || !info.IsResourceRequest {
+		return t.realTransport.RoundTrip(req)
+	}
+
+	// Record mutating traffic (the attempt, before any injected failure) so the
+	// fixture can detect when the controller has stopped writing (it has settled).
+	switch req.Method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		t.activity.recordMutation()
+	}
+
+	v := t.registry.ResolveTransport(req.Context(), ClientFacts{
+		Verb:        req.Method,
+		Group:       info.APIGroup,
+		Resource:    info.Resource,
+		Subresource: info.Subresource,
+		Namespace:   info.Namespace,
+		Name:        info.Name,
+	})
+	if v.Respond != nil {
+		return synthesizeResponse(*v.Respond)
+	}
+
+	return t.realTransport.RoundTrip(req)
+}
+
+// synthesizeResponse builds an *http.Response carrying a serialized metav1.Status,
+// as the real apiserver would return for an error.
+func synthesizeResponse(httpErr HTTPStatusError) (*http.Response, error) {
+	// Ensure the payload is a well-formed Status object. client-go decodes error
+	// bodies (using the response Content-Type) into the returned
+	// *apierrors.StatusError. If TypeMeta is missing the body may not round-trip,
+	// so backfill it.
+	status := httpErr.Status
+	if status.Kind == "" {
+		status.Kind = "Status"
+	}
+	if status.APIVersion == "" {
+		status.APIVersion = "v1"
+	}
+	bodyBytes, jsonErr := json.Marshal(status)
+	if jsonErr != nil {
+		return nil, fmt.Errorf("failed to marshal injected status error: %w", jsonErr)
+	}
+
+	// Set Content-Type so client-go decodes the Status body. Note client-go
+	// already maps the HTTP status code to a Reason (409 -> Conflict) when it
+	// can't decode the body, so IsConflict/IsTooManyRequests still work without
+	// this. What the header buys is the actual Status *payload* — Message and
+	// Details (e.g. Details.RetryAfterSeconds, used for client backoff via
+	// apierrors.SuggestsClientDelay) — so the injected fault behaves like a real
+	// apiserver response rather than a generic stub.
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+
+	return &http.Response{
+		StatusCode:    httpErr.StatusCode,
+		Status:        fmt.Sprintf("%d %s", httpErr.StatusCode, http.StatusText(httpErr.StatusCode)),
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Body:          io.NopCloser(bytes.NewReader(bodyBytes)),
+		ContentLength: int64(len(bodyBytes)),
+		Header:        header,
+	}, nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds the ability to define and inject failures into controllers programmatically and test them against controller scenarios. Discussed with a few folks in sig-testing and this seems like the way we want to go with testing controllers at scale. https://docs.google.com/document/d/1z8MQpr_jTwhmjLMUaqQyBk1EYG_Y_3D4y4YdMJ7V1Kk/edit?tab=t.0#bookmark=id.1bu5c9qdufeb for discussion.

The approach provides a structured and separate way to define failure scenarios and controller invariants. Controller authors can build test cases just in regards to invariants while folks who know what kind of scenarios can occur in production can create "failure scenarios" which inject failures into those test scenarios to ensure that various invariants hold. This split allows for the best use of knowledge. Those who are familiar with controller behavior do not need to understand the failure scenarios the underlying framework and those who are don't need to know what scenarios every controller wants to test against.

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/5647
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add test framework for controller failure injection
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
