### PR TITLE
apimachinery: add declarative validation for Condition.Message field …

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -24460,8 +24460,7 @@
         "type",
         "status",
         "lastTransitionTime",
-        "reason",
-        "message"
+        "reason"
       ],
       "type": "object"
     },

--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -8976,8 +8976,7 @@
           "type",
           "status",
           "lastTransitionTime",
-          "reason",
-          "message"
+          "reason"
         ],
         "type": "object"
       },

--- a/api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1_openapi.json
@@ -1444,8 +1444,7 @@
           "type",
           "status",
           "lastTransitionTime",
-          "reason",
-          "message"
+          "reason"
         ],
         "type": "object"
       },

--- a/api/openapi-spec/v3/apis__certificates.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__certificates.k8s.io__v1_openapi.json
@@ -669,8 +669,7 @@
           "type",
           "status",
           "lastTransitionTime",
-          "reason",
-          "message"
+          "reason"
         ],
         "type": "object"
       },

--- a/api/openapi-spec/v3/apis__certificates.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__certificates.k8s.io__v1beta1_openapi.json
@@ -465,8 +465,7 @@
           "type",
           "status",
           "lastTransitionTime",
-          "reason",
-          "message"
+          "reason"
         ],
         "type": "object"
       },

--- a/api/openapi-spec/v3/apis__lifecycle.k8s.io__v1alpha1_openapi.json
+++ b/api/openapi-spec/v3/apis__lifecycle.k8s.io__v1alpha1_openapi.json
@@ -646,8 +646,7 @@
           "type",
           "status",
           "lastTransitionTime",
-          "reason",
-          "message"
+          "reason"
         ],
         "type": "object"
       },

--- a/api/openapi-spec/v3/apis__networking.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__networking.k8s.io__v1_openapi.json
@@ -1124,8 +1124,7 @@
           "type",
           "status",
           "lastTransitionTime",
-          "reason",
-          "message"
+          "reason"
         ],
         "type": "object"
       },

--- a/api/openapi-spec/v3/apis__policy__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__policy__v1_openapi.json
@@ -326,8 +326,7 @@
           "type",
           "status",
           "lastTransitionTime",
-          "reason",
-          "message"
+          "reason"
         ],
         "type": "object"
       },

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1_openapi.json
@@ -1943,8 +1943,7 @@
           "type",
           "status",
           "lastTransitionTime",
-          "reason",
-          "message"
+          "reason"
         ],
         "type": "object"
       },

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1alpha3_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1alpha3_openapi.json
@@ -671,8 +671,7 @@
           "type",
           "status",
           "lastTransitionTime",
-          "reason",
-          "message"
+          "reason"
         ],
         "type": "object"
       },

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1beta1_openapi.json
@@ -1786,8 +1786,7 @@
           "type",
           "status",
           "lastTransitionTime",
-          "reason",
-          "message"
+          "reason"
         ],
         "type": "object"
       },

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1beta2_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1beta2_openapi.json
@@ -1943,8 +1943,7 @@
           "type",
           "status",
           "lastTransitionTime",
-          "reason",
-          "message"
+          "reason"
         ],
         "type": "object"
       },

--- a/api/openapi-spec/v3/apis__scheduling.k8s.io__v1alpha3_openapi.json
+++ b/api/openapi-spec/v3/apis__scheduling.k8s.io__v1alpha3_openapi.json
@@ -1078,8 +1078,7 @@
           "type",
           "status",
           "lastTransitionTime",
-          "reason",
-          "message"
+          "reason"
         ],
         "type": "object"
       },

--- a/api/openapi-spec/v3/apis__scheduling.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__scheduling.k8s.io__v1beta1_openapi.json
@@ -905,8 +905,7 @@
           "type",
           "status",
           "lastTransitionTime",
-          "reason",
-          "message"
+          "reason"
         ],
         "type": "object"
       },

--- a/api/openapi-spec/v3/apis__storagemigration.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__storagemigration.k8s.io__v1_openapi.json
@@ -277,8 +277,7 @@
           "type",
           "status",
           "lastTransitionTime",
-          "reason",
-          "message"
+          "reason"
         ],
         "type": "object"
       },

--- a/api/openapi-spec/v3/apis__storagemigration.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__storagemigration.k8s.io__v1beta1_openapi.json
@@ -277,8 +277,7 @@
           "type",
           "status",
           "lastTransitionTime",
-          "reason",
-          "message"
+          "reason"
         ],
         "type": "object"
       },

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -66323,7 +66323,7 @@ func schema_pkg_apis_meta_v1_Condition(ref common.ReferenceCallback) common.Open
 						},
 					},
 				},
