### PR TITLE
Emit initial-events-end bookmark in fake tracker Watch for WatchList

### DIFF
--- a/staging/src/k8s.io/client-go/metadata/metadatainformer/informer_test.go
+++ b/staging/src/k8s.io/client-go/metadata/metadatainformer/informer_test.go
@@ -263,3 +263,46 @@ func newPartialObjectMetadata(apiVersion, kind, namespace, name string) *metav1.
 		},
 	}
 }
+
+// TestWatchListClientWithManualListWatch is a regression test for
+// https://github.com/kubernetes/kubernetes/issues/135895.
+// When a user constructs a cache.ListWatch directly (without
+// ToListWatcherWithWatchListSemantics) using a fake metadata client,
+// the informer must still sync when WatchListClient is enabled.
+func TestWatchListClientWithManualListWatch(t *testing.T) {
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, true)
+
+	scheme := fake.NewTestScheme()
+	_ = metav1.AddMetaToScheme(scheme)
+	existingObj := newPartialObjectMetadata("apps/v1", "Deployment", "ns-foo", "dep-1")
+	fakeClient := fake.NewSimpleMetadataClient(scheme, existingObj)
+
+	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+
+	// Construct ListWatch manually without ToListWatcherWithWatchListSemantics,
+	// reproducing the pattern from the issue report.
+	lw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return fakeClient.Resource(gvr).Namespace("ns-foo").List(context.Background(), options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return fakeClient.Resource(gvr).Namespace("ns-foo").Watch(context.Background(), options)
+		},
+	}
+
+	informer := cache.NewSharedIndexInformer(lw, &metav1.PartialObjectMetadata{}, 0, cache.Indexers{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go informer.RunWithContext(ctx)
+
+	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+		t.Fatal("informer did not sync; WatchListClient with a manual ListWatch and fake metadata client is broken")
+	}
+
+	items := informer.GetStore().List()
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item in store, got %d", len(items))
+	}
+}

--- a/staging/src/k8s.io/client-go/testing/fixture.go
+++ b/staging/src/k8s.io/client-go/testing/fixture.go
@@ -452,6 +452,32 @@ func (t *tracker) Watch(gvr schema.GroupVersionResource, ns string, opts ...meta
 		}
 	}
 
+	// When SendInitialEvents is requested (WatchList protocol), emit the
+	// required initial-events-end bookmark so the reflector knows the
+	// initial list is complete and can mark the informer as synced.
+	if len(opts) > 0 && opts[0].SendInitialEvents != nil && *opts[0].SendInitialEvents {
+		resourceVersion, ok := t.resourceVersions[gvr]
+		if !ok {
+			resourceVersion = 1
+		}
+		var bookmarkObj runtime.Object
+		if objs := t.objects[gvr]; len(objs) > 0 {
+			for _, obj := range objs {
+				bookmarkObj = reflect.New(reflect.TypeOf(obj.Object).Elem()).Interface().(runtime.Object)
+				break
+			}
+		} else {
+			bookmarkObj = &metav1.PartialObjectMetadata{}
+		}
+		if accessor, err := meta.Accessor(bookmarkObj); err == nil {
+			accessor.SetAnnotations(map[string]string{
+				metav1.InitialEventsAnnotationKey: "true",
+			})
+			accessor.SetResourceVersion(fmt.Sprintf("%d", resourceVersion))
+			fakewatcher.Action(watch.Bookmark, bookmarkObj)
+		}
+	}
+
 	return fakewatcher, nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

Since v1.35, `WatchListClient` defaults to enabled. When users construct a `cache.ListWatch` directly, without `ToListWatcherWithWatchListSemantics`, using a fake client, the reflector attempts the WatchList path.

The `ObjectTracker.Watch()` implementation deliver existing objects as `Added` events but never emits the required `k8s.io/initial-events-end` bookmark. Because of that the informer hangs upforever waiting for sync.

My PR makes `ObjectTracker.Watch()` emit the `k8s.io/initial-events-end` bookmark when `SendInitialEvents=true` is set in the watch options which completes the WatchList protocol.

I added a regression test that reproduces the issue using a bare `cache.ListWatch` with a fake metadata client and `WatchListClient` enabled.

#### Which issue(s) this PR is related to:

Fixes #135895

#### Special notes for your reviewer:

* The factory path `NewFilteredMetadataInformer` is not affected because it wraps with `ToListWatcherWithWatchListSemantics` which detects `IsWatchListSemanticsUnsupported()`. The new bookmark code is only reached when users bypass that wrapping.
* The bookmark object type is derived with `reflect.New`. If no objects exist for the GVR then it falls back to `*metav1.PartialObjectMetadata` which works for metadata informers with an empty tracker.
* `IsWatchListSemanticsUnsupported()` is intentionally kept on the tracker and fake client path so the standard factory path continues to opt out of WatchList semantics. This change only makes the tracker implementation correct when WatchList is used directly.

#### Does this PR introduce a user-facing change?

```release-note
Fixed fake client ObjectTracker to emit the initial-events-end bookmark during WatchList, preventing informers from hanging when WatchListClient is enabled and cache.ListWatch is constructed without ToListWatcherWithWatchListSemantics.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```