### PR TITLE
kubelet: add failure threshold info to probe failure events

### DIFF
--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -79,8 +79,21 @@ func (pb *prober) recordContainerEvent(ctx context.Context, pod *v1.Pod, contain
 	pb.recorder.WithLogger(logger).Eventf(ref, eventType, reason, message, args...)
 }
 
-// probe probes the container.
+// ProbeContext carries probe run context from the worker for enriched event messages.
+type ProbeContext struct {
+	ResultRun        int
+	LastResult       results.Result
+	FailureThreshold int32
+	SuccessThreshold int32
+}
+
+// probe probes the container (backward-compatible wrapper).
 func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (results.Result, error) {
+	return pb.probeWithContext(ctx, probeType, pod, status, container, containerID, nil)
+}
+
+// probeWithContext probes the container with optional ProbeContext for enriched events.
+func (pb *prober) probeWithContext(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, probeCtx *ProbeContext) (results.Result, error) {
 	var probeSpec *v1.Probe
 	switch probeType {
 	case readiness:
@@ -120,7 +133,21 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 
 	case probe.Failure:
 		logger.V(1).Info("Probe failed", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result, "output", output)
-		pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed: %s", probeType, output)
+		if probeCtx != nil && probeCtx.FailureThreshold > 0 {
+			var failureCount int
+			if probeCtx.LastResult == results.Failure {
+				failureCount = probeCtx.ResultRun + 1
+			} else {
+				failureCount = 1
+			}
+			if failureCount < int(probeCtx.FailureThreshold) {
+				pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed (%d/%d, will be ignored): %s", probeType, failureCount, probeCtx.FailureThreshold, output)
+			} else {
+				pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed (%d/%d): %s", probeType, failureCount, probeCtx.FailureThreshold, output)
+			}
+		} else {
+			pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed: %s", probeType, output)
+		}
 		return results.Failure, nil
 
 	case probe.Unknown:

--- a/pkg/kubelet/prober/prober_test.go
+++ b/pkg/kubelet/prober/prober_test.go
@@ -364,6 +364,150 @@ func TestNewProber(t *testing.T) {
 
 }
 
+func TestProbeFailureWithThresholdContext(t *testing.T) {
+	err := v1.AddToScheme(legacyscheme.Scheme)
+	require.NoError(t, err, "failed to add v1 to scheme")
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: "test-probe-pod",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "test-probe-container",
+					LivenessProbe: &v1.Probe{
+						ProbeHandler: v1.ProbeHandler{
+							Exec: &v1.ExecAction{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	containerID := kubecontainer.ContainerID{Type: "test", ID: "foobar"}
+
+	testCases := []struct {
+		name             string
+		resultRun        int
+		lastResult       results.Result
+		failureThreshold int32
+		expectedMessage  string
+	}{
+		{
+			name:             "First failure of 3 threshold - should be ignored",
+			resultRun:        0,
+			lastResult:       results.Success,
+			failureThreshold: 3,
+			expectedMessage:  "Warning Unhealthy Liveness probe failed (1/3, will be ignored): ",
+		},
+		{
+			name:             "Second failure of 3 threshold - should be ignored",
+			resultRun:        1,
+			lastResult:       results.Failure,
+			failureThreshold: 3,
+			expectedMessage:  "Warning Unhealthy Liveness probe failed (2/3, will be ignored): ",
+		},
+		{
+			name:             "Third failure of 3 threshold - should NOT be ignored",
+			resultRun:        2,
+			lastResult:       results.Failure,
+			failureThreshold: 3,
+			expectedMessage:  "Warning Unhealthy Liveness probe failed (3/3): ",
+		},
+		{
+			name:             "Failure past threshold - should NOT be ignored",
+			resultRun:        3,
+			lastResult:       results.Failure,
+			failureThreshold: 3,
+			expectedMessage:  "Warning Unhealthy Liveness probe failed (4/3): ",
+		},
+		{
+			name:             "First failure of 1 threshold - should NOT be ignored",
+			resultRun:        0,
+			lastResult:       results.Success,
+			failureThreshold: 1,
+			expectedMessage:  "Warning Unhealthy Liveness probe failed (1/1): ",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+			fakeRecorder := record.NewFakeRecorder(10)
+
+			pb := &prober{
+				recorder: fakeRecorder,
+				exec:     fakeExecProber{probe.Failure, nil},
+			}
+
+			probeCtx := &ProbeContext{
+				ResultRun:        tc.resultRun,
+				LastResult:       tc.lastResult,
+				FailureThreshold: tc.failureThreshold,
+				SuccessThreshold: 1,
+			}
+
+			result, err := pb.probeWithContext(tCtx, liveness, pod, v1.PodStatus{}, pod.Spec.Containers[0], containerID, probeCtx)
+			require.NoError(t, err)
+			assert.Equal(t, results.Failure, result)
+
+			select {
+			case event := <-fakeRecorder.Events:
+				assert.Equal(t, tc.expectedMessage, event, "unexpected event message")
+			default:
+				t.Error("expected an event to be recorded")
+			}
+		})
+	}
+}
+
+func TestProbeFailureWithoutContext(t *testing.T) {
+	err := v1.AddToScheme(legacyscheme.Scheme)
+	require.NoError(t, err, "failed to add v1 to scheme")
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: "test-probe-pod",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "test-probe-container",
+					LivenessProbe: &v1.Probe{
+						ProbeHandler: v1.ProbeHandler{
+							Exec: &v1.ExecAction{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	containerID := kubecontainer.ContainerID{Type: "test", ID: "foobar"}
+
+	tCtx := ktesting.Init(t)
+	fakeRecorder := record.NewFakeRecorder(10)
+
+	pb := &prober{
+		recorder: fakeRecorder,
+		exec:     fakeExecProber{probe.Failure, nil},
+	}
+
+	// Call probe without context (backward compatibility)
+	result, err := pb.probe(tCtx, liveness, pod, v1.PodStatus{}, pod.Spec.Containers[0], containerID)
+	require.NoError(t, err)
+	assert.Equal(t, results.Failure, result)
+
+	select {
+	case event := <-fakeRecorder.Events:
+		assert.Equal(t, "Warning Unhealthy Liveness probe failed: ", event, "unexpected event message")
+	default:
+		t.Error("expected an event to be recorded")
+	}
+}
+
 func TestRecordContainerEventUnknownStatus(t *testing.T) {
 
 	err := v1.AddToScheme(legacyscheme.Scheme)

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -346,7 +346,13 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 	}
 
 	// Note, exec probe does NOT have access to pod environment variables or downward API
-	result, err := w.probeManager.prober.probe(ctx, w.probeType, w.pod, status, w.container, w.containerID)
+	probeCtx := &ProbeContext{
+		ResultRun:        w.resultRun,
+		LastResult:       w.lastResult,
+		FailureThreshold: w.spec.FailureThreshold,
+		SuccessThreshold: w.spec.SuccessThreshold,
+	}
+	result, err := w.probeManager.prober.probeWithContext(ctx, w.probeType, w.pod, status, w.container, w.containerID, probeCtx)
 	if err != nil {
 		// Prober error, throw away the result.
 		return true


### PR DESCRIPTION
This PR addresses issue #115823 by enhancing existing probe failure events with threshold context. When a probe fails, the event message now includes the current failure count, the threshold before action is taken, and a clear indication if the failure is being ignored.

Fixes #115823