### PR TITLE
Fix 130069 fix context todo kubelet cm - part 3

### DIFF
--- a/pkg/kubelet/apis/podresources/server_v1.go
+++ b/pkg/kubelet/apis/podresources/server_v1.go
@@ -62,6 +62,8 @@ func (p *v1PodResourcesServer) List(ctx context.Context, req *podresourcesv1.Lis
 	metrics.PodResourcesEndpointRequestsTotalCount.WithLabelValues("v1").Inc()
 	metrics.PodResourcesEndpointRequestsListCount.WithLabelValues("v1").Inc()
 
+	logger := klog.FromContext(ctx)
+
 	var pods []*v1.Pod
 	if p.useActivePods {
 		// GetActivePods already filters out terminal pods, so no need for additional filtering.
@@ -86,11 +88,11 @@ func (p *v1PodResourcesServer) List(ctx context.Context, req *podresourcesv1.Lis
 				continue
 			}
 
-			pRes.Containers = append(pRes.Containers, p.getContainerResources(pod, &container))
+			pRes.Containers = append(pRes.Containers, p.getContainerResources(logger, pod, &container))
 		}
 
 		for _, container := range pod.Spec.Containers {
-			pRes.Containers = append(pRes.Containers, p.getContainerResources(pod, &container))
+			pRes.Containers = append(pRes.Containers, p.getContainerResources(logger, pod, &container))
 		}
 		podResources[i] = &pRes
 	}