-				Required: []string{"type", "status", "lastTransitionTime", "reason", "message"},
+				Required: []string{"type", "status", "lastTransitionTime", "reason"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/zz_generated.openapi.go
@@ -4610,7 +4610,7 @@ func schema_pkg_apis_meta_v1_Condition(ref common.ReferenceCallback) common.Open
 						},
 					},
 				},
-				Required: []string{"type", "status", "lastTransitionTime", "reason", "message"},
+				Required: []string{"type", "status", "lastTransitionTime", "reason"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -241,8 +241,11 @@ message Condition {
   // message is a human readable message indicating details about the transition.
   // This may be an empty string.
   // +required
+  // +default=""
   // +kubebuilder:validation:Required
   // +kubebuilder:validation:MaxLength=32768
+  // +k8s:alpha(since: "1.37")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:maxBytes=32768
   optional string message = 6;
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -240,9 +240,7 @@ message Condition {
 
   // message is a human readable message indicating details about the transition.
   // This may be an empty string.
-  // +required
   // +default=""
-  // +kubebuilder:validation:Required
   // +kubebuilder:validation:MaxLength=32768
   // +k8s:alpha(since: "1.37")=+k8s:optional
   // +k8s:alpha(since: "1.37")=+k8s:maxBytes=32768

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -242,8 +242,11 @@ message Condition {
   // message is a human readable message indicating details about the transition.
   // This may be an empty string.
   // +required
+  // +default=""
   // +kubebuilder:validation:Required
   // +kubebuilder:validation:MaxLength=32768
+  // +k8s:alpha(since: "1.37")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:maxBytes=32768
   optional string message = 6;
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -241,12 +241,12 @@ message Condition {
 
   // message is a human readable message indicating details about the transition.
   // This may be an empty string.
-  // +required
+  // +optional
+  // +kubebuilder:validation:Optional
   // +default=""
-  // +kubebuilder:validation:Required
   // +kubebuilder:validation:MaxLength=32768
-  // +k8s:alpha(since: "1.37")=+k8s:optional
-  // +k8s:alpha(since: "1.37")=+k8s:maxBytes=32768
+  // +k8s:alpha(since: "1.38")=+k8s:optional
+  // +k8s:alpha(since: "1.38")=+k8s:maxBytes=32768
   optional string message = 6;
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1689,7 +1689,10 @@ type Condition struct {
 	// message is a human readable message indicating details about the transition.
 	// This may be an empty string.
 	// +required
+	// +default=""
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MaxLength=32768
+	// +k8s:alpha(since: "1.37")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:maxBytes=32768
 	Message string `json:"message" protobuf:"bytes,6,opt,name=message"`
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1688,9 +1688,7 @@ type Condition struct {
 	Reason string `json:"reason" protobuf:"bytes,5,opt,name=reason"`
 	// message is a human readable message indicating details about the transition.
 	// This may be an empty string.
-	// +required
 	// +default=""
-	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MaxLength=32768
 	// +k8s:alpha(since: "1.37")=+k8s:optional
 	// +k8s:alpha(since: "1.37")=+k8s:maxBytes=32768

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1697,7 +1697,10 @@ type Condition struct {
 	// message is a human readable message indicating details about the transition.
 	// This may be an empty string.
 	// +required
+	// +default=""
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MaxLength=32768
+	// +k8s:alpha(since: "1.37")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:maxBytes=32768
 	Message string `json:"message" protobuf:"bytes,6,opt,name=message"`
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1696,11 +1696,11 @@ type Condition struct {
 	Reason string `json:"reason" protobuf:"bytes,5,opt,name=reason"`
 	// message is a human readable message indicating details about the transition.
 	// This may be an empty string.
-	// +required
+	// +optional
+	// +kubebuilder:validation:Optional
 	// +default=""
-	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MaxLength=32768
-	// +k8s:alpha(since: "1.37")=+k8s:optional
-	// +k8s:alpha(since: "1.37")=+k8s:maxBytes=32768
+	// +k8s:alpha(since: "1.38")=+k8s:optional
+	// +k8s:alpha(since: "1.38")=+k8s:maxBytes=32768
 	Message string `json:"message" protobuf:"bytes,6,opt,name=message"`
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -376,7 +376,7 @@ func ValidateCondition(condition metav1.Condition, fldPath *field.Path) field.Er
 	}
 
 	if len(condition.Message) > maxMessageLen {
-		allErrs = append(allErrs, field.TooLong(fldPath.Child("message"), "" /*unused*/, maxMessageLen))
+		allErrs = append(allErrs, field.TooLong(fldPath.Child("message"), "" /*unused*/, maxMessageLen).WithOrigin("maxBytes").MarkCoveredByDeclarative())
 	}
 
 	return allErrs

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
@@ -188,7 +188,31 @@ func Validate_Condition(
 		errs = append(errs, fn(fldPath.Child("reason"), &obj.Reason, oldVal, oldObj != nil)...)
 	}
 
-	// field v1.Condition.Message has no validation
+	{ // field v1.Condition.Message
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// optional value-type fields with zero-value defaults are purely documentation
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 32768).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *v1.Condition) *string {
+				return &oldObj.Message
+			})
+		errs = append(errs, fn(fldPath.Child("message"), &obj.Message, oldVal, oldObj != nil)...)
+	}
+
 	return errs
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
@@ -191,7 +191,31 @@ func Validate_Condition(
 		errs = append(errs, fn(fldPath.Child("reason"), &obj.Reason, oldVal, oldObj != nil)...)
 	}
 
-	// field v1.Condition.Message has no validation
+	{ // field v1.Condition.Message
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// optional value-type fields with zero-value defaults are purely documentation
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 32768).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *v1.Condition) *string {
+				return &oldObj.Message
+			})
+		errs = append(errs, fn(fldPath.Child("message"), &obj.Message, oldVal, oldObj != nil)...)
+	}
+
 	return errs
 }
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/openapi/zz_generated.openapi.go
@@ -647,7 +647,7 @@ func schema_pkg_apis_meta_v1_Condition(ref common.ReferenceCallback) common.Open
 						},
 					},
 				},
