### PR TITLE
Reduce verbosity of conntrack test cases

### DIFF
--- a/test/e2e/network/conntrack.go
+++ b/test/e2e/network/conntrack.go
@@ -155,7 +155,8 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		clientPod := e2epod.NewAgnhostPod(ns, podClient, nil, nil, nil)
 		nodeSelection := e2epod.NodeSelection{Name: clientNodeInfo.name}
 		e2epod.SetNodeSelection(&clientPod.Spec, nodeSelection)
-		cmd := fmt.Sprintf(`date; for i in $(seq 1 3000); do echo "$(date) Try: ${i}"; echo hostname | nc -u -w 5 -p %d %s %d; echo; done`, srcPort, serverNodeInfo.nodeIP, udpService.Spec.Ports[0].NodePort)
+		testCmd := fmt.Sprintf(`echo hostname | nc -u -w 5 -p %d %s %d`, srcPort, serverNodeInfo.nodeIP, udpService.Spec.Ports[0].NodePort)
+		cmd := wrapCommandWithTimestampObservations(testCmd, 3000)
 		clientPod.Spec.Containers[0].Command = []string{"/bin/sh", "-c", cmd}
 		clientPod.Spec.Containers[0].Name = podClient
 		e2epod.NewPodClient(fr).CreateSync(ctx, clientPod)
@@ -233,7 +234,8 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		clientPod := e2epod.NewAgnhostPod(ns, podClient, nil, nil, nil)
 		nodeSelection := e2epod.NodeSelection{Name: clientNodeInfo.name}
 		e2epod.SetNodeSelection(&clientPod.Spec, nodeSelection)
-		cmd := fmt.Sprintf(`date; for i in $(seq 1 3000); do echo "$(date) Try: ${i}"; echo hostname | nc -u -w 5 -p %d %s %d; echo; done`, srcPort, udpService.Spec.ClusterIP, udpService.Spec.Ports[0].Port)
+		testCmd := fmt.Sprintf(`echo hostname | nc -u -w 5 -p %d %s %d`, srcPort, udpService.Spec.ClusterIP, udpService.Spec.Ports[0].Port)
+		cmd := wrapCommandWithTimestampObservations(testCmd, 3000)
 		clientPod.Spec.Containers[0].Command = []string{"/bin/sh", "-c", cmd}
 		clientPod.Spec.Containers[0].Name = podClient
 		e2epod.NewPodClient(fr).CreateSync(ctx, clientPod)
@@ -313,7 +315,8 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		clientPod := e2epod.NewAgnhostPod(ns, podClient, nil, nil, nil)
 		nodeSelection := e2epod.NodeSelection{Name: clientNodeInfo.name}
 		e2epod.SetNodeSelection(&clientPod.Spec, nodeSelection)
-		cmd := fmt.Sprintf(`date; for i in $(seq 1 3000); do echo "$(date) Try: ${i}"; echo hostname | nc -u -w 1 -p %d %s %d; echo; done`, srcPort, udpService.Spec.ClusterIP, udpService.Spec.Ports[0].Port)
+		testCmd := fmt.Sprintf(`echo hostname | nc -u -w 1 -p %d %s %d`, srcPort, udpService.Spec.ClusterIP, udpService.Spec.Ports[0].Port)
+		cmd := wrapCommandWithTimestampObservations(testCmd, 3000)
 		clientPod.Spec.Containers[0].Command = []string{"/bin/sh", "-c", cmd}
 		clientPod.Spec.Containers[0].Name = podClient
 		e2epod.NewPodClient(fr).CreateSync(ctx, clientPod)
@@ -406,7 +409,8 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		clientPod := e2epod.NewAgnhostPod(ns, podClient, nil, nil, nil)
 		nodeSelection := e2epod.NodeSelection{Name: clientNodeInfo.name}
 		e2epod.SetNodeSelection(&clientPod.Spec, nodeSelection)
-		cmd := fmt.Sprintf(`date; for i in $(seq 1 3000); do echo "$(date) Try: ${i}"; echo hostname | nc -u -w 5 -p %d %s %d; echo; done`, srcPort, udpService.Spec.ClusterIP, udpService.Spec.Ports[0].Port)
+		testCmd := fmt.Sprintf(`echo hostname | nc -u -w 5 -p %d %s %d`, srcPort, udpService.Spec.ClusterIP, udpService.Spec.Ports[0].Port)
+		cmd := wrapCommandWithTimestampObservations(testCmd, 3000)
 		clientPod.Spec.Containers[0].Command = []string{"/bin/sh", "-c", cmd}
 		clientPod.Spec.Containers[0].Name = podClient
 		clientPod.Spec.HostNetwork = true
