### PR TITLE
csi-translation-lib: add test for preserving input PV

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/translate_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/translate_test.go
@@ -495,4 +495,41 @@ func TestPluginNameMappings(t *testing.T) {
 	}
 }
 
-// TODO: test for not modifying the original PV.
+func TestTranslateInTreePVToCSIDoesNotModifyInput(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
+	testCases := []struct {
+		name string
+		pv   *v1.PersistentVolume
+	}{
+		{
+			name: "GCE PD",
+			pv:   makeGCEPDPV(nil, nil),
+		},
+		{
+			name: "AWS EBS",
+			pv:   makeAWSEBSPV(nil, nil),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			original := tc.pv.DeepCopy()
+
+			ctl := New()
+
+			_, err := ctl.TranslateInTreePVToCSI(
+				logger,
+				tc.pv,
+			)
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(original, tc.pv) {
+				t.Fatalf("input PV was modified:\noriginal: %#v\nafter: %#v", original, tc.pv)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds unit test coverage to verify that TranslateInTreePVToCSI() that does not modify the input PersistentVolume.

This replaces the existing TODO in translate_test.go, 
validates the documented contract that translation operates on a copied PV rather than mutating the real/original object.

The test creates sample in-tree PVs, performs translation, and 
asserts that the original PV remains unchanged after translation.

For easier debugging, the assertion output includes both the original and resulting PV values when a mismatch occurs.

#### Which issue(s) this PR is related to:
N/A (addresses inline TODO in `translate_test.go`)
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
None.
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None.
```


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```
