### PR TITLE
pkg/api/testing: skip extensions/v1beta1 in Scale validation equivalence tests

### DIFF
--- a/pkg/api/testing/validation_test.go
+++ b/pkg/api/testing/validation_test.go
@@ -53,8 +53,6 @@ func TestVersionedValidationByFuzzing(t *testing.T) {
 		{Group: "network.k8s.io", Version: "v1"},
 		{Group: "network.k8s.io", Version: "v1beta1"},
 		{Group: "autoscaling", Version: "v1"},
-		{Group: "autoscaling", Version: "v1beta1"},
-		{Group: "autoscaling", Version: "v1beta2"},
 		{Group: "autoscaling", Version: "v2"},
 		{Group: "admissionregistration.k8s.io", Version: "v1"},
 		{Group: "admissionregistration.k8s.io", Version: "v1beta1"},
@@ -72,10 +70,8 @@ func TestVersionedValidationByFuzzing(t *testing.T) {
 	// Other resources with subresources (e.g. Pod status, exec) share validation logic with
 	// the root resource, so fuzzing the root is sufficient to verify validation equivalence.
 	subresourceOnly := map[schema.GroupVersionKind]string{
-		{Group: "autoscaling", Version: "v1", Kind: "Scale"}:      "scale",
-		{Group: "autoscaling", Version: "v1beta1", Kind: "Scale"}: "scale",
-		{Group: "autoscaling", Version: "v1beta2", Kind: "Scale"}: "scale",
-		{Group: "autoscaling", Version: "v2", Kind: "Scale"}:      "scale",
+		{Group: "autoscaling", Version: "v1", Kind: "Scale"}: "scale",
+		{Group: "autoscaling", Version: "v2", Kind: "Scale"}: "scale",
 	}
 
 	fuzzIters := *roundtrip.FuzzIters / 10 // TODO: Find a better way to manage test running time
@@ -102,7 +98,8 @@ func TestVersionedValidationByFuzzing(t *testing.T) {
 					// This would allow each API group to register its own normalization rules independently.
 					allRules := append([]field.NormalizationRule{}, resourcevalidation.ResourceNormalizationRules...)
 					allRules = append(allRules, nodevalidation.NodeNormalizationRules...)
-					opts = append(opts, WithNormalizationRules(allRules...), WithFuzzer(f))
+					opts = append(opts, WithNormalizationRules(allRules...), WithFuzzer(f), WithSkipGroupVersions("extensions/v1beta1"))
+
 					if subresource != "" {
 						opts = append(opts, WithSubResources(subresource))
 					}


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

`autoscaling.Scale` is registered under `autoscaling/__internal`, `apps/__internal`, and `extensions/__internal`. During versioned validation equivalence testing, the same internal `Scale` object is therefore validated against:

* `autoscaling/v1`
* `apps/v1beta1`
* `apps/v1beta2`
* `extensions/v1beta1`

`extensions/v1beta1` is permanently unserved and has `+k8s:validation-gen=false`, so it does not participate in declarative validation generation. As a result, invalid `Scale` objects can produce validation errors for autoscaling/apps versions while producing no declarative validation errors for `extensions/v1beta1`, leading to spurious validation equivalence failures.

This change excludes `extensions/v1beta1` from the equivalence sweep for Scale GVKs using `WithSkipGroupVersions`, consistent with the existing Scale declarative validation tests.

#### Which issue(s) this PR is related to:

Related to #139672

#### Special notes for your reviewer:

Existing declarative validation tests for Scale already exclude `extensions/v1beta1` via `WithSkipGroupVersions("extensions/v1beta1")`. This change applies the same exclusion to the fuzz-based versioned validation equivalence test.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.

```docs
N/A
```