@@ -496,7 +500,8 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		clientPod := e2epod.NewAgnhostPod(ns, podClient, nil, nil, nil)
 		nodeSelection := e2epod.NodeSelection{Name: clientNodeInfo.name}
 		e2epod.SetNodeSelection(&clientPod.Spec, nodeSelection)
-		cmd := fmt.Sprintf(`date; for i in $(seq 1 3000); do echo "$(date) Try: ${i}"; echo hostname | nc -u -w 5 -p %d %s %d; echo; done`, srcPort, udpService.Spec.ClusterIP, udpService.Spec.Ports[0].Port)
+		testCmd := fmt.Sprintf(`echo hostname | nc -u -w 5 -p %d %s %d`, srcPort, udpService.Spec.ClusterIP, udpService.Spec.Ports[0].Port)
+		cmd := wrapCommandWithTimestampObservations(testCmd, 3000)
 		clientPod.Spec.Containers[0].Command = []string{"/bin/sh", "-c", cmd}
 		clientPod.Spec.Containers[0].Name = podClient
 		e2epod.NewPodClient(fr).CreateSync(ctx, clientPod)
@@ -688,7 +693,8 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		clientPod := e2epod.NewAgnhostPod(ns, podClient, nil, nil, nil)
 		nodeSelection := e2epod.NodeSelection{Name: clientNodeInfo.name}
 		e2epod.SetNodeSelection(&clientPod.Spec, nodeSelection)
-		cmd := fmt.Sprintf(`date; for i in $(seq 1 3000); do echo "$(date) Try: ${i}"; echo serverport | nc -u -w 5 -p %d %s %d; echo; done`, srcPort, serverNodeInfo.nodeIP, udpService.Spec.Ports[0].NodePort)
+		testCmd := fmt.Sprintf(`echo serverport | nc -u -w 5 -p %d %s %d`, srcPort, serverNodeInfo.nodeIP, udpService.Spec.Ports[0].NodePort)
+		cmd := wrapCommandWithTimestampObservations(testCmd, 3000)
 		clientPod.Spec.Containers[0].Command = []string{"/bin/sh", "-c", cmd}
 		clientPod.Spec.Containers[0].Name = podClient
 		e2epod.NewPodClient(fr).CreateSync(ctx, clientPod)

--- a/test/e2e/network/conntrack.go
+++ b/test/e2e/network/conntrack.go
@@ -164,7 +164,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		// Read the client pod logs
 		logs, err := e2epod.GetPodLogs(ctx, cs, ns, podClient, podClient)
 		framework.ExpectNoError(err)
-		framework.Logf("Pod client logs: %s", logs)
+		framework.Logf("Pod client logs: %s", collapseDuplicateLogs(logs))
 
 		// Add a backend pod to the service in the other node
 		ginkgo.By("creating a backend pod " + podBackend1 + " for the service " + serviceName)
@@ -186,7 +186,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, logContainsFn(podBackend1, podClient)); err != nil {
 			logs, err = e2epod.GetPodLogs(ctx, cs, ns, podClient, podClient)
 			framework.ExpectNoError(err)
-			framework.Logf("Pod client logs: %s", logs)
+			framework.Logf("Pod client logs: %s", collapseDuplicateLogs(logs))
 			framework.Failf("Failed to connect to backend 1")
 		}
 
@@ -211,7 +211,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, logContainsFn(podBackend2, podClient)); err != nil {
 			logs, err = e2epod.GetPodLogs(ctx, cs, ns, podClient, podClient)
 			framework.ExpectNoError(err)
-			framework.Logf("Pod client logs: %s", logs)
+			framework.Logf("Pod client logs: %s", collapseDuplicateLogs(logs))
 			framework.Failf("Failed to connect to backend 2")
 		}
 	})
@@ -243,7 +243,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		// Read the client pod logs
 		logs, err := e2epod.GetPodLogs(ctx, cs, ns, podClient, podClient)
 		framework.ExpectNoError(err)
