### PR TITLE
etcd3: serve unbounded lists with RangeStream when supported

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -32,6 +32,8 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/kubernetes"
 	"go.opentelemetry.io/otel/attribute"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 
 	etcdrpc "go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -730,6 +732,18 @@ func (s *store) GetCurrentResourceVersion(ctx context.Context) (uint64, error) {
 	return uint64(getResp.Revision), nil
 }
 
+// shouldStream determines whether a list request should use etcd RangeStream.
+func shouldStream(opts storage.ListOptions) bool {
+	// Only recursive lists stream, a non-recursive request reads a single object.
+	// Streaming's main goal is to bound unbounded reads, limited and continue requests are
+	// already bounded by pagination, so we are opting out of streaming for them for now.
+	if !opts.Recursive || opts.Predicate.Limit > 0 || opts.Predicate.Continue != "" {
+		return false
+	}
+	return utilfeature.DefaultFeatureGate.Enabled(features.EtcdRangeStream) &&
+		etcdfeature.DefaultFeatureSupportChecker.Supports(storage.RangeStream)
+}
+
 // GetList implements storage.Interface.
 func (s *store) GetList(ctx context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
 	keyPrefix, err := s.prepareKey(key, opts.Recursive)
@@ -778,7 +792,18 @@ func (s *store) GetList(ctx context.Context, key string, opts storage.ListOption
 
 	aggregator := s.listErrAggrFactory()
 
-	for chunk, chunkErr := range s.pagedChunks(ctx, keyPrefix, opts, withRev, limit, continueKey) {
+	chunks := s.pagedChunks(ctx, keyPrefix, opts, withRev, limit, continueKey)
+	if shouldStream(opts) {
+		streamChunks, supported := s.streamChunks(ctx, keyPrefix, withRev)
+		if supported {
+			chunks = streamChunks
+		} else {
+			etcdfeature.DefaultFeatureSupportChecker.MarkUnsupported(storage.RangeStream)
+			klog.V(4).Infof("etcd server does not support RangeStream for %v; falling back to paginated list", s.groupResource)
+		}
+	}
+
+	for chunk, chunkErr := range chunks {
 		if chunkErr != nil {
 			return chunkErr
 		}
@@ -825,7 +850,8 @@ func (s *store) GetList(ctx context.Context, key string, opts storage.ListOption
 	return s.finalizeList(listObj, opts.Predicate, uint64(withRev), continueValue, remainingItemCount, aggregator, v)
 }
 
-// listChunk is one batch of kvs from a list read.
+// listChunk is one batch of kvs from a list read: a page of a paginated Range, or a
+// chunk of a RangeStream.
 type listChunk struct {
 	kvs      []*mvccpb.KeyValue
 	revision *int64
@@ -884,6 +910,66 @@ func (s *store) listReadError(ctx context.Context, err error, withRev int64, pag
 		return storage.NewTooLargeResourceVersionError(uint64(withRev), currentRV, 0)
 	}
 	return interpretListError(err, paging, continueKey, keyPrefix)
+}
+
+// streamChunks reads the list as a single etcd RangeStream, pinned to withRev when
+// nonzero. supported is false when the etcd server does not implement RangeStream.
+func (s *store) streamChunks(ctx context.Context, keyPrefix string, withRev int64) (chunks iter.Seq2[listChunk, error], supported bool) {
+	startTime := time.Now()
+	streamOpts := []clientv3.OpOption{clientv3.WithRange(clientv3.GetPrefixRangeEnd(keyPrefix))}
+	if withRev > 0 {
+		streamOpts = append(streamOpts, clientv3.WithRev(withRev))
+	}
+	stream, streamErr := s.client.KV.GetStream(ctx, keyPrefix, streamOpts...)
+	var first clientv3.RangeStreamResponse
+	var firstOk bool
+	if streamErr == nil {
+		first, firstOk = <-stream
+		if firstOk && grpcstatus.Code(first.Err()) == grpccodes.Unimplemented {
+			return nil, false
+		}
+	} else if grpcstatus.Code(streamErr) == grpccodes.Unimplemented {
+		return nil, false
+	}
+	return func(yield func(listChunk, error) bool) {
+		var err error
+		defer func() {
+			metrics.RecordEtcdRequest("listStream", s.groupResource, err, startTime)
+		}()
+		if err = streamErr; err != nil {
+			yield(listChunk{}, s.listReadError(ctx, err, withRev, false, "", keyPrefix))
+			return
+		}
+		estimator := s.getResourceSizeEstimator()
+		var revision *int64
+		if withRev > 0 {
+			revision = &withRev
+		}
+		resp, ok := first, firstOk
+		for ok {
+			if err = resp.Err(); err != nil {
+				yield(listChunk{}, s.listReadError(ctx, err, withRev, false, "", keyPrefix))
+				return
+			}
+			rangeResp := resp.RangeResponse
+			if estimator != nil && len(rangeResp.Kvs) > 0 {
+				estimator.Update(rangeResp.Kvs)
+			}
+			// A pinned stream's final header holds the latest store revision, not withRev.
+			if revision == nil && rangeResp.Header != nil {
+				revision = &rangeResp.Header.Revision
+			}
+			next, nextOk := <-stream
+			if !yield(listChunk{kvs: rangeResp.Kvs, revision: revision, count: rangeResp.Count, hasMore: nextOk}, nil) {
+				return
+			}
+			resp, ok = next, nextOk
+		}
+		if revision == nil {
+			err = fmt.Errorf("rangeStream for %q completed without a revision", keyPrefix)
+			yield(listChunk{}, err)
+		}
+	}, true
 }
 
 func (s *store) finalizeList(listObj runtime.Object, pred storage.SelectionPredicate, rev uint64, continueValue string, remainingItemCount *int64, aggregator ListErrorAggregator, v reflect.Value) error {

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -49,7 +49,9 @@ import (
 	examplev1 "k8s.io/apiserver/pkg/apis/example/v1"
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage"
+	"k8s.io/apiserver/pkg/storage/etcd3/metrics"
 	"k8s.io/apiserver/pkg/storage/etcd3/testserver"
+	etcdfeature "k8s.io/apiserver/pkg/storage/feature"
 	storagemetrics "k8s.io/apiserver/pkg/storage/metrics"
 	storagetesting "k8s.io/apiserver/pkg/storage/testing"
 	"k8s.io/apiserver/pkg/storage/value"
@@ -329,11 +331,148 @@ func TestTransformationFailure(t *testing.T) {
 }
 
 func TestList(t *testing.T) {
+	for _, rangeStream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("rangeStream=%v", rangeStream), func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EtcdRangeStream, rangeStream)
+			resetFeatureSupportCheckerDuringTest(t)
+			ctx, store, client := testSetup(t)
+			kvRecorder := client.KV.(*storagetesting.KVRecorder)
+			storagetesting.RunTestList(ctx, t, store, compactStorage(store, client.Client), false, client.Kubernetes.(*storagetesting.KubernetesRecorder))
+			streamReads := kvRecorder.GetStreamReadsAndReset()
+			if rangeStream && streamReads == 0 {
+				t.Error("expected lists to be served by RangeStream")
+			}
+			if !rangeStream && streamReads > 0 {
+				t.Errorf("expected no RangeStream requests with the feature disabled, got %d", streamReads)
+			}
+		})
+	}
+}
+
+// TestGetListStreamFallsBackToPaginated verifies that a GetList against a server without
+// RangeStream support marks the feature unsupported and serves from the paginated path.
+func TestGetListStreamFallsBackToPaginated(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EtcdRangeStream, true)
+	resetFeatureSupportCheckerDuringTest(t)
+
+	ctx, store, _ := testSetup(t)
+	initList, err := initStoreData(ctx, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kvWrapper := newEtcdClientKVWrapper(store.client.KV)
+	kvWrapper.streamKV = unimplementedRangeStreamKV()
+	store.client.KV = kvWrapper
+
+	metrics.Register()
+	legacyregistry.Reset()
+	t.Cleanup(legacyregistry.Reset)
+
+	out := &example.PodList{}
+	if err := store.GetList(ctx, "/pods/", storage.ListOptions{Predicate: storage.Everything, Recursive: true}, out); err != nil {
+		t.Fatalf("GetList failed: %v", err)
+	}
+
+	if kvWrapper.getStreamCallCounter != 1 {
+		t.Errorf("expected GetStream to be called once, got %d", kvWrapper.getStreamCallCounter)
+	}
+	// The Unimplemented probe is not recorded, only the unary request serving the list.
+	expected := `# HELP etcd_requests_total [ALPHA] Etcd request counts for each operation and object type.
+# TYPE etcd_requests_total counter
+etcd_requests_total{group="",operation="list",resource="pods"} 1
+`
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expected), "etcd_requests_total", "etcd_request_errors_total"); err != nil {
+		t.Error(err)
+	}
+	if kvWrapper.getCallCounter == 0 {
+		t.Error("expected the paginated Get path to serve the list after fallback")
+	}
+	if etcdfeature.DefaultFeatureSupportChecker.Supports(storage.RangeStream) {
+		t.Error("expected RangeStream to be marked unsupported after the Unimplemented fallback")
+	}
+	if len(out.Items) != len(initList) {
+		t.Errorf("returned %d items, want %d", len(out.Items), len(initList))
+	}
+
+	// The feature is marked unsupported, so subsequent lists must not retry the stream.
+	if err := store.GetList(ctx, "/pods/", storage.ListOptions{Predicate: storage.Everything, Recursive: true}, &example.PodList{}); err != nil {
+		t.Fatalf("GetList failed: %v", err)
+	}
+	if kvWrapper.getStreamCallCounter != 1 {
+		t.Errorf("expected no further GetStream calls after fallback, got %d", kvWrapper.getStreamCallCounter)
+	}
+}
+
+// TestGetListStreamMultiChunk verifies the streamed request shapes on lists spanning
+// multiple RangeStream chunks (the etcd server chunks streams at 10 keys).
+func TestGetListStreamMultiChunk(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EtcdRangeStream, true)
+	resetFeatureSupportCheckerDuringTest(t)
 	ctx, store, client := testSetup(t)
