### PR TITLE
Add 'read on closed response body' error to ProbableEOF

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
@@ -100,6 +100,8 @@ func IsProbableEOF(err error) bool {
 		return true
 	case strings.Contains(msg, "read on closed response body"):
 		return true
+	case strings.Contains(msg, "response body closed"):
+		return true
 	}
 	return false
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
@@ -98,6 +98,8 @@ func IsProbableEOF(err error) bool {
 		return true
 	case strings.Contains(strings.ToLower(msg), "use of closed network connection"):
 		return true
+	case strings.Contains(msg, "read on closed response body"):
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

Add `"read on closed response body"`, `"response body closed"` to `IsProbableEOF`.

When `StreamWatcher.Stop()` closes the HTTP response body, `Decode()` fails with this error. Since `IsProbableEOF` does not recognize it, `receive()` can deliver a spurious `watch.Error` event to the result channel instead of closing cleanly.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #139782

#### Special notes for your reviewer:

#131339 attempted to fix this, but the PR was closed.