### PR TITLE
kubelet: prevent scheduling duplicate container starts in computePodActions

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1306,6 +1306,22 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 		// If container does not exist, or is not running, check whether we
 		// need to restart it.
 		if containerStatus == nil || containerStatus.State != kubecontainer.ContainerStateRunning {
+			// Check for a running duplicate before scheduling a new start.
+                	// FindContainerStatusByName returns only the first match and may return
+                	// an Exited status while a Running duplicate exists (e.g. when a CRI
+                	// StartContainer call timed out in kubelet but succeeded in the runtime).
+                	// See https://github.com/kubernetes/kubernetes/issues/139670
+                	hasRunningDuplicate := false
+                	for _, s := range podStatus.ContainerStatuses {
+                        	if s.Name == container.Name && s.State == kubecontainer.ContainerStateRunning {
+                                	hasRunningDuplicate = true
+                                	break
+                        	}
+                	}
+                	if hasRunningDuplicate {
+                        	keepCount++
+                        	continue
+                	}
 			if kubecontainer.ShouldContainerBeRestarted(logger, &container, pod, podStatus) {
 				logger.V(3).Info("Container of pod is not in the desired state and shall be started", "containerName", container.Name, "pod", klog.KObj(pod))
 				changes.ContainersToStart = append(changes.ContainersToStart, idx)

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -1479,6 +1479,42 @@ func TestComputePodActions(t *testing.T) {
 				ContainersToStart: []int{1},
 			},
 		},
+		"do not start container when running duplicate exists (issue 139670)": {
+                        mutatePodFn: func(pod *v1.Pod) {
+                                pod.Spec.RestartPolicy = v1.RestartPolicyAlways
+                        },
+                        mutateStatusFn: func(status *kubecontainer.PodStatus) {
+                                // Simulate issue #139670: a CRI StartContainer call timed out
+                                // in kubelet but succeeded in the runtime. kubelet sees the
+                                // first status as Exited (its stale view), but containerd has
+                                // a second Running container with the same name.
+                                // FindContainerStatusByName returns only the first (Exited) match,
+                                // so without the fix, computePodActions would schedule another start.
+                                duplicate := &kubecontainer.Status{
+                                        ID:    kubecontainer.ContainerID{Type: "test", ID: "duplicate-running-id"},
+                                        Name:  status.ContainerStatuses[0].Name,
+                                        State: kubecontainer.ContainerStateRunning,
+                                        Hash:  status.ContainerStatuses[0].Hash,
+                                }
+                                // Mark first status as Exited so FindContainerStatusByName
+                                // returns the stale Exited view
+                                status.ContainerStatuses[0].State = kubecontainer.ContainerStateExited
+                                // Insert duplicate Running entry after the Exited one
+                                // so FindContainerStatusByName finds Exited first
+                                rest := status.ContainerStatuses[1:]
+                                status.ContainerStatuses = append(
+                                        []*kubecontainer.Status{status.ContainerStatuses[0], duplicate},
+                                        rest...,
+                                )
+                        },
+                        actions: podActions{
+                                SandboxID: baseStatus.SandboxStatuses[0].Id,
+                                // Container 0 (foo1) must NOT be in ContainersToStart —
+                                // a running duplicate already exists in the runtime.
+                                ContainersToStart: []int{},
+                                ContainersToKill:  getKillMap(basePod, baseStatus, []int{}),
+                        },
+                },
 	} {
 		pod, status := makeBasePodAndStatus()
 		if test.mutatePodFn != nil {


### PR DESCRIPTION
/sig node
/kind bug

## What this PR does / why we need it

Fixes #139670

When a CRI `StartContainer` call times out in kubelet but succeeds in the
container runtime (e.g. containerd), kubelet may schedule another container
start on the next `syncPod` cycle. This results in two containers running
simultaneously for the same pod.

**Root cause:**

`computePodActions` uses `FindContainerStatusByName` to check if a container
is running. However, `FindContainerStatusByName` returns only the **first**
matching status. If the first status is `Exited` (kubelet's stale view after
the timeout), it misses a second `Running` status (the container containerd
actually started successfully).

This is already acknowledged in the codebase at line 1393:
// podStatus.FindContainerStatusByName cannot be used because there can be
// multiple container statuses per container

// When there are multiple containers' statuses with the same name,
// the first match will be returned.

**The race condition:**

kubelet calls CreateContainer --> succeeds ✅
kubelet calls StartContainer --> times out ❌ (from kubelet's perspective)
containerd actually started the container successfully ✅
Next syncPod cycle: FindContainerStatusByName returns Exited status
computePodActions appends to ContainersToStart --> second container created 💥
Both containers now Running for the same pod


## How this fixes it

Before appending to `ContainersToStart`, we now scan all entries in
`podStatus.ContainerStatuses` for a running instance with the same container
name. If one is found, we treat it as healthy (`keepCount++`) and skip
scheduling a new start.

This is the same pattern already used in `getContainersToReset()` which
explicitly avoids `FindContainerStatusByName` for the same reason.

## Related

This PR takes a **preventive** approach in `computePodActions` (stops
duplicate from being scheduled). PR #139702 by the original reporter takes
a **reactive** approach in the GC layer (cleans up duplicates after they
exist). Both approaches together provide more complete coverage.

## Testing

- Added unit test case in `TestComputePodActions`:
  `"do not start container when running duplicate exists (issue 139670)"`
  
  The test simulates the race condition by injecting a duplicate Running
  status after an Exited status for the same container name, and verifies
  that `computePodActions` does NOT add the container to `ContainersToStart`.

- All existing `TestComputePodActions` tests pass.


## Release note

```release-note
kubelet: fix a race condition where duplicate containers could be scheduled
for the same pod when a CRI StartContainer call timed out in kubelet but
succeeded in the container runtime.
```

## Which issue(s) this PR fixes
Fixes #139670