-				Required: []string{"type", "status", "lastTransitionTime", "reason", "message"},
+				Required: []string{"type", "status", "lastTransitionTime", "reason"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/kube-aggregator/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/generated/openapi/zz_generated.openapi.go
@@ -639,7 +639,7 @@ func schema_pkg_apis_meta_v1_Condition(ref common.ReferenceCallback) common.Open
 						},
 					},
 				},
-				Required: []string{"type", "status", "lastTransitionTime", "reason", "message"},
+				Required: []string{"type", "status", "lastTransitionTime", "reason"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/openapi/zz_generated.openapi.go
@@ -637,7 +637,7 @@ func schema_pkg_apis_meta_v1_Condition(ref common.ReferenceCallback) common.Open
 						},
 					},
 				},
-				Required: []string{"type", "status", "lastTransitionTime", "reason", "message"},
+				Required: []string{"type", "status", "lastTransitionTime", "reason"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/sample-controller/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/openapi/zz_generated.openapi.go
@@ -630,7 +630,7 @@ func schema_pkg_apis_meta_v1_Condition(ref common.ReferenceCallback) common.Open
 						},
 					},
 				},
-				Required: []string{"type", "status", "lastTransitionTime", "reason", "message"},
+				Required: []string{"type", "status", "lastTransitionTime", "reason"},
 			},
 		},
 		Dependencies: []string{

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1_test.go
@@ -64,6 +64,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].message": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
@@ -64,6 +64,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].message": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
@@ -64,6 +64,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].message": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/certificates/podcertificaterequest/declarative_validation_test.go
+++ b/test/declarative_validation/certificates/podcertificaterequest/declarative_validation_test.go
@@ -284,6 +284,18 @@ func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 					},
 				},
 				{
+					Name: "invalid message",
+					Conditions: []metav1.Condition{
+						meta.MkCondition(
+							meta.TweakType(string(certificates.PodCertificateRequestConditionTypeDenied)),
+							meta.TweakMessage(strings.Repeat("a", 32769)),
+						),
+					},
+					ExpectedErrs: field.ErrorList{
+						field.TooLong(field.NewPath("status", "conditions").Index(0).Child("message"), "", 1024).WithOrigin("maxBytes").MarkAlpha(),
+					},
+				},
+				{
 					Name: "invalid status value: Unknown",
 					Conditions: []metav1.Condition{
 						meta.MkCondition(

--- a/test/declarative_validation/certificates/podcertificaterequest/declarative_validation_test.go
+++ b/test/declarative_validation/certificates/podcertificaterequest/declarative_validation_test.go
@@ -303,7 +303,7 @@ func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 						),
 					},
 					ExpectedErrs: field.ErrorList{
-						field.TooLong(field.NewPath("status", "conditions").Index(0).Child("message"), "", 1024).WithOrigin("maxBytes").MarkAlpha(),
+						field.TooLong(field.NewPath("status", "conditions").Index(0).Child("message"), "", 32769).WithOrigin("maxBytes").MarkAlpha(),
 					},
 				},
 				{

--- a/test/declarative_validation/certificates/podcertificaterequest/declarative_validation_test.go
+++ b/test/declarative_validation/certificates/podcertificaterequest/declarative_validation_test.go
@@ -295,6 +295,18 @@ func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 					},
 				},
 				{
+					Name: "invalid message",
+					Conditions: []metav1.Condition{
+						meta.MkCondition(
+							meta.TweakType(string(certificates.PodCertificateRequestConditionTypeDenied)),
+							meta.TweakMessage(strings.Repeat("a", 32769)),
+						),
+					},
+					ExpectedErrs: field.ErrorList{
+						field.TooLong(field.NewPath("status", "conditions").Index(0).Child("message"), "", 1024).WithOrigin("maxBytes").MarkAlpha(),
+					},
+				},
+				{
 					Name: "invalid status value: Unknown",
 					Conditions: []metav1.Condition{
 						meta.MkCondition(

--- a/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1_test.go
@@ -64,6 +64,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].message": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1beta1_test.go
@@ -64,6 +64,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].message": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/lifecycle/eviction/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/lifecycle/eviction/zz_generated.validations.v1alpha1_test.go
@@ -82,6 +82,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].message": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/lifecycle/evictionrequest/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/lifecycle/evictionrequest/zz_generated.validations.v1alpha1_test.go
@@ -91,6 +91,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].message": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/meta/conditions.go
+++ b/test/declarative_validation/meta/conditions.go
@@ -157,6 +157,24 @@ func GenerateConditionTestCases(fldPath *field.Path) []ConditionTestCase {
 				field.TooLong(fldPath.Index(0).Child("reason"), "", 1024).WithOrigin("maxBytes").MarkAlpha(),
 			},
 		},
