### PR TITLE
Feat: kubectl top support v1.metrics.k8s.io

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top.go
@@ -17,6 +17,8 @@ limitations under the License.
 package top
 
 import (
+	"slices"
+
 	"github.com/spf13/cobra"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,6 +36,7 @@ const (
 
 var (
 	supportedMetricsAPIVersions = []string{
+		"v1",
 		"v1beta1",
 	}
 	topLong = templates.LongDesc(i18n.T(`
@@ -84,18 +87,16 @@ func NewCmdTop(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Com
 	return cmd
 }
 
-func SupportedMetricsAPIVersionAvailable(discoveredAPIGroups *metav1.APIGroupList) bool {
+func SupportedMetricsAPIVersionAvailable(discoveredAPIGroups *metav1.APIGroupList) string {
 	for _, discoveredAPIGroup := range discoveredAPIGroups.Groups {
 		if discoveredAPIGroup.Name != metricsapi.GroupName {
 			continue
 		}
 		for _, version := range discoveredAPIGroup.Versions {
-			for _, supportedVersion := range supportedMetricsAPIVersions {
-				if version.Version == supportedVersion {
-					return true
-				}
+			if slices.Contains(supportedMetricsAPIVersions, version.Version) {
+				return version.Version
 			}
 		}
 	}
-	return false
+	return ""
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 	metricsapi "k8s.io/metrics/pkg/apis/metrics"
+	metricsV1api "k8s.io/metrics/pkg/apis/metrics/v1"
 	metricsV1beta1api "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	metricsclientset "k8s.io/metrics/pkg/client/clientset/versioned"
 )
@@ -162,11 +163,11 @@ func (o TopNodeOptions) RunTopNode() error {
 
 	metricsAPIAvailable := SupportedMetricsAPIVersionAvailable(apiGroups)
 
-	if !metricsAPIAvailable {
+	if metricsAPIAvailable == "" {
 		return errors.New("Metrics API not available")
 	}
 
-	metrics, err := getNodeMetricsFromMetricsAPI(o.MetricsClient, o.ResourceName, selector)
+	metrics, err := getNodeMetricsFromMetricsAPI(o.MetricsClient, o.ResourceName, selector, metricsAPIAvailable)
 	if err != nil {
 		return err
 	}
@@ -213,8 +214,32 @@ func (o TopNodeOptions) RunTopNode() error {
 	return o.Printer.PrintNodeMetrics(metrics.Items, availableResources, o.NoHeaders, o.SortBy)
 }
 
-func getNodeMetricsFromMetricsAPI(metricsClient metricsclientset.Interface, resourceName string, selector labels.Selector) (*metricsapi.NodeMetricsList, error) {
+func getNodeMetricsFromMetricsAPI(metricsClient metricsclientset.Interface, resourceName string, selector labels.Selector, metricsVersion string) (*metricsapi.NodeMetricsList, error) {
 	var err error
+	if metricsVersion == "v1" {
+		versionedMetrics := &metricsV1api.NodeMetricsList{}
+		mc := metricsClient.MetricsV1()
+		nm := mc.NodeMetricses()
+		if resourceName != "" {
+			m, err := nm.Get(context.TODO(), resourceName, metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			versionedMetrics.Items = []metricsV1api.NodeMetrics{*m}
+		} else {
+			versionedMetrics, err = nm.List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
+			if err != nil {
+				return nil, err
+			}
+		}
+		metrics := &metricsapi.NodeMetricsList{}
+		err = metricsV1api.Convert_v1_NodeMetricsList_To_metrics_NodeMetricsList(versionedMetrics, metrics, nil)
+		if err != nil {
+			return nil, err
+		}
+		return metrics, nil
+	}
+	// fallback to metric v1beta1
 	versionedMetrics := &metricsV1beta1api.NodeMetricsList{}
 	mc := metricsClient.MetricsV1beta1()
 	nm := mc.NodeMetricses()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node_test.go
@@ -32,8 +32,7 @@ import (
 	core "k8s.io/client-go/testing"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	"k8s.io/kubectl/pkg/scheme"
-	metricsv1api "k8s.io/metrics/pkg/apis/metrics/v1"
-	metricsv1beta1api "k8s.io/metrics/pkg/apis/metrics/v1beta1"
+	metricsapi "k8s.io/metrics/pkg/apis/metrics"
 	metricsfake "k8s.io/metrics/pkg/client/clientset/versioned/fake"
 )
 
@@ -42,461 +41,167 @@ const (
 	apiVersion = "v1"
 )
 
-func TestTopNodeAllMetricsFrom(t *testing.T) {
-	expectedNodePath := fmt.Sprintf("/%s/%s/nodes", apiPrefix, apiVersion)
+func TestTopNode(t *testing.T) {
+	listNodePath := fmt.Sprintf("/%s/%s/nodes", apiPrefix, apiVersion)
 
-	t.Run("v1beta1", func(t *testing.T) {
-		metrics, nodes := testNodeV1beta1MetricsData()
-		fakeMetrics := &metricsfake.Clientset{}
-		fakeMetrics.AddReactor("list", "nodes", func(action core.Action) (bool, runtime.Object, error) {
-			return true, metrics, nil
-		})
-		result := runTopNodeTest(t, runTopNodeOpts{
-			apisBody:     apisV1beta1BodyWithMetrics,
-			expectedPath: expectedNodePath,
-			nodeBody:     nodes,
-			fakeMetrics:  fakeMetrics,
-		})
-		for _, m := range metrics.Items {
-			if !strings.Contains(result, m.Name) {
-				t.Errorf("missing metrics for %s: \n%s", m.Name, result)
-			}
-		}
-	})
-
-	t.Run("v1", func(t *testing.T) {
-		metrics, nodes := testNodeV1MetricsData()
-		fakeMetrics := &metricsfake.Clientset{}
-		fakeMetrics.AddReactor("list", "nodes", func(action core.Action) (bool, runtime.Object, error) {
-			return true, metrics, nil
-		})
-		result := runTopNodeTest(t, runTopNodeOpts{
-			apisBody:     apisV1BodyWithMetrics,
-			expectedPath: expectedNodePath,
-			nodeBody:     nodes,
-			fakeMetrics:  fakeMetrics,
-		})
-		for _, m := range metrics.Items {
-			if !strings.Contains(result, m.Name) {
-				t.Errorf("missing metrics for %s: \n%s", m.Name, result)
-			}
-		}
-	})
-}
-
-func TestTopNodeWithNameMetricsFrom(t *testing.T) {
-	t.Run("v1beta1", func(t *testing.T) {
-		metrics, nodes := testNodeV1beta1MetricsData()
-		expectedMetrics := metrics.Items[0]
-		expectedNode := nodes.Items[0]
-		nonExpectedMetrics := metrics.Items[1:]
-		expectedNodePath := fmt.Sprintf("/%s/%s/nodes/%s", apiPrefix, apiVersion, expectedMetrics.Name)
-
-		fakeMetrics := &metricsfake.Clientset{}
-		fakeMetrics.AddReactor("get", "nodes", func(action core.Action) (bool, runtime.Object, error) {
-			return true, &expectedMetrics, nil
-		})
-		result := runTopNodeTest(t, runTopNodeOpts{
-			apisBody:     apisV1beta1BodyWithMetrics,
-			expectedPath: expectedNodePath,
-			nodeBody:     &expectedNode,
-			fakeMetrics:  fakeMetrics,
-			cmdArgs:      []string{expectedMetrics.Name},
-		})
-		if !strings.Contains(result, expectedMetrics.Name) {
-			t.Errorf("missing metrics for %s: \n%s", expectedMetrics.Name, result)
-		}
-		for _, m := range nonExpectedMetrics {
-			if strings.Contains(result, m.Name) {
-				t.Errorf("unexpected metrics for %s: \n%s", m.Name, result)
-			}
-		}
-	})
-
-	t.Run("v1", func(t *testing.T) {
-		metrics, nodes := testNodeV1MetricsData()
-		expectedMetrics := metrics.Items[0]
-		expectedNode := nodes.Items[0]
-		nonExpectedMetrics := metrics.Items[1:]
-		expectedNodePath := fmt.Sprintf("/%s/%s/nodes/%s", apiPrefix, apiVersion, expectedMetrics.Name)
-
-		fakeMetrics := &metricsfake.Clientset{}
-		fakeMetrics.AddReactor("get", "nodes", func(action core.Action) (bool, runtime.Object, error) {
-			return true, &expectedMetrics, nil
-		})
-		result := runTopNodeTest(t, runTopNodeOpts{
-			apisBody:     apisV1BodyWithMetrics,
-			expectedPath: expectedNodePath,
-			nodeBody:     &expectedNode,
-			fakeMetrics:  fakeMetrics,
-			cmdArgs:      []string{expectedMetrics.Name},
-		})
-		if !strings.Contains(result, expectedMetrics.Name) {
-			t.Errorf("missing metrics for %s: \n%s", expectedMetrics.Name, result)
-		}
-		for _, m := range nonExpectedMetrics {
-			if strings.Contains(result, m.Name) {
-				t.Errorf("unexpected metrics for %s: \n%s", m.Name, result)
-			}
-		}
-	})
-}
-
-func TestTopNodeWithLabelSelectorMetricsFrom(t *testing.T) {
-	expectedNodePath := fmt.Sprintf("/%s/%s/nodes", apiPrefix, apiVersion)
-	label := "key=value"
-
-	t.Run("v1beta1", func(t *testing.T) {
-		metrics, nodes := testNodeV1beta1MetricsData()
-		expectedMetrics := &metricsv1beta1api.NodeMetricsList{
-			ListMeta: metrics.ListMeta,
-			Items:    metrics.Items[0:1],
-		}
-		expectedNodes := v1.NodeList{
-			ListMeta: nodes.ListMeta,
-			Items:    nodes.Items[0:1],
-		}
-		nonExpectedMetrics := &metricsv1beta1api.NodeMetricsList{
-			ListMeta: metrics.ListMeta,
-			Items:    metrics.Items[1:],
-		}
-		fakeMetrics := &metricsfake.Clientset{}
-		fakeMetrics.AddReactor("list", "nodes", func(action core.Action) (bool, runtime.Object, error) {
-			return true, expectedMetrics, nil
-		})
-		result := runTopNodeTest(t, runTopNodeOpts{
-			apisBody:     apisV1beta1BodyWithMetrics,
-			expectedPath: expectedNodePath,
-			nodeBody:     &expectedNodes,
-			fakeMetrics:  fakeMetrics,
-			selector:     label,
-		})
-		for _, m := range expectedMetrics.Items {
-			if !strings.Contains(result, m.Name) {
-				t.Errorf("missing metrics for %s: \n%s", m.Name, result)
-			}
-		}
-		for _, m := range nonExpectedMetrics.Items {
-			if strings.Contains(result, m.Name) {
-				t.Errorf("unexpected metrics for %s: \n%s", m.Name, result)
-			}
-		}
-	})
-
-	t.Run("v1", func(t *testing.T) {
-		metrics, nodes := testNodeV1MetricsData()
-		expectedMetrics := &metricsv1api.NodeMetricsList{
-			ListMeta: metrics.ListMeta,
-			Items:    metrics.Items[0:1],
-		}
-		expectedNodes := v1.NodeList{
-			ListMeta: nodes.ListMeta,
-			Items:    nodes.Items[0:1],
-		}
-		nonExpectedMetrics := &metricsv1api.NodeMetricsList{
-			ListMeta: metrics.ListMeta,
-			Items:    metrics.Items[1:],
-		}
-		fakeMetrics := &metricsfake.Clientset{}
-		fakeMetrics.AddReactor("list", "nodes", func(action core.Action) (bool, runtime.Object, error) {
-			return true, expectedMetrics, nil
-		})
-		result := runTopNodeTest(t, runTopNodeOpts{
-			apisBody:     apisV1BodyWithMetrics,
-			expectedPath: expectedNodePath,
-			nodeBody:     &expectedNodes,
-			fakeMetrics:  fakeMetrics,
-			selector:     label,
-		})
-		for _, m := range expectedMetrics.Items {
-			if !strings.Contains(result, m.Name) {
-				t.Errorf("missing metrics for %s: \n%s", m.Name, result)
-			}
-		}
-		for _, m := range nonExpectedMetrics.Items {
-			if strings.Contains(result, m.Name) {
-				t.Errorf("unexpected metrics for %s: \n%s", m.Name, result)
-			}
-		}
-	})
-}
-
-func TestTopNodeWithSortByCpuMetricsFrom(t *testing.T) {
-	expectedNodePath := fmt.Sprintf("/%s/%s/nodes", apiPrefix, apiVersion)
-
-	t.Run("v1beta1", func(t *testing.T) {
-		metrics, nodes := testNodeV1beta1MetricsData()
-		expectedMetrics := &metricsv1beta1api.NodeMetricsList{
-			ListMeta: metrics.ListMeta,
-			Items:    metrics.Items,
-		}
-		expectedNodes := v1.NodeList{
-			ListMeta: nodes.ListMeta,
-			Items:    nodes.Items,
-		}
-		expectedNodesNames := []string{"node2", "node3", "node1"}
-		fakemetrics := &metricsfake.Clientset{}
-		fakemetrics.AddReactor("list", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-			return true, expectedMetrics, nil
-		})
-
-		// Check the presence of node names in the output.
-		result := runTopNodeTest(t, runTopNodeOpts{
-			apisBody:     apisV1beta1BodyWithMetrics,
-			expectedPath: expectedNodePath,
-			nodeBody:     &expectedNodes,
-			fakeMetrics:  fakemetrics,
-			sortBy:       "cpu",
-		})
-
-		for _, m := range expectedMetrics.Items {
-			if !strings.Contains(result, m.Name) {
-				t.Errorf("missing metrics for %s: \n%s", m.Name, result)
-			}
-		}
-
-		resultNodes := extractNodeNamesFromTopOutput(result)
-
-		if !reflect.DeepEqual(resultNodes, expectedNodesNames) {
-			t.Errorf("kinds not matching:\n\texpectedKinds: %v\n\tgotKinds: %v\n", expectedNodesNames, resultNodes)
-		}
-	})
-
-	t.Run("v1", func(t *testing.T) {
-		metrics, nodes := testNodeV1MetricsData()
-		expectedMetrics := &metricsv1api.NodeMetricsList{
-			ListMeta: metrics.ListMeta,
-			Items:    metrics.Items,
-		}
-		expectedNodes := v1.NodeList{
-			ListMeta: nodes.ListMeta,
-			Items:    nodes.Items,
-		}
-		expectedNodesNames := []string{"node2", "node3", "node1"}
-		fakemetrics := &metricsfake.Clientset{}
-		fakemetrics.AddReactor("list", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-			return true, expectedMetrics, nil
-		})
-
-		// Check the presence of node names in the output.
-		result := runTopNodeTest(t, runTopNodeOpts{
-			apisBody:     apisV1BodyWithMetrics,
-			expectedPath: expectedNodePath,
-			nodeBody:     &expectedNodes,
-			fakeMetrics:  fakemetrics,
-			sortBy:       "cpu",
-		})
-
-		for _, m := range expectedMetrics.Items {
-			if !strings.Contains(result, m.Name) {
-				t.Errorf("missing metrics for %s: \n%s", m.Name, result)
-			}
-		}
-
-		resultNodes := extractNodeNamesFromTopOutput(result)
-
-		if !reflect.DeepEqual(resultNodes, expectedNodesNames) {
-			t.Errorf("kinds not matching:\n\texpectedKinds: %v\n\tgotKinds: %v\n", expectedNodesNames, resultNodes)
-		}
-	})
-}
-
-func TestTopNodeWithSortByMemoryMetricsFrom(t *testing.T) {
-	expectedNodePath := fmt.Sprintf("/%s/%s/nodes", apiPrefix, apiVersion)
-
-	t.Run("v1beta1", func(t *testing.T) {
-		metrics, nodes := testNodeV1beta1MetricsData()
-		expectedMetrics := &metricsv1beta1api.NodeMetricsList{
-			ListMeta: metrics.ListMeta,
-			Items:    metrics.Items,
-		}
-		expectedNodes := v1.NodeList{
-			ListMeta: nodes.ListMeta,
-			Items:    nodes.Items,
-		}
-		expectedNodesNames := []string{"node2", "node3", "node1"}
-		fakemetrics := &metricsfake.Clientset{}
-		fakemetrics.AddReactor("list", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-			return true, expectedMetrics, nil
-		})
-
-		// Check the presence of node names in the output.
-		result := runTopNodeTest(t, runTopNodeOpts{
-			apisBody:     apisV1beta1BodyWithMetrics,
-			expectedPath: expectedNodePath,
-			nodeBody:     &expectedNodes,
-			fakeMetrics:  fakemetrics,
-			sortBy:       "memory",
-		})
-
-		for _, m := range expectedMetrics.Items {
-			if !strings.Contains(result, m.Name) {
-				t.Errorf("missing metrics for %s: \n%s", m.Name, result)
-			}
-		}
-
-		resultNodes := extractNodeNamesFromTopOutput(result)
-
-		if !reflect.DeepEqual(resultNodes, expectedNodesNames) {
-			t.Errorf("kinds not matching:\n\texpectedKinds: %v\n\tgotKinds: %v\n", expectedNodesNames, resultNodes)
-		}
-	})
-
-	t.Run("v1", func(t *testing.T) {
-		metrics, nodes := testNodeV1MetricsData()
-		expectedMetrics := &metricsv1api.NodeMetricsList{
-			ListMeta: metrics.ListMeta,
-			Items:    metrics.Items,
-		}
-		expectedNodes := v1.NodeList{
-			ListMeta: nodes.ListMeta,
-			Items:    nodes.Items,
-		}
-		expectedNodesNames := []string{"node2", "node3", "node1"}
-		fakemetrics := &metricsfake.Clientset{}
-		fakemetrics.AddReactor("list", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-			return true, expectedMetrics, nil
-		})
-
-		// Check the presence of node names in the output.
-		result := runTopNodeTest(t, runTopNodeOpts{
-			apisBody:     apisV1BodyWithMetrics,
-			expectedPath: expectedNodePath,
-			nodeBody:     &expectedNodes,
-			fakeMetrics:  fakemetrics,
-			sortBy:       "memory",
-		})
-
-		for _, m := range expectedMetrics.Items {
-			if !strings.Contains(result, m.Name) {
-				t.Errorf("missing metrics for %s: \n%s", m.Name, result)
-			}
-		}
-
-		resultNodes := extractNodeNamesFromTopOutput(result)
-
-		if !reflect.DeepEqual(resultNodes, expectedNodesNames) {
-			t.Errorf("kinds not matching:\n\texpectedKinds: %v\n\tgotKinds: %v\n", expectedNodesNames, resultNodes)
-		}
-	})
-}
-
-func TestTopNodeWithSwap(t *testing.T) {
-	expectedNodePath := fmt.Sprintf("/%s/%s/nodes", apiPrefix, apiVersion)
-
-	swapCases := []struct {
-		name                  string
-		isSwapDisabledOnNodes bool
+	testCases := []struct {
+		name                string
+		args                []string
+		selector            string
+		sortBy              string
+		showSwap            bool
+		noSwapOnNodes       bool
+		nodeIndices         []int // fixture items served by the fakes; nil means all
+		expectedNodes       []string
+		nonExpectedNodes    []string
+		expectedSortedNodes []string
 	}{
 		{
-			name:                  "nodes with swap",
-			isSwapDisabledOnNodes: false,
+			name:          "all nodes",
+			expectedNodes: []string{"node1", "node2", "node3"},
 		},
 		{
-			name:                  "nodes without swap",
-			isSwapDisabledOnNodes: true,
+			name:             "node with name",
+			args:             []string{"node1"},
+			nodeIndices:      []int{0},
+			expectedNodes:    []string{"node1"},
+			nonExpectedNodes: []string{"node2", "node3"},
+		},
+		{
+			name:             "node with label selector",
+			selector:         "key=value",
+			nodeIndices:      []int{0},
+			expectedNodes:    []string{"node1"},
+			nonExpectedNodes: []string{"node2", "node3"},
+		},
+		{
+			name:                "node sort by cpu",
+			sortBy:              "cpu",
+			expectedNodes:       []string{"node1", "node2", "node3"},
+			expectedSortedNodes: []string{"node2", "node3", "node1"},
+		},
+		{
+			name:                "node sort by memory",
+			sortBy:              "memory",
+			expectedNodes:       []string{"node1", "node2", "node3"},
+			expectedSortedNodes: []string{"node2", "node3", "node1"},
+		},
+		{
+			name:          "nodes with swap",
+			showSwap:      true,
+			expectedNodes: []string{"node1", "node2", "node3"},
+		},
+		{
+			name:          "nodes without swap",
+			showSwap:      true,
+			noSwapOnNodes: true,
+			expectedNodes: []string{"node1", "node2", "node3"},
 		},
 	}
 
-	t.Run("v1beta1", func(t *testing.T) {
-		for _, tc := range swapCases {
-			t.Run(tc.name, func(t *testing.T) {
-				expectedMetrics, nodes := testNodeV1beta1MetricsData()
-				if tc.isSwapDisabledOnNodes {
-					for i := range expectedMetrics.Items {
-						delete(expectedMetrics.Items[i].Usage, "swap")
+	for _, version := range metricsAPIVersions {
+		t.Run(version.name, func(t *testing.T) {
+			for _, testCase := range testCases {
+				t.Run(testCase.name, func(t *testing.T) {
+					metrics, nodes := testNodeMetricsData()
+					if testCase.nodeIndices != nil {
+						var metricsItems []metricsapi.NodeMetrics
+						var nodeItems []v1.Node
+						for _, i := range testCase.nodeIndices {
+							metricsItems = append(metricsItems, metrics.Items[i])
+							nodeItems = append(nodeItems, nodes.Items[i])
+						}
+						metrics.Items = metricsItems
+						nodes.Items = nodeItems
 					}
-					for i := range nodes.Items {
-						nodes.Items[i].Status.NodeInfo.Swap = nil
+					if testCase.noSwapOnNodes {
+						for i := range metrics.Items {
+							delete(metrics.Items[i].Usage, "swap")
+						}
+						for i := range nodes.Items {
+							nodes.Items[i].Status.NodeInfo.Swap = nil
+						}
 					}
-				}
-				fakeMetrics := &metricsfake.Clientset{}
-				fakeMetrics.AddReactor("list", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-					return true, expectedMetrics, nil
+
+					metricsList, firstMetrics := versionedNodeMetricsList(t, version.name, metrics)
+					fakeMetrics := &metricsfake.Clientset{}
+					fakeMetrics.AddReactor("get", "nodes", func(action core.Action) (bool, runtime.Object, error) {
+						return true, firstMetrics, nil
+					})
+					fakeMetrics.AddReactor("list", "nodes", func(action core.Action) (bool, runtime.Object, error) {
+						return true, metricsList, nil
+					})
+
+					expectedPath := listNodePath
+					var nodeBody runtime.Object = nodes
+					if len(testCase.args) > 0 {
+						expectedPath = fmt.Sprintf("%s/%s", listNodePath, testCase.args[0])
+						nodeBody = &nodes.Items[0]
+					}
+
+					result := runTopNodeTest(t, runTopNodeOpts{
+						apisBody:     version.apisBody,
+						expectedPath: expectedPath,
+						nodeBody:     nodeBody,
+						fakeMetrics:  fakeMetrics,
+						cmdArgs:      testCase.args,
+						selector:     testCase.selector,
+						sortBy:       testCase.sortBy,
+						showSwap:     testCase.showSwap,
+					})
+
+					assertTopNodeOutput(t, topNodeAssertion{
+						result:              result,
+						expectedNodes:       testCase.expectedNodes,
+						nonExpectedNodes:    testCase.nonExpectedNodes,
+						expectedSortedNodes: testCase.expectedSortedNodes,
+						showSwap:            testCase.showSwap,
+						expectUnknownSwap:   testCase.noSwapOnNodes,
+					})
 				})
+			}
+		})
+	}
+}
 
-				result := runTopNodeTest(t, runTopNodeOpts{
-					apisBody:     apisV1beta1BodyWithMetrics,
-					expectedPath: expectedNodePath,
-					nodeBody:     nodes,
-					fakeMetrics:  fakeMetrics,
-					showSwap:     true,
-				})
+type topNodeAssertion struct {
+	result              string
+	expectedNodes       []string // names that should appear in the output
+	nonExpectedNodes    []string // names that should not appear in the output
+	expectedSortedNodes []string // sort assertion (column 0)
+	showSwap            bool
+	expectUnknownSwap   bool
+}
 
-				if !strings.Contains(result, "SWAP(bytes)") {
-					t.Errorf("missing SWAP(bytes) header: \n%s", result)
-				}
-				if !strings.Contains(result, "SWAP(%)") {
-					t.Errorf("missing SWAP(%%) header: \n%s", result)
-				}
-
-				if tc.isSwapDisabledOnNodes {
-					if !strings.Contains(result, "<unknown>") {
-						t.Errorf("expected swap to be <unknown>: \n%s", result)
-					}
-				}
-
-				for _, m := range expectedMetrics.Items {
-					if !strings.Contains(result, m.Name) {
-						t.Errorf("missing metrics for %s: \n%s", m.Name, result)
-					}
-					if _, foundSwapMetric := m.Usage["swap"]; foundSwapMetric != !tc.isSwapDisabledOnNodes {
-						t.Errorf("missing swap metric for %s: \n%s", m.Name, result)
-					}
-				}
-			})
+func assertTopNodeOutput(t *testing.T, a topNodeAssertion) {
+	t.Helper()
+	for _, name := range a.expectedNodes {
+		if !strings.Contains(a.result, name) {
+			t.Errorf("missing metrics for %s: \n%s", name, a.result)
 		}
-	})
-
-	t.Run("v1", func(t *testing.T) {
-		for _, tc := range swapCases {
-			t.Run(tc.name, func(t *testing.T) {
-				expectedMetrics, nodes := testNodeV1MetricsData()
-				if tc.isSwapDisabledOnNodes {
-					for i := range expectedMetrics.Items {
-						delete(expectedMetrics.Items[i].Usage, "swap")
-					}
-					for i := range nodes.Items {
-						nodes.Items[i].Status.NodeInfo.Swap = nil
-					}
-				}
-				fakeMetrics := &metricsfake.Clientset{}
-				fakeMetrics.AddReactor("list", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-					return true, expectedMetrics, nil
-				})
-
-				result := runTopNodeTest(t, runTopNodeOpts{
-					apisBody:     apisV1BodyWithMetrics,
-					expectedPath: expectedNodePath,
-					nodeBody:     nodes,
-					fakeMetrics:  fakeMetrics,
-					showSwap:     true,
-				})
-
-				if !strings.Contains(result, "SWAP(bytes)") {
-					t.Errorf("missing SWAP(bytes) header: \n%s", result)
-				}
-				if !strings.Contains(result, "SWAP(%)") {
-					t.Errorf("missing SWAP(%%) header: \n%s", result)
-				}
-
-				if tc.isSwapDisabledOnNodes {
-					if !strings.Contains(result, "<unknown>") {
-						t.Errorf("expected swap to be <unknown>: \n%s", result)
-					}
-				}
-
-				for _, m := range expectedMetrics.Items {
-					if !strings.Contains(result, m.Name) {
-						t.Errorf("missing metrics for %s: \n%s", m.Name, result)
-					}
-					if _, foundSwapMetric := m.Usage["swap"]; foundSwapMetric != !tc.isSwapDisabledOnNodes {
-						t.Errorf("missing swap metric for %s: \n%s", m.Name, result)
-					}
-				}
-			})
+	}
+	for _, name := range a.nonExpectedNodes {
+		if strings.Contains(a.result, name) {
+			t.Errorf("unexpected metrics for %s: \n%s", name, a.result)
 		}
-	})
+	}
+	if a.expectedSortedNodes != nil {
+		resultNodes := extractNodeNamesFromTopOutput(a.result)
+		if !reflect.DeepEqual(a.expectedSortedNodes, resultNodes) {
+			t.Errorf("nodes not matching:\n\texpectedNodes: %v\n\tresultNodes: %v\n", a.expectedSortedNodes, resultNodes)
+		}
+	}
+	if a.showSwap {
+		if !strings.Contains(a.result, "SWAP(bytes)") {
+			t.Errorf("missing SWAP(bytes) header: \n%s", a.result)
+		}
+		if !strings.Contains(a.result, "SWAP(%)") {
+			t.Errorf("missing SWAP(%%) header: \n%s", a.result)
+		}
+	}
+	if a.expectUnknownSwap && !strings.Contains(a.result, "<unknown>") {
+		t.Errorf("expected swap to be <unknown>: \n%s", a.result)
+	}
 }
 
 func extractNodeNamesFromTopOutput(result string) []string {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node_test.go
@@ -25,13 +25,14 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/rest/fake"
 	core "k8s.io/client-go/testing"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	"k8s.io/kubectl/pkg/scheme"
+	metricsv1api "k8s.io/metrics/pkg/apis/metrics/v1"
 	metricsv1beta1api "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	metricsfake "k8s.io/metrics/pkg/client/clientset/versioned/fake"
 )
@@ -42,446 +43,348 @@ const (
 )
 
 func TestTopNodeAllMetricsFrom(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
-	expectedMetrics, nodes := testNodeV1beta1MetricsData()
 	expectedNodePath := fmt.Sprintf("/%s/%s/nodes", apiPrefix, apiVersion)
 
-	tf := cmdtesting.NewTestFactory().WithNamespace("test")
-	defer tf.Cleanup()
-
-	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
-	ns := scheme.Codecs.WithoutConversion()
-
-	tf.Client = &fake.RESTClient{
-		NegotiatedSerializer: ns,
-		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			switch p, m := req.URL.Path, req.Method; {
-			case p == "/api":
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apibody)))}, nil
-			case p == "/apis":
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apisbodyWithMetrics)))}, nil
-			case p == expectedNodePath && m == "GET":
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, nodes)}, nil
-			default:
-				t.Fatalf("unexpected request: %#v\nGot URL: %#v\n", req, req.URL)
-				return nil, nil
+	t.Run("v1beta1", func(t *testing.T) {
+		metrics, nodes := testNodeV1beta1MetricsData()
+		fakeMetrics := &metricsfake.Clientset{}
+		fakeMetrics.AddReactor("list", "nodes", func(action core.Action) (bool, runtime.Object, error) {
+			return true, metrics, nil
+		})
+		result := runTopNodeTest(t, runTopNodeOpts{
+			apisBody:     apisV1beta1BodyWithMetrics,
+			expectedPath: expectedNodePath,
+			nodeBody:     nodes,
+			fakeMetrics:  fakeMetrics,
+		})
+		for _, m := range metrics.Items {
+			if !strings.Contains(result, m.Name) {
+				t.Errorf("missing metrics for %s: \n%s", m.Name, result)
 			}
-		}),
-	}
-	fakemetricsClientset := &metricsfake.Clientset{}
-	fakemetricsClientset.AddReactor("list", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-		return true, expectedMetrics, nil
-	})
-	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
-	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
-
-	cmd := NewCmdTopNode(tf, nil, streams)
-
-	// TODO in the long run, we want to test most of our commands like this. Wire the options struct with specific mocks
-	// TODO then check the particular Run functionality and harvest results from fake clients
-	cmdOptions := &TopNodeOptions{
-		IOStreams: streams,
-	}
-	if err := cmdOptions.Complete(tf, cmd, []string{}); err != nil {
-		t.Fatal(err)
-	}
-	cmdOptions.MetricsClient = fakemetricsClientset
-	if err := cmdOptions.Validate(); err != nil {
-		t.Fatal(err)
-	}
-	if err := cmdOptions.RunTopNode(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Check the presence of node names in the output.
-	result := buf.String()
-	for _, m := range expectedMetrics.Items {
-		if !strings.Contains(result, m.Name) {
-			t.Errorf("missing metrics for %s: \n%s", m.Name, result)
 		}
-	}
+	})
+
+	t.Run("v1", func(t *testing.T) {
+		metrics, nodes := testNodeV1MetricsData()
+		fakeMetrics := &metricsfake.Clientset{}
+		fakeMetrics.AddReactor("list", "nodes", func(action core.Action) (bool, runtime.Object, error) {
+			return true, metrics, nil
+		})
+		result := runTopNodeTest(t, runTopNodeOpts{
+			apisBody:     apisV1BodyWithMetrics,
+			expectedPath: expectedNodePath,
+			nodeBody:     nodes,
+			fakeMetrics:  fakeMetrics,
+		})
+		for _, m := range metrics.Items {
+			if !strings.Contains(result, m.Name) {
+				t.Errorf("missing metrics for %s: \n%s", m.Name, result)
+			}
+		}
+	})
 }
 
 func TestTopNodeWithNameMetricsFrom(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
-	metrics, nodes := testNodeV1beta1MetricsData()
-	expectedMetrics := metrics.Items[0]
-	expectedNode := nodes.Items[0]
-	nonExpectedMetrics := metricsv1beta1api.NodeMetricsList{
-		ListMeta: metrics.ListMeta,
-		Items:    metrics.Items[1:],
-	}
-	expectedNodePath := fmt.Sprintf("/%s/%s/nodes/%s", apiPrefix, apiVersion, expectedMetrics.Name)
+	t.Run("v1beta1", func(t *testing.T) {
+		metrics, nodes := testNodeV1beta1MetricsData()
+		expectedMetrics := metrics.Items[0]
+		expectedNode := nodes.Items[0]
+		nonExpectedMetrics := metrics.Items[1:]
+		expectedNodePath := fmt.Sprintf("/%s/%s/nodes/%s", apiPrefix, apiVersion, expectedMetrics.Name)
 
-	tf := cmdtesting.NewTestFactory().WithNamespace("test")
-	defer tf.Cleanup()
-
-	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
-	ns := scheme.Codecs.WithoutConversion()
-
-	tf.Client = &fake.RESTClient{
-		NegotiatedSerializer: ns,
-		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			switch p, m := req.URL.Path, req.Method; {
-			case p == "/api":
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apibody)))}, nil
-			case p == "/apis":
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apisbodyWithMetrics)))}, nil
-			case p == expectedNodePath && m == "GET":
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &expectedNode)}, nil
-			default:
-				t.Fatalf("unexpected request: %#v\nGot URL: %#v\n", req, req.URL)
-				return nil, nil
-			}
-		}),
-	}
-	fakemetricsClientset := &metricsfake.Clientset{}
-	fakemetricsClientset.AddReactor("get", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-		return true, &expectedMetrics, nil
-	})
-	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
-	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
-
-	cmd := NewCmdTopNode(tf, nil, streams)
-
-	// TODO in the long run, we want to test most of our commands like this. Wire the options struct with specific mocks
-	// TODO then check the particular Run functionality and harvest results from fake clients
-	cmdOptions := &TopNodeOptions{
-		IOStreams: streams,
-	}
-	if err := cmdOptions.Complete(tf, cmd, []string{expectedMetrics.Name}); err != nil {
-		t.Fatal(err)
-	}
-	cmdOptions.MetricsClient = fakemetricsClientset
-	if err := cmdOptions.Validate(); err != nil {
-		t.Fatal(err)
-	}
-	if err := cmdOptions.RunTopNode(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Check the presence of node names in the output.
-	result := buf.String()
-	if !strings.Contains(result, expectedMetrics.Name) {
-		t.Errorf("missing metrics for %s: \n%s", expectedMetrics.Name, result)
-	}
-	for _, m := range nonExpectedMetrics.Items {
-		if strings.Contains(result, m.Name) {
-			t.Errorf("unexpected metrics for %s: \n%s", m.Name, result)
+		fakeMetrics := &metricsfake.Clientset{}
+		fakeMetrics.AddReactor("get", "nodes", func(action core.Action) (bool, runtime.Object, error) {
+			return true, &expectedMetrics, nil
+		})
+		result := runTopNodeTest(t, runTopNodeOpts{
+			apisBody:     apisV1beta1BodyWithMetrics,
+			expectedPath: expectedNodePath,
+			nodeBody:     &expectedNode,
+			fakeMetrics:  fakeMetrics,
+			cmdArgs:      []string{expectedMetrics.Name},
+		})
+		if !strings.Contains(result, expectedMetrics.Name) {
+			t.Errorf("missing metrics for %s: \n%s", expectedMetrics.Name, result)
 		}
-	}
+		for _, m := range nonExpectedMetrics {
+			if strings.Contains(result, m.Name) {
+				t.Errorf("unexpected metrics for %s: \n%s", m.Name, result)
+			}
+		}
+	})
+
+	t.Run("v1", func(t *testing.T) {
+		metrics, nodes := testNodeV1MetricsData()
+		expectedMetrics := metrics.Items[0]
+		expectedNode := nodes.Items[0]
+		nonExpectedMetrics := metrics.Items[1:]
+		expectedNodePath := fmt.Sprintf("/%s/%s/nodes/%s", apiPrefix, apiVersion, expectedMetrics.Name)
+
+		fakeMetrics := &metricsfake.Clientset{}
+		fakeMetrics.AddReactor("get", "nodes", func(action core.Action) (bool, runtime.Object, error) {
+			return true, &expectedMetrics, nil
+		})
+		result := runTopNodeTest(t, runTopNodeOpts{
+			apisBody:     apisV1BodyWithMetrics,
+			expectedPath: expectedNodePath,
+			nodeBody:     &expectedNode,
+			fakeMetrics:  fakeMetrics,
+			cmdArgs:      []string{expectedMetrics.Name},
+		})
+		if !strings.Contains(result, expectedMetrics.Name) {
+			t.Errorf("missing metrics for %s: \n%s", expectedMetrics.Name, result)
+		}
+		for _, m := range nonExpectedMetrics {
+			if strings.Contains(result, m.Name) {
+				t.Errorf("unexpected metrics for %s: \n%s", m.Name, result)
+			}
+		}
+	})
 }
 
 func TestTopNodeWithLabelSelectorMetricsFrom(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
-	metrics, nodes := testNodeV1beta1MetricsData()
-	expectedMetrics := &metricsv1beta1api.NodeMetricsList{
-		ListMeta: metrics.ListMeta,
-		Items:    metrics.Items[0:1],
-	}
-	expectedNodes := v1.NodeList{
-		ListMeta: nodes.ListMeta,
-		Items:    nodes.Items[0:1],
-	}
-	nonExpectedMetrics := &metricsv1beta1api.NodeMetricsList{
-		ListMeta: metrics.ListMeta,
-		Items:    metrics.Items[1:],
-	}
-	label := "key=value"
 	expectedNodePath := fmt.Sprintf("/%s/%s/nodes", apiPrefix, apiVersion)
+	label := "key=value"
 
-	tf := cmdtesting.NewTestFactory().WithNamespace("test")
-	defer tf.Cleanup()
-
-	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
-	ns := scheme.Codecs.WithoutConversion()
-
-	tf.Client = &fake.RESTClient{
-		NegotiatedSerializer: ns,
-		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			switch p, m, _ := req.URL.Path, req.Method, req.URL.RawQuery; {
-			case p == "/api":
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apibody)))}, nil
-			case p == "/apis":
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apisbodyWithMetrics)))}, nil
-			case p == expectedNodePath && m == "GET":
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &expectedNodes)}, nil
-			default:
-				t.Fatalf("unexpected request: %#v\nGot URL: %#v\n", req, req.URL)
-				return nil, nil
+	t.Run("v1beta1", func(t *testing.T) {
+		metrics, nodes := testNodeV1beta1MetricsData()
+		expectedMetrics := &metricsv1beta1api.NodeMetricsList{
+			ListMeta: metrics.ListMeta,
+			Items:    metrics.Items[0:1],
+		}
+		expectedNodes := v1.NodeList{
+			ListMeta: nodes.ListMeta,
+			Items:    nodes.Items[0:1],
+		}
+		nonExpectedMetrics := &metricsv1beta1api.NodeMetricsList{
+			ListMeta: metrics.ListMeta,
+			Items:    metrics.Items[1:],
+		}
+		fakeMetrics := &metricsfake.Clientset{}
+		fakeMetrics.AddReactor("list", "nodes", func(action core.Action) (bool, runtime.Object, error) {
+			return true, expectedMetrics, nil
+		})
+		result := runTopNodeTest(t, runTopNodeOpts{
+			apisBody:     apisV1beta1BodyWithMetrics,
+			expectedPath: expectedNodePath,
+			nodeBody:     &expectedNodes,
+			fakeMetrics:  fakeMetrics,
+			selector:     label,
+		})
+		for _, m := range expectedMetrics.Items {
+			if !strings.Contains(result, m.Name) {
+				t.Errorf("missing metrics for %s: \n%s", m.Name, result)
 			}
-		}),
-	}
-
-	fakemetricsClientset := &metricsfake.Clientset{}
-	fakemetricsClientset.AddReactor("list", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-		return true, expectedMetrics, nil
+		}
+		for _, m := range nonExpectedMetrics.Items {
+			if strings.Contains(result, m.Name) {
+				t.Errorf("unexpected metrics for %s: \n%s", m.Name, result)
+			}
+		}
 	})
-	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
-	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
-	cmd := NewCmdTopNode(tf, nil, streams)
-	cmd.Flags().Set("selector", label)
-
-	// TODO in the long run, we want to test most of our commands like this. Wire the options struct with specific mocks
-	// TODO then check the particular Run functionality and harvest results from fake clients
-	cmdOptions := &TopNodeOptions{
-		IOStreams: streams,
-	}
-	if err := cmdOptions.Complete(tf, cmd, []string{}); err != nil {
-		t.Fatal(err)
-	}
-	cmdOptions.MetricsClient = fakemetricsClientset
-	if err := cmdOptions.Validate(); err != nil {
-		t.Fatal(err)
-	}
-	if err := cmdOptions.RunTopNode(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Check the presence of node names in the output.
-	result := buf.String()
-	for _, m := range expectedMetrics.Items {
-		if !strings.Contains(result, m.Name) {
-			t.Errorf("missing metrics for %s: \n%s", m.Name, result)
+	t.Run("v1", func(t *testing.T) {
+		metrics, nodes := testNodeV1MetricsData()
+		expectedMetrics := &metricsv1api.NodeMetricsList{
+			ListMeta: metrics.ListMeta,
+			Items:    metrics.Items[0:1],
 		}
-	}
-	for _, m := range nonExpectedMetrics.Items {
-		if strings.Contains(result, m.Name) {
-			t.Errorf("unexpected metrics for %s: \n%s", m.Name, result)
+		expectedNodes := v1.NodeList{
+			ListMeta: nodes.ListMeta,
+			Items:    nodes.Items[0:1],
 		}
-	}
+		nonExpectedMetrics := &metricsv1api.NodeMetricsList{
+			ListMeta: metrics.ListMeta,
+			Items:    metrics.Items[1:],
+		}
+		fakeMetrics := &metricsfake.Clientset{}
+		fakeMetrics.AddReactor("list", "nodes", func(action core.Action) (bool, runtime.Object, error) {
+			return true, expectedMetrics, nil
+		})
+		result := runTopNodeTest(t, runTopNodeOpts{
+			apisBody:     apisV1BodyWithMetrics,
+			expectedPath: expectedNodePath,
+			nodeBody:     &expectedNodes,
+			fakeMetrics:  fakeMetrics,
+			selector:     label,
+		})
+		for _, m := range expectedMetrics.Items {
+			if !strings.Contains(result, m.Name) {
+				t.Errorf("missing metrics for %s: \n%s", m.Name, result)
+			}
+		}
+		for _, m := range nonExpectedMetrics.Items {
+			if strings.Contains(result, m.Name) {
+				t.Errorf("unexpected metrics for %s: \n%s", m.Name, result)
+			}
+		}
+	})
 }
 
 func TestTopNodeWithSortByCpuMetricsFrom(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
-	metrics, nodes := testNodeV1beta1MetricsData()
-	expectedMetrics := &metricsv1beta1api.NodeMetricsList{
-		ListMeta: metrics.ListMeta,
-		Items:    metrics.Items[:],
-	}
-	expectedNodes := v1.NodeList{
-		ListMeta: nodes.ListMeta,
-		Items:    nodes.Items[:],
-	}
 	expectedNodePath := fmt.Sprintf("/%s/%s/nodes", apiPrefix, apiVersion)
-	expectedNodesNames := []string{"node2", "node3", "node1"}
 
-	tf := cmdtesting.NewTestFactory().WithNamespace("test")
-	defer tf.Cleanup()
-
-	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
-	ns := scheme.Codecs
-
-	tf.Client = &fake.RESTClient{
-		NegotiatedSerializer: ns,
-		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			switch p, m := req.URL.Path, req.Method; {
-			case p == "/api":
-				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apibody)))}, nil
-			case p == "/apis":
-				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apisbodyWithMetrics)))}, nil
-			case p == expectedNodePath && m == "GET":
-				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &expectedNodes)}, nil
-			default:
-				t.Fatalf("unexpected request: %#v\nGot URL: %#v\n", req, req.URL)
-				return nil, nil
-			}
-		}),
-	}
-	fakemetricsClientset := &metricsfake.Clientset{}
-	fakemetricsClientset.AddReactor("list", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-		return true, expectedMetrics, nil
-	})
-	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
-	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
-
-	cmd := NewCmdTopNode(tf, nil, streams)
-	cmd.Flags().Set("sort-by", "cpu")
-
-	// TODO in the long run, we want to test most of our commands like this. Wire the options struct with specific mocks
-	// TODO then check the particular Run functionality and harvest results from fake clients
-	cmdOptions := &TopNodeOptions{
-		IOStreams: streams,
-		SortBy:    "cpu",
-	}
-	if err := cmdOptions.Complete(tf, cmd, []string{}); err != nil {
-		t.Fatal(err)
-	}
-	cmdOptions.MetricsClient = fakemetricsClientset
-	if err := cmdOptions.Validate(); err != nil {
-		t.Fatal(err)
-	}
-	if err := cmdOptions.RunTopNode(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Check the presence of node names in the output.
-	result := buf.String()
-
-	for _, m := range expectedMetrics.Items {
-		if !strings.Contains(result, m.Name) {
-			t.Errorf("missing metrics for %s: \n%s", m.Name, result)
+	t.Run("v1beta1", func(t *testing.T) {
+		metrics, nodes := testNodeV1beta1MetricsData()
+		expectedMetrics := &metricsv1beta1api.NodeMetricsList{
+			ListMeta: metrics.ListMeta,
+			Items:    metrics.Items,
 		}
-	}
+		expectedNodes := v1.NodeList{
+			ListMeta: nodes.ListMeta,
+			Items:    nodes.Items,
+		}
+		expectedNodesNames := []string{"node2", "node3", "node1"}
+		fakemetrics := &metricsfake.Clientset{}
+		fakemetrics.AddReactor("list", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+			return true, expectedMetrics, nil
+		})
 
-	resultLines := strings.Split(result, "\n")
-	resultNodes := make([]string, len(resultLines)-2) // don't process first (header) and last (empty) line
+		// Check the presence of node names in the output.
+		result := runTopNodeTest(t, runTopNodeOpts{
+			apisBody:     apisV1beta1BodyWithMetrics,
+			expectedPath: expectedNodePath,
+			nodeBody:     &expectedNodes,
+			fakeMetrics:  fakemetrics,
+			sortBy:       "cpu",
+		})
 
-	for i, line := range resultLines[1 : len(resultLines)-1] { // don't process first (header) and last (empty) line
-		lineFirstColumn := strings.Split(line, " ")[0]
-		resultNodes[i] = lineFirstColumn
-	}
+		for _, m := range expectedMetrics.Items {
+			if !strings.Contains(result, m.Name) {
+				t.Errorf("missing metrics for %s: \n%s", m.Name, result)
+			}
+		}
 
-	if !reflect.DeepEqual(resultNodes, expectedNodesNames) {
-		t.Errorf("kinds not matching:\n\texpectedKinds: %v\n\tgotKinds: %v\n", expectedNodesNames, resultNodes)
-	}
+		resultNodes := extractNodeNamesFromTopOutput(result)
 
+		if !reflect.DeepEqual(resultNodes, expectedNodesNames) {
+			t.Errorf("kinds not matching:\n\texpectedKinds: %v\n\tgotKinds: %v\n", expectedNodesNames, resultNodes)
+		}
+	})
+
+	t.Run("v1", func(t *testing.T) {
+		metrics, nodes := testNodeV1MetricsData()
+		expectedMetrics := &metricsv1api.NodeMetricsList{
+			ListMeta: metrics.ListMeta,
+			Items:    metrics.Items,
+		}
+		expectedNodes := v1.NodeList{
+			ListMeta: nodes.ListMeta,
+			Items:    nodes.Items,
+		}
+		expectedNodesNames := []string{"node2", "node3", "node1"}
+		fakemetrics := &metricsfake.Clientset{}
+		fakemetrics.AddReactor("list", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+			return true, expectedMetrics, nil
+		})
+
+		// Check the presence of node names in the output.
+		result := runTopNodeTest(t, runTopNodeOpts{
+			apisBody:     apisV1BodyWithMetrics,
+			expectedPath: expectedNodePath,
+			nodeBody:     &expectedNodes,
+			fakeMetrics:  fakemetrics,
+			sortBy:       "cpu",
+		})
+
+		for _, m := range expectedMetrics.Items {
+			if !strings.Contains(result, m.Name) {
+				t.Errorf("missing metrics for %s: \n%s", m.Name, result)
+			}
+		}
+
+		resultNodes := extractNodeNamesFromTopOutput(result)
+
+		if !reflect.DeepEqual(resultNodes, expectedNodesNames) {
+			t.Errorf("kinds not matching:\n\texpectedKinds: %v\n\tgotKinds: %v\n", expectedNodesNames, resultNodes)
+		}
+	})
 }
 
 func TestTopNodeWithSortByMemoryMetricsFrom(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
-	metrics, nodes := testNodeV1beta1MetricsData()
-	expectedMetrics := &metricsv1beta1api.NodeMetricsList{
-		ListMeta: metrics.ListMeta,
-		Items:    metrics.Items[:],
-	}
-	expectedNodes := v1.NodeList{
-		ListMeta: nodes.ListMeta,
-		Items:    nodes.Items[:],
-	}
 	expectedNodePath := fmt.Sprintf("/%s/%s/nodes", apiPrefix, apiVersion)
-	expectedNodesNames := []string{"node2", "node3", "node1"}
 
-	tf := cmdtesting.NewTestFactory().WithNamespace("test")
-	defer tf.Cleanup()
-
-	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
-	ns := scheme.Codecs
-
-	tf.Client = &fake.RESTClient{
-		NegotiatedSerializer: ns,
-		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			switch p, m := req.URL.Path, req.Method; {
-			case p == "/api":
-				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apibody)))}, nil
-			case p == "/apis":
-				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apisbodyWithMetrics)))}, nil
-			case p == expectedNodePath && m == "GET":
-				return &http.Response{StatusCode: 200, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &expectedNodes)}, nil
-			default:
-				t.Fatalf("unexpected request: %#v\nGot URL: %#v\n", req, req.URL)
-				return nil, nil
-			}
-		}),
-	}
-	fakemetricsClientset := &metricsfake.Clientset{}
-	fakemetricsClientset.AddReactor("list", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-		return true, expectedMetrics, nil
-	})
-	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
-	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
-
-	cmd := NewCmdTopNode(tf, nil, streams)
-	cmd.Flags().Set("sort-by", "memory")
-
-	// TODO in the long run, we want to test most of our commands like this. Wire the options struct with specific mocks
-	// TODO then check the particular Run functionality and harvest results from fake clients
-	cmdOptions := &TopNodeOptions{
-		IOStreams: streams,
-		SortBy:    "memory",
-	}
-	if err := cmdOptions.Complete(tf, cmd, []string{}); err != nil {
-		t.Fatal(err)
-	}
-	cmdOptions.MetricsClient = fakemetricsClientset
-	if err := cmdOptions.Validate(); err != nil {
-		t.Fatal(err)
-	}
-	if err := cmdOptions.RunTopNode(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Check the presence of node names in the output.
-	result := buf.String()
-
-	for _, m := range expectedMetrics.Items {
-		if !strings.Contains(result, m.Name) {
-			t.Errorf("missing metrics for %s: \n%s", m.Name, result)
+	t.Run("v1beta1", func(t *testing.T) {
+		metrics, nodes := testNodeV1beta1MetricsData()
+		expectedMetrics := &metricsv1beta1api.NodeMetricsList{
+			ListMeta: metrics.ListMeta,
+			Items:    metrics.Items,
 		}
-	}
+		expectedNodes := v1.NodeList{
+			ListMeta: nodes.ListMeta,
+			Items:    nodes.Items,
+		}
+		expectedNodesNames := []string{"node2", "node3", "node1"}
+		fakemetrics := &metricsfake.Clientset{}
+		fakemetrics.AddReactor("list", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+			return true, expectedMetrics, nil
+		})
 
-	resultLines := strings.Split(result, "\n")
-	resultNodes := make([]string, len(resultLines)-2) // don't process first (header) and last (empty) line
+		// Check the presence of node names in the output.
+		result := runTopNodeTest(t, runTopNodeOpts{
+			apisBody:     apisV1beta1BodyWithMetrics,
+			expectedPath: expectedNodePath,
+			nodeBody:     &expectedNodes,
+			fakeMetrics:  fakemetrics,
+			sortBy:       "memory",
+		})
 
-	for i, line := range resultLines[1 : len(resultLines)-1] { // don't process first (header) and last (empty) line
-		lineFirstColumn := strings.Split(line, " ")[0]
-		resultNodes[i] = lineFirstColumn
-	}
+		for _, m := range expectedMetrics.Items {
+			if !strings.Contains(result, m.Name) {
+				t.Errorf("missing metrics for %s: \n%s", m.Name, result)
+			}
+		}
 
-	if !reflect.DeepEqual(resultNodes, expectedNodesNames) {
-		t.Errorf("kinds not matching:\n\texpectedKinds: %v\n\tgotKinds: %v\n", expectedNodesNames, resultNodes)
-	}
+		resultNodes := extractNodeNamesFromTopOutput(result)
 
+		if !reflect.DeepEqual(resultNodes, expectedNodesNames) {
+			t.Errorf("kinds not matching:\n\texpectedKinds: %v\n\tgotKinds: %v\n", expectedNodesNames, resultNodes)
+		}
+	})
+
+	t.Run("v1", func(t *testing.T) {
+		metrics, nodes := testNodeV1MetricsData()
+		expectedMetrics := &metricsv1api.NodeMetricsList{
+			ListMeta: metrics.ListMeta,
+			Items:    metrics.Items,
+		}
+		expectedNodes := v1.NodeList{
+			ListMeta: nodes.ListMeta,
+			Items:    nodes.Items,
+		}
+		expectedNodesNames := []string{"node2", "node3", "node1"}
+		fakemetrics := &metricsfake.Clientset{}
+		fakemetrics.AddReactor("list", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+			return true, expectedMetrics, nil
+		})
+
+		// Check the presence of node names in the output.
+		result := runTopNodeTest(t, runTopNodeOpts{
+			apisBody:     apisV1BodyWithMetrics,
+			expectedPath: expectedNodePath,
+			nodeBody:     &expectedNodes,
+			fakeMetrics:  fakemetrics,
+			sortBy:       "memory",
+		})
+
+		for _, m := range expectedMetrics.Items {
+			if !strings.Contains(result, m.Name) {
+				t.Errorf("missing metrics for %s: \n%s", m.Name, result)
+			}
+		}
+
+		resultNodes := extractNodeNamesFromTopOutput(result)
+
+		if !reflect.DeepEqual(resultNodes, expectedNodesNames) {
+			t.Errorf("kinds not matching:\n\texpectedKinds: %v\n\tgotKinds: %v\n", expectedNodesNames, resultNodes)
+		}
+	})
 }
 
 func TestTopNodeWithSwap(t *testing.T) {
-	runTopCmd := func(expectedMetrics *metricsv1beta1api.NodeMetricsList, nodes *v1.NodeList) (result string) {
-		cmdtesting.InitTestErrorHandler(t)
-		expectedNodePath := fmt.Sprintf("/%s/%s/nodes", apiPrefix, apiVersion)
+	expectedNodePath := fmt.Sprintf("/%s/%s/nodes", apiPrefix, apiVersion)
 
-		tf := cmdtesting.NewTestFactory().WithNamespace("test")
-		defer tf.Cleanup()
-
-		codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
-		ns := scheme.Codecs.WithoutConversion()
-
-		tf.Client = &fake.RESTClient{
-			NegotiatedSerializer: ns,
-			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-				switch p, m := req.URL.Path, req.Method; {
-				case p == "/api":
-					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apibody)))}, nil
-				case p == "/apis":
-					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apisbodyWithMetrics)))}, nil
-				case p == expectedNodePath && m == "GET":
-					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, nodes)}, nil
-				default:
-					t.Fatalf("unexpected request: %#v\nGot URL: %#v\n", req, req.URL)
-					return nil, nil
-				}
-			}),
-		}
-		fakemetricsClientset := &metricsfake.Clientset{}
-		fakemetricsClientset.AddReactor("list", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-			return true, expectedMetrics, nil
-		})
-		tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
-		streams, _, buf, _ := genericiooptions.NewTestIOStreams()
-
-		cmd := NewCmdTopNode(tf, nil, streams)
-
-		// TODO in the long run, we want to test most of our commands like this. Wire the options struct with specific mocks
-		// TODO then check the particular Run functionality and harvest results from fake clients
-		cmdOptions := &TopNodeOptions{
-			IOStreams: streams,
-			ShowSwap:  true,
-		}
-		if err := cmdOptions.Complete(tf, cmd, []string{}); err != nil {
-			t.Fatal(err)
-		}
-		cmdOptions.MetricsClient = fakemetricsClientset
-		if err := cmdOptions.Validate(); err != nil {
-			t.Fatal(err)
-		}
-		if err := cmdOptions.RunTopNode(); err != nil {
-			t.Fatal(err)
-		}
-
-		return buf.String()
-	}
-
-	for _, tc := range []struct {
+	swapCases := []struct {
 		name                  string
 		isSwapDisabledOnNodes bool
 	}{
@@ -493,42 +396,173 @@ func TestTopNodeWithSwap(t *testing.T) {
 			name:                  "nodes without swap",
 			isSwapDisabledOnNodes: true,
 		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			expectedMetrics, nodes := testNodeV1beta1MetricsData()
-			if tc.isSwapDisabledOnNodes {
-				for i := range expectedMetrics.Items {
-					delete(expectedMetrics.Items[i].Usage, "swap")
-				}
-				for i := range nodes.Items {
-					nodes.Items[i].Status.NodeInfo.Swap = nil
-				}
-			}
-
-			result := runTopCmd(expectedMetrics, nodes)
-			fmt.Printf("%s\n", result)
-
-			if !strings.Contains(result, "SWAP(bytes)") {
-				t.Errorf("missing SWAP(bytes) header: \n%s", result)
-			}
-			if !strings.Contains(result, "SWAP(%)") {
-				t.Errorf("missing SWAP(%%) header: \n%s", result)
-			}
-
-			if tc.isSwapDisabledOnNodes {
-				if !strings.Contains(result, "<unknown>") {
-					t.Errorf("expected swap to be <unknown>: \n%s", result)
-				}
-			}
-
-			for _, m := range expectedMetrics.Items {
-				if !strings.Contains(result, m.Name) {
-					t.Errorf("missing metrics for %s: \n%s", m.Name, result)
-				}
-				if _, foundSwapMetric := m.Usage["swap"]; foundSwapMetric != !tc.isSwapDisabledOnNodes {
-					t.Errorf("missing swap metric for %s: \n%s", m.Name, result)
-				}
-			}
-		})
 	}
+
+	t.Run("v1beta1", func(t *testing.T) {
+		for _, tc := range swapCases {
+			t.Run(tc.name, func(t *testing.T) {
+				expectedMetrics, nodes := testNodeV1beta1MetricsData()
+				if tc.isSwapDisabledOnNodes {
+					for i := range expectedMetrics.Items {
+						delete(expectedMetrics.Items[i].Usage, "swap")
+					}
+					for i := range nodes.Items {
+						nodes.Items[i].Status.NodeInfo.Swap = nil
+					}
+				}
+				fakeMetrics := &metricsfake.Clientset{}
+				fakeMetrics.AddReactor("list", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+					return true, expectedMetrics, nil
+				})
+
+				result := runTopNodeTest(t, runTopNodeOpts{
+					apisBody:     apisV1beta1BodyWithMetrics,
+					expectedPath: expectedNodePath,
+					nodeBody:     nodes,
+					fakeMetrics:  fakeMetrics,
+					showSwap:     true,
+				})
+
+				if !strings.Contains(result, "SWAP(bytes)") {
+					t.Errorf("missing SWAP(bytes) header: \n%s", result)
+				}
+				if !strings.Contains(result, "SWAP(%)") {
+					t.Errorf("missing SWAP(%%) header: \n%s", result)
+				}
+
+				if tc.isSwapDisabledOnNodes {
+					if !strings.Contains(result, "<unknown>") {
+						t.Errorf("expected swap to be <unknown>: \n%s", result)
+					}
+				}
+
+				for _, m := range expectedMetrics.Items {
+					if !strings.Contains(result, m.Name) {
+						t.Errorf("missing metrics for %s: \n%s", m.Name, result)
+					}
+					if _, foundSwapMetric := m.Usage["swap"]; foundSwapMetric != !tc.isSwapDisabledOnNodes {
+						t.Errorf("missing swap metric for %s: \n%s", m.Name, result)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("v1", func(t *testing.T) {
+		for _, tc := range swapCases {
+			t.Run(tc.name, func(t *testing.T) {
+				expectedMetrics, nodes := testNodeV1MetricsData()
+				if tc.isSwapDisabledOnNodes {
+					for i := range expectedMetrics.Items {
+						delete(expectedMetrics.Items[i].Usage, "swap")
+					}
+					for i := range nodes.Items {
+						nodes.Items[i].Status.NodeInfo.Swap = nil
+					}
+				}
+				fakeMetrics := &metricsfake.Clientset{}
+				fakeMetrics.AddReactor("list", "nodes", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+					return true, expectedMetrics, nil
+				})
+
+				result := runTopNodeTest(t, runTopNodeOpts{
+					apisBody:     apisV1BodyWithMetrics,
+					expectedPath: expectedNodePath,
+					nodeBody:     nodes,
+					fakeMetrics:  fakeMetrics,
+					showSwap:     true,
+				})
+
+				if !strings.Contains(result, "SWAP(bytes)") {
+					t.Errorf("missing SWAP(bytes) header: \n%s", result)
+				}
+				if !strings.Contains(result, "SWAP(%)") {
+					t.Errorf("missing SWAP(%%) header: \n%s", result)
+				}
+
+				if tc.isSwapDisabledOnNodes {
+					if !strings.Contains(result, "<unknown>") {
+						t.Errorf("expected swap to be <unknown>: \n%s", result)
+					}
+				}
+
+				for _, m := range expectedMetrics.Items {
+					if !strings.Contains(result, m.Name) {
+						t.Errorf("missing metrics for %s: \n%s", m.Name, result)
+					}
+					if _, foundSwapMetric := m.Usage["swap"]; foundSwapMetric != !tc.isSwapDisabledOnNodes {
+						t.Errorf("missing swap metric for %s: \n%s", m.Name, result)
+					}
+				}
+			})
+		}
+	})
+}
+
+func extractNodeNamesFromTopOutput(result string) []string {
+	lines := strings.Split(result, "\n")
+	names := make([]string, len(lines)-2) // don't process first (header) and last (empty) line
+	for i, line := range lines[1 : len(lines)-1] {
+		names[i] = strings.Split(line, " ")[0]
+	}
+	return names
+}
+
+func runTopNodeTest(t *testing.T, opts runTopNodeOpts) string {
+	cmdtesting.InitTestErrorHandler(t)
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+	ns := scheme.Codecs.WithoutConversion()
+
+	tf.Client = &fake.RESTClient{
+		NegotiatedSerializer: ns,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case p == "/api":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apibody)))}, nil
+			case p == "/apis":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(opts.apisBody)))}, nil
+			case p == opts.expectedPath && m == "GET":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, opts.nodeBody)}, nil
+			default:
+				t.Fatalf("unexpected request: %#v\nGot URL: %#v\n", req, req.URL)
+				return nil, nil
+			}
+		}),
+	}
+	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
+	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
+
+	cmd := NewCmdTopNode(tf, nil, streams)
+	cmdOptions := &TopNodeOptions{
+		IOStreams: streams,
+		Selector:  opts.selector,
+		SortBy:    opts.sortBy,
+		ShowSwap:  opts.showSwap,
+	}
+	if err := cmdOptions.Complete(tf, cmd, opts.cmdArgs); err != nil {
+		t.Fatal(err)
+	}
+	cmdOptions.MetricsClient = opts.fakeMetrics
+	if err := cmdOptions.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmdOptions.RunTopNode(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String()
+}
+
+type runTopNodeOpts struct {
+	apisBody     string
+	expectedPath string
+	nodeBody     runtime.Object // *v1.NodeList or *v1.Node — passed to cmdtesting.ObjBody
+	fakeMetrics  *metricsfake.Clientset
+	cmdArgs      []string
+	selector     string
+	sortBy       string
+	showSwap     bool
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 	metricsapi "k8s.io/metrics/pkg/apis/metrics"
+	metricsv1api "k8s.io/metrics/pkg/apis/metrics/v1"
 	metricsv1beta1api "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	metricsclientset "k8s.io/metrics/pkg/client/clientset/versioned"
 
@@ -194,10 +195,10 @@ func (o TopPodOptions) RunTopPod() error {
 
 	metricsAPIAvailable := SupportedMetricsAPIVersionAvailable(apiGroups)
 
-	if !metricsAPIAvailable {
+	if metricsAPIAvailable == "" {
 		return errors.New("Metrics API not available")
 	}
-	metrics, err := getMetricsFromMetricsAPI(o.MetricsClient, o.Namespace, o.ResourceName, o.AllNamespaces, labelSelector)
+	metrics, err := getMetricsFromMetricsAPI(o.MetricsClient, o.Namespace, o.ResourceName, o.AllNamespaces, labelSelector, metricsAPIAvailable)
 	if err != nil {
 		return err
 	}
@@ -229,12 +230,34 @@ func (o TopPodOptions) RunTopPod() error {
 	return o.Printer.PrintPodMetrics(metrics.Items, o.PrintContainers, o.AllNamespaces, o.NoHeaders, o.SortBy, o.Sum)
 }
 
-func getMetricsFromMetricsAPI(metricsClient metricsclientset.Interface, namespace, resourceName string, allNamespaces bool, labelSelector labels.Selector) (*metricsapi.PodMetricsList, error) {
+func getMetricsFromMetricsAPI(metricsClient metricsclientset.Interface, namespace, resourceName string, allNamespaces bool, labelSelector labels.Selector, metricsAPIAvailable string) (*metricsapi.PodMetricsList, error) {
 	var err error
 	ns := metav1.NamespaceAll
 	if !allNamespaces {
 		ns = namespace
 	}
+	if metricsAPIAvailable == "v1" {
+		versionedMetrics := &metricsv1api.PodMetricsList{}
+		if resourceName != "" {
+			m, err := metricsClient.MetricsV1().PodMetricses(ns).Get(context.TODO(), resourceName, metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			versionedMetrics.Items = []metricsv1api.PodMetrics{*m}
+		} else {
+			versionedMetrics, err = metricsClient.MetricsV1().PodMetricses(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector.String()})
+			if err != nil {
+				return nil, err
+			}
+		}
+		metrics := &metricsapi.PodMetricsList{}
+		err = metricsv1api.Convert_v1_PodMetricsList_To_metrics_PodMetricsList(versionedMetrics, metrics, nil)
+		if err != nil {
+			return nil, err
+		}
+		return metrics, nil
+	}
+	// fallback to metric v1beta1
 	versionedMetrics := &metricsv1beta1api.PodMetricsList{}
 	if resourceName != "" {
 		m, err := metricsClient.MetricsV1beta1().PodMetricses(ns).Get(context.TODO(), resourceName, metav1.GetOptions{})

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_test.go
@@ -35,7 +35,7 @@ import (
 	core "k8s.io/client-go/testing"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	"k8s.io/kubectl/pkg/scheme"
-	metricsv1alpha1api "k8s.io/metrics/pkg/apis/metrics/v1alpha1"
+	metricsv1api "k8s.io/metrics/pkg/apis/metrics/v1"
 	metricsv1beta1api "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	metricsfake "k8s.io/metrics/pkg/client/clientset/versioned/fake"
 )
@@ -79,27 +79,6 @@ const (
 	]
 }`
 
-	apisbodyWithMetrics = `{
-	"kind": "APIGroupList",
-	"apiVersion": "v1",
-	"groups": [
-		{
-			"name":"metrics.k8s.io",
-			"versions":[
-				{
-					"groupVersion":"metrics.k8s.io/v1beta1",
-					"version":"v1beta1"
-				}
-			],
-			"preferredVersion":{
-				"groupVersion":"metrics.k8s.io/v1beta1",
-				"version":"v1beta1"
-			},
-			"serverAddressByClientCIDRs":null
-		}
-	]
-}`
-
 	apisV1beta1BodyWithMetrics = `{
 	"kind": "APIGroupList",
 	"apiVersion": "v1",
@@ -120,10 +99,10 @@ const (
 		}
 	]
 }`
+	testNS = "testns"
 )
 
 func TestTopPod(t *testing.T) {
-	testNS := "testns"
 	testCases := []struct {
 		name               string
 		namespace          string
@@ -222,232 +201,239 @@ func TestTopPod(t *testing.T) {
 		},
 	}
 	cmdtesting.InitTestErrorHandler(t)
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			metricsList := testV1beta1PodMetricsData()
-			var expectedMetrics []metricsv1beta1api.PodMetrics
-			var expectedContainerNames, nonExpectedMetricsNames []string
-			for n, m := range metricsList {
-				if n < len(testCase.namespaces) {
-					m.Namespace = testCase.namespaces[n]
-					expectedMetrics = append(expectedMetrics, m)
-					for _, c := range m.Containers {
-						expectedContainerNames = append(expectedContainerNames, c.Name)
+
+	t.Run("v1beta1", func(t *testing.T) {
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				metricsList := testV1beta1PodMetricsData()
+				var expectedMetrics []metricsv1beta1api.PodMetrics
+				var expectedPodNames, expectedPodNamespaces []string
+				var expectedContainerNames, nonExpectedMetricsNames []string
+				for n, m := range metricsList {
+					if n < len(testCase.namespaces) {
+						m.Namespace = testCase.namespaces[n]
+						expectedMetrics = append(expectedMetrics, m)
+						expectedPodNames = append(expectedPodNames, m.Name)
+						expectedPodNamespaces = append(expectedPodNamespaces, m.Namespace)
+						for _, c := range m.Containers {
+							expectedContainerNames = append(expectedContainerNames, c.Name)
+						}
+					} else {
+						nonExpectedMetricsNames = append(nonExpectedMetricsNames, m.Name)
 					}
-				} else {
-					nonExpectedMetricsNames = append(nonExpectedMetricsNames, m.Name)
 				}
-			}
 
-			fakemetricsClientset := &metricsfake.Clientset{}
-
-			if len(expectedMetrics) == 1 {
+				fakemetricsClientset := &metricsfake.Clientset{}
 				fakemetricsClientset.AddReactor("get", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
 					return true, &expectedMetrics[0], nil
 				})
-			} else {
 				fakemetricsClientset.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-					res := &metricsv1beta1api.PodMetricsList{
-						ListMeta: metav1.ListMeta{
-							ResourceVersion: "2",
-						},
-						Items: expectedMetrics,
-					}
-					return true, res, nil
+					return true, &metricsv1beta1api.PodMetricsList{
+						ListMeta: metav1.ListMeta{ResourceVersion: "2"},
+						Items:    expectedMetrics,
+					}, nil
 				})
-			}
-			podList := &v1.PodList{
-				Items: []v1.Pod{
-					{
-						ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: testNS},
-						Spec:       v1.PodSpec{NodeName: "node-a"},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: testNS},
-						Spec:       v1.PodSpec{NodeName: "node-b"},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{Name: "pod3", Namespace: testNS},
-						Spec:       v1.PodSpec{NodeName: "node-c"},
-					},
-				},
-			}
 
-			tf := cmdtesting.NewTestFactory().WithNamespace(testNS)
-			defer tf.Cleanup()
+				result, _ := runTopPodTest(t, runTopPodOpts{
+					apisBody:    apisV1beta1BodyWithMetrics,
+					fakeMetrics: fakemetricsClientset,
+					options:     testCase.options,
+					cmdArgs:     testCase.args,
+				})
 
-			codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
-			ns := scheme.Codecs.WithoutConversion()
+				assertTopPodOutput(t, topPodAssertion{
+					result:                   result,
+					expectedPodNames:         expectedPodNames,
+					expectedPodNamespaces:    expectedPodNamespaces,
+					nonExpectedMetricsNames:  nonExpectedMetricsNames,
+					expectedContainerNames:   expectedContainerNames,
+					expectedSortedPods:       testCase.expectedPods,
+					expectedSortedContainers: testCase.expectedContainers,
+					showContainers:           testCase.containers,
+					listsNamespaces:          testCase.listsNamespaces,
+					showSwap:                 testCase.options != nil && testCase.options.ShowSwap,
+				})
+			})
+		}
+	})
 
