### PR TITLE
Reject a zero step in ResourceSlice validRange

### DIFF
--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -1175,14 +1175,18 @@ func validateRequestPolicyRange(defaultValue apiresource.Quantity, maxCapacity a
 		}
 	}
 	if valueRange.Step != nil {
-		added := valueRange.Min.DeepCopy()
-		added.Add(*valueRange.Step)
-		if added.Cmp(maxCapacity) > 0 {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("step"), valueRange.Step.String(), fmt.Sprintf("one step %s is larger than capacity value: %s", added.String(), maxCapacity.String())))
-		}
-		allErrs = append(allErrs, validateRequestPolicyRangeStep(defaultValue, *valueRange.Min, *valueRange.Step, fldPath.Child("step"))...)
-		if valueRange.Max != nil {
-			allErrs = append(allErrs, validateRequestPolicyRangeStep(*valueRange.Max, *valueRange.Min, *valueRange.Step, fldPath.Child("step"))...)
+		if valueRange.Step.Sign() <= 0 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("step"), valueRange.Step.String(), "must be greater than zero"))
+		} else {
+			added := valueRange.Min.DeepCopy()
+			added.Add(*valueRange.Step)
+			if added.Cmp(maxCapacity) > 0 {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("step"), valueRange.Step.String(), fmt.Sprintf("one step %s is larger than capacity value: %s", added.String(), maxCapacity.String())))
+			}
+			allErrs = append(allErrs, validateRequestPolicyRangeStep(defaultValue, *valueRange.Min, *valueRange.Step, fldPath.Child("step"))...)
+			if valueRange.Max != nil {
+				allErrs = append(allErrs, validateRequestPolicyRangeStep(*valueRange.Max, *valueRange.Min, *valueRange.Step, fldPath.Child("step"))...)
+			}
 		}
 	}
 	return allErrs

--- a/pkg/apis/resource/validation/validation_resourceslice_test.go
+++ b/pkg/apis/resource/validation/validation_resourceslice_test.go
@@ -834,6 +834,56 @@ func TestValidateResourceSlice(t *testing.T) {
 			}(),
 			consumableCapacityFeatureGate: true,
 		},
+		"invalid-request-policy-zero-step": {
+			wantFailures: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "devices").Index(1).Child("capacity").Key("cap").Child("requestPolicy").Child("validRange", "step"), "0", "must be greater than zero"),
+			},
+			slice: func() *resourceapi.ResourceSlice {
+				slice := testResourceSlice(goodName, goodName, goodName, 2)
+				slice.Spec.Devices[1].AllowMultipleAllocations = ptr.To(true)
+				capacity := resourceapi.DeviceCapacity{
+					Value: resource.MustParse("1Gi"),
+					RequestPolicy: &resourceapi.CapacityRequestPolicy{
+						Default: ptr.To(resource.MustParse("10Mi")),
+						ValidRange: &resourceapi.CapacityRequestPolicyRange{
+							Min:  ptr.To(resource.MustParse("1Mi")),
+							Max:  ptr.To(resource.MustParse("100Mi")),
+							Step: ptr.To(resource.MustParse("0")),
+						},
+					},
+				}
+				slice.Spec.Devices[1].Capacity = map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
+					"cap": capacity,
+				}
+				return slice
+			}(),
+			consumableCapacityFeatureGate: true,
+		},
+		"invalid-request-policy-negative-step": {
+			wantFailures: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "devices").Index(1).Child("capacity").Key("cap").Child("requestPolicy").Child("validRange", "step"), "-1Mi", "must be greater than zero"),
+			},
+			slice: func() *resourceapi.ResourceSlice {
+				slice := testResourceSlice(goodName, goodName, goodName, 2)
+				slice.Spec.Devices[1].AllowMultipleAllocations = ptr.To(true)
+				capacity := resourceapi.DeviceCapacity{
+					Value: resource.MustParse("1Gi"),
+					RequestPolicy: &resourceapi.CapacityRequestPolicy{
+						Default: ptr.To(resource.MustParse("10Mi")),
+						ValidRange: &resourceapi.CapacityRequestPolicyRange{
+							Min:  ptr.To(resource.MustParse("1Mi")),
+							Max:  ptr.To(resource.MustParse("100Mi")),
+							Step: ptr.To(resource.MustParse("-1Mi")),
+						},
+					},
+				}
+				slice.Spec.Devices[1].Capacity = map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
+					"cap": capacity,
+				}
+				return slice
+			}(),
+			consumableCapacityFeatureGate: true,
+		},
 		"invalid-node-selecor-label-value": {
 			wantFailures: field.ErrorList{field.Invalid(field.NewPath("spec", "nodeSelector", "nodeSelectorTerms").Index(0).Child("matchExpressions").Index(0).Child("values").Index(0), "-1", "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')")},
 			slice: func() *resourceapi.ResourceSlice {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
ResourceSlice validation panics with `runtime error: integer divide by zero` when the `DRAConsumableCapacity` feature gate is enabled and a capacity request policy sets `validRange.step: 0`. This adds a guard that rejects a non-positive `validRange.step` with a clear validation error before it reaches the modulo check, plus a regression test.

#### Which issue(s) this PR is related to:
Resolves #139653

#### Special notes for your reviewer:
This PR was written in part with the assistance of generative AI; all changes were authored and reviewed by me.

#### Does this PR introduce a user-facing change?
```release-note
Fixed a panic in ResourceSlice validation that could occur when the DRAConsumableCapacity feature was enabled and a capacity request policy set validRange.step to zero.
```
