### PR TITLE
authorization: enable optionalorrequired kube-api-linter rule

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3425,9 +3425,6 @@
           "x-kubernetes-list-type": "atomic"
         }
       },
-      "required": [
-        "verbs"
-      ],
       "type": "object"
     },
     "io.k8s.api.authorization.v1.ResourceAttributes": {
@@ -3508,9 +3505,6 @@
           "x-kubernetes-list-type": "atomic"
         }
       },
-      "required": [
-        "verbs"
-      ],
       "type": "object"
     },
     "io.k8s.api.authorization.v1.SelfSubjectAccessReview": {
@@ -3607,6 +3601,9 @@
           "type": "string"
         }
       },
+      "required": [
+        "namespace"
+      ],
       "type": "object"
     },
     "io.k8s.api.authorization.v1.SubjectAccessReview": {
@@ -3689,7 +3686,7 @@
       "description": "SubjectAccessReviewStatus",
       "properties": {
         "allowed": {
-          "description": "allowed is required. True if the action would be allowed, false otherwise.",
+          "description": "allowed is set to true if the action is allowed, and should be set to false otherwise.",
           "type": "boolean"
         },
         "denied": {
@@ -3705,9 +3702,6 @@
           "type": "string"
         }
       },
-      "required": [
-        "allowed"
-      ],
       "type": "object"
     },
     "io.k8s.api.authorization.v1.SubjectRulesReviewStatus": {
@@ -3738,11 +3732,6 @@
           "x-kubernetes-list-type": "atomic"
         }
       },
-      "required": [
-        "resourceRules",
-        "nonResourceRules",
-        "incomplete"
-      ],
       "type": "object"
     },
     "io.k8s.api.autoscaling.v1.CrossVersionObjectReference": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3435,9 +3435,6 @@
           "x-kubernetes-list-type": "atomic"
         }
       },
-      "required": [
-        "verbs"
-      ],
       "type": "object"
     },
     "io.k8s.api.authorization.v1.ResourceAttributes": {
@@ -3518,9 +3515,6 @@
           "x-kubernetes-list-type": "atomic"
         }
       },
-      "required": [
-        "verbs"
-      ],
       "type": "object"
     },
     "io.k8s.api.authorization.v1.SelfSubjectAccessReview": {
@@ -3617,6 +3611,9 @@
           "type": "string"
         }
       },
+      "required": [
+        "namespace"
+      ],
       "type": "object"
     },
     "io.k8s.api.authorization.v1.SubjectAccessReview": {
@@ -3699,7 +3696,7 @@
       "description": "SubjectAccessReviewStatus",
       "properties": {
         "allowed": {
-          "description": "allowed is required. True if the action would be allowed, false otherwise.",
+          "description": "allowed is set to true if the action is allowed, and should be set to false otherwise.",
           "type": "boolean"
         },
         "denied": {
@@ -3715,9 +3712,6 @@
           "type": "string"
         }
       },
-      "required": [
-        "allowed"
-      ],
       "type": "object"
     },
     "io.k8s.api.authorization.v1.SubjectRulesReviewStatus": {
@@ -3748,11 +3742,6 @@
           "x-kubernetes-list-type": "atomic"
         }
       },
-      "required": [
-        "resourceRules",
-        "nonResourceRules",
-        "incomplete"
-      ],
       "type": "object"
     },
     "io.k8s.api.autoscaling.v1.CrossVersionObjectReference": {

--- a/api/openapi-spec/v3/apis__authorization.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__authorization.k8s.io__v1_openapi.json
@@ -122,9 +122,6 @@
             "x-kubernetes-list-type": "atomic"
           }
         },
-        "required": [
-          "verbs"
-        ],
         "type": "object"
       },
       "io.k8s.api.authorization.v1.ResourceAttributes": {
@@ -213,9 +210,6 @@
             "x-kubernetes-list-type": "atomic"
           }
         },
-        "required": [
-          "verbs"
-        ],
         "type": "object"
       },
       "io.k8s.api.authorization.v1.SelfSubjectAccessReview": {
@@ -350,6 +344,9 @@
             "type": "string"
           }
         },
+        "required": [
+          "namespace"
+        ],
         "type": "object"
       },
       "io.k8s.api.authorization.v1.SubjectAccessReview": {
@@ -456,7 +453,7 @@
         "properties": {
           "allowed": {
             "default": false,
-            "description": "allowed is required. True if the action would be allowed, false otherwise.",
+            "description": "allowed is set to true if the action is allowed, and should be set to false otherwise.",
             "type": "boolean"
           },
           "denied": {
@@ -472,9 +469,6 @@
             "type": "string"
           }
         },
-        "required": [
-          "allowed"
-        ],
         "type": "object"
       },
       "io.k8s.api.authorization.v1.SubjectRulesReviewStatus": {
@@ -506,11 +500,6 @@
             "x-kubernetes-list-type": "atomic"
           }
         },
