### PR TITLE
apiserver/storageversion: fix infinite retry loop in updateStorageVersionFor

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storageversion/updater.go
+++ b/staging/src/k8s.io/apiserver/pkg/storageversion/updater.go
@@ -133,6 +133,8 @@ func updateStorageVersionFor(c Client, apiserverID string, gr schema.GroupResour
 			return nil
 		}
 		if apierrors.IsAlreadyExists(err) || apierrors.IsConflict(err) {
+			klog.Infof("retry %d, failed to update storage version for %v: %v", retry, gr, err)
+			retry++
 			time.Sleep(1 * time.Second)
 			continue
 		}


### PR DESCRIPTION
**What this PR does / why we need it:**

Fixes an infinite loop in `updateStorageVersionFor` when `singleUpdate` returns `AlreadyExists` or `Conflict` errors. The retry counter is not incremented before `continue`, so the loop never terminates. This can hang API server startup when a StorageVersion object has a persistent conflict during concurrent multi-instance startup.

Also adds a `klog.Infof` log line in the retry branch so transient conflict retries are visible in server logs, matching the existing log format in the general error branch.

**Which issue(s) this PR fixes:**

None (no existing issue found for this bug).

**Special notes for your reviewer:**

Continuation of #138984 which was accidentally closed and could not be reopened (branch history issue). The fix adds `retry++` and a `klog.Infof` line in the `AlreadyExists`/`Conflict` branch, matching the identical pattern in the general error branch below. The bug was introduced in #92459 (2020-02-24).

**Does this PR introduce a user-facing change?**

```release-note
Fixed an infinite retry loop in the StorageVersion updater that could hang API server startup when encountering persistent AlreadyExists or Conflict errors.
```

/kind bug
/sig api-machinery