-			tf.Client = &fake.RESTClient{
-				NegotiatedSerializer: ns,
-				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-					switch p := req.URL.Path; {
-					case p == "/api":
-						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apibody)))}, nil
-					case p == "/apis":
-						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apisbodyWithMetrics)))}, nil
-					case p == "/api/v1/namespaces/"+testNS+"/pods":
-						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, podList)}, nil
-					default:
-						t.Fatalf("%s: unexpected request: %#v\nGot URL: %#v",
-							testCase.name, req, req.URL)
-						return nil, nil
-					}
-				}),
-			}
-			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
-			streams, _, buf, _ := genericiooptions.NewTestIOStreams()
-
-			cmd := NewCmdTopPod(tf, nil, streams)
-			var cmdOptions *TopPodOptions
-			if testCase.options != nil {
-				cmdOptions = testCase.options
-			} else {
-				cmdOptions = &TopPodOptions{}
-			}
-			cmdOptions.IOStreams = streams
-
-			// TODO in the long run, we want to test most of our commands like this. Wire the options struct with specific mocks
-			// TODO then check the particular Run functionality and harvest results from fake clients.  We probably end up skipping the factory altogether.
-			if err := cmdOptions.Complete(tf, cmd, testCase.args); err != nil {
-				t.Fatal(err)
-			}
-			cmdOptions.MetricsClient = fakemetricsClientset
-			if err := cmdOptions.Validate(); err != nil {
-				t.Fatal(err)
-			}
-			if err := cmdOptions.RunTopPod(); err != nil {
-				t.Fatal(err)
-			}
-
-			// Check the presence of pod names&namespaces/container names in the output.
-			result := buf.String()
-			if testCase.containers {
-				for _, containerName := range expectedContainerNames {
-					if !strings.Contains(result, containerName) {
-						t.Errorf("missing metrics for container %s: \n%s", containerName, result)
+	t.Run("v1", func(t *testing.T) {
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				metricsList := testV1PodMetricsData()
+				var expectedMetrics []metricsv1api.PodMetrics
+				var expectedPodNames, expectedPodNamespaces []string
+				var expectedContainerNames, nonExpectedMetricsNames []string
+				for n, m := range metricsList {
+					if n < len(testCase.namespaces) {
+						m.Namespace = testCase.namespaces[n]
+						expectedMetrics = append(expectedMetrics, m)
+						expectedPodNames = append(expectedPodNames, m.Name)
+						expectedPodNamespaces = append(expectedPodNamespaces, m.Namespace)
+						for _, c := range m.Containers {
+							expectedContainerNames = append(expectedContainerNames, c.Name)
+						}
+					} else {
+						nonExpectedMetricsNames = append(nonExpectedMetricsNames, m.Name)
 					}
 				}
+
+				fakemetricsClientset := &metricsfake.Clientset{}
+				fakemetricsClientset.AddReactor("get", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+					return true, &expectedMetrics[0], nil
+				})
+				fakemetricsClientset.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+					return true, &metricsv1api.PodMetricsList{
+						ListMeta: metav1.ListMeta{ResourceVersion: "2"},
+						Items:    expectedMetrics,
+					}, nil
+				})
+
+				result, _ := runTopPodTest(t, runTopPodOpts{
+					apisBody:    apisV1BodyWithMetrics,
+					fakeMetrics: fakemetricsClientset,
+					options:     testCase.options,
+					cmdArgs:     testCase.args,
+				})
+
+				assertTopPodOutput(t, topPodAssertion{
+					result:                   result,
+					expectedPodNames:         expectedPodNames,
+					expectedPodNamespaces:    expectedPodNamespaces,
+					nonExpectedMetricsNames:  nonExpectedMetricsNames,
+					expectedContainerNames:   expectedContainerNames,
+					expectedSortedPods:       testCase.expectedPods,
+					expectedSortedContainers: testCase.expectedContainers,
+					showContainers:           testCase.containers,
+					listsNamespaces:          testCase.listsNamespaces,
+					showSwap:                 testCase.options != nil && testCase.options.ShowSwap,
+				})
+			})
+		}
+	})
+}
+
+type topPodAssertion struct {
+	result                   string
+	expectedPodNames         []string // names that should appear; parallel to expectedPodNamespaces
+	expectedPodNamespaces    []string
+	nonExpectedMetricsNames  []string
+	expectedContainerNames   []string
+	expectedSortedPods       []string // sort assertion (column 0)
+	expectedSortedContainers []string // sort assertion (column 1)
+	showContainers           bool
+	listsNamespaces          bool
+	showSwap                 bool
+}
+
+func assertTopPodOutput(t *testing.T, a topPodAssertion) {
+	t.Helper()
+	if a.showContainers {
+		for _, name := range a.expectedContainerNames {
+			if !strings.Contains(a.result, name) {
+				t.Errorf("missing metrics for container %s: \n%s", name, a.result)
 			}
-			for _, m := range expectedMetrics {
-				if !strings.Contains(result, m.Name) {
-					t.Errorf("missing metrics for %s: \n%s", m.Name, result)
-				}
-				if testCase.listsNamespaces && !strings.Contains(result, m.Namespace) {
-					t.Errorf("missing metrics for %s/%s: \n%s", m.Namespace, m.Name, result)
-				}
-			}
-			for _, name := range nonExpectedMetricsNames {
-				if strings.Contains(result, name) {
-					t.Errorf("unexpected metrics for %s: \n%s", name, result)
-				}
-			}
-			if testCase.expectedPods != nil {
-				resultPods := getResultColumnValues(result, 0)
-				if !reflect.DeepEqual(testCase.expectedPods, resultPods) {
-					t.Errorf("pods not matching:\n\texpectedPods: %v\n\tresultPods: %v\n", testCase.expectedPods, resultPods)
-				}
-			}
-			if testCase.expectedContainers != nil {
-				resultContainers := getResultColumnValues(result, 1)
-				if !reflect.DeepEqual(testCase.expectedContainers, resultContainers) {
-					t.Errorf("containers not matching:\n\texpectedContainers: %v\n\tresultContainers: %v\n", testCase.expectedContainers, resultContainers)
-				}
-			}
-			if testCase.options != nil && testCase.options.ShowSwap {
-				if !strings.Contains(result, "SWAP(bytes)") {
-					t.Errorf("missing SWAP(bytes) header: \n%s", result)
-				}
-			}
-		})
+		}
+	}
+	for i, name := range a.expectedPodNames {
+		if !strings.Contains(a.result, name) {
+			t.Errorf("missing metrics for %s: \n%s", name, a.result)
+		}
+		if a.listsNamespaces && !strings.Contains(a.result, a.expectedPodNamespaces[i]) {
+			t.Errorf("missing metrics for %s/%s: \n%s", a.expectedPodNamespaces[i], name, a.result)
+		}
+	}
+	for _, name := range a.nonExpectedMetricsNames {
+		if strings.Contains(a.result, name) {
+			t.Errorf("unexpected metrics for %s: \n%s", name, a.result)
+		}
+	}
+	if a.expectedSortedPods != nil {
+		resultPods := getResultColumnValues(a.result, 0)
+		if !reflect.DeepEqual(a.expectedSortedPods, resultPods) {
+			t.Errorf("pods not matching:\n\texpectedPods: %v\n\tresultPods: %v\n", a.expectedSortedPods, resultPods)
+		}
+	}
+	if a.expectedSortedContainers != nil {
+		resultContainers := getResultColumnValues(a.result, 1)
+		if !reflect.DeepEqual(a.expectedSortedContainers, resultContainers) {
+			t.Errorf("containers not matching:\n\texpectedContainers: %v\n\tresultContainers: %v\n", a.expectedSortedContainers, resultContainers)
+		}
+	}
+	if a.showSwap && !strings.Contains(a.result, "SWAP(bytes)") {
+		t.Errorf("missing SWAP(bytes) header: \n%s", a.result)
 	}
 }
 
 func TestTopPodWithSwap(t *testing.T) {
 	cmdtesting.InitTestErrorHandler(t)
+	expectedSwapBytes := map[string]string{
+		"pod1": "4Mi",
+		"pod2": "0Mi",
+		"pod3": "3Mi",
+	}
 
-	const testName = "TestTopPodWithSwap"
-	t.Run(testName, func(t *testing.T) {
+	t.Run("v1beta1", func(t *testing.T) {
 		metricsList := testV1beta1PodMetricsData()
-		fakemetricsClientset := &metricsfake.Clientset{}
-
-		fakemetricsClientset.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-			res := &metricsv1beta1api.PodMetricsList{
+		fakeMetrics := &metricsfake.Clientset{}
+		fakeMetrics.AddReactor("list", "pods", func(action core.Action) (bool, runtime.Object, error) {
+			return true, &metricsv1beta1api.PodMetricsList{
 				Items: metricsList,
-			}
-			return true, res, nil
+			}, nil
 		})
 
-		tf := cmdtesting.NewTestFactory()
-		defer tf.Cleanup()
+		stdout, _ := runTopPodTest(t, runTopPodOpts{
+			apisBody:    apisV1beta1BodyWithMetrics,
+			fakeMetrics: fakeMetrics,
+			options: &TopPodOptions{
+				ShowSwap: true,
+			},
+		})
 
-		ns := scheme.Codecs.WithoutConversion()
-
-		tf.Client = &fake.RESTClient{
-			NegotiatedSerializer: ns,
-			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-				switch req.URL.Path {
-				case "/api":
-					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apibody)))}, nil
-				case "/apis":
-					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apisbodyWithMetrics)))}, nil
-				default:
-					t.Fatalf("%s: unexpected request: %#v\nGot URL: %#v",
-						testName, req, req.URL)
-					return nil, nil
-				}
-			}),
-		}
-		streams, _, buf, _ := genericiooptions.NewTestIOStreams()
-
-		cmd := NewCmdTopPod(tf, nil, streams)
-		cmdOptions := &TopPodOptions{
-			ShowSwap: true,
-		}
-		cmdOptions.IOStreams = streams
-
-		if err := cmdOptions.Complete(tf, cmd, nil); err != nil {
-			t.Fatal(err)
-		}
-		cmdOptions.MetricsClient = fakemetricsClientset
-		if err := cmdOptions.Validate(); err != nil {
-			t.Fatal(err)
-		}
-		if err := cmdOptions.RunTopPod(); err != nil {
-			t.Fatal(err)
-		}
-
-		result := buf.String()
-
-		expectedSwapBytes := map[string]string{
-			"pod1": "4Mi",
-			"pod2": "0Mi",
-			"pod3": "3Mi",
-		}
-
-		actualSwapBytes := map[string]string{}
-		for _, line := range strings.Split(result, "\n")[1:] {
-			lineFields := strings.Fields(line)
-			if len(lineFields) < 4 {
-				continue
-			}
-
-			podName := lineFields[0]
-			swapBytes := lineFields[3]
-			actualSwapBytes[podName] = swapBytes
-		}
-
-		for expectedPodName, expectedSwapBytes := range expectedSwapBytes {
-			actualSwapBytes, found := actualSwapBytes[expectedPodName]
-			if !found {
-				t.Errorf("missing swap metrics for pod %s", expectedPodName)
-			}
-			if actualSwapBytes != expectedSwapBytes {
-				t.Errorf("unexpected swap metrics for pod %s: expected %s, got %s", expectedPodName, expectedSwapBytes, actualSwapBytes)
-			}
-		}
+		assertSwapBytesInTopOutput(t, stdout, expectedSwapBytes)
 	})
