### PR TITLE
Refactor watchCache to encapsulate history and storage under Law of Demeter

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -19,7 +19,6 @@ package cacher
 import (
 	"context"
 	"fmt"
-	"math"
 	"sync"
 	"time"
 
@@ -30,13 +29,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/cacher/delegator"
 	"k8s.io/apiserver/pkg/storage/cacher/metrics"
 	"k8s.io/apiserver/pkg/storage/cacher/progress"
 	"k8s.io/apiserver/pkg/storage/cacher/store"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/component-base/tracing"
 	"k8s.io/klog/v2"
@@ -53,13 +50,6 @@ const (
 	// resourceVersionTooHighRetrySeconds is the seconds before a operation should be retried by the client
 	// after receiving a 'too high resource version' error.
 	resourceVersionTooHighRetrySeconds = 1
-
-	// defaultLowerBoundCapacity is a default value for event cache capacity's lower bound.
-	// TODO: Figure out, to what value we can decreased it.
-	defaultLowerBoundCapacity = 100
-
-	// defaultUpperBoundCapacity should be able to keep the required history.
-	defaultUpperBoundCapacity = 100 * 1024
 )
 
 // watchCacheEvent is a single "watch event" that is send to users of
@@ -97,8 +87,8 @@ type watchCache struct {
 	// This handler is run at the end of every successful Replace() method.
 	onReplace func()
 
-	history watchCacheHistory
-	storage watchCacheStorage
+	history *watchCacheHistory
+	storage *watchCacheStorage
 
 	config *ImmutableWatchCacheConfig
 }
@@ -159,55 +149,13 @@ func newWatchCache(
 	wc := &watchCache{
 		resourceVersion: 0,
 		config:          config,
-		history: watchCacheHistory{
-			config:             config,
-			capacity:           defaultLowerBoundCapacity,
-			cache:              make([]*watchCacheEvent, defaultLowerBoundCapacity),
-			lowerBoundCapacity: defaultLowerBoundCapacity,
-			upperBoundCapacity: capacityUpperBound(eventFreshDuration),
-			startIndex:         0,
-			endIndex:           0,
-			eventFreshDuration: eventFreshDuration,
-		},
-		storage: watchCacheStorage{
-			config:              config,
-			store:               store.NewIndexer(indexers),
-			listResourceVersion: 0,
-		},
+		history:         newWatchCacheHistory(config, eventFreshDuration),
+		storage:         newWatchCacheStorage(config, indexers),
 	}
-	if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
-		wc.storage.snapshottingEnabled.Store(true)
-		wc.storage.snapshots = store.NewSnapshotter()
-	}
-	metrics.WatchCacheCapacity.WithLabelValues(config.groupResource.Group, config.groupResource.Resource).Set(float64(wc.history.capacity))
 	wc.cond = sync.NewCond(wc.RLocker())
 	wc.config.indexValidator = wc.history.isIndexValidLocked
 
 	return wc
-}
-
-// capacityUpperBound denotes the maximum possible capacity of the watch cache
-// to which it can resize.
-func capacityUpperBound(eventFreshDuration time.Duration) int {
-	if eventFreshDuration <= DefaultEventFreshDuration {
-		return defaultUpperBoundCapacity
-	}
-	// eventFreshDuration determines how long the watch events are supposed
-	// to be stored in the watch cache.
-	// In very high churn situations, there is a need to store more events
-	// in the watch cache, hence it would have to be upsized accordingly.
-	// Because of that, for larger values of eventFreshDuration, we set the
-	// upper bound of the watch cache's capacity proportionally to the ratio
-	// between eventFreshDuration and DefaultEventFreshDuration.
-	// Given that the watch cache size can only double, we round up that
-	// proportion to the next power of two.
-	exponent := int(math.Ceil((math.Log2(eventFreshDuration.Seconds() / DefaultEventFreshDuration.Seconds()))))
-	if maxExponent := int(math.Floor((math.Log2(math.MaxInt32 / defaultUpperBoundCapacity)))); exponent > maxExponent {
-		// Making sure that the capacity's upper bound fits in a 32-bit integer.
-		exponent = maxExponent
-		klog.Warningf("Capping watch cache capacity upper bound to %v", defaultUpperBoundCapacity<<exponent)
-	}
-	return defaultUpperBoundCapacity << exponent
 }
 
 // Add takes runtime.Object as an argument.
@@ -308,7 +256,7 @@ func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64) err
 			return err
 		}
 		if w.history.isCacheFullLocked() {
-			oldestRV := w.history.cache[w.history.startIndex%w.history.capacity].ResourceVersion
+			oldestRV := w.history.OldestResourceVersionLocked()
 			w.storage.CompactSnapshotsLocked(oldestRV)
 		}
 		w.storage.AddSnapshotLocked(w.resourceVersion)
@@ -448,7 +396,7 @@ func (w *watchCache) WaitUntilFreshAndGetKeys(ctx context.Context, resourceVersi
 	if err != nil {
 		return nil, err
 	}
-	return w.storage.store.ListKeys(), nil
+	return w.storage.ListKeys(), nil
 }
 
 // NOTICE: Structure follows the shouldDelegateList function in
