### PR TITLE
client-go: add UntilWithSync precondition error tests

### DIFF
--- a/staging/src/k8s.io/client-go/tools/watch/until_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/until_test.go
@@ -186,7 +186,6 @@ func TestUntilErrorCondition(t *testing.T) {
 }
 
 func TestUntilWithSync(t *testing.T) {
-	// FIXME: test preconditions
 	tt := []struct {
 		name             string
 		lw               cache.ListerWatcher
@@ -286,6 +285,56 @@ func TestUntilWithSync(t *testing.T) {
 			},
 			expectedErr:   nil,
 			expectedEvent: &watch.Event{Type: watch.Added, Object: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "first"}}},
+		},
+		{
+			name: "precondition returns false and error",
+			lw: func() cache.ListerWatcher {
+				fakeclient := fakeclient.NewSimpleClientset(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "first"}})
+
+				return toListWatcherWithUnSupportedWatchListSemantics(
+					&cache.ListWatch{
+						ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+							return fakeclient.CoreV1().Secrets("").List(context.TODO(), options)
+						},
+						WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+							return fakeclient.CoreV1().Secrets("").Watch(context.TODO(), options)
+						},
+					},
+				)
+			}(),
+			preconditionFunc: func(store cache.Store) (bool, error) {
+				return false, errors.New("precondition failed")
+			},
+			conditionFunc: func(e watch.Event) (bool, error) {
+				return true, errors.New("should never reach this")
+			},
+			expectedErr:   errors.New("precondition failed"),
+			expectedEvent: nil,
+		},
+		{
+			name: "precondition returns true and error",
+			lw: func() cache.ListerWatcher {
+				fakeclient := fakeclient.NewSimpleClientset(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "first"}})
+
+				return toListWatcherWithUnSupportedWatchListSemantics(
+					&cache.ListWatch{
+						ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+							return fakeclient.CoreV1().Secrets("").List(context.TODO(), options)
+						},
+						WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+							return fakeclient.CoreV1().Secrets("").Watch(context.TODO(), options)
+						},
+					},
+				)
+			}(),
+			preconditionFunc: func(store cache.Store) (bool, error) {
+				return true, errors.New("precondition failed")
+			},
+			conditionFunc: func(e watch.Event) (bool, error) {
+				return true, errors.New("should never reach this")
+			},
+			expectedErr:   errors.New("precondition failed"),
+			expectedEvent: nil,
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds unit test coverage for UntilWithSync to verify that errors returned from PreconditionFunc are propagated 
to the caller instead of proceeding to the watch loop.

This addresses the existing FIXME: test preconditions in until_test.go.

Adds coverage for:

* PreconditionFunc returns (false, error)
* PreconditionFunc returns (true, error)

Both cases verify that UntilWithSync returns the error and 
this nil event without invoking the condition function.

#### Which issue(s) this PR is related to:
N/A (addresses inline FIXME in `until_test.go`)
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
None.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```
