### PR TITLE
fix flaky hpa test by making per pod cpu load deterministic

### DIFF
--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -223,7 +223,7 @@ func (st *HPAScaleTest) run(ctx context.Context, name string, kind schema.GroupV
 	hpa := e2eautoscaling.CreateResourceHorizontalPodAutoscaler(ctx, rc, st.resourceType, st.metricTargetType, st.targetValue, st.minPods, st.maxPods)
 	ginkgo.DeferCleanup(e2eautoscaling.DeleteHorizontalPodAutoscaler, rc, hpa.Name)
 
-	// Pick the CPU load helper once. perPodCPULoad addresses each pod
+	// Pick the CPU load helper. perPodCPULoad addresses each pod
 	// directly via pod proxy (total/N millicores per pod), bypassing the
 	// random kube-proxy LB used by ConsumeCPU.
 	consumeCPU := rc.ConsumeCPU

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -223,6 +223,9 @@ func (st *HPAScaleTest) run(ctx context.Context, name string, kind schema.GroupV
 	hpa := e2eautoscaling.CreateResourceHorizontalPodAutoscaler(ctx, rc, st.resourceType, st.metricTargetType, st.targetValue, st.minPods, st.maxPods)
 	ginkgo.DeferCleanup(e2eautoscaling.DeleteHorizontalPodAutoscaler, rc, hpa.Name)
 
+	// TODO: the nested ifs to choose the consume mechanism should be refactored in a more generic way
+	// it should be passed as a parameter in e2eautoscaling.NewDynamicResourceConsumer()
+
 	// Pick the CPU load helper. perPodCPULoad addresses each pod
 	// directly via pod proxy (total/N millicores per pod), bypassing the
 	// random kube-proxy LB used by ConsumeCPU.

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -201,6 +201,7 @@ type HPAScaleTest struct {
 	secondScale      int32
 	resourceType     v1.ResourceName
 	metricTargetType autoscalingv2.MetricTargetType
+	perPodCPULoad    bool
 }
 
 // run is a method which runs an HPA lifecycle, from a starting state, to an expected
@@ -217,17 +218,29 @@ func (st *HPAScaleTest) run(ctx context.Context, name string, kind schema.GroupV
 	case memResource:
 		initMemTotal = st.initMemTotal
 	}
-	rc := e2eautoscaling.NewDynamicResourceConsumer(ctx, name, f.Namespace.Name, kind, st.initPods, initCPUTotal, initMemTotal, 0, st.perPodCPURequest, st.perPodMemRequest, f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle, nil)
+	rc := e2eautoscaling.NewDynamicResourceConsumer(ctx, name, f.Namespace.Name, kind, st.initPods, 0, initMemTotal, 0, st.perPodCPURequest, st.perPodMemRequest, f.ClientSet, f.ScalesGetter, e2eautoscaling.Disable, e2eautoscaling.Idle, nil)
 	ginkgo.DeferCleanup(rc.CleanUp)
 	hpa := e2eautoscaling.CreateResourceHorizontalPodAutoscaler(ctx, rc, st.resourceType, st.metricTargetType, st.targetValue, st.minPods, st.maxPods)
 	ginkgo.DeferCleanup(e2eautoscaling.DeleteHorizontalPodAutoscaler, rc, hpa.Name)
+
+	// Pick the CPU load helper once. perPodCPULoad addresses each pod
+	// directly via pod proxy (total/N millicores per pod), bypassing the
+	// random kube-proxy LB used by ConsumeCPU.
+	consumeCPU := rc.ConsumeCPU
+	if st.perPodCPULoad {
+		consumeCPU = rc.ConsumeCPUPerPod
+	}
+
+	if initCPUTotal > 0 {
+		consumeCPU(initCPUTotal)
+	}
 
 	rc.WaitForReplicas(ctx, st.firstScale, timeToWait)
 	if st.firstScaleStasis > 0 {
 		rc.EnsureDesiredReplicasInRange(ctx, st.firstScale, st.firstScale+1, st.firstScaleStasis, hpa.Name)
 	}
 	if st.resourceType == cpuResource && st.cpuBurst > 0 && st.secondScale > 0 {
-		rc.ConsumeCPU(st.cpuBurst)
+		consumeCPU(st.cpuBurst)
 		rc.WaitForReplicas(ctx, int(st.secondScale), timeToWait)
 	}
 	if st.resourceType == memResource && st.memBurst > 0 && st.secondScale > 0 {
@@ -253,6 +266,7 @@ func scaleUp(ctx context.Context, name string, kind schema.GroupVersionKind, res
 		secondScale:      5,
 		resourceType:     resourceType,
 		metricTargetType: metricTargetType,
+		perPodCPULoad:    checkStability,
 	}
 	if resourceType == cpuResource {
 		st.initCPUTotal = 250
@@ -283,6 +297,7 @@ func scaleDown(ctx context.Context, name string, kind schema.GroupVersionKind, r
 		secondScale:      1,
 		resourceType:     resourceType,
 		metricTargetType: metricTargetType,
+		perPodCPULoad:    checkStability,
 	}
 	if resourceType == cpuResource {
 		st.initCPUTotal = 325

--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -640,8 +640,6 @@ func (rc *ResourceConsumer) makeConsumeCPUPerPodRequests(ctx context.Context) {
 // bypasses kube-proxy load balancing, guaranteeing each pod receives exactly
 // its share.
 func (rc *ResourceConsumer) sendConsumeCPUPerPodRequest(ctx context.Context, millicoresTotal int) {
-	// Tests that can't rely on random LB use this path to deterministically adjust per-pod load.
-	// Retry transient list errors and fail loudly to avoid silent failures.
 	var readyPods []string
 	err := framework.Gomega().Eventually(ctx, func(ctx context.Context) error {
 		pods, err := rc.clientSet.CoreV1().Pods(rc.nsName).List(ctx, metav1.ListOptions{

--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -638,28 +638,29 @@ func (rc *ResourceConsumer) makeConsumeCPUPerPodRequests(ctx context.Context) {
 // sendConsumeCPUPerPodRequest distributes CPU load evenly across all running
 // pods by sending requests directly via the Kubernetes pod proxy API. This
 // bypasses kube-proxy load balancing, guaranteeing each pod receives exactly
-// its share. Falls back to sendConsumeCPURequest if pod listing fails.
+// its share.
 func (rc *ResourceConsumer) sendConsumeCPUPerPodRequest(ctx context.Context, millicoresTotal int) {
-	pods, err := rc.clientSet.CoreV1().Pods(rc.nsName).List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("name=%s", rc.name),
-	})
-	if err != nil {
-		framework.Logf("ConsumeCPUPerPod: failed to list pods: %v, falling back to service proxy", err)
-		rc.sendConsumeCPURequest(ctx, millicoresTotal)
-		return
-	}
-
+	// Tests that can't rely on random LB use this path to deterministically adjust per-pod load.
+	// Retry transient list errors and fail loudly to avoid silent failures.
 	var readyPods []string
-	for i := range pods.Items {
-		if pods.Items[i].Status.Phase == v1.PodRunning {
-			readyPods = append(readyPods, pods.Items[i].Name)
+	err := framework.Gomega().Eventually(ctx, func(ctx context.Context) error {
+		pods, err := rc.clientSet.CoreV1().Pods(rc.nsName).List(ctx, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("name=%s", rc.name),
+		})
+		if err != nil {
+			return err
 		}
-	}
-	if len(readyPods) == 0 {
-		framework.Logf("ConsumeCPUPerPod: no running pods, falling back to service proxy")
-		rc.sendConsumeCPURequest(ctx, millicoresTotal)
-		return
-	}
+		for i := range pods.Items {
+			if pods.Items[i].Status.Phase == v1.PodRunning {
+				readyPods = append(readyPods, pods.Items[i].Name)
+			}
+		}
+		if len(readyPods) == 0 {
+			return fmt.Errorf("ConsumeCPUPerPod: no running pods labeled name=%s", rc.name)
+		}
+		return nil
+	}).WithTimeout(serviceInitializationTimeout).WithPolling(serviceInitializationInterval).Should(gomega.Succeed())
+	framework.ExpectNoError(err)
 
 	perPodMillicores := millicoresTotal / len(readyPods)
 	if perPodMillicores == 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

Fixes [Flaking Test] [sig-autoscaling] Horizontal pod autoscaling (scale resource: CPU)

The test asserts replicas stay in [firstScale, firstScale+1] during a 10-min stasis window. `ConsumeCPU` helper POSTs once to the `ResourceConsumer` Service, and kube-proxy LBs it randomly to a single pod. The metrics snapshot can catch two pods at ~50% util and one idle, which will average ~33% against a 20% target, which drives desired = ceil(1.67 × 3) = 5 and breaches the bound.

Fix: add `perPodCPULoad` to`HPAScaleTest`. When set, CPU load goes through the existing `ConsumeCPUPerPod` helper, which splits total/N evenly across pods via pod proxy and bypasses the random LB. Steady state becomes 250m / 3 = 83.3m/pod = 16.7% util, which causes desired to be at 3. Only the explicit cpuBurst can drive `secondScale=5`.

Not sure what exact change made the test flaky, though. Maybe the recent changes to HPA controller responsiveness could be a cause?

The flag is wired from `checkStability` in `scaleUp`/`scaleDown`, so it only activates on the two tests that assert replica stasis. All other callers of `HPAScaleTest.run` are unchanged. This keeps the assertions written as-is.

#### Which issue(s) this PR is related to:

Fixes #139200

#### Special notes for your reviewer:
This PR fixes the test's load injection, not the controller's response to skewed snapshots. I went this way because the test's [3, 4] bound caps the per-snapshot average pod utilization at 26.67%, and `ConsumeCPU`'s random LB produces snapshots well above that whenever it dumps the full load on one pod. The load injection felt like the right layer to address.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs

```
