### PR TITLE
Remove deprecated wait helper usage in cache and CSI

### DIFF
--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -492,7 +493,13 @@ func (c *csiAttacher) waitForVolumeAttachDetachStatusWithLister(spec *volume.Spe
 		jitter        = 0.1
 		clock         = &clock.RealClock{}
 	)
-	backoffMgr := wait.NewExponentialBackoffManager(initBackoff, maxBackoff, resetDuration, backoffFactor, jitter, clock)
+	delay := wait.Backoff{
+		Duration: initBackoff,
+		Cap:      maxBackoff,
+		Steps:    math.MaxInt,
+		Factor:   backoffFactor,
+		Jitter:   jitter,
+	}.DelayWithReset(clock, resetDuration)
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -505,9 +512,8 @@ func (c *csiAttacher) waitForVolumeAttachDetachStatusWithLister(spec *volume.Spe
 	}
 
 	for {
-		t := backoffMgr.Backoff()
 		select {
-		case <-t.C():
+		case <-clock.After(delay()):
 			successful, err := verifyStatus()
 			if err != nil {
 				return err
@@ -516,7 +522,6 @@ func (c *csiAttacher) waitForVolumeAttachDetachStatusWithLister(spec *volume.Spe
 				return nil
 			}
 		case <-ctx.Done():
-			t.Stop()
 			klog.Error(log("%s timeout after %v [volume=%v; attachment.ID=%v]", operation, timeout, volumeHandle, attachID))
 			return fmt.Errorf("timed out waiting for external-attacher of %v CSI driver to %v volume %v", csiDriverName, strings.ToLower(operation), volumeHandle)
 		}

--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -512,8 +512,9 @@ func (c *csiAttacher) waitForVolumeAttachDetachStatusWithLister(spec *volume.Spe
 	}
 
 	for {
+		timer := clock.NewTimer(delay())
 		select {
-		case <-clock.After(delay()):
+		case <-timer.C():
 			successful, err := verifyStatus()
 			if err != nil {
 				return err
@@ -522,6 +523,12 @@ func (c *csiAttacher) waitForVolumeAttachDetachStatusWithLister(spec *volume.Spe
 				return nil
 			}
 		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C():
+				default:
+				}
+			}
 			klog.Error(log("%s timeout after %v [volume=%v; attachment.ID=%v]", operation, timeout, volumeHandle, attachID))
 			return fmt.Errorf("timed out waiting for external-attacher of %v CSI driver to %v volume %v", csiDriverName, strings.ToLower(operation), volumeHandle)
 		}

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -414,16 +414,15 @@ func WaitForNamedCacheSyncWithContext(ctx context.Context, cacheSyncs ...Informe
 // if the controller should shutdown
 // callers should prefer WaitForNamedCacheSync()
 func WaitForCacheSync(stopCh <-chan struct{}, cacheSyncs ...InformerSynced) bool {
-	err := wait.PollImmediateUntil(syncedPollPeriod,
-		func() (bool, error) {
+	err := wait.PollUntilContextCancel(wait.ContextForChannel(stopCh), syncedPollPeriod, true,
+		func(context.Context) (bool, error) {
 			for _, syncFunc := range cacheSyncs {
 				if !syncFunc() {
 					return false, nil
 				}
 			}
 			return true, nil
-		},
-		stopCh)
+		})
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Replaces two deprecated wait helper usages with their newer context/backoff alternatives:

- `WaitForCacheSync` now uses `wait.PollUntilContextCancel` with `wait.ContextForChannel(stopCh)`.
- CSI attach/detach status polling now uses `wait.Backoff.DelayWithReset` instead of `wait.NewExponentialBackoffManager`.

#### Which issue(s) this PR addresses:
Addresses #138353
Addresses #137068

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
None

#### Testing
- `go test ./staging/src/k8s.io/client-go/tools/cache`
- `go test ./pkg/volume/csi`