### PR TITLE
kubelet: sync parent directory after checkpoint file rename for crash durability

### DIFF
--- a/pkg/kubelet/util/store/filestore.go
+++ b/pkg/kubelet/util/store/filestore.go
@@ -147,7 +147,23 @@ func writeFile(fs utilfs.Filesystem, path string, data []byte) (retErr error) {
 		return err
 	}
 
-	return fs.Rename(tmpPath, path)
+	if err := fs.Rename(tmpPath, path); err != nil {
+		return err
+	}
+
+	return syncDirectory(fs, filepath.Dir(path))
+}
+
+func syncDirectory(_ utilfs.Filesystem, dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return nil
+	}
+	err = d.Sync()
+	if closeErr := d.Close(); err == nil {
+		err = closeErr
+	}
+	return err
 }
 
 func removePath(fs utilfs.Filesystem, path string) error {

--- a/pkg/kubelet/util/store/filestore_test.go
+++ b/pkg/kubelet/util/store/filestore_test.go
@@ -31,6 +31,16 @@ func TestFileStore(t *testing.T) {
 	testStore(t, store)
 }
 
+func TestFileStoreRealFS(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewFileStore(dir, &filesystem.DefaultFs{})
+	require.NoError(t, err)
+	require.NoError(t, store.Write("testkey", []byte("testdata")))
+	data, err := store.Read("testkey")
+	require.NoError(t, err)
+	assert.Equal(t, "testdata", string(data))
+}
+
 func testStore(t *testing.T, store Store) {
 	testCases := []struct {
 		key       string


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The checkpoint file store writes atomically via temp file + fsync + rename, but doesn't sync the parent directory after the rename. Without a directory fsync, the rename metadata may not be persisted on an unclean shutdown, which can result in a missing or corrupt checkpoint file on recovery.

This adds a directory fsync after the rename in writeFile to make the write fully durable. This fixes the root cause for all checkpoint users (allocation, CPU manager, memory manager, device manager) rather than just handling corruption after the fact.

#### Which issue(s) this PR is related to:

Fixes #135711

#### Special notes for your reviewer:

Pivoted approach based on review feedback from @natasha41575 — instead of gracefully handling corrupt checkpoints on read, this fixes the write path to prevent corruption in the first place by ensuring the rename is durable.

#### Does this PR introduce a user-facing change?

```release-note
kubelet: Fixed checkpoint file durability by syncing the parent directory after rename, preventing potential corruption on unclean shutdown.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

This PR was written in part with the assistance of generative AI.