### PR TITLE
hack: use HTTPS for GitHub API call in update-kustomize.sh

### DIFF
--- a/hack/update-kustomize.sh
+++ b/hack/update-kustomize.sh
@@ -25,7 +25,7 @@ kube::golang::setup_env
 kube::util::require-jq
 kube::util::ensure_clean_working_dir
 
-PUBLISHED_RELEASES=$(curl -sL 'http://api.github.com/repos/kubernetes-sigs/kustomize/releases?per_page=100' | jq '[ .[] | select(.draft == false and .prerelease == false) | { "tag_name": .tag_name, "published_at": .published_at } ]')
+PUBLISHED_RELEASES=$(curl -sL 'https://api.github.com/repos/kubernetes-sigs/kustomize/releases?per_page=100' | jq '[ .[] | select(.draft == false and .prerelease == false) | { "tag_name": .tag_name, "published_at": .published_at } ]')
 
 LATEST_KYAML=$(echo "${PUBLISHED_RELEASES}" | jq -r '[ .[] | select(.tag_name | startswith("kyaml/v")) ] | sort_by(.published_at) | last | .tag_name | scan("\/(v[\\d.]+)") | .[0]')
 LATEST_CONFIG=$(echo "${PUBLISHED_RELEASES}" | jq -r '[ .[] | select(.tag_name | startswith("cmd/config/v")) ] | sort_by(.published_at) | last | .tag_name | scan("\/(v[\\d.]+)") | .[0]')


### PR DESCRIPTION
**What this PR does / why we need it:**
The curl call to api.github.com in hack/update-kustomize.sh was using HTTP. GitHub API redirects HTTP to HTTPS anyway, so this avoids the redirect and uses a secure connection directly.

**Which issue(s) this PR fixes:**
N/A (minor security hygiene fix)

**AI usage disclosure (per the Kubernetes AI usage policy):**
This change was prepared with AI assistance. It is a one-line http -> https change in a helper script, which I have reviewed and understand.

**Does this PR introduce a user-facing change?**
```release-note
NONE
```