@@ -120,6 +122,8 @@ func (p *v1PodResourcesServer) Get(ctx context.Context, req *podresourcesv1.GetP
 	metrics.PodResourcesEndpointRequestsTotalCount.WithLabelValues("v1").Inc()
 	metrics.PodResourcesEndpointRequestsGetCount.WithLabelValues("v1").Inc()
 
+	logger := klog.FromContext(ctx)
+
 	pod, exist := p.podsProvider.GetPodByName(req.PodNamespace, req.PodName)
 	if !exist {
 		metrics.PodResourcesEndpointErrorsGetCount.WithLabelValues("v1").Inc()
@@ -138,11 +142,11 @@ func (p *v1PodResourcesServer) Get(ctx context.Context, req *podresourcesv1.GetP
 			continue
 		}
 
-		podResources.Containers = append(podResources.Containers, p.getContainerResources(pod, &container))
+		podResources.Containers = append(podResources.Containers, p.getContainerResources(logger, pod, &container))
 	}
 
 	for _, container := range pod.Spec.Containers {
-		podResources.Containers = append(podResources.Containers, p.getContainerResources(pod, &container))
+		podResources.Containers = append(podResources.Containers, p.getContainerResources(logger, pod, &container))
 	}
 
 	response := &podresourcesv1.GetPodResourcesResponse{
@@ -151,13 +155,13 @@ func (p *v1PodResourcesServer) Get(ctx context.Context, req *podresourcesv1.GetP
 	return response, nil
 }
 
-func (p *v1PodResourcesServer) getContainerResources(pod *v1.Pod, container *v1.Container) *podresourcesv1.ContainerResources {
+func (p *v1PodResourcesServer) getContainerResources(logger klog.Logger, pod *v1.Pod, container *v1.Container) *podresourcesv1.ContainerResources {
 	containerResources := &podresourcesv1.ContainerResources{
 		Name:             container.Name,
 		Devices:          p.devicesProvider.GetDevices(string(pod.UID), container.Name),
 		CpuIds:           p.cpusProvider.GetCPUs(string(pod.UID), container.Name),
 		Memory:           p.memoryProvider.GetMemory(string(pod.UID), container.Name),
-		DynamicResources: p.dynamicResourcesProvider.GetDynamicResources(pod, container),
+		DynamicResources: p.dynamicResourcesProvider.GetDynamicResources(logger, pod, container),
 	}
 	return containerResources
 }

--- a/pkg/kubelet/apis/podresources/server_v1_test.go
+++ b/pkg/kubelet/apis/podresources/server_v1_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestListPodResourcesV1(t *testing.T) {
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 	podName := "pod-name"
 	podNamespace := "pod-namespace"
 	podUID := types.UID("pod-uid")
@@ -223,7 +223,7 @@ func TestListPodResourcesV1(t *testing.T) {
 			mockDevicesProvider.EXPECT().GetDevices(string(podUID), containerName).Return(tc.devices).Maybe()
 			mockCPUsProvider.EXPECT().GetCPUs(string(podUID), containerName).Return(tc.cpus).Maybe()
 			mockMemoryProvider.EXPECT().GetMemory(string(podUID), containerName).Return(tc.memory).Maybe()
-			mockDynamicResourcesProvider.EXPECT().GetDynamicResources(pods[0], &containers[0]).Return(tc.dynamicResources).Maybe()
+			mockDynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pods[0], &containers[0]).Return(tc.dynamicResources).Maybe()
 			mockDevicesProvider.EXPECT().UpdateAllocatedDevices().Return().Maybe()
 			mockCPUsProvider.EXPECT().GetAllocatableCPUs().Return([]int64{}).Maybe()
 			mockDevicesProvider.EXPECT().GetAllocatableDevices().Return([]*podresourcesapi.ContainerDevices{}).Maybe()
@@ -289,7 +289,7 @@ func collectNamespacedNamesFromPodResources(prs []*podresourcesapi.PodResources)
 }
 
 func TestListPodResourcesUsesOnlyActivePodsV1(t *testing.T) {
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 	numaID := int64(1)
 
 	// we abuse the fact that we don't care about the assignments,
@@ -380,7 +380,7 @@ func TestListPodResourcesUsesOnlyActivePodsV1(t *testing.T) {
 			mockCPUsProvider.EXPECT().GetAllocatableCPUs().Return([]int64{}).Maybe()
 			mockDevicesProvider.EXPECT().GetAllocatableDevices().Return([]*podresourcesapi.ContainerDevices{}).Maybe()
 			mockMemoryProvider.EXPECT().GetAllocatableMemory().Return([]*podresourcesapi.ContainerMemory{}).Maybe()
-			mockDynamicResourcesProvider.EXPECT().GetDynamicResources(mock.Anything, mock.Anything).Return([]*podresourcesapi.DynamicResource{}).Maybe()
+			mockDynamicResourcesProvider.EXPECT().GetDynamicResources(logger, mock.Anything, mock.Anything).Return([]*podresourcesapi.DynamicResource{}).Maybe()
 
 			providers := PodResourcesProviders{
 				Pods:             mockPodsProvider,
@@ -404,7 +404,7 @@ func TestListPodResourcesUsesOnlyActivePodsV1(t *testing.T) {
 }
 
 func TestListPodResourcesWithInitContainersV1(t *testing.T) {
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 	podName := "pod-name"
 	podNamespace := "pod-namespace"
 	podUID := types.UID("pod-uid")
@@ -482,7 +482,7 @@ func TestListPodResourcesWithInitContainersV1(t *testing.T) {
 				devicesProvider.EXPECT().GetDevices(string(podUID), containerName).Return(devs).Maybe()
 				cpusProvider.EXPECT().GetCPUs(string(podUID), containerName).Return(cpus).Maybe()
 				memoryProvider.EXPECT().GetMemory(string(podUID), containerName).Return(memory).Maybe()
-				dynamicResourcesProvider.EXPECT().GetDynamicResources(pods[0], &pods[0].Spec.Containers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
+				dynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pods[0], &pods[0].Spec.Containers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
 
 			},
 			expectedResponse: &podresourcesapi.ListPodResourcesResponse{
@@ -534,12 +534,12 @@ func TestListPodResourcesWithInitContainersV1(t *testing.T) {
 				devicesProvider.EXPECT().GetDevices(string(podUID), initContainerName).Return(devs).Maybe()
 				cpusProvider.EXPECT().GetCPUs(string(podUID), initContainerName).Return(cpus).Maybe()
 				memoryProvider.EXPECT().GetMemory(string(podUID), initContainerName).Return(memory).Maybe()
-				dynamicResourcesProvider.EXPECT().GetDynamicResources(pods[0], &pods[0].Spec.InitContainers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
+				dynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pods[0], &pods[0].Spec.InitContainers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
 
 				devicesProvider.EXPECT().GetDevices(string(podUID), containerName).Return(devs).Maybe()
 				cpusProvider.EXPECT().GetCPUs(string(podUID), containerName).Return(cpus).Maybe()
 				memoryProvider.EXPECT().GetMemory(string(podUID), containerName).Return(memory).Maybe()
-				dynamicResourcesProvider.EXPECT().GetDynamicResources(pods[0], &pods[0].Spec.Containers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
+				dynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pods[0], &pods[0].Spec.Containers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
 
 			},
 			expectedResponse: &podresourcesapi.ListPodResourcesResponse{
@@ -891,7 +891,7 @@ func TestAllocatableResources(t *testing.T) {
 }
 
 func TestGetPodResourcesV1(t *testing.T) {
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 	podName := "pod-name"
 	podNamespace := "pod-namespace"
 	podUID := types.UID("pod-uid")
@@ -1033,7 +1033,7 @@ func TestGetPodResourcesV1(t *testing.T) {
 			mockDevicesProvider.EXPECT().GetDevices(string(podUID), containerName).Return(tc.devices).Maybe()
 			mockCPUsProvider.EXPECT().GetCPUs(string(podUID), containerName).Return(tc.cpus).Maybe()
 			mockMemoryProvider.EXPECT().GetMemory(string(podUID), containerName).Return(tc.memory).Maybe()
-			mockDynamicResourcesProvider.EXPECT().GetDynamicResources(pod, &containers[0]).Return(tc.dynamicResources).Maybe()
+			mockDynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pod, &containers[0]).Return(tc.dynamicResources).Maybe()
 			mockDevicesProvider.EXPECT().UpdateAllocatedDevices().Return().Maybe()
 			mockCPUsProvider.EXPECT().GetAllocatableCPUs().Return([]int64{}).Maybe()
 			mockDevicesProvider.EXPECT().GetAllocatableDevices().Return([]*podresourcesapi.ContainerDevices{}).Maybe()
@@ -1069,7 +1069,7 @@ func TestGetPodResourcesV1(t *testing.T) {
 }
 
 func TestGetPodResourcesWithInitContainersV1(t *testing.T) {
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 	podName := "pod-name"
 	podNamespace := "pod-namespace"
 	podUID := types.UID("pod-uid")
@@ -1145,7 +1145,7 @@ func TestGetPodResourcesWithInitContainersV1(t *testing.T) {
 				devicesProvider.EXPECT().GetDevices(string(podUID), containerName).Return(devs).Maybe()
 				cpusProvider.EXPECT().GetCPUs(string(podUID), containerName).Return(cpus).Maybe()
 				memoryProvider.EXPECT().GetMemory(string(podUID), containerName).Return(memory).Maybe()
-				dynamicResourcesProvider.EXPECT().GetDynamicResources(pod, &pod.Spec.Containers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
+				dynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pod, &pod.Spec.Containers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
 
 			},
 			expectedResponse: &podresourcesapi.GetPodResourcesResponse{
@@ -1193,13 +1193,12 @@ func TestGetPodResourcesWithInitContainersV1(t *testing.T) {
 				devicesProvider.EXPECT().GetDevices(string(podUID), initContainerName).Return(devs).Maybe()
 				cpusProvider.EXPECT().GetCPUs(string(podUID), initContainerName).Return(cpus).Maybe()
 				memoryProvider.EXPECT().GetMemory(string(podUID), initContainerName).Return(memory).Maybe()
-				dynamicResourcesProvider.EXPECT().GetDynamicResources(pod, &pod.Spec.InitContainers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
+				dynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pod, &pod.Spec.InitContainers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
 
 				devicesProvider.EXPECT().GetDevices(string(podUID), containerName).Return(devs).Maybe()
 				cpusProvider.EXPECT().GetCPUs(string(podUID), containerName).Return(cpus).Maybe()
 				memoryProvider.EXPECT().GetMemory(string(podUID), containerName).Return(memory).Maybe()
-				dynamicResourcesProvider.EXPECT().GetDynamicResources(pod, &pod.Spec.Containers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
-
+				dynamicResourcesProvider.EXPECT().GetDynamicResources(logger, pod, &pod.Spec.Containers[0]).Return([]*podresourcesapi.DynamicResource{}).Maybe()
 			},
 			expectedResponse: &podresourcesapi.GetPodResourcesResponse{
 				PodResources: &podresourcesapi.PodResources{

--- a/pkg/kubelet/apis/podresources/testing/mocks.go
+++ b/pkg/kubelet/apis/podresources/testing/mocks.go
@@ -23,6 +23,7 @@ package testing
 import (
 	mock "github.com/stretchr/testify/mock"
 	v10 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 	"k8s.io/kubelet/pkg/apis/podresources/v1"
 )
 
@@ -670,16 +671,16 @@ func (_m *MockDynamicResourcesProvider) EXPECT() *MockDynamicResourcesProvider_E
 }
 
 // GetDynamicResources provides a mock function for the type MockDynamicResourcesProvider
-func (_mock *MockDynamicResourcesProvider) GetDynamicResources(pod *v10.Pod, container *v10.Container) []*v1.DynamicResource {
-	ret := _mock.Called(pod, container)
+func (_mock *MockDynamicResourcesProvider) GetDynamicResources(logger klog.Logger, pod *v10.Pod, container *v10.Container) []*v1.DynamicResource {
+	ret := _mock.Called(logger, pod, container)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetDynamicResources")
 	}
 
 	var r0 []*v1.DynamicResource
-	if returnFunc, ok := ret.Get(0).(func(*v10.Pod, *v10.Container) []*v1.DynamicResource); ok {
-		r0 = returnFunc(pod, container)
+	if returnFunc, ok := ret.Get(0).(func(klog.Logger, *v10.Pod, *v10.Container) []*v1.DynamicResource); ok {
+		r0 = returnFunc(logger, pod, container)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*v1.DynamicResource)
@@ -694,25 +695,31 @@ type MockDynamicResourcesProvider_GetDynamicResources_Call struct {
 }
 
 // GetDynamicResources is a helper method to define mock.On call
+//   - logger klog.Logger
 //   - pod *v10.Pod
 //   - container *v10.Container
-func (_e *MockDynamicResourcesProvider_Expecter) GetDynamicResources(pod interface{}, container interface{}) *MockDynamicResourcesProvider_GetDynamicResources_Call {
-	return &MockDynamicResourcesProvider_GetDynamicResources_Call{Call: _e.mock.On("GetDynamicResources", pod, container)}
+func (_e *MockDynamicResourcesProvider_Expecter) GetDynamicResources(logger interface{}, pod interface{}, container interface{}) *MockDynamicResourcesProvider_GetDynamicResources_Call {
+	return &MockDynamicResourcesProvider_GetDynamicResources_Call{Call: _e.mock.On("GetDynamicResources", logger, pod, container)}
 }
 
-func (_c *MockDynamicResourcesProvider_GetDynamicResources_Call) Run(run func(pod *v10.Pod, container *v10.Container)) *MockDynamicResourcesProvider_GetDynamicResources_Call {
+func (_c *MockDynamicResourcesProvider_GetDynamicResources_Call) Run(run func(logger klog.Logger, pod *v10.Pod, container *v10.Container)) *MockDynamicResourcesProvider_GetDynamicResources_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *v10.Pod
+		var arg0 klog.Logger
 		if args[0] != nil {
-			arg0 = args[0].(*v10.Pod)
+			arg0 = args[0].(klog.Logger)
 		}
-		var arg1 *v10.Container
+		var arg1 *v10.Pod
 		if args[1] != nil {
-			arg1 = args[1].(*v10.Container)
+			arg1 = args[1].(*v10.Pod)
+		}
+		var arg2 *v10.Container
+		if args[2] != nil {
+			arg2 = args[2].(*v10.Container)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -723,7 +730,7 @@ func (_c *MockDynamicResourcesProvider_GetDynamicResources_Call) Return(dynamicR
 	return _c
 }
 
-func (_c *MockDynamicResourcesProvider_GetDynamicResources_Call) RunAndReturn(run func(pod *v10.Pod, container *v10.Container) []*v1.DynamicResource) *MockDynamicResourcesProvider_GetDynamicResources_Call {
+func (_c *MockDynamicResourcesProvider_GetDynamicResources_Call) RunAndReturn(run func(logger klog.Logger, pod *v10.Pod, container *v10.Container) []*v1.DynamicResource) *MockDynamicResourcesProvider_GetDynamicResources_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/kubelet/apis/podresources/types.go
+++ b/pkg/kubelet/apis/podresources/types.go
@@ -19,6 +19,7 @@ package podresources
 
 import (
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
 )
 
@@ -56,7 +57,7 @@ type MemoryProvider interface {
 
 type DynamicResourcesProvider interface {
 	// GetDynamicResources returns information about dynamic resources assigned to pods and containers
-	GetDynamicResources(pod *v1.Pod, container *v1.Container) []*podresourcesapi.DynamicResource
+	GetDynamicResources(logger klog.Logger, pod *v1.Pod, container *v1.Container) []*podresourcesapi.DynamicResource
 }
 
 type PodResourcesProviders struct {

--- a/pkg/kubelet/cm/container_manager.go
+++ b/pkg/kubelet/cm/container_manager.go
@@ -93,12 +93,12 @@ type ContainerManager interface {
 	GetNodeAllocatableReservation() v1.ResourceList
 
 	// GetCapacity returns the amount of compute resources tracked by container manager available on the node.
-	GetCapacity(localStorageCapacityIsolation bool) v1.ResourceList
+	GetCapacity(logger klog.Logger, localStorageCapacityIsolation bool) v1.ResourceList
 
 	// GetDevicePluginResourceCapacity returns the node capacity (amount of total device plugin resources),
 	// node allocatable (amount of total healthy resources reported by device plugin),
 	// and inactive device plugin resources previously registered on the node.
-	GetDevicePluginResourceCapacity() (v1.ResourceList, v1.ResourceList, []string)
+	GetDevicePluginResourceCapacity(logger klog.Logger) (v1.ResourceList, v1.ResourceList, []string)
 
 	// UpdateQOSCgroups performs housekeeping updates to ensure that the top
 	// level QoS containers have their desired state in a thread-safe way
@@ -115,7 +115,7 @@ type ContainerManager interface {
 	// any registered device plugin resource
 	UpdatePluginResources(*schedulerframework.NodeInfo, *lifecycle.PodAdmitAttributes) error
 
-	InternalContainerLifecycle() InternalContainerLifecycle
+	InternalContainerLifecycle(logger klog.Logger) InternalContainerLifecycle
 
 	// GetPodCgroupRoot returns the cgroup which contains all pods.
 	GetPodCgroupRoot() string
@@ -134,7 +134,7 @@ type ContainerManager interface {
 	ShouldResetExtendedResourceCapacity() bool
 
 	// GetAllocateResourcesPodAdmitHandler returns an instance of a PodAdmitHandler responsible for allocating pod resources.
-	GetAllocateResourcesPodAdmitHandler() lifecycle.PodAdmitHandler
+	GetAllocateResourcesPodAdmitHandler(logger klog.Logger) lifecycle.PodAdmitHandler
 
 	// GetNodeAllocatableAbsolute returns the absolute value of Node Allocatable which is primarily useful for enforcement.
 	GetNodeAllocatableAbsolute() v1.ResourceList
@@ -157,10 +157,10 @@ type ContainerManager interface {
 
 	// PodHasExclusiveCPUs returns true if the provided pod has containers with exclusive CPUs,
 	// This means that at least one sidecar container or one app container has exclusive CPUs allocated.
-	PodHasExclusiveCPUs(pod *v1.Pod) bool
+	PodHasExclusiveCPUs(logger klog.Logger, pod *v1.Pod) bool
 
 	// ContainerHasExclusiveCPUs returns true if the provided container in the pod has exclusive cpu
-	ContainerHasExclusiveCPUs(pod *v1.Pod, container *v1.Container) bool
+	ContainerHasExclusiveCPUs(logger klog.Logger, pod *v1.Pod, container *v1.Container) bool
 
 	// Implements the PodResources Provider API
 	podresources.CPUsProvider

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -416,11 +416,7 @@ func (cm *containerManagerImpl) NewPodContainerManager() PodContainerManager {
 	}
 }
 
-func (cm *containerManagerImpl) PodHasExclusiveCPUs(pod *v1.Pod) bool {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
-
+func (cm *containerManagerImpl) PodHasExclusiveCPUs(logger klog.Logger, pod *v1.Pod) bool {
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.PodLevelResourceManagers) && resourcehelper.IsPodLevelResourcesSet(pod) {
 		for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
 			if cm.cpuManager.GetResourceIsolationLevel(pod, &container) != cmqos.ResourceIsolationContainer {
@@ -435,11 +431,7 @@ func (cm *containerManagerImpl) PodHasExclusiveCPUs(pod *v1.Pod) bool {
 	return podHasExclusiveCPUs(logger, cm.cpuManager, pod)
 }
 
-func (cm *containerManagerImpl) ContainerHasExclusiveCPUs(pod *v1.Pod, container *v1.Container) bool {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
-
+func (cm *containerManagerImpl) ContainerHasExclusiveCPUs(logger klog.Logger, pod *v1.Pod, container *v1.Container) bool {
 	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.PodLevelResourceManagers) {
 		if cm.cpuManager.GetResourceIsolationLevel(pod, container) != cmqos.ResourceIsolationContainer {
 			return false
@@ -452,7 +444,7 @@ func (cm *containerManagerImpl) ContainerHasExclusiveCPUs(pod *v1.Pod, container
 	return containerHasExclusiveCPUs(logger, cm.cpuManager, pod, container)
 }
 
-func (cm *containerManagerImpl) InternalContainerLifecycle() InternalContainerLifecycle {
+func (cm *containerManagerImpl) InternalContainerLifecycle(_ klog.Logger) InternalContainerLifecycle {
 	return &internalContainerLifecycleImpl{cm.cpuManager, cm.memoryManager, cm.topologyManager}
 }
 
@@ -782,7 +774,7 @@ func (cm *containerManagerImpl) UpdatePluginResources(node *schedulerframework.N
 	return cm.deviceManager.UpdatePluginResources(node, attrs)
 }
 
-func (cm *containerManagerImpl) GetAllocateResourcesPodAdmitHandler() lifecycle.PodAdmitHandler {
+func (cm *containerManagerImpl) GetAllocateResourcesPodAdmitHandler(_ klog.Logger) lifecycle.PodAdmitHandler {
 	return cm.topologyManager
 }
 
@@ -971,12 +963,9 @@ func isKernelPid(pid int) bool {
 
 // GetCapacity returns node capacity data for "cpu", "memory", "ephemeral-storage", and "huge-pages*"
 // At present this method is only invoked when introspecting ephemeral storage
-func (cm *containerManagerImpl) GetCapacity(localStorageCapacityIsolation bool) v1.ResourceList {
+func (cm *containerManagerImpl) GetCapacity(logger klog.Logger, localStorageCapacityIsolation bool) v1.ResourceList {
 	cm.RLock()
 	defer cm.RUnlock()
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
 	if localStorageCapacityIsolation {
 		// We store allocatable ephemeral-storage in the capacity property once we Start() the container manager
 		if _, ok := cm.capacity[v1.ResourceEphemeralStorage]; !ok {
@@ -1002,8 +991,8 @@ func (cm *containerManagerImpl) GetCapacity(localStorageCapacityIsolation bool) 
 	return cm.capacity
 }
 
-func (cm *containerManagerImpl) GetDevicePluginResourceCapacity() (v1.ResourceList, v1.ResourceList, []string) {
-	return cm.deviceManager.GetCapacity()
+func (cm *containerManagerImpl) GetDevicePluginResourceCapacity(logger klog.Logger) (v1.ResourceList, v1.ResourceList, []string) {
+	return cm.deviceManager.GetCapacity(logger)
 }
 
 func (cm *containerManagerImpl) GetDevices(podUID, containerName string) []*podresourcesapi.ContainerDevices {
@@ -1048,10 +1037,7 @@ func (cm *containerManagerImpl) GetAllocatableMemory() []*podresourcesapi.Contai
 	return containerMemoryFromBlock(cm.memoryManager.GetAllocatableMemory())
 }
 
-func (cm *containerManagerImpl) GetDynamicResources(pod *v1.Pod, container *v1.Container) []*podresourcesapi.DynamicResource {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
+func (cm *containerManagerImpl) GetDynamicResources(logger klog.Logger, pod *v1.Pod, container *v1.Container) []*podresourcesapi.DynamicResource {
 	if !utilfeature.DefaultFeatureGate.Enabled(kubefeatures.DynamicResourceAllocation) {
 		return []*podresourcesapi.DynamicResource{}
 	}

--- a/pkg/kubelet/cm/container_manager_linux_test.go
+++ b/pkg/kubelet/cm/container_manager_linux_test.go
@@ -214,6 +214,8 @@ func TestGetCapacity(t *testing.T) {
 	ephemeralStorageFromCapacity := int64(2000)
 	ephemeralStorageFromCadvisor := int64(8000)
 
+	logger, _ := ktesting.NewTestContext(t)
+
 	mockCadvisor := cadvisortest.NewMockInterface(t)
 	rootfs := cadvisorapi.FsInfo{
 		Capacity: 8000,
@@ -279,7 +281,7 @@ func TestGetCapacity(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			ret := c.cm.GetCapacity(!c.disablelocalStorageCapacityIsolation)
+			ret := c.cm.GetCapacity(logger, !c.disablelocalStorageCapacityIsolation)
 			if v, exists := ret[v1.ResourceEphemeralStorage]; !exists {
 				if !c.expectedNoEphemeralStorage {
 					t.Errorf("did not get any ephemeral storage data")
@@ -380,6 +382,7 @@ func TestNewPodContainerManager(t *testing.T) {
 }
 
 func TestContainerHasExclusiveCPUs(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	guaranteedQOSResources := v1.ResourceRequirements{
 		Requests: v1.ResourceList{
 			v1.ResourceCPU:    resource.MustParse("1"),
@@ -558,13 +561,14 @@ func TestContainerHasExclusiveCPUs(t *testing.T) {
 			}
 			require.NotNil(t, targetContainer, "container %s not found in pod spec", tc.containerName)
 
-			result := cm.ContainerHasExclusiveCPUs(tc.pod, targetContainer)
+			result := cm.ContainerHasExclusiveCPUs(logger, tc.pod, targetContainer)
 			assert.Equal(t, tc.expectExclusiveCPUs, result)
 		})
 	}
 }
 
 func TestPodHasExclusiveCPUs(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	testCases := []struct {
 		name                            string
 		pod                             *v1.Pod
@@ -717,7 +721,7 @@ func TestPodHasExclusiveCPUs(t *testing.T) {
 				cpuManager: mockReader,
 			}
 
-			result := cm.PodHasExclusiveCPUs(tc.pod)
+			result := cm.PodHasExclusiveCPUs(logger, tc.pod)
 			assert.Equal(t, tc.expectExclusiveCPUs, result)
 		})
 	}

--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -85,7 +85,7 @@ func (cm *containerManagerStub) GetNodeAllocatableReservation() v1.ResourceList 
 	return nil
 }
 
-func (cm *containerManagerStub) GetCapacity(localStorageCapacityIsolation bool) v1.ResourceList {
+func (cm *containerManagerStub) GetCapacity(_ klog.Logger, localStorageCapacityIsolation bool) v1.ResourceList {
 	if !localStorageCapacityIsolation {
 		return v1.ResourceList{}
 	}
@@ -105,7 +105,7 @@ func (cm *containerManagerStub) GetHealthCheckers() []healthz.HealthChecker {
 	return []healthz.HealthChecker{}
 }
 
-func (cm *containerManagerStub) GetDevicePluginResourceCapacity() (v1.ResourceList, v1.ResourceList, []string) {
+func (cm *containerManagerStub) GetDevicePluginResourceCapacity(_ klog.Logger) (v1.ResourceList, v1.ResourceList, []string) {
 	return cm.extendedPluginResources, cm.extendedPluginResources, []string{}
 }
 
@@ -129,8 +129,8 @@ func (cm *containerManagerStub) UpdatePluginResources(*schedulerframework.NodeIn
 	return nil
 }
 
-func (cm *containerManagerStub) InternalContainerLifecycle() InternalContainerLifecycle {
-	return &internalContainerLifecycleImpl{cm.cpuManager, cm.memoryManager, topologymanager.NewFakeManager()}
+func (cm *containerManagerStub) InternalContainerLifecycle(logger klog.Logger) InternalContainerLifecycle {
+	return &internalContainerLifecycleImpl{cm.cpuManager, cm.memoryManager, topologymanager.NewFakeManager(logger)}
 }
 
 func (cm *containerManagerStub) GetPodCgroupRoot() string {
@@ -149,8 +149,8 @@ func (cm *containerManagerStub) ShouldResetExtendedResourceCapacity() bool {
 	return cm.shouldResetExtendedResourceCapacity
 }
 
-func (cm *containerManagerStub) GetAllocateResourcesPodAdmitHandler() lifecycle.PodAdmitHandler {
-	return topologymanager.NewFakeManager()
+func (cm *containerManagerStub) GetAllocateResourcesPodAdmitHandler(logger klog.Logger) lifecycle.PodAdmitHandler {
+	return topologymanager.NewFakeManager(logger)
 }
 
 func (cm *containerManagerStub) UpdateAllocatedDevices() {
@@ -173,7 +173,7 @@ func (cm *containerManagerStub) GetAllocatableMemory() []*podresourcesapi.Contai
 	return nil
 }
 
-func (cm *containerManagerStub) GetDynamicResources(pod *v1.Pod, container *v1.Container) []*podresourcesapi.DynamicResource {
+func (cm *containerManagerStub) GetDynamicResources(logger klog.Logger, pod *v1.Pod, container *v1.Container) []*podresourcesapi.DynamicResource {
 	return nil
 }
 
@@ -200,11 +200,11 @@ func (cm *containerManagerStub) Updates() <-chan resourceupdates.Update {
 	return nil
 }
 
-func (cm *containerManagerStub) PodHasExclusiveCPUs(pod *v1.Pod) bool {
+func (cm *containerManagerStub) PodHasExclusiveCPUs(logger klog.Logger, pod *v1.Pod) bool {
 	return false
 }
 
-func (cm *containerManagerStub) ContainerHasExclusiveCPUs(pod *v1.Pod, container *v1.Container) bool {
+func (cm *containerManagerStub) ContainerHasExclusiveCPUs(logger klog.Logger, pod *v1.Pod, container *v1.Container) bool {
 	return false
 }
 

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -135,7 +135,7 @@ func NewContainerManager(ctx context.Context, mountUtil mount.Interface, cadviso
 		cadvisorInterface: cadvisorInterface,
 	}
 
-	cm.topologyManager = topologymanager.NewFakeManager()
+	cm.topologyManager = topologymanager.NewFakeManager(logger)
 	cm.cpuManager = cpumanager.NewFakeManager(logger)
 	cm.memoryManager = memorymanager.NewFakeManager(logger)
 
@@ -242,7 +242,7 @@ func (cm *containerManagerImpl) GetNodeAllocatableReservation() v1.ResourceList 
 	return result
 }
 
-func (cm *containerManagerImpl) GetCapacity(localStorageCapacityIsolation bool) v1.ResourceList {
+func (cm *containerManagerImpl) GetCapacity(_ klog.Logger, localStorageCapacityIsolation bool) v1.ResourceList {
 	return cm.capacity
 }
 
@@ -255,8 +255,8 @@ func (cm *containerManagerImpl) GetHealthCheckers() []healthz.HealthChecker {
 	return []healthz.HealthChecker{cm.deviceManager.GetHealthChecker()}
 }
 
-func (cm *containerManagerImpl) GetDevicePluginResourceCapacity() (v1.ResourceList, v1.ResourceList, []string) {
-	return cm.deviceManager.GetCapacity()
+func (cm *containerManagerImpl) GetDevicePluginResourceCapacity(logger klog.Logger) (v1.ResourceList, v1.ResourceList, []string) {
+	return cm.deviceManager.GetCapacity(logger)
 }
 
 func (cm *containerManagerImpl) NewPodContainerManager() PodContainerManager {
@@ -297,7 +297,7 @@ func (cm *containerManagerImpl) UpdatePluginResources(node *schedulerframework.N
 	return cm.deviceManager.UpdatePluginResources(node, attrs)
 }
 
-func (cm *containerManagerImpl) InternalContainerLifecycle() InternalContainerLifecycle {
+func (cm *containerManagerImpl) InternalContainerLifecycle(_ klog.Logger) InternalContainerLifecycle {
 	return &internalContainerLifecycleImpl{cm.cpuManager, cm.memoryManager, cm.topologyManager}
 }
 
@@ -317,7 +317,7 @@ func (cm *containerManagerImpl) ShouldResetExtendedResourceCapacity() bool {
 	return cm.deviceManager.ShouldResetExtendedResourceCapacity()
 }
 
-func (cm *containerManagerImpl) GetAllocateResourcesPodAdmitHandler() lifecycle.PodAdmitHandler {
+func (cm *containerManagerImpl) GetAllocateResourcesPodAdmitHandler(_ klog.Logger) lifecycle.PodAdmitHandler {
 	return cm.topologyManager
 }
 
@@ -357,7 +357,7 @@ func (cm *containerManagerImpl) GetNodeAllocatableAbsolute() v1.ResourceList {
 	return nil
 }
 
-func (cm *containerManagerImpl) GetDynamicResources(pod *v1.Pod, container *v1.Container) []*podresourcesapi.DynamicResource {
+func (cm *containerManagerImpl) GetDynamicResources(logger klog.Logger, pod *v1.Pod, container *v1.Container) []*podresourcesapi.DynamicResource {
 	return nil
 }
 
@@ -373,16 +373,10 @@ func (cm *containerManagerImpl) PodMightNeedToUnprepareResources(UID types.UID) 
 	return false
 }
 
-func (cm *containerManagerImpl) PodHasExclusiveCPUs(pod *v1.Pod) bool {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
+func (cm *containerManagerImpl) PodHasExclusiveCPUs(logger klog.Logger, pod *v1.Pod) bool {
 	return podHasExclusiveCPUs(logger, cm.cpuManager, pod)
 }
 
-func (cm *containerManagerImpl) ContainerHasExclusiveCPUs(pod *v1.Pod, container *v1.Container) bool {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
+func (cm *containerManagerImpl) ContainerHasExclusiveCPUs(logger klog.Logger, pod *v1.Pod, container *v1.Container) bool {
 	return containerHasExclusiveCPUs(logger, cm.cpuManager, pod, container)
 }

--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -83,7 +83,7 @@ type Manager interface {
 	// GetTopologyHints implements the topologymanager.HintProvider Interface
 	// and is consulted to achieve NUMA aware resource alignment among this
 	// and other resource controllers.
-	GetTopologyHints(logger logr.Logger, pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint
+	GetTopologyHints(logger klog.Logger, pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint
 
 	// GetExclusiveCPUs implements the podresources.CPUsProvider interface to provide
 	// exclusively allocated cpus for the container
@@ -95,7 +95,7 @@ type Manager interface {
 	GetPodTopologyHints(logger logr.Logger, pod *v1.Pod) map[string][]topologymanager.TopologyHint
 
 	// AllocatePod is called to trigger the allocation of CPUs to a pod.
-	AllocatePod(logger logr.Logger, pod *v1.Pod) error
+	AllocatePod(logger klog.Logger, pod *v1.Pod) error
 
 	// GetAllocatableCPUs returns the total set of CPUs available for allocation.
 	GetAllocatableCPUs() cpuset.CPUSet
@@ -285,7 +285,7 @@ func (m *manager) Allocate(ctx context.Context, p *v1.Pod, c *v1.Container) erro
 	return nil
 }
 
-func (m *manager) AllocatePod(logger logr.Logger, pod *v1.Pod) error {
+func (m *manager) AllocatePod(logger klog.Logger, pod *v1.Pod) error {
 	// Garbage collect any stranded resources before allocating CPUs.
 	m.removeStaleState(logger)
 
@@ -352,7 +352,7 @@ func (m *manager) State() state.Reader {
 	return m.state
 }
 
-func (m *manager) GetTopologyHints(logger logr.Logger, pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint {
+func (m *manager) GetTopologyHints(logger klog.Logger, pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint {
 	// Garbage collect any stranded resources before providing TopologyHints
 	m.removeStaleState(logger)
 	// Delegate to active policy

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -366,7 +366,7 @@ func TestCPUManagerAdd(t *testing.T) {
 		},
 		0,
 		cpuset.New(),
-		topologymanager.NewFakeManager(),
+		topologymanager.NewFakeManager(logger),
 		nil)
 	testCases := []struct {
 		description        string
@@ -622,7 +622,7 @@ func TestCPUManagerAddWithInitContainers(t *testing.T) {
 
 	for _, testCase := range testCases {
 		logger, ctx := ktesting.NewTestContext(t)
-		policy, _ := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(), nil)
+		policy, _ := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(logger), nil)
 
 		mockState := &mockState{
 			assignments:   testCase.stAssignments,
@@ -786,7 +786,7 @@ func TestCPUManagerGenerate(t *testing.T) {
 			defer os.RemoveAll(sDir)
 
 			logger, _ := ktesting.NewTestContext(t)
-			mgr, err := NewManager(logger, testCase.cpuPolicyName, nil, 5*time.Second, machineInfo, cpuset.New(), testCase.nodeAllocatableReservation, sDir, topologymanager.NewFakeManager())
+			mgr, err := NewManager(logger, testCase.cpuPolicyName, nil, 5*time.Second, machineInfo, cpuset.New(), testCase.nodeAllocatableReservation, sDir, topologymanager.NewFakeManager(logger))
 			if testCase.expectedError != nil {
 				if !strings.Contains(err.Error(), testCase.expectedError.Error()) {
 					t.Errorf("Unexpected error message. Have: %s wants %s", err.Error(), testCase.expectedError.Error())
@@ -879,7 +879,7 @@ func TestReconcileState(t *testing.T) {
 		},
 		0,
 		cpuset.New(),
-		topologymanager.NewFakeManager(),
+		topologymanager.NewFakeManager(logger),
 		nil)
 
 	testCases := []struct {
@@ -1404,7 +1404,7 @@ func TestCPUManagerAddWithResvList(t *testing.T) {
 		},
 		1,
 		cpuset.New(0),
-		topologymanager.NewFakeManager(),
+		topologymanager.NewFakeManager(logger),
 		nil)
 	testCases := []struct {
 		description        string
@@ -1522,7 +1522,7 @@ func TestCPUManagerHandlePolicyOptions(t *testing.T) {
 			defer os.RemoveAll(sDir)
 
 			logger, _ := ktesting.NewTestContext(t)
-			_, err = NewManager(logger, testCase.cpuPolicyName, testCase.cpuPolicyOptions, 5*time.Second, machineInfo, cpuset.New(), nodeAllocatableReservation, sDir, topologymanager.NewFakeManager())
+			_, err = NewManager(logger, testCase.cpuPolicyName, testCase.cpuPolicyOptions, 5*time.Second, machineInfo, cpuset.New(), nodeAllocatableReservation, sDir, topologymanager.NewFakeManager(logger))
 			if err == nil {
 				t.Errorf("Expected error, but NewManager succeeded")
 			}
@@ -1556,7 +1556,7 @@ func TestCPUManagerGetAllocatableCPUs(t *testing.T) {
 		},
 		1,
 		cpuset.New(0),
-		topologymanager.NewFakeManager(),
+		topologymanager.NewFakeManager(logger),
 		nil)
 
 	testCases := []struct {

--- a/pkg/kubelet/cm/cpumanager/fake_cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/fake_cpu_manager.go
@@ -63,7 +63,7 @@ func (m *fakeManager) RemoveContainer(logger logr.Logger, containerID string) er
 	return nil
 }
 
-func (m *fakeManager) GetTopologyHints(logger logr.Logger, pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint {
+func (m *fakeManager) GetTopologyHints(logger klog.Logger, pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint {
 	logger.Info("Get container topology hints")
 	return map[string][]topologymanager.TopologyHint{}
 }
@@ -73,7 +73,7 @@ func (m *fakeManager) GetPodTopologyHints(logger logr.Logger, pod *v1.Pod) map[s
 	return map[string][]topologymanager.TopologyHint{}
 }
 
-func (m *fakeManager) AllocatePod(logger logr.Logger, pod *v1.Pod) error {
+func (m *fakeManager) AllocatePod(logger klog.Logger, pod *v1.Pod) error {
 	logger.Info("AllocatePod", "pod", klog.KObj(pod))
 	return nil
 }

--- a/pkg/kubelet/cm/cpumanager/policy_options_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_options_test.go
@@ -25,6 +25,7 @@ import (
 	pkgfeatures "k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/topology"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 type optionAvailTest struct {
@@ -139,6 +140,7 @@ func TestPolicyOptionsAlwaysAvailableOnceGA(t *testing.T) {
 }
 
 func TestValidateStaticPolicyOptions(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	testCases := []struct {
 		description   string
 		policyOption  map[string]string
@@ -195,7 +197,7 @@ func TestValidateStaticPolicyOptions(t *testing.T) {
 			if testCase.topoMgrPolicy == topologymanager.PolicySingleNumaNode {
 				topoMgrPolicy = topologymanager.NewSingleNumaNodePolicy(&topologymanager.NUMAInfo{}, topologymanager.PolicyOptions{})
 			}
-			topoMgrStore := topologymanager.NewFakeManagerWithPolicy(topoMgrPolicy)
+			topoMgrStore := topologymanager.NewFakeManagerWithPolicy(logger, topoMgrPolicy)
 
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.CPUManagerPolicyAlphaOptions, true)
 			policyOpt, _ := NewStaticPolicyOptions(testCase.policyOption)

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -417,7 +417,7 @@ func (p *staticPolicy) AllocatePod(logger logr.Logger, s state.State, pod *v1.Po
 	}
 
 	// 4. Allocate the entire CPU "bubble" for the pod using the hint from the Topology Manager.
-	hint := p.affinity.GetAffinity(podUID, append(pod.Spec.InitContainers, pod.Spec.Containers...)[0].Name)
+	hint := p.affinity.GetAffinity(logger, podUID, append(pod.Spec.InitContainers, pod.Spec.Containers...)[0].Name)
 	podAllocation, err := p.allocateCPUs(logger, s, totalPodCPUs, hint.NUMANodeAffinity, cpuset.New())
 	if err != nil {
 		logger.Error(err, "Unable to allocate CPUs for pod", "totalPodCPUs", totalPodCPUs)
@@ -603,7 +603,7 @@ func (p *staticPolicy) Allocate(logger logr.Logger, s state.State, pod *v1.Pod, 
 	}
 
 	// Call Topology Manager to get the aligned socket affinity across all hint providers.
-	hint := p.affinity.GetAffinity(string(pod.UID), container.Name)
+	hint := p.affinity.GetAffinity(logger, string(pod.UID), container.Name)
 	logger.Info("Topology Affinity", "affinity", hint)
 
 	// Allocate CPUs according to the NUMA affinity contained in the hint.

--- a/pkg/kubelet/cm/cpumanager/policy_static_restore_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_restore_test.go
@@ -122,7 +122,7 @@ func TestCPUManagerRestoreState(t *testing.T) {
 				cpuset.New(),
 				v1.ResourceList{v1.ResourceCPU: *resource.NewQuantity(1, resource.DecimalSI)},
 				sDir,
-				topologymanager.NewFakeManager(),
+				topologymanager.NewFakeManager(logger),
 			)
 			if err != nil {
 				t.Fatalf("could not create manager: %v", err)
@@ -197,7 +197,7 @@ func TestCPUManagerRestoreState(t *testing.T) {
 				cpuset.New(),
 				v1.ResourceList{v1.ResourceCPU: *resource.NewQuantity(1, resource.DecimalSI)},
 				sDir,
-				topologymanager.NewFakeManager(),
+				topologymanager.NewFakeManager(logger),
 			)
 			if err != nil {
 				t.Fatalf("could not create manager 2: %v", err)

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -93,7 +93,7 @@ func (spt staticPolicyTest) PseudoClone() staticPolicyTest {
 
 func TestStaticPolicyName(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
-	policy, err := NewStaticPolicy(logger, topoSingleSocketHT, 1, cpuset.New(), topologymanager.NewFakeManager(), nil)
+	policy, err := NewStaticPolicy(logger, topoSingleSocketHT, 1, cpuset.New(), topologymanager.NewFakeManager(logger), nil)
 	if err != nil {
 		t.Fatalf("NewStaticPolicy() failed: %v", err)
 	}
@@ -195,7 +195,7 @@ func TestStaticPolicyStart(t *testing.T) {
 		t.Run(testCase.description, func(t *testing.T) {
 			logger, _ := ktesting.NewTestContext(t)
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.CPUManagerPolicyAlphaOptions, true)
-			p, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(), testCase.options)
+			p, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(logger), testCase.options)
 			if err != nil {
 				t.Fatalf("NewStaticPolicy() failed: %v", err)
 			}
@@ -691,15 +691,15 @@ func TestStaticPolicyAdd(t *testing.T) {
 }
 
 func runStaticPolicyTestCase(t *testing.T, testCase staticPolicyTest) {
-	tm := topologymanager.NewFakeManager()
+	logger, _ := ktesting.NewTestContext(t)
+	tm := topologymanager.NewFakeManager(logger)
 	if testCase.topologyHint != nil {
-		tm = topologymanager.NewFakeManagerWithHint(testCase.topologyHint)
+		tm = topologymanager.NewFakeManagerWithHint(logger, testCase.topologyHint)
 	}
 	cpus := cpuset.New()
 	if testCase.reservedCPUs != nil {
 		cpus = testCase.reservedCPUs.Clone()
 	}
-	logger, _ := ktesting.NewTestContext(t)
 	policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, cpus, tm, testCase.options)
 	if err != nil {
 		t.Fatalf("NewStaticPolicy() failed: %v", err)
@@ -775,7 +775,7 @@ func TestStaticPolicyReuseCPUs(t *testing.T) {
 
 	for _, testCase := range testCases {
 		logger, _ := ktesting.NewTestContext(t)
-		policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(), nil)
+		policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(logger), nil)
 		if err != nil {
 			t.Fatalf("NewStaticPolicy() failed: %v", err)
 		}
@@ -832,7 +832,7 @@ func TestStaticPolicyDoNotReuseCPUs(t *testing.T) {
 
 	for _, testCase := range testCases {
 		logger, _ := ktesting.NewTestContext(t)
-		policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(), nil)
+		policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(logger), nil)
 		if err != nil {
 			t.Fatalf("NewStaticPolicy() failed: %v", err)
 		}
@@ -918,7 +918,7 @@ func TestStaticPolicyRemove(t *testing.T) {
 
 	for _, testCase := range testCases {
 		logger, _ := ktesting.NewTestContext(t)
-		policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(), nil)
+		policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, cpuset.New(), topologymanager.NewFakeManager(logger), nil)
 		if err != nil {
 			t.Fatalf("NewStaticPolicy() failed: %v", err)
 		}
@@ -1012,7 +1012,7 @@ func TestTopologyAwareAllocateCPUs(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		logger, _ := ktesting.NewTestContext(t)
-		p, err := NewStaticPolicy(logger, tc.topo, 0, cpuset.New(), topologymanager.NewFakeManager(), nil)
+		p, err := NewStaticPolicy(logger, tc.topo, 0, cpuset.New(), topologymanager.NewFakeManager(logger), nil)
 		if err != nil {
 			t.Fatalf("NewStaticPolicy() failed: %v", err)
 		}
@@ -1113,7 +1113,7 @@ func TestStaticPolicyStartWithResvList(t *testing.T) {
 		t.Run(testCase.description, func(t *testing.T) {
 			logger, _ := ktesting.NewTestContext(t)
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.CPUManagerPolicyAlphaOptions, true)
-			p, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, testCase.reserved, topologymanager.NewFakeManager(), testCase.cpuPolicyOptions)
+			p, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, testCase.reserved, topologymanager.NewFakeManager(logger), testCase.cpuPolicyOptions)
 			if !reflect.DeepEqual(err, testCase.expNewErr) {
 				t.Errorf("StaticPolicy Start() error (%v). expected error: %v but got: %v",
 					testCase.description, testCase.expNewErr, err)
@@ -1191,7 +1191,7 @@ func TestStaticPolicyAddWithResvList(t *testing.T) {
 
 	for _, testCase := range testCases {
 		logger, _ := ktesting.NewTestContext(t)
-		policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, testCase.reserved, topologymanager.NewFakeManager(), nil)
+		policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, testCase.reserved, topologymanager.NewFakeManager(logger), nil)
 		if err != nil {
 			t.Fatalf("NewStaticPolicy() failed: %v", err)
 		}
@@ -1960,7 +1960,7 @@ func TestStaticPolicyAddWithUncoreAlignment(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
 			logger, _ := ktesting.NewTestContext(t)
-			policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, testCase.reserved, topologymanager.NewFakeManager(), testCase.cpuPolicyOptions)
+			policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, testCase.reserved, topologymanager.NewFakeManager(logger), testCase.cpuPolicyOptions)
 			if err != nil {
 				t.Fatalf("NewStaticPolicy() failed with %v", err)
 			}
@@ -2469,7 +2469,7 @@ func TestStaticPolicyAllocatePod(t *testing.T) {
 			metrics.ResourceManagerAllocationErrorsTotal.Reset()
 			metrics.ResourceManagerContainerAssignments.Reset()
 
-			policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, testCase.reservedCPUs, topologymanager.NewFakeManager(), testCase.options)
+			policy, err := NewStaticPolicy(logger, testCase.topo, testCase.numReservedCPUs, testCase.reservedCPUs, topologymanager.NewFakeManager(logger), testCase.options)
 			if err != nil {
 				t.Fatalf("NewStaticPolicy() failed: %v", err)
 			}

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -467,10 +467,7 @@ func (m *ManagerImpl) markResourceUnhealthy(logger klog.Logger, resourceName str
 // cm.UpdatePluginResource() run during predicate Admit guarantees we adjust nodeinfo
 // capacity for already allocated pods so that they can continue to run. However, new pods
 // requiring device plugin resources will not be scheduled till device plugin re-registers.
-func (m *ManagerImpl) GetCapacity() (v1.ResourceList, v1.ResourceList, []string) {
-	// Use logger.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
+func (m *ManagerImpl) GetCapacity(logger klog.Logger) (v1.ResourceList, v1.ResourceList, []string) {
 	var capacity = v1.ResourceList{}
 	var allocatable = v1.ResourceList{}
 	deletedResources := sets.New[string]()
@@ -709,7 +706,7 @@ func (m *ManagerImpl) devicesToAllocate(ctx context.Context, podUID, contName, r
 	}
 
 	// Filters available Devices based on NUMA affinity.
-	aligned, unaligned, noAffinity := m.filterByAffinity(podUID, contName, resource, available)
+	aligned, unaligned, noAffinity := m.filterByAffinity(logger, podUID, contName, resource, available)
 
 	// If we can allocate all remaining devices from the set of aligned ones, then
 	// give the plugin the chance to influence which ones to allocate from that set.
@@ -761,9 +758,9 @@ func (m *ManagerImpl) devicesToAllocate(ctx context.Context, podUID, contName, r
 	return nil, fmt.Errorf("unexpectedly allocated less resources than required. Requested: %d, Got: %d", required, required-needed)
 }
 
-func (m *ManagerImpl) filterByAffinity(podUID, contName, resource string, available sets.Set[string]) (sets.Set[string], sets.Set[string], sets.Set[string]) {
+func (m *ManagerImpl) filterByAffinity(logger klog.Logger, podUID, contName, resource string, available sets.Set[string]) (sets.Set[string], sets.Set[string], sets.Set[string]) {
 	// If alignment information is not available, just pass the available list back.
-	hint := m.topologyAffinityStore.GetAffinity(podUID, contName)
+	hint := m.topologyAffinityStore.GetAffinity(logger, podUID, contName)
 	if !m.deviceHasTopologyAlignment(resource) || hint.NUMANodeAffinity == nil {
 		return sets.New[string](), sets.New[string](), available
 	}
@@ -1149,7 +1146,7 @@ func (m *ManagerImpl) GetAllocatableDevices() ResourceDeviceInstances {
 }
 
 // AllocatePod is called to trigger the allocation of resources to a pod.
-func (m *ManagerImpl) AllocatePod(_ klog.Logger, _ *v1.Pod) error {
+func (m *ManagerImpl) AllocatePod(logger klog.Logger, pod *v1.Pod) error {
 	// Device Manager does not support pod level resource allocation.
 	return nil
 }

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -99,7 +99,7 @@ func tmpSocketDir() (socketDir, socketName, pluginSocketName string, err error) 
 func TestNewManagerImpl(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	socketDir, socketName, _, err := tmpSocketDir()
-	topologyStore := topologymanager.NewFakeManager()
+	topologyStore := topologymanager.NewFakeManager(logger)
 	require.NoError(t, err)
 	defer os.RemoveAll(socketDir)
 	_, err = newManagerImpl(logger, socketName, nil, topologyStore)
@@ -160,7 +160,7 @@ func TestDevicePluginReRegistration(t *testing.T) {
 			case <-time.After(5 * time.Second):
 				t.Fatalf("timeout while waiting for manager update")
 			}
-			capacity, allocatable, _ := m.GetCapacity()
+			capacity, allocatable, _ := m.GetCapacity(logger)
 			resourceCapacity := capacity[v1.ResourceName(testResourceName)]
 			resourceAllocatable := allocatable[v1.ResourceName(testResourceName)]
 			require.Equal(t, resourceCapacity.Value(), resourceAllocatable.Value(), "capacity should equal to allocatable")
@@ -177,7 +177,7 @@ func TestDevicePluginReRegistration(t *testing.T) {
 			case <-time.After(5 * time.Second):
 				t.Fatalf("timeout while waiting for manager update")
 			}
-			capacity, allocatable, _ = m.GetCapacity()
+			capacity, allocatable, _ = m.GetCapacity(logger)
 			resourceCapacity = capacity[v1.ResourceName(testResourceName)]
 			resourceAllocatable = allocatable[v1.ResourceName(testResourceName)]
 			require.Equal(t, resourceCapacity.Value(), resourceAllocatable.Value(), "capacity should equal to allocatable")
@@ -195,7 +195,7 @@ func TestDevicePluginReRegistration(t *testing.T) {
 			case <-time.After(5 * time.Second):
 				t.Fatalf("timeout while waiting for manager update")
 			}
-			capacity, allocatable, _ = m.GetCapacity()
+			capacity, allocatable, _ = m.GetCapacity(logger)
 			resourceCapacity = capacity[v1.ResourceName(testResourceName)]
 			resourceAllocatable = allocatable[v1.ResourceName(testResourceName)]
 			require.Equal(t, resourceCapacity.Value(), resourceAllocatable.Value(), "capacity should equal to allocatable")
@@ -240,7 +240,7 @@ func TestDevicePluginReRegistrationProbeMode(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.FailNow()
 	}
-	capacity, allocatable, _ := m.GetCapacity()
+	capacity, allocatable, _ := m.GetCapacity(logger)
 	resourceCapacity := capacity[v1.ResourceName(testResourceName)]
 	resourceAllocatable := allocatable[v1.ResourceName(testResourceName)]
 	require.Equal(t, resourceCapacity.Value(), resourceAllocatable.Value(), "capacity should equal to allocatable")
@@ -256,7 +256,7 @@ func TestDevicePluginReRegistrationProbeMode(t *testing.T) {
 		t.FailNow()
 	}
 
-	capacity, allocatable, _ = m.GetCapacity()
+	capacity, allocatable, _ = m.GetCapacity(logger)
 	resourceCapacity = capacity[v1.ResourceName(testResourceName)]
 	resourceAllocatable = allocatable[v1.ResourceName(testResourceName)]
 	require.Equal(t, resourceCapacity.Value(), resourceAllocatable.Value(), "capacity should equal to allocatable")
@@ -273,7 +273,7 @@ func TestDevicePluginReRegistrationProbeMode(t *testing.T) {
 		t.FailNow()
 	}
 
-	capacity, allocatable, _ = m.GetCapacity()
+	capacity, allocatable, _ = m.GetCapacity(logger)
 	resourceCapacity = capacity[v1.ResourceName(testResourceName)]
 	resourceAllocatable = allocatable[v1.ResourceName(testResourceName)]
 	require.Equal(t, resourceCapacity.Value(), resourceAllocatable.Value(), "capacity should equal to allocatable")
@@ -288,7 +288,7 @@ func TestDevicePluginReRegistrationProbeMode(t *testing.T) {
 
 func setupDeviceManager(t *testing.T, devs []*pluginapi.Device, callback monitorCallback, socketName string,
 	topology []cadvisorapi.Node, logger klog.Logger) (Manager, <-chan interface{}) {
-	topologyStore := topologymanager.NewFakeManager()
+	topologyStore := topologymanager.NewFakeManager(logger)
 	m, err := newManagerImpl(logger, socketName, topology, topologyStore)
 	require.NoError(t, err)
 	updateChan := make(chan interface{})
@@ -365,7 +365,7 @@ func cleanup(logger klog.Logger, m Manager, p *plugin.Stub) error {
 func TestUpdateCapacityAllocatable(t *testing.T) {
 	logger, tCtx := ktesting.NewTestContext(t)
 	socketDir, socketName, _, err := tmpSocketDir()
-	topologyStore := topologymanager.NewFakeManager()
+	topologyStore := topologymanager.NewFakeManager(logger)
 	require.NoError(t, err)
 	defer os.RemoveAll(socketDir)
 	testManager, err := newManagerImpl(logger, socketName, nil, topologyStore)
@@ -386,7 +386,7 @@ func TestUpdateCapacityAllocatable(t *testing.T) {
 	e1 := &endpointImpl{}
 	testManager.endpoints[resourceName1] = endpointInfo{e: e1, opts: nil}
 	callback(logger, resourceName1, devs)
-	capacity, allocatable, removedResources := testManager.GetCapacity()
+	capacity, allocatable, removedResources := testManager.GetCapacity(logger)
 	resource1Capacity, ok := capacity[v1.ResourceName(resourceName1)]
 	as.True(ok)
 	resource1Allocatable, ok := allocatable[v1.ResourceName(resourceName1)]
@@ -398,7 +398,7 @@ func TestUpdateCapacityAllocatable(t *testing.T) {
 	// Deletes an unhealthy device should NOT change allocatable but change capacity.
 	devs1 := devs[:len(devs)-1]
 	callback(logger, resourceName1, devs1)
-	capacity, allocatable, removedResources = testManager.GetCapacity()
+	capacity, allocatable, removedResources = testManager.GetCapacity(logger)
 	resource1Capacity, ok = capacity[v1.ResourceName(resourceName1)]
 	as.True(ok)
 	resource1Allocatable, ok = allocatable[v1.ResourceName(resourceName1)]
@@ -410,7 +410,7 @@ func TestUpdateCapacityAllocatable(t *testing.T) {
 	// Updates a healthy device to unhealthy should reduce allocatable by 1.
 	devs[1].Health = pluginapi.Unhealthy
 	callback(logger, resourceName1, devs)
-	capacity, allocatable, removedResources = testManager.GetCapacity()
+	capacity, allocatable, removedResources = testManager.GetCapacity(logger)
 	resource1Capacity, ok = capacity[v1.ResourceName(resourceName1)]
 	as.True(ok)
 	resource1Allocatable, ok = allocatable[v1.ResourceName(resourceName1)]
@@ -422,7 +422,7 @@ func TestUpdateCapacityAllocatable(t *testing.T) {
 	// Deletes a healthy device should reduce capacity and allocatable by 1.
 	devs2 := devs[1:]
 	callback(logger, resourceName1, devs2)
-	capacity, allocatable, removedResources = testManager.GetCapacity()
+	capacity, allocatable, removedResources = testManager.GetCapacity(logger)
 	resource1Capacity, ok = capacity[v1.ResourceName(resourceName1)]
 	as.True(ok)
 	resource1Allocatable, ok = allocatable[v1.ResourceName(resourceName1)]
@@ -439,7 +439,7 @@ func TestUpdateCapacityAllocatable(t *testing.T) {
 	testManager.endpoints[resourceName2] = eInfo
 	testManager.endpointStore[resourceName2] = map[string]*endpointInfo{socketName: &eInfo}
 	callback(logger, resourceName2, devs)
-	capacity, allocatable, removedResources = testManager.GetCapacity()
+	capacity, allocatable, removedResources = testManager.GetCapacity(logger)
 	as.Len(capacity, 2)
 	resource2Capacity, ok := capacity[v1.ResourceName(resourceName2)]
 	as.True(ok)
@@ -452,7 +452,7 @@ func TestUpdateCapacityAllocatable(t *testing.T) {
 	// Expires resourceName1 endpoint. Verifies testManager.GetCapacity() reports that resourceName1
 	// is removed from capacity and it no longer exists in healthyDevices after the call.
 	e1.setStopTime(time.Now().Add(-1*endpointStopGracePeriod - time.Duration(10)*time.Second))
-	capacity, allocatable, removed := testManager.GetCapacity()
+	capacity, allocatable, removed := testManager.GetCapacity(logger)
 	as.Equal([]string{resourceName1}, removed)
 	as.NotContains(capacity, v1.ResourceName(resourceName1))
 	as.NotContains(allocatable, v1.ResourceName(resourceName1))
@@ -476,7 +476,7 @@ func TestUpdateCapacityAllocatable(t *testing.T) {
 	// Marks resourceName2 unhealthy and verifies its capacity/allocatable are
 	// correctly updated.
 	testManager.markResourceUnhealthy(logger, resourceName2)
-	capacity, allocatable, removed = testManager.GetCapacity()
+	capacity, allocatable, removed = testManager.GetCapacity(logger)
 	val, ok = capacity[v1.ResourceName(resourceName2)]
 	as.True(ok)
 	as.Equal(int64(3), val.Value())
@@ -497,7 +497,7 @@ func TestUpdateCapacityAllocatable(t *testing.T) {
 	as.NoError(err)
 	as.Len(testManager.endpoints, 1)
 	as.Contains(testManager.endpoints, resourceName2)
-	capacity, allocatable, removed = testManager.GetCapacity()
+	capacity, allocatable, removed = testManager.GetCapacity(logger)
 	val, ok = capacity[v1.ResourceName(resourceName2)]
 	as.True(ok)
 	as.Equal(int64(0), val.Value())
@@ -511,7 +511,7 @@ func TestUpdateCapacityAllocatable(t *testing.T) {
 func TestGetAllocatableDevicesMultipleResources(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	socketDir, socketName, _, err := tmpSocketDir()
-	topologyStore := topologymanager.NewFakeManager()
+	topologyStore := topologymanager.NewFakeManager(logger)
 	require.NoError(t, err)
 	defer os.RemoveAll(socketDir)
 	testManager, err := newManagerImpl(logger, socketName, nil, topologyStore)
@@ -553,7 +553,7 @@ func TestGetAllocatableDevicesMultipleResources(t *testing.T) {
 func TestGetAllocatableDevicesHealthTransition(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	socketDir, socketName, _, err := tmpSocketDir()
-	topologyStore := topologymanager.NewFakeManager()
+	topologyStore := topologymanager.NewFakeManager(logger)
 	require.NoError(t, err)
 	defer os.RemoveAll(socketDir)
 	testManager, err := newManagerImpl(logger, socketName, nil, topologyStore)
@@ -860,7 +860,7 @@ func makePod(limits v1.ResourceList) *v1.Pod {
 	}
 }
 
-func getTestManager(tmpDir string, activePods ActivePodsFunc, testRes []TestResource) (*wrappedManagerImpl, error) {
+func getTestManager(logger klog.Logger, tmpDir string, activePods ActivePodsFunc, testRes []TestResource) (*wrappedManagerImpl, error) {
 	monitorCallback := func(logger klog.Logger, resourceName string, devices []*pluginapi.Device) {}
 	ckm, err := checkpointmanager.NewCheckpointManager(tmpDir)
 	if err != nil {
@@ -873,7 +873,7 @@ func getTestManager(tmpDir string, activePods ActivePodsFunc, testRes []TestReso
 		endpoints:             make(map[string]endpointInfo),
 		podDevices:            newPodDevices(),
 		devicesToReuse:        make(PodReusableDevices),
-		topologyAffinityStore: topologymanager.NewFakeManager(),
+		topologyAffinityStore: topologymanager.NewFakeManager(logger),
 		activePods:            activePods,
 		sourcesReady:          &sourcesReadyStub{},
 		checkpointManager:     ckm,
@@ -930,6 +930,7 @@ type TestResource struct {
 }
 
 func TestFilterByAffinity(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	as := require.New(t)
 	allDevices := ResourceDeviceInstances{
 		"res1": map[string]*pluginapi.Device{
@@ -988,7 +989,7 @@ func TestFilterByAffinity(t *testing.T) {
 		Preferred:        true,
 	}
 	testManager := ManagerImpl{
-		topologyAffinityStore: topologymanager.NewFakeManagerWithHint(&fakeHint),
+		topologyAffinityStore: topologymanager.NewFakeManagerWithHint(logger, &fakeHint),
 		allDevices:            allDevices,
 	}
 
@@ -1013,7 +1014,7 @@ func TestFilterByAffinity(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		fromAffinity, notFromAffinity, withoutTopology := testManager.filterByAffinity("", "", "res1", testCase.available)
+		fromAffinity, notFromAffinity, withoutTopology := testManager.filterByAffinity(logger, "", "", "res1", testCase.available)
 		as.Truef(fromAffinity.Equal(testCase.fromAffinityExpected), "expect devices from affinity to be %v but got %v", testCase.fromAffinityExpected, fromAffinity)
 		as.Truef(notFromAffinity.Equal(testCase.notFromAffinityExpected), "expect devices not from affinity to be %v but got %v", testCase.notFromAffinityExpected, notFromAffinity)
 		as.Truef(withoutTopology.Equal(testCase.withoutTopologyExpected), "expect devices without topology to be %v but got %v", testCase.notFromAffinityExpected, notFromAffinity)
@@ -1021,7 +1022,7 @@ func TestFilterByAffinity(t *testing.T) {
 }
 
 func TestPodContainerDeviceAllocation(t *testing.T) {
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 	res1 := TestResource{
 		resourceName:     "domain1.com/resource1",
 		resourceQuantity: *resource.NewQuantity(int64(2), resource.DecimalSI),
@@ -1044,7 +1045,7 @@ func TestPodContainerDeviceAllocation(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "checkpoint")
 	as.NoError(err)
 	defer os.RemoveAll(tmpDir)
-	testManager, err := getTestManager(tmpDir, podsStub.getActivePods, testResources)
+	testManager, err := getTestManager(logger, tmpDir, podsStub.getActivePods, testResources)
 	as.NoError(err)
 
 	testPods := []*v1.Pod{
@@ -1226,7 +1227,7 @@ func TestPodContainerDeviceToAllocate(t *testing.T) {
 }
 
 func TestDevicesToAllocateConflictWithUpdateAllocatedDevices(t *testing.T) {
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 	podToAllocate := "podToAllocate"
 	containerToAllocate := "containerToAllocate"
 	podToRemove := "podToRemove"
@@ -1263,7 +1264,7 @@ func TestDevicesToAllocateConflictWithUpdateAllocatedDevices(t *testing.T) {
 		podDevices:            newPodDevices(),
 		activePods:            func() []*v1.Pod { return []*v1.Pod{} },
 		sourcesReady:          &sourcesReadyStub{},
-		topologyAffinityStore: topologymanager.NewFakeManager(),
+		topologyAffinityStore: topologymanager.NewFakeManager(logger),
 	}
 
 	testManager.endpoints[resourceName] = endpointInfo{
@@ -1287,7 +1288,7 @@ func TestDevicesToAllocateConflictWithUpdateAllocatedDevices(t *testing.T) {
 }
 
 func TestGetDeviceRunContainerOptions(t *testing.T) {
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 	res1 := TestResource{
 		resourceName:     "domain1.com/resource1",
 		resourceQuantity: *resource.NewQuantity(int64(2), resource.DecimalSI),
@@ -1314,7 +1315,7 @@ func TestGetDeviceRunContainerOptions(t *testing.T) {
 	as.NoError(err)
 	defer os.RemoveAll(tmpDir)
 
-	testManager, err := getTestManager(tmpDir, podsStub.getActivePods, testResources)
+	testManager, err := getTestManager(logger, tmpDir, podsStub.getActivePods, testResources)
 	as.NoError(err)
 
 	pod1 := makePod(v1.ResourceList{
@@ -1351,7 +1352,7 @@ func TestGetDeviceRunContainerOptions(t *testing.T) {
 }
 
 func TestInitContainerDeviceAllocation(t *testing.T) {
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 	// Requesting to create a pod that requests resourceName1 in init containers and normal containers
 	// should succeed with devices allocated to init containers reallocated to normal containers.
 	res1 := TestResource{
@@ -1377,7 +1378,7 @@ func TestInitContainerDeviceAllocation(t *testing.T) {
 	as.NoError(err)
 	defer os.RemoveAll(tmpDir)
 
-	testManager, err := getTestManager(tmpDir, podsStub.getActivePods, testResources)
+	testManager, err := getTestManager(logger, tmpDir, podsStub.getActivePods, testResources)
 	as.NoError(err)
 
 	podWithPluginResourcesInInitContainers := &v1.Pod{
@@ -1453,7 +1454,7 @@ func TestInitContainerDeviceAllocation(t *testing.T) {
 }
 
 func TestRestartableInitContainerDeviceAllocation(t *testing.T) {
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 	// Requesting to create a pod that requests resourceName1 in restartable
 	// init containers and normal containers should succeed with devices
 	// allocated to init containers not reallocated to normal containers.
@@ -1479,7 +1480,7 @@ func TestRestartableInitContainerDeviceAllocation(t *testing.T) {
 	as.NoError(err)
 	defer os.RemoveAll(tmpDir)
 
-	testManager, err := getTestManager(tmpDir, podsStub.getActivePods, testResources)
+	testManager, err := getTestManager(logger, tmpDir, podsStub.getActivePods, testResources)
 	as.NoError(err)
 
 	containerRestartPolicyAlways := v1.ContainerRestartPolicyAlways
@@ -1637,7 +1638,7 @@ func TestUpdatePluginResources(t *testing.T) {
 }
 
 func TestDevicePreStartContainer(t *testing.T) {
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 	// Ensures that if device manager is indicated to invoke `PreStartContainer` RPC
 	// by device plugin, then device manager invokes PreStartContainer at endpoint interface.
 	// Also verifies that final allocation of mounts, envs etc is same as expected.
@@ -1655,7 +1656,7 @@ func TestDevicePreStartContainer(t *testing.T) {
 	as.NoError(err)
 	defer os.RemoveAll(tmpDir)
 
-	testManager, err := getTestManager(tmpDir, podsStub.getActivePods, []TestResource{res1})
+	testManager, err := getTestManager(logger, tmpDir, podsStub.getActivePods, []TestResource{res1})
 	as.NoError(err)
 
 	ch := make(chan []string, 1)
@@ -2202,7 +2203,7 @@ func TestEndpointSyncOnDisconnect(t *testing.T) {
 	// Expire endpoint to shorten the test
 	ep.stopTime = time.Now().Add(-endpointStopGracePeriod * 2)
 	// Call GetCapacity to trigger https://github.com/kubernetes/kubernetes/issues/133702
-	manager.GetCapacity()
+	manager.GetCapacity(logger)
 
 	require.Empty(t, manager.endpoints)
 	require.Empty(t, manager.healthyDevices)

--- a/pkg/kubelet/cm/devicemanager/topology_hints_test.go
+++ b/pkg/kubelet/cm/devicemanager/topology_hints_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
@@ -36,7 +37,7 @@ type mockAffinityStore struct {
 	hint topologymanager.TopologyHint
 }
 
-func (m *mockAffinityStore) GetAffinity(podUID string, containerName string) topologymanager.TopologyHint {
+func (m *mockAffinityStore) GetAffinity(_ klog.Logger, podUID string, containerName string) topologymanager.TopologyHint {
 	return m.hint
 }
 
@@ -61,8 +62,9 @@ func makeSocketMask(sockets ...int) bitmask.BitMask {
 }
 
 func TestGetTopologyHints(t *testing.T) {
-	tCtx := ktesting.Init(t)
 	tcases := getCommonTestCases()
+
+	logger, _ := ktesting.NewTestContext(t)
 
 	for _, tc := range tcases {
 		m := ManagerImpl{
@@ -98,7 +100,7 @@ func TestGetTopologyHints(t *testing.T) {
 			}
 		}
 
-		hints := m.GetTopologyHints(tCtx.Logger(), tc.pod, &tc.pod.Spec.Containers[0])
+		hints := m.GetTopologyHints(logger, tc.pod, &tc.pod.Spec.Containers[0])
 
 		for r := range tc.expectedHints {
 			sort.SliceStable(hints[r], func(i, j int) bool {
@@ -927,7 +929,7 @@ func TestGetPodDeviceRequest(t *testing.T) {
 }
 
 func TestGetPodTopologyHints(t *testing.T) {
-	tCtx := ktesting.Init(t)
+	logger, _ := ktesting.NewTestContext(t)
 	tcases := getCommonTestCases()
 	tcases = append(tcases, getPodScopeTestCases()...)
 
@@ -966,7 +968,7 @@ func TestGetPodTopologyHints(t *testing.T) {
 			}
 		}
 
-		hints := m.GetPodTopologyHints(tCtx.Logger(), tc.pod)
+		hints := m.GetPodTopologyHints(logger, tc.pod)
 
 		for r := range tc.expectedHints {
 			sort.SliceStable(hints[r], func(i, j int) bool {
@@ -983,7 +985,7 @@ func TestGetPodTopologyHints(t *testing.T) {
 }
 
 func TestDeviceNUMANodes(t *testing.T) {
-	tCtx := ktesting.Init(t)
+	logger, _ := ktesting.NewTestContext(t)
 	resource := "testdevice"
 	deviceOnNode := func(id string, node int) *pluginapi.Device {
 		return &pluginapi.Device{
@@ -1002,7 +1004,7 @@ func TestDeviceNUMANodes(t *testing.T) {
 			"b": deviceOnNode("b", 5),
 		}
 
-		nodes := m.deviceNUMANodes(tCtx.Logger(), resource)
+		nodes := m.deviceNUMANodes(logger, resource)
 		expected := []int{3, 5}
 		if !reflect.DeepEqual(nodes, expected) {
 			t.Fatalf("expected nodes %v, got %v", expected, nodes)
@@ -1019,7 +1021,7 @@ func TestDeviceNUMANodes(t *testing.T) {
 			"b": {ID: "b", Topology: nil},
 		}
 
-		nodes := m.deviceNUMANodes(tCtx.Logger(), resource)
+		nodes := m.deviceNUMANodes(logger, resource)
 		expected := []int{4}
 		if !reflect.DeepEqual(nodes, expected) {
 			t.Fatalf("expected nodes %v, got %v", expected, nodes)
@@ -1035,7 +1037,7 @@ func TestDeviceNUMANodes(t *testing.T) {
 			"b": {ID: "b", Topology: nil},
 		}
 
-		nodes := m.deviceNUMANodes(tCtx.Logger(), resource)
+		nodes := m.deviceNUMANodes(logger, resource)
 		if len(nodes) != 0 {
 			t.Fatalf("expected empty nodes, got %v", nodes)
 		}
@@ -1051,7 +1053,7 @@ func TestDeviceNUMANodes(t *testing.T) {
 			"b": deviceOnNode("b", 99),
 		}
 
-		nodes := m.deviceNUMANodes(tCtx.Logger(), resource)
+		nodes := m.deviceNUMANodes(logger, resource)
 		expected := []int{0}
 		if !reflect.DeepEqual(nodes, expected) {
 			t.Fatalf("expected nodes %v (node 99 should be dropped), got %v", expected, nodes)
@@ -1060,7 +1062,7 @@ func TestDeviceNUMANodes(t *testing.T) {
 }
 
 func TestGenerateDeviceTopologyHintsFiltersNUMANodes(t *testing.T) {
-	tCtx := ktesting.Init(t)
+	logger, _ := ktesting.NewTestContext(t)
 	resource := "gpu"
 
 	t.Run("two node machine, device on one node", func(t *testing.T) {
@@ -1075,7 +1077,7 @@ func TestGenerateDeviceTopologyHintsFiltersNUMANodes(t *testing.T) {
 			},
 		}
 
-		hints := m.generateDeviceTopologyHints(tCtx.Logger(), resource, sets.New[string]("a"), nil, 1)
+		hints := m.generateDeviceTopologyHints(logger, resource, sets.New[string]("a"), nil, 1)
 
 		maskNode0, _ := bitmask.NewBitMask(0)
 		expected := []topologymanager.TopologyHint{
@@ -1108,7 +1110,7 @@ func TestGenerateDeviceTopologyHintsFiltersNUMANodes(t *testing.T) {
 			},
 		}
 
-		hints := m.generateDeviceTopologyHints(tCtx.Logger(), resource, sets.New[string]("gpu0", "gpu1"), nil, 1)
+		hints := m.generateDeviceTopologyHints(logger, resource, sets.New[string]("gpu0", "gpu1"), nil, 1)
 		sort.SliceStable(hints, func(i, j int) bool { return hints[i].LessThan(hints[j]) })
 
 		maskNode0, _ := bitmask.NewBitMask(0)
@@ -1142,7 +1144,7 @@ func TestGenerateDeviceTopologyHintsFiltersNUMANodes(t *testing.T) {
 			},
 		}
 
-		hints := m.generateDeviceTopologyHints(tCtx.Logger(), resource, sets.New[string]("a", "b"), nil, 1)
+		hints := m.generateDeviceTopologyHints(logger, resource, sets.New[string]("a", "b"), nil, 1)
 
 		fullMask, _ := bitmask.NewBitMask(0, 1)
 		fullMaskCount := 0
@@ -1168,7 +1170,7 @@ func TestGenerateDeviceTopologyHintsFiltersNUMANodes(t *testing.T) {
 			},
 		}
 
-		hints := m.generateDeviceTopologyHints(tCtx.Logger(), resource, nil, sets.New[string]("a"), 1)
+		hints := m.generateDeviceTopologyHints(logger, resource, nil, sets.New[string]("a"), 1)
 
 		expected := []topologymanager.TopologyHint{
 			{NUMANodeAffinity: makeSocketMask(0), Preferred: true},
@@ -1194,7 +1196,7 @@ func TestGenerateDeviceTopologyHintsFiltersNUMANodes(t *testing.T) {
 			},
 		}
 
-		hints := m.generateDeviceTopologyHints(tCtx.Logger(), resource, sets.New[string]("b"), sets.New[string]("a"), 2)
+		hints := m.generateDeviceTopologyHints(logger, resource, sets.New[string]("b"), sets.New[string]("a"), 2)
 
 		expected := []topologymanager.TopologyHint{
 			{NUMANodeAffinity: makeSocketMask(0, 1), Preferred: true},
@@ -1209,7 +1211,7 @@ func TestGenerateDeviceTopologyHintsFiltersNUMANodes(t *testing.T) {
 // the device hints produced by our changed code, without needing to wire up
 // real CPU/memory managers.
 func TestFilteredDeviceHintsMergeWithOtherProviders(t *testing.T) {
-	tCtx := ktesting.Init(t)
+	logger, _ := ktesting.NewTestContext(t)
 	t.Run("device on node 0", func(t *testing.T) {
 		numaNodes := []int{0, 1}
 		numaInfo := &topologymanager.NUMAInfo{
@@ -1228,7 +1230,7 @@ func TestFilteredDeviceHintsMergeWithOtherProviders(t *testing.T) {
 			},
 		}
 
-		deviceHints := m.generateDeviceTopologyHints(tCtx.Logger(), "gpu", sets.New[string]("gpu0"), nil, 1)
+		deviceHints := m.generateDeviceTopologyHints(logger, "gpu", sets.New[string]("gpu0"), nil, 1)
 
 		providersHints := []map[string][]topologymanager.TopologyHint{
 			{"gpu": deviceHints},
@@ -1263,7 +1265,7 @@ func TestFilteredDeviceHintsMergeWithOtherProviders(t *testing.T) {
 			},
 		}
 
-		deviceHints := m.generateDeviceTopologyHints(tCtx.Logger(), "gpu", sets.New[string]("gpu0"), nil, 1)
+		deviceHints := m.generateDeviceTopologyHints(logger, "gpu", sets.New[string]("gpu0"), nil, 1)
 
 		providersHints := []map[string][]topologymanager.TopologyHint{
 			{"gpu": deviceHints},
@@ -1298,7 +1300,7 @@ func TestFilteredDeviceHintsMergeWithOtherProviders(t *testing.T) {
 			},
 		}
 
-		deviceHints := m.generateDeviceTopologyHints(tCtx.Logger(), "gpu", sets.New[string]("gpu0"), nil, 1)
+		deviceHints := m.generateDeviceTopologyHints(logger, "gpu", sets.New[string]("gpu0"), nil, 1)
 
 		providersHints := []map[string][]topologymanager.TopologyHint{
 			{"gpu": deviceHints},
@@ -1318,7 +1320,7 @@ func TestFilteredDeviceHintsMergeWithOtherProviders(t *testing.T) {
 
 func assertMergePreferred(t *testing.T, numaInfo *topologymanager.NUMAInfo, providersHints []map[string][]topologymanager.TopologyHint, expectedMask bitmask.BitMask) {
 	t.Helper()
-	tCtx := ktesting.Init(t)
+	logger, _ := ktesting.NewTestContext(t)
 	for _, policyName := range []string{"best-effort", "restricted"} {
 		t.Run(policyName, func(t *testing.T) {
 			var policy topologymanager.Policy
@@ -1329,7 +1331,7 @@ func assertMergePreferred(t *testing.T, numaInfo *topologymanager.NUMAInfo, prov
 				policy = topologymanager.NewRestrictedPolicy(numaInfo, topologymanager.PolicyOptions{})
 			}
 
-			bestHint, admit := policy.Merge(tCtx.Logger(), providersHints)
+			bestHint, admit := policy.Merge(logger, providersHints)
 			if !admit {
 				t.Fatalf("expected pod to be admitted under %s policy", policyName)
 			}

--- a/pkg/kubelet/cm/devicemanager/types.go
+++ b/pkg/kubelet/cm/devicemanager/types.go
@@ -61,7 +61,7 @@ type Manager interface {
 
 	// GetCapacity returns the amount of available device plugin resource capacity, resource allocatable
 	// and inactive device plugin resources previously registered on the node.
-	GetCapacity() (v1.ResourceList, v1.ResourceList, []string)
+	GetCapacity(logger klog.Logger) (v1.ResourceList, v1.ResourceList, []string)
 
 	// GetWatcherHandler returns the plugin handler for the device manager.
 	GetWatcherHandler() cache.PluginHandler

--- a/pkg/kubelet/cm/fake_container_manager.go
+++ b/pkg/kubelet/cm/fake_container_manager.go
@@ -125,7 +125,7 @@ func (cm *FakeContainerManager) GetNodeAllocatableReservation() v1.ResourceList 
 	return nil
 }
 
-func (cm *FakeContainerManager) GetCapacity(localStorageCapacityIsolation bool) v1.ResourceList {
+func (cm *FakeContainerManager) GetCapacity(_ klog.Logger, localStorageCapacityIsolation bool) v1.ResourceList {
 	cm.Lock()
 	defer cm.Unlock()
 	cm.CalledFunctions = append(cm.CalledFunctions, "GetCapacity")
@@ -154,7 +154,7 @@ func (cm *FakeContainerManager) GetHealthCheckers() []healthz.HealthChecker {
 	return []healthz.HealthChecker{}
 }
 
-func (cm *FakeContainerManager) GetDevicePluginResourceCapacity() (v1.ResourceList, v1.ResourceList, []string) {
+func (cm *FakeContainerManager) GetDevicePluginResourceCapacity(_ klog.Logger) (v1.ResourceList, v1.ResourceList, []string) {
 	cm.Lock()
 	defer cm.Unlock()
 	cm.CalledFunctions = append(cm.CalledFunctions, "GetDevicePluginResourceCapacity")
@@ -182,11 +182,11 @@ func (cm *FakeContainerManager) UpdatePluginResources(*schedulerframework.NodeIn
 	return nil
 }
 
-func (cm *FakeContainerManager) InternalContainerLifecycle() InternalContainerLifecycle {
+func (cm *FakeContainerManager) InternalContainerLifecycle(logger klog.Logger) InternalContainerLifecycle {
 	cm.Lock()
 	defer cm.Unlock()
 	cm.CalledFunctions = append(cm.CalledFunctions, "InternalContainerLifecycle")
-	return &internalContainerLifecycleImpl{cm.cpuManager, cm.memoryManager, topologymanager.NewFakeManager()}
+	return &internalContainerLifecycleImpl{cm.cpuManager, cm.memoryManager, topologymanager.NewFakeManager(logger)}
 }
 
 func (cm *FakeContainerManager) GetPodCgroupRoot() string {
@@ -217,11 +217,11 @@ func (cm *FakeContainerManager) ShouldResetExtendedResourceCapacity() bool {
 	return cm.shouldResetExtendedResourceCapacity
 }
 
-func (cm *FakeContainerManager) GetAllocateResourcesPodAdmitHandler() lifecycle.PodAdmitHandler {
+func (cm *FakeContainerManager) GetAllocateResourcesPodAdmitHandler(logger klog.Logger) lifecycle.PodAdmitHandler {
 	cm.Lock()
 	defer cm.Unlock()
 	cm.CalledFunctions = append(cm.CalledFunctions, "GetAllocateResourcesPodAdmitHandler")
-	return topologymanager.NewFakeManager()
+	return topologymanager.NewFakeManager(logger)
 }
 
 func (cm *FakeContainerManager) UpdateAllocatedDevices() {
@@ -257,7 +257,7 @@ func (cm *FakeContainerManager) GetAllocatableMemory() []*podresourcesapi.Contai
 	return nil
 }
 
-func (cm *FakeContainerManager) GetDynamicResources(pod *v1.Pod, container *v1.Container) []*podresourcesapi.DynamicResource {
+func (cm *FakeContainerManager) GetDynamicResources(logger klog.Logger, pod *v1.Pod, container *v1.Container) []*podresourcesapi.DynamicResource {
 	return nil
 }
 
@@ -288,10 +288,10 @@ func (cm *FakeContainerManager) Updates() <-chan resourceupdates.Update {
 	return nil
 }
 
-func (cm *FakeContainerManager) PodHasExclusiveCPUs(pod *v1.Pod) bool {
+func (cm *FakeContainerManager) PodHasExclusiveCPUs(logger klog.Logger, pod *v1.Pod) bool {
 	return false
 }
 
-func (cm *FakeContainerManager) ContainerHasExclusiveCPUs(pod *v1.Pod, container *v1.Container) bool {
+func (cm *FakeContainerManager) ContainerHasExclusiveCPUs(logger klog.Logger, pod *v1.Pod, container *v1.Container) bool {
 	return false
 }

--- a/pkg/kubelet/cm/internal_container_lifecycle.go
+++ b/pkg/kubelet/cm/internal_container_lifecycle.go
@@ -47,7 +47,7 @@ func (i *internalContainerLifecycleImpl) PreStartContainer(logger klog.Logger, p
 		i.memoryManager.AddContainer(logger, pod, container, containerID)
 	}
 
-	i.topologyManager.AddContainer(pod, container, containerID)
+	i.topologyManager.AddContainer(logger, pod, container, containerID)
 
 	return nil
 }

--- a/pkg/kubelet/cm/internal_container_lifecycle_test.go
+++ b/pkg/kubelet/cm/internal_container_lifecycle_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"k8s.io/klog/v2"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2/ktesting"
@@ -51,7 +52,7 @@ type mockTopologyManager struct {
 	topologymanager.Manager
 }
 
-func (topologyManager *mockTopologyManager) AddContainer(*v1.Pod, *v1.Container, string) {
+func (topologyManager *mockTopologyManager) AddContainer(klog.Logger, *v1.Pod, *v1.Container, string) {
 	topologyManager.called = true
 }
 

--- a/pkg/kubelet/cm/memorymanager/memory_manager_test.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager_test.go
@@ -79,7 +79,7 @@ func returnPolicyByName(logger klog.Logger, testCase testMemoryManager) Policy {
 			err: fmt.Errorf("fake reg error"),
 		}
 	case PolicyTypeStatic:
-		policy, _ := NewPolicyStatic(logger, &testCase.machineInfo, testCase.reserved, topologymanager.NewFakeManager())
+		policy, _ := NewPolicyStatic(logger, &testCase.machineInfo, testCase.reserved, topologymanager.NewFakeManager(logger))
 		return policy
 	case policyTypeNone:
 		return NewPolicyNone(logger)
@@ -1945,7 +1945,7 @@ func TestNewManager(t *testing.T) {
 					Limits:   v1.ResourceList{v1.ResourceMemory: *resource.NewQuantity(gb, resource.BinarySI)},
 				},
 			},
-			affinity:         topologymanager.NewFakeManager(),
+			affinity:         topologymanager.NewFakeManager(logger),
 			expectedError:    nil,
 			expectedReserved: expectedReserved,
 		},
@@ -1968,7 +1968,7 @@ func TestNewManager(t *testing.T) {
 					},
 				},
 			},
-			affinity:         topologymanager.NewFakeManager(),
+			affinity:         topologymanager.NewFakeManager(logger),
 			expectedError:    fmt.Errorf("the total amount \"3Gi\" of type %q is not equal to the value \"2Gi\" determined by Node Allocatable feature", v1.ResourceMemory),
 			expectedReserved: expectedReserved,
 		},
@@ -1978,7 +1978,7 @@ func TestNewManager(t *testing.T) {
 			machineInfo:                machineInfo,
 			nodeAllocatableReservation: v1.ResourceList{},
 			systemReservedMemory:       []kubeletconfig.MemoryReservation{},
-			affinity:                   topologymanager.NewFakeManager(),
+			affinity:                   topologymanager.NewFakeManager(logger),
 			expectedError:              fmt.Errorf("[memorymanager] you should specify the system reserved memory"),
 			expectedReserved:           expectedReserved,
 		},
@@ -1988,7 +1988,7 @@ func TestNewManager(t *testing.T) {
 			machineInfo:                machineInfo,
 			nodeAllocatableReservation: v1.ResourceList{},
 			systemReservedMemory:       []kubeletconfig.MemoryReservation{},
-			affinity:                   topologymanager.NewFakeManager(),
+			affinity:                   topologymanager.NewFakeManager(logger),
 			expectedError:              fmt.Errorf("unknown policy: \"fake\""),
 			expectedReserved:           expectedReserved,
 		},
@@ -1998,7 +1998,7 @@ func TestNewManager(t *testing.T) {
 			machineInfo:                machineInfo,
 			nodeAllocatableReservation: v1.ResourceList{},
 			systemReservedMemory:       []kubeletconfig.MemoryReservation{},
-			affinity:                   topologymanager.NewFakeManager(),
+			affinity:                   topologymanager.NewFakeManager(logger),
 			expectedError:              nil,
 			expectedReserved:           expectedReserved,
 		},

--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -22,7 +22,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/go-logr/logr"
 	cadvisorapi "github.com/google/cadvisor/lib/model"
 
 	v1 "k8s.io/api/core/v1"
@@ -105,7 +104,7 @@ func (p *staticPolicy) Start(logger klog.Logger, s state.State) error {
 // shared pool. Such a configuration is invalid because it would lead to
 // containers in the shared pool having no memory allocated, causing them to
 // fail.
-func (p *staticPolicy) validatePodScopeResources(logger logr.Logger, pod *v1.Pod) error {
+func (p *staticPolicy) validatePodScopeResources(logger klog.Logger, pod *v1.Pod) error {
 	podTotalMemory, err := getPodRequestedResources(logger, pod)
 	if err != nil {
 		return err
@@ -181,7 +180,7 @@ func (p *staticPolicy) validatePodScopeResources(logger logr.Logger, pod *v1.Pod
 // It's called once per pod by the Topology Manager's pod-scope admit handler.
 // The logic here allocates a single NUMA-aligned "bubble" of memory for the
 // entire pod. All containers within the pod will share this NUMA binding.
-func (p *staticPolicy) AllocatePod(logger logr.Logger, s state.State, pod *v1.Pod) (rerr error) {
+func (p *staticPolicy) AllocatePod(logger klog.Logger, s state.State, pod *v1.Pod) (rerr error) {
 	podUID := string(pod.UID)
 	logger = klog.LoggerWithValues(logger, "pod", klog.KObj(pod))
 	logger.V(4).Info("AllocatePod called for pod-level managed pod")
@@ -219,7 +218,7 @@ func (p *staticPolicy) AllocatePod(logger logr.Logger, s state.State, pod *v1.Po
 
 	// 3. Handle hints and NUMA alignment.
 	machineState := s.GetMachineState()
-	bestHint := p.affinity.GetAffinity(podUID, append(pod.Spec.InitContainers, pod.Spec.Containers...)[0].Name)
+	bestHint := p.affinity.GetAffinity(logger, podUID, append(pod.Spec.InitContainers, pod.Spec.Containers...)[0].Name)
 	if bestHint.NUMANodeAffinity == nil {
 		defaultHint, err := p.getDefaultHint(machineState, pod, podTotalMemory)
 		if err != nil {
@@ -456,7 +455,7 @@ func (p *staticPolicy) Allocate(ctx context.Context, s state.State, pod *v1.Pod,
 	}
 
 	// Call Topology Manager to get the aligned affinity across all hint providers.
-	hint := p.affinity.GetAffinity(podUID, container.Name)
+	hint := p.affinity.GetAffinity(logger, podUID, container.Name)
 	logger.Info("Got topology affinity", "hint", hint)
 
 	requestedResources, err := getContainerRequestedResources(logger, pod, container)
@@ -698,7 +697,7 @@ func regenerateHints(logger klog.Logger, pod *v1.Pod, ctn *v1.Container, ctnBloc
 	return hints
 }
 
-func getPodRequestedResources(logger logr.Logger, pod *v1.Pod) (map[v1.ResourceName]uint64, error) {
+func getPodRequestedResources(logger klog.Logger, pod *v1.Pod) (map[v1.ResourceName]uint64, error) {
 	// If pod-level resources are set, use them directly.
 	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) && resourcehelper.IsPodLevelResourcesSet(pod) {
 		requestedResources := make(map[v1.ResourceName]uint64)
@@ -772,7 +771,7 @@ func getPodRequestedResources(logger logr.Logger, pod *v1.Pod) (map[v1.ResourceN
 	return reqRsrcs, nil
 }
 
-func (p *staticPolicy) GetPodTopologyHints(logger logr.Logger, s state.State, pod *v1.Pod) map[string][]topologymanager.TopologyHint {
+func (p *staticPolicy) GetPodTopologyHints(logger klog.Logger, s state.State, pod *v1.Pod) map[string][]topologymanager.TopologyHint {
 	logger = klog.LoggerWithValues(logger, "pod", klog.KObj(pod))
 
 	if v1qos.GetPodQOS(pod) != v1.PodQOSGuaranteed {
@@ -830,7 +829,7 @@ func (p *staticPolicy) GetPodTopologyHints(logger logr.Logger, s state.State, po
 // GetTopologyHints implements the topologymanager.HintProvider Interface
 // and is consulted to achieve NUMA aware resource alignment among this
 // and other resource controllers.
-func (p *staticPolicy) GetTopologyHints(logger logr.Logger, s state.State, pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint {
+func (p *staticPolicy) GetTopologyHints(logger klog.Logger, s state.State, pod *v1.Pod, container *v1.Container) map[string][]topologymanager.TopologyHint {
 	logger = klog.LoggerWithValues(logger, "pod", klog.KObj(pod))
 
 	if v1qos.GetPodQOS(pod) != v1.PodQOSGuaranteed {
@@ -861,7 +860,7 @@ func (p *staticPolicy) GetTopologyHints(logger logr.Logger, s state.State, pod *
 	return p.calculateHints(s.GetMachineState(), pod, requestedResources)
 }
 
-func getContainerRequestedResources(logger logr.Logger, pod *v1.Pod, container *v1.Container) (map[v1.ResourceName]uint64, error) {
+func getContainerRequestedResources(logger klog.Logger, pod *v1.Pod, container *v1.Container) (map[v1.ResourceName]uint64, error) {
 	requestedResources := map[v1.ResourceName]uint64{}
 	// For pod-level resource management, a container is only considered for exclusive
 	// memory if its request equals its limit for both the CPU and Memory. This

--- a/pkg/kubelet/cm/memorymanager/policy_static_restore_test.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static_restore_test.go
@@ -117,7 +117,7 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 					},
 				},
 			}
-			affinity := topologymanager.NewFakeManager()
+			affinity := topologymanager.NewFakeManager(logger)
 
 			// Create new manager
 			sDir := t.TempDir()

--- a/pkg/kubelet/cm/memorymanager/policy_static_test.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static_test.go
@@ -178,9 +178,9 @@ type requiredMetrics struct {
 
 func initTests(t *testing.T, testCase *testStaticPolicy, hint *topologymanager.TopologyHint, initContainersReusableMemory reusableMemory) (Policy, state.State, error) {
 	logger, _ := ktesting.NewTestContext(t)
-	manager := topologymanager.NewFakeManager()
+	manager := topologymanager.NewFakeManager(logger)
 	if hint != nil {
-		manager = topologymanager.NewFakeManagerWithHint(hint)
+		manager = topologymanager.NewFakeManagerWithHint(logger, hint)
 	}
 
 	p, err := NewPolicyStatic(logger, testCase.machineInfo, testCase.systemReserved, manager)

--- a/pkg/kubelet/cm/pod_container_manager_linux.go
+++ b/pkg/kubelet/cm/pod_container_manager_linux.go
@@ -79,7 +79,7 @@ func (m *podContainerManagerImpl) EnsureExists(logger klog.Logger, pod *v1.Pod) 
 	alreadyExists := m.Exists(pod)
 	if !alreadyExists {
 		enforceCPULimits := m.enforceCPULimits
-		if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.DisableCPUQuotaWithExclusiveCPUs) && m.podContainerManager.PodHasExclusiveCPUs(pod) {
+		if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.DisableCPUQuotaWithExclusiveCPUs) && m.podContainerManager.PodHasExclusiveCPUs(logger, pod) {
 			logger.V(2).Info("Disabled CFS quota", "pod", klog.KObj(pod))
 			enforceCPULimits = false
 		}

--- a/pkg/kubelet/cm/testing/mocks.go
+++ b/pkg/kubelet/cm/testing/mocks.go
@@ -68,16 +68,16 @@ func (_m *MockContainerManager) EXPECT() *MockContainerManager_Expecter {
 }
 
 // ContainerHasExclusiveCPUs provides a mock function for the type MockContainerManager
-func (_mock *MockContainerManager) ContainerHasExclusiveCPUs(pod *v1.Pod, container *v1.Container) bool {
-	ret := _mock.Called(pod, container)
+func (_mock *MockContainerManager) ContainerHasExclusiveCPUs(logger klog.Logger, pod *v1.Pod, container *v1.Container) bool {
+	ret := _mock.Called(logger, pod, container)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ContainerHasExclusiveCPUs")
 	}
 
 	var r0 bool
-	if returnFunc, ok := ret.Get(0).(func(*v1.Pod, *v1.Container) bool); ok {
-		r0 = returnFunc(pod, container)
+	if returnFunc, ok := ret.Get(0).(func(klog.Logger, *v1.Pod, *v1.Container) bool); ok {
+		r0 = returnFunc(logger, pod, container)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
@@ -90,25 +90,31 @@ type MockContainerManager_ContainerHasExclusiveCPUs_Call struct {
 }
 
 // ContainerHasExclusiveCPUs is a helper method to define mock.On call
+//   - logger klog.Logger
 //   - pod *v1.Pod
 //   - container *v1.Container
-func (_e *MockContainerManager_Expecter) ContainerHasExclusiveCPUs(pod interface{}, container interface{}) *MockContainerManager_ContainerHasExclusiveCPUs_Call {
-	return &MockContainerManager_ContainerHasExclusiveCPUs_Call{Call: _e.mock.On("ContainerHasExclusiveCPUs", pod, container)}
+func (_e *MockContainerManager_Expecter) ContainerHasExclusiveCPUs(logger interface{}, pod interface{}, container interface{}) *MockContainerManager_ContainerHasExclusiveCPUs_Call {
+	return &MockContainerManager_ContainerHasExclusiveCPUs_Call{Call: _e.mock.On("ContainerHasExclusiveCPUs", logger, pod, container)}
 }
 
-func (_c *MockContainerManager_ContainerHasExclusiveCPUs_Call) Run(run func(pod *v1.Pod, container *v1.Container)) *MockContainerManager_ContainerHasExclusiveCPUs_Call {
+func (_c *MockContainerManager_ContainerHasExclusiveCPUs_Call) Run(run func(logger klog.Logger, pod *v1.Pod, container *v1.Container)) *MockContainerManager_ContainerHasExclusiveCPUs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *v1.Pod
+		var arg0 klog.Logger
 		if args[0] != nil {
-			arg0 = args[0].(*v1.Pod)
+			arg0 = args[0].(klog.Logger)
 		}
-		var arg1 *v1.Container
+		var arg1 *v1.Pod
 		if args[1] != nil {
-			arg1 = args[1].(*v1.Container)
+			arg1 = args[1].(*v1.Pod)
+		}
+		var arg2 *v1.Container
+		if args[2] != nil {
+			arg2 = args[2].(*v1.Container)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -119,7 +125,7 @@ func (_c *MockContainerManager_ContainerHasExclusiveCPUs_Call) Return(b bool) *M
 	return _c
 }
 
-func (_c *MockContainerManager_ContainerHasExclusiveCPUs_Call) RunAndReturn(run func(pod *v1.Pod, container *v1.Container) bool) *MockContainerManager_ContainerHasExclusiveCPUs_Call {
+func (_c *MockContainerManager_ContainerHasExclusiveCPUs_Call) RunAndReturn(run func(logger klog.Logger, pod *v1.Pod, container *v1.Container) bool) *MockContainerManager_ContainerHasExclusiveCPUs_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -263,16 +269,16 @@ func (_c *MockContainerManager_GetAllocatableMemory_Call) RunAndReturn(run func(
 }
 
 // GetAllocateResourcesPodAdmitHandler provides a mock function for the type MockContainerManager
-func (_mock *MockContainerManager) GetAllocateResourcesPodAdmitHandler() lifecycle.PodAdmitHandler {
-	ret := _mock.Called()
+func (_mock *MockContainerManager) GetAllocateResourcesPodAdmitHandler(logger klog.Logger) lifecycle.PodAdmitHandler {
+	ret := _mock.Called(logger)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAllocateResourcesPodAdmitHandler")
 	}
 
 	var r0 lifecycle.PodAdmitHandler
-	if returnFunc, ok := ret.Get(0).(func() lifecycle.PodAdmitHandler); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(klog.Logger) lifecycle.PodAdmitHandler); ok {
+		r0 = returnFunc(logger)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(lifecycle.PodAdmitHandler)
@@ -287,13 +293,20 @@ type MockContainerManager_GetAllocateResourcesPodAdmitHandler_Call struct {
 }
 
 // GetAllocateResourcesPodAdmitHandler is a helper method to define mock.On call
-func (_e *MockContainerManager_Expecter) GetAllocateResourcesPodAdmitHandler() *MockContainerManager_GetAllocateResourcesPodAdmitHandler_Call {
-	return &MockContainerManager_GetAllocateResourcesPodAdmitHandler_Call{Call: _e.mock.On("GetAllocateResourcesPodAdmitHandler")}
+//   - logger klog.Logger
+func (_e *MockContainerManager_Expecter) GetAllocateResourcesPodAdmitHandler(logger interface{}) *MockContainerManager_GetAllocateResourcesPodAdmitHandler_Call {
+	return &MockContainerManager_GetAllocateResourcesPodAdmitHandler_Call{Call: _e.mock.On("GetAllocateResourcesPodAdmitHandler", logger)}
 }
 
-func (_c *MockContainerManager_GetAllocateResourcesPodAdmitHandler_Call) Run(run func()) *MockContainerManager_GetAllocateResourcesPodAdmitHandler_Call {
+func (_c *MockContainerManager_GetAllocateResourcesPodAdmitHandler_Call) Run(run func(logger klog.Logger)) *MockContainerManager_GetAllocateResourcesPodAdmitHandler_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 klog.Logger
+		if args[0] != nil {
+			arg0 = args[0].(klog.Logger)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -303,7 +316,7 @@ func (_c *MockContainerManager_GetAllocateResourcesPodAdmitHandler_Call) Return(
 	return _c
 }
 
-func (_c *MockContainerManager_GetAllocateResourcesPodAdmitHandler_Call) RunAndReturn(run func() lifecycle.PodAdmitHandler) *MockContainerManager_GetAllocateResourcesPodAdmitHandler_Call {
+func (_c *MockContainerManager_GetAllocateResourcesPodAdmitHandler_Call) RunAndReturn(run func(logger klog.Logger) lifecycle.PodAdmitHandler) *MockContainerManager_GetAllocateResourcesPodAdmitHandler_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -368,16 +381,16 @@ func (_c *MockContainerManager_GetCPUs_Call) RunAndReturn(run func(podUID string
 }
 
 // GetCapacity provides a mock function for the type MockContainerManager
-func (_mock *MockContainerManager) GetCapacity(localStorageCapacityIsolation bool) v1.ResourceList {
-	ret := _mock.Called(localStorageCapacityIsolation)
+func (_mock *MockContainerManager) GetCapacity(logger klog.Logger, localStorageCapacityIsolation bool) v1.ResourceList {
+	ret := _mock.Called(logger, localStorageCapacityIsolation)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCapacity")
 	}
 
 	var r0 v1.ResourceList
-	if returnFunc, ok := ret.Get(0).(func(bool) v1.ResourceList); ok {
-		r0 = returnFunc(localStorageCapacityIsolation)
+	if returnFunc, ok := ret.Get(0).(func(klog.Logger, bool) v1.ResourceList); ok {
+		r0 = returnFunc(logger, localStorageCapacityIsolation)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(v1.ResourceList)
@@ -392,19 +405,25 @@ type MockContainerManager_GetCapacity_Call struct {
 }
 
 // GetCapacity is a helper method to define mock.On call
+//   - logger klog.Logger
 //   - localStorageCapacityIsolation bool
-func (_e *MockContainerManager_Expecter) GetCapacity(localStorageCapacityIsolation interface{}) *MockContainerManager_GetCapacity_Call {
-	return &MockContainerManager_GetCapacity_Call{Call: _e.mock.On("GetCapacity", localStorageCapacityIsolation)}
+func (_e *MockContainerManager_Expecter) GetCapacity(logger interface{}, localStorageCapacityIsolation interface{}) *MockContainerManager_GetCapacity_Call {
+	return &MockContainerManager_GetCapacity_Call{Call: _e.mock.On("GetCapacity", logger, localStorageCapacityIsolation)}
 }
 
-func (_c *MockContainerManager_GetCapacity_Call) Run(run func(localStorageCapacityIsolation bool)) *MockContainerManager_GetCapacity_Call {
+func (_c *MockContainerManager_GetCapacity_Call) Run(run func(logger klog.Logger, localStorageCapacityIsolation bool)) *MockContainerManager_GetCapacity_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 bool
+		var arg0 klog.Logger
 		if args[0] != nil {
-			arg0 = args[0].(bool)
+			arg0 = args[0].(klog.Logger)
+		}
+		var arg1 bool
+		if args[1] != nil {
+			arg1 = args[1].(bool)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -415,14 +434,14 @@ func (_c *MockContainerManager_GetCapacity_Call) Return(resourceList v1.Resource
 	return _c
 }
 
-func (_c *MockContainerManager_GetCapacity_Call) RunAndReturn(run func(localStorageCapacityIsolation bool) v1.ResourceList) *MockContainerManager_GetCapacity_Call {
+func (_c *MockContainerManager_GetCapacity_Call) RunAndReturn(run func(logger klog.Logger, localStorageCapacityIsolation bool) v1.ResourceList) *MockContainerManager_GetCapacity_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetDevicePluginResourceCapacity provides a mock function for the type MockContainerManager
-func (_mock *MockContainerManager) GetDevicePluginResourceCapacity() (v1.ResourceList, v1.ResourceList, []string) {
-	ret := _mock.Called()
+func (_mock *MockContainerManager) GetDevicePluginResourceCapacity(logger klog.Logger) (v1.ResourceList, v1.ResourceList, []string) {
+	ret := _mock.Called(logger)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetDevicePluginResourceCapacity")
@@ -431,25 +450,25 @@ func (_mock *MockContainerManager) GetDevicePluginResourceCapacity() (v1.Resourc
 	var r0 v1.ResourceList
 	var r1 v1.ResourceList
 	var r2 []string
-	if returnFunc, ok := ret.Get(0).(func() (v1.ResourceList, v1.ResourceList, []string)); ok {
-		return returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(klog.Logger) (v1.ResourceList, v1.ResourceList, []string)); ok {
+		return returnFunc(logger)
 	}
-	if returnFunc, ok := ret.Get(0).(func() v1.ResourceList); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(klog.Logger) v1.ResourceList); ok {
+		r0 = returnFunc(logger)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(v1.ResourceList)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func() v1.ResourceList); ok {
-		r1 = returnFunc()
+	if returnFunc, ok := ret.Get(1).(func(klog.Logger) v1.ResourceList); ok {
+		r1 = returnFunc(logger)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(v1.ResourceList)
 		}
 	}
-	if returnFunc, ok := ret.Get(2).(func() []string); ok {
-		r2 = returnFunc()
+	if returnFunc, ok := ret.Get(2).(func(klog.Logger) []string); ok {
+		r2 = returnFunc(logger)
 	} else {
 		if ret.Get(2) != nil {
 			r2 = ret.Get(2).([]string)
@@ -464,13 +483,20 @@ type MockContainerManager_GetDevicePluginResourceCapacity_Call struct {
 }
 
 // GetDevicePluginResourceCapacity is a helper method to define mock.On call
-func (_e *MockContainerManager_Expecter) GetDevicePluginResourceCapacity() *MockContainerManager_GetDevicePluginResourceCapacity_Call {
-	return &MockContainerManager_GetDevicePluginResourceCapacity_Call{Call: _e.mock.On("GetDevicePluginResourceCapacity")}
+//   - logger klog.Logger
+func (_e *MockContainerManager_Expecter) GetDevicePluginResourceCapacity(logger interface{}) *MockContainerManager_GetDevicePluginResourceCapacity_Call {
+	return &MockContainerManager_GetDevicePluginResourceCapacity_Call{Call: _e.mock.On("GetDevicePluginResourceCapacity", logger)}
 }
 
-func (_c *MockContainerManager_GetDevicePluginResourceCapacity_Call) Run(run func()) *MockContainerManager_GetDevicePluginResourceCapacity_Call {
+func (_c *MockContainerManager_GetDevicePluginResourceCapacity_Call) Run(run func(logger klog.Logger)) *MockContainerManager_GetDevicePluginResourceCapacity_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 klog.Logger
+		if args[0] != nil {
+			arg0 = args[0].(klog.Logger)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -480,7 +506,7 @@ func (_c *MockContainerManager_GetDevicePluginResourceCapacity_Call) Return(reso
 	return _c
 }
 
-func (_c *MockContainerManager_GetDevicePluginResourceCapacity_Call) RunAndReturn(run func() (v1.ResourceList, v1.ResourceList, []string)) *MockContainerManager_GetDevicePluginResourceCapacity_Call {
+func (_c *MockContainerManager_GetDevicePluginResourceCapacity_Call) RunAndReturn(run func(logger klog.Logger) (v1.ResourceList, v1.ResourceList, []string)) *MockContainerManager_GetDevicePluginResourceCapacity_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -545,16 +571,16 @@ func (_c *MockContainerManager_GetDevices_Call) RunAndReturn(run func(podUID str
 }
 
 // GetDynamicResources provides a mock function for the type MockContainerManager
-func (_mock *MockContainerManager) GetDynamicResources(pod *v1.Pod, container *v1.Container) []*v10.DynamicResource {
-	ret := _mock.Called(pod, container)
+func (_mock *MockContainerManager) GetDynamicResources(logger klog.Logger, pod *v1.Pod, container *v1.Container) []*v10.DynamicResource {
+	ret := _mock.Called(logger, pod, container)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetDynamicResources")
 	}
 
 	var r0 []*v10.DynamicResource
-	if returnFunc, ok := ret.Get(0).(func(*v1.Pod, *v1.Container) []*v10.DynamicResource); ok {
-		r0 = returnFunc(pod, container)
+	if returnFunc, ok := ret.Get(0).(func(klog.Logger, *v1.Pod, *v1.Container) []*v10.DynamicResource); ok {
+		r0 = returnFunc(logger, pod, container)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*v10.DynamicResource)
@@ -569,25 +595,31 @@ type MockContainerManager_GetDynamicResources_Call struct {
 }
 
 // GetDynamicResources is a helper method to define mock.On call
+//   - logger klog.Logger
 //   - pod *v1.Pod
 //   - container *v1.Container
-func (_e *MockContainerManager_Expecter) GetDynamicResources(pod interface{}, container interface{}) *MockContainerManager_GetDynamicResources_Call {
-	return &MockContainerManager_GetDynamicResources_Call{Call: _e.mock.On("GetDynamicResources", pod, container)}
+func (_e *MockContainerManager_Expecter) GetDynamicResources(logger interface{}, pod interface{}, container interface{}) *MockContainerManager_GetDynamicResources_Call {
+	return &MockContainerManager_GetDynamicResources_Call{Call: _e.mock.On("GetDynamicResources", logger, pod, container)}
 }
 
-func (_c *MockContainerManager_GetDynamicResources_Call) Run(run func(pod *v1.Pod, container *v1.Container)) *MockContainerManager_GetDynamicResources_Call {
+func (_c *MockContainerManager_GetDynamicResources_Call) Run(run func(logger klog.Logger, pod *v1.Pod, container *v1.Container)) *MockContainerManager_GetDynamicResources_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *v1.Pod
+		var arg0 klog.Logger
 		if args[0] != nil {
-			arg0 = args[0].(*v1.Pod)
+			arg0 = args[0].(klog.Logger)
 		}
-		var arg1 *v1.Container
+		var arg1 *v1.Pod
 		if args[1] != nil {
-			arg1 = args[1].(*v1.Container)
+			arg1 = args[1].(*v1.Pod)
+		}
+		var arg2 *v1.Container
+		if args[2] != nil {
+			arg2 = args[2].(*v1.Container)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -598,7 +630,7 @@ func (_c *MockContainerManager_GetDynamicResources_Call) Return(dynamicResources
 	return _c
 }
 
-func (_c *MockContainerManager_GetDynamicResources_Call) RunAndReturn(run func(pod *v1.Pod, container *v1.Container) []*v10.DynamicResource) *MockContainerManager_GetDynamicResources_Call {
+func (_c *MockContainerManager_GetDynamicResources_Call) RunAndReturn(run func(logger klog.Logger, pod *v1.Pod, container *v1.Container) []*v10.DynamicResource) *MockContainerManager_GetDynamicResources_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1099,16 +1131,16 @@ func (_c *MockContainerManager_GetResources_Call) RunAndReturn(run func(ctx cont
 }
 
 // InternalContainerLifecycle provides a mock function for the type MockContainerManager
-func (_mock *MockContainerManager) InternalContainerLifecycle() cm.InternalContainerLifecycle {
-	ret := _mock.Called()
+func (_mock *MockContainerManager) InternalContainerLifecycle(logger klog.Logger) cm.InternalContainerLifecycle {
+	ret := _mock.Called(logger)
 
 	if len(ret) == 0 {
 		panic("no return value specified for InternalContainerLifecycle")
 	}
 
 	var r0 cm.InternalContainerLifecycle
-	if returnFunc, ok := ret.Get(0).(func() cm.InternalContainerLifecycle); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(klog.Logger) cm.InternalContainerLifecycle); ok {
+		r0 = returnFunc(logger)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(cm.InternalContainerLifecycle)
@@ -1123,13 +1155,20 @@ type MockContainerManager_InternalContainerLifecycle_Call struct {
 }
 
 // InternalContainerLifecycle is a helper method to define mock.On call
-func (_e *MockContainerManager_Expecter) InternalContainerLifecycle() *MockContainerManager_InternalContainerLifecycle_Call {
-	return &MockContainerManager_InternalContainerLifecycle_Call{Call: _e.mock.On("InternalContainerLifecycle")}
+//   - logger klog.Logger
+func (_e *MockContainerManager_Expecter) InternalContainerLifecycle(logger interface{}) *MockContainerManager_InternalContainerLifecycle_Call {
+	return &MockContainerManager_InternalContainerLifecycle_Call{Call: _e.mock.On("InternalContainerLifecycle", logger)}
 }
 
-func (_c *MockContainerManager_InternalContainerLifecycle_Call) Run(run func()) *MockContainerManager_InternalContainerLifecycle_Call {
+func (_c *MockContainerManager_InternalContainerLifecycle_Call) Run(run func(logger klog.Logger)) *MockContainerManager_InternalContainerLifecycle_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 klog.Logger
+		if args[0] != nil {
+			arg0 = args[0].(klog.Logger)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -1139,7 +1178,7 @@ func (_c *MockContainerManager_InternalContainerLifecycle_Call) Return(internalC
 	return _c
 }
 
-func (_c *MockContainerManager_InternalContainerLifecycle_Call) RunAndReturn(run func() cm.InternalContainerLifecycle) *MockContainerManager_InternalContainerLifecycle_Call {
+func (_c *MockContainerManager_InternalContainerLifecycle_Call) RunAndReturn(run func(logger klog.Logger) cm.InternalContainerLifecycle) *MockContainerManager_InternalContainerLifecycle_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1191,16 +1230,16 @@ func (_c *MockContainerManager_NewPodContainerManager_Call) RunAndReturn(run fun
 }
 
 // PodHasExclusiveCPUs provides a mock function for the type MockContainerManager
-func (_mock *MockContainerManager) PodHasExclusiveCPUs(pod *v1.Pod) bool {
-	ret := _mock.Called(pod)
+func (_mock *MockContainerManager) PodHasExclusiveCPUs(logger klog.Logger, pod *v1.Pod) bool {
+	ret := _mock.Called(logger, pod)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PodHasExclusiveCPUs")
 	}
 
 	var r0 bool
-	if returnFunc, ok := ret.Get(0).(func(*v1.Pod) bool); ok {
-		r0 = returnFunc(pod)
+	if returnFunc, ok := ret.Get(0).(func(klog.Logger, *v1.Pod) bool); ok {
+		r0 = returnFunc(logger, pod)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
@@ -1213,19 +1252,25 @@ type MockContainerManager_PodHasExclusiveCPUs_Call struct {
 }
 
 // PodHasExclusiveCPUs is a helper method to define mock.On call
+//   - logger klog.Logger
 //   - pod *v1.Pod
-func (_e *MockContainerManager_Expecter) PodHasExclusiveCPUs(pod interface{}) *MockContainerManager_PodHasExclusiveCPUs_Call {
-	return &MockContainerManager_PodHasExclusiveCPUs_Call{Call: _e.mock.On("PodHasExclusiveCPUs", pod)}
+func (_e *MockContainerManager_Expecter) PodHasExclusiveCPUs(logger interface{}, pod interface{}) *MockContainerManager_PodHasExclusiveCPUs_Call {
+	return &MockContainerManager_PodHasExclusiveCPUs_Call{Call: _e.mock.On("PodHasExclusiveCPUs", logger, pod)}
 }
 
-func (_c *MockContainerManager_PodHasExclusiveCPUs_Call) Run(run func(pod *v1.Pod)) *MockContainerManager_PodHasExclusiveCPUs_Call {
+func (_c *MockContainerManager_PodHasExclusiveCPUs_Call) Run(run func(logger klog.Logger, pod *v1.Pod)) *MockContainerManager_PodHasExclusiveCPUs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *v1.Pod
+		var arg0 klog.Logger
 		if args[0] != nil {
-			arg0 = args[0].(*v1.Pod)
+			arg0 = args[0].(klog.Logger)
+		}
+		var arg1 *v1.Pod
+		if args[1] != nil {
+			arg1 = args[1].(*v1.Pod)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -1236,7 +1281,7 @@ func (_c *MockContainerManager_PodHasExclusiveCPUs_Call) Return(b bool) *MockCon
 	return _c
 }
 
-func (_c *MockContainerManager_PodHasExclusiveCPUs_Call) RunAndReturn(run func(pod *v1.Pod) bool) *MockContainerManager_PodHasExclusiveCPUs_Call {
+func (_c *MockContainerManager_PodHasExclusiveCPUs_Call) RunAndReturn(run func(logger klog.Logger, pod *v1.Pod) bool) *MockContainerManager_PodHasExclusiveCPUs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
@@ -32,9 +32,7 @@ type fakeManager struct {
 }
 
 // NewFakeManager returns an instance of FakeManager
-func NewFakeManager() Manager {
-	// Use klog.TODO() because changing NewManager requires changes in too many other components
-	logger := klog.TODO()
+func NewFakeManager(logger klog.Logger) Manager {
 	logger.Info("NewFakeManager")
 	return &fakeManager{}
 }
@@ -47,9 +45,7 @@ func NewFakeManagerWithScope(scope string) Manager {
 }
 
 // NewFakeManagerWithHint returns an instance of fake topology manager with specified topology hints
-func NewFakeManagerWithHint(hint *TopologyHint) Manager {
-	// Use klog.TODO() because changing NewManager requires changes in too many other components
-	logger := klog.TODO()
+func NewFakeManagerWithHint(logger klog.Logger, hint *TopologyHint) Manager {
 	logger.Info("NewFakeManagerWithHint")
 	return &fakeManager{
 		hint:   hint,
@@ -58,20 +54,14 @@ func NewFakeManagerWithHint(hint *TopologyHint) Manager {
 }
 
 // NewFakeManagerWithPolicy returns an instance of fake topology manager with specified policy
-func NewFakeManagerWithPolicy(policy Policy) Manager {
-	// Use klog.TODO() because changing NewManager requires changes in too many other components
-	logger := klog.TODO()
+func NewFakeManagerWithPolicy(logger klog.Logger, policy Policy) Manager {
 	logger.Info("NewFakeManagerWithPolicy", "policy", policy.Name())
 	return &fakeManager{
 		policy: policy,
 	}
 }
 
-func (m *fakeManager) GetAffinity(podUID string, containerName string) TopologyHint {
-	// Use context.TODO() because we currently do not have a proper context to pass in.
-	// Replace this with an appropriate context when refactoring this function to accept a context parameter.
-	ctx := context.TODO()
-	logger := klog.FromContext(ctx)
+func (m *fakeManager) GetAffinity(logger klog.Logger, podUID string, containerName string) TopologyHint {
 	logger.Info("GetAffinity", "podUID", podUID, "containerName", containerName)
 	if m.hint == nil {
 		return TopologyHint{}
@@ -92,11 +82,7 @@ func (m *fakeManager) AddHintProvider(logger klog.Logger, h HintProvider) {
 	logger.Info("AddHintProvider", "hintProvider", h)
 }
 
-func (m *fakeManager) AddContainer(pod *v1.Pod, container *v1.Container, containerID string) {
-	// Use context.TODO() because we currently do not have a proper context to pass in.
-	// Replace this with an appropriate context when refactoring this function to accept a context parameter.
-	ctx := context.TODO()
-	logger := klog.FromContext(ctx)
+func (m *fakeManager) AddContainer(logger klog.Logger, pod *v1.Pod, container *v1.Container, containerID string) {
 	logger.Info("AddContainer", "pod", klog.KObj(pod), "containerName", container.Name, "containerID", containerID)
 }
 

--- a/pkg/kubelet/cm/topologymanager/fake_topology_manager_test.go
+++ b/pkg/kubelet/cm/topologymanager/fake_topology_manager_test.go
@@ -26,7 +26,8 @@ import (
 )
 
 func TestNewFakeManager(t *testing.T) {
-	fm := NewFakeManager()
+	logger, _ := ktesting.NewTestContext(t)
+	fm := NewFakeManager(logger)
 
 	if _, ok := fm.(Manager); !ok {
 		t.Errorf("Result is not Manager type")
@@ -35,6 +36,7 @@ func TestNewFakeManager(t *testing.T) {
 }
 
 func TestFakeGetAffinity(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	tcases := []struct {
 		name          string
 		containerName string
@@ -50,7 +52,7 @@ func TestFakeGetAffinity(t *testing.T) {
 	}
 	for _, tc := range tcases {
 		fm := fakeManager{}
-		actual := fm.GetAffinity(tc.podUID, tc.containerName)
+		actual := fm.GetAffinity(logger, tc.podUID, tc.containerName)
 		if !reflect.DeepEqual(actual, tc.expected) {
 			t.Errorf("Expected Affinity in result to be %v, got %v", tc.expected, actual)
 		}

--- a/pkg/kubelet/cm/topologymanager/scope.go
+++ b/pkg/kubelet/cm/topologymanager/scope.go
@@ -45,7 +45,7 @@ type Scope interface {
 	Admit(ctx context.Context, pod *v1.Pod) lifecycle.PodAdmitResult
 	// AddHintProvider adds a hint provider to manager to indicate the hint provider
 	// wants to be consoluted with when making topology hints
-	AddHintProvider(h HintProvider)
+	AddHintProvider(logger klog.Logger, h HintProvider)
 	// AddContainer adds pod to Manager for tracking
 	AddContainer(pod *v1.Pod, container *v1.Container, containerID string)
 	// RemoveContainer removes pod from Manager tracking
@@ -88,7 +88,7 @@ func (s *scope) setTopologyHints(podUID string, containerName string, th Topolog
 	s.podTopologyHints[podUID][containerName] = th
 }
 
-func (s *scope) GetAffinity(podUID string, containerName string) TopologyHint {
+func (s *scope) GetAffinity(_ klog.Logger, podUID string, containerName string) TopologyHint {
 	return s.getTopologyHints(podUID, containerName)
 }
 
@@ -96,7 +96,7 @@ func (s *scope) GetPolicy() Policy {
 	return s.policy
 }
 
-func (s *scope) AddHintProvider(h HintProvider) {
+func (s *scope) AddHintProvider(_ klog.Logger, h HintProvider) {
 	s.hintProviders = append(s.hintProviders, h)
 }
 

--- a/pkg/kubelet/cm/topologymanager/scope_test.go
+++ b/pkg/kubelet/cm/topologymanager/scope_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestGetAffinity(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	tcases := []struct {
 		name          string
 		containerName string
@@ -42,7 +43,7 @@ func TestGetAffinity(t *testing.T) {
 	}
 	for _, tc := range tcases {
 		scope := scope{}
-		actual := scope.GetAffinity(tc.podUID, tc.containerName)
+		actual := scope.GetAffinity(logger, tc.podUID, tc.containerName)
 		if !reflect.DeepEqual(actual, tc.expected) {
 			t.Errorf("Expected Affinity in result to be %v, got %v", tc.expected, actual)
 		}

--- a/pkg/kubelet/cm/topologymanager/topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager.go
@@ -88,7 +88,7 @@ type Manager interface {
 	// wants to be consulted with when making topology hints
 	AddHintProvider(logger klog.Logger, h HintProvider)
 	// AddContainer adds pod to Manager for tracking
-	AddContainer(pod *v1.Pod, container *v1.Container, containerID string)
+	AddContainer(logger klog.Logger, pod *v1.Pod, container *v1.Container, containerID string)
 	// RemoveContainer removes pod from Manager tracking
 	RemoveContainer(logger klog.Logger, containerID string) error
 	// Store is the interface for storing pod topology hints
@@ -125,7 +125,7 @@ type HintProvider interface {
 
 // Store interface is to allow Hint Providers to retrieve pod affinity
 type Store interface {
-	GetAffinity(podUID string, containerName string) TopologyHint
+	GetAffinity(logger klog.Logger, podUID string, containerName string) TopologyHint
 	GetPolicy() Policy
 	Name() string
 }
@@ -235,8 +235,8 @@ func (m *manager) initializeMetrics() {
 	metrics.ContainerAlignedComputeResourcesFailure.WithLabelValues(metrics.AlignScopePod, metrics.AlignedNUMANode).Add(0)
 }
 
-func (m *manager) GetAffinity(podUID string, containerName string) TopologyHint {
-	return m.scope.GetAffinity(podUID, containerName)
+func (m *manager) GetAffinity(logger klog.Logger, podUID string, containerName string) TopologyHint {
+	return m.scope.GetAffinity(logger, podUID, containerName)
 }
 
 func (m *manager) GetPolicy() Policy {
@@ -247,11 +247,11 @@ func (m *manager) Name() string {
 	return m.scope.Name()
 }
 
-func (m *manager) AddHintProvider(_ klog.Logger, h HintProvider) {
-	m.scope.AddHintProvider(h)
+func (m *manager) AddHintProvider(logger klog.Logger, h HintProvider) {
+	m.scope.AddHintProvider(logger, h)
 }
 
-func (m *manager) AddContainer(pod *v1.Pod, container *v1.Container, containerID string) {
+func (m *manager) AddContainer(_ klog.Logger, pod *v1.Pod, container *v1.Container, containerID string) {
 	m.scope.AddContainer(pod, container, containerID)
 }
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1123,7 +1123,7 @@ func NewMainKubelet(ctx context.Context,
 	klet.AddPodSyncLoopHandler(activeDeadlineHandler)
 	klet.AddPodSyncHandler(activeDeadlineHandler)
 
-	handlers = append(handlers, klet.containerManager.GetAllocateResourcesPodAdmitHandler())
+	handlers = append(handlers, klet.containerManager.GetAllocateResourcesPodAdmitHandler(logger))
 
 	criticalPodAdmissionHandler := preemption.NewCriticalPodAdmissionHandler(klet.getAllocatedPods, killPodNow(ctx, klet.podWorkers, kubeDeps.Recorder), kubeDeps.Recorder)
 	handlers = append(handlers, lifecycle.NewPredicateAdmitHandler(klet.GetCachedNode, criticalPodAdmissionHandler, klet.containerManager.UpdatePluginResources))

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/klog/v2"
 
 	cadvisorapi "github.com/google/cadvisor/lib/model"
 	"github.com/google/go-cmp/cmp"
@@ -160,7 +161,7 @@ func (lcm *localCM) GetNodeAllocatableReservation() v1.ResourceList {
 	return lcm.allocatableReservation
 }
 
-func (lcm *localCM) GetCapacity(localStorageCapacityIsolation bool) v1.ResourceList {
+func (lcm *localCM) GetCapacity(_ klog.Logger, localStorageCapacityIsolation bool) v1.ResourceList {
 	if !localStorageCapacityIsolation {
 		delete(lcm.capacity, v1.ResourceEphemeralStorage)
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -138,7 +138,7 @@ func (m *kubeGenericRuntimeManager) generateLinuxContainerResources(ctx context.
 
 	// If pod has exclusive cpu and the container in question has integer cpu requests
 	// the cfs quota will not be enforced
-	disableCPUQuota := utilfeature.DefaultFeatureGate.Enabled(kubefeatures.DisableCPUQuotaWithExclusiveCPUs) && m.containerManager.ContainerHasExclusiveCPUs(pod, container)
+	disableCPUQuota := utilfeature.DefaultFeatureGate.Enabled(kubefeatures.DisableCPUQuotaWithExclusiveCPUs) && m.containerManager.ContainerHasExclusiveCPUs(logger, pod, container)
 	logger.V(5).Info("Enforcing CFS quota", "pod", klog.KObj(pod), "unlimited", disableCPUQuota)
 	lcr := m.calculateLinuxResources(cpuRequest, cpuLimit, memoryLimit, disableCPUQuota)
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -273,7 +273,7 @@ func NewKubeGenericRuntimeManager(
 		runtimeService:               runtimeService,
 		imageService:                 imageService,
 		containerManager:             containerManager,
-		internalLifecycle:            containerManager.InternalContainerLifecycle(),
+		internalLifecycle:            containerManager.InternalContainerLifecycle(logger),
 		logManager:                   logManager,
 		runtimeClassManager:          runtimeClassManager,
 		logReduction:                 logreduction.NewLogReduction(identicalErrorDelay),
@@ -829,7 +829,7 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 	pcm := m.containerManager.NewPodContainerManager()
 	//TODO(vinaykul,InPlacePodVerticalScaling): Figure out best way to get enforceMemoryQoS value (parameter #4 below) in platform-agnostic way
 	enforceCPULimits := m.cpuCFSQuota
-	if utilfeature.DefaultFeatureGate.Enabled(features.DisableCPUQuotaWithExclusiveCPUs) && m.containerManager.PodHasExclusiveCPUs(pod) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.DisableCPUQuotaWithExclusiveCPUs) && m.containerManager.PodHasExclusiveCPUs(logger, pod) {
 		enforceCPULimits = false
 		logger.V(2).Info("Disabled CFS quota", "pod", klog.KObj(pod))
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -4592,8 +4592,8 @@ func TestDoPodResizeAction(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodLevelResourcesVerticalScaling, tc.enablePLR)
 
 			mockCM := cmtesting.NewMockContainerManager(t)
-			mockCM.EXPECT().PodHasExclusiveCPUs(mock.Anything).Return(false).Maybe()
-			mockCM.EXPECT().ContainerHasExclusiveCPUs(mock.Anything, mock.Anything).Return(false).Maybe()
+			mockCM.EXPECT().PodHasExclusiveCPUs(logger, mock.Anything).Return(false).Maybe()
+			mockCM.EXPECT().ContainerHasExclusiveCPUs(logger, mock.Anything, mock.Anything).Return(false).Maybe()
 			m.containerManager = mockCM
 			mockPCM := cmtesting.NewMockPodContainerManager(t)
 			mockCM.EXPECT().NewPodContainerManager().Return(mockPCM)

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux.go
@@ -60,7 +60,7 @@ func (m *kubeGenericRuntimeManager) calculateSandboxResources(ctx context.Contex
 	}
 
 	// If pod has exclusive cpu the sandbox will not have cfs quote enforced
-	disableCPUQuota := utilfeature.DefaultFeatureGate.Enabled(features.DisableCPUQuotaWithExclusiveCPUs) && m.containerManager.PodHasExclusiveCPUs(pod)
+	disableCPUQuota := utilfeature.DefaultFeatureGate.Enabled(features.DisableCPUQuotaWithExclusiveCPUs) && m.containerManager.PodHasExclusiveCPUs(logger, pod)
 
 	logger.V(5).Info("Enforcing CFS quota", "pod", klog.KObj(pod), "unlimited", disableCPUQuota)
 	return m.calculateLinuxResources(cpuRequest, lim.Cpu(), lim.Memory(), disableCPUQuota)

--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -196,8 +196,8 @@ func MachineInfo(nodeName string,
 	maxPods int,
 	podsPerCore int,
 	machineInfoFunc func() (*cadvisorapi.MachineInfo, error), // typically Kubelet.GetCachedMachineInfo
-	capacityFunc func(localStorageCapacityIsolation bool) v1.ResourceList, // typically Kubelet.containerManager.GetCapacity
-	devicePluginResourceCapacityFunc func() (v1.ResourceList, v1.ResourceList, []string), // typically Kubelet.containerManager.GetDevicePluginResourceCapacity
+	capacityFunc func(logger klog.Logger, localStorageCapacityIsolation bool) v1.ResourceList, // typically Kubelet.containerManager.GetCapacity
+	devicePluginResourceCapacityFunc func(logger klog.Logger) (v1.ResourceList, v1.ResourceList, []string), // typically Kubelet.containerManager.GetDevicePluginResourceCapacity
 	nodeAllocatableReservationFunc func() v1.ResourceList, // typically Kubelet.containerManager.GetNodeAllocatableReservation
 	recordEventFunc func(eventType, event, message string), // typically Kubelet.recordEvent
 	localStorageCapacityIsolation bool,
@@ -255,14 +255,14 @@ func MachineInfo(nodeName string,
 
 			// TODO: all the node resources should use ContainerManager.GetCapacity instead of deriving the
 			// capacity for every node status request
-			initialCapacity := capacityFunc(localStorageCapacityIsolation)
+			initialCapacity := capacityFunc(logger, localStorageCapacityIsolation)
 			if initialCapacity != nil {
 				if v, exists := initialCapacity[v1.ResourceEphemeralStorage]; exists {
 					node.Status.Capacity[v1.ResourceEphemeralStorage] = v
 				}
 			}
 
-			devicePluginCapacity, devicePluginAllocatable, removedDevicePlugins = devicePluginResourceCapacityFunc()
+			devicePluginCapacity, devicePluginAllocatable, removedDevicePlugins = devicePluginResourceCapacityFunc(logger)
 			for k, v := range devicePluginCapacity {
 				if old, ok := node.Status.Capacity[k]; !ok || old.Value() != v.Value() {
 					logger.V(2).Info("Updated capacity for device plugin", "plugin", k, "capacity", v.Value())

--- a/pkg/kubelet/nodestatus/setters_test.go
+++ b/pkg/kubelet/nodestatus/setters_test.go
@@ -919,10 +919,10 @@ func TestMachineInfo(t *testing.T) {
 			machineInfoFunc := func() (*cadvisorapi.MachineInfo, error) {
 				return tc.machineInfo, tc.machineInfoError
 			}
-			capacityFunc := func(localStorageCapacityIsolation bool) v1.ResourceList {
+			capacityFunc := func(_ klog.Logger, localStorageCapacityIsolation bool) v1.ResourceList {
 				return tc.capacity
 			}
-			devicePluginResourceCapacityFunc := func() (v1.ResourceList, v1.ResourceList, []string) {
+			devicePluginResourceCapacityFunc := func(_ klog.Logger) (v1.ResourceList, v1.ResourceList, []string) {
 				c := tc.devicePluginResourceCapacity
 				return c.capacity, c.allocatable, c.inactive
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR is the second part of replacing the appropriate context with the `context.TODO()` or `context.Background()` in the `./pkg/kubelet/cm/`. 
I break it down into multiple parts to keep PRs small and readable.

[First PR](https://github.com/kubernetes/kubernetes/pull/139075)
[Second PR](https://github.com/kubernetes/kubernetes/pull/139093)

#### Which issue(s) this PR is related to:

Part of https://github.com/kubernetes/kubernetes/issues/130069

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
NONE
```