### PR TITLE
Validate UTF-8 in docker credential auth field

### DIFF
--- a/pkg/credentialprovider/config.go
+++ b/pkg/credentialprovider/config.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"unicode/utf8"
 
 	"k8s.io/klog/v2"
 )
@@ -297,6 +298,11 @@ func decodeDockerConfigFieldAuth(field string) (username, password string, err e
 	}
 
 	if err != nil {
+		return
+	}
+
+	if !utf8.Valid(decoded) {
+		err = fmt.Errorf("invalid UTF-8 in auth field")
 		return
 	}
 

--- a/pkg/credentialprovider/config_test.go
+++ b/pkg/credentialprovider/config_test.go
@@ -171,6 +171,17 @@ func TestDockerConfigEntryJSONDecode(t *testing.T) {
 			fail: true,
 		},
 
+		// auth field with non-UTF-8 data causes failure
+		{
+			input: []byte(`{"auth": "/v4=", "email": "foo@example.com"}`),
+			expect: DockerConfigEntry{
+				Username: "",
+				Password: "",
+				Email:    "foo@example.com",
+			},
+			fail: true,
+		},
+
 		// invalid JSON causes failure
 		{
 			input: []byte(`{"email": false}`),
@@ -254,6 +265,12 @@ func TestDecodeDockerConfigFieldAuth(t *testing.T) {
 		// only new line characters are ignored
 		{
 			input: "Zm9vOmJhcg== ",
+			fail:  true,
+		},
+
+		// non-UTF-8 auth field
+		{
+			input: "/v4=",
 			fail:  true,
 		},
 


### PR DESCRIPTION
Fixes #131982


/kind bug



Docker credential `auth` fields are base64-decoded and then converted directly to a Go string. Since Go strings can contain arbitrary byte sequences, non-UTF-8 credentials are currently accepted without validation.

This change adds an explicit UTF-8 validation step after base64 decoding in `decodeDockerConfigFieldAuth`. Invalid UTF-8 sequences now return an error instead of being silently accepted.

The implementation follows the existing Kubernetes pattern using `utf8.Valid(...)`, as seen in other validation code paths.

Additionally, regression tests have been added for:

* `TestDockerConfigEntryJSONDecode`
* `TestDecodeDockerConfigFieldAuth`

to ensure non-UTF-8 credentials are rejected through both the JSON deserialization path and the direct helper function.

#### issue(s) this PR is related to:

Fixes #131982

#### Special notes for reviewer:

The change is intentionally minimal and only affects validation of invalid credential data. Valid Docker credentials are unaffected.
#### Does this PR introduce a user-facing change?

```release-note
NONE
```