### PR TITLE
perf: observability for Pods that specify a `schedulerName` the cluster

### DIFF
--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -135,6 +135,8 @@ func (sched *Scheduler) addPod(obj interface{}) {
 		sched.addAssignedPodToCache(pod)
 	} else if responsibleForPod(pod, sched.Profiles) {
 		sched.addPodToSchedulingQueue(pod)
+	} else {
+		logger.V(4).Info("Pod is ignored by this scheduler because of mismatched scheduler name", "pod", klog.KObj(pod), "schedulerName", pod.Spec.SchedulerName)
 	}
 }
 

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -19,6 +19,7 @@ package scheduler
 import (
 	"context"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -267,6 +268,33 @@ func TestUpdateAssignedPodInCache(t *testing.T) {
 				t.Errorf("Want pod UID %v, got %v", tt.newPod.UID, pod.UID)
 			}
 		})
+	}
+}
+
+func TestAddPodLogsUnhandledSchedulerName(t *testing.T) {
+	// The ignored-pod message is logged at V(4), so the logger must be
+	// configured with a matching verbosity for the entry to be buffered.
+	logger := ktesting.NewLogger(t, ktesting.NewConfig(ktesting.BufferLogs(true), ktesting.Verbosity(4)))
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	pod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").SchedulerName("other-scheduler").Obj()
+
+	sched := &Scheduler{
+		Cache:           internalcache.New(ctx, nil, false),
+		SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
+		logger:          logger,
+		Profiles: profile.Map{
+			testSchedulerName: nil,
+		},
+	}
+
+	sched.addPod(pod)
+
+	output := logger.GetSink().(ktesting.Underlier).GetBuffer().String()
+	expectedMsg := "Pod is ignored by this scheduler because of mismatched scheduler name"
+	if !strings.Contains(output, expectedMsg) {
+		t.Errorf("Expected log message %q, got: %s", expectedMsg, output)
 	}
 }
 


### PR DESCRIPTION
Resolves #116982.

Use case: apply a deployment with `schedulerName` specified: ``` apiVersion: apps/v1 kind: Deployment metadata: name: nginx-deployment spec: selector: matchLabels: app: nginx replicas: 3 template: metadata: labels: app: nginx spec: schedulerName: test  # test not exist containers: - name: nginx image: nginx:1.7.9 ports: - containerPort: 80 ```

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

This PR was written in part with the assistance of generative AI; all changes were authored and reviewed by me.