### PR TITLE
Feature: Add PodGroupPostFilter extension point

### DIFF
--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -69427,6 +69427,13 @@ func schema_k8sio_kube_scheduler_config_v1_Plugins(ref common.ReferenceCallback)
 							Ref:         ref(configv1.PluginSet{}.OpenAPIModelName()),
 						},
 					},
+					"podGroupPostFilter": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PodGroupPostFilter is a list of plugins that are invoked after the workload scheduling phase, but only when the PodGroup cannot be scheduled (equivalent to PostFilter for single pods).",
+							Default:     map[string]interface{}{},
+							Ref:         ref(configv1.PluginSet{}.OpenAPIModelName()),
+						},
+					},
 				},
 			},
 		},

--- a/pkg/scheduler/apis/config/testing/defaults/defaults.go
+++ b/pkg/scheduler/apis/config/testing/defaults/defaults.go
@@ -105,6 +105,11 @@ var ExpandedPluginsV1 = &config.Plugins{
 			{Name: names.DefaultPreemption},
 		},
 	},
+	PodGroupPostFilter: config.PluginSet{
+		Enabled: []config.Plugin{
+			{Name: names.DefaultPreemption},
+		},
+	},
 	PreScore: config.PluginSet{
 		Enabled: []config.Plugin{
 			{Name: names.TaintToleration},

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -182,6 +182,10 @@ type Plugins struct {
 
 	// PlacementScore is a list of plugins that should be invoked during workload scheduling cycle when ranking pod group assignments.
 	PlacementScore PluginSet
+
+	// PodGroupPostFilter is a list of plugins that are invoked after the workload scheduling phase,
+	// but only when the PodGroup cannot be scheduled (equivalent to PostFilter for single pods).
+	PodGroupPostFilter PluginSet
 }
 
 // PluginSet specifies enabled and disabled plugins for an extension point.

--- a/pkg/scheduler/apis/config/v1/default_plugins.go
+++ b/pkg/scheduler/apis/config/v1/default_plugins.go
@@ -120,6 +120,7 @@ func mergePlugins(logger klog.Logger, defaultPlugins, customPlugins *v1.Plugins)
 	defaultPlugins.PostBind = mergePluginSet(logger, defaultPlugins.PostBind, customPlugins.PostBind)
 	defaultPlugins.PlacementGenerate = mergePluginSet(logger, defaultPlugins.PlacementGenerate, customPlugins.PlacementGenerate)
 	defaultPlugins.PlacementScore = mergePluginSet(logger, defaultPlugins.PlacementScore, customPlugins.PlacementScore)
+	defaultPlugins.PodGroupPostFilter = mergePluginSet(logger, defaultPlugins.PodGroupPostFilter, customPlugins.PodGroupPostFilter)
 	return defaultPlugins
 }
 

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -767,6 +767,9 @@ func autoConvert_v1_Plugins_To_config_Plugins(in *configv1.Plugins, out *config.
 	if err := Convert_v1_PluginSet_To_config_PluginSet(&in.PlacementScore, &out.PlacementScore, s); err != nil {
 		return err
 	}
+	if err := Convert_v1_PluginSet_To_config_PluginSet(&in.PodGroupPostFilter, &out.PodGroupPostFilter, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -819,6 +822,9 @@ func autoConvert_config_Plugins_To_v1_Plugins(in *config.Plugins, out *configv1.
 		return err
 	}
 	if err := Convert_config_PluginSet_To_v1_PluginSet(&in.PlacementScore, &out.PlacementScore, s); err != nil {
+		return err
+	}
+	if err := Convert_config_PluginSet_To_v1_PluginSet(&in.PodGroupPostFilter, &out.PodGroupPostFilter, s); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/scheduler/apis/config/validation/validation.go
+++ b/pkg/scheduler/apis/config/validation/validation.go
@@ -165,18 +165,19 @@ func validatePluginConfig(path *field.Path, apiVersion string, profile *config.K
 
 	if profile.Plugins != nil {
 		stagesToPluginSet := map[string]config.PluginSet{
-			"preEnqueue": profile.Plugins.PreEnqueue,
-			"queueSort":  profile.Plugins.QueueSort,
-			"preFilter":  profile.Plugins.PreFilter,
-			"filter":     profile.Plugins.Filter,
-			"postFilter": profile.Plugins.PostFilter,
-			"preScore":   profile.Plugins.PreScore,
-			"score":      profile.Plugins.Score,
-			"reserve":    profile.Plugins.Reserve,
-			"permit":     profile.Plugins.Permit,
-			"preBind":    profile.Plugins.PreBind,
-			"bind":       profile.Plugins.Bind,
-			"postBind":   profile.Plugins.PostBind,
+			"preEnqueue":         profile.Plugins.PreEnqueue,
+			"queueSort":          profile.Plugins.QueueSort,
+			"preFilter":          profile.Plugins.PreFilter,
+			"filter":             profile.Plugins.Filter,
+			"postFilter":         profile.Plugins.PostFilter,
+			"preScore":           profile.Plugins.PreScore,
+			"score":              profile.Plugins.Score,
+			"reserve":            profile.Plugins.Reserve,
+			"permit":             profile.Plugins.Permit,
+			"preBind":            profile.Plugins.PreBind,
+			"bind":               profile.Plugins.Bind,
+			"postBind":           profile.Plugins.PostBind,
+			"podGroupPostFilter": profile.Plugins.PodGroupPostFilter,
 		}
 
 		pluginsPath := path.Child("plugins")

--- a/pkg/scheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/zz_generated.deepcopy.go
@@ -445,6 +445,7 @@ func (in *Plugins) DeepCopyInto(out *Plugins) {
 	in.MultiPoint.DeepCopyInto(&out.MultiPoint)
 	in.PlacementGenerate.DeepCopyInto(&out.PlacementGenerate)
 	in.PlacementScore.DeepCopyInto(&out.PlacementScore)
+	in.PodGroupPostFilter.DeepCopyInto(&out.PodGroupPostFilter)
 	return
 }
 

--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -160,25 +160,6 @@ type SortedScoredNodes interface {
 	Len() int
 }
 
-// PodGroupSchedulingFunc is a function that will be run to check feasibility of a pod group
-// scheduling during workload-aware preemption algorithm.
-type PodGroupSchedulingFunc func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status)
-
-// PodGroupPostFilterResult stores information about nominated nodes for a pod group.
-type PodGroupPostFilterResult struct {
-	NominatedNodeNames map[*v1.Pod]*fwk.NominatingInfo
-}
-
-// PodGroupPostFilterPlugin is an interface for plugins that are called
-// after a PodGroup cannot be scheduled.
-// It should not be used by any other plugin but DefaultPreemption.
-type PodGroupPostFilterPlugin interface {
-	fwk.Plugin
-
-	// PodGroupPostFilter is called after a PodGroup cannot be scheduled.
-	PodGroupPostFilter(ctx context.Context, pgInfo fwk.PodGroupInfo, pgSchedulingFunc PodGroupSchedulingFunc) (*PodGroupPostFilterResult, *fwk.Status)
-}
-
 // PlacementFeasiblePlugin is an interface for plugins that are called after each pod in a pod group is evaluated.
 // It is used to determine if a pod group is schedulable, may become schedulable or will not become schedulable regardless of the scheduling result of the remaining pods in the pod group.
 type PlacementFeasiblePlugin interface {
@@ -311,7 +292,7 @@ type Framework interface {
 	RunPlacementScorePlugins(ctx context.Context, state fwk.PodGroupCycleState, podGroupInfo fwk.PodGroupInfo, placements []*fwk.PodGroupAssignments, placementStates []fwk.PlacementCycleState) (ns []fwk.PlacementPluginScores, status *fwk.Status)
 
 	// RunPodGroupPostFilterPlugins runs the set of configured PodGroupPostFilter plugins.
-	RunPodGroupPostFilterPlugins(ctx context.Context, state *CycleState, podGroupInfo fwk.PodGroupInfo, pgSchedulingFunc PodGroupSchedulingFunc) (*PodGroupPostFilterResult, *fwk.Status)
+	RunPodGroupPostFilterPlugins(ctx context.Context, state *CycleState, podGroupInfo fwk.PodGroupInfo, pgSchedulingFunc fwk.PodGroupSchedulingFunc) (*fwk.PodGroupPostFilterResult, *fwk.Status)
 
 	// HasFilterPlugins returns true if at least one Filter plugin is defined.
 	HasFilterPlugins() bool
@@ -323,7 +304,7 @@ type Framework interface {
 	HasScorePlugins() bool
 
 	// PodGroupPostFilterPlugins returns registered PodGroupPostFilter plugins.
-	PodGroupPostFilterPlugins() []PodGroupPostFilterPlugin
+	PodGroupPostFilterPlugins() []fwk.PodGroupPostFilterPlugin
 
 	// ListPlugins returns a map of extension point name to list of configured Plugins.
 	ListPlugins() *config.Plugins

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption.go
@@ -33,7 +33,6 @@ import (
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
-	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 	"k8s.io/kubernetes/pkg/scheduler/framework/preemption"
@@ -437,7 +436,7 @@ func filterPodsWithPDBViolation(podInfos []fwk.PodInfo, pdbs []*policy.PodDisrup
 }
 
 // PodGroupPostFilter runs a default preemption for the pod group.
-func (pl *DefaultPreemption) PodGroupPostFilter(ctx context.Context, pgInfo fwk.PodGroupInfo, pgSchedulingFunc framework.PodGroupSchedulingFunc) (postFilterResult *framework.PodGroupPostFilterResult, status *fwk.Status) {
+func (pl *DefaultPreemption) PodGroupPostFilter(ctx context.Context, state fwk.PodGroupCycleState, pgInfo fwk.PodGroupInfo, pgSchedulingFunc fwk.PodGroupSchedulingFunc) (postFilterResult *fwk.PodGroupPostFilterResult, status *fwk.Status) {
 	pg := pgInfo.GetPodGroup()
 
 	if pg.Spec.SchedulingConstraints != nil && len(pg.Spec.SchedulingConstraints.Topology) > 0 {

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -2634,7 +2634,7 @@ func TestPreEnqueue(t *testing.T) {
 					UnscheduledPods: []*v1.Pod{tt.podToTriggerPreemption},
 					PodGroup:        pg,
 				}
-				var pgSchedulingFunc framework.PodGroupSchedulingFunc = func(_ context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
+				var pgSchedulingFunc fwk.PodGroupSchedulingFunc = func(_ context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
 					nodeInfo, _ := f.SnapshotSharedLister().NodeInfos().Get("node1")
 					if len(nodeInfo.GetPods()) == 0 {
 						return &fwk.PodGroupAssignments{
@@ -2652,7 +2652,7 @@ func TestPreEnqueue(t *testing.T) {
 					}
 					return nil, fwk.NewStatus(fwk.Unschedulable, "need to preempt")
 				}
-				p.PodGroupPostFilter(ctx, pgInfo, pgSchedulingFunc)
+				p.PodGroupPostFilter(ctx, state, pgInfo, pgSchedulingFunc)
 			} else {
 				p.PostFilter(ctx, state, tt.podToTriggerPreemption, filteredNodesStatuses)
 			}
@@ -2722,7 +2722,8 @@ func TestDefaultPreemption_PodGroupPostFilter_ErrorWrapping(t *testing.T) {
 		PodGroup:        preemptorPG,
 	}
 
-	_, gotStatus := pl.PodGroupPostFilter(ctx, pgInfo, mockSchedulingFunc)
+	state := framework.NewCycleState()
+	_, gotStatus := pl.PodGroupPostFilter(ctx, state, pgInfo, mockSchedulingFunc)
 
 	if gotStatus.Code() != fwk.Error {
 		t.Fatalf("Expected status code %v, got status: %v", fwk.Error, gotStatus)
@@ -2789,7 +2790,8 @@ func TestDefaultPreemption_PodGroupPostFilter_SchedulingConstraints(t *testing.T
 		PodGroup:        pgWithConstraints,
 	}
 
-	_, gotStatus := pl.PodGroupPostFilter(ctx, pgInfo, mockSchedulingFunc)
+	state := framework.NewCycleState()
+	_, gotStatus := pl.PodGroupPostFilter(ctx, state, pgInfo, mockSchedulingFunc)
 	if gotStatus.Code() != fwk.Unschedulable {
 		t.Fatalf("Expected status code %v, got status: %v", fwk.Unschedulable, gotStatus)
 	}
@@ -2872,7 +2874,8 @@ func TestDefaultPreemption_PodGroupPostFilter_InvalidSnapshot(t *testing.T) {
 				UnscheduledPods: preemptorPods,
 				PodGroup:        pgOk,
 			}
-			_, gotStatus := pl.PodGroupPostFilter(ctx, pgInfo, mockSchedulingFunc)
+			state := framework.NewCycleState()
+			_, gotStatus := pl.PodGroupPostFilter(ctx, state, pgInfo, mockSchedulingFunc)
 			if gotStatus.Code() != fwk.Error {
 				t.Fatalf("Expected status code %v, got status: %v", fwk.Error, gotStatus)
 			}

--- a/pkg/scheduler/framework/preemption/podgrouppreemption.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1"
 	schedulingapi "k8s.io/api/scheduling/v1alpha3"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	policylisters "k8s.io/client-go/listers/policy/v1"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
@@ -91,7 +92,7 @@ func (ev *PodGroupEvaluator) Preempt(ctx context.Context, pg *schedulingapi.PodG
 }
 
 type selectVictimsResult struct {
-	nominatedNodeNames map[*v1.Pod]*fwk.NominatingInfo
+	nominatedNodeNames map[types.NamespacedName]*fwk.NominatingInfo
 	victims            *extenderv1.Victims
 }
 
@@ -255,10 +256,12 @@ func (ev *PodGroupEvaluator) selectVictimsOnDomain(
 	v := &extenderv1.Victims{
 		Pods: podsToPreempt,
 	}
-	n := make(map[*v1.Pod]*fwk.NominatingInfo)
+	n := make(map[types.NamespacedName]*fwk.NominatingInfo)
 	for _, p := range podGroupAssignments.ProposedAssignments {
 		if p.GetNodeName() != "" {
-			n[p.GetPod()] = &fwk.NominatingInfo{
+			pod := p.GetPod()
+			podKey := types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
+			n[podKey] = &fwk.NominatingInfo{
 				NominatingMode:    fwk.ModeOverride,
 				NominatedNodeName: p.GetNodeName(),
 			}

--- a/pkg/scheduler/framework/preemption/podgrouppreemption.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	policylisters "k8s.io/client-go/listers/policy/v1"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
-	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 	"k8s.io/kubernetes/pkg/scheduler/util"
 
@@ -68,7 +67,7 @@ func NewPodGroupEvaluator(fh fwk.Handle, executor *Executor, enablePodGroupPreem
 // scheduling after modifying the node state.
 // The caller is expected to backup the NodeInfo before calling this function
 // And rollback the state to the backup after function is finished.
-func (ev *PodGroupEvaluator) Preempt(ctx context.Context, pg *schedulingapi.PodGroup, pods []*v1.Pod, podGroupSchedulingFunc framework.PodGroupSchedulingFunc) (*framework.PodGroupPostFilterResult, *fwk.Status) {
+func (ev *PodGroupEvaluator) Preempt(ctx context.Context, pg *schedulingapi.PodGroup, pods []*v1.Pod, podGroupSchedulingFunc fwk.PodGroupSchedulingFunc) (*fwk.PodGroupPostFilterResult, *fwk.Status) {
 	// In case of workload-aware preemption, the domain is whole cluster.
 	// We do not make a snapshot of node info. Those nodes will be shared
 	// with the PodGroup scheduling algorithm passed as podGroupSchedulingFunc.
@@ -88,7 +87,7 @@ func (ev *PodGroupEvaluator) Preempt(ctx context.Context, pg *schedulingapi.PodG
 		return nil, status
 	}
 	status = ev.Executor.actuatePodGroupPreemption(ctx, res.victims, preemptor.pods, preemptor.podGroup, names.DefaultPreemption)
-	return &framework.PodGroupPostFilterResult{NominatedNodeNames: res.nominatedNodeNames}, status
+	return &fwk.PodGroupPostFilterResult{NominatingInfos: res.nominatedNodeNames}, status
 }
 
 type selectVictimsResult struct {
@@ -104,7 +103,7 @@ func (ev *PodGroupEvaluator) selectVictimsOnDomain(
 	preemptor *podGroupPreemptor,
 	domain *domain,
 	pdbs []*policy.PodDisruptionBudget,
-	podGroupSchedulingFunc framework.PodGroupSchedulingFunc) (*selectVictimsResult, *fwk.Status) {
+	podGroupSchedulingFunc fwk.PodGroupSchedulingFunc) (*selectVictimsResult, *fwk.Status) {
 	logger := klog.FromContext(ctx)
 
 	nameToNode := make(map[string]fwk.NodeInfo)

--- a/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
@@ -1212,7 +1212,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 			// Create a mock podGroupSchedulingFunc.
 			// This simulates whether the preempting PodGroup can schedule given the current
 			// hypothetical state of the cluster (where some candidate victims might be removed).
-			var mockSchedulingFunc framework.PodGroupSchedulingFunc = func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
+			var mockSchedulingFunc fwk.PodGroupSchedulingFunc = func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
 				if tt.customMockSchedulingFunc != nil {
 					return tt.customMockSchedulingFunc(ctx, domainNodes)
 				}

--- a/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
@@ -27,6 +27,7 @@ import (
 	policy "k8s.io/api/policy/v1"
 	schedulingapi "k8s.io/api/scheduling/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2/ktesting"
 	fwk "k8s.io/kube-scheduler/framework"
@@ -1498,7 +1499,8 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain_NominatedNodes(t *testing.T) {
 		t.Errorf("Expected 1 nominated node name, got %d", len(result.nominatedNodeNames))
 	}
 
-	if info, ok := result.nominatedNodeNames[p1]; !ok || info.NominatedNodeName != "node1" {
+	namespacedName := types.NamespacedName{Namespace: p1.Namespace, Name: p1.Name}
+	if info, ok := result.nominatedNodeNames[namespacedName]; !ok || info.NominatedNodeName != "node1" {
 		t.Errorf("Expected p1 to be nominated for node1, got %v", info)
 	}
 }

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -76,7 +76,7 @@ type frameworkImpl struct {
 	postBindPlugins           []fwk.PostBindPlugin
 	permitPlugins             []fwk.PermitPlugin
 	batchablePlugins          []fwk.SignPlugin
-	podGroupPostFilterPlugins []framework.PodGroupPostFilterPlugin
+	podGroupPostFilterPlugins []fwk.PodGroupPostFilterPlugin
 
 	placementGeneratePlugins   []fwk.PlacementGeneratePlugin
 	placementFeasiblePlugins   []framework.PlacementFeasiblePlugin
@@ -140,6 +140,7 @@ func (f *frameworkImpl) getExtensionPoints(plugins *config.Plugins) []extensionP
 		{&plugins.QueueSort, &f.queueSortPlugins},
 		{&plugins.PlacementGenerate, &f.placementGeneratePlugins},
 		{&plugins.PlacementScore, &f.placementScorePlugins},
+		{&plugins.PodGroupPostFilter, &f.podGroupPostFilterPlugins},
 	}
 }
 
@@ -483,19 +484,6 @@ func NewFramework(ctx context.Context, r Registry, profile *config.KubeScheduler
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.OpportunisticBatching) {
 		f.computeBatchablePlugins()
-	}
-
-	// Put default preemption as the only PodGroupPostFilterPlugin
-	if utilfeature.DefaultFeatureGate.Enabled(features.GenericWorkload) {
-		if dp, ok := f.pluginsMap[names.DefaultPreemption]; ok {
-			if _, ok := dp.(framework.PodGroupPostFilterPlugin); ok {
-				f.podGroupPostFilterPlugins = append(f.podGroupPostFilterPlugins, dp.(framework.PodGroupPostFilterPlugin))
-			} else {
-				logger.V(2).Info("Workload Aware Preemption is enabled, but default preemption plugin does not fulfill PodGroupPostFilterPlugin interface. Workload Aware Preemption will not be used.")
-			}
-		} else {
-			logger.V(2).Info("Workload Aware Preemption is enabled, but default preemption plugin is not set. Workload Aware Preemption will not be used.")
-		}
 	}
 
 	// Use GangScheduling plugin as the only PlacementFeasiblePlugin.
@@ -1221,7 +1209,7 @@ func (f *frameworkImpl) runPostFilterPlugin(ctx context.Context, pl fwk.PostFilt
 }
 
 // RunPodGroupPostFilterPlugins runs the set of configured PodGroupPostFilter plugins.
-func (f *frameworkImpl) RunPodGroupPostFilterPlugins(ctx context.Context, state *framework.CycleState, podGroupInfo fwk.PodGroupInfo, pgSchedulingFunc framework.PodGroupSchedulingFunc) (*framework.PodGroupPostFilterResult, *fwk.Status) {
+func (f *frameworkImpl) RunPodGroupPostFilterPlugins(ctx context.Context, state *framework.CycleState, podGroupInfo fwk.PodGroupInfo, pgSchedulingFunc fwk.PodGroupSchedulingFunc) (*fwk.PodGroupPostFilterResult, *fwk.Status) {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.GenericWorkload) {
 		return nil, fwk.NewStatus(fwk.Unschedulable, "generic workload feature is disabled, cannot perform PodGroupPostFilter")
 	}
@@ -1240,7 +1228,7 @@ func (f *frameworkImpl) RunPodGroupPostFilterPlugins(ctx context.Context, state 
 			logger := klog.LoggerWithName(logger, pl.Name())
 			ctx = klog.NewContext(ctx, logger)
 		}
-		res, status := pl.PodGroupPostFilter(ctx, podGroupInfo, pgSchedulingFunc)
+		res, status := pl.PodGroupPostFilter(ctx, state, podGroupInfo, pgSchedulingFunc)
 		if status.IsSuccess() {
 			return res, status
 		} else if status.Code() == fwk.UnschedulableAndUnresolvable {
@@ -2260,8 +2248,8 @@ func (f *frameworkImpl) HasScorePlugins() bool {
 	return len(f.scorePlugins) > 0
 }
 
-// PodGroupPostFilterPlugins returns registered PodGroup PostFilter plugins.
-func (f *frameworkImpl) PodGroupPostFilterPlugins() []framework.PodGroupPostFilterPlugin {
+// PodGroupPostFilterPlugins returns registered PodGroupPostFilter plugins.
+func (f *frameworkImpl) PodGroupPostFilterPlugins() []fwk.PodGroupPostFilterPlugin {
 	return f.podGroupPostFilterPlugins
 }
 

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/scheduling/v1alpha3"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -191,7 +191,6 @@ type PluginNotImplementingScore struct{}
 func (pl *PluginNotImplementingScore) Name() string {
 	return pluginNotImplementingScore
 }
-
 func newTestPlugin(_ context.Context, injArgs runtime.Object, f fwk.Handle) (fwk.Plugin, error) {
 	return &TestPlugin{name: testPlugin}, nil
 }
@@ -285,10 +284,6 @@ func (pl *TestPlugin) ScorePlacement(ctx context.Context, state fwk.PlacementCyc
 
 func (pl *TestPlugin) PlacementScoreExtensions() fwk.PlacementScoreExtensions {
 	return nil
-}
-
-func (pl *TestPlugin) PodGroupPostFilter(ctx context.Context, pgInfo fwk.PodGroupInfo, pgSchedulingFunc framework.PodGroupSchedulingFunc) (*framework.PodGroupPostFilterResult, *fwk.Status) {
-	return pl.inj.PodGroupPostFilterResult, fwk.NewStatus(fwk.Code(pl.inj.PodGroupPostFilterStatus), injectReason)
 }
 
 func newTestCloseErrorPlugin(_ context.Context, injArgs runtime.Object, f fwk.Handle) (fwk.Plugin, error) {
@@ -476,7 +471,7 @@ var registry = func() Registry {
 	r.Register(testCloseErrorPlugin, newTestCloseErrorPlugin)
 	r.Register(placementGeneratePlugin, newTestPlacementGeneratePlugin)
 	r.Register(placementScorePlugin1, newPlacementScorePluginFactory(placementScorePlugin1))
-	r.Register(defaultPreemptionPlugin, newTestPlugin)
+	r.Register(defaultPreemptionPlugin, newMockDefaultPreemptionPlugin)
 	return r
 }()
 
@@ -791,11 +786,11 @@ func TestPodGroupPostFilterPlugins(t *testing.T) {
 	tests := []struct {
 		name                   string
 		plugins                *config.Plugins
-		featureGate            bool
 		wantPodGroupPostFilter bool
+		expectError            bool
 	}{
 		{
-			name: "should fill pod group post filter with feature gate and default preemption",
+			name: "should fill pod group post filter when explicitly configured with default preemption",
 			plugins: &config.Plugins{
 				QueueSort: config.PluginSet{
 					Enabled: []config.Plugin{
@@ -812,12 +807,16 @@ func TestPodGroupPostFilterPlugins(t *testing.T) {
 						{Name: defaultPreemptionPlugin},
 					},
 				},
+				PodGroupPostFilter: config.PluginSet{
+					Enabled: []config.Plugin{
+						{Name: defaultPreemptionPlugin},
+					},
+				},
 			},
-			featureGate:            true,
 			wantPodGroupPostFilter: true,
 		},
 		{
-			name: "should not fill pod group post filter when feature gate is disabled",
+			name: "should not fill pod group post filter when not configured",
 			plugins: &config.Plugins{
 				QueueSort: config.PluginSet{
 					Enabled: []config.Plugin{
@@ -835,11 +834,10 @@ func TestPodGroupPostFilterPlugins(t *testing.T) {
 					},
 				},
 			},
-			featureGate:            false,
 			wantPodGroupPostFilter: false,
 		},
 		{
-			name: "should not fill pod group post filter when post filter plugin is not default preemption",
+			name: "should fail framework initialization when configured plugin does not implement PodGroupPostFilterPlugin interface",
 			plugins: &config.Plugins{
 				QueueSort: config.PluginSet{
 					Enabled: []config.Plugin{
@@ -851,59 +849,74 @@ func TestPodGroupPostFilterPlugins(t *testing.T) {
 						{Name: bindPlugin},
 					},
 				},
-				PostFilter: config.PluginSet{
+				PodGroupPostFilter: config.PluginSet{
 					Enabled: []config.Plugin{
 						{Name: testPlugin},
 					},
 				},
 			},
-			featureGate:            false,
-			wantPodGroupPostFilter: false,
+			expectError: true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.featureGate {
-				featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-					features.GenericWorkload: true,
-				})
-			}
-
 			_, ctx := ktesting.NewTestContext(t)
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
 			profile := &config.KubeSchedulerProfile{
-				Plugins: &config.Plugins{
-					QueueSort: config.PluginSet{
-						Enabled: []config.Plugin{
-							{Name: queueSortPlugin},
-						},
-					},
-					Bind: config.PluginSet{
-						Enabled: []config.Plugin{
-							{Name: bindPlugin},
-						},
-					},
-					PostFilter: config.PluginSet{
-						Enabled: []config.Plugin{
-							{Name: defaultPreemptionPlugin},
-						},
-					},
-				},
+				Plugins: tc.plugins,
 			}
-			f, _ := NewFramework(ctx, registry, profile)
+			f, err := NewFramework(ctx, registry, profile)
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Expected framework initialization to fail, but it succeeded")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected framework initialization error: %v", err)
+			}
 
-			if tc.wantPodGroupPostFilter && len(f.PodGroupPostFilterPlugins()) != 1 {
-				t.Errorf("Expected 1 pod group post filter plugin, got %d", len(f.PodGroupPostFilterPlugins()))
+			if tc.wantPodGroupPostFilter && len(f.(*frameworkImpl).podGroupPostFilterPlugins) != 1 {
+				t.Errorf("Expected 1 pod group post filter plugin, got %d", len(f.(*frameworkImpl).podGroupPostFilterPlugins))
 			}
-			if !tc.wantPodGroupPostFilter && len(f.PodGroupPostFilterPlugins()) != 0 {
-				t.Errorf("Expected 0 pod group post filter plugin, got %d", len(f.PodGroupPostFilterPlugins()))
+			if !tc.wantPodGroupPostFilter && len(f.(*frameworkImpl).podGroupPostFilterPlugins) != 0 {
+				t.Errorf("Expected 0 pod group post filter plugin, got %d", len(f.(*frameworkImpl).podGroupPostFilterPlugins))
 			}
 		})
 	}
+}
 
+type TestPodGroupPostFilterPlugin struct {
+	name string
+	inj  injectedResult
+}
+
+func (pl *TestPodGroupPostFilterPlugin) Name() string {
+	return pl.name
+}
+
+func (pl *TestPodGroupPostFilterPlugin) PostFilter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, filteredNodeStatusMap fwk.NodeToStatusReader) (*fwk.PostFilterResult, *fwk.Status) {
+	return nil, nil
+}
+
+func (pl *TestPodGroupPostFilterPlugin) PodGroupPostFilter(ctx context.Context, state fwk.PodGroupCycleState, pgInfo fwk.PodGroupInfo, pgSchedulingFunc fwk.PodGroupSchedulingFunc) (*fwk.PodGroupPostFilterResult, *fwk.Status) {
+	return pl.inj.PodGroupPostFilterResult, fwk.NewStatus(fwk.Code(pl.inj.PodGroupPostFilterStatus), injectReason)
+}
+
+// mockDefaultPreemptionPlugin is used to simulate a default preemption plugin that implements PodGroupPostFilterPlugin
+type mockDefaultPreemptionPlugin struct {
+	TestPlugin
+}
+
+func (pl *mockDefaultPreemptionPlugin) PodGroupPostFilter(ctx context.Context, state fwk.PodGroupCycleState, pgInfo fwk.PodGroupInfo, pgSchedulingFunc fwk.PodGroupSchedulingFunc) (*fwk.PodGroupPostFilterResult, *fwk.Status) {
+	return nil, nil
+}
+
+func newMockDefaultPreemptionPlugin(_ context.Context, injArgs runtime.Object, f fwk.Handle) (fwk.Plugin, error) {
+	return &mockDefaultPreemptionPlugin{TestPlugin: TestPlugin{name: defaultPreemptionPlugin}}, nil
 }
 
 func TestRunPodGroupPostFilterPlugins(t *testing.T) {
@@ -911,21 +924,15 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 	tests := []struct {
 		name                string
 		podGroupInfo        *framework.QueuedPodGroupInfo
-		existingPodGroups   []*v1alpha3.PodGroup
-		plugins             []*TestPlugin
+		plugins             []*TestPodGroupPostFilterPlugin
 		featureFlagEnabeled bool
 		expectedStatus      *fwk.Status
-		expectedResult      *framework.PodGroupPostFilterResult
+		expectedResult      *fwk.PodGroupPostFilterResult
 	}{
 		{
 			name: "no registered plugins",
 			podGroupInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg1"},
-			},
-			existingPodGroups: []*v1alpha3.PodGroup{
-				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pg1"},
-				},
 			},
 			featureFlagEnabeled: true,
 			expectedStatus:      fwk.NewStatus(fwk.Unschedulable),
@@ -943,12 +950,7 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 			podGroupInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg1"},
 			},
-			existingPodGroups: []*v1alpha3.PodGroup{
-				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pg1"},
-				},
-			},
-			plugins: []*TestPlugin{
+			plugins: []*TestPodGroupPostFilterPlugin{
 				{
 					name: "plugin1",
 					inj: injectedResult{
@@ -964,12 +966,7 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 			podGroupInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg1"},
 			},
-			existingPodGroups: []*v1alpha3.PodGroup{
-				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pg1"},
-				},
-			},
-			plugins: []*TestPlugin{
+			plugins: []*TestPodGroupPostFilterPlugin{
 				{
 					name: "plugin1",
 					inj: injectedResult{
@@ -985,18 +982,13 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 			podGroupInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg1"},
 			},
-			existingPodGroups: []*v1alpha3.PodGroup{
-				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pg1"},
-				},
-			},
-			plugins: []*TestPlugin{
+			plugins: []*TestPodGroupPostFilterPlugin{
 				{
 					name: "plugin1",
 					inj: injectedResult{
 						PodGroupPostFilterStatus: int(fwk.Success),
-						PodGroupPostFilterResult: &framework.PodGroupPostFilterResult{
-							NominatedNodeNames: map[*v1.Pod]*fwk.NominatingInfo{
+						PodGroupPostFilterResult: &fwk.PodGroupPostFilterResult{
+							NominatingInfos: map[*v1.Pod]*fwk.NominatingInfo{
 								pod1: {NominatedNodeName: "node1"},
 							},
 						},
@@ -1011,8 +1003,8 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 			},
 			featureFlagEnabeled: true,
 			expectedStatus:      fwk.NewStatus(fwk.Success, injectReason),
-			expectedResult: &framework.PodGroupPostFilterResult{
-				NominatedNodeNames: map[*v1.Pod]*fwk.NominatingInfo{
+			expectedResult: &fwk.PodGroupPostFilterResult{
+				NominatingInfos: map[*v1.Pod]*fwk.NominatingInfo{
 					pod1: {NominatedNodeName: "node1"},
 				},
 			},
@@ -1022,12 +1014,7 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 			podGroupInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg1"},
 			},
-			existingPodGroups: []*v1alpha3.PodGroup{
-				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pg1"},
-				},
-			},
-			plugins: []*TestPlugin{
+			plugins: []*TestPodGroupPostFilterPlugin{
 				{
 					name: "plugin1",
 					inj: injectedResult{
@@ -1049,12 +1036,7 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 			podGroupInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg1"},
 			},
-			existingPodGroups: []*v1alpha3.PodGroup{
-				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pg1"},
-				},
-			},
-			plugins: []*TestPlugin{
+			plugins: []*TestPodGroupPostFilterPlugin{
 				{
 					name: "plugin1",
 					inj: injectedResult{
@@ -1065,8 +1047,8 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 					name: "plugin2",
 					inj: injectedResult{
 						PodGroupPostFilterStatus: int(fwk.Success),
-						PodGroupPostFilterResult: &framework.PodGroupPostFilterResult{
-							NominatedNodeNames: map[*v1.Pod]*fwk.NominatingInfo{
+						PodGroupPostFilterResult: &fwk.PodGroupPostFilterResult{
+							NominatingInfos: map[*v1.Pod]*fwk.NominatingInfo{
 								pod1: {NominatedNodeName: "node2"},
 							},
 						},
@@ -1075,8 +1057,8 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 			},
 			featureFlagEnabeled: true,
 			expectedStatus:      fwk.NewStatus(fwk.Success, injectReason),
-			expectedResult: &framework.PodGroupPostFilterResult{
-				NominatedNodeNames: map[*v1.Pod]*fwk.NominatingInfo{
+			expectedResult: &fwk.PodGroupPostFilterResult{
+				NominatingInfos: map[*v1.Pod]*fwk.NominatingInfo{
 					pod1: {NominatedNodeName: "node2"},
 				},
 			},
@@ -1086,12 +1068,7 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 			podGroupInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg1"},
 			},
-			existingPodGroups: []*v1alpha3.PodGroup{
-				{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pg1"},
-				},
-			},
-			plugins: []*TestPlugin{
+			plugins: []*TestPodGroupPostFilterPlugin{
 				{
 					name: "plugin1",
 					inj: injectedResult{
@@ -1145,11 +1122,7 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 				},
 			}
 
-			var objs []runtime.Object
-			for _, pg := range tc.existingPodGroups {
-				objs = append(objs, pg)
-			}
-			client := clientsetfake.NewClientset(objs...)
+			client := clientsetfake.NewClientset()
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 
 			schedFwk, err := NewFramework(ctx, reg, &profileCfg,
@@ -1161,13 +1134,13 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 			}
 
 			fwkImpl := schedFwk.(*frameworkImpl)
-			var postFilterPlugins []framework.PodGroupPostFilterPlugin
+			var postFilterPlugins []fwk.PodGroupPostFilterPlugin
 			for _, pl := range tc.plugins {
 				postFilterPlugins = append(postFilterPlugins, pl)
 			}
 			fwkImpl.podGroupPostFilterPlugins = postFilterPlugins
 
-			var pgSchedulingFunc framework.PodGroupSchedulingFunc = func(_ context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
+			var pgSchedulingFunc fwk.PodGroupSchedulingFunc = func(_ context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
 				return &fwk.PodGroupAssignments{}, nil
 			}
 
@@ -4588,29 +4561,29 @@ func buildScoreConfigWithWeights(weights map[string]int32, ps ...string) *config
 }
 
 type injectedResult struct {
-	ScoreRes                 int64                               `json:"scoreRes,omitempty"`
-	NormalizeRes             int64                               `json:"normalizeRes,omitempty"`
-	ScoreStatus              int                                 `json:"scoreStatus,omitempty"`
-	NormalizeStatus          int                                 `json:"normalizeStatus,omitempty"`
-	PreFilterResult          *fwk.PreFilterResult                `json:"preFilterResult,omitempty"`
-	PreFilterStatus          int                                 `json:"preFilterStatus,omitempty"`
-	PreFilterAddPodStatus    int                                 `json:"preFilterAddPodStatus,omitempty"`
-	PreFilterRemovePodStatus int                                 `json:"preFilterRemovePodStatus,omitempty"`
-	FilterStatus             int                                 `json:"filterStatus,omitempty"`
-	PostFilterStatus         int                                 `json:"postFilterStatus,omitempty"`
-	PreScoreStatus           int                                 `json:"preScoreStatus,omitempty"`
-	ReserveStatus            int                                 `json:"reserveStatus,omitempty"`
-	PreBindPreFlightStatus   int                                 `json:"preBindPreFlightStatus,omitempty"`
-	PreBindStatus            int                                 `json:"preBindStatus,omitempty"`
-	BindStatus               int                                 `json:"bindStatus,omitempty"`
-	PermitStatus             int                                 `json:"permitStatus,omitempty"`
-	PermitTimeout            time.Duration                       `json:"permitTimeout,omitempty"`
-	GeneratePlacementsResult []*fwk.Placement                    `json:"generatePlacementsResult,omitempty"`
-	GeneratePlacementsStatus int                                 `json:"generatePlacementsStatus,omitempty"`
-	PlacementScoreStatus     int                                 `json:"placementScoreStatus,omitempty"`
-	PlacementFeasibleStatus  int                                 `json:"placementFeasibleStatus,omitempty"`
-	PodGroupPostFilterStatus int                                 `json:"podGroupPostFilterStatus,omitempty"`
-	PodGroupPostFilterResult *framework.PodGroupPostFilterResult `json:"podGroupPostFilterResult,omitempty"`
+	ScoreRes                 int64                         `json:"scoreRes,omitempty"`
+	NormalizeRes             int64                         `json:"normalizeRes,omitempty"`
+	ScoreStatus              int                           `json:"scoreStatus,omitempty"`
+	NormalizeStatus          int                           `json:"normalizeStatus,omitempty"`
+	PreFilterResult          *fwk.PreFilterResult          `json:"preFilterResult,omitempty"`
+	PreFilterStatus          int                           `json:"preFilterStatus,omitempty"`
+	PreFilterAddPodStatus    int                           `json:"preFilterAddPodStatus,omitempty"`
+	PreFilterRemovePodStatus int                           `json:"preFilterRemovePodStatus,omitempty"`
+	FilterStatus             int                           `json:"filterStatus,omitempty"`
+	PostFilterStatus         int                           `json:"postFilterStatus,omitempty"`
+	PreScoreStatus           int                           `json:"preScoreStatus,omitempty"`
+	ReserveStatus            int                           `json:"reserveStatus,omitempty"`
+	PreBindPreFlightStatus   int                           `json:"preBindPreFlightStatus,omitempty"`
+	PreBindStatus            int                           `json:"preBindStatus,omitempty"`
+	BindStatus               int                           `json:"bindStatus,omitempty"`
+	PermitStatus             int                           `json:"permitStatus,omitempty"`
+	PermitTimeout            time.Duration                 `json:"permitTimeout,omitempty"`
+	GeneratePlacementsResult []*fwk.Placement              `json:"generatePlacementsResult,omitempty"`
+	GeneratePlacementsStatus int                           `json:"generatePlacementsStatus,omitempty"`
+	PlacementScoreStatus     int                           `json:"placementScoreStatus,omitempty"`
+	PlacementFeasibleStatus  int                           `json:"placementFeasibleStatus,omitempty"`
+	PodGroupPostFilterStatus int                           `json:"podGroupPostFilterStatus,omitempty"`
+	PodGroupPostFilterResult *fwk.PodGroupPostFilterResult `json:"podGroupPostFilterResult,omitempty"`
 }
 
 func setScoreRes(inj injectedResult) (int64, *fwk.Status) {

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -988,8 +988,8 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 					inj: injectedResult{
 						PodGroupPostFilterStatus: int(fwk.Success),
 						PodGroupPostFilterResult: &fwk.PodGroupPostFilterResult{
-							NominatingInfos: map[*v1.Pod]*fwk.NominatingInfo{
-								pod1: {NominatedNodeName: "node1"},
+							NominatingInfos: map[types.NamespacedName]*fwk.NominatingInfo{
+								{Namespace: pod1.Namespace, Name: pod1.Name}: {NominatedNodeName: "node1"},
 							},
 						},
 					},
@@ -1004,8 +1004,8 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 			featureFlagEnabeled: true,
 			expectedStatus:      fwk.NewStatus(fwk.Success, injectReason),
 			expectedResult: &fwk.PodGroupPostFilterResult{
-				NominatingInfos: map[*v1.Pod]*fwk.NominatingInfo{
-					pod1: {NominatedNodeName: "node1"},
+				NominatingInfos: map[types.NamespacedName]*fwk.NominatingInfo{
+					{Namespace: pod1.Namespace, Name: pod1.Name}: {NominatedNodeName: "node1"},
 				},
 			},
 		},
@@ -1048,8 +1048,8 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 					inj: injectedResult{
 						PodGroupPostFilterStatus: int(fwk.Success),
 						PodGroupPostFilterResult: &fwk.PodGroupPostFilterResult{
-							NominatingInfos: map[*v1.Pod]*fwk.NominatingInfo{
-								pod1: {NominatedNodeName: "node2"},
+							NominatingInfos: map[types.NamespacedName]*fwk.NominatingInfo{
+								{Namespace: pod1.Namespace, Name: pod1.Name}: {NominatedNodeName: "node2"},
 							},
 						},
 					},
@@ -1058,8 +1058,8 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 			featureFlagEnabeled: true,
 			expectedStatus:      fwk.NewStatus(fwk.Success, injectReason),
 			expectedResult: &fwk.PodGroupPostFilterResult{
-				NominatingInfos: map[*v1.Pod]*fwk.NominatingInfo{
-					pod1: {NominatedNodeName: "node2"},
+				NominatingInfos: map[types.NamespacedName]*fwk.NominatingInfo{
+					{Namespace: pod1.Namespace, Name: pod1.Name}: {NominatedNodeName: "node2"},
 				},
 			},
 		},

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
@@ -230,7 +231,9 @@ func (sched *Scheduler) podGroupCycle(ctx context.Context, schedFwk framework.Fr
 		pgPostFilterResult, status := schedFwk.RunPodGroupPostFilterPlugins(ctx, podGroupCycleState, podGroupInfo.PodGroupInfo, pgSchedulingFunc)
 		if status.IsSuccess() {
 			for i := range result.podResults {
-				if nodeNameInfo, ok := pgPostFilterResult.NominatingInfos[result.podResults[i].pod]; ok {
+				pod := result.podResults[i].pod
+				namespacedName := types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
+				if nodeNameInfo, ok := pgPostFilterResult.NominatingInfos[namespacedName]; ok {
 					result.podResults[i].scheduleResult.nominatingInfo = nodeNameInfo
 					result.waitingOnPreemption = true
 				}

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -218,10 +218,10 @@ func (sched *Scheduler) podGroupCycle(ctx context.Context, schedFwk framework.Fr
 	result = completePodGroupAlgorithmResult(ctx, podGroupInfo, podGroupCycleState, runAllPostFilters, result)
 	metrics.PodGroupSchedulingAlgorithmLatency.Observe(metrics.SinceInSeconds(start))
 
-	// Run workload aware preemption if required. If the preemption is successful,
+	// Run pod group post filter plugins if scheduling failed. If any of the plugins is successful,
 	// we need to put the pods from pod group back into the scheduling queue.
 	if result.status.Code() == fwk.Unschedulable {
-		var pgSchedulingFunc framework.PodGroupSchedulingFunc = func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
+		var pgSchedulingFunc fwk.PodGroupSchedulingFunc = func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
 			res := sched.podGroupSchedulingAlgorithm(ctx, schedFwk, podGroupCycleState, podGroupInfo, runWithoutPostFilters)
 			return &fwk.PodGroupAssignments{
 				ProposedAssignments: makeProposedAssignments(&res),
@@ -229,16 +229,18 @@ func (sched *Scheduler) podGroupCycle(ctx context.Context, schedFwk framework.Fr
 		}
 		pgPostFilterResult, status := schedFwk.RunPodGroupPostFilterPlugins(ctx, podGroupCycleState, podGroupInfo.PodGroupInfo, pgSchedulingFunc)
 		if status.IsSuccess() {
-			result.waitingOnPreemption = true
 			for i := range result.podResults {
-				if nodeNameInfo, ok := pgPostFilterResult.NominatedNodeNames[result.podResults[i].pod]; ok {
+				if nodeNameInfo, ok := pgPostFilterResult.NominatingInfos[result.podResults[i].pod]; ok {
 					result.podResults[i].scheduleResult.nominatingInfo = nodeNameInfo
+					result.waitingOnPreemption = true
 				}
 			}
-		} else if status.IsError() {
+		}
+
+		if status.IsError() {
 			result.status = status
-		} else {
-			result.status.AppendReason(status.String())
+		} else if msg := status.Message(); msg != "" {
+			result.status.AppendReason(msg)
 		}
 	}
 

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -71,7 +71,7 @@ type fakePodGroupPlugin struct {
 
 var _ fwk.FilterPlugin = &fakePodGroupPlugin{}
 var _ fwk.PostFilterPlugin = &fakePodGroupPlugin{}
-var _ framework.PodGroupPostFilterPlugin = &fakePodGroupPlugin{}
+var _ fwk.PodGroupPostFilterPlugin = &fakePodGroupPlugin{}
 
 func (mp *fakePodGroupPlugin) Name() string { return "FakePodGroupPlugin" }
 
@@ -94,7 +94,7 @@ func (mp *fakePodGroupPlugin) Permit(ctx context.Context, state fwk.CycleState, 
 	return fwk.NewStatus(fwk.Error, "unexpected call to permit"), 0
 }
 
-func (mp *fakePodGroupPlugin) PodGroupPostFilter(ctx context.Context, pgInfo fwk.PodGroupInfo, pgSchedulingFunc framework.PodGroupSchedulingFunc) (*framework.PodGroupPostFilterResult, *fwk.Status) {
+func (mp *fakePodGroupPlugin) PodGroupPostFilter(ctx context.Context, state fwk.PodGroupCycleState, pgInfo fwk.PodGroupInfo, pgSchedulingFunc fwk.PodGroupSchedulingFunc) (*fwk.PodGroupPostFilterResult, *fwk.Status) {
 	mp.podGroupPostFilterCalled = true
 	if mp.podGroupPostFilterStatus == nil {
 		return nil, fwk.NewStatus(fwk.Unschedulable, "default fake podgroup postfilter failure")
@@ -107,7 +107,7 @@ func (mp *fakePodGroupPlugin) PodGroupPostFilter(ctx context.Context, pgInfo fwk
 	for _, passedPod := range pods {
 		n[passedPod] = mp.podGroupPostFilterResult[passedPod.Name]
 	}
-	return &framework.PodGroupPostFilterResult{NominatedNodeNames: n}, mp.podGroupPostFilterStatus
+	return &fwk.PodGroupPostFilterResult{NominatingInfos: n}, mp.podGroupPostFilterStatus
 }
 
 type fakePlacementFeasibleState struct {
@@ -662,6 +662,11 @@ func TestPodGroupCycle_PodGroupPostFilter(t *testing.T) {
 				}
 			}
 
+			var pgPostFilterPlugins []config.Plugin
+			if tt.postFilterPlugin == "DefaultPreemption" {
+				pgPostFilterPlugins = []config.Plugin{{Name: "DefaultPreemption"}}
+			}
+
 			profileCfg := config.KubeSchedulerProfile{
 				SchedulerName: "test-scheduler",
 				Plugins: &config.Plugins{
@@ -676,6 +681,9 @@ func TestPodGroupCycle_PodGroupPostFilter(t *testing.T) {
 					},
 					PostFilter: config.PluginSet{
 						Enabled: []config.Plugin{{Name: tt.postFilterPlugin}},
+					},
+					PodGroupPostFilter: config.PluginSet{
+						Enabled: pgPostFilterPlugins,
 					},
 				},
 			}
@@ -2835,7 +2843,7 @@ func TestPodGroupCycle_NominatedNodes(t *testing.T) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// Mock PodGroupPostFilter to return NominatedNodeNames
+	// Mock PodGroupPostFilter to return NominatingInfos
 	nominatedNodes := map[string]*fwk.NominatingInfo{
 		p1.Name: {NominatingMode: fwk.ModeOverride, NominatedNodeName: "node1"},
 	}
@@ -2862,6 +2870,9 @@ func TestPodGroupCycle_NominatedNodes(t *testing.T) {
 				Enabled: []config.Plugin{{Name: defaultbinder.Name}},
 			},
 			PostFilter: config.PluginSet{
+				Enabled: []config.Plugin{{Name: "DefaultPreemption"}},
+			},
+			PodGroupPostFilter: config.PluginSet{
 				Enabled: []config.Plugin{{Name: "DefaultPreemption"}},
 			},
 		},

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -31,6 +31,7 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -103,9 +104,10 @@ func (mp *fakePodGroupPlugin) PodGroupPostFilter(ctx context.Context, state fwk.
 		return nil, mp.podGroupPostFilterStatus
 	}
 	pods := pgInfo.GetUnscheduledPods()
-	n := make(map[*v1.Pod]*fwk.NominatingInfo, len(pods))
+	n := make(map[types.NamespacedName]*fwk.NominatingInfo, len(pods))
 	for _, passedPod := range pods {
-		n[passedPod] = mp.podGroupPostFilterResult[passedPod.Name]
+		namespacedName := types.NamespacedName{Namespace: passedPod.Namespace, Name: passedPod.Name}
+		n[namespacedName] = mp.podGroupPostFilterResult[passedPod.Name]
 	}
 	return &fwk.PodGroupPostFilterResult{NominatingInfos: n}, mp.podGroupPostFilterStatus
 }

--- a/staging/src/k8s.io/kube-scheduler/config/v1/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1/types.go
@@ -238,6 +238,10 @@ type Plugins struct {
 
 	// PlacementScore is a list of plugins that should be invoked during workload scheduling cycle when ranking pod group assignments.
 	PlacementScore PluginSet `json:"placementScore,omitempty"`
+
+	// PodGroupPostFilter is a list of plugins that are invoked after the workload scheduling phase,
+	// but only when the PodGroup cannot be scheduled (equivalent to PostFilter for single pods).
+	PodGroupPostFilter PluginSet `json:"podGroupPostFilter,omitempty"`
 }
 
 // PluginSet specifies enabled and disabled plugins for an extension point.

--- a/staging/src/k8s.io/kube-scheduler/config/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1/zz_generated.deepcopy.go
@@ -487,6 +487,7 @@ func (in *Plugins) DeepCopyInto(out *Plugins) {
 	in.MultiPoint.DeepCopyInto(&out.MultiPoint)
 	in.PlacementGenerate.DeepCopyInto(&out.PlacementGenerate)
 	in.PlacementScore.DeepCopyInto(&out.PlacementScore)
+	in.PodGroupPostFilter.DeepCopyInto(&out.PodGroupPostFilter)
 	return
 }
 

--- a/staging/src/k8s.io/kube-scheduler/framework/interface.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/interface.go
@@ -590,6 +590,33 @@ type PostFilterPlugin interface {
 	PostFilter(ctx context.Context, state CycleState, pod *v1.Pod, filteredNodeStatusMap NodeToStatusReader) (*PostFilterResult, *Status)
 }
 
+// PodGroupSchedulingFunc is a function that will be run to check feasibility of a pod group scheduling.
+type PodGroupSchedulingFunc func(ctx context.Context) (*PodGroupAssignments, *Status)
+
+// PodGroupPostFilterResult stores information about nominated nodes for a pod group.
+type PodGroupPostFilterResult struct {
+	// NominatingInfos maps pods in the pod group to their nominated node info. It only contains pods that have a nominated node.
+	NominatingInfos map[*v1.Pod]*NominatingInfo
+}
+
+// PodGroupPostFilterPlugin is an interface for "PodGroupPostFilter" plugins. These plugins are called
+// after a PodGroup cannot be scheduled.
+type PodGroupPostFilterPlugin interface {
+	Plugin
+
+	// PodGroupPostFilter is called by the scheduling framework
+	// when the pod group scheduling cycle failed.
+	//
+	//
+	// A PodGroupPostFilter plugin should return one of the following statuses:
+	// - Unschedulable: the plugin gets executed successfully but the PodGroup cannot be made schedulable.
+	// - UnschedulableAndUnresolvable: the plugin gets executed successfully but the PodGroup cannot be made schedulable,
+	//   and other PodGroupPostFilter plugins cannot make the group schedulable so evaluation of subsequent plugins is skipped.
+	// - Success: the plugin gets executed successfully, the PodGroup can be made schedulable and evaluation of subsequent plugins is skipped.
+	// - Error: the plugin aborts due to some internal error.
+	PodGroupPostFilter(ctx context.Context, state PodGroupCycleState, pgInfo PodGroupInfo, pgSchedulingFunc PodGroupSchedulingFunc) (*PodGroupPostFilterResult, *Status)
+}
+
 // PreScorePlugin is an interface for "PreScore" plugin. PreScore is an
 // informational extension point. Plugins will be called with a list of nodes
 // that passed the filtering phase. A plugin may use this data to update internal

--- a/staging/src/k8s.io/kube-scheduler/framework/interface.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/interface.go
@@ -596,7 +596,7 @@ type PodGroupSchedulingFunc func(ctx context.Context) (*PodGroupAssignments, *St
 // PodGroupPostFilterResult stores information about nominated nodes for a pod group.
 type PodGroupPostFilterResult struct {
 	// NominatingInfos maps pods in the pod group to their nominated node info. It only contains pods that have a nominated node.
-	NominatingInfos map[*v1.Pod]*NominatingInfo
+	NominatingInfos map[types.NamespacedName]*NominatingInfo
 }
 
 // PodGroupPostFilterPlugin is an interface for "PodGroupPostFilter" plugins. These plugins are called

--- a/test/integration/scheduler/podgroup/podgroup_test.go
+++ b/test/integration/scheduler/podgroup/podgroup_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -753,6 +754,7 @@ func TestWorkloadAwarePreemptionInvocation(t *testing.T) {
 
 // mockPostFilterPlugin is a custom PostFilter plugin that just counts invocations.
 type mockPostFilterPlugin struct {
+	lock  sync.Mutex
 	count int
 }
 
@@ -761,8 +763,16 @@ func (m *mockPostFilterPlugin) Name() string {
 }
 
 func (m *mockPostFilterPlugin) PostFilter(ctx context.Context, state framework.CycleState, pod *v1.Pod, filteredNodeStatusMap framework.NodeToStatusReader) (*framework.PostFilterResult, *framework.Status) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
 	m.count++
 	return nil, framework.NewStatus(framework.Unschedulable)
+}
+
+func (m *mockPostFilterPlugin) getCount() int {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	return m.count
 }
 
 func TestPostFilterInvocationCount(t *testing.T) {
@@ -866,12 +876,130 @@ func TestPostFilterInvocationCount(t *testing.T) {
 	// but should not be called in WAP.
 	// Only one pod is evaluated for pod group because minCount=3 can't be satisfied with the remaining 2 pods.
 	err = wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 10*time.Second, false, func(ctx context.Context) (bool, error) {
-		if mockPlugin.count == 1 {
+		if mockPlugin.getCount() == 1 {
 			return true, nil
 		}
 		return false, nil
 	})
 	if err != nil {
-		t.Errorf("MockPostFilter was called %d times, expected exactly 3", mockPlugin.count)
+		t.Errorf("MockPostFilter was called %d times, expected exactly 3", mockPlugin.getCount())
+	}
+}
+
+// mockPodGroupPostFilterPlugin is a custom PodGroupPostFilter plugin that just counts invocations.
+type mockPodGroupPostFilterPlugin struct {
+	name  string
+	lock  sync.Mutex
+	count int
+}
+
+func (m *mockPodGroupPostFilterPlugin) Name() string {
+	return m.name
+}
+
+func (m *mockPodGroupPostFilterPlugin) PodGroupPostFilter(ctx context.Context, state framework.PodGroupCycleState, pgInfo framework.PodGroupInfo, pgSchedulingFunc framework.PodGroupSchedulingFunc) (*framework.PodGroupPostFilterResult, *framework.Status) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.count++
+	return &framework.PodGroupPostFilterResult{}, framework.NewStatus(framework.Unschedulable)
+}
+
+func (m *mockPodGroupPostFilterPlugin) getCount() int {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	return m.count
+}
+
+func TestPodGroupPostFilterIteration(t *testing.T) {
+	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+		features.GenericWorkload: true,
+	})
+
+	node := st.MakeNode().Name("node").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj()
+
+	pg := st.MakePodGroup().Namespace("default").Name("pg1").DisruptionModeAll().Priority(100).MinCount(2).Obj()
+
+	highPods := []*v1.Pod{
+		st.MakePod().Namespace("default").Name("high-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg1").Priority(100).Obj(),
+		st.MakePod().Namespace("default").Name("high-2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg1").Priority(100).Obj(),
+	}
+
+	mockPlugin1 := &mockPodGroupPostFilterPlugin{name: "MockPlugin1"}
+	mockPlugin2 := &mockPodGroupPostFilterPlugin{name: "MockPlugin2"}
+
+	registry := frameworkruntime.Registry{
+		"MockPlugin1": func(ctx context.Context, obj runtime.Object, handle framework.Handle) (framework.Plugin, error) {
+			return mockPlugin1, nil
+		},
+		"MockPlugin2": func(ctx context.Context, obj runtime.Object, handle framework.Handle) (framework.Plugin, error) {
+			return mockPlugin2, nil
+		},
+	}
+
+	cfg := configtesting.V1ToInternalWithDefaults(t, configv1.KubeSchedulerConfiguration{
+		Profiles: []configv1.KubeSchedulerProfile{{
+			SchedulerName: ptr.To(v1.DefaultSchedulerName),
+			Plugins: &configv1.Plugins{
+				MultiPoint: configv1.PluginSet{
+					Enabled: []configv1.Plugin{
+						{Name: "GangScheduling"},
+					},
+				},
+				PodGroupPostFilter: configv1.PluginSet{
+					Enabled: []configv1.Plugin{
+						{Name: "MockPlugin1"},
+						{Name: "MockPlugin2"},
+					},
+					Disabled: []configv1.Plugin{
+						{Name: "DefaultPreemption"},
+					},
+				},
+			},
+		}},
+	})
+
+	testCtx := testutils.InitTestSchedulerWithNS(t, "pg-post-filter-iter",
+		scheduler.WithPodMaxBackoffSeconds(100),
+		scheduler.WithPodInitialBackoffSeconds(100),
+		scheduler.WithFrameworkOutOfTreeRegistry(registry),
+		scheduler.WithProfiles(cfg.Profiles...),
+	)
+	cs, ns := testCtx.ClientSet, testCtx.NS.Name
+
+	if _, err := cs.CoreV1().Nodes().Create(testCtx.Ctx, node, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create node: %v", err)
+	}
+
+	pg.Namespace = ns
+	if _, err := cs.SchedulingV1alpha3().PodGroups(ns).Create(testCtx.Ctx, pg, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create PodGroup: %v", err)
+	}
+
+	pgLister := testCtx.InformerFactory.Scheduling().V1alpha3().PodGroups().Lister()
+	err := wait.PollUntilContextTimeout(testCtx.Ctx, 10*time.Millisecond, 10*time.Second, false, func(ctx context.Context) (bool, error) {
+		_, err := pgLister.PodGroups(ns).Get(pg.Name)
+		return err == nil, nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to wait for PodGroup to be synced: %v", err)
+	}
+
+	for _, p := range highPods {
+		p.Namespace = ns
+		_, err := cs.CoreV1().Pods(ns).Create(testCtx.Ctx, p, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Failed to create pod %s: %v", p.Name, err)
+		}
+
+	}
+
+	err = wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 10*time.Second, false, func(ctx context.Context) (bool, error) {
+		if mockPlugin1.getCount() == 1 && mockPlugin2.getCount() == 1 {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Errorf("Plugins were not called exactly once. MockPlugin1: %d, MockPlugin2: %d", mockPlugin1.getCount(), mockPlugin2.getCount())
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR introduces a new scheduler framework extension point: `PodGroupPostFilter`.
This extension point runs after `PostFilter` but operates on PodGroups (used in GangScheduling) rather than individual pods.

This PR builds on top of PR #139616 (which decoupled WAP logic) by introducing a fully configurable `PodGroupPostFilter` extension point into the scheduler API.

Changes in this PR:

1. Adds `PodGroupPostFilter` to the framework and validation API types, exporting the interfaces (such as `PodGroupInfo` and `PodGroupPostFilterResult`) via `staging/src/k8s.io/kube-scheduler/framework` so out-of-tree plugins can implement it.
2. Implements `RunPodGroupPostFilterPlugins` inside `framework.go` to properly execute registered plugins

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/5710-workload-aware-preemption
Related PR: #139616

#### Special notes for your reviewer:

• This PR is split into logical commits mimicking previous extension point PRs:
  1. API config changes for PodGroupPostFilter
  2. Framework iteration implementation and configuration

#### Does this PR introduce a user-facing change?

```release-note
Introduces `PodGroupPostFilter` extension point to the scheduling framework. This replaces internal hardcoding for `WorkloadAwarePreemption` with a proper, configurable extension point for operating on PodGroups.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

- [KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/5710-workload-aware-preemption
