### PR TITLE
feat: volumeBinding's Score plugin in enabled by default in v1beta3 and

### DIFF
--- a/pkg/scheduler/apis/config/testing/defaults/defaults.go
+++ b/pkg/scheduler/apis/config/testing/defaults/defaults.go
@@ -50,6 +50,16 @@ var PluginsV1 = &config.Plugins{
 			{Name: names.NodeDeclaredFeatures},
 		},
 	},
+	PreScore: config.PluginSet{
+		Disabled: []config.Plugin{
+			{Name: names.VolumeBinding},
+		},
+	},
+	Score: config.PluginSet{
+		Disabled: []config.Plugin{
+			{Name: names.VolumeBinding},
+		},
+	},
 }
 
 // ExpandedPluginsV1 default set of v1 plugins after MultiPoint expansion
@@ -110,7 +120,6 @@ var ExpandedPluginsV1 = &config.Plugins{
 			{Name: names.TaintToleration},
 			{Name: names.NodeAffinity},
 			{Name: names.NodeResourcesFit},
-			{Name: names.VolumeBinding},
 			{Name: names.PodTopologySpread},
 			{Name: names.InterPodAffinity},
 			{Name: names.NodeResourcesBalancedAllocation},
@@ -127,7 +136,6 @@ var ExpandedPluginsV1 = &config.Plugins{
 			// - This is a score coming from user preference.
 			{Name: names.NodeAffinity, Weight: 2},
 			{Name: names.NodeResourcesFit, Weight: 1},
-			{Name: names.VolumeBinding, Weight: 1},
 			// Weight is doubled because:
 			// - This is a score coming from user preference.
 			// - It makes its signal comparable to NodeResourcesLeastAllocated.

--- a/pkg/scheduler/apis/config/v1/default_plugins.go
+++ b/pkg/scheduler/apis/config/v1/default_plugins.go
@@ -70,6 +70,9 @@ func applyFeatureGates(config *v1.Plugins) {
 	if utilfeature.DefaultFeatureGate.Enabled(features.TopologyAwareWorkloadScheduling) {
 		applyTopologyAwareWorkloadScheduling(config)
 	}
+	if !utilfeature.DefaultFeatureGate.Enabled(features.StorageCapacityScoring) {
+		disableVolumeBindingScoring(config)
+	}
 }
 
 func applyDynamicResources(config *v1.Plugins) {
@@ -97,6 +100,12 @@ func applyGangScheduling(config *v1.Plugins) {
 func applyTopologyAwareWorkloadScheduling(config *v1.Plugins) {
 	config.MultiPoint.Enabled = append(config.MultiPoint.Enabled, v1.Plugin{Name: names.TopologyPlacementGenerator})
 	config.MultiPoint.Enabled = append(config.MultiPoint.Enabled, v1.Plugin{Name: names.PodGroupPodsCount, Weight: ptr.To[int32](1)})
+}
+
+func disableVolumeBindingScoring(config *v1.Plugins) {
+	// Keep VolumeBinding enabled in MultiPoint for its filtering and binding extension points.
+	config.PreScore.Disabled = append(config.PreScore.Disabled, v1.Plugin{Name: names.VolumeBinding})
+	config.Score.Disabled = append(config.Score.Disabled, v1.Plugin{Name: names.VolumeBinding})
 }
 
 // mergePlugins merges the custom set into the given default one, handling disabled sets.

--- a/pkg/scheduler/apis/config/v1/default_plugins_test.go
+++ b/pkg/scheduler/apis/config/v1/default_plugins_test.go
@@ -38,6 +38,38 @@ func TestApplyFeatureGates(t *testing.T) {
 		wantConfig *v1.Plugins
 	}{
 		{
+			name: "Feature gate StorageCapacityScoring enabled",
+			features: map[featuregate.Feature]bool{
+				features.StorageCapacityScoring: true,
+			},
+			wantConfig: &v1.Plugins{
+				MultiPoint: v1.PluginSet{
+					Enabled: []v1.Plugin{
+						{Name: names.SchedulingGates},
+						{Name: names.PrioritySort},
+						{Name: names.NodeUnschedulable},
+						{Name: names.NodeName},
+						{Name: names.TaintToleration, Weight: ptr.To[int32](3)},
+						{Name: names.NodeAffinity, Weight: ptr.To[int32](2)},
+						{Name: names.NodePorts},
+						{Name: names.NodeResourcesFit, Weight: ptr.To[int32](1)},
+						{Name: names.VolumeRestrictions},
+						{Name: names.NodeVolumeLimits},
+						{Name: names.VolumeBinding},
+						{Name: names.VolumeZone},
+						{Name: names.PodTopologySpread, Weight: ptr.To[int32](2)},
+						{Name: names.InterPodAffinity, Weight: ptr.To[int32](2)},
+						{Name: names.DynamicResources, Weight: ptr.To[int32](2)},
+						{Name: names.DefaultPreemption},
+						{Name: names.NodeResourcesBalancedAllocation, Weight: ptr.To[int32](1)},
+						{Name: names.ImageLocality, Weight: ptr.To[int32](1)},
+						{Name: names.DefaultBinder},
+						{Name: names.NodeDeclaredFeatures},
+					},
+				},
+			},
+		},
+		{
 			name: "Feature gate DynamicResourceAllocation disabled",
 			features: map[featuregate.Feature]bool{
 				features.DynamicResourceAllocation: false,
@@ -242,6 +274,10 @@ func TestApplyFeatureGates(t *testing.T) {
 			featuregatetesting.SetFeatureGatesDuringTest(t, feature.DefaultFeatureGate, test.features)
 
 			gotConfig := getDefaultPlugins()
+			if !feature.DefaultFeatureGate.Enabled(features.StorageCapacityScoring) {
+				test.wantConfig.PreScore.Disabled = []v1.Plugin{{Name: names.VolumeBinding}}
+				test.wantConfig.Score.Disabled = []v1.Plugin{{Name: names.VolumeBinding}}
+			}
 			if diff := cmp.Diff(test.wantConfig, gotConfig); diff != "" {
 				t.Errorf("unexpected config diff (-want, +got): %s", diff)
 			}

--- a/pkg/scheduler/apis/config/v1/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1/defaults_test.go
@@ -376,6 +376,16 @@ func TestSchedulerDefaults(t *testing.T) {
 									{Name: names.NodeDeclaredFeatures},
 								},
 							},
+							PreScore: configv1.PluginSet{
+								Disabled: []configv1.Plugin{
+									{Name: names.VolumeBinding},
+								},
+							},
+							Score: configv1.PluginSet{
+								Disabled: []configv1.Plugin{
+									{Name: names.VolumeBinding},
+								},
+							},
 							Bind: configv1.PluginSet{
 								Enabled: []configv1.Plugin{
 									{Name: "BarPlugin"},


### PR DESCRIPTION
Resolves #113705.

Followed up with @alculquicondor, VolumeBinding Score plugin is enabled only when the feature gate `VolumeCapacityPriority ` is enabled:

#### What type of PR is this?

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```