### PR TITLE
Migrate metav1.Condition ObservedGeneration to declarative validation

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -210,6 +210,8 @@ message Condition {
   // with respect to the current state of the instance.
   // +optional
   // +kubebuilder:validation:Minimum=0
+  // +k8s:alpha(since: "1.37")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:minimum=0
   optional int64 observedGeneration = 3;
 
   // lastTransitionTime is the last time the condition transitioned from one status to another.

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1642,6 +1642,8 @@ type Condition struct {
 	// with respect to the current state of the instance.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
+	// +k8s:alpha(since: "1.37")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:minimum=0
 	ObservedGeneration int64 `json:"observedGeneration,omitempty" protobuf:"varint,3,opt,name=observedGeneration"`
 	// lastTransitionTime is the last time the condition transitioned from one status to another.
 	// This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -328,7 +328,7 @@ func ValidateCondition(condition metav1.Condition, fldPath *field.Path) field.Er
 	}
 
 	if condition.ObservedGeneration < 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("observedGeneration"), condition.ObservedGeneration, "must be greater than or equal to zero"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("observedGeneration"), condition.ObservedGeneration, "must be greater than or equal to zero").WithOrigin("minimum").MarkCoveredByDeclarative())
 	}
 
 	if condition.LastTransitionTime.IsZero() {

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -293,7 +293,7 @@ func ValidateConditions(conditions []metav1.Condition, fldPath *field.Path) fiel
 	conditionTypeToFirstIndex := map[string]int{}
 	for i, condition := range conditions {
 		if _, ok := conditionTypeToFirstIndex[condition.Type]; ok {
-			allErrs = append(allErrs, field.Duplicate(fldPath.Index(i), condition.Type).MarkCoveredByDeclarative().MarkAlpha())
+			allErrs = append(allErrs, field.Duplicate(fldPath.Index(i), condition.Type).MarkCoveredByDeclarative())
 		} else {
 			conditionTypeToFirstIndex[condition.Type] = i
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
@@ -67,7 +67,38 @@ func Validate_Condition(
 	}
 
 	// field v1.Condition.Status has no validation
-	// field v1.Condition.ObservedGeneration has no validation
+
+	{ // field v1.Condition.ObservedGeneration
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int64,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *v1.Condition) *int64 {
+				return &oldObj.ObservedGeneration
+			})
+		errs = append(errs, fn(fldPath.Child("observedGeneration"), &obj.ObservedGeneration, oldVal, oldObj != nil)...)
+	}
+
 	// field v1.Condition.LastTransitionTime has no validation
 	// field v1.Condition.Reason has no validation
 	// field v1.Condition.Message has no validation

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1_test.go
@@ -33,6 +33,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].observedGeneration": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"status.conditions[*].type": {
 				{ErrorType: "FieldValueRequired"},
 			},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
@@ -33,6 +33,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].observedGeneration": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"status.conditions[*].type": {
 				{ErrorType: "FieldValueRequired"},
 			},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
@@ -33,6 +33,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].observedGeneration": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"status.conditions[*].type": {
 				{ErrorType: "FieldValueRequired"},
 			},

--- a/test/declarative_validation/certificates/podcertificaterequest/declarative_validation_test.go
+++ b/test/declarative_validation/certificates/podcertificaterequest/declarative_validation_test.go
@@ -83,6 +83,32 @@ func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 						field.Invalid(field.NewPath("status", "conditions").Child("[1]", "type"), certificates.PodCertificateRequestConditionTypeDenied, `There may be at most one condition with type "Issued", "Denied", or "Failed"`).MarkFromImperative(),
 					},
 				},
+				{
+					Name: "invalid negative observedGeneration",
+					Conditions: []metav1.Condition{
+						meta.MkCondition(
+							meta.TweakType(string(certificates.PodCertificateRequestConditionTypeDenied)),
+							meta.TweakObservedGeneration(-1),
+						),
+					},
+					ExpectedErrs: field.ErrorList{
+						field.Invalid(
+							field.NewPath("status", "conditions").Index(0).Child("observedGeneration"),
+							int64(-1),
+							"",
+						).WithOrigin("minimum").MarkAlpha(),
+					},
+				},
+				{
+					Name: "valid observedGeneration zero",
+					Conditions: []metav1.Condition{
+						meta.MkCondition(
+							meta.TweakType(string(certificates.PodCertificateRequestConditionTypeDenied)),
+							meta.TweakObservedGeneration(0),
+						),
+					},
+					ExpectedErrs: nil,
+				},
 			}
 
 			for _, tc := range testCases {

--- a/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1beta1_test.go
@@ -33,6 +33,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].observedGeneration": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"status.conditions[*].type": {
 				{ErrorType: "FieldValueRequired"},
 			},