-		framework.Logf("Pod client logs: %s", logs)
+		framework.Logf("Pod client logs: %s", collapseDuplicateLogs(logs))
 
 		// Add a backend pod to the service in the other node
 		ginkgo.By("creating a backend pod " + podBackend1 + " for the service " + serviceName)
@@ -265,7 +265,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, logContainsFn(podBackend1, podClient)); err != nil {
 			logs, err = e2epod.GetPodLogs(ctx, cs, ns, podClient, podClient)
 			framework.ExpectNoError(err)
-			framework.Logf("Pod client logs: %s", logs)
+			framework.Logf("Pod client logs: %s", collapseDuplicateLogs(logs))
 			framework.Failf("Failed to connect to backend 1")
 		}
 
@@ -290,7 +290,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, logContainsFn(podBackend2, podClient)); err != nil {
 			logs, err = e2epod.GetPodLogs(ctx, cs, ns, podClient, podClient)
 			framework.ExpectNoError(err)
-			framework.Logf("Pod client logs: %s", logs)
+			framework.Logf("Pod client logs: %s", collapseDuplicateLogs(logs))
 			framework.Failf("Failed to connect to backend 2")
 		}
 	})
@@ -324,7 +324,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		// Read the client pod logs
 		logs, err := e2epod.GetPodLogs(ctx, cs, ns, podClient, podClient)
 		framework.ExpectNoError(err)
-		framework.Logf("Pod client logs: %s", logs)
+		framework.Logf("Pod client logs: %s", collapseDuplicateLogs(logs))
 
 		// Create a daemonset for the Service with InternalTrafficPolicy Local so there is one Server in each Pod
 		// and all pods in the node sends the traffic to the local server.
@@ -360,7 +360,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, logContainsFn(podBackend1, podClient)); err != nil {
 			logs, err = e2epod.GetPodLogs(ctx, cs, ns, podClient, podClient)
 			framework.ExpectNoError(err)
-			framework.Logf("Pod client logs: %s", logs)
+			framework.Logf("Pod client logs: %s", collapseDuplicateLogs(logs))
 			framework.Failf("Failed to connect to backend 1")
 		}
 
@@ -386,7 +386,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, logContainsFn(podBackend2, podClient)); err != nil {
 			logs, err = e2epod.GetPodLogs(ctx, cs, ns, podClient, podClient)
 			framework.ExpectNoError(err)
-			framework.Logf("Pod client logs: %s", logs)
+			framework.Logf("Pod client logs: %s", collapseDuplicateLogs(logs))
 			framework.Failf("Failed to connect to backend 3")
 		}
 	})
@@ -419,7 +419,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		// Read the client pod logs
 		logs, err := e2epod.GetPodLogs(ctx, cs, ns, podClient, podClient)
 		framework.ExpectNoError(err)
-		framework.Logf("Pod client logs: %s", logs)
+		framework.Logf("Pod client logs: %s", collapseDuplicateLogs(logs))
 
 		// Add a backend pod to the service in the other node
 		ginkgo.By("creating a backend pod " + podBackend1 + " for the service " + serviceName)
@@ -441,7 +441,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, logContainsFn(podBackend1, podClient)); err != nil {
 			logs, err = e2epod.GetPodLogs(ctx, cs, ns, podClient, podClient)
 			framework.ExpectNoError(err)
-			framework.Logf("Pod client logs: %s", logs)
+			framework.Logf("Pod client logs: %s", collapseDuplicateLogs(logs))
 			framework.Failf("Failed to connect to backend 1")
 		}
 
@@ -466,7 +466,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, logContainsFn(podBackend2, podClient)); err != nil {
 			logs, err = e2epod.GetPodLogs(ctx, cs, ns, podClient, podClient)
 			framework.ExpectNoError(err)
-			framework.Logf("Pod client logs: %s", logs)
+			framework.Logf("Pod client logs: %s", collapseDuplicateLogs(logs))
 			framework.Failf("Failed to connect to backend 2")
 		}
 	})
@@ -509,7 +509,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		// Read the client pod logs
 		logs, err := e2epod.GetPodLogs(ctx, cs, ns, podClient, podClient)
 		framework.ExpectNoError(err)
-		framework.Logf("Pod client logs: %s", logs)
+		framework.Logf("Pod client logs: %s", collapseDuplicateLogs(logs))
 
 		// Add a backend pod to the service in the other node
 		ginkgo.By("creating a backend pod " + podBackend1 + " for the service " + serviceName)
