### PR TITLE
api: skip null values in ResourceList JSON deserialization

### DIFF
--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -17,6 +17,9 @@ limitations under the License.
 package v1
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -7017,6 +7020,33 @@ const (
 
 // ResourceList is a set of (resource name, quantity) pairs.
 type ResourceList map[ResourceName]resource.Quantity
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+// Null values for individual resources are skipped instead of being
+// deserialized as zero-value Quantity, ensuring consistent behavior
+// between kubectl create and kubectl apply.
+func (rl *ResourceList) UnmarshalJSON(data []byte) error {
+	var raw map[ResourceName]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if raw == nil {
+		return nil
+	}
+	result := make(ResourceList, len(raw))
+	for name, val := range raw {
+		if string(val) == "null" {
+			continue
+		}
+		var q resource.Quantity
+		if err := json.Unmarshal(val, &q); err != nil {
+			return fmt.Errorf("failed to unmarshal resource %q: %w", name, err)
+		}
+		result[name] = q
+	}
+	*rl = result
+	return nil
+}
 
 // +genclient
 // +genclient:nonNamespaced

--- a/staging/src/k8s.io/api/core/v1/types_test.go
+++ b/staging/src/k8s.io/api/core/v1/types_test.go
@@ -17,9 +17,12 @@ limitations under the License.
 package v1
 
 import (
+	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // Test_ServiceSpecRemovedFieldProtobufNumberReservation tests that the reserved protobuf field numbers
@@ -56,6 +59,74 @@ func TestEphemeralContainer(t *testing.T) {
 		if !reflect.DeepEqual(ephemeralField, containerField) {
 			t.Errorf("field %v differs:\n\t%#v\n\t%#v", ephemeralField.Name, ephemeralField, containerField)
 		}
+	}
+}
+
+func TestResourceListUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected ResourceList
+	}{
+		{
+			name:  "null value is skipped",
+			input: `{"cpu": null, "memory": "128Mi"}`,
+			expected: ResourceList{
+				ResourceMemory: resource.MustParse("128Mi"),
+			},
+		},
+		{
+			name:  "all null values",
+			input: `{"cpu": null, "memory": null}`,
+			expected: ResourceList{},
+		},
+		{
+			name:  "no null values",
+			input: `{"cpu": "100m", "memory": "128Mi"}`,
+			expected: ResourceList{
+				ResourceCPU:    resource.MustParse("100m"),
+				ResourceMemory: resource.MustParse("128Mi"),
+			},
+		},
+		{
+			name:     "null object",
+			input:    `null`,
+			expected: nil,
+		},
+		{
+			name:     "empty object",
+			input:    `{}`,
+			expected: ResourceList{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rl ResourceList
+			if err := json.Unmarshal([]byte(tt.input), &rl); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.expected == nil {
+				if rl != nil {
+					t.Errorf("expected nil, got %v", rl)
+				}
+				return
+			}
+			if len(rl) != len(tt.expected) {
+				t.Errorf("expected %d entries, got %d: %v", len(tt.expected), len(rl), rl)
+				return
+			}
+			for k, v := range tt.expected {
+				got, ok := rl[k]
+				if !ok {
+					t.Errorf("missing key %q", k)
+					continue
+				}
+				if !got.Equal(v) {
+					t.Errorf("key %q: expected %v, got %v", k, v, got)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind api-change
/sig api-machinery

#### What this PR does / why we need it

Adds a custom `UnmarshalJSON` to `ResourceList` that skips null-valued entries instead of deserializing them as zero-value Quantity. Previously, `kubectl create` with a YAML containing `cpu: null` in resource limits would convert it to `cpu: 0`, causing a validation error or incorrect resource allocation. `kubectl apply` already handled this correctly by stripping nulls during strategic merge patch, so this makes the behavior consistent.

#### Which issue(s) this PR fixes

Fixes #135423

#### Special notes for your reviewer

A previous attempt at this fix was made in #135468 but went stale. The approach is the same (custom UnmarshalJSON on ResourceList) but with a clean commit history and passing CI.

This is an API-level change in the deserialization behavior of `ResourceList`. Null values in JSON are now treated as "field not set" rather than "field set to zero." This matches the existing behavior of `kubectl apply` and the semantic intent of null in JSON.

#### Does this PR introduce a user-facing change?

```release-note
Fixed an inconsistency where kubectl create would convert null resource values (e.g., cpu: null) to zero instead of treating them as unset, causing validation errors that did not occur with kubectl apply.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancements Proposals), usage docs, etc.

N/A

This PR was written in part with the assistance of generative AI.