### PR TITLE
fix: remove duplicate running containers

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_gc.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_gc.go
@@ -60,9 +60,8 @@ type containerGCInfo struct {
 	name string
 	// Creation time for the container.
 	createTime time.Time
-	// If true, the container is in unknown state. Garbage collector should try
-	// to stop containers before removal.
-	unknown bool
+	// State of the container.
+	state runtimeapi.ContainerState
 }
 
 // sandboxGCInfo is the internal information kept for sandboxes being considered for GC.
@@ -134,14 +133,14 @@ func (cgc *containerGC) removeOldestN(ctx context.Context, containers []containe
 		sort.Sort(byCreated(containers))
 	}
 	for i := len(containers) - 1; i >= numToKeep; i-- {
-		if containers[i].unknown {
-			// Containers in known state could be running, we should try
+		if containers[i].state == runtimeapi.ContainerState_CONTAINER_UNKNOWN || containers[i].state == runtimeapi.ContainerState_CONTAINER_RUNNING {
+			// Containers in unknown state could be running, we should try
 			// to stop it before removal.
 			id := kubecontainer.ContainerID{
 				Type: cgc.manager.runtimeName,
 				ID:   containers[i].id,
 			}
-			message := "Container is in unknown state, try killing it before removal"
+			message := "Container is in unknown or running state, try killing it before removal"
 			if err := cgc.manager.killContainer(ctx, nil, id, containers[i].name, message, reasonUnknown, nil, nil); err != nil {
 				logger.Error(err, "Failed to stop container", "containerID", containers[i].id)
 				continue
@@ -187,51 +186,54 @@ func (cgc *containerGC) removeSandbox(ctx context.Context, sandboxID string) {
 	}
 }
 
-// evictableContainers gets all containers that are evictable. Evictable containers are: not running
-// and created more than MinAge ago.
-func (cgc *containerGC) evictableContainers(ctx context.Context, minAge time.Duration) (containersByEvictUnit, error) {
+// evictableContainers gets all containers that are evictable. Evictable containers are as follow:
+// 1. not running and created more than MinAge ago.
+// 2. running and created duplicated and older in the same pod.
+func (cgc *containerGC) evictableContainers(ctx context.Context, minAge time.Duration) (containersByEvictUnit, containersByEvictUnit, error) {
 	containers, err := cgc.manager.getContainers(ctx, listOptions{})
 	if err != nil {
-		return containersByEvictUnit{}, err
+		return containersByEvictUnit{}, containersByEvictUnit{}, err
 	}
 
 	evictUnits := make(containersByEvictUnit)
+	evictRunningUnits := make(containersByEvictUnit)
 	newestGCTime := time.Now().Add(-minAge)
 	for _, container := range containers {
-		// Prune out running containers.
-		if container.State == runtimeapi.ContainerState_CONTAINER_RUNNING {
-			continue
-		}
-
 		createdAt := time.Unix(0, container.CreatedAt)
-		if newestGCTime.Before(createdAt) {
-			continue
-		}
-
 		labeledInfo := getContainerInfoFromLabels(ctx, container.Labels)
 		containerInfo := containerGCInfo{
 			id:         container.Id,
 			name:       container.Metadata.Name,
 			createTime: createdAt,
-			unknown:    container.State == runtimeapi.ContainerState_CONTAINER_UNKNOWN,
+			state:      container.State,
 		}
 		key := evictUnit{
 			uid:  labeledInfo.PodUID,
 			name: containerInfo.name,
 		}
-		evictUnits[key] = append(evictUnits[key], containerInfo)
+		if container.State == runtimeapi.ContainerState_CONTAINER_RUNNING {
+			evictRunningUnits[key] = append(evictRunningUnits[key], containerInfo)
+		} else {
+			if newestGCTime.Before(createdAt) {
+				continue
+			}
+			evictUnits[key] = append(evictUnits[key], containerInfo)
+		}
 	}
 
-	return evictUnits, nil
+	return evictUnits, evictRunningUnits, nil
 }
 
 // evict all containers that are evictable
 func (cgc *containerGC) evictContainers(ctx context.Context, gcPolicy kubecontainer.GCPolicy, allSourcesReady bool, evictNonDeletedPods bool) error {
 	// Separate containers by evict units.
-	evictUnits, err := cgc.evictableContainers(ctx, gcPolicy.MinAge)
+	evictUnits, evictRunningUnits, err := cgc.evictableContainers(ctx, gcPolicy.MinAge)
 	if err != nil {
 		return err
 	}
+
+	// Remove duplicated containers in running state.
+	cgc.enforceMaxContainersPerEvictUnit(ctx, evictRunningUnits, 1)
 
 	// Remove deleted pod containers if all sources are ready.
 	if allSourcesReady {

--- a/pkg/kubelet/kuberuntime/kuberuntime_gc_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_gc_test.go
@@ -388,6 +388,17 @@ func TestContainerGC(t *testing.T) {
 			evictTerminatingPods: true,
 			allSourcesReady:      false,
 		},
+		{
+			description: "duplicate running containers should be removed",
+			containers: []containerTemplate{
+				makeGCContainer("foo", "bar", 0, 0, runtimeapi.ContainerState_CONTAINER_RUNNING),
+				makeGCContainer("foo", "bar", 1, 1, runtimeapi.ContainerState_CONTAINER_RUNNING),
+				makeGCContainer("foo1", "bar1", 0, 0, runtimeapi.ContainerState_CONTAINER_RUNNING),
+			},
+			remain:               []int{1, 2},
+			evictTerminatingPods: true,
+			allSourcesReady:      false,
+		},
 	} {
 		t.Run(test.description, func(t *testing.T) {
 			tCtx := ktesting.Init(t)


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
When timeout and other issues occur during the interaction between kubelet and CRI, containers may be created repeatedly, although the goal is to have only one running container. However, the current container GC handling logic does not process containers that are running. Therefore, I implemented some additional handling to clean up these duplicate containers that are in a running state, ensuring that ultimately only one container is running.

#### Which issue(s) this PR is related to:
Fixes [#139670](https://github.com/kubernetes/kubernetes/issues/139670)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

