### PR TITLE
Fix Windows Mem affinity to always use CPU Manager allocation

### DIFF
--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -171,6 +171,15 @@ func NewContainerManager(ctx context.Context, mountUtil mount.Interface, cadviso
 		cm.topologyManager.AddHintProvider(logger, cm.cpuManager)
 
 		logger.Info("Creating memory manager")
+		// On Windows memory affinity is best-effort and there is no cpuset.mems
+		// equivalent to pin memory to a NUMA node directly. We choose to have
+		// memory placement follow the CPU manager's NUMA decision as a best-effort
+		// design. Wrap the topology manager store so the memory manager's
+		// GetAffinity returns the NUMA nodes of the container's exclusive CPUs.
+		// This relies on the CPU manager already being registered as a hint
+		// provider above, so its Allocate runs first and its CPUs are committed by
+		// the time the memory manager reads the affinity.
+		memoryAffinity := newCPUFollowingStore(cm.topologyManager, cm.cpuManager, machineInfo)
 		cm.memoryManager, err = memorymanager.NewManager(
 			logger,
 			nodeConfig.MemoryManagerPolicy,
@@ -178,7 +187,7 @@ func NewContainerManager(ctx context.Context, mountUtil mount.Interface, cadviso
 			cm.GetNodeAllocatableReservation(),
 			nodeConfig.MemoryManagerReservedMemory,
 			nodeConfig.KubeletRootDir,
-			cm.topologyManager,
+			memoryAffinity,
 		)
 		if err != nil {
 			logger.Error(err, "Failed to initialize memory manager")

--- a/pkg/kubelet/cm/cpu_following_store_windows.go
+++ b/pkg/kubelet/cm/cpu_following_store_windows.go
@@ -1,0 +1,162 @@
+//go:build windows
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cm
+
+import (
+	cadvisorapi "github.com/google/cadvisor/lib/model"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/cpuset"
+
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
+)
+
+// This file implements the Windows-only "memory follows CPU" mechanism for NUMA
+// placement.
+//
+// On Windows there is no cpuset.mems: memory cannot be pinned to a NUMA node, and
+// the kernel serves a thread's pages from the NUMA node of the CPU it runs on. CPU
+// affinity is therefore the only NUMA lever that is actually enforced, and it is
+// owned by the CPU Manager. To keep the Memory Manager's per-NUMA bookkeeping
+// consistent with what the OS actually does — and to avoid the CPU-affinity union
+// in computeFinalCpuSet — the Memory Manager must mirror the CPU Manager's NUMA
+// decision rather than choose its own nodes independently.
+//
+// cpuFollowingStore (below) is that mechanism: a Topology Manager Store wrapper,
+// injected as the Memory Manager's affinity store in container_manager_windows.go.
+// It makes the Memory Manager read back the NUMA nodes of a container's exclusive
+// CPUs, and reports (via IsHintAuthoritative) whether the resulting hint is
+// authoritative, i.e. whether there is a CPU decision to follow at all — when
+// there is not (CPU Manager policy "none", or a shared / non-Guaranteed
+// container), the Memory Manager falls back to its own calculation.
+
+// By the time any HintProvider's Allocate() is called the
+// Topology Manager has already collected hints from every provider (including
+// the CPU Manager) and stored the merged best affinity. The CPU Manager's
+// Allocate runs before the Memory Manager's in the current registration order,
+// but correctness does not depend on that ordering — GetAffinity reads the
+// already-committed exclusive CPUs, which are available once the Topology
+// Manager's admit cycle reaches the Allocate stage. This should be revisited
+// if the admit flow changes.
+type cpuFollowingStore struct {
+	// Store is the wrapped Topology Manager; GetPolicy and Name are promoted from
+	// it, and GetAffinity falls back to it when there is nothing to follow.
+	topologymanager.Store
+	cpuManager cpumanager.Manager
+	// cpuToNode maps a logical CPU id to the NUMA node id that contains it, built
+	// once from the machine topology (the same mapping the CPU Manager uses).
+	cpuToNode map[int]int
+}
+
+var _ topologymanager.AuthoritativeStore = &cpuFollowingStore{}
+
+// newCPUFollowingStore builds the wrapper from the base Topology Manager store,
+// the CPU Manager, and the machine topology.
+func newCPUFollowingStore(base topologymanager.Store, cpuManager cpumanager.Manager, machineInfo *cadvisorapi.MachineInfo) *cpuFollowingStore {
+	cpuToNode := make(map[int]int)
+	for _, node := range machineInfo.Topology {
+		for _, core := range node.Cores {
+			for _, cpu := range core.Threads {
+				cpuToNode[cpu] = node.Id
+			}
+		}
+	}
+	return &cpuFollowingStore{
+		Store:      base,
+		cpuManager: cpuManager,
+		cpuToNode:  cpuToNode,
+	}
+}
+
+// GetAffinity returns the NUMA affinity the Memory Manager should use for the
+// given container. When the container owns exclusive CPUs, GetAffinity
+// reconstructs a narrower hint that mirrors the CPU Manager's NUMA decision
+// exactly (the set of NUMA nodes owning those CPUs). This keeps memory
+// bookkeeping aligned with CPU affinity on Windows, where the OS serves pages
+// from the NUMA node of the running CPU.
+//
+// The recomputed hint may be narrower than the merged best-hint stored by the
+// Topology Manager (which could span additional NUMA nodes when device-manager
+// hints are factored in). We log when the two differ so the divergence is
+// observable; this needs revisiting before GA.
+//
+// If the container has no exclusive CPUs (shared pool / non-Guaranteed) or the
+// CPUs cannot be mapped to NUMA nodes, it defers to the wrapped store.
+func (s *cpuFollowingStore) GetAffinity(logger klog.Logger, podUID string, containerName string) topologymanager.TopologyHint {
+	base := s.Store.GetAffinity(logger, podUID, containerName)
+
+	exclusiveCPUs := s.cpuManager.GetExclusiveCPUs(podUID, containerName)
+	if exclusiveCPUs.IsEmpty() {
+		// Nothing to follow: this container did not get exclusive CPUs, so let the
+		// Topology Manager's own hint stand.
+		logger.V(5).Info("GetAffinity: no exclusive CPUs, using stored hint", "podUID", podUID, "containerName", containerName, "hint", base.NUMANodeAffinity)
+		return base
+	}
+
+	mask := s.numaMaskForCPUs(exclusiveCPUs)
+	if mask == nil || mask.IsEmpty() {
+		logger.V(4).Info("GetAffinity: exclusive CPUs not mappable to NUMA nodes, falling back to stored hint", "podUID", podUID, "containerName", containerName, "exclusiveCPUs", exclusiveCPUs, "hint", base.NUMANodeAffinity)
+		return base
+	}
+
+	recomputed := topologymanager.TopologyHint{
+		NUMANodeAffinity: mask,
+		Preferred:        base.Preferred,
+	}
+
+	if !recomputed.IsEqual(base) {
+		logger.V(4).Info("GetAffinity: recomputed hint from CPU Manager differs from stored topology hint", "podUID", podUID, "containerName", containerName, "exclusiveCPUs", exclusiveCPUs, "recomputedHint", recomputed.NUMANodeAffinity, "storedHint", base.NUMANodeAffinity)
+	} else {
+		logger.V(5).Info("GetAffinity: recomputed hint matches stored hint", "podUID", podUID, "containerName", containerName, "hint", recomputed.NUMANodeAffinity)
+	}
+
+	return recomputed
+}
+
+// IsHintAuthoritative reports whether the affinity hint for the given container
+// is authoritative and must be used as-is (not extended to additional NUMA
+// nodes). On Windows this is true exactly when the CPU manager assigned the
+// container exclusive CPUs: the memory manager then follows the CPU manager's
+// NUMA decision (stay synced, do not extend). When there are none — e.g. CPU
+// manager policy "none", or a shared/non-Guaranteed container — the hint is not
+// authoritative and the memory manager does its own calculation.
+func (s *cpuFollowingStore) IsHintAuthoritative(podUID, containerName string) bool {
+	return s.cpuManager.GetExclusiveCPUs(podUID, containerName).Size() > 0
+}
+
+// numaMaskForCPUs returns the set of NUMA nodes that contain the given CPUs.
+func (s *cpuFollowingStore) numaMaskForCPUs(cpus cpuset.CPUSet) bitmask.BitMask {
+	nodeSet := sets.New[int]()
+	for _, cpu := range cpus.List() {
+		if node, ok := s.cpuToNode[cpu]; ok {
+			nodeSet.Insert(node)
+		}
+	}
+	if nodeSet.Len() == 0 {
+		return nil
+	}
+	mask, err := bitmask.NewBitMask(sets.List(nodeSet)...)
+	if err != nil {
+		return nil
+	}
+	return mask
+}

--- a/pkg/kubelet/cm/cpu_following_store_windows_test.go
+++ b/pkg/kubelet/cm/cpu_following_store_windows_test.go
@@ -1,0 +1,168 @@
+//go:build windows
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cm
+
+import (
+	"testing"
+
+	cadvisorapi "github.com/google/cadvisor/lib/model"
+
+	"k8s.io/klog/v2"
+	"k8s.io/utils/cpuset"
+
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
+)
+
+// cpuFollowingFakeCPUManager implements cpumanager.Manager, but only GetExclusiveCPUs is
+// meaningful. The remaining methods are satisfied by the embedded (nil) interface
+// and must not be called by the code under test (they would panic).
+type cpuFollowingFakeCPUManager struct {
+	cpumanager.Manager
+	exclusive map[string]cpuset.CPUSet
+}
+
+func (f *cpuFollowingFakeCPUManager) GetExclusiveCPUs(podUID, containerName string) cpuset.CPUSet {
+	if cpus, ok := f.exclusive[podUID+"/"+containerName]; ok {
+		return cpus
+	}
+	return cpuset.New()
+}
+
+// cpuFollowingFakeStore is a minimal topologymanager.Store that always returns a preset hint.
+type cpuFollowingFakeStore struct {
+	base topologymanager.TopologyHint
+}
+
+func (f *cpuFollowingFakeStore) GetAffinity(_ klog.Logger, podUID, containerName string) topologymanager.TopologyHint {
+	return f.base
+}
+func (f *cpuFollowingFakeStore) GetPolicy() topologymanager.Policy { return nil }
+func (f *cpuFollowingFakeStore) Name() string                      { return "fake" }
+
+func cpuFollowingMustBitMask(t *testing.T, bits ...int) bitmask.BitMask {
+	t.Helper()
+	m, err := bitmask.NewBitMask(bits...)
+	if err != nil {
+		t.Fatalf("NewBitMask(%v): %v", bits, err)
+	}
+	return m
+}
+
+// cpuFollowingTestMachineInfo describes 2 NUMA nodes: CPUs 0-3 on node 0, CPUs 4-7 on node 1.
+func cpuFollowingTestMachineInfo() *cadvisorapi.MachineInfo {
+	return &cadvisorapi.MachineInfo{
+		Topology: []cadvisorapi.Node{
+			{Id: 0, Cores: []cadvisorapi.Core{
+				{Id: 0, Threads: []int{0, 1}},
+				{Id: 1, Threads: []int{2, 3}},
+			}},
+			{Id: 1, Cores: []cadvisorapi.Core{
+				{Id: 2, Threads: []int{4, 5}},
+				{Id: 3, Threads: []int{6, 7}},
+			}},
+		},
+	}
+}
+
+func TestCPUFollowingStoreGetAffinity(t *testing.T) {
+	// base is the Topology Manager's own hint; deliberately a different node ({1})
+	// than the exclusive-CPU-derived masks so "follow" and "fall back" are
+	// distinguishable.
+	baseHint := topologymanager.TopologyHint{NUMANodeAffinity: cpuFollowingMustBitMask(t, 1), Preferred: true}
+
+	testCases := []struct {
+		name          string
+		exclusiveCPUs cpuset.CPUSet
+		expectFollow  bool  // true → expect derived mask; false → expect base returned
+		expectedNodes []int // only used when expectFollow is true
+	}{
+		{
+			name:          "exclusive CPUs on a single node follows that node",
+			exclusiveCPUs: cpuset.New(0, 1),
+			expectFollow:  true,
+			expectedNodes: []int{0},
+		},
+		{
+			name:          "exclusive CPUs spanning two nodes follows both",
+			exclusiveCPUs: cpuset.New(1, 4),
+			expectFollow:  true,
+			expectedNodes: []int{0, 1},
+		},
+		{
+			name:          "exclusive CPUs partially mapped follows only the mapped node(s)",
+			exclusiveCPUs: cpuset.New(0, 99), // 0 -> node 0; 99 has no NUMA node and is dropped
+			expectFollow:  true,
+			expectedNodes: []int{0},
+		},
+		{
+			name:          "no exclusive CPUs (e.g. CPU policy none) falls back to base",
+			exclusiveCPUs: cpuset.New(),
+			expectFollow:  false,
+		},
+		{
+			name:          "exclusive CPUs not mapped to any NUMA node falls back to base",
+			exclusiveCPUs: cpuset.New(99),
+			expectFollow:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cpuMgr := &cpuFollowingFakeCPUManager{exclusive: map[string]cpuset.CPUSet{"pod/ctr": tc.exclusiveCPUs}}
+			store := newCPUFollowingStore(&cpuFollowingFakeStore{base: baseHint}, cpuMgr, cpuFollowingTestMachineInfo())
+
+			got := store.GetAffinity(klog.Background(), "pod", "ctr")
+
+			if !tc.expectFollow {
+				if !got.NUMANodeAffinity.IsEqual(baseHint.NUMANodeAffinity) {
+					t.Errorf("expected fall back to base %v, got %v", baseHint.NUMANodeAffinity, got.NUMANodeAffinity)
+				}
+				return
+			}
+
+			want := cpuFollowingMustBitMask(t, tc.expectedNodes...)
+			if got.NUMANodeAffinity == nil || !got.NUMANodeAffinity.IsEqual(want) {
+				t.Errorf("expected NUMA affinity %v, got %v", want, got.NUMANodeAffinity)
+			}
+			if got.Preferred != baseHint.Preferred {
+				t.Errorf("expected Preferred %v (carried from base), got %v", baseHint.Preferred, got.Preferred)
+			}
+		})
+	}
+}
+
+func TestCPUFollowingStoreIsHintAuthoritative(t *testing.T) {
+	cpuMgr := &cpuFollowingFakeCPUManager{exclusive: map[string]cpuset.CPUSet{
+		"pod/with":    cpuset.New(0, 1),
+		"pod/without": cpuset.New(),
+	}}
+	store := newCPUFollowingStore(&cpuFollowingFakeStore{}, cpuMgr, cpuFollowingTestMachineInfo())
+
+	if !store.IsHintAuthoritative("pod", "with") {
+		t.Errorf("expected IsHintAuthoritative=true for a container with exclusive CPUs")
+	}
+	if store.IsHintAuthoritative("pod", "without") {
+		t.Errorf("expected IsHintAuthoritative=false for a container with an empty CPU set")
+	}
+	if store.IsHintAuthoritative("pod", "missing") {
+		t.Errorf("expected IsHintAuthoritative=false for an unknown container")
+	}
+}

--- a/pkg/kubelet/cm/internal_container_lifecycle_windows.go
+++ b/pkg/kubelet/cm/internal_container_lifecycle_windows.go
@@ -81,31 +81,20 @@ func (i *internalContainerLifecycleImpl) PreCreateContainer(logger klog.Logger, 
 }
 
 // computeFinalCpuSet determines the final set of CPUs to use based on the CPU and memory managers
-// and is extracted so that it can be tested
+// and is extracted so that it can be tested.
+//
+// When the CPU Manager has allocated CPUs, those CPUs are always used as-is. The CPU Manager's
+// allocation is authoritative — it already considered topology hints from the Topology Manager
+// and picked exact CPUs. Expanding with NUMA CPUs (the former "Case 3" union) would cause a
+// bookkeeping/enforcement mismatch (reconcileState overwrites any expansion) and could break CPU
+// isolation guarantees by including CPUs exclusively allocated to other containers.
+//
+// When only the Memory Manager is active, NUMA node CPUs are used to provide memory locality
+// through CPU affinity, since Windows has no direct NUMA memory pinning mechanism.
 func computeFinalCpuSet(allocatedCPUs cpuset.CPUSet, allNumaNodeCPUs []winstats.GroupAffinity) sets.Set[int] {
-	if !allocatedCPUs.IsEmpty() && len(allNumaNodeCPUs) > 0 {
-		// Both CPU and memory managers are enabled
-
-		numaNodeAffinityCPUSet := computeCPUSet(allNumaNodeCPUs)
-		cpuManagerAffinityCPUSet := sets.New[int](allocatedCPUs.List()...)
-
-		// Determine which set of CPUs to use using the following logic outlined in the KEP:
-		// Case 1: CPU manager selects more CPUs than those available in the NUMA nodes selected by the memory manager
-		// Case 2: CPU manager selects fewer CPUs, and they all fall within the CPUs available in the NUMA nodes selected by the memory manager
-		// Case 3: CPU manager selects fewer CPUs, but some are outside of the CPUs available in the NUMA nodes selected by the memory manager
-
-		if cpuManagerAffinityCPUSet.Len() > numaNodeAffinityCPUSet.Len() {
-			// Case 1, use CPU manager selected CPUs
-			return cpuManagerAffinityCPUSet
-		} else if numaNodeAffinityCPUSet.IsSuperset(cpuManagerAffinityCPUSet) {
-			// case 2, use CPU manager selected CPUstry
-			return cpuManagerAffinityCPUSet
-		} else {
-			// Case 3, merge CPU manager and memory manager selected CPUs
-			return cpuManagerAffinityCPUSet.Union(numaNodeAffinityCPUSet)
-		}
-	} else if !allocatedCPUs.IsEmpty() {
-		// Only CPU manager is enabled, use CPU manager selected CPUs
+	if !allocatedCPUs.IsEmpty() {
+		// CPU Manager has allocated CPUs — use them directly.
+		// This covers all cases: CPU manager only, or both managers active.
 		return sets.New[int](allocatedCPUs.List()...)
 	} else if len(allNumaNodeCPUs) > 0 {
 		// Only memory manager is enabled, use CPUs associated with selected NUMA nodes

--- a/pkg/kubelet/cm/internal_container_lifecycle_windows_test.go
+++ b/pkg/kubelet/cm/internal_container_lifecycle_windows_test.go
@@ -132,7 +132,8 @@ func TestComputeFinalCpuSet(t *testing.T) {
 			allNumaNodeCPUs: []winstats.GroupAffinity{
 				{Mask: 0b1100, Group: 0}, // CPUs 2 and 3 in Group 0
 			},
-			expectedCPUSet: sets.New[int](0, 1, 2, 3),
+			// CPU Manager allocation is authoritative; NUMA CPUs are not merged in.
+			expectedCPUSet: sets.New[int](0, 1),
 		},
 		{
 			name:            "Only CPU manager enabled",

--- a/pkg/kubelet/cm/memorymanager/memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager.go
@@ -165,7 +165,15 @@ func NewManager(logger klog.Logger, policyName string, machineInfo *cadvisorapi.
 			if err != nil {
 				return nil, err
 			}
-			policy, err = NewPolicyBestEffort(logger, machineInfo, systemReserved, affinity)
+			// The Windows BestEffort policy follows the CPU manager's NUMA
+			// decision, which it reads through the affinity Store. That requires
+			// the richer AuthoritativeStore interface (implemented by the Windows
+			// cpuFollowingStore); a plain Store is not sufficient.
+			authStore, ok := affinity.(topologymanager.AuthoritativeStore)
+			if !ok {
+				return nil, fmt.Errorf("policy %q requires an AuthoritativeStore affinity", policyTypeBestEffort)
+			}
+			policy, err = NewPolicyBestEffort(logger, machineInfo, systemReserved, authStore)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/kubelet/cm/memorymanager/memory_manager_test.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager_test.go
@@ -1920,6 +1920,16 @@ func getPolicyNameForOs() policyType {
 	return PolicyTypeStatic
 }
 
+// getAffinityForOs returns an affinity Store matching the policy selected by
+// getPolicyNameForOs. On Windows the BestEffort policy requires an
+// AuthoritativeStore, so a plain fake manager is not sufficient.
+func getAffinityForOs(logger klog.Logger) topologymanager.Store {
+	if goruntime.GOOS == "windows" {
+		return &fakeBestEffortAffinity{}
+	}
+	return topologymanager.NewFakeManager(logger)
+}
+
 func TestNewManager(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	machineInfo := returnMachineInfo()
@@ -1947,7 +1957,7 @@ func TestNewManager(t *testing.T) {
 					Limits:   v1.ResourceList{v1.ResourceMemory: *resource.NewQuantity(gb, resource.BinarySI)},
 				},
 			},
-			affinity:         topologymanager.NewFakeManager(logger),
+			affinity:         getAffinityForOs(logger),
 			expectedError:    nil,
 			expectedReserved: expectedReserved,
 		},
@@ -1970,7 +1980,7 @@ func TestNewManager(t *testing.T) {
 					},
 				},
 			},
-			affinity:         topologymanager.NewFakeManager(logger),
+			affinity:         getAffinityForOs(logger),
 			expectedError:    fmt.Errorf("the total amount \"3Gi\" of type %q is not equal to the value \"2Gi\" determined by Node Allocatable feature", v1.ResourceMemory),
 			expectedReserved: expectedReserved,
 		},
@@ -1980,7 +1990,7 @@ func TestNewManager(t *testing.T) {
 			machineInfo:                machineInfo,
 			nodeAllocatableReservation: v1.ResourceList{},
 			systemReservedMemory:       []kubeletconfig.MemoryReservation{},
-			affinity:                   topologymanager.NewFakeManager(logger),
+			affinity:                   getAffinityForOs(logger),
 			expectedError:              fmt.Errorf("[memorymanager] you should specify the system reserved memory"),
 			expectedReserved:           expectedReserved,
 		},

--- a/pkg/kubelet/cm/memorymanager/policy_best_effort.go
+++ b/pkg/kubelet/cm/memorymanager/policy_best_effort.go
@@ -39,11 +39,16 @@ const policyTypeBestEffort policyType = "BestEffort"
 // bestEffortPolicy is implementation of the policy interface for the BestEffort policy
 type bestEffortPolicy struct {
 	static *staticPolicy
+	// affinity is the same Store used by the static policy, but typed as an
+	// AuthoritativeStore so the policy can ask whether a container's hint is
+	// authoritative (Windows: the container follows the CPU manager's NUMA
+	// decision) and therefore must not be extended to additional NUMA nodes.
+	affinity topologymanager.AuthoritativeStore
 }
 
 var _ Policy = &bestEffortPolicy{}
 
-func NewPolicyBestEffort(logger klog.Logger, machineInfo *cadvisorapi.MachineInfo, reserved systemReservedMemory, affinity topologymanager.Store) (Policy, error) {
+func NewPolicyBestEffort(logger klog.Logger, machineInfo *cadvisorapi.MachineInfo, reserved systemReservedMemory, affinity topologymanager.AuthoritativeStore) (Policy, error) {
 	p, err := NewPolicyStatic(logger, machineInfo, reserved, affinity)
 
 	if err != nil {
@@ -51,7 +56,8 @@ func NewPolicyBestEffort(logger klog.Logger, machineInfo *cadvisorapi.MachineInf
 	}
 
 	return &bestEffortPolicy{
-		static: p.(*staticPolicy),
+		static:   p.(*staticPolicy),
+		affinity: affinity,
 	}, nil
 }
 
@@ -64,6 +70,12 @@ func (p *bestEffortPolicy) Start(logger klog.Logger, s state.State) error {
 }
 
 func (p *bestEffortPolicy) Allocate(ctx context.Context, s state.State, pod *v1.Pod, container *v1.Container, operation lifecycle.Operation) (rerr error) {
+	// On Windows the container follows the CPU manager's NUMA decision when its
+	// affinity hint is authoritative (it owns exclusive CPUs). In that case the
+	// static policy must not extend the hint to additional NUMA nodes (memory
+	// placement follows CPU affinity), so signal that through skipExtend before
+	// delegating. Otherwise the static policy extends the hint as usual.
+	p.static.skipExtend = p.affinity.IsHintAuthoritative(string(pod.UID), container.Name)
 	return p.static.Allocate(ctx, s, pod, container, operation)
 }
 

--- a/pkg/kubelet/cm/memorymanager/policy_best_effort_test.go
+++ b/pkg/kubelet/cm/memorymanager/policy_best_effort_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memorymanager
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	cadvisorapi "github.com/google/cadvisor/lib/model"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
+
+	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager/state"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
+	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
+)
+
+// fakeBestEffortAffinity is a topologymanager.AuthoritativeStore that returns a
+// preset hint.
+type fakeBestEffortAffinity struct {
+	hint              topologymanager.TopologyHint
+	hintAuthoritative bool
+}
+
+func (f *fakeBestEffortAffinity) GetAffinity(_ klog.Logger, podUID, containerName string) topologymanager.TopologyHint {
+	return f.hint
+}
+func (f *fakeBestEffortAffinity) GetPolicy() topologymanager.Policy { return nil }
+func (f *fakeBestEffortAffinity) Name() string                      { return "fake" }
+
+// IsHintAuthoritative mirrors the Windows cpuFollowingStore: when the container
+// follows the CPU manager's NUMA decision, its hint is authoritative and the
+// memory manager must not extend it to additional NUMA nodes.
+func (f *fakeBestEffortAffinity) IsHintAuthoritative(_, _ string) bool { return f.hintAuthoritative }
+
+// bestEffortTestMachineState returns a fresh 2-NUMA-node state: node 0 has only
+// 1Gi free (too little for the 4Gi request), node 1 has 10Gi free.
+func bestEffortTestMachineState() state.NUMANodeMap {
+	return state.NUMANodeMap{
+		0: &state.NUMANodeState{
+			Cells: []int{0},
+			MemoryMap: map[v1.ResourceName]*state.MemoryTable{
+				v1.ResourceMemory: {
+					Allocatable:    1 * gb,
+					Free:           1 * gb,
+					Reserved:       0,
+					SystemReserved: 512 * mb,
+					TotalMemSize:   1*gb + 512*mb,
+				},
+			},
+		},
+		1: &state.NUMANodeState{
+			Cells: []int{1},
+			MemoryMap: map[v1.ResourceName]*state.MemoryTable{
+				v1.ResourceMemory: {
+					Allocatable:    10 * gb,
+					Free:           10 * gb,
+					Reserved:       0,
+					SystemReserved: 0,
+					TotalMemSize:   10 * gb,
+				},
+			},
+		},
+	}
+}
+
+// TestBestEffortPolicyAllocateFollowsCPUManager verifies that the Windows
+// BestEffort policy skips hint extension when the container follows the CPU
+// manager's NUMA decision (it owns exclusive CPUs), and otherwise extends like
+// the static policy.
+func TestBestEffortPolicyAllocateFollowsCPUManager(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
+	machineInfo := &cadvisorapi.MachineInfo{
+		Topology: []cadvisorapi.Node{
+			{Id: 0, Memory: 1*gb + 512*mb},
+			{Id: 1, Memory: 10 * gb},
+		},
+	}
+	systemReserved := systemReservedMemory{
+		0: map[v1.ResourceName]uint64{v1.ResourceMemory: 512 * mb},
+	}
+	// Guaranteed container requesting 4Gi; the affinity hint is node 0, which has
+	// only 1Gi free, so the hint does not satisfy the request and the extend
+	// branch is reachable.
+	requirements := &v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("2"),
+			v1.ResourceMemory: resource.MustParse("4Gi"),
+		},
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("2"),
+			v1.ResourceMemory: resource.MustParse("4Gi"),
+		},
+	}
+
+	testCases := []struct {
+		name             string
+		hasExclusiveCPUs bool
+		expectedNUMA     []int
+	}{
+		{
+			name:             "has exclusive CPUs: follows CPU manager, no hint extension",
+			hasExclusiveCPUs: true,
+			expectedNUMA:     []int{0},
+		},
+		{
+			name:             "no exclusive CPUs: extends like the static policy",
+			hasExclusiveCPUs: false,
+			expectedNUMA:     []int{0, 1},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			affinity := &fakeBestEffortAffinity{
+				hint:              topologymanager.TopologyHint{NUMANodeAffinity: newNUMAAffinity(0), Preferred: false},
+				hintAuthoritative: tc.hasExclusiveCPUs,
+			}
+			p, err := NewPolicyBestEffort(logger, machineInfo, systemReserved, affinity)
+			if err != nil {
+				t.Fatalf("NewPolicyBestEffort() failed: %v", err)
+			}
+
+			s := state.NewMemoryState(logger)
+			s.SetMachineState(bestEffortTestMachineState())
+
+			pod := getPod("pod1", "container1", requirements)
+			if err := p.Allocate(context.Background(), s, pod, &pod.Spec.Containers[0], lifecycle.AddOperation); err != nil {
+				t.Fatalf("Allocate() failed: %v", err)
+			}
+
+			blocks := s.GetMemoryBlocks("pod1", "container1")
+			if len(blocks) != 1 {
+				t.Fatalf("expected exactly 1 memory block, got %d: %+v", len(blocks), blocks)
+			}
+			if got := blocks[0].NUMAAffinity; !reflect.DeepEqual(got, tc.expectedNUMA) {
+				t.Errorf("expected memory block on NUMA nodes %v, got %v", tc.expectedNUMA, got)
+			}
+		})
+	}
+}

