### PR TITLE
Fix TestCheckpointStateRestore for newer Go versions

### DIFF
--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint_test.go
@@ -323,7 +323,7 @@ func TestCheckpointStateRestore(t *testing.T) {
 			}`,
 			"static",
 			containermap.ContainerMap{},
-			"cannot unmarshal string into Go struct field CPUManagerCheckpointV2.entries of type map[string]string",
+			"cannot unmarshal string into Go struct field CPUManagerCheckpointV2.entries",
 			nil,
 		},
 		{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:
Update expected error message to be compatible with newer Go versions that include the specific map key in JSON unmarshal errors.

Old: CPUManagerCheckpointV2.entries of type
New: CPUManagerCheckpointV2.entries.containerID1 of type

The test now checks only the common prefix that works across Go versions.

#### Which issue(s) this PR is related to:
Fixes #139685

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
