### PR TITLE
node lifecycle controller: mark pods not ready on false->unknown transition

### DIFF
--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -750,13 +750,14 @@ func (nc *Controller) monitorNodeHealth(ctx context.Context) error {
 		}
 
 		if currentReadyCondition != nil {
+			transitionedToNotReady := currentReadyCondition.Status != v1.ConditionTrue &&
+				(observedReadyCondition.Status == v1.ConditionTrue ||
+					(currentReadyCondition.Status == v1.ConditionUnknown && observedReadyCondition.Status == v1.ConditionFalse))
+
 			pods, err := nc.getPodsAssignedToNode(node.Name)
 			if err != nil {
 				utilruntime.HandleErrorWithContext(ctx, err, "Unable to list pods of node", node.Name)
-				if currentReadyCondition.Status != v1.ConditionTrue && observedReadyCondition.Status == v1.ConditionTrue {
-					// If error happened during node status transition (Ready -> NotReady)
-					// we need to mark node for retry to force MarkPodsNotReady execution
-					// in the next iteration.
+				if transitionedToNotReady {
 					nc.nodesToRetry.Store(node.Name, struct{}{})
 				}
 				return
@@ -764,12 +765,13 @@ func (nc *Controller) monitorNodeHealth(ctx context.Context) error {
 			nc.processTaintBaseEviction(ctx, node, currentReadyCondition)
 
 			_, needsRetry := nc.nodesToRetry.Load(node.Name)
-			switch {
-			case currentReadyCondition.Status != v1.ConditionTrue && observedReadyCondition.Status == v1.ConditionTrue:
-				// Report node event only once when status changed.
+			shouldRecordEvent := currentReadyCondition.Status != v1.ConditionTrue && observedReadyCondition.Status == v1.ConditionTrue
+			shouldMarkPodsNotReady := transitionedToNotReady || (needsRetry && observedReadyCondition.Status != v1.ConditionTrue)
+
+			if shouldRecordEvent {
 				controllerutil.RecordNodeStatusChange(logger, nc.recorder, node, "NodeNotReady")
-				fallthrough
-			case needsRetry && observedReadyCondition.Status != v1.ConditionTrue:
+			}
+			if shouldMarkPodsNotReady {
 				if err = controllerutil.MarkPodsNotReady(ctx, nc.kubeClient, nc.recorder, pods, node.Name); err != nil {
 					utilruntime.HandleErrorWithContext(ctx, err, "Unable to mark all pods NotReady on node; queuing for retry", "node", node.Name)
 					nc.nodesToRetry.Store(node.Name, struct{}{})

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
@@ -2431,6 +2431,30 @@ func TestMonitorNodeHealthMarkPodsNotReadyRetry(t *testing.T) {
 			},
 			expectedPodStatusUpdates: 1,
 		},
+		// Node transitions from NotReady (false) to Unreachable (unknown) without going back through Ready.
+		// Pods must be marked not ready in this case. (#112733)
+		{
+			desc: "node transitions from NotReady to Unreachable, pods must be marked not ready",
+			fakeNodeHandler: &testutil.FakeNodeHandler{
+				Clientset: fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*testutil.NewPod("pod0", "node0")}}),
+			},
+			fakeGetPodsAssignedToNode: fakeGetPodsAssignedToNode,
+			nodeIterations: []nodeIteration{
+				{
+					timeToPass: 0,
+					newNodes:   makeNodes(v1.ConditionTrue, timeNow, timeNow),
+				},
+				{
+					timeToPass: 0,
+					newNodes:   makeNodes(v1.ConditionFalse, timeNow, timeNow),
+				},
+				{
+					timeToPass: testNodeMonitorGracePeriod + 10*time.Second,
+					newNodes:   makeNodes(v1.ConditionFalse, timeNow, timeNow),
+				},
+			},
+			expectedPodStatusUpdates: 1,
+		},
 	}
 
 	for _, item := range table {


### PR DESCRIPTION
When a node's Ready condition transitions from `false` to `unknown` (for example, when containerd crashes and then the kubelet also loses connectivity), the node controller was not calling `MarkPodsNotReady`. Pods kept their Ready condition set to `true`, so traffic could still be sent to the broken node.

The bug is in `monitorNodeHealth`. The transition checks that trigger `MarkPodsNotReady` and retry scheduling only checked for transitions starting from `Ready=true`. This completely misses the `false -> unknown` transition.

The fix introduces a `transitionedToNotReady` predicate that covers both `true -> false/unknown` and `false -> unknown` transitions, and refactors the switch-fallthrough block into clean conditional statements.

Fixes #112733
