### PR TITLE
Fix typos in API type comments

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15795,7 +15795,7 @@
       "description": "DeviceClassSpec is used in a [DeviceClass] to define what can be allocated and how to configure it.",
       "properties": {
         "config": {
-          "description": "Config defines configuration parameters that apply to each device that is claimed via this class. Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
+          "description": "Config defines configuration parameters that apply to each device that is claimed via this class. Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.resource.v1.DeviceClassConfiguration"
           },
@@ -17370,7 +17370,7 @@
       "description": "DeviceClassSpec is used in a [DeviceClass] to define what can be allocated and how to configure it.",
       "properties": {
         "config": {
-          "description": "Config defines configuration parameters that apply to each device that is claimed via this class. Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
+          "description": "Config defines configuration parameters that apply to each device that is claimed via this class. Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceClassConfiguration"
           },
@@ -18585,7 +18585,7 @@
       "description": "DeviceClassSpec is used in a [DeviceClass] to define what can be allocated and how to configure it.",
       "properties": {
         "config": {
-          "description": "Config defines configuration parameters that apply to each device that is claimed via this class. Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
+          "description": "Config defines configuration parameters that apply to each device that is claimed via this class. Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.resource.v1beta2.DeviceClassConfiguration"
           },

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1_openapi.json
@@ -660,7 +660,7 @@
         "description": "DeviceClassSpec is used in a [DeviceClass] to define what can be allocated and how to configure it.",
         "properties": {
           "config": {
-            "description": "Config defines configuration parameters that apply to each device that is claimed via this class. Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
+            "description": "Config defines configuration parameters that apply to each device that is claimed via this class. Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.resource.v1.DeviceClassConfiguration"
             },

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1beta1_openapi.json
@@ -674,7 +674,7 @@
         "description": "DeviceClassSpec is used in a [DeviceClass] to define what can be allocated and how to configure it.",
         "properties": {
           "config": {
-            "description": "Config defines configuration parameters that apply to each device that is claimed via this class. Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
+            "description": "Config defines configuration parameters that apply to each device that is claimed via this class. Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.resource.v1beta1.DeviceClassConfiguration"
             },

--- a/api/openapi-spec/v3/apis__resource.k8s.io__v1beta2_openapi.json
+++ b/api/openapi-spec/v3/apis__resource.k8s.io__v1beta2_openapi.json
@@ -660,7 +660,7 @@
         "description": "DeviceClassSpec is used in a [DeviceClass] to define what can be allocated and how to configure it.",
         "properties": {
           "config": {
-            "description": "Config defines configuration parameters that apply to each device that is claimed via this class. Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
+            "description": "Config defines configuration parameters that apply to each device that is claimed via this class. Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.resource.v1beta2.DeviceClassConfiguration"
             },

--- a/pkg/apis/resource/types.go
+++ b/pkg/apis/resource/types.go
@@ -1807,7 +1807,7 @@ type DeviceClassSpec struct {
 	Selectors []DeviceSelector
 
 	// Config defines configuration parameters that apply to each device that is claimed via this class.
-	// Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor
+	// Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor
 	// configuration applies to exactly one driver.
 	//
 	// They are passed to the driver, but are not considered while allocating the claim.

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -47193,7 +47193,7 @@ func schema_k8sio_api_resource_v1_DeviceClassSpec(ref common.ReferenceCallback) 
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Config defines configuration parameters that apply to each device that is claimed via this class. Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
+							Description: "Config defines configuration parameters that apply to each device that is claimed via this class. Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -50063,7 +50063,7 @@ func schema_k8sio_api_resource_v1beta1_DeviceClassSpec(ref common.ReferenceCallb
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Config defines configuration parameters that apply to each device that is claimed via this class. Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
+							Description: "Config defines configuration parameters that apply to each device that is claimed via this class. Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -52313,7 +52313,7 @@ func schema_k8sio_api_resource_v1beta2_DeviceClassSpec(ref common.ReferenceCallb
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "Config defines configuration parameters that apply to each device that is claimed via this class. Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
+							Description: "Config defines configuration parameters that apply to each device that is claimed via this class. Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -71310,7 +71310,7 @@ func schema_k8sio_kubelet_config_v1beta1_KubeletConfiguration(ref common.Referen
 					},
 					"eventBurst": {
 						SchemaProps: spec.SchemaProps{
-							Description: "eventBurst is the maximum size of a burst of event creations, temporarily allows event creations to burst to this number, while still not exceeding eventRecordQPS. This field canot be a negative number and it is only used when eventRecordQPS > 0. Default: 100",
+							Description: "eventBurst is the maximum size of a burst of event creations, temporarily allows event creations to burst to this number, while still not exceeding eventRecordQPS. This field cannot be a negative number and it is only used when eventRecordQPS > 0. Default: 100",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},

--- a/staging/src/k8s.io/api/resource/v1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1/generated.proto
@@ -772,7 +772,7 @@ message DeviceClassSpec {
   repeated DeviceSelector selectors = 1;
 
   // Config defines configuration parameters that apply to each device that is claimed via this class.
-  // Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor
+  // Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor
   // configuration applies to exactly one driver.
   //
   // They are passed to the driver, but are not considered while allocating the claim.

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -1971,7 +1971,7 @@ type DeviceClassSpec struct {
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,1,opt,name=selectors"`
 
 	// Config defines configuration parameters that apply to each device that is claimed via this class.
-	// Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor
+	// Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor
 	// configuration applies to exactly one driver.
 	//
 	// They are passed to the driver, but are not considered while allocating the claim.

--- a/staging/src/k8s.io/api/resource/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/resource/v1/types_swagger_doc_generated.go
@@ -230,7 +230,7 @@ func (DeviceClassList) SwaggerDoc() map[string]string {
 var map_DeviceClassSpec = map[string]string{
 	"":                     "DeviceClassSpec is used in a [DeviceClass] to define what can be allocated and how to configure it.",
 	"selectors":            "Each selector must be satisfied by a device which is claimed via this class.",
-	"config":               "Config defines configuration parameters that apply to each device that is claimed via this class. Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
+	"config":               "Config defines configuration parameters that apply to each device that is claimed via this class. Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
 	"extendedResourceName": "ExtendedResourceName is the extended resource name for the devices of this class. The devices of this class can be used to satisfy a pod's extended resource requests. It has the same format as the name of a pod's extended resource. It should be unique among all the device classes in a cluster. If two device classes have the same name, then the class created later is picked to satisfy a pod's extended resource requests. If two classes are created at the same time, then the name of the class lexicographically sorted first is picked.",
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta1/generated.proto
@@ -780,7 +780,7 @@ message DeviceClassSpec {
   repeated DeviceSelector selectors = 1;
 
   // Config defines configuration parameters that apply to each device that is claimed via this class.
-  // Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor
+  // Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor
   // configuration applies to exactly one driver.
   //
   // They are passed to the driver, but are not considered while allocating the claim.

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -1972,7 +1972,7 @@ type DeviceClassSpec struct {
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,1,opt,name=selectors"`
 
 	// Config defines configuration parameters that apply to each device that is claimed via this class.
-	// Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor
+	// Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor
 	// configuration applies to exactly one driver.
 	//
 	// They are passed to the driver, but are not considered while allocating the claim.

--- a/staging/src/k8s.io/api/resource/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types_swagger_doc_generated.go
@@ -239,7 +239,7 @@ func (DeviceClassList) SwaggerDoc() map[string]string {
 var map_DeviceClassSpec = map[string]string{
 	"":                     "DeviceClassSpec is used in a [DeviceClass] to define what can be allocated and how to configure it.",
 	"selectors":            "Each selector must be satisfied by a device which is claimed via this class.",
-	"config":               "Config defines configuration parameters that apply to each device that is claimed via this class. Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
+	"config":               "Config defines configuration parameters that apply to each device that is claimed via this class. Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
 	"extendedResourceName": "ExtendedResourceName is the extended resource name for the devices of this class. The devices of this class can be used to satisfy a pod's extended resource requests. It has the same format as the name of a pod's extended resource. It should be unique among all the device classes in a cluster. If two device classes have the same name, then the class created later is picked to satisfy a pod's extended resource requests. If two classes are created at the same time, then the name of the class lexicographically sorted first is picked.",
 }
 

--- a/staging/src/k8s.io/api/resource/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/resource/v1beta2/generated.proto
@@ -775,7 +775,7 @@ message DeviceClassSpec {
   repeated DeviceSelector selectors = 1;
 
   // Config defines configuration parameters that apply to each device that is claimed via this class.
-  // Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor
+  // Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor
   // configuration applies to exactly one driver.
   //
   // They are passed to the driver, but are not considered while allocating the claim.

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -2118,7 +2118,7 @@ type DeviceClassSpec struct {
 	Selectors []DeviceSelector `json:"selectors,omitempty" protobuf:"bytes,1,opt,name=selectors"`
 
 	// Config defines configuration parameters that apply to each device that is claimed via this class.
-	// Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor
+	// Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor
 	// configuration applies to exactly one driver.
 	//
 	// They are passed to the driver, but are not considered while allocating the claim.

--- a/staging/src/k8s.io/api/resource/v1beta2/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types_swagger_doc_generated.go
@@ -230,7 +230,7 @@ func (DeviceClassList) SwaggerDoc() map[string]string {
 var map_DeviceClassSpec = map[string]string{
 	"":                     "DeviceClassSpec is used in a [DeviceClass] to define what can be allocated and how to configure it.",
 	"selectors":            "Each selector must be satisfied by a device which is claimed via this class.",
-	"config":               "Config defines configuration parameters that apply to each device that is claimed via this class. Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
+	"config":               "Config defines configuration parameters that apply to each device that is claimed via this class. Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
 	"extendedResourceName": "ExtendedResourceName is the extended resource name for the devices of this class. The devices of this class can be used to satisfy a pod's extended resource requests. It has the same format as the name of a pod's extended resource. It should be unique among all the device classes in a cluster. If two device classes have the same name, then the class created later is picked to satisfy a pod's extended resource requests. If two classes are created at the same time, then the name of the class lexicographically sorted first is picked.",
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/deviceclassspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1/deviceclassspec.go
@@ -27,7 +27,7 @@ type DeviceClassSpecApplyConfiguration struct {
 	// Each selector must be satisfied by a device which is claimed via this class.
 	Selectors []DeviceSelectorApplyConfiguration `json:"selectors,omitempty"`
 	// Config defines configuration parameters that apply to each device that is claimed via this class.
-	// Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor
+	// Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor
 	// configuration applies to exactly one driver.
 	//
 	// They are passed to the driver, but are not considered while allocating the claim.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceclassspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta1/deviceclassspec.go
@@ -27,7 +27,7 @@ type DeviceClassSpecApplyConfiguration struct {
 	// Each selector must be satisfied by a device which is claimed via this class.
 	Selectors []DeviceSelectorApplyConfiguration `json:"selectors,omitempty"`
 	// Config defines configuration parameters that apply to each device that is claimed via this class.
-	// Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor
+	// Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor
 	// configuration applies to exactly one driver.
 	//
 	// They are passed to the driver, but are not considered while allocating the claim.

--- a/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/deviceclassspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/resource/v1beta2/deviceclassspec.go
@@ -27,7 +27,7 @@ type DeviceClassSpecApplyConfiguration struct {
 	// Each selector must be satisfied by a device which is claimed via this class.
 	Selectors []DeviceSelectorApplyConfiguration `json:"selectors,omitempty"`
 	// Config defines configuration parameters that apply to each device that is claimed via this class.
-	// Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor
+	// Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor
 	// configuration applies to exactly one driver.
 	//
 	// They are passed to the driver, but are not considered while allocating the claim.

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -280,7 +280,7 @@ type KubeletConfiguration struct {
 	EventRecordQPS *int32 `json:"eventRecordQPS,omitempty"`
 	// eventBurst is the maximum size of a burst of event creations, temporarily
 	// allows event creations to burst to this number, while still not exceeding
-	// eventRecordQPS. This field canot be a negative number and it is only used
+	// eventRecordQPS. This field cannot be a negative number and it is only used
 	// when eventRecordQPS > 0.
 	// Default: 100
 	// +optional


### PR DESCRIPTION
**What this PR does / why we need it:**

This PR addresses the feedback from @lmktfy on `kubernetes/website#56102`,
where it was noted that typos in generated documentation should be fixed at the
source rather than in the generated Markdown files.

Fixes two spelling mistakes in Go type comments that are the source for
auto‑generated documentation pages.

**Changes:**
- `canot` → `cannot` in kubelet config types
- `classses` → `classes` in resource API types