### PR TITLE
test/e2e/network: fix hostNetwork tests broken by --hostname-override

### DIFF
--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -87,6 +87,13 @@ const (
 	// netexec dial commands
 	// the destination will echo its hostname.
 	echoHostname = "hostname"
+	// the destination will echo its Kubernetes node name via the /envvar endpoint.
+	// Used for hostNetwork pods where os.Hostname() is unreliable when --hostname-override is set.
+	echoNodename = "envvar?var=NODE_NAME"
+	// echoNodenameUDP is the UDP equivalent of echoNodename. The agnhost UDP handler
+	// expects space-separated "envvar NODE_NAME"; percent-encoding the space here
+	// lets Go's url.ParseQuery at the dial relay decode it back to that form.
+	echoNodenameUDP = "envvar%20NODE_NAME"
 )
 
 // Option is used to configure the NetworkingTest object
@@ -217,12 +224,28 @@ type NetexecDialResponse struct {
 
 // DialFromEndpointContainer executes a curl via kubectl exec in an endpoint container.   Returns an error to be handled by the caller.
 func (config *NetworkingTestConfig) DialFromEndpointContainer(ctx context.Context, protocol, targetIP string, targetPort, maxTries, minTries int, expectedEps sets.String) error {
-	return config.DialFromContainer(ctx, protocol, echoHostname, config.EndpointPods[0].Status.PodIP, targetIP, EndpointHTTPPort, targetPort, maxTries, minTries, expectedEps)
+	dialCmd := echoHostname
+	if config.EndpointsHostNetwork {
+		if protocol == "udp" || protocol == "sctp" {
+			dialCmd = echoNodenameUDP
+		} else {
+			dialCmd = echoNodename
+		}
+	}
+	return config.DialFromContainer(ctx, protocol, dialCmd, config.EndpointPods[0].Status.PodIP, targetIP, EndpointHTTPPort, targetPort, maxTries, minTries, expectedEps)
 }
 
 // DialFromTestContainer executes a curl via kubectl exec in a test container. Returns an error to be handled by the caller.
 func (config *NetworkingTestConfig) DialFromTestContainer(ctx context.Context, protocol, targetIP string, targetPort, maxTries, minTries int, expectedEps sets.String) error {
-	return config.DialFromContainer(ctx, protocol, echoHostname, config.TestContainerPod.Status.PodIP, targetIP, testContainerHTTPPort, targetPort, maxTries, minTries, expectedEps)
+	dialCmd := echoHostname
+	if config.EndpointsHostNetwork {
+		if protocol == "udp" || protocol == "sctp" {
+			dialCmd = echoNodenameUDP
+		} else {
+			dialCmd = echoNodename
+		}
+	}
+	return config.DialFromContainer(ctx, protocol, dialCmd, config.TestContainerPod.Status.PodIP, targetIP, testContainerHTTPPort, targetPort, maxTries, minTries, expectedEps)
 }
 
 // DialEchoFromTestContainer executes a curl via kubectl exec in a test container. The response is expected to match the echoMessage,  Returns an error to be handled by the caller.
@@ -264,28 +287,12 @@ func (config *NetworkingTestConfig) EndpointHostnames() sets.String {
 	for _, p := range config.EndpointPods {
 
 		if config.EndpointsHostNetwork {
-			// Hostname behavior for hostNetwork pods is not well defined and when
-			// using the flag hostname-override in the kubelet, the node reported
-			// hostname on host network pods will not match the node's hostanme.
-			// It seems that the node.status.addresses hostname value is the only
-			// one that matches the value returned by os.Hostname
-			// used by the agnhost web handler, so we'll use that value.
-			// If by any circumstances the node does not provide that hostnae address
-			// we use the value of the node name.
-			// xref: https://issues.k8s.io/126087
-			hostname := p.Spec.NodeSelector["kubernetes.io/hostname"]
-			for _, n := range config.Nodes {
-				if n.Name == p.Spec.NodeSelector["kubernetes.io/hostname"] {
-					for _, address := range n.Status.Addresses {
-						if address.Type == v1.NodeHostName {
-							hostname = address.Address
-							break
-						}
-					}
-					break
-				}
-			}
-			expectedEps.Insert(hostname)
+			// For hostNetwork pods, spec.nodeName is the only reliable node identifier.
+			// os.Hostname() diverges from the k8s node name when --hostname-override is
+			// set on kubelet (e.g. DigitalOcean, kops). We use /envvar?var=NODE_NAME
+			// backed by the Downward API to read spec.nodeName directly.
+			// xref: https://issues.k8s.io/121018
+			expectedEps.Insert(p.Spec.NodeName)
 		} else {
 			expectedEps.Insert(p.Name)
 		}
@@ -327,6 +334,7 @@ func makeCURLDialCommand(ipPort, dialCmd, protocol, targetIP string, targetPort 
 // Returns nil if no error, or error message if failed after trying maxTries.
 func (config *NetworkingTestConfig) DialFromContainer(ctx context.Context, protocol, dialCommand, containerIP, targetIP string, containerHTTPPort, targetPort, maxTries, minTries int, expectedResponses sets.String) error {
 	ipPort := net.JoinHostPort(containerIP, strconv.Itoa(containerHTTPPort))
+
 	cmd := makeCURLDialCommand(ipPort, dialCommand, protocol, targetIP, targetPort)
 
 	responses := sets.NewString()
@@ -362,7 +370,7 @@ func (config *NetworkingTestConfig) DialFromContainer(ctx context.Context, proto
 		// TODO: get rid of this delay #36281
 		time.Sleep(hitEndpointRetryDelay)
 	}
-	if dialCommand == echoHostname {
+	if dialCommand == echoHostname || dialCommand == echoNodename || dialCommand == echoNodenameUDP {
 		config.diagnoseMissingEndpoints(responses)
 	}
 	returnMsg := fmt.Errorf("did not find expected responses... \nTries %d\nCommand %v\nretrieved %v\nexpected %v", maxTries, cmd, responses, expectedResponses)
@@ -477,13 +485,22 @@ func (config *NetworkingTestConfig) GetHTTPCodeFromTestContainer(ctx context.Con
 func (config *NetworkingTestConfig) DialFromNode(ctx context.Context, protocol, targetIP string, targetPort, maxTries, minTries int, expectedEps sets.String) error {
 	var cmd string
 	if protocol == "udp" {
-		cmd = fmt.Sprintf("echo hostName | nc -w 1 -u %s %d", targetIP, targetPort)
+		if config.EndpointsHostNetwork {
+			// UDP handler expects space-separated "envvar NODE_NAME".
+			cmd = fmt.Sprintf("echo 'envvar NODE_NAME' | nc -w 1 -u %s %d", targetIP, targetPort)
+		} else {
+			cmd = fmt.Sprintf("echo hostName | nc -w 1 -u %s %d", targetIP, targetPort)
+		}
 	} else {
 		ipPort := net.JoinHostPort(targetIP, strconv.Itoa(targetPort))
 		// The current versions of curl included in CentOS and RHEL distros
 		// misinterpret square brackets around IPv6 as globbing, so use the -g
 		// argument to disable globbing to handle the IPv6 case.
-		cmd = fmt.Sprintf("curl -g -q -s --max-time 15 --connect-timeout 1 http://%s/hostName", ipPort)
+		if config.EndpointsHostNetwork {
+			cmd = fmt.Sprintf("curl -g -q -s --max-time 15 --connect-timeout 1 'http://%s/envvar?var=NODE_NAME'", ipPort)
+		} else {
+			cmd = fmt.Sprintf("curl -g -q -s --max-time 15 --connect-timeout 1 http://%s/hostName", ipPort)
+		}
 	}
 
 	// TODO: This simply tells us that we can reach the endpoints. Check that
@@ -658,6 +675,14 @@ func (config *NetworkingTestConfig) createNetShellPodSpec(podName, hostname stri
 				ValueFrom: &v1.EnvVarSource{
 					FieldRef: &v1.ObjectFieldSelector{
 						FieldPath: "status.podIPs",
+					},
+				},
+			},
+			{
+				Name: "NODE_NAME",
+				ValueFrom: &v1.EnvVarSource{
+					FieldRef: &v1.ObjectFieldSelector{
+						FieldPath: "spec.nodeName",
 					},
 				},
 			},

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -2701,6 +2701,12 @@ var _ = common.SIGDescribe("Services", func() {
 		webserverPod0 := e2epod.NewAgnhostPod(ns, "echo-hostname-0", nil, nil, nil, "netexec", "--http-port", strconv.Itoa(endpointPort), "--udp-port", strconv.Itoa(endpointPort))
 		webserverPod0.Labels = jig.Labels
 		webserverPod0.Spec.HostNetwork = true
+		webserverPod0.Spec.Containers[0].Env = append(webserverPod0.Spec.Containers[0].Env, v1.EnvVar{
+			Name: "NODE_NAME",
+			ValueFrom: &v1.EnvVarSource{
+				FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
+			},
+		})
 		e2epod.SetNodeSelection(&webserverPod0.Spec, e2epod.NodeSelection{Name: node0.Name})
 
 		_, err = cs.CoreV1().Pods(ns).Create(ctx, webserverPod0, metav1.CreateOptions{})
@@ -2729,8 +2735,8 @@ var _ = common.SIGDescribe("Services", func() {
 		serviceAddress := net.JoinHostPort(svc.Spec.ClusterIP, strconv.Itoa(servicePort))
 		for range 5 {
 			// the first pause pod should be on the same node as the webserver, so it can connect to the local pod using clusterIP
-			// note that the expected hostname is the node name because the backend pod is on host network
-			execHostnameTest(*pausePod0, serviceAddress, node0.Name)
+			// note that the expected value is the node name because the backend pod is on host network
+			execNodenameTest(*pausePod0, serviceAddress, node0.Name)
 
 			// the second pause pod is on a different node, so it should see a connection error every time
 			cmd := fmt.Sprintf(`curl -q -s --connect-timeout 5 %s/hostname`, serviceAddress)
@@ -2758,8 +2764,8 @@ var _ = common.SIGDescribe("Services", func() {
 		// assert 5 times that the first pause pod can connect to the Service locally and the second one errors with a timeout
 		for range 5 {
 			// the first pause pod should be on the same node as the webserver, so it can connect to the local pod using clusterIP
-			// note that the expected hostname is the node name because the backend pod is on host network
-			execHostnameTest(*pausePod2, serviceAddress, node0.Name)
+			// note that the expected value is the node name because the backend pod is on host network
+			execNodenameTest(*pausePod2, serviceAddress, node0.Name)
 
 			// the second pause pod is on a different node, so it should see a connection error every time
 			cmd := fmt.Sprintf(`curl -q -s --connect-timeout 5 %s/hostname`, serviceAddress)

--- a/test/e2e/network/util.go
+++ b/test/e2e/network/util.go
@@ -183,6 +183,36 @@ func execHostnameTest(sourcePod v1.Pod, targetAddr, targetHostname string) {
 	gomega.Expect(hostname).To(gomega.Equal(targetHostname))
 }
 
+// execNodenameTest executes curl to access "/envvar?var=NODE_NAME" endpoint on target address
+// from given Pod. Unlike execHostnameTest it does not strip FQDN suffixes because Kubernetes
+// node names are always short identifiers, not FQDNs.
+// xref: https://issues.k8s.io/121018
+func execNodenameTest(sourcePod v1.Pod, targetAddr, expectedNodeName string) {
+	var (
+		err     error
+		stdout  string
+		timeout = 2 * time.Minute
+	)
+
+	framework.Logf("Waiting up to %v to get response from %s", timeout, targetAddr)
+	cmd := fmt.Sprintf(`curl -q -s --max-time 30 '%s/envvar?var=NODE_NAME'`, targetAddr)
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(2 * time.Second) {
+		stdout, err = e2eoutput.RunHostCmd(sourcePod.Namespace, sourcePod.Name, cmd)
+		if err != nil {
+			framework.Logf("got err: %v, retry until timeout", err)
+			continue
+		}
+		if strings.TrimSpace(stdout) == "" {
+			framework.Logf("got empty stdout, retry until timeout")
+			continue
+		}
+		break
+	}
+
+	framework.ExpectNoError(err, "not able to connect to %s after %v", targetAddr, timeout)
+	gomega.Expect(strings.TrimSpace(stdout)).To(gomega.Equal(expectedNodeName))
+}
+
 // createSecondNodePortService creates a service with the same selector as config.NodePortService and same HTTP Port
 func createSecondNodePortService(ctx context.Context, f *framework.Framework, config *e2enetwork.NetworkingTestConfig) (*v1.Service, int) {
 	svc := &v1.Service{


### PR DESCRIPTION
## What this fixes

Two e2e tests have been flaking on any cluster that sets `--hostname-override` on kubelet (DigitalOcean/kops uses the droplet IP; some AWS+kops setups use the EC2 instance ID):

- `[sig-network] Networking Granular Checks: Services should function for service endpoints using hostNetwork`
- `[sig-network] Services should respect internalTrafficPolicy=Local Pod and Node, to Pod (hostNetwork: true)`

Both tests compare a response from a hostNetwork pod against the Kubernetes node name. The response comes from agnhost's `/hostname` endpoint, which calls `os.Hostname()`. On distros where `--hostname-override` diverges from the system hostname, `os.Hostname()` returns neither the k8s node name nor any predictable truncation of it.

## Fix

Use `spec.nodeName` via the Downward API — the only unambiguous source of the k8s node name:

- Inject `NODE_NAME=spec.nodeName` into hostNetwork endpoint pods via Downward API (both in `createNetShellPodSpec` and the service.go test pod).
- Add `echoNodename = "envvar?var=NODE_NAME"` and switch hostNetwork dial paths to use it via `endpointDialCommand()`.
- `EndpointHostnames()` now inserts `p.Spec.NodeName` for hostNetwork pods.
- For UDP/SCTP, the dial relay sends the request as raw bytes — HTTP query-string syntax can't be reused. `echoNodenameUDP = "envvar%20NODE_NAME"` percent-encodes the space so `url.ParseQuery` at the relay decodes it to `"envvar NODE_NAME"` as the agnhost UDP handler expects.
- `DialFromNode` updated symmetrically for both HTTP and UDP.
- Add `execNodenameTest()` in `util.go` — no FQDN truncation since node names are always unqualified.

Non-hostNetwork code paths are entirely unchanged.

## Prerequisites (all merged)

| PR | Description |
|----|-------------|
| #138737 | Add `/envvar` endpoint to agnhost, bump to 2.65.0 |
| kubernetes/k8s.io#9608 | Promote agnhost:2.65.0 staging → prod |
| #139756 | Bump agnhost image references to 2.65.0 |

## Local smoke test

```
/envvar?var=NODE_NAME  → kind-control-plane   (matches spec.nodeName ✓)
/hostname              → agnhost-downward      (diverges — proves the bug ✓)
echoNodenameUDP decode → "envvar NODE_NAME"    (url.ParseQuery %20 → space ✓)
```

Fixes #121018

/cc @aojea