### PR TITLE
apimachinery: fix YAML stream splitter dropping %YAML directives

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
@@ -394,6 +394,25 @@ type YAMLReader struct {
 	reader Reader
 }
 
+// isYAMLDirective returns true if b only contains YAML directives
+// (lines beginning with '%'), comments, or blank lines.
+func isYAMLDirective(b []byte) bool {
+	for _, line := range strings.Split(string(b), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if len(trimmed) == 0 {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "%") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
 func NewYAMLReader(r *bufio.Reader) *YAMLReader {
 	return &YAMLReader{
 		reader: &LineReader{reader: r},
@@ -421,6 +440,16 @@ func (r *YAMLReader) Read() ([]byte, error) {
 				}
 			}
 			if buffer.Len() != 0 {
+				// If the buffer only contains YAML directives (lines starting
+				// with '%', e.g. %YAML 1.1 or %TAG), this --- is the required
+				// document start marker and must stay with the directives.
+				if isYAMLDirective(buffer.Bytes()) {
+					buffer.Write(line)
+					if err == io.EOF { //nolint:errorlint
+						return buffer.Bytes(), nil
+					}
+					continue
+				}
 				return buffer.Bytes(), nil
 			}
 			if err == io.EOF { //nolint:errorlint

--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
@@ -244,6 +244,65 @@ stuff: 3
 	}
 }
 
+func TestDecodeYAMLWithDirective(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "YAML 1.1 directive with content",
+			input: "%YAML 1.1\n---\nstuff: 1\n",
+			want:  `yaml.generic{"stuff":1}`,
+		},
+		{
+			name:  "TAG directive with content",
+			input: "%TAG !e! tag:example.com,2000:\n---\nstuff: 2\n",
+			want:  `yaml.generic{"stuff":2}`,
+		},
+		{
+			name:  "directive followed by second document",
+			input: "%YAML 1.1\n---\nstuff: 1\n---\nstuff: 2\n",
+			want:  `yaml.generic{"stuff":1}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewYAMLToJSONDecoder(bytes.NewReader([]byte(tt.input)))
+			obj := generic{}
+			if err := s.Decode(&obj); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if fmt.Sprintf("%#v", obj) != tt.want {
+				t.Errorf("expected %s, got %#v", tt.want, obj)
+			}
+		})
+	}
+}
+
+func TestYAMLReaderWithDirective(t *testing.T) {
+	input := "%YAML 1.1\n---\nstuff: 1\n---\nother: 2\n"
+	reader := NewYAMLReader(bufio.NewReader(bytes.NewReader([]byte(input))))
+
+	doc1, err := reader.Read()
+	if err != nil {
+		t.Fatalf("unexpected error reading first document: %v", err)
+	}
+	expected1 := "%YAML 1.1\n---\nstuff: 1\n"
+	if string(doc1) != expected1 {
+		t.Errorf("first document: expected %q, got %q", expected1, string(doc1))
+	}
+
+	doc2, err := reader.Read()
+	if err != nil {
+		t.Fatalf("unexpected error reading second document: %v", err)
+	}
+	expected2 := "other: 2\n"
+	if string(doc2) != expected2 {
+		t.Errorf("second document: expected %q, got %q", expected2, string(doc2))
+	}
+}
+
 func TestDecodeBrokenYAML(t *testing.T) {
 	s := NewYAMLOrJSONDecoder(bytes.NewReader([]byte(`---
 stuff: 1


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

If you put a %YAML 1.1 directive at the top of your YAML config file (which is valid per the YAML spec), kubectl apply chokes on it. The YAML stream splitter treats --- as a document boundary no matter what, so it splits the directive into its own "document" and the actual content into another.

The fix makes the splitter recognize when the buffer only has directives (%YAML, %TAG) and keeps the following --- with them instead of splitting there.

Tested on a kind cluster with both single and multi document YAML files using %YAML 1.1 directive. Before the fix kubectl apply errors out, after the fix it applies cleanly.

#### Which issue(s) this PR is related to:

Fixes #135998

#### Special notes for your reviewer:

Previous PR #136020 had the same fix but got stale botted.

#### Does this PR introduce a user-facing change?

```release-note
kubectl: Fixed kubectl apply failing to parse YAML files that start with a %YAML 1.1 directive.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

This PR was written in part with the assistance of generative AI.