### PR TITLE
 probe: clarify error for unresolved named probe ports

### DIFF
--- a/pkg/kubelet/lifecycle/handlers_test.go
+++ b/pkg/kubelet/lifecycle/handlers_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -230,7 +231,7 @@ func TestRunHandlerHttps(t *testing.T) {
 	pod.Spec.Containers = []v1.Container{container}
 
 	t.Run("consistent", func(t *testing.T) {
-		container.Lifecycle.PostStart.HTTPGet.Port = intstr.FromString("70")
+		container.Lifecycle.PostStart.HTTPGet.Port = intstr.FromInt32(70)
 		pod.Spec.Containers = []v1.Container{container}
 		_, err := handlerRunner.Run(tCtx, containerID, &pod, &container, container.Lifecycle.PostStart)
 
@@ -252,7 +253,7 @@ func TestRunHandlerHTTPPort(t *testing.T) {
 	}{
 		{
 			Name:     "consistent/with port",
-			Port:     intstr.FromString("70"),
+			Port:     intstr.FromInt32(70),
 			Expected: "https://foo:70/bar",
 		}, {
 			Name:        "consistent/without port",
@@ -324,7 +325,7 @@ func TestRunHTTPHandler(t *testing.T) {
 			PodIP: "",
 			HTTPGet: &v1.HTTPGetAction{
 				Path:        "foo",
-				Port:        intstr.FromString("42"),
+				Port:        intstr.FromInt32(42),
 				Host:        "example.test",
 				Scheme:      "http",
 				HTTPHeaders: []v1.HTTPHeader{},
@@ -343,7 +344,7 @@ func TestRunHTTPHandler(t *testing.T) {
 			PodIP: "233.252.0.1",
 			HTTPGet: &v1.HTTPGetAction{
 				Path:        "foo",
-				Port:        intstr.FromString("42"),
+				Port:        intstr.FromInt32(42),
 				Scheme:      "http",
 				HTTPHeaders: []v1.HTTPHeader{},
 			},
@@ -361,7 +362,7 @@ func TestRunHTTPHandler(t *testing.T) {
 			PodIP: "233.252.0.1",
 			HTTPGet: &v1.HTTPGetAction{
 				Path:        "/foo",
-				Port:        intstr.FromString("42"),
+				Port:        intstr.FromInt32(42),
 				Scheme:      "http",
 				HTTPHeaders: []v1.HTTPHeader{},
 			},
@@ -379,7 +380,7 @@ func TestRunHTTPHandler(t *testing.T) {
 			PodIP: "233.252.0.1",
 			HTTPGet: &v1.HTTPGetAction{
 				Path:        "foo",
-				Port:        intstr.FromString("42"),
+				Port:        intstr.FromInt32(42),
 				Scheme:      "http",
 				HTTPHeaders: []v1.HTTPHeader{},
 			},
@@ -415,7 +416,7 @@ func TestRunHTTPHandler(t *testing.T) {
 			PodIP: "233.252.0.1",
 			HTTPGet: &v1.HTTPGetAction{
 				Path:        "foo",
-				Port:        intstr.FromString("4430"),
+				Port:        intstr.FromInt32(4430),
 				Scheme:      "https",
 				HTTPHeaders: []v1.HTTPHeader{},
 			},
@@ -433,7 +434,7 @@ func TestRunHTTPHandler(t *testing.T) {
 			PodIP: "233.252.0.1",
 			HTTPGet: &v1.HTTPGetAction{
 				Path:        "foo",
-				Port:        intstr.FromString("80"),
+				Port:        intstr.FromInt32(80),
 				Scheme:      "baz",
 				HTTPHeaders: []v1.HTTPHeader{},
 			},
@@ -451,7 +452,7 @@ func TestRunHTTPHandler(t *testing.T) {
 			PodIP: "233.252.0.1",
 			HTTPGet: &v1.HTTPGetAction{
 				Path:        "foo?k=v",
-				Port:        intstr.FromString("80"),
+				Port:        intstr.FromInt32(80),
 				Scheme:      "http",
 				HTTPHeaders: []v1.HTTPHeader{},
 			},
@@ -469,7 +470,7 @@ func TestRunHTTPHandler(t *testing.T) {
 			PodIP: "233.252.0.1",
 			HTTPGet: &v1.HTTPGetAction{
 				Path:        "foo#frag",
-				Port:        intstr.FromString("80"),
+				Port:        intstr.FromInt32(80),
 				Scheme:      "http",
 				HTTPHeaders: []v1.HTTPHeader{},
 			},
@@ -487,7 +488,7 @@ func TestRunHTTPHandler(t *testing.T) {
 			PodIP: "233.252.0.1",
 			HTTPGet: &v1.HTTPGetAction{
 				Path:   "foo",
-				Port:   intstr.FromString("80"),
+				Port:   intstr.FromInt32(80),
 				Scheme: "http",
 				HTTPHeaders: []v1.HTTPHeader{
 					{
@@ -512,7 +513,7 @@ func TestRunHTTPHandler(t *testing.T) {
 			HTTPGet: &v1.HTTPGetAction{
 				Host:   "example.test",
 				Path:   "foo",
-				Port:   intstr.FromString("80"),
+				Port:   intstr.FromInt32(80),
 				Scheme: "http",
 				HTTPHeaders: []v1.HTTPHeader{
 					{
@@ -707,6 +708,10 @@ func TestRunHandlerHttpsFailureFallback(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	portNumber, err := strconv.Atoi(port)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	recorder := &record.FakeRecorder{Events: make(chan string, 10)}
 
@@ -724,7 +729,7 @@ func TestRunHandlerHttpsFailureFallback(t *testing.T) {
 					// set the scheme to https to ensure it falls back to HTTP.
 					Scheme: "https",
 					Host:   "127.0.0.1",
-					Port:   intstr.FromString(port),
+					Port:   intstr.FromInt32(int32(portNumber)),
 					Path:   "bar",
 					HTTPHeaders: []v1.HTTPHeader{
 						{

--- a/pkg/kubelet/prober/prober_test.go
+++ b/pkg/kubelet/prober/prober_test.go
@@ -54,7 +54,6 @@ func TestGetURLParts(t *testing.T) {
 		{&v1.HTTPGetAction{Host: "", Port: intstr.FromString("not-found"), Path: ""}, false, "", -1, ""},
 		{&v1.HTTPGetAction{Host: "", Port: intstr.FromString("found"), Path: ""}, true, "127.0.0.1", 93, ""},
 		{&v1.HTTPGetAction{Host: "", Port: intstr.FromInt32(76), Path: ""}, true, "127.0.0.1", 76, ""},
-		{&v1.HTTPGetAction{Host: "", Port: intstr.FromString("118"), Path: ""}, true, "127.0.0.1", 118, ""},
 		{&v1.HTTPGetAction{Host: "hostname", Port: intstr.FromInt32(76), Path: "path"}, true, "hostname", 76, "path"},
 	}
 
@@ -108,7 +107,6 @@ func TestGetTCPAddrParts(t *testing.T) {
 		{&v1.TCPSocketAction{Port: intstr.FromString("not-found")}, false, "", -1},
 		{&v1.TCPSocketAction{Port: intstr.FromString("found")}, true, "1.2.3.4", 93},
 		{&v1.TCPSocketAction{Port: intstr.FromInt32(76)}, true, "1.2.3.4", 76},
-		{&v1.TCPSocketAction{Port: intstr.FromString("118")}, true, "1.2.3.4", 118},
 	}
 
 	for _, test := range testCases {

--- a/pkg/probe/util.go
+++ b/pkg/probe/util.go
@@ -18,8 +18,6 @@ package probe
 
 import (
 	"fmt"
-	"strconv"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -32,10 +30,7 @@ func ResolveContainerPort(param intstr.IntOrString, container *v1.Container) (in
 		port = param.IntValue()
 	case intstr.String:
 		if port, err = findPortByName(container, param.StrVal); err != nil {
-			// Last ditch effort - maybe it was an int stored as string?
-			if port, err = strconv.Atoi(param.StrVal); err != nil {
-				return port, err
-			}
+			return port, err
 		}
 	default:
 		return port, fmt.Errorf("intOrString had no kind: %+v", param)
@@ -53,5 +48,5 @@ func findPortByName(container *v1.Container, portName string) (int, error) {
 			return int(port.ContainerPort), nil
 		}
 	}
-	return 0, fmt.Errorf("port %s not found", portName)
+	return 0, fmt.Errorf("port %q not found", portName)
 }

--- a/pkg/probe/util_test.go
+++ b/pkg/probe/util_test.go
@@ -19,6 +19,7 @@ package probe
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -34,6 +35,7 @@ func TestFindPortByName(t *testing.T) {
 		args    args
 		want    int
 		wantErr bool
+		errMsg  string
 	}{
 		{
 			name: "get port from exist port name",
@@ -74,6 +76,7 @@ func TestFindPortByName(t *testing.T) {
 			},
 			want:    0,
 			wantErr: true,
+			errMsg:  `port "http" not found`,
 		},
 	}
 
@@ -84,6 +87,9 @@ func TestFindPortByName(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("findPortByName() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+			if tt.errMsg != "" {
+				require.EqualError(t, err, tt.errMsg)
 			}
 			if got != tt.want {
 				t.Errorf("findPortByName() = %v, want %v", got, tt.want)
@@ -103,6 +109,7 @@ func TestResolveContainerPort(t *testing.T) {
 		args    args
 		want    int
 		wantErr bool
+		errMsg  string
 	}{
 		{
 			name: "get port by int type",
@@ -157,6 +164,7 @@ func TestResolveContainerPort(t *testing.T) {
 			},
 			want:    0,
 			wantErr: true,
+			errMsg:  `port "foo" not found`,
 		},
 		{
 			name: "invalid param type",
@@ -186,6 +194,9 @@ func TestResolveContainerPort(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ResolveContainerPort() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+			if tt.errMsg != "" {
+				require.EqualError(t, err, tt.errMsg)
 			}
 			if got != tt.want {
 				t.Errorf("ResolveContainerPort() = %v, want %v", got, tt.want)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR fixes error reporting for HTTP/TCP liveness, readiness, and startup probes when a probe references a named port that does not exist in the container.

Previously, `ResolveContainerPort` fell back to `strconv.Atoi` for `intstr.String` values after named port lookup failed. For unresolved named ports, that hid the real error behind a parse failure like:

`strconv.Atoi: parsing "metrcis": invalid syntax`

This change:

- removes the `Atoi` fallback from the string branch in `ResolveContainerPort`
- returns a clearer `port "<name>" not found` error for unresolved named ports
- keeps existing probe behavior unchanged (`probe.Unknown`)
- updates tests that relied on numeric ports being passed as strings

This matches API validation more closely because string port names must contain at least one letter, so numeric-string fallback in this path is misleading rather than useful.

#### Which issue(s) this PR is related to:

Fixes #139283

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```