--- a/test/declarative_validation/meta/conditions.go
+++ b/test/declarative_validation/meta/conditions.go
@@ -68,9 +68,16 @@ func GenerateConditionTestCases(fldPath *field.Path) []ConditionTestCase {
 				field.Invalid(
 					fldPath.Index(0).Child("observedGeneration"),
 					int64(-1),
-					"must be greater than or equal to zero",
+					"",
 				).WithOrigin("minimum").MarkAlpha(),
 			},
+		},
+		{
+			Name: "valid observedGeneration zero",
+			Conditions: []metav1.Condition{
+				MkCondition(TweakObservedGeneration(0)),
+			},
+			ExpectedErrs: nil,
 		},
 	}
 }

--- a/test/declarative_validation/meta/conditions.go
+++ b/test/declarative_validation/meta/conditions.go
@@ -59,6 +59,19 @@ func GenerateConditionTestCases(fldPath *field.Path) []ConditionTestCase {
 				field.Required(fldPath.Index(0).Child("type"), "").MarkAlpha(),
 			},
 		},
+		{
+			Name: "invalid negative observedGeneration",
+			Conditions: []metav1.Condition{
+				MkCondition(TweakObservedGeneration(-1)),
+			},
+			ExpectedErrs: field.ErrorList{
+				field.Invalid(
+					fldPath.Index(0).Child("observedGeneration"),
+					int64(-1),
+					"must be greater than or equal to zero",
+				).WithOrigin("minimum").MarkAlpha(),
+			},
+		},
 	}
 }
 
@@ -101,5 +114,11 @@ func TweakType(condType string) func(*metav1.Condition) {
 func TweakStatus(status metav1.ConditionStatus) func(*metav1.Condition) {
 	return func(c *metav1.Condition) {
 		c.Status = status
+	}
+}
+
+func TweakObservedGeneration(gen int64) func(*metav1.Condition) {
+	return func(c *metav1.Condition) {
+		c.ObservedGeneration = gen
 	}
 }

--- a/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1_test.go
@@ -33,6 +33,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].observedGeneration": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"status.conditions[*].type": {
 				{ErrorType: "FieldValueRequired"},
 			},

--- a/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1beta1_test.go
@@ -33,6 +33,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].observedGeneration": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"status.conditions[*].type": {
 				{ErrorType: "FieldValueRequired"},
 			},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1alpha3_test.go
@@ -37,6 +37,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].observedGeneration": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"status.conditions[*].type": {
 				{ErrorType: "FieldValueRequired"},
 			},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1beta2_test.go
@@ -37,6 +37,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].observedGeneration": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"status.conditions[*].type": {
 				{ErrorType: "FieldValueRequired"},
 			},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1_test.go
@@ -165,6 +165,9 @@ func init() {
 			"status.devices[*].conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.devices[*].conditions[*].observedGeneration": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"status.devices[*].conditions[*].type": {
 				{ErrorType: "FieldValueRequired"},
 			},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta1_test.go
@@ -165,6 +165,9 @@ func init() {
 			"status.devices[*].conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.devices[*].conditions[*].observedGeneration": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"status.devices[*].conditions[*].type": {
 				{ErrorType: "FieldValueRequired"},
 			},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta2_test.go
@@ -165,6 +165,9 @@ func init() {
 			"status.devices[*].conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.devices[*].conditions[*].observedGeneration": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"status.devices[*].conditions[*].type": {
 				{ErrorType: "FieldValueRequired"},
 			},

--- a/test/declarative_validation/resource/resourcepoolstatusrequest/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/resource/resourcepoolstatusrequest/zz_generated.validations.v1alpha3_test.go
@@ -51,6 +51,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].observedGeneration": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"status.conditions[*].type": {
 				{ErrorType: "FieldValueRequired"},
 			},

--- a/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1alpha3_test.go
@@ -98,6 +98,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].observedGeneration": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"status.conditions[*].type": {
 				{ErrorType: "FieldValueRequired"},
 			},

--- a/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1beta1_test.go
@@ -33,6 +33,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].observedGeneration": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"status.conditions[*].type": {
 				{ErrorType: "FieldValueRequired"},
 			},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Migrates `metav1.Condition.ObservedGeneration` validation to Declarative Validation.

This PR:

* Adds declarative validation tags for `ObservedGeneration`:

  * `+k8s:optional`
  * `+k8s:minimum=0`
* Marks the corresponding handwritten validation as covered by declarative validation.
* Adds declarative validation test coverage for invalid negative `ObservedGeneration` values.
* Regenerates validation code and generated declarative validation tests.

#### Which issue(s) this PR is related to:

Part of #139638

#### Special notes for your reviewer:

This PR covers Batch 5 (`ObservedGeneration`) from the metav1.Condition declarative validation migration tracking issue.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5073-declarative-validation
```