-        "required": [
-          "resourceRules",
-          "nonResourceRules",
-          "incomplete"
-        ],
         "type": "object"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -231,7 +231,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
@@ -257,6 +257,11 @@ linters:
       # WorkloadSpec.CompositePodGroupTemplates is a union member that is conditionally optional (+k8s:ifEnabled("CompositePodGroup")=+k8s:optional), but the linter requires a static +k8s:optional tag.
       - text: "dependenttags: field WorkloadSpec\\.CompositePodGroupTemplates with marker \\+k8s:unionMember is missing required marker.*"
         path: "staging/src/k8s.io/api/scheduling/v1alpha3/types\\.go"
+      
+      # The (SubjectAccessReview|SelfSubjectAccessReview|LocalSubjectAccessReview).Spec fields hold a union type, but nonpointerstructs does not understand unions today.
+      # Validation requires exactly one of spec.resourceAttributes or spec.nonResourceAttributes, so an empty spec is always rejected and the field is required in practice.
+      - text: "nonpointerstructs: field (SubjectAccessReview|SelfSubjectAccessReview|LocalSubjectAccessReview)\\.Spec is a non-pointer struct with no required fields\\..*"
+        path: "staging/src/k8s.io/api/authorization/(v1|v1beta1)/types\\.go"
       
       # NoReferences - Existing fields that use Reference/References suffixes instead of Ref/Refs.
       # These fields use the Reference suffix, but renaming them would be a breaking change, so they are allowlisted.

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -241,7 +241,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|extensions|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|batch|certificates|core|discovery|extensions|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
@@ -267,6 +267,11 @@ linters:
       # WorkloadSpec.CompositePodGroupTemplates is a union member that is conditionally optional (+k8s:ifEnabled("CompositePodGroup")=+k8s:optional), but the linter requires a static +k8s:optional tag.
       - text: "dependenttags: field WorkloadSpec\\.CompositePodGroupTemplates with marker \\+k8s:unionMember is missing required marker.*"
         path: "staging/src/k8s.io/api/scheduling/(v1alpha3|v1beta1)/types\\.go"
+      
+      # The (SubjectAccessReview|SelfSubjectAccessReview|LocalSubjectAccessReview).Spec fields hold a union type, but nonpointerstructs does not understand unions today.
+      # Validation requires exactly one of spec.resourceAttributes or spec.nonResourceAttributes, so an empty spec is always rejected and the field is required in practice.
+      - text: "nonpointerstructs: field (SubjectAccessReview|SelfSubjectAccessReview|LocalSubjectAccessReview)\\.Spec is a non-pointer struct with no required fields\\..*"
+        path: "staging/src/k8s.io/api/authorization/(v1|v1beta1)/types\\.go"
       
       # NoReferences - Existing fields that use Reference/References suffixes instead of Ref/Refs.
       # These fields use the Reference suffix, but renaming them would be a breaking change, so they are allowlisted.

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -246,7 +246,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
@@ -272,6 +272,11 @@ linters:
       # WorkloadSpec.CompositePodGroupTemplates is a union member that is conditionally optional (+k8s:ifEnabled("CompositePodGroup")=+k8s:optional), but the linter requires a static +k8s:optional tag.
       - text: "dependenttags: field WorkloadSpec\\.CompositePodGroupTemplates with marker \\+k8s:unionMember is missing required marker.*"
         path: "staging/src/k8s.io/api/scheduling/v1alpha3/types\\.go"
+      
+      # The (SubjectAccessReview|SelfSubjectAccessReview|LocalSubjectAccessReview).Spec fields hold a union type, but nonpointerstructs does not understand unions today.
+      # Validation requires exactly one of spec.resourceAttributes or spec.nonResourceAttributes, so an empty spec is always rejected and the field is required in practice.
+      - text: "nonpointerstructs: field (SubjectAccessReview|SelfSubjectAccessReview|LocalSubjectAccessReview)\\.Spec is a non-pointer struct with no required fields\\..*"
+        path: "staging/src/k8s.io/api/authorization/(v1|v1beta1)/types\\.go"
       
       # NoReferences - Existing fields that use Reference/References suffixes instead of Ref/Refs.
       # These fields use the Reference suffix, but renaming them would be a breaking change, so they are allowlisted.

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -256,7 +256,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|extensions|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|batch|certificates|core|discovery|extensions|networking|storage)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
@@ -282,6 +282,11 @@ linters:
       # WorkloadSpec.CompositePodGroupTemplates is a union member that is conditionally optional (+k8s:ifEnabled("CompositePodGroup")=+k8s:optional), but the linter requires a static +k8s:optional tag.
       - text: "dependenttags: field WorkloadSpec\\.CompositePodGroupTemplates with marker \\+k8s:unionMember is missing required marker.*"
         path: "staging/src/k8s.io/api/scheduling/(v1alpha3|v1beta1)/types\\.go"
