### PR TITLE
fix : false positive rejecting profile names containing '..'

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -5342,6 +5342,7 @@ func ValidateAppArmorProfileField(profile *core.AppArmorProfile, fldPath *field.
 			} else if localhostProfile == "" {
 				allErrs = append(allErrs, field.Required(fldPath.Child("localhostProfile"), "must be set when AppArmor type is Localhost"))
 			}
+			allErrs = append(allErrs, validatePathNoBacksteps(*profile.LocalhostProfile, fldPath.Child("localhostProfile"))...)
 
 			const maxLocalhostProfileLength = 4095 // PATH_MAX - 1
 			if len(*profile.LocalhostProfile) > maxLocalhostProfileLength {
@@ -5391,6 +5392,10 @@ func ValidateAppArmorProfileFormat(profile string) error {
 	}
 	if !strings.HasPrefix(profile, v1.DeprecatedAppArmorBetaProfileNamePrefix) {
 		return fmt.Errorf("invalid AppArmor profile name: %q", profile)
+	}
+	profilePath := strings.TrimPrefix(profile, v1.DeprecatedAppArmorBetaProfileNamePrefix)
+	if errs := validatePathNoBacksteps(profilePath, field.NewPath("localhostProfile")); len(errs) > 0 {
+		return fmt.Errorf("invalid AppArmor profile name: %q, must not contain '..'", profile)
 	}
 	return nil
 }

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -11106,6 +11106,22 @@ func TestValidatePod(t *testing.T) {
 				},
 			}),
 		),
+		"localhost AppArmor profile with absolute path": *podtest.MakePod("123",
+			podtest.SetSecurityContext(&core.PodSecurityContext{
+				AppArmorProfile: &core.AppArmorProfile{
+					Type:             core.AppArmorProfileTypeLocalhost,
+					LocalhostProfile: ptr.To("/usr/sbin/ntpd"),
+				},
+			}),
+		),
+		"localhost AppArmor profile with dots in name": *podtest.MakePod("123",
+			podtest.SetSecurityContext(&core.PodSecurityContext{
+				AppArmorProfile: &core.AppArmorProfile{
+					Type:             core.AppArmorProfileTypeLocalhost,
+					LocalhostProfile: ptr.To("my..profile"),
+				},
+			}),
+		),
 		"syntactically valid sysctls": *podtest.MakePod("123",
 			podtest.SetSecurityContext(&core.PodSecurityContext{
 				Sysctls: []core.Sysctl{{
@@ -12498,6 +12514,28 @@ func TestValidatePod(t *testing.T) {
 					AppArmorProfile: &core.AppArmorProfile{
 						Type:             core.AppArmorProfileTypeLocalhost,
 						LocalhostProfile: ptr.To(strings.Repeat("a", 4096)),
+					},
+				}),
+			),
+		},
+		"AppArmor localhost profile with backsteps": {
+			expectedError: "must not contain '..'",
+			spec: *podtest.MakePod("123",
+				podtest.SetSecurityContext(&core.PodSecurityContext{
+					AppArmorProfile: &core.AppArmorProfile{
+						Type:             core.AppArmorProfileTypeLocalhost,
+						LocalhostProfile: ptr.To("../foo"),
+					},
+				}),
+			),
+		},
+		"AppArmor localhost profile with mid-path backsteps": {
+			expectedError: "must not contain '..'",
+			spec: *podtest.MakePod("123",
+				podtest.SetSecurityContext(&core.PodSecurityContext{
+					AppArmorProfile: &core.AppArmorProfile{
+						Type:             core.AppArmorProfileTypeLocalhost,
+						LocalhostProfile: ptr.To("foo/../bar"),
 					},
 				}),
 			),
@@ -27313,6 +27351,8 @@ func TestValidateAppArmorProfileFormat(t *testing.T) {
 		{"baz", false}, // Missing local prefix.
 		{v1.DeprecatedAppArmorBetaProfileNamePrefix + "/usr/sbin/ntpd", true},
 		{v1.DeprecatedAppArmorBetaProfileNamePrefix + "foo-bar", true},
+		{v1.DeprecatedAppArmorBetaProfileNamePrefix + "../../../foo", false},
+		{v1.DeprecatedAppArmorBetaProfileNamePrefix + "foo/../bar", false},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

This PR addresses two related issues in AppArmor localhostProfile validation:

**Bug fix:** `ValidateAppArmorProfileFormat` (the deprecated annotation API)
used `strings.Contains(profilePath, "..")` to reject path traversal.
This check incorrectly rejected valid profile names that contain `..`
as part of the name (e.g. `my..profile`).

**Hardening / consistency:** The field API (`ValidateAppArmorProfileField`)
already uses `validatePathNoBacksteps()`, which correctly treats `..` only
as a path component. This PR aligns the annotation API with the same logic.

## Which issue(s) this PR fixes

Ref: #64841

## Does this PR introduce a user-facing change?

```release-note
AppArmor localhostProfile validation no longer rejects profile names
containing '..' as part of the name (e.g. 'my..profile').