### PR TITLE
Automated cherry pick of #139667: fix(kubeadm): use KubernetesAPICallTimeout for mandatory kubeadm-config fetch during join

### DIFF
--- a/cmd/kubeadm/app/cmd/certs.go
+++ b/cmd/kubeadm/app/cmd/certs.go
@@ -350,7 +350,7 @@ func getInternalCfg(cfgPath string, client kubernetes.Interface, cfg kubeadmapiv
 		getNodeRegistration := true
 		getAPIEndpoint := staticpodutil.IsControlPlaneNode()
 		getComponentConfigs := true
-		internalcfg, err := configutil.FetchInitConfigurationFromCluster(client, printer, logPrefix, getNodeRegistration, getAPIEndpoint, getComponentConfigs)
+		internalcfg, err := configutil.FetchInitConfigurationFromCluster(client, printer, logPrefix, getNodeRegistration, getAPIEndpoint, getComponentConfigs, true)
 		if err == nil {
 			printer.Println() // add empty line to separate the FetchInitConfigurationFromCluster output from the command output
 			// certificate renewal or expiration checking doesn't depend on a running cluster, which means the CertificatesDir

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -715,7 +715,7 @@ func fetchInitConfiguration(client clientset.Interface) (*kubeadmapi.InitConfigu
 	getNodeRegistration := false
 	getAPIEndpoint := false
 	getComponentConfigs := true
-	initConfiguration, err := configutil.FetchInitConfigurationFromCluster(client, nil, "preflight", getNodeRegistration, getAPIEndpoint, getComponentConfigs)
+	initConfiguration, err := configutil.FetchInitConfigurationFromCluster(client, nil, "preflight", getNodeRegistration, getAPIEndpoint, getComponentConfigs, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to fetch the kubeadm-config ConfigMap")
 	}

--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -136,7 +136,7 @@ func newResetData(cmd *cobra.Command, opts *resetOptions, in io.Reader, out io.W
 		getNodeRegistration := true
 		getAPIEndpoint := staticpodutil.IsControlPlaneNode()
 		getComponentConfigs := true
-		initCfg, err = configutil.FetchInitConfigurationFromCluster(client, nil, "reset", getNodeRegistration, getAPIEndpoint, getComponentConfigs)
+		initCfg, err = configutil.FetchInitConfigurationFromCluster(client, nil, "reset", getNodeRegistration, getAPIEndpoint, getComponentConfigs, true)
 		if err != nil {
 			klog.Warningf("[reset] Unable to fetch the kubeadm-config ConfigMap from cluster: %v", err)
 		}

--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -232,7 +232,7 @@ func newApplyData(cmd *cobra.Command, args []string, applyFlags *applyFlags) (*a
 	getNodeRegistration := true
 	isControlPlaneNode := true
 	getComponentConfigs := true
-	initCfg, err := configutil.FetchInitConfigurationFromCluster(client, nil, "upgrade", getNodeRegistration, isControlPlaneNode, getComponentConfigs)
+	initCfg, err := configutil.FetchInitConfigurationFromCluster(client, nil, "upgrade", getNodeRegistration, isControlPlaneNode, getComponentConfigs, false)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			_, _ = printer.Printf("[upgrade] In order to upgrade, a ConfigMap called %q in the %q namespace must exist.\n", constants.KubeadmConfigConfigMap, metav1.NamespaceSystem)

--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -96,7 +96,7 @@ func enforceRequirements(flagSet *pflag.FlagSet, flags *applyPlanFlags, args []s
 	getNodeRegistration := true
 	getAPIEndpoint := staticpodutil.IsControlPlaneNode()
 	getComponentConfigs := true
-	initCfg, err := configutil.FetchInitConfigurationFromCluster(client, printer, "upgrade/config", getNodeRegistration, getAPIEndpoint, getComponentConfigs)
+	initCfg, err := configutil.FetchInitConfigurationFromCluster(client, printer, "upgrade/config", getNodeRegistration, getAPIEndpoint, getComponentConfigs, false)
 	if err != nil {
 		return nil, nil, nil, nil, errors.Wrap(err, "[upgrade/init config] FATAL")
 	}

--- a/cmd/kubeadm/app/cmd/upgrade/diff.go
+++ b/cmd/kubeadm/app/cmd/upgrade/diff.go
@@ -107,7 +107,7 @@ func validateManifestsPath(manifests ...string) (err error) {
 }
 
 // FetchInitConfigurationFunc defines the signature of the function which will fetch InitConfiguration from cluster.
-type FetchInitConfigurationFunc func(client clientset.Interface, printer output.Printer, logPrefix string, getNodeRegistration, getAPIEndpoint, getComponentConfigs bool) (*kubeadmapi.InitConfiguration, error)
+type FetchInitConfigurationFunc func(client clientset.Interface, printer output.Printer, logPrefix string, getNodeRegistration, getAPIEndpoint, getComponentConfigs, shortConfigMapGet bool) (*kubeadmapi.InitConfiguration, error)
 
 func runDiff(fs *pflag.FlagSet, flags *diffFlags, args []string, fetchInitConfigurationFromCluster FetchInitConfigurationFunc) error {
 	externalCfg := &v1beta4.UpgradeConfiguration{}
@@ -123,7 +123,7 @@ func runDiff(fs *pflag.FlagSet, flags *diffFlags, args []string, fetchInitConfig
 	getNodeRegistration := true
 	getAPIEndpoint := staticpodutil.IsControlPlaneNode()
 	getComponentConfigs := false
-	initCfg, err := fetchInitConfigurationFromCluster(client, &output.TextPrinter{}, "upgrade/diff", getNodeRegistration, getAPIEndpoint, getComponentConfigs)
+	initCfg, err := fetchInitConfigurationFromCluster(client, &output.TextPrinter{}, "upgrade/diff", getNodeRegistration, getAPIEndpoint, getComponentConfigs, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/kubeadm/app/cmd/upgrade/diff_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/diff_test.go
@@ -45,7 +45,7 @@ func createTestRunDiffFile(contents []byte) (string, error) {
 	return file.Name(), nil
 }
 
-func fakeFetchInitConfig(client clientset.Interface, printer output.Printer, logPrefix string, getNodeRegistration, getAPIEndpoint, getComponentConfigs bool) (*kubeadmapi.InitConfiguration, error) {
+func fakeFetchInitConfig(client clientset.Interface, printer output.Printer, logPrefix string, getNodeRegistration, getAPIEndpoint, getComponentConfigs, shortConfigMapGet bool) (*kubeadmapi.InitConfiguration, error) {
 	return &kubeadmapi.InitConfiguration{
 		ClusterConfiguration: kubeadmapi.ClusterConfiguration{
 			KubernetesVersion: "v1.0.1",

--- a/cmd/kubeadm/app/cmd/upgrade/node.go
+++ b/cmd/kubeadm/app/cmd/upgrade/node.go
@@ -195,7 +195,7 @@ func newNodeData(cmd *cobra.Command, nodeOptions *nodeOptions, out io.Writer) (*
 	getNodeRegistration := true
 	getAPIEndpoint := isControlPlaneNode
 	getComponentConfigs := true
-	initCfg, err := configutil.FetchInitConfigurationFromCluster(client, nil, "upgrade", getNodeRegistration, getAPIEndpoint, getComponentConfigs)
+	initCfg, err := configutil.FetchInitConfigurationFromCluster(client, nil, "upgrade", getNodeRegistration, getAPIEndpoint, getComponentConfigs, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to fetch the kubeadm-config ConfigMap")
 	}

--- a/cmd/kubeadm/app/util/config/cluster.go
+++ b/cmd/kubeadm/app/util/config/cluster.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pkg/errors"
 
 	authv1 "k8s.io/api/authentication/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	errorsutil "k8s.io/apimachinery/pkg/util/errors"
@@ -53,8 +54,10 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/output"
 )
 
-// FetchInitConfigurationFromCluster fetches configuration from a ConfigMap in the cluster
-func FetchInitConfigurationFromCluster(client clientset.Interface, printer output.Printer, logPrefix string, getNodeRegistration, getAPIEndpoint, getComponentConfigs bool) (*kubeadmapi.InitConfiguration, error) {
+// FetchInitConfigurationFromCluster fetches configuration from a ConfigMap in the cluster.
+// If shortConfigMapGet is true, a short retry is used when fetching the kubeadm-config ConfigMap,
+// which is suitable for callers like "kubeadm reset" that don't need a long retry.
+func FetchInitConfigurationFromCluster(client clientset.Interface, printer output.Printer, logPrefix string, getNodeRegistration, getAPIEndpoint, getComponentConfigs, shortConfigMapGet bool) (*kubeadmapi.InitConfiguration, error) {
 	if printer == nil {
 		printer = &output.TextPrinter{}
 	}
@@ -63,7 +66,7 @@ func FetchInitConfigurationFromCluster(client clientset.Interface, printer outpu
 	_, _ = printer.Printf("[%s] Use 'kubeadm init phase upload-config --config your-config-file' to re-upload it.\n", logPrefix)
 
 	// Fetch the actual config from cluster
-	cfg, err := getInitConfigurationFromCluster(constants.KubernetesDir, client, getNodeRegistration, getAPIEndpoint, getComponentConfigs)
+	cfg, err := getInitConfigurationFromCluster(constants.KubernetesDir, client, getNodeRegistration, getAPIEndpoint, getComponentConfigs, shortConfigMapGet)
 	if err != nil {
 		return nil, err
 	}
@@ -80,9 +83,31 @@ func FetchInitConfigurationFromCluster(client clientset.Interface, printer outpu
 }
 
 // getInitConfigurationFromCluster is separate only for testing purposes, don't call it directly, use FetchInitConfigurationFromCluster instead
-func getInitConfigurationFromCluster(kubeconfigDir string, client clientset.Interface, getNodeRegistration, getAPIEndpoint, getComponentConfigs bool) (*kubeadmapi.InitConfiguration, error) {
+func getInitConfigurationFromCluster(kubeconfigDir string, client clientset.Interface, getNodeRegistration, getAPIEndpoint, getComponentConfigs, shortConfigMapGet bool) (*kubeadmapi.InitConfiguration, error) {
 	// Also, the config map really should be KubeadmConfigConfigMap...
-	configMap, err := apiclient.GetConfigMapWithShortRetry(client, metav1.NamespaceSystem, constants.KubeadmConfigConfigMap)
+	var configMap *v1.ConfigMap
+	var err error
+	if shortConfigMapGet {
+		configMap, err = apiclient.GetConfigMapWithShortRetry(client, metav1.NamespaceSystem, constants.KubeadmConfigConfigMap)
+	} else {
+		var lastErr error
+		err = wait.PollUntilContextTimeout(context.Background(),
+			constants.KubernetesAPICallRetryInterval,
+			kubeadmapi.GetActiveTimeouts().KubernetesAPICall.Duration,
+			true, func(_ context.Context) (bool, error) {
+				var err error
+				configMap, err = client.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(
+					context.Background(), constants.KubeadmConfigConfigMap, metav1.GetOptions{})
+				if err == nil {
+					return true, nil
+				}
+				lastErr = err
+				return false, nil
+			})
+		if err != nil {
+			err = lastErr
+		}
+	}
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get config map")
 	}

--- a/cmd/kubeadm/app/util/config/cluster_test.go
+++ b/cmd/kubeadm/app/util/config/cluster_test.go
@@ -640,7 +640,7 @@ func TestGetInitConfigurationFromCluster(t *testing.T) {
 			}
 
 			getComponentConfigs := true
-			cfg, err := getInitConfigurationFromCluster(tmpdir, client, rt.getNodeRegistration, rt.getAPIEndpoint, getComponentConfigs)
+			cfg, err := getInitConfigurationFromCluster(tmpdir, client, rt.getNodeRegistration, rt.getAPIEndpoint, getComponentConfigs, true)
 			if rt.expectedError != (err != nil) {
 				t.Errorf("unexpected return err from getInitConfigurationFromCluster: %v", err)
 				return


### PR DESCRIPTION
Cherry pick of #139667 on release-1.33.

#139667: fix(kubeadm): use KubernetesAPICallTimeout for mandatory kubeadm-config fetch during join

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

/kind bug
/sig cluster-lifecycle
/area kubeadm

```release-note
kubeadm: during "kubeadm join", use the KubernetesAPICall timeout
(default 1 minute) when fetching the kubeadm-config ConfigMap, instead
of the short 350ms retry used for optional component configs. A new
shortConfigMapGet parameter is added to FetchInitConfigurationFromCluster
so that callers like "kubeadm reset" can still use the short retry.
```