### PR TITLE
PoC: Add UserValidationRules to AuthenticationConfiguration

### DIFF
--- a/pkg/kubeapiserver/authenticator/config.go
+++ b/pkg/kubeapiserver/authenticator/config.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"sync/atomic"
 	"time"
 
@@ -28,8 +29,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/apis/apiserver"
+	apiservervalidation "k8s.io/apiserver/pkg/apis/apiserver/validation"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/authenticatorfactory"
+	authenticationcel "k8s.io/apiserver/pkg/authentication/cel"
 	"k8s.io/apiserver/pkg/authentication/group"
 	"k8s.io/apiserver/pkg/authentication/request/anonymous"
 	"k8s.io/apiserver/pkg/authentication/request/bearertoken"
@@ -239,6 +242,50 @@ func (config Config) New(serverLifecycle context.Context) (authenticator.Request
 
 	authenticator = group.NewAuthenticatedGroupAdder(authenticator)
 
+	// Apply top-level userValidationRules.
+	// Create the pointer and wrap the authenticator whenever AuthenticationConfig is in use,
+	// so that hot-reload can add/remove rules without restarting the server.
+	if config.AuthenticationConfig != nil {
+		var initialRules authenticationcel.UserMapper
+		if len(config.AuthenticationConfig.UserValidationRules) > 0 {
+			compiledRules, errs := apiservervalidation.CompileAndValidateUserValidationRules(
+				authenticationcel.NewDefaultCompiler(), config.AuthenticationConfig.UserValidationRules,
+			)
+			if errs != nil {
+				return nil, nil, nil, nil, errs.ToAggregate()
+			}
+			initialRules = compiledRules
+		}
+		userValidationRulesPtr := &atomic.Pointer[authenticationcel.UserMapper]{}
+		userValidationRulesPtr.Store(&initialRules)
+		authenticator = &userValidatingAuthenticator{
+			delegate: authenticator,
+			rulesPtr: userValidationRulesPtr,
+		}
+
+		// Extend the hot-reload callback to also update the user validation rules.
+		if updateAuthenticationConfig != nil {
+			prevUpdate := updateAuthenticationConfig
+			updateAuthenticationConfig = func(ctx context.Context, authCfg *apiserver.AuthenticationConfiguration) error {
+				if err := prevUpdate(ctx, authCfg); err != nil {
+					return err
+				}
+				var newRules authenticationcel.UserMapper
+				if len(authCfg.UserValidationRules) > 0 {
+					compiled, ruleErrs := apiservervalidation.CompileAndValidateUserValidationRules(
+						authenticationcel.NewDefaultCompiler(), authCfg.UserValidationRules,
+					)
+					if ruleErrs != nil {
+						return ruleErrs.ToAggregate()
+					}
+					newRules = compiled
+				}
+				userValidationRulesPtr.Store(&newRules)
+				return nil
+			}
+		}
+	}
+
 	if config.Anonymous.Enabled {
 		// If the authenticator chain returns an error, return an error (don't consider a bad bearer token
 		// or invalid username/password combination anonymous).
@@ -252,6 +299,50 @@ type jwtAuthenticatorWithCancel struct {
 	jwtAuthenticator authenticator.Token
 	healthCheck      func() error
 	cancel           func()
+}
+
+// userValidatingAuthenticator wraps an authenticator.Request and applies top-level
+// user validation rules (CEL expressions) to the authenticated user. This enables
+// blocking specific credentials (e.g., by x509 fingerprint) regardless of which
+// authenticator produced the user.Info.
+type userValidatingAuthenticator struct {
+	delegate authenticator.Request
+	rulesPtr *atomic.Pointer[authenticationcel.UserMapper]
+}
+
+func (a *userValidatingAuthenticator) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+	resp, ok, err := a.delegate.AuthenticateRequest(req)
+	if err != nil || !ok {
+		return resp, ok, err
+	}
+
+	rules := a.rulesPtr.Load()
+	if rules == nil || *rules == nil {
+		return resp, ok, nil
+	}
+
+	userInfoVal := authenticationcel.NewUserInfoMapper(resp.User)
+
+	evalResults, err := (*rules).EvalUser(req.Context(), userInfoVal)
+	if err != nil {
+		return nil, false, fmt.Errorf("error evaluating user validation rule: %w", err)
+	}
+
+	for _, result := range evalResults {
+		val, isBool := result.EvalResult.Value().(bool)
+		if !isBool {
+			return nil, false, fmt.Errorf("user validation rule must return a boolean")
+		}
+		if !val {
+			msg := fmt.Sprintf("validation expression '%s' failed", result.ExpressionAccessor.GetExpression())
+			if condition, ok := result.ExpressionAccessor.(*authenticationcel.UserValidationCondition); ok && condition.Message != "" {
+				msg = condition.Message
+			}
+			return nil, false, fmt.Errorf("user validation failed: %s", msg)
+		}
+	}
+
+	return resp, true, nil
 }
 
 func newJWTAuthenticator(serverLifecycle context.Context, config *apiserver.AuthenticationConfiguration, oidcSigningAlgs []string, apiAudiences authenticator.Audiences, disallowedIssuers []string, egressLookup egressselector.Lookup, apiServerID string) (_ *jwtAuthenticatorWithCancel, buildErr error) {

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/types.go
@@ -168,6 +168,14 @@ type TracingConfiguration struct {
 type AuthenticationConfiguration struct {
 	metav1.TypeMeta
 
+	// UserValidationRules are rules that are applied to the authenticated user
+	// from any authenticator (x509, JWT, webhook, etc.) before completing
+	// authentication. The rules are logically ANDed together; all must return
+	// true for authentication to succeed. This allows blocking specific
+	// credentials regardless of the authentication method used.
+	// +optional
+	UserValidationRules []UserValidationRule
+
 	JWT []JWTAuthenticator
 
 	// If present --anonymous-auth must not be set

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1/types.go
@@ -56,6 +56,14 @@ type AdmissionPluginConfiguration struct {
 type AuthenticationConfiguration struct {
 	metav1.TypeMeta `json:""`
 
+	// userValidationRules are rules that are applied to the authenticated user
+	// from any authenticator (x509, JWT, webhook, etc.) before completing
+	// authentication. The rules are logically ANDed together; all must return
+	// true for authentication to succeed. This allows blocking specific
+	// credentials regardless of the authentication method used.
+	// +optional
+	UserValidationRules []UserValidationRule `json:"userValidationRules,omitempty"`
+
 	// jwt is a list of authenticator to authenticate Kubernetes users using
 	// JWT compliant tokens. The authenticator will attempt to parse a raw ID token,
 	// verify it's been signed by the configured issuer. The public key to verify the

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1/zz_generated.conversion.go
@@ -417,6 +417,7 @@ func Convert_apiserver_AnonymousAuthConfig_To_v1_AnonymousAuthConfig(in *apiserv
 }
 
 func autoConvert_v1_AuthenticationConfiguration_To_apiserver_AuthenticationConfiguration(in *AuthenticationConfiguration, out *apiserver.AuthenticationConfiguration, s conversion.Scope) error {
+	out.UserValidationRules = *(*[]apiserver.UserValidationRule)(unsafe.Pointer(&in.UserValidationRules))
 	if in.JWT != nil {
 		in, out := &in.JWT, &out.JWT
 		*out = make([]apiserver.JWTAuthenticator, len(*in))
@@ -438,6 +439,7 @@ func Convert_v1_AuthenticationConfiguration_To_apiserver_AuthenticationConfigura
 }
 
 func autoConvert_apiserver_AuthenticationConfiguration_To_v1_AuthenticationConfiguration(in *apiserver.AuthenticationConfiguration, out *AuthenticationConfiguration, s conversion.Scope) error {
+	out.UserValidationRules = *(*[]UserValidationRule)(unsafe.Pointer(&in.UserValidationRules))
 	if in.JWT != nil {
 		in, out := &in.JWT, &out.JWT
 		*out = make([]JWTAuthenticator, len(*in))

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1/zz_generated.deepcopy.go
@@ -141,6 +141,11 @@ func (in *AnonymousAuthConfig) DeepCopy() *AnonymousAuthConfig {
 func (in *AuthenticationConfiguration) DeepCopyInto(out *AuthenticationConfiguration) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.UserValidationRules != nil {
+		in, out := &in.UserValidationRules, &out.UserValidationRules
+		*out = make([]UserValidationRule, len(*in))
+		copy(*out, *in)
+	}
 	if in.JWT != nil {
 		in, out := &in.JWT, &out.JWT
 		*out = make([]JWTAuthenticator, len(*in))

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
@@ -169,6 +169,14 @@ type TracingConfiguration struct {
 type AuthenticationConfiguration struct {
 	metav1.TypeMeta `json:""`
 
+	// userValidationRules are rules that are applied to the authenticated user
+	// from any authenticator (x509, JWT, webhook, etc.) before completing
+	// authentication. The rules are logically ANDed together; all must return
+	// true for authentication to succeed. This allows blocking specific
+	// credentials regardless of the authentication method used.
+	// +optional
+	UserValidationRules []UserValidationRule `json:"userValidationRules,omitempty"`
+
 	// jwt is a list of authenticator to authenticate Kubernetes users using
 	// JWT compliant tokens. The authenticator will attempt to parse a raw ID token,
 	// verify it's been signed by the configured issuer. The public key to verify the

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.conversion.go
@@ -387,6 +387,7 @@ func Convert_apiserver_AnonymousAuthConfig_To_v1alpha1_AnonymousAuthConfig(in *a
 }
 
 func autoConvert_v1alpha1_AuthenticationConfiguration_To_apiserver_AuthenticationConfiguration(in *AuthenticationConfiguration, out *apiserver.AuthenticationConfiguration, s conversion.Scope) error {
+	out.UserValidationRules = *(*[]apiserver.UserValidationRule)(unsafe.Pointer(&in.UserValidationRules))
 	if in.JWT != nil {
 		in, out := &in.JWT, &out.JWT
 		*out = make([]apiserver.JWTAuthenticator, len(*in))
@@ -408,6 +409,7 @@ func Convert_v1alpha1_AuthenticationConfiguration_To_apiserver_AuthenticationCon
 }
 
 func autoConvert_apiserver_AuthenticationConfiguration_To_v1alpha1_AuthenticationConfiguration(in *apiserver.AuthenticationConfiguration, out *AuthenticationConfiguration, s conversion.Scope) error {
+	out.UserValidationRules = *(*[]UserValidationRule)(unsafe.Pointer(&in.UserValidationRules))
 	if in.JWT != nil {
 		in, out := &in.JWT, &out.JWT
 		*out = make([]JWTAuthenticator, len(*in))

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.deepcopy.go
@@ -119,6 +119,11 @@ func (in *AnonymousAuthConfig) DeepCopy() *AnonymousAuthConfig {
 func (in *AuthenticationConfiguration) DeepCopyInto(out *AuthenticationConfiguration) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.UserValidationRules != nil {
+		in, out := &in.UserValidationRules, &out.UserValidationRules
+		*out = make([]UserValidationRule, len(*in))
+		copy(*out, *in)
+	}
 	if in.JWT != nil {
 		in, out := &in.JWT, &out.JWT
 		*out = make([]JWTAuthenticator, len(*in))

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/types.go
@@ -140,6 +140,14 @@ type TracingConfiguration struct {
 type AuthenticationConfiguration struct {
 	metav1.TypeMeta `json:""`
 
+	// userValidationRules are rules that are applied to the authenticated user
+	// from any authenticator (x509, JWT, webhook, etc.) before completing
+	// authentication. The rules are logically ANDed together; all must return
+	// true for authentication to succeed. This allows blocking specific
+	// credentials regardless of the authentication method used.
+	// +optional
+	UserValidationRules []UserValidationRule `json:"userValidationRules,omitempty"`
+
 	// jwt is a list of authenticator to authenticate Kubernetes users using
 	// JWT compliant tokens. The authenticator will attempt to parse a raw ID token,
 	// verify it's been signed by the configured issuer. The public key to verify the

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/zz_generated.conversion.go
@@ -323,6 +323,7 @@ func Convert_apiserver_AnonymousAuthConfig_To_v1beta1_AnonymousAuthConfig(in *ap
 }
 
 func autoConvert_v1beta1_AuthenticationConfiguration_To_apiserver_AuthenticationConfiguration(in *AuthenticationConfiguration, out *apiserver.AuthenticationConfiguration, s conversion.Scope) error {
+	out.UserValidationRules = *(*[]apiserver.UserValidationRule)(unsafe.Pointer(&in.UserValidationRules))
 	if in.JWT != nil {
 		in, out := &in.JWT, &out.JWT
 		*out = make([]apiserver.JWTAuthenticator, len(*in))
@@ -344,6 +345,7 @@ func Convert_v1beta1_AuthenticationConfiguration_To_apiserver_AuthenticationConf
 }
 
 func autoConvert_apiserver_AuthenticationConfiguration_To_v1beta1_AuthenticationConfiguration(in *apiserver.AuthenticationConfiguration, out *AuthenticationConfiguration, s conversion.Scope) error {
+	out.UserValidationRules = *(*[]UserValidationRule)(unsafe.Pointer(&in.UserValidationRules))
 	if in.JWT != nil {
 		in, out := &in.JWT, &out.JWT
 		*out = make([]JWTAuthenticator, len(*in))

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/zz_generated.deepcopy.go
@@ -66,6 +66,11 @@ func (in *AnonymousAuthConfig) DeepCopy() *AnonymousAuthConfig {
 func (in *AuthenticationConfiguration) DeepCopyInto(out *AuthenticationConfiguration) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.UserValidationRules != nil {
+		in, out := &in.UserValidationRules, &out.UserValidationRules
+		*out = make([]UserValidationRule, len(*in))
+		copy(*out, *in)
+	}
 	if in.JWT != nil {
 		in, out := &in.JWT, &out.JWT
 		*out = make([]JWTAuthenticator, len(*in))

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation.go
@@ -83,6 +83,12 @@ func ValidateAuthenticationConfiguration(compiler authenticationcel.Compiler, c 
 		}
 	}
 
+	// Validate top-level userValidationRules (applied to all authenticators)
+	if len(c.UserValidationRules) > 0 {
+		state := &validationState{}
+		allErrs = append(allErrs, validateUserValidationRules(compiler, state, c.UserValidationRules, field.NewPath("userValidationRules"))...)
+	}
+
 	return allErrs
 }
 
@@ -91,6 +97,14 @@ func ValidateAuthenticationConfiguration(compiler authenticationcel.Compiler, c 
 // This is exported for use in oidc package.
 func CompileAndValidateJWTAuthenticator(compiler authenticationcel.Compiler, authenticator api.JWTAuthenticator, disallowedIssuers []string) (authenticationcel.CELMapper, field.ErrorList) {
 	return validateJWTAuthenticator(compiler, authenticator, nil, sets.New(disallowedIssuers...), utilfeature.DefaultFeatureGate.Enabled(features.StructuredAuthenticationConfigurationEgressSelector))
+}
+
+// CompileAndValidateUserValidationRules validates the given top-level user validation rules and returns
+// a compiled UserMapper. This is exported for use in the authenticator package.
+func CompileAndValidateUserValidationRules(compiler authenticationcel.Compiler, rules []api.UserValidationRule) (authenticationcel.UserMapper, field.ErrorList) {
+	state := &validationState{}
+	errs := validateUserValidationRules(compiler, state, rules, field.NewPath("userValidationRules"))
+	return state.mapper.UserValidationRules, errs
 }
 
 func validateJWTAuthenticator(compiler authenticationcel.Compiler, authenticator api.JWTAuthenticator, fldPath *field.Path, disallowedIssuers sets.Set[string], structuredAuthnEgressSelectorFeatureEnabled bool) (authenticationcel.CELMapper, field.ErrorList) {

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/zz_generated.deepcopy.go
@@ -141,6 +141,11 @@ func (in *AnonymousAuthConfig) DeepCopy() *AnonymousAuthConfig {
 func (in *AuthenticationConfiguration) DeepCopyInto(out *AuthenticationConfiguration) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.UserValidationRules != nil {
+		in, out := &in.UserValidationRules, &out.UserValidationRules
+		*out = make([]UserValidationRule, len(*in))
+		copy(*out, *in)
+	}
 	if in.JWT != nil {
 		in, out := &in.JWT, &out.JWT
 		*out = make([]JWTAuthenticator, len(*in))

--- a/staging/src/k8s.io/apiserver/pkg/authentication/cel/userinfo.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/cel/userinfo.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cel
+
+import (
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+	apiservercel "k8s.io/apiserver/pkg/cel"
+	"k8s.io/apiserver/pkg/cel/lazy"
+)
+
+// NewUserInfoMapper creates a traits.Mapper from a user.Info that can be used
+// as input when evaluating CEL user validation expressions. The returned mapper
+// supports both direct string-key access (e.g. user.extra['example.org/foo'])
+// and escaped identifier-based access (e.g. user.extra.example__dot__org__slash__foo).
+func NewUserInfoMapper(info user.Info) traits.Mapper {
+	lazyMap := lazy.NewMapValue(types.NewObjectType("kubernetes.UserInfo"))
+	addField := func(name string, get func() any) {
+		lazyMap.Append(name, func(_ *lazy.MapValue) ref.Val {
+			return userInfoNativeToValue(get())
+		})
+	}
+	addField("username", func() any { return info.GetName() })
+	addField("uid", func() any { return info.GetUID() })
+	addField("groups", func() any { return info.GetGroups() })
+	addField("extra", func() any { return info.GetExtra() })
+	return lazyMap
+}
+
+// userInfoNativeToValue converts a Go value to a CEL ref.Val, wrapping maps
+// and lists to support __dot__-escaped key lookups.
+func userInfoNativeToValue(value any) ref.Val {
+	return userInfoUnescapeWrapper(types.DefaultTypeAdapter.NativeToValue(value))
+}
+
+// userInfoUnescapeWrapper wraps a CEL value to support __dot__-escaped key lookups
+// for maps and lists.
+func userInfoUnescapeWrapper(value ref.Val) ref.Val {
+	switch v := value.(type) {
+	case traits.Mapper:
+		return &userInfoUnescapeMapper{Mapper: v}
+	case traits.Lister:
+		return &userInfoUnescapeLister{Lister: v}
+	default:
+		return value
+	}
+}
+
+type userInfoUnescapeMapper struct {
+	traits.Mapper
+}
+
+func (m *userInfoUnescapeMapper) Find(key ref.Val) (ref.Val, bool) {
+	name, ok := userInfoUnescapedName(key)
+	if ok {
+		key = name
+	}
+	value, ok := m.Mapper.Find(key)
+	return userInfoUnescapeWrapper(value), ok
+}
+
+type userInfoUnescapeLister struct {
+	traits.Lister
+}
+
+func (l *userInfoUnescapeLister) Get(index ref.Val) ref.Val {
+	return userInfoUnescapeWrapper(l.Lister.Get(index))
+}
+
+func userInfoUnescapedName(key ref.Val) (types.String, bool) {
+	n, ok := key.(types.String)
+	if !ok {
+		return "", false
+	}
+	ns := string(n)
+	name, ok := apiservercel.Unescape(ns)
+	if !ok || name == ns {
+		return "", false
+	}
+	return types.String(name), true
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This extends the AuthenticationConfiguration with `userValidationRules`. These can be used to manage x509 certificate revocation by adding fingerprints to the CEL expression.

#### Which issue(s) this PR is related to:

Related to https://github.com/kubernetes/kubernetes/issues/18982

#### Special notes for your reviewer:

THIS IS A DRAFT. I do not expect full reviews. It is intended as a discussion starter and exploration of potential solutions.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The AuthenticationConfiguration was extended with a new `userValidationRules` field. It can be used to handle revoked certificates by listing fingerprints of revoked certificates in a CEL expression.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
