### PR TITLE
Automated cherry pick of #139651: Align DeviceTaintRule informer API version with handlers

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
@@ -25,7 +25,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
-	resourcealphaapi "k8s.io/api/resource/v1alpha3"
+	resourcebetaapi "k8s.io/api/resource/v1beta2"
 	labels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/diff"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -395,15 +395,15 @@ func sliceDriverPoolDeviceIndexFunc(obj any) ([]string, error) {
 	return indexValues, nil
 }
 
-func driverPoolDeviceIndexPatchKey(patch *resourcealphaapi.DeviceTaintRule) string {
-	deviceSelector := ptr.Deref(patch.Spec.DeviceSelector, resourcealphaapi.DeviceTaintSelector{})
+func driverPoolDeviceIndexPatchKey(patch *resourcebetaapi.DeviceTaintRule) string {
+	deviceSelector := ptr.Deref(patch.Spec.DeviceSelector, resourcebetaapi.DeviceTaintSelector{})
 	driverKey := ptr.Deref(deviceSelector.Driver, anyDriver)
 	poolKey := ptr.Deref(deviceSelector.Pool, anyPool)
 	deviceKey := ptr.Deref(deviceSelector.Device, anyDevice)
 	return deviceID(driverKey, poolKey, deviceKey)
 }
 
-func (t *Tracker) sliceNamesForPatch(ctx context.Context, patch *resourcealphaapi.DeviceTaintRule) []string {
+func (t *Tracker) sliceNamesForPatch(ctx context.Context, patch *resourcebetaapi.DeviceTaintRule) []string {
 	patchKey := driverPoolDeviceIndexPatchKey(patch)
 	sliceNames, err := t.resourceSlices.GetIndexer().IndexKeys(driverPoolDeviceIndexName, patchKey)
 	if err != nil {
@@ -469,7 +469,7 @@ func (t *Tracker) resourceSliceDelete(ctx context.Context) func(obj any) {
 func (t *Tracker) deviceTaintAdd(ctx context.Context) func(obj any) {
 	logger := klog.FromContext(ctx)
 	return func(obj any) {
-		rule, ok := obj.(*resourcealphaapi.DeviceTaintRule)
+		rule, ok := obj.(*resourcebetaapi.DeviceTaintRule)
 		if !ok {
 			return
 		}
@@ -487,11 +487,11 @@ func (t *Tracker) deviceTaintAdd(ctx context.Context) func(obj any) {
 func (t *Tracker) deviceTaintUpdate(ctx context.Context) func(oldObj, newObj any) {
 	logger := klog.FromContext(ctx)
 	return func(oldObj, newObj any) {
-		oldRule, ok := oldObj.(*resourcealphaapi.DeviceTaintRule)
+		oldRule, ok := oldObj.(*resourcebetaapi.DeviceTaintRule)
 		if !ok {
 			return
 		}
-		newRule, ok := newObj.(*resourcealphaapi.DeviceTaintRule)
+		newRule, ok := newObj.(*resourcebetaapi.DeviceTaintRule)
 		if !ok {
 			return
 		}
@@ -519,7 +519,7 @@ func (t *Tracker) deviceTaintDelete(ctx context.Context) func(obj any) {
 		if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 			obj = tombstone.Obj
 		}
-		patch, ok := obj.(*resourcealphaapi.DeviceTaintRule)
+		patch, ok := obj.(*resourcebetaapi.DeviceTaintRule)
 		if !ok {
 			return
 		}
@@ -631,7 +631,7 @@ func (t *Tracker) syncSlice(ctx context.Context, name string, sendEvent bool) {
 		return
 	}
 
-	patches := typedSlice[*resourcealphaapi.DeviceTaintRule](t.deviceTaints.GetIndexer().List())
+	patches := typedSlice[*resourcebetaapi.DeviceTaintRule](t.deviceTaints.GetIndexer().List())
 	patchedSlice, err := t.applyPatches(ctx, slice, patches)
 	if err != nil {
 		t.handleError(ctx, err, "failed to apply patches to ResourceSlice", "resourceslice", klog.KObj(slice))
@@ -666,7 +666,7 @@ func (t *Tracker) syncSlice(ctx context.Context, name string, sendEvent bool) {
 	}
 }
 
-func (t *Tracker) applyPatches(ctx context.Context, slice *resourceapi.ResourceSlice, taintRules []*resourcealphaapi.DeviceTaintRule) (*resourceapi.ResourceSlice, error) {
+func (t *Tracker) applyPatches(ctx context.Context, slice *resourceapi.ResourceSlice, taintRules []*resourcebetaapi.DeviceTaintRule) (*resourceapi.ResourceSlice, error) {
 	logger := klog.FromContext(ctx)
 
 	// slice will be DeepCopied just-in-time, only when necessary.

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
-	resourcealphaapi "k8s.io/api/resource/v1alpha3"
+	resourcebetaapi "k8s.io/api/resource/v1beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
@@ -116,7 +116,7 @@ func applyEventPair(tCtx *testContext, event any) {
 			require.NoError(tCtx, err)
 			tCtx.resourceSliceAdd(tCtx.Context)(pair[1])
 		}
-	case [2]*resourcealphaapi.DeviceTaintRule:
+	case [2]*resourcebetaapi.DeviceTaintRule:
 		store := tCtx.deviceTaints.GetStore()
 		switch {
 		case pair[0] != nil && pair[1] != nil:
@@ -279,39 +279,39 @@ var (
 	slice2               = sliceWithDevices(slice2NoDevices, devices2)
 	slice2Tainted        = sliceWithDevices(slice2, taintedDevices2)
 
-	alphaDeviceTaint = func(taint resourceapi.DeviceTaint) resourcealphaapi.DeviceTaint {
-		return resourcealphaapi.DeviceTaint{
+	alphaDeviceTaint = func(taint resourceapi.DeviceTaint) resourcebetaapi.DeviceTaint {
+		return resourcebetaapi.DeviceTaint{
 			Key:       taint.Key,
 			Value:     taint.Value,
-			Effect:    resourcealphaapi.DeviceTaintEffect(taint.Effect),
+			Effect:    resourcebetaapi.DeviceTaintEffect(taint.Effect),
 			TimeAdded: taint.TimeAdded,
 		}
 	}
-	taintAllDevicesRule = &resourcealphaapi.DeviceTaintRule{
+	taintAllDevicesRule = &resourcebetaapi.DeviceTaintRule{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "rule",
 		},
-		Spec: resourcealphaapi.DeviceTaintRuleSpec{
+		Spec: resourcebetaapi.DeviceTaintRuleSpec{
 			Taint: alphaDeviceTaint(deviceTaint1),
 		},
 	}
-	taintPoolDevicesRule = func(rule *resourcealphaapi.DeviceTaintRule, pool string) *resourcealphaapi.DeviceTaintRule {
+	taintPoolDevicesRule = func(rule *resourcebetaapi.DeviceTaintRule, pool string) *resourcebetaapi.DeviceTaintRule {
 		rule = rule.DeepCopy()
-		rule.Spec.DeviceSelector = &resourcealphaapi.DeviceTaintSelector{
+		rule.Spec.DeviceSelector = &resourcebetaapi.DeviceTaintSelector{
 			Pool: &pool,
 		}
 		return rule
 	}
-	taintDriverDevicesRule = func(rule *resourcealphaapi.DeviceTaintRule, driver string) *resourcealphaapi.DeviceTaintRule {
+	taintDriverDevicesRule = func(rule *resourcebetaapi.DeviceTaintRule, driver string) *resourcebetaapi.DeviceTaintRule {
 		rule = rule.DeepCopy()
-		rule.Spec.DeviceSelector = &resourcealphaapi.DeviceTaintSelector{
+		rule.Spec.DeviceSelector = &resourcebetaapi.DeviceTaintSelector{
 			Driver: &driver,
 		}
 		return rule
 	}
-	taintNamedDevicesRule = func(rule *resourcealphaapi.DeviceTaintRule, name string) *resourcealphaapi.DeviceTaintRule {
+	taintNamedDevicesRule = func(rule *resourcebetaapi.DeviceTaintRule, name string) *resourcebetaapi.DeviceTaintRule {
 		rule = rule.DeepCopy()
-		rule.Spec.DeviceSelector = &resourcealphaapi.DeviceTaintSelector{
+		rule.Spec.DeviceSelector = &resourcebetaapi.DeviceTaintSelector{
 			Device: &name,
 		}
 		return rule
@@ -720,8 +720,8 @@ func BenchmarkEventHandlers(b *testing.B) {
 	now := time.Now()
 	benchmarks := map[string]struct {
 		resourceSlices []*resourceapi.ResourceSlice
-		taintRules     []*resourcealphaapi.DeviceTaintRule
-		loop           func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, taintRules []*resourcealphaapi.DeviceTaintRule, i int)
+		taintRules     []*resourcebetaapi.DeviceTaintRule
+		loop           func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, taintRules []*resourcebetaapi.DeviceTaintRule, i int)
 	}{
 		"resource-slice-add-no-taint-rules": {
 			resourceSlices: func() []*resourceapi.ResourceSlice {
@@ -738,7 +738,7 @@ func BenchmarkEventHandlers(b *testing.B) {
 				}
 				return resourceSlices
 			}(),
-			loop: func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, _ []*resourcealphaapi.DeviceTaintRule, i int) {
+			loop: func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, _ []*resourcebetaapi.DeviceTaintRule, i int) {
 				tracker.resourceSliceAdd(ctx)(resourceSlices[i%len(resourceSlices)])
 			},
 		},
@@ -757,23 +757,23 @@ func BenchmarkEventHandlers(b *testing.B) {
 				}
 				return resourceSlices
 			}(),
-			taintRules: []*resourcealphaapi.DeviceTaintRule{
+			taintRules: []*resourcebetaapi.DeviceTaintRule{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "taintRule",
 					},
-					Spec: resourcealphaapi.DeviceTaintRuleSpec{
+					Spec: resourcebetaapi.DeviceTaintRuleSpec{
 						DeviceSelector: nil, // all slices
-						Taint: resourcealphaapi.DeviceTaint{
+						Taint: resourcebetaapi.DeviceTaint{
 							Key:       "example.com/taint",
 							Value:     "tainted",
-							Effect:    resourcealphaapi.DeviceTaintEffectNoExecute,
+							Effect:    resourcebetaapi.DeviceTaintEffectNoExecute,
 							TimeAdded: &metav1.Time{Time: now},
 						},
 					},
 				},
 			},
-			loop: func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, taintRules []*resourcealphaapi.DeviceTaintRule, i int) {
+			loop: func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, taintRules []*resourcebetaapi.DeviceTaintRule, i int) {
 				tracker.deviceTaintAdd(ctx)(taintRules[i%len(taintRules)])
 			},
 		},
@@ -792,23 +792,23 @@ func BenchmarkEventHandlers(b *testing.B) {
 				}
 				return resourceSlices
 			}(),
-			taintRules: []*resourcealphaapi.DeviceTaintRule{
+			taintRules: []*resourcebetaapi.DeviceTaintRule{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "taintRule",
 					},
-					Spec: resourcealphaapi.DeviceTaintRuleSpec{
+					Spec: resourcebetaapi.DeviceTaintRuleSpec{
 						DeviceSelector: nil, // all slices
-						Taint: resourcealphaapi.DeviceTaint{
+						Taint: resourcebetaapi.DeviceTaint{
 							Key:       "example.com/taint",
 							Value:     "tainted",
-							Effect:    resourcealphaapi.DeviceTaintEffectNoExecute,
+							Effect:    resourcebetaapi.DeviceTaintEffectNoExecute,
 							TimeAdded: &metav1.Time{Time: now},
 						},
 					},
 				},
 			},
-			loop: func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, _ []*resourcealphaapi.DeviceTaintRule, i int) {
+			loop: func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, _ []*resourcebetaapi.DeviceTaintRule, i int) {
 				tracker.resourceSliceAdd(ctx)(resourceSlices[i%len(resourceSlices)])
 			},
 		},
@@ -841,25 +841,25 @@ func BenchmarkEventHandlers(b *testing.B) {
 				resourceSlices[nSlices/2].Spec.Devices[nDevices/2].Name = "patchme"
 				return resourceSlices
 			}(),
-			taintRules: []*resourcealphaapi.DeviceTaintRule{
+			taintRules: []*resourcebetaapi.DeviceTaintRule{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "taintRule",
 					},
-					Spec: resourcealphaapi.DeviceTaintRuleSpec{
-						DeviceSelector: &resourcealphaapi.DeviceTaintSelector{
+					Spec: resourcebetaapi.DeviceTaintRuleSpec{
+						DeviceSelector: &resourcebetaapi.DeviceTaintSelector{
 							Device: ptr.To("patchme"),
 						},
-						Taint: resourcealphaapi.DeviceTaint{
+						Taint: resourcebetaapi.DeviceTaint{
 							Key:       "example.com/taint",
 							Value:     "tainted",
-							Effect:    resourcealphaapi.DeviceTaintEffectNoExecute,
+							Effect:    resourcebetaapi.DeviceTaintEffectNoExecute,
 							TimeAdded: &metav1.Time{Time: now},
 						},
 					},
 				},
 			},
-			loop: func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, taintRules []*resourcealphaapi.DeviceTaintRule, i int) {
+			loop: func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, taintRules []*resourcebetaapi.DeviceTaintRule, i int) {
 				tracker.deviceTaintAdd(ctx)(taintRules[i%len(taintRules)])
 			},
 		},
@@ -886,26 +886,26 @@ func BenchmarkEventHandlers(b *testing.B) {
 				}
 				return resourceSlices
 			}(),
-			taintRules: []*resourcealphaapi.DeviceTaintRule{
+			taintRules: []*resourcebetaapi.DeviceTaintRule{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "patch",
 					},
-					Spec: resourcealphaapi.DeviceTaintRuleSpec{
-						DeviceSelector: &resourcealphaapi.DeviceTaintSelector{
+					Spec: resourcebetaapi.DeviceTaintRuleSpec{
+						DeviceSelector: &resourcebetaapi.DeviceTaintSelector{
 							Pool:   ptr.To("pool-250"),
 							Device: ptr.To("patchme"),
 						},
-						Taint: resourcealphaapi.DeviceTaint{
+						Taint: resourcebetaapi.DeviceTaint{
 							Key:       "example.com/taint",
 							Value:     "tainted",
-							Effect:    resourcealphaapi.DeviceTaintEffectNoExecute,
+							Effect:    resourcebetaapi.DeviceTaintEffectNoExecute,
 							TimeAdded: &metav1.Time{Time: now},
 						},
 					},
 				},
 			},
-			loop: func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, patches []*resourcealphaapi.DeviceTaintRule, i int) {
+			loop: func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, patches []*resourcebetaapi.DeviceTaintRule, i int) {
 				tracker.resourceSliceAdd(ctx)(resourceSlices[250]) // the slice affected by the patch
 			},
 		},
@@ -927,21 +927,21 @@ func BenchmarkEventHandlers(b *testing.B) {
 				}
 				return resourceSlices
 			}(),
-			taintRules: func() []*resourcealphaapi.DeviceTaintRule {
-				patches := make([]*resourcealphaapi.DeviceTaintRule, 500)
+			taintRules: func() []*resourcebetaapi.DeviceTaintRule {
+				patches := make([]*resourcebetaapi.DeviceTaintRule, 500)
 				for i := range patches {
-					patches[i] = &resourcealphaapi.DeviceTaintRule{
+					patches[i] = &resourcebetaapi.DeviceTaintRule{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "taint-rule-" + strconv.Itoa(i),
 						},
-						Spec: resourcealphaapi.DeviceTaintRuleSpec{
-							DeviceSelector: &resourcealphaapi.DeviceTaintSelector{
+						Spec: resourcebetaapi.DeviceTaintRuleSpec{
+							DeviceSelector: &resourcebetaapi.DeviceTaintSelector{
 								Pool: ptr.To("pool-" + strconv.Itoa(i)),
 							},
-							Taint: resourcealphaapi.DeviceTaint{
+							Taint: resourcebetaapi.DeviceTaint{
 								Key:       "example.com/taint",
 								Value:     "tainted",
-								Effect:    resourcealphaapi.DeviceTaintEffectNoExecute,
+								Effect:    resourcebetaapi.DeviceTaintEffectNoExecute,
 								TimeAdded: &metav1.Time{Time: now},
 							},
 						},
@@ -949,7 +949,7 @@ func BenchmarkEventHandlers(b *testing.B) {
 				}
 				return patches
 			}(),
-			loop: func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, taintRules []*resourcealphaapi.DeviceTaintRule, i int) {
+			loop: func(ctx context.Context, b *testing.B, tracker *Tracker, resourceSlices []*resourceapi.ResourceSlice, taintRules []*resourcebetaapi.DeviceTaintRule, i int) {
 				tracker.deviceTaintAdd(ctx)(taintRules[i%len(taintRules)])
 			},
 		},

--- a/test/integration/dra/device_taints.go
+++ b/test/integration/dra/device_taints.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/controller/devicetainteviction"
 	"k8s.io/kubernetes/pkg/features"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/ptr"
 )
@@ -402,4 +403,95 @@ func testEvictCluster(tCtx ktesting.TContext, useRule useRuleMode) {
 				"Message": gomega.Equal(fmt.Sprintf("%d pods evicted since starting the controller.", numPods)),
 			}))))
 	}
+}
+
+func testNoScheduleRule(tCtx ktesting.TContext, useRule useRuleMode) {
+	tCtx.Parallel()
+
+	startScheduler(tCtx)
+
+	namespace := createTestNamespace(tCtx, nil)
+	class, driverName := createTestClass(tCtx, namespace)
+	slice := st.MakeResourceSlice("worker-0", driverName).Devices(device1)
+
+	taintKey := "testing"
+	ruleName := "rule-" + namespace
+	switch useRule {
+	case useV1alpha3Rule:
+		rule := &resourcealpha.DeviceTaintRule{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ruleName,
+			},
+			Spec: resourcealpha.DeviceTaintRuleSpec{
+				DeviceSelector: &resourcealpha.DeviceTaintSelector{
+					Driver: &driverName,
+				},
+				Taint: resourcealpha.DeviceTaint{
+					Key:    taintKey,
+					Effect: resourcealpha.DeviceTaintEffectNoSchedule,
+				},
+			},
+		}
+		_ = must(tCtx, tCtx.Client().ResourceV1alpha3().DeviceTaintRules().Create, rule, metav1.CreateOptions{})
+		tCtx.CleanupCtx(func(tCtx ktesting.TContext) {
+			err := tCtx.Client().ResourceV1alpha3().DeviceTaintRules().Delete(tCtx, ruleName, metav1.DeleteOptions{})
+			if apierrors.IsNotFound(err) {
+				return
+			}
+			tCtx.ExpectNoError(err)
+		})
+	case useV1beta2Rule:
+		rule := &resourcebeta.DeviceTaintRule{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: ruleName,
+			},
+			Spec: resourcebeta.DeviceTaintRuleSpec{
+				DeviceSelector: &resourcebeta.DeviceTaintSelector{
+					Driver: &driverName,
+				},
+				Taint: resourcebeta.DeviceTaint{
+					Key:    taintKey,
+					Effect: resourcebeta.DeviceTaintEffectNoSchedule,
+				},
+			},
+		}
+		_ = must(tCtx, tCtx.Client().ResourceV1beta2().DeviceTaintRules().Create, rule, metav1.CreateOptions{})
+		tCtx.CleanupCtx(func(tCtx ktesting.TContext) {
+			err := tCtx.Client().ResourceV1beta2().DeviceTaintRules().Delete(tCtx, ruleName, metav1.DeleteOptions{})
+			if apierrors.IsNotFound(err) {
+				return
+			}
+			tCtx.ExpectNoError(err)
+		})
+	case useNoRule:
+		slice.Spec.Devices[0].Taints = []resourceapi.DeviceTaint{
+			{
+				Key:    taintKey,
+				Effect: resourceapi.DeviceTaintEffectNoSchedule,
+			},
+		}
+	}
+
+	// Creating the ResourceSlice after the DeviceTaintRule exercises additional
+	// code paths in the ResourceSlice tracker.
+	_ = createSlice(tCtx, slice.Obj())
+
+	pod := st.MakePod().Name(podName).Namespace(namespace).
+		Container("my-container").
+		Obj()
+
+	untoleratingClaim := createClaim(tCtx, namespace, "-untolerating", class, claim)
+	untoleratingPod := createPod(tCtx, namespace, "-untolerating", pod, untoleratingClaim)
+	expectPodUnschedulable(tCtx, untoleratingPod, "cannot allocate all claims")
+
+	toleratingClaim := claim.DeepCopy()
+	toleratingClaim.Spec.Devices.Requests[0].Exactly.Tolerations = []resourceapi.DeviceToleration{
+		{
+			Key:    taintKey,
+			Effect: resourceapi.DeviceTaintEffectNoSchedule,
+		},
+	}
+	_ = createClaim(tCtx, namespace, "-tolerating", class, toleratingClaim)
+	toleratingPod := createPod(tCtx, namespace, "-tolerating", pod)
+	waitForPodScheduled(tCtx, namespace, toleratingPod.Name)
 }

--- a/test/integration/dra/dra.go
+++ b/test/integration/dra/dra.go
@@ -134,6 +134,7 @@ func run(tCtx ktesting.TContext, whatRE string) {
 			f: func(tCtx ktesting.TContext) {
 				runSubTest(tCtx, "Pod", func(tCtx ktesting.TContext) { testPod(tCtx, true) })
 				runSubTest(tCtx, "EvictClusterWithSlices", func(tCtx ktesting.TContext) { testEvictCluster(tCtx, useNoRule) })
+				runSubTest(tCtx, "NoScheduleWithSlices", func(tCtx ktesting.TContext) { testNoScheduleRule(tCtx, useNoRule) })
 				// Number of devices per slice is chosen so that Filter takes a few seconds:
 				// without a timeout, the test doesn't run too long, but long enough that a short timeout triggers.
 				runSubTest(tCtx, "FilterTimeout", func(tCtx ktesting.TContext) { testFilterTimeout(tCtx, 21) })
@@ -249,6 +250,9 @@ func run(tCtx ktesting.TContext, whatRE string) {
 				runSubTest(tCtx, "EvictClusterWithV1alpha3Rule", func(tCtx ktesting.TContext) { testEvictCluster(tCtx, useV1alpha3Rule) })
 				runSubTest(tCtx, "EvictClusterWithV1beta2Rule", func(tCtx ktesting.TContext) { testEvictCluster(tCtx, useV1beta2Rule) })
 				runSubTest(tCtx, "EvictClusterWithSlices", func(tCtx ktesting.TContext) { testEvictCluster(tCtx, useNoRule) })
+				runSubTest(tCtx, "NoScheduleWithV1alpha3Rule", func(tCtx ktesting.TContext) { testNoScheduleRule(tCtx, useV1alpha3Rule) })
+				runSubTest(tCtx, "NoScheduleWithV1beta2Rule", func(tCtx ktesting.TContext) { testNoScheduleRule(tCtx, useV1beta2Rule) })
+				runSubTest(tCtx, "NoScheduleWithSlices", func(tCtx ktesting.TContext) { testNoScheduleRule(tCtx, useNoRule) })
 				runSubTest(tCtx, "InvalidResourceSlices", testInvalidResourceSlices)
 				// Number of devices per slice is chosen so that Filter takes a few seconds: The allocator
 				// in the experimental channel has an improvement that requires a higher number here than


### PR DESCRIPTION
Cherry pick of #139651 on release-1.36.

#139651: Align DeviceTaintRule informer API version with handlers

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug
/kind failing-test


```release-note
Fixed a bug when the DRADeviceTaintRules feature is enabled that caused kube-scheduler to panic when DeviceTaintRules exist and ResourceSlices are changed or to ignore new changes to DeviceTaintRules.
```