### PR TITLE
kubeadm: explicitly set the kube-proxy mode to 'iptables'

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/kubeproxy.go
+++ b/cmd/kubeadm/app/componentconfigs/kubeproxy.go
@@ -132,6 +132,14 @@ func (kp *kubeProxyConfig) Default(cfg *kubeadmapi.ClusterConfiguration, localAP
 			"For newer Linux kernel versions, we recommend using the \"nftables\" mode, which has been GA since v1.33. "+
 			"For older Linux kernel versions, you can use the \"iptables\" mode which is still the default one.", kind)
 	}
+
+	// kube-proxy throws warnings if the user has not explicitly set the mode.
+	// In a future release the default mode will switch from "iptables" to "nftables" too.
+	// TODO: apply the required changes in future releases:
+	// - https://github.com/kubernetes/kubeadm/issues/3309
+	if kp.config.Mode == "" {
+		kp.config.Mode = "iptables"
+	}
 }
 
 // Mutate is NOP for the kube-proxy config

--- a/cmd/kubeadm/app/componentconfigs/kubeproxy_test.go
+++ b/cmd/kubeadm/app/componentconfigs/kubeproxy_test.go
@@ -48,6 +48,8 @@ func testKubeProxyConfigMap(contents string) *v1.ConfigMap {
 }
 
 func TestKubeProxyDefault(t *testing.T) {
+	const defaultMode = "iptables"
+
 	tests := []struct {
 		name       string
 		clusterCfg kubeadmapi.ClusterConfiguration
@@ -65,6 +67,7 @@ func TestKubeProxyDefault(t *testing.T) {
 					ClientConnection: componentbaseconfig.ClientConnectionConfiguration{
 						Kubeconfig: kubeproxyKubeConfigFileName,
 					},
+					Mode: defaultMode,
 				},
 			},
 		},
@@ -81,6 +84,7 @@ func TestKubeProxyDefault(t *testing.T) {
 					ClientConnection: componentbaseconfig.ClientConnectionConfiguration{
 						Kubeconfig: kubeproxyKubeConfigFileName,
 					},
+					Mode: defaultMode,
 				},
 			},
 		},
@@ -100,6 +104,7 @@ func TestKubeProxyDefault(t *testing.T) {
 						Kubeconfig: kubeproxyKubeConfigFileName,
 					},
 					ClusterCIDR: "192.168.0.0/16",
+					Mode:        defaultMode,
 				},
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup deprecation

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

In 1.37 kube-proxy will start throwing warnings if the user has not set the 'mode' field explicitly.

This is part of the steps to migrate the default 'mode' from 'iptables' to 'nftables'.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

xref
- https://github.com/kubernetes/kubeadm/issues/3309

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: if the user is providing a KubeProxyConfiguration with an empty value for the 'mode' field or if KubeProxyConfiguration is not provided, explicitly set the mode to 'iptables'. In 1.37 kube-proxy will start throwing a warning if the user has not explicitly set the field. This is part of the plan to switch the default mode to 'nftables' in a future release.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
