### PR TITLE
cacher: move hasPathPrefix helper to new key subpackage

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/cacher/delegator"
+	"k8s.io/apiserver/pkg/storage/cacher/key"
 	"k8s.io/apiserver/pkg/storage/cacher/metrics"
 	"k8s.io/apiserver/pkg/storage/cacher/progress"
 	"k8s.io/apiserver/pkg/storage/cacher/store"
@@ -1212,10 +1213,10 @@ func forgetWatcher(c *Cacher, w *cacheWatcher, index int, scope namespacedName, 
 	}
 }
 
-func filterWithAttrsAndPrefixFunction(key string, p storage.SelectionPredicate, groupResource schema.GroupResource) filterWithAttrsFunc {
+func filterWithAttrsAndPrefixFunction(prefix string, p storage.SelectionPredicate, groupResource schema.GroupResource) filterWithAttrsFunc {
 	isSharded := utilfeature.DefaultFeatureGate.Enabled(features.ShardedListAndWatch) && p.ShardSelector != nil && !p.ShardSelector.Empty()
 	filterFunc := func(objKey string, label labels.Set, field fields.Set, obj runtime.Object) bool {
-		if !hasPathPrefix(objKey, key) {
+		if !key.HasPathPrefix(objKey, prefix) {
 			return false
 		}
 		if isSharded {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/key/key.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/key/key.go
@@ -1,0 +1,46 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package key
+
+import (
+	"strings"
+)
+
+// HasPathPrefix returns true if the string s matches pathPrefix exactly, or if s is prefixed with pathPrefix at a path segment boundary.
+func HasPathPrefix(s, pathPrefix string) bool {
+	// Short circuit if s doesn't contain the prefix at all
+	if !strings.HasPrefix(s, pathPrefix) {
+		return false
+	}
+
+	pathPrefixLength := len(pathPrefix)
+
+	if len(s) == pathPrefixLength {
+		// Exact match
+		return true
+	}
+	if strings.HasSuffix(pathPrefix, "/") {
+		// pathPrefix already ensured a path segment boundary
+		return true
+	}
+	if s[pathPrefixLength:pathPrefixLength+1] == "/" {
+		// The next character in s is a path segment boundary
+		// Check this instead of normalizing pathPrefix to avoid allocating on every call
+		return true
+	}
+	return false
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/key/key_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/key/key_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package key
+
+import (
+	"testing"
+)
+
+func TestHasPathPrefix(t *testing.T) {
+	validTestcases := []struct {
+		s      string
+		prefix string
+	}{
+		// Exact matches
+		{"", ""},
+		{"a", "a"},
+		{"a/", "a/"},
+		{"a/../", "a/../"},
+
+		// Path prefix matches
+		{"a/b", "a"},
+		{"a/b", "a/"},
+		{"中文/", "中文"},
+	}
+	for i, tc := range validTestcases {
+		if !HasPathPrefix(tc.s, tc.prefix) {
+			t.Errorf(`%d: Expected HasPathPrefix("%s","%s") to be true`, i, tc.s, tc.prefix)
+		}
+	}
+
+	invalidTestcases := []struct {
+		s      string
+		prefix string
+	}{
+		// Mismatch
+		{"a", "b"},
+
+		// Dir requirement
+		{"a", "a/"},
+
+		// Prefix mismatch
+		{"ns2", "ns"},
+		{"ns2", "ns/"},
+		{"中文文", "中文"},
+
+		// Ensure no normalization is applied
+		{"a/c/../b/", "a/b/"},
+		{"a/", "a/b/.."},
+	}
+	for i, tc := range invalidTestcases {
+		if HasPathPrefix(tc.s, tc.prefix) {
+			t.Errorf(`%d: Expected HasPathPrefix("%s","%s") to be false`, i, tc.s, tc.prefix)
+		}
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/util.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/util.go
@@ -18,34 +18,8 @@ package cacher
 
 import (
 	"math"
-	"strings"
 	"time"
 )
-
-// hasPathPrefix returns true if the string matches pathPrefix exactly, or if is prefixed with pathPrefix at a path segment boundary
-func hasPathPrefix(s, pathPrefix string) bool {
-	// Short circuit if s doesn't contain the prefix at all
-	if !strings.HasPrefix(s, pathPrefix) {
-		return false
-	}
-
-	pathPrefixLength := len(pathPrefix)
-
-	if len(s) == pathPrefixLength {
-		// Exact match
-		return true
-	}
-	if strings.HasSuffix(pathPrefix, "/") {
-		// pathPrefix already ensured a path segment boundary
-		return true
-	}
-	if s[pathPrefixLength:pathPrefixLength+1] == "/" {
-		// The next character in s is a path segment boundary
-		// Check this instead of normalizing pathPrefix to avoid allocating on every call
-		return true
-	}
-	return false
-}
 
 // calculateRetryAfterForUnreadyCache calculates the retry duration based on the cache downtime.
 func calculateRetryAfterForUnreadyCache(downtime time.Duration) int {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/util_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/util_test.go
@@ -21,54 +21,6 @@ import (
 	"time"
 )
 
-func TestHasPathPrefix(t *testing.T) {
-	validTestcases := []struct {
-		s      string
-		prefix string
-	}{
-		// Exact matches
-		{"", ""},
-		{"a", "a"},
-		{"a/", "a/"},
-		{"a/../", "a/../"},
-
-		// Path prefix matches
-		{"a/b", "a"},
-		{"a/b", "a/"},
-		{"中文/", "中文"},
-	}
-	for i, tc := range validTestcases {
-		if !hasPathPrefix(tc.s, tc.prefix) {
-			t.Errorf(`%d: Expected hasPathPrefix("%s","%s") to be true`, i, tc.s, tc.prefix)
-		}
-	}
-
-	invalidTestcases := []struct {
-		s      string
-		prefix string
-	}{
-		// Mismatch
-		{"a", "b"},
-
-		// Dir requirement
-		{"a", "a/"},
-
-		// Prefix mismatch
-		{"ns2", "ns"},
-		{"ns2", "ns/"},
-		{"中文文", "中文"},
-
-		// Ensure no normalization is applied
-		{"a/c/../b/", "a/b/"},
-		{"a/", "a/b/.."},
-	}
-	for i, tc := range invalidTestcases {
-		if hasPathPrefix(tc.s, tc.prefix) {
-			t.Errorf(`%d: Expected hasPathPrefix("%s","%s") to be false`, i, tc.s, tc.prefix)
-		}
-	}
-}
-
 func TestCalculateRetryAfterForUnreadyCache(t *testing.T) {
 	tests := []struct {
 		downtime time.Duration

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_storage.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_storage.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/features"
+	"k8s.io/apiserver/pkg/storage/cacher/key"
 	"k8s.io/apiserver/pkg/storage/cacher/store"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/cache"
@@ -151,7 +152,7 @@ func (l listSnapshot) OrderedListPrefix(prefix string, continueKey string) ([]in
 		if len(continueKey) > 0 && continueKey >= elem.Key {
 			continue
 		}
-		if !hasPathPrefix(elem.Key, prefix) {
+		if !key.HasPathPrefix(elem.Key, prefix) {
 			continue
 		}
 		result = append(result, item)


### PR DESCRIPTION
This way key.HasPathPrefix can be used from both cacher and store

/kind cleanup

```release-note
NONE
```

/cc @michaelasp @Jefftree @p0lyn0mial @AwesomePatrol 