+      
+      # The (SubjectAccessReview|SelfSubjectAccessReview|LocalSubjectAccessReview).Spec fields hold a union type, but nonpointerstructs does not understand unions today.
+      # Validation requires exactly one of spec.resourceAttributes or spec.nonResourceAttributes, so an empty spec is always rejected and the field is required in practice.
+      - text: "nonpointerstructs: field (SubjectAccessReview|SelfSubjectAccessReview|LocalSubjectAccessReview)\\.Spec is a non-pointer struct with no required fields\\..*"
+        path: "staging/src/k8s.io/api/authorization/(v1|v1beta1)/types\\.go"
       
       # NoReferences - Existing fields that use Reference/References suffixes instead of Ref/Refs.
       # These fields use the Reference suffix, but renaming them would be a breaking change, so they are allowlisted.

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -107,7 +107,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
+  path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
@@ -133,6 +133,11 @@
 # WorkloadSpec.CompositePodGroupTemplates is a union member that is conditionally optional (+k8s:ifEnabled("CompositePodGroup")=+k8s:optional), but the linter requires a static +k8s:optional tag.
 - text: "dependenttags: field WorkloadSpec\\.CompositePodGroupTemplates with marker \\+k8s:unionMember is missing required marker.*"
   path: "staging/src/k8s.io/api/scheduling/v1alpha3/types\\.go"
+
+# The (SubjectAccessReview|SelfSubjectAccessReview|LocalSubjectAccessReview).Spec fields hold a union type, but nonpointerstructs does not understand unions today.
+# Validation requires exactly one of spec.resourceAttributes or spec.nonResourceAttributes, so an empty spec is always rejected and the field is required in practice.
+- text: "nonpointerstructs: field (SubjectAccessReview|SelfSubjectAccessReview|LocalSubjectAccessReview)\\.Spec is a non-pointer struct with no required fields\\..*"
+  path: "staging/src/k8s.io/api/authorization/(v1|v1beta1)/types\\.go"
 
 # NoReferences - Existing fields that use Reference/References suffixes instead of Ref/Refs.
 # These fields use the Reference suffix, but renaming them would be a breaking change, so they are allowlisted.

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -117,7 +117,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|extensions|networking|storage)"
+  path: "staging/src/k8s.io/api/(admissionregistration|autoscaling|batch|certificates|core|discovery|extensions|networking|storage)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"
@@ -143,6 +143,11 @@
 # WorkloadSpec.CompositePodGroupTemplates is a union member that is conditionally optional (+k8s:ifEnabled("CompositePodGroup")=+k8s:optional), but the linter requires a static +k8s:optional tag.
 - text: "dependenttags: field WorkloadSpec\\.CompositePodGroupTemplates with marker \\+k8s:unionMember is missing required marker.*"
   path: "staging/src/k8s.io/api/scheduling/(v1alpha3|v1beta1)/types\\.go"
+
+# The (SubjectAccessReview|SelfSubjectAccessReview|LocalSubjectAccessReview).Spec fields hold a union type, but nonpointerstructs does not understand unions today.
+# Validation requires exactly one of spec.resourceAttributes or spec.nonResourceAttributes, so an empty spec is always rejected and the field is required in practice.
+- text: "nonpointerstructs: field (SubjectAccessReview|SelfSubjectAccessReview|LocalSubjectAccessReview)\\.Spec is a non-pointer struct with no required fields\\..*"
+  path: "staging/src/k8s.io/api/authorization/(v1|v1beta1)/types\\.go"
 
 # NoReferences - Existing fields that use Reference/References suffixes instead of Ref/Refs.
 # These fields use the Reference suffix, but renaming them would be a breaking change, so they are allowlisted.

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -13275,7 +13275,6 @@ func schema_k8sio_api_authorization_v1_NonResourceRule(ref common.ReferenceCallb
 						},
 					},
 				},
-				Required: []string{"verbs"},
 			},
 		},
 	}
@@ -13441,7 +13440,6 @@ func schema_k8sio_api_authorization_v1_ResourceRule(ref common.ReferenceCallback
 						},
 					},
 				},
-				Required: []string{"verbs"},
 			},
 		},
 	}
@@ -13591,6 +13589,7 @@ func schema_k8sio_api_authorization_v1_SelfSubjectRulesReviewSpec(ref common.Ref
 						},
 					},
 				},
+				Required: []string{"namespace"},
 			},
 		},
 	}
