### PR TITLE
refactor: use AddEventHandlerWithOptions in node controllers

### DIFF
--- a/pkg/controller/nodeipam/ipam/range_allocator.go
+++ b/pkg/controller/nodeipam/ipam/range_allocator.go
@@ -130,7 +130,7 @@ func NewCIDRRangeAllocator(ctx context.Context, client clientset.Interface, node
 		}
 	}
 
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := nodeInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			key, err := cache.MetaNamespaceKeyFunc(obj)
 			if err == nil {
@@ -163,7 +163,10 @@ func NewCIDRRangeAllocator(ctx context.Context, client clientset.Interface, node
 				utilruntime.HandleErrorWithContext(ctx, err, "Error while processing CIDR Release")
 			}
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
+	if err != nil {
+		return nil, err
+	}
 
 	return ra, nil
 }

--- a/pkg/controller/ttl/ttl_controller.go
+++ b/pkg/controller/ttl/ttl_controller.go
@@ -87,7 +87,7 @@ func NewTTLController(ctx context.Context, nodeInformer informers.NodeInformer, 
 		),
 	}
 	logger := klog.FromContext(ctx)
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := nodeInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			ttlc.addNode(logger, obj)
 		},
@@ -97,7 +97,8 @@ func NewTTLController(ctx context.Context, nodeInformer informers.NodeInformer, 
 		DeleteFunc: func(obj interface{}) {
 			ttlc.deleteNode(logger, obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
+	utilruntime.Must(err)
 
 	ttlc.nodeStore = listers.NewNodeLister(nodeInformer.Informer().GetIndexer())
 	ttlc.hasSynced = nodeInformer.Informer().HasSynced


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Migrate plain `AddEventHandler` calls in the nodeipam range allocator and the ttl
controller to `AddEventHandlerWithOptions` with `cache.HandlerOptions{Logger:
&logger}`, so the contextual logger is propagated into the informer handler
goroutines.

The logger is already in scope (`klog.FromContext(ctx)`) at each call site, so
this is a pure API migration with no behaviour change.

**Files changed (2):**
- `pkg/controller/nodeipam/ipam/range_allocator.go` (1 call site)
- `pkg/controller/ttl/ttl_controller.go` (1 call site)

#### Which issue(s) this PR is related to:

Part of #126379

#### Special notes for your reviewer:

Error handling follows each constructor's existing convention:
`NewCIDRRangeAllocator` already returns an error, so the handler error is
returned; `NewTTLController` does not, so it uses `utilruntime.Must(err)`.
Verified with `go build` and `go vet` on both packages.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
