### PR TITLE
Wait for CRD in discovery before starting GC

### DIFF
--- a/test/integration/garbagecollector/garbage_collector_test.go
+++ b/test/integration/garbagecollector/garbage_collector_test.go
@@ -1370,6 +1370,21 @@ func TestCascadingDeleteOnCRDConversionFailure(t *testing.T) {
 		t.Fatalf("Error updating CRD with conversion webhook: %v", err)
 	}
 
+	if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 15*time.Second, true, func(ctx context.Context) (bool, error) {
+		groupResource, err := apiExtensionClient.Discovery().ServerResourcesForGroupVersion(newDefinition.Spec.Group + "/v1")
+		if err != nil {
+			return false, nil
+		}
+		for _, resource := range groupResource.APIResources {
+			if resource.Name == newDefinition.Spec.Names.Plural {
+				return true, nil
+			}
+		}
+		return false, nil
+	}); err != nil {
+		t.Fatalf("Failed waiting for updated CRD version to appear in discovery: %v", err)
+	}
+
 	ctx.startGC(5)
 	// make sure gc.Sync finds the new CRD and starts monitoring it
 	time.Sleep(ctx.syncPeriod + 1*time.Second)


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
`TestCascadingDeleteOnCRDConversionFailure` could flake because the garbage collector was started and synced before the updated CRD (with the failing conversion webhook) had propagated to discovery, so the test raced discovery propagation. This adds a short poll that waits for the updated CRD version to appear in discovery before starting the GC, removing the race without changing what the test asserts.

#### Which issue(s) this PR is related to:
Resolves #139687

#### Special notes for your reviewer:
This PR was written in part with the assistance of generative AI; all changes were authored and reviewed by me.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