@@ -13738,7 +13737,7 @@ func schema_k8sio_api_authorization_v1_SubjectAccessReviewStatus(ref common.Refe
 				Properties: map[string]spec.Schema{
 					"allowed": {
 						SchemaProps: spec.SchemaProps{
-							Description: "allowed is required. True if the action would be allowed, false otherwise.",
+							Description: "allowed is set to true if the action is allowed, and should be set to false otherwise.",
 							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
@@ -13766,7 +13765,6 @@ func schema_k8sio_api_authorization_v1_SubjectAccessReviewStatus(ref common.Refe
 						},
 					},
 				},
-				Required: []string{"allowed"},
 			},
 		},
 	}
@@ -13831,7 +13829,6 @@ func schema_k8sio_api_authorization_v1_SubjectRulesReviewStatus(ref common.Refer
 						},
 					},
 				},
-				Required: []string{"resourceRules", "nonResourceRules", "incomplete"},
 			},
 		},
 		Dependencies: []string{
@@ -13963,7 +13960,6 @@ func schema_k8sio_api_authorization_v1beta1_NonResourceRule(ref common.Reference
 						},
 					},
 				},
-				Required: []string{"verbs"},
 			},
 		},
 	}
@@ -14129,7 +14125,6 @@ func schema_k8sio_api_authorization_v1beta1_ResourceRule(ref common.ReferenceCal
 						},
 					},
 				},
-				Required: []string{"verbs"},
 			},
 		},
 	}
@@ -14279,6 +14274,7 @@ func schema_k8sio_api_authorization_v1beta1_SelfSubjectRulesReviewSpec(ref commo
 						},
 					},
 				},
+				Required: []string{"namespace"},
 			},
 		},
 	}
@@ -14426,7 +14422,7 @@ func schema_k8sio_api_authorization_v1beta1_SubjectAccessReviewStatus(ref common
 				Properties: map[string]spec.Schema{
 					"allowed": {
 						SchemaProps: spec.SchemaProps{
-							Description: "allowed is required. True if the action would be allowed, false otherwise.",
+							Description: "allowed is set to true if the action is allowed, and should be set to false otherwise.",
 							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
@@ -14454,7 +14450,6 @@ func schema_k8sio_api_authorization_v1beta1_SubjectAccessReviewStatus(ref common
 						},
 					},
 				},
-				Required: []string{"allowed"},
 			},
 		},
 	}
@@ -14519,7 +14514,6 @@ func schema_k8sio_api_authorization_v1beta1_SubjectRulesReviewStatus(ref common.
 						},
 					},
 				},
-				Required: []string{"resourceRules", "nonResourceRules", "incomplete"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -13156,7 +13156,6 @@ func schema_k8sio_api_authorization_v1_NonResourceRule(ref common.ReferenceCallb
 						},
 					},
 				},
-				Required: []string{"verbs"},
 			},
 		},
 	}
@@ -13322,7 +13321,6 @@ func schema_k8sio_api_authorization_v1_ResourceRule(ref common.ReferenceCallback
 						},
 					},
 				},
-				Required: []string{"verbs"},
 			},
 		},
 	}
@@ -13472,6 +13470,7 @@ func schema_k8sio_api_authorization_v1_SelfSubjectRulesReviewSpec(ref common.Ref
 						},
 					},
 				},
+				Required: []string{"namespace"},
 			},
 		},
 	}
@@ -13619,7 +13618,7 @@ func schema_k8sio_api_authorization_v1_SubjectAccessReviewStatus(ref common.Refe
 				Properties: map[string]spec.Schema{
 					"allowed": {
 						SchemaProps: spec.SchemaProps{
-							Description: "allowed is required. True if the action would be allowed, false otherwise.",
+							Description: "allowed is set to true if the action is allowed, and should be set to false otherwise.",
 							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
@@ -13647,7 +13646,6 @@ func schema_k8sio_api_authorization_v1_SubjectAccessReviewStatus(ref common.Refe
 						},
 					},
 				},
-				Required: []string{"allowed"},
 			},
 		},
 	}
@@ -13712,7 +13710,6 @@ func schema_k8sio_api_authorization_v1_SubjectRulesReviewStatus(ref common.Refer
 						},
 					},
 				},
-				Required: []string{"resourceRules", "nonResourceRules", "incomplete"},
 			},
 		},
 		Dependencies: []string{
@@ -13844,7 +13841,6 @@ func schema_k8sio_api_authorization_v1beta1_NonResourceRule(ref common.Reference
 						},
 					},
 				},
-				Required: []string{"verbs"},
 			},
 		},
 	}
@@ -14010,7 +14006,6 @@ func schema_k8sio_api_authorization_v1beta1_ResourceRule(ref common.ReferenceCal
 						},
 					},
 				},
-				Required: []string{"verbs"},
 			},
 		},
 	}
@@ -14160,6 +14155,7 @@ func schema_k8sio_api_authorization_v1beta1_SelfSubjectRulesReviewSpec(ref commo
 						},
 					},
 				},
+				Required: []string{"namespace"},
 			},
 		},
 	}