-	storagetesting.RunTestList(ctx, t, store, compactStorage(store, client.Client), false, client.Kubernetes.(*storagetesting.KubernetesRecorder))
+	kvRecorder := client.KV.(*storagetesting.KVRecorder)
+
+	const podCount = 25
+	for i := range podCount {
+		pod := &example.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: fmt.Sprintf("pod-%02d", i)}}
+		if err := store.Create(ctx, fmt.Sprintf("/pods/ns/pod-%02d", i), pod, &example.Pod{}, 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	streamedList := func(t *testing.T, rv string, rvMatch metav1.ResourceVersionMatch) *example.PodList {
+		t.Helper()
+		out := &example.PodList{}
+		opts := storage.ListOptions{ResourceVersion: rv, ResourceVersionMatch: rvMatch, Predicate: storage.Everything, Recursive: true}
+		if err := store.GetList(ctx, "/pods/", opts, out); err != nil {
+			t.Fatalf("GetList failed: %v", err)
+		}
+		if streams := kvRecorder.GetStreamReadsAndReset(); streams == 0 {
+			t.Error("expected the list to be served by RangeStream")
+		}
+		if out.Continue != "" || out.RemainingItemCount != nil {
+			t.Errorf("streamed list must not paginate, got continue %q, remainingItemCount %v", out.Continue, out.RemainingItemCount)
+		}
+		return out
+	}
+
+	snapshot := streamedList(t, "", "")
+	if len(snapshot.Items) != podCount {
+		t.Errorf("consistent list returned %d items, want %d", len(snapshot.Items), podCount)
+	}
+
+	extraPod := &example.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "pod-extra"}}
+	if err := store.Create(ctx, "/pods/ns/pod-extra", extraPod, &example.Pod{}, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// A pinned stream returns the snapshot at the exact revision, not later writes.
+	exact := streamedList(t, snapshot.ResourceVersion, metav1.ResourceVersionMatchExact)
+	if len(exact.Items) != podCount {
+		t.Errorf("exact list returned %d items, want %d", len(exact.Items), podCount)
+	}
+	if exact.ResourceVersion != snapshot.ResourceVersion {
+		t.Errorf("exact list returned resourceVersion %s, want %s", exact.ResourceVersion, snapshot.ResourceVersion)
+	}
+
+	// An unpinned stream at a minimum revision serves the latest data.
+	notOlder := streamedList(t, snapshot.ResourceVersion, "")
+	if len(notOlder.Items) != podCount+1 {
+		t.Errorf("notOlderThan list returned %d items, want %d", len(notOlder.Items), podCount+1)
+	}
 }
 
 func TestListMetrics(t *testing.T) {
+	for _, rangeStream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("rangeStream=%v", rangeStream), func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EtcdRangeStream, rangeStream)
+			resetFeatureSupportCheckerDuringTest(t)
+			testListMetrics(t)
+		})
+	}
+}
+
+func testListMetrics(t *testing.T) {
 	ctx, store, _ := testSetup(t)
 
 	storagemetrics.Register()
@@ -374,8 +513,14 @@ apiserver_storage_list_total{group="",index="",resource="pods",storage="etcd"} 1
 }
 
 func TestConsistentList(t *testing.T) {
-	ctx, store, client := testSetup(t)
-	storagetesting.RunTestConsistentList(ctx, t, store, increaseRVFunc(client.Client), false, true, false)
+	for _, rangeStream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("rangeStream=%v", rangeStream), func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EtcdRangeStream, rangeStream)
+			resetFeatureSupportCheckerDuringTest(t)
+			ctx, store, client := testSetup(t)
+			storagetesting.RunTestConsistentList(ctx, t, store, increaseRVFunc(client.Client), false, true, false)
+		})
+	}
 }
 
 func TestCompactRevision(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testserver/test_server.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testserver/test_server.go
@@ -128,7 +128,8 @@ func RunEtcd(t testing.TB, cfg *embed.Config) *kubernetes.Client {
 	if err != nil {
 		t.Fatal(err)
 	}
-	client.KV = storagetesting.NewKVRecorder(client.KV)
-	client.Kubernetes = storagetesting.NewKubernetesRecorder(client.Kubernetes)
+	kubernetesRecorder := storagetesting.NewKubernetesRecorder(client.Kubernetes)
+	client.KV = storagetesting.NewKVRecorder(client.KV, kubernetesRecorder)
+	client.Kubernetes = kubernetesRecorder
 	return client
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/recorder.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/recorder.go
@@ -30,10 +30,11 @@ type KVRecorder struct {
 
 	reads       uint64
 	streamReads uint64
+	lists       *KubernetesRecorder
 }
 
-func NewKVRecorder(kv clientv3.KV) *KVRecorder {
-	return &KVRecorder{KV: kv}
+func NewKVRecorder(kv clientv3.KV, lists *KubernetesRecorder) *KVRecorder {
+	return &KVRecorder{KV: kv, lists: lists}
 }
 
 func (r *KVRecorder) Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
@@ -47,6 +48,9 @@ func (r *KVRecorder) GetReadsAndReset() uint64 {
 
 func (r *KVRecorder) GetStream(ctx context.Context, key string, opts ...clientv3.OpOption) (clientv3.GetStreamChan, error) {
 	atomic.AddUint64(&r.streamReads, 1)
+	if r.lists != nil {
+		r.lists.record(ctx, RecordedList{Key: key, ListOptions: kubernetes.ListOptions{Revision: clientv3.OpGet(key, opts...).Rev()}})
+	}
 	return r.KV.GetStream(ctx, key, opts...)
 }
 
@@ -69,13 +73,18 @@ func NewKubernetesRecorder(client kubernetes.Interface) *KubernetesRecorder {
 }
 
 func (r *KubernetesRecorder) List(ctx context.Context, key string, opts kubernetes.ListOptions) (kubernetes.ListResponse, error) {
-	recorderKey, ok := ctx.Value(RecorderContextKey).(string)
-	if ok {
-		r.mux.Lock()
-		r.listsPerKey[recorderKey] = append(r.listsPerKey[recorderKey], RecordedList{Key: key, ListOptions: opts})
-		r.mux.Unlock()
-	}
+	r.record(ctx, RecordedList{Key: key, ListOptions: opts})
 	return r.Interface.List(ctx, key, opts)
+}
+
+func (r *KubernetesRecorder) record(ctx context.Context, list RecordedList) {
+	recorderKey, ok := ctx.Value(RecorderContextKey).(string)
+	if !ok {
+		return
+	}
+	r.mux.Lock()
+	defer r.mux.Unlock()
+	r.listsPerKey[recorderKey] = append(r.listsPerKey[recorderKey], list)
 }
 
 func (r *KubernetesRecorder) ListRequestForKey(key string) []RecordedList {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Serve unbounded recursive lists from etcd with RangeStream (KEP-5966) instead of a single Range that buffers the whole response. When the feature gate is on and etcd supports RangeStream, GetList streams the result in chunks through the same loop the paged path uses, and falls back to paginated Range when etcd returns Unimplemented. Only unbounded lists stream (recursive, no limit, no continue token), the shape the watch cache's initial list and the consistent-read fallback use. Anything limited or continued stays on the paginated path.

The refactors that made room for this landed as separate PRs, all now merged:
- https://github.com/kubernetes/kubernetes/pull/139971
- https://github.com/kubernetes/kubernetes/pull/140022
- https://github.com/kubernetes/kubernetes/pull/140105
- https://github.com/kubernetes/kubernetes/pull/140106
- https://github.com/kubernetes/kubernetes/pull/140302
- https://github.com/kubernetes/kubernetes/pull/140446
- https://github.com/kubernetes/kubernetes/pull/140537
- https://github.com/kubernetes/kubernetes/pull/140547

#### Which issue(s) this PR is related to:

KEP-5966: etcd RangeStream

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5966-etcd-rangestream
```
