### PR TITLE
Ensure is_xfs evaluates to true in quota tests

### DIFF
--- a/test/e2e_node/quota_lsci_test.go
+++ b/test/e2e_node/quota_lsci_test.go
@@ -48,10 +48,7 @@ func runOneQuotaTest(f *framework.Framework, quotasRequested bool, userNamespace
 	sizeLimit := resource.MustParse("100Mi")
 	useOverLimit := 101 /* Mb */
 	useUnderLimit := 99 /* Mb */
-	// As for why we do this: see comment below at isXfs.
-	if isXfs(framework.TestContext.KubeletRootDir) {
-		useUnderLimit = 50 /* Mb */
-	}
+
 	priority := 0
 	if quotasRequested {
 		priority = 1
@@ -87,6 +84,16 @@ func runOneQuotaTest(f *framework.Framework, quotasRequested bool, userNamespace
 				pod: diskConcealingPod(fmt.Sprintf("emptydir-concealed-disk-under-sizelimit-quotas-%v", quotasRequested), useUnderLimit, &v1.VolumeSource{
 					EmptyDir: &v1.EmptyDirVolumeSource{SizeLimit: &sizeLimit},
 				}, v1.ResourceRequirements{}),
+				prePodCreationModificationFunc: func(ctx context.Context, pod *v1.Pod) {
+					// XFS speculative preallocation can inflate apparent usage (see isXfs).
+					if isXfs(framework.TestContext.KubeletRootDir) {
+						pod.Spec.Containers[0].Command = []string{
+							"perl",
+							"-e",
+							fmt.Sprintf(writeConcealedPodCommand, filepath.Join(volumeMountPath, "file"), 50 /* Mb */),
+						}
+					}
+				},
 			},
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR fixes an issue where is_xfs was not evaluated correctly, which led to speculative preallocation in XFS not being accounted for. (https://internals-for-interns.com/posts/xfs-filesystem/)


Bug: https://testgrid.k8s.io/sig-node-cri-o#ci-node-crio-kubelet-serial
```
E2eNode Suite.[It] [sig-node] LocalStorageCapacityIsolationFSQuotaMonitoring [Feature:LocalStorageCapacityIsolationQuota] [Feature:LSCIQuotaMonitoring] [Feature:UserNamespacesSupport] when we run containers that should cause use quotas for LSCI monitoring (quotas enabled: true, userNamespacesEnabled: true) should eventually evict all of the correct pods [Disruptive] [Serial] [Slow]
```
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-node-crio-kubelet-serial/2066268006966628352

Test result:
```
export KUBE_SSH_USER=core && make test-e2e-node REMOTE=true RUNTIME=remote FOCUS="LocalStorageCapacityIsolationFSQuotaMonitoring.*quotas enabled: true.*userNamespacesEnabled: true" IMAGE_CONFIG_FILE="$HOME/image_config.yaml" TEST_ARGS='--kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --kubelet-cgroups=/system.slice/kubelet.service --fail-swap-on=false --feature-gates=EventedPLEG=true" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"' INSTANCE_PREFIX="ngopalak" CLEANUP=false CONTAINER_RUNTIME_ENDPOINT="unix:///var/run/crio/crio.sock" SKIP="\[Flaky\]"
...
------------------------------
[ReportAfterSuite] PASSED [0.039 seconds]
[ReportAfterSuite] Kubernetes e2e JUnit report
k8s.io/kubernetes/test/e2e/framework/test_context.go:579
------------------------------

Ran 1 of 1205 Specs in 192.804 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 1204 Skipped


Ginkgo ran 1 suite in 3m15.979843424s
Test Suite Passed

Success Finished Test Suite on Host ngopalak-fedora-coreos-44-20260523-3-1-gcp-x86-64. Refer to artifacts directory for ginkgo log for this host.
<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
<                              FINISH TEST                               <
<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
```

Passing log https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/139745/pull-node-crio-kubelet-serial/2066490290033659904:
```

E2eNode Suite: [It] [sig-node] LocalStorageCapacityIsolationFSQuotaMonitoring [Feature:LocalStorageCapacityIsolationQuota] [Feature:LSCIQuotaMonitoring] [Feature:UserNamespacesSupport] when we run containers that should cause use quotas for LSCI monitoring (quotas enabled: true, userNamespacesEnabled: true) should eventually evict all of the correct pods [Disruptive] [Serial] [Slow] | 3m5s
-- | --

```

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
