### PR TITLE
test: add content-type sub-benchmarks for list from watch cache

### DIFF
--- a/test/integration/apiserver/watchcache_test.go
+++ b/test/integration/apiserver/watchcache_test.go
@@ -25,8 +25,15 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	genericfeatures "k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	clientfeatures "k8s.io/client-go/features"
+	clientfeaturestesting "k8s.io/client-go/features/testing"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
 	"k8s.io/kubernetes/pkg/controlplane"
@@ -168,7 +175,13 @@ func TestWatchCacheUpdatedByEtcd(t *testing.T) {
 
 func BenchmarkListFromWatchCache(b *testing.B) {
 	tCtx := ktesting.Init(b)
-	c, _, tearDownFn := framework.StartTestServer(tCtx, b, framework.TestServerSetup{
+
+	// Enable CBOR on the server and allow the client to negotiate it so that the
+	// "cbor" content-type sub-benchmark exercises the CBOR (de)serialization path.
+	featuregatetesting.SetFeatureGateDuringTest(b, utilfeature.DefaultFeatureGate, genericfeatures.CBORServingAndStorage, true)
+	clientfeaturestesting.SetFeatureDuringTest(b, clientfeatures.ClientsAllowCBOR, true)
+
+	c, restConfig, tearDownFn := framework.StartTestServer(tCtx, b, framework.TestServerSetup{
 		ModifyServerConfig: func(config *controlplane.Config) {
 			// Switch off endpoints reconciler to avoid unnecessary operations.
 			config.Extra.EndpointReconcilerType = reconcilers.NoneEndpointReconcilerType
@@ -215,16 +228,30 @@ func BenchmarkListFromWatchCache(b *testing.B) {
 		b.Error(err)
 	}
 
-	b.ResetTimer()
-
 	opts := metav1.ListOptions{
 		ResourceVersion: "0",
 	}
-	for i := 0; i < b.N; i++ {
-		secrets, err := c.CoreV1().Secrets("").List(tCtx, opts)
-		if err != nil {
-			b.Errorf("failed to list secrets: %v", err)
-		}
-		b.Logf("Number of secrets: %d", len(secrets.Items))
+
+	// Benchmark the list request served from the watch cache across the wire
+	// formats the apiserver supports, reusing the same populated dataset.
+	for _, contentType := range []struct {
+		name  string
+		value string
+	}{
+		{name: "protobuf", value: runtime.ContentTypeProtobuf},
+		{name: "json", value: runtime.ContentTypeJSON},
+		{name: "cbor", value: runtime.ContentTypeCBOR},
+	} {
+		config := rest.CopyConfig(restConfig)
+		config.ContentType = contentType.value
+		client := clientset.NewForConfigOrDie(config)
+
+		b.Run(contentType.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				if _, err := client.CoreV1().Secrets("").List(tCtx, opts); err != nil {
+					b.Errorf("failed to list secrets: %v", err)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig api-machinery

#### What this PR does / why we need it:

`BenchmarkListFromWatchCache` only measured a list served from the watch cache
over the default protobuf wire format. This restructures it to share the
expensive dataset setup (100 namespaces x 1000 secrets) and run `b.Run`
sub-benchmarks for **protobuf**, **JSON** and **CBOR**, so the serialization
cost of each content type can be compared on the same data.

CBOR is exercised by enabling the `CBORServingAndStorage` server feature gate and
the `ClientsAllowCBOR` client-go feature gate, then setting the client
`ContentType` per sub-benchmark.

This is the content-type axis from the discussion in #130169 (CBOR was called out
as the most valuable one). I left the additional resource types (pod/CR) out of
this PR. Opening it to make the proposed `b.Run`-per-content-type structure
concrete, happy to adjust per the issue discussion.

Verified it compiles (`go test -c ./test/integration/apiserver/`); the benchmark
itself runs in CI / against a real apiserver.

#### Which issue(s) this PR is related to:

Part of #130169

#### Special notes for your reviewer:

The dataset setup is unchanged and stays outside the timed sub-benchmarks.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
