### PR TITLE
docs(scheduler): clarify VolumeBinding Score gate note

### DIFF
--- a/pkg/scheduler/apis/config/v1/default_plugins.go
+++ b/pkg/scheduler/apis/config/v1/default_plugins.go
@@ -41,6 +41,9 @@ func getDefaultPlugins() *v1.Plugins {
 				{Name: names.NodeResourcesFit, Weight: ptr.To[int32](1)},
 				{Name: names.VolumeRestrictions},
 				{Name: names.NodeVolumeLimits},
+				// Enabling VolumeBinding Score without regard to the VolumeCapacityPriority
+				// feature gate is an incorrect configuration pattern. This is intentionally
+				// retained for backward compatibility; see issue 113705.
 				{Name: names.VolumeBinding},
 				{Name: names.VolumeZone},
 				{Name: names.PodTopologySpread, Weight: ptr.To[int32](2)},


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
Adds a clarifying code comment, per the accepted resolution in #113705 (ahg-g, Huang-Wei, alculquicondor), that enabling the VolumeBinding Score plugin without regard to the `VolumeCapacityPriority` feature gate is an incorrect configuration pattern, intentionally retained for backward compatibility. The maintainers chose to keep the behavior as-is (a real fix would break existing configs) and add a comment so the pattern is not copied.

#### Which issue(s) this PR is related to:
Resolves #113705

#### Special notes for your reviewer:
This is a comment-only change: no API, runtime behavior, default-plugin, or generated-file change. The auto-applied `kind/api-change` label is a path heuristic (the file lives under `pkg/scheduler/apis/config/v1`); the diff adds three comment lines only.
This PR was written in part with the assistance of generative AI; all changes were authored and reviewed by me.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