@@ -508,14 +456,7 @@ func (w *watchCache) waitAndGetExactSnapshot(ctx context.Context, resourceVersio
 		return nil, err
 	}
 
-	if w.storage.snapshots == nil {
-		return nil, errors.NewResourceExpired(fmt.Sprintf("too old resource version: %d", resourceVersion))
-	}
-	store, ok := w.storage.snapshots.GetLessOrEqual(resourceVersion)
-	if !ok {
-		return nil, errors.NewResourceExpired(fmt.Sprintf("too old resource version: %d", resourceVersion))
-	}
-	return store, nil
+	return w.storage.GetExactSnapshotLocked(resourceVersion)
 }
 
 func (w *watchCache) waitAndListConsistent(ctx context.Context, key, continueKey string, matchValues []storage.MatchValue) (resp listResp, index string, err error) {
@@ -554,7 +495,7 @@ func (w *watchCache) waitAndGetLatestSnapshot(ctx context.Context, minResourceVe
 	// want - they will be filtered out later. The fact that we return less things is only further performance improvement.
 	// TODO: if multiple indexes match, return the one with the fewest items, so as to do as much filtering as possible.
 	for _, matchValue := range matchValues {
-		if result, err := w.storage.store.ByIndex(matchValue.IndexName, matchValue.Value); err == nil {
+		if result, err := w.storage.ByIndex(matchValue.IndexName, matchValue.Value); err == nil {
 			return listSnapshot{Items: result}, w.resourceVersion, matchValue.IndexName, nil
 		}
 	}
@@ -577,7 +518,7 @@ func (w *watchCache) WaitUntilFreshAndGet(ctx context.Context, resourceVersion u
 	if err != nil {
 		return nil, false, 0, err
 	}
-	value, exists, err := w.storage.store.GetByKey(key)
+	value, exists, err := w.storage.GetByKey(key)
 	return value, exists, w.resourceVersion, err
 }
 
@@ -621,16 +562,9 @@ func (w *watchCache) Replace(objs []interface{}, resourceVersion string) error {
 	// Empty the cyclic buffer, ensuring startIndex doesn't decrease.
 	w.history.ResetLocked()
 
-	if err := w.storage.store.Replace(toReplace, resourceVersion); err != nil {
+	if err := w.storage.ReplaceLocked(toReplace, resourceVersion, version); err != nil {
 		return err
 	}
-	if w.storage.snapshots != nil {
-		w.storage.snapshots.Reset()
-		if w.storage.snapshottingEnabled.Load() {
-			w.storage.snapshots.Add(version, w.storage.store)
-		}
-	}
-	w.storage.listResourceVersion = version
 	w.resourceVersion = version
 	if w.onReplace != nil {
 		w.onReplace()
@@ -656,7 +590,7 @@ func (w *watchCache) Resync() error {
 func (w *watchCache) getListResourceVersion() uint64 {
 	w.RLock()
 	defer w.RUnlock()
-	return w.storage.listResourceVersion
+	return w.storage.ListResourceVersion()
 }
 
 func (w *watchCache) suggestedWatchChannelSize(indexExists, triggerUsed bool) int {
@@ -691,7 +625,7 @@ func (w *watchCache) getAllEventsSinceLocked(resourceVersion uint64, key string,
 		resourceVersion = w.resourceVersion
 	}
 
-	return w.history.GetIntervalLocked(resourceVersion, w.storage.listResourceVersion, w.RWMutex.RLocker())
+	return w.history.GetIntervalLocked(resourceVersion, w.storage.ListResourceVersion(), w.RWMutex.RLocker())
 }
 
 // getIntervalFromStoreLocked returns a watchCacheInterval

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_history.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_history.go
@@ -25,7 +25,56 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apiserver/pkg/storage/cacher/metrics"
+	"k8s.io/klog/v2"
 )
+
+const (
+	// defaultLowerBoundCapacity is a default value for event cache capacity's lower bound.
+	// TODO: Figure out, to what value we can decreased it.
+	defaultLowerBoundCapacity = 100
+
+	// defaultUpperBoundCapacity should be able to keep the required history.
+	defaultUpperBoundCapacity = 100 * 1024
+)
+
+func newWatchCacheHistory(config *ImmutableWatchCacheConfig, eventFreshDuration time.Duration) *watchCacheHistory {
+	h := &watchCacheHistory{
+		config:             config,
+		capacity:           defaultLowerBoundCapacity,
+		cache:              make([]*watchCacheEvent, defaultLowerBoundCapacity),
+		lowerBoundCapacity: defaultLowerBoundCapacity,
+		upperBoundCapacity: capacityUpperBound(eventFreshDuration),
+		startIndex:         0,
+		endIndex:           0,
+		eventFreshDuration: eventFreshDuration,
+	}
+	metrics.WatchCacheCapacity.WithLabelValues(config.groupResource.Group, config.groupResource.Resource).Set(float64(h.capacity))
+	return h
+}
+
+// capacityUpperBound denotes the maximum possible capacity of the watch cache
+// to which it can resize.
+func capacityUpperBound(eventFreshDuration time.Duration) int {
+	if eventFreshDuration <= DefaultEventFreshDuration {
+		return defaultUpperBoundCapacity
+	}
+	// eventFreshDuration determines how long the watch events are supposed
+	// to be stored in the watch cache.
+	// In very high churn situations, there is a need to store more events
+	// in the watch cache, hence it would have to be upsized accordingly.
+	// Because of that, for larger values of eventFreshDuration, we set the
+	// upper bound of the watch cache's capacity proportionally to the ratio
+	// between eventFreshDuration and DefaultEventFreshDuration.
+	// Given that the watch cache size can only double, we round up that
+	// proportion to the next power of two.
+	exponent := int(math.Ceil((math.Log2(eventFreshDuration.Seconds() / DefaultEventFreshDuration.Seconds()))))
+	if maxExponent := int(math.Floor((math.Log2(math.MaxInt32 / defaultUpperBoundCapacity)))); exponent > maxExponent {
+		// Making sure that the capacity's upper bound fits in a 32-bit integer.
+		exponent = maxExponent
+		klog.Warningf("Capping watch cache capacity upper bound to %v", defaultUpperBoundCapacity<<exponent)
+	}
+	return defaultUpperBoundCapacity << exponent
+}
 
 type watchCacheHistory struct {
 	config *ImmutableWatchCacheConfig
@@ -198,4 +247,14 @@ func (w *watchCacheHistory) GetIntervalLocked(resourceVersion uint64, listResour
 	}
 	ci := newCacheInterval(w.startIndex+first, w.endIndex, indexerFunc, w.config.indexValidator, resourceVersion, locker)
 	return ci, nil
+}
+
+// OldestResourceVersionLocked returns the resource version of the oldest event in the cyclic buffer.
+func (w *watchCacheHistory) OldestResourceVersionLocked() uint64 {
+	return w.cache[w.startIndex%w.capacity].ResourceVersion
+}
+
+// Capacity returns the current capacity of the event history cache.
+func (w *watchCacheHistory) Capacity() int {
+	return w.capacity
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_storage.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_storage.go
@@ -21,12 +21,27 @@ import (
 	"sort"
 	"sync/atomic"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage/cacher/store"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/tools/cache"
 )
+
+func newWatchCacheStorage(config *ImmutableWatchCacheConfig, indexers *cache.Indexers) *watchCacheStorage {
+	storage := &watchCacheStorage{
+		config:              config,
+		store:               store.NewIndexer(indexers),
+		listResourceVersion: 0,
+	}
+	if utilfeature.DefaultFeatureGate.Enabled(features.ListFromCacheSnapshot) {
+		storage.snapshottingEnabled.Store(true)
+		storage.snapshots = store.NewSnapshotter()
+	}
+	return storage
+}
 
 type watchCacheStorage struct {
 	config *ImmutableWatchCacheConfig
@@ -198,4 +213,41 @@ func (w *watchCacheStorage) CompactSnapshotsLocked(oldestRV uint64) {
 	if w.snapshots != nil && w.snapshottingEnabled.Load() {
 		w.snapshots.RemoveLess(oldestRV)
 	}
+}
+
+// ReplaceLocked replaces the elements in the underlying store and resets snapshots.
+func (w *watchCacheStorage) ReplaceLocked(toReplace []interface{}, resourceVersion string, version uint64) error {
+	if err := w.store.Replace(toReplace, resourceVersion); err != nil {
+		return err
+	}
+	if w.snapshots != nil {
+		w.snapshots.Reset()
+		if w.snapshottingEnabled.Load() {
+			w.snapshots.Add(version, w.store)
+		}
+	}
+	w.listResourceVersion = version
+	return nil
+}
+
+// GetExactSnapshotLocked retrieves a snapshot less than or equal to the given resource version.
+func (w *watchCacheStorage) GetExactSnapshotLocked(resourceVersion uint64) (store.Snapshot, error) {
+	if w.snapshots == nil {
+		return nil, errors.NewResourceExpired(fmt.Sprintf("too old resource version: %d", resourceVersion))
+	}
+	snap, ok := w.snapshots.GetLessOrEqual(resourceVersion)
+	if !ok {
+		return nil, errors.NewResourceExpired(fmt.Sprintf("too old resource version: %d", resourceVersion))
+	}
+	return snap, nil
+}
+
+// ByIndex retrieves elements from the indexer by index name and value.
+func (w *watchCacheStorage) ByIndex(indexName, value string) ([]interface{}, error) {
+	return w.store.ByIndex(indexName, value)
+}
+
+// ListResourceVersion returns the list resource version.
+func (w *watchCacheStorage) ListResourceVersion() uint64 {
+	return w.listResourceVersion
 }


### PR DESCRIPTION
This change decouples the coordinating watchCache struct from the internal states of watchCacheHistory and watchCacheStorage by encapsulating them with clean method boundaries.

/kind cleanup

```release-note
NONE
```

/cc @Jefftree @p0lyn0mial @michaelasp 