### PR TITLE
Encapsulate storage mutations and snapshots inside watchCacheStorage

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -219,8 +219,7 @@ func (w *watchCache) Add(obj interface{}) error {
 	}
 	event := watch.Event{Type: watch.Added, Object: object}
 
-	f := func(elem *store.Element) error { return w.storage.store.Add(elem) }
-	return w.processEvent(event, resourceVersion, f)
+	return w.processEvent(event, resourceVersion)
 }
 
 // Update takes runtime.Object as an argument.
@@ -231,8 +230,7 @@ func (w *watchCache) Update(obj interface{}) error {
 	}
 	event := watch.Event{Type: watch.Modified, Object: object}
 
-	f := func(elem *store.Element) error { return w.storage.store.Update(elem) }
-	return w.processEvent(event, resourceVersion, f)
+	return w.processEvent(event, resourceVersion)
 }
 
 // Delete takes runtime.Object as an argument.
@@ -243,8 +241,7 @@ func (w *watchCache) Delete(obj interface{}) error {
 	}
 	event := watch.Event{Type: watch.Deleted, Object: object}
 
-	f := func(elem *store.Element) error { return w.storage.store.Delete(elem) }
-	return w.processEvent(event, resourceVersion, f)
+	return w.processEvent(event, resourceVersion)
 }
 
 func (w *watchCache) objectToVersionedRuntimeObject(obj interface{}) (runtime.Object, uint64, error) {
@@ -261,7 +258,7 @@ func (w *watchCache) objectToVersionedRuntimeObject(obj interface{}) (runtime.Ob
 
 // processEvent is safe as long as there is at most one call to it in flight
 // at any point in time.
-func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64, updateFunc func(*store.Element) error) error {
+func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64) error {
 	metrics.EventsReceivedCounter.WithLabelValues(w.config.groupResource.Group, w.config.groupResource.Resource).Inc()
 
 	key, err := w.config.keyFunc(event.Object)
@@ -284,12 +281,12 @@ func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64, upd
 		RecordTime:      w.config.clock.Now(),
 	}
 
-	// We can call w.storage.store.Get() outside of a critical section,
-	// because the w.storage.store itself is thread-safe and the only
-	// place where w.storage.store is modified is below (via updateFunc)
+	// We can call w.storage.Get() outside of a critical section,
+	// because the w.storage itself is thread-safe and the only
+	// place where it is modified is below (via UpdateStoreLocked)
 	// and these calls are serialized because reflector is processing
 	// events one-by-one.
-	previous, exists, err := w.storage.store.Get(elem)
+	previous, exists, err := w.storage.Get(event.Object)
 	if err != nil {
 		return err
 	}
@@ -308,18 +305,15 @@ func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64, upd
 		w.resourceVersion = resourceVersion
 		defer w.cond.Broadcast()
 
-		err := updateFunc(elem)
-		if err != nil {
+		if err := w.storage.UpdateStoreLocked(event.Type, elem); err != nil {
 			return err
 		}
-		if w.storage.snapshots != nil && w.storage.snapshottingEnabled.Load() {
-			if w.history.isCacheFullLocked() {
-				oldestRV := w.history.cache[w.history.startIndex%w.history.capacity].ResourceVersion
-				w.storage.snapshots.RemoveLess(oldestRV)
-			}
-			w.storage.snapshots.Add(w.resourceVersion, w.storage.store)
+		if w.history.isCacheFullLocked() {
+			oldestRV := w.history.cache[w.history.startIndex%w.history.capacity].ResourceVersion
+			w.storage.CompactSnapshotsLocked(oldestRV)
 		}
-		return err
+		w.storage.AddSnapshotLocked(w.resourceVersion)
+		return nil
 	}(); err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_storage.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_storage.go
@@ -22,6 +22,7 @@ import (
 	"sync/atomic"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage/cacher/store"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -169,4 +170,32 @@ func (w *watchCacheStorage) ListKeys() []string {
 // List returns list of pointers to <store.Element> objects.
 func (w *watchCacheStorage) List() []interface{} {
 	return w.store.List()
+}
+
+// UpdateStoreLocked executes a mutation (Add, Update, Delete) on the underlying store.
+func (w *watchCacheStorage) UpdateStoreLocked(eventType watch.EventType, elem *store.Element) error {
+	switch eventType {
+	case watch.Added:
+		return w.store.Add(elem)
+	case watch.Modified:
+		return w.store.Update(elem)
+	case watch.Deleted:
+		return w.store.Delete(elem)
+	default:
+		return fmt.Errorf("unexpected event type: %v", eventType)
+	}
+}
+
+// AddSnapshotLocked collects a new snapshot if snapshotting is enabled.
+func (w *watchCacheStorage) AddSnapshotLocked(version uint64) {
+	if w.snapshots != nil && w.snapshottingEnabled.Load() {
+		w.snapshots.Add(version, w.store)
+	}
+}
+
+// CompactSnapshotsLocked prunes snapshots older than the oldest history version.
+func (w *watchCacheStorage) CompactSnapshotsLocked(oldestRV uint64) {
+	if w.snapshots != nil && w.snapshottingEnabled.Load() {
+		w.snapshots.RemoveLess(oldestRV)
+	}
 }


### PR DESCRIPTION
/cc @p0lyn0mial @Jefftree @michaelasp

/kind cleanup

```release-note
NONE
```