@@ -14307,7 +14303,7 @@ func schema_k8sio_api_authorization_v1beta1_SubjectAccessReviewStatus(ref common
 				Properties: map[string]spec.Schema{
 					"allowed": {
 						SchemaProps: spec.SchemaProps{
-							Description: "allowed is required. True if the action would be allowed, false otherwise.",
+							Description: "allowed is set to true if the action is allowed, and should be set to false otherwise.",
 							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
@@ -14335,7 +14331,6 @@ func schema_k8sio_api_authorization_v1beta1_SubjectAccessReviewStatus(ref common
 						},
 					},
 				},
-				Required: []string{"allowed"},
 			},
 		},
 	}
@@ -14400,7 +14395,6 @@ func schema_k8sio_api_authorization_v1beta1_SubjectRulesReviewStatus(ref common.
 						},
 					},
 				},
-				Required: []string{"resourceRules", "nonResourceRules", "incomplete"},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/api/authorization/v1/generated.proto
+++ b/staging/src/k8s.io/api/authorization/v1/generated.proto
@@ -104,6 +104,7 @@ message LocalSubjectAccessReview {
 
   // spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace
   // you made the request against.  If empty, it is defaulted.
+  // +required
   optional SubjectAccessReviewSpec spec = 2;
 
   // status is filled in by the server and indicates whether the request is allowed or not
@@ -125,6 +126,7 @@ message NonResourceAttributes {
 // NonResourceRule holds information that describes a rule for the non-resource
 message NonResourceRule {
   // verbs is a list of kubernetes non-resource API verbs, like: get, post, put, delete, patch, head, options.  "*" means all.
+  // +optional
   // +listType=atomic
   repeated string verbs = 1;
 
@@ -181,6 +183,7 @@ message ResourceAttributes {
 // may contain duplicates, and possibly be incomplete.
 message ResourceRule {
   // verbs is a list of kubernetes resource API verbs, like: get, list, watch, create, update, delete, proxy.  "*" means all.
+  // +optional
   // +listType=atomic
   repeated string verbs = 1;
 
@@ -214,6 +217,7 @@ message SelfSubjectAccessReview {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec holds information about the request being evaluated.  user and groups must be empty
+  // +required
   optional SelfSubjectAccessReviewSpec spec = 2;
 
   // status is filled in by the server and indicates whether the request is allowed or not
@@ -252,6 +256,7 @@ message SelfSubjectRulesReview {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec holds information about the request being evaluated.
+  // +required
   optional SelfSubjectRulesReviewSpec spec = 2;
 
   // status is filled in by the server and indicates the set of actions a user can perform.
@@ -262,6 +267,7 @@ message SelfSubjectRulesReview {
 // SelfSubjectRulesReviewSpec defines the specification for SelfSubjectRulesReview.
 message SelfSubjectRulesReviewSpec {
   // namespace to evaluate rules for. Required.
+  // +required
   optional string namespace = 1;
 }
 
@@ -275,6 +281,7 @@ message SubjectAccessReview {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec holds information about the request being evaluated
+  // +required
   optional SubjectAccessReviewSpec spec = 2;
 
   // status is filled in by the server and indicates whether the request is allowed or not
@@ -319,7 +326,8 @@ message SubjectAccessReviewSpec {
 
 // SubjectAccessReviewStatus
 message SubjectAccessReviewStatus {
-  // allowed is required. True if the action would be allowed, false otherwise.
+  // allowed is set to true if the action is allowed, and should be set to false otherwise.
+  // +optional
   optional bool allowed = 1;
 
   // denied is optional. True if the action would be denied, otherwise
@@ -347,16 +355,19 @@ message SubjectAccessReviewStatus {
 message SubjectRulesReviewStatus {
   // resourceRules is the list of actions the subject is allowed to perform on resources.
   // The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
+  // +optional
   // +listType=atomic
   repeated ResourceRule resourceRules = 1;
 
   // nonResourceRules is the list of actions the subject is allowed to perform on non-resources.
   // The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
+  // +optional
   // +listType=atomic
   repeated NonResourceRule nonResourceRules = 2;
 
   // incomplete is true when the rules returned by this call are incomplete. This is most commonly
   // encountered when an authorizer, such as an external authorizer, doesn't support rules evaluation.
+  // +optional
   optional bool incomplete = 3;
 
   // evaluationError can appear in combination with Rules. It indicates an error occurred during

--- a/staging/src/k8s.io/api/authorization/v1/types.go
+++ b/staging/src/k8s.io/api/authorization/v1/types.go
@@ -39,6 +39,7 @@ type SubjectAccessReview struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec holds information about the request being evaluated
+	// +required
 	Spec SubjectAccessReviewSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status is filled in by the server and indicates whether the request is allowed or not
@@ -65,6 +66,7 @@ type SelfSubjectAccessReview struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec holds information about the request being evaluated.  user and groups must be empty
+	// +required
 	Spec SelfSubjectAccessReviewSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status is filled in by the server and indicates whether the request is allowed or not
@@ -91,6 +93,7 @@ type LocalSubjectAccessReview struct {
 
 	// spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace
 	// you made the request against.  If empty, it is defaulted.
+	// +required
 	Spec SubjectAccessReviewSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status is filled in by the server and indicates whether the request is allowed or not
@@ -253,7 +256,8 @@ type SelfSubjectAccessReviewSpec struct {
 
 // SubjectAccessReviewStatus
 type SubjectAccessReviewStatus struct {
-	// allowed is required. True if the action would be allowed, false otherwise.
+	// allowed is set to true if the action is allowed, and should be set to false otherwise.
+	// +optional
 	Allowed bool `json:"allowed" protobuf:"varint,1,opt,name=allowed"`
 	// denied is optional. True if the action would be denied, otherwise
 	// false. If both allowed is false and denied is false, then the
@@ -293,6 +297,7 @@ type SelfSubjectRulesReview struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec holds information about the request being evaluated.
+	// +required
 	Spec SelfSubjectRulesReviewSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status is filled in by the server and indicates the set of actions a user can perform.
@@ -303,6 +308,7 @@ type SelfSubjectRulesReview struct {
 // SelfSubjectRulesReviewSpec defines the specification for SelfSubjectRulesReview.
 type SelfSubjectRulesReviewSpec struct {
 	// namespace to evaluate rules for. Required.
+	// +required
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,1,opt,name=namespace"`
 }
 
@@ -313,14 +319,17 @@ type SelfSubjectRulesReviewSpec struct {
 type SubjectRulesReviewStatus struct {
 	// resourceRules is the list of actions the subject is allowed to perform on resources.
 	// The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
+	// +optional
 	// +listType=atomic
 	ResourceRules []ResourceRule `json:"resourceRules" protobuf:"bytes,1,rep,name=resourceRules"`
 	// nonResourceRules is the list of actions the subject is allowed to perform on non-resources.
 	// The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
+	// +optional
 	// +listType=atomic
 	NonResourceRules []NonResourceRule `json:"nonResourceRules" protobuf:"bytes,2,rep,name=nonResourceRules"`
 	// incomplete is true when the rules returned by this call are incomplete. This is most commonly
 	// encountered when an authorizer, such as an external authorizer, doesn't support rules evaluation.
+	// +optional
 	Incomplete bool `json:"incomplete" protobuf:"bytes,3,rep,name=incomplete"`
 	// evaluationError can appear in combination with Rules. It indicates an error occurred during
 	// rule evaluation, such as an authorizer that doesn't support rule evaluation, and that
@@ -333,6 +342,7 @@ type SubjectRulesReviewStatus struct {
 // may contain duplicates, and possibly be incomplete.
 type ResourceRule struct {
 	// verbs is a list of kubernetes resource API verbs, like: get, list, watch, create, update, delete, proxy.  "*" means all.
+	// +optional
 	// +listType=atomic
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
@@ -355,6 +365,7 @@ type ResourceRule struct {
 // NonResourceRule holds information that describes a rule for the non-resource
 type NonResourceRule struct {
 	// verbs is a list of kubernetes non-resource API verbs, like: get, post, put, delete, patch, head, options.  "*" means all.
+	// +optional
 	// +listType=atomic
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 

--- a/staging/src/k8s.io/api/authorization/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/authorization/v1/types_swagger_doc_generated.go
@@ -175,7 +175,7 @@ func (SubjectAccessReviewSpec) SwaggerDoc() map[string]string {
 
 var map_SubjectAccessReviewStatus = map[string]string{
 	"":                "SubjectAccessReviewStatus",
-	"allowed":         "allowed is required. True if the action would be allowed, false otherwise.",
+	"allowed":         "allowed is set to true if the action is allowed, and should be set to false otherwise.",
 	"denied":          "denied is optional. True if the action would be denied, otherwise false. If both allowed is false and denied is false, then the authorizer has no opinion on whether to authorize the action. Denied may not be true if Allowed is true.",
 	"reason":          "reason is optional.  It indicates why a request was allowed or denied.",
 	"evaluationError": "evaluationError is an indication that some error occurred during the authorization check. It is entirely possible to get an error and be able to continue determine authorization status in spite of it. For instance, RBAC can be missing a role, but enough roles are still present and bound to reason about the request.",

--- a/staging/src/k8s.io/api/authorization/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/authorization/v1beta1/generated.proto
@@ -51,6 +51,7 @@ message LocalSubjectAccessReview {
 
   // spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace
   // you made the request against.  If empty, it is defaulted.
+  // +required
   optional SubjectAccessReviewSpec spec = 2;
 
   // status is filled in by the server and indicates whether the request is allowed or not
@@ -72,6 +73,7 @@ message NonResourceAttributes {
 // NonResourceRule holds information that describes a rule for the non-resource
 message NonResourceRule {
   // verbs is a list of kubernetes non-resource API verbs, like: get, post, put, delete, patch, head, options.  "*" means all.
+  // +optional
   // +listType=atomic
   repeated string verbs = 1;
 
@@ -128,6 +130,7 @@ message ResourceAttributes {
 // may contain duplicates, and possibly be incomplete.
 message ResourceRule {
   // verbs is a list of kubernetes resource API verbs, like: get, list, watch, create, update, delete, proxy.  "*" means all.
+  // +optional
   // +listType=atomic
   repeated string verbs = 1;
 
@@ -161,6 +164,7 @@ message SelfSubjectAccessReview {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec holds information about the request being evaluated.  user and groups must be empty
+  // +required
   optional SelfSubjectAccessReviewSpec spec = 2;
 
   // status is filled in by the server and indicates whether the request is allowed or not
@@ -199,6 +203,7 @@ message SelfSubjectRulesReview {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec holds information about the request being evaluated.
+  // +required
   optional SelfSubjectRulesReviewSpec spec = 2;
 
   // status is filled in by the server and indicates the set of actions a user can perform.
@@ -209,6 +214,7 @@ message SelfSubjectRulesReview {
 // SelfSubjectRulesReviewSpec defines the specification for SelfSubjectRulesReview.
 message SelfSubjectRulesReviewSpec {
   // namespace to evaluate rules for. Required.
+  // +required
   optional string namespace = 1;
 }
 
@@ -222,6 +228,7 @@ message SubjectAccessReview {
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // spec holds information about the request being evaluated
+  // +required
   optional SubjectAccessReviewSpec spec = 2;
 
   // status is filled in by the server and indicates whether the request is allowed or not
@@ -266,7 +273,8 @@ message SubjectAccessReviewSpec {
 
 // SubjectAccessReviewStatus
 message SubjectAccessReviewStatus {
-  // allowed is required. True if the action would be allowed, false otherwise.
+  // allowed is set to true if the action is allowed, and should be set to false otherwise.
+  // +optional
   optional bool allowed = 1;
 
   // denied is optional. True if the action would be denied, otherwise
@@ -294,16 +302,19 @@ message SubjectAccessReviewStatus {
 message SubjectRulesReviewStatus {
   // resourceRules is the list of actions the subject is allowed to perform on resources.
   // The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
+  // +optional
   // +listType=atomic
   repeated ResourceRule resourceRules = 1;
 
   // nonResourceRules is the list of actions the subject is allowed to perform on non-resources.
   // The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
+  // +optional
   // +listType=atomic
   repeated NonResourceRule nonResourceRules = 2;
 
   // incomplete is true when the rules returned by this call are incomplete. This is most commonly
   // encountered when an authorizer, such as an external authorizer, doesn't support rules evaluation.
+  // +optional
   optional bool incomplete = 3;
 
   // evaluationError can appear in combination with Rules. It indicates an error occurred during

--- a/staging/src/k8s.io/api/authorization/v1beta1/types.go
+++ b/staging/src/k8s.io/api/authorization/v1beta1/types.go
@@ -42,6 +42,7 @@ type SubjectAccessReview struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec holds information about the request being evaluated
+	// +required
 	Spec SubjectAccessReviewSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status is filled in by the server and indicates whether the request is allowed or not
@@ -70,6 +71,7 @@ type SelfSubjectAccessReview struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec holds information about the request being evaluated.  user and groups must be empty
+	// +required
 	Spec SelfSubjectAccessReviewSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status is filled in by the server and indicates whether the request is allowed or not
@@ -98,6 +100,7 @@ type LocalSubjectAccessReview struct {
 
 	// spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace
 	// you made the request against.  If empty, it is defaulted.
+	// +required
 	Spec SubjectAccessReviewSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status is filled in by the server and indicates whether the request is allowed or not
@@ -206,7 +209,8 @@ type SelfSubjectAccessReviewSpec struct {
 
 // SubjectAccessReviewStatus
 type SubjectAccessReviewStatus struct {
-	// allowed is required. True if the action would be allowed, false otherwise.
+	// allowed is set to true if the action is allowed, and should be set to false otherwise.
+	// +optional
 	Allowed bool `json:"allowed" protobuf:"varint,1,opt,name=allowed"`
 	// denied is optional. True if the action would be denied, otherwise
 	// false. If both allowed is false and denied is false, then the
@@ -248,6 +252,7 @@ type SelfSubjectRulesReview struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
 	// spec holds information about the request being evaluated.
+	// +required
 	Spec SelfSubjectRulesReviewSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
 	// status is filled in by the server and indicates the set of actions a user can perform.
@@ -258,6 +263,7 @@ type SelfSubjectRulesReview struct {
 // SelfSubjectRulesReviewSpec defines the specification for SelfSubjectRulesReview.
 type SelfSubjectRulesReviewSpec struct {
 	// namespace to evaluate rules for. Required.
+	// +required
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,1,opt,name=namespace"`
 }
 
@@ -268,14 +274,17 @@ type SelfSubjectRulesReviewSpec struct {
 type SubjectRulesReviewStatus struct {
 	// resourceRules is the list of actions the subject is allowed to perform on resources.
 	// The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
+	// +optional
 	// +listType=atomic
 	ResourceRules []ResourceRule `json:"resourceRules" protobuf:"bytes,1,rep,name=resourceRules"`
 	// nonResourceRules is the list of actions the subject is allowed to perform on non-resources.
 	// The list ordering isn't significant, may contain duplicates, and possibly be incomplete.
+	// +optional
 	// +listType=atomic
 	NonResourceRules []NonResourceRule `json:"nonResourceRules" protobuf:"bytes,2,rep,name=nonResourceRules"`
 	// incomplete is true when the rules returned by this call are incomplete. This is most commonly
 	// encountered when an authorizer, such as an external authorizer, doesn't support rules evaluation.
+	// +optional
 	Incomplete bool `json:"incomplete" protobuf:"bytes,3,rep,name=incomplete"`
 	// evaluationError can appear in combination with Rules. It indicates an error occurred during
 	// rule evaluation, such as an authorizer that doesn't support rule evaluation, and that
@@ -288,6 +297,7 @@ type SubjectRulesReviewStatus struct {
 // may contain duplicates, and possibly be incomplete.
 type ResourceRule struct {
 	// verbs is a list of kubernetes resource API verbs, like: get, list, watch, create, update, delete, proxy.  "*" means all.
+	// +optional
 	// +listType=atomic
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
@@ -310,6 +320,7 @@ type ResourceRule struct {
 // NonResourceRule holds information that describes a rule for the non-resource
 type NonResourceRule struct {
 	// verbs is a list of kubernetes non-resource API verbs, like: get, post, put, delete, patch, head, options.  "*" means all.
+	// +optional
 	// +listType=atomic
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 

--- a/staging/src/k8s.io/api/authorization/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/authorization/v1beta1/types_swagger_doc_generated.go
@@ -155,7 +155,7 @@ func (SubjectAccessReviewSpec) SwaggerDoc() map[string]string {
 
 var map_SubjectAccessReviewStatus = map[string]string{
 	"":                "SubjectAccessReviewStatus",
-	"allowed":         "allowed is required. True if the action would be allowed, false otherwise.",
+	"allowed":         "allowed is set to true if the action is allowed, and should be set to false otherwise.",
 	"denied":          "denied is optional. True if the action would be denied, otherwise false. If both allowed is false and denied is false, then the authorizer has no opinion on whether to authorize the action. Denied may not be true if Allowed is true.",
 	"reason":          "reason is optional.  It indicates why a request was allowed or denied.",
 	"evaluationError": "evaluationError is an indication that some error occurred during the authorization check. It is entirely possible to get an error and be able to continue determine authorization status in spite of it. For instance, RBAC can be missing a role, but enough roles are still present and bound to reason about the request.",


### PR DESCRIPTION
Enables the `optionalorrequired` and `nonpointerstructs` kube-api-linter rules for the `authorization` API group. Part of #134671, addresses #136861.

**What:**
- Tags every field in `authorization/v1` and `v1beta1` as `+optional` / `+required`.
- `spec` on `SubjectAccessReview`, `SelfSubjectAccessReview` and `LocalSubjectAccessReview` is `+required`: validation rejects an empty spec unconditionally, so the published `required: [spec]` is unchanged for these kinds.
- Those same three spec fields are excepted from `nonpointerstructs` in `hack/kube-api-linter/exceptions.yaml`. Every member of `SubjectAccessReviewSpec` and `SelfSubjectAccessReviewSpec` is optional, so the rule reports the field as having no required members and wants it marked optional; it doesn't model the union. Marking them optional would drop `required: [spec]`, which is what the previous bullet fixes. The exception is scoped to those fields and versions, so new violations elsewhere in the group still surface. Same rationale as the existing `SchedulingPolicy` exception.
- The `*Status` fields are `+optional` per review — there's no status validation on this API and it's non-persistent, so the server is the only writer. This does drop the `required` lists for `allowed`, `verbs`, `incomplete`, `resourceRules` and `nonResourceRules` from the published schema; the wire encoding is unaffected since none of these have `omitempty`.
- Generated protobuf and OpenAPI specs regenerated.

```release-note
Updated the authorization API group to improve OpenAPI schema correctness for fields being optional or required.
```

/sig auth
