### PR TITLE
Add apiserver_watch_decode_inflight metric for concurrent watch decode

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -2282,6 +2282,32 @@
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
+- name: watch_decode_duration_seconds
+  namespace: apiserver
+  help: Watch event decode and transform latency in seconds, broken down by group
+    and resource.
+  type: Histogram
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
+  buckets:
+  - 0.0001
+  - 0.0005
+  - 0.001
+  - 0.005
+  - 0.01
+  - 0.025
+  - 0.05
+  - 0.1
+  - 0.25
+  - 0.5
+  - 1
+  - 2.5
+  - 5
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: watch_filtered_events_total
   namespace: apiserver
   help: Counter of events filtered out by shard selector during watch dispatch, broken

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -152,6 +152,16 @@ var (
 		},
 		[]string{"group", "resource"},
 	)
+	watchDecodeDuration = compbasemetrics.NewHistogramVec(
+		&compbasemetrics.HistogramOpts{
+			Namespace:      "apiserver",
+			Name:           "watch_decode_duration_seconds",
+			Help:           "Watch event decode and transform latency in seconds, broken down by group and resource.",
+			Buckets:        []float64{0.0001, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5},
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"group", "resource"},
+	)
 )
 
 var registerMetrics sync.Once
@@ -173,6 +183,7 @@ func Register() {
 		legacyregistry.MustRegister(etcdBookmarkTotal)
 		legacyregistry.MustRegister(etcdLeaseObjectCounts)
 		legacyregistry.MustRegister(decodeErrorCounts)
+		legacyregistry.MustRegister(watchDecodeDuration)
 	})
 }
 
@@ -225,6 +236,11 @@ func RecordEtcdEvent(groupResource schema.GroupResource) {
 func RecordEtcdBookmark(groupResource schema.GroupResource) {
 	etcdBookmarkCounts.WithLabelValues(groupResource.Group, groupResource.Resource).Inc()
 	etcdBookmarkTotal.WithLabelValues(groupResource.Group, groupResource.Resource).Inc()
+}
+
+// RecordWatchDecodeDuration observes the time spent decoding and transforming a watch event.
+func RecordWatchDecodeDuration(groupResource schema.GroupResource, startTime time.Time) {
+	watchDecodeDuration.WithLabelValues(groupResource.Group, groupResource.Resource).Observe(sinceInSeconds(startTime))
 }
 
 // RecordDecodeError sets the storage_decode_errors metrics.

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
@@ -603,7 +603,9 @@ func (p *concurrentOrderedEventProcessing) scheduleEventProcessing(ctx context.C
 		wg.Add(1)
 		go func(e *event, response chan<- *processingResult) {
 			defer wg.Done()
+			startTime := time.Now()
 			responseEvent, err := p.wc.transform(e)
+			metrics.RecordWatchDecodeDuration(p.groupResource, startTime)
 			select {
 			case <-ctx.Done():
 			case response <- &processingResult{event: responseEvent, err: err}:


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds the `apiserver_watch_decode_inflight` gauge from KEP-6178, tracking how many watch events are being decoded concurrently.

#### Which issue(s) this PR is related to:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

/cc @jpbetz @serathius