### PR TITLE
WIP: apiserver/cacher: reduce watchCache lock hold time for WatchList from O(N) to O(1)

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -631,5 +631,20 @@ func (w *watchCache) getAllEventsSinceLocked(resourceVersion uint64, key string,
 // that covers the entire storage state.
 // This function assumes to be called under the watchCache lock.
 func (w *watchCache) getIntervalFromStoreLocked(key string, matchesSingle bool) (*watchCacheInterval, error) {
+	if !matchesSingle && w.storage.snapshots != nil && w.storage.snapshottingEnabled.Load() {
+		// Latest() is safe here because this method is called under the
+		// watchCache read lock. Both processEvent and Replace set
+		// w.resourceVersion and add a snapshot at that same RV atomically
+		// under the write lock. Under RLock we see a consistent view:
+		// Latest() returns the snapshot at exactly resourceVersion.
+		// The snapshot is immutable, so lazySnapshotCacheIntervalSource can
+		// iterate it lazily outside the lock in the processInterval goroutine.
+		if snap, ok := w.storage.snapshots.Latest(); ok {
+			return &watchCacheInterval{
+				resourceVersion: w.resourceVersion,
+				source:          &lazySnapshotCacheIntervalSource{snapshot: snap, key: key, resourceVersion: w.resourceVersion},
+			}, nil
+		}
+	}
 	return newCacheIntervalFromStore(w.resourceVersion, w.storage.StoreLocked(), key, matchesSingle)
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval.go
@@ -228,6 +228,53 @@ func (s *snapshotCacheIntervalSource) Next() (*watchCacheEvent, error) {
 	return event, nil
 }
 
+// lazySnapshotCacheIntervalSource serves events by lazily loading items from an
+// immutable store.Snapshot. The snapshot's OrderedListPrefix is called on the
+// first Next() call, which typically runs in a goroutine outside the watchCache
+// lock. This avoids holding the lock while iterating over the entire store.
+type lazySnapshotCacheIntervalSource struct {
+	// snapshot is an immutable point-in-time copy of the store.
+	snapshot store.Snapshot
+
+	// key is the prefix passed to OrderedListPrefix when loading items.
+	key string
+
+	// resourceVersion is assigned to every watchCacheEvent produced by this source.
+	resourceVersion uint64
+
+	// items holds the result of OrderedListPrefix, populated on the first Next() call.
+	items []interface{}
+
+	// currentIndex tracks the current position within items.
+	currentIndex int
+
+	// loaded indicates whether items have been populated from the snapshot.
+	loaded bool
+}
+
+func (s *lazySnapshotCacheIntervalSource) Next() (*watchCacheEvent, error) {
+	if !s.loaded {
+		var err error
+		// TODO (p0lyn0mial): instead of materializing the entire slice
+		// we could yield one element per Next() call which should reduce memory
+		// from O(N) to O(1).
+		s.items, err = s.snapshot.OrderedListPrefix(s.key, "")
+		if err != nil {
+			return nil, err
+		}
+		s.loaded = true
+	}
+	if s.currentIndex >= len(s.items) {
+		return nil, nil
+	}
+	elem, ok := s.items[s.currentIndex].(*store.Element)
+	if !ok {
+		return nil, fmt.Errorf("not a storeElement: %v", s.items[s.currentIndex])
+	}
+	s.currentIndex++
+	return storeElementToWatchCacheEvent(elem, s.resourceVersion), nil
+}
+
 const bufferSize = 100
 
 // watchCacheIntervalBuffer is used to reduce acquiring

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval.go
@@ -24,6 +24,11 @@ import (
 	"k8s.io/apiserver/pkg/storage/cacher/store"
 )
 
+// cacheIntervalSource provides the iteration logic for a watchCacheInterval.
+type cacheIntervalSource interface {
+	Next() (*watchCacheEvent, error)
+}
+
 // watchCacheInterval serves as an abstraction over a source
 // of watchCacheEvents. It maintains a window of events over
 // an underlying source and these events can be served using
@@ -57,6 +62,10 @@ import (
 // valid and should not be used to retrieve and serve elements
 // from the underlying source.
 type watchCacheInterval struct {
+	// source provides the iteration logic for this interval.
+	// When set, Next() delegates to source.Next().
+	source cacheIntervalSource
+
 	// startIndex denotes the starting point of the interval
 	// being considered. The value is the index in the actual
 	// source of watchCacheEvents. If the source of events is
@@ -118,6 +127,19 @@ func newCacheInterval(startIndex, endIndex int, indexer indexerFunc, indexValida
 	}
 }
 
+// snapshotCacheIntervalSource serves events from a pre-populated buffer.
+type snapshotCacheIntervalSource struct {
+	buffer *watchCacheIntervalBuffer
+}
+
+func (s *snapshotCacheIntervalSource) Next() (*watchCacheEvent, error) {
+	event, exists := s.buffer.next()
+	if !exists {
+		return nil, nil
+	}
+	return event, nil
+}
+
 // newCacheIntervalFromStore is meant to handle the case of rv=0, such that the events
 // returned by Next() need to be events from a List() done on the underlying store of
 // the watch cache.
@@ -157,10 +179,7 @@ func newCacheIntervalFromStore(resourceVersion uint64, snap store.Snapshot, key 
 		buffer.endIndex++
 	}
 	ci := &watchCacheInterval{
-		startIndex: 0,
-		// Simulate that we already have all the events we're looking for.
-		endIndex:        0,
-		buffer:          buffer,
+		source:          &snapshotCacheIntervalSource{buffer: buffer},
 		resourceVersion: resourceVersion,
 	}
 
@@ -171,6 +190,9 @@ func newCacheIntervalFromStore(resourceVersion uint64, snap store.Snapshot, key 
 // interval is still valid. An error is returned if the interval is
 // invalidated.
 func (wci *watchCacheInterval) Next() (*watchCacheEvent, error) {
+	if wci.source != nil {
+		return wci.source.Next()
+	}
 	// if there are items in the buffer to return, return from
 	// the buffer.
 	if event, exists := wci.buffer.next(); exists {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval.go
@@ -96,14 +96,7 @@ func newCacheIntervalFromStore(resourceVersion uint64, snap store.Snapshot, key 
 		if !ok {
 			return nil, fmt.Errorf("not a storeElement: %v", elem)
 		}
-		buffer.buffer[i] = &watchCacheEvent{
-			Type:            watch.Added,
-			Object:          elem.Object,
-			ObjLabels:       elem.Labels,
-			ObjFields:       elem.Fields,
-			Key:             elem.Key,
-			ResourceVersion: resourceVersion,
-		}
+		buffer.buffer[i] = storeElementToWatchCacheEvent(elem, resourceVersion)
 		buffer.endIndex++
 	}
 	ci := &watchCacheInterval{
@@ -112,6 +105,17 @@ func newCacheIntervalFromStore(resourceVersion uint64, snap store.Snapshot, key 
 	}
 
 	return ci, nil
+}
+
+func storeElementToWatchCacheEvent(elem *store.Element, resourceVersion uint64) *watchCacheEvent {
+	return &watchCacheEvent{
+		Type:            watch.Added,
+		Object:          elem.Object,
+		ObjLabels:       elem.Labels,
+		ObjFields:       elem.Fields,
+		Key:             elem.Key,
+		ResourceVersion: resourceVersion,
+	}
 }
 
 // historyCacheIntervalSource serves events from the watchCache circular buffer.

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval.go
@@ -44,6 +44,13 @@ type watchCacheInterval struct {
 	initialEventsEndBookmark *watchCacheEvent
 }
 
+// Next returns the next item in the cache interval provided the cache
+// interval is still valid. An error is returned if the interval is
+// invalidated.
+func (wci *watchCacheInterval) Next() (*watchCacheEvent, error) {
+	return wci.source.Next()
+}
+
 type indexerFunc func(int) *watchCacheEvent
 type indexValidator func(int) bool
 
@@ -59,6 +66,52 @@ func newCacheInterval(startIndex, endIndex int, indexer indexerFunc, indexValida
 		},
 		resourceVersion: resourceVersion,
 	}
+}
+
+// newCacheIntervalFromStore is meant to handle the case of rv=0, such that the events
+// returned by Next() need to be events from a List() done on the underlying store of
+// the watch cache.
+// The items returned in the interval will be sorted by Key.
+func newCacheIntervalFromStore(resourceVersion uint64, snap store.Snapshot, key string, matchesSingle bool) (*watchCacheInterval, error) {
+	buffer := &watchCacheIntervalBuffer{}
+	var allItems []interface{}
+	var err error
+	if matchesSingle {
+		item, exists, err := snap.GetByKey(key)
+		if err != nil {
+			return nil, err
+		}
+		if exists {
+			allItems = append(allItems, item)
+		}
+	} else {
+		allItems, err = snap.OrderedListPrefix("", "")
+		if err != nil {
+			return nil, err
+		}
+	}
+	buffer.buffer = make([]*watchCacheEvent, len(allItems))
+	for i, item := range allItems {
+		elem, ok := item.(*store.Element)
+		if !ok {
+			return nil, fmt.Errorf("not a storeElement: %v", elem)
+		}
+		buffer.buffer[i] = &watchCacheEvent{
+			Type:            watch.Added,
+			Object:          elem.Object,
+			ObjLabels:       elem.Labels,
+			ObjFields:       elem.Fields,
+			Key:             elem.Key,
+			ResourceVersion: resourceVersion,
+		}
+		buffer.endIndex++
+	}
+	ci := &watchCacheInterval{
+		source:          &snapshotCacheIntervalSource{buffer: buffer},
+		resourceVersion: resourceVersion,
+	}
+
+	return ci, nil
 }
 
 // historyCacheIntervalSource serves events from the watchCache circular buffer.
@@ -119,72 +172,6 @@ type historyCacheIntervalSource struct {
 	lock sync.Locker
 }
 
-// snapshotCacheIntervalSource serves events from a pre-populated buffer.
-type snapshotCacheIntervalSource struct {
-	buffer *watchCacheIntervalBuffer
-}
-
-func (s *snapshotCacheIntervalSource) Next() (*watchCacheEvent, error) {
-	event, exists := s.buffer.next()
-	if !exists {
-		return nil, nil
-	}
-	return event, nil
-}
-
-// newCacheIntervalFromStore is meant to handle the case of rv=0, such that the events
-// returned by Next() need to be events from a List() done on the underlying store of
-// the watch cache.
-// The items returned in the interval will be sorted by Key.
-func newCacheIntervalFromStore(resourceVersion uint64, snap store.Snapshot, key string, matchesSingle bool) (*watchCacheInterval, error) {
-	buffer := &watchCacheIntervalBuffer{}
-	var allItems []interface{}
-	var err error
-	if matchesSingle {
-		item, exists, err := snap.GetByKey(key)
-		if err != nil {
-			return nil, err
-		}
-		if exists {
-			allItems = append(allItems, item)
-		}
-	} else {
-		allItems, err = snap.OrderedListPrefix("", "")
-		if err != nil {
-			return nil, err
-		}
-	}
-	buffer.buffer = make([]*watchCacheEvent, len(allItems))
-	for i, item := range allItems {
-		elem, ok := item.(*store.Element)
-		if !ok {
-			return nil, fmt.Errorf("not a storeElement: %v", elem)
-		}
-		buffer.buffer[i] = &watchCacheEvent{
-			Type:            watch.Added,
-			Object:          elem.Object,
-			ObjLabels:       elem.Labels,
-			ObjFields:       elem.Fields,
-			Key:             elem.Key,
-			ResourceVersion: resourceVersion,
-		}
-		buffer.endIndex++
-	}
-	ci := &watchCacheInterval{
-		source:          &snapshotCacheIntervalSource{buffer: buffer},
-		resourceVersion: resourceVersion,
-	}
-
-	return ci, nil
-}
-
-// Next returns the next item in the cache interval provided the cache
-// interval is still valid. An error is returned if the interval is
-// invalidated.
-func (wci *watchCacheInterval) Next() (*watchCacheEvent, error) {
-	return wci.source.Next()
-}
-
 func (s *historyCacheIntervalSource) Next() (*watchCacheEvent, error) {
 	// if there are items in the buffer to return, return from
 	// the buffer.
@@ -222,6 +209,19 @@ func (s *historyCacheIntervalSource) fillBuffer() {
 		s.buffer.endIndex++
 		s.startIndex++
 	}
+}
+
+// snapshotCacheIntervalSource serves events from a pre-populated buffer.
+type snapshotCacheIntervalSource struct {
+	buffer *watchCacheIntervalBuffer
+}
+
+func (s *snapshotCacheIntervalSource) Next() (*watchCacheEvent, error) {
+	event, exists := s.buffer.next()
+	if !exists {
+		return nil, nil
+	}
+	return event, nil
 }
 
 const bufferSize = 100

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval.go
@@ -30,42 +30,56 @@ type cacheIntervalSource interface {
 }
 
 // watchCacheInterval serves as an abstraction over a source
-// of watchCacheEvents. It maintains a window of events over
-// an underlying source and these events can be served using
-// the exposed Next() API. The main intent for doing things
-// this way is to introduce an upper bound of memory usage
-// for starting a watch and reduce the maximum possible time
-// interval for which the lock would be held while events are
-// copied over.
-//
-// The source of events for the interval is typically either
-// the watchCache circular buffer, if events being retrieved
-// need to be for resource versions > 0 or the underlying
-// implementation of Store, if resource version = 0.
-//
-// Furthermore, an interval can be either valid or invalid at
-// any given point of time. The notion of validity makes sense
-// only in cases where the window of events in the underlying
-// source can change over time - i.e. for watchCache circular
-// buffer. When the circular buffer is full and an event needs
-// to be popped off, watchCache::startIndex is incremented. In
-// this case, an interval tracking that popped event is valid
-// only if it has already been copied to its internal buffer.
-// However, for efficiency we perform that lazily and we mark
-// an interval as invalid iff we need to copy events from the
-// watchCache and we end up needing events that have already
-// been popped off. This translates to the following condition:
-//
-//	watchCacheInterval::startIndex >= watchCache::startIndex.
-//
-// When this condition becomes false, the interval is no longer
-// valid and should not be used to retrieve and serve elements
-// from the underlying source.
+// of watchCacheEvents. It delegates iteration to a cacheIntervalSource
+// and holds common metadata (resourceVersion, initialEventsEndBookmark).
 type watchCacheInterval struct {
 	// source provides the iteration logic for this interval.
-	// When set, Next() delegates to source.Next().
 	source cacheIntervalSource
 
+	// resourceVersion is the resourceVersion from which
+	// the interval was constructed.
+	resourceVersion uint64
+
+	// initialEventsEndBookmark will be sent after sending all events in cacheInterval
+	initialEventsEndBookmark *watchCacheEvent
+}
+
+type indexerFunc func(int) *watchCacheEvent
+type indexValidator func(int) bool
+
+func newCacheInterval(startIndex, endIndex int, indexer indexerFunc, indexValidator indexValidator, resourceVersion uint64, locker sync.Locker) *watchCacheInterval {
+	return &watchCacheInterval{
+		source: &historyCacheIntervalSource{
+			startIndex:     startIndex,
+			endIndex:       endIndex,
+			indexer:        indexer,
+			indexValidator: indexValidator,
+			buffer:         &watchCacheIntervalBuffer{buffer: make([]*watchCacheEvent, bufferSize)},
+			lock:           locker,
+		},
+		resourceVersion: resourceVersion,
+	}
+}
+
+// historyCacheIntervalSource serves events from the watchCache circular buffer.
+// It maintains a window of events over the underlying source and copies them
+// in batches into an internal buffer to reduce lock acquisition frequency.
+//
+// An interval can be either valid or invalid at any given point of time.
+// When the circular buffer is full and an event needs to be popped off,
+// watchCache::startIndex is incremented. In this case, an interval tracking
+// that popped event is valid only if it has already been copied to its
+// internal buffer. However, for efficiency we perform that lazily and we
+// mark an interval as invalid iff we need to copy events from the watchCache
+// and we end up needing events that have already been popped off. This
+// translates to the following condition:
+//
+//	historyCacheIntervalSource::startIndex >= watchCache::startIndex.
+//
+// When this condition becomes false, the interval is no longer valid and
+// should not be used to retrieve and serve elements from the underlying
+// source.
+type historyCacheIntervalSource struct {
 	// startIndex denotes the starting point of the interval
 	// being considered. The value is the index in the actual
 	// source of watchCacheEvents. If the source of events is
@@ -97,34 +111,12 @@ type watchCacheInterval struct {
 	// lock on each invocation of Next().
 	buffer *watchCacheIntervalBuffer
 
-	// resourceVersion is the resourceVersion from which
-	// the interval was constructed.
-	resourceVersion uint64
-
 	// lock effectively protects access to the underlying source
 	// of events through - indexer and indexValidator.
 	//
 	// Given that indexer and indexValidator only read state, if
 	// possible, Locker obtained through RLocker() is provided.
 	lock sync.Locker
-
-	// initialEventsEndBookmark will be sent after sending all events in cacheInterval
-	initialEventsEndBookmark *watchCacheEvent
-}
-
-type indexerFunc func(int) *watchCacheEvent
-type indexValidator func(int) bool
-
-func newCacheInterval(startIndex, endIndex int, indexer indexerFunc, indexValidator indexValidator, resourceVersion uint64, locker sync.Locker) *watchCacheInterval {
-	return &watchCacheInterval{
-		startIndex:      startIndex,
-		endIndex:        endIndex,
-		indexer:         indexer,
-		indexValidator:  indexValidator,
-		buffer:          &watchCacheIntervalBuffer{buffer: make([]*watchCacheEvent, bufferSize)},
-		resourceVersion: resourceVersion,
-		lock:            locker,
-	}
 }
 
 // snapshotCacheIntervalSource serves events from a pre-populated buffer.
@@ -190,51 +182,52 @@ func newCacheIntervalFromStore(resourceVersion uint64, snap store.Snapshot, key 
 // interval is still valid. An error is returned if the interval is
 // invalidated.
 func (wci *watchCacheInterval) Next() (*watchCacheEvent, error) {
-	if wci.source != nil {
-		return wci.source.Next()
-	}
+	return wci.source.Next()
+}
+
+func (s *historyCacheIntervalSource) Next() (*watchCacheEvent, error) {
 	// if there are items in the buffer to return, return from
 	// the buffer.
-	if event, exists := wci.buffer.next(); exists {
+	if event, exists := s.buffer.next(); exists {
 		return event, nil
 	}
 	// check if there are still other events in this interval
 	// that can be processed.
-	if wci.startIndex >= wci.endIndex {
+	if s.startIndex >= s.endIndex {
 		return nil, nil
 	}
-	wci.lock.Lock()
-	defer wci.lock.Unlock()
+	s.lock.Lock()
+	defer s.lock.Unlock()
 
-	if valid := wci.indexValidator(wci.startIndex); !valid {
-		return nil, fmt.Errorf("cache interval invalidated, interval startIndex: %d", wci.startIndex)
+	if valid := s.indexValidator(s.startIndex); !valid {
+		return nil, fmt.Errorf("cache interval invalidated, interval startIndex: %d", s.startIndex)
 	}
 
-	wci.fillBuffer()
-	if event, exists := wci.buffer.next(); exists {
+	s.fillBuffer()
+	if event, exists := s.buffer.next(); exists {
 		return event, nil
 	}
 	return nil, nil
 }
 
-func (wci *watchCacheInterval) fillBuffer() {
-	wci.buffer.startIndex = 0
-	wci.buffer.endIndex = 0
-	for wci.startIndex < wci.endIndex && !wci.buffer.isFull() {
-		event := wci.indexer(wci.startIndex)
+func (s *historyCacheIntervalSource) fillBuffer() {
+	s.buffer.startIndex = 0
+	s.buffer.endIndex = 0
+	for s.startIndex < s.endIndex && !s.buffer.isFull() {
+		event := s.indexer(s.startIndex)
 		if event == nil {
 			break
 		}
-		wci.buffer.buffer[wci.buffer.endIndex] = event
-		wci.buffer.endIndex++
-		wci.startIndex++
+		s.buffer.buffer[s.buffer.endIndex] = event
+		s.buffer.endIndex++
+		s.startIndex++
 	}
 }
 
 const bufferSize = 100
 
 // watchCacheIntervalBuffer is used to reduce acquiring
-// the lock on each invocation of watchCacheInterval.Next().
+// the lock on each invocation of historyCacheIntervalSource.Next().
 type watchCacheIntervalBuffer struct {
 	// buffer is used to hold watchCacheEvents that
 	// the interval returns on a call to Next().

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval_test.go
@@ -401,12 +401,6 @@ func TestCacheIntervalNextFromStore(t *testing.T) {
 	}
 
 	for i := 0; i < numEvents; i++ {
-		// The interval buffer can never be empty unless
-		// all elements obtained through List() have been
-		// returned.
-		if wci.buffer.isEmpty() && i != numEvents {
-			t.Fatal("expected non-empty interval buffer")
-		}
 		event, err := wci.Next()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -424,9 +418,13 @@ func TestCacheIntervalNextFromStore(t *testing.T) {
 		}
 	}
 
-	// The interval's buffer should now be empty.
-	if !wci.buffer.isEmpty() {
-		t.Error("expected cache interval's buffer to be empty")
+	// All events should have been consumed.
+	event, err := wci.Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event != nil {
+		t.Errorf("expected nil event after consuming all events, got %v", *event)
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval_test.go
@@ -47,6 +47,10 @@ func intervalFromEvents(events []*watchCacheEvent) *watchCacheInterval {
 	return newCacheInterval(startIndex, endIndex, indexer, indexValidator, 0, locker)
 }
 
+func historySource(wci *watchCacheInterval) *historyCacheIntervalSource {
+	return wci.source.(*historyCacheIntervalSource)
+}
+
 func bufferFromEvents(events []*watchCacheEvent) *watchCacheIntervalBuffer {
 	wcib := &watchCacheIntervalBuffer{
 		buffer:     make([]*watchCacheEvent, bufferSize),
@@ -202,33 +206,34 @@ func TestFillBuffer(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			events := generateEvents(0, c.numEventsToFill)
 			wci := intervalFromEvents(events)
+			src := historySource(wci)
 
 			for i := 0; i < len(events); i++ {
 				if i%bufferSize == 0 {
-					wci.fillBuffer()
+					src.fillBuffer()
 				}
-				event, ok := wci.buffer.next()
+				event, ok := src.buffer.next()
 				if err := verifyEvent(ok, event, events[i]); err != nil {
 					t.Error(err)
 				}
 				// If we have already received bufferSize number of events,
 				// buffer should be empty and we should receive no event.
 				if i%bufferSize == bufferSize-1 {
-					event, ok := wci.buffer.next()
+					event, ok := src.buffer.next()
 					if err := verifyNoEvent(ok, event); err != nil {
 						t.Error(err)
 					}
 				}
 			}
 			// buffer should be empty and return no event.
-			event, ok := wci.buffer.next()
+			event, ok := src.buffer.next()
 			if err := verifyNoEvent(ok, event); err != nil {
 				t.Error(err)
 			}
 			// Buffer should be empty now, an additional fillBuffer()
 			// should make no difference.
-			wci.fillBuffer()
-			event, ok = wci.buffer.next()
+			src.fillBuffer()
+			event, ok = src.buffer.next()
 			if err := verifyNoEvent(ok, event); err != nil {
 				t.Error(err)
 			}
@@ -306,6 +311,7 @@ func TestCacheIntervalNextFromWatchCache(t *testing.T) {
 				wc.resourceVersion,
 				&wc.RWMutex,
 			)
+			src := historySource(wci)
 
 			numExpectedEvents := wc.history.endIndex - c.intervalStartIndex
 			for i := 0; i < numExpectedEvents; i++ {
@@ -320,7 +326,7 @@ func TestCacheIntervalNextFromWatchCache(t *testing.T) {
 					// i.e. freshly filling in the interval buffer.
 					if i%bufferSize == 0 && i != c.eventsAddedToWatchcache {
 						originalCacheStartIndex := wc.history.startIndex
-						wc.history.startIndex = wci.startIndex + 1
+						wc.history.startIndex = src.startIndex + 1
 						event, err := wci.Next()
 						if err == nil {
 							t.Errorf("expected non-nil error")
@@ -339,7 +345,7 @@ func TestCacheIntervalNextFromWatchCache(t *testing.T) {
 				// or when received is equal to the number of expected events.
 				// The latter happens when partial filling occurs and no more
 				// events are left post the partial fill.
-				if wci.buffer.isEmpty() != (i%bufferSize == 0 || i == numExpectedEvents) {
+				if src.buffer.isEmpty() != (i%bufferSize == 0 || i == numExpectedEvents) {
 					t.Error("expected empty interval buffer")
 					return
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR introduces a cacheIntervalSource interface with three implementations:

- historyCacheIntervalSource: existing batched circular buffer path (unchanged)
- storeCacheIntervalSource: existing eager store copy (unchanged, used as fallback)
- lazySnapshotCacheIntervalSource: grabs an immutable snapshot reference under RLock in O(1), then iterates it lazily in the processInterval goroutine outside the lock


When ListFromCacheSnapshot is enabled, WatchList lock hold time drops from O(N) to O(1).


`benchstat results (count=10, default benchtime, 150K pods):`

```
goos: darwin
goarch: arm64
pkg: k8s.io/apiserver/pkg/storage/cacher
cpu: Apple M4 Pro
                                                                                                                                    │ /tmp/old.txt │            /tmp/new.txt             │
                                                                                                                                    │    sec/op    │    sec/op     vs base               │
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=DeleteCreate/Parallelism=25/Background=WatchList/UseIndex=true-14   170.8µ ± 29%   146.6µ ± 15%       ~ (p=0.165 n=10)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallelism=25/Background=WatchList/UseIndex=true-14          91.07µ ± 17%   93.10µ ± 16%       ~ (p=1.000 n=10)
geomean                                                                                                                               124.7µ         116.8µ        -6.33%

                                                                                                                                    │ /tmp/old.txt │            /tmp/new.txt             │
                                                                                                                                    │ list-calls/s │ list-calls/s  vs base               │
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=DeleteCreate/Parallelism=25/Background=WatchList/UseIndex=true-14    10.15 ± 70%    13.69 ± 38%       ~ (p=0.218 n=10)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallelism=25/Background=WatchList/UseIndex=true-14          10.305 ± 32%    7.982 ± 81%       ~ (p=1.000 n=10)
geomean                                                                                                                                10.23          10.45        +2.23%

                                                                                                                                    │ /tmp/old.txt │            /tmp/new.txt             │
                                                                                                                                    │ list-objs/s  │ list-objs/s  vs base                │
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=DeleteCreate/Parallelism=25/Background=WatchList/UseIndex=true-14    226.4 ± 68%   410.8 ± 39%  +81.41% (p=0.003 n=10)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallelism=25/Background=WatchList/UseIndex=true-14           205.5 ± 26%   239.4 ± 81%        ~ (p=0.105 n=10)
geomean                                                                                                                                215.7         313.6        +45.39%

                                                                                                                                    │    /tmp/old.txt     │                /tmp/new.txt                 │
                                                                                                                                    │ watch-latency-p99-s │ watch-latency-p99-s  vs base                │
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=DeleteCreate/Parallelism=25/Background=WatchList/UseIndex=true-14           8.561 ± 67%          3.965 ± 130%        ~ (p=0.075 n=10)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallelism=25/Background=WatchList/UseIndex=true-14                  3.592 ± 43%          3.332 ±  59%        ~ (p=0.280 n=10)
geomean                                                                                                                                       5.545                3.634         -34.46%

                                                                                                                                    │ /tmp/old.txt │            /tmp/new.txt             │
                                                                                                                                    │   writes/s   │   writes/s    vs base               │
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=DeleteCreate/Parallelism=25/Background=WatchList/UseIndex=true-14   65.99k ± 14%   70.25k ± 23%       ~ (p=0.165 n=10)
StoreWriteThroughput/Namespaces=50/Pods=150000/Nodes=5000/Traffic=Patch/Parallelism=25/Background=WatchList/UseIndex=true-14          61.57k ±  9%   66.49k ±  7%       ~ (p=0.089 n=10)
geomean                                                                                                                               63.74k         68.35k        +7.23%
```

#### Which issue(s) this PR is related to:
xref: https://github.com/kubernetes/kubernetes/issues/139526

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