--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -60,6 +60,15 @@ type staticPolicy struct {
 	// Note that the restartable init container memory is not included here,
 	// because it is not reusable.
 	initContainersReusableMemory reusableMemory
+	// skipExtend, when true, disables extending the Topology Manager hint to
+	// additional NUMA nodes even when the hint does not, by itself, satisfy the
+	// container's memory request. The Linux static policy always leaves it false.
+	// It is set per container by the Windows BestEffort policy (see
+	// policy_best_effort.go) when the container follows the CPU manager's NUMA
+	// decision: Windows has no cpuset.mems, so memory placement follows CPU
+	// affinity and the hint must not be widened beyond the CPU manager's
+	// exclusive-CPU nodes.
+	skipExtend bool
 }
 
 var _ Policy = &staticPolicy{}
@@ -489,8 +498,11 @@ func (p *staticPolicy) Allocate(ctx context.Context, s state.State, pod *v1.Pod,
 	}
 
 	// topology manager returns the hint that does not satisfy completely the container request
-	// we should extend this hint to the one who will satisfy the request and include the current hint
-	if !isAffinitySatisfyRequest(machineState, bestHint.NUMANodeAffinity, requestedResources) {
+	// we should extend this hint to the one who will satisfy the request and include the current hint,
+	// unless skipExtend is set. skipExtend is set per container by the Windows BestEffort policy when
+	// the container follows the CPU manager's NUMA decision (see policy_best_effort.go); the Linux
+	// static policy never sets it, so the hint is extended as usual.
+	if !isAffinitySatisfyRequest(machineState, bestHint.NUMANodeAffinity, requestedResources) && !p.skipExtend {
 		extendedHint, err := p.extendTopologyManagerHint(machineState, pod, requestedResources, bestHint.NUMANodeAffinity)
 		if err != nil {
 			return err

--- a/pkg/kubelet/cm/topologymanager/topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager.go
@@ -130,6 +130,21 @@ type Store interface {
 	Name() string
 }
 
+// AuthoritativeStore is an optional extension of Store that reports whether the
+// affinity hint for a container is authoritative. When IsHintAuthoritative
+// returns true, the consumer must use the hint as-is and must not extend it to
+// additional NUMA nodes.
+//
+// This is used on Windows, where memory placement has to follow the CPU
+// manager's NUMA decision (Windows has no cpuset.mems): the affinity Store is a
+// wrapper that owns the CPU-following knowledge, so the coupling between the CPU
+// and memory managers passes through the Store rather than being a peer-to-peer
+// dependency between the two managers.
+type AuthoritativeStore interface {
+	Store
+	IsHintAuthoritative(podUID, containerName string) bool
+}
+
 // TopologyHint is a struct containing the NUMANodeAffinity for a Container
 type TopologyHint struct {
 	NUMANodeAffinity bitmask.BitMask


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/sig-windows
/sig-node

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
On Windows, when both the CPU Manager (`static` policy) and the Memory Manager
are active under the `WindowsCPUAndMemoryAffinity` feature gate,
`computeFinalCpuSet()` in `internal_container_lifecycle_windows.go` merged the two
managers' results. In the partial-overlap case ("Case 3" — the CPU Manager's CPUs
fall partly outside the Memory Manager's selected NUMA node) it returned the
**union** of the CPU Manager's CPUs and *all* of the NUMA node's CPUs:
That union had two problems:

Isolation violation. The unioned NUMA-node CPUs can include CPUs the CPU Manager exclusively allocated to other containers. Those containers are pinned to the same CPUs, so the affinity masks overlap and the exclusivity guarantee is broken.
Reverted by reconciliation. The expanded set is written only into the CRI request, never into CPU Manager state. The CPU Manager's reconcileState() loop reads state as the source of truth and re-applies the original (smaller) set via UpdateContainerResources, so the union is a no-op in steady state.
This PR makes computeFinalCpuSet() always return the CPU Manager's allocated set
when the CPU Manager has assigned CPUs (collapsing the former Cases 1/2/3). The CPU
Manager's allocation is authoritative — it already accounts for Topology Manager
hints. NUMA-node CPUs are used only when the Memory Manager is the sole provider.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
On Windows nodes with the alpha `WindowsCPUAndMemoryAffinity` feature gate enabled, a guaranteed container's CPU affinity now always matches the CPU Manager's exclusive allocation. Previously, when the CPU Manager and Memory Manager selected partially different NUMA nodes, the affinity could be widened to the union of both sets, which could include CPUs exclusively allocated to other containers and break CPU isolation.

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```
Changes behavior of memory affinity on Windows when feature is enabled
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
