### PR TITLE
imagepolicy: enable commentstart kube-api-linter rule

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -147,7 +147,7 @@ linters:
       # Commentstart - Ignore commentstart issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "godoc for field .* should start with '.* ...'"
-        path: "staging/src/k8s.io/api/(apps|batch|certificates|core|extensions|flowcontrol|imagepolicy|networking|resource|scheduling|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(apps|batch|certificates|core|extensions|flowcontrol|networking|resource|scheduling|storage|storagemigration)"
       
       # notimestamp: Legacy 'Timestamp' fields retained for backward compatibility
       - text: 'notimestamp: naming convention "notimestamp": field TokenRequestStatus.ExpirationTimestamp: prefer use of the term ''time'' over ''timestamp'''

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -162,7 +162,7 @@ linters:
       # Commentstart - Ignore commentstart issues for existing API group
       # TODO: For each existing API group, we aim to remove it over time.
       - text: "godoc for field .* should start with '.* ...'"
-        path: "staging/src/k8s.io/api/(apps|batch|certificates|core|extensions|flowcontrol|imagepolicy|networking|resource|scheduling|storage|storagemigration)"
+        path: "staging/src/k8s.io/api/(apps|batch|certificates|core|extensions|flowcontrol|networking|resource|scheduling|storage|storagemigration)"
       
       # notimestamp: Legacy 'Timestamp' fields retained for backward compatibility
       - text: 'notimestamp: naming convention "notimestamp": field TokenRequestStatus.ExpirationTimestamp: prefer use of the term ''time'' over ''timestamp'''

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -23,7 +23,7 @@
 # Commentstart - Ignore commentstart issues for existing API group
 # TODO: For each existing API group, we aim to remove it over time.
 - text: "godoc for field .* should start with '.* ...'"
-  path: "staging/src/k8s.io/api/(apps|batch|certificates|core|extensions|flowcontrol|imagepolicy|networking|resource|scheduling|storage|storagemigration)"
+  path: "staging/src/k8s.io/api/(apps|batch|certificates|core|extensions|flowcontrol|networking|resource|scheduling|storage|storagemigration)"
 
 # notimestamp: Legacy 'Timestamp' fields retained for backward compatibility
 - text: 'notimestamp: naming convention "notimestamp": field TokenRequestStatus.ExpirationTimestamp: prefer use of the term ''time'' over ''timestamp'''

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -40510,21 +40510,21 @@ func schema_k8sio_api_imagepolicy_v1alpha1_ImageReview(ref common.ReferenceCallb
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Description: "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
 							Default:     map[string]interface{}{},
 							Ref:         ref(metav1.ObjectMeta{}.OpenAPIModelName()),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Spec holds information about the pod being evaluated",
+							Description: "spec holds information about the pod being evaluated",
 							Default:     map[string]interface{}{},
 							Ref:         ref(imagepolicyv1alpha1.ImageReviewSpec{}.OpenAPIModelName()),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Status is filled in by the backend and indicates whether the pod should be allowed.",
+							Description: "status is filled in by the backend and indicates whether the pod should be allowed.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(imagepolicyv1alpha1.ImageReviewStatus{}.OpenAPIModelName()),
 						},