+
+	t.Run("v1", func(t *testing.T) {
+		metricsList := testV1PodMetricsData()
+		fakeMetrics := &metricsfake.Clientset{}
+		fakeMetrics.AddReactor("list", "pods", func(action core.Action) (bool, runtime.Object, error) {
+			return true, &metricsv1api.PodMetricsList{
+				Items: metricsList,
+			}, nil
+		})
+
+		stdout, _ := runTopPodTest(t, runTopPodOpts{
+			apisBody:    apisV1BodyWithMetrics,
+			fakeMetrics: fakeMetrics,
+			options: &TopPodOptions{
+				ShowSwap: true,
+			},
+		})
+
+		assertSwapBytesInTopOutput(t, stdout, expectedSwapBytes)
+	})
+}
+
+func assertSwapBytesInTopOutput(t *testing.T, stdout string, expected map[string]string) {
+	t.Helper()
+	actual := map[string]string{}
+	for _, line := range strings.Split(stdout, "\n")[1:] {
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+		actual[fields[0]] = fields[3]
+	}
+	for podName, expectedBytes := range expected {
+		actualBytes, found := actual[podName]
+		if !found {
+			t.Errorf("missing swap metrics for pod %s", podName)
+			continue
+		}
+		if actualBytes != expectedBytes {
+			t.Errorf("unexpected swap metrics for pod %s: expected %s, got %s", podName, expectedBytes, actualBytes)
+		}
+	}
 }
 
 func getResultColumnValues(result string, columnIndex int) []string {
@@ -463,11 +449,9 @@ func getResultColumnValues(result string, columnIndex int) []string {
 }
 
 func TestTopPodNoResourcesFound(t *testing.T) {
-	testNS := "testns"
 	testCases := []struct {
 		name           string
 		options        *TopPodOptions
-		namespace      string
 		expectedOutput string
 		expectedErr    string
 	}{
@@ -479,85 +463,233 @@ func TestTopPodNoResourcesFound(t *testing.T) {
 		},
 		{
 			name:           "all in namespace",
-			namespace:      testNS,
 			expectedOutput: "",
 			expectedErr:    "No resources found in " + testNS + " namespace.\n",
 		},
 	}
 	cmdtesting.InitTestErrorHandler(t)
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			fakemetricsClientset := &metricsfake.Clientset{}
-			fakemetricsClientset.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-				res := &metricsv1beta1api.PodMetricsList{
-					ListMeta: metav1.ListMeta{
-						ResourceVersion: "2",
-					},
-					Items: nil, // No metrics found
+
+	t.Run("v1beta1", func(t *testing.T) {
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				fakeMetrics := &metricsfake.Clientset{}
+				fakeMetrics.AddReactor("list", "pods", func(action core.Action) (bool, runtime.Object, error) {
+					return true, &metricsv1beta1api.PodMetricsList{
+						ListMeta: metav1.ListMeta{ResourceVersion: "2"},
+						Items:    nil,
+					}, nil
+				})
+				buf, errbuf := runTopPodTest(t, runTopPodOpts{
+					apisBody:    apisV1beta1BodyWithMetrics,
+					fakeMetrics: fakeMetrics,
+					options:     testCase.options,
+					extraPaths:  emptyPodListResponse,
+				})
+				if e, a := testCase.expectedOutput, buf; e != a {
+					t.Errorf("Unexpected output:\nExpected:\n%v\nActual:\n%v", e, a)
 				}
-				return true, res, nil
+				if e, a := testCase.expectedErr, errbuf; e != a {
+					t.Errorf("Unexpected error:\nExpected:\n%v\nActual:\n%v", e, a)
+				}
 			})
+		}
+	})
 
