### PR TITLE
fix: client-go/certificate rejects unsupported and malformed keys

### DIFF
--- a/staging/src/k8s.io/client-go/util/certificate/certificate_manager.go
+++ b/staging/src/k8s.io/client-go/util/certificate/certificate_manager.go
@@ -834,17 +834,28 @@ func validateKeyStrength(key crypto.Signer) error {
 		minRSAKeyBits   = 2048
 		minECDSAKeyBits = 256
 	)
+	if key == nil {
+		return errors.New("key is nil")
+	}
 	switch k := key.(type) {
 	case *rsa.PrivateKey:
+		if k == nil || k.N == nil {
+			return errors.New("RSA private key is invalid")
+		}
 		if bits := k.N.BitLen(); bits < minRSAKeyBits {
 			return fmt.Errorf("RSA key size %d bits is below the minimum of %d",
 				bits, minRSAKeyBits)
 		}
 	case *ecdsa.PrivateKey:
+		if k == nil || k.Curve == nil {
+			return errors.New("ECDSA private key is invalid")
+		}
 		if bits := k.Curve.Params().BitSize; bits < minECDSAKeyBits {
 			return fmt.Errorf("ECDSA key curve %s (%d bits) is below the minimum of %d",
 				k.Curve.Params().Name, bits, minECDSAKeyBits)
 		}
+	default:
+		return fmt.Errorf("unsupported key type: %T", key)
 	}
 	return nil
 }

--- a/staging/src/k8s.io/client-go/util/certificate/certificate_manager_test.go
+++ b/staging/src/k8s.io/client-go/util/certificate/certificate_manager_test.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"context"
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -1267,6 +1269,13 @@ eaVq8eqxqzGSxwanMrwbD/1PQ97kNdi53No=
 -----END PRIVATE KEY-----
 `
 
+// testGenerateEd25519KeyPEM is an Ed25519 private key fixture.
+// This key is for testing purposes only and is not considered secure.
+const testGenerateEd25519KeyPEM = `-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIAj5VQbcKpXshAc5NjYJ+6z9UJtiTbgQyWIi7RwNvQUF
+-----END PRIVATE KEY-----
+`
+
 func TestGenerateKeyConfig(t *testing.T) {
 	parsedECKey1 := parsePEMKey(t, testGenerateECKeyPEM1)
 	parsedECKey2 := parsePEMKey(t, testGenerateECKeyPEM2)
@@ -1358,6 +1367,36 @@ func TestValidateKeyStrength(t *testing.T) {
 			name:    "ECDSA P-256 is secure",
 			key:     parsePEMKey(t, testGenerateECKeyPEM1),
 			wantErr: false,
+		},
+		{
+			name:    "nil key is insecure",
+			key:     nil,
+			wantErr: true,
+		},
+		{
+			name:    "nil RSA key pointer is insecure",
+			key:     (*rsa.PrivateKey)(nil),
+			wantErr: true,
+		},
+		{
+			name:    "RSA key with nil N is insecure",
+			key:     &rsa.PrivateKey{},
+			wantErr: true,
+		},
+		{
+			name:    "nil ECDSA key pointer is insecure",
+			key:     (*ecdsa.PrivateKey)(nil),
+			wantErr: true,
+		},
+		{
+			name:    "ECDSA key with nil Curve is insecure",
+			key:     &ecdsa.PrivateKey{},
+			wantErr: true,
+		},
+		{
+			name:    "unsupported key type is insecure",
+			key:     parsePEMKey(t, testGenerateEd25519KeyPEM),
+			wantErr: true,
 		},
 	}
 


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Enhance  validateKeyStrength  in client-go certificate manager. 

Because manager accepts custom key generation functions. Invalid, nil, or unsupported keys from custom functions cause errors.

So it needs to strengthen the private key validation to detect the error and return the information


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

"N/A"

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