@@ -540,7 +540,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, logContainsFn(podBackend1, podClient)); err != nil {
 			logs, err = e2epod.GetPodLogs(ctx, cs, ns, podClient, podClient)
 			framework.ExpectNoError(err)
-			framework.Logf("Pod client logs: %s", logs)
+			framework.Logf("Pod client logs: %s", collapseDuplicateLogs(logs))
 			framework.Failf("Failed to connect to backend pod")
 		}
 
@@ -738,7 +738,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, logContainsFn("8080", podClient)); err != nil {
 			logs, err := e2epod.GetPodLogs(ctx, cs, ns, podClient, podClient)
 			framework.ExpectNoError(err)
-			framework.Logf("Pod client logs: %s", logs)
+			framework.Logf("Pod client logs: %s", collapseDuplicateLogs(logs))
 			framework.Failf("Failed to connect to backend 2")
 		}
 
@@ -763,7 +763,7 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, logContainsFn("9090", podClient)); err != nil {
 			logs, err := e2epod.GetPodLogs(ctx, cs, ns, podClient, podClient)
 			framework.ExpectNoError(err)
-			framework.Logf("Pod client logs: %s", logs)
+			framework.Logf("Pod client logs: %s", collapseDuplicateLogs(logs))
 			framework.Failf("Failed to connect to backend 2")
 		}
 	})

--- a/test/e2e/network/util.go
+++ b/test/e2e/network/util.go
@@ -251,3 +251,17 @@ func testEndpointReachability(ctx context.Context, endpoint string, port int32, 
 	}
 	return nil
 }
+
+// wrapCommandWithTimestampObservations creates a command to be run 'iter'
+// times, with consistent wrapping to emit logs for retrospective analysis of
+// execution timestamps.
+func wrapCommandWithTimestampObservations(cmd string, iter int) string {
+	finalCmd := `date; `
+	finalCmd += fmt.Sprintf("for i in $(seq 1 %d); do", iter)
+	finalCmd += `echo "$(date) Try: ${i}"; `
+	finalCmd += cmd + `; `
+	finalCmd += `echo; `
+	finalCmd += `done`
+
+	return finalCmd
+}

--- a/test/e2e/network/util.go
+++ b/test/e2e/network/util.go
@@ -258,10 +258,45 @@ func testEndpointReachability(ctx context.Context, endpoint string, port int32, 
 func wrapCommandWithTimestampObservations(cmd string, iter int) string {
 	finalCmd := `date; `
 	finalCmd += fmt.Sprintf("for i in $(seq 1 %d); do", iter)
-	finalCmd += `echo "$(date) Try: ${i}"; `
+	finalCmd += `echo "$(date)"; `
 	finalCmd += cmd + `; `
-	finalCmd += `echo; `
 	finalCmd += `done`
 
 	return finalCmd
+}
+
+// collapseDuplicateLogs compresses multiple duplicate lines in the input logs
+// into a single line in the output log, with an optional suffix "(N times)".
+func collapseDuplicateLogs(logs string) string {
+	result := []string{}
+	prev := ""
+	count := 0
+
+	for line := range strings.Lines(logs) {
+		if line == "" {
+			continue
+		}
+		if line == prev {
+			count += 1
+			continue
+		}
+		if prev != "" {
+			outputLine := prev
+			if count > 1 {
+				outputLine += fmt.Sprintf(" (%d times)", count)
+			}
+			result = append(result, outputLine)
+			count = 0
+		}
+		prev = line
+		count = count + 1
+	}
+	if count > 0 {
+		outputLine := prev
+		if count > 1 {
+			outputLine += fmt.Sprintf(" (%d times)", count)
+		}
+		result = append(result, outputLine)
+	}
+	return strings.Join(result, "\n")
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Summarize client pod execution timestamps in conntrack tests.

Don't emit iteration counters or empty logs in client logs. When
printing the logs, ignore newlines and collapse duplicate timestamps
lines. If the timestamp occurred multiple times, emit the timestamp just
once with a count of how many duplicates occurred.

This should reduce some of the test case output from emitting 6000+ lines
down to about 12 lines without losing granularity.

#### Which issue(s) this PR is related to:

Fixes: https://github.com/kubernetes/kubernetes/issues/139683

#### Special notes for your reviewer:

Only compile-tested at this stage; I assume that by submitting this change,
Kubernetes CI will run the affected code changes?

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