-			tf := cmdtesting.NewTestFactory().WithNamespace(testNS)
-			defer tf.Cleanup()
+	t.Run("v1", func(t *testing.T) {
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				fakeMetrics := &metricsfake.Clientset{}
+				fakeMetrics.AddReactor("list", "pods", func(action core.Action) (bool, runtime.Object, error) {
+					return true, &metricsv1api.PodMetricsList{
+						ListMeta: metav1.ListMeta{ResourceVersion: "2"},
+						Items:    nil,
+					}, nil
+				})
+				buf, errbuf := runTopPodTest(t, runTopPodOpts{
+					apisBody:    apisV1BodyWithMetrics,
+					fakeMetrics: fakeMetrics,
+					options:     testCase.options,
+					extraPaths:  emptyPodListResponse,
+				})
+				if e, a := testCase.expectedOutput, buf; e != a {
+					t.Errorf("Unexpected output:\nExpected:\n%v\nActual:\n%v", e, a)
+				}
+				if e, a := testCase.expectedErr, errbuf; e != a {
+					t.Errorf("Unexpected error:\nExpected:\n%v\nActual:\n%v", e, a)
+				}
+			})
+		}
+	})
+}
 
-			ns := scheme.Codecs.WithoutConversion()
+func emptyPodListResponse(req *http.Request) (*http.Response, error) {
+	body, _ := marshallBody(metricsv1beta1api.PodMetricsList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "2"},
+		Items:    nil,
+	})
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     cmdtesting.DefaultHeader(),
+		Body:       body,
+	}, nil
+}
 
