### PR TITLE
Replacing deprecated sets.NewString with generic implementation

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/helper.go
+++ b/staging/src/k8s.io/client-go/discovery/helper.go
@@ -71,7 +71,7 @@ func ServerSupportsVersion(client DiscoveryInterface, requiredGV schema.GroupVer
 		return err
 	}
 	versions := metav1.ExtractGroupVersions(groups)
-	serverVersions := sets.String{}
+	serverVersions := sets.Set[string]{}
 	for _, v := range versions {
 		serverVersions.Insert(v)
 	}

--- a/staging/src/k8s.io/client-go/listers/extensions/v1beta1/daemonset_expansion_test.go
+++ b/staging/src/k8s.io/client-go/listers/extensions/v1beta1/daemonset_expansion_test.go
@@ -33,7 +33,7 @@ func TestDaemonSetLister(t *testing.T) {
 	testCases := []struct {
 		inDSs             []*extensions.DaemonSet
 		list              func() ([]*extensions.DaemonSet, error)
-		outDaemonSetNames sets.String
+		outDaemonSetNames sets.Set[string]
 		expectErr         bool
 	}{
 		// Basic listing
@@ -44,7 +44,7 @@ func TestDaemonSetLister(t *testing.T) {
 			list: func() ([]*extensions.DaemonSet, error) {
 				return lister.List(labels.Everything())
 			},
-			outDaemonSetNames: sets.NewString("basic"),
+			outDaemonSetNames: sets.New[string]("basic"),
 		},
 		// Listing multiple daemon sets
 		{
@@ -56,7 +56,7 @@ func TestDaemonSetLister(t *testing.T) {
 			list: func() ([]*extensions.DaemonSet, error) {
 				return lister.List(labels.Everything())
 			},
-			outDaemonSetNames: sets.NewString("basic", "complex", "complex2"),
+			outDaemonSetNames: sets.New[string]("basic", "complex", "complex2"),
 		},
 		// No pod labels
 		{
@@ -74,7 +74,7 @@ func TestDaemonSetLister(t *testing.T) {
 				}
 				return lister.GetPodDaemonSets(pod)
 			},
-			outDaemonSetNames: sets.NewString(),
+			outDaemonSetNames: sets.New[string](),
 			expectErr:         true,
 		},
 		// No DS selectors
@@ -94,7 +94,7 @@ func TestDaemonSetLister(t *testing.T) {
 				}
 				return lister.GetPodDaemonSets(pod)
 			},
-			outDaemonSetNames: sets.NewString(),
+			outDaemonSetNames: sets.New[string](),
 			expectErr:         true,
 		},
 		// Matching labels to selectors and namespace
@@ -123,7 +123,7 @@ func TestDaemonSetLister(t *testing.T) {
 				}
 				return lister.GetPodDaemonSets(pod)
 			},
-			outDaemonSetNames: sets.NewString("bar"),
+			outDaemonSetNames: sets.New[string]("bar"),
 		},
 	}
 	for _, c := range testCases {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR replaces the deprecated type for the set.String and set.NewString within client-go.

#### Which issue(s) this PR is related to:
Related to: #133935 

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
