### PR TITLE
cleanup: remove retired heapster support from grab-profiles.sh

### DIFF
--- a/hack/grab-profiles.sh
+++ b/hack/grab-profiles.sh
@@ -67,14 +67,12 @@ profile_components=""
 output_dir="."
 tunnel_port="${tunnel_port:-1234}"
 
-if ! args=$(getopt -o s:mho:k:c -l server:,master,heapster,output:,kubelet:,scheduler,controller-manager,help,inuse-space,inuse-objects,alloc-space,alloc-objects,cpu,kubelet-binary:,master-binary:,scheduler-binary:,controller-manager-binary:,scheduler-port:,controller-manager-port: -- "$@"); then
+if ! args=$(getopt -o s:mo:k:c -l server:,master,output:,kubelet:,scheduler,controller-manager,help,inuse-space,inuse-objects,alloc-space,alloc-objects,cpu,kubelet-binary:,master-binary:,scheduler-binary:,controller-manager-binary:,scheduler-port:,controller-manager-port: -- "$@"); then
   >&2 echo "Error in getopt"
   exit 1
 fi
 
-HEAPSTER_VERSION="v0.18.2"
 MASTER_PPROF_PATH=""
-HEAPSTER_PPROF_PATH="/api/v1/namespaces/kube-system/services/monitoring-heapster/proxy"
 KUBELET_PPROF_PATH_PREFIX="/api/v1/proxy/nodes"
 SCHEDULER_PPROF_PATH_PREFIX="/api/v1/namespaces/kube-system/pods/kube-scheduler/proxy"
 CONTROLLER_MANAGER_PPROF_PATH_PREFIX="/api/v1/namespaces/kube-system/pods/kube-controller-manager/proxy"
@@ -104,10 +102,6 @@ while true; do
       fi
       master_binary=$1
       shift
-      ;;
-    -h|--heapster)
-      shift
-      profile_components="heapster ${profile_components}"
       ;;
     -k|--kubelet)
       shift
@@ -211,7 +205,6 @@ while true; do
         -o/--output,
         -s/--server,
         -m/--master,
-        -h/--heapster,
         --inuse-space,
         --inuse-objects,
         --alloc-space,
@@ -273,14 +266,6 @@ for component in ${profile_components}; do
     scheduler)
       path="${SCHEDULER_PPROF_PATH_PREFIX}-${server_addr}:${scheduler_port}"
       binary=${scheduler_binary}
-      ;;
-    heapster)
-      rm heapster
-      wget https://github.com/kubernetes/heapster/releases/download/${HEAPSTER_VERSION}/heapster
-      kube::util::trap_add 'rm -f heapster' EXIT
-      kube::util::trap_add 'rm -f heapster' SIGTERM
-      binary=heapster
-      path=${HEAPSTER_PPROF_PATH}
       ;;
     kubelet)
       path="${KUBELET_PPROF_PATH_PREFIX}"


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Removes the stale `--heapster` (`-h`) flag and all related code from
`hack/grab-profiles.sh`. Heapster was retired in 2019 and moved to
`kubernetes-retired/heapster`. The rest of the codebase already removed
Heapster references (e.g. #87498, #85512, #90368), but this script was
missed. Specifically this removes:
- `HEAPSTER_VERSION` and `HEAPSTER_PPROF_PATH` variables
- The `-h|--heapster` flag from `getopt` and the `while` loop
- The `heapster)` case block in the component loop (which `wget`s from a defunct URL)
- `-h/--heapster` from the `--help` output

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
This is the same pattern as #136379 — removing stale references to
retired tooling from `hack/` scripts. No logic is affected; only the
heapster-specific code paths are removed.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
```