-			tf.Client = &fake.RESTClient{
-				NegotiatedSerializer: ns,
-				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-					switch p := req.URL.Path; {
-					case p == "/api":
-						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apibody)))}, nil
-					case p == "/apis":
-						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apisbodyWithMetrics)))}, nil
-					case p == "/api/v1/namespaces/"+testNS+"/pods":
-						// Top Pod calls this endpoint to check if there are pods whenever it gets no metrics,
-						// so we need to return no pods for this test scenario
-						body, _ := marshallBody(metricsv1alpha1api.PodMetricsList{
-							ListMeta: metav1.ListMeta{
-								ResourceVersion: "2",
-							},
-							Items: nil, // No pods found
-						})
-						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: body}, nil
-					default:
-						t.Fatalf("%s: unexpected request: %#v\nGot URL: %#v",
-							testCase.name, req, req.URL)
-						return nil, nil
-					}
-				}),
-			}
-			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
-			streams, _, buf, errbuf := genericiooptions.NewTestIOStreams()
+type runTopPodOpts struct {
+	apisBody    string
+	fakeMetrics *metricsfake.Clientset
+	options     *TopPodOptions
+	cmdArgs     []string
+	extraPaths  func(req *http.Request) (*http.Response, error)
+}
 
-			cmd := NewCmdTopPod(tf, nil, streams)
-			var cmdOptions *TopPodOptions
-			if testCase.options != nil {
-				cmdOptions = testCase.options
-			} else {
-				cmdOptions = &TopPodOptions{}
-			}
-			cmdOptions.IOStreams = streams
+func runTopPodTest(t *testing.T, opts runTopPodOpts) (stdout string, stderr string) {
+	tf := cmdtesting.NewTestFactory().WithNamespace(testNS)
+	defer tf.Cleanup()
 
-			if err := cmdOptions.Complete(tf, cmd, nil); err != nil {
-				t.Fatal(err)
-			}
-			cmdOptions.MetricsClient = fakemetricsClientset
-			if err := cmdOptions.Validate(); err != nil {
-				t.Fatal(err)
-			}
-			if err := cmdOptions.RunTopPod(); err != nil {
-				t.Fatal(err)
-			}
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+	ns := scheme.Codecs.WithoutConversion()
 
-			if e, a := testCase.expectedOutput, buf.String(); e != a {
-				t.Errorf("Unexpected output:\nExpected:\n%v\nActual:\n%v", e, a)
+	tf.Client = &fake.RESTClient{
+		NegotiatedSerializer: ns,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Path {
+			case "/api":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apibody)))}, nil
+			case "/apis":
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(opts.apisBody)))}, nil
+			case "/api/v1/namespaces/" + testNS + "/pods":
+				if opts.extraPaths != nil {
+					return opts.extraPaths(req)
+				}
+				// The command lists pods directly (e.g. to resolve a field
+				// selector, or to check pod age when no metrics are returned),
+				// so serve the standard pod list by default.
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, defaultPodList())}, nil
+			default:
+				t.Fatalf("unexpected request: %#v\nGot URL: %#v", req, req.URL)
+				return nil, nil
 			}
