### PR TITLE
Skip DRADeviceTaints upgrade/downgrade test

### DIFF
--- a/test/e2e_dra/devicetaints_test.go
+++ b/test/e2e_dra/devicetaints_test.go
@@ -33,6 +33,8 @@ import (
 // - A pod which gets scheduled on the previous release because of a toleration is kept running after an upgrade.
 // - A DeviceTaintRule created to evict the pod before a downgrade prevents pod scheduling after a downgrade.
 func deviceTaints(tCtx ktesting.TContext, b *drautils.Builder) upgradedTestFunc {
+	tCtx.Skip("v1.36.1 artifacts have a bug that prevent this from passing: https://github.com/kubernetes/kubernetes/pull/139651")
+
 	namespace := tCtx.Namespace()
 	taintKey := "devicetaints"
 	taintValueFromSlice := "from-slice"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR skips the `TestUpgradeDowngrade/*/device-taints` tests from `k8s.io/kubernetes/test/e2e_dra` which are failing due to a known bug in the v1.36 artifacts fetched for the test.

The bug is fixed on master by #139651 and a backport to release-1.36 is open in https://github.com/kubernetes/kubernetes/pull/139681. If the cherry pick is accepted, then we can revert this once a 1.36 patch release is cut with the fix.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

The `partitionable-devices` test is collateral damage from the kube-scheduler panic induced by the `device-taints` test and not a separate issue. Skipping the `device-taints` test makes the whole CI job succeed.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