+		{
+			Name: "invalid message",
+			Conditions: []metav1.Condition{
+				MkCondition(TweakMessage(strings.Repeat("a", 32769))),
+			},
+			ExpectedErrs: field.ErrorList{
+				field.TooLongCharacters(fldPath.Index(0).Child("message"), "", 1024).WithOrigin("maxBytes").MarkAlpha(),
+			},
+		},
+		{
+			Name: "invalid non ascii characters message",
+			Conditions: []metav1.Condition{
+				MkCondition(TweakMessage(strings.Repeat("आ", 32769))),
+			},
+			ExpectedErrs: field.ErrorList{
+				field.TooLongCharacters(fldPath.Index(0).Child("message"), "", 1024).WithOrigin("maxBytes").MarkAlpha(),
+			},
+		},
 	}
 }
 
@@ -211,6 +229,12 @@ func TweakObservedGeneration(gen int64) func(*metav1.Condition) {
 func TweakLastTransitionTime(t metav1.Time) func(*metav1.Condition) {
 	return func(c *metav1.Condition) {
 		c.LastTransitionTime = t
+	}
+}
+
+func TweakMessage(message string) func(*metav1.Condition) {
+	return func(c *metav1.Condition) {
+		c.Message = message
 	}
 }
 

--- a/test/declarative_validation/meta/conditions.go
+++ b/test/declarative_validation/meta/conditions.go
@@ -241,6 +241,24 @@ func GenerateConditionTestCases(fldPath *field.Path) []ConditionTestCase {
 				field.TooLong(fldPath.Index(0).Child("reason"), "", 1024).WithOrigin("maxBytes").MarkAlpha(),
 			},
 		},
+		{
+			Name: "invalid message",
+			Conditions: []metav1.Condition{
+				MkCondition(TweakMessage(strings.Repeat("a", 32769))),
+			},
+			ExpectedErrs: field.ErrorList{
+				field.TooLongCharacters(fldPath.Index(0).Child("message"), "", 1024).WithOrigin("maxBytes").MarkAlpha(),
+			},
+		},
+		{
+			Name: "invalid non ascii characters message",
+			Conditions: []metav1.Condition{
+				MkCondition(TweakMessage(strings.Repeat("आ", 32769))),
+			},
+			ExpectedErrs: field.ErrorList{
+				field.TooLongCharacters(fldPath.Index(0).Child("message"), "", 1024).WithOrigin("maxBytes").MarkAlpha(),
+			},
+		},
 	}
 }
 