-			if e, a := testCase.expectedErr, errbuf.String(); e != a {
-				t.Errorf("Unexpected error:\nExpected:\n%v\nActual:\n%v", e, a)
-			}
+		}),
+	}
+	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
+	streams, _, buf, errbuf := genericiooptions.NewTestIOStreams()
+
+	cmd := NewCmdTopPod(tf, nil, streams)
+	var cmdOptions *TopPodOptions
+	if opts.options != nil {
+		cmdOptions = opts.options
+	} else {
+		cmdOptions = &TopPodOptions{}
+	}
+	cmdOptions.IOStreams = streams
+
+	if err := cmdOptions.Complete(tf, cmd, opts.cmdArgs); err != nil {
+		t.Fatal(err)
+	}
+	cmdOptions.MetricsClient = opts.fakeMetrics
+	if err := cmdOptions.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmdOptions.RunTopPod(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String(), errbuf.String()
+}
+
+func defaultPodList() *v1.PodList {
+	return &v1.PodList{
+		Items: []v1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: testNS},
+				Spec:       v1.PodSpec{NodeName: "node-a"},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: testNS},
+				Spec:       v1.PodSpec{NodeName: "node-b"},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod3", Namespace: testNS},
+				Spec:       v1.PodSpec{NodeName: "node-c"},
+			},
+		},
+	}
+}
+
+// TestTopPodFieldSelectorFiltersMetrics verifies that, when a field selector is
+// given, metrics for pods that do not match the selector are filtered out. The
+// metrics API returns all three pods, while the pod list endpoint only returns
+// pod1, so the client must drop pod2 and pod3.
+func TestTopPodFieldSelectorFiltersMetrics(t *testing.T) {
+	cmdtesting.InitTestErrorHandler(t)
+
+	onlyPod1 := func(req *http.Request) (*http.Response, error) {
+		body, _ := marshallBody(v1.PodList{
+			ListMeta: metav1.ListMeta{ResourceVersion: "2"},
+			Items: []v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: testNS},
+					Spec:       v1.PodSpec{NodeName: "node-a"},
+				},
+			},
 		})
+		return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: body}, nil
+	}
+
+	t.Run("v1beta1", func(t *testing.T) {
+		metricsList := testV1beta1PodMetricsData()
+		for i := range metricsList {
+			metricsList[i].Namespace = testNS
+		}
+		fakeMetrics := &metricsfake.Clientset{}
+		fakeMetrics.AddReactor("list", "pods", func(action core.Action) (bool, runtime.Object, error) {
+			return true, &metricsv1beta1api.PodMetricsList{
+				ListMeta: metav1.ListMeta{ResourceVersion: "2"},
+				Items:    metricsList,
+			}, nil
+		})
+
+		result, _ := runTopPodTest(t, runTopPodOpts{
+			apisBody:    apisV1beta1BodyWithMetrics,
+			fakeMetrics: fakeMetrics,
+			options:     &TopPodOptions{FieldSelector: "spec.nodeName=node-a"},
+			extraPaths:  onlyPod1,
+		})
+		assertFieldSelectorFiltered(t, result)
+	})
+
+	t.Run("v1", func(t *testing.T) {
+		metricsList := testV1PodMetricsData()
+		for i := range metricsList {
+			metricsList[i].Namespace = testNS
+		}
+		fakeMetrics := &metricsfake.Clientset{}
+		fakeMetrics.AddReactor("list", "pods", func(action core.Action) (bool, runtime.Object, error) {
+			return true, &metricsv1api.PodMetricsList{
+				ListMeta: metav1.ListMeta{ResourceVersion: "2"},
+				Items:    metricsList,
+			}, nil
+		})
+
+		result, _ := runTopPodTest(t, runTopPodOpts{
+			apisBody:    apisV1BodyWithMetrics,
+			fakeMetrics: fakeMetrics,
+			options:     &TopPodOptions{FieldSelector: "spec.nodeName=node-a"},
+			extraPaths:  onlyPod1,
+		})
+		assertFieldSelectorFiltered(t, result)
+	})
+}
+
+func assertFieldSelectorFiltered(t *testing.T, result string) {
+	t.Helper()
+	if !strings.Contains(result, "pod1") {
+		t.Errorf("expected metrics for pod1, got:\n%s", result)
+	}
+	if strings.Contains(result, "pod2") {
+		t.Errorf("unexpected metrics for pod2, got:\n%s", result)
+	}
+	if strings.Contains(result, "pod3") {
+		t.Errorf("unexpected metrics for pod3, got:\n%s", result)
 	}
 }
 
@@ -635,98 +767,76 @@ func testV1beta1PodMetricsData() []metricsv1beta1api.PodMetrics {
 	}
 }
 
-func TestTopPodFieldSelectorFiltersMetrics(t *testing.T) {
-	testNS := "testns"
-
-	metricsList := testV1beta1PodMetricsData()
-	metricsList[0].Namespace = testNS
-	metricsList[1].Namespace = testNS
-	metricsList[2].Namespace = testNS
-
-	fakemetricsClientset := &metricsfake.Clientset{}
-	fakemetricsClientset.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-		return true, &metricsv1beta1api.PodMetricsList{
-			ListMeta: metav1.ListMeta{
-				ResourceVersion: "2",
+func testV1PodMetricsData() []metricsv1api.PodMetrics {
+	return []metricsv1api.PodMetrics{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "test", ResourceVersion: "10", Labels: map[string]string{"key": "value"}},
+			Window:     metav1.Duration{Duration: time.Minute},
+			Containers: []metricsv1api.ContainerMetrics{
+				{
+					Name: "container1-1",
+					Usage: v1.ResourceList{
+						v1.ResourceCPU:     *resource.NewMilliQuantity(1, resource.DecimalSI),
+						v1.ResourceMemory:  *resource.NewQuantity(2*(1024*1024), resource.DecimalSI),
+						"swap":             *resource.NewQuantity(1*(1024*1024), resource.DecimalSI),
+						v1.ResourceStorage: *resource.NewQuantity(3*(1024*1024), resource.DecimalSI),
+					},
+				},
+				{
+					Name: "container1-2",
+					Usage: v1.ResourceList{
+						v1.ResourceCPU:     *resource.NewMilliQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory:  *resource.NewQuantity(5*(1024*1024), resource.DecimalSI),
+						"swap":             *resource.NewQuantity(3*(1024*1024), resource.DecimalSI),
+						v1.ResourceStorage: *resource.NewQuantity(6*(1024*1024), resource.DecimalSI),
+					},
+				},
 			},
-			Items: metricsList,
-		}, nil
-	})
-
-	tf := cmdtesting.NewTestFactory().WithNamespace(testNS)
-	defer tf.Cleanup()
-
-	ns := scheme.Codecs.WithoutConversion()
-	tf.Client = &fake.RESTClient{
-		NegotiatedSerializer: ns,
-		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			switch req.URL.Path {
-			case "/api":
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apibody)))}, nil
-			case "/apis":
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(bytes.NewReader([]byte(apisbodyWithMetrics)))}, nil
-			case "/api/v1/namespaces/" + testNS + "/pods":
-				body, _ := marshallBody(v1.PodList{
-					ListMeta: metav1.ListMeta{
-						ResourceVersion: "2",
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: "test", ResourceVersion: "11", Labels: map[string]string{"key": "value"}},
+			Window:     metav1.Duration{Duration: time.Minute},
+			Containers: []metricsv1api.ContainerMetrics{
+				{
+					Name: "container2-1",
+					Usage: v1.ResourceList{
+						v1.ResourceCPU:     *resource.NewMilliQuantity(7, resource.DecimalSI),
+						v1.ResourceMemory:  *resource.NewQuantity(8*(1024*1024), resource.DecimalSI),
+						v1.ResourceStorage: *resource.NewQuantity(9*(1024*1024), resource.DecimalSI),
 					},
-					Items: []v1.Pod{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      "pod1",
-								Namespace: testNS,
-							},
-							Spec: v1.PodSpec{
-								NodeName: "node-a",
-							},
-						},
+				},
+				{
+					Name: "container2-2",
+					Usage: v1.ResourceList{
+						v1.ResourceCPU:     *resource.NewMilliQuantity(10, resource.DecimalSI),
+						v1.ResourceMemory:  *resource.NewQuantity(11*(1024*1024), resource.DecimalSI),
+						v1.ResourceStorage: *resource.NewQuantity(12*(1024*1024), resource.DecimalSI),
 					},
-				})
-
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: body}, nil
-
-			default:
-				t.Fatalf("unexpected request: %#v\nGot URL: %#v", req, req.URL)
-				return nil, nil
-			}
-		}),
-	}
-
-	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
-
-	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
-	cmd := NewCmdTopPod(tf, nil, streams)
-
-	cmdOptions := &TopPodOptions{
-		FieldSelector: "spec.nodeName=node-a",
-		IOStreams:     streams,
-	}
-
-	if err := cmdOptions.Complete(tf, cmd, nil); err != nil {
-		t.Fatal(err)
-	}
-
-	cmdOptions.MetricsClient = fakemetricsClientset
-
-	if err := cmdOptions.Validate(); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := cmdOptions.RunTopPod(); err != nil {
-		t.Fatal(err)
-	}
-
-	result := buf.String()
-
-	if !strings.Contains(result, "pod1") {
-		t.Errorf("expected metrics for pod1, got:\n%s", result)
-	}
-
-	if strings.Contains(result, "pod2") {
-		t.Errorf("unexpected metrics for pod2, got:\n%s", result)
-	}
-
-	if strings.Contains(result, "pod3") {
-		t.Errorf("unexpected metrics for pod3, got:\n%s", result)
+				},
+				{
+					Name: "container2-3",
+					Usage: v1.ResourceList{
+						v1.ResourceCPU:     *resource.NewMilliQuantity(13, resource.DecimalSI),
+						v1.ResourceMemory:  *resource.NewQuantity(14*(1024*1024), resource.DecimalSI),
+						v1.ResourceStorage: *resource.NewQuantity(15*(1024*1024), resource.DecimalSI),
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod3", Namespace: "test", ResourceVersion: "12"},
+			Window:     metav1.Duration{Duration: time.Minute},
+			Containers: []metricsv1api.ContainerMetrics{
+				{
+					Name: "container3-1",
+					Usage: v1.ResourceList{
+						v1.ResourceCPU:     *resource.NewMilliQuantity(7, resource.DecimalSI),
+						v1.ResourceMemory:  *resource.NewQuantity(8*(1024*1024), resource.DecimalSI),
+						"swap":             *resource.NewQuantity(3*(1024*1024), resource.DecimalSI),
+						v1.ResourceStorage: *resource.NewQuantity(9*(1024*1024), resource.DecimalSI),
+					},
+				},
+			},
+		},
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"io"
 	"net/http"
-	"net/url"
 	"reflect"
 	"strings"
 	"testing"
@@ -35,7 +34,7 @@ import (
 	core "k8s.io/client-go/testing"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	"k8s.io/kubectl/pkg/scheme"
-	metricsv1api "k8s.io/metrics/pkg/apis/metrics/v1"
+	metricsapi "k8s.io/metrics/pkg/apis/metrics"
 	metricsv1beta1api "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	metricsfake "k8s.io/metrics/pkg/client/clientset/versioned/fake"
 )
@@ -105,15 +104,24 @@ const (
 func TestTopPod(t *testing.T) {
 	testCases := []struct {
 		name               string
-		namespace          string
 		options            *TopPodOptions
 		args               []string
-		expectedQuery      string
 		expectedPods       []string
 		expectedContainers []string
 		namespaces         []string
 		containers         bool
 		listsNamespaces    bool
+		// extraPaths overrides the response of the pod list endpoint, e.g. to
+		// simulate server-side filtering by the core API.
+		extraPaths func(req *http.Request) (*http.Response, error)
+		// expectedInOutput/nonExpectedInOutput override the pod names derived
+		// from namespaces, for cases where the printed pods differ from what
+		// the metrics API returned (e.g. client-side field selector filtering).
+		expectedInOutput    []string
+		nonExpectedInOutput []string
+		expectedSwapBytes   map[string]string // exact swap column values per pod
+		expectedOutput      *string           // exact stdout match
+		expectedErr         *string           // exact stderr match
 	}{
 		{
 			name:            "all namespaces",
@@ -131,16 +139,14 @@ func TestTopPod(t *testing.T) {
 			namespaces: []string{testNS},
 		},
 		{
-			name:          "pod with label selector",
-			options:       &TopPodOptions{LabelSelector: "key=value"},
-			expectedQuery: "labelSelector=" + url.QueryEscape("key=value"),
-			namespaces:    []string{testNS, testNS},
+			name:       "pod with label selector",
+			options:    &TopPodOptions{LabelSelector: "key=value"},
+			namespaces: []string{testNS, testNS},
 		},
 		{
-			name:          "pod with field selector",
-			options:       &TopPodOptions{FieldSelector: "key=value"},
-			expectedQuery: "fieldSelector=" + url.QueryEscape("key=value"),
-			namespaces:    []string{testNS, testNS},
+			name:       "pod with field selector",
+			options:    &TopPodOptions{FieldSelector: "key=value"},
+			namespaces: []string{testNS, testNS},
 		},
 		{
 			name:    "pod with container metrics",
@@ -199,118 +205,109 @@ func TestTopPod(t *testing.T) {
 			namespaces:      []string{testNS, "secondtestns", "thirdtestns"},
 			listsNamespaces: true,
 		},
+		{
+			name:              "swap values",
+			options:           &TopPodOptions{ShowSwap: true},
+			namespaces:        []string{testNS, testNS, testNS},
+			expectedSwapBytes: map[string]string{"pod1": "4Mi", "pod2": "0Mi", "pod3": "3Mi"},
+		},
+		{
+			// The metrics API returns all three pods, while the pod list
+			// endpoint only returns pod1, so the client must drop pod2 and pod3.
+			name:                "pod with field selector filtering metrics",
+			options:             &TopPodOptions{FieldSelector: "spec.nodeName=node-a"},
+			namespaces:          []string{testNS, testNS, testNS},
+			extraPaths:          onlyPod1ListResponse,
+			expectedInOutput:    []string{"pod1"},
+			nonExpectedInOutput: []string{"pod2", "pod3"},
+		},
+		{
+			name:           "no resources found in all namespaces",
+			options:        &TopPodOptions{AllNamespaces: true},
+			extraPaths:     emptyPodListResponse,
+			expectedOutput: new(""),
+			expectedErr:    new("No resources found\n"),
+		},
+		{
+			name:           "no resources found in namespace",
+			extraPaths:     emptyPodListResponse,
+			expectedOutput: new(""),
+			expectedErr:    new("No resources found in " + testNS + " namespace.\n"),
+		},
 	}
 	cmdtesting.InitTestErrorHandler(t)
 
-	t.Run("v1beta1", func(t *testing.T) {
-		for _, testCase := range testCases {
-			t.Run(testCase.name, func(t *testing.T) {
-				metricsList := testV1beta1PodMetricsData()
-				var expectedMetrics []metricsv1beta1api.PodMetrics
-				var expectedPodNames, expectedPodNamespaces []string
-				var expectedContainerNames, nonExpectedMetricsNames []string
-				for n, m := range metricsList {
-					if n < len(testCase.namespaces) {
-						m.Namespace = testCase.namespaces[n]
-						expectedMetrics = append(expectedMetrics, m)
-						expectedPodNames = append(expectedPodNames, m.Name)
-						expectedPodNamespaces = append(expectedPodNamespaces, m.Namespace)
-						for _, c := range m.Containers {
-							expectedContainerNames = append(expectedContainerNames, c.Name)
+	for _, version := range metricsAPIVersions {
+		t.Run(version.name, func(t *testing.T) {
+			for _, testCase := range testCases {
+				t.Run(testCase.name, func(t *testing.T) {
+					metricsItems := testPodMetricsData()
+					var expectedMetrics []metricsapi.PodMetrics
+					var expectedPodNames, expectedPodNamespaces []string
+					var expectedContainerNames, nonExpectedMetricsNames []string
+					for n, m := range metricsItems {
+						if n < len(testCase.namespaces) {
+							m.Namespace = testCase.namespaces[n]
+							expectedMetrics = append(expectedMetrics, m)
+							expectedPodNames = append(expectedPodNames, m.Name)
+							expectedPodNamespaces = append(expectedPodNamespaces, m.Namespace)
+							for _, c := range m.Containers {
+								expectedContainerNames = append(expectedContainerNames, c.Name)
+							}
+						} else {
+							nonExpectedMetricsNames = append(nonExpectedMetricsNames, m.Name)
 						}
-					} else {
-						nonExpectedMetricsNames = append(nonExpectedMetricsNames, m.Name)
 					}
-				}
+					if testCase.expectedInOutput != nil || testCase.nonExpectedInOutput != nil {
+						expectedPodNames = testCase.expectedInOutput
+						nonExpectedMetricsNames = testCase.nonExpectedInOutput
+					}
 
-				fakemetricsClientset := &metricsfake.Clientset{}
-				fakemetricsClientset.AddReactor("get", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-					return true, &expectedMetrics[0], nil
-				})
-				fakemetricsClientset.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-					return true, &metricsv1beta1api.PodMetricsList{
+					metricsList, firstMetrics := versionedPodMetricsList(t, version.name, &metricsapi.PodMetricsList{
 						ListMeta: metav1.ListMeta{ResourceVersion: "2"},
 						Items:    expectedMetrics,
-					}, nil
-				})
+					})
+					fakemetricsClientset := &metricsfake.Clientset{}
+					fakemetricsClientset.AddReactor("get", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+						return true, firstMetrics, nil
+					})
+					fakemetricsClientset.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+						return true, metricsList, nil
+					})
 
-				result, _ := runTopPodTest(t, runTopPodOpts{
-					apisBody:    apisV1beta1BodyWithMetrics,
-					fakeMetrics: fakemetricsClientset,
-					options:     testCase.options,
-					cmdArgs:     testCase.args,
-				})
+					result, stderr := runTopPodTest(t, runTopPodOpts{
+						apisBody:    version.apisBody,
+						fakeMetrics: fakemetricsClientset,
+						options:     testCase.options,
+						cmdArgs:     testCase.args,
+						extraPaths:  testCase.extraPaths,
+					})
 
-				assertTopPodOutput(t, topPodAssertion{
-					result:                   result,
-					expectedPodNames:         expectedPodNames,
-					expectedPodNamespaces:    expectedPodNamespaces,
-					nonExpectedMetricsNames:  nonExpectedMetricsNames,
-					expectedContainerNames:   expectedContainerNames,
-					expectedSortedPods:       testCase.expectedPods,
-					expectedSortedContainers: testCase.expectedContainers,
-					showContainers:           testCase.containers,
-					listsNamespaces:          testCase.listsNamespaces,
-					showSwap:                 testCase.options != nil && testCase.options.ShowSwap,
-				})
-			})
-		}
-	})
-
-	t.Run("v1", func(t *testing.T) {
-		for _, testCase := range testCases {
-			t.Run(testCase.name, func(t *testing.T) {
-				metricsList := testV1PodMetricsData()
-				var expectedMetrics []metricsv1api.PodMetrics
-				var expectedPodNames, expectedPodNamespaces []string
-				var expectedContainerNames, nonExpectedMetricsNames []string
-				for n, m := range metricsList {
-					if n < len(testCase.namespaces) {
-						m.Namespace = testCase.namespaces[n]
-						expectedMetrics = append(expectedMetrics, m)
-						expectedPodNames = append(expectedPodNames, m.Name)
-						expectedPodNamespaces = append(expectedPodNamespaces, m.Namespace)
-						for _, c := range m.Containers {
-							expectedContainerNames = append(expectedContainerNames, c.Name)
-						}
-					} else {
-						nonExpectedMetricsNames = append(nonExpectedMetricsNames, m.Name)
+					assertTopPodOutput(t, topPodAssertion{
+						result:                   result,
+						expectedPodNames:         expectedPodNames,
+						expectedPodNamespaces:    expectedPodNamespaces,
+						nonExpectedMetricsNames:  nonExpectedMetricsNames,
+						expectedContainerNames:   expectedContainerNames,
+						expectedSortedPods:       testCase.expectedPods,
+						expectedSortedContainers: testCase.expectedContainers,
+						showContainers:           testCase.containers,
+						listsNamespaces:          testCase.listsNamespaces,
+						showSwap:                 testCase.options != nil && testCase.options.ShowSwap,
+					})
+					if testCase.expectedSwapBytes != nil {
+						assertSwapBytesInTopOutput(t, result, testCase.expectedSwapBytes)
 					}
-				}
-
-				fakemetricsClientset := &metricsfake.Clientset{}
-				fakemetricsClientset.AddReactor("get", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-					return true, &expectedMetrics[0], nil
+					if testCase.expectedOutput != nil && *testCase.expectedOutput != result {
+						t.Errorf("Unexpected output:\nExpected:\n%v\nActual:\n%v", *testCase.expectedOutput, result)
+					}
+					if testCase.expectedErr != nil && *testCase.expectedErr != stderr {
+						t.Errorf("Unexpected error:\nExpected:\n%v\nActual:\n%v", *testCase.expectedErr, stderr)
+					}
 				})
-				fakemetricsClientset.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
-					return true, &metricsv1api.PodMetricsList{
-						ListMeta: metav1.ListMeta{ResourceVersion: "2"},
-						Items:    expectedMetrics,
-					}, nil
-				})
-
-				result, _ := runTopPodTest(t, runTopPodOpts{
-					apisBody:    apisV1BodyWithMetrics,
-					fakeMetrics: fakemetricsClientset,
-					options:     testCase.options,
-					cmdArgs:     testCase.args,
-				})
-
-				assertTopPodOutput(t, topPodAssertion{
-					result:                   result,
-					expectedPodNames:         expectedPodNames,
-					expectedPodNamespaces:    expectedPodNamespaces,
-					nonExpectedMetricsNames:  nonExpectedMetricsNames,
-					expectedContainerNames:   expectedContainerNames,
-					expectedSortedPods:       testCase.expectedPods,
-					expectedSortedContainers: testCase.expectedContainers,
-					showContainers:           testCase.containers,
-					listsNamespaces:          testCase.listsNamespaces,
-					showSwap:                 testCase.options != nil && testCase.options.ShowSwap,
-				})
-			})
-		}
-	})
+			}
+		})
+	}
 }
 
 type topPodAssertion struct {
@@ -365,55 +362,6 @@ func assertTopPodOutput(t *testing.T, a topPodAssertion) {
 	}
 }
 
