### PR TITLE
kubelet/allocation: propagate logger/context

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager.go
+++ b/pkg/kubelet/allocation/allocation_manager.go
@@ -73,7 +73,7 @@ type Manager interface {
 	UpdatePodFromAllocation(pod *v1.Pod) (*v1.Pod, bool)
 
 	// SetAllocatedResources checkpoints the resources allocated to a pod's containers.
-	SetAllocatedResources(allocatedPod *v1.Pod) error
+	SetAllocatedResources(logger klog.Logger, allocatedPod *v1.Pod) error
 
 	// AddPodAdmitHandlers adds the admit handlers to the allocation manager.
 	// TODO: See if we can remove this and just add them in the allocation manager constructor.
@@ -85,10 +85,10 @@ type Manager interface {
 	// the pod cannot be admitted.
 	// allocatedPods should represent the pods that have already been admitted, along with their
 	// admitted (allocated) resources.
-	AddPod(activePods []*v1.Pod, pod *v1.Pod) (ok bool, reason, message string)
+	AddPod(ctx context.Context, activePods []*v1.Pod, pod *v1.Pod) (ok bool, reason, message string)
 
 	// RemovePod removes any stored state for the given pod UID.
-	RemovePod(uid types.UID)
+	RemovePod(logger klog.Logger, uid types.UID)
 
 	// RemoveOrphanedPods removes the stored state for any pods not included in the set of remaining pods.
 	RemoveOrphanedPods(remainingPods sets.Set[types.UID])
@@ -98,7 +98,7 @@ type Manager interface {
 	Run(ctx context.Context)
 
 	// PushPendingResize queues a pod with a pending resize request for later reevaluation.
-	PushPendingResize(uid types.UID)
+	PushPendingResize(logger klog.Logger, uid types.UID)
 
 	// HasPendingResizes returns whether there are currently any pending resizes.
 	HasPendingResizes() bool
@@ -132,10 +132,8 @@ func NewManager(checkpointDirectory string,
 	getPodByUID func(types.UID) (*v1.Pod, bool),
 	sourcesReady config.SourcesReady,
 	recorder record.EventRecorderLogger,
+	logger klog.Logger,
 ) Manager {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
 	return &manager{
 		allocated: newStateImpl(logger, checkpointDirectory, allocatedPodsStateFile),
 
@@ -156,7 +154,7 @@ func newStateImpl(logger klog.Logger, checkpointDirectory, checkpointName string
 		return state.NewNoopStateCheckpoint()
 	}
 
-	stateImpl, err := state.NewStateCheckpoint(checkpointDirectory, checkpointName)
+	stateImpl, err := state.NewStateCheckpoint(logger, checkpointDirectory, checkpointName)
 	if err != nil {
 		// This is a critical, non-recoverable failure.
 		logger.Error(err, "Failed to initialize allocation checkpoint manager",
@@ -170,6 +168,7 @@ func newStateImpl(logger klog.Logger, checkpointDirectory, checkpointName string
 // NewInMemoryManager returns an allocation manager that doesn't persist state.
 // For testing purposes only!
 func NewInMemoryManager(
+	logger klog.Logger,
 	statusManager status.Manager,
 	triggerPodSync func(context.Context, *v1.Pod),
 	getActivePods func() []*v1.Pod,
@@ -178,7 +177,7 @@ func NewInMemoryManager(
 	recorder record.EventRecorderLogger,
 ) Manager {
 	return &manager{
-		allocated: state.NewStateMemory(nil),
+		allocated: state.NewStateMemory(logger, nil),
 
 		statusManager: statusManager,
 		admitHandlers: lifecycle.PodAdmitHandlers{},
@@ -271,10 +270,7 @@ func (m *manager) retryPendingResizes(ctx context.Context, trigger string) []*v1
 	return successfulResizes
 }
 
-func (m *manager) PushPendingResize(uid types.UID) {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
+func (m *manager) PushPendingResize(logger klog.Logger, uid types.UID) {
 	m.allocationMutex.Lock()
 	defer m.allocationMutex.Unlock()
 
@@ -476,10 +472,7 @@ func updatePodFromAllocation(pod *v1.Pod, allocated state.PodResourceInfo) (*v1.
 }
 
 // SetAllocatedResources checkpoints the resources allocated to a pod's containers
-func (m *manager) SetAllocatedResources(pod *v1.Pod) error {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
+func (m *manager) SetAllocatedResources(logger klog.Logger, pod *v1.Pod) error {
 	return m.allocated.SetPodResourceInfo(logger, pod.UID, allocationFromPod(pod))
 }
 
@@ -506,10 +499,7 @@ func (m *manager) AddPodAdmitHandlers(handlers lifecycle.PodAdmitHandlers) {
 	}
 }
 
-func (m *manager) AddPod(activePods []*v1.Pod, pod *v1.Pod) (bool, string, string) {
-	// Use context.TODO() because we currently do not have a proper context to pass in.
-	// Replace this with an appropriate context when refactoring this function to accept a context parameter.
-	ctx := context.TODO()
+func (m *manager) AddPod(ctx context.Context, activePods []*v1.Pod, pod *v1.Pod) (bool, string, string) {
 	logger := klog.FromContext(ctx)
 	m.allocationMutex.Lock()
 	defer m.allocationMutex.Unlock()
@@ -526,7 +516,7 @@ func (m *manager) AddPod(activePods []*v1.Pod, pod *v1.Pod) (bool, string, strin
 
 	if ok && utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		// Checkpoint the resource values at which the Pod has been admitted or resized.
-		if err := m.SetAllocatedResources(pod); err != nil {
+		if err := m.SetAllocatedResources(logger, pod); err != nil {
 			// TODO(vinaykul,InPlacePodVerticalScaling): Can we recover from this in some way? Investigate
 			logger.Error(err, "SetPodAllocation failed", "pod", klog.KObj(pod))
 		}
@@ -535,11 +525,8 @@ func (m *manager) AddPod(activePods []*v1.Pod, pod *v1.Pod) (bool, string, strin
 	return ok, reason, message
 }
 
-func (m *manager) RemovePod(uid types.UID) {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
-	if err := m.allocated.RemovePod(uid); err != nil {
+func (m *manager) RemovePod(logger klog.Logger, uid types.UID) {
+	if err := m.allocated.RemovePod(logger, uid); err != nil {
 		// If the deletion fails, it will be retried by RemoveOrphanedPods, so we can safely ignore the error.
 		logger.V(3).Info("Failed to delete pod allocation", "podUID", uid, "err", err)
 	}
@@ -562,7 +549,7 @@ func (m *manager) handlePodResourcesResize(ctx context.Context, pod *v1.Pod) (bo
 	fit, reason, message := m.canAdmitPod(ctx, m.getAllocatedPods(m.getActivePods()), pod, lifecycle.ResizeOperation)
 	if fit {
 		// Update pod resource allocation checkpoint
-		if err := m.SetAllocatedResources(pod); err != nil {
+		if err := m.SetAllocatedResources(logger, pod); err != nil {
 			return false, err
 		}
 		m.statusManager.ClearPodResizePendingCondition(pod.UID)

--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -310,7 +310,8 @@ func TestRetryPendingResizes(t *testing.T) {
 		t.Skip("InPlacePodVerticalScaling is not currently supported for Windows")
 	}
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
+
 	containerRestartPolicyAlways := v1.ContainerRestartPolicyAlways
 
 	cpu2m := resource.MustParse("2m")
@@ -783,11 +784,11 @@ func TestRetryPendingResizes(t *testing.T) {
 				allocationManager := makeAllocationManager(t, &containertest.FakeRuntime{PodStatus: *podStatus}, []*v1.Pod{testPod1, testPod2, testPod3}, nil)
 
 				if !tt.newResourcesAllocated {
-					require.NoError(t, allocationManager.SetAllocatedResources(originalPod))
+					require.NoError(t, allocationManager.SetAllocatedResources(logger, originalPod))
 				} else {
-					require.NoError(t, allocationManager.SetAllocatedResources(newPod))
+					require.NoError(t, allocationManager.SetAllocatedResources(logger, newPod))
 				}
-				t.Cleanup(func() { allocationManager.RemovePod(originalPod.UID) })
+				t.Cleanup(func() { allocationManager.RemovePod(logger, originalPod.UID) })
 
 				if tt.originalInProgress {
 					allocationManager.(*manager).statusManager.SetPodResizeInProgressCondition(originalPod.UID, "", originalInProgressMsg, 0)
@@ -799,7 +800,7 @@ func TestRetryPendingResizes(t *testing.T) {
 				allocationManager.(*manager).getPodByUID = func(uid types.UID) (*v1.Pod, bool) {
 					return newPod, true
 				}
-				allocationManager.PushPendingResize(originalPod.UID)
+				allocationManager.PushPendingResize(logger, originalPod.UID)
 				allocationManager.RetryPendingResizes(tCtx, TriggerReasonPodUpdated)
 
 				var updatedPod *v1.Pod
@@ -870,7 +871,7 @@ func TestRetryPendingResizesGuanteedQOSPods(t *testing.T) {
 		t.Skip("InPlacePodVerticalScaling is not currently supported for Windows")
 	}
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 
 	nodeConfig := cm.NodeConfig{}
 	nodeConfig.CPUManagerPolicy = string(cpumanager.PolicyStatic)
@@ -1068,13 +1069,13 @@ func TestRetryPendingResizesGuanteedQOSPods(t *testing.T) {
 				}
 				allocationManager := makeAllocationManager(t, &containertest.FakeRuntime{PodStatus: *podStatus}, []*v1.Pod{guaranteedQOSPod, guaranteedQOSPodWithSidecar, bestEffortPod}, &nodeConfig)
 
-				require.NoError(t, allocationManager.SetAllocatedResources(originalPod))
-				t.Cleanup(func() { allocationManager.RemovePod(originalPod.UID) })
+				require.NoError(t, allocationManager.SetAllocatedResources(logger, originalPod))
+				t.Cleanup(func() { allocationManager.RemovePod(logger, originalPod.UID) })
 
 				allocationManager.(*manager).getPodByUID = func(uid types.UID) (*v1.Pod, bool) {
 					return newPod, true
 				}
-				allocationManager.PushPendingResize(originalPod.UID)
+				allocationManager.PushPendingResize(logger, originalPod.UID)
 				allocationManager.RetryPendingResizes(tCtx, TriggerReasonPodUpdated)
 
 				var updatedPod *v1.Pod
@@ -1125,7 +1126,7 @@ func TestRetryPendingResizesWithSwap(t *testing.T) {
 		features.InPlacePodVerticalScaling: true,
 		features.NodeSwap:                  true,
 	})
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 	noSwapContainerName, swapContainerName := "test-container-noswap", "test-container-limitedswap"
 
 	cpu500m := resource.MustParse("500m")
@@ -1248,13 +1249,13 @@ func TestRetryPendingResizesWithSwap(t *testing.T) {
 			}
 			allocationManager := makeAllocationManager(t, runtime, []*v1.Pod{testPod}, nil)
 
-			require.NoError(t, allocationManager.SetAllocatedResources(originalPod))
-			t.Cleanup(func() { allocationManager.RemovePod(originalPod.UID) })
+			require.NoError(t, allocationManager.SetAllocatedResources(logger, originalPod))
+			t.Cleanup(func() { allocationManager.RemovePod(logger, originalPod.UID) })
 
 			allocationManager.(*manager).getPodByUID = func(uid types.UID) (*v1.Pod, bool) {
 				return newPod, true
 			}
-			allocationManager.PushPendingResize(testPod.UID)
+			allocationManager.PushPendingResize(logger, testPod.UID)
 			allocationManager.RetryPendingResizes(tCtx, TriggerReasonPodUpdated)
 
 			var updatedPod *v1.Pod
@@ -1294,7 +1295,7 @@ func TestRetryPendingResizesMultipleConditions(t *testing.T) {
 		t.Skip("InPlacePodVerticalScaling is not currently supported for Windows")
 	}
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 
 	cpu500m := resource.MustParse("500m")
 	cpu1000m := resource.MustParse("1")
@@ -1348,7 +1349,7 @@ func TestRetryPendingResizesMultipleConditions(t *testing.T) {
 	}
 
 	allocationManager := makeAllocationManager(t, &containertest.FakeRuntime{PodStatus: *podStatus}, []*v1.Pod{testPod}, nil)
-	require.NoError(t, allocationManager.SetAllocatedResources(testPod))
+	require.NoError(t, allocationManager.SetAllocatedResources(logger, testPod))
 	allocationManager.(*manager).getPodByUID = func(uid types.UID) (*v1.Pod, bool) {
 		return testPod, true
 	}
@@ -1464,7 +1465,7 @@ func TestRetryPendingResizesMultipleConditions(t *testing.T) {
 				},
 			}
 
-			allocationManager.PushPendingResize(testPod.UID)
+			allocationManager.PushPendingResize(logger, testPod.UID)
 			allocationManager.RetryPendingResizes(tCtx, TriggerReasonPodUpdated)
 
 			conditions := allocationManager.(*manager).statusManager.GetPodResizeConditions(testPod.UID)
@@ -1505,6 +1506,8 @@ func TestAllocationManagerAddPodWithPLR(t *testing.T) {
 	if goruntime.GOOS == "windows" {
 		t.Skip("InPlacePodVerticalScaling is not currently supported for Windows")
 	}
+
+	logger, tCtx := ktesting.NewTestContext(t)
 
 	const containerName = "c1"
 
@@ -1746,7 +1749,7 @@ func TestAllocationManagerAddPodWithPLR(t *testing.T) {
 			}
 
 			for podUID, resources := range tc.initialAllocatedResourcesState {
-				err := allocationManager.SetAllocatedResources(podForAllocation(podUID, resources))
+				err := allocationManager.SetAllocatedResources(logger, podForAllocation(podUID, resources))
 				require.NoError(t, err)
 			}
 
@@ -1755,7 +1758,7 @@ func TestAllocationManagerAddPodWithPLR(t *testing.T) {
 				allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{handler})
 			}
 
-			ok, reason, message := allocationManager.AddPod(tc.currentActivePods, tc.podToAdd)
+			ok, reason, message := allocationManager.AddPod(tCtx, tc.currentActivePods, tc.podToAdd)
 			require.Equal(t, tc.expectAdmit, ok)
 			require.Equal(t, tc.admissionFailureReason, reason)
 			require.Equal(t, tc.admissionFailureMessage, message)
@@ -1807,6 +1810,8 @@ func TestAllocationManagerAddPod(t *testing.T) {
 	if goruntime.GOOS == "windows" {
 		t.Skip("InPlacePodVerticalScaling is not currently supported for Windows")
 	}
+
+	logger, tCtx := ktesting.NewTestContext(t)
 
 	const containerName = "c1"
 
@@ -2002,7 +2007,7 @@ func TestAllocationManagerAddPod(t *testing.T) {
 			}
 
 			for podUID, resources := range tc.initialAllocatedResourcesState {
-				err := allocationManager.SetAllocatedResources(podForAllocation(podUID, resources))
+				err := allocationManager.SetAllocatedResources(logger, podForAllocation(podUID, resources))
 				require.NoError(t, err)
 			}
 
@@ -2011,7 +2016,7 @@ func TestAllocationManagerAddPod(t *testing.T) {
 				allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{handler})
 			}
 
-			ok, reason, message := allocationManager.AddPod(tc.currentActivePods, tc.podToAdd)
+			ok, reason, message := allocationManager.AddPod(tCtx, tc.currentActivePods, tc.podToAdd)
 			require.Equal(t, tc.expectAdmit, ok)
 			require.Equal(t, tc.admissionFailureReason, reason)
 			require.Equal(t, tc.admissionFailureMessage, message)
@@ -2038,6 +2043,8 @@ func TestAllocationManagerAddPod(t *testing.T) {
 }
 
 func TestIsResizeIncreasingRequests(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
 	cpu500m := resource.MustParse("500m")
 	cpu1000m := resource.MustParse("1")
 	cpu1500m := resource.MustParse("1500m")
@@ -2216,7 +2223,7 @@ func TestIsResizeIncreasingRequests(t *testing.T) {
 			}
 
 			allocationManager := makeAllocationManager(t, &containertest.FakeRuntime{}, []*v1.Pod{testPod}, nil)
-			require.NoError(t, allocationManager.SetAllocatedResources(testPod))
+			require.NoError(t, allocationManager.SetAllocatedResources(logger, testPod))
 
 			if tc.newPodRequests != nil {
 				testPod.Spec.Resources.Requests = tc.newPodRequests
@@ -2230,6 +2237,8 @@ func TestIsResizeIncreasingRequests(t *testing.T) {
 }
 
 func TestSortPendingResizes(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
 	cpu500m := resource.MustParse("500m")
 	cpu1000m := resource.MustParse("1")
 	cpu1500m := resource.MustParse("1500m")
@@ -2259,7 +2268,7 @@ func TestSortPendingResizes(t *testing.T) {
 	testPods := []*v1.Pod{createTestPod(0), createTestPod(1), createTestPod(2), createTestPod(3), createTestPod(4), createTestPod(5), createTestPod(6)}
 	allocationManager := makeAllocationManager(t, &containertest.FakeRuntime{}, testPods, nil)
 	for _, testPod := range testPods {
-		require.NoError(t, allocationManager.SetAllocatedResources(testPod))
+		require.NoError(t, allocationManager.SetAllocatedResources(logger, testPod))
 	}
 
 	// testPods[0] has the highest priority, as it doesn't increase resource requests (pod-level).
@@ -2296,14 +2305,14 @@ func TestSortPendingResizes(t *testing.T) {
 
 	// Push all the pods to the queue.
 	for i := range testPods {
-		allocationManager.PushPendingResize(testPods[i].UID)
+		allocationManager.PushPendingResize(logger, testPods[i].UID)
 	}
 	require.Equal(t, expected, allocationManager.(*manager).podsWithPendingResizes)
 
 	// Clear the queue and push the pods in reverse order to spice things up.
 	allocationManager.(*manager).podsWithPendingResizes = nil
 	for i := len(testPods) - 1; i >= 0; i-- {
-		allocationManager.PushPendingResize(testPods[i].UID)
+		allocationManager.PushPendingResize(logger, testPods[i].UID)
 	}
 	require.Equal(t, expected, allocationManager.(*manager).podsWithPendingResizes)
 }
@@ -2313,9 +2322,10 @@ func TestRecordPodDeferredAcceptedResizes(t *testing.T) {
 		t.Skip("InPlacePodVerticalScaling is not currently supported for Windows")
 	}
 
+	logger, tCtx := ktesting.NewTestContext(t)
+
 	metrics.Register()
 	metrics.PodDeferredAcceptedResizes.Reset()
-	tCtx := ktesting.Init(t)
 
 	cpu500m := resource.MustParse("500m")
 	cpu1000m := resource.MustParse("1")
@@ -2392,7 +2402,7 @@ func TestRecordPodDeferredAcceptedResizes(t *testing.T) {
 			resizedPod.Spec.Containers[0].Resources.Requests = v1.ResourceList{v1.ResourceCPU: cpu500m, v1.ResourceMemory: mem500M}
 
 			am := makeAllocationManager(t, &containertest.FakeRuntime{}, []*v1.Pod{original}, nil)
-			require.NoError(t, am.SetAllocatedResources(original))
+			require.NoError(t, am.SetAllocatedResources(logger, original))
 			if tc.hasPendingCondition {
 				am.(*manager).statusManager.SetPodResizePendingCondition(original.UID, v1.PodReasonDeferred, "message", 1)
 			}
@@ -2400,7 +2410,7 @@ func TestRecordPodDeferredAcceptedResizes(t *testing.T) {
 			am.(*manager).getPodByUID = func(uid types.UID) (*v1.Pod, bool) {
 				return resizedPod, true
 			}
-			am.PushPendingResize(original.UID)
+			am.PushPendingResize(logger, original.UID)
 			resizedPods := am.(*manager).retryPendingResizes(tCtx, tc.trigger)
 
 			require.Len(t, resizedPods, 1)
@@ -2429,6 +2439,7 @@ func makeAllocationManager(t *testing.T, runtime *containertest.FakeRuntime, all
 		containerManager = cm.NewFakeContainerManagerWithNodeConfig(*nodeConfig)
 	}
 	allocationManager := NewInMemoryManager(
+		logger,
 		statusManager,
 		func(_ context.Context, pod *v1.Pod) {
 			/* For testing, just mark the pod as having a pod sync triggered in an annotation. */

--- a/pkg/kubelet/allocation/state/state.go
+++ b/pkg/kubelet/allocation/state/state.go
@@ -58,10 +58,10 @@ type Reader interface {
 }
 
 type writer interface {
-	SetContainerResources(podUID types.UID, containerName string, resources v1.ResourceRequirements) error
+	SetContainerResources(logger klog.Logger, podUID types.UID, containerName string, resources v1.ResourceRequirements) error
 	SetPodResourceInfo(logger klog.Logger, podUID types.UID, resourceInfo PodResourceInfo) error
-	SetPodLevelResources(podUID types.UID, alloc *v1.ResourceRequirements) error
-	RemovePod(podUID types.UID) error
+	SetPodLevelResources(logger klog.Logger, podUID types.UID, alloc *v1.ResourceRequirements) error
+	RemovePod(logger klog.Logger, podUID types.UID) error
 	// RemoveOrphanedPods removes the stored state for any pods not included in the set of remaining pods.
 	RemoveOrphanedPods(remainingPods sets.Set[types.UID])
 }

--- a/pkg/kubelet/allocation/state/state_checkpoint.go
+++ b/pkg/kubelet/allocation/state/state_checkpoint.go
@@ -41,10 +41,7 @@ type stateCheckpoint struct {
 }
 
 // NewStateCheckpoint creates new State for keeping track of pod resource information with checkpoint backend
-func NewStateCheckpoint(stateDir, checkpointName string) (State, error) {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
+func NewStateCheckpoint(logger klog.Logger, stateDir, checkpointName string) (State, error) {
 	checkpointManager, err := checkpointmanager.NewCheckpointManager(stateDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize checkpoint manager for pod resource information tracking: %w", err)
@@ -58,7 +55,7 @@ func NewStateCheckpoint(stateDir, checkpointName string) (State, error) {
 	}
 
 	stateCheckpoint := &stateCheckpoint{
-		cache:             NewStateMemory(pra),
+		cache:             NewStateMemory(logger, pra),
 		checkpointManager: checkpointManager,
 		checkpointName:    checkpointName,
 		lastChecksum:      checksum,
@@ -137,13 +134,10 @@ func (sc *stateCheckpoint) GetPodResourceInfo(podUID types.UID) (PodResourceInfo
 }
 
 // SetContainerResoruces sets resources information for a pod's container
-func (sc *stateCheckpoint) SetContainerResources(podUID types.UID, containerName string, resources v1.ResourceRequirements) error {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
+func (sc *stateCheckpoint) SetContainerResources(logger klog.Logger, podUID types.UID, containerName string, resources v1.ResourceRequirements) error {
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
-	err := sc.cache.SetContainerResources(podUID, containerName, resources)
+	err := sc.cache.SetContainerResources(logger, podUID, containerName, resources)
 	if err != nil {
 		return err
 	}
@@ -151,13 +145,10 @@ func (sc *stateCheckpoint) SetContainerResources(podUID types.UID, containerName
 }
 
 // SetPodLevelResources sets resources information for a pod's resources at pod-level.
-func (sc *stateCheckpoint) SetPodLevelResources(podUID types.UID, resInfo *v1.ResourceRequirements) error {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
+func (sc *stateCheckpoint) SetPodLevelResources(logger klog.Logger, podUID types.UID, resInfo *v1.ResourceRequirements) error {
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
-	err := sc.cache.SetPodLevelResources(podUID, resInfo)
+	err := sc.cache.SetPodLevelResources(logger, podUID, resInfo)
 	if err != nil {
 		return err
 	}
@@ -176,13 +167,13 @@ func (sc *stateCheckpoint) SetPodResourceInfo(logger klog.Logger, podUID types.U
 }
 
 // Delete deletes resource information for specified pod
-func (sc *stateCheckpoint) RemovePod(podUID types.UID) error {
+func (sc *stateCheckpoint) RemovePod(logger klog.Logger, podUID types.UID) error {
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
 	// Skip writing the checkpoint for pod deletion, since there is no side effect to
 	// keeping a deleted pod. Deleted pods will eventually be cleaned up by RemoveOrphanedPods.
 	// The deletion will be stored the next time a non-delete update is made.
-	return sc.cache.RemovePod(podUID)
+	return sc.cache.RemovePod(logger, podUID)
 }
 
 func (sc *stateCheckpoint) RemoveOrphanedPods(remainingPods sets.Set[types.UID]) {
@@ -214,11 +205,11 @@ func (sc *noopStateCheckpoint) GetPodResourceInfo(_ types.UID) (PodResourceInfo,
 	return PodResourceInfo{}, false
 }
 
-func (sc *noopStateCheckpoint) SetContainerResources(_ types.UID, _ string, _ v1.ResourceRequirements) error {
+func (sc *noopStateCheckpoint) SetContainerResources(_ klog.Logger, _ types.UID, _ string, _ v1.ResourceRequirements) error {
 	return nil
 }
 
-func (sc *noopStateCheckpoint) SetPodLevelResources(_ types.UID, _ *v1.ResourceRequirements) error {
+func (sc *noopStateCheckpoint) SetPodLevelResources(_ klog.Logger, _ types.UID, _ *v1.ResourceRequirements) error {
 	return nil
 }
 
@@ -226,7 +217,7 @@ func (sc *noopStateCheckpoint) SetPodResourceInfo(_ klog.Logger, _ types.UID, _ 
 	return nil
 }
 
-func (sc *noopStateCheckpoint) RemovePod(_ types.UID) error {
+func (sc *noopStateCheckpoint) RemovePod(_ klog.Logger, _ types.UID) error {
 	return nil
 }
 

--- a/pkg/kubelet/allocation/state/state_checkpoint_test.go
+++ b/pkg/kubelet/allocation/state/state_checkpoint_test.go
@@ -33,8 +33,9 @@ import (
 const testCheckpoint = "pod_status_manager_state"
 
 func newTestStateCheckpoint(t *testing.T) *stateCheckpoint {
+	logger, _ := ktesting.NewTestContext(t)
 	testingDir := getTestDir(t)
-	cache := NewStateMemory(PodResourceInfoMap{})
+	cache := NewStateMemory(logger, PodResourceInfoMap{})
 	checkpointManager, err := checkpointmanager.NewCheckpointManager(testingDir)
 	require.NoError(t, err, "failed to create checkpoint manager")
 	checkpointName := "pod_state_checkpoint"
@@ -118,7 +119,7 @@ func Test_stateCheckpoint_storeState(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			logger, _ := ktesting.NewTestContext(t)
 			testDir := getTestDir(t)
-			originalSC, err := NewStateCheckpoint(testDir, testCheckpoint)
+			originalSC, err := NewStateCheckpoint(logger, testDir, testCheckpoint)
 			require.NoError(t, err)
 
 			for podUID, alloc := range tt.args.resInfoMap {
@@ -129,7 +130,7 @@ func Test_stateCheckpoint_storeState(t *testing.T) {
 			actual := originalSC.GetPodResourceInfoMap()
 			verifyPodResourceAllocation(t, &tt.args.resInfoMap, &actual, "stored pod resource allocation is not equal to original pod resource allocation")
 
-			newSC, err := NewStateCheckpoint(testDir, testCheckpoint)
+			newSC, err := NewStateCheckpoint(logger, testDir, testCheckpoint)
 			require.NoError(t, err)
 
 			actual = newSC.GetPodResourceInfoMap()
@@ -192,7 +193,7 @@ func Test_stateCheckpoint_formatUpgraded(t *testing.T) {
 
 	require.Equal(t, expectedPodResourceAllocation, actualPodResourceAllocation, "pod resource allocation info is not equal")
 
-	sc.cache = NewStateMemory(actualPodResourceAllocation)
+	sc.cache = NewStateMemory(logger, actualPodResourceAllocation)
 
 	actualPodResourceAllocation = sc.cache.GetPodResourceInfoMap()
 

--- a/pkg/kubelet/allocation/state/state_mem.go
+++ b/pkg/kubelet/allocation/state/state_mem.go
@@ -33,10 +33,7 @@ type stateMemory struct {
 var _ State = &stateMemory{}
 
 // NewStateMemory creates new State to track resources resourcesated to pods
-func NewStateMemory(resources PodResourceInfoMap) State {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
+func NewStateMemory(logger klog.Logger, resources PodResourceInfoMap) State {
 	if resources == nil {
 		resources = PodResourceInfoMap{}
 	}
@@ -89,11 +86,7 @@ func (s *stateMemory) GetPodResourceInfo(podUID types.UID) (PodResourceInfo, boo
 	return resourceInfo, ok
 }
 
-func (s *stateMemory) SetContainerResources(podUID types.UID, containerName string, resources v1.ResourceRequirements) error {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
-
+func (s *stateMemory) SetContainerResources(logger klog.Logger, podUID types.UID, containerName string, resources v1.ResourceRequirements) error {
 	s.Lock()
 	defer s.Unlock()
 
@@ -115,10 +108,7 @@ func (s *stateMemory) SetContainerResources(podUID types.UID, containerName stri
 	return nil
 }
 
-func (s *stateMemory) SetPodLevelResources(podUID types.UID, resources *v1.ResourceRequirements) error {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
+func (s *stateMemory) SetPodLevelResources(logger klog.Logger, podUID types.UID, resources *v1.ResourceRequirements) error {
 	s.Lock()
 	defer s.Unlock()
 
@@ -144,10 +134,7 @@ func (s *stateMemory) SetPodResourceInfo(logger klog.Logger, podUID types.UID, r
 	return nil
 }
 
-func (s *stateMemory) RemovePod(podUID types.UID) error {
-	// Use klog.TODO() because we currently do not have a proper logger to pass in.
-	// Replace this with an appropriate logger when refactoring this function to accept a logger parameter.
-	logger := klog.TODO()
+func (s *stateMemory) RemovePod(logger klog.Logger, podUID types.UID) error {
 	s.Lock()
 	defer s.Unlock()
 	delete(s.podResources, podUID)

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -150,7 +150,7 @@ type Runtime interface {
 	// (allocated resources != actuated resources).
 	IsPodResizeInProgress(allocatedPod *v1.Pod, podStatus *PodStatus) bool
 	// UpdateActuatedPodLevelResources updates pod-level resources in actuatedState
-	UpdateActuatedPodLevelResources(actuatedPod *v1.Pod) error
+	UpdateActuatedPodLevelResources(logger klog.Logger, actuatedPod *v1.Pod) error
 }
 
 var (

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/flowcontrol"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/credentialprovider"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
@@ -595,6 +596,6 @@ func (f *FakeRuntime) IsPodResizeInProgress(allocatedPod *v1.Pod, podStatus *kub
 	return f.PodResizeInProgress
 }
 
-func (f *FakeRuntime) UpdateActuatedPodLevelResources(allocatedPod *v1.Pod) error {
+func (f *FakeRuntime) UpdateActuatedPodLevelResources(logger klog.Logger, allocatedPod *v1.Pod) error {
 	return nil
 }

--- a/pkg/kubelet/container/testing/mocks.go
+++ b/pkg/kubelet/container/testing/mocks.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/cri-api/pkg/apis/runtime/v1"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/credentialprovider"
 	"k8s.io/kubernetes/pkg/kubelet/container"
 	types0 "k8s.io/kubernetes/pkg/kubelet/types"
@@ -1668,16 +1669,16 @@ func (_c *MockRuntime_Type_Call) RunAndReturn(run func() string) *MockRuntime_Ty
 }
 
 // UpdateActuatedPodLevelResources provides a mock function for the type MockRuntime
-func (_mock *MockRuntime) UpdateActuatedPodLevelResources(actuatedPod *v10.Pod) error {
-	ret := _mock.Called(actuatedPod)
+func (_mock *MockRuntime) UpdateActuatedPodLevelResources(logger klog.Logger, actuatedPod *v10.Pod) error {
+	ret := _mock.Called(logger, actuatedPod)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateActuatedPodLevelResources")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(*v10.Pod) error); ok {
-		r0 = returnFunc(actuatedPod)
+	if returnFunc, ok := ret.Get(0).(func(klog.Logger, *v10.Pod) error); ok {
+		r0 = returnFunc(logger, actuatedPod)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -1690,19 +1691,25 @@ type MockRuntime_UpdateActuatedPodLevelResources_Call struct {
 }
 
 // UpdateActuatedPodLevelResources is a helper method to define mock.On call
+//   - logger klog.Logger
 //   - actuatedPod *v10.Pod
-func (_e *MockRuntime_Expecter) UpdateActuatedPodLevelResources(actuatedPod interface{}) *MockRuntime_UpdateActuatedPodLevelResources_Call {
-	return &MockRuntime_UpdateActuatedPodLevelResources_Call{Call: _e.mock.On("UpdateActuatedPodLevelResources", actuatedPod)}
+func (_e *MockRuntime_Expecter) UpdateActuatedPodLevelResources(logger interface{}, actuatedPod interface{}) *MockRuntime_UpdateActuatedPodLevelResources_Call {
+	return &MockRuntime_UpdateActuatedPodLevelResources_Call{Call: _e.mock.On("UpdateActuatedPodLevelResources", logger, actuatedPod)}
 }
 
-func (_c *MockRuntime_UpdateActuatedPodLevelResources_Call) Run(run func(actuatedPod *v10.Pod)) *MockRuntime_UpdateActuatedPodLevelResources_Call {
+func (_c *MockRuntime_UpdateActuatedPodLevelResources_Call) Run(run func(logger klog.Logger, actuatedPod *v10.Pod)) *MockRuntime_UpdateActuatedPodLevelResources_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *v10.Pod
+		var arg0 klog.Logger
 		if args[0] != nil {
-			arg0 = args[0].(*v10.Pod)
+			arg0 = args[0].(klog.Logger)
+		}
+		var arg1 *v10.Pod
+		if args[1] != nil {
+			arg1 = args[1].(*v10.Pod)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -1713,7 +1720,7 @@ func (_c *MockRuntime_UpdateActuatedPodLevelResources_Call) Return(err error) *M
 	return _c
 }
 
-func (_c *MockRuntime_UpdateActuatedPodLevelResources_Call) RunAndReturn(run func(actuatedPod *v10.Pod) error) *MockRuntime_UpdateActuatedPodLevelResources_Call {
+func (_c *MockRuntime_UpdateActuatedPodLevelResources_Call) RunAndReturn(run func(logger klog.Logger, actuatedPod *v10.Pod) error) *MockRuntime_UpdateActuatedPodLevelResources_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -719,6 +719,7 @@ func NewMainKubelet(ctx context.Context,
 		klet.podManager.GetPodByUID,
 		klet.sourcesReady,
 		kubeDeps.Recorder,
+		logger,
 	)
 
 	klet.resourceAnalyzer = serverstats.NewResourceAnalyzer(ctx, klet, kubeCfg.VolumeStatsAggPeriod.Duration, kubeDeps.Recorder)
@@ -2195,7 +2196,7 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 					return false, nil, fmt.Errorf("failed to ensure that the pod: %v cgroups exist and are correctly applied: %v", pod.UID, err)
 				}
 
-				if err = kl.containerRuntime.UpdateActuatedPodLevelResources(pod); err != nil {
+				if err = kl.containerRuntime.UpdateActuatedPodLevelResources(logger, pod); err != nil {
 					return false, nil, fmt.Errorf("failed to update the state of pod-level resources for the pod %v : %w", pod.UID, err)
 				}
 			}
@@ -2889,7 +2890,7 @@ func (kl *Kubelet) HandlePodAdditions(ctx context.Context, pods []*v1.Pod) {
 			// Check if we can admit the pod; if not, reject it.
 			// We failed pods that we rejected, so activePods include all admitted
 			// pods that are alive.
-			if ok, reason, message := kl.allocationManager.AddPod(kl.GetActivePods(), pod); !ok {
+			if ok, reason, message := kl.allocationManager.AddPod(ctx, kl.GetActivePods(), pod); !ok {
 				kl.rejectPod(ctx, pod, reason, message)
 				// We avoid recording the metric in canAdmitPod because it's called
 				// repeatedly during a resize, which would inflate the metric.
@@ -2919,7 +2920,7 @@ func (kl *Kubelet) HandlePodAdditions(ctx context.Context, pods []*v1.Pod) {
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		kl.statusManager.BackfillPodResizeConditions(pods)
 		for _, uid := range pendingResizes {
-			kl.allocationManager.PushPendingResize(uid)
+			kl.allocationManager.PushPendingResize(logger, uid)
 		}
 		if len(pendingResizes) > 0 {
 			kl.allocationManager.RetryPendingResizes(ctx, allocation.TriggerReasonPodsAdded)
@@ -2948,7 +2949,7 @@ func (kl *Kubelet) HandlePodUpdates(ctx context.Context, pods []*v1.Pod) {
 			if recordResizeOperations(oldPod, pod) {
 				_, updatedFromAllocation := kl.allocationManager.UpdatePodFromAllocation(pod)
 				if updatedFromAllocation {
-					kl.allocationManager.PushPendingResize(pod.UID)
+					kl.allocationManager.PushPendingResize(logger, pod.UID)
 					// TODO(natasha41575): If the resize is immediately actuated, it will trigger a pod sync
 					// and we will end up calling UpdatePod twice. Figure out if there is a way to avoid this.
 					kl.allocationManager.RetryPendingResizes(ctx, allocation.TriggerReasonPodUpdated)
@@ -3082,7 +3083,7 @@ func (kl *Kubelet) HandlePodRemoves(ctx context.Context, pods []*v1.Pod) {
 	for _, pod := range pods {
 		kl.podCertificateManager.ForgetPod(ctx, pod)
 		kl.podManager.RemovePod(pod)
-		kl.allocationManager.RemovePod(pod.UID)
+		kl.allocationManager.RemovePod(logger, pod.UID)
 
 		pod, mirrorPod, wasMirror := kl.podManager.GetPodAndMirrorPod(pod)
 		if wasMirror {

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -6569,7 +6569,7 @@ func TestConvertToAPIContainerStatusesDataRace(t *testing.T) {
 }
 
 func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 	if goruntime.GOOS != "linux" {
 		t.Skip("InPlacePodVerticalScaling cgroup resource reporting is only supported on Linux")
 	}
@@ -7017,7 +7017,7 @@ func TestConvertToAPIContainerStatusesForResources(t *testing.T) {
 			} else {
 				tPod.Spec.Containers[0].Resources = tc.Resources
 			}
-			err := kubelet.allocationManager.SetAllocatedResources(tPod)
+			err := kubelet.allocationManager.SetAllocatedResources(logger, tPod)
 			require.NoError(t, err)
 			resources := tc.ActualResources
 			if resources == nil {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -339,6 +339,7 @@ func newTestKubeletWithImageList(
 	}
 
 	kubelet.allocationManager = allocation.NewInMemoryManager(
+		logger,
 		kubelet.statusManager,
 		func(ctx context.Context, pod *v1.Pod) { kubelet.HandlePodSyncs(ctx, []*v1.Pod{pod}) },
 		kubelet.GetActivePods,
@@ -2780,6 +2781,8 @@ func TestHandlePodAdditionsInvokesPodAdmitHandlers(t *testing.T) {
 }
 
 func TestPodResourceAllocationReset(t *testing.T) {
+	logger, tCtx := ktesting.NewTestContext(t)
+
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
 	testKubelet := newTestKubelet(t, false)
 	defer testKubelet.Cleanup()
@@ -2975,10 +2978,9 @@ func TestPodResourceAllocationReset(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tCtx := ktesting.Init(t)
 			if tc.existingPodAllocation != nil {
 				// when kubelet restarts, AllocatedResources has already existed before adding pod
-				err := kubelet.allocationManager.SetAllocatedResources(tc.existingPodAllocation)
+				err := kubelet.allocationManager.SetAllocatedResources(logger, tc.existingPodAllocation)
 				if err != nil {
 					t.Fatalf("failed to set pod allocation: %v", err)
 				}
@@ -4160,7 +4162,7 @@ func TestSyncPodWithErrorsDuringInPlacePodResize(t *testing.T) {
 }
 
 func TestHandlePodUpdates_RecordContainerRequestedResizes(t *testing.T) {
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 	metrics.Register()
 	metrics.ContainerRequestedResizes.Reset()
 
@@ -4741,7 +4743,7 @@ func TestHandlePodUpdates_RecordContainerRequestedResizes(t *testing.T) {
 			kubelet := testKubelet.kubelet
 
 			kubelet.podManager.AddPod(initialPod)
-			require.NoError(t, kubelet.allocationManager.SetAllocatedResources(initialPod))
+			require.NoError(t, kubelet.allocationManager.SetAllocatedResources(logger, initialPod))
 			kubelet.HandlePodUpdates(tCtx, []*v1.Pod{updatedPod})
 
 			tc.updateExpectedFunc(&expectedMetrics)
@@ -4805,7 +4807,7 @@ func TestHandlePodReconcile_RetryPendingResizes(t *testing.T) {
 		t.Skip("InPlacePodVerticalScaling is not currently supported for Windows")
 	}
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 
 	testKubelet := newTestKubeletExcludeAdmitHandlers(t, false /* controllerAttachDetachEnabled */, true /*enableResizing*/)
 	defer testKubelet.Cleanup()
@@ -4927,21 +4929,21 @@ func TestHandlePodReconcile_RetryPendingResizes(t *testing.T) {
 			handler := &testPodAdmitHandler{podsToReject: []*v1.Pod{pendingResizeAllocated}}
 			kubelet.allocationManager.AddPodAdmitHandlers(lifecycle.PodAdmitHandlers{handler})
 
-			require.NoError(t, kubelet.allocationManager.SetAllocatedResources(pendingResizeAllocated))
-			require.NoError(t, kubelet.allocationManager.SetAllocatedResources(tc.oldPod))
+			require.NoError(t, kubelet.allocationManager.SetAllocatedResources(logger, pendingResizeAllocated))
+			require.NoError(t, kubelet.allocationManager.SetAllocatedResources(logger, tc.oldPod))
 
 			// We only expect status resources to change in HandlePodReconcile.
 			tc.oldPod.Spec = tc.newPod.Spec
 
 			kubelet.podManager.AddPod(pendingResizeDesired)
 			kubelet.podManager.AddPod(tc.oldPod)
-			kubelet.allocationManager.PushPendingResize(pendingResizeDesired.UID)
+			kubelet.allocationManager.PushPendingResize(logger, pendingResizeDesired.UID)
 
 			kubelet.statusManager.ClearPodResizePendingCondition(pendingResizeDesired.UID)
 			kubelet.HandlePodReconcile(tCtx, []*v1.Pod{tc.newPod})
 			require.Equal(t, tc.shouldRetryPendingResize, kubelet.statusManager.IsPodResizeDeferred(pendingResizeDesired.UID))
 
-			kubelet.allocationManager.RemovePod(pendingResizeDesired.UID)
+			kubelet.allocationManager.RemovePod(logger, pendingResizeDesired.UID)
 			kubelet.podManager.RemovePod((pendingResizeDesired))
 			kubelet.podManager.RemovePod(tc.oldPod)
 		})

--- a/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/component-base/logs/logreduction"
 	internalapi "k8s.io/cri-api/pkg/apis"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/credentialprovider"
 	"k8s.io/kubernetes/pkg/kubelet/allocation/state"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
@@ -96,6 +97,7 @@ func (f *fakePodPullingTimeRecorder) RecordImageStartedPulling(podUID types.UID)
 func (f *fakePodPullingTimeRecorder) RecordImageFinishedPulling(podUID types.UID) {}
 
 func newFakeKubeRuntimeManager(ctx context.Context, runtimeService internalapi.RuntimeService, imageService internalapi.ImageManagerService, machineInfo *cadvisorapi.MachineInfo, osInterface kubecontainer.OSInterface, runtimeHelper kubecontainer.RuntimeHelper, tracer trace.Tracer, recorder *record.FakeRecorder) (*kubeGenericRuntimeManager, error) {
+	logger := klog.FromContext(ctx)
 	kubeRuntimeManager := &kubeGenericRuntimeManager{
 		recorder:               recorder,
 		cpuCFSQuota:            false,
@@ -114,7 +116,7 @@ func newFakeKubeRuntimeManager(ctx context.Context, runtimeService internalapi.R
 		logManager:             logs.NewStubContainerLogManager(),
 		memoryThrottlingFactor: 0.9,
 		podLogsDirectory:       fakePodLogsDirectory,
-		actuatedState:          state.NewStateMemory(nil),
+		actuatedState:          state.NewStateMemory(logger, nil),
 	}
 
 	// Initialize swap controller availability check (always false for tests)

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -262,7 +262,7 @@ func (m *kubeGenericRuntimeManager) startContainer(ctx context.Context, podSandb
 	}
 
 	// When creating a container, mark the resources as actuated.
-	if err := m.setActuatedContainerResources(pod, container); err != nil {
+	if err := m.setActuatedContainerResources(logger, pod, container); err != nil {
 		m.recordContainerEvent(ctx, pod, container, "", v1.EventTypeWarning, events.FailedToCreateContainer, "Error: %v", err)
 		return err.Error(), ErrCreateContainerConfig
 	}
@@ -408,23 +408,24 @@ func (m *kubeGenericRuntimeManager) generateContainerConfig(ctx context.Context,
 }
 
 func (m *kubeGenericRuntimeManager) updateContainerResources(ctx context.Context, pod *v1.Pod, container *v1.Container, containerID kubecontainer.ContainerID) error {
+	logger := klog.FromContext(ctx)
 	containerResources := m.generateContainerResources(ctx, pod, container)
 	if containerResources == nil {
 		return fmt.Errorf("container %q updateContainerResources failed: cannot generate resources config", containerID.String())
 	}
 	err := m.runtimeService.UpdateContainerResources(ctx, containerID.ID, containerResources)
 	if err == nil {
-		err = m.setActuatedContainerResources(pod, container)
+		err = m.setActuatedContainerResources(logger, pod, container)
 	}
 	return err
 }
 
-func (m *kubeGenericRuntimeManager) setActuatedContainerResources(pod *v1.Pod, container *v1.Container) error {
+func (m *kubeGenericRuntimeManager) setActuatedContainerResources(logger klog.Logger, pod *v1.Pod, container *v1.Container) error {
 	containerResources := container.Resources
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodLevelResourcesVerticalScaling) {
 		containerResources.Limits = kubeutil.GetLimits(&kubeutil.ResourceOpts{PodResources: pod.Spec.Resources, ContainerResources: &container.Resources})
 	}
-	return m.actuatedState.SetContainerResources(pod.UID, container.Name, containerResources)
+	return m.actuatedState.SetContainerResources(logger, pod.UID, container.Name, containerResources)
 }
 
 func (m *kubeGenericRuntimeManager) updatePodSandboxResources(ctx context.Context, sandboxID string, pod *v1.Pod, podResources *cm.ResourceConfig) error {

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -316,7 +316,7 @@ func TestToKubeContainerStatusWithResources(t *testing.T) {
 		t.Skip("InPlacePodVerticalScaling is not currently supported on Windows.")
 	}
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 
 	const (
 		podUID    types.UID = "12345-abcd"
@@ -490,8 +490,8 @@ func TestToKubeContainerStatusWithResources(t *testing.T) {
 			}
 
 			if test.actuatedResources != nil {
-				require.NoError(t, m.actuatedState.SetContainerResources(podUID, meta.Name, *test.actuatedResources))
-				t.Cleanup(func() { _ = m.actuatedState.RemovePod(podUID) })
+				require.NoError(t, m.actuatedState.SetContainerResources(logger, podUID, meta.Name, *test.actuatedResources))
+				t.Cleanup(func() { _ = m.actuatedState.RemovePod(logger, podUID) })
 			}
 
 			actual := m.toKubeContainerStatus(tCtx, podUID, input, cid.Type)

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -372,7 +372,7 @@ func NewKubeGenericRuntimeManager(
 		versionCacheTTL,
 	)
 
-	kubeRuntimeManager.actuatedState, err = state.NewStateCheckpoint(rootDirectory, actuatedPodsStateFile)
+	kubeRuntimeManager.actuatedState, err = state.NewStateCheckpoint(logger, rootDirectory, actuatedPodsStateFile)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to initialize actuated state checkpoint: %w", err)
 	}
@@ -907,7 +907,7 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 			}
 
 		}
-		if err = m.actuatedState.SetPodLevelResources(pod.UID, actuatedPodResources); err != nil {
+		if err = m.actuatedState.SetPodLevelResources(logger, pod.UID, actuatedPodResources); err != nil {
 			logger.Error(err, "SetPodLevelResources failed", "pod", pod.Name, "UID", pod.UID,
 				"pod", format.Pod(pod), "resourceName", resourceName)
 			return err
@@ -2161,7 +2161,7 @@ func (m *kubeGenericRuntimeManager) GarbageCollect(ctx context.Context, gcPolicy
 	// Remove terminated pods from the actuated state.
 	for uid := range m.actuatedState.GetPodResourceInfoMap() {
 		if m.podStateProvider.ShouldPodContentBeRemoved(uid) {
-			if err := m.actuatedState.RemovePod(uid); err != nil {
+			if err := m.actuatedState.RemovePod(logger, uid); err != nil {
 				// No need to act on the error beyond logging it here.
 				logger.Error(err, "Failed to remove pod from actuated state", "podUID", uid)
 			}
@@ -2198,7 +2198,7 @@ func (m *kubeGenericRuntimeManager) ListPodSandboxMetrics(ctx context.Context) (
 	return m.runtimeService.ListPodSandboxMetrics(ctx)
 }
 
-func (m *kubeGenericRuntimeManager) UpdateActuatedPodLevelResources(actuatedPod *v1.Pod) error {
+func (m *kubeGenericRuntimeManager) UpdateActuatedPodLevelResources(logger klog.Logger, actuatedPod *v1.Pod) error {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		return nil
 	}
@@ -2211,7 +2211,7 @@ func (m *kubeGenericRuntimeManager) UpdateActuatedPodLevelResources(actuatedPod 
 		return nil
 	}
 
-	return m.actuatedState.SetPodLevelResources(actuatedPod.UID, actuatedPod.Spec.Resources)
+	return m.actuatedState.SetPodLevelResources(logger, actuatedPod.UID, actuatedPod.Spec.Resources)
 }
 
 // isPodResizeInProgress checks whether the actuated resizable resources differ from

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -90,7 +90,7 @@ func withRecorder(recorder *record.FakeRecorder) testRuntimeManagerOption {
 	}
 }
 
-func createTestRuntimeManager(tCtx ktesting.TContext, opts ...testRuntimeManagerOption) (*apitest.FakeRuntimeService, *apitest.FakeImageService, *kubeGenericRuntimeManager, error) {
+func createTestRuntimeManager(ctx context.Context, opts ...testRuntimeManagerOption) (*apitest.FakeRuntimeService, *apitest.FakeImageService, *kubeGenericRuntimeManager, error) {
 	options := &testRuntimeManagerOptions{}
 	for _, opt := range opts {
 		opt(options)
@@ -113,7 +113,7 @@ func createTestRuntimeManager(tCtx ktesting.TContext, opts ...testRuntimeManager
 		MemoryCapacity: uint64(memoryCapacityQuantity.Value()),
 	}
 	osInterface := &containertest.FakeOS{}
-	manager, err := newFakeKubeRuntimeManager(tCtx, fakeRuntimeService, fakeImageService, machineInfo, osInterface, &containertest.FakeRuntimeHelper{}, noopoteltrace.NewTracerProvider().Tracer(""), options.recorder)
+	manager, err := newFakeKubeRuntimeManager(ctx, fakeRuntimeService, fakeImageService, machineInfo, osInterface, &containertest.FakeRuntimeHelper{}, noopoteltrace.NewTracerProvider().Tracer(""), options.recorder)
 	return fakeRuntimeService, fakeImageService, manager, err
 }
 
@@ -1887,7 +1887,7 @@ func verifyActions(t *testing.T, expected, actual *podActions, desc string) {
 }
 
 func TestComputePodActionsWithInitContainers(t *testing.T) {
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 	_, _, m, err := createTestRuntimeManager(tCtx)
 	require.NoError(t, err)
 
@@ -2202,7 +2202,7 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 				}
 				// Sync the state manager with the base (old) values before the resize
 				resources := pod.Spec.InitContainers[0].Resources
-				require.NoError(t, m.actuatedState.SetContainerResources(pod.UID, pod.Spec.InitContainers[0].Name, resources))
+				require.NoError(t, m.actuatedState.SetContainerResources(logger, pod.UID, pod.Spec.InitContainers[0].Name, resources))
 			}
 
 			if test.mutatePodFn != nil {
@@ -3049,7 +3049,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 	}
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
 
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 	_, _, m, err := createTestRuntimeManager(tCtx)
 	m.machineInfo.MemoryCapacity = 17179860387 // 16GB
 	assert.NoError(t, err)
@@ -3070,11 +3070,11 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 	setupActuatedResources := func(pod *v1.Pod, container *v1.Container, actuatedResources v1.ResourceRequirements) {
 		actuatedContainer := container.DeepCopy()
 		actuatedContainer.Resources = actuatedResources
-		require.NoError(t, m.actuatedState.SetContainerResources(pod.UID, actuatedContainer.Name, actuatedContainer.Resources))
+		require.NoError(t, m.actuatedState.SetContainerResources(logger, pod.UID, actuatedContainer.Name, actuatedContainer.Resources))
 	}
 
 	setupActuatedPodResources := func(pod *v1.Pod, actuatedPodResources *v1.ResourceRequirements) {
-		require.NoError(t, m.actuatedState.SetPodLevelResources(pod.UID, actuatedPodResources))
+		require.NoError(t, m.actuatedState.SetPodLevelResources(logger, pod.UID, actuatedPodResources))
 
 	}
 
@@ -3915,7 +3915,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 			if test.setupFn != nil {
 				test.setupFn(pod)
 			}
-			t.Cleanup(func() { _ = m.actuatedState.RemovePod(pod.UID) })
+			t.Cleanup(func() { _ = m.actuatedState.RemovePod(logger, pod.UID) })
 
 			for idx := range pod.Spec.Containers {
 				// compute hash
@@ -4225,7 +4225,7 @@ func TestDoPodResizeAction(t *testing.T) {
 		t.Skip("unsupported OS")
 	}
 
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
 	metrics.Register()
 	metrics.PodResizeDurationMilliseconds.Reset()
@@ -4649,7 +4649,7 @@ func TestDoPodResizeAction(t *testing.T) {
 						v1.ResourceMemory: *resource.NewQuantity(tc.currentPodLevelResources.memoryLimit, resource.BinarySI),
 					},
 				}
-				require.NoError(t, m.actuatedState.SetPodLevelResources(pod.UID, initialActuated))
+				require.NoError(t, m.actuatedState.SetPodLevelResources(logger, pod.UID, initialActuated))
 			}
 			pod.Spec.Containers[0].Resources = v1.ResourceRequirements{
 				Requests: v1.ResourceList{
@@ -5119,6 +5119,7 @@ func TestIncrementImageVolumeMetrics(t *testing.T) {
 }
 
 func TestIsPodResizeInProgress(t *testing.T) {
+	logger, tCtx := ktesting.NewTestContext(t)
 	type testResources struct {
 		cpuReq, cpuLim, memReq, memLim int64
 	}
@@ -5426,7 +5427,6 @@ func TestIsPodResizeInProgress(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodLevelResourcesVerticalScaling, test.inplacePodLevelResizeEnabled)
-			tCtx := ktesting.Init(t)
 			_, _, m, err := createTestRuntimeManager(tCtx)
 			require.NoError(t, err)
 
@@ -5467,7 +5467,7 @@ func TestIsPodResizeInProgress(t *testing.T) {
 				if c.actuated != nil {
 					actuatedContainer := container.DeepCopy()
 					actuatedContainer.Resources = mkRequirements(*c.actuated)
-					require.NoError(t, m.actuatedState.SetContainerResources(pod.UID, actuatedContainer.Name, actuatedContainer.Resources))
+					require.NoError(t, m.actuatedState.SetContainerResources(logger, pod.UID, actuatedContainer.Name, actuatedContainer.Resources))
 
 					fetched, found := m.actuatedState.GetContainerResources(pod.UID, container.Name)
 					require.True(t, found)
@@ -5484,7 +5484,7 @@ func TestIsPodResizeInProgress(t *testing.T) {
 
 				if test.podLevelResources.actuated != nil {
 					actuatedReqs := mkRequirements(*test.podLevelResources.actuated)
-					require.NoError(t, m.actuatedState.SetPodLevelResources(pod.UID, &actuatedReqs))
+					require.NoError(t, m.actuatedState.SetPodLevelResources(logger, pod.UID, &actuatedReqs))
 
 					fetched, found := m.actuatedState.GetPodLevelResources(pod.UID)
 					require.True(t, found)

--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -397,7 +397,7 @@ func createPodWorkers(logger klog.Logger) (*podWorkers, *containertest.FakeRunti
 	return createPodWorkersWithLogger(logger)
 }
 
-func createPodWorkersWithLogger(_ klog.Logger) (*podWorkers, *containertest.FakeRuntime, map[types.UID][]syncPodRecord) {
+func createPodWorkersWithLogger(logger klog.Logger) (*podWorkers, *containertest.FakeRuntime, map[types.UID][]syncPodRecord) {
 	lock := sync.Mutex{}
 	processed := make(map[types.UID][]syncPodRecord)
 	fakeRecorder := &record.FakeRecorder{}
@@ -460,7 +460,7 @@ func createPodWorkersWithLogger(_ klog.Logger) (*podWorkers, *containertest.Fake
 		time.Second,
 		time.Millisecond,
 		fakeCache,
-		allocation.NewInMemoryManager(nil, nil, nil, nil, nil, nil),
+		allocation.NewInMemoryManager(logger, nil, nil, nil, nil, nil, nil),
 	)
 	workers := w.(*podWorkers)
 	workers.clock = clock
@@ -2151,7 +2151,7 @@ func (kl *simpleFakeKubelet) SyncTerminatedPod(ctx context.Context, pod *v1.Pod,
 // TestFakePodWorkers verifies that the fakePodWorkers behaves the same way as the real podWorkers
 // for their invocation of the syncPodFn.
 func TestFakePodWorkers(t *testing.T) {
-	tCtx := ktesting.Init(t)
+	logger, tCtx := ktesting.NewTestContext(t)
 	fakeRecorder := &record.FakeRecorder{}
 	fakeRuntime := &containertest.FakeRuntime{}
 	fakeCache := containertest.NewFakeCache(fakeRuntime)
@@ -2168,7 +2168,7 @@ func TestFakePodWorkers(t *testing.T) {
 		time.Second,
 		time.Second,
 		fakeCache,
-		allocation.NewInMemoryManager(nil, nil, nil, nil, nil, nil),
+		allocation.NewInMemoryManager(logger, nil, nil, nil, nil, nil, nil),
 	)
 	fakePodWorkers := &fakePodWorkers{
 		syncPodFn: kubeletForFakeWorkers.SyncPod,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Replaced k`log.TODO()`/`context.TODO()` in the allocation manager APIs with proper logger/context parameters passed by callers.

#### Which issue(s) this PR is related to:

Ref: https://github.com/kubernetes/kubernetes/issues/130069

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```