@@ -295,6 +313,12 @@ func TweakObservedGeneration(gen int64) func(*metav1.Condition) {
 func TweakLastTransitionTime(t metav1.Time) func(*metav1.Condition) {
 	return func(c *metav1.Condition) {
 		c.LastTransitionTime = t
+	}
+}
+
+func TweakMessage(message string) func(*metav1.Condition) {
+	return func(c *metav1.Condition) {
+		c.Message = message
 	}
 }
 

--- a/test/declarative_validation/meta/conditions.go
+++ b/test/declarative_validation/meta/conditions.go
@@ -242,21 +242,35 @@ func GenerateConditionTestCases(fldPath *field.Path) []ConditionTestCase {
 			},
 		},
 		{
+			Name: "valid message at max length",
+			Conditions: []metav1.Condition{
+				MkCondition(TweakMessage(strings.Repeat("a", 32768))),
+			},
+			ExpectedErrs: nil,
+		},
+		{
+			Name: "valid non ascii characters message at max length",
+			Conditions: []metav1.Condition{
+				MkCondition(TweakMessage(strings.Repeat("आ", 10922) + "aa")),
+			},
+			ExpectedErrs: nil,
+		},
+		{
 			Name: "invalid message",
 			Conditions: []metav1.Condition{
 				MkCondition(TweakMessage(strings.Repeat("a", 32769))),
 			},
 			ExpectedErrs: field.ErrorList{
-				field.TooLongCharacters(fldPath.Index(0).Child("message"), "", 1024).WithOrigin("maxBytes").MarkAlpha(),
+				field.TooLong(fldPath.Index(0).Child("message"), "", 32768).WithOrigin("maxBytes").MarkAlpha(),
 			},
 		},
 		{
 			Name: "invalid non ascii characters message",
 			Conditions: []metav1.Condition{
-				MkCondition(TweakMessage(strings.Repeat("आ", 32769))),
+				MkCondition(TweakMessage(strings.Repeat("आ", 10923))),
 			},
 			ExpectedErrs: field.ErrorList{
-				field.TooLongCharacters(fldPath.Index(0).Child("message"), "", 1024).WithOrigin("maxBytes").MarkAlpha(),
+				field.TooLong(fldPath.Index(0).Child("message"), "", 32768).WithOrigin("maxBytes").MarkAlpha(),
 			},
 		},
 	}

--- a/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1_test.go
@@ -64,6 +64,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].message": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1beta1_test.go
@@ -64,6 +64,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].message": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1_test.go
@@ -68,6 +68,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].message": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1alpha3_test.go
@@ -68,6 +68,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].message": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1beta2_test.go
@@ -68,6 +68,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].message": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1_test.go
@@ -223,6 +223,9 @@ func init() {
 			"status.devices[*].conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.devices[*].conditions[*].message": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"status.devices[*].conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta1_test.go
@@ -223,6 +223,9 @@ func init() {
 			"status.devices[*].conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.devices[*].conditions[*].message": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"status.devices[*].conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta2_test.go
@@ -223,6 +223,9 @@ func init() {
 			"status.devices[*].conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.devices[*].conditions[*].message": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"status.devices[*].conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/resource/resourcepoolstatusrequest/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/resource/resourcepoolstatusrequest/zz_generated.validations.v1alpha3_test.go
@@ -86,6 +86,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].message": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/scheduling/compositepodgroup/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/scheduling/compositepodgroup/zz_generated.validations.v1alpha3_test.go
@@ -122,6 +122,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].message": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1alpha3_test.go
@@ -141,6 +141,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].message": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1beta1_test.go
@@ -141,6 +141,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].message": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1_test.go
@@ -64,6 +64,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].message": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1beta1_test.go
@@ -64,6 +64,9 @@ func init() {
 			"status.conditions[*]": {
 				{ErrorType: "FieldValueDuplicate"},
 			},
+			"status.conditions[*].message": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"status.conditions[*].observedGeneration": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},


### PR DESCRIPTION
Which issue(s) this PR is related to:
  Part of #139638
  KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5073-declarative-validation

  Special notes for your reviewer:
  Migrates metav1.Condition.Message field validation to Declarative Validation as part of KEP-5073 (batch 2).

  - Adds +k8s:optional and +k8s:maxLength=32768 declarative validation tags to the Message field
  - Marks the corresponding handwritten TooLong check as covered by declarative validation
  - Adds declarative validation test coverage for empty and over-length message values
  - Regenerates validation code and generated declarative validation tests

  Does this PR introduce a user-facing change?
  NONE
