### PR TITLE
Automatically discover all GVs with declarative validation in TestVersionedValidationByFuzzing

### DIFF
--- a/pkg/api/testing/validation_test.go
+++ b/pkg/api/testing/validation_test.go
@@ -18,10 +18,12 @@ package testing
 
 import (
 	"math/rand"
+	"reflect"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
 	"k8s.io/apimachinery/pkg/api/apitesting/roundtrip"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -29,40 +31,23 @@ import (
 	resourcevalidation "k8s.io/kubernetes/pkg/apis/resource/validation"
 )
 
-// FIXME: Automatically finds all group/versions supporting declarative validation, or add
-// a reflexive test that verifies that they are all registered.
-func TestVersionedValidationByFuzzing(t *testing.T) {
-	typesWithDeclarativeValidation := []schema.GroupVersion{
-		// Registered group versions for versioned validation fuzz testing:
-		{Group: "", Version: "v1"},
-		{Group: "batch", Version: "v1"},
-		{Group: "batch", Version: "v1beta1"},
-		{Group: "certificates.k8s.io", Version: "v1"},
-		{Group: "certificates.k8s.io", Version: "v1alpha1"},
-		{Group: "certificates.k8s.io", Version: "v1beta1"},
-		{Group: "resource.k8s.io", Version: "v1"},
-		{Group: "resource.k8s.io", Version: "v1alpha3"},
-		{Group: "resource.k8s.io", Version: "v1beta1"},
-		{Group: "resource.k8s.io", Version: "v1beta2"},
-		{Group: "storage.k8s.io", Version: "v1"},
-		{Group: "storage.k8s.io", Version: "v1alpha1"},
-		{Group: "storage.k8s.io", Version: "v1beta1"},
-		{Group: "node.k8s.io", Version: "v1"},
-		{Group: "node.k8s.io", Version: "v1alpha1"},
-		{Group: "node.k8s.io", Version: "v1beta1"},
-		{Group: "network.k8s.io", Version: "v1"},
-		{Group: "network.k8s.io", Version: "v1beta1"},
-		{Group: "autoscaling", Version: "v1"},
-		{Group: "autoscaling", Version: "v2"},
-		{Group: "admissionregistration.k8s.io", Version: "v1"},
-		{Group: "admissionregistration.k8s.io", Version: "v1beta1"},
-		{Group: "admissionregistration.k8s.io", Version: "v1alpha1"},
-		{Group: "discovery.k8s.io", Version: "v1"},
-		{Group: "discovery.k8s.io", Version: "v1beta1"},
-		{Group: "admissionregistration.k8s.io", Version: "v1"},
-		{Group: "admissionregistration.k8s.io", Version: "v1beta1"},
-		{Group: "admissionregistration.k8s.io", Version: "v1alpha1"},
+// getGVsWithDeclarativeValidation gets all group/versions supporting declarative validation.
+func getGVsWithDeclarativeValidation() []schema.GroupVersion {
+	var groupVersions []schema.GroupVersion
+
+	for gvk, rtype := range legacyscheme.Scheme.AllKnownTypes() {
+		obj, ok := reflect.New(rtype).Interface().(runtime.Object)
+		if !ok || !legacyscheme.Scheme.HasValidationFunc(obj) {
+			continue
+		}
+		groupVersions = append(groupVersions, gvk.GroupVersion())
 	}
+
+	return groupVersions
+}
+
+func TestVersionedValidationByFuzzing(t *testing.T) {
+	typesWithDeclarativeValidation := getGVsWithDeclarativeValidation()
 
 	// subresourceOnly specifies the subresource path for types that can only be validated
 	// as subresources (e.g. autoscaling/Scale) and do not support root-level validation.
@@ -72,6 +57,8 @@ func TestVersionedValidationByFuzzing(t *testing.T) {
 	subresourceOnly := map[schema.GroupVersionKind]string{
 		{Group: "autoscaling", Version: "v1", Kind: "Scale"}: "scale",
 		{Group: "autoscaling", Version: "v2", Kind: "Scale"}: "scale",
+		{Group: "apps", Version: "v1beta1", Kind: "Scale"}:   "scale",
+		{Group: "apps", Version: "v1beta2", Kind: "Scale"}:   "scale",
 	}
 
 	fuzzIters := *roundtrip.FuzzIters / 10 // TODO: Find a better way to manage test running time
@@ -81,7 +68,7 @@ func TestVersionedValidationByFuzzing(t *testing.T) {
 		for kind := range legacyscheme.Scheme.KnownTypes(gv) {
 			gvk := gv.WithKind(kind)
 			t.Run(gvk.String(), func(t *testing.T) {
-				for i := 0; i < fuzzIters; i++ {
+				for range fuzzIters {
 					obj, err := legacyscheme.Scheme.New(gvk)
 					if err != nil {
 						t.Fatalf("could not create a %v: %s", kind, err)

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
@@ -387,6 +387,12 @@ func (s *Scheme) ValidateUpdate(ctx context.Context, options []string, object, o
 	return nil
 }
 
+// HasValidatationFunc checks if the provided object supports declarative validation.
+func (s *Scheme) HasValidationFunc(obj Object) bool {
+	_, ok := s.validationFuncs[reflect.TypeOf(obj)]
+	return ok
+}
+
 // Convert will attempt to convert in into out. Both must be pointers. For easy
 // testing of conversion functions. Returns an error if the conversion isn't
 // possible. You can call this with types that haven't been registered (for example,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Now types with declarative validation are hardcoded in `‎pkg/api/testing/validation_test.go`. This PR resolves an old `FIXME` comment by discovering all group/versions that support such validation.

#### Which issue(s) this PR is related to:
Depends on #139746 being merged first. After that this PR can be easily rebased.

#### Special notes for your reviewer:
N/A
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
N/A
