### PR TITLE
Fix DRA allocator widening config scoped to subrequests

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -2480,6 +2480,44 @@ func TestAllocator(t *testing.T,
 				},
 			)},
 		},
+		"claim-config-scoped-to-subrequests-of-one-request": {
+			features: Features{
+				PrioritizedList: true,
+			},
+			claimsToAllocate: objects(
+				claim(claim0).withRequests(
+					requestWithPrioritizedList(req0,
+						subRequest(subReq0, classA, 1),
+						subRequest(subReq1, classB, 1),
+					),
+					deviceRequest(req1, classA, 1),
+				).withConfigs(
+					objects(
+						deviceClaimConfig([]string{req0SubReq0, req0SubReq1}, deviceConfiguration(driverA, "scoped")),
+					),
+				),
+			),
+			classes: objects(class(classA, driverA), class(classB, driverB)),
+			slices: unwrap(
+				sliceWithMultipleDevices(slice1, node1, pool1, driverA, 2),
+			),
+			node: node(node1, region1),
+
+			expectResults: []any{allocationResultWithConfigs(
+				localNodeSelector(node1),
+				objects(
+					deviceAllocationResult(req0SubReq0, driverA, pool1, device0, false),
+					deviceAllocationResult(req1, driverA, pool1, device1, false),
+				),
+				[]resourceapi.DeviceAllocationConfiguration{
+					{
+						Source:              resourceapi.AllocationConfigSourceClaim,
+						Requests:            []string{req0SubReq0, req0SubReq1},
+						DeviceConfiguration: deviceConfiguration(driverA, "scoped"),
+					},
+				},
+			)},
+		},
 		"prioritized-list-subrequests-with-expressions": {
 			features: Features{
 				PrioritizedList: true,

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -489,7 +489,28 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 		// If a config applies to all requests, clear its Requests
 		// field to take advantage of the "empty means all" semantic.
 		for i := range allocationResult.Devices.Config {
-			if len(allocationResult.Devices.Config[i].Requests) == len(claim.Spec.Devices.Requests) {
+			requests := allocationResult.Devices.Config[i].Requests
+			if len(requests) == 0 {
+				continue
+			}
+			appliesToAll := true
+			for requestIndex, request := range claim.Spec.Devices.Requests {
+				if slices.Contains(requests, request.Name) {
+					continue
+				}
+				requestKey := requestIndices{claimIndex: claimIndex, requestIndex: requestIndex}
+				requestData := alloc.requestData[requestKey]
+				if requestData.parentRequest != nil {
+					subRequest := request.FirstAvailable[requestData.selectedSubRequestIndex]
+					subRequestName := fmt.Sprintf("%s/%s", request.Name, subRequest.Name)
+					if slices.Contains(requests, subRequestName) {
+						continue
+					}
+				}
+				appliesToAll = false
+				break
+			}
+			if appliesToAll {
 				allocationResult.Devices.Config[i].Requests = nil
 			}
 		}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
@@ -486,7 +486,28 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 		// If a config applies to all requests, clear its Requests
 		// field to take advantage of the "empty means all" semantic.
 		for i := range allocationResult.Devices.Config {
-			if len(allocationResult.Devices.Config[i].Requests) == len(claim.Spec.Devices.Requests) {
+			requests := allocationResult.Devices.Config[i].Requests
+			if len(requests) == 0 {
+				continue
+			}
+			appliesToAll := true
+			for requestIndex, request := range claim.Spec.Devices.Requests {
+				if slices.Contains(requests, request.Name) {
+					continue
+				}
+				requestKey := requestIndices{claimIndex: claimIndex, requestIndex: requestIndex}
+				requestData := alloc.requestData[requestKey]
+				if requestData.parentRequest != nil {
+					subRequest := request.FirstAvailable[requestData.selectedSubRequestIndex]
+					subRequestName := fmt.Sprintf("%s/%s", request.Name, subRequest.Name)
+					if slices.Contains(requests, subRequestName) {
+						continue
+					}
+				}
+				appliesToAll = false
+				break
+			}
+			if appliesToAll {
 				allocationResult.Devices.Config[i].Requests = nil
 			}
 		}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/allocator_stable.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/allocator_stable.go
@@ -391,7 +391,28 @@ func (a *Allocator) Allocate(ctx context.Context, node *v1.Node, claims []*resou
 		// If a config applies to all requests, clear its Requests
 		// field to take advantage of the "empty means all" semantic.
 		for i := range allocationResult.Devices.Config {
-			if len(allocationResult.Devices.Config[i].Requests) == len(claim.Spec.Devices.Requests) {
+			requests := allocationResult.Devices.Config[i].Requests
+			if len(requests) == 0 {
+				continue
+			}
+			appliesToAll := true
+			for requestIndex, request := range claim.Spec.Devices.Requests {
+				if slices.Contains(requests, request.Name) {
+					continue
+				}
+				requestKey := requestIndices{claimIndex: claimIndex, requestIndex: requestIndex}
+				requestData := alloc.requestData[requestKey]
+				if requestData.parentRequest != nil {
+					subRequest := request.FirstAvailable[requestData.selectedSubRequestIndex]
+					subRequestName := fmt.Sprintf("%s/%s", request.Name, subRequest.Name)
+					if slices.Contains(requests, subRequestName) {
+						continue
+					}
+				}
+				appliesToAll = false
+				break
+			}
+			if appliesToAll {
 				allocationResult.Devices.Config[i].Requests = nil
 			}
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The structured DRA allocator post-processes each claim's resolved configs and
clears `DeviceAllocationConfiguration.Requests` to `nil` when a config applies
to every request, taking advantage of the "empty Requests means all requests"
semantic.

The condition it used was a length comparison:

    len(config.Requests) == len(claim.Spec.Devices.Requests)

This is not equivalent to "this config covers every request in the claim". A
`Requests` entry can be a subrequest reference of the form
`"<request>/<subRequest>"`. A config scoped to N subrequests of a *single*
request has N entries, so when the claim happens to have N top-level requests
the lengths match and the config's `Requests` was cleared — silently widening a
narrowly-scoped config to the entire claim.

This PR clears `Requests` only when the config covers every top-level request,
either by the request's name or by the request's selected subrequest. The check
reuses the same matching rules already used when the configs are built, so the
existing behavior for a single request with subrequests (where clearing is
still correct) is unchanged.

The fix is applied to all three allocator variants (`stable`, `incubating`,
`experimental`), which are kept in sync.

**Which issue(s) this PR fixes**:

Fixes #139803

**Special notes for your reviewer**:

A regression test (`claim-config-scoped-to-subrequests-of-one-request`) is added
to the shared allocator test suite. It uses a claim with two top-level requests
where one config is scoped to two subrequests of the first request; the config
must remain scoped instead of being widened to the whole claim. The test fails
against the previous length-based check and passes with this change, and runs
against all three allocator implementations.

**Does this PR introduce a user-facing change?**

```release-note
Fixed a bug in the structured DRA allocator where a device configuration scoped to specific subrequests could be incorrectly applied to all requests in a claim when the number of referenced subrequests happened to equal the number of top-level requests.