-func TestTopPodWithSwap(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
-	expectedSwapBytes := map[string]string{
-		"pod1": "4Mi",
-		"pod2": "0Mi",
-		"pod3": "3Mi",
-	}
-
-	t.Run("v1beta1", func(t *testing.T) {
-		metricsList := testV1beta1PodMetricsData()
-		fakeMetrics := &metricsfake.Clientset{}
-		fakeMetrics.AddReactor("list", "pods", func(action core.Action) (bool, runtime.Object, error) {
-			return true, &metricsv1beta1api.PodMetricsList{
-				Items: metricsList,
-			}, nil
-		})
-
-		stdout, _ := runTopPodTest(t, runTopPodOpts{
-			apisBody:    apisV1beta1BodyWithMetrics,
-			fakeMetrics: fakeMetrics,
-			options: &TopPodOptions{
-				ShowSwap: true,
-			},
-		})
-
-		assertSwapBytesInTopOutput(t, stdout, expectedSwapBytes)
-	})
-
-	t.Run("v1", func(t *testing.T) {
-		metricsList := testV1PodMetricsData()
-		fakeMetrics := &metricsfake.Clientset{}
-		fakeMetrics.AddReactor("list", "pods", func(action core.Action) (bool, runtime.Object, error) {
-			return true, &metricsv1api.PodMetricsList{
-				Items: metricsList,
-			}, nil
-		})
-
-		stdout, _ := runTopPodTest(t, runTopPodOpts{
-			apisBody:    apisV1BodyWithMetrics,
-			fakeMetrics: fakeMetrics,
-			options: &TopPodOptions{
-				ShowSwap: true,
-			},
-		})
-
-		assertSwapBytesInTopOutput(t, stdout, expectedSwapBytes)
-	})
-}
-
 func assertSwapBytesInTopOutput(t *testing.T, stdout string, expected map[string]string) {
 	t.Helper()
 	actual := map[string]string{}
@@ -446,80 +394,6 @@ func getResultColumnValues(result string, columnIndex int) []string {
 	}
 
 	return values
-}
-
-func TestTopPodNoResourcesFound(t *testing.T) {
-	testCases := []struct {
-		name           string
-		options        *TopPodOptions
-		expectedOutput string
-		expectedErr    string
-	}{
-		{
-			name:           "all namespaces",
-			options:        &TopPodOptions{AllNamespaces: true},
-			expectedOutput: "",
-			expectedErr:    "No resources found\n",
-		},
-		{
-			name:           "all in namespace",
-			expectedOutput: "",
-			expectedErr:    "No resources found in " + testNS + " namespace.\n",
-		},
-	}
-	cmdtesting.InitTestErrorHandler(t)
-
-	t.Run("v1beta1", func(t *testing.T) {
-		for _, testCase := range testCases {
-			t.Run(testCase.name, func(t *testing.T) {
-				fakeMetrics := &metricsfake.Clientset{}
-				fakeMetrics.AddReactor("list", "pods", func(action core.Action) (bool, runtime.Object, error) {
-					return true, &metricsv1beta1api.PodMetricsList{
-						ListMeta: metav1.ListMeta{ResourceVersion: "2"},
-						Items:    nil,
-					}, nil
-				})
-				buf, errbuf := runTopPodTest(t, runTopPodOpts{
-					apisBody:    apisV1beta1BodyWithMetrics,
-					fakeMetrics: fakeMetrics,
-					options:     testCase.options,
-					extraPaths:  emptyPodListResponse,
-				})
-				if e, a := testCase.expectedOutput, buf; e != a {
-					t.Errorf("Unexpected output:\nExpected:\n%v\nActual:\n%v", e, a)
-				}
-				if e, a := testCase.expectedErr, errbuf; e != a {
-					t.Errorf("Unexpected error:\nExpected:\n%v\nActual:\n%v", e, a)
-				}
-			})
-		}
-	})
-
-	t.Run("v1", func(t *testing.T) {
-		for _, testCase := range testCases {
-			t.Run(testCase.name, func(t *testing.T) {
-				fakeMetrics := &metricsfake.Clientset{}
-				fakeMetrics.AddReactor("list", "pods", func(action core.Action) (bool, runtime.Object, error) {
-					return true, &metricsv1api.PodMetricsList{
-						ListMeta: metav1.ListMeta{ResourceVersion: "2"},
-						Items:    nil,
-					}, nil
-				})
-				buf, errbuf := runTopPodTest(t, runTopPodOpts{
-					apisBody:    apisV1BodyWithMetrics,
-					fakeMetrics: fakeMetrics,
-					options:     testCase.options,
-					extraPaths:  emptyPodListResponse,
-				})
-				if e, a := testCase.expectedOutput, buf; e != a {
-					t.Errorf("Unexpected output:\nExpected:\n%v\nActual:\n%v", e, a)
-				}
-				if e, a := testCase.expectedErr, errbuf; e != a {
-					t.Errorf("Unexpected error:\nExpected:\n%v\nActual:\n%v", e, a)
-				}
-			})
-		}
-	})
 }
 
 func emptyPodListResponse(req *http.Request) (*http.Response, error) {
@@ -615,90 +489,27 @@ func defaultPodList() *v1.PodList {
 	}
 }
 
-// TestTopPodFieldSelectorFiltersMetrics verifies that, when a field selector is
-// given, metrics for pods that do not match the selector are filtered out. The
-// metrics API returns all three pods, while the pod list endpoint only returns
-// pod1, so the client must drop pod2 and pod3.
-func TestTopPodFieldSelectorFiltersMetrics(t *testing.T) {
-	cmdtesting.InitTestErrorHandler(t)
-
-	onlyPod1 := func(req *http.Request) (*http.Response, error) {
-		body, _ := marshallBody(v1.PodList{
-			ListMeta: metav1.ListMeta{ResourceVersion: "2"},
-			Items: []v1.Pod{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: testNS},
-					Spec:       v1.PodSpec{NodeName: "node-a"},
-				},
+// onlyPod1ListResponse serves a pod list containing only pod1, simulating the
+// core API filtering pods by a field selector.
+func onlyPod1ListResponse(req *http.Request) (*http.Response, error) {
+	body, _ := marshallBody(v1.PodList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "2"},
+		Items: []v1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: testNS},
+				Spec:       v1.PodSpec{NodeName: "node-a"},
 			},
-		})
-		return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: body}, nil
-	}
-
-	t.Run("v1beta1", func(t *testing.T) {
-		metricsList := testV1beta1PodMetricsData()
-		for i := range metricsList {
-			metricsList[i].Namespace = testNS
-		}
-		fakeMetrics := &metricsfake.Clientset{}
-		fakeMetrics.AddReactor("list", "pods", func(action core.Action) (bool, runtime.Object, error) {
-			return true, &metricsv1beta1api.PodMetricsList{
-				ListMeta: metav1.ListMeta{ResourceVersion: "2"},
-				Items:    metricsList,
-			}, nil
-		})
-
-		result, _ := runTopPodTest(t, runTopPodOpts{
-			apisBody:    apisV1beta1BodyWithMetrics,
-			fakeMetrics: fakeMetrics,
-			options:     &TopPodOptions{FieldSelector: "spec.nodeName=node-a"},
-			extraPaths:  onlyPod1,
-		})
-		assertFieldSelectorFiltered(t, result)
+		},
 	})
-
-	t.Run("v1", func(t *testing.T) {
-		metricsList := testV1PodMetricsData()
-		for i := range metricsList {
-			metricsList[i].Namespace = testNS
-		}
-		fakeMetrics := &metricsfake.Clientset{}
-		fakeMetrics.AddReactor("list", "pods", func(action core.Action) (bool, runtime.Object, error) {
-			return true, &metricsv1api.PodMetricsList{
-				ListMeta: metav1.ListMeta{ResourceVersion: "2"},
-				Items:    metricsList,
-			}, nil
-		})
-
-		result, _ := runTopPodTest(t, runTopPodOpts{
-			apisBody:    apisV1BodyWithMetrics,
-			fakeMetrics: fakeMetrics,
-			options:     &TopPodOptions{FieldSelector: "spec.nodeName=node-a"},
-			extraPaths:  onlyPod1,
-		})
-		assertFieldSelectorFiltered(t, result)
-	})
+	return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: body}, nil
 }
 