@@ -40546,7 +40546,7 @@ func schema_k8sio_api_imagepolicy_v1alpha1_ImageReviewContainerSpec(ref common.R
 				Properties: map[string]spec.Schema{
 					"image": {
 						SchemaProps: spec.SchemaProps{
-							Description: "This can be in the form image:tag or image@SHA:012345679abcdef.",
+							Description: "image can be in the form image:tag or image@SHA:012345679abcdef.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -40571,7 +40571,7 @@ func schema_k8sio_api_imagepolicy_v1alpha1_ImageReviewSpec(ref common.ReferenceC
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Containers is a list of a subset of the information in each container of the Pod being created.",
+							Description: "containers is a list of a subset of the information in each container of the Pod being created.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -40584,7 +40584,7 @@ func schema_k8sio_api_imagepolicy_v1alpha1_ImageReviewSpec(ref common.ReferenceC
 					},
 					"annotations": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Annotations is a list of key-value pairs extracted from the Pod's annotations. It only includes keys which match the pattern `*.image-policy.k8s.io/*`. It is up to each webhook backend to determine how to interpret these annotations, if at all.",
+							Description: "annotations is a list of key-value pairs extracted from the Pod's annotations. It only includes keys which match the pattern `*.image-policy.k8s.io/*`. It is up to each webhook backend to determine how to interpret these annotations, if at all.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,
@@ -40599,7 +40599,7 @@ func schema_k8sio_api_imagepolicy_v1alpha1_ImageReviewSpec(ref common.ReferenceC
 					},
 					"namespace": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Namespace is the namespace the pod is being created in.",
+							Description: "namespace is the namespace the pod is being created in.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -40621,7 +40621,7 @@ func schema_k8sio_api_imagepolicy_v1alpha1_ImageReviewStatus(ref common.Referenc
 				Properties: map[string]spec.Schema{
 					"allowed": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Allowed indicates that all images were allowed to be run.",
+							Description: "allowed indicates that all images were allowed to be run.",
 							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
@@ -40629,14 +40629,14 @@ func schema_k8sio_api_imagepolicy_v1alpha1_ImageReviewStatus(ref common.Referenc
 					},
 					"reason": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Reason should be empty unless Allowed is false in which case it may contain a short description of what is wrong.  Kubernetes may truncate excessively long errors when displaying to the user.",
+							Description: "reason should be empty unless Allowed is false in which case it may contain a short description of what is wrong.  Kubernetes may truncate excessively long errors when displaying to the user.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"auditAnnotations": {
 						SchemaProps: spec.SchemaProps{
-							Description: "AuditAnnotations will be added to the attributes object of the admission controller request using 'AddAnnotation'.  The keys should be prefix-less (i.e., the admission controller will add an appropriate prefix).",
+							Description: "auditAnnotations will be added to the attributes object of the admission controller request using 'AddAnnotation'.  The keys should be prefix-less (i.e., the admission controller will add an appropriate prefix).",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,

--- a/staging/src/k8s.io/api/imagepolicy/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/imagepolicy/v1alpha1/generated.proto
@@ -31,58 +31,58 @@ option go_package = "k8s.io/api/imagepolicy/v1alpha1";
 // ImageReview checks if the set of images in a pod are allowed.
 // +k8s:supportsSubresource="/status"
 message ImageReview {
-  // Standard object's metadata.
+  // metadata is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // Spec holds information about the pod being evaluated
+  // spec holds information about the pod being evaluated
   // +optional
   optional ImageReviewSpec spec = 2;
 
-  // Status is filled in by the backend and indicates whether the pod should be allowed.
+  // status is filled in by the backend and indicates whether the pod should be allowed.
   // +optional
   optional ImageReviewStatus status = 3;
 }
 
 // ImageReviewContainerSpec is a description of a container within the pod creation request.
 message ImageReviewContainerSpec {
-  // This can be in the form image:tag or image@SHA:012345679abcdef.
+  // image can be in the form image:tag or image@SHA:012345679abcdef.
   // +optional
   optional string image = 1;
 }
 
 // ImageReviewSpec is a description of the pod creation request.
 message ImageReviewSpec {
-  // Containers is a list of a subset of the information in each container of the Pod being created.
+  // containers is a list of a subset of the information in each container of the Pod being created.
   // +optional
   // +listType=atomic
   repeated ImageReviewContainerSpec containers = 1;
 
-  // Annotations is a list of key-value pairs extracted from the Pod's annotations.
+  // annotations is a list of key-value pairs extracted from the Pod's annotations.
   // It only includes keys which match the pattern `*.image-policy.k8s.io/*`.
   // It is up to each webhook backend to determine how to interpret these annotations, if at all.
   // +optional
   map<string, string> annotations = 2;
 
-  // Namespace is the namespace the pod is being created in.
+  // namespace is the namespace the pod is being created in.
   // +optional
   optional string namespace = 3;
 }
 
 // ImageReviewStatus is the result of the review for the pod creation request.
 message ImageReviewStatus {
-  // Allowed indicates that all images were allowed to be run.
+  // allowed indicates that all images were allowed to be run.
   // +optional
   optional bool allowed = 1;
 
-  // Reason should be empty unless Allowed is false in which case it
+  // reason should be empty unless Allowed is false in which case it
   // may contain a short description of what is wrong.  Kubernetes
   // may truncate excessively long errors when displaying to the user.
   // +optional
   optional string reason = 2;
 
-  // AuditAnnotations will be added to the attributes object of the
+  // auditAnnotations will be added to the attributes object of the
   // admission controller request using 'AddAnnotation'.  The keys should
   // be prefix-less (i.e., the admission controller will add an
   // appropriate prefix).

--- a/staging/src/k8s.io/api/imagepolicy/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/imagepolicy/v1alpha1/types.go
@@ -29,39 +29,39 @@ import (
 // +k8s:supportsSubresource="/status"
 type ImageReview struct {
 	metav1.TypeMeta `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Spec holds information about the pod being evaluated
+	// spec holds information about the pod being evaluated
 	// +optional
 	Spec ImageReviewSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 
-	// Status is filled in by the backend and indicates whether the pod should be allowed.
+	// status is filled in by the backend and indicates whether the pod should be allowed.
 	// +optional
 	Status ImageReviewStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
 // ImageReviewSpec is a description of the pod creation request.
 type ImageReviewSpec struct {
-	// Containers is a list of a subset of the information in each container of the Pod being created.
+	// containers is a list of a subset of the information in each container of the Pod being created.
 	// +optional
 	// +listType=atomic
 	Containers []ImageReviewContainerSpec `json:"containers,omitempty" protobuf:"bytes,1,rep,name=containers"`
-	// Annotations is a list of key-value pairs extracted from the Pod's annotations.
+	// annotations is a list of key-value pairs extracted from the Pod's annotations.
 	// It only includes keys which match the pattern `*.image-policy.k8s.io/*`.
 	// It is up to each webhook backend to determine how to interpret these annotations, if at all.
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty" protobuf:"bytes,2,rep,name=annotations"`
-	// Namespace is the namespace the pod is being created in.
+	// namespace is the namespace the pod is being created in.
 	// +optional
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,3,opt,name=namespace"`
 }
 
 // ImageReviewContainerSpec is a description of a container within the pod creation request.
 type ImageReviewContainerSpec struct {
-	// This can be in the form image:tag or image@SHA:012345679abcdef.
+	// image can be in the form image:tag or image@SHA:012345679abcdef.
 	// +optional
 	Image string `json:"image,omitempty" protobuf:"bytes,1,opt,name=image"`
 	// In future, we may add command line overrides, exec health check command lines, and so on.
@@ -69,15 +69,15 @@ type ImageReviewContainerSpec struct {
 
 // ImageReviewStatus is the result of the review for the pod creation request.
 type ImageReviewStatus struct {
-	// Allowed indicates that all images were allowed to be run.
+	// allowed indicates that all images were allowed to be run.
 	// +optional
 	Allowed bool `json:"allowed" protobuf:"varint,1,opt,name=allowed"`
-	// Reason should be empty unless Allowed is false in which case it
+	// reason should be empty unless Allowed is false in which case it
 	// may contain a short description of what is wrong.  Kubernetes
 	// may truncate excessively long errors when displaying to the user.
 	// +optional
 	Reason string `json:"reason,omitempty" protobuf:"bytes,2,opt,name=reason"`
-	// AuditAnnotations will be added to the attributes object of the
+	// auditAnnotations will be added to the attributes object of the
 	// admission controller request using 'AddAnnotation'.  The keys should
 	// be prefix-less (i.e., the admission controller will add an
 	// appropriate prefix).

--- a/staging/src/k8s.io/api/imagepolicy/v1alpha1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/imagepolicy/v1alpha1/types_swagger_doc_generated.go
@@ -29,9 +29,9 @@ package v1alpha1
 // AUTO-GENERATED FUNCTIONS START HERE. DO NOT EDIT.
 var map_ImageReview = map[string]string{
 	"":         "ImageReview checks if the set of images in a pod are allowed.",
-	"metadata": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-	"spec":     "Spec holds information about the pod being evaluated",
-	"status":   "Status is filled in by the backend and indicates whether the pod should be allowed.",
+	"metadata": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+	"spec":     "spec holds information about the pod being evaluated",
+	"status":   "status is filled in by the backend and indicates whether the pod should be allowed.",
 }
 
 func (ImageReview) SwaggerDoc() map[string]string {
@@ -40,7 +40,7 @@ func (ImageReview) SwaggerDoc() map[string]string {
 
 var map_ImageReviewContainerSpec = map[string]string{
 	"":      "ImageReviewContainerSpec is a description of a container within the pod creation request.",
-	"image": "This can be in the form image:tag or image@SHA:012345679abcdef.",
+	"image": "image can be in the form image:tag or image@SHA:012345679abcdef.",
 }
 
 func (ImageReviewContainerSpec) SwaggerDoc() map[string]string {
@@ -49,9 +49,9 @@ func (ImageReviewContainerSpec) SwaggerDoc() map[string]string {
 
 var map_ImageReviewSpec = map[string]string{
 	"":            "ImageReviewSpec is a description of the pod creation request.",
-	"containers":  "Containers is a list of a subset of the information in each container of the Pod being created.",
-	"annotations": "Annotations is a list of key-value pairs extracted from the Pod's annotations. It only includes keys which match the pattern `*.image-policy.k8s.io/*`. It is up to each webhook backend to determine how to interpret these annotations, if at all.",
-	"namespace":   "Namespace is the namespace the pod is being created in.",
+	"containers":  "containers is a list of a subset of the information in each container of the Pod being created.",
+	"annotations": "annotations is a list of key-value pairs extracted from the Pod's annotations. It only includes keys which match the pattern `*.image-policy.k8s.io/*`. It is up to each webhook backend to determine how to interpret these annotations, if at all.",
+	"namespace":   "namespace is the namespace the pod is being created in.",
 }
 
 func (ImageReviewSpec) SwaggerDoc() map[string]string {
@@ -60,9 +60,9 @@ func (ImageReviewSpec) SwaggerDoc() map[string]string {
 
 var map_ImageReviewStatus = map[string]string{
 	"":                 "ImageReviewStatus is the result of the review for the pod creation request.",
-	"allowed":          "Allowed indicates that all images were allowed to be run.",
-	"reason":           "Reason should be empty unless Allowed is false in which case it may contain a short description of what is wrong.  Kubernetes may truncate excessively long errors when displaying to the user.",
-	"auditAnnotations": "AuditAnnotations will be added to the attributes object of the admission controller request using 'AddAnnotation'.  The keys should be prefix-less (i.e., the admission controller will add an appropriate prefix).",
+	"allowed":          "allowed indicates that all images were allowed to be run.",
+	"reason":           "reason should be empty unless Allowed is false in which case it may contain a short description of what is wrong.  Kubernetes may truncate excessively long errors when displaying to the user.",
+	"auditAnnotations": "auditAnnotations will be added to the attributes object of the admission controller request using 'AddAnnotation'.  The keys should be prefix-less (i.e., the admission controller will add an appropriate prefix).",
 }
 
 func (ImageReviewStatus) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/client-go/applyconfigurations/imagepolicy/v1alpha1/imagereview.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/imagepolicy/v1alpha1/imagereview.go
@@ -33,12 +33,12 @@ import (
 // ImageReview checks if the set of images in a pod are allowed.
 type ImageReviewApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration `json:""`
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	// Spec holds information about the pod being evaluated
+	// spec holds information about the pod being evaluated
 	Spec *ImageReviewSpecApplyConfiguration `json:"spec,omitempty"`
-	// Status is filled in by the backend and indicates whether the pod should be allowed.
+	// status is filled in by the backend and indicates whether the pod should be allowed.
 	Status *ImageReviewStatusApplyConfiguration `json:"status,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/imagepolicy/v1alpha1/imagereviewcontainerspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/imagepolicy/v1alpha1/imagereviewcontainerspec.go
@@ -23,7 +23,7 @@ package v1alpha1
 //
 // ImageReviewContainerSpec is a description of a container within the pod creation request.
 type ImageReviewContainerSpecApplyConfiguration struct {
-	// This can be in the form image:tag or image@SHA:012345679abcdef.
+	// image can be in the form image:tag or image@SHA:012345679abcdef.
 	Image *string `json:"image,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/imagepolicy/v1alpha1/imagereviewspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/imagepolicy/v1alpha1/imagereviewspec.go
@@ -23,13 +23,13 @@ package v1alpha1
 //
 // ImageReviewSpec is a description of the pod creation request.
 type ImageReviewSpecApplyConfiguration struct {
-	// Containers is a list of a subset of the information in each container of the Pod being created.
+	// containers is a list of a subset of the information in each container of the Pod being created.
 	Containers []ImageReviewContainerSpecApplyConfiguration `json:"containers,omitempty"`
-	// Annotations is a list of key-value pairs extracted from the Pod's annotations.
+	// annotations is a list of key-value pairs extracted from the Pod's annotations.
 	// It only includes keys which match the pattern `*.image-policy.k8s.io/*`.
 	// It is up to each webhook backend to determine how to interpret these annotations, if at all.
 	Annotations map[string]string `json:"annotations,omitempty"`
-	// Namespace is the namespace the pod is being created in.
+	// namespace is the namespace the pod is being created in.
 	Namespace *string `json:"namespace,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/imagepolicy/v1alpha1/imagereviewstatus.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/imagepolicy/v1alpha1/imagereviewstatus.go
@@ -23,13 +23,13 @@ package v1alpha1
 //
 // ImageReviewStatus is the result of the review for the pod creation request.
 type ImageReviewStatusApplyConfiguration struct {
-	// Allowed indicates that all images were allowed to be run.
+	// allowed indicates that all images were allowed to be run.
 	Allowed *bool `json:"allowed,omitempty"`
-	// Reason should be empty unless Allowed is false in which case it
+	// reason should be empty unless Allowed is false in which case it
 	// may contain a short description of what is wrong.  Kubernetes
 	// may truncate excessively long errors when displaying to the user.
 	Reason *string `json:"reason,omitempty"`
-	// AuditAnnotations will be added to the attributes object of the
+	// auditAnnotations will be added to the attributes object of the
 	// admission controller request using 'AddAnnotation'.  The keys should
 	// be prefix-less (i.e., the admission controller will add an
 	// appropriate prefix).


### PR DESCRIPTION
Enables the `commentstart` kube-api-linter (KAL) rule for the `imagepolicy` API group by removing it from the rule's exclusion list in `hack/kube-api-linter/exceptions.yaml` and updating the field godoc comments in `imagepolicy/v1alpha1` to start with the serialized (JSON) field name, as the rule requires.

This is part of the wider effort to enable KAL rules on the built-in API groups one group at a time.

**What:**
- Drop `imagepolicy` from the `commentstart` exclusion regex.
- Update the 10 field godoc comments in `staging/src/k8s.io/api/imagepolicy/v1alpha1/types.go` to begin with their JSON field name.
- Regenerate the affected generated files (swagger doc, protobuf `.proto`, OpenAPI, golangci config, client-go applyconfigurations) — kept in a separate commit.

**Verification:**
- `hack/verify-golangci-lint.sh staging/src/k8s.io/api/...` → 0 issues.
- `hack/verify-codegen.sh` → passes.

Part of #134671

/sig api-machinery
/area code-generation

```release-note
NONE
```