### PR TITLE
Fix volumesInUse not cleared during graceful shutdown

### DIFF
--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager.go
@@ -128,6 +128,16 @@ func newPodManager(conf *Config) *podManager {
 // killPods terminates pods by priority.
 func (m *podManager) killPods(ctx context.Context, activePods []*v1.Pod) error {
 	groups := groupByPriority(m.shutdownGracePeriodByPodPriority, activePods)
+
+	// Wait for any pre-existing unmounted volumes to be fully detached.
+	// This handles the case where pods were deleted/evicted just before shutdown,
+	// and their volumes are still being unstaged. Without this wait, we might kill
+	// CSI drivers (which could be in the first or only group) before those orphan
+	// volumes finish unstaging.
+	if err := m.volumeManager.WaitForAllPodsUnmount(ctx, nil); err != nil {
+		m.logger.Error(err, "Failed waiting for pre-existing unmounted volumes to detach")
+	}
+
 	for _, group := range groups {
 		select {
 		case <-ctx.Done():

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
@@ -355,6 +355,12 @@ func (m *managerImpl) processShutdownEvent(ctx context.Context) error {
 	activePods := m.getPods()
 
 	defer func() {
+		// Ensures Node.status.volumesInUse reflects the actual state (empty) before kubelet exits.
+		// Must be called before releasing the inhibit lock to prevent systemd from killing kubelet
+		// before the status update completes.
+		nodeStatusCtx := klog.NewContext(ctx, m.logger)
+		m.syncNodeStatus(nodeStatusCtx)
+
 		m.dbusCon.ReleaseInhibitLock(m.inhibitLock)
 		m.logger.V(1).Info("Shutdown manager completed processing shutdown event, node will shutdown shortly")
 	}()

--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux_test.go
+++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux_test.go
@@ -794,6 +794,58 @@ func Test_processShutdownEvent_VolumeUnmountTimeout(t *testing.T) {
 	assert.Contains(t, log, expectedLogMessage, "Expected log message not found")
 }
 
+func Test_processShutdownEvent_VolumeUnmount(t *testing.T) {
+	tCtx := testutilsktesting.Init(t)
+
+	var (
+		fakeRecorder = &record.FakeRecorder{}
+		nodeRef      = &v1.ObjectReference{Kind: "Node", Name: "test", UID: types.UID("test"), Namespace: ""}
+		fakeclock    = testingclock.NewFakeClock(time.Now())
+	)
+
+	fakeVolumeManager := volumemanager.NewFakeVolumeManager(
+		[]v1.UniqueVolumeName{"vol1"}, 0, nil, false,
+	)
+
+	volumesInUse := fakeVolumeManager.GetVolumesInUse()
+	assert.NotEmpty(t, volumesInUse)
+
+	var syncNodeStatusMux sync.Mutex
+	syncNodeStatus := func(context.Context) {
+		syncNodeStatusMux.Lock()
+		defer syncNodeStatusMux.Unlock()
+		volumesInUse = fakeVolumeManager.GetVolumesInUse()
+	}
+
+	logger := ktesting.NewLogger(t, ktesting.DefaultConfig)
+	m := &managerImpl{
+		logger:         logger,
+		recorder:       fakeRecorder,
+		nodeRef:        nodeRef,
+		getPods:        func() []*v1.Pod { return nil },
+		syncNodeStatus: syncNodeStatus,
+		dbusCon:        &fakeDbus{},
+		podManager: &podManager{
+			logger:        logger,
+			volumeManager: fakeVolumeManager,
+			shutdownGracePeriodByPodPriority: []kubeletconfig.ShutdownGracePeriodByPodPriority{
+				{
+					Priority:                   1,
+					ShutdownGracePeriodSeconds: 2,
+				},
+			},
+			killPodFunc: func(pod *v1.Pod, isEvicted bool, gracePeriodOverride *int64, fn func(*v1.PodStatus)) error {
+				return nil
+			},
+			clock: fakeclock,
+		},
+	}
+
+	err := m.processShutdownEvent(tCtx)
+	require.NoError(t, err, "managerImpl.processShutdownEvent() should not return an error")
+	assert.Empty(t, volumesInUse, "syncNodeStatus should be called after WaitForAllPodsUnmount")
+}
+
 // TestStartDbusConnectionClosedOnError verifies that when start() fails after
 // creating a dbus connection, the connection is properly closed to avoid
 // leaking goroutines and file descriptors. See #120613.

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -113,9 +113,10 @@ type VolumeManager interface {
 	WaitForUnmount(ctx context.Context, pod *v1.Pod) error
 
 	// WaitForAllPodsUnmount is a version of WaitForUnmount that blocks and
-	// waits until all the volumes belonging to all the pods are unmounted.
-	// An error is returned if there's at least one Pod with volumes not unmounted
-	// within the duration defined in podAttachAndMountTimeout.
+	// waits until all the volumes belonging to all the pods are unmounted and
+	// fully detached.
+	// An error is returned if volumes are not fully detached within the duration
+	// defined in podAttachAndMountTimeout.
 	WaitForAllPodsUnmount(ctx context.Context, pods []*v1.Pod) error
 
 	// GetMountedVolumesForPod returns a VolumeMap containing the volumes
@@ -510,18 +511,33 @@ func (vm *volumeManager) WaitForUnmount(ctx context.Context, pod *v1.Pod) error 
 }
 
 func (vm *volumeManager) WaitForAllPodsUnmount(ctx context.Context, pods []*v1.Pod) error {
-	if len(pods) == 0 {
-		return nil
+	if len(pods) > 0 {
+		funcs := make([]func() error, 0, len(pods))
+		for _, pod := range pods {
+			funcs = append(funcs, func() error {
+				return vm.WaitForUnmount(ctx, pod)
+			})
+		}
+
+		if err := utilerrors.AggregateGoroutines(funcs...); err != nil {
+			return err
+		}
 	}
 
-	funcs := make([]func() error, 0, len(pods))
-	for _, pod := range pods {
-		funcs = append(funcs, func() error {
-			return vm.WaitForUnmount(ctx, pod)
+	// Wait for all unmounted volumes to be fully detached.
+	err := wait.PollUntilContextTimeout(
+		ctx,
+		reconcilerLoopSleepPeriod,
+		podAttachAndMountTimeout,
+		true,
+		func(_ context.Context) (bool, error) {
+			return len(vm.actualStateOfWorld.GetUnmountedVolumes()) == 0, nil
 		})
+	if err != nil {
+		return fmt.Errorf("waiting for volumes to be fully detached: %w", err)
 	}
 
-	return utilerrors.AggregateGoroutines(funcs...)
+	return nil
 }
 
 func (vm *volumeManager) getVolumesNotInDSW(uniquePodName types.UniquePodName, expectedVolumes []string) []string {

--- a/pkg/kubelet/volumemanager/volume_manager_fake.go
+++ b/pkg/kubelet/volumemanager/volume_manager_fake.go
@@ -18,6 +18,7 @@ package volumemanager
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -28,6 +29,7 @@ import (
 
 // FakeVolumeManager is a test implementation that just tracks calls
 type FakeVolumeManager struct {
+	mu                        sync.Mutex
 	volumes                   map[v1.UniqueVolumeName]bool
 	reportedInUse             map[v1.UniqueVolumeName]bool
 	unmountDelay              time.Duration
@@ -74,6 +76,9 @@ func (f *FakeVolumeManager) WaitForAllPodsUnmount(ctx context.Context, pods []*v
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-time.After(f.unmountDelay):
+		f.mu.Lock()
+		f.volumes = nil
+		f.mu.Unlock()
 		return f.unmountError
 	}
 }
@@ -95,6 +100,8 @@ func (f *FakeVolumeManager) GetExtraSupplementalGroupsForPod(pod *v1.Pod) []int6
 
 // GetVolumesInUse returns a list of the initial volumes
 func (f *FakeVolumeManager) GetVolumesInUse() []v1.UniqueVolumeName {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	inuse := []v1.UniqueVolumeName{}
 	for v := range f.volumes {
 		inuse = append(inuse, v)
@@ -114,6 +121,8 @@ func (f *FakeVolumeManager) VolumeIsAttached(volumeName v1.UniqueVolumeName) boo
 
 // MarkVolumesAsReportedInUse adds the given volumes to the reportedInUse map
 func (f *FakeVolumeManager) MarkVolumesAsReportedInUse(volumesReportedAsInUse []v1.UniqueVolumeName) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	for _, reportedVolume := range volumesReportedAsInUse {
 		if _, ok := f.volumes[reportedVolume]; ok {
 			f.reportedInUse[reportedVolume] = true
@@ -124,6 +133,8 @@ func (f *FakeVolumeManager) MarkVolumesAsReportedInUse(volumesReportedAsInUse []
 // GetVolumesReportedInUse is a test function only that returns a list of volumes
 // from the reportedInUse map
 func (f *FakeVolumeManager) GetVolumesReportedInUse() []v1.UniqueVolumeName {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	inuse := []v1.UniqueVolumeName{}
 	for reportedVolume := range f.reportedInUse {
 		inuse = append(inuse, reportedVolume)

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -778,6 +778,10 @@ func TestWaitForAllPodsUnmount(t *testing.T) {
 				}
 			} else {
 				require.NoError(t, err, "Expected no error")
+				// Verify that GetVolumesInUse() is empty after WaitForAllPodsUnmount completes
+				// This proves that volumes were fully detached (not just unmounted)
+				require.Empty(t, manager.GetVolumesInUse(),
+					"GetVolumesInUse() should be empty after WaitForAllPodsUnmount completes")
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

During graceful node shutdown, `Node.status.volumesInUse` was not properly cleared before kubelet exited. This caused volumes to remain "stuck" in the attach/detach controller's cache until the 6-minute force-detach timeout, preventing volumes from being attached to other nodes.

**Root cause:** Multiple race conditions in the shutdown flow:

1. **WaitForAllPodsUnmount only waited for NodeUnpublishVolume**, not NodeUnstageVolume. The full detach chain (Populator → Unpublish → Unstage → MarkDetached) happens asynchronously with no synchronization.

2. **The only syncNodeStatus call was fire-and-forget** (`go m.syncNodeStatus`), called before volume cleanup, and not guaranteed to complete before kubelet exits.

3. **The systemd inhibit lock was released without any synchronous status update**, allowing systemd to kill kubelet before the cleared state was persisted.

**Fix:**

1. **Extended `WaitForAllPodsUnmount`** to wait for `GetUnmountedVolumes() == 0`, ensuring the entire detach chain completes before returning. This also works when called with an empty pod list (handles orphan volumes from pods deleted/evicted just before shutdown).

2. **Added initial `WaitForAllPodsUnmount(nil)` call** in `killPods()` before the group loop to handle pre-existing orphan volumes that are still being unstaged.

3. **Added synchronous `syncNodeStatus` call** in the defer block of `processShutdownEvent`, ensuring it runs after `killPods` completes and before the inhibit lock is released. This guarantees the cleared `volumesInUse` state is persisted to the API server before systemd can terminate kubelet. The existing fire-and-forget async call is kept to quickly mark the node as NotReady for the scheduler.

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/issues/2000

Related to PR #136029 (AD controller changes) — this fix handles the graceful shutdown case (kubelet can help), while #136029 handles the node deletion case (kubelet can't help).

#### Special notes for your reviewer:

This kubelet-side fix is complementary to the AD controller 6-minute force-detach mechanism. With this fix, volumes are available for re-attachment immediately after shutdown, rather than waiting for the 6-minute timeout.

#### Does this PR introduce a user-facing change?

```release-note
During graceful node shutdown, volumesInUse is now properly cleared from Node.status before kubelet exits. Volumes can be immediately attached to other nodes after the node shuts down, without waiting for the 6-minute force-detach timeout.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

---

## Manual E2E test: Verifying volumesInUse is cleared during shutdown

### Test setup

- Kubelet config: GracefulNodeShutdown + GracefulNodeShutdownBasedOnPodPriority enabled
- Test pod: `default/test-disk-pod` with a PVC backed by a CSI block storage volume
- Shutdown priority groups:
  ```yaml
  shutdownGracePeriodByPodPriority:
    - priority: 0              → 20s
    - priority: 2000000000     → 15s  (cluster-critical)
    - priority: 2000001000     → 30s  (node-critical: csi-plugin, cni, node-local-dns)
  ```

### Result: volumesInUse cleared in 1.53 seconds

The API server audit log captures the exact moment kubelet patches `volumesInUse: null`:

**API server audit log** (node status patches):
```
# Normal heartbeat before shutdown
requestReceivedTimestamp: 2026-06-11T17:56:18.273448Z
userAgent: kubelet
requestObject: {"status":{"conditions":[{"lastHeartbeatTime":"2026-06-11T17:56:18Z","type":"Ready"}]}}

# 1st syncNodeStatus (async): marks node as NotReady
requestReceivedTimestamp: 2026-06-11T17:57:05.678343Z
userAgent: kubelet
requestObject: {"status":{"conditions":[{"lastTransitionTime":"2026-06-11T17:57:05Z","message":"node is shutting down","reason":"KubeletNotReady","status":"False","type":"Ready"}]}}

# 2nd syncNodeStatus (sync, in defer): clears volumesInUse ← OUR FIX
requestReceivedTimestamp: 2026-06-11T17:57:07.198629Z
userAgent: kubelet
requestObject: {"status":{"volumesInUse":null, ...}}

# KCM ADC reacts in 106ms: clears volumesAttached
requestReceivedTimestamp: 2026-06-11T17:57:07.304106Z
userAgent: kube-controller-manager/...attachdetach-controller
requestObject: {"status":{"volumesAttached":null}}
```

**Kubelet logs** (from `journalctl -b -1 -u kubelet`, timezone +8:00):
```
01:57:05.675  Shutdown manager detected new shutdown event
01:57:05.676  Node became not ready (reason: KubeletNotReady, message: node is shutting down)
01:57:05.677  Killing pod priority=0: test-disk-pod gracePeriod=10
01:57:06.284  Finished killing pod: test-disk-pod
01:57:06.397  UnmountVolume started for CSI volume (NodeUnpublishVolume)
01:57:06.400  UnmountVolume.TearDown succeeded for CSI volume
01:57:06.498  UnmountDevice started for CSI volume (NodeUnstageVolume)
01:57:06.501  UnmountDevice succeeded for CSI volume
01:57:06.685  Done waiting for all pods in group to terminate, gracePeriod=20 priority=0
01:57:06.685  Killing pod priority=2000001000: csi-plugin, terway, node-local-dns, kube-proxy
01:57:06.893  All node-critical pods killed (208ms)
01:57:07.16x  Done waiting for all pods in group to terminate, gracePeriod=30 priority=2000001000
01:57:07.198  [syncNodeStatus in defer] patches volumesInUse: null ← OUR FIX
01:57:07.209  Shutdown manager completed, inhibit lock released
01:57:23.963  Kubelet: Ready=True (new boot)
```

The KCM attach/detach controller saw `volumesInUse: null` and immediately set `volumesAttached: null`, making the volume available for other nodes **without waiting for the 6-minute timeout**.