-func assertFieldSelectorFiltered(t *testing.T, result string) {
-	t.Helper()
-	if !strings.Contains(result, "pod1") {
-		t.Errorf("expected metrics for pod1, got:\n%s", result)
-	}
-	if strings.Contains(result, "pod2") {
-		t.Errorf("unexpected metrics for pod2, got:\n%s", result)
-	}
-	if strings.Contains(result, "pod3") {
-		t.Errorf("unexpected metrics for pod3, got:\n%s", result)
-	}
-}
-
-func testV1beta1PodMetricsData() []metricsv1beta1api.PodMetrics {
-	return []metricsv1beta1api.PodMetrics{
+func testPodMetricsData() []metricsapi.PodMetrics {
+	return []metricsapi.PodMetrics{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "test", ResourceVersion: "10", Labels: map[string]string{"key": "value"}},
 			Window:     metav1.Duration{Duration: time.Minute},
-			Containers: []metricsv1beta1api.ContainerMetrics{
+			Containers: []metricsapi.ContainerMetrics{
 				{
 					Name: "container1-1",
 					Usage: v1.ResourceList{
@@ -722,7 +533,7 @@ func testV1beta1PodMetricsData() []metricsv1beta1api.PodMetrics {
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: "test", ResourceVersion: "11", Labels: map[string]string{"key": "value"}},
 			Window:     metav1.Duration{Duration: time.Minute},
-			Containers: []metricsv1beta1api.ContainerMetrics{
+			Containers: []metricsapi.ContainerMetrics{
 				{
 					Name: "container2-1",
 					Usage: v1.ResourceList{
@@ -752,81 +563,7 @@ func testV1beta1PodMetricsData() []metricsv1beta1api.PodMetrics {
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "pod3", Namespace: "test", ResourceVersion: "12"},
 			Window:     metav1.Duration{Duration: time.Minute},
-			Containers: []metricsv1beta1api.ContainerMetrics{
-				{
-					Name: "container3-1",
-					Usage: v1.ResourceList{
-						v1.ResourceCPU:     *resource.NewMilliQuantity(7, resource.DecimalSI),
-						v1.ResourceMemory:  *resource.NewQuantity(8*(1024*1024), resource.DecimalSI),
-						"swap":             *resource.NewQuantity(3*(1024*1024), resource.DecimalSI),
-						v1.ResourceStorage: *resource.NewQuantity(9*(1024*1024), resource.DecimalSI),
-					},
-				},
-			},
-		},
-	}
-}
-
-func testV1PodMetricsData() []metricsv1api.PodMetrics {
-	return []metricsv1api.PodMetrics{
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "test", ResourceVersion: "10", Labels: map[string]string{"key": "value"}},
-			Window:     metav1.Duration{Duration: time.Minute},
-			Containers: []metricsv1api.ContainerMetrics{
-				{
-					Name: "container1-1",
-					Usage: v1.ResourceList{
-						v1.ResourceCPU:     *resource.NewMilliQuantity(1, resource.DecimalSI),
-						v1.ResourceMemory:  *resource.NewQuantity(2*(1024*1024), resource.DecimalSI),
-						"swap":             *resource.NewQuantity(1*(1024*1024), resource.DecimalSI),
-						v1.ResourceStorage: *resource.NewQuantity(3*(1024*1024), resource.DecimalSI),
-					},
-				},
-				{
-					Name: "container1-2",
-					Usage: v1.ResourceList{
-						v1.ResourceCPU:     *resource.NewMilliQuantity(4, resource.DecimalSI),
-						v1.ResourceMemory:  *resource.NewQuantity(5*(1024*1024), resource.DecimalSI),
-						"swap":             *resource.NewQuantity(3*(1024*1024), resource.DecimalSI),
-						v1.ResourceStorage: *resource.NewQuantity(6*(1024*1024), resource.DecimalSI),
-					},
-				},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: "test", ResourceVersion: "11", Labels: map[string]string{"key": "value"}},
-			Window:     metav1.Duration{Duration: time.Minute},
-			Containers: []metricsv1api.ContainerMetrics{
-				{
-					Name: "container2-1",
-					Usage: v1.ResourceList{
-						v1.ResourceCPU:     *resource.NewMilliQuantity(7, resource.DecimalSI),
-						v1.ResourceMemory:  *resource.NewQuantity(8*(1024*1024), resource.DecimalSI),
-						v1.ResourceStorage: *resource.NewQuantity(9*(1024*1024), resource.DecimalSI),
-					},
-				},
-				{
-					Name: "container2-2",
-					Usage: v1.ResourceList{
-						v1.ResourceCPU:     *resource.NewMilliQuantity(10, resource.DecimalSI),
-						v1.ResourceMemory:  *resource.NewQuantity(11*(1024*1024), resource.DecimalSI),
-						v1.ResourceStorage: *resource.NewQuantity(12*(1024*1024), resource.DecimalSI),
-					},
-				},
-				{
-					Name: "container2-3",
-					Usage: v1.ResourceList{
-						v1.ResourceCPU:     *resource.NewMilliQuantity(13, resource.DecimalSI),
-						v1.ResourceMemory:  *resource.NewQuantity(14*(1024*1024), resource.DecimalSI),
-						v1.ResourceStorage: *resource.NewQuantity(15*(1024*1024), resource.DecimalSI),
-					},
-				},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: "pod3", Namespace: "test", ResourceVersion: "12"},
-			Window:     metav1.Duration{Duration: time.Minute},
-			Containers: []metricsv1api.ContainerMetrics{
+			Containers: []metricsapi.ContainerMetrics{
 				{
 					Name: "container3-1",
 					Usage: v1.ResourceList{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_test.go
@@ -54,7 +54,53 @@ const (
 	]
 }`
 
+	apisV1BodyWithMetrics = `{
+	"kind": "APIGroupList",
+	"apiVersion": "v1",
+	"groups": [
+		{
+			"name":"metrics.k8s.io",
+			"versions":[
+				{
+					"groupVersion":"metrics.k8s.io/v1",
+					"version":"v1"
+				},
+				{
+					"groupVersion":"metrics.k8s.io/v1beta1",
+					"version":"v1beta1"
+				}
+			],
+			"preferredVersion":{
+				"groupVersion":"metrics.k8s.io/v1",
+				"version":"v1"
+			},
+			"serverAddressByClientCIDRs":null
+		}
+	]
+}`
+
 	apisbodyWithMetrics = `{
+	"kind": "APIGroupList",
+	"apiVersion": "v1",
+	"groups": [
+		{
+			"name":"metrics.k8s.io",
+			"versions":[
+				{
+					"groupVersion":"metrics.k8s.io/v1beta1",
+					"version":"v1beta1"
+				}
+			],
+			"preferredVersion":{
+				"groupVersion":"metrics.k8s.io/v1beta1",
+				"version":"v1beta1"
+			},
+			"serverAddressByClientCIDRs":null
+		}
+	]
+}`
+
+	apisV1beta1BodyWithMetrics = `{
 	"kind": "APIGroupList",
 	"apiVersion": "v1",
 	"groups": [

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_test.go
@@ -27,12 +27,23 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+	metricsapi "k8s.io/metrics/pkg/apis/metrics"
 	metricsv1api "k8s.io/metrics/pkg/apis/metrics/v1"
 	metricsv1beta1api "k8s.io/metrics/pkg/apis/metrics/v1beta1"
-	"k8s.io/utils/ptr"
 )
+
+// metricsAPIVersions lists the metrics API versions the top commands support,
+// so tests can run every case against each version.
+var metricsAPIVersions = []struct {
+	name     string
+	apisBody string
+}{
+	{"v1", apisV1BodyWithMetrics},
+	{"v1beta1", apisV1beta1BodyWithMetrics},
+}
 
 func TestTopSubcommandsExist(t *testing.T) {
 	cmdtesting.InitTestErrorHandler(t)
@@ -54,105 +65,66 @@ func marshallBody(metrics interface{}) (io.ReadCloser, error) {
 	return io.NopCloser(bytes.NewReader(result)), nil
 }
 
-func testNodeV1beta1MetricsData() (*metricsv1beta1api.NodeMetricsList, *v1.NodeList) {
-	metrics := &metricsv1beta1api.NodeMetricsList{
-		ListMeta: metav1.ListMeta{
-			ResourceVersion: "1",
-		},
-		Items: []metricsv1beta1api.NodeMetrics{
-			{
-				ObjectMeta: metav1.ObjectMeta{Name: "node1", ResourceVersion: "10", Labels: map[string]string{"key": "value"}},
-				Window:     metav1.Duration{Duration: time.Minute},
-				Usage: v1.ResourceList{
-					v1.ResourceCPU:     *resource.NewMilliQuantity(1, resource.DecimalSI),
-					"swap":             *resource.NewQuantity(1*(1024*1024), resource.DecimalSI),
-					v1.ResourceMemory:  *resource.NewQuantity(2*(1024*1024), resource.DecimalSI),
-					v1.ResourceStorage: *resource.NewQuantity(3*(1024*1024), resource.DecimalSI),
-				},
-			},
-			{
-				ObjectMeta: metav1.ObjectMeta{Name: "node2", ResourceVersion: "11"},
-				Window:     metav1.Duration{Duration: time.Minute},
-				Usage: v1.ResourceList{
-					v1.ResourceCPU:     *resource.NewMilliQuantity(5, resource.DecimalSI),
-					"swap":             *resource.NewQuantity(2*(1024*1024), resource.DecimalSI),
-					v1.ResourceMemory:  *resource.NewQuantity(6*(1024*1024), resource.DecimalSI),
-					v1.ResourceStorage: *resource.NewQuantity(7*(1024*1024), resource.DecimalSI),
-				},
-			},
-			{
-				ObjectMeta: metav1.ObjectMeta{Name: "node3", ResourceVersion: "11"},
-				Window:     metav1.Duration{Duration: time.Minute},
-				Usage: v1.ResourceList{
-					v1.ResourceCPU:     *resource.NewMilliQuantity(3, resource.DecimalSI),
-					"swap":             *resource.NewQuantity(0, resource.DecimalSI),
-					v1.ResourceMemory:  *resource.NewQuantity(4*(1024*1024), resource.DecimalSI),
-					v1.ResourceStorage: *resource.NewQuantity(5*(1024*1024), resource.DecimalSI),
-				},
-			},
-		},
+// versionedNodeMetricsList converts internal node metrics to the given
+// metrics API version, returning the list and its first item for use as fake
+// clientset reactor return values.
+func versionedNodeMetricsList(t *testing.T, version string, in *metricsapi.NodeMetricsList) (list, first runtime.Object) {
+	t.Helper()
+	switch version {
+	case "v1":
+		out := &metricsv1api.NodeMetricsList{}
+		if err := metricsv1api.Convert_metrics_NodeMetricsList_To_v1_NodeMetricsList(in, out, nil); err != nil {
+			t.Fatal(err)
+		}
+		return out, &out.Items[0]
+	case "v1beta1":
+		out := &metricsv1beta1api.NodeMetricsList{}
+		if err := metricsv1beta1api.Convert_metrics_NodeMetricsList_To_v1beta1_NodeMetricsList(in, out, nil); err != nil {
+			t.Fatal(err)
+		}
+		return out, &out.Items[0]
+	default:
+		t.Fatalf("unsupported metrics API version %q", version)
+		return nil, nil
 	}
-	nodes := &v1.NodeList{
-		ListMeta: metav1.ListMeta{
-			ResourceVersion: "15",
-		},
-		Items: []v1.Node{
-			{
-				ObjectMeta: metav1.ObjectMeta{Name: "node1", ResourceVersion: "10"},
-				Status: v1.NodeStatus{
-					Allocatable: v1.ResourceList{
-						v1.ResourceCPU:     *resource.NewMilliQuantity(10, resource.DecimalSI),
-						v1.ResourceMemory:  *resource.NewQuantity(20*(1024*1024), resource.DecimalSI),
-						v1.ResourceStorage: *resource.NewQuantity(30*(1024*1024), resource.DecimalSI),
-					},
-					NodeInfo: v1.NodeSystemInfo{
-						Swap: &v1.NodeSwapStatus{
-							Capacity: ptr.To(int64(10 * (1024 * 1024 * 1024))),
-						},
-					},
-				},
-			},
-			{
-				ObjectMeta: metav1.ObjectMeta{Name: "node2", ResourceVersion: "11"},
-				Status: v1.NodeStatus{
-					Allocatable: v1.ResourceList{
-						v1.ResourceCPU:     *resource.NewMilliQuantity(50, resource.DecimalSI),
-						v1.ResourceMemory:  *resource.NewQuantity(60*(1024*1024), resource.DecimalSI),
-						v1.ResourceStorage: *resource.NewQuantity(70*(1024*1024), resource.DecimalSI),
-					},
-					NodeInfo: v1.NodeSystemInfo{
-						Swap: &v1.NodeSwapStatus{
-							Capacity: ptr.To(int64(20 * (1024 * 1024 * 1024))),
-						},
-					},
-				},
-			},
-			{
-				ObjectMeta: metav1.ObjectMeta{Name: "node3", ResourceVersion: "11"},
-				Status: v1.NodeStatus{
-					Allocatable: v1.ResourceList{
-						v1.ResourceCPU:     *resource.NewMilliQuantity(30, resource.DecimalSI),
-						v1.ResourceMemory:  *resource.NewQuantity(40*(1024*1024), resource.DecimalSI),
-						v1.ResourceStorage: *resource.NewQuantity(50*(1024*1024), resource.DecimalSI),
-					},
-					NodeInfo: v1.NodeSystemInfo{
-						Swap: &v1.NodeSwapStatus{
-							Capacity: ptr.To(int64(30 * (1024 * 1024 * 1024))),
-						},
-					},
-				},
-			},
-		},
-	}
-	return metrics, nodes
 }
 
-func testNodeV1MetricsData() (*metricsv1api.NodeMetricsList, *v1.NodeList) {
-	metrics := &metricsv1api.NodeMetricsList{
+// versionedPodMetricsList converts internal pod metrics to the given metrics
+// API version, returning the list and its first item (nil for an empty list)
+// for use as fake clientset reactor return values.
+func versionedPodMetricsList(t *testing.T, version string, in *metricsapi.PodMetricsList) (list, first runtime.Object) {
+	t.Helper()
+	switch version {
+	case "v1":
+		out := &metricsv1api.PodMetricsList{}
+		if err := metricsv1api.Convert_metrics_PodMetricsList_To_v1_PodMetricsList(in, out, nil); err != nil {
+			t.Fatal(err)
+		}
+		if len(out.Items) == 0 {
+			return out, nil
+		}
+		return out, &out.Items[0]
+	case "v1beta1":
+		out := &metricsv1beta1api.PodMetricsList{}
+		if err := metricsv1beta1api.Convert_metrics_PodMetricsList_To_v1beta1_PodMetricsList(in, out, nil); err != nil {
+			t.Fatal(err)
+		}
+		if len(out.Items) == 0 {
+			return out, nil
+		}
+		return out, &out.Items[0]
+	default:
+		t.Fatalf("unsupported metrics API version %q", version)
+		return nil, nil
+	}
+}
+
+func testNodeMetricsData() (*metricsapi.NodeMetricsList, *v1.NodeList) {
+	metrics := &metricsapi.NodeMetricsList{
 		ListMeta: metav1.ListMeta{
 			ResourceVersion: "1",
 		},
-		Items: []metricsv1api.NodeMetrics{
+		Items: []metricsapi.NodeMetrics{
 			{
 				ObjectMeta: metav1.ObjectMeta{Name: "node1", ResourceVersion: "10", Labels: map[string]string{"key": "value"}},
 				Window:     metav1.Duration{Duration: time.Minute},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+	metricsv1api "k8s.io/metrics/pkg/apis/metrics/v1"
 	metricsv1beta1api "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	"k8s.io/utils/ptr"
 )
@@ -137,6 +138,99 @@ func testNodeV1beta1MetricsData() (*metricsv1beta1api.NodeMetricsList, *v1.NodeL
 					NodeInfo: v1.NodeSystemInfo{
 						Swap: &v1.NodeSwapStatus{
 							Capacity: ptr.To(int64(30 * (1024 * 1024 * 1024))),
+						},
+					},
+				},
+			},
+		},
+	}
+	return metrics, nodes
+}
+
+func testNodeV1MetricsData() (*metricsv1api.NodeMetricsList, *v1.NodeList) {
+	metrics := &metricsv1api.NodeMetricsList{
+		ListMeta: metav1.ListMeta{
+			ResourceVersion: "1",
+		},
+		Items: []metricsv1api.NodeMetrics{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1", ResourceVersion: "10", Labels: map[string]string{"key": "value"}},
+				Window:     metav1.Duration{Duration: time.Minute},
+				Usage: v1.ResourceList{
+					v1.ResourceCPU:     *resource.NewMilliQuantity(1, resource.DecimalSI),
+					"swap":             *resource.NewQuantity(1*(1024*1024), resource.DecimalSI),
+					v1.ResourceMemory:  *resource.NewQuantity(2*(1024*1024), resource.DecimalSI),
+					v1.ResourceStorage: *resource.NewQuantity(3*(1024*1024), resource.DecimalSI),
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "node2", ResourceVersion: "11"},
+				Window:     metav1.Duration{Duration: time.Minute},
+				Usage: v1.ResourceList{
+					v1.ResourceCPU:     *resource.NewMilliQuantity(5, resource.DecimalSI),
+					"swap":             *resource.NewQuantity(2*(1024*1024), resource.DecimalSI),
+					v1.ResourceMemory:  *resource.NewQuantity(6*(1024*1024), resource.DecimalSI),
+					v1.ResourceStorage: *resource.NewQuantity(7*(1024*1024), resource.DecimalSI),
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "node3", ResourceVersion: "11"},
+				Window:     metav1.Duration{Duration: time.Minute},
+				Usage: v1.ResourceList{
+					v1.ResourceCPU:     *resource.NewMilliQuantity(3, resource.DecimalSI),
+					"swap":             *resource.NewQuantity(0, resource.DecimalSI),
+					v1.ResourceMemory:  *resource.NewQuantity(4*(1024*1024), resource.DecimalSI),
+					v1.ResourceStorage: *resource.NewQuantity(5*(1024*1024), resource.DecimalSI),
+				},
+			},
+		},
+	}
+	nodes := &v1.NodeList{
+		ListMeta: metav1.ListMeta{
+			ResourceVersion: "15",
+		},
+		Items: []v1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1", ResourceVersion: "10"},
+				Status: v1.NodeStatus{
+					Allocatable: v1.ResourceList{
+						v1.ResourceCPU:     *resource.NewMilliQuantity(10, resource.DecimalSI),
+						v1.ResourceMemory:  *resource.NewQuantity(20*(1024*1024), resource.DecimalSI),
+						v1.ResourceStorage: *resource.NewQuantity(30*(1024*1024), resource.DecimalSI),
+					},
+					NodeInfo: v1.NodeSystemInfo{
+						Swap: &v1.NodeSwapStatus{
+							Capacity: new(int64(10 * (1024 * 1024 * 1024))),
+						},
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "node2", ResourceVersion: "11"},
+				Status: v1.NodeStatus{
+					Allocatable: v1.ResourceList{
+						v1.ResourceCPU:     *resource.NewMilliQuantity(50, resource.DecimalSI),
+						v1.ResourceMemory:  *resource.NewQuantity(60*(1024*1024), resource.DecimalSI),
+						v1.ResourceStorage: *resource.NewQuantity(70*(1024*1024), resource.DecimalSI),
+					},
+					NodeInfo: v1.NodeSystemInfo{
+						Swap: &v1.NodeSwapStatus{
+							Capacity: new(int64(20 * (1024 * 1024 * 1024))),
+						},
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "node3", ResourceVersion: "11"},
+				Status: v1.NodeStatus{
+					Allocatable: v1.ResourceList{
+						v1.ResourceCPU:     *resource.NewMilliQuantity(30, resource.DecimalSI),
+						v1.ResourceMemory:  *resource.NewQuantity(40*(1024*1024), resource.DecimalSI),
+						v1.ResourceStorage: *resource.NewQuantity(50*(1024*1024), resource.DecimalSI),
+					},
+					NodeInfo: v1.NodeSystemInfo{
+						Swap: &v1.NodeSwapStatus{
+							Capacity: new(int64(30 * (1024 * 1024 * 1024))),
 						},
 					},
 				},


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

metrics.k8s.io is moving to GA; `kubectl top` should support it.

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/issues/5207

#### Special notes for your reviewer:

This will be handled after PR #139223 is merged.

Some content were written in part with the assistance of generative AI.

#### Does this PR introduce a user-facing change?

```release-note
kubectl top support v1.metrics.k8s.io
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/5207
```
